### PR TITLE
Avoid unnecessary copy of CSSSelectorList with non nested style rule

### DIFF
--- a/Source/WebCore/dom/SelectorQuery.cpp
+++ b/Source/WebCore/dom/SelectorQuery.cpp
@@ -609,10 +609,10 @@ SelectorQuery* SelectorQueryCache::add(const String& selectors, const Document& 
         if (selectorList->selectorsNeedNamespaceResolution())
             return nullptr;
 
-        // FIXME: Remove this fixup step or at least make it not make a copy in the common case.
-        auto resolvedSelectorList = CSSSelectorParser::resolveNestingParent(*selectorList, nullptr);
+        if (selectorList->hasExplicitNestingParent())
+            selectorList = CSSSelectorParser::resolveNestingParent(WTFMove(*selectorList), nullptr);
 
-        return makeUnique<SelectorQuery>(WTFMove(resolvedSelectorList));
+        return makeUnique<SelectorQuery>(WTFMove(*selectorList));
     }).iterator->value.get();
 }
 

--- a/Source/WebCore/style/RuleSetBuilder.cpp
+++ b/Source/WebCore/style/RuleSetBuilder.cpp
@@ -220,6 +220,11 @@ void RuleSetBuilder::resolveSelectorListWithNesting(StyleRuleWithNesting& rule)
     const CSSSelectorList* parentResolvedSelectorList = nullptr;
     if (m_styleRuleStack.size()) 
         parentResolvedSelectorList =  m_styleRuleStack.last();
+
+    // If it's a top-level rule wihout a nesting parent selector, keep the selector list as is.
+    if (!rule.selectorList().hasExplicitNestingParent() && !parentResolvedSelectorList)
+        return;
+
     auto resolvedSelectorList = CSSSelectorParser::resolveNestingParent(rule.selectorList(), parentResolvedSelectorList);
     ASSERT(!resolvedSelectorList.hasExplicitNestingParent());
     rule.wrapperAdoptSelectorList(WTFMove(resolvedSelectorList));    


### PR DESCRIPTION
#### 547e70e42ef9715daf53fc649da6899a1f0096ad
<pre>
Avoid unnecessary copy of CSSSelectorList with non nested style rule
<a href="https://bugs.webkit.org/show_bug.cgi?id=255443">https://bugs.webkit.org/show_bug.cgi?id=255443</a>
rdar://108037598

Reviewed by Antti Koivisto.

resolveNestingParent() creates a copy of the selector list
and resolves it.
We should avoid calling it altogether when it&apos;s unnecessary
(top level and no &amp; selector).

* Source/WebCore/dom/SelectorQuery.cpp:
(WebCore::SelectorQueryCache::add):
* Source/WebCore/style/RuleSetBuilder.cpp:
(WebCore::Style::RuleSetBuilder::resolveSelectorListWithNesting):

Canonical link: <a href="https://commits.webkit.org/262953@main">https://commits.webkit.org/262953@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/de247cfb809f64c389893c329ba860215c5b8ea8

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/3156 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/3217 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/3327 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/4569 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/3514 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/3124 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/3278 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/3244 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/2745 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/3187 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/3501 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/2832 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/4375 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/999 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/2806 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/2647 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/2778 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/2857 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/4117 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/3232 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/2577 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/2816 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/2808 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/764 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/2809 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/3075 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->