### PR TITLE
Caret is incorrectly clipped in limited cases

### DIFF
--- a/Source/WebCore/editing/FrameSelection.cpp
+++ b/Source/WebCore/editing/FrameSelection.cpp
@@ -1759,8 +1759,13 @@ IntRect FrameSelection::absoluteCaretBounds(bool* insideFixed)
 
 static void repaintCaretForLocalRect(Node* node, const LayoutRect& rect, CaretAnimator* caretAnimator)
 {
-    if (auto* caretPainter = rendererForCaretPainting(node))
-        caretPainter->repaintRectangle(caretAnimator ? caretAnimator->repaintCaretRectForLocalRect(rect) : rect);
+    if (auto* caretPainter = rendererForCaretPainting(node)) {
+        LayoutRect adjustedRect = caretAnimator ? caretAnimator->caretRepaintRectForLocalRect(rect) : rect;
+        if (adjustedRect == rect)
+            caretPainter->repaintRectangle(adjustedRect);
+        else
+            caretPainter->repaintRectangle(adjustedRect, RenderObject::ClipRepaintToLayer::No, RenderObject::ForceRepaint::Yes, RenderObject::ClipRepaintToContainer::No);
+    }
 }
 
 bool FrameSelection::recomputeCaretRect()

--- a/Source/WebCore/platform/CaretAnimator.cpp
+++ b/Source/WebCore/platform/CaretAnimator.cpp
@@ -66,7 +66,7 @@ void CaretAnimator::paint(const Node&, GraphicsContext& context, const FloatRect
     context.fillRect(caret, color);
 }
 
-LayoutRect CaretAnimator::repaintCaretRectForLocalRect(LayoutRect rect) const
+LayoutRect CaretAnimator::caretRepaintRectForLocalRect(LayoutRect rect) const
 {
     return rect;
 }

--- a/Source/WebCore/platform/CaretAnimator.h
+++ b/Source/WebCore/platform/CaretAnimator.h
@@ -90,11 +90,7 @@ public:
 
     PresentationProperties presentationProperties() const { return m_presentationProperties; }
     virtual void paint(const Node&, GraphicsContext&, const FloatRect&, const Color&, const LayoutPoint&) const;
-    virtual LayoutRect repaintCaretRectForLocalRect(LayoutRect) const;
-#if defined(__has_include) && __has_include(<WebKitAdditions/RenderBlockAdditions.h>)
-    // FIXME: https://bugs.webkit.org/show_bug.cgi?id=255602 - Remove staging from CaretAnimator.h
-    virtual void addLine(float, float, TextDirection) const { }
-#endif
+    virtual LayoutRect caretRepaintRectForLocalRect(LayoutRect) const;
 
 protected:
     explicit CaretAnimator(CaretAnimationClient& client)

--- a/Source/WebCore/platform/graphics/BifurcatedGraphicsContext.cpp
+++ b/Source/WebCore/platform/graphics/BifurcatedGraphicsContext.cpp
@@ -302,6 +302,14 @@ IntRect BifurcatedGraphicsContext::clipBounds() const
     return m_primaryContext.clipBounds();
 }
 
