### PR TITLE
Some dynamically sized Interaction Regions occlusions are missing

### DIFF
--- a/LayoutTests/interaction-region/full-page-overlay-expected.txt
+++ b/LayoutTests/interaction-region/full-page-overlay-expected.txt
@@ -1,48 +1,20 @@
 (GraphicsLayer
   (anchor 0.00 0.00)
-  (bounds 1536.00 2008.00)
+  (bounds 1536.00 5013.00)
   (children 1
     (GraphicsLayer
-      (bounds 1536.00 2008.00)
+      (bounds 1536.00 5013.00)
       (contentsOpaque 1)
       (drawsContent 1)
       (backgroundColor #FFFFFF)
       (event region
-        (rect (0,0) width=1536 height=2008)
-      )
-      (children 2
-        (GraphicsLayer
-          (preserves3D 1)
-          (children 1
-            (GraphicsLayer
-              (bounds 1536.00 2008.00)
-              (contentsOpaque 1)
-              (event region
-                (rect (0,0) width=1536 height=2008)
+        (rect (0,0) width=1536 height=5013)
 
-              (interaction regions [
-                (occlusion (0,0) width=1536 height=2008)
-                (borderRadius 0.00)])
-              )
-            )
-          )
-        )
-        (GraphicsLayer
-          (preserves3D 1)
-          (children 1
-            (GraphicsLayer
-              (bounds 1536.00 2008.00)
-              (contentsOpaque 1)
-              (event region
-                (rect (0,0) width=1536 height=2008)
-
-              (interaction regions [
-                (occlusion (0,0) width=1536 height=2008)
-                (borderRadius 0.00)])
-              )
-            )
-          )
-        )
+      (interaction regions [
+        (occlusion (0,0) width=1536 height=2008)
+        (borderRadius 0.00),
+        (occlusion (0,0) width=1536 height=5000)
+        (borderRadius 0.00)])
       )
     )
   )

--- a/LayoutTests/interaction-region/full-page-overlay.html
+++ b/LayoutTests/interaction-region/full-page-overlay.html
@@ -4,18 +4,17 @@
     <meta name="viewport" content="initial-scale=0.5">
     <style>
         html, body {
-            width: 100%;
-            height: 100%;
             margin: 0;
         }
 
         .overlay {
-            position: fixed;
+            position: absolute;
             top: 0;
             left: 0;
-            z-index: 1;
             width: 100%;
             height: 100%;
+            z-index: 1;
+            opacity: 0.5;
             background-color: purple;
         }
 
@@ -24,20 +23,24 @@
         }
 
         .spacer {
-            height: 2000px;
+            height: 5000px;
         }
     </style>
 </head>
 <body>
-<div class="overlay"></div>
 <div class="tappable-overlay overlay"></div>
-<div class="spacer"></div>
+<div class="spacer">
+    <div id="dynamic" class="overlay"></div>
+</div>
 
 <pre id="results"></pre>
 <script>
 document.body.addEventListener("click", function(e) {
     console.log(e, "event delegation");
 });
+
+let dynamicallySizedOverlay = document.querySelector("#dynamic");
+dynamicallySizedOverlay.style.height = dynamicallySizedOverlay.parentElement.offsetHeight + "px";
 
 if (window.testRunner)
     testRunner.dumpAsText();

--- a/Source/WebCore/page/InteractionRegion.cpp
+++ b/Source/WebCore/page/InteractionRegion.cpp
@@ -142,8 +142,7 @@ std::optional<InteractionRegion> interactionRegionForRenderedRegion(RenderObject
     auto& mainFrameView = *localFrame->view();
 
     FloatSize frameViewSize = mainFrameView.size();
-    // Adding some wiggle room, we use this to avoid extreme cases.
-    auto scale = 1 / mainFrameView.visibleContentScaleFactor() + 0.2;
+    auto scale = 1 / mainFrameView.visibleContentScaleFactor();
     frameViewSize.scale(scale, scale);
     auto frameViewArea = frameViewSize.area();
 
@@ -183,7 +182,7 @@ std::optional<InteractionRegion> interactionRegionForRenderedRegion(RenderObject
     bool hasPointer = cursorTypeForElement(*matchedElement) == CursorType::Pointer || shouldAllowNonPointerCursorForElement(*matchedElement);
     bool isTooBigForInteraction = checkedRegionArea.value() > frameViewArea / 2;
     if (!hasListener || !hasPointer || isTooBigForInteraction) {
-        bool isOverlay = checkedRegionArea.value() <= frameViewArea && (renderer.style().specifiedZIndex() > 0 || renderer.isFixedPositioned());
+        bool isOverlay = renderer.style().specifiedZIndex() > 0 || renderer.isFixedPositioned();
         if (isOverlay && isOriginalMatch) {
             return { {
                 InteractionRegion::Type::Occlusion,


### PR DESCRIPTION
#### b6fce29cdde4c9295e6adf20940ede4b84731cb0
<pre>
Some dynamically sized Interaction Regions occlusions are missing
<a href="https://bugs.webkit.org/show_bug.cgi?id=255457">https://bugs.webkit.org/show_bug.cgi?id=255457</a>
&lt;rdar://107960700&gt;

Reviewed by Tim Horton.

Remove the size limit on occlusion regions (but not interaction
regions).

* LayoutTests/interaction-region/full-page-overlay-expected.txt:
* LayoutTests/interaction-region/full-page-overlay.html:
Update the test to cover this scenario.

* Source/WebCore/page/InteractionRegion.cpp:
(WebCore::interactionRegionForRenderedRegion):
Remove the &quot;padding&quot; added to the frame view&apos;s area, since it was
originally introduced for occlusions.
Remove the area check in the occlusion branch.

Canonical link: <a href="https://commits.webkit.org/262992@main">https://commits.webkit.org/262992@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b1f61168aaae4b973c2073adf830255e95f44acf

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/3179 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/3241 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/3351 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/4593 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/3537 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/3148 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/3306 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/3268 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/2766 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/3211 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/3530 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/2862 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/4402 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/1029 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/2833 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/2689 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/2808 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/2884 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/4150 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/3256 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/2601 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/2839 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/2835 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/792 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/2833 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/3098 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->