### PR TITLE
Default camera whose facingMode is unknown should be selected by getUserMedia if there is no facingMode constraint

### DIFF
--- a/LayoutTests/fast/mediastream/default-camera-test-expected.txt
+++ b/LayoutTests/fast/mediastream/default-camera-test-expected.txt
@@ -1,0 +1,4 @@
+
+
+PASS Check default cameras in case of default device having an unknown facing mode
+

--- a/LayoutTests/fast/mediastream/default-camera-test.html
+++ b/LayoutTests/fast/mediastream/default-camera-test.html
@@ -1,0 +1,37 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="utf-8">
+    <script src="../../resources/testharness.js"></script>
+    <script src="../../resources/testharnessreport.js"></script>
+</head>
+<body>
+    <video id="video"></video>
+    <script>
+    let setup = async (test) => {
+        if (!window.testRunner)
+            return Promise.reject("test requires internal API");
+
+        test.add_cleanup(() => {
+            testRunner.resetMockMediaDevices();
+        });
+    }
+
+    promise_test(async (test) => {
+        await setup(test);
+
+        // camera device should be the default device.
+        testRunner.addMockCameraDevice("myCamera", "my new camera", { facingMode: "unknown", fillColor: "green" });
+
+        let stream = await navigator.mediaDevices.getUserMedia({ video: true });
+        assert_equals(stream.getVideoTracks()[0].label, "my new camera");
+
+        stream = await navigator.mediaDevices.getUserMedia({ video: { facingMode: 'user' } });
+        assert_equals(stream.getVideoTracks()[0].label, "Mock video device 1");
+
+        stream = await navigator.mediaDevices.getUserMedia({ video: { facingMode: 'environment' } });
+        assert_equals(stream.getVideoTracks()[0].label, "Mock video device 2");
+    }, "Check default cameras in case of default device having an unknown facing mode");
+    </script>
+</body>
+</html>

