### PR TITLE
[margin-trim] Trimmed block-end margins for grid items in horizontal writing-mode should be refected in computed style.

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/computed-margin-values/grid-block-end-column-auto-flow-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/computed-margin-values/grid-block-end-column-auto-flow-expected.txt
@@ -1,0 +1,7 @@
+
+PASS grid > item 1
+PASS grid > item 2
+PASS grid > item 3
+PASS grid > item 4
+PASS grid > item 5
+

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/computed-margin-values/grid-block-end-column-auto-flow.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/computed-margin-values/grid-block-end-column-auto-flow.html
@@ -1,0 +1,60 @@
+<!DOCTYPE html>
+<html>
+<head>
+<link rel="author" href="mailto:sammy.gill@apple.com">
+<link rel="help" href="https://w3c.github.io/csswg-drafts/css-box-4/#margin-trim-grid">
+<meta name="assert" content="Trimmed block-end margins for grid items should be reflected in computed style">
+</head>
+<style>
+grid {
+    display: grid;
+    width: min-content;
+    grid-auto-flow: column;
+    border: 1px solid black;
+    grid-template-rows: auto auto auto;
+    margin-trim: block-end;
+}
+item {
+    display: block;
+    width: 50px;
+    height: 50px;
+    margin-block-end: 10px;
+}
+.span-four {
+    grid-row: span 4;
+}
+item:nth-child(1) {
+    grid-row: 1;
+    background-color: green;
+}
+item:nth-child(2) {
+    grid-row: 2;
+    background-color: blue;
+}
+item:nth-child(3) {
+    grid-row: 3;
+    background-color: purple;
+}
+item:nth-child(4) {
+    background-color:burlywood;
+}
+item:nth-child(5) {
+    background-color: grey;
+    grid-row: 4;
+}
+</style>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/resources/check-layout-th.js"></script>
+<body onload="checkLayout('grid > item')">
+    <div id="target">
+    <grid>
+        <item data-expected-margin-bottom="10"></item>
+        <item data-expected-margin-bottom="10"></item>
+        <item data-expected-margin-bottom="10"></item>
+        <item data-expected-margin-bottom="0" class="span-four"></item>
+        <item data-expected-margin-bottom="0"></item>
+    </grid>
+    </div>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/computed-margin-values/grid-block-end-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/computed-margin-values/grid-block-end-expected.txt
@@ -1,0 +1,6 @@
+
+PASS grid > item 1
+PASS grid > item 2
+PASS grid > item 3
+PASS grid > item 4
+

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/computed-margin-values/grid-block-end-item-spans-multiple-rows-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/computed-margin-values/grid-block-end-item-spans-multiple-rows-expected.txt
@@ -1,0 +1,4 @@
+
+PASS grid > item 1
+PASS grid > item 2
+

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/computed-margin-values/grid-block-end-item-spans-multiple-rows.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/computed-margin-values/grid-block-end-item-spans-multiple-rows.html
@@ -1,0 +1,43 @@
+<!DOCTYPE html>
+<html>
+<head>
+<title></title>
+<link rel="author" href="mailto:sammy.gill@apple.com">
+<link rel="help" href="https://w3c.github.io/csswg-drafts/css-box-4/#margin-trim-grid">
+<meta name="assert" content="item that spans into last row should have block-end margin trimmed">
+</head>
+<style>
+grid {
+    display: grid;
+    border: 1px solid black;
+    grid-template-columns: auto auto;
+    margin-trim: block-end;
+}
+item {
+    display: block;
+    width: 50px;
+    height: 50px;
+    margin-bottom: 10px;
+}
+.row-two {
+    grid-row: 2;
+    background-color: green;
+}
+.span-two-rows {
+    grid-row: span 2;
+    background-color: blue;
+    height: 90px;
+}
+</style>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/resources/check-layout-th.js"></script>
+<body onload="checkLayout('grid > item')">
+    <div id="target">
+    <grid>
+        <item data-expected-margin-bottom="0" class="span-two-rows"></item>
+        <item data-expected-margin-bottom="0" class="row-two"></item>
+    </grid>
+    </div>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/computed-margin-values/grid-block-end.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/computed-margin-values/grid-block-end.html
@@ -1,0 +1,56 @@
+<!DOCTYPE html>
+<html>
+<head>
+<title></title>
+<link rel="author" href="mailto:sammy.gill@apple.com">
+<link rel="help" href="https://w3c.github.io/csswg-drafts/css-box-4/#margin-trim-grid">
+<meta name="assert" content="Trimmed block-end margins for grid items should be reflected in computed style">
+</head>
+<style>
+grid {
+    display: grid;
+    width: min-content;
+    border: 1px solid black;
+    grid-template-columns: repeat(4, auto);
+    margin-trim: block-end;
+}
+item {
+    display: block;
+    width: 50px;
+    height: 50px;
+    margin-bottom: 10px;
+}
+.locked-position {
+    grid-row: 2;
+    grid-column: 2;
+    margin-block-end: 50px;
+    background-color: magenta;
+}
+.span-three-columns {
+    grid-column: span 3;
+    background-color: purple;
+}
+.span-five-columns {
+    grid-column: span 5;
+}
+item:nth-child(1) {
+    background-color: green;
+}
+item:nth-child(4) {
+    background-color: blue;
+}
+</style>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/resources/check-layout-th.js"></script>
+<body onload="checkLayout('grid > item')">
+    <div id="target">
+    <grid>
+        <item class="span-five-columns" data-expected-margin-bottom="10"></item>
+        <item class="locked-position" data-expected-margin-bottom="50"></item>
+        <item class="span-three-columns" data-expected-margin-bottom="10"></item>
+        <item data-expected-margin-bottom="0"></item>
+    </grid>
+    </div>
+</body>
+</html>

