### PR TITLE
Adopt the new NodeName enumeration more broadly in attributeChanged() overrides

### DIFF
--- a/Source/WebCore/html/HTMLAreaElement.cpp
+++ b/Source/WebCore/html/HTMLAreaElement.cpp
@@ -29,6 +29,7 @@
 #include "HTMLParserIdioms.h"
 #include "HitTestResult.h"
 #include "LocalFrame.h"
+#include "NodeName.h"
 #include "Path.h"
 #include "RenderImage.h"
 #include "RenderView.h"
@@ -55,7 +56,8 @@ Ref<HTMLAreaElement> HTMLAreaElement::create(const QualifiedName& tagName, Docum
 
 void HTMLAreaElement::attributeChanged(const QualifiedName& name, const AtomString& oldValue, const AtomString& newValue, AttributeModificationReason attributeModificationReason)
 {
-    if (name == shapeAttr) {
+    switch (name.nodeName()) {
+    case AttributeNames::shapeAttr:
         if (equalLettersIgnoringASCIICase(newValue, "default"_s))
             m_shape = Default;
         else if (equalLettersIgnoringASCIICase(newValue, "circle"_s) || equalLettersIgnoringASCIICase(newValue, "circ"_s))
@@ -67,13 +69,18 @@ void HTMLAreaElement::attributeChanged(const QualifiedName& name, const AtomStri
             m_shape = Rect;
         }
         invalidateCachedRegion();
-    } else if (name == coordsAttr) {
+        break;
+    case AttributeNames::coordsAttr:
         m_coords = parseHTMLListOfOfFloatingPointNumberValues(newValue.string());
         invalidateCachedRegion();
-    } else if (name == altAttr) {
+        break;
+    case AttributeNames::altAttr:
         // Do nothing.
-    } else
+        break;
+    default:
         HTMLAnchorElement::attributeChanged(name, oldValue, newValue, attributeModificationReason);
+        break;
+    }
 }
 
 void HTMLAreaElement::invalidateCachedRegion()

--- a/Source/WebCore/html/HTMLAttributeNames.in
+++ b/Source/WebCore/html/HTMLAttributeNames.in
@@ -385,6 +385,7 @@ rows
 rowspan
 rules
 sandbox
+save
 scheme
 scope
 scoped
@@ -411,6 +412,7 @@ standby
 start
 step
 style
+subtitle
 summary
 tabindex
 tableborder

--- a/Source/WebCore/html/HTMLBodyElement.cpp
+++ b/Source/WebCore/html/HTMLBodyElement.cpp
@@ -133,38 +133,38 @@ const AtomString& HTMLBodyElement::eventNameForWindowEventHandlerAttribute(const
 
 void HTMLBodyElement::attributeChanged(const QualifiedName& name, const AtomString& oldValue, const AtomString& newValue, AttributeModificationReason attributeModificationReason)
 {
-    if (name == vlinkAttr || name == alinkAttr || name == linkAttr) {
-        auto parsedColor = parseLegacyColorValue(newValue);
-        if (name == linkAttr) {
-            if (parsedColor)
-                document().setLinkColor(*parsedColor);
-            else
-                document().resetLinkColor();
-        } else if (name == vlinkAttr) {
-            if (parsedColor)
-                document().setVisitedLinkColor(*parsedColor);
-            else
-                document().resetVisitedLinkColor();
-        } else {
-            ASSERT(name == alinkAttr);
-            if (parsedColor)
-                document().setActiveLinkColor(*parsedColor);
-            else
-                document().resetActiveLinkColor();
-        }
+    switch (name.nodeName()) {
+    case AttributeNames::vlinkAttr:
+        if (auto parsedColor = parseLegacyColorValue(newValue))
+            document().setVisitedLinkColor(*parsedColor);
+        else
+            document().resetVisitedLinkColor();
         invalidateStyleForSubtree();
         return;
-    }
-
-    // FIXME: Emit "selectionchange" event at <input> / <textarea> elements and remove this special-case.
-    // https://bugs.webkit.org/show_bug.cgi?id=234348
-    if (name == onselectionchangeAttr) {
+    case AttributeNames::alinkAttr:
+        if (auto parsedColor = parseLegacyColorValue(newValue))
+            document().setActiveLinkColor(*parsedColor);
+        else
+            document().resetActiveLinkColor();
+        invalidateStyleForSubtree();
+        return;
+    case AttributeNames::linkAttr:
+        if (auto parsedColor = parseLegacyColorValue(newValue))
+            document().setLinkColor(*parsedColor);
+        else
+            document().resetLinkColor();
+        invalidateStyleForSubtree();
+        return;
+    case AttributeNames::onselectionchangeAttr:
+        // FIXME: Emit "selectionchange" event at <input> / <textarea> elements and remove this special-case.
+        // https://bugs.webkit.org/show_bug.cgi?id=234348
         document().setAttributeEventListener(eventNames().selectionchangeEvent, name, newValue, mainThreadNormalWorld());
         return;
+    default:
+        break;
     }
 
-    auto& eventName = eventNameForWindowEventHandlerAttribute(name);
-    if (!eventName.isNull()) {
+    if (auto& eventName = eventNameForWindowEventHandlerAttribute(name); !eventName.isNull()) {
         document().setWindowAttributeEventListener(eventName, name, newValue, mainThreadNormalWorld());
         return;
     }

--- a/Source/WebCore/html/HTMLEmbedElement.cpp
+++ b/Source/WebCore/html/HTMLEmbedElement.cpp
@@ -33,6 +33,7 @@
 #include "HTMLParserIdioms.h"
 #include "LocalFrame.h"
 #include "LocalFrameView.h"
+#include "NodeName.h"
 #include "PluginDocument.h"
 #include "RenderEmbeddedObject.h"
 #include "RenderWidget.h"
@@ -98,23 +99,29 @@ static bool hasTypeOrSrc(const HTMLEmbedElement& embed)
 void HTMLEmbedElement::attributeChanged(const QualifiedName& name, const AtomString& oldValue, const AtomString& newValue, AttributeModificationReason attributeModificationReason)
 {
     HTMLPlugInImageElement::attributeChanged(name, oldValue, newValue, attributeModificationReason);
-    if (name == typeAttr) {
+    switch (name.nodeName()) {
+    case AttributeNames::typeAttr:
         m_serviceType = newValue.string().left(newValue.find(';')).convertToASCIILowercase();
         // FIXME: The only difference between this and HTMLObjectElement's corresponding
         // code is that HTMLObjectElement does setNeedsWidgetUpdate(true). Consider moving
         // this up to the HTMLPlugInImageElement to be shared.
         if (renderer() && !hasTypeOrSrc(*this))
             invalidateStyle();
-    } else if (name == codeAttr) {
+        break;
+    case AttributeNames::codeAttr:
         m_url = stripLeadingAndTrailingHTMLSpaces(newValue);
         // FIXME: Why no call to updateImageLoaderWithNewURLSoon?
         // FIXME: If both code and src attributes are specified, last one parsed/changed wins. That can't be right!
-    } else if (name == srcAttr) {
+        break;
+    case AttributeNames::srcAttr:
         m_url = stripLeadingAndTrailingHTMLSpaces(newValue);
         updateImageLoaderWithNewURLSoon();
         if (renderer() && !hasTypeOrSrc(*this))
             invalidateStyle();
         // FIXME: If both code and src attributes are specified, last one parsed/changed wins. That can't be right!
+        break;
+    default:
+        break;
     }
 }
 

--- a/Source/WebCore/html/HTMLFrameSetElement.cpp
+++ b/Source/WebCore/html/HTMLFrameSetElement.cpp
@@ -39,6 +39,7 @@
 #include "Length.h"
 #include "LocalFrame.h"
 #include "MouseEvent.h"
+#include "NodeName.h"
 #include "RenderFrameSet.h"
 #include "Text.h"
 #include <wtf/IsoMallocInlines.h>
@@ -85,13 +86,13 @@ void HTMLFrameSetElement::collectPresentationalHintsForAttribute(const Qualified
 
 void HTMLFrameSetElement::attributeChanged(const QualifiedName& name, const AtomString& oldValue, const AtomString& newValue, AttributeModificationReason attributeModificationReason)
 {
-    auto& eventName = HTMLBodyElement::eventNameForWindowEventHandlerAttribute(name);
-    if (!eventName.isNull())
+    if (auto& eventName = HTMLBodyElement::eventNameForWindowEventHandlerAttribute(name); !eventName.isNull())
         document().setWindowAttributeEventListener(eventName, name, newValue, mainThreadNormalWorld());
     else
         HTMLElement::attributeChanged(name, oldValue, newValue, attributeModificationReason);
 
-    if (name == rowsAttr) {
+    switch (name.nodeName()) {
+    case AttributeNames::rowsAttr:
         // FIXME: What is the right thing to do when removing this attribute?
         // Why not treat it the same way we treat setting it to the empty string?
         if (!newValue.isNull()) {
@@ -99,10 +100,8 @@ void HTMLFrameSetElement::attributeChanged(const QualifiedName& name, const Atom
             // FIXME: Would be nice to optimize the case where m_rowLengths did not change.
             invalidateStyleForSubtree();
         }
-        return;
-    }
-
-    if (name == colsAttr) {
+        break;
+    case AttributeNames::colsAttr:
         // FIXME: What is the right thing to do when removing this attribute?
         // Why not treat it the same way we treat setting it to the empty string?
         if (!newValue.isNull()) {
@@ -110,10 +109,8 @@ void HTMLFrameSetElement::attributeChanged(const QualifiedName& name, const Atom
             // FIXME: Would be nice to optimize the case where m_colLengths did not change.
             invalidateStyleForSubtree();
         }
-        return;
-    }
-
-    if (name == frameborderAttr) {
+        break;
+    case AttributeNames::frameborderAttr:
         if (!newValue.isNull()) {
             if (equalLettersIgnoringASCIICase(newValue, "no"_s) || newValue == "0"_s) {
                 m_frameborder = false;
@@ -126,30 +123,26 @@ void HTMLFrameSetElement::attributeChanged(const QualifiedName& name, const Atom
             m_frameborderSet = false;
         }
         // FIXME: Do we need to trigger repainting?
-        return;
-    }
-
-    if (name == noresizeAttr) {
+        break;
+    case AttributeNames::noresizeAttr:
         // FIXME: This should set m_noresize to false if the value is null.
         m_noresize = true;
-        return;
-    }
-
-    if (name == borderAttr) {
+        break;
+    case AttributeNames::borderAttr:
         if (!newValue.isNull()) {
             m_border = parseHTMLInteger(newValue).value_or(0);
             m_borderSet = true;
         } else
             m_borderSet = false;
         // FIXME: Do we need to trigger repainting?
-        return;
-    }
-
-    if (name == bordercolorAttr) {
+        break;
+    case AttributeNames::bordercolorAttr:
         m_borderColorSet = !newValue.isEmpty();
         // FIXME: Clearly wrong: This can overwrite the value inherited from the parent frameset.
         // FIXME: Do we need to trigger repainting?
-        return;
+        break;
+    default:
+        break;
     }
 }
 

--- a/Source/WebCore/html/HTMLLinkElement.cpp
+++ b/Source/WebCore/html/HTMLLinkElement.cpp
@@ -54,6 +54,7 @@
 #include "MediaQueryParser.h"
 #include "MediaQueryParserContext.h"
 #include "MouseEvent.h"
+#include "NodeName.h"
 #include "Page.h"
 #include "ParsedContentType.h"
 #include "RenderStyle.h"
@@ -161,7 +162,8 @@ void HTMLLinkElement::setDisabledState(bool disabled)
 
 void HTMLLinkElement::attributeChanged(const QualifiedName& name, const AtomString& oldValue, const AtomString& newValue, AttributeModificationReason attributeModificationReason)
 {
-    if (name == relAttr) {
+    switch (name.nodeName()) {
+    case AttributeNames::relAttr: {
         auto parsedRel = LinkRelAttribute(document(), newValue);
         auto didMutateRel = parsedRel != m_relAttribute;
         m_relAttribute = WTFMove(parsedRel);
@@ -169,30 +171,28 @@ void HTMLLinkElement::attributeChanged(const QualifiedName& name, const AtomStri
             m_relList->associatedAttributeValueChanged(newValue);
         if (didMutateRel)
             process();
-        return;
+        break;
     }
-    if (name == hrefAttr) {
+    case AttributeNames::hrefAttr: {
         URL url = getNonEmptyURLAttribute(hrefAttr);
         if (url == m_url)
             return;
         m_url = WTFMove(url);
         process();
-        return;
+        break;
     }
-    if (name == typeAttr) {
+    case AttributeNames::typeAttr:
         if (newValue == m_type)
             return;
         m_type = newValue;
         process();
-        return;
-    }
-    if (name == sizesAttr) {
+        break;
+    case AttributeNames::sizesAttr:
         if (m_sizes)
             m_sizes->associatedAttributeValueChanged(newValue);
         process();
-        return;
-    }
-    if (name == mediaAttr) {
+        break;
+    case AttributeNames::mediaAttr: {
         auto media = newValue.string().convertToASCIILowercase();
         if (media == m_media)
             return;
@@ -200,18 +200,19 @@ void HTMLLinkElement::attributeChanged(const QualifiedName& name, const AtomStri
         process();
         if (m_sheet && !isDisabled())
             m_styleScope->didChangeActiveStyleSheetCandidates();
-        return;
+        break;
     }
-    if (name == disabledAttr) {
+    case AttributeNames::disabledAttr:
         setDisabledState(!newValue.isNull());
-        return;
-    }
-    if (name == titleAttr) {
+        break;
+    case AttributeNames::titleAttr:
         if (m_sheet && !isInShadowTree())
             m_sheet->setTitle(newValue);
-        return;
+        break;
+    default:
+        HTMLElement::attributeChanged(name, oldValue, newValue, attributeModificationReason);
+        break;
     }
-    HTMLElement::attributeChanged(name, oldValue, newValue, attributeModificationReason);
 }
 
 bool HTMLLinkElement::shouldLoadLink()

--- a/Source/WebCore/html/HTMLMediaElement.cpp
+++ b/Source/WebCore/html/HTMLMediaElement.cpp
@@ -90,6 +90,7 @@
 #include "MediaResourceLoader.h"
 #include "NavigatorMediaDevices.h"
 #include "NetworkingContext.h"
+#include "NodeName.h"
 #include "PODIntervalTree.h"
 #include "PageGroup.h"
 #include "PageInlines.h"
@@ -774,10 +775,11 @@ bool HTMLMediaElement::isInteractiveContent() const
 
 void HTMLMediaElement::attributeChanged(const QualifiedName& name, const AtomString& oldValue, const AtomString& newValue, AttributeModificationReason attributeModificationReason)
 {
-    if (name == idAttr)
+    switch (name.nodeName()) {
+    case AttributeNames::idAttr:
         m_id = newValue;
-
-    if (name == srcAttr) {
+        break;
+    case AttributeNames::srcAttr:
         // https://html.spec.whatwg.org/multipage/embedded-content.html#location-of-the-media-resource
         // Location of the Media Resource
         // 12 February 2017
@@ -786,11 +788,14 @@ void HTMLMediaElement::attributeChanged(const QualifiedName& name, const AtomStr
         // agent must invoke the media element's media element load algorithm.
         if (!newValue.isNull())
             prepareForLoad();
-    } else if (name == controlsAttr)
+        return;
+    case AttributeNames::controlsAttr:
         configureMediaControls();
-    else if (name == loopAttr)
+        return;
+    case AttributeNames::loopAttr:
         updateSleepDisabling();
-    else if (name == preloadAttr) {
+        return;
+    case AttributeNames::preloadAttr:
         if (equalLettersIgnoringASCIICase(newValue, "none"_s))
             m_preload = MediaPlayer::Preload::None;
         else if (equalLettersIgnoringASCIICase(newValue, "metadata"_s))
@@ -800,26 +805,30 @@ void HTMLMediaElement::attributeChanged(const QualifiedName& name, const AtomStr
             // "missing value default", so use it for everything except "none" and "metadata"
             m_preload = MediaPlayer::Preload::Auto;
         }
-
         // The attribute must be ignored if the autoplay attribute is present
         if (!autoplay() && !m_havePreparedToPlay && m_player)
             m_player->setPreload(mediaSession().effectivePreloadForElement());
-
-    } else if (name == mediagroupAttr)
+        return;
+    case AttributeNames::mediagroupAttr:
         setMediaGroup(newValue);
-    else if (name == autoplayAttr) {
+        return;
+    case AttributeNames::autoplayAttr:
         if (processingUserGestureForMedia())
             removeBehaviorRestrictionsAfterFirstUserGesture();
-    } else if (name == titleAttr) {
+        return;
+    case AttributeNames::titleAttr:
         if (m_mediaSession)
             m_mediaSession->clientCharacteristicsChanged(false);
-    }
+        return;
 #if ENABLE(WIRELESS_PLAYBACK_TARGET)
-    else if (name == webkitwirelessvideoplaybackdisabledAttr)
+    case AttributeNames::webkitwirelessvideoplaybackdisabledAttr:
         mediaSession().setWirelessVideoPlaybackDisabled(newValue != nullAtom());
+        return;
 #endif
-    else
-        HTMLElement::attributeChanged(name, oldValue, newValue, attributeModificationReason);
+    default:
+        break;
+    }
+    HTMLElement::attributeChanged(name, oldValue, newValue, attributeModificationReason);
 }
 
 void HTMLMediaElement::finishParsingChildren()

--- a/Source/WebCore/html/HTMLMetaElement.cpp
+++ b/Source/WebCore/html/HTMLMetaElement.cpp
@@ -36,6 +36,7 @@
 #include "MediaQueryEvaluator.h"
 #include "MediaQueryParser.h"
 #include "MediaQueryParserContext.h"
+#include "NodeName.h"
 #include "RenderStyle.h"
 #include "Settings.h"
 #include "StyleResolveForDocument.h"
@@ -97,30 +98,27 @@ void HTMLMetaElement::attributeChanged(const QualifiedName& name, const AtomStri
 {
     HTMLElement::attributeChanged(name, oldValue, newValue, attributeModificationReason);
 
-    if (name == nameAttr) {
+    switch (name.nodeName()) {
+    case AttributeNames::nameAttr:
         process();
         if (isInDocumentTree()) {
             if (equalLettersIgnoringASCIICase(oldValue, "theme-color"_s) && !equalLettersIgnoringASCIICase(newValue, "theme-color"_s))
                 document().metaElementThemeColorChanged(*this);
         }
-        return;
-    }
-
-    if (name == contentAttr) {
+        break;
+    case AttributeNames::contentAttr:
         m_contentColor = std::nullopt;
         process();
-        return;
-    }
-
-    if (name == http_equivAttr) {
+        break;
+    case AttributeNames::http_equivAttr:
         process();
-        return;
-    }
-
-    if (name == mediaAttr) {
+        break;
+    case AttributeNames::mediaAttr:
         m_mediaQueryList = { };
         process();
-        return;
+        break;
+    default:
+        break;
     }
 }
 

--- a/Source/WebCore/html/HTMLMeterElement.cpp
+++ b/Source/WebCore/html/HTMLMeterElement.cpp
@@ -29,6 +29,7 @@
 #include "HTMLNames.h"
 #include "HTMLParserIdioms.h"
 #include "HTMLStyleElement.h"
+#include "NodeName.h"
 #include "Page.h"
 #include "RenderMeter.h"
 #include "RenderTheme.h"
@@ -73,10 +74,19 @@ bool HTMLMeterElement::childShouldCreateRenderer(const Node& child) const
 
 void HTMLMeterElement::attributeChanged(const QualifiedName& name, const AtomString& oldValue, const AtomString& newValue, AttributeModificationReason attributeModificationReason)
 {
-    if (name == valueAttr || name == minAttr || name == maxAttr || name == lowAttr || name == highAttr || name == optimumAttr)
+    switch (name.nodeName()) {
+    case AttributeNames::valueAttr:
+    case AttributeNames::minAttr:
+    case AttributeNames::maxAttr:
+    case AttributeNames::lowAttr:
+    case AttributeNames::highAttr:
+    case AttributeNames::optimumAttr:
         didElementStateChange();
-    else
+        break;
+    default:
         HTMLElement::attributeChanged(name, oldValue, newValue, attributeModificationReason);
+        break;
+    }
 }
 
 double HTMLMeterElement::min() const

--- a/Source/WebCore/html/HTMLObjectElement.cpp
+++ b/Source/WebCore/html/HTMLObjectElement.cpp
@@ -107,20 +107,26 @@ void HTMLObjectElement::attributeChanged(const QualifiedName& name, const AtomSt
     bool invalidateRenderer = false;
     bool needsWidgetUpdate = false;
 
-    if (name == typeAttr) {
+    switch (name.nodeName()) {
+    case AttributeNames::typeAttr:
         m_serviceType = newValue.string().left(newValue.find(';')).convertToASCIILowercase();
         invalidateRenderer = !hasAttributeWithoutSynchronization(classidAttr);
         needsWidgetUpdate = true;
-    } else if (name == dataAttr) {
+        break;
+    case AttributeNames::dataAttr:
         m_url = stripLeadingAndTrailingHTMLSpaces(newValue);
         invalidateRenderer = !hasAttributeWithoutSynchronization(classidAttr);
         needsWidgetUpdate = true;
         updateImageLoaderWithNewURLSoon();
-    } else if (name == classidAttr) {
+        break;
+    case AttributeNames::classidAttr:
         invalidateRenderer = true;
         needsWidgetUpdate = true;
-    } else
+        break;
+    default:
         FormListedElement::parseAttribute(name, newValue);
+        break;
+    }
 
     if (needsWidgetUpdate) {
         setNeedsWidgetUpdate(true);

--- a/Source/WebCore/html/HTMLStyleElement.cpp
+++ b/Source/WebCore/html/HTMLStyleElement.cpp
@@ -32,6 +32,7 @@
 #include "HTMLNames.h"
 #include "MediaQueryParser.h"
 #include "MediaQueryParserContext.h"
+#include "NodeName.h"
 #include "Page.h"
 #include "ScriptableDocumentParser.h"
 #include "ShadowRoot.h"
@@ -78,9 +79,12 @@ Ref<HTMLStyleElement> HTMLStyleElement::create(Document& document)
 
 void HTMLStyleElement::attributeChanged(const QualifiedName& name, const AtomString& oldValue, const AtomString& newValue, AttributeModificationReason attributeModificationReason)
 {
-    if (name == titleAttr && sheet() && !isInShadowTree())
-        sheet()->setTitle(newValue);
-    else if (name == mediaAttr) {
+    switch (name.nodeName()) {
+    case AttributeNames::titleAttr:
+        if (sheet() && !isInShadowTree())
+            sheet()->setTitle(newValue);
+        break;
+    case AttributeNames::mediaAttr:
         m_styleSheetOwner.setMedia(newValue);
         if (sheet()) {
             sheet()->setMediaQueries(MQ::MediaQueryParser::parse(newValue, MediaQueryParserContext(document())));
@@ -88,13 +92,17 @@ void HTMLStyleElement::attributeChanged(const QualifiedName& name, const AtomStr
                 scope->didChangeStyleSheetContents();
         } else
             m_styleSheetOwner.childrenChanged(*this);
-    } else if (name == typeAttr) {
+        break;
+    case AttributeNames::typeAttr:
         m_styleSheetOwner.setContentType(newValue);
         m_styleSheetOwner.childrenChanged(*this);
         if (auto* scope = m_styleSheetOwner.styleScope())
             scope->didChangeStyleSheetContents();
-    } else
+        break;
+    default:
         HTMLElement::attributeChanged(name, oldValue, newValue, attributeModificationReason);
+        break;
+    }
 }
 
 void HTMLStyleElement::finishParsingChildren()

--- a/Source/WebCore/html/HTMLTrackElement.cpp
+++ b/Source/WebCore/html/HTMLTrackElement.cpp
@@ -37,6 +37,7 @@
 #include "HTMLNames.h"
 #include "LoadableTextTrack.h"
 #include "Logging.h"
+#include "NodeName.h"
 #include <wtf/IsoMallocInlines.h>
 #include <wtf/SetForScope.h>
 #include <wtf/text/CString.h>
@@ -105,17 +106,24 @@ void HTMLTrackElement::removedFromAncestor(RemovalType removalType, ContainerNod
 
 void HTMLTrackElement::attributeChanged(const QualifiedName& name, const AtomString& oldValue, const AtomString& newValue, AttributeModificationReason attributeModificationReason)
 {
-    if (name == srcAttr) {
-        scheduleLoad();
-
     // 4.8.10.12.3 Sourcing out-of-band text tracks
     // As the kind, label, and srclang attributes are set, changed, or removed, the text track must update accordingly...
-    } else if (name == kindAttr)
+    switch (name.nodeName()) {
+    case AttributeNames::srcAttr:
+        scheduleLoad();
+        break;
+    case AttributeNames::kindAttr:
         track().setKindKeywordIgnoringASCIICase(newValue.string());
-    else if (name == labelAttr)
+        break;
+    case AttributeNames::labelAttr:
         track().setLabel(newValue);
-    else if (name == srclangAttr)
+        break;
+    case AttributeNames::srclangAttr:
         track().setLanguage(newValue);
+        break;
+    default:
+        break;
+    }
 
     HTMLElement::attributeChanged(name, oldValue, newValue, attributeModificationReason);
 }

--- a/Source/WebCore/html/NumberInputType.cpp
+++ b/Source/WebCore/html/NumberInputType.cpp
@@ -40,6 +40,7 @@
 #include "InputTypeNames.h"
 #include "KeyboardEvent.h"
 #include "LocalizedStrings.h"
+#include "NodeName.h"
 #include "PlatformLocale.h"
 #include "RenderTextControl.h"
 #include "StepRange.h"
@@ -285,18 +286,25 @@ bool NumberInputType::supportsPlaceholder() const
 void NumberInputType::attributeChanged(const QualifiedName& name)
 {
     ASSERT(element());
-    if (name == maxAttr || name == minAttr) {
+    switch (name.nodeName()) {
+    case AttributeNames::maxAttr:
+    case AttributeNames::minAttr:
         if (auto* element = this->element()) {
             element->invalidateStyleForSubtree();
             if (auto* renderer = element->renderer())
                 renderer->setNeedsLayoutAndPrefWidthsRecalc();
         }
-    } else if (name == stepAttr) {
+        break;
+    case AttributeNames::stepAttr:
         if (auto* element = this->element()) {
             if (auto* renderer = element->renderer())
                 renderer->setNeedsLayoutAndPrefWidthsRecalc();
         }
+        break;
+    default:
+        break;
     }
+
     TextFieldInputType::attributeChanged(name);
 }
 

--- a/Source/WebCore/html/RangeInputType.cpp
+++ b/Source/WebCore/html/RangeInputType.cpp
@@ -43,6 +43,7 @@
 #include "InputTypeNames.h"
 #include "KeyboardEvent.h"
 #include "MouseEvent.h"
+#include "NodeName.h"
 #include "PlatformMouseEvent.h"
 #include "RenderSlider.h"
 #include "ScopedEventQueue.h"
@@ -327,7 +328,10 @@ bool RangeInputType::accessKeyAction(bool sendMouseEvents)
 
 void RangeInputType::attributeChanged(const QualifiedName& name)
 {
-    if (name == maxAttr || name == minAttr || name == valueAttr) {
+    switch (name.nodeName()) {
+    case AttributeNames::maxAttr:
+    case AttributeNames::minAttr:
+    case AttributeNames::valueAttr:
         // Sanitize the value.
         if (auto* element = this->element()) {
             if (element->hasDirtyValue())
@@ -335,6 +339,9 @@ void RangeInputType::attributeChanged(const QualifiedName& name)
         }
         if (hasCreatedShadowSubtree())
             typedSliderThumbElement().setPositionFromValue();
+        break;
+    default:
+        break;
     }
     InputType::attributeChanged(name);
 }

--- a/Source/WebCore/mathml/MathMLFractionElement.cpp
+++ b/Source/WebCore/mathml/MathMLFractionElement.cpp
@@ -30,6 +30,7 @@
 #if ENABLE(MATHML)
 
 #include "ElementInlines.h"
+#include "NodeName.h"
 #include "RenderMathMLFraction.h"
 #include "Settings.h"
 #include <wtf/IsoMallocInlines.h>
@@ -111,12 +112,19 @@ MathMLFractionElement::FractionAlignment MathMLFractionElement::denominatorAlign
 
 void MathMLFractionElement::attributeChanged(const QualifiedName& name, const AtomString& oldValue, const AtomString& newValue, AttributeModificationReason attributeModificationReason)
 {
-    if (name == linethicknessAttr)
+    switch (name.nodeName()) {
+    case AttributeNames::linethicknessAttr:
         m_lineThickness = std::nullopt;
-    else if (name == numalignAttr)
+        break;
+    case AttributeNames::numalignAttr:
         m_numeratorAlignment = std::nullopt;
-    else if (name == denomalignAttr)
+        break;
+    case AttributeNames::denomalignAttr:
         m_denominatorAlignment = std::nullopt;
+        break;
+    default:
+        break;
+    }
 
     MathMLElement::attributeChanged(name, oldValue, newValue, attributeModificationReason);
 }

--- a/Source/WebCore/mathml/MathMLMathElement.cpp
+++ b/Source/WebCore/mathml/MathMLMathElement.cpp
@@ -57,11 +57,11 @@ RenderPtr<RenderElement> MathMLMathElement::createElementRenderer(RenderStyle&& 
 
 void MathMLMathElement::attributeChanged(const QualifiedName& name, const AtomString& oldValue, const AtomString& newValue, AttributeModificationReason attributeModificationReason)
 {
-    bool mathVariantAttribute = name == mathvariantAttr;
-    if (mathVariantAttribute)
+    if (name == mathvariantAttr) {
         m_mathVariant = std::nullopt;
-    if ((mathVariantAttribute) && renderer())
-        MathMLStyle::resolveMathMLStyleTree(renderer());
+        if (renderer())
+            MathMLStyle::resolveMathMLStyleTree(renderer());
+    }
 
     MathMLElement::attributeChanged(name, oldValue, newValue, attributeModificationReason);
 }

--- a/Source/WebCore/mathml/MathMLOperatorElement.cpp
+++ b/Source/WebCore/mathml/MathMLOperatorElement.cpp
@@ -30,6 +30,7 @@
 #if ENABLE(MATHML)
 
 #include "ElementInlines.h"
+#include "NodeName.h"
 #include "RenderMathMLOperator.h"
 #include <wtf/IsoMallocInlines.h>
 #include <wtf/unicode/CharacterNames.h>
@@ -210,44 +211,56 @@ void MathMLOperatorElement::childrenChanged(const ChildChange& change)
     MathMLTokenElement::childrenChanged(change);
 }
 
-static std::optional<MathMLOperatorDictionary::Flag> attributeNameToPropertyFlag(const QualifiedName& name)
-{
-    if (name == accentAttr)
-        return Accent;
-    if (name == fenceAttr)
-        return Fence;
-    if (name == largeopAttr)
-        return LargeOp;
-    if (name == movablelimitsAttr)
-        return MovableLimits;
-    if (name == separatorAttr)
-        return Separator;
-    if (name == stretchyAttr)
-        return Stretchy;
-    if (name == symmetricAttr)
-        return Symmetric;
-    return std::nullopt;
-}
-
 void MathMLOperatorElement::attributeChanged(const QualifiedName& name, const AtomString& oldValue, const AtomString& newValue, AttributeModificationReason attributeModificationReason)
 {
-    if (name == formAttr) {
+    switch (name.nodeName()) {
+    case AttributeNames::formAttr:
         m_dictionaryProperty = std::nullopt;
         m_properties.dirtyFlags = MathMLOperatorDictionary::allFlags;
-    } else if (auto flag = attributeNameToPropertyFlag(name))
-        m_properties.dirtyFlags |= flag.value();
-    else if (name == lspaceAttr)
+        break;
+    case AttributeNames::lspaceAttr:
         m_leadingSpace = std::nullopt;
-    else if (name == rspaceAttr)
+        if (renderer())
+            downcast<RenderMathMLOperator>(*renderer()).updateFromElement();
+        break;
+    case AttributeNames::rspaceAttr:
         m_trailingSpace = std::nullopt;
-    else if (name == minsizeAttr)
+        if (renderer())
+            downcast<RenderMathMLOperator>(*renderer()).updateFromElement();
+        break;
+    case AttributeNames::minsizeAttr:
         m_minSize = std::nullopt;
-    else if (name == maxsizeAttr)
+        break;
+    case AttributeNames::maxsizeAttr:
         m_maxSize = std::nullopt;
-
-    if ((name == stretchyAttr || name == lspaceAttr || name == rspaceAttr || name == movablelimitsAttr) && renderer()) {
-        downcast<RenderMathMLOperator>(*renderer()).updateFromElement();
-        return;
+        break;
+    case AttributeNames::stretchyAttr:
+        m_properties.dirtyFlags |= Stretchy;
+        if (renderer())
+            downcast<RenderMathMLOperator>(*renderer()).updateFromElement();
+        break;
+    case AttributeNames::movablelimitsAttr:
+        m_properties.dirtyFlags |= MovableLimits;
+        if (renderer())
+            downcast<RenderMathMLOperator>(*renderer()).updateFromElement();
+        break;
+    case AttributeNames::accentAttr:
+        m_properties.dirtyFlags |= Accent;
+        break;
+    case AttributeNames::fenceAttr:
+        m_properties.dirtyFlags |= Fence;
+        break;
+    case AttributeNames::largeopAttr:
+        m_properties.dirtyFlags |= LargeOp;
+        break;
+    case AttributeNames::separatorAttr:
+        m_properties.dirtyFlags |= Separator;
+        break;
+    case AttributeNames::symmetricAttr:
+        m_properties.dirtyFlags |= Symmetric;
+        break;
+    default:
+        break;
     }
 
     MathMLTokenElement::attributeChanged(name, oldValue, newValue, attributeModificationReason);

--- a/Source/WebCore/mathml/MathMLPaddedElement.cpp
+++ b/Source/WebCore/mathml/MathMLPaddedElement.cpp
@@ -29,6 +29,7 @@
 
 #if ENABLE(MATHML)
 
+#include "NodeName.h"
 #include "RenderMathMLPadded.h"
 #include <wtf/IsoMallocInlines.h>
 
@@ -75,17 +76,25 @@ const MathMLElement::Length& MathMLPaddedElement::voffset()
 
 void MathMLPaddedElement::attributeChanged(const QualifiedName& name, const AtomString& oldValue, const AtomString& newValue, AttributeModificationReason attributeModificationReason)
 {
-    if (name == widthAttr)
+    switch (name.nodeName()) {
+    case AttributeNames::widthAttr:
         m_width = std::nullopt;
-    else if (name == heightAttr)
+        break;
+    case AttributeNames::heightAttr:
         m_height = std::nullopt;
-    else if (name == depthAttr)
+        break;
+    case AttributeNames::depthAttr:
         m_depth = std::nullopt;
-    else if (name == lspaceAttr)
+        break;
+    case AttributeNames::lspaceAttr:
         m_lspace = std::nullopt;
-    else if (name == voffsetAttr)
+        break;
+    case AttributeNames::voffsetAttr:
         m_voffset = std::nullopt;
-
+        break;
+    default:
+        break;
+    }
     MathMLElement::attributeChanged(name, oldValue, newValue, attributeModificationReason);
 }
 

--- a/Source/WebCore/mathml/MathMLPresentationElement.cpp
+++ b/Source/WebCore/mathml/MathMLPresentationElement.cpp
@@ -364,11 +364,11 @@ std::optional<MathMLElement::MathVariant> MathMLPresentationElement::specifiedMa
 
 void MathMLPresentationElement::attributeChanged(const QualifiedName& name, const AtomString& oldValue, const AtomString& newValue, AttributeModificationReason attributeModificationReason)
 {
-    bool mathVariantAttribute = name == mathvariantAttr && acceptsMathVariantAttribute();
-    if (mathVariantAttribute)
+    if (name == mathvariantAttr && acceptsMathVariantAttribute()) {
         m_mathVariant = std::nullopt;
-    if ((mathVariantAttribute) && renderer())
-        MathMLStyle::resolveMathMLStyleTree(renderer());
+        if (renderer())
+            MathMLStyle::resolveMathMLStyleTree(renderer());
+    }
 
     MathMLElement::attributeChanged(name, oldValue, newValue, attributeModificationReason);
 }

--- a/Source/WebCore/mathml/MathMLSpaceElement.cpp
+++ b/Source/WebCore/mathml/MathMLSpaceElement.cpp
@@ -29,6 +29,7 @@
 
 #if ENABLE(MATHML)
 
+#include "NodeName.h"
 #include "RenderMathMLSpace.h"
 #include <wtf/IsoMallocInlines.h>
 
@@ -65,13 +66,19 @@ const MathMLElement::Length& MathMLSpaceElement::depth()
 
 void MathMLSpaceElement::attributeChanged(const QualifiedName& name, const AtomString& oldValue, const AtomString& newValue, AttributeModificationReason attributeModificationReason)
 {
-    if (name == widthAttr)
+    switch (name.nodeName()) {
+    case AttributeNames::widthAttr:
         m_width = std::nullopt;
-    else if (name == heightAttr)
+        break;
+    case AttributeNames::heightAttr:
         m_height = std::nullopt;
-    else if (name == depthAttr)
+        break;
+    case AttributeNames::depthAttr:
         m_depth = std::nullopt;
-
+        break;
+    default:
+        break;
+    }
     MathMLPresentationElement::attributeChanged(name, oldValue, newValue, attributeModificationReason);
 }
 

--- a/Source/WebCore/svg/SVGAnimationElement.cpp
+++ b/Source/WebCore/svg/SVGAnimationElement.cpp
@@ -33,6 +33,7 @@
 #include "Document.h"
 #include "FloatConversion.h"
 #include "HTMLParserIdioms.h"
+#include "NodeName.h"
 #include "RenderObject.h"
 #include "SVGAnimateColorElement.h"
 #include "SVGAnimateElement.h"
@@ -168,7 +169,8 @@ void SVGAnimationElement::attributeChanged(const QualifiedName& name, const Atom
     SVGTests::parseAttribute(name, newValue);
     SVGSMILElement::attributeChanged(name, oldValue, newValue, attributeModificationReason);
 
-    if (name == SVGNames::valuesAttr) {
+    switch (name.nodeName()) {
+    case AttributeNames::valuesAttr:
         // Per the SMIL specification, leading and trailing white space,
         // and white space before and after semicolon separators, is allowed and will be ignored.
         // http://www.w3.org/TR/SVG11/animate.html#ValuesAttribute
@@ -176,46 +178,37 @@ void SVGAnimationElement::attributeChanged(const QualifiedName& name, const Atom
         newValue.string().split(';', [this](StringView innerValue) {
             m_values.append(innerValue.stripLeadingAndTrailingMatchedCharacters(isHTMLSpace<UChar>).toString());
         });
-
         updateAnimationMode();
-        return;
-    }
-
-    if (name == SVGNames::keyTimesAttr) {
+        break;
+    case AttributeNames::keyTimesAttr:
         m_keyTimesFromAttribute = parseKeyTimes(newValue, true);
-        return;
-    }
-
-    if (name == SVGNames::keyPointsAttr) {
+        break;
+    case AttributeNames::keyPointsAttr:
         if (hasTagName(SVGNames::animateMotionTag)) {
-            // This is specified to be an animateMotion attribute only but it is simpler to put it here 
+            // This is specified to be an animateMotion attribute only but it is simpler to put it here
             // where the other timing calculatations are.
             m_keyPoints = parseKeyTimes(newValue, false);
         }
-        return;
-    }
-
-    if (name == SVGNames::keySplinesAttr) {
+        break;
+    case AttributeNames::keySplinesAttr:
         if (auto keySplines = parseKeySplines(newValue))
             m_keySplines = WTFMove(*keySplines);
         else
             m_keySplines.clear();
-        return;
-    }
-
-    if (name == SVGNames::attributeTypeAttr) {
+        break;
+    case AttributeNames::attributeTypeAttr:
         setAttributeType(newValue);
-        return;
-    }
-
-    if (name == SVGNames::calcModeAttr) {
+        break;
+    case AttributeNames::calcModeAttr:
         setCalcMode(newValue);
-        return;
-    }
-
-    if (name == SVGNames::fromAttr || name == SVGNames::toAttr || name == SVGNames::byAttr) {
+        break;
+    case AttributeNames::fromAttr:
+    case AttributeNames::toAttr:
+    case AttributeNames::byAttr:
         updateAnimationMode();
-        return;
+        break;
+    default:
+        break;
     }
 }
 

--- a/Source/WebCore/svg/SVGCircleElement.cpp
+++ b/Source/WebCore/svg/SVGCircleElement.cpp
@@ -23,6 +23,7 @@
 #include "SVGCircleElement.h"
 
 #include "LegacyRenderSVGEllipse.h"
+#include "NodeName.h"
 #include "RenderSVGEllipse.h"
 #include "RenderSVGResource.h"
 #include "SVGElementInlines.h"
@@ -54,13 +55,19 @@ void SVGCircleElement::attributeChanged(const QualifiedName& name, const AtomStr
 {
     SVGParsingError parseError = NoError;
 
-    if (name == SVGNames::cxAttr)
+    switch (name.nodeName()) {
+    case AttributeNames::cxAttr:
         m_cx->setBaseValInternal(SVGLengthValue::construct(SVGLengthMode::Width, newValue, parseError));
-    else if (name == SVGNames::cyAttr)
+        break;
+    case AttributeNames::cyAttr:
         m_cy->setBaseValInternal(SVGLengthValue::construct(SVGLengthMode::Height, newValue, parseError));
-    else if (name == SVGNames::rAttr)
+        break;
+    case AttributeNames::rAttr:
         m_r->setBaseValInternal(SVGLengthValue::construct(SVGLengthMode::Other, newValue, parseError, SVGLengthNegativeValuesMode::Forbid));
-
+        break;
+    default:
+        break;
+    }
     reportAttributeParsingError(parseError, name, newValue);
 
     SVGGeometryElement::attributeChanged(name, oldValue, newValue, attributeModificationReason);

--- a/Source/WebCore/svg/SVGComponentTransferFunctionElement.cpp
+++ b/Source/WebCore/svg/SVGComponentTransferFunctionElement.cpp
@@ -22,6 +22,7 @@
 #include "config.h"
 #include "SVGComponentTransferFunctionElement.h"
 
+#include "NodeName.h"
 #include "SVGComponentTransferFunctionElementInlines.h"
 #include "SVGFEComponentTransferElement.h"
 #include "SVGNames.h"
@@ -51,41 +52,33 @@ void SVGComponentTransferFunctionElement::attributeChanged(const QualifiedName& 
 {
     SVGElement::attributeChanged(name, oldValue, newValue, attributeModificationReason);
 
-    if (name == SVGNames::typeAttr) {
+    switch (name.nodeName()) {
+    case AttributeNames::typeAttr: {
         ComponentTransferType propertyValue = SVGPropertyTraits<ComponentTransferType>::fromString(newValue);
         if (propertyValue > 0)
             m_type->setBaseValInternal<ComponentTransferType>(propertyValue);
-        return;
+        break;
     }
-
-    if (name == SVGNames::tableValuesAttr) {
+    case AttributeNames::tableValuesAttr:
         m_tableValues->baseVal()->parse(newValue);
-        return;
-    }
-
-    if (name == SVGNames::slopeAttr) {
+        break;
+    case AttributeNames::slopeAttr:
         m_slope->setBaseValInternal(newValue.toFloat());
-        return;
-    }
-
-    if (name == SVGNames::interceptAttr) {
+        break;
+    case AttributeNames::interceptAttr:
         m_intercept->setBaseValInternal(newValue.toFloat());
-        return;
-    }
-
-    if (name == SVGNames::amplitudeAttr) {
+        break;
+    case AttributeNames::amplitudeAttr:
         m_amplitude->setBaseValInternal(newValue.toFloat());
-        return;
-    }
-
-    if (name == SVGNames::exponentAttr) {
+        break;
+    case AttributeNames::exponentAttr:
         m_exponent->setBaseValInternal(newValue.toFloat());
-        return;
-    }
-
-    if (name == SVGNames::offsetAttr) {
+        break;
+    case AttributeNames::offsetAttr:
         m_offset->setBaseValInternal(newValue.toFloat());
-        return;
+        break;
+    default:
+        break;
     }
 }
 

--- a/Source/WebCore/svg/SVGElement.cpp
+++ b/Source/WebCore/svg/SVGElement.cpp
@@ -593,20 +593,25 @@ void SVGElement::attributeChanged(const QualifiedName& name, const AtomString& o
 {
     StyledElement::attributeChanged(name, oldValue, newValue, attributeModificationReason);
 
-    if (name == HTMLNames::idAttr)
+    switch (name.nodeName()) {
+    case AttributeNames::idAttr:
         document().accessSVGExtensions().rebuildAllElementReferencesForTarget(*this);
-    else if (name == HTMLNames::classAttr) {
+        break;
+    case AttributeNames::classAttr:
         m_className->setBaseValInternal(newValue);
-    } else if (name == HTMLNames::tabindexAttr) {
+        break;
+    case AttributeNames::tabindexAttr:
         if (newValue.isEmpty())
             setTabIndexExplicitly(std::nullopt);
         else if (auto optionalTabIndex = parseHTMLInteger(newValue))
             setTabIndexExplicitly(optionalTabIndex.value());
-    } else {
-        auto& eventName = HTMLElement::eventNameForEventHandlerAttribute(name);
-        if (!eventName.isNull())
+        break;
+    default:
+        if (auto& eventName = HTMLElement::eventNameForEventHandlerAttribute(name); !eventName.isNull())
             setAttributeEventListener(eventName, name, newValue);
+        break;
     }
+
     // Changes to the style attribute are processed lazily (see Element::getAttribute() and related methods),
     // so we don't want changes to the style attribute to result in extra work here except invalidateInstances().
     if (name == HTMLNames::styleAttr)

--- a/Source/WebCore/svg/SVGEllipseElement.cpp
+++ b/Source/WebCore/svg/SVGEllipseElement.cpp
@@ -23,6 +23,7 @@
 #include "SVGEllipseElement.h"
 
 #include "LegacyRenderSVGEllipse.h"
+#include "NodeName.h"
 #include "RenderSVGEllipse.h"
 #include "RenderSVGResource.h"
 #include "SVGElementInlines.h"
@@ -55,17 +56,23 @@ void SVGEllipseElement::attributeChanged(const QualifiedName& name, const AtomSt
 {
     SVGParsingError parseError = NoError;
 
-    if (name == SVGNames::cxAttr)
+    switch (name.nodeName()) {
+    case AttributeNames::cxAttr:
         m_cx->setBaseValInternal(SVGLengthValue::construct(SVGLengthMode::Width, newValue, parseError));
-    else if (name == SVGNames::cyAttr)
+        break;
+    case AttributeNames::cyAttr:
         m_cy->setBaseValInternal(SVGLengthValue::construct(SVGLengthMode::Height, newValue, parseError));
-    else if (name == SVGNames::rxAttr)
+        break;
+    case AttributeNames::rxAttr:
         m_rx->setBaseValInternal(SVGLengthValue::construct(SVGLengthMode::Width, newValue, parseError, SVGLengthNegativeValuesMode::Forbid));
-    else if (name == SVGNames::ryAttr)
+        break;
+    case AttributeNames::ryAttr:
         m_ry->setBaseValInternal(SVGLengthValue::construct(SVGLengthMode::Height, newValue, parseError, SVGLengthNegativeValuesMode::Forbid));
-
+        break;
+    default:
+        break;
+    }
     reportAttributeParsingError(parseError, name, newValue);
-
     SVGGeometryElement::attributeChanged(name, oldValue, newValue, attributeModificationReason);
 }
 

--- a/Source/WebCore/svg/SVGFEBlendElement.cpp
+++ b/Source/WebCore/svg/SVGFEBlendElement.cpp
@@ -24,6 +24,7 @@
 #include "SVGFEBlendElement.h"
 
 #include "FEBlend.h"
+#include "NodeName.h"
 #include "SVGNames.h"
 #include <wtf/IsoMallocInlines.h>
 
@@ -53,21 +54,21 @@ void SVGFEBlendElement::attributeChanged(const QualifiedName& name, const AtomSt
 {
     SVGFilterPrimitiveStandardAttributes::attributeChanged(name, oldValue, newValue, attributeModificationReason);
 
-    if (name == SVGNames::modeAttr) {
+    switch (name.nodeName()) {
+    case AttributeNames::modeAttr: {
         BlendMode mode = BlendMode::Normal;
         if (parseBlendMode(newValue, mode))
             m_mode->setBaseValInternal<BlendMode>(mode);
-        return;
+        break;
     }
-
-    if (name == SVGNames::inAttr) {
+    case AttributeNames::inAttr:
         m_in1->setBaseValInternal(newValue);
-        return;
-    }
-
-    if (name == SVGNames::in2Attr) {
+        break;
+    case AttributeNames::in2Attr:
         m_in2->setBaseValInternal(newValue);
-        return;
+        break;
+    default:
+        break;
     }
 }
 

--- a/Source/WebCore/svg/SVGFEColorMatrixElement.cpp
+++ b/Source/WebCore/svg/SVGFEColorMatrixElement.cpp
@@ -23,6 +23,7 @@
 #include "SVGFEColorMatrixElement.h"
 
 #include "FEColorMatrix.h"
+#include "NodeName.h"
 #include "SVGNames.h"
 #include <wtf/IsoMallocInlines.h>
 
@@ -62,21 +63,21 @@ void SVGFEColorMatrixElement::attributeChanged(const QualifiedName& name, const 
 {
     SVGFilterPrimitiveStandardAttributes::attributeChanged(name, oldValue, newValue, attributeModificationReason);
 
-    if (name == SVGNames::typeAttr) {
+    switch (name.nodeName()) {
+    case AttributeNames::typeAttr: {
         auto propertyValue = SVGPropertyTraits<ColorMatrixType>::fromString(newValue);
         if (propertyValue > 0)
             m_type->setBaseValInternal<ColorMatrixType>(propertyValue);
-        return;
+        break;
     }
-
-    if (name == SVGNames::inAttr) {
+    case AttributeNames::inAttr:
         m_in1->setBaseValInternal(newValue);
-        return;
-    }
-
-    if (name == SVGNames::valuesAttr) {
+        break;
+    case AttributeNames::valuesAttr:
         m_values->baseVal()->parse(newValue);
-        return;
+        break;
+    default:
+        break;
     }
 }
 

--- a/Source/WebCore/svg/SVGFECompositeElement.cpp
+++ b/Source/WebCore/svg/SVGFECompositeElement.cpp
@@ -23,6 +23,7 @@
 #include "SVGFECompositeElement.h"
 
 #include "FEComposite.h"
+#include "NodeName.h"
 #include "SVGNames.h"
 #include <wtf/IsoMallocInlines.h>
 
@@ -56,41 +57,33 @@ void SVGFECompositeElement::attributeChanged(const QualifiedName& name, const At
 {
     SVGFilterPrimitiveStandardAttributes::attributeChanged(name, oldValue, newValue, attributeModificationReason);
 
-    if (name == SVGNames::operatorAttr) {
+    switch (name.nodeName()) {
+    case AttributeNames::operatorAttr: {
         CompositeOperationType propertyValue = SVGPropertyTraits<CompositeOperationType>::fromString(newValue);
         if (propertyValue > 0)
             m_svgOperator->setBaseValInternal<CompositeOperationType>(propertyValue);
-        return;
+        break;
     }
-
-    if (name == SVGNames::inAttr) {
+    case AttributeNames::inAttr:
         m_in1->setBaseValInternal(newValue);
-        return;
-    }
-
-    if (name == SVGNames::in2Attr) {
+        break;
+    case AttributeNames::in2Attr:
         m_in2->setBaseValInternal(newValue);
-        return;
-    }
-
-    if (name == SVGNames::k1Attr) {
+        break;
+    case AttributeNames::k1Attr:
         m_k1->setBaseValInternal(newValue.toFloat());
-        return;
-    }
-
-    if (name == SVGNames::k2Attr) {
+        break;
+    case AttributeNames::k2Attr:
         m_k2->setBaseValInternal(newValue.toFloat());
-        return;
-    }
-
-    if (name == SVGNames::k3Attr) {
+        break;
+    case AttributeNames::k3Attr:
         m_k3->setBaseValInternal(newValue.toFloat());
-        return;
-    }
-
-    if (name == SVGNames::k4Attr) {
+        break;
+    case AttributeNames::k4Attr:
         m_k4->setBaseValInternal(newValue.toFloat());
-        return;
+        break;
+    default:
+        break;
     }
 }
 

--- a/Source/WebCore/svg/SVGFEConvolveMatrixElement.cpp
+++ b/Source/WebCore/svg/SVGFEConvolveMatrixElement.cpp
@@ -23,6 +23,7 @@
 
 #include "CommonAtomStrings.h"
 #include "FEConvolveMatrix.h"
+#include "NodeName.h"
 #include "SVGNames.h"
 #include "SVGParserUtilities.h"
 #include <wtf/IsoMallocInlines.h>
@@ -61,77 +62,64 @@ void SVGFEConvolveMatrixElement::attributeChanged(const QualifiedName& name, con
 {
     SVGFilterPrimitiveStandardAttributes::attributeChanged(name, oldValue, newValue, attributeModificationReason);
 
-    if (name == SVGNames::inAttr) {
+    switch (name.nodeName()) {
+    case AttributeNames::inAttr:
         m_in1->setBaseValInternal(newValue);
-        return;
-    }
-
-    if (name == SVGNames::orderAttr) {
+        break;
+    case AttributeNames::orderAttr: {
         auto result = parseNumberOptionalNumber(newValue);
         if (result && result->first >= 1 && result->second >= 1) {
             m_orderX->setBaseValInternal(result->first);
             m_orderY->setBaseValInternal(result->second);
         } else
             document().accessSVGExtensions().reportWarning("feConvolveMatrix: problem parsing order=\"" + newValue + "\". Filtered element will not be displayed.");
-        return;
+        break;
     }
-
-    if (name == SVGNames::edgeModeAttr) {
+    case AttributeNames::edgeModeAttr: {
         EdgeModeType propertyValue = SVGPropertyTraits<EdgeModeType>::fromString(newValue);
         if (propertyValue != EdgeModeType::Unknown)
             m_edgeMode->setBaseValInternal<EdgeModeType>(propertyValue);
         else
             document().accessSVGExtensions().reportWarning("feConvolveMatrix: problem parsing edgeMode=\"" + newValue + "\". Filtered element will not be displayed.");
-        return;
+        break;
     }
-
-    if (name == SVGNames::kernelMatrixAttr) {
+    case AttributeNames::kernelMatrixAttr:
         m_kernelMatrix->baseVal()->parse(newValue);
-        return;
-    }
-
-    if (name == SVGNames::divisorAttr) {
-        float divisor = newValue.toFloat();
-        if (divisor)
+        break;
+    case AttributeNames::divisorAttr:
+        if (float divisor = newValue.toFloat())
             m_divisor->setBaseValInternal(divisor);
         else
             document().accessSVGExtensions().reportWarning("feConvolveMatrix: problem parsing divisor=\"" + newValue + "\". Filtered element will not be displayed.");
-        return;
-    }
-    
-    if (name == SVGNames::biasAttr) {
+        break;
+    case AttributeNames::biasAttr:
         m_bias->setBaseValInternal(newValue.toFloat());
-        return;
-    }
-
-    if (name == SVGNames::targetXAttr) {
+        break;
+    case AttributeNames::targetXAttr:
         m_targetX->setBaseValInternal(parseInteger<unsigned>(newValue).value_or(0));
-        return;
-    }
-
-    if (name == SVGNames::targetYAttr) {
+        break;
+    case AttributeNames::targetYAttr:
         m_targetY->setBaseValInternal(parseInteger<unsigned>(newValue).value_or(0));
-        return;
-    }
-
-    if (name == SVGNames::kernelUnitLengthAttr) {
+        break;
+    case AttributeNames::kernelUnitLengthAttr: {
         auto result = parseNumberOptionalNumber(newValue);
         if (result && result->first > 0 && result->second > 0) {
             m_kernelUnitLengthX->setBaseValInternal(result->first);
             m_kernelUnitLengthY->setBaseValInternal(result->second);
         } else
             document().accessSVGExtensions().reportWarning("feConvolveMatrix: problem parsing kernelUnitLength=\"" + newValue + "\". Filtered element will not be displayed.");
-        return;
+        break;
     }
-
-    if (name == SVGNames::preserveAlphaAttr) {
+    case AttributeNames::preserveAlphaAttr:
         if (newValue == trueAtom())
             m_preserveAlpha->setBaseValInternal(true);
         else if (newValue == falseAtom())
             m_preserveAlpha->setBaseValInternal(false);
         else
             document().accessSVGExtensions().reportWarning("feConvolveMatrix: problem parsing preserveAlphaAttr=\"" + newValue  + "\". Filtered element will not be displayed.");
-        return;
+        break;
+    default:
+        break;
     }
 }
 

--- a/Source/WebCore/svg/SVGFEDiffuseLightingElement.cpp
+++ b/Source/WebCore/svg/SVGFEDiffuseLightingElement.cpp
@@ -22,6 +22,7 @@
 #include "SVGFEDiffuseLightingElement.h"
 
 #include "FEDiffuseLighting.h"
+#include "NodeName.h"
 #include "RenderStyle.h"
 #include "SVGFELightElement.h"
 #include "SVGNames.h"
@@ -55,27 +56,24 @@ void SVGFEDiffuseLightingElement::attributeChanged(const QualifiedName& name, co
 {
     SVGFilterPrimitiveStandardAttributes::attributeChanged(name, oldValue, newValue, attributeModificationReason);
 
-    if (name == SVGNames::inAttr) {
+    switch (name.nodeName()) {
+    case AttributeNames::inAttr:
         m_in1->setBaseValInternal(newValue);
-        return;
-    }
-
-    if (name == SVGNames::surfaceScaleAttr) {
+        break;
+    case AttributeNames::surfaceScaleAttr:
         m_surfaceScale->setBaseValInternal(newValue.toFloat());
-        return;
-    }
-
-    if (name == SVGNames::diffuseConstantAttr) {
+        break;
+    case AttributeNames::diffuseConstantAttr:
         m_diffuseConstant->setBaseValInternal(newValue.toFloat());
-        return;
-    }
-
-    if (name == SVGNames::kernelUnitLengthAttr) {
+        break;
+    case AttributeNames::kernelUnitLengthAttr:
         if (auto result = parseNumberOptionalNumber(newValue)) {
             m_kernelUnitLengthX->setBaseValInternal(result->first);
             m_kernelUnitLengthY->setBaseValInternal(result->second);
         }
-        return;
+        break;
+    default:
+        break;
     }
 }
 

--- a/Source/WebCore/svg/SVGFEDisplacementMapElement.cpp
+++ b/Source/WebCore/svg/SVGFEDisplacementMapElement.cpp
@@ -22,6 +22,7 @@
 #include "SVGFEDisplacementMapElement.h"
 
 #include "FEDisplacementMap.h"
+#include "NodeName.h"
 #include "SVGNames.h"
 #include <wtf/IsoMallocInlines.h>
 
@@ -53,33 +54,30 @@ void SVGFEDisplacementMapElement::attributeChanged(const QualifiedName& name, co
 {
     SVGFilterPrimitiveStandardAttributes::attributeChanged(name, oldValue, newValue, attributeModificationReason);
 
-    if (name == SVGNames::xChannelSelectorAttr) {
+    switch (name.nodeName()) {
+    case AttributeNames::xChannelSelectorAttr: {
         auto propertyValue = SVGPropertyTraits<ChannelSelectorType>::fromString(newValue);
         if (propertyValue > 0)
             m_xChannelSelector->setBaseValInternal<ChannelSelectorType>(propertyValue);
-        return;
+        break;
     }
-
-    if (name == SVGNames::yChannelSelectorAttr) {
+    case AttributeNames::yChannelSelectorAttr: {
         auto propertyValue = SVGPropertyTraits<ChannelSelectorType>::fromString(newValue);
         if (propertyValue > 0)
             m_yChannelSelector->setBaseValInternal<ChannelSelectorType>(propertyValue);
-        return;
+        break;
     }
-
-    if (name == SVGNames::inAttr) {
+    case AttributeNames::inAttr:
         m_in1->setBaseValInternal(newValue);
-        return;
-    }
-
-    if (name == SVGNames::in2Attr) {
+        break;
+    case AttributeNames::in2Attr:
         m_in2->setBaseValInternal(newValue);
-        return;
-    }
-
-    if (name == SVGNames::scaleAttr) {
+        break;
+    case AttributeNames::scaleAttr:
         m_scale->setBaseValInternal(newValue.toFloat());
-        return;
+        break;
+    default:
+        break;
     }
 }
 

--- a/Source/WebCore/svg/SVGFEDropShadowElement.cpp
+++ b/Source/WebCore/svg/SVGFEDropShadowElement.cpp
@@ -21,6 +21,7 @@
 #include "config.h"
 #include "SVGFEDropShadowElement.h"
 
+#include "NodeName.h"
 #include "RenderStyle.h"
 #include "SVGNames.h"
 #include "SVGParserUtilities.h"
@@ -61,27 +62,24 @@ void SVGFEDropShadowElement::attributeChanged(const QualifiedName& name, const A
 {
     SVGFilterPrimitiveStandardAttributes::attributeChanged(name, oldValue, newValue, attributeModificationReason);
 
-    if (name == SVGNames::stdDeviationAttr) {
+    switch (name.nodeName()) {
+    case AttributeNames::stdDeviationAttr:
         if (auto result = parseNumberOptionalNumber(newValue)) {
             m_stdDeviationX->setBaseValInternal(result->first);
             m_stdDeviationY->setBaseValInternal(result->second);
         }
-        return;
-    }
-
-    if (name == SVGNames::inAttr) {
+        break;
+    case AttributeNames::inAttr:
         m_in1->setBaseValInternal(newValue);
-        return;
-    }
-
-    if (name == SVGNames::dxAttr) {
+        break;
+    case AttributeNames::dxAttr:
         m_dx->setBaseValInternal(newValue.toFloat());
-        return;
-    }
-
-    if (name == SVGNames::dyAttr) {
+        break;
+    case AttributeNames::dyAttr:
         m_dy->setBaseValInternal(newValue.toFloat());
-        return;
+        break;
+    default:
+        break;
     }
 }
 

--- a/Source/WebCore/svg/SVGFEGaussianBlurElement.cpp
+++ b/Source/WebCore/svg/SVGFEGaussianBlurElement.cpp
@@ -23,6 +23,7 @@
 #include "SVGFEGaussianBlurElement.h"
 
 #include "FEGaussianBlur.h"
+#include "NodeName.h"
 #include "SVGNames.h"
 #include "SVGParserUtilities.h"
 #include <wtf/IsoMallocInlines.h>
@@ -60,26 +61,26 @@ void SVGFEGaussianBlurElement::attributeChanged(const QualifiedName& name, const
 {
     SVGFilterPrimitiveStandardAttributes::attributeChanged(name, oldValue, newValue, attributeModificationReason);
 
-    if (name == SVGNames::stdDeviationAttr) {
+    switch (name.nodeName()) {
+    case AttributeNames::stdDeviationAttr:
         if (auto result = parseNumberOptionalNumber(newValue)) {
             m_stdDeviationX->setBaseValInternal(result->first);
             m_stdDeviationY->setBaseValInternal(result->second);
         }
-        return;
-    }
-
-    if (name == SVGNames::inAttr) {
+        break;
+    case AttributeNames::inAttr:
         m_in1->setBaseValInternal(newValue);
-        return;
-    }
-
-    if (name == SVGNames::edgeModeAttr) {
+        break;
+    case AttributeNames::edgeModeAttr: {
         auto propertyValue = SVGPropertyTraits<EdgeModeType>::fromString(newValue);
         if (propertyValue != EdgeModeType::Unknown)
             m_edgeMode->setBaseValInternal<EdgeModeType>(propertyValue);
         else
             document().accessSVGExtensions().reportWarning("feGaussianBlur: problem parsing edgeMode=\"" + newValue + "\". Filtered element will not be displayed.");
-        return;
+        break;
+    }
+    default:
+        break;
     }
 }
 

--- a/Source/WebCore/svg/SVGFELightElement.cpp
+++ b/Source/WebCore/svg/SVGFELightElement.cpp
@@ -24,6 +24,7 @@
 #include "SVGFELightElement.h"
 
 #include "ElementChildIteratorInlines.h"
+#include "NodeName.h"
 #include "RenderObject.h"
 #include "RenderSVGResource.h"
 #include "SVGElementTypeHelpers.h"
@@ -72,54 +73,39 @@ void SVGFELightElement::attributeChanged(const QualifiedName& name, const AtomSt
 {
     SVGElement::attributeChanged(name, oldValue, newValue, attributeModificationReason);
 
-    if (name == SVGNames::azimuthAttr) {
+    switch (name.nodeName()) {
+    case AttributeNames::azimuthAttr:
         m_azimuth->setBaseValInternal(newValue.toFloat());
-        return;
-    }
-
-    if (name == SVGNames::elevationAttr) {
+        break;
+    case AttributeNames::elevationAttr:
         m_elevation->setBaseValInternal(newValue.toFloat());
-        return;
-    }
-
-    if (name == SVGNames::xAttr) {
+        break;
+    case AttributeNames::xAttr:
         m_x->setBaseValInternal(newValue.toFloat());
-        return;
-    }
-
-    if (name == SVGNames::yAttr) {
+        break;
+    case AttributeNames::yAttr:
         m_y->setBaseValInternal(newValue.toFloat());
-        return;
-    }
-
-    if (name == SVGNames::zAttr) {
+        break;
+    case AttributeNames::zAttr:
         m_z->setBaseValInternal(newValue.toFloat());
-        return;
-    }
-
-    if (name == SVGNames::pointsAtXAttr) {
+        break;
+    case AttributeNames::pointsAtXAttr:
         m_pointsAtX->setBaseValInternal(newValue.toFloat());
-        return;
-    }
-
-    if (name == SVGNames::pointsAtYAttr) {
+        break;
+    case AttributeNames::pointsAtYAttr:
         m_pointsAtY->setBaseValInternal(newValue.toFloat());
-        return;
-    }
-
-    if (name == SVGNames::pointsAtZAttr) {
+        break;
+    case AttributeNames::pointsAtZAttr:
         m_pointsAtZ->setBaseValInternal(newValue.toFloat());
-        return;
-    }
-
-    if (name == SVGNames::specularExponentAttr) {
+        break;
+    case AttributeNames::specularExponentAttr:
         m_specularExponent->setBaseValInternal(newValue.toFloat());
-        return;
-    }
-
-    if (name == SVGNames::limitingConeAngleAttr) {
+        break;
+    case AttributeNames::limitingConeAngleAttr:
         m_limitingConeAngle->setBaseValInternal(newValue.toFloat());
-        return;
+        break;
+    default:
+        break;
     }
 }
 

--- a/Source/WebCore/svg/SVGFEMorphologyElement.cpp
+++ b/Source/WebCore/svg/SVGFEMorphologyElement.cpp
@@ -23,6 +23,7 @@
 #include "SVGFEMorphologyElement.h"
 
 #include "FEMorphology.h"
+#include "NodeName.h"
 #include "SVGNames.h"
 #include "SVGParserUtilities.h"
 #include <wtf/IsoMallocInlines.h>
@@ -53,24 +54,24 @@ void SVGFEMorphologyElement::attributeChanged(const QualifiedName& name, const A
 {
     SVGFilterPrimitiveStandardAttributes::attributeChanged(name, oldValue, newValue, attributeModificationReason);
 
-    if (name == SVGNames::operatorAttr) {
+    switch (name.nodeName()) {
+    case AttributeNames::operatorAttr: {
         MorphologyOperatorType propertyValue = SVGPropertyTraits<MorphologyOperatorType>::fromString(newValue);
         if (propertyValue != MorphologyOperatorType::Unknown)
             m_svgOperator->setBaseValInternal<MorphologyOperatorType>(propertyValue);
-        return;
+        break;
     }
-
-    if (name == SVGNames::inAttr) {
+    case AttributeNames::inAttr:
         m_in1->setBaseValInternal(newValue);
-        return;
-    }
-
-    if (name == SVGNames::radiusAttr) {
+        break;
+    case AttributeNames::radiusAttr:
         if (auto result = parseNumberOptionalNumber(newValue)) {
             m_radiusX->setBaseValInternal(result->first);
             m_radiusY->setBaseValInternal(result->second);
         }
-        return;
+        break;
+    default:
+        break;
     }
 }
 

--- a/Source/WebCore/svg/SVGFEOffsetElement.cpp
+++ b/Source/WebCore/svg/SVGFEOffsetElement.cpp
@@ -23,6 +23,7 @@
 #include "SVGFEOffsetElement.h"
 
 #include "FEOffset.h"
+#include "NodeName.h"
 #include "SVGNames.h"
 #include <wtf/IsoMallocInlines.h>
 
@@ -52,19 +53,18 @@ void SVGFEOffsetElement::attributeChanged(const QualifiedName& name, const AtomS
 {
     SVGFilterPrimitiveStandardAttributes::attributeChanged(name, oldValue, newValue, attributeModificationReason);
 
-    if (name == SVGNames::dxAttr) {
+    switch (name.nodeName()) {
+    case AttributeNames::dxAttr:
         m_dx->setBaseValInternal(newValue.toFloat());
-        return;
-    }
-
-    if (name == SVGNames::dyAttr) {
+        break;
+    case AttributeNames::dyAttr:
         m_dy->setBaseValInternal(newValue.toFloat());
-        return;
-    }
-
-    if (name == SVGNames::inAttr) {
+        break;
+    case AttributeNames::inAttr:
         m_in1->setBaseValInternal(newValue);
-        return;
+        break;
+    default:
+        break;
     }
 }
 

--- a/Source/WebCore/svg/SVGFESpecularLightingElement.cpp
+++ b/Source/WebCore/svg/SVGFESpecularLightingElement.cpp
@@ -24,6 +24,7 @@
 #include "SVGFESpecularLightingElement.h"
 
 #include "FESpecularLighting.h"
+#include "NodeName.h"
 #include "RenderStyle.h"
 #include "SVGFELightElement.h"
 #include "SVGNames.h"
@@ -58,32 +59,27 @@ void SVGFESpecularLightingElement::attributeChanged(const QualifiedName& name, c
 {
     SVGFilterPrimitiveStandardAttributes::attributeChanged(name, oldValue, newValue, attributeModificationReason);
 
-    if (name == SVGNames::inAttr) {
+    switch (name.nodeName()) {
+    case AttributeNames::inAttr:
         m_in1->setBaseValInternal(newValue);
-        return;
-    }
-
-    if (name == SVGNames::surfaceScaleAttr) {
+        break;
+    case AttributeNames::surfaceScaleAttr:
         m_surfaceScale->setBaseValInternal(newValue.toFloat());
-        return;
-    }
-
-    if (name == SVGNames::specularConstantAttr) {
+        break;
+    case AttributeNames::specularConstantAttr:
         m_specularConstant->setBaseValInternal(newValue.toFloat());
-        return;
-    }
-
-    if (name == SVGNames::specularExponentAttr) {
+        break;
+    case AttributeNames::specularExponentAttr:
         m_specularExponent->setBaseValInternal(newValue.toFloat());
-        return;
-    }
-
-    if (name == SVGNames::kernelUnitLengthAttr) {
+        break;
+    case AttributeNames::kernelUnitLengthAttr:
         if (auto result = parseNumberOptionalNumber(newValue)) {
             m_kernelUnitLengthX->setBaseValInternal(result->first);
             m_kernelUnitLengthY->setBaseValInternal(result->second);
         }
-        return;
+        break;
+    default:
+        break;
     }
 }
 

--- a/Source/WebCore/svg/SVGFETurbulenceElement.cpp
+++ b/Source/WebCore/svg/SVGFETurbulenceElement.cpp
@@ -22,6 +22,7 @@
 #include "config.h"
 #include "SVGFETurbulenceElement.h"
 
+#include "NodeName.h"
 #include "SVGNames.h"
 #include "SVGParserUtilities.h"
 #include <wtf/IsoMallocInlines.h>
@@ -53,24 +54,34 @@ Ref<SVGFETurbulenceElement> SVGFETurbulenceElement::create(const QualifiedName& 
 
 void SVGFETurbulenceElement::attributeChanged(const QualifiedName& name, const AtomString& oldValue, const AtomString& newValue, AttributeModificationReason attributeModificationReason)
 {
-    if (name == SVGNames::typeAttr) {
+    switch (name.nodeName()) {
+    case AttributeNames::typeAttr: {
         TurbulenceType propertyValue = SVGPropertyTraits<TurbulenceType>::fromString(newValue);
         if (propertyValue != TurbulenceType::Unknown)
             m_type->setBaseValInternal<TurbulenceType>(propertyValue);
-    } else if (name == SVGNames::stitchTilesAttr) {
+        break;
+    }
+    case AttributeNames::stitchTilesAttr: {
         SVGStitchOptions propertyValue = SVGPropertyTraits<SVGStitchOptions>::fromString(newValue);
         if (propertyValue > 0)
             m_stitchTiles->setBaseValInternal<SVGStitchOptions>(propertyValue);
-    } else if (name == SVGNames::baseFrequencyAttr) {
+        break;
+    }
+    case AttributeNames::baseFrequencyAttr:
         if (auto result = parseNumberOptionalNumber(newValue)) {
             m_baseFrequencyX->setBaseValInternal(result->first);
             m_baseFrequencyY->setBaseValInternal(result->second);
         }
-    } else if (name == SVGNames::seedAttr)
+        break;
+    case AttributeNames::seedAttr:
         m_seed->setBaseValInternal(newValue.toFloat());
-    else if (name == SVGNames::numOctavesAttr)
+        break;
+    case AttributeNames::numOctavesAttr:
         m_numOctaves->setBaseValInternal(parseInteger<unsigned>(newValue).value_or(0));
-
+        break;
+    default:
+        break;
+    }
     SVGFilterPrimitiveStandardAttributes::attributeChanged(name, oldValue, newValue, attributeModificationReason);
 }
 

--- a/Source/WebCore/svg/SVGFilterElement.cpp
+++ b/Source/WebCore/svg/SVGFilterElement.cpp
@@ -67,23 +67,34 @@ void SVGFilterElement::attributeChanged(const QualifiedName& name, const AtomStr
 {
     SVGParsingError parseError = NoError;
 
-    if (name == SVGNames::filterUnitsAttr) {
+    switch (name.nodeName()) {
+    case AttributeNames::filterUnitsAttr: {
         SVGUnitTypes::SVGUnitType propertyValue = SVGPropertyTraits<SVGUnitTypes::SVGUnitType>::fromString(newValue);
         if (propertyValue > 0)
             m_filterUnits->setBaseValInternal<SVGUnitTypes::SVGUnitType>(propertyValue);
-    } else if (name == SVGNames::primitiveUnitsAttr) {
+        break;
+    }
+    case AttributeNames::primitiveUnitsAttr: {
         SVGUnitTypes::SVGUnitType propertyValue = SVGPropertyTraits<SVGUnitTypes::SVGUnitType>::fromString(newValue);
         if (propertyValue > 0)
             m_primitiveUnits->setBaseValInternal<SVGUnitTypes::SVGUnitType>(propertyValue);
-    } else if (name == SVGNames::xAttr)
+        break;
+    }
+    case AttributeNames::xAttr:
         m_x->setBaseValInternal(SVGLengthValue::construct(SVGLengthMode::Width, newValue, parseError));
-    else if (name == SVGNames::yAttr)
+        break;
+    case AttributeNames::yAttr:
         m_y->setBaseValInternal(SVGLengthValue::construct(SVGLengthMode::Height, newValue, parseError));
-    else if (name == SVGNames::widthAttr)
+        break;
+    case AttributeNames::widthAttr:
         m_width->setBaseValInternal(SVGLengthValue::construct(SVGLengthMode::Width, newValue, parseError));
-    else if (name == SVGNames::heightAttr)
+        break;
+    case AttributeNames::heightAttr:
         m_height->setBaseValInternal(SVGLengthValue::construct(SVGLengthMode::Height, newValue, parseError));
-
+        break;
+    default:
+        break;
+    }
     reportAttributeParsingError(parseError, name, newValue);
 
     SVGURIReference::parseAttribute(name, newValue);

--- a/Source/WebCore/svg/SVGFilterPrimitiveStandardAttributes.cpp
+++ b/Source/WebCore/svg/SVGFilterPrimitiveStandardAttributes.cpp
@@ -24,6 +24,7 @@
 #include "SVGFilterPrimitiveStandardAttributes.h"
 
 #include "FilterEffect.h"
+#include "NodeName.h"
 #include "RenderSVGResourceFilterPrimitive.h"
 #include "SVGElementInlines.h"
 #include <wtf/IsoMallocInlines.h>
@@ -50,17 +51,25 @@ void SVGFilterPrimitiveStandardAttributes::attributeChanged(const QualifiedName&
 {
     SVGParsingError parseError = NoError;
 
-    if (name == SVGNames::xAttr)
+    switch (name.nodeName()) {
+    case AttributeNames::xAttr:
         m_x->setBaseValInternal(SVGLengthValue::construct(SVGLengthMode::Width, newValue, parseError));
-    else if (name == SVGNames::yAttr)
+        break;
+    case AttributeNames::yAttr:
         m_y->setBaseValInternal(SVGLengthValue::construct(SVGLengthMode::Height, newValue, parseError));
-    else if (name == SVGNames::widthAttr)
+        break;
+    case AttributeNames::widthAttr:
         m_width->setBaseValInternal(SVGLengthValue::construct(SVGLengthMode::Width, newValue, parseError));
-    else if (name == SVGNames::heightAttr)
+        break;
+    case AttributeNames::heightAttr:
         m_height->setBaseValInternal(SVGLengthValue::construct(SVGLengthMode::Height, newValue, parseError));
-    else if (name == SVGNames::resultAttr)
+        break;
+    case AttributeNames::resultAttr:
         m_result->setBaseValInternal(newValue);
-
+        break;
+    default:
+        break;
+    }
     reportAttributeParsingError(parseError, name, newValue);
 
     SVGElement::attributeChanged(name, oldValue, newValue, attributeModificationReason);

--- a/Source/WebCore/svg/SVGForeignObjectElement.cpp
+++ b/Source/WebCore/svg/SVGForeignObjectElement.cpp
@@ -24,6 +24,7 @@
 
 #include "CSSPropertyNames.h"
 #include "LegacyRenderSVGForeignObject.h"
+#include "NodeName.h"
 #include "RenderSVGForeignObject.h"
 #include "RenderSVGResource.h"
 #include "SVGElementInlines.h"
@@ -59,15 +60,22 @@ void SVGForeignObjectElement::attributeChanged(const QualifiedName& name, const 
 {
     SVGParsingError parseError = NoError;
 
-    if (name == SVGNames::xAttr)
+    switch (name.nodeName()) {
+    case AttributeNames::xAttr:
         m_x->setBaseValInternal(SVGLengthValue::construct(SVGLengthMode::Width, newValue, parseError));
-    else if (name == SVGNames::yAttr)
+        break;
+    case AttributeNames::yAttr:
         m_y->setBaseValInternal(SVGLengthValue::construct(SVGLengthMode::Height, newValue, parseError));
-    else if (name == SVGNames::widthAttr)
+        break;
+    case AttributeNames::widthAttr:
         m_width->setBaseValInternal(SVGLengthValue::construct(SVGLengthMode::Width, newValue, parseError));
-    else if (name == SVGNames::heightAttr)
+        break;
+    case AttributeNames::heightAttr:
         m_height->setBaseValInternal(SVGLengthValue::construct(SVGLengthMode::Height, newValue, parseError));
-
+        break;
+    default:
+        break;
+    }
     reportAttributeParsingError(parseError, name, newValue);
 
     SVGGraphicsElement::attributeChanged(name, oldValue, newValue, attributeModificationReason);

--- a/Source/WebCore/svg/SVGGlyphRefElement.cpp
+++ b/Source/WebCore/svg/SVGGlyphRefElement.cpp
@@ -21,6 +21,7 @@
 #include "config.h"
 #include "SVGGlyphRefElement.h"
 
+#include "NodeName.h"
 #include "SVGElementTypeHelpers.h"
 #include "SVGGlyphElement.h"
 #include "SVGNames.h"
@@ -66,14 +67,22 @@ void SVGGlyphRefElement::attributeChanged(const QualifiedName& name, const AtomS
     SVGElement::attributeChanged(name, oldValue, newValue, attributeModificationReason);
 
     // FIXME: Is the error handling in parseFloat correct for these attributes?
-    if (name == SVGNames::xAttr)
+    switch (name.nodeName()) {
+    case AttributeNames::xAttr:
         m_x = parseFloat(newValue);
-    else if (name == SVGNames::yAttr)
+        break;
+    case AttributeNames::yAttr:
         m_y = parseFloat(newValue);
-    else if (name == SVGNames::dxAttr)
+        break;
+    case AttributeNames::dxAttr:
         m_dx = parseFloat(newValue);
-    else if (name == SVGNames::dyAttr)
+        break;
+    case AttributeNames::dyAttr:
         m_dy = parseFloat(newValue);
+        break;
+    default:
+        break;
+    }
 }
 
 void SVGGlyphRefElement::setX(float x)

--- a/Source/WebCore/svg/SVGGradientElement.cpp
+++ b/Source/WebCore/svg/SVGGradientElement.cpp
@@ -24,6 +24,7 @@
 #include "SVGGradientElement.h"
 
 #include "ElementChildIteratorInlines.h"
+#include "NodeName.h"
 #include "RenderSVGResourceLinearGradient.h"
 #include "RenderSVGResourceRadialGradient.h"
 #include "SVGElementTypeHelpers.h"
@@ -54,23 +55,24 @@ void SVGGradientElement::attributeChanged(const QualifiedName& name, const AtomS
     SVGURIReference::parseAttribute(name, newValue);
     SVGElement::attributeChanged(name, oldValue, newValue, attributeModificationReason);
 
-    if (name == SVGNames::gradientUnitsAttr) {
+    switch (name.nodeName()) {
+    case AttributeNames::gradientUnitsAttr: {
         auto propertyValue = SVGPropertyTraits<SVGUnitTypes::SVGUnitType>::fromString(newValue);
         if (propertyValue > 0)
             m_gradientUnits->setBaseValInternal<SVGUnitTypes::SVGUnitType>(propertyValue);
-        return;
+        break;
     }
-
-    if (name == SVGNames::gradientTransformAttr) {
+    case AttributeNames::gradientTransformAttr:
         m_gradientTransform->baseVal()->parse(newValue);
-        return;
-    }
-
-    if (name == SVGNames::spreadMethodAttr) {
+        break;
+    case AttributeNames::spreadMethodAttr: {
         auto propertyValue = SVGPropertyTraits<SVGSpreadMethodType>::fromString(newValue);
         if (propertyValue > 0)
             m_spreadMethod->setBaseValInternal<SVGSpreadMethodType>(propertyValue);
-        return;
+        break;
+    }
+    default:
+        break;
     }
 }
 

--- a/Source/WebCore/svg/SVGImageElement.cpp
+++ b/Source/WebCore/svg/SVGImageElement.cpp
@@ -26,6 +26,7 @@
 
 #include "CSSPropertyNames.h"
 #include "LegacyRenderSVGImage.h"
+#include "NodeName.h"
 #include "RenderImageResource.h"
 #include "RenderSVGImage.h"
 #include "RenderSVGResource.h"
@@ -94,22 +95,26 @@ void SVGImageElement::attributeChanged(const QualifiedName& name, const AtomStri
     SVGURIReference::parseAttribute(name, newValue);
     SVGGraphicsElement::attributeChanged(name, oldValue, newValue, attributeModificationReason);
 
-    if (name == SVGNames::preserveAspectRatioAttr) {
+    SVGParsingError parseError = NoError;
+    switch (name.nodeName()) {
+    case AttributeNames::preserveAspectRatioAttr:
         m_preserveAspectRatio->setBaseValInternal(SVGPreserveAspectRatioValue { newValue });
         return;
-    }
-
-    SVGParsingError parseError = NoError;
-
-    if (name == SVGNames::xAttr)
+    case AttributeNames::xAttr:
         m_x->setBaseValInternal(SVGLengthValue::construct(SVGLengthMode::Width, newValue, parseError));
-    else if (name == SVGNames::yAttr)
+        break;
+    case AttributeNames::yAttr:
         m_y->setBaseValInternal(SVGLengthValue::construct(SVGLengthMode::Height, newValue, parseError));
-    else if (name == SVGNames::widthAttr)
+        break;
+    case AttributeNames::widthAttr:
         m_width->setBaseValInternal(SVGLengthValue::construct(SVGLengthMode::Width, newValue, parseError, SVGLengthNegativeValuesMode::Forbid));
-    else if (name == SVGNames::heightAttr)
+        break;
+    case AttributeNames::heightAttr:
         m_height->setBaseValInternal(SVGLengthValue::construct(SVGLengthMode::Height, newValue, parseError, SVGLengthNegativeValuesMode::Forbid));
-
+        break;
+    default:
+        break;
+    }
     reportAttributeParsingError(parseError, name, newValue);
 }
 

--- a/Source/WebCore/svg/SVGLineElement.cpp
+++ b/Source/WebCore/svg/SVGLineElement.cpp
@@ -23,6 +23,7 @@
 #include "SVGLineElement.h"
 
 #include "LegacyRenderSVGShape.h"
+#include "NodeName.h"
 #include "RenderSVGResource.h"
 #include "RenderSVGShape.h"
 #include "SVGLengthValue.h"
@@ -55,15 +56,22 @@ void SVGLineElement::attributeChanged(const QualifiedName& name, const AtomStrin
 {
     SVGParsingError parseError = NoError;
 
-    if (name == SVGNames::x1Attr)
+    switch (name.nodeName()) {
+    case AttributeNames::x1Attr:
         m_x1->setBaseValInternal(SVGLengthValue::construct(SVGLengthMode::Width, newValue, parseError));
-    else if (name == SVGNames::y1Attr)
+        break;
+    case AttributeNames::y1Attr:
         m_y1->setBaseValInternal(SVGLengthValue::construct(SVGLengthMode::Height, newValue, parseError));
-    else if (name == SVGNames::x2Attr)
+        break;
+    case AttributeNames::x2Attr:
         m_x2->setBaseValInternal(SVGLengthValue::construct(SVGLengthMode::Width, newValue, parseError));
-    else if (name == SVGNames::y2Attr)
+        break;
+    case AttributeNames::y2Attr:
         m_y2->setBaseValInternal(SVGLengthValue::construct(SVGLengthMode::Height, newValue, parseError));
-
+        break;
+    default:
+        break;
+    }
     reportAttributeParsingError(parseError, name, newValue);
 
     SVGGeometryElement::attributeChanged(name, oldValue, newValue, attributeModificationReason);

--- a/Source/WebCore/svg/SVGLinearGradientElement.cpp
+++ b/Source/WebCore/svg/SVGLinearGradientElement.cpp
@@ -28,6 +28,7 @@
 #include "Document.h"
 #include "FloatPoint.h"
 #include "LinearGradientAttributes.h"
+#include "NodeName.h"
 #include "RenderSVGResourceLinearGradient.h"
 #include "SVGElementTypeHelpers.h"
 #include "SVGLengthValue.h"
@@ -64,15 +65,22 @@ void SVGLinearGradientElement::attributeChanged(const QualifiedName& name, const
 {
     SVGParsingError parseError = NoError;
 
-    if (name == SVGNames::x1Attr)
+    switch (name.nodeName()) {
+    case AttributeNames::x1Attr:
         m_x1->setBaseValInternal(SVGLengthValue::construct(SVGLengthMode::Width, newValue, parseError));
-    else if (name == SVGNames::y1Attr)
+        break;
+    case AttributeNames::y1Attr:
         m_y1->setBaseValInternal(SVGLengthValue::construct(SVGLengthMode::Height, newValue, parseError));
-    else if (name == SVGNames::x2Attr)
+        break;
+    case AttributeNames::x2Attr:
         m_x2->setBaseValInternal(SVGLengthValue::construct(SVGLengthMode::Width, newValue, parseError));
-    else if (name == SVGNames::y2Attr)
+        break;
+    case AttributeNames::y2Attr:
         m_y2->setBaseValInternal(SVGLengthValue::construct(SVGLengthMode::Height, newValue, parseError));
-
+        break;
+    default:
+        break;
+    }
     reportAttributeParsingError(parseError, name, newValue);
 
     SVGGradientElement::attributeChanged(name, oldValue, newValue, attributeModificationReason);

--- a/Source/WebCore/svg/SVGMarkerElement.cpp
+++ b/Source/WebCore/svg/SVGMarkerElement.cpp
@@ -23,6 +23,7 @@
 #include "config.h"
 #include "SVGMarkerElement.h"
 
+#include "NodeName.h"
 #include "RenderSVGResourceMarker.h"
 #include "SVGNames.h"
 #include <wtf/IsoMallocInlines.h>
@@ -64,31 +65,35 @@ void SVGMarkerElement::attributeChanged(const QualifiedName& name, const AtomStr
     SVGFitToViewBox::parseAttribute(name, newValue);
     SVGElement::attributeChanged(name, oldValue, newValue, attributeModificationReason);
 
-    if (name == SVGNames::markerUnitsAttr) {
+    SVGParsingError parseError = NoError;
+    switch (name.nodeName()) {
+    case AttributeNames::markerUnitsAttr: {
         auto propertyValue = SVGPropertyTraits<SVGMarkerUnitsType>::fromString(newValue);
         if (propertyValue > 0)
             m_markerUnits->setBaseValInternal<SVGMarkerUnitsType>(propertyValue);
         return;
     }
-
-    if (name == SVGNames::orientAttr) {
+    case AttributeNames::orientAttr: {
         auto pair = SVGPropertyTraits<std::pair<SVGAngleValue, SVGMarkerOrientType>>::fromString(newValue);
         m_orientAngle->setBaseValInternal(pair.first);
         m_orientType->setBaseValInternal(pair.second);
         return;
     }
-
-    SVGParsingError parseError = NoError;
-
-    if (name == SVGNames::refXAttr)
+    case AttributeNames::refXAttr:
         m_refX->setBaseValInternal(SVGLengthValue::construct(SVGLengthMode::Width, newValue, parseError));
-    else if (name == SVGNames::refYAttr)
+        break;
+    case AttributeNames::refYAttr:
         m_refY->setBaseValInternal(SVGLengthValue::construct(SVGLengthMode::Height, newValue, parseError));
-    else if (name == SVGNames::markerWidthAttr)
+        break;
+    case AttributeNames::markerWidthAttr:
         m_markerWidth->setBaseValInternal(SVGLengthValue::construct(SVGLengthMode::Width, newValue, parseError));
-    else if (name == SVGNames::markerHeightAttr)
+        break;
+    case AttributeNames::markerHeightAttr:
         m_markerHeight->setBaseValInternal(SVGLengthValue::construct(SVGLengthMode::Height, newValue, parseError));
-
+        break;
+    default:
+        break;
+    }
     reportAttributeParsingError(parseError, name, newValue);
 }
 

--- a/Source/WebCore/svg/SVGMaskElement.cpp
+++ b/Source/WebCore/svg/SVGMaskElement.cpp
@@ -26,6 +26,7 @@
 #include "config.h"
 #include "SVGMaskElement.h"
 
+#include "NodeName.h"
 #include "RenderSVGResourceMaskerInlines.h"
 #include "SVGElementInlines.h"
 #include "SVGNames.h"
@@ -69,30 +70,36 @@ void SVGMaskElement::attributeChanged(const QualifiedName& name, const AtomStrin
     SVGTests::parseAttribute(name, newValue);
     SVGElement::attributeChanged(name, oldValue, newValue, attributeModificationReason);
 
-    if (name == SVGNames::maskUnitsAttr) {
+
+    SVGParsingError parseError = NoError;
+    switch (name.nodeName()) {
+    case AttributeNames::maskUnitsAttr: {
         auto propertyValue = SVGPropertyTraits<SVGUnitTypes::SVGUnitType>::fromString(newValue);
         if (propertyValue > 0)
             m_maskUnits->setBaseValInternal<SVGUnitTypes::SVGUnitType>(propertyValue);
         return;
     }
-    if (name == SVGNames::maskContentUnitsAttr) {
+    case AttributeNames::maskContentUnitsAttr: {
         auto propertyValue = SVGPropertyTraits<SVGUnitTypes::SVGUnitType>::fromString(newValue);
         if (propertyValue > 0)
             m_maskContentUnits->setBaseValInternal<SVGUnitTypes::SVGUnitType>(propertyValue);
         return;
     }
-
-    SVGParsingError parseError = NoError;
-
-    if (name == SVGNames::xAttr)
+    case AttributeNames::xAttr:
         m_x->setBaseValInternal(SVGLengthValue::construct(SVGLengthMode::Width, newValue, parseError));
-    else if (name == SVGNames::yAttr)
+        break;
+    case AttributeNames::yAttr:
         m_y->setBaseValInternal(SVGLengthValue::construct(SVGLengthMode::Height, newValue, parseError));
-    else if (name == SVGNames::widthAttr)
+        break;
+    case AttributeNames::widthAttr:
         m_width->setBaseValInternal(SVGLengthValue::construct(SVGLengthMode::Width, newValue, parseError));
-    else if (name == SVGNames::heightAttr)
+        break;
+    case AttributeNames::heightAttr:
         m_height->setBaseValInternal(SVGLengthValue::construct(SVGLengthMode::Height, newValue, parseError));
-
+        break;
+    default:
+        break;
+    }
     reportAttributeParsingError(parseError, name, newValue);
 }
 

--- a/Source/WebCore/svg/SVGPatternElement.cpp
+++ b/Source/WebCore/svg/SVGPatternElement.cpp
@@ -29,6 +29,7 @@
 #include "FloatConversion.h"
 #include "GraphicsContext.h"
 #include "ImageBuffer.h"
+#include "NodeName.h"
 #include "PatternAttributes.h"
 #include "RenderSVGResourcePattern.h"
 #include "SVGElementInlines.h"
@@ -77,34 +78,39 @@ void SVGPatternElement::attributeChanged(const QualifiedName& name, const AtomSt
     SVGFitToViewBox::parseAttribute(name, newValue);
     SVGElement::attributeChanged(name, oldValue, newValue, attributeModificationReason);
 
-    if (name == SVGNames::patternUnitsAttr) {
+    SVGParsingError parseError = NoError;
+    switch (name.nodeName()) {
+    case AttributeNames::patternUnitsAttr: {
         auto propertyValue = SVGPropertyTraits<SVGUnitTypes::SVGUnitType>::fromString(newValue);
         if (propertyValue > 0)
             m_patternUnits->setBaseValInternal<SVGUnitTypes::SVGUnitType>(propertyValue);
         return;
     }
-    if (name == SVGNames::patternContentUnitsAttr) {
+    case AttributeNames::patternContentUnitsAttr: {
         auto propertyValue = SVGPropertyTraits<SVGUnitTypes::SVGUnitType>::fromString(newValue);
         if (propertyValue > 0)
             m_patternContentUnits->setBaseValInternal<SVGUnitTypes::SVGUnitType>(propertyValue);
         return;
     }
-    if (name == SVGNames::patternTransformAttr) {
+    case AttributeNames::patternTransformAttr: {
         m_patternTransform->baseVal()->parse(newValue);
         return;
     }
-
-    SVGParsingError parseError = NoError;
-
-    if (name == SVGNames::xAttr)
+    case AttributeNames::xAttr:
         m_x->setBaseValInternal(SVGLengthValue::construct(SVGLengthMode::Width, newValue, parseError));
-    else if (name == SVGNames::yAttr)
+        break;
+    case AttributeNames::yAttr:
         m_y->setBaseValInternal(SVGLengthValue::construct(SVGLengthMode::Height, newValue, parseError));
-    else if (name == SVGNames::widthAttr)
+        break;
+    case AttributeNames::widthAttr:
         m_width->setBaseValInternal(SVGLengthValue::construct(SVGLengthMode::Width, newValue, parseError, SVGLengthNegativeValuesMode::Forbid));
-    else if (name == SVGNames::heightAttr)
+        break;
+    case AttributeNames::heightAttr:
         m_height->setBaseValInternal(SVGLengthValue::construct(SVGLengthMode::Height, newValue, parseError, SVGLengthNegativeValuesMode::Forbid));
-
+        break;
+    default:
+        break;
+    }
     reportAttributeParsingError(parseError, name, newValue);
 }
 

--- a/Source/WebCore/svg/SVGRadialGradientElement.cpp
+++ b/Source/WebCore/svg/SVGRadialGradientElement.cpp
@@ -27,6 +27,7 @@
 
 #include "FloatConversion.h"
 #include "FloatPoint.h"
+#include "NodeName.h"
 #include "RadialGradientAttributes.h"
 #include "RenderSVGResourceRadialGradient.h"
 #include "SVGElementTypeHelpers.h"
@@ -66,21 +67,29 @@ void SVGRadialGradientElement::attributeChanged(const QualifiedName& name, const
 {
     SVGParsingError parseError = NoError;
 
-    if (name == SVGNames::cxAttr)
+    switch (name.nodeName()) {
+    case AttributeNames::cxAttr:
         m_cx->setBaseValInternal(SVGLengthValue::construct(SVGLengthMode::Width, newValue, parseError));
-    else if (name == SVGNames::cyAttr)
+        break;
+    case AttributeNames::cyAttr:
         m_cy->setBaseValInternal(SVGLengthValue::construct(SVGLengthMode::Height, newValue, parseError));
-    else if (name == SVGNames::rAttr)
+        break;
+    case AttributeNames::rAttr:
         m_r->setBaseValInternal(SVGLengthValue::construct(SVGLengthMode::Other, newValue, parseError, SVGLengthNegativeValuesMode::Forbid));
-    else if (name == SVGNames::fxAttr)
+        break;
+    case AttributeNames::fxAttr:
         m_fx->setBaseValInternal(SVGLengthValue::construct(SVGLengthMode::Width, newValue, parseError));
-    else if (name == SVGNames::fyAttr)
+        break;
+    case AttributeNames::fyAttr:
         m_fy->setBaseValInternal(SVGLengthValue::construct(SVGLengthMode::Height, newValue, parseError));
-    else if (name == SVGNames::frAttr)
+        break;
+    case AttributeNames::frAttr:
         m_fr->setBaseValInternal(SVGLengthValue::construct(SVGLengthMode::Other, newValue, parseError, SVGLengthNegativeValuesMode::Forbid));
-
+        break;
+    default:
+        break;
+    }
     reportAttributeParsingError(parseError, name, newValue);
-
     SVGGradientElement::attributeChanged(name, oldValue, newValue, attributeModificationReason);
 }
 

--- a/Source/WebCore/svg/SVGRectElement.cpp
+++ b/Source/WebCore/svg/SVGRectElement.cpp
@@ -24,6 +24,7 @@
 #include "SVGRectElement.h"
 
 #include "LegacyRenderSVGRect.h"
+#include "NodeName.h"
 #include "RenderSVGRect.h"
 #include "RenderSVGResource.h"
 #include "SVGElementInlines.h"
@@ -58,21 +59,29 @@ void SVGRectElement::attributeChanged(const QualifiedName& name, const AtomStrin
 {
     SVGParsingError parseError = NoError;
 
-    if (name == SVGNames::xAttr)
+    switch (name.nodeName()) {
+    case AttributeNames::xAttr:
         m_x->setBaseValInternal(SVGLengthValue::construct(SVGLengthMode::Width, newValue, parseError));
-    else if (name == SVGNames::yAttr)
+        break;
+    case AttributeNames::yAttr:
         m_y->setBaseValInternal(SVGLengthValue::construct(SVGLengthMode::Height, newValue, parseError));
-    else if (name == SVGNames::rxAttr)
+        break;
+    case AttributeNames::rxAttr:
         m_rx->setBaseValInternal(SVGLengthValue::construct(SVGLengthMode::Width, newValue, parseError, SVGLengthNegativeValuesMode::Forbid));
-    else if (name == SVGNames::ryAttr)
+        break;
+    case AttributeNames::ryAttr:
         m_ry->setBaseValInternal(SVGLengthValue::construct(SVGLengthMode::Height, newValue, parseError, SVGLengthNegativeValuesMode::Forbid));
-    else if (name == SVGNames::widthAttr)
+        break;
+    case AttributeNames::widthAttr:
         m_width->setBaseValInternal(SVGLengthValue::construct(SVGLengthMode::Width, newValue, parseError, SVGLengthNegativeValuesMode::Forbid));
-    else if (name == SVGNames::heightAttr)
+        break;
+    case AttributeNames::heightAttr:
         m_height->setBaseValInternal(SVGLengthValue::construct(SVGLengthMode::Height, newValue, parseError, SVGLengthNegativeValuesMode::Forbid));
-
+        break;
+    default:
+        break;
+    }
     reportAttributeParsingError(parseError, name, newValue);
-
     SVGGeometryElement::attributeChanged(name, oldValue, newValue, attributeModificationReason);
 }
 

--- a/Source/WebCore/svg/SVGSVGElement.cpp
+++ b/Source/WebCore/svg/SVGSVGElement.cpp
@@ -33,6 +33,7 @@
 #include "LegacyRenderSVGRoot.h"
 #include "LegacyRenderSVGViewportContainer.h"
 #include "LocalFrame.h"
+#include "NodeName.h"
 #include "RenderSVGResource.h"
 #include "RenderSVGRoot.h"
 #include "RenderSVGViewportContainer.h"
@@ -172,39 +173,40 @@ void SVGSVGElement::attributeChanged(const QualifiedName& name, const AtomString
     if (!nearestViewportElement() && isConnected()) {
         // For these events, the outermost <svg> element works like a <body> element does,
         // setting certain event handlers directly on the window object.
-        if (name == HTMLNames::onunloadAttr) {
+        switch (name.nodeName()) {
+        case AttributeNames::onunloadAttr:
             document().setWindowAttributeEventListener(eventNames().unloadEvent, name, newValue, mainThreadNormalWorld());
             return;
-        }
-        if (name == HTMLNames::onresizeAttr) {
+        case AttributeNames::onresizeAttr:
             document().setWindowAttributeEventListener(eventNames().resizeEvent, name, newValue, mainThreadNormalWorld());
             return;
-        }
-        if (name == HTMLNames::onscrollAttr) {
+        case AttributeNames::onscrollAttr:
             document().setWindowAttributeEventListener(eventNames().scrollEvent, name, newValue, mainThreadNormalWorld());
             return;
-        }
-        if (name == SVGNames::onzoomAttr) {
+        case AttributeNames::onzoomAttr:
             document().setWindowAttributeEventListener(eventNames().zoomEvent, name, newValue, mainThreadNormalWorld());
             return;
-        }
-        if (name == HTMLNames::onabortAttr) {
+        case AttributeNames::onabortAttr:
             document().setWindowAttributeEventListener(eventNames().abortEvent, name, newValue, mainThreadNormalWorld());
             return;
-        }
-        if (name == HTMLNames::onerrorAttr) {
+        case AttributeNames::onerrorAttr:
             document().setWindowAttributeEventListener(eventNames().errorEvent, name, newValue, mainThreadNormalWorld());
             return;
+        default:
+            break;
         }
     }
 
     SVGParsingError parseError = NoError;
 
-    if (name == SVGNames::xAttr)
+    switch (name.nodeName()) {
+    case AttributeNames::xAttr:
         m_x->setBaseValInternal(SVGLengthValue::construct(SVGLengthMode::Width, newValue, parseError));
-    else if (name == SVGNames::yAttr)
+        break;
+    case AttributeNames::yAttr:
         m_y->setBaseValInternal(SVGLengthValue::construct(SVGLengthMode::Height, newValue, parseError));
-    else if (name == SVGNames::widthAttr) {
+        break;
+    case AttributeNames::widthAttr: {
         auto length = SVGLengthValue::construct(SVGLengthMode::Width, newValue, parseError, SVGLengthNegativeValuesMode::Forbid);
         if (parseError != NoError || newValue.isEmpty()) {
             // FIXME: This is definitely the correct behavior for a missing/removed attribute.
@@ -212,7 +214,9 @@ void SVGSVGElement::attributeChanged(const QualifiedName& name, const AtomString
             length = SVGLengthValue(SVGLengthMode::Width, "100%"_s);
         }
         m_width->setBaseValInternal(length);
-    } else if (name == SVGNames::heightAttr) {
+        break;
+    }
+    case AttributeNames::heightAttr: {
         auto length = SVGLengthValue::construct(SVGLengthMode::Height, newValue, parseError, SVGLengthNegativeValuesMode::Forbid);
         if (parseError != NoError || newValue.isEmpty()) {
             // FIXME: This is definitely the correct behavior for a removed attribute.
@@ -220,8 +224,11 @@ void SVGSVGElement::attributeChanged(const QualifiedName& name, const AtomString
             length = SVGLengthValue(SVGLengthMode::Height, "100%"_s);
         }
         m_height->setBaseValInternal(length);
+        break;
     }
-
+    default:
+        break;
+    }
     reportAttributeParsingError(parseError, name, newValue);
 }
 

--- a/Source/WebCore/svg/SVGStyleElement.cpp
+++ b/Source/WebCore/svg/SVGStyleElement.cpp
@@ -26,6 +26,7 @@
 #include "CSSStyleSheet.h"
 #include "CommonAtomStrings.h"
 #include "Document.h"
+#include "NodeName.h"
 #include "SVGElementInlines.h"
 #include "SVGNames.h"
 #include <wtf/IsoMallocInlines.h>
@@ -95,18 +96,19 @@ void SVGStyleElement::attributeChanged(const QualifiedName& name, const AtomStri
 {
     SVGElement::attributeChanged(name, oldValue, newValue, attributeModificationReason);
 
-    if (name == SVGNames::titleAttr) {
+    switch (name.nodeName()) {
+    case AttributeNames::titleAttr:
         if (sheet() && !isInShadowTree())
             sheet()->setTitle(newValue);
-        return;
-    }
-    if (name == SVGNames::typeAttr) {
+        break;
+    case AttributeNames::typeAttr:
         m_styleSheetOwner.setContentType(newValue);
-        return;
-    }
-    if (name == SVGNames::mediaAttr) {
+        break;
+    case AttributeNames::mediaAttr:
         m_styleSheetOwner.setMedia(newValue);
-        return;
+        break;
+    default:
+        break;
     }
 }
 

--- a/Source/WebCore/svg/SVGTextPathElement.cpp
+++ b/Source/WebCore/svg/SVGTextPathElement.cpp
@@ -22,6 +22,7 @@
 #include "config.h"
 #include "SVGTextPathElement.h"
 
+#include "NodeName.h"
 #include "RenderSVGResource.h"
 #include "RenderSVGTextPath.h"
 #include "SVGDocumentExtensions.h"
@@ -67,18 +68,25 @@ void SVGTextPathElement::attributeChanged(const QualifiedName& name, const AtomS
 {
     SVGParsingError parseError = NoError;
 
-    if (name == SVGNames::startOffsetAttr)
+    switch (name.nodeName()) {
+    case AttributeNames::startOffsetAttr:
         m_startOffset->setBaseValInternal(SVGLengthValue::construct(SVGLengthMode::Other, newValue, parseError));
-    else if (name == SVGNames::methodAttr) {
+        break;
+    case AttributeNames::methodAttr: {
         SVGTextPathMethodType propertyValue = SVGPropertyTraits<SVGTextPathMethodType>::fromString(newValue);
         if (propertyValue > 0)
             m_method->setBaseValInternal<SVGTextPathMethodType>(propertyValue);
-    } else if (name == SVGNames::spacingAttr) {
+        break;
+    }
+    case AttributeNames::spacingAttr: {
         SVGTextPathSpacingType propertyValue = SVGPropertyTraits<SVGTextPathSpacingType>::fromString(newValue);
         if (propertyValue > 0)
             m_spacing->setBaseValInternal<SVGTextPathSpacingType>(propertyValue);
+        break;
     }
-
+    default:
+        break;
+    }
     reportAttributeParsingError(parseError, name, newValue);
 
     SVGURIReference::parseAttribute(name, newValue);

--- a/Source/WebCore/svg/SVGTextPositioningElement.cpp
+++ b/Source/WebCore/svg/SVGTextPositioningElement.cpp
@@ -23,6 +23,7 @@
 #include "config.h"
 #include "SVGTextPositioningElement.h"
 
+#include "NodeName.h"
 #include "RenderSVGInline.h"
 #include "RenderSVGResource.h"
 #include "RenderSVGText.h"
@@ -55,29 +56,24 @@ void SVGTextPositioningElement::attributeChanged(const QualifiedName& name, cons
 {
     SVGTextContentElement::attributeChanged(name, oldValue, newValue, attributeModificationReason);
 
-    if (name == SVGNames::xAttr) {
+    switch (name.nodeName()) {
+    case AttributeNames::xAttr:
         m_x->baseVal()->parse(newValue);
-        return;
-    }
-
-    if (name == SVGNames::yAttr) {
+        break;
+    case AttributeNames::yAttr:
         m_y->baseVal()->parse(newValue);
-        return;
-    }
-
-    if (name == SVGNames::dxAttr) {
+        break;
+    case AttributeNames::dxAttr:
         m_dx->baseVal()->parse(newValue);
-        return;
-    }
-
-    if (name == SVGNames::dyAttr) {
+        break;
+    case AttributeNames::dyAttr:
         m_dy->baseVal()->parse(newValue);
-        return;
-    }
-
-    if (name == SVGNames::rotateAttr) {
+        break;
+    case AttributeNames::rotateAttr:
         m_rotate->baseVal()->parse(newValue);
-        return;
+        break;
+    default:
+        break;
     }
 }
 

--- a/Source/WebCore/svg/SVGUseElement.cpp
+++ b/Source/WebCore/svg/SVGUseElement.cpp
@@ -84,15 +84,22 @@ void SVGUseElement::attributeChanged(const QualifiedName& name, const AtomString
 {
     SVGParsingError parseError = NoError;
 
-    if (name == SVGNames::xAttr)
+    switch (name.nodeName()) {
+    case AttributeNames::xAttr:
         m_x->setBaseValInternal(SVGLengthValue::construct(SVGLengthMode::Width, newValue, parseError));
-    else if (name == SVGNames::yAttr)
+        break;
+    case AttributeNames::yAttr:
         m_y->setBaseValInternal(SVGLengthValue::construct(SVGLengthMode::Height, newValue, parseError));
-    else if (name == SVGNames::widthAttr)
+        break;
+    case AttributeNames::widthAttr:
         m_width->setBaseValInternal(SVGLengthValue::construct(SVGLengthMode::Width, newValue, parseError, SVGLengthNegativeValuesMode::Forbid));
-    else if (name == SVGNames::heightAttr)
+        break;
+    case AttributeNames::heightAttr:
         m_height->setBaseValInternal(SVGLengthValue::construct(SVGLengthMode::Height, newValue, parseError, SVGLengthNegativeValuesMode::Forbid));
-
+        break;
+    default:
+        break;
+    }
     reportAttributeParsingError(parseError, name, newValue);
 
     SVGURIReference::parseAttribute(name, newValue);

--- a/Source/WebCore/svg/animation/SVGSMILElement.cpp
+++ b/Source/WebCore/svg/animation/SVGSMILElement.cpp
@@ -36,6 +36,7 @@
 #include "EventSender.h"
 #include "FloatConversion.h"
 #include "LocalFrameView.h"
+#include "NodeName.h"
 #include "Page.h"
 #include "SMILTimeContainer.h"
 #include "SVGDocumentExtensions.h"
@@ -479,7 +480,8 @@ void SVGSMILElement::attributeChanged(const QualifiedName& name, const AtomStrin
 {
     SVGElement::attributeChanged(name, oldValue, newValue, attributeModificationReason);
 
-    if (name == SVGNames::beginAttr) {
+    switch (name.nodeName()) {
+    case AttributeNames::beginAttr:
         if (!m_conditions.isEmpty()) {
             disconnectConditions();
             m_conditions.clear();
@@ -488,7 +490,8 @@ void SVGSMILElement::attributeChanged(const QualifiedName& name, const AtomStrin
         parseBeginOrEnd(newValue, Begin);
         if (isConnected())
             connectConditions();
-    } else if (name == SVGNames::endAttr) {
+        break;
+    case AttributeNames::endAttr:
         if (!m_conditions.isEmpty()) {
             disconnectConditions();
             m_conditions.clear();
@@ -497,10 +500,16 @@ void SVGSMILElement::attributeChanged(const QualifiedName& name, const AtomStrin
         parseBeginOrEnd(newValue, End);
         if (isConnected())
             connectConditions();
-    } else if (name == SVGNames::onendAttr)
+        break;
+    case AttributeNames::onendAttr:
         setAttributeEventListener(eventNames().endEventEvent, name, newValue);
-    else if (name == SVGNames::onbeginAttr)
+        break;
+    case AttributeNames::onbeginAttr:
         setAttributeEventListener(eventNames().beginEventEvent, name, newValue);
+        break;
+    default:
+        break;
+    }
 }
 
 void SVGSMILElement::svgAttributeChanged(const QualifiedName& attrName)


### PR DESCRIPTION
#### 0b09da912f832f692add40fb131cbd32ecd2b029
<pre>
Adopt the new NodeName enumeration more broadly in attributeChanged() overrides
<a href="https://bugs.webkit.org/show_bug.cgi?id=255466">https://bugs.webkit.org/show_bug.cgi?id=255466</a>

Reviewed by Darin Adler.

Adopt the new NodeName enumeration more broadly in attributeChanged() overrides.
Switch statements are more efficient when dealing with a lot of attribute names.
It also results in nicer code.

* Source/WebCore/html/HTMLAreaElement.cpp:
(WebCore::HTMLAreaElement::attributeChanged):
* Source/WebCore/html/HTMLAttachmentElement.cpp:
(WebCore::HTMLAttachmentElement::ensureModernShadowTree):
(WebCore::HTMLAttachmentElement::setFile):
(WebCore::HTMLAttachmentElement::attributeChanged):
(WebCore::HTMLAttachmentElement::attachmentSubtitle const):
(WebCore::HTMLAttachmentElement::updateAttributes):
(WebCore::subtitleAttr): Deleted.
(WebCore::saveAttr): Deleted.
* Source/WebCore/html/HTMLAttributeNames.in:
* Source/WebCore/html/HTMLBodyElement.cpp:
(WebCore::HTMLBodyElement::attributeChanged):
* Source/WebCore/html/HTMLEmbedElement.cpp:
(WebCore::HTMLEmbedElement::attributeChanged):
* Source/WebCore/html/HTMLFrameSetElement.cpp:
(WebCore::HTMLFrameSetElement::attributeChanged):
* Source/WebCore/html/HTMLIFrameElement.cpp:
(WebCore::HTMLIFrameElement::attributeChanged):
* Source/WebCore/html/HTMLImageElement.cpp:
(WebCore::HTMLImageElement::attributeChanged):
* Source/WebCore/html/HTMLLinkElement.cpp:
(WebCore::HTMLLinkElement::attributeChanged):
* Source/WebCore/html/HTMLMediaElement.cpp:
(WebCore::HTMLMediaElement::attributeChanged):
* Source/WebCore/html/HTMLMetaElement.cpp:
(WebCore::HTMLMetaElement::attributeChanged):
* Source/WebCore/html/HTMLMeterElement.cpp:
(WebCore::HTMLMeterElement::attributeChanged):
* Source/WebCore/html/HTMLObjectElement.cpp:
(WebCore::HTMLObjectElement::attributeChanged):
* Source/WebCore/html/HTMLSourceElement.cpp:
(WebCore::HTMLSourceElement::attributeChanged):
* Source/WebCore/html/HTMLStyleElement.cpp:
(WebCore::HTMLStyleElement::attributeChanged):
* Source/WebCore/html/HTMLTrackElement.cpp:
(WebCore::HTMLTrackElement::attributeChanged):
* Source/WebCore/html/NumberInputType.cpp:
(WebCore::NumberInputType::attributeChanged):
* Source/WebCore/html/RangeInputType.cpp:
(WebCore::RangeInputType::attributeChanged):
* Source/WebCore/mathml/MathMLElement.cpp:
(WebCore::MathMLElement::attributeChanged):
* Source/WebCore/mathml/MathMLFractionElement.cpp:
(WebCore::MathMLFractionElement::attributeChanged):
* Source/WebCore/mathml/MathMLMathElement.cpp:
(WebCore::MathMLMathElement::attributeChanged):
* Source/WebCore/mathml/MathMLOperatorElement.cpp:
(WebCore::attributeNameToPropertyFlag):
(WebCore::MathMLOperatorElement::attributeChanged):
* Source/WebCore/mathml/MathMLPaddedElement.cpp:
(WebCore::MathMLPaddedElement::attributeChanged):
* Source/WebCore/mathml/MathMLPresentationElement.cpp:
(WebCore::MathMLPresentationElement::attributeChanged):
* Source/WebCore/mathml/MathMLSpaceElement.cpp:
(WebCore::MathMLSpaceElement::attributeChanged):
* Source/WebCore/svg/SVGAnimationElement.cpp:
(WebCore::SVGAnimationElement::attributeChanged):
* Source/WebCore/svg/SVGCircleElement.cpp:
(WebCore::SVGCircleElement::attributeChanged):
* Source/WebCore/svg/SVGComponentTransferFunctionElement.cpp:
(WebCore::SVGComponentTransferFunctionElement::attributeChanged):
* Source/WebCore/svg/SVGElement.cpp:
(WebCore::SVGElement::attributeChanged):
* Source/WebCore/svg/SVGEllipseElement.cpp:
(WebCore::SVGEllipseElement::attributeChanged):
* Source/WebCore/svg/SVGFEBlendElement.cpp:
(WebCore::SVGFEBlendElement::attributeChanged):
* Source/WebCore/svg/SVGFEColorMatrixElement.cpp:
(WebCore::SVGFEColorMatrixElement::attributeChanged):
* Source/WebCore/svg/SVGFECompositeElement.cpp:
(WebCore::SVGFECompositeElement::attributeChanged):
(WebCore::SVGFECompositeElement::setFilterEffectAttribute): Deleted.
(WebCore::SVGFECompositeElement::svgAttributeChanged): Deleted.
(WebCore::SVGFECompositeElement::createFilterEffect const): Deleted.
* Source/WebCore/svg/SVGFEConvolveMatrixElement.cpp:
(WebCore::SVGFEConvolveMatrixElement::attributeChanged):
* Source/WebCore/svg/SVGFEDiffuseLightingElement.cpp:
(WebCore::SVGFEDiffuseLightingElement::attributeChanged):
* Source/WebCore/svg/SVGFEDisplacementMapElement.cpp:
(WebCore::SVGFEDisplacementMapElement::attributeChanged):
* Source/WebCore/svg/SVGFEDropShadowElement.cpp:
(WebCore::SVGFEDropShadowElement::attributeChanged):
* Source/WebCore/svg/SVGFEGaussianBlurElement.cpp:
(WebCore::SVGFEGaussianBlurElement::attributeChanged):
* Source/WebCore/svg/SVGFELightElement.cpp:
(WebCore::SVGFELightElement::attributeChanged):
* Source/WebCore/svg/SVGFEMorphologyElement.cpp:
(WebCore::SVGFEMorphologyElement::attributeChanged):
(WebCore::SVGFEMorphologyElement::setFilterEffectAttribute): Deleted.
(WebCore::SVGFEMorphologyElement::svgAttributeChanged): Deleted.
(WebCore::SVGFEMorphologyElement::isIdentity const): Deleted.
(WebCore::SVGFEMorphologyElement::outsets const): Deleted.
(WebCore::SVGFEMorphologyElement::createFilterEffect const): Deleted.
* Source/WebCore/svg/SVGFEOffsetElement.cpp:
(WebCore::SVGFEOffsetElement::attributeChanged):
* Source/WebCore/svg/SVGFESpecularLightingElement.cpp:
(WebCore::SVGFESpecularLightingElement::attributeChanged):
* Source/WebCore/svg/SVGFETurbulenceElement.cpp:
(WebCore::SVGFETurbulenceElement::attributeChanged):
* Source/WebCore/svg/SVGFilterElement.cpp:
(WebCore::SVGFilterElement::attributeChanged):
* Source/WebCore/svg/SVGFilterPrimitiveStandardAttributes.cpp:
(WebCore::SVGFilterPrimitiveStandardAttributes::attributeChanged):
* Source/WebCore/svg/SVGForeignObjectElement.cpp:
(WebCore::SVGForeignObjectElement::attributeChanged):
* Source/WebCore/svg/SVGGlyphRefElement.cpp:
(WebCore::SVGGlyphRefElement::attributeChanged):
* Source/WebCore/svg/SVGGradientElement.cpp:
(WebCore::SVGGradientElement::attributeChanged):
* Source/WebCore/svg/SVGImageElement.cpp:
(WebCore::SVGImageElement::attributeChanged):
* Source/WebCore/svg/SVGLineElement.cpp:
(WebCore::SVGLineElement::attributeChanged):
* Source/WebCore/svg/SVGLinearGradientElement.cpp:
(WebCore::SVGLinearGradientElement::attributeChanged):
* Source/WebCore/svg/SVGMarkerElement.cpp:
(WebCore::SVGMarkerElement::attributeChanged):
* Source/WebCore/svg/SVGMaskElement.cpp:
(WebCore::SVGMaskElement::attributeChanged):
* Source/WebCore/svg/SVGPatternElement.cpp:
(WebCore::SVGPatternElement::attributeChanged):
* Source/WebCore/svg/SVGRadialGradientElement.cpp:
(WebCore::SVGRadialGradientElement::attributeChanged):
* Source/WebCore/svg/SVGRectElement.cpp:
(WebCore::SVGRectElement::attributeChanged):
* Source/WebCore/svg/SVGSVGElement.cpp:
(WebCore::SVGSVGElement::attributeChanged):
* Source/WebCore/svg/SVGStyleElement.cpp:
(WebCore::SVGStyleElement::attributeChanged):
* Source/WebCore/svg/SVGTextPathElement.cpp:
(WebCore::SVGTextPathElement::attributeChanged):
* Source/WebCore/svg/SVGTextPositioningElement.cpp:
(WebCore::SVGTextPositioningElement::attributeChanged):
* Source/WebCore/svg/SVGUseElement.cpp:
(WebCore::SVGUseElement::attributeChanged):
* Source/WebCore/svg/animation/SVGSMILElement.cpp:
(WebCore::SVGSMILElement::attributeChanged):

Canonical link: <a href="https://commits.webkit.org/262999@main">https://commits.webkit.org/262999@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ff98dbc841cda8262bf204a5f8227933813e1b18

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/3266 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/3324 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/3435 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/4676 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/3593 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/3236 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/3379 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/3345 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/2831 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/3300 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/3589 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/2929 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/4496 "Built successfully") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/39/builds/1090 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/2902 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/2823 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/2872 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/2955 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/4233 "260 api tests failed or timed out") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/3335 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/2661 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/2901 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/2903 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/799 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/2897 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/3176 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->