+void BifurcatedGraphicsContext::resetClip()
+{
+    m_primaryContext.resetClip();
+    m_secondaryContext.resetClip();
+
+    VERIFY_STATE_SYNCHRONIZATION();
+}
+
 void BifurcatedGraphicsContext::setLineCap(LineCap lineCap)
 {
     m_primaryContext.setLineCap(lineCap);

--- a/Source/WebCore/platform/graphics/BifurcatedGraphicsContext.h
+++ b/Source/WebCore/platform/graphics/BifurcatedGraphicsContext.h
@@ -82,6 +82,7 @@ public:
 
     RenderingMode renderingMode() const final;
 
+    void resetClip() final;
     void clip(const FloatRect&) final;
     void clipOut(const FloatRect&) final;
 

--- a/Source/WebCore/platform/graphics/GraphicsContext.h
+++ b/Source/WebCore/platform/graphics/GraphicsContext.h
@@ -287,6 +287,7 @@ public:
 
     // Clipping
 
+    virtual void resetClip() = 0;
     virtual void clip(const FloatRect&) = 0;
     WEBCORE_EXPORT virtual void clipRoundedRect(const FloatRoundedRect&);
 

--- a/Source/WebCore/platform/graphics/NullGraphicsContext.h
+++ b/Source/WebCore/platform/graphics/NullGraphicsContext.h
@@ -97,6 +97,7 @@ private:
     void setCTM(const AffineTransform&) final { }
     AffineTransform getCTM(IncludeDeviceScale = PossiblyIncludeDeviceScale) const final { return { }; }
     void clearRect(const FloatRect&) final { }
+    void resetClip() final { }
     void clip(const FloatRect&) final { }
     void clipOut(const FloatRect&) final { }
     void save() final { }

--- a/Source/WebCore/platform/graphics/cairo/GraphicsContextCairo.cpp
+++ b/Source/WebCore/platform/graphics/cairo/GraphicsContextCairo.cpp
@@ -192,6 +192,11 @@ void GraphicsContextCairo::fillRect(const FloatRect& rect, const Color& color)
     Cairo::fillRect(*this, rect, color, Cairo::ShadowState(state()));
 }
 
