### PR TITLE
Web Inspector: Elements tab: Event badge popover does not dismiss when clicking its trigger again while it is visible

### DIFF
--- a/Source/WebInspectorUI/UserInterface/Views/DOMTreeElement.js
+++ b/Source/WebInspectorUI/UserInterface/Views/DOMTreeElement.js
@@ -2140,6 +2140,9 @@ WI.DOMTreeElement = class DOMTreeElement extends WI.TreeElement
 
     async _handleEventBadgeClicked(event)
     {
+        if (this._eventBadgePopover)
+            return;
+
         let {listeners} = await this.representedObject.getEventListeners({includeAncestors: false});
         console.assert(listeners.length, listeners);
 
@@ -2148,9 +2151,9 @@ WI.DOMTreeElement = class DOMTreeElement extends WI.TreeElement
             return WI.Rect.rectFromClientRect(this._elementForBadgeType.get(WI.DOMTreeElement.BadgeType.Event).getBoundingClientRect()).pad(2);
         };
 
-        let popover = new WI.Popover(this);
-        popover.windowResizeHandler = function(event) {
-            popover.present(calculateTargetFrame(), preferredEdges, {updateContent: true, shouldAnimate: false});
+        this._eventBadgePopover = new WI.Popover(this);
+        this._eventBadgePopover.windowResizeHandler = (event) => {
+            this._eventBadgePopover.present(calculateTargetFrame(), preferredEdges, {updateContent: true, shouldAnimate: false});
         };
 
         let sections = WI.EventListenerSectionGroup.groupIntoSectionsByEvent(listeners, {hideTarget: true});
@@ -2158,7 +2161,7 @@ WI.DOMTreeElement = class DOMTreeElement extends WI.TreeElement
             section.addEventListener(WI.DetailsSection.Event.CollapsedStateChanged, function(event) {
                 const shouldAnimate = false;
                 this.update(shouldAnimate);
-            }, popover);
+            }, this._eventBadgePopover);
         }
 
         const title = "";
@@ -2168,7 +2171,7 @@ WI.DOMTreeElement = class DOMTreeElement extends WI.TreeElement
         contentElement.className = "event-badge-popover-content";
         contentElement.appendChild(detailsSection.element);
 
-        popover.presentNewContentWithFrame(contentElement, calculateTargetFrame(), preferredEdges);
+        this._eventBadgePopover.presentNewContentWithFrame(contentElement, calculateTargetFrame(), preferredEdges);
     }
 
     _handleScrollableBadgeClicked(event)
@@ -2213,6 +2216,14 @@ WI.DOMTreeElement = class DOMTreeElement extends WI.TreeElement
     _handleShownDOMTreeBadgesChanged(event)
     {
         this._createBadges();
+    }
+
+    // Popover delegate
+
+    didDismissPopover(popover)
+    {
+        if (popover === this._eventBadgePopover)
+            this._eventBadgePopover = null;
     }
 };
 


### PR DESCRIPTION
#### 3ac060544790d4b26eeb70a20de0ae55722008cb
<pre>
Web Inspector: Elements tab: Event badge popover does not dismiss when clicking its trigger again while it is visible
<a href="https://bugs.webkit.org/show_bug.cgi?id=255463">https://bugs.webkit.org/show_bug.cgi?id=255463</a>

Reviewed by Devin Rousso.

A popover will auto-dismiss when clicking outside it.
Popover triggers are always outside them.

When it&apos;s done dismissing, after a CSS transition ends,
a popover will call `didDismissPopover()` on its delegate.

This patch uses this mechanism to clear the instance for a
visible event badge popover and avoid showing a popover again
when its trigger is clicked repeatedly.

* Source/WebInspectorUI/UserInterface/Views/DOMTreeElement.js:
(WI.DOMTreeElement.prototype.async _handleEventBadgeClicked):
(WI.DOMTreeElement.async _handleEventBadgeClicked.popover.windowResizeHandler): Deleted.

Canonical link: <a href="https://commits.webkit.org/263015@main">https://commits.webkit.org/263015@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/46ffe01584eabada09c1f2d1a1b54e2b6de7460d

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/3298 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/3357 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/3473 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/4715 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/3629 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/3419 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/3380 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/2863 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/3338 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/3625 "2 failures") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/2972 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/4537 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/1128 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/2938 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/2855 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/2910 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/2991 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/4271 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/3371 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/2694 "3 failures") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/2933 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/2939 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/810 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/2935 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/3208 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->