### PR TITLE
[macOS] background tab suspension - 3.5% MBA8,2 membuster regression

### DIFF
--- a/Source/WebKit/UIProcess/ProcessThrottler.cpp
+++ b/Source/WebKit/UIProcess/ProcessThrottler.cpp
@@ -343,28 +343,28 @@ void ProcessThrottler::delaySuspension()
         m_dropSuspendedAssertionTimer.startOneShot(removeAllAssertionsTimeout);
 }
 
-ProcessThrottler::TimedActivity::TimedActivity(Seconds timeout, ProcessThrottler::ActivityVariant&& activity)
-    : m_timer(RunLoop::main(), this, &TimedActivity::activityTimedOut)
+ProcessThrottlerTimedActivity::ProcessThrottlerTimedActivity(Seconds timeout, ProcessThrottler::ActivityVariant&& activity)
+    : m_timer(RunLoop::main(), this, &ProcessThrottlerTimedActivity::activityTimedOut)
     , m_timeout(timeout)
     , m_activity(WTFMove(activity))
 {
     updateTimer();
 }
 
-auto ProcessThrottler::TimedActivity::operator=(ProcessThrottler::ActivityVariant&& activity) -> TimedActivity&
+auto ProcessThrottlerTimedActivity::operator=(ProcessThrottler::ActivityVariant&& activity) -> ProcessThrottlerTimedActivity&
 {
     m_activity = WTFMove(activity);
     updateTimer();
     return *this;
 }
 
-void ProcessThrottler::TimedActivity::activityTimedOut()
+void ProcessThrottlerTimedActivity::activityTimedOut()
 {
-    RELEASE_LOG_ERROR(ProcessSuspension, "%p - TimedActivity::activityTimedOut:", this);
+    RELEASE_LOG_ERROR(ProcessSuspension, "%p - ProcessThrottlerTimedActivity::activityTimedOut:", this);
     m_activity = nullptr;
 }
 
-void ProcessThrottler::TimedActivity::updateTimer()
+void ProcessThrottlerTimedActivity::updateTimer()
 {
     if (std::holds_alternative<std::nullptr_t>(m_activity))
         m_timer.stop();

--- a/Source/WebKit/UIProcess/ProcessThrottler.h
+++ b/Source/WebKit/UIProcess/ProcessThrottler.h
@@ -82,27 +82,14 @@ private:
     ProcessThrottlerActivityType m_type;
 };
 
