### PR TITLE
Use document URL as source of ResizeObserver loop limit error

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/resize-observer/calculate-depth-for-node-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/resize-observer/calculate-depth-for-node-expected.txt
@@ -1,6 +1,6 @@
 CONSOLE MESSAGE: ResizeObserver loop completed with undelivered notifications.
 
-Harness Error (FAIL), message = Script error.
+Harness Error (FAIL), message = ResizeObserver loop completed with undelivered notifications.
 
 FAIL "Calculate depth for node" algorithm with Shadow DOM assert_false: expected false got true
 

--- a/Source/WebCore/dom/Document.cpp
+++ b/Source/WebCore/dom/Document.cpp
@@ -8547,11 +8547,7 @@ void Document::updateResizeObservations(Page& page)
 
     if (hasSkippedResizeObservations()) {
         setHasSkippedResizeObservations(false);
-        String url;
-        unsigned line = 0;
-        unsigned column = 0;
-        getParserLocation(url, line, column);
-        reportException("ResizeObserver loop completed with undelivered notifications."_s, line, column, url, nullptr, nullptr);
+        reportException("ResizeObserver loop completed with undelivered notifications."_s, 0, 0, url().string(), nullptr, nullptr);
         // Starting a new schedule the next round of notify.
         scheduleRenderingUpdate(RenderingUpdateStep::ResizeObservations);
     }


### PR DESCRIPTION
#### 7b6d036d50a030bf898eedbe36ad583a50cb2b7f
<pre>
Use document URL as source of ResizeObserver loop limit error
<a href="https://bugs.webkit.org/show_bug.cgi?id=255439">https://bugs.webkit.org/show_bug.cgi?id=255439</a>
rdar://107905388

Reviewed by Simon Fraser.

In Document::updateResizeObservations we throw an error if we exceed
some limit for the number of times we loop processing ResizeObserver
notifications. This uses getParserLocation to get the location to use in
the error, which returns the empty string if parsing the document has
finished. But when we pass in the empty string to reportException, we
end up censoring the error message as &quot;Script error.&quot; because we think
the error came from a different origin, and the &quot;ResizeObserver loop
completed with undelivered notifications.&quot; message gets lost.

We can use the document URL here instead. There&apos;s no clear more specific
location to use, since when this error is thrown there is no JS on the
stack (updateResizeObservations is one of the rendering update steps),
and no specific ResizeObserver is necessarily the one that caused the
limit to be exceeded.

* LayoutTests/imported/w3c/web-platform-tests/resize-observer/calculate-depth-for-node-expected.txt:
* Source/WebCore/dom/Document.cpp:
(WebCore::Document::updateResizeObservations):

Canonical link: <a href="https://commits.webkit.org/262989@main">https://commits.webkit.org/262989@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9a4d0e57f8ed6f6d0a2bbf1030ea891069eb1cb6

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/3150 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/3210 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/3320 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/4562 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/3508 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/3117 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/3271 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/3237 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/2739 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/3181 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/3498 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/2827 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/4368 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/996 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/2802 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/2642 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/2774 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/2853 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/4111 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/3225 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/2573 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/2810 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/2804 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/2802 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/376 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/3069 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->