--- a/Source/WebCore/rendering/RenderBox.cpp
+++ b/Source/WebCore/rendering/RenderBox.cpp
@@ -1474,7 +1474,7 @@ bool RenderBox::hasTrimmedMargin(std::optional<MarginTrimType> marginTrimType) c
         return false;
     }
     if (containingBlock && containingBlock->isRenderGrid())
-        ASSERT(!marginTrimType || marginTrimType.value() == MarginTrimType::BlockStart);
+        ASSERT(!marginTrimType || marginTrimType.value() == MarginTrimType::BlockStart || marginTrimType.value() == MarginTrimType::BlockEnd);
 #endif
     if (!hasRareData())
         return false;
@@ -3824,8 +3824,8 @@ LayoutUnit RenderBox::constrainBlockMarginInAvailableSpaceOrTrim(const RenderBox
         // be done at this level within RenderBox. We should be able to leave the 
         // trimming responsibility to each of those contexts and not need to
         // do any of it here (trimming the margin and setting the rare data bit)
-        if (isGridItem() && marginSide == MarginTrimType::BlockStart)
-            const_cast<RenderBox&>(*this).markMarginAsTrimmed(MarginTrimType::BlockStart);
+        if (isGridItem())
+            const_cast<RenderBox&>(*this).markMarginAsTrimmed(marginSide);
         return 0_lu;
     }
     


### PR DESCRIPTION
#### 7e8288073ff2c88c74a6b7bf0a19f131bcedbe97
<pre>
[margin-trim] Trimmed block-end margins for grid items in horizontal writing-mode should be refected in computed style.
<a href="https://bugs.webkit.org/show_bug.cgi?id=253717">https://bugs.webkit.org/show_bug.cgi?id=253717</a>
rdar://106559562

Reviewed by Alan Baradlay.

When a grid has block-end margin-trim specified, then it should
trim the block-end margins of any of its items on the last row.
These margins that end up getting trimmed should be reflected in the
computed style of that margin as having being trimmed (value of 0). This
can be done by setting the rare data margin-trim bit for the &quot;bottm,&quot;
margin of the renderer during layout.

Since the trimming for the block-end margins of grid item occurs in
RenderBox::constrainBlockMarginInAvailableSpaceOrTrim, then that is the
appropriate place to set the rare data bit for the trimmed margin. The
renderer can set this bit by calling markMarginAsTrimmed and passing in
the margin that has been trimmed.

ComputedStyleExtractor should then be able to use
RenderBox::hasTrimmedMargin, which returns true if the rare data bit is set
for the passed in margin, to determine if the &quot;bottom,&quot; margin has been
trimmed during layout.

* LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/computed-margin-values/grid-block-end-column-auto-flow-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/computed-margin-values/grid-block-end-column-auto-flow.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/computed-margin-values/grid-block-end-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/computed-margin-values/grid-block-end-item-spans-multiple-rows-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/computed-margin-values/grid-block-end-item-spans-multiple-rows.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/computed-margin-values/grid-block-end.html: Added.
* Source/WebCore/css/ComputedStyleExtractor.cpp:
(WebCore::rendererCanHaveTrimmedMargin):
(WebCore::isLayoutDependent):
(WebCore::ComputedStyleExtractor::valueForPropertyInStyle):
* Source/WebCore/rendering/RenderBox.cpp:
(WebCore::RenderBox::hasTrimmedMargin const):
(WebCore::RenderBox::constrainBlockMarginInAvailableSpaceOrTrim const):

Canonical link: <a href="https://commits.webkit.org/263002@main">https://commits.webkit.org/263002@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d9690133245fa5ad473ed9abbfe82cff72bce4b1

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/3225 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/3288 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/3402 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/4642 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/3570 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/3198 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/3350 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/3318 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/2807 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/3260 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/3567 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/2902 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/4455 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/1068 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/2873 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/2793 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/2848 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/2925 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/4200 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/3304 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/2639 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/2875 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/2875 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/803 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/2872 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/3142 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->