-class ProcessThrottler : public CanMakeWeakPtr<ProcessThrottler> {
-public:
-    ProcessThrottler(ProcessThrottlerClient&, bool shouldTakeUIBackgroundAssertion);
-    ~ProcessThrottler();
-
+class ProcessThrottlerTimedActivity {
+    WTF_MAKE_FAST_ALLOCATED;
+    WTF_MAKE_NONCOPYABLE(ProcessThrottlerTimedActivity);
     using Activity = ProcessThrottlerActivity;
-
-    using ForegroundActivity = Activity;
-    UniqueRef<Activity> foregroundActivity(ASCIILiteral name);
-
-    using BackgroundActivity = Activity;
-    UniqueRef<Activity> backgroundActivity(ASCIILiteral name);
-
     using ActivityVariant = std::variant<std::nullptr_t, UniqueRef<Activity>>;
-    static bool isValidBackgroundActivity(const ActivityVariant&);
-    static bool isValidForegroundActivity(const ActivityVariant&);
-
-    class TimedActivity {
     public:
-        explicit TimedActivity(Seconds timeout, ActivityVariant&& = nullptr);
-        TimedActivity& operator=(ActivityVariant&&);
+        explicit ProcessThrottlerTimedActivity(Seconds timeout, ActivityVariant&& = nullptr);
+        ProcessThrottlerTimedActivity& operator=(ActivityVariant&&);
 
     private:
         void activityTimedOut();
@@ -111,7 +98,26 @@ public:
         RunLoop::Timer m_timer;
         Seconds m_timeout;
         ActivityVariant m_activity;
-    };
+};
+
+class ProcessThrottler : public CanMakeWeakPtr<ProcessThrottler> {
+public:
+    ProcessThrottler(ProcessThrottlerClient&, bool shouldTakeUIBackgroundAssertion);
+    ~ProcessThrottler();
+
+    using Activity = ProcessThrottlerActivity;
+    using ActivityVariant = std::variant<std::nullptr_t, UniqueRef<Activity>>;
+
+    using ForegroundActivity = Activity;
+    UniqueRef<Activity> foregroundActivity(ASCIILiteral name);
+
+    using BackgroundActivity = Activity;
+    UniqueRef<Activity> backgroundActivity(ASCIILiteral name);
+
+    static bool isValidBackgroundActivity(const ActivityVariant&);
+    static bool isValidForegroundActivity(const ActivityVariant&);
+
+    using TimedActivity = ProcessThrottlerTimedActivity;
 
     void didConnectToProcess(ProcessID);
     void didDisconnectFromProcess();

--- a/Source/WebKit/UIProcess/ios/WebPageProxyIOS.mm
+++ b/Source/WebKit/UIProcess/ios/WebPageProxyIOS.mm
@@ -1547,17 +1547,17 @@ void WebPageProxy::setScreenIsBeingCaptured(bool captured)
 
 void WebPageProxy::willOpenAppLink()
 {
-    if (m_openingAppLinkActivity && m_openingAppLinkActivity->isValid())
+    if (m_processActivityState.hasValidOpeningAppLinkActivity())
         return;
 
     // We take a background activity for 25 seconds when switching to another app via an app link in case the WebPage
     // needs to run script to pass information to the native app.
     // We chose 25 seconds because the system only gives us 30 seconds and we don't want to get too close to that limit
     // to avoid assertion invalidation (or even termination).
-    m_openingAppLinkActivity = process().throttler().backgroundActivity("Opening AppLink"_s).moveToUniquePtr();
+    m_processActivityState.takeOpeningAppLinkActivity();
     WorkQueue::main().dispatchAfter(25_s, [weakThis = WeakPtr { *this }] {
         if (weakThis)
-            weakThis->m_openingAppLinkActivity = nullptr;
+            weakThis->m_processActivityState.dropOpeningAppLinkActivity();
     });
 }
 


### PR DESCRIPTION
#### 0420e99f106002c9da9e4803154ae715289a3087
<pre>
[macOS] background tab suspension - 3.5% MBA8,2 membuster regression
<a href="https://bugs.webkit.org/show_bug.cgi?id=255226">https://bugs.webkit.org/show_bug.cgi?id=255226</a>
rdar://106969950

Reviewed by Chris Dumez.

Membuster sends a low memory signal to web content processes to measure
the memory impact of our low memory handler. When runningboard
throttling is enabled on MBA8,2 the web content process never gets
scheduled due to the machine only having 2 cores and the web content
process having a priority of darwin_bg. This fix holds the foreground
assertion for 8 minutes after the last foreground activity is released
to ensure we have enough time to handle the low memory signal in
membuster. I also tried having the web content process take an assertion
on itself for the duration of the low memory handler but that did not
fix the regression.

* Source/WebKit/UIProcess/ProcessThrottler.cpp:
(WebKit::ProcessThrottlerTimedActivity::ProcessThrottlerTimedActivity):
(WebKit::ProcessThrottlerTimedActivity::operator=):
(WebKit::ProcessThrottlerTimedActivity::activityTimedOut):
(WebKit::ProcessThrottlerTimedActivity::updateTimer):
(WebKit::ProcessThrottler::TimedActivity::TimedActivity): Deleted.
(WebKit::ProcessThrottler::TimedActivity::operator=): Deleted.
(WebKit::ProcessThrottler::TimedActivity::activityTimedOut): Deleted.
(WebKit::ProcessThrottler::TimedActivity::updateTimer): Deleted.
* Source/WebKit/UIProcess/ProcessThrottler.h:
* Source/WebKit/UIProcess/WebPageProxy.cpp:
(WebKit::WebPageProxy::ProcessActivityState::ProcessActivityState):
(WebKit::WebPageProxy::ProcessActivityState::takeVisibleActivity):
(WebKit::WebPageProxy::ProcessActivityState::takeAudibleActivity):
(WebKit::WebPageProxy::ProcessActivityState::takeCapturingActivity):
(WebKit::WebPageProxy::ProcessActivityState::reset):
(WebKit::WebPageProxy::ProcessActivityState::dropVisibleActivity):
(WebKit::WebPageProxy::ProcessActivityState::dropAudibleActivity):
(WebKit::WebPageProxy::ProcessActivityState::dropCapturingActivity):
(WebKit::WebPageProxy::ProcessActivityState::hasValidVisibleActivity const):
(WebKit::WebPageProxy::ProcessActivityState::hasValidAudibleActivity const):
(WebKit::WebPageProxy::ProcessActivityState::hasValidCapturingActivity const):
(WebKit::WebPageProxy::ProcessActivityState::takeOpeningAppLinkActivity):
(WebKit::WebPageProxy::ProcessActivityState::dropOpeningAppLinkActivity):
(WebKit::WebPageProxy::ProcessActivityState::hasValidOpeningAppLinkActivity const):
(WebKit::WebPageProxy::close):
(WebKit::WebPageProxy::updateThrottleState):
(WebKit::WebPageProxy::clearAudibleActivity):
(WebKit::WebPageProxy::waitForDidUpdateActivityState):
(WebKit::WebPageProxy::resetStateAfterProcessExited):
* Source/WebKit/UIProcess/WebPageProxy.h:
* Source/WebKit/UIProcess/ios/WebPageProxyIOS.mm:
(WebKit::WebPageProxy::willOpenAppLink):

Canonical link: <a href="https://commits.webkit.org/263264@main">https://commits.webkit.org/263264@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5068918be2b4445aff935261676f02ccef5a638f

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/4032 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/4131 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/4243 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/5478 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/4283 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/4226 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/4107 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/4405 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/4084 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/4273 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/3639 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/5479 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/1774 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/3615 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/5797 "") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/3599 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/3676 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/5185 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/4086 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/3287 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/3600 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/3615 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/1003 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/3653 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/3878 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->