### PR TITLE
GraphicsLayerWC leaks BitmapTexture in BitmapTexturePool

### DIFF
--- a/Source/WebCore/platform/graphics/texmap/BitmapTexturePool.h
+++ b/Source/WebCore/platform/graphics/texmap/BitmapTexturePool.h
@@ -44,6 +44,7 @@ public:
 #endif
 
     RefPtr<BitmapTexture> acquireTexture(const IntSize&, const BitmapTexture::Flags);
+    void releaseUnusedTexturesTimerFired();
 
 private:
     struct Entry {
@@ -59,7 +60,6 @@ private:
     };
 
     void scheduleReleaseUnusedTextures();
-    void releaseUnusedTexturesTimerFired();
     RefPtr<BitmapTexture> createTexture(const BitmapTexture::Flags);
 
 #if USE(TEXTURE_MAPPER_GL)

--- a/Source/WebCore/platform/graphics/texmap/TextureMapper.cpp
+++ b/Source/WebCore/platform/graphics/texmap/TextureMapper.cpp
@@ -38,6 +38,16 @@ RefPtr<BitmapTexture> TextureMapper::acquireTextureFromPool(const IntSize& size,
     return selectedTexture;
 }
 
+#if USE(GRAPHICS_LAYER_WC)
+void TextureMapper::releaseUnusedTexturesNow()
+{
+    // GraphicsLayerWC runs TextureMapper in the OpenGL thread of the
+    // GPU process that doesn't use RunLoop. RunLoop::Timer doesn't
+    // work in the thread.
+    m_texturePool->releaseUnusedTexturesTimerFired();
+}
+#endif
+
 std::unique_ptr<TextureMapper> TextureMapper::create()
 {
     return platformCreateAccelerated();

--- a/Source/WebCore/platform/graphics/texmap/TextureMapper.h
+++ b/Source/WebCore/platform/graphics/texmap/TextureMapper.h
@@ -92,6 +92,9 @@ public:
     virtual IntSize maxTextureSize() const = 0;
 
     virtual RefPtr<BitmapTexture> acquireTextureFromPool(const IntSize&, const BitmapTexture::Flags = BitmapTexture::SupportsAlpha);
+#if USE(GRAPHICS_LAYER_WC)
+    WEBCORE_EXPORT void releaseUnusedTexturesNow();
+#endif
 
     void setPatternTransform(const TransformationMatrix& p) { m_patternTransform = p; }
     void setWrapMode(WrapMode m) { m_wrapMode = m; }

--- a/Source/WebKit/GPUProcess/graphics/wc/WCScene.cpp
+++ b/Source/WebKit/GPUProcess/graphics/wc/WCScene.cpp
@@ -87,6 +87,7 @@ std::optional<UpdateInfo> WCScene::update(WCUpateInfo&& update)
 {
     if (!m_context->makeContextCurrent())
         return std::nullopt;
+    m_textureMapper->releaseUnusedTexturesNow();
 
     for (auto id : update.addedLayers) {
         auto layer = makeUnique<Layer>();


### PR DESCRIPTION
#### e9dc300e16eb7fc765368bd157a2eba4759a45d6
<pre>
GraphicsLayerWC leaks BitmapTexture in BitmapTexturePool
<a href="https://bugs.webkit.org/show_bug.cgi?id=255435">https://bugs.webkit.org/show_bug.cgi?id=255435</a>

Reviewed by Don Olmstead.

GraphicsLayerWC runs TextureMapper in the OpenGL thread of the GPU
process that doesn&apos;t use RunLoop. BitmapTexturePool leaks cached
textures because RunLoop::Timer doesn&apos;t work in the thread.

We should explicitly remove cached textures in the thread.

* Source/WebCore/platform/graphics/texmap/BitmapTexturePool.h:
* Source/WebCore/platform/graphics/texmap/TextureMapper.cpp:
(WebCore::TextureMapper::releaseUnusedTexturesNow):
* Source/WebCore/platform/graphics/texmap/TextureMapper.h:
* Source/WebKit/GPUProcess/graphics/wc/WCScene.cpp:
(WebKit::WCScene::update):

Canonical link: <a href="https://commits.webkit.org/262984@main">https://commits.webkit.org/262984@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b524b703f04f58e2d6bd937f664fc60c11d976f9

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/3136 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/3196 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/3306 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/4548 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/3496 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/3104 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/3257 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/3223 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/2726 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/3167 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/3487 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/2814 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/4354 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/985 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/2789 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/2632 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/2759 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/2840 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/4101 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/3211 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/2563 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/2797 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/2791 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/2788 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/373 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/3055 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->