### PR TITLE
Add missing service worker content filter check

### DIFF
--- a/LayoutTests/TestExpectations
+++ b/LayoutTests/TestExpectations
@@ -1010,6 +1010,7 @@ webkit.org/b/217617 imported/w3c/web-platform-tests/service-workers/service-work
 # This test adds a lot of iframes and is slow to run.
 fast/dom/connected-subframe-counter-overflow.html [ Slow ]
 
+http/wpt/service-workers/basic-fetch-with-contentfilter-allow-after-adding-data.html [ Skip ]
 http/wpt/service-workers/basic-fetch-with-contentfilter.https.html [ Skip ]
 
 # Reenable it when having a custom gc exposed in service workers.

--- a/LayoutTests/http/wpt/service-workers/basic-fetch-with-contentfilter-allow-after-adding-data-expected.txt
+++ b/LayoutTests/http/wpt/service-workers/basic-fetch-with-contentfilter-allow-after-adding-data-expected.txt
@@ -1,0 +1,5 @@
+
+
+PASS Setup worker
+PASS Fetch with content filter
+

--- a/LayoutTests/http/wpt/service-workers/basic-fetch-with-contentfilter-allow-after-adding-data.html
+++ b/LayoutTests/http/wpt/service-workers/basic-fetch-with-contentfilter-allow-after-adding-data.html
@@ -1,0 +1,41 @@
+<html>
+<head>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/service-workers/service-worker/resources/test-helpers.sub.js"></script>
+</head>
+<body>
+<script>
+var scope = "resources";
+var activeWorker;
+
+if (window.internals) {
+    var settings = window.internals.mockContentFilterSettings;
+    settings.enabled = true;
+    settings.decisionPoint = "afterFinishedAddingData";
+    settings.decision = "allow";
+    settings.blockedString = "<!DOCTYPE html><body>PASS";
+}
+
+promise_test(async (test) => {
+    var registration = await navigator.serviceWorker.register("basic-fetch-with-contentfilter.js", { scope : scope });
+    activeWorker = registration.active;
+    if (activeWorker)
+        return;
+    activeWorker = registration.installing;
+    return new Promise(resolve => {
+        activeWorker.addEventListener('statechange', () => {
+            if (activeWorker.state === "activated")
+                resolve();
+        });
+    });
+}, "Setup worker");
+
+promise_test(async (test) => {
+    const iframe = await with_iframe(scope);
+
+    assert_equals(iframe.contentWindow.document.body.innerHTML, "Test");
+}, "Fetch with content filter");
+</script>
+</body>
+</html>

--- a/LayoutTests/http/wpt/service-workers/basic-fetch-with-contentfilter.js
+++ b/LayoutTests/http/wpt/service-workers/basic-fetch-with-contentfilter.js
@@ -1,6 +1,6 @@
 function doTest(event)
 {
-    event.respondWith(new Response('Test', { status: 200, statusText: "Hello from service worker", headers: [["Hello", "World"]] }));
+    event.respondWith(new Response('<html><body>Test</body></html>', { status: 200, statusText: "Hello from service worker", headers: [["Content-Type", "text/html; charset=utf-8"]] }));
 }
 
 self.addEventListener("fetch", doTest);

--- a/LayoutTests/platform/ios/TestExpectations
+++ b/LayoutTests/platform/ios/TestExpectations
@@ -4372,6 +4372,7 @@ webkit.org/b/251875 fast/dynamic/create-renderer-for-whitespace-only-text.html [
 
 webkit.org/b/252504 http/tests/site-isolation [ Skip ]
 
+http/wpt/service-workers/basic-fetch-with-contentfilter-allow-after-adding-data.html [ Pass ]
 http/wpt/service-workers/basic-fetch-with-contentfilter.https.html [ Pass ]
 
 http/tests/misc/heic-accept-header.html [ Pass ]

--- a/LayoutTests/platform/mac/TestExpectations
+++ b/LayoutTests/platform/mac/TestExpectations
@@ -2748,6 +2748,7 @@ webkit.org/b/251099 [ Ventura+ ] fast/images/avif-image-document.html [ Pass Cra
 # AVIF overlay images are only supported on macOS and iOS post Ventura.
 [ Ventura+ ] fast/images/image-overlay-mutiple-frames.html [ Pass ImageOnlyFailure ]
 
+http/wpt/service-workers/basic-fetch-with-contentfilter-allow-after-adding-data.html [ Pass ]
 http/wpt/service-workers/basic-fetch-with-contentfilter.https.html [ Pass ]
 
 http/tests/misc/heic-accept-header.html [ Pass ]

--- a/Source/WebKit/NetworkProcess/NetworkResourceLoader.cpp
+++ b/Source/WebKit/NetworkProcess/NetworkResourceLoader.cpp
@@ -2023,6 +2023,7 @@ void NetworkResourceLoader::serviceWorkerDidFinish()
 {
     if (!m_contentFilter)
         return;
+    m_contentFilter->continueAfterNotifyFinished(m_parameters.request.url());
     m_contentFilter->stopFilteringMainResource();
 }
 


### PR DESCRIPTION
#### 09061adb503c45ce2605787b9f412333d8a43efd
<pre>
Add missing service worker content filter check
<a href="https://bugs.webkit.org/show_bug.cgi?id=255418">https://bugs.webkit.org/show_bug.cgi?id=255418</a>
rdar://107453214

Reviewed by Brent Fulgham.

This patch was authored by Ben Nham and Per Arne Vollan.

Add missing service worker content filter check after finished adding data. This fixes an issue where
service workers are incorrectly blocked.

* LayoutTests/TestExpectations:
* LayoutTests/http/wpt/service-workers/basic-fetch-with-contentfilter-allow-after-adding-data-expected.txt: Added.
* LayoutTests/http/wpt/service-workers/basic-fetch-with-contentfilter-allow-after-adding-data.html: Added.
* LayoutTests/http/wpt/service-workers/basic-fetch-with-contentfilter.js:
(doTest):
* LayoutTests/platform/ios/TestExpectations:
* LayoutTests/platform/mac/TestExpectations:
* Source/WebKit/NetworkProcess/NetworkResourceLoader.cpp:
(WebKit::NetworkResourceLoader::serviceWorkerDidFinish):

Canonical link: <a href="https://commits.webkit.org/262972@main">https://commits.webkit.org/262972@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c454908576f620e279b78ee94e9e4765963ad2a4

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/3171 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/3232 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/3342 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/4584 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/3529 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/3296 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/3259 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/2759 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/3202 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/3521 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/2851 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/4391 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/1019 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/2824 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/2664 "1 flakes 139 failures") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/2798 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/2875 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/4139 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/3247 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/2593 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/2831 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/2826 "Passed tests") | | 
| [  ~~🛠 🧪 merge~~](https://ews-build.webkit.org/#/builders/19/builds/779 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/2824 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/370 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/3090 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->