### PR TITLE
Respond to feedback after 262943@main

### DIFF
--- a/Source/WebKit/UIProcess/ProvisionalFrameProxy.cpp
+++ b/Source/WebKit/UIProcess/ProvisionalFrameProxy.cpp
@@ -49,7 +49,7 @@
 
 namespace WebKit {
 
-ProvisionalFrameProxy::ProvisionalFrameProxy(WebFrameProxy& frame, Ref<WebProcessProxy>&& process, const WebCore::ResourceRequest& request, bool newProcess)
+ProvisionalFrameProxy::ProvisionalFrameProxy(WebFrameProxy& frame, Ref<WebProcessProxy>&& process, const WebCore::ResourceRequest& request, bool didCreateNewProcess)
     : m_frame(frame)
     , m_process(WTFMove(process))
     , m_visitedLinkStore(frame.page()->visitedLinkStore())
@@ -66,7 +66,7 @@ ProvisionalFrameProxy::ProvisionalFrameProxy(WebFrameProxy& frame, Ref<WebProces
     auto* drawingArea = page.drawingArea();
     ASSERT(drawingArea);
 
-    if (newProcess) {
+    if (didCreateNewProcess) {
         auto parameters = page.creationParameters(m_process, *drawingArea);
         parameters.subframeProcessFrameTreeInitializationParameters = { {
             frame.frameID(),
@@ -87,7 +87,7 @@ ProvisionalFrameProxy::ProvisionalFrameProxy(WebFrameProxy& frame, Ref<WebProces
     // FIXME: Add more parameters as appropriate.
     // FIXME: This gives too much cookie access. This should be removed after putting the entire frame tree in all web processes.
     auto giveAllCookieAccess = LoadedWebArchive::Yes;
-    if (newProcess) {
+    if (didCreateNewProcess) {
         page.websiteDataStore().networkProcess().sendWithAsyncReply(Messages::NetworkProcess::AddAllowedFirstPartyForCookies(m_process->coreProcessIdentifier(), WebCore::RegistrableDomain(request.url()), giveAllCookieAccess), [process = m_process, loadParameters = WTFMove(loadParameters), pageID = m_pageID] () mutable {
             // FIXME: Do we need a LoadRequestWaitingForProcessLaunch version?
             process->send(Messages::WebPage::LoadRequest(loadParameters), pageID);

--- a/Source/WebKit/UIProcess/ProvisionalFrameProxy.h
+++ b/Source/WebKit/UIProcess/ProvisionalFrameProxy.h
@@ -52,7 +52,7 @@ struct FrameInfoData;
 class ProvisionalFrameProxy : public IPC::MessageReceiver, public IPC::MessageSender {
     WTF_MAKE_FAST_ALLOCATED;
 public:
-    ProvisionalFrameProxy(WebFrameProxy&, Ref<WebProcessProxy>&&, const WebCore::ResourceRequest&, bool);
+    ProvisionalFrameProxy(WebFrameProxy&, Ref<WebProcessProxy>&&, const WebCore::ResourceRequest&, bool shouldUseNewProcess);
     ~ProvisionalFrameProxy();
 
     WebProcessProxy& process() { return m_process.get(); }

--- a/Source/WebKit/UIProcess/SubframePageProxy.h
+++ b/Source/WebKit/UIProcess/SubframePageProxy.h
@@ -60,7 +60,9 @@ private:
     WebCore::PageIdentifier m_webPageID;
     Ref<WebProcessProxy> m_process;
     WeakPtr<WebPageProxy> m_page;
-    bool m_isInSameProcessAsMainFrame { false };
+
+    // FIXME: We shouldn't make a SubframePageProxy for frames in the same process as the main frame.
+    const bool m_isInSameProcessAsMainFrame { false };
 };
 
 }

--- a/Source/WebKit/UIProcess/WebPageProxy.h
+++ b/Source/WebKit/UIProcess/WebPageProxy.h
@@ -28,7 +28,6 @@
 #include "APIObject.h"
 #include "MessageReceiver.h"
 #include "MessageSender.h"
-#include <WebCore/RegistrableDomain.h>
 #include <wtf/ProcessID.h>
 #include <wtf/UniqueRef.h>
 
@@ -2140,8 +2139,7 @@ public:
     WKQuickLookPreviewController *quickLookPreviewController() const { return m_quickLookPreviewController.get(); }
 #endif
 
-    WebCore::RegistrableDomain registrableDomainForSubframeID(WebCore::FrameIdentifier identifier) const { return m_registrableDomainForSubframeID.get(identifier); }
-    SubframePageProxy* subpageFrameProxyForRegistrableDomain(WebCore::RegistrableDomain domain) const { return m_subframePageProxyForDomain.get(domain); }
+    SubframePageProxy* subpageFrameProxyForRegistrableDomain(WebCore::RegistrableDomain) const;
     SubframePageProxy* subframePageProxyForFrameID(WebCore::FrameIdentifier) const;
 
     void requestImageBitmap(const WebCore::ElementContext&, CompletionHandler<void(const ShareableBitmapHandle&, const String& sourceMIMEType)>&&);
@@ -3238,9 +3236,6 @@ private:
 #endif
 
     RefPtr<WebPageProxy> m_pageToCloneSessionStorageFrom;
-
-    HashMap<WebCore::RegistrableDomain, UniqueRef<SubframePageProxy>>  m_subframePageProxyForDomain;
-    HashMap<WebCore::FrameIdentifier, WebCore::RegistrableDomain>  m_registrableDomainForSubframeID;
 };
 
 } // namespace WebKit

--- a/Source/WebKit/UIProcess/WebPageProxyInternals.h
+++ b/Source/WebKit/UIProcess/WebPageProxyInternals.h
@@ -41,6 +41,7 @@
 #include "WebURLSchemeHandlerIdentifier.h"
 #include "WindowKind.h"
 #include <WebCore/PrivateClickMeasurement.h>
+#include <WebCore/RegistrableDomain.h>
 #include <WebCore/ResourceRequest.h>
 #include <pal/HysteresisActivity.h>
 
@@ -211,6 +212,9 @@ struct WebPageProxy::Internals final : WebPopupMenuProxy::Client
     WebCore::IntRect visibleScrollerThumbRect;
     WebCore::PageIdentifier webPageID;
     WindowKind windowKind { WindowKind::Unparented };
+
+    HashMap<WebCore::RegistrableDomain, UniqueRef<SubframePageProxy>> domainToSubframePageProxyMap;
+    HashMap<WebCore::FrameIdentifier, WebCore::RegistrableDomain> frameIdentifierToDomainMap;
 
 #if ENABLE(APPLE_PAY)
     std::unique_ptr<WebPaymentCoordinatorProxy> paymentCoordinator;

--- a/Source/WebKit/UIProcess/WebProcessPool.h
+++ b/Source/WebKit/UIProcess/WebProcessPool.h
@@ -450,10 +450,7 @@ public:
     bool hasForegroundWebProcesses() const { return m_foregroundWebProcessCounter.value(); }
     bool hasBackgroundWebProcesses() const { return m_backgroundWebProcessCounter.value(); }
 
-    enum class DidCreateNewProcess : bool {
-        No,
-        Yes,
-    };
+    enum class DidCreateNewProcess : bool { No, Yes };
     void processForNavigation(WebPageProxy&, WebFrameProxy&, const API::Navigation&, Ref<WebProcessProxy>&& sourceProcess, const URL& sourceURL, ProcessSwapRequestedByClient, WebProcessProxy::LockdownMode, const FrameInfoData&, Ref<WebsiteDataStore>&&, CompletionHandler<void(Ref<WebProcessProxy>&&, SuspendedPageProxy*, ASCIILiteral, DidCreateNewProcess)>&&);
 
     void didReachGoodTimeToPrewarm();

--- a/Source/WebKit/WebProcess/WebPage/WebFrame.cpp
+++ b/Source/WebKit/WebProcess/WebPage/WebFrame.cpp
@@ -155,6 +155,9 @@ Ref<WebFrame> WebFrame::createLocalSubframeHostedInAnotherProcess(WebPage& page,
     auto frame = create(page);
     RELEASE_ASSERT(page.corePage());
     RELEASE_ASSERT(parent.coreAbstractFrame());
+
+    // FIXME: we should always have an invalidator, and we should unconditionally handle message receiver
+    // addition in the constructor and removal in the destructor.
     if (invalidator)
         WebProcess::singleton().removeMessageReceiver(Messages::WebFrame::messageReceiverName(), frameID.object());
     auto coreFrame = LocalFrame::createSubframeHostedInAnotherProcess(*page.corePage(), makeUniqueRef<WebFrameLoaderClient>(frame.get(), WTFMove(invalidator)), frameID, *parent.coreAbstractFrame());

--- a/Source/WebKit/WebProcess/WebPage/WebPage.cpp
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.cpp
@@ -1788,7 +1788,7 @@ void WebPage::loadRequestByCreatingNewLocalFrameOrConvertingRemoteFrame(LocalFra
         return;
     }
 
-    // If there is an existing RemoteFrame, let's remove it and later convert it to a LocalFrame
+    // If there is an existing RemoteFrame, let's remove it and later convert it to a LocalFrame.
     RefPtr<WebFrame> parentWebFrame;
     RefPtr<WebCore::RemoteFrame> coreRemoteFrame;
     std::optional<ScopeExit<Function<void()>>> invalidator;


### PR DESCRIPTION
#### 3ea88cae0eed9608777523ae826204f0ba7e2422
<pre>
Respond to feedback after 262943@main
<a href="https://bugs.webkit.org/show_bug.cgi?id=255437">https://bugs.webkit.org/show_bug.cgi?id=255437</a>
rdar://108032616

Reviewed by Chris Dumez.

Chris gave some excellent feedback.  This takes it into account to polish the code a little more.
I also move the maps to WebPageProxy::Internals so we don&apos;t have to include an extra header from
WebPageProxy.h.

* Source/WebKit/UIProcess/ProvisionalFrameProxy.cpp:
(WebKit::ProvisionalFrameProxy::ProvisionalFrameProxy):
* Source/WebKit/UIProcess/ProvisionalFrameProxy.h:
* Source/WebKit/UIProcess/SubframePageProxy.h:
* Source/WebKit/UIProcess/WebPageProxy.cpp:
(WebKit::WebPageProxy::subframePageProxyForFrameID const):
(WebKit::WebPageProxy::addSubframePageProxyForFrameID):
(WebKit::WebPageProxy::registrableDomainForSubframeID const):
(WebKit::WebPageProxy::subpageFrameProxyForRegistrableDomain const):
* Source/WebKit/UIProcess/WebPageProxy.h:
* Source/WebKit/UIProcess/WebPageProxyInternals.h:
* Source/WebKit/UIProcess/WebProcessPool.h:
* Source/WebKit/WebProcess/WebPage/WebPage.cpp:
(WebKit::WebPage::loadRequestByCreatingNewLocalFrameOrConvertingRemoteFrame):

Canonical link: <a href="https://commits.webkit.org/262973@main">https://commits.webkit.org/262973@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/02c85eb6300a15fd16456228379456e90fd5872f

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/3170 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/3231 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/3341 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/4583 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/3528 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/3302 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/3258 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/2758 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/3201 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/15/builds/3526 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/2849 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/4398 "Built successfully") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/39/builds/1025 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/2822 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/2670 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/2804 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/2873 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/4147 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/3246 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/2592 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/2830 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/2824 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/2823 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/371 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/3089 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->