### PR TITLE
[popover] Improve popover-shadow-dom.html

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/popovers/popover-shadow-dom-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/popovers/popover-shadow-dom-expected.txt
@@ -5,6 +5,6 @@ Test 2 Popover 1
 PASS Popovers located inside shadow DOM can still be shown
 PASS anchor references do not cross shadow boundaries
 FAIL anchor references use the flat tree not the DOM tree assert_true: expected true got false
-FAIL The popover stack is preserved across shadow-inclusive ancestors assert_true: popover1 not open expected true got false
-FAIL Popover ancestor relationships are within a root, not within the document assert_true: popover1 not open expected true got false
+PASS The popover stack is preserved across shadow-inclusive ancestors
+PASS Popover ancestor relationships are within a root, not within the document
 

--- a/Source/WebCore/html/HTMLElement.cpp
+++ b/Source/WebCore/html/HTMLElement.cpp
@@ -1297,10 +1297,10 @@ static HTMLElement* topmostPopoverAncestor(Element& newPopover)
             topmostAncestor = candidateAncestor;
     };
 
-    checkAncestor(newPopover.parentElement());
+    checkAncestor(newPopover.parentElementInComposedTree());
 
     // Iterate over all popover invokers in the document.
-    for (auto& invoker : descendantsOfType<HTMLFormControlElement>(newPopover.document())) {
+    for (auto& invoker : descendantsOfType<HTMLFormControlElement>(newPopover.treeScope().rootNode())) {
         // popoverTargetElement() already checks if the form control can invoke popovers.
         if (invoker.popoverTargetElement() == &newPopover)
             checkAncestor(&invoker);


### PR DESCRIPTION
#### 24ea38a3724493f8068a99385c075b2f2e20d944
<pre>
[popover] Improve popover-shadow-dom.html
<a href="https://bugs.webkit.org/show_bug.cgi?id=255486">https://bugs.webkit.org/show_bug.cgi?id=255486</a>

Reviewed by Tim Nguyen.

Improve popover-shadow-dom.html result by taking shadow dom into account as specified [1, 2].

[1] <a href="https://html.spec.whatwg.org/#topmost-popover-ancestor">https://html.spec.whatwg.org/#topmost-popover-ancestor</a> (Step 9)
[2] <a href="https://html.spec.whatwg.org/#topmost-popover-ancestor">https://html.spec.whatwg.org/#topmost-popover-ancestor</a> (Step 10)

* LayoutTests/imported/w3c/web-platform-tests/html/semantics/popovers/popover-shadow-dom-expected.txt:
* Source/WebCore/html/HTMLElement.cpp:
(WebCore::topmostPopoverAncestor):

Canonical link: <a href="https://commits.webkit.org/263016@main">https://commits.webkit.org/263016@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b291da6ccf6e6445a3db4cb9ee214abda2a80a2e

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/3277 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/3335 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/3446 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/4687 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/3604 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/3247 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/3392 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/3356 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/2841 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/3311 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/3602 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/2945 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/4509 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/1104 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/2914 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/2834 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/2885 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/2967 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/4247 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/3346 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/2672 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/2912 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/2915 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/811 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/2908 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/3187 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->