### PR TITLE
Sync 'suspendRedraw' and 'unsuspendRedraw' in SVGSVGElement.idl as per IDL Spec

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/svg/idlharness.window-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/svg/idlharness.window-expected.txt
@@ -415,8 +415,8 @@ PASS SVGSVGElement interface: operation createSVGRect()
 PASS SVGSVGElement interface: operation createSVGTransform()
 PASS SVGSVGElement interface: operation createSVGTransformFromMatrix(optional DOMMatrix2DInit)
 PASS SVGSVGElement interface: operation getElementById(DOMString)
-FAIL SVGSVGElement interface: operation suspendRedraw(unsigned long) assert_equals: property has wrong .length expected 1 but got 0
-FAIL SVGSVGElement interface: operation unsuspendRedraw(unsigned long) assert_equals: property has wrong .length expected 1 but got 0
+PASS SVGSVGElement interface: operation suspendRedraw(unsigned long)
+PASS SVGSVGElement interface: operation unsuspendRedraw(unsigned long)
 PASS SVGSVGElement interface: operation unsuspendRedrawAll()
 PASS SVGSVGElement interface: operation forceRedraw()
 PASS SVGSVGElement interface: attribute viewBox
@@ -450,13 +450,9 @@ PASS SVGSVGElement interface: calling createSVGTransformFromMatrix(optional DOMM
 PASS SVGSVGElement interface: objects.svg must inherit property "getElementById(DOMString)" with the proper type
 PASS SVGSVGElement interface: calling getElementById(DOMString) on objects.svg with too few arguments must throw TypeError
 PASS SVGSVGElement interface: objects.svg must inherit property "suspendRedraw(unsigned long)" with the proper type
-FAIL SVGSVGElement interface: calling suspendRedraw(unsigned long) on objects.svg with too few arguments must throw TypeError assert_throws_js: Called with 0 arguments function "function () {
-            fn.apply(obj, args);
-        }" did not throw
+PASS SVGSVGElement interface: calling suspendRedraw(unsigned long) on objects.svg with too few arguments must throw TypeError
 PASS SVGSVGElement interface: objects.svg must inherit property "unsuspendRedraw(unsigned long)" with the proper type
-FAIL SVGSVGElement interface: calling unsuspendRedraw(unsigned long) on objects.svg with too few arguments must throw TypeError assert_throws_js: Called with 0 arguments function "function () {
-            fn.apply(obj, args);
-        }" did not throw
+PASS SVGSVGElement interface: calling unsuspendRedraw(unsigned long) on objects.svg with too few arguments must throw TypeError
 PASS SVGSVGElement interface: objects.svg must inherit property "unsuspendRedrawAll()" with the proper type
 PASS SVGSVGElement interface: objects.svg must inherit property "forceRedraw()" with the proper type
 PASS SVGSVGElement interface: objects.svg must inherit property "viewBox" with the proper type

--- a/Source/WebCore/svg/SVGSVGElement.idl
+++ b/Source/WebCore/svg/SVGSVGElement.idl
@@ -64,9 +64,10 @@
     float getCurrentTime();
     undefined setCurrentTime(float seconds);
 
-    // Deprecated SVG redrawing
-    unsigned long suspendRedraw(optional unsigned long maxWaitMilliseconds = 0);
-    undefined unsuspendRedraw(optional unsigned long suspendHandleId = 0);
+    // Deprecated SVG redrawing methods that have no effect when called,
+    // but which are kept for compatibility reasons.
+    unsigned long suspendRedraw(unsigned long maxWaitMilliseconds);
+    undefined unsuspendRedraw(unsigned long suspendHandleId);
     undefined unsuspendRedrawAll();
     undefined forceRedraw();
 };


### PR DESCRIPTION
#### be5d129926f8a700534be0e15ce5cbf0e1d061d7
<pre>
Sync &apos;suspendRedraw&apos; and &apos;unsuspendRedraw&apos; in SVGSVGElement.idl as per IDL Spec

<a href="https://bugs.webkit.org/show_bug.cgi?id=255453">https://bugs.webkit.org/show_bug.cgi?id=255453</a>

Reviewed by Said Abou-Hallawa.

This patch aligns WebKit with web-spec [1].

[1] <a href="https://www.w3.org/TR/SVG2/struct.html#InterfaceSVGSVGElement">https://www.w3.org/TR/SVG2/struct.html#InterfaceSVGSVGElement</a>

* Source/WebCore/svg/SVGSVGElement.idl:
* LayoutTests/imported/w3c/web-platform-tests/svg/idlharness.window-expected.txt: Rebaselined

Canonical link: <a href="https://commits.webkit.org/262978@main">https://commits.webkit.org/262978@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/babd0dbd95b720f2d7ac7d2193c4ce86bde30c1a

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/3181 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/3243 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/3353 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/4595 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/3539 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/3150 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/3308 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/3270 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/2769 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/3213 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/3532 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/2865 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/4404 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/1031 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/2835 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/2674 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/2810 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/2886 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/4151 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/3258 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/2603 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/2841 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/2837 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/785 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/2835 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/3100 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->