### PR TITLE
Do not take into account device orientation for cameras whose position is unspecified

### DIFF
--- a/LayoutTests/fast/mediastream/camera-unknown-facing-mode-expected.txt
+++ b/LayoutTests/fast/mediastream/camera-unknown-facing-mode-expected.txt
@@ -1,0 +1,5 @@
+
+
+PASS Width and height before and after rotation with default device
+PASS Width and height before and after rotation with new device
+

--- a/LayoutTests/fast/mediastream/camera-unknown-facing-mode.html
+++ b/LayoutTests/fast/mediastream/camera-unknown-facing-mode.html
@@ -1,0 +1,79 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="utf-8">
+    <script src="../../resources/testharness.js"></script>
+    <script src="../../resources/testharnessreport.js"></script>
+</head>
+<body>
+    <video id="video"></video>
+    <script>
+    let setup = async (test) => {
+        if (!window.testRunner)
+            return Promise.reject("test requires internal API");
+
+        test.add_cleanup(() => {
+            testRunner.resetMockMediaDevices();
+            testRunner.setMockCameraOrientation(0);
+        });
+    }
+
+    async function getSettingsBeforeAndAfterRotation(deviceId)
+    {
+        testRunner.setMockCameraOrientation(0);
+
+        const stream = await navigator.mediaDevices.getUserMedia({ video: { deviceId } });
+        video.srcObject = stream;
+        await video.play();
+
+        const track = stream.getVideoTracks()[0];
+        const initialSettings = track.getSettings();
+
+        video.srcObject = null;
+
+        testRunner.setMockCameraOrientation(90);
+        await new Promise(resolve => setTimeout(resolve, 100));
+
+        video.srcObject = stream;
+        await video.play();
+
+        return [initialSettings, track.getSettings()];
+    }
+
+     promise_test(async (test) => {
+         await setup(test);
+ 
+         const results = await getSettingsBeforeAndAfterRotation("default");
+ 
+         assert_equals(results[0].facingMode, "user");
+         assert_equals(results[0].width, 640, "initial width");
+         assert_equals(results[0].height, 480, "initial height");
+         assert_equals(results[1].width, 480, "final width");
+         assert_equals(results[1].height, 640, "final height");
+     }, "Width and height before and after rotation with default device");
+
+    promise_test(async (test) => {
+        await setup(test);
+
+        testRunner.addMockCameraDevice("myCamera", "my new camera", { facingMode: "unknown", fillColor: "green" });
+        const stream = await navigator.mediaDevices.getUserMedia({ video: true });
+
+        const devices = await navigator.mediaDevices.enumerateDevices();
+        let deviceId = "";
+        devices.forEach(device => {
+            if (device.label == "my new camera")
+                deviceId = device.deviceId;
+        });
+        stream.getVideoTracks()[0].stop();
+
+        const results = await getSettingsBeforeAndAfterRotation(deviceId);
+
+         assert_equals(results[0].facingMode, undefined);
+        assert_equals(results[0].width, 640, "initial width");
+        assert_equals(results[0].height, 480, "initial height");
+        assert_equals(results[1].width, 640, "final width");
+        assert_equals(results[1].height, 480, "final height");
+    }, "Width and height before and after rotation with new device");
+    </script>
+</body>
+</html>

