### PR TITLE
[margin-trim] Trimmed inline-start margins for grid items in horizontal writing-mode should be reflected in computed style.

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/computed-margin-values/grid-inline-start-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/computed-margin-values/grid-inline-start-expected.txt
@@ -1,0 +1,7 @@
+
+PASS grid > item 1
+PASS grid > item 2
+PASS grid > item 3
+PASS grid > item 4
+PASS grid > item 5
+

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/computed-margin-values/grid-inline-start-item-negative-span-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/computed-margin-values/grid-inline-start-item-negative-span-expected.txt
@@ -1,0 +1,4 @@
+
+PASS grid > item 1
+PASS grid > item 2
+

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/computed-margin-values/grid-inline-start-item-negative-span.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/computed-margin-values/grid-inline-start-item-negative-span.html
@@ -1,0 +1,42 @@
+<!DOCTYPE html>
+<html>
+<head>
+<title></title>
+<link rel="author" href="mailto:sammy.gill@apple.com">
+<link rel="help" href="https://w3c.github.io/csswg-drafts/css-box-4/#margin-trim-grid">
+<meta name="assert" content="trimmed inline-start margins in grid should be reflected in computed style">
+</head>
+<style>
+grid {
+    display: grid;
+    width: min-content;
+    outline: 1px solid black;
+    grid-template-columns: repeat(2, auto);
+    margin-trim: inline-start;
+}
+item {
+    display: block;
+    width: 50px;
+    height: 50px;
+    margin-inline-start: 10px;
+    background-color: green;
+}
+.negative-line-number {
+    width: 50px;
+    grid-row: 2;
+    grid-column: -3;
+    background-color: blue;
+}
+</style>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/resources/check-layout-th.js"></script>
+<body onload="checkLayout('grid > item')">
+    <div id="target">
+    <grid>
+        <item data-expected-margin-left="0" class="negative-line-number"></item>
+        <item data-expected-margin-left="0"></item>
+    </grid>
+    </div>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/computed-margin-values/grid-inline-start.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/computed-margin-values/grid-inline-start.html
@@ -1,0 +1,63 @@
+<!DOCTYPE html>
+<html>
+<head>
+<title></title>
+<link rel="author" href="mailto:sammy.gill@apple.com">
+<link rel="help" href="https://w3c.github.io/csswg-drafts/css-box-4/#margin-trim-grid">
+<meta name="assert" content="trimmed inline-start margins in grid should be reflected in computed style">
+</head>
+<style>
+grid {
+    display: grid;
+    width: min-content;
+    outline: 1px solid black;
+    grid-template-columns: repeat(2, auto);
+    margin-trim: inline-start;
+}
+item {
+    display: block;
+    width: 50px;
+    height: 50px;
+}
+.locked-position {
+    grid-row: 3;
+    grid-column: 1;
+    margin-inline-start: -30px;
+}
+item:nth-child(1) {
+    background-color: green;
+    margin-inline-start: 30px;
+}
+item:nth-child(2) {
+    background-color: blue;
+    margin-inline-start: 10px;
+}
+item:nth-child(3) {
+    background-color: orchid;
+    margin-inline-start: 10%;
+}
+item:nth-child(4) {
+    background-color: maroon;
+}
+item:nth-child(5) {
+    background-color: salmon;
+    width: auto;
+    grid-column: span 2;
+    margin-inline-start: 10px;
+}
+</style>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/resources/check-layout-th.js"></script>
+<body onload="checkLayout('grid > item')">
+    <div id="target">
+    <grid>
+        <item data-expected-margin-left="0"></item>
+        <item data-expected-margin-left="10"></item>
+        <item data-expected-margin-left="0"></item>
+        <item class="locked-position" data-expected-margin-left="0"></item>
+        <item data-expected-margin-left="0"></item>
+    </grid>
+    </div>
+</body>
+</html>

--- a/Source/WebCore/css/ComputedStyleExtractor.cpp
+++ b/Source/WebCore/css/ComputedStyleExtractor.cpp
@@ -2312,9 +2312,9 @@ static bool rendererCanHaveTrimmedMargin(const RenderBox& renderer, std::optiona
             return !containingBlock->style().marginTrim().isEmpty();
         return containingBlock->style().marginTrim().contains(marginTrimType.value());
     }
