### PR TITLE
[IFC][Integration][Line clamp] Block children starting with lines exceeding `maximumLineCountForLineClamp` should be fully collapsed.

### DIFF
--- a/LayoutTests/fast/text/layout-overflow-hidden-for-line-clamped-content-expected.html
+++ b/LayoutTests/fast/text/layout-overflow-hidden-for-line-clamped-content-expected.html
@@ -1,0 +1,10 @@
+<style>
+.clamped {
+  font-family: Ahem;
+  display: -webkit-box;
+  -webkit-box-orient: vertical;
+  -webkit-line-clamp: 1;
+  overflow: hidden;
+}
+</style>
+<div class="clamped">TEST<br />CASE</div>

--- a/LayoutTests/fast/text/layout-overflow-hidden-for-line-clamped-content.html
+++ b/LayoutTests/fast/text/layout-overflow-hidden-for-line-clamped-content.html
@@ -1,0 +1,11 @@
+<style>
+.clamped {
+  font-family: Ahem;
+  display: -webkit-box;
+  -webkit-box-orient: vertical;
+  -webkit-line-clamp: 1;
+  overflow: hidden;
+}
+</style>
+<!-- PASS if a single line of TEST with ellipses -->
+<div class="clamped">TEST<br />CASE<br /><div></div>FAIL</div>

--- a/Source/WebCore/layout/integration/inline/LayoutIntegrationLineLayout.cpp
+++ b/Source/WebCore/layout/integration/inline/LayoutIntegrationLineLayout.cpp
@@ -819,21 +819,17 @@ std::optional<size_t> LineLayout::lastLineIndexForContentHeight() const
         ASSERT_NOT_REACHED();
         return lines.size() - 1;
     }
-    auto visibleLines = layoutState->visibleLineCountForLineClamp();
     // Previous block containers may have already produced some lines.
-    auto remainingNumberOfLines = maximumLines - visibleLines.value_or(0);
-    if (!remainingNumberOfLines) {
-        // This block is fully collapsed.
-        return { };
-    }
-    if (remainingNumberOfLines > 0) {
+    auto visibleLines = layoutState->visibleLineCountForLineClamp().value_or(0);
+    if (visibleLines < maximumLines) {
+        auto remainingNumberOfLines = maximumLines - visibleLines;
         auto lastLineIndex = std::min(lines.size(), remainingNumberOfLines) - 1;
         // FIXME: Clamped line is supposed to have trailing ellipsis. Assert on lines[lastLineIndex].hasEllipsis() when we have some means to clear
         // line content after probing layout.
         return lastLineIndex;
     }
-    ASSERT_NOT_REACHED();
-    return lines.size() - 1;
+    // This block is fully collapsed.
+    return { };
 }
 
 bool LineLayout::isPaginated() const


### PR DESCRIPTION
#### 71f363c22510a871c79e265d62436443c7802743
<pre>
[IFC][Integration][Line clamp] Block children starting with lines exceeding `maximumLineCountForLineClamp` should be fully collapsed.
<a href="https://bugs.webkit.org/show_bug.cgi?id=255487">https://bugs.webkit.org/show_bug.cgi?id=255487</a>

Reviewed by Alan Baradlay.

`-webkit-line-clamp` expects the logical height of the content box to be
collapsed to the last visible line.

At `LineLayout::lastLineIndexForContentHeight()`, `visibleLineCountForLineClamp`
of the current layout state may be greater than `maximumLineCountForLineClamp`
when multiple children are being laid out within the same context of line clamp.
In this case, the last line index should be returned as empty in order for the
individual child block to be fully collapsed.

* LayoutTests/fast/text/layout-overflow-hidden-for-line-clamped-content-expected.html: Added.
* LayoutTests/fast/text/layout-overflow-hidden-for-line-clamped-content.html: Added.
* Source/WebCore/layout/integration/inline/LayoutIntegrationLineLayout.cpp:
(WebCore::LayoutIntegration::LineLayout::lastLineIndexForContentHeight const):

Canonical link: <a href="https://commits.webkit.org/263079@main">https://commits.webkit.org/263079@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d2402ba1404f496ecaef771005d8dbab755d94b8

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/3295 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/3354 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/3469 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/4711 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/3625 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/3271 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/3415 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/3377 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/2858 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/3334 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/3621 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/2968 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/4533 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/1124 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/2934 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/2851 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/2906 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/2987 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/4272 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/3367 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/2691 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/2930 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/2935 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/862 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/2931 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/3205 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->