### PR TITLE
[margin-trim] Trimmed inline-end margins for grid items in horizontal writing-mode should be reflected in computed style.

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/computed-margin-values/grid-inline-end-columns-added-to-end-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/computed-margin-values/grid-inline-end-columns-added-to-end-expected.txt
@@ -1,0 +1,4 @@
+
+PASS grid > item 1
+PASS grid > item 2
+

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/computed-margin-values/grid-inline-end-columns-added-to-end.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/computed-margin-values/grid-inline-end-columns-added-to-end.html
@@ -1,0 +1,55 @@
+<!DOCTYPE html>
+<html>
+<head>
+<title></title>
+<link rel="author" href="mailto:sammy.gill@apple.com">
+<link rel="help" href="https://drafts.csswg.org/css-box-4/#margin-trim-grid">
+<meta name="assert" content="spanning grid item adds columns to implicit grid and should be trimmed">
+<style>
+grid {
+    display: grid;
+    grid-template-columns: repeat(2, auto);
+    outline: 1px solid black;
+    margin-trim: inline-end;
+}
+item {
+    display: block;
+    height: 50px;
+}
+.span-three {
+    grid-column: span 3;
+}
+.locked-position {
+    grid-row: 1;
+    grid-column: 2;
+}
+item:nth-child(1) {
+    background-color: aqua;
+    margin-inline-end: 10px;
+}
+item:nth-child(2) {
+    background-color: blueviolet;
+    margin-inline-end: 30%;
+}
+item:nth-child(3) {
+    background-color: blue;
+    margin-inline-end: -30px;
+}
+item:nth-child(4) {
+    background-color: coral;
+    margin-inline-end: 10px;
+}
+</style>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/resources/check-layout-th.js"></script>
+</head>
+<body onload="checkLayout('grid > item')">
+    <div id="target">
+        <grid>
+            <item class="locked-position" data-expected-margin-right="10"></item>
+            <item class="span-three"></item>
+        </grid>
+    </div>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/computed-margin-values/grid-inline-end-items-in-last-column-trimmed-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/computed-margin-values/grid-inline-end-items-in-last-column-trimmed-expected.txt
@@ -1,0 +1,6 @@
+
+PASS grid > item 1
+PASS grid > item 2
+PASS grid > item 3
+PASS grid > item 4
+

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/computed-margin-values/grid-inline-end-items-in-last-column-trimmed.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/computed-margin-values/grid-inline-end-items-in-last-column-trimmed.html
@@ -1,0 +1,54 @@
+<!DOCTYPE html>
+<html>
+<head>
+<title></title>
+<link rel="author" href="mailto:sammy.gill@apple.com">
+<link rel="help" href="https://drafts.csswg.org/css-box-4/#margin-trim-grid">
+<meta name="assert" content="trimmed inline-end margins for grid items should be reflected in computed style">
+<style>
+grid {
+    display: grid;
+    grid-template-columns: repeat(2, auto);
+    outline: 1px solid black;
+    margin-trim: inline-end;
+}
+item {
+    display: block;
+    height: 50px;
+}
+.locked-position {
+    grid-row: 2;
+    grid-column: 2;
+}
+item:nth-child(1) {
+    background-color: aqua;
+    margin-inline-end: 10px;
+}
+item:nth-child(2) {
+    background-color: blueviolet;
+    margin-inline-end: 30%;
+}
+item:nth-child(3) {
+    background-color: blue;
+    margin-inline-end: -30px;
+}
+item:nth-child(4) {
+    background-color: coral;
+    margin-inline-end: 10px;
+}
+</style>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/resources/check-layout-th.js"></script>
+</head>
+<body onload="checkLayout('grid > item')">
+    <div id="target">
+        <grid>
+            <item data-expected-margin-right="10"></item>
+            <item data-expected-margin-right="0"></item>
+            <item class="locked-position" data-expected-margin-right="0"></item>
+            <item data-expected-margin-right="10"></item>
+        </grid>
+    </div>
+</body>
+</html>

