### PR TITLE
Drop AttributeName alias and use AttributeNames namespace instead

### DIFF
--- a/Source/WebCore/dom/Element.cpp
+++ b/Source/WebCore/dom/Element.cpp
@@ -2032,13 +2032,13 @@ bool Element::isElementsArrayReflectionAttribute(const Settings& settings, const
         return false;
 
     switch (name.nodeName()) {
-    case AttributeName::aria_controlsAttr:
-    case AttributeName::aria_describedbyAttr:
-    case AttributeName::aria_detailsAttr:
-    case AttributeName::aria_errormessageAttr:
-    case AttributeName::aria_flowtoAttr:
-    case AttributeName::aria_labelledbyAttr:
-    case AttributeName::aria_ownsAttr:
+    case AttributeNames::aria_controlsAttr:
+    case AttributeNames::aria_describedbyAttr:
+    case AttributeNames::aria_detailsAttr:
+    case AttributeNames::aria_errormessageAttr:
+    case AttributeNames::aria_flowtoAttr:
+    case AttributeNames::aria_labelledbyAttr:
+    case AttributeNames::aria_ownsAttr:
         return true;
     default:
         break;
@@ -2052,10 +2052,10 @@ void Element::attributeChanged(const QualifiedName& name, const AtomString& oldV
 
     if (!valueIsSameAsBefore) {
         switch (name.nodeName()) {
-        case AttributeName::classAttr:
+        case AttributeNames::classAttr:
             classAttributeChanged(newValue);
             break;
-        case AttributeName::idAttr: {
+        case AttributeNames::idAttr: {
             AtomString oldId = elementData()->idForStyleResolution();
             AtomString newId = makeIdForStyleResolution(newValue, document().inQuirksMode());
             if (newId != oldId) {
@@ -2069,37 +2069,37 @@ void Element::attributeChanged(const QualifiedName& name, const AtomString& oldV
                 treeScope().idTargetObserverRegistry().notifyObservers(*newValue.impl());
             break;
         }
-        case AttributeName::nameAttr:
+        case AttributeNames::nameAttr:
             elementData()->setHasNameAttribute(!newValue.isNull());
             break;
-        case AttributeName::nonceAttr:
+        case AttributeNames::nonceAttr:
             if (is<HTMLElement>(*this) || is<SVGElement>(*this))
                 setNonce(newValue.isNull() ? emptyAtom() : newValue);
             break;
-        case AttributeName::pseudoAttr:
+        case AttributeNames::pseudoAttr:
             if (needsStyleInvalidation() && isInShadowTree())
                 invalidateStyleForSubtree();
             break;
-        case AttributeName::slotAttr:
+        case AttributeNames::slotAttr:
             if (auto* parent = parentElement()) {
                 if (auto* shadowRoot = parent->shadowRoot())
                     shadowRoot->hostChildElementDidChangeSlotAttribute(*this, oldValue, newValue);
             }
             break;
-        case AttributeName::partAttr:
+        case AttributeNames::partAttr:
             partAttributeChanged(newValue);
             break;
-        case AttributeName::exportpartsAttr:
+        case AttributeNames::exportpartsAttr:
             if (auto* shadowRoot = this->shadowRoot()) {
                 shadowRoot->invalidatePartMappings();
                 Style::Invalidator::invalidateShadowParts(*shadowRoot);
             }
             break;
-        case AttributeName::accesskeyAttr:
+        case AttributeNames::accesskeyAttr:
             document().invalidateAccessKeyCache();
             break;
-        case AttributeName::XML_langAttr:
-        case AttributeName::langAttr:
+        case AttributeNames::XML::langAttr:
+        case AttributeNames::langAttr:
             if (name == HTMLNames::langAttr)
                 setHasLangAttr(!newValue.isNull());
             else

--- a/Source/WebCore/dom/make_names.pl
+++ b/Source/WebCore/dom/make_names.pl
@@ -1078,7 +1078,6 @@ sub printNodeNameHeaderFile
     }
     print F "};\n";
     print F "\n";
-    print F "using AttributeName = NodeName;\n";
     print F "using ElementName = NodeName;\n";
     print F "\n";
     print F "namespace ElementNames {\n";
@@ -1097,7 +1096,7 @@ sub printNodeNameHeaderFile
         print F "namespace $namespace {\n" unless $namespace eq "";
         for my $attrKey (sort byAttrNameOrder keys %{$allAttrsPerNamespace{$namespace}}) {
             my $enumValue = $allAttrs{$attrKey}{nodeNameEnumValue};
-            print F "inline constexpr auto $allAttrs{$attrKey}{tagEnumValue} = AttributeName::$enumValue;\n" unless $handledAttrs{$enumValue};
+            print F "inline constexpr auto $allAttrs{$attrKey}{tagEnumValue} = NodeName::$enumValue;\n" unless $handledAttrs{$enumValue};
             $handledAttrs{$enumValue} = 1;
         }
         if ($namespace eq "") {

--- a/Source/WebCore/html/BaseDateAndTimeInputType.cpp
+++ b/Source/WebCore/html/BaseDateAndTimeInputType.cpp
@@ -387,18 +387,18 @@ bool BaseDateAndTimeInputType::hasCustomFocusLogic() const
 void BaseDateAndTimeInputType::attributeChanged(const QualifiedName& name)
 {
     switch (name.nodeName()) {
-    case AttributeName::maxAttr:
-    case AttributeName::minAttr:
+    case AttributeNames::maxAttr:
+    case AttributeNames::minAttr:
         if (auto* element = this->element())
             element->invalidateStyleForSubtree();
         break;
-    case AttributeName::valueAttr:
+    case AttributeNames::valueAttr:
         if (auto* element = this->element()) {
             if (!element->hasDirtyValue())
                 updateInnerTextValue();
         }
         break;
-    case AttributeName::stepAttr:
+    case AttributeNames::stepAttr:
         if (m_dateTimeEditElement)
             updateInnerTextValue();
         break;

--- a/Source/WebCore/html/HTMLBodyElement.cpp
+++ b/Source/WebCore/html/HTMLBodyElement.cpp
@@ -69,13 +69,13 @@ HTMLBodyElement::~HTMLBodyElement() = default;
 bool HTMLBodyElement::hasPresentationalHintsForAttribute(const QualifiedName& name) const
 {
     switch (name.nodeName()) {
-    case AttributeName::backgroundAttr:
-    case AttributeName::marginwidthAttr:
-    case AttributeName::leftmarginAttr:
-    case AttributeName::marginheightAttr:
-    case AttributeName::topmarginAttr:
-    case AttributeName::bgcolorAttr:
-    case AttributeName::textAttr:
+    case AttributeNames::backgroundAttr:
+    case AttributeNames::marginwidthAttr:
+    case AttributeNames::leftmarginAttr:
+    case AttributeNames::marginheightAttr:
+    case AttributeNames::topmarginAttr:
+    case AttributeNames::bgcolorAttr:
+    case AttributeNames::textAttr:
         return true;
     default:
         break;
@@ -86,7 +86,7 @@ bool HTMLBodyElement::hasPresentationalHintsForAttribute(const QualifiedName& na
 void HTMLBodyElement::collectPresentationalHintsForAttribute(const QualifiedName& name, const AtomString& value, MutableStyleProperties& style)
 {
     switch (name.nodeName()) {
-    case AttributeName::backgroundAttr: {
+    case AttributeNames::backgroundAttr: {
         String url = stripLeadingAndTrailingHTMLSpaces(value);
         if (!url.isEmpty()) {
             auto imageValue = CSSImageValue::create(document().completeURL(url), LoadedFromOpaqueSource::No, localName());
@@ -94,20 +94,20 @@ void HTMLBodyElement::collectPresentationalHintsForAttribute(const QualifiedName
         }
         break;
     }
-    case AttributeName::marginwidthAttr:
-    case AttributeName::leftmarginAttr:
+    case AttributeNames::marginwidthAttr:
+    case AttributeNames::leftmarginAttr:
         addHTMLLengthToStyle(style, CSSPropertyMarginRight, value);
         addHTMLLengthToStyle(style, CSSPropertyMarginLeft, value);
         break;
-    case AttributeName::marginheightAttr:
-    case AttributeName::topmarginAttr:
+    case AttributeNames::marginheightAttr:
+    case AttributeNames::topmarginAttr:
         addHTMLLengthToStyle(style, CSSPropertyMarginBottom, value);
         addHTMLLengthToStyle(style, CSSPropertyMarginTop, value);
         break;
-    case AttributeName::bgcolorAttr:
+    case AttributeNames::bgcolorAttr:
         addHTMLColorToStyle(style, CSSPropertyBackgroundColor, value);
         break;
-    case AttributeName::textAttr:
+    case AttributeNames::textAttr:
         addHTMLColorToStyle(style, CSSPropertyColor, value);
         break;
     default:

--- a/Source/WebCore/html/HTMLElement.cpp
+++ b/Source/WebCore/html/HTMLElement.cpp
@@ -159,13 +159,13 @@ void HTMLElement::mapLanguageAttributeToLocale(const AtomString& value, MutableS
 bool HTMLElement::hasPresentationalHintsForAttribute(const QualifiedName& name) const
 {
     switch (name.nodeName()) {
-    case AttributeName::alignAttr:
-    case AttributeName::contenteditableAttr:
-    case AttributeName::hiddenAttr:
-    case AttributeName::langAttr:
-    case AttributeName::XML_langAttr:
-    case AttributeName::draggableAttr:
-    case AttributeName::dirAttr:
+    case AttributeNames::alignAttr:
+    case AttributeNames::contenteditableAttr:
+    case AttributeNames::hiddenAttr:
+    case AttributeNames::langAttr:
+    case AttributeNames::XML::langAttr:
+    case AttributeNames::draggableAttr:
+    case AttributeNames::dirAttr:
         return true;
     default:
         break;
@@ -235,13 +235,13 @@ static bool elementAffectsDirectionality(const Node& node)
 void HTMLElement::collectPresentationalHintsForAttribute(const QualifiedName& name, const AtomString& value, MutableStyleProperties& style)
 {
     switch (name.nodeName()) {
-    case AttributeName::alignAttr:
+    case AttributeNames::alignAttr:
         if (equalLettersIgnoringASCIICase(value, "middle"_s))
             addPropertyToPresentationalHintStyle(style, CSSPropertyTextAlign, CSSValueCenter);
         else
             addPropertyToPresentationalHintStyle(style, CSSPropertyTextAlign, value);
         break;
-    case AttributeName::contenteditableAttr: {
+    case AttributeNames::contenteditableAttr: {
         CSSValueID userModifyValue = CSSValueReadWrite;
         switch (contentEditableType(value)) {
         case ContentEditableType::Inherit:
@@ -264,10 +264,10 @@ void HTMLElement::collectPresentationalHintsForAttribute(const QualifiedName& na
         addPropertyToPresentationalHintStyle(style, CSSPropertyWebkitUserModify, userModifyValue);
         break;
     }
-    case AttributeName::hiddenAttr:
+    case AttributeNames::hiddenAttr:
         addPropertyToPresentationalHintStyle(style, CSSPropertyDisplay, CSSValueNone);
         break;
-    case AttributeName::draggableAttr:
+    case AttributeNames::draggableAttr:
         if (equalLettersIgnoringASCIICase(value, "true"_s)) {
             addPropertyToPresentationalHintStyle(style, CSSPropertyWebkitUserDrag, CSSValueElement);
             if (!isDraggableIgnoringAttributes())
@@ -275,7 +275,7 @@ void HTMLElement::collectPresentationalHintsForAttribute(const QualifiedName& na
         } else if (equalLettersIgnoringASCIICase(value, "false"_s))
             addPropertyToPresentationalHintStyle(style, CSSPropertyWebkitUserDrag, CSSValueNone);
         break;
-    case AttributeName::dirAttr:
+    case AttributeNames::dirAttr:
         if (equalLettersIgnoringASCIICase(value, "auto"_s))
             addPropertyToPresentationalHintStyle(style, CSSPropertyUnicodeBidi, unicodeBidiAttributeForDirAuto(*this));
         else if (equalLettersIgnoringASCIICase(value, "rtl"_s) || equalLettersIgnoringASCIICase(value, "ltr"_s)) {
@@ -284,10 +284,10 @@ void HTMLElement::collectPresentationalHintsForAttribute(const QualifiedName& na
                 addPropertyToPresentationalHintStyle(style, CSSPropertyUnicodeBidi, CSSValueIsolate);
         }
         break;
-    case AttributeName::XML_langAttr:
+    case AttributeNames::XML::langAttr:
         mapLanguageAttributeToLocale(value, style);
         break;
-    case AttributeName::langAttr:
+    case AttributeNames::langAttr:
         // xml:lang has a higher priority than lang.
         if (!hasAttributeWithoutSynchronization(XMLNames::langAttr))
             mapLanguageAttributeToLocale(value, style);
@@ -396,26 +396,26 @@ void HTMLElement::attributeChanged(const QualifiedName& name, const AtomString& 
     StyledElement::attributeChanged(name, oldValue, newValue, attributeModificationReason);
 
     switch (name.nodeName()) {
-    case AttributeName::dirAttr:
+    case AttributeNames::dirAttr:
         dirAttributeChanged(newValue);
         return;
-    case AttributeName::tabindexAttr:
+    case AttributeNames::tabindexAttr:
         if (auto optionalTabIndex = parseHTMLInteger(newValue))
             setTabIndexExplicitly(optionalTabIndex.value());
         else
             setTabIndexExplicitly(std::nullopt);
         return;
-    case AttributeName::inertAttr:
+    case AttributeNames::inertAttr:
         if (document().settings().inertAttributeEnabled())
             invalidateStyleInternal();
         return;
-    case AttributeName::inputmodeAttr:
+    case AttributeNames::inputmodeAttr:
         if (auto& document = this->document(); this == document.focusedElement()) {
             if (auto* page = document.page())
                 page->chrome().client().focusedElementDidChangeInputMode(*this, canonicalInputMode());
         }
         return;
-    case AttributeName::popoverAttr:
+    case AttributeNames::popoverAttr:
         if (document().settings().popoverAttributeEnabled() && !document().quirks().shouldDisablePopoverAttributeQuirk())
             popoverAttributeChanged(newValue);
         return;

--- a/Source/WebCore/html/HTMLFormElement.cpp
+++ b/Source/WebCore/html/HTMLFormElement.cpp
@@ -506,7 +506,7 @@ void HTMLFormElement::resetListedFormControlElements()
 void HTMLFormElement::attributeChanged(const QualifiedName& name, const AtomString& oldValue, const AtomString& newValue, AttributeModificationReason attributeModificationReason)
 {
     switch (name.nodeName()) {
-    case AttributeName::actionAttr:
+    case AttributeNames::actionAttr:
         m_attributes.parseAction(newValue);
         if (!m_attributes.action().isEmpty()) {
             if (RefPtr f = document().frame()) {
@@ -515,25 +515,25 @@ void HTMLFormElement::attributeChanged(const QualifiedName& name, const AtomStri
             }
         }
         break;
-    case AttributeName::targetAttr:
+    case AttributeNames::targetAttr:
         m_attributes.setTarget(newValue);
         break;
-    case AttributeName::methodAttr:
+    case AttributeNames::methodAttr:
         m_attributes.updateMethodType(newValue, document().settings().dialogElementEnabled());
         break;
-    case AttributeName::enctypeAttr:
+    case AttributeNames::enctypeAttr:
         m_attributes.updateEncodingType(newValue);
         break;
-    case AttributeName::accept_charsetAttr:
+    case AttributeNames::accept_charsetAttr:
         m_attributes.setAcceptCharset(newValue);
         break;
-    case AttributeName::autocompleteAttr:
+    case AttributeNames::autocompleteAttr:
         if (!shouldAutocomplete())
             document().registerForDocumentSuspensionCallbacks(*this);
         else
             document().unregisterForDocumentSuspensionCallbacks(*this);
         break;
-    case AttributeName::relAttr:
+    case AttributeNames::relAttr:
         if (m_relList)
             m_relList->associatedAttributeValueChanged(newValue);
         break;

--- a/Source/WebCore/html/HTMLInputElement.cpp
+++ b/Source/WebCore/html/HTMLInputElement.cpp
@@ -666,12 +666,12 @@ bool HTMLInputElement::accessKeyAction(bool sendMouseEvents)
 bool HTMLInputElement::hasPresentationalHintsForAttribute(const QualifiedName& name) const
 {
     switch (name.nodeName()) {
-    case AttributeName::vspaceAttr:
-    case AttributeName::hspaceAttr:
-    case AttributeName::widthAttr:
-    case AttributeName::heightAttr:
+    case AttributeNames::vspaceAttr:
+    case AttributeNames::hspaceAttr:
+    case AttributeNames::widthAttr:
+    case AttributeNames::heightAttr:
         return true;
-    case AttributeName::borderAttr:
+    case AttributeNames::borderAttr:
         return isImageButton();
     default:
         return HTMLTextFormControlElement::hasPresentationalHintsForAttribute(name);
@@ -682,35 +682,35 @@ bool HTMLInputElement::hasPresentationalHintsForAttribute(const QualifiedName& n
 void HTMLInputElement::collectPresentationalHintsForAttribute(const QualifiedName& name, const AtomString& value, MutableStyleProperties& style)
 {
     switch (name.nodeName()) {
-    case AttributeName::vspaceAttr:
+    case AttributeNames::vspaceAttr:
         if (isImageButton()) {
             addHTMLLengthToStyle(style, CSSPropertyMarginTop, value);
             addHTMLLengthToStyle(style, CSSPropertyMarginBottom, value);
         }
         break;
-    case AttributeName::hspaceAttr:
+    case AttributeNames::hspaceAttr:
         if (isImageButton()) {
             addHTMLLengthToStyle(style, CSSPropertyMarginLeft, value);
             addHTMLLengthToStyle(style, CSSPropertyMarginRight, value);
         }
         break;
-    case AttributeName::alignAttr:
+    case AttributeNames::alignAttr:
         if (m_inputType->shouldRespectAlignAttribute())
             applyAlignmentAttributeToStyle(value, style);
         break;
-    case AttributeName::widthAttr:
+    case AttributeNames::widthAttr:
         if (m_inputType->shouldRespectHeightAndWidthAttributes())
             addHTMLLengthToStyle(style, CSSPropertyWidth, value);
         if (isImageButton())
             applyAspectRatioFromWidthAndHeightAttributesToStyle(value, attributeWithoutSynchronization(heightAttr), style);
         break;
-    case AttributeName::heightAttr:
+    case AttributeNames::heightAttr:
         if (m_inputType->shouldRespectHeightAndWidthAttributes())
             addHTMLLengthToStyle(style, CSSPropertyHeight, value);
         if (isImageButton())
             applyAspectRatioFromWidthAndHeightAttributesToStyle(attributeWithoutSynchronization(widthAttr), value, style);
         break;
-    case AttributeName::borderAttr:
+    case AttributeNames::borderAttr:
         if (isImageButton())
             applyBorderAttributeToStyle(value, style);
         break;
@@ -748,10 +748,10 @@ void HTMLInputElement::attributeChanged(const QualifiedName& name, const AtomStr
     HTMLTextFormControlElement::attributeChanged(name, oldValue, newValue, attributeModificationReason);
 
     switch (name.nodeName()) {
-    case AttributeName::typeAttr:
+    case AttributeNames::typeAttr:
         updateType();
         break;
-    case AttributeName::valueAttr:
+    case AttributeNames::valueAttr:
         // Changes to the value attribute may change whether or not this element has a default value.
         // If this field is autocomplete=off that might affect the return value of needsSuspensionCallback.
         if (m_autocomplete == Off) {
@@ -767,13 +767,13 @@ void HTMLInputElement::attributeChanged(const QualifiedName& name, const AtomStr
         updateValidity();
         m_valueAttributeWasUpdatedAfterParsing = !m_parsingInProgress;
         break;
-    case AttributeName::nameAttr:
+    case AttributeNames::nameAttr:
         removeFromRadioButtonGroup();
         m_name = newValue;
         addToRadioButtonGroup();
         HTMLTextFormControlElement::attributeChanged(name, oldValue, newValue, attributeModificationReason);
         break;
-    case AttributeName::checkedAttr:
+    case AttributeNames::checkedAttr:
         if (m_inputType->isCheckable())
             invalidateStyleForSubtree();
         // Another radio button in the same group might be checked by state
@@ -786,7 +786,7 @@ void HTMLInputElement::attributeChanged(const QualifiedName& name, const AtomStr
             m_dirtyCheckednessFlag = false;
         }
         break;
-    case AttributeName::autocompleteAttr:
+    case AttributeNames::autocompleteAttr:
         if (equalLettersIgnoringASCIICase(newValue, "off"_s)) {
             m_autocomplete = Off;
             registerForSuspensionCallbackIfNeeded();
@@ -802,35 +802,35 @@ void HTMLInputElement::attributeChanged(const QualifiedName& name, const AtomStr
                 unregisterForSuspensionCallbackIfNeeded();
         }
         break;
-    case AttributeName::maxlengthAttr:
+    case AttributeNames::maxlengthAttr:
         maxLengthAttributeChanged(newValue);
         break;
-    case AttributeName::minlengthAttr:
+    case AttributeNames::minlengthAttr:
         minLengthAttributeChanged(newValue);
         break;
-    case AttributeName::sizeAttr: {
+    case AttributeNames::sizeAttr: {
         unsigned oldSize = m_size;
         m_size = limitToOnlyHTMLNonNegativeNumbersGreaterThanZero(newValue, defaultSize);
         if (m_size != oldSize && renderer())
             renderer()->setNeedsLayoutAndPrefWidthsRecalc();
         break;
     }
-    case AttributeName::resultsAttr:
+    case AttributeNames::resultsAttr:
         m_maxResults = newValue.isNull() ? -1 : std::min(parseHTMLInteger(newValue).value_or(0), maxSavedResults);
         break;
-    case AttributeName::autosaveAttr:
-    case AttributeName::incrementalAttr:
+    case AttributeNames::autosaveAttr:
+    case AttributeNames::incrementalAttr:
         invalidateStyleForSubtree();
         break;
-    case AttributeName::maxAttr:
-    case AttributeName::minAttr:
-    case AttributeName::multipleAttr:
-    case AttributeName::patternAttr:
-    case AttributeName::stepAttr:
+    case AttributeNames::maxAttr:
+    case AttributeNames::minAttr:
+    case AttributeNames::multipleAttr:
+    case AttributeNames::patternAttr:
+    case AttributeNames::stepAttr:
         updateValidity();
         break;
 #if ENABLE(DATALIST_ELEMENT)
-    case AttributeName::listAttr:
+    case AttributeNames::listAttr:
         m_hasNonEmptyList = !newValue.isEmpty();
         if (m_hasNonEmptyList) {
             resetListAttributeTargetObserver();

--- a/Source/WebCore/html/HTMLOListElement.cpp
+++ b/Source/WebCore/html/HTMLOListElement.cpp
@@ -87,7 +87,7 @@ void HTMLOListElement::collectPresentationalHintsForAttribute(const QualifiedNam
 void HTMLOListElement::attributeChanged(const QualifiedName& name, const AtomString& oldValue, const AtomString& newValue, AttributeModificationReason attributeModificationReason)
 {
     switch (name.nodeName()) {
-    case AttributeName::startAttr: {
+    case AttributeNames::startAttr: {
         int oldStart = start();
         m_start = optionalValue(parseHTMLInteger(newValue));
         if (oldStart == start())
@@ -95,7 +95,7 @@ void HTMLOListElement::attributeChanged(const QualifiedName& name, const AtomStr
         RenderListItem::updateItemValuesForOrderedList(*this);
         break;
     }
-    case AttributeName::reversedAttr: {
+    case AttributeNames::reversedAttr: {
         bool reversed = !newValue.isNull();
         if (reversed == m_isReversed)
             return;

--- a/Source/WebCore/html/HTMLOptionElement.cpp
+++ b/Source/WebCore/html/HTMLOptionElement.cpp
@@ -177,7 +177,7 @@ int HTMLOptionElement::index() const
 void HTMLOptionElement::attributeChanged(const QualifiedName& name, const AtomString& oldValue, const AtomString& newValue, AttributeModificationReason attributeModificationReason)
 {
     switch (name.nodeName()) {
-    case AttributeName::disabledAttr: {
+    case AttributeNames::disabledAttr: {
         bool newDisabled = !newValue.isNull();
         if (m_disabled != newDisabled) {
             Style::PseudoClassChangeInvalidation disabledInvalidation(*this, { { CSSSelector::PseudoClassDisabled, newDisabled },  { CSSSelector::PseudoClassEnabled, !newDisabled } });
@@ -187,7 +187,7 @@ void HTMLOptionElement::attributeChanged(const QualifiedName& name, const AtomSt
         }
         break;
     }
-    case AttributeName::selectedAttr: {
+    case AttributeNames::selectedAttr: {
         // FIXME: Use PseudoClassChangeInvalidation in other elements that implement matchesDefaultPseudoClass().
         Style::PseudoClassChangeInvalidation defaultInvalidation(*this, CSSSelector::PseudoClassDefault, !newValue.isNull());
         m_isDefault = !newValue.isNull();
@@ -200,7 +200,7 @@ void HTMLOptionElement::attributeChanged(const QualifiedName& name, const AtomSt
         break;
     }
 #if ENABLE(DATALIST_ELEMENT)
-    case AttributeName::valueAttr:
+    case AttributeNames::valueAttr:
         for (auto& dataList : ancestorsOfType<HTMLDataListElement>(*this))
             dataList.optionElementChildrenChanged();
         break;

--- a/Source/WebCore/html/HTMLSelectElement.cpp
+++ b/Source/WebCore/html/HTMLSelectElement.cpp
@@ -294,7 +294,7 @@ bool HTMLSelectElement::hasPresentationalHintsForAttribute(const QualifiedName& 
 void HTMLSelectElement::attributeChanged(const QualifiedName& name, const AtomString& oldValue, const AtomString& newValue, AttributeModificationReason attributeModificationReason)
 {
     switch (name.nodeName()) {
-    case AttributeName::sizeAttr: {
+    case AttributeNames::sizeAttr: {
         unsigned oldSize = m_size;
         unsigned size = limitToOnlyHTMLNonNegative(newValue);
 
@@ -311,7 +311,7 @@ void HTMLSelectElement::attributeChanged(const QualifiedName& name, const AtomSt
         }
         break;
     }
-    case AttributeName::multipleAttr:
+    case AttributeNames::multipleAttr:
         parseMultipleAttribute(newValue);
         break;
     default:

--- a/Source/WebCore/html/HTMLTableElement.cpp
+++ b/Source/WebCore/html/HTMLTableElement.cpp
@@ -371,14 +371,14 @@ void HTMLTableElement::attributeChanged(const QualifiedName& name, const AtomStr
     unsigned short oldPadding = m_padding;
 
     switch (name.nodeName()) {
-    case AttributeName::borderAttr:
+    case AttributeNames::borderAttr:
         // FIXME: This attribute is a mess.
         m_borderAttr = parseBorderWidthAttribute(newValue);
         break;
-    case AttributeName::bordercolorAttr:
+    case AttributeNames::bordercolorAttr:
         m_borderColorAttr = !newValue.isEmpty();
         break;
-    case AttributeName::frameAttr: {
+    case AttributeNames::frameAttr: {
         // FIXME: This attribute is a mess.
         bool borderTop;
         bool borderRight;
@@ -387,7 +387,7 @@ void HTMLTableElement::attributeChanged(const QualifiedName& name, const AtomStr
         m_frameAttr = getBordersFromFrameAttributeValue(newValue, borderTop, borderRight, borderBottom, borderLeft);
         break;
     }
-    case AttributeName::rulesAttr:
+    case AttributeNames::rulesAttr:
         m_rulesAttr = UnsetRules;
         if (equalLettersIgnoringASCIICase(newValue, "none"_s))
             m_rulesAttr = NoneRules;
@@ -400,7 +400,7 @@ void HTMLTableElement::attributeChanged(const QualifiedName& name, const AtomStr
         else if (equalLettersIgnoringASCIICase(newValue, "all"_s))
             m_rulesAttr = AllRules;
         break;
-    case AttributeName::cellpaddingAttr:
+    case AttributeNames::cellpaddingAttr:
         if (!newValue.isEmpty())
             m_padding = std::max(0, parseHTMLInteger(newValue).value_or(0));
         else

--- a/Source/WebCore/html/HTMLTextAreaElement.cpp
+++ b/Source/WebCore/html/HTMLTextAreaElement.cpp
@@ -149,7 +149,7 @@ void HTMLTextAreaElement::attributeChanged(const QualifiedName& name, const Atom
     HTMLTextFormControlElement::attributeChanged(name, oldValue, newValue, attributeModificationReason);
 
     switch (name.nodeName()) {
-    case AttributeName::rowsAttr: {
+    case AttributeNames::rowsAttr: {
         unsigned rows = limitToOnlyHTMLNonNegativeNumbersGreaterThanZero(newValue, defaultRows);
         if (m_rows != rows) {
             m_rows = rows;
@@ -158,7 +158,7 @@ void HTMLTextAreaElement::attributeChanged(const QualifiedName& name, const Atom
         }
         break;
     }
-    case AttributeName::colsAttr: {
+    case AttributeNames::colsAttr: {
         unsigned cols = limitToOnlyHTMLNonNegativeNumbersGreaterThanZero(newValue, defaultCols);
         if (m_cols != cols) {
             m_cols = cols;
@@ -167,7 +167,7 @@ void HTMLTextAreaElement::attributeChanged(const QualifiedName& name, const Atom
         }
         break;
     }
-    case AttributeName::wrapAttr: {
+    case AttributeNames::wrapAttr: {
         // The virtual/physical values were a Netscape extension of HTML 3.0, now deprecated.
         // The soft/hard /off values are a recommendation for HTML 4 extension by IE and NS 4.
         WrapMethod wrap;
@@ -184,11 +184,11 @@ void HTMLTextAreaElement::attributeChanged(const QualifiedName& name, const Atom
         }
         break;
     }
-    case AttributeName::maxlengthAttr:
+    case AttributeNames::maxlengthAttr:
         internalSetMaxLength(parseHTMLNonNegativeInteger(newValue).value_or(-1));
         updateValidity();
         break;
-    case AttributeName::minlengthAttr:
+    case AttributeNames::minlengthAttr:
         internalSetMinLength(parseHTMLNonNegativeInteger(newValue).value_or(-1));
         updateValidity();
         break;


### PR DESCRIPTION
#### 91443cf6c0695787120fd50b15fc2fc298aff88b
<pre>
Drop AttributeName alias and use AttributeNames namespace instead
<a href="https://bugs.webkit.org/show_bug.cgi?id=255456">https://bugs.webkit.org/show_bug.cgi?id=255456</a>

Reviewed by Ryosuke Niwa.

Drop AttributeName alias and use AttributeNames namespace instead. This is more
consistent with what we do for ElementNames and looks nicer for attributes in
namespaces (such as XML::langAttr).

* Source/WebCore/dom/Element.cpp:
(WebCore::Element::isElementsArrayReflectionAttribute):
(WebCore::Element::attributeChanged):
* Source/WebCore/dom/make_names.pl:
(printNodeNameHeaderFile):
* Source/WebCore/html/BaseDateAndTimeInputType.cpp:
(WebCore::BaseDateAndTimeInputType::attributeChanged):
* Source/WebCore/html/HTMLBodyElement.cpp:
(WebCore::HTMLBodyElement::hasPresentationalHintsForAttribute const):
(WebCore::HTMLBodyElement::collectPresentationalHintsForAttribute):
* Source/WebCore/html/HTMLElement.cpp:
(WebCore::HTMLElement::hasPresentationalHintsForAttribute const):
(WebCore::HTMLElement::collectPresentationalHintsForAttribute):
(WebCore::HTMLElement::attributeChanged):
* Source/WebCore/html/HTMLFormElement.cpp:
(WebCore::HTMLFormElement::attributeChanged):
* Source/WebCore/html/HTMLInputElement.cpp:
(WebCore::HTMLInputElement::hasPresentationalHintsForAttribute const):
(WebCore::HTMLInputElement::collectPresentationalHintsForAttribute):
(WebCore::HTMLInputElement::attributeChanged):
* Source/WebCore/html/HTMLOListElement.cpp:
(WebCore::HTMLOListElement::attributeChanged):
* Source/WebCore/html/HTMLOptionElement.cpp:
(WebCore::HTMLOptionElement::attributeChanged):
* Source/WebCore/html/HTMLSelectElement.cpp:
(WebCore::HTMLSelectElement::attributeChanged):
* Source/WebCore/html/HTMLTableElement.cpp:
(WebCore::HTMLTableElement::attributeChanged):
* Source/WebCore/html/HTMLTextAreaElement.cpp:
(WebCore::HTMLTextAreaElement::attributeChanged):

Canonical link: <a href="https://commits.webkit.org/262974@main">https://commits.webkit.org/262974@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ca78371f87f7bd1e5878ce868c63e521813f1baa

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/3177 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/3238 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/3348 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/4590 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/3534 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/3145 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/3303 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/3265 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/2765 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/3208 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/3527 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/2859 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/4399 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/1026 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/2830 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/2672 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/2805 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/2881 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/4149 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/3253 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/2598 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/2837 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/2832 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/780 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/2830 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/3096 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->