### PR TITLE
GraphicsLayerWC: site isolation support

### DIFF
--- a/Source/WebCore/platform/graphics/texmap/TextureMapperGL.cpp
+++ b/Source/WebCore/platform/graphics/texmap/TextureMapperGL.cpp
@@ -205,6 +205,7 @@ void TextureMapperGL::beginPainting(PaintFlags flags, BitmapTexture* surface)
 
 void TextureMapperGL::endPainting()
 {
+    glBindFramebuffer(GL_FRAMEBUFFER, data().targetFrameBuffer);
     if (data().didModifyStencil) {
         glClearStencil(1);
         glClear(GL_STENCIL_BUFFER_BIT);

--- a/Source/WebKit/GPUProcess/GPUConnectionToWebProcess.cpp
+++ b/Source/WebKit/GPUProcess/GPUConnectionToWebProcess.cpp
@@ -154,6 +154,7 @@
 #if USE(GRAPHICS_LAYER_WC)
 #include "RemoteWCLayerTreeHost.h"
 #include "WCContentBufferManager.h"
+#include "WCRemoteFrameHostLayerManager.h"
 #endif
 
 #if ENABLE(IPC_TESTING_API)
@@ -359,9 +360,12 @@ void GPUConnectionToWebProcess::didClose(IPC::Connection& connection)
     // RemoteGraphicsContextsGL objects are unneeded after connection closes.
     m_remoteGraphicsContextGLMap.clear();
 #endif
-#if USE(GRAPHICS_LAYER_WC) && ENABLE(WEBGL)
-    remoteGraphicsContextGLStreamWorkQueue().dispatch([webProcessIdentifier = m_webProcessIdentifier] {
+#if USE(GRAPHICS_LAYER_WC)
+    remoteGraphicsStreamWorkQueue().dispatch([webProcessIdentifier = m_webProcessIdentifier] {
+#if ENABLE(WEBGL)
         WCContentBufferManager::singleton().removeAllContentBuffersForProcess(webProcessIdentifier);
+#endif
+        WCRemoteFrameHostLayerManager::singleton().removeAllLayersForProcess(webProcessIdentifier);
     });
 #endif
 #if PLATFORM(COCOA) && USE(LIBWEBRTC)

--- a/Source/WebKit/GPUProcess/graphics/wc/RemoteWCLayerTreeHost.cpp
+++ b/Source/WebKit/GPUProcess/graphics/wc/RemoteWCLayerTreeHost.cpp
@@ -38,7 +38,7 @@
 
 namespace WebKit {
 
-static IPC::StreamConnectionWorkQueue& remoteGraphicsStreamWorkQueue()
+IPC::StreamConnectionWorkQueue& remoteGraphicsStreamWorkQueue()
 {
 #if ENABLE(WEBGL)
     return remoteGraphicsContextGLStreamWorkQueue();

--- a/Source/WebKit/GPUProcess/graphics/wc/RemoteWCLayerTreeHost.h
+++ b/Source/WebKit/GPUProcess/graphics/wc/RemoteWCLayerTreeHost.h
@@ -34,6 +34,10 @@
 #include "WCSharedSceneContextHolder.h"
 #include <WebCore/ProcessIdentifier.h>
 
+namespace IPC {
+class StreamConnectionWorkQueue;
+}
+
 namespace WebKit {
 class GPUConnectionToWebProcess;
 class WCScene;
@@ -62,6 +66,8 @@ private:
     RefPtr<WCSharedSceneContextHolder::Holder> m_sharedSceneContextHolder;
     std::unique_ptr<WCScene> m_scene;
 };
+
+IPC::StreamConnectionWorkQueue& remoteGraphicsStreamWorkQueue();
 
 } // namespace WebKit
 

--- a/Source/WebKit/GPUProcess/graphics/wc/WCRemoteFrameHostLayerManager.cpp
+++ b/Source/WebKit/GPUProcess/graphics/wc/WCRemoteFrameHostLayerManager.cpp
@@ -1,0 +1,111 @@
+/*
+ * Copyright (C) 2023 Sony Interactive Entertainment Inc.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "WCRemoteFrameHostLayerManager.h"
+
+#if USE(GRAPHICS_LAYER_WC)
+
+#include <WebCore/BitmapTexture.h>
+#include <WebCore/TextureMapperPlatformLayer.h>
+#include <wtf/NeverDestroyed.h>
+
+namespace WebKit {
+
+class WCRemoteFrameHostLayer final : public WebCore::TextureMapperPlatformLayer {
+    WTF_MAKE_FAST_ALLOCATED();
+public:
+    void paintToTextureMapper(WebCore::TextureMapper& textureMapper, const WebCore::FloatRect& targetRect, const WebCore::TransformationMatrix& modelViewMatrix, float opacity) override
+    {
+        if (m_texture)
+            textureMapper.drawTexture(*m_texture, targetRect, modelViewMatrix, opacity);
+    }
+
+    void setTexture(RefPtr<WebCore::BitmapTexture> texture)
+    {
+        m_texture = texture;
+    }
+
+private:
+    RefPtr<WebCore::BitmapTexture> m_texture;
+};
+
+class WCRemoteFrameHostLayerManager::RemoteFrameHostLayerData final {
+    WTF_MAKE_FAST_ALLOCATED();
+public:
+    RemoteFrameHostLayerData(WebCore::ProcessIdentifier webProcessIdentifier)
+        : m_webProcessIdentifier(webProcessIdentifier)
+    {
+    }
+
+    WebCore::ProcessIdentifier webProcessIdentifier() const { return m_webProcessIdentifier; }
+    void setWebProcessIdentifier(WebCore::ProcessIdentifier webProcessIdentifier) { m_webProcessIdentifier = webProcessIdentifier; }
+    WCRemoteFrameHostLayer& layer() { return m_layer; }
+
+private:
+    // A web process identifier currently owning the texture. Remote frame process or frame host process.
+    WebCore::ProcessIdentifier m_webProcessIdentifier;
+    WCRemoteFrameHostLayer m_layer;
+};
+
+WCRemoteFrameHostLayerManager& WCRemoteFrameHostLayerManager::singleton()
+{
+    static NeverDestroyed<WCRemoteFrameHostLayerManager> manager;
+    return manager;
+}
+
+WebCore::TextureMapperPlatformLayer* WCRemoteFrameHostLayerManager::acquireRemoteFrameHostLayer(WebCore::LayerHostingContextIdentifier layerHostingContextIdentifier, WebCore::ProcessIdentifier webProcessIdentifier)
+{
+    auto& data = *m_layers.ensure(layerHostingContextIdentifier, [&] {
+        return makeUnique<RemoteFrameHostLayerData>(webProcessIdentifier);
+    }).iterator->value;
+    // Transfer the data ownership to the frame host process.
+    data.setWebProcessIdentifier(webProcessIdentifier);
+    return &data.layer();
+}
+
+void WCRemoteFrameHostLayerManager::releaseRemoteFrameHostLayer(WebCore::LayerHostingContextIdentifier layerHostingContextIdentifier)
+{
+    m_layers.remove(layerHostingContextIdentifier);
+}
+
+void WCRemoteFrameHostLayerManager::updateTexture(WebCore::LayerHostingContextIdentifier layerHostingContextIdentifier, WebCore::ProcessIdentifier webProcessIdentifier, RefPtr<WebCore::BitmapTexture> texture)
+{
+    m_layers.ensure(layerHostingContextIdentifier, [&] {
+        // Create a new data if the frame host didn't create it yet. The initial owner is the remote frame process.
+        return makeUnique<RemoteFrameHostLayerData>(webProcessIdentifier);
+    }).iterator->value->layer().setTexture(WTFMove(texture));
+}
+
+void WCRemoteFrameHostLayerManager::removeAllLayersForProcess(WebCore::ProcessIdentifier webProcessIdentifier)
+{
+    m_layers.removeIf([&](auto& iterator) {
+        return iterator.value->webProcessIdentifier() == webProcessIdentifier;
+    });
+}
+
+} // namespace WebKit
+
+#endif // USE(GRAPHICS_LAYER_WC)

--- a/Source/WebKit/GPUProcess/graphics/wc/WCRemoteFrameHostLayerManager.h
+++ b/Source/WebKit/GPUProcess/graphics/wc/WCRemoteFrameHostLayerManager.h
@@ -1,0 +1,58 @@
+/*
+ * Copyright (C) 2023 Sony Interactive Entertainment Inc.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#if USE(GRAPHICS_LAYER_WC)
+
+#include <WebCore/LayerHostingContextIdentifier.h>
+#include <WebCore/ProcessIdentifier.h>
+#include <wtf/HashMap.h>
+
+namespace WebCore {
+class BitmapTexture;
+class TextureMapperPlatformLayer;
+}
+
+namespace WebKit {
+
+class WCRemoteFrameHostLayerManager {
+public:
+    static WCRemoteFrameHostLayerManager& singleton();
+
+    WebCore::TextureMapperPlatformLayer* acquireRemoteFrameHostLayer(WebCore::LayerHostingContextIdentifier, WebCore::ProcessIdentifier);
+    void releaseRemoteFrameHostLayer(WebCore::LayerHostingContextIdentifier);
+
+    void updateTexture(WebCore::LayerHostingContextIdentifier, WebCore::ProcessIdentifier, RefPtr<WebCore::BitmapTexture>);
+    void removeAllLayersForProcess(WebCore::ProcessIdentifier);
+
+private:
+    class RemoteFrameHostLayerData;
+    HashMap<WebCore::LayerHostingContextIdentifier, std::unique_ptr<RemoteFrameHostLayerData>> m_layers;
+};
+
+} // namespace WebKit
+
+#endif // USE(GRAPHICS_LAYER_WC)

--- a/Source/WebKit/GPUProcess/graphics/wc/WCScene.cpp
+++ b/Source/WebKit/GPUProcess/graphics/wc/WCScene.cpp
@@ -31,6 +31,7 @@
 #include "RemoteGraphicsContextGL.h"
 #include "WCContentBuffer.h"
 #include "WCContentBufferManager.h"
+#include "WCRemoteFrameHostLayerManager.h"
 #include "WCSceneContext.h"
 #include "WCUpdateInfo.h"
 #include <WebCore/TextureMapperGLHeaders.h>
@@ -48,6 +49,8 @@ public:
     {
         if (contentBuffer)
             contentBuffer->setClient(nullptr);
+        if (hostIdentifier)
+            WCRemoteFrameHostLayerManager::singleton().releaseRemoteFrameHostLayer(*hostIdentifier);
     }
 
     // WCContentBuffer::Client
@@ -61,6 +64,7 @@ public:
     std::unique_ptr<WebCore::TextureMapperSparseBackingStore> backingStore;
     std::unique_ptr<WebCore::TextureMapperLayer> backdropLayer;
     WCContentBuffer* contentBuffer { nullptr };
+    Markable<WebCore::LayerHostingContextIdentifier> hostIdentifier;
 };
 
 void WCScene::initialize(WCSceneContext& context)
@@ -211,6 +215,16 @@ std::optional<UpdateInfo> WCScene::update(WCUpdateInfo&& update)
                 }
             }
         }
+        if (layerUpdate.changes & WCLayerChange::RemoteFrame) {
+            if (layerUpdate.hostIdentifier) {
+                auto platformLayer = WCRemoteFrameHostLayerManager::singleton().acquireRemoteFrameHostLayer(*layerUpdate.hostIdentifier, m_webProcessIdentifier);
+                layer->texmapLayer.setContentsLayer(platformLayer);
+            } else {
+                ASSERT(layer->hostIdentifier);
+                WCRemoteFrameHostLayerManager::singleton().releaseRemoteFrameHostLayer(*layer->hostIdentifier);
+            }
+            layer->hostIdentifier = layerUpdate.hostIdentifier;
+        }
     }
 
     for (auto id : update.removedLayers)
@@ -220,24 +234,40 @@ std::optional<UpdateInfo> WCScene::update(WCUpdateInfo&& update)
     rootLayer->applyAnimationsRecursively(MonotonicTime::now());
 
     WebCore::IntSize windowSize = expandedIntSize(rootLayer->size());
-    glViewport(0, 0, windowSize.width(), windowSize.height());
+    if (windowSize.isEmpty())
+        return std::nullopt;
 
     WebCore::BitmapTexture* surface = nullptr;
     RefPtr<WebCore::BitmapTexture> texture;
-    if (m_usesOffscreenRendering) {
+    bool showFPS = true;
+    bool readPixel = false;
+    RefPtr<ShareableBitmap> bitmap;
+
+    if (update.remoteContextHostedIdentifier) {
+        showFPS = false;
         texture = m_textureMapper->acquireTextureFromPool(windowSize);
         surface = texture.get();
-    }
+    } else if (m_usesOffscreenRendering) {
+        readPixel = true;
+        texture = m_textureMapper->acquireTextureFromPool(windowSize);
+        surface = texture.get();
+    } else
+        glViewport(0, 0, windowSize.width(), windowSize.height());
 
     m_textureMapper->beginPainting(0, surface);
     rootLayer->paint(*m_textureMapper);
-    m_fpsCounter.updateFPSAndDisplay(*m_textureMapper);
+    if (showFPS)
+        m_fpsCounter.updateFPSAndDisplay(*m_textureMapper);
+    if (readPixel) {
+        bitmap = ShareableBitmap::create({ windowSize });
+        glReadPixels(0, 0, windowSize.width(), windowSize.height(), GL_BGRA, GL_UNSIGNED_BYTE, bitmap->data());
+    }
     m_textureMapper->endPainting();
 
     std::optional<UpdateInfo> result;
-    if (m_usesOffscreenRendering) {
-        auto bitmap = ShareableBitmap::create({ windowSize });
-        glReadPixels(0, 0, windowSize.width(), windowSize.height(), GL_BGRA, GL_UNSIGNED_BYTE, bitmap->data());
+    if (update.remoteContextHostedIdentifier)
+        WCRemoteFrameHostLayerManager::singleton().updateTexture(*update.remoteContextHostedIdentifier, m_webProcessIdentifier, WTFMove(texture));
+    else if (m_usesOffscreenRendering) {
         if (auto handle = bitmap->createHandle()) {
             result.emplace();
             result->viewSize = windowSize;

--- a/Source/WebKit/PlatformPlayStation.cmake
+++ b/Source/WebKit/PlatformPlayStation.cmake
@@ -188,6 +188,7 @@ if (USE_GRAPHICS_LAYER_WC)
 
         GPUProcess/graphics/wc/RemoteWCLayerTreeHost.cpp
         GPUProcess/graphics/wc/WCContentBufferManager.cpp
+        GPUProcess/graphics/wc/WCRemoteFrameHostLayerManager.cpp
         GPUProcess/graphics/wc/WCScene.cpp
         GPUProcess/graphics/wc/WCSceneContext.cpp
 

--- a/Source/WebKit/PlatformWin.cmake
+++ b/Source/WebKit/PlatformWin.cmake
@@ -11,6 +11,7 @@ list(APPEND WebKit_SOURCES
 
     GPUProcess/graphics/wc/RemoteWCLayerTreeHost.cpp
     GPUProcess/graphics/wc/WCContentBufferManager.cpp
+    GPUProcess/graphics/wc/WCRemoteFrameHostLayerManager.cpp
     GPUProcess/graphics/wc/WCScene.cpp
     GPUProcess/graphics/wc/WCSceneContext.cpp
 

--- a/Source/WebKit/WebProcess/WebPage/wc/DrawingAreaWC.cpp
+++ b/Source/WebKit/WebProcess/WebPage/wc/DrawingAreaWC.cpp
@@ -39,6 +39,7 @@
 #include "WebPage.h"
 #include "WebPageCreationParameters.h"
 #include "WebPageInlines.h"
+#include "WebPreferencesKeys.h"
 #include "WebProcess.h"
 #include <WebCore/ImageBuffer.h>
 #include <WebCore/LocalFrame.h>
@@ -53,11 +54,8 @@ DrawingAreaWC::DrawingAreaWC(WebPage& webPage, const WebPageCreationParameters& 
     , m_remoteWCLayerTreeHostProxy(makeUnique<RemoteWCLayerTreeHostProxy>(webPage, parameters.usesOffscreenRendering))
     , m_layerFactory(*this)
     , m_updateRenderingTimer(*this, &DrawingAreaWC::updateRendering)
-    , m_rootLayer(GraphicsLayer::create(graphicsLayerFactory(), this->m_rootLayerClient))
     , m_commitQueue(WorkQueue::create("DrawingAreaWC CommitQueue"_s))
 {
-    m_rootLayer->setName(MAKE_STATIC_STRING_IMPL("drawing area root"));
-    m_rootLayer->setSize(m_webPage.size());
 }
 
 DrawingAreaWC::~DrawingAreaWC()
@@ -73,40 +71,61 @@ GraphicsLayerFactory* DrawingAreaWC::graphicsLayerFactory()
 
 void DrawingAreaWC::updateRootLayers()
 {
-    Vector<Ref<GraphicsLayer>> children;
-    if (m_contentLayer) {
-        children.append(*m_contentLayer);
-        if (m_viewOverlayRootLayer)
-            children.append(*m_viewOverlayRootLayer);
+    for (auto& rootLayer : m_rootLayers) {
+        Vector<Ref<GraphicsLayer>> children;
+        if (rootLayer.contentLayer) {
+            children.append(*rootLayer.contentLayer);
+            if (rootLayer.viewOverlayRootLayer)
+                children.append(*rootLayer.viewOverlayRootLayer);
+        }
+        rootLayer.layer->setChildren(WTFMove(children));
     }
-    m_rootLayer->setChildren(WTFMove(children));
     triggerRenderingUpdate();
 }
 
-void DrawingAreaWC::setRootCompositingLayer(WebCore::Frame&, GraphicsLayer* rootLayer)
+void DrawingAreaWC::setRootCompositingLayer(WebCore::Frame& frame, GraphicsLayer* rootGraphicsLayer)
 {
-    m_contentLayer = rootLayer;
-    if (rootLayer)
+    for (auto& rootLayer : m_rootLayers) {
+        if (rootLayer.frameID == frame.frameID())
+            rootLayer.contentLayer = rootGraphicsLayer;
+    }
+    if (rootGraphicsLayer)
         send(Messages::DrawingAreaProxy::EnterAcceleratedCompositingMode(m_backingStoreStateID, { }));
     updateRootLayers();
 }
 
-void DrawingAreaWC::attachViewOverlayGraphicsLayer(WebCore::FrameIdentifier, GraphicsLayer* layer)
+void DrawingAreaWC::addRootFrame(WebCore::FrameIdentifier frameID)
 {
-    m_viewOverlayRootLayer = layer;
-    updateRootLayers();
+    auto layer = GraphicsLayer::create(graphicsLayerFactory(), this->m_rootLayerClient);
+    // FIXME: This has an unnecessary string allocation. Adding a StringTypeAdapter for FrameIdentifier or ProcessQualified would remove that.
+    layer->setName(makeString("drawing area root "_s, frameID.toString()));
+    m_rootLayers.append(RootLayerInfo {
+        WTFMove(layer),
+        nullptr,
+        nullptr,
+        frameID
+    });
 }
 
-void DrawingAreaWC::updatePreferences(const WebPreferencesStore&)
+void DrawingAreaWC::attachViewOverlayGraphicsLayer(WebCore::FrameIdentifier frameID, GraphicsLayer* layer)
+{
+    if (auto* layerInfo = rootLayerInfoWithFrameIdentifier(frameID)) {
+        layerInfo->viewOverlayRootLayer = layer;
+        updateRootLayers();
+    }
+}
+
+void DrawingAreaWC::updatePreferences(const WebPreferencesStore& store)
 {
     Settings& settings = m_webPage.corePage()->settings();
     settings.setAcceleratedCompositingForFixedPositionEnabled(settings.acceleratedCompositingEnabled());
+    settings.setForceCompositingMode(store.getBoolValueForKey(WebPreferencesKey::siteIsolationEnabledKey()));
 }
 
 bool DrawingAreaWC::shouldUseTiledBackingForFrameView(const WebCore::LocalFrameView& frameView) const
 {
     auto* localFrame = dynamicDowncast<WebCore::LocalFrame>(frameView.frame());
-    return localFrame && localFrame->isMainFrame();
+    return localFrame && localFrame->isRootFrame();
 }
 
 void DrawingAreaWC::setLayerTreeStateIsFrozen(bool isFrozen)
@@ -124,7 +143,6 @@ void DrawingAreaWC::updateGeometryWC(uint64_t backingStoreStateID, IntSize viewS
 {
     m_backingStoreStateID = backingStoreStateID;
     m_webPage.setSize(viewSize);
-    m_rootLayer->setSize(m_webPage.size());
 }
 
 void DrawingAreaWC::setNeedsDisplay()
@@ -209,7 +227,10 @@ static void flushLayerImageBuffers(WCUpdateInfo& info)
 
 bool DrawingAreaWC::isCompositingMode()
 {
-    return m_contentLayer;
+    auto& mainWebFrame = m_webPage.mainWebFrame();
+    if (!mainWebFrame.isRootFrame())
+        return true;
+    return rootLayerInfoWithFrameIdentifier(mainWebFrame.frameID())->contentLayer;
 }
 
 void DrawingAreaWC::updateRendering()
@@ -244,32 +265,50 @@ void DrawingAreaWC::updateRendering()
 
 void DrawingAreaWC::sendUpdateAC()
 {
-    m_rootLayer->flushCompositingStateForThisLayerOnly();
+    bool didProcessMainFrame = false;
+    for (auto it = m_rootLayers.begin(); it != m_rootLayers.end(); it++) {
+        auto& rootLayer = *it;
+        auto frame = WebProcess::singleton().webFrame(rootLayer.frameID);
+        ASSERT(frame);
+        m_updateInfo.remoteContextHostedIdentifier = frame->layerHostingContextIdentifier();
+        m_updateInfo.rootLayer = rootLayer.layer->primaryLayerID();
 
-    // Because our view-relative overlay root layer is not attached to the FrameView's GraphicsLayer tree, we need to flush it manually.
-    if (m_viewOverlayRootLayer) {
-        FloatRect visibleRect({ }, m_webPage.size());
-        m_viewOverlayRootLayer->flushCompositingState(visibleRect);
-    }
+        bool isLastFrame = (it + 1) == m_rootLayers.end();
+        bool isMainFrame = frame->isMainFrame();
+        didProcessMainFrame = didProcessMainFrame || isMainFrame;
+        bool willCallDisplayDidRefresh = isMainFrame || (!didProcessMainFrame && isLastFrame);
+        IntSize size;
+        if (isMainFrame)
+            size = m_webPage.size();
+        else
+            size = frame->size();
+        rootLayer.layer->setSize(size);
+        rootLayer.layer->flushCompositingStateForThisLayerOnly();
 
-    m_updateInfo.rootLayer = m_rootLayer->primaryLayerID();
+        // Because our view-relative overlay root layer is not attached to the FrameView's GraphicsLayer tree, we need to flush it manually.
+        FloatRect visibleRect({ }, size);
+        if (rootLayer.viewOverlayRootLayer)
+            rootLayer.viewOverlayRootLayer->flushCompositingState(visibleRect);
 
-    m_commitQueue->dispatch([this, weakThis = WeakPtr(*this), stateID = m_backingStoreStateID, updateInfo = std::exchange(m_updateInfo, { })]() mutable {
-        flushLayerImageBuffers(updateInfo);
-        RunLoop::main().dispatch([this, weakThis = WTFMove(weakThis), stateID, updateInfo = WTFMove(updateInfo)]() mutable {
-            if (!weakThis)
-                return;
-            m_remoteWCLayerTreeHostProxy->update(WTFMove(updateInfo), [this, weakThis = WTFMove(weakThis), stateID](std::optional<UpdateInfo> updateInfo) {
+        m_commitQueue->dispatch([this, weakThis = WeakPtr(*this), stateID = m_backingStoreStateID, updateInfo = std::exchange(m_updateInfo, { }), willCallDisplayDidRefresh]() mutable {
+            flushLayerImageBuffers(updateInfo);
+            RunLoop::main().dispatch([this, weakThis = WTFMove(weakThis), stateID, updateInfo = WTFMove(updateInfo), willCallDisplayDidRefresh]() mutable {
                 if (!weakThis)
                     return;
-                if (updateInfo && stateID == m_backingStoreStateID) {
-                    send(Messages::DrawingAreaProxy::Update(m_backingStoreStateID, WTFMove(*updateInfo)));
-                    return;
-                }
-                displayDidRefresh();
+                m_remoteWCLayerTreeHostProxy->update(WTFMove(updateInfo), [this, weakThis = WTFMove(weakThis), stateID, willCallDisplayDidRefresh](std::optional<UpdateInfo> updateInfo) {
+                    if (!weakThis)
+                        return;
+                    if (updateInfo && stateID == m_backingStoreStateID) {
+                        ASSERT(willCallDisplayDidRefresh);
+                        send(Messages::DrawingAreaProxy::Update(m_backingStoreStateID, WTFMove(*updateInfo)));
+                        return;
+                    }
+                    if (willCallDisplayDidRefresh)
+                        displayDidRefresh();
+                });
             });
         });
-    });
+    }
 }
 
 static bool shouldPaintBoundsRect(const IntRect& bounds, const Vector<IntRect, 1>& rects)
@@ -390,6 +429,18 @@ void DrawingAreaWC::displayDidRefresh()
         m_hasDeferredRenderingUpdate = false;
         triggerRenderingUpdate();
     }
+}
+
+DrawingAreaWC::RootLayerInfo* DrawingAreaWC::rootLayerInfoWithFrameIdentifier(WebCore::FrameIdentifier frameID)
+{
+    auto index = m_rootLayers.findIf([&] (const auto& layer) {
+        return layer.frameID == frameID;
+    });
+    if (index == WTF::notFound) {
+        ASSERT_NOT_REACHED();
+        return nullptr;
+    }
+    return &m_rootLayers[index];
 }
 
 } // namespace WebKit

--- a/Source/WebKit/WebProcess/WebPage/wc/DrawingAreaWC.h
+++ b/Source/WebKit/WebProcess/WebPage/wc/DrawingAreaWC.h
@@ -60,6 +60,7 @@ private:
 #endif
     void updateGeometryWC(uint64_t, WebCore::IntSize) override;
     void setRootCompositingLayer(WebCore::Frame&, WebCore::GraphicsLayer*) override;
+    void addRootFrame(WebCore::FrameIdentifier) override;
     void attachViewOverlayGraphicsLayer(WebCore::FrameIdentifier, WebCore::GraphicsLayer*) override;
     void updatePreferences(const WebPreferencesStore&) override;
     bool shouldUseTiledBackingForFrameView(const WebCore::LocalFrameView&) const override;
@@ -76,6 +77,14 @@ private:
     void sendUpdateNonAC();
     void updateRootLayers();
 
+    struct RootLayerInfo {
+        Ref<WebCore::GraphicsLayer> layer;
+        RefPtr<WebCore::GraphicsLayer> contentLayer;
+        RefPtr<WebCore::GraphicsLayer> viewOverlayRootLayer;
+        WebCore::FrameIdentifier frameID;
+    };
+    RootLayerInfo* rootLayerInfoWithFrameIdentifier(WebCore::FrameIdentifier);
+
     WebCore::GraphicsLayerClient m_rootLayerClient;
     std::unique_ptr<RemoteWCLayerTreeHostProxy> m_remoteWCLayerTreeHostProxy;
     WCLayerFactory m_layerFactory;
@@ -87,9 +96,7 @@ private:
     bool m_waitDidUpdate { false };
     bool m_isForceRepaintCompletionHandlerDeferred { false };
     WCUpdateInfo m_updateInfo;
-    Ref<WebCore::GraphicsLayer> m_rootLayer;
-    RefPtr<WebCore::GraphicsLayer> m_contentLayer;
-    RefPtr<WebCore::GraphicsLayer> m_viewOverlayRootLayer;
+    Vector<RootLayerInfo, 1> m_rootLayers;
     Ref<WorkQueue> m_commitQueue;
     int64_t m_backingStoreStateID { 0 };
     WebCore::Region m_dirtyRegion;

--- a/Source/WebKit/WebProcess/WebPage/wc/GraphicsLayerWC.cpp
+++ b/Source/WebKit/WebProcess/WebPage/wc/GraphicsLayerWC.cpp
@@ -402,6 +402,14 @@ void GraphicsLayerWC::setContentsToPlatformLayer(PlatformLayer* platformLayer, C
     updateDebugIndicators();
 }
 
+void GraphicsLayerWC::setContentsToPlatformLayerHost(WebCore::LayerHostingContextIdentifier identifier)
+{
+    if (m_hostIdentifier && *m_hostIdentifier == identifier)
+        return;
+    m_hostIdentifier = identifier;
+    noteLayerPropertyChanged(WCLayerChange::RemoteFrame);
+}
+
 void GraphicsLayerWC::setContentsDisplayDelegate(RefPtr<WebCore::GraphicsLayerContentsDisplayDelegate>&& displayDelegate, ContentsLayerPurpose purpose)
 {
     auto platformLayer = displayDelegate ? displayDelegate->platformLayer() : nullptr;
@@ -591,6 +599,8 @@ void GraphicsLayerWC::flushCompositingStateForThisLayerOnly()
             update.contentBufferIdentifiers = static_cast<WCPlatformLayerGCGL*>(m_platformLayer)->takeContentBufferIdentifiers();
 #endif
     }
+    if (update.changes & WCLayerChange::RemoteFrame)
+        update.hostIdentifier = m_hostIdentifier;
     m_observer->commitLayerUpdateInfo(WTFMove(update));
 }
 

--- a/Source/WebKit/WebProcess/WebPage/wc/GraphicsLayerWC.h
+++ b/Source/WebKit/WebProcess/WebPage/wc/GraphicsLayerWC.h
@@ -85,6 +85,7 @@ public:
     void setBackfaceVisibility(bool) override;
     void setContentsToSolidColor(const WebCore::Color&) override;
     void setContentsToPlatformLayer(PlatformLayer*, ContentsLayerPurpose) override;
+    void setContentsToPlatformLayerHost(WebCore::LayerHostingContextIdentifier) override;
     void setContentsDisplayDelegate(RefPtr<WebCore::GraphicsLayerContentsDisplayDelegate>&&, ContentsLayerPurpose) override;
     bool shouldDirectlyCompositeImage(WebCore::Image*) const override { return false; }
     bool usesContentsLayer() const override;
@@ -126,6 +127,7 @@ private:
     Observer* m_observer;
     std::unique_ptr<WCTiledBacking> m_tiledBacking;
     PlatformLayer* m_platformLayer { nullptr };
+    Markable<WebCore::LayerHostingContextIdentifier> m_hostIdentifier;
     WebCore::Color m_solidColor;
     WebCore::Color m_debugBorderColor;
     OptionSet<WCLayerChange> m_uncommittedChanges;

--- a/Source/WebKit/WebProcess/WebPage/wc/WCUpdateInfo.serialization.in
+++ b/Source/WebKit/WebProcess/WebPage/wc/WCUpdateInfo.serialization.in
@@ -32,6 +32,7 @@ header: "WCUpdateInfo.h"
 }
 
 struct WebKit::WCUpdateInfo {
+    Markable<WebCore::LayerHostingContextIdentifier> remoteContextHostedIdentifier;
     WebCore::PlatformLayerIdentifier rootLayer;
     Vector<WebCore::PlatformLayerIdentifier> addedLayers;
     Vector<WebCore::PlatformLayerIdentifier> removedLayers;


### PR DESCRIPTION
#### dc5a423def84441a34100343e210d96406307e04
<pre>
GraphicsLayerWC: site isolation support
<a href="https://bugs.webkit.org/show_bug.cgi?id=254902">https://bugs.webkit.org/show_bug.cgi?id=254902</a>

Reviewed by Don Olmstead.

This is the initial support of site isolation for GraphicsLayerWC.
Cocoa port (aka RemoteLayerTree and GraphicsLayerCARemote) transfers a
layer tree to UI process, GraphicsLayerWC transfers a layer tree to
GPU process. GPU process renders a remote child frame into a texture,
and attach the texture into the content of iframe layer of the parent
frame&apos;s layer tree. Added WCRemoteFrameHostLayerManager class to
manage a HashMap from a LayerHostingContextIdentifier to a
BitmapTexture.

This has a problem now. Updating remote child frame&apos;s layer tree
doesn&apos;t trigger the parent frame&apos;s repaint. For the workaround, you
need to manually click a browser window of MiniBrowser to repaint.
Keep http/tests/site-isolation tests skipped for WinCairo.

MiniBrowser has to enable SiteIsolationEnabled option to test it by
using the internal settings menu item or adding the following code.
&gt; WKPreferencesSetBoolValueForKeyForTesting(preferences.get(), true, createWKString(&quot;SiteIsolationEnabled&quot;).get());

Fixed a bug of TextureMapperGL::endPainting. It should restore a
previous frame buffer that TextureMapperGL::beginPainting saved.
TextureMapperGL supports the offscreen rendering mode for
WebKitTestRunner pixel dump mode. It&apos;s not a problem for
WebKitTestRunner because it renders a layer tree always to a texture.
In site-isolation, however, remote frame&apos;s layer tree renders to a
texture and main frame layer tree to a frame buffer. After rendering
to a texture, it has to restore the previous frame buffer.

* Source/WebCore/platform/graphics/texmap/TextureMapperGL.cpp:
(WebCore::TextureMapperGL::endPainting): Restore the previous framebuffer.
* Source/WebKit/GPUProcess/GPUConnectionToWebProcess.cpp:
(WebKit::GPUConnectionToWebProcess::didClose):
* Source/WebKit/GPUProcess/graphics/wc/RemoteWCLayerTreeHost.cpp:
(WebKit::remoteGraphicsStreamWorkQueue):
* Source/WebKit/GPUProcess/graphics/wc/RemoteWCLayerTreeHost.h:
* Source/WebKit/GPUProcess/graphics/wc/WCRemoteFrameHostLayerManager.cpp: Added.
(WebKit::WCRemoteFrameHostLayerManager::singleton):
(WebKit::WCRemoteFrameHostLayerManager::acquireRemoteFrameHostLayer):
(WebKit::WCRemoteFrameHostLayerManager::releaseRemoteFrameHostLayer):
(WebKit::WCRemoteFrameHostLayerManager::updateTexture):
(WebKit::WCRemoteFrameHostLayerManager::removeAllLayersForProcess):
* Source/WebKit/GPUProcess/graphics/wc/WCRemoteFrameHostLayerManager.h: Added.
* Source/WebKit/GPUProcess/graphics/wc/WCScene.cpp:
(WebKit::WCScene::update):
* Source/WebKit/PlatformPlayStation.cmake:
* Source/WebKit/PlatformWin.cmake:
* Source/WebKit/WebProcess/WebPage/wc/DrawingAreaWC.cpp:
(WebKit::DrawingAreaWC::DrawingAreaWC):
(WebKit::DrawingAreaWC::updateRootLayers):
(WebKit::DrawingAreaWC::setRootCompositingLayer):
(WebKit::DrawingAreaWC::addRootFrame):
(WebKit::DrawingAreaWC::attachViewOverlayGraphicsLayer):
(WebKit::DrawingAreaWC::updatePreferences):
(WebKit::DrawingAreaWC::shouldUseTiledBackingForFrameView const):
(WebKit::DrawingAreaWC::updateGeometryWC):
(WebKit::DrawingAreaWC::isCompositingMode):
(WebKit::DrawingAreaWC::sendUpdateAC):
(WebKit::DrawingAreaWC::rootLayerInfoWithFrameIdentifier):
* Source/WebKit/WebProcess/WebPage/wc/DrawingAreaWC.h:
* Source/WebKit/WebProcess/WebPage/wc/GraphicsLayerWC.cpp:
(WebKit::GraphicsLayerWC::setContentsToPlatformLayerHost):
(WebKit::GraphicsLayerWC::flushCompositingStateForThisLayerOnly):
* Source/WebKit/WebProcess/WebPage/wc/GraphicsLayerWC.h:
* Source/WebKit/WebProcess/WebPage/wc/WCUpdateInfo.h:
(WebKit::WCLayerUpdateInfo::encode const):
(WebKit::WCLayerUpdateInfo::decode):
(WebKit::WCUpdateInfo::encode const):
(WebKit::WCUpdateInfo::decode):

Canonical link: <a href="https://commits.webkit.org/265099@main">https://commits.webkit.org/265099@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f90ac071f40c8e8491d58b554725329730e28328

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/9834 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/10082 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/10327 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/11486 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/32/builds/9558 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/9843 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/12066 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/10032 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/12491 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/9988 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/10792 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/8337 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/2/builds/11891 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/8099 "Passed tests") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/10/builds/8920 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/2/builds/11891 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/9197 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/9069 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/2/builds/11891 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/9569 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/7787 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/8735 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/12959 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/1114 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/9344 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->