### PR TITLE
Partial Sync SVGAnimationElement.idl with IDL Spec

### DIFF
--- a/LayoutTests/svg/custom/elementTimeControl-nan-crash.html
+++ b/LayoutTests/svg/custom/elementTimeControl-nan-crash.html
@@ -2,14 +2,15 @@
 <html>
 <head>
 <script>
+    if (window.testRunner)
+        testRunner.dumpAsText();
+
     function crash() {
         var animate = document.getElementById('animate');
         var svg = document.getElementById('svg');
-        animate.endElementAt(NaN);
-        animate.beginElementAt(NaN);
+        try { animate.endElementAt(NaN); } catch (e) {}
+        try { animate.beginElementAt(NaN); } catch (e) {}
         svg.setCurrentTime(2);
-        if (window.testRunner)
-            testRunner.dumpAsText();
     }
 </script>
 </head>

--- a/LayoutTests/svg/dom/SVGAnimationElement-begin-end-arguments-typechecks-expected.txt
+++ b/LayoutTests/svg/dom/SVGAnimationElement-begin-end-arguments-typechecks-expected.txt
@@ -1,0 +1,22 @@
+Check that invalid values of arguments throw TypeError.
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+SVGAnimationElement
+
+beginElementAt(float offset)
+PASS animateElement.beginElementAt(0) did not throw exception.
+PASS animateElement.beginElementAt(NaN) threw exception TypeError: The provided value is non-finite.
+PASS animateElement.beginElementAt(Infinity) threw exception TypeError: The provided value is non-finite.
+PASS animateElement.beginElementAt() threw exception TypeError: Not enough arguments.
+
+endElementAt(float offset)
+PASS animateElement.endElementAt(0) did not throw exception.
+PASS animateElement.endElementAt(NaN) threw exception TypeError: The provided value is non-finite.
+PASS animateElement.endElementAt(Infinity) threw exception TypeError: The provided value is non-finite.
+PASS animateElement.endElementAt() threw exception TypeError: Not enough arguments.
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/svg/dom/SVGAnimationElement-begin-end-arguments-typechecks.html
+++ b/LayoutTests/svg/dom/SVGAnimationElement-begin-end-arguments-typechecks.html
@@ -1,0 +1,26 @@
+<!DOCTYPE html>
+<script src="../../resources/js-test.js"></script>
+<svg>
+  <animate></animate>
+</svg>
+<script>
+description('Check that invalid values of arguments throw TypeError.');
+
+var animateElement = document.querySelector('animate');
+
+debug('SVGAnimationElement');
+
+debug('');
+debug('beginElementAt(float offset)');
+shouldNotThrow('animateElement.beginElementAt(0)');
+shouldThrow('animateElement.beginElementAt(NaN)');
+shouldThrow('animateElement.beginElementAt(Infinity)');
+shouldThrow('animateElement.beginElementAt()');
+
+debug('');
+debug('endElementAt(float offset)');
+shouldNotThrow('animateElement.endElementAt(0)');
+shouldThrow('animateElement.endElementAt(NaN)');
+shouldThrow('animateElement.endElementAt(Infinity)');
+shouldThrow('animateElement.endElementAt()');
+</script>

--- a/Source/WebCore/svg/SVGAnimationElement.cpp
+++ b/Source/WebCore/svg/SVGAnimationElement.cpp
@@ -6,7 +6,7 @@
  * Copyright (C) 2009 Cameron McCormack <cam@mcc.id.au>
  * Copyright (C) Research In Motion Limited 2010. All rights reserved.
  * Copyright (C) 2014 Adobe Systems Incorporated. All rights reserved.
