### PR TITLE
REGRESSION (259904@main): Gmail App stutters / jitters when scrolling down in compose view

### DIFF
--- a/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
+++ b/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
@@ -3711,7 +3711,7 @@ LiveRangeSelectionEnabled:
     WebKitLegacy:
       default: true
     WebKit:
-      default: true
+      default: WebKit::defaultLiveRangeSelectionEnabled()
     WebCore:
       default: true
 

--- a/Source/WTF/wtf/cocoa/RuntimeApplicationChecksCocoa.h
+++ b/Source/WTF/wtf/cocoa/RuntimeApplicationChecksCocoa.h
@@ -107,6 +107,7 @@ enum class SDKAlignedBehavior {
     UsesGameControllerPhysicalInputProfile,
     ScreenOrientationAPIEnabled,
     PopoverAttributeEnabled,
+    LiveRangeSelectionEnabledForAllApps,
 
     NumberOfBehaviors
 };

--- a/Source/WebCore/platform/RuntimeApplicationChecks.h
+++ b/Source/WebCore/platform/RuntimeApplicationChecks.h
@@ -114,6 +114,7 @@ WEBCORE_EXPORT bool isFIFACompanion();
 WEBCORE_EXPORT bool isFeedly();
 WEBCORE_EXPORT bool isFirefox();
 WEBCORE_EXPORT bool isIMDb();
+WEBCORE_EXPORT bool isGmail();
 WEBCORE_EXPORT bool isJWLibrary();
 WEBCORE_EXPORT bool isLaBanquePostale();
 WEBCORE_EXPORT bool isLutron();

--- a/Source/WebCore/platform/cocoa/RuntimeApplicationChecksCocoa.mm
+++ b/Source/WebCore/platform/cocoa/RuntimeApplicationChecksCocoa.mm
@@ -227,6 +227,12 @@ bool IOSApplication::isIMDb()
     return isIMDb;
 }
 
+bool IOSApplication::isGmail()
+{
+    static bool isGmail = applicationBundleIsEqualTo("com.google.Gmail"_s);
+    return isGmail;
+}
+
 bool IOSApplication::isWebBookmarksD()
 {
     static bool isWebBookmarksD = applicationBundleIsEqualTo("com.apple.webbookmarksd"_s);

--- a/Source/WebKit/Shared/WebPreferencesDefaultValues.cpp
+++ b/Source/WebKit/Shared/WebPreferencesDefaultValues.cpp
@@ -217,6 +217,16 @@ bool defaultShouldDropSuspendedAssertionAfterDelay()
 #endif
 }
 
+bool defaultLiveRangeSelectionEnabled()
+{
+#if PLATFORM(IOS_FAMILY)
+    static bool enableForAllApps = linkedOnOrAfterSDKWithBehavior(SDKAlignedBehavior::LiveRangeSelectionEnabledForAllApps);
+    if (!enableForAllApps && WebCore::IOSApplication::isGmail())
+        return false;
+#endif
+    return true;
+}
+
 bool defaultShowModalDialogEnabled()
 {
 #if PLATFORM(COCOA)

--- a/Source/WebKit/Shared/WebPreferencesDefaultValues.h
+++ b/Source/WebKit/Shared/WebPreferencesDefaultValues.h
@@ -97,6 +97,7 @@ bool defaultGamepadVibrationActuatorEnabled();
 bool defaultRunningBoardThrottlingEnabled();
 bool defaultShouldDropSuspendedAssertionAfterDelay();
 bool defaultShowModalDialogEnabled();
+bool defaultLiveRangeSelectionEnabled();
 
 bool defaultShouldEnableScreenOrientationAPI();
 bool defaultPopoverAttributeEnabled();


### PR DESCRIPTION
#### 51677708a84b70ea867ffe8810705f094414620e
<pre>
REGRESSION (259904@main): Gmail App stutters / jitters when scrolling down in compose view
<a href="https://bugs.webkit.org/show_bug.cgi?id=255431">https://bugs.webkit.org/show_bug.cgi?id=255431</a>
rdar://106644805

Reviewed by Ryosuke Niwa.

In the iOS Gmail app when Live Range Selection is enabled by default, the web view used for compose
gets into a state where it constantly modifies the selection without any visual change. This is
because the page installs a `selectionchange` event listener on the document element; when fired,
this event listener creates a new `span` element whose text is a single zero-width joiner character,
and then inserts this node into the selection range via `getSelection().getRangeAt(0).insertNode()`.

When live range selection is enabled, this causes each `selectionchange` event to mutate the
selection, queueing a subsequent `selectionchange` event in the process. Since the event is
scheduled, this doesn&apos;t end up being an infinite loop; however, it does lead to various issues, such
as the fact that attempts to scroll the selection off-screen cause the scroll position to stutter as
we scroll to reveal the selection range that is being set every frame.

Fix this by adding a linked-on-or-after check for live range selection. For now, we additionally
limit this to Gmail (currently the only known third-party app to encounter this bincompat issue),
in hopes that we&apos;ll be able to remove legacy (non-live-range) code sooner, once the Gmail app adapts
to live ranges.

* Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml:
* Source/WTF/wtf/cocoa/RuntimeApplicationChecksCocoa.h:
* Source/WebCore/platform/RuntimeApplicationChecks.h:
* Source/WebCore/platform/cocoa/RuntimeApplicationChecksCocoa.mm:
(WebCore::IOSApplication::isGmail):

Add a new method to check for the Gmail app, so that we can disable Live Range Selection for only
Gmail (until they adjust their injected script to be compatible with our new behavior).

* Source/WebKit/Shared/WebPreferencesDefaultValues.cpp:
(WebKit::defaultLiveRangeSelectionEnabled):
* Source/WebKit/Shared/WebPreferencesDefaultValues.h:

Canonical link: <a href="https://commits.webkit.org/262960@main">https://commits.webkit.org/262960@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0072735bd7227f34fa905abf3b00df49919cc975

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/3132 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/3192 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/3302 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/4544 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/3492 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/3100 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/3253 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/3219 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/2722 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/3163 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/3484 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/2810 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/4349 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/982 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/2785 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/2629 "Passed tests") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/2580 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/2756 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/2836 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/4093 "Passed tests") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/2955 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/3207 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/2560 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/3199 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/2793 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/2787 "Passed tests") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/782 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/766 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/2784 "Built successfully") | | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/24/builds/3281 "Built successfully") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/3051 "Built successfully") | | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/3/builds/902 "Passed tests") | 
<!--EWS-Status-Bubble-End-->