### PR TITLE
Adjust cursor animator properties

### DIFF
--- a/Source/WebCore/platform/CaretAnimator.cpp
+++ b/Source/WebCore/platform/CaretAnimator.cpp
@@ -39,6 +39,14 @@ Page* CaretAnimator::page() const
     return nullptr;
 }
 
+void CaretAnimator::stop(CaretAnimatorStopReason)
+{
+    if (!m_isActive)
+        return;
+
+    didEnd();
+}
+
 void CaretAnimator::serviceCaretAnimation(ReducedResolutionSeconds timestamp)
 {
     if (!isActive())

--- a/Source/WebCore/platform/CaretAnimator.h
+++ b/Source/WebCore/platform/CaretAnimator.h
@@ -31,11 +31,6 @@
 
 namespace WebCore {
 
-enum class CaretAnimatorType : uint8_t {
-    Default,
-    Alternate
-};
-
 class CaretAnimator;
 class Color;
 class Document;
@@ -43,6 +38,16 @@ class FloatRect;
 class GraphicsContext;
 class Node;
 class Page;
+
+enum class CaretAnimatorType : uint8_t {
+    Default,
+    Alternate
+};
+
+enum class CaretAnimatorStopReason : uint8_t {
+    Default,
+    CaretRectChanged,
+};
 
 class CaretAnimationClient {
 public:
@@ -70,12 +75,7 @@ public:
 
     virtual void start(ReducedResolutionSeconds currentTime) = 0;
 
-    void stop()
-    {
-        if (!m_isActive)
-            return;
-        didEnd();
-    }
+    virtual void stop(CaretAnimatorStopReason = CaretAnimatorStopReason::Default);
 
     bool isActive() const { return m_isActive; }
 
@@ -91,7 +91,10 @@ public:
     PresentationProperties presentationProperties() const { return m_presentationProperties; }
     virtual void paint(const Node&, GraphicsContext&, const FloatRect&, const Color&, const LayoutPoint&) const;
     virtual LayoutRect repaintCaretRectForLocalRect(LayoutRect) const;
+#if defined(__has_include) && __has_include(<WebKitAdditions/RenderBlockAdditions.h>)
+    // FIXME: https://bugs.webkit.org/show_bug.cgi?id=255602 - Remove staging from CaretAnimator.h
     virtual void addLine(float, float, TextDirection) const { }
+#endif
 
 protected:
     explicit CaretAnimator(CaretAnimationClient& client)

--- a/Source/WebCore/rendering/RenderBlock.cpp
+++ b/Source/WebCore/rendering/RenderBlock.cpp
@@ -82,15 +82,6 @@
 
 namespace WebCore {
 
-#if USE(APPLE_INTERNAL_SDK) && __has_include(<WebKitAdditions/RenderBlockAdditions.h>)
-#include <WebKitAdditions/RenderBlockAdditions.h>
-#else
-inline static bool renderCaretInsideContentsClip()
-{
-    return true;
-}
-#endif
-
 using namespace HTMLNames;
 using namespace WTF::Unicode;
 
@@ -1137,9 +1128,6 @@ void RenderBlock::paint(PaintInfo& paintInfo, const LayoutPoint& paintOffset)
     if (pushedClip)
         popContentsClip(paintInfo, phase, adjustedPaintOffset);
 
-    if (!renderCaretInsideContentsClip())
-        paintCarets(paintInfo, adjustedPaintOffset);
-
     // Our scrollbar widgets paint exactly when we tell them to, so that they work properly with
     // z-index. We paint after we painted the background/border, so that the scrollbars will
     // sit above the background/border.
@@ -1384,8 +1372,7 @@ void RenderBlock::paintObject(PaintInfo& paintInfo, const LayoutPoint& paintOffs
     // 7. paint caret.
     // If the caret's node's render object's containing block is this block, and the paint action is PaintPhase::Foreground,
     // then paint the caret.
-    if (renderCaretInsideContentsClip())
-        paintCarets(paintInfo, paintOffset);
+    paintCarets(paintInfo, paintOffset);
 }
 
 static ContinuationOutlineTableMap* continuationOutlineTable()

--- a/Source/WebKit/UIProcess/WebPageProxy.cpp
+++ b/Source/WebKit/UIProcess/WebPageProxy.cpp
@@ -10638,6 +10638,11 @@ void WebPageProxy::setCaretAnimatorType(WebCore::CaretAnimatorType caretType)
     send(Messages::WebPage::SetCaretAnimatorType(caretType));
 }
 
+void WebPageProxy::setCaretBlinkingSuspended(bool suspended)
+{
+    send(Messages::WebPage::SetCaretBlinkingSuspended(suspended));
+}
+
 void WebPageProxy::performImmediateActionHitTestAtLocation(FloatPoint point)
 {
     send(Messages::WebPage::PerformImmediateActionHitTestAtLocation(point));

--- a/Source/WebKit/UIProcess/WebPageProxy.h
+++ b/Source/WebKit/UIProcess/WebPageProxy.h
@@ -1047,6 +1047,7 @@ public:
 
 #if PLATFORM(MAC)
     void setCaretAnimatorType(WebCore::CaretAnimatorType);
+    void setCaretBlinkingSuspended(bool);
     void attributedSubstringForCharacterRangeAsync(const EditingRange&, CompletionHandler<void(const WebCore::AttributedString&, const EditingRange&)>&&);
 
     void startWindowDrag();

--- a/Source/WebKit/WebProcess/WebPage/WebPage.cpp
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.cpp
@@ -5856,6 +5856,12 @@ void WebPage::setCaretAnimatorType(WebCore::CaretAnimatorType caretType)
     frame->selection().caretAnimatorInvalidated(caretType);
 }
 
+void WebPage::setCaretBlinkingSuspended(bool suspended)
+{
+    Ref frame = CheckedRef(m_page->focusController())->focusedOrMainFrame();
+    frame->selection().setCaretBlinkingSuspended(suspended);
+}
+
 RetainPtr<PDFDocument> WebPage::pdfDocumentForPrintingFrame(LocalFrame* coreFrame)
 {
     PluginView* pluginView = pluginViewForFrame(coreFrame);

--- a/Source/WebKit/WebProcess/WebPage/WebPage.h
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.h
@@ -1026,6 +1026,7 @@ public:
 
 #if PLATFORM(MAC)
     void setCaretAnimatorType(WebCore::CaretAnimatorType);
+    void setCaretBlinkingSuspended(bool);
     void attributedSubstringForCharacterRangeAsync(const EditingRange&, CompletionHandler<void(const WebCore::AttributedString&, const EditingRange&)>&&);
     void requestAcceptsFirstMouse(int eventNumber, const WebKit::WebMouseEvent&);
 #endif

--- a/Source/WebKit/WebProcess/WebPage/WebPage.messages.in
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.messages.in
@@ -508,6 +508,7 @@ GenerateSyntheticEditingCommand(enum:uint8_t WebKit::SyntheticEditingCommandType
     AttributedSubstringForCharacterRangeAsync(struct WebKit::EditingRange range) -> (struct WebCore::AttributedString string, struct WebKit::EditingRange range)
     RequestAcceptsFirstMouse(int eventNumber, WebKit::WebMouseEvent event) AllowedWhenWaitingForSyncReplyDuringUnboundedIPC
     SetCaretAnimatorType(enum:uint8_t WebCore::CaretAnimatorType caretType)
+    SetCaretBlinkingSuspended(bool blinkSuspended)
 #endif
 
 #if ENABLE(IMAGE_ANALYSIS_ENHANCEMENTS)


### PR DESCRIPTION
#### cebe6cd67d9d949d227afe615b2965806c96b71a
<pre>
Adjust cursor animator properties
<a href="https://bugs.webkit.org/show_bug.cgi?id=255399">https://bugs.webkit.org/show_bug.cgi?id=255399</a>
&lt;radar://107662722&gt;

Reviewed by Aditya Keerthi.

This patch allows suspending the blink state of the
cursor from the UI process, moves logic from an
static internal function to a virtual function,
and corrects an issue where the caret does not
start animating after a transition.

This also removes CaretAnimator::addLine which is no longer used.

* Source/WebCore/editing/FrameSelection.cpp:
(WebCore::CaretBase::paintCaret const):
(WebCore::FrameSelection::caretAnimatorInvalidated):
Ensure animator starts animating after a caret transition.

(WebCore::FrameSelection::updateAppearance):
With CaretAnimator&apos;s stop function virtual, send the reason
for why the stop was issued.

* Source/WebCore/platform/CaretAnimator.cpp:
(WebCore::CaretAnimator::adjustedClipRect const):
Allow specific animator&apos;s to override the clip rectangle.

* Source/WebCore/platform/CaretAnimator.h:
(WebCore::CaretAnimator::stop):
Allow for a reason to be used in determining stop behavior.

(WebCore::CaretAnimator::addLine const): Deleted.
This is no longer needed.

* Source/WebCore/rendering/RenderBlock.cpp:
(WebCore::RenderBlock::paint):
(WebCore::RenderBlock::paintObject):
Revert previously added changes.

(WebCore::renderCaretInsideContentsClip): Deleted.
This is no longer used, instead CaretAnimator has a virtual member
function to control the clip rectangle.

* Source/WebKit/UIProcess/WebPageProxy.cpp:
(WebKit::WebPageProxy::setCaretBlinkingSuspended):
* Source/WebKit/UIProcess/WebPageProxy.h:
* Source/WebKit/WebProcess/WebPage/WebPage.cpp:
(WebKit::WebPage::setCaretBlinkingSuspended):
* Source/WebKit/WebProcess/WebPage/WebPage.h:
* Source/WebKit/WebProcess/WebPage/WebPage.messages.in:
Allow blink to be suspended from the UI process.

Canonical link: <a href="https://commits.webkit.org/263083@main">https://commits.webkit.org/263083@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/553690682ba820e9fa60ead869857dc58c54b227

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/3560 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/3607 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/3746 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/4984 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/3835 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/3539 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/3700 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/3648 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/3093 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/3603 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/3855 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/3221 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/4806 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/1362 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/3183 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/3084 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/3162 "Passed tests") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/3242 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/4571 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/3619 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/2922 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/3160 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/3181 "Passed tests") | | 
| [❌ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/861 "Failed to push commit to Webkit repository") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/3187 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/3438 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->