### PR TITLE
Use CreationData in FreeType font implementation

### DIFF
--- a/Source/WebCore/platform/graphics/FontCustomPlatformData.h
+++ b/Source/WebCore/platform/graphics/FontCustomPlatformData.h
@@ -68,7 +68,7 @@ public:
     {
     }
 #else
-    FontCustomPlatformData(FT_Face, FragmentedSharedBuffer&);
+    FontCustomPlatformData(FT_Face, FontPlatformData::CreationData&&);
 #endif
     WEBCORE_EXPORT ~FontCustomPlatformData();
 
@@ -78,13 +78,12 @@ public:
 
 #if PLATFORM(WIN)
     String name;
-    FontPlatformData::CreationData creationData;
 #elif USE(CORE_TEXT)
     RetainPtr<CTFontDescriptorRef> fontDescriptor;
-    FontPlatformData::CreationData creationData;
 #else
     RefPtr<cairo_font_face_t> m_fontFace;
 #endif
+    FontPlatformData::CreationData creationData;
 
     RenderingResourceIdentifier m_renderingResourceIdentifier;
 };

--- a/Source/WebCore/platform/graphics/FontPlatformData.cpp
+++ b/Source/WebCore/platform/graphics/FontPlatformData.cpp
@@ -72,7 +72,7 @@ FontPlatformData FontPlatformData::cloneWithSyntheticOblique(const FontPlatformD
 }
 #endif
 
-#if !USE(FREETYPE) && (!USE(CORE_TEXT) || !PLATFORM(COCOA))
+#if !USE(FREETYPE) && !PLATFORM(COCOA)
 // FIXME: Don't other platforms also need to reinstantiate their copy.m_font for scaled size?
 FontPlatformData FontPlatformData::cloneWithSize(const FontPlatformData& source, float size)
 {
@@ -103,11 +103,7 @@ void FontPlatformData::updateSizeWithFontSizeAdjust(const FontSizeAdjust& fontSi
 
 const FontPlatformData::CreationData* FontPlatformData::creationData() const
 {
-#if PLATFORM(WIN) || USE(CORE_TEXT)
     return m_customPlatformData ? &m_customPlatformData->creationData : nullptr;
-#else
-    return nullptr;
-#endif
 }
 
 #if !PLATFORM(COCOA) && !USE(FREETYPE)

--- a/Source/WebCore/platform/graphics/FontPlatformData.h
+++ b/Source/WebCore/platform/graphics/FontPlatformData.h
@@ -122,7 +122,7 @@ public:
 #endif
 
 #if USE(FREETYPE)
-    FontPlatformData(cairo_font_face_t*, RefPtr<FcPattern>&&, float size, bool fixedWidth, bool syntheticBold, bool syntheticOblique, FontOrientation);
+    FontPlatformData(cairo_font_face_t*, RefPtr<FcPattern>&&, float size, bool fixedWidth, bool syntheticBold, bool syntheticOblique, FontOrientation, const FontCustomPlatformData* = nullptr);
 #endif
 
     class Attributes {

--- a/Source/WebCore/platform/graphics/freetype/FontPlatformDataFreeType.cpp
+++ b/Source/WebCore/platform/graphics/freetype/FontPlatformDataFreeType.cpp
@@ -29,6 +29,7 @@
 #include "CairoUtilities.h"
 #include "FontCache.h"
 #include "FontCacheFreeType.h"
+#include "FontCustomPlatformData.h"
 #include "SharedBuffer.h"
 #include <cairo-ft.h>
 #include <fontconfig/fcfreetype.h>
@@ -115,8 +116,8 @@ static void setCairoFontOptionsFromFontConfigPattern(cairo_font_options_t* optio
 #endif
 }
 
-FontPlatformData::FontPlatformData(cairo_font_face_t* fontFace, RefPtr<FcPattern>&& pattern, float size, bool fixedWidth, bool syntheticBold, bool syntheticOblique, FontOrientation orientation)
-    : FontPlatformData(size, syntheticBold, syntheticOblique, orientation)
+FontPlatformData::FontPlatformData(cairo_font_face_t* fontFace, RefPtr<FcPattern>&& pattern, float size, bool fixedWidth, bool syntheticBold, bool syntheticOblique, FontOrientation orientation, const FontCustomPlatformData* customPlatformData)
+    : FontPlatformData(size, syntheticBold, syntheticOblique, orientation, FontWidthVariant::RegularWidth, TextRenderingMode::AutoTextRendering, customPlatformData)
 {
     m_pattern = WTFMove(pattern);
     m_fixedWidth = fixedWidth;

--- a/Source/WebCore/platform/graphics/freetype/SimpleFontDataFreeType.cpp
+++ b/Source/WebCore/platform/graphics/freetype/SimpleFontDataFreeType.cpp
@@ -206,7 +206,8 @@ RefPtr<Font> Font::platformCreateScaledFont(const FontDescription& fontDescripti
         m_platformData.isFixedWidth(),
         m_platformData.syntheticBold(),
         m_platformData.syntheticOblique(),
-        fontDescription.orientation()),
+        fontDescription.orientation(),
+        m_platformData.customPlatformData()),
         origin(), Interstitial::No);
 }
 

--- a/Source/WebCore/platform/graphics/win/SimpleFontDataWin.cpp
+++ b/Source/WebCore/platform/graphics/win/SimpleFontDataWin.cpp
@@ -61,7 +61,7 @@ RefPtr<Font> Font::platformCreateScaledFont(const FontDescription& fontDescripti
     GetObject(m_platformData.hfont(), sizeof(LOGFONT), &winfont);
     winfont.lfHeight = -lroundf(scaledSize * cWindowsFontScaleFactor);
     auto hfont = adoptGDIObject(::CreateFontIndirect(&winfont));
-    return Font::create(FontPlatformData(WTFMove(hfont), scaledSize, m_platformData.syntheticBold(), m_platformData.syntheticOblique()), origin());
+    return Font::create(FontPlatformData(WTFMove(hfont), scaledSize, m_platformData.syntheticBold(), m_platformData.syntheticOblique(), m_platformData.customPlatformData()), origin());
 }
 
 } // namespace WebCore


