### PR TITLE
Combine Base64DecodeOptions and Base64DecodeMode

### DIFF
--- a/Source/JavaScriptCore/jsc.cpp
+++ b/Source/JavaScriptCore/jsc.cpp
@@ -1410,7 +1410,7 @@ JSC_DEFINE_HOST_FUNCTION(functionAtob, (JSGlobalObject* globalObject, CallFrame*
     if (encodedString.isNull())
         return JSValue::encode(jsEmptyString(vm));
 
-    auto decodedData = base64Decode(encodedString, { Base64DecodeOptions::ValidatePadding, Base64DecodeOptions::IgnoreSpacesAndNewLines, Base64DecodeOptions::DiscardVerticalTab });
+    auto decodedData = base64Decode(encodedString, Base64DecodeMode::DefaultValidatePaddingAndIgnoreWhitespace);
     if (!decodedData)
         return JSValue::encode(throwException(globalObject, scope, createError(globalObject, "Invalid character in argument for atob."_s)));
 

--- a/Source/WTF/wtf/text/Base64.h
+++ b/Source/WTF/wtf/text/Base64.h
@@ -1,7 +1,7 @@
 /*
  * Copyright (C) 2006 Alexey Proskuryakov <ap@webkit.org>
  * Copyright (C) 2010 Patrick Gansterer <paroga@paroga.com>
- * Copyright (C) 2013, 2016 Apple Inc. All rights reserved.
+ * Copyright (C) 2013, 2016, 2023 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -34,49 +34,49 @@
 
 namespace WTF {
 
-enum class Base64EncodeMap : bool { Default, URL };
+enum class Base64EncodeMode : bool { Default, URL };
 
-enum class Base64DecodeOptions : uint8_t {
-    ValidatePadding         = 1 << 0,
-    IgnoreSpacesAndNewLines = 1 << 1,
-    DiscardVerticalTab      = 1 << 2,
-};
-
-enum class Base64DecodeMap : bool { Default, URL };
+// - ::DefaultIgnorePadding and ::URL ignore padding-related requirements.
+//   Note that no mode enforces "Canonical Encoding" as defined in RFC 4648.
+// - ::DefaultValidatePadding and ::DefaultValidatePaddingAndIgnoreWhitespace
+//   enforce a correct number of trailing equal signs in the input.
+// - ::DefaultValidatePaddingAndIgnoreWhitespace ignores ASCII whitespace in
+//   the input. It matches <https://infra.spec.whatwg.org/#forgiving-base64>.
+enum class Base64DecodeMode { DefaultIgnorePadding, DefaultValidatePadding, DefaultValidatePaddingAndIgnoreWhitespace, URL };
 
 struct Base64Specification {
     Span<const std::byte> input;
-    Base64EncodeMap map;
+    Base64EncodeMode mode;
 };
 
 // If the input string is pathologically large, just return nothing.
 // Rather than being perfectly precise, this is a bit conservative.
 static constexpr unsigned maximumBase64EncoderInputBufferSize = std::numeric_limits<unsigned>::max() / 77 * 76 / 4 * 3 - 2;
 
-unsigned calculateBase64EncodedSize(unsigned inputLength, Base64EncodeMap);
+unsigned calculateBase64EncodedSize(unsigned inputLength, Base64EncodeMode);
 
 template<typename CharacterType> bool isBase64OrBase64URLCharacter(CharacterType);
 
-WTF_EXPORT_PRIVATE void base64Encode(Span<const std::byte>, Span<UChar>, Base64EncodeMap = Base64EncodeMap::Default);
-WTF_EXPORT_PRIVATE void base64Encode(Span<const std::byte>, Span<LChar>, Base64EncodeMap = Base64EncodeMap::Default);
+WTF_EXPORT_PRIVATE void base64Encode(Span<const std::byte>, Span<UChar>, Base64EncodeMode = Base64EncodeMode::Default);
+WTF_EXPORT_PRIVATE void base64Encode(Span<const std::byte>, Span<LChar>, Base64EncodeMode = Base64EncodeMode::Default);
 
-WTF_EXPORT_PRIVATE Vector<uint8_t> base64EncodeToVector(Span<const std::byte>, Base64EncodeMap = Base64EncodeMap::Default);
-Vector<uint8_t> base64EncodeToVector(Span<const uint8_t>, Base64EncodeMap = Base64EncodeMap::Default);
-Vector<uint8_t> base64EncodeToVector(Span<const char>, Base64EncodeMap = Base64EncodeMap::Default);
-Vector<uint8_t> base64EncodeToVector(const CString&, Base64EncodeMap = Base64EncodeMap::Default);
-Vector<uint8_t> base64EncodeToVector(const void*, unsigned, Base64EncodeMap = Base64EncodeMap::Default);
+WTF_EXPORT_PRIVATE Vector<uint8_t> base64EncodeToVector(Span<const std::byte>, Base64EncodeMode = Base64EncodeMode::Default);
+Vector<uint8_t> base64EncodeToVector(Span<const uint8_t>, Base64EncodeMode = Base64EncodeMode::Default);
+Vector<uint8_t> base64EncodeToVector(Span<const char>, Base64EncodeMode = Base64EncodeMode::Default);
+Vector<uint8_t> base64EncodeToVector(const CString&, Base64EncodeMode = Base64EncodeMode::Default);
+Vector<uint8_t> base64EncodeToVector(const void*, unsigned, Base64EncodeMode = Base64EncodeMode::Default);
 
-WTF_EXPORT_PRIVATE String base64EncodeToString(Span<const std::byte>, Base64EncodeMap = Base64EncodeMap::Default);
-String base64EncodeToString(Span<const uint8_t>, Base64EncodeMap = Base64EncodeMap::Default);
-String base64EncodeToString(Span<const char>, Base64EncodeMap = Base64EncodeMap::Default);
-String base64EncodeToString(const CString&, Base64EncodeMap = Base64EncodeMap::Default);
-String base64EncodeToString(const void*, unsigned, Base64EncodeMap = Base64EncodeMap::Default);
+WTF_EXPORT_PRIVATE String base64EncodeToString(Span<const std::byte>, Base64EncodeMode = Base64EncodeMode::Default);
+String base64EncodeToString(Span<const uint8_t>, Base64EncodeMode = Base64EncodeMode::Default);
+String base64EncodeToString(Span<const char>, Base64EncodeMode = Base64EncodeMode::Default);
+String base64EncodeToString(const CString&, Base64EncodeMode = Base64EncodeMode::Default);
+String base64EncodeToString(const void*, unsigned, Base64EncodeMode = Base64EncodeMode::Default);
 
-WTF_EXPORT_PRIVATE std::optional<Vector<uint8_t>> base64Decode(Span<const std::byte>, OptionSet<Base64DecodeOptions> = { }, Base64DecodeMap = Base64DecodeMap::Default);
-WTF_EXPORT_PRIVATE std::optional<Vector<uint8_t>> base64Decode(StringView, OptionSet<Base64DecodeOptions> = { }, Base64DecodeMap = Base64DecodeMap::Default);
-std::optional<Vector<uint8_t>> base64Decode(Span<const uint8_t>, OptionSet<Base64DecodeOptions> = { }, Base64DecodeMap = Base64DecodeMap::Default);
-std::optional<Vector<uint8_t>> base64Decode(Span<const char>, OptionSet<Base64DecodeOptions> = { }, Base64DecodeMap = Base64DecodeMap::Default);
-std::optional<Vector<uint8_t>> base64Decode(const void*, unsigned, OptionSet<Base64DecodeOptions> = { }, Base64DecodeMap = Base64DecodeMap::Default);
+WTF_EXPORT_PRIVATE std::optional<Vector<uint8_t>> base64Decode(Span<const std::byte>, Base64DecodeMode = Base64DecodeMode::DefaultIgnorePadding);
+WTF_EXPORT_PRIVATE std::optional<Vector<uint8_t>> base64Decode(StringView, Base64DecodeMode = Base64DecodeMode::DefaultIgnorePadding);
+std::optional<Vector<uint8_t>> base64Decode(Span<const uint8_t>, Base64DecodeMode = Base64DecodeMode::DefaultIgnorePadding);
+std::optional<Vector<uint8_t>> base64Decode(Span<const char>, Base64DecodeMode = Base64DecodeMode::DefaultIgnorePadding);
+std::optional<Vector<uint8_t>> base64Decode(const void*, unsigned, Base64DecodeMode = Base64DecodeMode::DefaultIgnorePadding);
 
 // All the same functions modified for base64url, as defined in RFC 4648.
 // This format uses '-' and '_' instead of '+' and '/' respectively.
@@ -102,10 +102,10 @@ std::optional<Vector<uint8_t>> base64URLDecode(const void*, unsigned);
 
 // Versions for use with StringBuilder / makeString.
 
-Base64Specification base64Encoded(Span<const std::byte>, Base64EncodeMap = Base64EncodeMap::Default);
-Base64Specification base64Encoded(Span<const uint8_t>, Base64EncodeMap = Base64EncodeMap::Default);
-Base64Specification base64Encoded(const CString&, Base64EncodeMap = Base64EncodeMap::Default);
-Base64Specification base64Encoded(const void*, unsigned, Base64EncodeMap = Base64EncodeMap::Default);
+Base64Specification base64Encoded(Span<const std::byte>, Base64EncodeMode = Base64EncodeMode::Default);
+Base64Specification base64Encoded(Span<const uint8_t>, Base64EncodeMode = Base64EncodeMode::Default);
+Base64Specification base64Encoded(const CString&, Base64EncodeMode = Base64EncodeMode::Default);
+Base64Specification base64Encoded(const void*, unsigned, Base64EncodeMode = Base64EncodeMode::Default);
 
 Base64Specification base64URLEncoded(Span<const std::byte>);
 Base64Specification base64URLEncoded(Span<const uint8_t>);
@@ -113,134 +113,134 @@ Base64Specification base64URLEncoded(const CString&);
 Base64Specification base64URLEncoded(const void*, unsigned);
 
 
-inline Vector<uint8_t> base64EncodeToVector(Span<const uint8_t> input, Base64EncodeMap map)
+inline Vector<uint8_t> base64EncodeToVector(Span<const uint8_t> input, Base64EncodeMode mode)
 {
-    return base64EncodeToVector(asBytes(input), map);
+    return base64EncodeToVector(asBytes(input), mode);
 }
 
-inline Vector<uint8_t> base64EncodeToVector(Span<const char> input, Base64EncodeMap map)
+inline Vector<uint8_t> base64EncodeToVector(Span<const char> input, Base64EncodeMode mode)
 {
-    return base64EncodeToVector(asBytes(input), map);
+    return base64EncodeToVector(asBytes(input), mode);
 }
 
-inline Vector<uint8_t> base64EncodeToVector(const CString& input, Base64EncodeMap map)
+inline Vector<uint8_t> base64EncodeToVector(const CString& input, Base64EncodeMode mode)
 {
-    return base64EncodeToVector(input.bytes(), map);
+    return base64EncodeToVector(input.bytes(), mode);
 }
 
-inline Vector<uint8_t> base64EncodeToVector(const void* input, unsigned length, Base64EncodeMap map)
+inline Vector<uint8_t> base64EncodeToVector(const void* input, unsigned length, Base64EncodeMode mode)
 {
-    return base64EncodeToVector({ static_cast<const std::byte*>(input), length }, map);
+    return base64EncodeToVector({ static_cast<const std::byte*>(input), length }, mode);
 }
 
-inline String base64EncodeToString(Span<const uint8_t> input, Base64EncodeMap map)
+inline String base64EncodeToString(Span<const uint8_t> input, Base64EncodeMode mode)
 {
-    return base64EncodeToString(asBytes(input), map);
+    return base64EncodeToString(asBytes(input), mode);
 }
 
-inline String base64EncodeToString(Span<const char> input, Base64EncodeMap map)
+inline String base64EncodeToString(Span<const char> input, Base64EncodeMode mode)
 {
-    return base64EncodeToString(asBytes(input), map);
+    return base64EncodeToString(asBytes(input), mode);
 }
 
-inline String base64EncodeToString(const CString& input, Base64EncodeMap map)
+inline String base64EncodeToString(const CString& input, Base64EncodeMode mode)
 {
-    return base64EncodeToString(input.bytes(), map);
+    return base64EncodeToString(input.bytes(), mode);
 }
 
-inline String base64EncodeToString(const void* input, unsigned length, Base64EncodeMap map)
+inline String base64EncodeToString(const void* input, unsigned length, Base64EncodeMode mode)
 {
-    return base64EncodeToString({ static_cast<const std::byte*>(input), length }, map);
+    return base64EncodeToString({ static_cast<const std::byte*>(input), length }, mode);
 }
 
-inline std::optional<Vector<uint8_t>> base64Decode(Span<const uint8_t> input, OptionSet<Base64DecodeOptions> options, Base64DecodeMap map)
+inline std::optional<Vector<uint8_t>> base64Decode(Span<const uint8_t> input, Base64DecodeMode mode)
 {
-    return base64Decode(asBytes(input), options, map);
+    return base64Decode(asBytes(input), mode);
 }
 
-inline std::optional<Vector<uint8_t>> base64Decode(Span<const char> input, OptionSet<Base64DecodeOptions> options, Base64DecodeMap map)
+inline std::optional<Vector<uint8_t>> base64Decode(Span<const char> input, Base64DecodeMode mode)
 {
-    return base64Decode(asBytes(input), options, map);
+    return base64Decode(asBytes(input), mode);
 }
 
-inline std::optional<Vector<uint8_t>> base64Decode(const void* input, unsigned length, OptionSet<Base64DecodeOptions> options, Base64DecodeMap map)
+inline std::optional<Vector<uint8_t>> base64Decode(const void* input, unsigned length, Base64DecodeMode mode)
 {
-    return base64Decode({ static_cast<const std::byte*>(input), length }, options, map);
+    return base64Decode({ static_cast<const std::byte*>(input), length }, mode);
 }
 
 inline Vector<uint8_t> base64URLEncodeToVector(Span<const std::byte> input)
 {
-    return base64EncodeToVector(input, Base64EncodeMap::URL);
+    return base64EncodeToVector(input, Base64EncodeMode::URL);
 }
 
 inline Vector<uint8_t> base64URLEncodeToVector(Span<const uint8_t> input)
 {
-    return base64EncodeToVector(input, Base64EncodeMap::URL);
+    return base64EncodeToVector(input, Base64EncodeMode::URL);
 }
 
 inline Vector<uint8_t> base64URLEncodeToVector(Span<const char> input)
 {
-    return base64EncodeToVector(input, Base64EncodeMap::URL);
+    return base64EncodeToVector(input, Base64EncodeMode::URL);
 }
 
 inline Vector<uint8_t> base64URLEncodeToVector(const CString& input)
 {
-    return base64EncodeToVector(input, Base64EncodeMap::URL);
+    return base64EncodeToVector(input, Base64EncodeMode::URL);
 }
 
 inline Vector<uint8_t> base64URLEncodeToVector(const void* input, unsigned length)
 {
-    return base64EncodeToVector(input, length, Base64EncodeMap::URL);
+    return base64EncodeToVector(input, length, Base64EncodeMode::URL);
 }
 
 inline String base64URLEncodeToString(Span<const std::byte> input)
 {
-    return base64EncodeToString(input, Base64EncodeMap::URL);
+    return base64EncodeToString(input, Base64EncodeMode::URL);
 }
 
 inline String base64URLEncodeToString(Span<const uint8_t> input)
 {
-    return base64EncodeToString(input, Base64EncodeMap::URL);
+    return base64EncodeToString(input, Base64EncodeMode::URL);
 }
 
 inline String base64URLEncodeToString(Span<const char> input)
 {
-    return base64EncodeToString(input, Base64EncodeMap::URL);
+    return base64EncodeToString(input, Base64EncodeMode::URL);
 }
 
 inline String base64URLEncodeToString(const CString& input)
 {
-    return base64EncodeToString(input, Base64EncodeMap::URL);
+    return base64EncodeToString(input, Base64EncodeMode::URL);
 }
 
 inline String base64URLEncodeToString(const void* input, unsigned length)
 {
-    return base64EncodeToString(input, length, Base64EncodeMap::URL);
+    return base64EncodeToString(input, length, Base64EncodeMode::URL);
 }
 
 inline std::optional<Vector<uint8_t>> base64URLDecode(StringView input)
 {
-    return base64Decode(input, { }, Base64DecodeMap::URL);
+    return base64Decode(input, Base64DecodeMode::URL);
 }
 
 inline std::optional<Vector<uint8_t>> base64URLDecode(Span<const std::byte> input)
 {
-    return base64Decode(input, { }, Base64DecodeMap::URL);
+    return base64Decode(input, Base64DecodeMode::URL);
 }
 
 inline std::optional<Vector<uint8_t>> base64URLDecode(Span<const uint8_t> input)
 {
-    return base64Decode(input, { }, Base64DecodeMap::URL);
+    return base64Decode(input, Base64DecodeMode::URL);
 }
 
 inline std::optional<Vector<uint8_t>> base64URLDecode(Span<const char> input)
 {
-    return base64Decode(input, { }, Base64DecodeMap::URL);
+    return base64Decode(input, Base64DecodeMode::URL);
 }
 
 inline std::optional<Vector<uint8_t>> base64URLDecode(const void* input, unsigned length)
 {
-    return base64Decode(input, length, { }, Base64DecodeMap::URL);
+    return base64Decode(input, length, Base64DecodeMode::URL);
 }
 
 template<typename CharacterType> bool isBase64OrBase64URLCharacter(CharacterType c)
@@ -248,7 +248,7 @@ template<typename CharacterType> bool isBase64OrBase64URLCharacter(CharacterType
     return isASCIIAlphanumeric(c) || c == '+' || c == '/' || c == '-' || c == '_';
 }
 
-inline unsigned calculateBase64EncodedSize(unsigned inputLength, Base64EncodeMap map)
+inline unsigned calculateBase64EncodedSize(unsigned inputLength, Base64EncodeMode mode)
 {
     if (!inputLength)
         return 0;
@@ -264,11 +264,11 @@ inline unsigned calculateBase64EncodedSize(unsigned inputLength, Base64EncodeMap
         return ((inputLength * 4) + 2) / 3;
     };
 
-    switch (map) {
-    case Base64EncodeMap::Default:
+    switch (mode) {
+    case Base64EncodeMode::Default:
         return basePaddedEncodedSize();
 
-    case Base64EncodeMap::URL:
+    case Base64EncodeMode::URL:
         return baseUnpaddedEncodedSize();
     }
 
@@ -276,51 +276,51 @@ inline unsigned calculateBase64EncodedSize(unsigned inputLength, Base64EncodeMap
     return 0;
 }
 
-inline Base64Specification base64Encoded(Span<const std::byte> input, Base64EncodeMap map)
+inline Base64Specification base64Encoded(Span<const std::byte> input, Base64EncodeMode mode)
 {
-    return { input, map };
+    return { input, mode };
 }
 
-inline Base64Specification base64Encoded(Span<const uint8_t> input, Base64EncodeMap map)
+inline Base64Specification base64Encoded(Span<const uint8_t> input, Base64EncodeMode mode)
 {
-    return base64Encoded(asBytes(input), map);
+    return base64Encoded(asBytes(input), mode);
 }
 
-inline Base64Specification base64Encoded(const CString& input, Base64EncodeMap map)
+inline Base64Specification base64Encoded(const CString& input, Base64EncodeMode mode)
 {
-    return base64Encoded(input.bytes(), map);
+    return base64Encoded(input.bytes(), mode);
 }
 
-inline Base64Specification base64Encoded(const void* input, unsigned length, Base64EncodeMap map)
+inline Base64Specification base64Encoded(const void* input, unsigned length, Base64EncodeMode mode)
 {
-    return base64Encoded({ static_cast<const std::byte*>(input), length }, map);
+    return base64Encoded({ static_cast<const std::byte*>(input), length }, mode);
 }
 
 inline Base64Specification base64URLEncoded(Span<const std::byte> input)
 {
-    return base64Encoded(input, Base64EncodeMap::URL);
+    return base64Encoded(input, Base64EncodeMode::URL);
 }
 
 inline Base64Specification base64URLEncoded(Span<const uint8_t> input)
 {
-    return base64Encoded(input, Base64EncodeMap::URL);
+    return base64Encoded(input, Base64EncodeMode::URL);
 }
 
 inline Base64Specification base64URLEncoded(const CString& input)
 {
-    return base64Encoded(input, Base64EncodeMap::URL);
+    return base64Encoded(input, Base64EncodeMode::URL);
 }
 
 inline Base64Specification base64URLEncoded(const void* input, unsigned length)
 {
-    return base64Encoded(input, length, Base64EncodeMap::URL);
+    return base64Encoded(input, length, Base64EncodeMode::URL);
 }
 
 template<> class StringTypeAdapter<Base64Specification> {
 public:
     StringTypeAdapter(const Base64Specification& base64)
         : m_base64 { base64 }
-        , m_encodedLength { calculateBase64EncodedSize(base64.input.size(), base64.map) }
+        , m_encodedLength { calculateBase64EncodedSize(base64.input.size(), base64.mode) }
     {
     }
 
@@ -329,7 +329,7 @@ public:
 
     template<typename CharacterType> void writeTo(CharacterType* destination) const
     {
-        base64Encode(m_base64.input, makeSpan(destination, m_encodedLength), m_base64.map);
+        base64Encode(m_base64.input, makeSpan(destination, m_encodedLength), m_base64.mode);
     }
 
 private:
@@ -339,12 +339,11 @@ private:
 
 } // namespace WTF
 
-using WTF::Base64DecodeOptions;
+using WTF::Base64DecodeMode;
 using WTF::base64Decode;
 using WTF::base64EncodeToString;
 using WTF::base64EncodeToVector;
 using WTF::base64Encoded;
-using WTF::base64URLDecode;
 using WTF::base64URLDecode;
 using WTF::base64URLEncodeToString;
 using WTF::base64URLEncodeToVector;

--- a/Source/WebCore/page/Base64Utilities.cpp
+++ b/Source/WebCore/page/Base64Utilities.cpp
@@ -46,7 +46,7 @@ ExceptionOr<String> Base64Utilities::atob(const String& encodedString)
     if (encodedString.isNull())
         return String();
 
-    auto decodedData = base64Decode(encodedString, { Base64DecodeOptions::ValidatePadding, Base64DecodeOptions::IgnoreSpacesAndNewLines, Base64DecodeOptions::DiscardVerticalTab });
+    auto decodedData = base64Decode(encodedString, Base64DecodeMode::DefaultValidatePaddingAndIgnoreWhitespace);
     if (!decodedData)
         return Exception { InvalidCharacterError };
 

--- a/Source/WebCore/page/Page.cpp
+++ b/Source/WebCore/page/Page.cpp
@@ -2199,7 +2199,7 @@ void Page::userStyleSheetLocationChanged()
     if (url.protocolIsData() && url.string().startsWith("data:text/css;charset=utf-8;base64,"_s)) {
         m_didLoadUserStyleSheet = true;
 
-        if (auto styleSheetAsUTF8 = base64Decode(PAL::decodeURLEscapeSequences(StringView(url.string()).substring(35)), Base64DecodeOptions::IgnoreSpacesAndNewLines))
+        if (auto styleSheetAsUTF8 = base64Decode(PAL::decodeURLEscapeSequences(StringView(url.string()).substring(35)), Base64DecodeMode::DefaultValidatePaddingAndIgnoreWhitespace))
             m_userStyleSheet = String::fromUTF8(styleSheetAsUTF8->data(), styleSheetAsUTF8->size());
     }
 

--- a/Source/WebCore/platform/graphics/avfoundation/CDMFairPlayStreaming.cpp
+++ b/Source/WebCore/platform/graphics/avfoundation/CDMFairPlayStreaming.cpp
@@ -114,7 +114,7 @@ static Vector<Ref<SharedBuffer>> extractSinfData(const SharedBuffer& buffer)
         if (!keyID)
             continue;
 
-        auto sinfData = base64Decode(keyID, Base64DecodeOptions::IgnoreSpacesAndNewLines);
+        auto sinfData = base64Decode(keyID, Base64DecodeMode::DefaultValidatePaddingAndIgnoreWhitespace);
         if (!sinfData)
             continue;
 

--- a/Source/WebCore/platform/network/DataURLDecoder.cpp
+++ b/Source/WebCore/platform/network/DataURLDecoder.cpp
@@ -160,7 +160,7 @@ static std::optional<Result> decodeSynchronously(DecodeTask& task)
         return std::nullopt;
 
     if (task.isBase64) {
-        auto decodedData = base64Decode(PAL::decodeURLEscapeSequences(task.encodedData), { Base64DecodeOptions::ValidatePadding, Base64DecodeOptions::IgnoreSpacesAndNewLines, Base64DecodeOptions::DiscardVerticalTab });
+        auto decodedData = base64Decode(PAL::decodeURLEscapeSequences(task.encodedData), Base64DecodeMode::DefaultValidatePaddingAndIgnoreWhitespace);
         if (!decodedData)
             return std::nullopt;
         task.result.data = WTFMove(*decodedData);

--- a/Source/WebKit/UIProcess/Inspector/gtk/RemoteWebInspectorUIProxyGtk.cpp
+++ b/Source/WebKit/UIProcess/Inspector/gtk/RemoteWebInspectorUIProxyGtk.cpp
@@ -136,7 +136,7 @@ void RemoteWebInspectorUIProxy::platformSave(Vector<InspectorFrontendClient::Sav
     Vector<uint8_t> dataVector;
     CString dataString;
     if (saveDatas[0].base64Encoded) {
-        auto decodedData = base64Decode(saveDatas[0].content, Base64DecodeOptions::ValidatePadding);
+        auto decodedData = base64Decode(saveDatas[0].content, Base64DecodeMode::DefaultValidatePadding);
         if (!decodedData)
             return;
         decodedData->shrinkToFit();

--- a/Source/WebKit/UIProcess/Inspector/gtk/WebInspectorUIProxyGtk.cpp
+++ b/Source/WebKit/UIProcess/Inspector/gtk/WebInspectorUIProxyGtk.cpp
@@ -523,7 +523,7 @@ void WebInspectorUIProxy::platformSave(Vector<WebCore::InspectorFrontendClient::
     Vector<uint8_t> dataVector;
     CString dataString;
     if (saveDatas[0].base64Encoded) {
-        auto decodedData = base64Decode(saveDatas[0].content, Base64DecodeOptions::ValidatePadding);
+        auto decodedData = base64Decode(saveDatas[0].content, Base64DecodeMode::DefaultValidatePadding);
         if (!decodedData)
             return;
         decodedData->shrinkToFit();

--- a/Source/WebKit/UIProcess/Inspector/mac/WebInspectorUIProxyMac.mm
+++ b/Source/WebKit/UIProcess/Inspector/mac/WebInspectorUIProxyMac.mm
@@ -402,7 +402,7 @@ void WebInspectorUIProxy::showSavePanel(NSWindow *frontendWindow, NSURL *platfor
 
         if ([controller base64Encoded]) {
             String contentString = [controller content];
-            auto decodedData = base64Decode(contentString, Base64DecodeOptions::ValidatePadding);
+            auto decodedData = base64Decode(contentString, Base64DecodeMode::DefaultValidatePadding);
             if (!decodedData)
                 return;
             auto dataContent = adoptNS([[NSData alloc] initWithBytes:decodedData->data() length:decodedData->size()]);

--- a/Source/WebKitLegacy/mac/WebCoreSupport/WebInspectorClient.mm
+++ b/Source/WebKitLegacy/mac/WebCoreSupport/WebInspectorClient.mm
@@ -423,7 +423,7 @@ void WebInspectorFrontendClient::save(Vector<InspectorFrontendClient::SaveData>&
         m_suggestedToActualURLMap.set(suggestedURLCopy, actualURL);
 
         if (base64Encoded) {
-            auto decodedData = base64Decode(contentCopy, Base64DecodeOptions::ValidatePadding);
+            auto decodedData = base64Decode(contentCopy, Base64DecodeMode::DefaultValidatePadding);
             if (!decodedData)
                 return;
             RetainPtr<NSData> dataContent = adoptNS([[NSData alloc] initWithBytes:decodedData->data() length:decodedData->size()]);


### PR DESCRIPTION
#### 252a605f349215717db4711cc3bfb7b7ea3bf446
<pre>
Combine Base64DecodeOptions and Base64DecodeMode
<a href="https://bugs.webkit.org/show_bug.cgi?id=255479">https://bugs.webkit.org/show_bug.cgi?id=255479</a>
rdar://108082420

Reviewed by Darin Adler.

<a href="https://bugs.webkit.org/show_bug.cgi?id=184529#c11">https://bugs.webkit.org/show_bug.cgi?id=184529#c11</a> gave a bunch of feedback that was unfortunately
overlooked. This attempts to address it. In particular:

* Using WebKit&apos;s isUnicodeCompatibleASCIIWhitespace was an accident and not intentional. All callers
  want isASCIIWhitespace (which excludes U+000B (\v)).
* The isLatin1() check was thought to be needed to address a test, but that wasn&apos;t actually the
  case.

Additionally this folds Base64DecodeOptions into Base64DecodeMode reducing the number of decoding
variants we offer to callers and making them more explicit.

We might be able to shrink that even more with some additional investigation, in particular as part
of properly standardizing CSP and SRI base64/base64url requirements.

Base64EncodeMap is renamed to Base64EncodeMode for parity.

* Source/JavaScriptCore/jsc.cpp:
(JSC_DEFINE_HOST_FUNCTION):
* Source/WTF/wtf/text/Base64.cpp:
(WTF::base64EncodeInternal):
(WTF::base64Encode):
(WTF::base64EncodeToVector):
(WTF::base64EncodeToString):
(WTF::base64DecodeInternal):
(WTF::base64Decode):
* Source/WTF/wtf/text/Base64.h:
(WTF::base64EncodeToVector):
(WTF::base64EncodeToString):
(WTF::base64Decode):
(WTF::base64URLEncodeToVector):
(WTF::base64URLEncodeToString):
(WTF::base64URLDecode):
(WTF::calculateBase64EncodedSize):
(WTF::base64Encoded):
(WTF::base64URLEncoded):
(WTF::StringTypeAdapter&lt;Base64Specification&gt;::writeTo const):
* Source/WebCore/page/Base64Utilities.cpp:
(WebCore::Base64Utilities::atob):
* Source/WebCore/page/Page.cpp:
(WebCore::Page::userStyleSheetLocationChanged):

<a href="https://bugs.webkit.org/show_bug.cgi?id=255442">https://bugs.webkit.org/show_bug.cgi?id=255442</a> covers cleaning this up further, but this at least
aligns it with data: URL requirements.

* Source/WebCore/platform/graphics/avfoundation/CDMFairPlayStreaming.cpp:
(WebCore::extractSinfData):
* Source/WebCore/platform/network/DataURLDecoder.cpp:
(WebCore::DataURLDecoder::decodeSynchronously):
* Source/WebKit/UIProcess/Inspector/gtk/RemoteWebInspectorUIProxyGtk.cpp:
(WebKit::RemoteWebInspectorUIProxy::platformSave):
* Source/WebKit/UIProcess/Inspector/gtk/WebInspectorUIProxyGtk.cpp:
(WebKit::WebInspectorUIProxy::platformSave):
* Source/WebKit/UIProcess/Inspector/mac/WebInspectorUIProxyMac.mm:
(WebKit::WebInspectorUIProxy::showSavePanel):
* Source/WebKitLegacy/mac/WebCoreSupport/WebInspectorClient.mm:
(WebInspectorFrontendClient::save):

Canonical link: <a href="https://commits.webkit.org/263298@main">https://commits.webkit.org/263298@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c35c087de3e7147a9f7125e4b52844d385b63903

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/4161 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/4277 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/4395 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/5627 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/4408 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/4152 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/4380 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/4242 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/4631 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/4222 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/4398 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/3753 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/5620 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/1894 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/3730 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/5935 "1 flakes 141 failures") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/3457 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/3721 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/3820 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/5311 "Passed tests") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/3952 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/4198 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/3402 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/4256 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/3711 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/3728 "Passed tests") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/1043 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/1024 "Built successfully and passed tests") | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/4/builds/7830 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/24/builds/4352 "Built successfully") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/3993 "Built successfully") | | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/3/builds/1161 "Passed tests") | 
<!--EWS-Status-Bubble-End-->