+void GraphicsContextCairo::resetClip()
+{
+    ASSERT_NOT_REACHED("resetClip is not supported on Cairo");
+}
+
 void GraphicsContextCairo::clip(const FloatRect& rect)
 {
     Cairo::clip(*this, rect);

--- a/Source/WebCore/platform/graphics/cairo/GraphicsContextCairo.h
+++ b/Source/WebCore/platform/graphics/cairo/GraphicsContextCairo.h
@@ -97,6 +97,7 @@ public:
     void beginTransparencyLayer(float) final;
     void endTransparencyLayer() final;
 
+    void resetClip() final;
     void clip(const FloatRect&) final;
     void clipOut(const FloatRect&) final;
     void clipOut(const Path&) final;

--- a/Source/WebCore/platform/graphics/cg/GraphicsContextCG.cpp
+++ b/Source/WebCore/platform/graphics/cg/GraphicsContextCG.cpp
@@ -969,6 +969,11 @@ void GraphicsContextCG::fillRectWithRoundedHole(const FloatRect& rect, const Flo
     setFillColor(oldFillColor);
 }
 
+void GraphicsContextCG::resetClip()
+{
+    CGContextResetClip(platformContext());
+}
+
 void GraphicsContextCG::clip(const FloatRect& rect)
 {
     CGContextClipToRect(platformContext(), rect);

--- a/Source/WebCore/platform/graphics/cg/GraphicsContextCG.h
+++ b/Source/WebCore/platform/graphics/cg/GraphicsContextCG.h
@@ -82,6 +82,7 @@ public:
 
     RenderingMode renderingMode() const final;
 
+    void resetClip() final;
     void clip(const FloatRect&) final;
     void clipOut(const FloatRect&) final;
 

--- a/Source/WebCore/platform/graphics/displaylists/DisplayList.cpp
+++ b/Source/WebCore/platform/graphics/displaylists/DisplayList.cpp
@@ -223,6 +223,8 @@ void DisplayList::append(ItemHandle item)
         return append<ClipOutToPath>(item.get<ClipOutToPath>());
     case ItemType::ClipPath:
         return append<ClipPath>(item.get<ClipPath>());
+    case ItemType::ResetClip:
+        return append<ResetClip>(item.get<ResetClip>());
     case ItemType::DrawFilteredImageBuffer:
         return append<DrawFilteredImageBuffer>(item.get<DrawFilteredImageBuffer>());
     case ItemType::DrawGlyphs:

--- a/Source/WebCore/platform/graphics/displaylists/DisplayListItemBuffer.cpp
+++ b/Source/WebCore/platform/graphics/displaylists/DisplayListItemBuffer.cpp
@@ -109,6 +109,9 @@ void ItemHandle::apply(GraphicsContext& context)
     case ItemType::ClipPath:
         get<ClipPath>().apply(context);
         return;
+    case ItemType::ResetClip:
+        get<ResetClip>().apply(context);
+        return;
     case ItemType::DrawFilteredImageBuffer:
         ASSERT_NOT_REACHED();
         return;
@@ -338,6 +341,9 @@ void ItemHandle::destroy()
     case ItemType::ClipToImageBuffer:
         static_assert(std::is_trivially_destructible<ClipToImageBuffer>::value);
         return;
+    case ItemType::ResetClip:
+        static_assert(std::is_trivially_destructible<ResetClip>::value);
+        return;
     case ItemType::ConcatenateCTM:
         static_assert(std::is_trivially_destructible<ConcatenateCTM>::value);
         return;
@@ -548,6 +554,8 @@ bool ItemHandle::safeCopy(ItemType itemType, ItemHandle destination) const
         return copyInto<ClipOut>(itemOffset, *this);
     case ItemType::ClipToImageBuffer:
         return copyInto<ClipToImageBuffer>(itemOffset, *this);
+    case ItemType::ResetClip:
+        return copyInto<ResetClip>(itemOffset, *this);
     case ItemType::ConcatenateCTM:
         return copyInto<ConcatenateCTM>(itemOffset, *this);
     case ItemType::DrawDotsForDocumentMarker:

--- a/Source/WebCore/platform/graphics/displaylists/DisplayListItemType.cpp
+++ b/Source/WebCore/platform/graphics/displaylists/DisplayListItemType.cpp
@@ -76,6 +76,8 @@ static size_t sizeOfItemInBytes(ItemType type)
         return sizeof(ClipOutToPath);
     case ItemType::ClipPath:
         return sizeof(ClipPath);
+    case ItemType::ResetClip:
+        return sizeof(ResetClip);
     case ItemType::DrawFilteredImageBuffer:
         return sizeof(DrawFilteredImageBuffer);
     case ItemType::DrawGlyphs:
@@ -190,6 +192,7 @@ bool isDrawingItem(ItemType type)
     case ItemType::ClipToImageBuffer:
     case ItemType::ClipOutToPath:
     case ItemType::ClipPath:
+    case ItemType::ResetClip:
     case ItemType::ConcatenateCTM:
     case ItemType::Restore:
     case ItemType::Rotate:
@@ -315,6 +318,7 @@ bool isInlineItem(ItemType type)
     case ItemType::Clip:
     case ItemType::ClipOut:
     case ItemType::ClipToImageBuffer:
+    case ItemType::ResetClip:
     case ItemType::ConcatenateCTM:
     case ItemType::DrawEllipse:
     case ItemType::DrawFilteredImageBuffer:

--- a/Source/WebCore/platform/graphics/displaylists/DisplayListItemType.h
+++ b/Source/WebCore/platform/graphics/displaylists/DisplayListItemType.h
@@ -55,6 +55,7 @@ enum class ItemType : uint8_t {
     ClipToImageBuffer,
     ClipOutToPath,
     ClipPath,
+    ResetClip,
     DrawControlPart,
     DrawFilteredImageBuffer,
     DrawGlyphs,

--- a/Source/WebCore/platform/graphics/displaylists/DisplayListItems.cpp
+++ b/Source/WebCore/platform/graphics/displaylists/DisplayListItems.cpp
@@ -148,6 +148,11 @@ void ClipPath::apply(GraphicsContext& context) const
     context.clipPath(m_path, m_windRule);
 }
 
+void ResetClip::apply(GraphicsContext& context) const
+{
+    context.resetClip();
+}
+
 DrawFilteredImageBuffer::DrawFilteredImageBuffer(std::optional<RenderingResourceIdentifier> sourceImageIdentifier, const FloatRect& sourceImageRect, Filter& filter)
     : m_sourceImageIdentifier(sourceImageIdentifier)
     , m_sourceImageRect(sourceImageRect)
@@ -473,6 +478,7 @@ TextStream& operator<<(TextStream& ts, ItemType type)
     case ItemType::ClipToImageBuffer: ts << "clip-to-image-buffer"; break;
     case ItemType::ClipOutToPath: ts << "clip-out-to-path"; break;
     case ItemType::ClipPath: ts << "clip-path"; break;
+    case ItemType::ResetClip: ts << "reset-clip"; break;
     case ItemType::DrawFilteredImageBuffer: ts << "draw-filtered-image-buffer"; break;
     case ItemType::DrawGlyphs: ts << "draw-glyphs"; break;
     case ItemType::DrawDecomposedGlyphs: ts << "draw-decomposed-glyphs"; break;
@@ -1068,6 +1074,7 @@ void dumpItemHandle(TextStream& ts, const ItemHandle& item, OptionSet<AsTextFlag
     case ItemType::ApplyFillPattern:
 #endif
     case ItemType::ClearShadow:
+    case ItemType::ResetClip:
         break;
     }
 }

--- a/Source/WebCore/platform/graphics/displaylists/DisplayListItems.h
+++ b/Source/WebCore/platform/graphics/displaylists/DisplayListItems.h
@@ -468,6 +468,19 @@ private:
     WindRule m_windRule;
 };
 
