### PR TITLE
Fix setSelectorText() to overwrite both selector and original selector

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-nesting/cssom-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-nesting/cssom-expected.txt
@@ -8,6 +8,7 @@ PASS Simple CSSOM manipulation of subrules 5
 PASS Simple CSSOM manipulation of subrules 6
 FAIL Simple CSSOM manipulation of subrules 7 assert_equals: @supports is added expected ".a {\n  color: red;\n  & .b { color: green; }\n  @supports selector(&) {\n  & div { font-size: 10px; }\n}\n  & .c { color: blue; }\n}" but got ".a {\n  color: red;\n  & .b { color: green; }\n  @supports selector(&) {\n}\n  & .c { color: blue; }\n}"
 FAIL Simple CSSOM manipulation of subrules 8 assert_equals: color is changed, new rule is ignored expected ".a {\n  color: olivedrab;\n  & .b { color: green; }\n  & .c { color: blue; }\n}" but got ".a {\n  color: olivedrab;\n  & .b { color: green; }\n  @supports selector(&) {\n}\n  & .c { color: blue; }\n}"
-FAIL Simple CSSOM manipulation of subrules 9 assert_equals: one rule is kept unchanged, the other is changed expected ".a {\n  color: red;\n  & .b { color: green; }\n  .c div.b &, div & { color: blue; }\n}" but got ".a {\n  color: olivedrab;\n  & .b { color: green; }\n  @supports selector(&) {\n}\n  & .c { color: blue; }\n}"
-FAIL Simple CSSOM manipulation of subrules 10 assert_equals: invalid rule containing ampersand is kept in serialization expected ".a {\n  :is(!& .foo, .b) { color: green; }\n}" but got ".a {\n  :is(.b) { color: green; }\n}"
+PASS Simple CSSOM manipulation of subrules 9
+PASS Simple CSSOM manipulation of subrules 10
+FAIL Simple CSSOM manipulation of subrules 11 assert_equals: invalid rule containing ampersand is kept in serialization expected ".a {\n  :is(!& .foo, .b) { color: green; }\n}" but got ".a {\n  :is(.b) { color: green; }\n}"
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-nesting/cssom.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-nesting/cssom.html
@@ -125,6 +125,17 @@
 }`, 'color is changed, new rule is ignored');
   });
 
+  test(() => {
+    const text = '.a { .b { color:black; } }';
+    document.getElementById('ss').innerHTML = text;
+    let [ss] = document.styleSheets;
+    ss.cssRules[0].cssRules[0].selectorText = '.c';
+    assert_equals(ss.cssRules[0].cssText,
+`.a {
+  .c { color: black; }
+}`, 'selector text is changed');
+  });
+
   // We cannot insert anything starting with an tag, as that would cause
   // the serialized rule not to parse back. Compounds starting with a tag
   // that are _not_ the first compound in a complex selector are OK, though,

--- a/Source/WebCore/css/CSSStyleRule.cpp
+++ b/Source/WebCore/css/CSSStyleRule.cpp
@@ -124,7 +124,10 @@ void CSSStyleRule::setSelectorText(const String& selectorText)
 
     CSSStyleSheet::RuleMutationScope mutationScope(this);
 
-    m_styleRule->wrapperAdoptSelectorList(WTFMove(*selectorList));
+    if (m_styleRule->isStyleRuleWithNesting())
+        downcast<StyleRuleWithNesting>(m_styleRule).wrapperAdoptOriginalSelectorList(WTFMove(*selectorList));
+    else
+        m_styleRule->wrapperAdoptSelectorList(WTFMove(*selectorList));
 
     if (hasCachedSelectorText()) {
         selectorTextCache().remove(this);

--- a/Source/WebCore/css/StyleRule.h
+++ b/Source/WebCore/css/StyleRule.h
@@ -165,6 +165,7 @@ public:
     const Vector<Ref<StyleRuleBase>>& nestedRules() const { return m_nestedRules; }
     Vector<Ref<StyleRuleBase>>& nestedRules() { return m_nestedRules; }
     const CSSSelectorList& originalSelectorList() const { return m_originalSelectorList; }
+    void wrapperAdoptOriginalSelectorList(CSSSelectorList&&);
 
 protected:
     StyleRuleWithNesting(const StyleRuleWithNesting&);
@@ -428,6 +429,12 @@ inline void StyleRule::wrapperAdoptSelectorList(CSSSelectorList&& selectors)
 #if ENABLE(CSS_SELECTOR_JIT)
     m_compiledSelectors = nullptr;
 #endif
+}
+
+inline void StyleRuleWithNesting::wrapperAdoptOriginalSelectorList(CSSSelectorList&& selectors)
+{
+    m_originalSelectorList = CSSSelectorList { selectors };
+    StyleRule::wrapperAdoptSelectorList(WTFMove(selectors));
 }
 
 #if ENABLE(CSS_SELECTOR_JIT)


### PR DESCRIPTION
#### fdf42acd549d2f4bef233f855cc9f2c0af9d0a6a
<pre>
Fix setSelectorText() to overwrite both selector and original selector
<a href="https://bugs.webkit.org/show_bug.cgi?id=255446">https://bugs.webkit.org/show_bug.cgi?id=255446</a>
rdar://108041191

Reviewed by Antti Koivisto.

Before this patch, only the StyleRule selector was overwritten:
selector matching was correct but CSSOM cssText() displayed the wrong selector.

* LayoutTests/imported/w3c/web-platform-tests/css/css-nesting/cssom-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-nesting/cssom.html:
* Source/WebCore/css/CSSStyleRule.cpp:
(WebCore::CSSStyleRule::setSelectorText):
* Source/WebCore/css/StyleRule.h:
(WebCore::StyleRuleWithNesting::wrapperAdoptOriginalSelectorList):

Canonical link: <a href="https://commits.webkit.org/262961@main">https://commits.webkit.org/262961@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/52fc84eb4f331e6855107a0f5d5e38858b7b65e3

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/3162 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/3223 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/3333 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/4575 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/3520 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/3130 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/3284 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/3250 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/2751 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/3193 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/3509 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/2841 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/4382 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/1007 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/2815 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/2655 "1 flakes 178 failures") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/2786 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/2866 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/4130 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/3238 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/2583 "3 failures") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/2822 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/2817 "Passed tests") | | 
| [  ~~🛠 🧪 merge~~](https://ews-build.webkit.org/#/builders/19/builds/769 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/2815 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/3081 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->