### PR TITLE
[MSE][GStreamer] Avoid unneeded timechanged notifications

### DIFF
--- a/Source/WebCore/platform/graphics/gstreamer/mse/MediaPlayerPrivateGStreamerMSE.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/mse/MediaPlayerPrivateGStreamerMSE.cpp
@@ -303,7 +303,8 @@ void MediaPlayerPrivateGStreamerMSE::propagateReadyStateToPlayer()
 
     // The readyState change may be a result of monitorSourceBuffers() finding that currentTime == duration, which
     // should cause the video to be marked as ended. Let's have the player check that.
-    m_player->timeChanged();
+    if (!m_isWaitingForPreroll || currentMediaTime() == durationMediaTime())
+        m_player->timeChanged();
 }
 
 void MediaPlayerPrivateGStreamerMSE::asyncStateChangeDone()


### PR DESCRIPTION
#### c6dd1fbfea75773bdffbf034e532930577168acd
<pre>
[MSE][GStreamer] Avoid unneeded timechanged notifications
<a href="https://bugs.webkit.org/show_bug.cgi?id=255452">https://bugs.webkit.org/show_bug.cgi?id=255452</a>

Reviewed by Philippe Normand.

The YouTube MSE Conformance Tests 2021[1][2] added a check to ensure that the initial warm up time
of the player is less than 500 ms in accuracy tests. While these tests pass on a fast desktop
computer, they fail on a lower end device (eg: Raspberry Pi 3). This is because there&apos;s a first
timeupdate event triggered as soon as the appended init segment is processed, but the processing
time of the next appended data segment takes too much time, so when playback actually starts, the
next timeupdate event comes later than 500ms from the first one, causing the test to fail on slow
platforms.

Since the default time of the video element should be 0 from the begining and the time reported by
that initial timeupdate is actually 0 (no change), that initial timeupdate event is redundant (and
wasn&apos;t happening before the WebKitMediaSrc rework[3]).

This patch honors the original source code comment, which states that the timeupdate notification
makes sense when currentTime has reached the duration, avoiding the notification in other cases,
at least when still waiting for an initial preroll.

[1] <a href="https://ytlr-cert.appspot.com/2021/main.html?tests=35">https://ytlr-cert.appspot.com/2021/main.html?tests=35</a>,36,37,38&amp;command=run
[2] <a href="https://ytlr-cert.appspot.com/2021/media/conformanceTest.js">https://ytlr-cert.appspot.com/2021/media/conformanceTest.js</a>, line 886 (best displayed as <a href="https://pastebin.com/fPx1EW22)">https://pastebin.com/fPx1EW22)</a>
[3] <a href="https://github.com/WebKit/WebKit/commit/9382c6ef1a5b64d1701c691c63fe84de22cf932b">https://github.com/WebKit/WebKit/commit/9382c6ef1a5b64d1701c691c63fe84de22cf932b</a>

* Source/WebCore/platform/graphics/gstreamer/mse/MediaPlayerPrivateGStreamerMSE.cpp:
(WebCore::MediaPlayerPrivateGStreamerMSE::propagateReadyStateToPlayer): Don&apos;t notify timeupdate before prerolling unless currentTime has reached the duration.

Canonical link: <a href="https://commits.webkit.org/263019@main">https://commits.webkit.org/263019@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/de26931222c68f4c87bdfbbd2b3fbc32116e6bb9

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/3168 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/3229 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/3339 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/4581 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/3526 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/3136 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/3292 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/3256 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/2756 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/3199 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/3517 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/2848 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/4388 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/1015 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/2821 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/2660 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/2794 "Passed tests") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/2872 "3 failures") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/4135 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/3244 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/2590 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/2828 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/2823 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/815 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/2821 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/3087 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->