- * Copyright (C) 2013 Google Inc. All rights reserved.
+ * Copyright (C) 2013-2014 Google Inc. All rights reserved.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Library General Public
@@ -251,7 +251,7 @@ void SVGAnimationElement::beginElement()
 
 void SVGAnimationElement::beginElementAt(float offset)
 {
-    if (std::isnan(offset))
+    if (!std::isfinite(offset))
         return;
     SMILTime elapsed = this->elapsed();
     addBeginTime(elapsed, elapsed + offset, SMILTimeWithOrigin::ScriptOrigin);
@@ -264,7 +264,7 @@ void SVGAnimationElement::endElement()
 
 void SVGAnimationElement::endElementAt(float offset)
 {
-    if (std::isnan(offset))
+    if (!std::isfinite(offset))
         return;
     SMILTime elapsed = this->elapsed();
     addEndTime(elapsed, elapsed + offset, SMILTimeWithOrigin::ScriptOrigin);

--- a/Source/WebCore/svg/SVGAnimationElement.idl
+++ b/Source/WebCore/svg/SVGAnimationElement.idl
@@ -24,19 +24,21 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE. 
  */
 
+// https://svgwg.org/specs/animations/#InterfaceSVGAnimationElement
+
 [
     Exposed=Window
 ] interface SVGAnimationElement : SVGElement {
-    readonly attribute SVGElement targetElement;
+    readonly attribute SVGElement? targetElement;
 
-    unrestricted float getStartTime();
-    unrestricted float getCurrentTime();
-    unrestricted float getSimpleDuration();
+    float getStartTime();
+    float getCurrentTime();
+    float getSimpleDuration();
 
     undefined beginElement();
-    undefined beginElementAt(optional unrestricted float offset = NaN);
+    undefined beginElementAt(float offset);
     undefined endElement();
-    undefined endElementAt(optional unrestricted float offset = NaN);
+    undefined endElementAt(float offset);
 };
 
 SVGAnimationElement includes SVGTests;


### PR DESCRIPTION
#### c7a661464e1fe2ba634157ac3b4ee756728be7a6
<pre>
Partial Sync SVGAnimationElement.idl with IDL Spec

<a href="https://bugs.webkit.org/show_bug.cgi?id=250575">https://bugs.webkit.org/show_bug.cgi?id=250575</a>
rdar://problem/104475517

Reviewed by Said Abou-Hallawa.

This patch is to align WebKit with web-spec [1].

[1]: <a href="https://svgwg.org/specs/animations/#InterfaceSVGAnimationElement">https://svgwg.org/specs/animations/#InterfaceSVGAnimationElement</a>

Cherry-Pick: <a href="https://src.chromium.org/viewvc/blink?revision=171485&amp">https://src.chromium.org/viewvc/blink?revision=171485&amp</a>;view=revision &amp;
<a href="https://src.chromium.org/viewvc/blink?view=revision&amp">https://src.chromium.org/viewvc/blink?view=revision&amp</a>;revision=190359

This patch aligns WebKit with web-specification by dropping unnecessary NaN
and remove &apos;optional&apos; and &apos;unrestricted&apos; from IDL file as needed.

* Source/WebCore/svg/SVGAnimationElement.cpp:
(SVGAnimationElement::beginElementAt): Remove early return for &apos;nan&apos; values
(SVGAnimationElement::endElementAt): Ditto
* Source/WebCore/svg/SVGAnimationElement.idl: Align with web-spec
* LayoutTests/svg/custom/elementTimeControl-nan-crash.html: Updated to Dump Text
* LayoutTests/svg/dom/SVGAnimationElement-begin-end-arguments-typechecks.html: Add Testcase
* LayoutTests/svg/dom/SVGAnimationElement-begin-end-arguments-typechecks-expected.txt: Add Testcase Expectation

Canonical link: <a href="https://commits.webkit.org/263253@main">https://commits.webkit.org/263253@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/812557bcc541a96cf786bdeee8c1c6ac41e2e137

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/4018 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/4115 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/4227 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/5461 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/4267 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/3996 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/4207 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/4090 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/4259 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/4068 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/4256 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/3626 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/5407 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/1756 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/3602 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/5732 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/3581 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/3663 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/5132 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/4070 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/3275 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/3585 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/3602 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/989 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/3637 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/3864 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->