### PR TITLE
[CoordinatedGraphics] Simplify drawing area resize implementation

### DIFF
--- a/Source/WebKit/UIProcess/CoordinatedGraphics/DrawingAreaProxyCoordinatedGraphics.cpp
+++ b/Source/WebKit/UIProcess/CoordinatedGraphics/DrawingAreaProxyCoordinatedGraphics.cpp
@@ -36,7 +36,6 @@
 #include "WebPageProxy.h"
 #include "WebPreferences.h"
 #include "WebProcessProxy.h"
-#include <WebCore/PlatformDisplay.h>
 #include <WebCore/Region.h>
 
 #if PLATFORM(GTK)
@@ -76,35 +75,8 @@ void DrawingAreaProxyCoordinatedGraphics::paint(BackingStore::PlatformGraphicsCo
     if (isInAcceleratedCompositingMode())
         return;
 
-    ASSERT(m_currentBackingStoreStateID <= m_nextBackingStoreStateID);
-    if (m_currentBackingStoreStateID < m_nextBackingStoreStateID) {
-        // Tell the web process to do a full backing store update now, in case we previously told
-        // it about our next state but didn't request an immediate update.
-        sendUpdateBackingStoreState(RespondImmediately);
-
-        // If we haven't yet received our first bits from the WebProcess then don't paint anything.
-        if (!m_hasReceivedFirstUpdate)
-            return;
-
-        if (m_isWaitingForDidUpdateBackingStoreState) {
-            // Wait for a DidUpdateBackingStoreState message that contains the new bits before we paint
-            // what's currently in the backing store.
-            waitForAndDispatchDidUpdateBackingStoreState();
-        }
-
-        // Dispatching DidUpdateBackingStoreState (either beneath sendUpdateBackingStoreState or
-        // beneath waitForAndDispatchDidUpdateBackingStoreState) could destroy our backing store or
-        // change the compositing mode.
-        if (!m_backingStore || isInAcceleratedCompositingMode())
-            return;
-    } else {
-        ASSERT(!m_isWaitingForDidUpdateBackingStoreState);
-        if (!m_backingStore) {
-            // The view has asked us to paint before the web process has painted anything. There's
-            // nothing we can do.
-            return;
-        }
-    }
+    if (!m_backingStore)
+        return;
 
     m_backingStore->paint(context, rect);
     unpaintedRegion.subtract(IntRect(IntPoint(), m_backingStore->size()));
@@ -115,12 +87,18 @@ void DrawingAreaProxyCoordinatedGraphics::paint(BackingStore::PlatformGraphicsCo
 
 void DrawingAreaProxyCoordinatedGraphics::sizeDidChange()
 {
-    backingStoreStateDidChange(RespondImmediately);
+    if (!m_webPageProxy.hasRunningProcess())
+        return;
+
+    if (m_isWaitingForDidUpdateGeometry)
+        return;
+
+    sendUpdateGeometry();
 }
 
 void DrawingAreaProxyCoordinatedGraphics::deviceScaleFactorDidChange()
 {
-    backingStoreStateDidChange(RespondImmediately);
+    m_webPageProxy.send(Messages::DrawingArea::SetDeviceScaleFactor(m_webPageProxy.deviceScaleFactor()), m_identifier);
 }
 
 void DrawingAreaProxyCoordinatedGraphics::waitForBackingStoreUpdateOnNextPaint()
@@ -154,89 +132,38 @@ void DrawingAreaProxyCoordinatedGraphics::commitTransientZoom(double scale, Floa
 }
 #endif
 
-void DrawingAreaProxyCoordinatedGraphics::update(uint64_t backingStoreStateID, const UpdateInfo& updateInfo)
+void DrawingAreaProxyCoordinatedGraphics::update(uint64_t, const UpdateInfo& updateInfo)
 {
-    ASSERT_ARG(backingStoreStateID, backingStoreStateID <= m_currentBackingStoreStateID);
-    if (backingStoreStateID < m_currentBackingStoreStateID)
+    if (m_isWaitingForDidUpdateGeometry && updateInfo.viewSize != m_lastSentSize) {
+        m_webPageProxy.send(Messages::DrawingArea::DisplayDidRefresh(), m_identifier);
         return;
+    }
 
     // FIXME: Handle the case where the view is hidden.
 
 #if !PLATFORM(WPE)
     incorporateUpdate(updateInfo);
 #endif
-    m_webPageProxy.send(Messages::DrawingArea::DisplayDidRefresh(), m_identifier);
+
+    if (!m_isWaitingForDidUpdateGeometry)
+        m_webPageProxy.send(Messages::DrawingArea::DisplayDidRefresh(), m_identifier);
 }
 
-void DrawingAreaProxyCoordinatedGraphics::didUpdateBackingStoreState(uint64_t backingStoreStateID, const UpdateInfo& updateInfo, const LayerTreeContext& layerTreeContext)
+void DrawingAreaProxyCoordinatedGraphics::enterAcceleratedCompositingMode(uint64_t, const LayerTreeContext& layerTreeContext)
 {
-    ASSERT_ARG(backingStoreStateID, backingStoreStateID <= m_nextBackingStoreStateID);
-    ASSERT_ARG(backingStoreStateID, backingStoreStateID > m_currentBackingStoreStateID);
-    m_currentBackingStoreStateID = backingStoreStateID;
-
-    m_isWaitingForDidUpdateBackingStoreState = false;
-
-    // Stop the responsiveness timer that was started in sendUpdateBackingStoreState.
-    m_webPageProxy.process().stopResponsivenessTimer();
-
-    if (layerTreeContext != m_layerTreeContext) {
-        if (layerTreeContext.isEmpty() && !m_layerTreeContext.isEmpty()) {
-            exitAcceleratedCompositingMode();
-            ASSERT(m_layerTreeContext.isEmpty());
-        } else if (!layerTreeContext.isEmpty() && m_layerTreeContext.isEmpty()) {
-            enterAcceleratedCompositingMode(layerTreeContext);
-            ASSERT(layerTreeContext == m_layerTreeContext);
-        } else {
-            updateAcceleratedCompositingMode(layerTreeContext);
-            ASSERT(layerTreeContext == m_layerTreeContext);
-        }
-    }
-
-    if (m_nextBackingStoreStateID != m_currentBackingStoreStateID)
-        sendUpdateBackingStoreState(RespondImmediately);
-    else
-        m_hasReceivedFirstUpdate = true;
-
-#if !PLATFORM(WPE)
-    if (isInAcceleratedCompositingMode()) {
-        ASSERT(!m_backingStore);
-        return;
-    }
-
-    // If we have a backing store the right size, reuse it.
-    if (m_backingStore && (m_backingStore->size() != updateInfo.viewSize || m_backingStore->deviceScaleFactor() != updateInfo.deviceScaleFactor))
-        m_backingStore = nullptr;
-    incorporateUpdate(updateInfo);
-#endif
-}
-
-void DrawingAreaProxyCoordinatedGraphics::enterAcceleratedCompositingMode(uint64_t backingStoreStateID, const LayerTreeContext& layerTreeContext)
-{
-    ASSERT_ARG(backingStoreStateID, backingStoreStateID <= m_currentBackingStoreStateID);
-    if (backingStoreStateID < m_currentBackingStoreStateID)
-        return;
-
     enterAcceleratedCompositingMode(layerTreeContext);
 }
 
-void DrawingAreaProxyCoordinatedGraphics::exitAcceleratedCompositingMode(uint64_t backingStoreStateID, const UpdateInfo& updateInfo)
+void DrawingAreaProxyCoordinatedGraphics::exitAcceleratedCompositingMode(uint64_t, const UpdateInfo& updateInfo)
 {
-    ASSERT_ARG(backingStoreStateID, backingStoreStateID <= m_currentBackingStoreStateID);
-    if (backingStoreStateID < m_currentBackingStoreStateID)
-        return;
-
     exitAcceleratedCompositingMode();
 #if !PLATFORM(WPE)
     incorporateUpdate(updateInfo);
 #endif
 }
 
-void DrawingAreaProxyCoordinatedGraphics::updateAcceleratedCompositingMode(uint64_t backingStoreStateID, const LayerTreeContext& layerTreeContext)
+void DrawingAreaProxyCoordinatedGraphics::updateAcceleratedCompositingMode(uint64_t, const LayerTreeContext& layerTreeContext)
 {
-    ASSERT_ARG(backingStoreStateID, backingStoreStateID <= m_currentBackingStoreStateID);
-    if (backingStoreStateID < m_currentBackingStoreStateID)
-        return;
-
     updateAcceleratedCompositingMode(layerTreeContext);
 }
 
@@ -253,7 +180,7 @@ void DrawingAreaProxyCoordinatedGraphics::incorporateUpdate(const UpdateInfo& up
     if (updateInfo.updateRectBounds.isEmpty())
         return;
 
-    if (!m_backingStore)
+    if (!m_backingStore || m_backingStore->size() != updateInfo.viewSize)
         m_backingStore = makeUnique<BackingStore>(updateInfo.viewSize, updateInfo.deviceScaleFactor, m_webPageProxy);
 
     m_backingStore->incorporateUpdate(updateInfo);
@@ -277,7 +204,7 @@ void DrawingAreaProxyCoordinatedGraphics::enterAcceleratedCompositingMode(const 
 {
     ASSERT(!isInAcceleratedCompositingMode());
 #if !PLATFORM(WPE)
-    m_backingStore = nullptr;
+    discardBackingStore();
 #endif
     m_layerTreeContext = layerTreeContext;
     m_webPageProxy.enterAcceleratedCompositingMode(layerTreeContext);
@@ -299,67 +226,29 @@ void DrawingAreaProxyCoordinatedGraphics::updateAcceleratedCompositingMode(const
     m_webPageProxy.updateAcceleratedCompositingMode(layerTreeContext);
 }
 
-void DrawingAreaProxyCoordinatedGraphics::backingStoreStateDidChange(RespondImmediatelyOrNot respondImmediatelyOrNot)
+void DrawingAreaProxyCoordinatedGraphics::sendUpdateGeometry()
 {
-    ++m_nextBackingStoreStateID;
-    sendUpdateBackingStoreState(respondImmediatelyOrNot);
+    ASSERT(!m_isWaitingForDidUpdateGeometry);
+    m_lastSentSize = m_size;
+    m_isWaitingForDidUpdateGeometry = true;
+
+    m_webPageProxy.sendWithAsyncReply(Messages::DrawingArea::UpdateGeometry(m_size), [weakThis = WeakPtr { *this }] {
+        if (!weakThis)
+            return;
+        weakThis->didUpdateGeometry();
+    }, m_identifier);
 }
 
-void DrawingAreaProxyCoordinatedGraphics::sendUpdateBackingStoreState(RespondImmediatelyOrNot respondImmediatelyOrNot)
+void DrawingAreaProxyCoordinatedGraphics::didUpdateGeometry()
 {
-    ASSERT(m_currentBackingStoreStateID < m_nextBackingStoreStateID);
+    ASSERT(m_isWaitingForDidUpdateGeometry);
 
-    if (!m_webPageProxy.hasRunningProcess())
-        return;
+    m_isWaitingForDidUpdateGeometry = false;
 
-    if (m_isWaitingForDidUpdateBackingStoreState)
-        return;
-
-    if (m_webPageProxy.viewSize().isEmpty() && !m_webPageProxy.useFixedLayout())
-        return;
-
-    m_isWaitingForDidUpdateBackingStoreState = respondImmediatelyOrNot == RespondImmediately;
-
-    m_webPageProxy.send(Messages::DrawingArea::UpdateBackingStoreState(m_nextBackingStoreStateID, respondImmediatelyOrNot == RespondImmediately, m_webPageProxy.deviceScaleFactor(), m_size, m_scrollOffset), m_identifier);
-    m_scrollOffset = IntSize();
-
-    if (m_isWaitingForDidUpdateBackingStoreState) {
-        // Start the responsiveness timer. We will stop it when we hear back from the WebProcess
-        // in didUpdateBackingStoreState.
-        m_webPageProxy.process().startResponsivenessTimer();
-    }
-
-    if (m_isWaitingForDidUpdateBackingStoreState && !m_layerTreeContext.isEmpty()) {
-        // Wait for the DidUpdateBackingStoreState message. Normally we do this in DrawingAreaProxyCoordinatedGraphics::paint, but that
-        // function is never called when in accelerated compositing mode.
-        waitForAndDispatchDidUpdateBackingStoreState();
-    }
-}
-
-void DrawingAreaProxyCoordinatedGraphics::waitForAndDispatchDidUpdateBackingStoreState()
-{
-    ASSERT(m_isWaitingForDidUpdateBackingStoreState);
-
-    if (!m_webPageProxy.hasRunningProcess())
-        return;
-    if (m_webPageProxy.process().state() == WebProcessProxy::State::Launching)
-        return;
-    if (!m_webPageProxy.isViewVisible())
-        return;
-#if PLATFORM(WAYLAND) && USE(EGL)
-    // Never block the UI process in Wayland when waiting for DidUpdateBackingStoreState after a resize,
-    // because the nested compositor needs to handle the web process requests that happens while resizing.
-    if (PlatformDisplay::sharedDisplay().type() == PlatformDisplay::Type::Wayland && isInAcceleratedCompositingMode())
-        return;
-#endif
-
-    // FIXME: waitForAndDispatchImmediately will always return the oldest DidUpdateBackingStoreState message that
-    // hasn't yet been processed. But it might be better to skip ahead to some other DidUpdateBackingStoreState
-    // message, if multiple DidUpdateBackingStoreState messages are waiting to be processed. For instance, we could
-    // choose the most recent one, or the one that is closest to our current size.
-
-    // The timeout, in seconds, we use when waiting for a DidUpdateBackingStoreState message when we're asked to paint.
-    m_webPageProxy.process().connection()->waitForAndDispatchImmediately<Messages::DrawingAreaProxy::DidUpdateBackingStoreState>(m_identifier.toUInt64(), Seconds::fromMilliseconds(500));
+    // If the view was resized while we were waiting for a DidUpdateGeometry reply from the web process,
+    // we need to resend the new size here.
+    if (m_lastSentSize != m_size)
+        sendUpdateGeometry();
 }
 
 #if !PLATFORM(WPE)
@@ -377,10 +266,7 @@ void DrawingAreaProxyCoordinatedGraphics::discardBackingStoreSoon()
 
 void DrawingAreaProxyCoordinatedGraphics::discardBackingStore()
 {
-    if (!m_backingStore)
-        return;
     m_backingStore = nullptr;
-    backingStoreStateDidChange(DoNotRespondImmediately);
 }
 #endif
 

--- a/Source/WebKit/UIProcess/CoordinatedGraphics/DrawingAreaProxyCoordinatedGraphics.h
+++ b/Source/WebKit/UIProcess/CoordinatedGraphics/DrawingAreaProxyCoordinatedGraphics.h
@@ -64,7 +64,6 @@ private:
 
     // IPC message handlers
     void update(uint64_t backingStoreStateID, const UpdateInfo&) override;
-    void didUpdateBackingStoreState(uint64_t backingStoreStateID, const UpdateInfo&, const LayerTreeContext&) override;
     void enterAcceleratedCompositingMode(uint64_t backingStoreStateID, const LayerTreeContext&) override;
     void exitAcceleratedCompositingMode(uint64_t backingStoreStateID, const UpdateInfo&) override;
     void updateAcceleratedCompositingMode(uint64_t backingStoreStateID, const LayerTreeContext&) override;
@@ -81,10 +80,8 @@ private:
     void exitAcceleratedCompositingMode();
     void updateAcceleratedCompositingMode(const LayerTreeContext&);
 
-    enum RespondImmediatelyOrNot { DoNotRespondImmediately, RespondImmediately };
-    void backingStoreStateDidChange(RespondImmediatelyOrNot);
-    void sendUpdateBackingStoreState(RespondImmediatelyOrNot);
-    void waitForAndDispatchDidUpdateBackingStoreState();
+    void sendUpdateGeometry();
+    void didUpdateGeometry();
 
 #if !PLATFORM(WPE)
     void discardBackingStoreSoon();
@@ -116,15 +113,6 @@ private:
 #endif
     };
 
-    // The state ID corresponding to our current backing store. Updated whenever we allocate
-    // a new backing store. Any messages received that correspond to an earlier state are ignored,
-    // as they don't apply to our current backing store.
-    uint64_t m_currentBackingStoreStateID { 0 };
-
-    // The next backing store state ID we will request the web process update to. Incremented
-    // whenever our state changes in a way that will require a new backing store to be allocated.
-    uint64_t m_nextBackingStoreStateID { 0 };
-
     // The current layer tree context.
     LayerTreeContext m_layerTreeContext;
 
@@ -134,6 +122,13 @@ private:
 
     // For a new Drawing Area don't draw anything until the WebProcess has sent over the first content.
     bool m_hasReceivedFirstUpdate { false };
+
+    // Whether we're waiting for a DidUpdateGeometry message from the web process.
+    bool m_isWaitingForDidUpdateGeometry { false };
+
+    // The last size we sent to the web process.
+    WebCore::IntSize m_lastSentSize;
+
 
 #if !PLATFORM(WPE)
     bool m_isBackingStoreDiscardable { true };

--- a/Source/WebKit/UIProcess/DrawingAreaProxy.h
+++ b/Source/WebKit/UIProcess/DrawingAreaProxy.h
@@ -87,8 +87,6 @@ public:
     bool setSize(const WebCore::IntSize&, const WebCore::IntSize& scrollOffset = { });
 
 #if USE(COORDINATED_GRAPHICS) || USE(TEXTURE_MAPPER)
-    // The timeout we use when waiting for a UpdateGeometry reply.
-    static constexpr Seconds didUpdateBackingStoreStateTimeout() { return Seconds::fromMilliseconds(500); }
     virtual void targetRefreshRateDidChange(unsigned) { }
 #endif
 
@@ -162,7 +160,6 @@ private:
 
 #if USE(COORDINATED_GRAPHICS) || USE(TEXTURE_MAPPER)
     virtual void update(uint64_t /* backingStoreStateID */, const UpdateInfo&) { }
-    virtual void didUpdateBackingStoreState(uint64_t /* backingStoreStateID */, const UpdateInfo&, const LayerTreeContext&) { }
     virtual void exitAcceleratedCompositingMode(uint64_t /* backingStoreStateID */, const UpdateInfo&) { }
 #endif
 };

--- a/Source/WebKit/UIProcess/DrawingAreaProxy.messages.in
+++ b/Source/WebKit/UIProcess/DrawingAreaProxy.messages.in
@@ -28,7 +28,6 @@ messages -> DrawingAreaProxy NotRefCounted {
 
 #if USE(COORDINATED_GRAPHICS) || USE(TEXTURE_MAPPER)
     Update(uint64_t stateID, WebKit::UpdateInfo updateInfo)
-    DidUpdateBackingStoreState(uint64_t backingStoreStateID, WebKit::UpdateInfo updateInfo, WebKit::LayerTreeContext context)
     ExitAcceleratedCompositingMode(uint64_t backingStoreStateID, WebKit::UpdateInfo updateInfo)
 #endif
 }

--- a/Source/WebKit/UIProcess/wc/DrawingAreaProxyWC.cpp
+++ b/Source/WebKit/UIProcess/wc/DrawingAreaProxyWC.cpp
@@ -59,7 +59,7 @@ void DrawingAreaProxyWC::sizeDidChange()
 {
     discardBackingStore();
     m_currentBackingStoreStateID++;
-    m_webPageProxy.send(Messages::DrawingArea::UpdateGeometry(m_currentBackingStoreStateID, m_size), m_identifier);
+    m_webPageProxy.send(Messages::DrawingArea::UpdateGeometryWC(m_currentBackingStoreStateID, m_size), m_identifier);
 }
 
 void DrawingAreaProxyWC::dispatchAfterEnsuringDrawing(CompletionHandler<void()>&& completionHandler)

--- a/Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/DrawingAreaCoordinatedGraphics.cpp
+++ b/Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/DrawingAreaCoordinatedGraphics.cpp
@@ -45,6 +45,7 @@
 #include <WebCore/PageOverlayController.h>
 #include <WebCore/Region.h>
 #include <WebCore/Settings.h>
+#include <wtf/SetForScope.h>
 
 #if USE(GLIB_EVENT_LOOP)
 #include <wtf/glib/RunLoopSourcePriority.h>
@@ -165,12 +166,6 @@ void DrawingAreaCoordinatedGraphics::scroll(const IntRect& scrollRect, const Int
 
 void DrawingAreaCoordinatedGraphics::forceRepaint()
 {
-    if (m_inUpdateBackingStoreState) {
-        m_forceRepaintAfterBackingStoreStateUpdate = true;
-        return;
-    }
-    m_forceRepaintAfterBackingStoreStateUpdate = false;
-
     if (!m_layerTreeHost) {
         m_isWaitingForDidUpdate = false;
         m_dirtyRegion = m_webPage.bounds();
@@ -292,6 +287,11 @@ void DrawingAreaCoordinatedGraphics::didChangeViewportAttributes(ViewportAttribu
 }
 #endif
 
+void DrawingAreaCoordinatedGraphics::setDeviceScaleFactor(float deviceScaleFactor)
+{
+    m_webPage.setDeviceScaleFactor(deviceScaleFactor);
+}
+
 bool DrawingAreaCoordinatedGraphics::supportsAsyncScrolling() const
 {
     return m_supportsAsyncScrolling;
@@ -340,7 +340,7 @@ void DrawingAreaCoordinatedGraphics::setRootCompositingLayer(WebCore::Frame&, Gr
             // compositing code via display() and layout.
             // If we're leaving compositing mode because of a setSize, it is safe to
             // exit accelerated compositing mode right away.
-            if (m_inUpdateBackingStoreState)
+            if (m_inUpdateGeometry)
                 exitAcceleratedCompositingMode();
             else
                 exitAcceleratedCompositingModeSoon();
@@ -371,11 +371,6 @@ void DrawingAreaCoordinatedGraphics::layerHostDidFlushLayers()
 {
     ASSERT(m_layerTreeHost);
     m_layerTreeHost->forceRepaint();
-
-    if (m_shouldSendDidUpdateBackingStoreState && !exitAcceleratedCompositingModePending()) {
-        sendDidUpdateBackingStoreState();
-        return;
-    }
 }
 #endif
 
@@ -405,65 +400,36 @@ void DrawingAreaCoordinatedGraphics::attachViewOverlayGraphicsLayer(GraphicsLaye
         m_previousLayerTreeHost->setViewOverlayRootLayer(viewOverlayRootLayer);
 }
 
-void DrawingAreaCoordinatedGraphics::updateBackingStoreState(uint64_t stateID, bool respondImmediately, float deviceScaleFactor, const IntSize& size, const IntSize& scrollOffset)
+void DrawingAreaCoordinatedGraphics::updateGeometry(const IntSize& size, CompletionHandler<void()>&& completionHandler)
 {
-    if (stateID != m_backingStoreStateID && !m_layerTreeHost)
+    SetForScope inUpdateGeometry(m_inUpdateGeometry, true);
+    m_webPage.setSize(size);
+
+    if (!m_layerTreeHost)
         m_dirtyRegion = IntRect(IntPoint(), size);
 
-    ASSERT(!m_inUpdateBackingStoreState);
-    m_inUpdateBackingStoreState = true;
+    LayerTreeContext previousLayerTreeContext;
+    if (m_layerTreeHost) {
+        previousLayerTreeContext = m_layerTreeHost->layerTreeContext();
+        m_layerTreeHost->sizeDidChange(m_webPage.size());
+    } else if (m_previousLayerTreeHost)
+        m_previousLayerTreeHost->sizeDidChange(m_webPage.size());
 
-    ASSERT_ARG(stateID, stateID >= m_backingStoreStateID);
-    if (stateID != m_backingStoreStateID) {
-        m_backingStoreStateID = stateID;
-        m_shouldSendDidUpdateBackingStoreState = true;
-
-        m_webPage.setDeviceScaleFactor(deviceScaleFactor);
-        m_webPage.setSize(size);
-        m_webPage.updateRendering();
-        m_webPage.finalizeRenderingUpdate({ });
-        m_webPage.flushPendingEditorStateUpdate();
-        m_webPage.scrollMainFrameIfNotAtMaxScrollPosition(scrollOffset);
-        m_webPage.didUpdateRendering();
-
-        if (m_layerTreeHost)
-            m_layerTreeHost->sizeDidChange(m_webPage.size());
-        else if (m_previousLayerTreeHost)
-            m_previousLayerTreeHost->sizeDidChange(m_webPage.size());
+    if (m_layerTreeHost) {
+        auto layerTreeContext = m_layerTreeHost->layerTreeContext();
+        m_layerTreeHost->forceRepaint();
+        if (layerTreeContext != previousLayerTreeContext)
+            send(Messages::DrawingAreaProxy::UpdateAcceleratedCompositingMode(0, layerTreeContext));
     } else {
-        ASSERT(size == m_webPage.size());
-        if (!m_shouldSendDidUpdateBackingStoreState) {
-            // We've already sent a DidUpdateBackingStoreState message for this state. We have nothing more to do.
-            m_inUpdateBackingStoreState = false;
-            if (m_forceRepaintAfterBackingStoreStateUpdate)
-                forceRepaint();
-            return;
-        }
+        UpdateInfo updateInfo;
+        updateInfo.viewSize = m_webPage.size();
+        updateInfo.deviceScaleFactor = m_webPage.corePage()->deviceScaleFactor();
+        display(updateInfo);
+        if (!m_layerTreeHost)
+            send(Messages::DrawingAreaProxy::Update(0, updateInfo));
     }
 
-    // The UI process has updated to a new backing store state. Any Update messages we sent before
-    // this point will be ignored. We wait to set this to false until after updating the page's
-    // size so that any displays triggered by the relayout will be ignored. If we're supposed to
-    // respond to the UpdateBackingStoreState message immediately, we'll do a display anyway in
-    // sendDidUpdateBackingStoreState; otherwise we shouldn't do one right now.
-    m_isWaitingForDidUpdate = false;
-
-    if (respondImmediately) {
-        // Make sure to resume painting if we're supposed to respond immediately, otherwise we'll just
-        // send back an empty UpdateInfo struct.
-        bool wasSuspended = m_isPaintingSuspended;
-        if (m_isPaintingSuspended)
-            resumePainting();
-
-        sendDidUpdateBackingStoreState();
-        if (wasSuspended)
-            suspendPainting();
-    }
-
-    m_inUpdateBackingStoreState = false;
-
-    if (m_forceRepaintAfterBackingStoreStateUpdate)
-        forceRepaint();
+    completionHandler();
 }
 
 void DrawingAreaCoordinatedGraphics::targetRefreshRateDidChange(unsigned rate)
@@ -529,47 +495,6 @@ void DrawingAreaCoordinatedGraphics::commitTransientZoom(double scale, FloatPoin
     m_transientZoom = false;
 }
 #endif
-
-void DrawingAreaCoordinatedGraphics::sendDidUpdateBackingStoreState()
-{
-    ASSERT(!m_isWaitingForDidUpdate);
-    ASSERT(m_shouldSendDidUpdateBackingStoreState);
-
-    if (!m_isPaintingSuspended && !m_layerTreeHost) {
-        UpdateInfo updateInfo;
-        display(updateInfo);
-        if (!m_layerTreeHost) {
-            m_shouldSendDidUpdateBackingStoreState = false;
-
-            LayerTreeContext layerTreeContext;
-            send(Messages::DrawingAreaProxy::DidUpdateBackingStoreState(m_backingStoreStateID, updateInfo, layerTreeContext));
-            m_compositingAccordingToProxyMessages = false;
-            return;
-        }
-    }
-
-    ASSERT(m_shouldSendDidUpdateBackingStoreState);
-    m_shouldSendDidUpdateBackingStoreState = false;
-
-    UpdateInfo updateInfo;
-    updateInfo.viewSize = m_webPage.size();
-    updateInfo.deviceScaleFactor = m_webPage.corePage()->deviceScaleFactor();
-
-    LayerTreeContext layerTreeContext;
-    if (m_layerTreeHost) {
-        layerTreeContext = m_layerTreeHost->layerTreeContext();
-
-        // We don't want the layer tree host to notify after the next scheduled
-        // layer flush because that might end up sending an EnterAcceleratedCompositingMode
-        // message back to the UI process, but the updated layer tree context
-        // will be sent back in the DidUpdateBackingStoreState message.
-        m_layerTreeHost->setShouldNotifyAfterNextScheduledLayerFlush(false);
-        m_layerTreeHost->forceRepaint();
-    }
-
-    send(Messages::DrawingAreaProxy::DidUpdateBackingStoreState(m_backingStoreStateID, updateInfo, layerTreeContext));
-    m_compositingAccordingToProxyMessages = !layerTreeContext.isEmpty();
-}
 
 void DrawingAreaCoordinatedGraphics::exitAcceleratedCompositingModeSoon()
 {
@@ -666,7 +591,7 @@ void DrawingAreaCoordinatedGraphics::enterAcceleratedCompositingMode(GraphicsLay
             m_layerTreeHost->pauseRendering();
     }
 
-    if (!m_inUpdateBackingStoreState)
+    if (!m_inUpdateGeometry)
         m_layerTreeHost->setShouldNotifyAfterNextScheduledLayerFlush(true);
 
     m_layerTreeHost->setRootCompositingLayer(graphicsLayer);
@@ -692,7 +617,7 @@ void DrawingAreaCoordinatedGraphics::sendEnterAcceleratedCompositingModeIfNeeded
         return;
     }
 
-    send(Messages::DrawingAreaProxy::EnterAcceleratedCompositingMode(m_backingStoreStateID, m_layerTreeHost->layerTreeContext()));
+    send(Messages::DrawingAreaProxy::EnterAcceleratedCompositingMode(0, m_layerTreeHost->layerTreeContext()));
     m_compositingAccordingToProxyMessages = true;
 }
 
@@ -718,13 +643,8 @@ void DrawingAreaCoordinatedGraphics::exitAcceleratedCompositingMode()
 
     m_dirtyRegion = m_webPage.bounds();
 
-    if (m_inUpdateBackingStoreState)
+    if (m_inUpdateGeometry)
         return;
-
-    if (m_shouldSendDidUpdateBackingStoreState) {
-        sendDidUpdateBackingStoreState();
-        return;
-    }
 
     UpdateInfo updateInfo;
     if (m_isPaintingSuspended) {
@@ -736,12 +656,12 @@ void DrawingAreaCoordinatedGraphics::exitAcceleratedCompositingMode()
     // Send along a complete update of the page so we can paint the contents right after we exit the
     // accelerated compositing mode, eliminiating flicker.
     if (m_compositingAccordingToProxyMessages) {
-        send(Messages::DrawingAreaProxy::ExitAcceleratedCompositingMode(m_backingStoreStateID, updateInfo));
+        send(Messages::DrawingAreaProxy::ExitAcceleratedCompositingMode(0, updateInfo));
         m_compositingAccordingToProxyMessages = false;
     } else {
         // If we left accelerated compositing mode before we sent an EnterAcceleratedCompositingMode message to the
         // UI process, we still need to let it know about the new contents, so send an Update message.
-        send(Messages::DrawingAreaProxy::Update(m_backingStoreStateID, updateInfo));
+        send(Messages::DrawingAreaProxy::Update(0, updateInfo));
     }
 }
 
@@ -772,18 +692,13 @@ void DrawingAreaCoordinatedGraphics::display()
 {
     ASSERT(!m_layerTreeHost);
     ASSERT(!m_isWaitingForDidUpdate);
-    ASSERT(!m_inUpdateBackingStoreState);
+    ASSERT(!m_inUpdateGeometry);
 
     if (m_layerTreeStateIsFrozen)
         return;
 
     if (m_isPaintingSuspended)
         return;
-
-    if (m_shouldSendDidUpdateBackingStoreState) {
-        sendDidUpdateBackingStoreState();
-        return;
-    }
 
     UpdateInfo updateInfo;
     display(updateInfo);
@@ -798,10 +713,10 @@ void DrawingAreaCoordinatedGraphics::display()
     }
 
     if (m_compositingAccordingToProxyMessages) {
-        send(Messages::DrawingAreaProxy::ExitAcceleratedCompositingMode(m_backingStoreStateID, updateInfo));
+        send(Messages::DrawingAreaProxy::ExitAcceleratedCompositingMode(0, updateInfo));
         m_compositingAccordingToProxyMessages = false;
     } else
-        send(Messages::DrawingAreaProxy::Update(m_backingStoreStateID, updateInfo));
+        send(Messages::DrawingAreaProxy::Update(0, updateInfo));
     m_isWaitingForDidUpdate = true;
     m_scheduledWhileWaitingForDidUpdate = false;
 }

--- a/Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/DrawingAreaCoordinatedGraphics.h
+++ b/Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/DrawingAreaCoordinatedGraphics.h
@@ -83,16 +83,15 @@ private:
     void attachViewOverlayGraphicsLayer(WebCore::GraphicsLayer*) override;
 
     // IPC message handlers.
-    void updateBackingStoreState(uint64_t backingStoreStateID, bool respondImmediately, float deviceScaleFactor, const WebCore::IntSize&, const WebCore::IntSize& scrollOffset) override;
+    void updateGeometry(const WebCore::IntSize&, CompletionHandler<void()>&&) override;
     void targetRefreshRateDidChange(unsigned rate) override;
     void displayDidRefresh() override;
+    void setDeviceScaleFactor(float) override;
 
 #if PLATFORM(GTK)
     void adjustTransientZoom(double scale, WebCore::FloatPoint origin) override;
     void commitTransientZoom(double scale, WebCore::FloatPoint origin) override;
 #endif
-
-    void sendDidUpdateBackingStoreState();
 
     void exitAcceleratedCompositingModeSoon();
     bool exitAcceleratedCompositingModePending() const { return m_exitCompositingTimer.isActive(); }
@@ -109,14 +108,8 @@ private:
     void display();
     void display(UpdateInfo&);
 
-    uint64_t m_backingStoreStateID { 0 };
-
-    // Whether we're currently processing an UpdateBackingStoreState message.
-    bool m_inUpdateBackingStoreState { false };
-
-    // When true, we should send an UpdateBackingStoreState message instead of any other messages
-    // we normally send to the UI process.
-    bool m_shouldSendDidUpdateBackingStoreState { false };
+    // Whether we're currently processing an UpdateGeometry message.
+    bool m_inUpdateGeometry { false };
 
     // True between sending the 'enter compositing' messages, and the 'exit compositing' message.
     bool m_compositingAccordingToProxyMessages { false };
@@ -145,7 +138,7 @@ private:
     WebCore::IntRect m_scrollRect;
     WebCore::IntSize m_scrollOffset;
 
-    // Whether we're waiting for a DidUpdate message. Used for throttling paints so that the 
+    // Whether we're waiting for a DidUpdate message. Used for throttling paints so that the
     // web process won't paint more frequent than the UI process can handle.
     bool m_isWaitingForDidUpdate { false };
     bool m_scheduledWhileWaitingForDidUpdate { false };

--- a/Source/WebKit/WebProcess/WebPage/DrawingArea.h
+++ b/Source/WebKit/WebProcess/WebPage/DrawingArea.h
@@ -149,7 +149,7 @@ public:
 #endif
 
 #if USE(GRAPHICS_LAYER_WC)
-    virtual void updateGeometry(uint64_t, WebCore::IntSize) { };
+    virtual void updateGeometryWC(uint64_t, WebCore::IntSize) { };
 #endif
 
 #if USE(COORDINATED_GRAPHICS) || USE(GRAPHICS_LAYER_TEXTURE_MAPPER)
@@ -157,6 +157,7 @@ public:
 #endif
 
 #if USE(COORDINATED_GRAPHICS) || USE(TEXTURE_MAPPER)
+    virtual void updateGeometry(const WebCore::IntSize&, CompletionHandler<void()>&&) = 0;
     virtual void didChangeViewportAttributes(WebCore::ViewportAttributes&&) = 0;
     virtual void deviceOrPageScaleFactorChanged() = 0;
 #endif
@@ -201,6 +202,7 @@ private:
     virtual void updateBackingStoreState(uint64_t /*backingStoreStateID*/, bool /*respondImmediately*/, float /*deviceScaleFactor*/, const WebCore::IntSize& /*size*/,
                                          const WebCore::IntSize& /*scrollOffset*/) { }
     virtual void targetRefreshRateDidChange(unsigned /*rate*/) { }
+    virtual void setDeviceScaleFactor(float) { }
 #endif
     virtual void displayDidRefresh() { }
 

--- a/Source/WebKit/WebProcess/WebPage/DrawingArea.messages.in
+++ b/Source/WebKit/WebProcess/WebPage/DrawingArea.messages.in
@@ -22,8 +22,9 @@
 
 messages -> DrawingArea NotRefCounted {
 #if USE(COORDINATED_GRAPHICS) || USE(TEXTURE_MAPPER)
-    UpdateBackingStoreState(uint64_t backingStoreStateID, bool respondImmediately, float deviceScaleFactor, WebCore::IntSize size, WebCore::IntSize scrollOffset)
+    UpdateGeometry(WebCore::IntSize size) -> ()
     TargetRefreshRateDidChange(unsigned rate)
+    SetDeviceScaleFactor(float deviceScaleFactor)
 #endif
 
     DisplayDidRefresh()
@@ -41,7 +42,7 @@ messages -> DrawingArea NotRefCounted {
 #endif
 
 #if USE(GRAPHICS_LAYER_WC)
-    UpdateGeometry(uint64_t backingStoreStateID, WebCore::IntSize viewSize)
+    UpdateGeometryWC(uint64_t backingStoreStateID, WebCore::IntSize viewSize)
 #endif
 
 #if PLATFORM(COCOA) || PLATFORM(GTK)

--- a/Source/WebKit/WebProcess/WebPage/wc/DrawingAreaWC.cpp
+++ b/Source/WebKit/WebProcess/WebPage/wc/DrawingAreaWC.cpp
@@ -120,7 +120,7 @@ void DrawingAreaWC::setLayerTreeStateIsFrozen(bool isFrozen)
     }
 }
 
-void DrawingAreaWC::updateGeometry(uint64_t backingStoreStateID, IntSize viewSize)
+void DrawingAreaWC::updateGeometryWC(uint64_t backingStoreStateID, IntSize viewSize)
 {
     m_backingStoreStateID = backingStoreStateID;
     m_webPage.setSize(viewSize);

--- a/Source/WebKit/WebProcess/WebPage/wc/DrawingAreaWC.h
+++ b/Source/WebKit/WebProcess/WebPage/wc/DrawingAreaWC.h
@@ -55,7 +55,10 @@ private:
     void deviceOrPageScaleFactorChanged() override { }
     void setLayerTreeStateIsFrozen(bool) override;
     bool layerTreeStateIsFrozen() const override { return m_isRenderingSuspended; }
-    void updateGeometry(uint64_t, WebCore::IntSize) override;
+#if USE(GRAPHICS_LAYER_TEXTURE_MAPPER)    
+    void updateGeometry(const WebCore::IntSize&, CompletionHandler<void()>&&) override { }
+#endif
+    void updateGeometryWC(uint64_t, WebCore::IntSize) override;
     void setRootCompositingLayer(WebCore::Frame&, WebCore::GraphicsLayer*) override;
     void attachViewOverlayGraphicsLayer(WebCore::GraphicsLayer*) override;
     void updatePreferences(const WebPreferencesStore&) override;


### PR DESCRIPTION
#### 44655c8e68f9087772f26f8935f5e1a1280f0c33
<pre>
[CoordinatedGraphics] Simplify surface resize
<a href="https://bugs.webkit.org/show_bug.cgi?id=285991">https://bugs.webkit.org/show_bug.cgi?id=285991</a>

Reviewed by NOBODY (OOPS!).

We currently have a method in the threaded compositor to set the new
size, which schedules an update without waiting for the layer flush. We
can pass the size and device scale factor as part of the composition
request, which always happens after the layer flush. Then the compositor
always tries to resize the surface to the requested size, and only when
it changed it calls glViewport with the new size.
This patch also handles the completion handler of
DrawingAreaProxyCoordinatedGraphics::deviceScaleFactorDidChange()
correctly making SetDeviceScaleFactor async like in apple ports and
waiting for the response to call the completion handler.

* Source/WebKit/UIProcess/CoordinatedGraphics/DrawingAreaProxyCoordinatedGraphics.cpp:
(WebKit::DrawingAreaProxyCoordinatedGraphics::deviceScaleFactorDidChange):
* Source/WebKit/WebProcess/WebPage/AcceleratedSurface.cpp:
(WebKit::AcceleratedSurface::AcceleratedSurface):
(WebKit::AcceleratedSurface::resize):
(WebKit::AcceleratedSurface::hostResize): Deleted.
* Source/WebKit/WebProcess/WebPage/AcceleratedSurface.h:
(WebKit::AcceleratedSurface::clientResize): Deleted.
(WebKit::AcceleratedSurface::size const): Deleted.
* Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/DrawingAreaCoordinatedGraphics.cpp:
(WebKit::DrawingAreaCoordinatedGraphics::setDeviceScaleFactor):
(WebKit::DrawingAreaCoordinatedGraphics::deviceOrPageScaleFactorChanged): Deleted.
* Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/DrawingAreaCoordinatedGraphics.h:
* Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/LayerTreeHost.cpp:
(WebKit::LayerTreeHost::LayerTreeHost):
(WebKit::LayerTreeHost::flushLayers):
(WebKit::LayerTreeHost::sizeDidChange):
(WebKit::LayerTreeHost::deviceOrPageScaleFactorChanged): Deleted.
* Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/LayerTreeHost.h:
* Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/LayerTreeHostTextureMapper.cpp:
(WebKit::LayerTreeHost::deviceOrPageScaleFactorChanged): Deleted.
* Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/LayerTreeHostTextureMapper.h:
* Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/ThreadedCompositor.cpp:
(WebKit::ThreadedCompositor::create):
(WebKit::ThreadedCompositor::ThreadedCompositor):
(WebKit::ThreadedCompositor::renderLayerTree):
(WebKit::ThreadedCompositor::requestComposition):
(WebKit::ThreadedCompositor::setViewportSize): Deleted.
* Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/ThreadedCompositor.h:
* Source/WebKit/WebProcess/WebPage/DrawingArea.h:
(WebKit::DrawingArea::updateBackingStoreState):
(WebKit::DrawingArea::setDeviceScaleFactor):
* Source/WebKit/WebProcess/WebPage/DrawingArea.messages.in:
* Source/WebKit/WebProcess/WebPage/WebPage.cpp:
(WebKit::WebPage::didScalePage):
(WebKit::WebPage::setDeviceScaleFactor):
* Source/WebKit/WebProcess/WebPage/dmabuf/AcceleratedSurfaceDMABuf.cpp:
(WebKit::AcceleratedSurfaceDMABuf::resize):
(WebKit::AcceleratedSurfaceDMABuf::clientResize): Deleted.
* Source/WebKit/WebProcess/WebPage/dmabuf/AcceleratedSurfaceDMABuf.h:
* Source/WebKit/WebProcess/WebPage/libwpe/AcceleratedSurfaceLibWPE.cpp:
(WebKit::AcceleratedSurfaceLibWPE::AcceleratedSurfaceLibWPE):
(WebKit::AcceleratedSurfaceLibWPE::initialize):
(WebKit::AcceleratedSurfaceLibWPE::resize):
(WebKit::AcceleratedSurfaceLibWPE::clientResize): Deleted.
* Source/WebKit/WebProcess/WebPage/libwpe/AcceleratedSurfaceLibWPE.h:
* Source/WebKit/WebProcess/WebPage/wc/DrawingAreaWC.h:
</pre>