### PR TITLE
[WPE][GTK] Gardening `imported/w3c/web-platform-tests/preload/prefetch-*`

### DIFF
--- a/LayoutTests/platform/glib/imported/w3c/web-platform-tests/preload/prefetch-headers-expected.txt
+++ b/LayoutTests/platform/glib/imported/w3c/web-platform-tests/preload/prefetch-headers-expected.txt
@@ -1,0 +1,5 @@
+
+FAIL Prefetch should include Sec-Purpose=prefetch and Sec-Fetch-Dest=empty headers assert_equals: expected (string) "empty" but got (undefined) undefined
+FAIL Prefetch should not include proprietary headers (X-moz/Purpose) assert_false: expected false got true
+PASS Prefetch should respect CORS mode
+

--- a/LayoutTests/platform/glib/imported/w3c/web-platform-tests/preload/prefetch-types-expected.txt
+++ b/LayoutTests/platform/glib/imported/w3c/web-platform-tests/preload/prefetch-types-expected.txt
@@ -1,0 +1,27 @@
+
+FAIL Prefetch as= should work when consumed as  (http://web-platform.test:8800) assert_equals: expected (string) "empty" but got (undefined) undefined
+FAIL Prefetch as= should work when consumed as image (http://web-platform.test:8800) assert_equals: expected (string) "empty" but got (undefined) undefined
+FAIL Prefetch as= should work when consumed as script (http://web-platform.test:8800) assert_equals: expected (string) "empty" but got (undefined) undefined
+FAIL Prefetch as= should work when consumed as style (http://web-platform.test:8800) assert_equals: expected (string) "empty" but got (undefined) undefined
+FAIL Prefetch as= should work when consumed as document (http://web-platform.test:8800) assert_equals: expected (string) "empty" but got (undefined) undefined
+FAIL Prefetch as=image should work when consumed as  (http://web-platform.test:8800) assert_equals: expected (string) "empty" but got (undefined) undefined
+FAIL Prefetch as=image should work when consumed as image (http://web-platform.test:8800) assert_equals: expected (string) "empty" but got (undefined) undefined
+FAIL Prefetch as=image should work when consumed as script (http://web-platform.test:8800) assert_equals: expected (string) "empty" but got (undefined) undefined
+FAIL Prefetch as=image should work when consumed as style (http://web-platform.test:8800) assert_equals: expected (string) "empty" but got (undefined) undefined
+FAIL Prefetch as=image should work when consumed as document (http://web-platform.test:8800) assert_equals: expected (string) "empty" but got (undefined) undefined
+FAIL Prefetch as=script should work when consumed as  (http://web-platform.test:8800) assert_equals: expected (string) "empty" but got (undefined) undefined
+FAIL Prefetch as=script should work when consumed as image (http://web-platform.test:8800) assert_equals: expected (string) "empty" but got (undefined) undefined
+FAIL Prefetch as=script should work when consumed as script (http://web-platform.test:8800) assert_equals: expected (string) "empty" but got (undefined) undefined
+FAIL Prefetch as=script should work when consumed as style (http://web-platform.test:8800) assert_equals: expected (string) "empty" but got (undefined) undefined
+FAIL Prefetch as=script should work when consumed as document (http://web-platform.test:8800) assert_equals: expected (string) "empty" but got (undefined) undefined
+FAIL Prefetch as=style should work when consumed as  (http://web-platform.test:8800) assert_equals: expected (string) "empty" but got (undefined) undefined
+FAIL Prefetch as=style should work when consumed as image (http://web-platform.test:8800) assert_equals: expected (string) "empty" but got (undefined) undefined
+FAIL Prefetch as=style should work when consumed as script (http://web-platform.test:8800) assert_equals: expected (string) "empty" but got (undefined) undefined
+FAIL Prefetch as=style should work when consumed as style (http://web-platform.test:8800) assert_equals: expected (string) "empty" but got (undefined) undefined
+FAIL Prefetch as=style should work when consumed as document (http://web-platform.test:8800) assert_equals: expected (string) "empty" but got (undefined) undefined
+FAIL Prefetch as=document should work when consumed as  (http://web-platform.test:8800) assert_equals: expected (string) "empty" but got (undefined) undefined
+FAIL Prefetch as=document should work when consumed as image (http://web-platform.test:8800) assert_equals: expected (string) "empty" but got (undefined) undefined
+FAIL Prefetch as=document should work when consumed as script (http://web-platform.test:8800) assert_equals: expected (string) "empty" but got (undefined) undefined
+FAIL Prefetch as=document should work when consumed as style (http://web-platform.test:8800) assert_equals: expected (string) "empty" but got (undefined) undefined
+FAIL Prefetch as=document should work when consumed as document (http://web-platform.test:8800) assert_equals: expected (string) "empty" but got (undefined) undefined
+

--- a/LayoutTests/platform/gtk/TestExpectations
+++ b/LayoutTests/platform/gtk/TestExpectations
@@ -2160,8 +2160,6 @@ imported/w3c/web-platform-tests/css/css-pseudo/selection-background-painting-ord
 # Failing preload tests
 imported/w3c/web-platform-tests/preload/link-header-preload-nonce.html [ Failure ]
 imported/w3c/web-platform-tests/preload/onerror-event.html [ Failure ]
-imported/w3c/web-platform-tests/preload/prefetch-headers.html [ Failure ]
-imported/w3c/web-platform-tests/preload/prefetch-types.html [ Failure ]
 imported/w3c/web-platform-tests/preload/preload-csp.sub.html [ Failure ]
 imported/w3c/web-platform-tests/preload/preload-default-csp.sub.html [ Failure ]
 imported/w3c/web-platform-tests/preload/preload-dynamic-csp.html [ Failure ]


### PR DESCRIPTION
#### 27863d63d5d6982499cec42ea3754fdda997137f
<pre>
[WPE][GTK] Gardening `imported/w3c/web-platform-tests/preload/prefetch-*`

Unreviewed test gardening.

According to the spec [1] `Sec-Fetch-*` headers are only sent to
trustworthy URLs which basically either `localhost` or `https:`.

On WPE and GTK we run http tests against `<a href="http://web-platform.test">http://web-platform.test</a>:8800`
and not `<a href="http://localhost`">http://localhost`</a> because these two ports use localhost aliases.

We also still send `Purpose` header because `Sec-Purpose` is not
standardized yet.

[1] <a href="https://w3c.github.io/webappsec-fetch-metadata/#framework">https://w3c.github.io/webappsec-fetch-metadata/#framework</a>

* LayoutTests/platform/glib/imported/w3c/web-platform-tests/preload/prefetch-headers-expected.txt: Added.
* LayoutTests/platform/glib/imported/w3c/web-platform-tests/preload/prefetch-types-expected.txt: Added.
* LayoutTests/platform/gtk/TestExpectations:

Canonical link: <a href="https://commits.webkit.org/262915@main">https://commits.webkit.org/262915@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9f54963037eddcf1de99e2815ec03ce422575d65

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/2998 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/3062 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/3165 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/4407 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/3393 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/3141 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/3103 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/2621 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/3028 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/3386 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/2689 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/4201 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/883 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/2669 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/2516 "3 flakes 143 failures") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/2657 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/2720 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/3939 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/3066 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/2458 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/2695 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/2671 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/2683 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/352 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/2886 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->