-    if (containingBlock->isRenderGrid() && (!marginTrimType || marginTrimType.value() == MarginTrimType::BlockStart || marginTrimType.value() == MarginTrimType::BlockEnd)) {
+    if (containingBlock->isRenderGrid() && (!marginTrimType || marginTrimType.value() == MarginTrimType::BlockStart || marginTrimType.value() == MarginTrimType::BlockEnd || marginTrimType.value() == MarginTrimType::InlineStart)) {
         if (!marginTrimType)
-            return containingBlock->style().marginTrim().containsAny({ MarginTrimType::BlockStart, MarginTrimType::BlockEnd });
+            return containingBlock->style().marginTrim().containsAny({ MarginTrimType::BlockStart, MarginTrimType::BlockEnd, MarginTrimType::InlineStart });
         return containingBlock->style().marginTrim().contains(marginTrimType.value());
     }
     return false;
@@ -2359,7 +2359,7 @@ static bool isLayoutDependent(CSSPropertyID propertyID, const RenderStyle* style
     case CSSPropertyMarginBottom:
         return paddingOrMarginIsRendererDependent<&RenderStyle::marginBottom>(style, renderer) ||  (is<RenderBox>(renderer) && rendererCanHaveTrimmedMargin(downcast<RenderBox>(*renderer), MarginTrimType::BlockEnd));
     case CSSPropertyMarginLeft:
-        return paddingOrMarginIsRendererDependent<&RenderStyle::marginLeft>(style, renderer) || (isFlexItem(renderer) && rendererCanHaveTrimmedMargin(downcast<RenderBox>(*renderer), MarginTrimType::InlineStart));
+        return paddingOrMarginIsRendererDependent<&RenderStyle::marginLeft>(style, renderer) || (is<RenderBox>(renderer) && rendererCanHaveTrimmedMargin(downcast<RenderBox>(*renderer), MarginTrimType::InlineStart));
     case CSSPropertyPadding: {
         if (!renderer || !renderer->isBox())
             return false;
@@ -3317,10 +3317,13 @@ RefPtr<CSSValue> ComputedStyleExtractor::valueForPropertyInStyle(const RenderSty
             && box->hasTrimmedMargin(PhysicalDirection::Bottom))
             return zoomAdjustedPixelValue(box->marginBottom(), style);
         return zoomAdjustedPaddingOrMarginPixelValue<&RenderStyle::marginBottom, &RenderBoxModelObject::marginBottom>(style, renderer);
-    case CSSPropertyMarginLeft:
-        if (auto* box = dynamicDowncast<RenderBox>(renderer); box && box->isFlexItem() && box->hasTrimmedMargin(PhysicalDirection::Left))
+    case CSSPropertyMarginLeft: {
+        if (auto* box = dynamicDowncast<RenderBox>(renderer);  box 
+            && rendererCanHaveTrimmedMargin(*box, MarginTrimType::InlineStart) 
+            && box->hasTrimmedMargin(PhysicalDirection::Left))
             return zoomAdjustedPixelValue(box->marginLeft(), style);
         return zoomAdjustedPaddingOrMarginPixelValue<&RenderStyle::marginLeft, &RenderBoxModelObject::marginLeft>(style, renderer);
+    }
     case CSSPropertyMarginTrim: {
         auto marginTrim = style.marginTrim();
         if (marginTrim.isEmpty())


### PR DESCRIPTION
#### 53332e5f72569d46fc8b69c2f0808f1f4ca190f7
<pre>
[margin-trim] Trimmed inline-start margins for grid items in horizontal writing-mode should be reflected in computed style.
<a href="https://bugs.webkit.org/show_bug.cgi?id=253718">https://bugs.webkit.org/show_bug.cgi?id=253718</a>
rdar://106559597

Reviewed by Alan Baradlay.

When a grid has inline-start specified for margin trim, it will trim the
inline-start margins of any items that are placed in the first column
of the grid. These trimmed margins should be reflected when querying the
computed style for the item. In order for this to happen,
ComputedStyleExtractor must be able to identify when the inline-start/left
margins of a grid item are trimmed. We can accomplish this by setting
the rare data bits for the renderer as this margin is trimmed during
layout. Then, ComputedStyleExtractor will be able to check to see if
this bit is set.

The inline-start margins for grid items are trimmed inside of
RenderBox::computeOrTrimInlineMargin as the renderer is going through
layout. This function is called as the renderer is trying to determine
its inline margin values as part of RenderBox::computeLogicalWidthInFragment.
The renderer of the grid item will consult with the grid via
shouldTrimChildMargin to determine if it should return a trimmed margin
value. At this time the renderer can also call into markMarginAsTrimmed
to set the rare data bit for the margin.

Once layout is finished, ComputedStyleExtractor can use
RenderBox::hasTrimmedMargin to check if the &quot;left,&quot; margin is trimmed.
This function will return true only if the rare data bit is set for that
specified margin.

* LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/computed-margin-values/grid-inline-start-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/computed-margin-values/grid-inline-start-item-negative-span-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/computed-margin-values/grid-inline-start-item-negative-span.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/computed-margin-values/grid-inline-start.html: Added.
* Source/WebCore/css/ComputedStyleExtractor.cpp:
(WebCore::rendererCanHaveTrimmedMargin):
(WebCore::isLayoutDependent):
(WebCore::ComputedStyleExtractor::valueForPropertyInStyle):
* Source/WebCore/rendering/RenderBox.cpp:
(WebCore::RenderBox::physicalToFlowRelativeDirectionMapping const):
(WebCore::RenderBox::hasTrimmedMargin const):
(WebCore::RenderBox::computeOrTrimInlineMargin const):

Canonical link: <a href="https://commits.webkit.org/263006@main">https://commits.webkit.org/263006@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e8d8bb086e832d1525c76a14abe02bd8d6ab8eb7

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/3290 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/3349 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/3462 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/4704 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/3619 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/3264 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/3408 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/3372 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/2852 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/3327 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/3615 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/2963 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/4526 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/1118 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/2924 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/2844 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/2899 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/2977 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/4260 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/3361 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/2686 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/2925 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/2925 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/804 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/2925 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/3200 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->