### PR DESCRIPTION
#### a387beb77af3254490adc82a17eb9a3c92b29d6a
<pre>
Use CreationData in FreeType font implementation
<a href="https://bugs.webkit.org/show_bug.cgi?id=255476">https://bugs.webkit.org/show_bug.cgi?id=255476</a>

Reviewed by Michael Catanzaro.

FreeType is the only Font backend that isn&apos;t using `CreationData`. Use
it to share implementation and behavior of `FontCustomPlatformData`.

During development found that `m_renderingResourceIdentifier` wasn&apos;t
initialized for FreeType in `FontCustomPlatformData`. Also saw that
the Windows implementation of `Font::platformCreateScaledFont` did not
propagate the platform data.

* Source/WebCore/platform/graphics/FontCustomPlatformData.h:
* Source/WebCore/platform/graphics/FontPlatformData.cpp:
* Source/WebCore/platform/graphics/FontPlatformData.h:
* Source/WebCore/platform/graphics/freetype/FontCustomPlatformDataFreeType.cpp:
* Source/WebCore/platform/graphics/freetype/FontPlatformDataFreeType.cpp:
* Source/WebCore/platform/graphics/freetype/SimpleFontDataFreeType.cpp:
* Source/WebCore/platform/graphics/win/SimpleFontDataWin.cpp:

Canonical link: <a href="https://commits.webkit.org/263084@main">https://commits.webkit.org/263084@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/bdd060cc1cdce303a57e1a6447af0731d042ad69

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/3258 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/3316 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/3427 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/4668 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/3587 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/3228 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/3370 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/3337 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/2824 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/3292 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/3582 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/2919 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/4487 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/1083 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/2892 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/2812 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/2863 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/2945 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/4220 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/3327 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/2654 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/2893 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/2893 "Passed tests") | | 
| [❌ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/864 "Failed to push commit to Webkit repository") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/2889 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/3168 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->