### PR TITLE
Update HTML fast parser to use ElementNames

### DIFF
--- a/Source/WebCore/html/parser/HTMLDocumentParserFastPath.cpp
+++ b/Source/WebCore/html/parser/HTMLDocumentParserFastPath.cpp
@@ -294,7 +294,7 @@ private:
         };
 
         struct A : ContainerTag<HTMLAnchorElement, PermittedParents::FlowContent> {
-            static constexpr ElementName tagName = ElementName::HTML_a;
+            static constexpr ElementName tagName = ElementNames::HTML::a;
             static constexpr Char tagNameCharacters[] = { 'a' };
 
             static RefPtr<HTMLElement> parseChild(HTMLFastPathParser& self)
@@ -308,7 +308,7 @@ private:
         };
 
         struct AWithPhrasingContent : ContainsPhrasingContentTag<HTMLAnchorElement, PermittedParents::PhrasingOrFlowContent> {
-            static constexpr ElementName tagName = ElementName::HTML_a;
+            static constexpr ElementName tagName = ElementNames::HTML::a;
             static constexpr Char tagNameCharacters[] = { 'a' };
 
             static RefPtr<HTMLElement> parseChild(HTMLFastPathParser& self)
@@ -322,7 +322,7 @@ private:
         };
 
         struct B : ContainsPhrasingContentTag<HTMLElement, PermittedParents::PhrasingOrFlowContent> {
-            static constexpr ElementName tagName = ElementName::HTML_b;
+            static constexpr ElementName tagName = ElementNames::HTML::b;
             static constexpr Char tagNameCharacters[] = { 'b' };
 
             static Ref<HTMLElement> create(Document& document)
@@ -332,22 +332,22 @@ private:
         };
 
         struct Br : VoidTag<HTMLBRElement, PermittedParents::PhrasingOrFlowContent> {
-            static constexpr ElementName tagName = ElementName::HTML_br;
+            static constexpr ElementName tagName = ElementNames::HTML::br;
             static constexpr Char tagNameCharacters[] = { 'b', 'r' };
         };
 
         struct Button : ContainsPhrasingContentTag<HTMLButtonElement, PermittedParents::PhrasingOrFlowContent> {
-            static constexpr ElementName tagName = ElementName::HTML_button;
+            static constexpr ElementName tagName = ElementNames::HTML::button;
             static constexpr Char tagNameCharacters[] = { 'b', 'u', 't', 't', 'o', 'n' };
         };
 
         struct Div : ContainerTag<HTMLDivElement, PermittedParents::FlowContent> {
-            static constexpr ElementName tagName = ElementName::HTML_div;
+            static constexpr ElementName tagName = ElementNames::HTML::div;
             static constexpr Char tagNameCharacters[] = { 'd', 'i', 'v' };
         };
 
         struct Footer : ContainerTag<HTMLElement, PermittedParents::FlowContent> {
-            static constexpr ElementName tagName = ElementName::HTML_footer;
+            static constexpr ElementName tagName = ElementNames::HTML::footer;
             static constexpr Char tagNameCharacters[] = { 'f', 'o', 'o', 't', 'e', 'r' };
 
             static Ref<HTMLElement> create(Document& document)
@@ -357,7 +357,7 @@ private:
         };
 
         struct I : ContainsPhrasingContentTag<HTMLElement, PermittedParents::PhrasingOrFlowContent> {
-            static constexpr ElementName tagName = ElementName::HTML_i;
+            static constexpr ElementName tagName = ElementNames::HTML::i;
             static constexpr Char tagNameCharacters[] = { 'i' };
 
             static Ref<HTMLElement> create(Document& document)
@@ -367,7 +367,7 @@ private:
         };
 
         struct Input : VoidTag<HTMLInputElement, PermittedParents::PhrasingOrFlowContent> {
-            static constexpr ElementName tagName = ElementName::HTML_input;
+            static constexpr ElementName tagName = ElementNames::HTML::input;
             static constexpr Char tagNameCharacters[] = { 'i', 'n', 'p', 'u', 't' };
 
             static Ref<HTMLInputElement> create(Document& document)
@@ -377,17 +377,17 @@ private:
         };
 
         struct Li : ContainerTag<HTMLLIElement, PermittedParents::Special> {
-            static constexpr ElementName tagName = ElementName::HTML_li;
+            static constexpr ElementName tagName = ElementNames::HTML::li;
             static constexpr Char tagNameCharacters[] = { 'l', 'i' };
         };
 
         struct Label : ContainsPhrasingContentTag<HTMLLabelElement, PermittedParents::PhrasingOrFlowContent> {
-            static constexpr ElementName tagName = ElementName::HTML_label;
+            static constexpr ElementName tagName = ElementNames::HTML::label;
             static constexpr Char tagNameCharacters[] = { 'l', 'a', 'b', 'e', 'l' };
         };
 
         struct Option : ContainerTag<HTMLOptionElement, PermittedParents::Special> {
-            static constexpr ElementName tagName = ElementName::HTML_option;
+            static constexpr ElementName tagName = ElementNames::HTML::option;
             static constexpr Char tagNameCharacters[] = { 'o', 'p', 't', 'i', 'o', 'n' };
 
             static RefPtr<HTMLElement> parseChild(HTMLFastPathParser& self)
@@ -398,7 +398,7 @@ private:
         };
 
         struct Ol : ContainerTag<HTMLOListElement, PermittedParents::FlowContent> {
-            static constexpr ElementName tagName = ElementName::HTML_ol;
+            static constexpr ElementName tagName = ElementNames::HTML::ol;
             static constexpr Char tagNameCharacters[] = { 'o', 'l' };
 
             static RefPtr<HTMLElement> parseChild(HTMLFastPathParser& self)
@@ -408,12 +408,12 @@ private:
         };
 
         struct P : ContainsPhrasingContentTag<HTMLParagraphElement, PermittedParents::FlowContent> {
-            static constexpr ElementName tagName = ElementName::HTML_p;
+            static constexpr ElementName tagName = ElementNames::HTML::p;
             static constexpr Char tagNameCharacters[] = { 'p' };
         };
 
         struct Select : ContainerTag<HTMLSelectElement, PermittedParents::PhrasingOrFlowContent> {
-            static constexpr ElementName tagName = ElementName::HTML_select;
+            static constexpr ElementName tagName = ElementNames::HTML::select;
             static constexpr Char tagNameCharacters[] = { 's', 'e', 'l', 'e', 'c', 't' };
 
             static RefPtr<HTMLElement> parseChild(HTMLFastPathParser& self)
@@ -423,12 +423,12 @@ private:
         };
 
         struct Span : ContainsPhrasingContentTag<HTMLSpanElement, PermittedParents::PhrasingOrFlowContent> {
-            static constexpr ElementName tagName = ElementName::HTML_span;
+            static constexpr ElementName tagName = ElementNames::HTML::span;
             static constexpr Char tagNameCharacters[] = { 's', 'p', 'a', 'n' };
         };
 
         struct Strong : ContainsPhrasingContentTag<HTMLElement, PermittedParents::PhrasingOrFlowContent> {
-            static constexpr ElementName tagName = ElementName::HTML_strong;
+            static constexpr ElementName tagName = ElementNames::HTML::strong;
             static constexpr Char tagNameCharacters[] = { 's', 't', 'r', 'o', 'n', 'g' };
 
             static Ref<HTMLElement> create(Document& document)
@@ -438,7 +438,7 @@ private:
         };
 
         struct Ul : ContainerTag<HTMLUListElement, PermittedParents::FlowContent> {
-            static constexpr ElementName tagName = ElementName::HTML_ul;
+            static constexpr ElementName tagName = ElementNames::HTML::ul;
             static constexpr Char tagNameCharacters[] = { 'u', 'l' };
 
             static RefPtr<HTMLElement> parseChild(HTMLFastPathParser& self)


### PR DESCRIPTION
#### c1214f91699c859aff4af77037accd28d45f8976
<pre>
Update HTML fast parser to use ElementNames
<a href="https://bugs.webkit.org/show_bug.cgi?id=255424">https://bugs.webkit.org/show_bug.cgi?id=255424</a>
rdar://108022113

Reviewed by NOBODY (OOPS!).

Use ElementNames namespace values instead of ElementName enumeration values as
I was told this is the preferred way. ElementName enumeration values contain
underscores and are thus not as readable.

* Source/WebCore/html/parser/HTMLDocumentParserFastPath.cpp:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c1214f91699c859aff4af77037accd28d45f8976

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/3111 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/3171 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/3280 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/4523 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/3472 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/3079 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/3232 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/3198 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/2702 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/3142 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/3463 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/2783 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/4326 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/961 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/2760 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/2605 "10 flakes 140 failures") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/2735 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/2811 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/4065 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/3187 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/2539 "3 failures") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/2773 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/2762 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/2764 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/3030 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->