--- a/Source/WebCore/platform/mediastream/mac/AVVideoCaptureSource.mm
+++ b/Source/WebCore/platform/mediastream/mac/AVVideoCaptureSource.mm
@@ -615,6 +615,9 @@ void AVVideoCaptureSource::shutdownCaptureSession()
 void AVVideoCaptureSource::monitorOrientation(OrientationNotifier& notifier)
 {
 #if PLATFORM(IOS_FAMILY)
+    if ([device() deviceType] == AVCaptureDeviceTypeExternalUnknown)
+        return;
+
     notifier.addObserver(*this);
     orientationChanged(notifier.orientation());
 #else

--- a/Source/WebCore/platform/mock/MockRealtimeVideoSource.cpp
+++ b/Source/WebCore/platform/mock/MockRealtimeVideoSource.cpp
@@ -143,7 +143,8 @@ const RealtimeMediaSourceCapabilities& MockRealtimeVideoSource::capabilities()
 
         if (mockCamera()) {
             auto facingMode = std::get<MockCameraProperties>(m_device.properties).facingMode;
-            capabilities.addFacingMode(facingMode);
+            if (facingMode != VideoFacingMode::Unknown)
+                capabilities.addFacingMode(facingMode);
             capabilities.setDeviceId(hashedId());
             updateCapabilities(capabilities);
 
@@ -208,7 +209,8 @@ const RealtimeMediaSourceSettings& MockRealtimeVideoSource::settings()
     supportedConstraints.setSupportsAspectRatio(true);
     supportedConstraints.setSupportsDeviceId(true);
     if (mockCamera()) {
-        supportedConstraints.setSupportsFacingMode(true);
+        if (facingMode() != VideoFacingMode::Unknown)
+            supportedConstraints.setSupportsFacingMode(true);
         if (isZoomSupported(presets())) {
             supportedConstraints.setSupportsZoom(true);
             settings.setZoom(zoom());
@@ -538,7 +540,7 @@ void MockRealtimeVideoSource::orientationChanged(IntDegrees orientation)
 
 void MockRealtimeVideoSource::monitorOrientation(OrientationNotifier& notifier)
 {
-    if (!mockCamera())
+    if (!mockCamera() || std::get<MockCameraProperties>(m_device.properties).facingMode == VideoFacingMode::Unknown)
         return;
 
     notifier.addObserver(*this);

--- a/Source/WebKit/UIProcess/API/C/WKMockMediaDevice.h
+++ b/Source/WebKit/UIProcess/API/C/WKMockMediaDevice.h
@@ -32,7 +32,7 @@
 extern "C" {
 #endif
 
-WK_EXPORT void WKAddMockMediaDevice(WKContextRef, WKStringRef persistentId, WKStringRef label, WKStringRef type);
+WK_EXPORT void WKAddMockMediaDevice(WKContextRef, WKStringRef persistentId, WKStringRef label, WKStringRef type, WKDictionaryRef properties);
 WK_EXPORT void WKClearMockMediaDevices(WKContextRef);
 WK_EXPORT void WKRemoveMockMediaDevice(WKContextRef, WKStringRef persistentId);
 WK_EXPORT void WKResetMockMediaDevices(WKContextRef);

--- a/Tools/WebKitTestRunner/InjectedBundle/Bindings/TestRunner.idl
+++ b/Tools/WebKitTestRunner/InjectedBundle/Bindings/TestRunner.idl
@@ -399,7 +399,7 @@ interface TestRunner {
 
     undefined installFakeHelvetica(DOMString configuration);
 
-    undefined addMockCameraDevice(DOMString persistentId, DOMString label);
+    undefined addMockCameraDevice(DOMString persistentId, DOMString label, object properties);
     undefined addMockMicrophoneDevice(DOMString persistentId, DOMString label);
     undefined addMockScreenDevice(DOMString persistentId, DOMString label);
     undefined clearMockMediaDevices();

--- a/Tools/WebKitTestRunner/InjectedBundle/TestRunner.cpp
+++ b/Tools/WebKitTestRunner/InjectedBundle/TestRunner.cpp
@@ -1865,28 +1865,55 @@ void TestRunner::callDidReceiveLoadedSubresourceDomainsCallback(Vector<String>&&
     callTestRunnerCallback(LoadedSubresourceDomainsCallbackID, 1, &result);
 }
 
-void TestRunner::addMockMediaDevice(JSStringRef persistentId, JSStringRef label, const char* type)
+void TestRunner::addMockMediaDevice(JSStringRef persistentId, JSStringRef label, const char* type, WKDictionaryRef properties)
 {
     postSynchronousMessage("AddMockMediaDevice", createWKDictionary({
         { "PersistentID", toWK(persistentId) },
         { "Label", toWK(label) },
         { "Type", toWK(type) },
+        { "Properties", properties },
     }));
 }
 
-void TestRunner::addMockCameraDevice(JSStringRef persistentId, JSStringRef label)
+void TestRunner::addMockCameraDevice(JSStringRef persistentId, JSStringRef label, JSValueRef properties)
 {
-    addMockMediaDevice(persistentId, label, "camera");
+    auto context = mainFrameJSContext();
+
+    Vector<WKRetainPtr<WKStringRef>> strings;
+    Vector<WKStringRef> keys;
+    Vector<WKTypeRef> values;
+
+    if (auto object = JSValueToObject(context, properties, nullptr)) {
+        JSPropertyNameArrayRef propertyNameArray = JSObjectCopyPropertyNames(context, object);
+        size_t length = JSPropertyNameArrayGetCount(propertyNameArray);
+
+        for (size_t i = 0; i < length; ++i) {
+            JSStringRef jsPropertyName = JSPropertyNameArrayGetNameAtIndex(propertyNameArray, i);
+            auto jsPropertyValue = JSObjectGetProperty(context, object, jsPropertyName, 0);
+            
+            auto propertyName = toWK(jsPropertyName);
+            auto propertyValue = toWKString(context, jsPropertyValue);
+            
+            keys.append(propertyName.get());
+            values.append(propertyValue.get());
+            strings.append(WTFMove(propertyName));
+            strings.append(WTFMove(propertyValue));
+        }
+        JSPropertyNameArrayRelease(propertyNameArray);
+    }
+
+    auto wkProperties = adoptWK(WKDictionaryCreate(keys.data(), values.data(), keys.size()));
+    addMockMediaDevice(persistentId, label, "camera", wkProperties.get());
 }
 
 void TestRunner::addMockMicrophoneDevice(JSStringRef persistentId, JSStringRef label)
 {
-    addMockMediaDevice(persistentId, label, "microphone");
+    addMockMediaDevice(persistentId, label, "microphone", nullptr);
 }
 
 void TestRunner::addMockScreenDevice(JSStringRef persistentId, JSStringRef label)
 {
-    addMockMediaDevice(persistentId, label, "screen");
+    addMockMediaDevice(persistentId, label, "screen", nullptr);
 }
 
 void TestRunner::clearMockMediaDevices()

--- a/Tools/WebKitTestRunner/InjectedBundle/TestRunner.h
+++ b/Tools/WebKitTestRunner/InjectedBundle/TestRunner.h
@@ -506,7 +506,7 @@ public:
     void dumpAllHTTPRedirectedResponseHeaders() { m_dumpAllHTTPRedirectedResponseHeaders = true; }
     bool shouldDumpAllHTTPRedirectedResponseHeaders() const { return m_dumpAllHTTPRedirectedResponseHeaders; }
 
-    void addMockCameraDevice(JSStringRef persistentId, JSStringRef label);
+    void addMockCameraDevice(JSStringRef persistentId, JSStringRef label, JSValueRef properties);
     void addMockMicrophoneDevice(JSStringRef persistentId, JSStringRef label);
     void addMockScreenDevice(JSStringRef persistentId, JSStringRef label);
     void clearMockMediaDevices();
@@ -578,7 +578,7 @@ private:
     void setDumpPixels(bool);
     void setWaitUntilDone(bool);
 
-    void addMockMediaDevice(JSStringRef persistentId, JSStringRef label, const char* type);
+    void addMockMediaDevice(JSStringRef persistentId, JSStringRef label, const char* type, WKDictionaryRef);
 
     WKRetainPtr<WKURLRef> m_testURL; // Set by InjectedBundlePage once provisional load starts.
 

--- a/Tools/WebKitTestRunner/TestController.cpp
+++ b/Tools/WebKitTestRunner/TestController.cpp
@@ -3920,9 +3920,9 @@ void TestController::removeAllCookies()
     m_currentInvocation->didRemoveAllCookies();
 }
 
-void TestController::addMockMediaDevice(WKStringRef persistentID, WKStringRef label, WKStringRef type)
+void TestController::addMockMediaDevice(WKStringRef persistentID, WKStringRef label, WKStringRef type, WKDictionaryRef properties)
 {
-    WKAddMockMediaDevice(platformContext(), persistentID, label, type);
+    WKAddMockMediaDevice(platformContext(), persistentID, label, type, properties);
 }
 
 void TestController::clearMockMediaDevices()

--- a/Tools/WebKitTestRunner/TestController.h
+++ b/Tools/WebKitTestRunner/TestController.h
@@ -323,7 +323,7 @@ public:
     bool didReceiveServerRedirectForProvisionalNavigation() const { return m_didReceiveServerRedirectForProvisionalNavigation; }
     void clearDidReceiveServerRedirectForProvisionalNavigation() { m_didReceiveServerRedirectForProvisionalNavigation = false; }
 
-    void addMockMediaDevice(WKStringRef persistentID, WKStringRef label, WKStringRef type);
+    void addMockMediaDevice(WKStringRef persistentID, WKStringRef label, WKStringRef type, WKDictionaryRef properties);
     void clearMockMediaDevices();
     void removeMockMediaDevice(WKStringRef persistentID);
     void setMockMediaDeviceIsEphemeral(WKStringRef, bool);

--- a/Tools/WebKitTestRunner/TestInvocation.cpp
+++ b/Tools/WebKitTestRunner/TestInvocation.cpp
@@ -1006,7 +1006,8 @@ WKRetainPtr<WKTypeRef> TestInvocation::didReceiveSynchronousMessageFromInjectedB
         auto persistentID = stringValue(messageBodyDictionary, "PersistentID");
         auto label = stringValue(messageBodyDictionary, "Label");
         auto type = stringValue(messageBodyDictionary, "Type");
-        TestController::singleton().addMockMediaDevice(persistentID, label, type);
+        auto properties = dictionaryValue(value(messageBodyDictionary, "Properties"));
+        TestController::singleton().addMockMediaDevice(persistentID, label, type, properties);
         return nullptr;
     }
 


### PR DESCRIPTION
#### d0a00be94060f009349aca4f348324686b799056
<pre>
Do not take into account device orientation for cameras whose position is unspecified
<a href="https://bugs.webkit.org/show_bug.cgi?id=255448">https://bugs.webkit.org/show_bug.cgi?id=255448</a>
rdar://problem/108043783

Reviewed by Eric Carlson.

Skip orientation monitoring in case facing mode is unspecified, as this means the sensor is not guaranteed to be attached to the device.
Update mock infrastructure accordingly and allow to add cameras with undefined facing mode.

Covered by added test.

* LayoutTests/fast/mediastream/camera-unknown-facing-mode-expected.txt: Added.
* LayoutTests/fast/mediastream/camera-unknown-facing-mode.html: Added.
* Source/WebCore/platform/mediastream/mac/AVVideoCaptureSource.mm:
(WebCore::AVVideoCaptureSource::monitorOrientation):
* Source/WebCore/platform/mock/MockRealtimeVideoSource.cpp:
(WebCore::MockRealtimeVideoSource::capabilities):
(WebCore::MockRealtimeVideoSource::settings):
(WebCore::MockRealtimeVideoSource::monitorOrientation):
* Source/WebKit/UIProcess/API/C/WKMockMediaDevice.cpp:
(WKAddMockMediaDevice):
* Source/WebKit/UIProcess/API/C/WKMockMediaDevice.h:
* Tools/WebKitTestRunner/InjectedBundle/Bindings/TestRunner.idl:
* Tools/WebKitTestRunner/InjectedBundle/TestRunner.cpp:
(WTR::TestRunner::addMockMediaDevice):
(WTR::TestRunner::addMockCameraDevice):
(WTR::TestRunner::addMockMicrophoneDevice):
(WTR::TestRunner::addMockScreenDevice):
* Tools/WebKitTestRunner/InjectedBundle/TestRunner.h:
* Tools/WebKitTestRunner/TestController.cpp:
(WTR::TestController::addMockMediaDevice):
* Tools/WebKitTestRunner/TestController.h:
* Tools/WebKitTestRunner/TestInvocation.cpp:
(WTR::TestInvocation::didReceiveSynchronousMessageFromInjectedBundle):

Canonical link: <a href="https://commits.webkit.org/263018@main">https://commits.webkit.org/263018@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b3f7c10c2e021c29daed8adab3be965c1dc6229f

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/3165 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/3226 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/3336 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/4578 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/3523 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/3133 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/3288 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/3253 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/2753 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/3196 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/3513 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/2845 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/4385 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/1011 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/2818 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/2657 "144 failures") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/2790 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/2869 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/4132 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/3241 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/2586 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/2825 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/2820 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/812 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/2818 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/3084 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->