### PR TITLE
[JSC] Add IndexedProxyObjectLoad IC to optimize "get" trap for indexed properties

### DIFF
--- a/JSTests/microbenchmarks/proxy-get-indexed.js
+++ b/JSTests/microbenchmarks/proxy-get-indexed.js
@@ -1,0 +1,16 @@
+(function() {
+var proxy = new Proxy([], {
+    get(target, propertyName, receiver) {
+        return propertyName;
+    }
+});
+
+var length = 20;
+for (var i = 0; i < (1e7 / length); ++i) {
+    for (var j = 0; j < length; ++j)
+        var lastPropertyName = proxy[j];
+}
+
+if (lastPropertyName !== `${length - 1}`)
+    throw new Error("Bad assertion!");
+})();

--- a/JSTests/microbenchmarks/proxy-get.js
+++ b/JSTests/microbenchmarks/proxy-get.js
@@ -1,3 +1,4 @@
+(function() {
 var proxy = new Proxy({}, {
     get(target, propertyName, receiver) {
         return 42;
@@ -6,3 +7,4 @@ var proxy = new Proxy({}, {
 
 for (var i = 0; i < 1e7; ++i)
     proxy.test;
+})();

--- a/Source/JavaScriptCore/bytecode/AccessCase.cpp
+++ b/Source/JavaScriptCore/bytecode/AccessCase.cpp
@@ -113,6 +113,7 @@ Ref<AccessCase> AccessCase::create(VM& vm, JSCell* owner, AccessType type, Cache
     case IndexedResizableTypedArrayFloat32Load:
     case IndexedResizableTypedArrayFloat64Load:
     case IndexedStringLoad:
+    case IndexedProxyObjectLoad:
     case IndexedNoIndexingMiss:
     case IndexedInt32Store:
     case IndexedDoubleStore:
@@ -374,6 +375,7 @@ bool AccessCase::guardedByStructureCheckSkippingConstantIdentifierCheck() const
     case IndexedResizableTypedArrayFloat32Load:
     case IndexedResizableTypedArrayFloat64Load:
     case IndexedStringLoad:
+    case IndexedProxyObjectLoad:
     case IndexedInt32Store:
     case IndexedDoubleStore:
     case IndexedContiguousStore:
@@ -483,6 +485,7 @@ bool AccessCase::requiresIdentifierNameMatch() const
     case IndexedResizableTypedArrayFloat32Load:
     case IndexedResizableTypedArrayFloat64Load:
     case IndexedStringLoad:
+    case IndexedProxyObjectLoad:
     case IndexedNoIndexingMiss:
     case IndexedInt32Store:
     case IndexedDoubleStore:
@@ -571,6 +574,7 @@ bool AccessCase::requiresInt32PropertyCheck() const
     case IndexedResizableTypedArrayFloat32Load:
     case IndexedResizableTypedArrayFloat64Load:
     case IndexedStringLoad:
+    case IndexedProxyObjectLoad:
     case IndexedNoIndexingMiss:
     case IndexedInt32Store:
     case IndexedDoubleStore:
@@ -668,6 +672,7 @@ bool AccessCase::needsScratchFPR() const
     case IndexedResizableTypedArrayInt32Store:
         return false;
     case IndexedDoubleLoad:
+    case IndexedProxyObjectLoad:
     case IndexedTypedArrayFloat32Load:
     case IndexedTypedArrayFloat64Load:
     case IndexedTypedArrayUint32Load:
@@ -730,7 +735,8 @@ void AccessCase::forEachDependentCell(VM&, const Functor& functor) const
     }
     case ProxyObjectHas:
     case ProxyObjectLoad:
-    case ProxyObjectStore: {
+    case ProxyObjectStore:
+    case IndexedProxyObjectLoad: {
         auto& accessor = this->as<ProxyObjectAccessCase>();
         if (accessor.callLinkInfo())
             accessor.callLinkInfo()->forEachDependentCell(functor);
@@ -829,6 +835,7 @@ bool AccessCase::doesCalls(VM& vm, Vector<JSCell*>* cellsToMarkIfDoesCalls) cons
     case ProxyObjectHas:
     case ProxyObjectLoad:
     case ProxyObjectStore:
+    case IndexedProxyObjectLoad:
         doesCalls = true;
         break;
     case IntrinsicGetter: {
@@ -993,6 +1000,7 @@ bool AccessCase::canReplace(const AccessCase& other) const
     case IndexedResizableTypedArrayFloat32Load:
     case IndexedResizableTypedArrayFloat64Load:
     case IndexedStringLoad:
+    case IndexedProxyObjectLoad:
     case IndexedInt32Store:
     case IndexedDoubleStore:
     case IndexedContiguousStore:
@@ -1268,6 +1276,7 @@ inline void AccessCase::runWithDowncast(const Func& func)
     case ProxyObjectHas:
     case ProxyObjectLoad:
     case ProxyObjectStore:
+    case IndexedProxyObjectLoad:
         func(static_cast<ProxyObjectAccessCase*>(this));
         break;
     }
@@ -1380,8 +1389,9 @@ bool AccessCase::canBeShared(const AccessCase& lhs, const AccessCase& rhs)
     case Setter:
     case ProxyObjectHas:
     case ProxyObjectLoad:
-    case ProxyObjectStore: {
-        // Getter / Setter / ProxyObjectHas / ProxyObjectLoad / ProxyObjectStore relies on CodeBlock, which makes sharing impossible.
+    case ProxyObjectStore:
+    case IndexedProxyObjectLoad: {
+        // These types rely on CodeBlock, which makes sharing impossible.
         return false;
     }
 

--- a/Source/JavaScriptCore/bytecode/AccessCase.h
+++ b/Source/JavaScriptCore/bytecode/AccessCase.h
@@ -148,6 +148,7 @@ DECLARE_ALLOCATOR_WITH_HEAP_IDENTIFIER(AccessCase);
     macro(IndexedResizableTypedArrayFloat32Load) \
     macro(IndexedResizableTypedArrayFloat64Load) \
     macro(IndexedStringLoad) \
+    macro(IndexedProxyObjectLoad) \
     macro(IndexedNoIndexingMiss) \
     macro(IndexedInt32Store) \
     macro(IndexedDoubleStore) \

--- a/Source/JavaScriptCore/bytecode/GetByStatus.cpp
+++ b/Source/JavaScriptCore/bytecode/GetByStatus.cpp
@@ -252,7 +252,8 @@ GetByStatus GetByStatus::computeForStubInfoWithoutExitSiteFeedback(
             switch (access.type()) {
             case AccessCase::ModuleNamespaceLoad:
                 return GetByStatus(access.as<ModuleNamespaceAccessCase>());
-            case AccessCase::ProxyObjectLoad: {
+            case AccessCase::ProxyObjectLoad:
+            case AccessCase::IndexedProxyObjectLoad: {
                 auto& accessCase = access.as<ProxyObjectAccessCase>();
                 auto status = GetByStatus(accessCase);
                 auto callLinkStatus = makeUnique<CallLinkStatus>();

--- a/Source/JavaScriptCore/bytecode/Repatch.cpp
+++ b/Source/JavaScriptCore/bytecode/Repatch.cpp
@@ -706,6 +706,11 @@ static InlineCacheAction tryCacheArrayGetByVal(JSGlobalObject* globalObject, Cod
                 if (!base->isObject())
                     return GiveUpOnCache;
 
+                if (base->inherits<ProxyObject>()) {
+                    newCase = ProxyObjectAccessCase::create(vm, codeBlock, AccessCase::IndexedProxyObjectLoad, nullptr);
+                    break;
+                }
+
                 if (base->structure()->mayInterceptIndexedAccesses() || base->structure()->typeInfo().interceptsGetOwnPropertySlotByIndexEvenWhenLengthIsNotZero())
                     return GiveUpOnCache;
 
@@ -861,7 +866,7 @@ static InlineCacheAction tryCachePutBy(JSGlobalObject* globalObject, CodeBlock* 
 
         JSCell* baseCell = baseValue.asCell();
 
-        bool isProxyObject = baseCell->type() == ProxyObjectType;
+        bool isProxyObject = baseCell->inherits<ProxyObject>();
         if (!isProxyObject) {
             if (!slot.isCacheablePut() && !slot.isCacheableCustom() && !slot.isCacheableSetter())
                 return GiveUpOnCache;

--- a/Source/JavaScriptCore/jit/JITOperations.cpp
+++ b/Source/JavaScriptCore/jit/JITOperations.cpp
@@ -60,6 +60,7 @@
 #include "JSWithScope.h"
 #include "LLIntEntrypoint.h"
 #include "MegamorphicCache.h"
+#include "NumberPrototype.h"
 #include "ObjectConstructor.h"
 #include "PropertyName.h"
 #include "RegExpObject.h"
@@ -1813,6 +1814,16 @@ JSC_DEFINE_JIT_OPERATION(operationSetFunctionName, void, (JSGlobalObject* global
     JSFunction* func = jsCast<JSFunction*>(funcCell);
     JSValue name = JSValue::decode(encodedName);
     func->setFunctionName(globalObject, name);
+}
+
+JSC_DEFINE_JIT_OPERATION(operationInt32ToStringWithRadix10, JSCell*, (VM* vmPointer, int32_t value))
+{
+    VM& vm = *vmPointer;
+    CallFrame* callFrame = DECLARE_CALL_FRAME(vm);
+    JITOperationPrologueCallFrameTracer tracer(vm, callFrame);
+
+    int32_t radix = 10;
+    return int32ToString(vm, value, radix);
 }
 
 JSC_DEFINE_JIT_OPERATION(operationNewObject, JSCell*, (VM* vmPointer, Structure* structure))

--- a/Source/JavaScriptCore/jit/JITOperations.h
+++ b/Source/JavaScriptCore/jit/JITOperations.h
@@ -249,6 +249,7 @@ JSC_DECLARE_JIT_OPERATION(operationNewAsyncFunctionWithInvalidatedReallocationWa
 JSC_DECLARE_JIT_OPERATION(operationNewAsyncGeneratorFunction, EncodedJSValue, (VM*, JSScope*, JSCell*));
 JSC_DECLARE_JIT_OPERATION(operationNewAsyncGeneratorFunctionWithInvalidatedReallocationWatchpoint, EncodedJSValue, (VM*, JSScope*, JSCell*));
 JSC_DECLARE_JIT_OPERATION(operationSetFunctionName, void, (JSGlobalObject*, JSCell*, EncodedJSValue));
+JSC_DECLARE_JIT_OPERATION(operationInt32ToStringWithRadix10, JSCell*, (VM*, int32_t));
 JSC_DECLARE_JIT_OPERATION(operationNewObject, JSCell*, (VM*, Structure*));
 JSC_DECLARE_JIT_OPERATION(operationNewPromise, JSCell*, (VM*, Structure*));
 JSC_DECLARE_JIT_OPERATION(operationNewInternalPromise, JSCell*, (VM*, Structure*));


### PR DESCRIPTION
#### 1f9a51f504de1f3b8c42f51114d8d770372c3388
<pre>
[JSC] Add IndexedProxyObjectLoad IC to optimize &quot;get&quot; trap for indexed properties
<a href="https://bugs.webkit.org/show_bug.cgi?id=255465">https://bugs.webkit.org/show_bug.cgi?id=255465</a>
&lt;rdar://problem/108061093&gt;

Reviewed by NOBODY (OOPS!).

This change introduces a new access case for indexed ProxyObject loads, and ensures that
DFG inlines it as Call just like for non-indexed ProxyObjectLoad, while converting integer
property name to a string beforehand as per spec [1].

Since branchIfNotInt32() is emitted purely for alignment with other Indexed* access cases,
as it&apos;s unnecessary for ProxyObject targets, we can call int32ToString() directly.

This patch progresses provided microbenchmark by 3.2X and likely affects JS3 Proxy subtests.

Also, harmonizes ProxyObject checks in Repatch.cpp to consistently use inherits&lt;&gt;.

                              ToT                      patch

proxy-get-indexed      644.6094+-6.3488     ^    200.5755+-0.2555        ^ definitely 3.2138x faster

[1]: <a href="https://tc39.es/ecma262/#sec-evaluate-property-access-with-expression-key">https://tc39.es/ecma262/#sec-evaluate-property-access-with-expression-key</a> (step 3)

* JSTests/microbenchmarks/proxy-get-indexed.js: Added.
* JSTests/microbenchmarks/proxy-get.js:
* Source/JavaScriptCore/bytecode/AccessCase.cpp:
(JSC::AccessCase::create):
(JSC::AccessCase::guardedByStructureCheckSkippingConstantIdentifierCheck const):
(JSC::AccessCase::requiresIdentifierNameMatch const):
(JSC::AccessCase::requiresInt32PropertyCheck const):
(JSC::AccessCase::needsScratchFPR const):
(JSC::AccessCase::forEachDependentCell const):
(JSC::AccessCase::doesCalls const):
(JSC::AccessCase::canReplace const):
(JSC::AccessCase::runWithDowncast):
(JSC::AccessCase::canBeShared):
* Source/JavaScriptCore/bytecode/AccessCase.h:
* Source/JavaScriptCore/bytecode/GetByStatus.cpp:
(JSC::GetByStatus::computeForStubInfoWithoutExitSiteFeedback):
* Source/JavaScriptCore/bytecode/InlineCacheCompiler.cpp:
(JSC::InlineCacheCompiler::generateWithGuard):
(JSC::InlineCacheCompiler::generateImpl):
(JSC::InlineCacheCompiler::emitProxyObjectAccess):
(JSC::InlineCacheCompiler::regenerate):
* Source/JavaScriptCore/bytecode/Repatch.cpp:
(JSC::tryCacheArrayGetByVal):
(JSC::tryCachePutBy):
* Source/JavaScriptCore/dfg/DFGByteCodeParser.cpp:
(JSC::DFG::ByteCodeParser::handleProxyObjectLoad):
(JSC::DFG::ByteCodeParser::handleGetById):
(JSC::DFG::ByteCodeParser::parseBlock):
* Source/JavaScriptCore/jit/JITOperations.cpp:
(JSC::JSC_DEFINE_JIT_OPERATION):
* Source/JavaScriptCore/jit/JITOperations.h:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1f9a51f504de1f3b8c42f51114d8d770372c3388

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/3670 "1 style error") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/3754 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/3860 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/5096 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/3955 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/3830 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/3759 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/3179 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/3714 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/3944 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/3306 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/4946 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/1450 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/3277 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/3357 "Passed tests") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/3006 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/3258 "Passed tests") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/3336 "3 failures") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/4716 "268 api tests failed or timed out") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/3445 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/3723 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/3012 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/3742 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/3257 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/3277 "Passed tests") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/949 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/3289 "Built successfully") | | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/24/builds/3834 "Built successfully") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/3534 "Built successfully") | | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/3/builds/1062 "Passed tests") | 
<!--EWS-Status-Bubble-End-->