--- a/Source/WebCore/css/ComputedStyleExtractor.cpp
+++ b/Source/WebCore/css/ComputedStyleExtractor.cpp
@@ -2284,13 +2284,6 @@ static inline bool isNonReplacedInline(RenderObject& renderer)
     return renderer.isInline() && !renderer.isReplacedOrInlineBlock();
 }
 
-static bool isFlexItem(const RenderObject* renderer)
-{
-    if (auto* box = dynamicDowncast<RenderBox>(renderer))
-        return box->isFlexItem();
-    return false;
-}
-
 static bool rendererCanHaveTrimmedMargin(const RenderBox& renderer, std::optional<MarginTrimType> marginTrimType)
 {
     // A renderer will have a specific margin marked as trimmed by setting its rare data bit if:
@@ -2307,14 +2300,9 @@ static bool rendererCanHaveTrimmedMargin(const RenderBox& renderer, std::optiona
     if (!renderer.isFlexItem() && containingBlock->isBlockContainer())
         return false;
 
-    if (containingBlock->isFlexibleBox()) {
+    if (containingBlock->isFlexibleBox() || containingBlock->isRenderGrid()) {
         if (!marginTrimType)
             return !containingBlock->style().marginTrim().isEmpty();
-        return containingBlock->style().marginTrim().contains(marginTrimType.value());
-    }
-    if (containingBlock->isRenderGrid() && (!marginTrimType || marginTrimType.value() == MarginTrimType::BlockStart || marginTrimType.value() == MarginTrimType::BlockEnd || marginTrimType.value() == MarginTrimType::InlineStart)) {
-        if (!marginTrimType)
-            return containingBlock->style().marginTrim().containsAny({ MarginTrimType::BlockStart, MarginTrimType::BlockEnd, MarginTrimType::InlineStart });
         return containingBlock->style().marginTrim().contains(marginTrimType.value());
     }
     return false;
@@ -2355,7 +2343,7 @@ static bool isLayoutDependent(CSSPropertyID propertyID, const RenderStyle* style
     case CSSPropertyMarginTop:
         return paddingOrMarginIsRendererDependent<&RenderStyle::marginTop>(style, renderer) || (is<RenderBox>(renderer) && (rendererCanHaveTrimmedMargin(downcast<RenderBox>(*renderer), MarginTrimType::BlockStart)));
     case CSSPropertyMarginRight:
-        return paddingOrMarginIsRendererDependent<&RenderStyle::marginRight>(style, renderer) || (isFlexItem(renderer) && rendererCanHaveTrimmedMargin(downcast<RenderBox>(*renderer), MarginTrimType::InlineEnd));
+        return paddingOrMarginIsRendererDependent<&RenderStyle::marginRight>(style, renderer) || ((is<RenderBox>(renderer)) && rendererCanHaveTrimmedMargin(downcast<RenderBox>(*renderer), MarginTrimType::InlineEnd));
     case CSSPropertyMarginBottom:
         return paddingOrMarginIsRendererDependent<&RenderStyle::marginBottom>(style, renderer) ||  (is<RenderBox>(renderer) && rendererCanHaveTrimmedMargin(downcast<RenderBox>(*renderer), MarginTrimType::BlockEnd));
     case CSSPropertyMarginLeft:
@@ -3294,7 +3282,7 @@ RefPtr<CSSValue> ComputedStyleExtractor::valueForPropertyInStyle(const RenderSty
         return zoomAdjustedPaddingOrMarginPixelValue<&RenderStyle::marginTop, &RenderBoxModelObject::marginTop>(style, renderer);
     }
     case CSSPropertyMarginRight: {
-        if (auto* box = dynamicDowncast<RenderBox>(renderer); box && box->isFlexItem() 
+        if (auto* box = dynamicDowncast<RenderBox>(renderer); box
             && rendererCanHaveTrimmedMargin(*box, MarginTrimType::InlineEnd)
             && box->hasTrimmedMargin(PhysicalDirection::Right))
             return zoomAdjustedPixelValue(box->marginRight(), style);

--- a/Source/WebCore/rendering/RenderBox.cpp
+++ b/Source/WebCore/rendering/RenderBox.cpp
@@ -1473,8 +1473,6 @@ bool RenderBox::hasTrimmedMargin(std::optional<MarginTrimType> marginTrimType) c
         ASSERT_NOT_IMPLEMENTED_YET();
         return false;
     }
-    if (containingBlock && containingBlock->isRenderGrid())
-        ASSERT(!marginTrimType || marginTrimType.value() == MarginTrimType::BlockStart || marginTrimType.value() == MarginTrimType::BlockEnd || marginTrimType.value() == MarginTrimType::InlineStart);
 #endif
     if (!hasRareData())
         return false;
@@ -3039,8 +3037,8 @@ LayoutUnit RenderBox::computeOrTrimInlineMargin(const RenderBlock& containingBlo
         // be done at this level within RenderBox. We should be able to leave the 
         // trimming responsibility to each of those contexts and not need to
         // do any of it here (trimming the margin and setting the rare data bit)
-        if (isGridItem() && marginSide == MarginTrimType::InlineStart)
-            const_cast<RenderBox&>(*this).markMarginAsTrimmed(MarginTrimType::InlineStart);
+        if (isGridItem() && (marginSide == MarginTrimType::InlineStart || marginSide == MarginTrimType::InlineEnd))
+            const_cast<RenderBox&>(*this).markMarginAsTrimmed(marginSide);
         return 0_lu;
     }
     return computeInlineMargin();


### PR DESCRIPTION
#### 67d0e83ce37305ee9471d1ef55e851b10004c8f2
<pre>
[margin-trim] Trimmed inline-end margins for grid items in horizontal writing-mode should be reflected in computed style.
<a href="https://bugs.webkit.org/show_bug.cgi?id=253719">https://bugs.webkit.org/show_bug.cgi?id=253719</a>
rdar://106559432

Reviewed by Alan Baradlay.

When a grid has inline-end specified for margin trim, it will trim the
margins in the last column. Currently these trimmed margins are not
showing up as &quot;trimmed,&quot; in the computed style of the element, but they
should be shown as a margin value of 0. In order to reflect this trimming
within the computed style, ComputedStyleExtractor must be able to identify
when a particular margin has been trimmed during layout. We can accomplish
this by setting the margin-trim rare data bit for the respective margin
to indicate that is has been trimmed. This bit can then be checked for
a renderer after layout has completed to check if a specific margin
was trimmed.

The inline-end margins for grid items are trimmed inside RenderBox::computeOrTrimInlineMargin
as the renderer is going through layout. When a grid item reaches this
point, it consults with the grid via shouldTrimChildMargin to determine
if it should consider its own value as trimmed. If this returns true,
the function will return a value of 0_lu for the margin, but at this
point we can also set the margin-trim rare data bit for the renderer.
This is done via a call to markMarginAsTrimmed with the appropriate
margin side passed in.

When ComputedStyleExtractor is then trying to get the value for the
&quot;right,&quot; margin, it can use RenderBox::hasTrimmedMargin with an argument
of PhysicalDirection::Right to check if that renderer had its margin
trimmed during layout.

* LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/computed-margin-values/grid-inline-end-columns-added-to-end-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/computed-margin-values/grid-inline-end-columns-added-to-end.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/computed-margin-values/grid-inline-end-items-in-last-column-trimmed-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/computed-margin-values/grid-inline-end-items-in-last-column-trimmed.html: Added.
* Source/WebCore/css/ComputedStyleExtractor.cpp:
(WebCore::rendererCanHaveTrimmedMargin):
(WebCore::isLayoutDependent):
(WebCore::ComputedStyleExtractor::valueForPropertyInStyle):
(WebCore::isFlexItem): Deleted.
* Source/WebCore/rendering/RenderBox.cpp:
(WebCore::RenderBox::hasTrimmedMargin const):
(WebCore::RenderBox::computeOrTrimInlineMargin const):

Canonical link: <a href="https://commits.webkit.org/263008@main">https://commits.webkit.org/263008@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/db209431c352ae7c4196849fa424a53ff736b960

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/3294 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/3353 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/3468 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/4710 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/3624 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/3270 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/3414 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/3376 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/2859 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/3333 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/3620 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/2967 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/4532 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/1123 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/2933 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/2850 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/2905 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/2986 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/4266 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/3366 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/2690 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/2929 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/2934 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/806 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/2930 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/3204 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->