+class ResetClip {
+public:
+    static constexpr ItemType itemType = ItemType::ResetClip;
+    static constexpr bool isInlineItem = true;
+    static constexpr bool isDrawingItem = false;
+
+    ResetClip()
+    {
+    }
+
+    WEBCORE_EXPORT void apply(GraphicsContext&) const;
+};
+
 class DrawFilteredImageBuffer {
 public:
     static constexpr ItemType itemType = ItemType::DrawFilteredImageBuffer;
@@ -1419,6 +1432,7 @@ using DisplayListItem = std::variant
     , FillRectWithGradient
     , FillRectWithRoundedHole
     , FillRoundedRect
+    , ResetClip
     , Restore
     , Rotate
     , Save
@@ -1479,6 +1493,7 @@ WEBCORE_EXPORT void dumpItem(TextStream&, const ClipOut&, OptionSet<AsTextFlag>)
 WEBCORE_EXPORT void dumpItem(TextStream&, const ClipToImageBuffer&, OptionSet<AsTextFlag>);
 WEBCORE_EXPORT void dumpItem(TextStream&, const ClipOutToPath&, OptionSet<AsTextFlag>);
 WEBCORE_EXPORT void dumpItem(TextStream&, const ClipPath&, OptionSet<AsTextFlag>);
+WEBCORE_EXPORT void dumpItem(TextStream&, const ResetClip&, OptionSet<AsTextFlag>);
 WEBCORE_EXPORT void dumpItem(TextStream&, const DrawControlPart&, OptionSet<AsTextFlag>);
 WEBCORE_EXPORT void dumpItem(TextStream&, const DrawFilteredImageBuffer&, OptionSet<AsTextFlag>);
 WEBCORE_EXPORT void dumpItem(TextStream&, const DrawGlyphs&, OptionSet<AsTextFlag>);
@@ -1569,6 +1584,7 @@ template<> struct EnumTraits<WebCore::DisplayList::ItemType> {
     WebCore::DisplayList::ItemType::ClipToImageBuffer,
     WebCore::DisplayList::ItemType::ClipOutToPath,
     WebCore::DisplayList::ItemType::ClipPath,
+    WebCore::DisplayList::ItemType::ResetClip,
     WebCore::DisplayList::ItemType::DrawGlyphs,
     WebCore::DisplayList::ItemType::DrawDecomposedGlyphs,
     WebCore::DisplayList::ItemType::DrawImageBuffer,

--- a/Source/WebCore/platform/graphics/displaylists/DisplayListRecorder.cpp
+++ b/Source/WebCore/platform/graphics/displaylists/DisplayListRecorder.cpp
@@ -537,6 +537,11 @@ void Recorder::drawControlPart(ControlPart& part, const FloatRoundedRect& border
     recordDrawControlPart(part, borderRect, deviceScaleFactor, style);
 }
 
+void Recorder::resetClip()
+{
+    recordResetClip();
+}
+
 void Recorder::clip(const FloatRect& rect)
 {
     appendStateChangeItemIfNecessary(); // Conservative: we do not know if the clip application might use state such as antialiasing.

--- a/Source/WebCore/platform/graphics/displaylists/DisplayListRecorder.h
+++ b/Source/WebCore/platform/graphics/displaylists/DisplayListRecorder.h
@@ -85,6 +85,7 @@ protected:
     virtual void recordSetLineJoin(LineJoin) = 0;
     virtual void recordSetMiterLimit(float) = 0;
     virtual void recordClearShadow() = 0;
+    virtual void recordResetClip() = 0;
     virtual void recordClip(const FloatRect&) = 0;
     virtual void recordClipOut(const FloatRect&) = 0;
     virtual void recordClipToImageBuffer(ImageBuffer&, const FloatRect& destinationRect) = 0;
@@ -265,6 +266,7 @@ private:
     WEBCORE_EXPORT void beginTransparencyLayer(float opacity) final;
     WEBCORE_EXPORT void endTransparencyLayer() final;
 
+    WEBCORE_EXPORT void resetClip() final;
     WEBCORE_EXPORT void clip(const FloatRect&) final;
     WEBCORE_EXPORT void clipOut(const FloatRect&) final;
     WEBCORE_EXPORT void clipOut(const Path&) final;

--- a/Source/WebCore/platform/graphics/displaylists/DisplayListRecorderImpl.cpp
+++ b/Source/WebCore/platform/graphics/displaylists/DisplayListRecorderImpl.cpp
@@ -134,6 +134,11 @@ void RecorderImpl::recordClearShadow()
     append<ClearShadow>();
 }
 
+void RecorderImpl::recordResetClip()
+{
+    append<ResetClip>();
+}
+
 void RecorderImpl::recordClip(const FloatRect& clipRect)
 {
     append<Clip>(clipRect);

--- a/Source/WebCore/platform/graphics/displaylists/DisplayListRecorderImpl.h
+++ b/Source/WebCore/platform/graphics/displaylists/DisplayListRecorderImpl.h
@@ -60,6 +60,7 @@ private:
     void recordSetLineJoin(LineJoin) final;
     void recordSetMiterLimit(float) final;
     void recordClearShadow() final;
+    void recordResetClip() final;
     void recordClip(const FloatRect&) final;
     void recordClipOut(const FloatRect&) final;
     void recordClipToImageBuffer(ImageBuffer&, const FloatRect& destinationRect) final;

--- a/Source/WebCore/platform/graphics/nicosia/cairo/NicosiaCairoOperationRecorder.cpp
+++ b/Source/WebCore/platform/graphics/nicosia/cairo/NicosiaCairoOperationRecorder.cpp
@@ -1048,6 +1048,11 @@ void CairoOperationRecorder::endTransparencyLayer()
     append(createCommand<EndTransparencyLayer>());
 }
 
+void CairoOperationRecorder::resetClip()
+{
+    ASSERT_NOT_REACHED("resetClip is not supported on Cairo");
+}
+
 void CairoOperationRecorder::clip(const FloatRect& rect)
 {
     struct Clip final : PaintingOperation, OperationData<FloatRect> {

--- a/Source/WebCore/platform/graphics/nicosia/cairo/NicosiaCairoOperationRecorder.h
+++ b/Source/WebCore/platform/graphics/nicosia/cairo/NicosiaCairoOperationRecorder.h
@@ -93,6 +93,7 @@ private:
     void beginTransparencyLayer(float) override;
     void endTransparencyLayer() override;
 
+    void resetClip() override;
     void clip(const WebCore::FloatRect&) override;
     void clipOut(const WebCore::FloatRect&) override;
     void clipOut(const WebCore::Path&) override;

--- a/Source/WebCore/rendering/GlyphDisplayListCache.cpp
+++ b/Source/WebCore/rendering/GlyphDisplayListCache.cpp
@@ -63,6 +63,7 @@ static bool canShareDisplayListWithItem(DisplayList::ItemType itemType)
     case ItemType::ClipToImageBuffer:
     case ItemType::ClipOutToPath:
     case ItemType::ClipPath:
+    case ItemType::ResetClip:
     case ItemType::DrawControlPart:
     case ItemType::DrawFilteredImageBuffer:
     case ItemType::DrawSystemImage:

--- a/Source/WebCore/rendering/RenderObject.h
+++ b/Source/WebCore/rendering/RenderObject.h
@@ -661,6 +661,11 @@ public:
     // Repaint a specific subrectangle within a given object.  The rect |r| is in the object's coordinate space.
     WEBCORE_EXPORT void repaintRectangle(const LayoutRect&, bool shouldClipToLayer = true) const;
 
+    enum class ClipRepaintToContainer : bool { No, Yes };
+    enum class ClipRepaintToLayer : bool { No, Yes };
+    enum class ForceRepaint : bool { No, Yes };
+    void repaintRectangle(const LayoutRect&, ClipRepaintToLayer, ForceRepaint, ClipRepaintToContainer) const;
+
     // Repaint a slow repaint object, which, at this time, means we are repainting an object with background-attachment:fixed.
     void repaintSlowRepaintObject() const;
 
@@ -699,7 +704,7 @@ public:
     // Given a rect in the object's coordinate space, compute a rect  in the coordinate space
     // of repaintContainer suitable for the given VisibleRectContext.
     LayoutRect computeRect(const LayoutRect&, const RenderLayerModelObject* repaintContainer, VisibleRectContext) const;
-    LayoutRect computeRectForRepaint(const LayoutRect& rect, const RenderLayerModelObject* repaintContainer) const { return computeRect(rect, repaintContainer, visibleRectContextForRepaint()); }
+    virtual LayoutRect computeRectForRepaint(const LayoutRect& rect, const RenderLayerModelObject* repaintContainer) const { return computeRect(rect, repaintContainer, visibleRectContextForRepaint()); }
     FloatRect computeFloatRectForRepaint(const FloatRect&, const RenderLayerModelObject* repaintContainer) const;
 
     // Given a rect in the object's coordinate space, compute the location in container space where this rect is visible,
@@ -827,9 +832,7 @@ protected:
 
     bool isSetNeedsLayoutForbidden() const;
 
-    enum class ClipRepaintToLayer : bool { No, Yes };
-    enum class ForceRepaint : bool { No, Yes };
-    void issueRepaint(std::optional<LayoutRect> partialRepaintRect = std::nullopt, ClipRepaintToLayer = ClipRepaintToLayer::No, ForceRepaint = ForceRepaint::No) const;
+    void issueRepaint(std::optional<LayoutRect> partialRepaintRect = std::nullopt, ClipRepaintToLayer = ClipRepaintToLayer::No, ForceRepaint = ForceRepaint::No, ClipRepaintToContainer = ClipRepaintToContainer::Yes) const;
 
 private:
     void addAbsoluteRectForLayer(LayoutRect& result);

--- a/Source/WebKit/GPUProcess/graphics/RemoteDisplayListRecorder.cpp
+++ b/Source/WebKit/GPUProcess/graphics/RemoteDisplayListRecorder.cpp
@@ -229,6 +229,11 @@ void RemoteDisplayListRecorder::clipPath(const Path& path, WindRule rule)
     handleItem(DisplayList::ClipPath(path, rule));
 }
 
+void RemoteDisplayListRecorder::resetClip()
+{
+    handleItem(DisplayList::ResetClip());
+}
+
 void RemoteDisplayListRecorder::drawFilteredImageBuffer(std::optional<RenderingResourceIdentifier> sourceImageIdentifier, const FloatRect& sourceImageRect, Ref<Filter> filter)
 {
     RefPtr<ImageBuffer> sourceImage;

--- a/Source/WebKit/GPUProcess/graphics/RemoteDisplayListRecorder.h
+++ b/Source/WebKit/GPUProcess/graphics/RemoteDisplayListRecorder.h
@@ -78,6 +78,7 @@ public:
     void clipToImageBuffer(WebCore::RenderingResourceIdentifier, const WebCore::FloatRect& destinationRect);
     void clipOutToPath(const WebCore::Path&);
     void clipPath(const WebCore::Path&, WebCore::WindRule);
+    void resetClip();
     void drawGlyphs(WebCore::DisplayList::DrawGlyphs&&);
     void drawDecomposedGlyphs(WebCore::RenderingResourceIdentifier fontIdentifier, WebCore::RenderingResourceIdentifier decomposedGlyphsIdentifier);
     void drawFilteredImageBuffer(std::optional<WebCore::RenderingResourceIdentifier> sourceImageIdentifier, const WebCore::FloatRect& sourceImageRect, Ref<WebCore::Filter>);

--- a/Source/WebKit/GPUProcess/graphics/RemoteDisplayListRecorder.messages.in
+++ b/Source/WebKit/GPUProcess/graphics/RemoteDisplayListRecorder.messages.in
@@ -44,6 +44,7 @@ messages -> RemoteDisplayListRecorder NotRefCounted Stream {
     ClipToImageBuffer(WebCore::RenderingResourceIdentifier renderingResourceIdentifier, WebCore::FloatRect destinationRect)
     ClipOutToPath(WebCore::Path path)
     ClipPath(WebCore::Path path, enum:bool WebCore::WindRule windRule)
+    ResetClip()
     DrawGlyphs(WebCore::DisplayList::DrawGlyphs item)
     DrawDecomposedGlyphs(WebCore::RenderingResourceIdentifier fontIdentifier, WebCore::RenderingResourceIdentifier decomposedGlyphsIdentifier)
     DrawFilteredImageBuffer(std::optional<WebCore::RenderingResourceIdentifier> sourceImageIdentifier, WebCore::FloatRect sourceImageRect, Ref<WebCore::Filter> filter)

--- a/Source/WebKit/WebProcess/GPU/graphics/RemoteDisplayListRecorderProxy.cpp
+++ b/Source/WebKit/WebProcess/GPU/graphics/RemoteDisplayListRecorderProxy.cpp
@@ -185,6 +185,11 @@ void RemoteDisplayListRecorderProxy::recordClipPath(const Path& path, WindRule r
     send(Messages::RemoteDisplayListRecorder::ClipPath(path, rule));
 }
 
+void RemoteDisplayListRecorderProxy::recordResetClip()
+{
+    send(Messages::RemoteDisplayListRecorder::ResetClip());
+}
+
 void RemoteDisplayListRecorderProxy::recordDrawFilteredImageBuffer(ImageBuffer* sourceImage, const FloatRect& sourceImageRect, Filter& filter)
 {
     std::optional<RenderingResourceIdentifier> identifier;

--- a/Source/WebKit/WebProcess/GPU/graphics/RemoteDisplayListRecorderProxy.h
+++ b/Source/WebKit/WebProcess/GPU/graphics/RemoteDisplayListRecorderProxy.h
@@ -81,6 +81,7 @@ private:
     void recordClipToImageBuffer(WebCore::ImageBuffer&, const WebCore::FloatRect& destinationRect) final;
     void recordClipOutToPath(const WebCore::Path&) final;
     void recordClipPath(const WebCore::Path&, WebCore::WindRule) final;
+    void recordResetClip() final;
     void recordDrawFilteredImageBuffer(WebCore::ImageBuffer*, const WebCore::FloatRect& sourceImageRect, WebCore::Filter&) final;
     void recordDrawGlyphs(const WebCore::Font&, const WebCore::GlyphBufferGlyph*, const WebCore::GlyphBufferAdvance*, unsigned count, const WebCore::FloatPoint& localAnchor, WebCore::FontSmoothingMode) final;
     void recordDrawDecomposedGlyphs(const WebCore::Font&, const WebCore::DecomposedGlyphs&) final;


### PR DESCRIPTION
#### 235d3f38636339f2b6c0ac79a177f7f735c13ce7
<pre>
Caret is incorrectly clipped in limited cases
<a href="https://bugs.webkit.org/show_bug.cgi?id=255474">https://bugs.webkit.org/show_bug.cgi?id=255474</a>
&lt;radar://108056572&gt;

Reviewed by Simon Fraser.

Allow caret to render outside the current clip rectangle.

Change is mostly mechanical, interesting part in RenderObject.cpp
and FrameSelection.cpp.

* Source/WebCore/platform/graphics/BifurcatedGraphicsContext.cpp:
(WebCore::BifurcatedGraphicsContext::resetClip):
* Source/WebCore/platform/graphics/BifurcatedGraphicsContext.h:
* Source/WebCore/platform/graphics/GraphicsContext.h:
* Source/WebCore/platform/graphics/NullGraphicsContext.h:
* Source/WebCore/platform/graphics/cg/GraphicsContextCG.cpp:
(WebCore::GraphicsContextCG::resetClip):
* Source/WebCore/platform/graphics/cg/GraphicsContextCG.h:
* Source/WebCore/platform/graphics/displaylists/DisplayList.cpp:
(WebCore::DisplayList::DisplayList::append):
* Source/WebCore/platform/graphics/displaylists/DisplayListItemBuffer.cpp:
(WebCore::DisplayList::ItemHandle::apply):
(WebCore::DisplayList::ItemHandle::destroy):
(WebCore::DisplayList::ItemHandle::safeCopy const):
* Source/WebCore/platform/graphics/displaylists/DisplayListItemType.cpp:
(WebCore::DisplayList::sizeOfItemInBytes):
(WebCore::DisplayList::isDrawingItem):
(WebCore::DisplayList::isInlineItem):
* Source/WebCore/platform/graphics/displaylists/DisplayListItemType.h:
* Source/WebCore/platform/graphics/displaylists/DisplayListItems.cpp:
(WebCore::DisplayList::ResetClip::apply const):
(WebCore::DisplayList::operator&lt;&lt;):
(WebCore::DisplayList::dumpItemHandle):
* Source/WebCore/platform/graphics/displaylists/DisplayListItems.h:
(WebCore::DisplayList::ResetClip::ResetClip):
* Source/WebCore/platform/graphics/displaylists/DisplayListRecorder.cpp:
(WebCore::DisplayList::Recorder::resetClip):
* Source/WebCore/platform/graphics/displaylists/DisplayListRecorder.h:
* Source/WebCore/platform/graphics/displaylists/DisplayListRecorderImpl.cpp:
(WebCore::DisplayList::RecorderImpl::recordResetClip):
* Source/WebCore/platform/graphics/displaylists/DisplayListRecorderImpl.h:
* Source/WebCore/rendering/GlyphDisplayListCache.cpp:
(WebCore::canShareDisplayListWithItem):
* Source/WebKit/GPUProcess/graphics/RemoteDisplayListRecorder.cpp:
(WebKit::RemoteDisplayListRecorder::resetClip):
* Source/WebKit/GPUProcess/graphics/RemoteDisplayListRecorder.h:
* Source/WebKit/GPUProcess/graphics/RemoteDisplayListRecorder.messages.in:
* Source/WebKit/WebProcess/GPU/graphics/RemoteDisplayListRecorderProxy.cpp:
(WebKit::RemoteDisplayListRecorderProxy::recordResetClip):
* Source/WebKit/WebProcess/GPU/graphics/RemoteDisplayListRecorderProxy.h:

* Source/WebCore/editing/FrameSelection.cpp:
(WebCore::repaintCaretForLocalRect):
repaint without clipping if the rectangle is changed by the animator.

* Source/WebCore/platform/CaretAnimator.cpp:
(WebCore::CaretAnimator::caretRepaintRectForLocalRect const):
(WebCore::CaretAnimator::repaintCaretRectForLocalRect const): Deleted.
* Source/WebCore/platform/CaretAnimator.h:
Renamed member function.

* Source/WebCore/rendering/RenderObject.cpp:
(WebCore::RenderObject::issueRepaint const):
(WebCore::RenderObject::repaintRectangle const):
* Source/WebCore/rendering/RenderObject.h:
Allow RenderObject to repaint the rectangle without clipping to
the container frame.

Canonical link: <a href="https://commits.webkit.org/263346@main">https://commits.webkit.org/263346@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4869895d7393ae126ae7765363a7e271ed470e62

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/4281 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/4400 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/4522 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/5754 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/4512 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/4276 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/4510 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/4363 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/4733 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/4343 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/4501 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/3854 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/5750 "Built successfully") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/39/builds/1996 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/3830 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/6632 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/3825 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/3897 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/5434 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/4308 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/3495 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/3824 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/3828 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/1059 "Built successfully and passed tests") | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/4/builds/7892 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/4179 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->