--- a/LayoutTests/fast/mediastream/getUserMedia-default.html
+++ b/LayoutTests/fast/mediastream/getUserMedia-default.html
@@ -44,9 +44,9 @@ promise_test((test) => {
 }, "Checking default video tracks settings except height");
 
 promise_test((test) => {
-    return navigator.mediaDevices.getUserMedia({ audio: true, video: { frameRate: {ideal: 60 } } }).then((stream) => {
+    return navigator.mediaDevices.getUserMedia({ audio: true, video: { frameRate: { ideal: 60 } } }).then((stream) => {
         let settings = stream.getVideoTracks()[0].getSettings();
-        assert_equals(settings.frameRate, 30, "frame rate");
+        assert_equals(settings.frameRate, 60, "frame rate");
         assert_equals(settings.width, settings.height == 640 ? 480 : 640, "frame width");
         assert_equals(settings.height, settings.width = 640 ? 480 : 640, "frame height");
     });

--- a/Source/WebCore/platform/mediastream/MediaConstraints.cpp
+++ b/Source/WebCore/platform/mediastream/MediaConstraints.cpp
@@ -364,7 +364,7 @@ bool MediaTrackConstraintSetMap::isEmpty() const
     return !size();
 }
 
-static inline void addDefaultVideoConstraints(MediaTrackConstraintSetMap& videoConstraints, bool addFrameRateConstraint, bool addSizeConstraint, bool addFacingModeConstraint)
+static inline void addDefaultVideoConstraints(MediaTrackConstraintSetMap& videoConstraints, bool addFrameRateConstraint, bool addSizeConstraint)
 {
     if (addFrameRateConstraint) {
         DoubleConstraint frameRateConstraint({ }, MediaConstraintType::FrameRate);
@@ -379,11 +379,6 @@ static inline void addDefaultVideoConstraints(MediaTrackConstraintSetMap& videoC
         IntConstraint heightConstraint({ }, MediaConstraintType::Height);
         heightConstraint.setIdeal(480);
         videoConstraints.set(MediaConstraintType::Height, WTFMove(heightConstraint));
-    }
-    if (addFacingModeConstraint) {
-        StringConstraint facingModeConstraint({ }, MediaConstraintType::FacingMode);
-        facingModeConstraint.setIdeal("user"_s);
-        videoConstraints.set(MediaConstraintType::FacingMode, WTFMove(facingModeConstraint));
     }
 }
 
@@ -401,7 +396,7 @@ bool MediaConstraints::isConstraintSet(const Function<bool(const MediaTrackConst
 
 void MediaConstraints::setDefaultVideoConstraints()
 {
-    // 640x480, 30fps, front-facing camera
+    // 640x480, 30fps camera
     bool needsFrameRateConstraints = !isConstraintSet([](const MediaTrackConstraintSetMap& constraint) {
         return !!constraint.frameRate() || !!constraint.width() || !!constraint.height();
     });
@@ -410,11 +405,7 @@ void MediaConstraints::setDefaultVideoConstraints()
         return !!constraint.width() || !!constraint.height();
     });
     
-    bool needsFacingModeConstraints = !isConstraintSet([](const MediaTrackConstraintSetMap& constraint) {
-        return !!constraint.facingMode() || !!constraint.deviceId();
-    });
-    
-    addDefaultVideoConstraints(mandatoryConstraints, needsFrameRateConstraints, needsSizeConstraints, needsFacingModeConstraints);
+    addDefaultVideoConstraints(mandatoryConstraints, needsFrameRateConstraints, needsSizeConstraints);
 }
 
 void MediaConstraint::log() const

--- a/Source/WebCore/platform/mediastream/RealtimeMediaSource.cpp
+++ b/Source/WebCore/platform/mediastream/RealtimeMediaSource.cpp
@@ -782,8 +782,7 @@ bool RealtimeMediaSource::selectSettings(const MediaConstraints& constraints, Fl
     minimumDistance = distance;
 
     // 4. If candidates is empty, return undefined as the result of the SelectSettings() algorithm.
-    if (candidates.isEmpty())
-        return true;
+    // We skip this check since our implementation will compute empty candidates in case no mandatory constraints is given.
 
     // 5. Iterate over the 'advanced' ConstraintSets in newConstraints in the order in which they were specified.
     //    For each ConstraintSet:

--- a/Source/WebCore/platform/mock/MockMediaDevice.h
+++ b/Source/WebCore/platform/mock/MockMediaDevice.h
@@ -198,6 +198,11 @@ struct MockMediaDevice {
         return isSpeaker() ? &std::get<MockSpeakerProperties>(properties) : nullptr;
     }
 
+    const MockCameraProperties* cameraProperties() const
+    {
+        return isCamera() ? &std::get<MockCameraProperties>(properties) : nullptr;
+    }
+
     template<class Encoder>
     void encode(Encoder& encoder) const
     {


### PR DESCRIPTION
#### 302d5fe7dea9aa2c8473a26803453147efc80a24
<pre>
Default camera whose facingMode is unknown should be selected by getUserMedia if there is no facingMode constraint
<a href="https://bugs.webkit.org/show_bug.cgi?id=255451">https://bugs.webkit.org/show_bug.cgi?id=255451</a>
rdar://problem/108045715

Reviewed by Eric Carlson.

Remove the facingMode constraint that was added by default to favor user facing cameras.
Instead, we now rely on the order of camera devices, which should favor the front camera over the background cameras by default.
If another camera becomes the default camera, we will favor this camera.
Selection of the default camera in case fitness distance is the same is guaranteed by the fact we are using a stable sort.

We update RealtimeMediaSource::selectSettings as not setting anymore the facing mode might end up with empty candidates in RealtimeMediaSource::selectSettings
in the case there is no provided mandatory constraints but advanced constraints are added.
In this case, we should not have empty candidates but all possible candidates, hence why we remove the early return defined in the spec.

Update test infrastructure so that adding a mock camera that has an unknown facing mode will make this camera the default camera.
Covered by LayoutTests/fast/mediastream/default-camera-test.html.
Updating LayoutTests/fast/mediastream/getUserMedia-default.html to expect 60fps since ideal is set to 60 fps and this constraint no longer competes with facingMode constraint.

* LayoutTests/fast/mediastream/default-camera-test-expected.txt: Added.
* LayoutTests/fast/mediastream/default-camera-test.html: Added.
* LayoutTests/fast/mediastream/getUserMedia-default.html:
* Source/WebCore/platform/mediastream/MediaConstraints.cpp:
(WebCore::addDefaultVideoConstraints):
(WebCore::MediaConstraints::setDefaultVideoConstraints):
* Source/WebCore/platform/mediastream/RealtimeMediaSource.cpp:
(WebCore::RealtimeMediaSource::selectSettings):
* Source/WebCore/platform/mock/MockMediaDevice.h:
(WebCore::MockMediaDevice::cameraProperties const):
* Source/WebCore/platform/mock/MockRealtimeMediaSourceCenter.cpp:
(WebCore::createMockDevice):
(WebCore::MockRealtimeMediaSourceCenter::setDevices):
(WebCore::shouldBeDefaultDevice):
(WebCore::MockRealtimeMediaSourceCenter::addDevice):

Canonical link: <a href="https://commits.webkit.org/263022@main">https://commits.webkit.org/263022@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f663de4f3349453f22c812baedeeaa46300d5bf1

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/3349 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/3409 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/3529 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/4771 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/3681 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/3328 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/3474 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/3433 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/2910 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/3390 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/3669 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/3021 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/4593 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/1173 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/2983 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/2902 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/2955 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/3037 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/4334 "run-api-tests-without-change (failure)") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/3421 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/2740 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/2984 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/2984 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/817 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/2989 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/3261 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->