### PR TITLE
Adopt new NodeName enumeration in hasPresentationalHintsForAttribute() & collectPresentationalHintsForAttribute()

### DIFF
--- a/Source/WebCore/html/HTMLFontElement.cpp
+++ b/Source/WebCore/html/HTMLFontElement.cpp
@@ -31,6 +31,7 @@
 #include "HTMLNames.h"
 #include "HTMLParserIdioms.h"
 #include "MutableStyleProperties.h"
+#include "NodeName.h"
 #include "StyleProperties.h"
 #include <wtf/IsoMallocInlines.h>
 #include <wtf/text/StringBuilder.h>
@@ -178,24 +179,39 @@ bool HTMLFontElement::cssValueFromFontSizeNumber(const String& s, CSSValueID& si
 
 bool HTMLFontElement::hasPresentationalHintsForAttribute(const QualifiedName& name) const
 {
-    if (name == sizeAttr || name == colorAttr || name == faceAttr)
+    switch (name.nodeName()) {
+    case AttributeNames::sizeAttr:
+    case AttributeNames::colorAttr:
+    case AttributeNames::faceAttr:
         return true;
+    default:
+        break;
+    }
     return HTMLElement::hasPresentationalHintsForAttribute(name);
 }
 
 void HTMLFontElement::collectPresentationalHintsForAttribute(const QualifiedName& name, const AtomString& value, MutableStyleProperties& style)
 {
-    if (name == sizeAttr) {
+    switch (name.nodeName()) {
+    case AttributeNames::sizeAttr: {
         CSSValueID size = CSSValueInvalid;
         if (cssValueFromFontSizeNumber(value, size))
             addPropertyToPresentationalHintStyle(style, CSSPropertyFontSize, size);
-    } else if (name == colorAttr)
+        break;
+    }
+    case AttributeNames::colorAttr:
         addHTMLColorToStyle(style, CSSPropertyColor, value);
-    else if (name == faceAttr && !value.isEmpty()) {
-        if (auto fontFaceValue = CSSValuePool::singleton().createFontFaceValue(value))
-            style.setProperty(CSSProperty(CSSPropertyFontFamily, WTFMove(fontFaceValue)));
-    } else
+        break;
+    case AttributeNames::faceAttr:
+        if (!value.isEmpty()) {
+            if (auto fontFaceValue = CSSValuePool::singleton().createFontFaceValue(value))
+                style.setProperty(CSSProperty(CSSPropertyFontFamily, WTFMove(fontFaceValue)));
+        }
+        break;
+    default:
         HTMLElement::collectPresentationalHintsForAttribute(name, value, style);
+        break;
+    }
 }
 
 }

--- a/Source/WebCore/html/HTMLHRElement.cpp
+++ b/Source/WebCore/html/HTMLHRElement.cpp
@@ -30,6 +30,7 @@
 #include "HTMLNames.h"
 #include "HTMLParserIdioms.h"
 #include "MutableStyleProperties.h"
+#include "NodeName.h"
 #include <wtf/IsoMallocInlines.h>
 
 namespace WebCore {
@@ -56,14 +57,22 @@ Ref<HTMLHRElement> HTMLHRElement::create(const QualifiedName& tagName, Document&
 
 bool HTMLHRElement::hasPresentationalHintsForAttribute(const QualifiedName& name) const
 {
-    if (name == widthAttr || name == colorAttr || name == noshadeAttr || name == sizeAttr)
+    switch (name.nodeName()) {
+    case AttributeNames::widthAttr:
+    case AttributeNames::colorAttr:
+    case AttributeNames::noshadeAttr:
+    case AttributeNames::sizeAttr:
         return true;
+    default:
+        break;
+    }
     return HTMLElement::hasPresentationalHintsForAttribute(name);
 }
 
 void HTMLHRElement::collectPresentationalHintsForAttribute(const QualifiedName& name, const AtomString& value, MutableStyleProperties& style)
 {
-    if (name == alignAttr) {
+    switch (name.nodeName()) {
+    case AttributeNames::alignAttr:
         if (equalLettersIgnoringASCIICase(value, "left"_s)) {
             addPropertyToPresentationalHintStyle(style, CSSPropertyMarginLeft, 0, CSSUnitType::CSS_PX);
             addPropertyToPresentationalHintStyle(style, CSSPropertyMarginRight, CSSValueAuto);
@@ -74,31 +83,36 @@ void HTMLHRElement::collectPresentationalHintsForAttribute(const QualifiedName& 
             addPropertyToPresentationalHintStyle(style, CSSPropertyMarginLeft, CSSValueAuto);
             addPropertyToPresentationalHintStyle(style, CSSPropertyMarginRight, CSSValueAuto);
         }
-    } else if (name == widthAttr) {
+        break;
+    case AttributeNames::widthAttr:
         if (auto valueInteger = parseHTMLInteger(value); valueInteger && !*valueInteger)
             addPropertyToPresentationalHintStyle(style, CSSPropertyWidth, 1, CSSUnitType::CSS_PX);
         else
             addHTMLLengthToStyle(style, CSSPropertyWidth, value);
-    } else if (name == colorAttr) {
+        break;
+    case AttributeNames::colorAttr:
         addPropertyToPresentationalHintStyle(style, CSSPropertyBorderStyle, CSSValueSolid);
         addHTMLColorToStyle(style, CSSPropertyBorderColor, value);
         addHTMLColorToStyle(style, CSSPropertyBackgroundColor, value);
-    } else if (name == noshadeAttr) {
+        break;
+    case AttributeNames::noshadeAttr:
         if (!hasAttributeWithoutSynchronization(colorAttr)) {
             addPropertyToPresentationalHintStyle(style, CSSPropertyBorderStyle, CSSValueSolid);
-
             auto darkGrayValue = CSSValuePool::singleton().createColorValue(Color::darkGray);
             style.setProperty(CSSPropertyBorderColor, darkGrayValue.ptr());
             style.setProperty(CSSPropertyBackgroundColor, WTFMove(darkGrayValue));
         }
-    } else if (name == sizeAttr) {
-        int size = parseHTMLInteger(value).value_or(0);
-        if (size <= 1)
-            addPropertyToPresentationalHintStyle(style, CSSPropertyBorderBottomWidth, 0, CSSUnitType::CSS_PX);
-        else
+        break;
+    case AttributeNames::sizeAttr:
+        if (int size = parseHTMLInteger(value).value_or(0); size > 1)
             addPropertyToPresentationalHintStyle(style, CSSPropertyHeight, size - 2, CSSUnitType::CSS_PX);
-    } else
+        else
+            addPropertyToPresentationalHintStyle(style, CSSPropertyBorderBottomWidth, 0, CSSUnitType::CSS_PX);
+        break;
+    default:
         HTMLElement::collectPresentationalHintsForAttribute(name, value, style);
+        break;
+    }
 }
 
 bool HTMLHRElement::canContainRangeEndPoint() const

--- a/Source/WebCore/html/HTMLIFrameElement.cpp
+++ b/Source/WebCore/html/HTMLIFrameElement.cpp
@@ -75,28 +75,41 @@ DOMTokenList& HTMLIFrameElement::sandbox()
 
 bool HTMLIFrameElement::hasPresentationalHintsForAttribute(const QualifiedName& name) const
 {
-    if (name == widthAttr || name == heightAttr || name == frameborderAttr)
+    switch (name.nodeName()) {
+    case AttributeNames::widthAttr:
+    case AttributeNames::heightAttr:
+    case AttributeNames::frameborderAttr:
         return true;
+    default:
+        break;
+    }
     return HTMLFrameElementBase::hasPresentationalHintsForAttribute(name);
 }
 
 void HTMLIFrameElement::collectPresentationalHintsForAttribute(const QualifiedName& name, const AtomString& value, MutableStyleProperties& style)
 {
-    if (name == widthAttr)
+    switch (name.nodeName()) {
+    case AttributeNames::widthAttr:
         addHTMLLengthToStyle(style, CSSPropertyWidth, value);
-    else if (name == heightAttr)
+        break;
+    case AttributeNames::heightAttr:
         addHTMLLengthToStyle(style, CSSPropertyHeight, value);
-    else if (name == alignAttr)
+        break;
+    case AttributeNames::alignAttr:
         applyAlignmentAttributeToStyle(value, style);
-    else if (name == frameborderAttr) {
+        break;
+    case AttributeNames::frameborderAttr:
         // Frame border doesn't really match the HTML4 spec definition for iframes. It simply adds
         // a presentational hint that the border should be off if set to zero.
         if (!parseHTMLInteger(value).value_or(0)) {
             // Add a rule that nulls out our border width.
             addPropertyToPresentationalHintStyle(style, CSSPropertyBorderWidth, 0, CSSUnitType::CSS_PX);
         }
-    } else
+        break;
+    default:
         HTMLFrameElementBase::collectPresentationalHintsForAttribute(name, value, style);
+        break;
+    }
 }
 
 void HTMLIFrameElement::attributeChanged(const QualifiedName& name, const AtomString& oldValue, const AtomString& newValue, AttributeModificationReason attributeModificationReason)

--- a/Source/WebCore/html/HTMLImageElement.cpp
+++ b/Source/WebCore/html/HTMLImageElement.cpp
@@ -143,33 +143,52 @@ Ref<HTMLImageElement> HTMLImageElement::createForLegacyFactoryFunction(Document&
 
 bool HTMLImageElement::hasPresentationalHintsForAttribute(const QualifiedName& name) const
 {
-    if (name == widthAttr || name == heightAttr || name == borderAttr || name == vspaceAttr || name == hspaceAttr || name == valignAttr)
+    switch (name.nodeName()) {
+    case AttributeNames::widthAttr:
+    case AttributeNames::heightAttr:
+    case AttributeNames::borderAttr:
+    case AttributeNames::vspaceAttr:
+    case AttributeNames::hspaceAttr:
+    case AttributeNames::valignAttr:
         return true;
+    default:
+        break;
+    }
     return HTMLElement::hasPresentationalHintsForAttribute(name);
 }
 
 void HTMLImageElement::collectPresentationalHintsForAttribute(const QualifiedName& name, const AtomString& value, MutableStyleProperties& style)
 {
-    if (name == widthAttr) {
+    switch (name.nodeName()) {
+    case AttributeNames::widthAttr:
         addHTMLMultiLengthToStyle(style, CSSPropertyWidth, value);
         applyAspectRatioFromWidthAndHeightAttributesToStyle(value, attributeWithoutSynchronization(heightAttr), style);
-    } else if (name == heightAttr) {
+        break;
+    case AttributeNames::heightAttr:
         addHTMLMultiLengthToStyle(style, CSSPropertyHeight, value);
         applyAspectRatioFromWidthAndHeightAttributesToStyle(attributeWithoutSynchronization(widthAttr), value, style);
-    } else if (name == borderAttr)
+        break;
+    case AttributeNames::borderAttr:
         applyBorderAttributeToStyle(value, style);
-    else if (name == vspaceAttr) {
+        break;
+    case AttributeNames::vspaceAttr:
         addHTMLLengthToStyle(style, CSSPropertyMarginTop, value);
         addHTMLLengthToStyle(style, CSSPropertyMarginBottom, value);
-    } else if (name == hspaceAttr) {
+        break;
+    case AttributeNames::hspaceAttr:
         addHTMLLengthToStyle(style, CSSPropertyMarginLeft, value);
         addHTMLLengthToStyle(style, CSSPropertyMarginRight, value);
-    } else if (name == alignAttr)
+        break;
+    case AttributeNames::alignAttr:
         applyAlignmentAttributeToStyle(value, style);
-    else if (name == valignAttr)
+        break;
+    case AttributeNames::valignAttr:
         addPropertyToPresentationalHintStyle(style, CSSPropertyVerticalAlign, value);
-    else
+        break;
+    default:
         HTMLElement::collectPresentationalHintsForAttribute(name, value, style);
+        break;
+    }
 }
 
 void HTMLImageElement::collectExtraStyleForPresentationalHints(MutableStyleProperties& style)

--- a/Source/WebCore/html/HTMLMarqueeElement.cpp
+++ b/Source/WebCore/html/HTMLMarqueeElement.cpp
@@ -29,6 +29,7 @@
 #include "ElementInlines.h"
 #include "HTMLNames.h"
 #include "HTMLParserIdioms.h"
+#include "NodeName.h"
 #include "RenderLayer.h"
 #include "RenderLayerScrollableArea.h"
 #include "RenderMarquee.h"
@@ -65,53 +66,79 @@ int HTMLMarqueeElement::minimumDelay() const
 
 bool HTMLMarqueeElement::hasPresentationalHintsForAttribute(const QualifiedName& name) const
 {
-    if (name == widthAttr || name == heightAttr || name == bgcolorAttr || name == vspaceAttr || name == hspaceAttr || name == scrollamountAttr || name == scrolldelayAttr || name == loopAttr || name == behaviorAttr || name == directionAttr)
+    switch (name.nodeName()) {
+    case AttributeNames::widthAttr:
+    case AttributeNames::heightAttr:
+    case AttributeNames::bgcolorAttr:
+    case AttributeNames::vspaceAttr:
+    case AttributeNames::hspaceAttr:
+    case AttributeNames::scrollamountAttr:
+    case AttributeNames::scrolldelayAttr:
+    case AttributeNames::loopAttr:
+    case AttributeNames::behaviorAttr:
+    case AttributeNames::directionAttr:
         return true;
+    default:
+        break;
+    }
     return HTMLElement::hasPresentationalHintsForAttribute(name);
 }
 
 void HTMLMarqueeElement::collectPresentationalHintsForAttribute(const QualifiedName& name, const AtomString& value, MutableStyleProperties& style)
 {
-    if (name == widthAttr) {
+    switch (name.nodeName()) {
+    case AttributeNames::widthAttr:
         if (!value.isEmpty())
             addHTMLLengthToStyle(style, CSSPropertyWidth, value);
-    } else if (name == heightAttr) {
+        break;
+    case AttributeNames::heightAttr:
         if (!value.isEmpty())
             addHTMLLengthToStyle(style, CSSPropertyHeight, value);
-    } else if (name == bgcolorAttr) {
+        break;
+    case AttributeNames::bgcolorAttr:
         if (!value.isEmpty())
             addHTMLColorToStyle(style, CSSPropertyBackgroundColor, value);
-    } else if (name == vspaceAttr) {
+        break;
+    case AttributeNames::vspaceAttr:
         if (!value.isEmpty()) {
             addHTMLLengthToStyle(style, CSSPropertyMarginTop, value);
             addHTMLLengthToStyle(style, CSSPropertyMarginBottom, value);
         }
-    } else if (name == hspaceAttr) {
+        break;
+    case AttributeNames::hspaceAttr:
         if (!value.isEmpty()) {
             addHTMLLengthToStyle(style, CSSPropertyMarginLeft, value);
             addHTMLLengthToStyle(style, CSSPropertyMarginRight, value);
         }
-    } else if (name == scrollamountAttr) {
+        break;
+    case AttributeNames::scrollamountAttr:
         if (!value.isEmpty())
             addHTMLLengthToStyle(style, CSSPropertyWebkitMarqueeIncrement, value);
-    } else if (name == scrolldelayAttr) {
+        break;
+    case AttributeNames::scrolldelayAttr:
         if (!value.isEmpty())
             addHTMLNumberToStyle(style, CSSPropertyWebkitMarqueeSpeed, value);
-    } else if (name == loopAttr) {
+        break;
+    case AttributeNames::loopAttr:
         if (!value.isEmpty()) {
             if (value == "-1"_s || equalLettersIgnoringASCIICase(value, "infinite"_s))
                 addPropertyToPresentationalHintStyle(style, CSSPropertyWebkitMarqueeRepetition, CSSValueInfinite);
             else
                 addHTMLNumberToStyle(style, CSSPropertyWebkitMarqueeRepetition, value);
         }
-    } else if (name == behaviorAttr) {
+        break;
+    case AttributeNames::behaviorAttr:
         if (!value.isEmpty())
             addPropertyToPresentationalHintStyle(style, CSSPropertyWebkitMarqueeStyle, value);
-    } else if (name == directionAttr) {
+        break;
+    case AttributeNames::directionAttr:
         if (!value.isEmpty())
             addPropertyToPresentationalHintStyle(style, CSSPropertyWebkitMarqueeDirection, value);
-    } else
+        break;
+    default:
         HTMLElement::collectPresentationalHintsForAttribute(name, value, style);
+        break;
+    }
 }
 
 void HTMLMarqueeElement::start()

--- a/Source/WebCore/html/HTMLPlugInElement.cpp
+++ b/Source/WebCore/html/HTMLPlugInElement.cpp
@@ -35,6 +35,7 @@
 #include "LocalFrame.h"
 #include "Logging.h"
 #include "MIMETypeRegistry.h"
+#include "NodeName.h"
 #include "Page.h"
 #include "PluginData.h"
 #include "PluginReplacement.h"
@@ -134,27 +135,43 @@ RenderWidget* HTMLPlugInElement::renderWidgetLoadingPlugin() const
 
 bool HTMLPlugInElement::hasPresentationalHintsForAttribute(const QualifiedName& name) const
 {
-    if (name == widthAttr || name == heightAttr || name == vspaceAttr || name == hspaceAttr || name == alignAttr)
+    switch (name.nodeName()) {
+    case AttributeNames::widthAttr:
+    case AttributeNames::heightAttr:
+    case AttributeNames::vspaceAttr:
+    case AttributeNames::hspaceAttr:
+    case AttributeNames::alignAttr:
         return true;
+    default:
+        break;
+    }
     return HTMLFrameOwnerElement::hasPresentationalHintsForAttribute(name);
 }
 
 void HTMLPlugInElement::collectPresentationalHintsForAttribute(const QualifiedName& name, const AtomString& value, MutableStyleProperties& style)
 {
-    if (name == widthAttr)
+    switch (name.nodeName()) {
+    case AttributeNames::widthAttr:
         addHTMLLengthToStyle(style, CSSPropertyWidth, value);
-    else if (name == heightAttr)
+        break;
+    case AttributeNames::heightAttr:
         addHTMLLengthToStyle(style, CSSPropertyHeight, value);
-    else if (name == vspaceAttr) {
+        break;
+    case AttributeNames::vspaceAttr:
         addHTMLLengthToStyle(style, CSSPropertyMarginTop, value);
         addHTMLLengthToStyle(style, CSSPropertyMarginBottom, value);
-    } else if (name == hspaceAttr) {
+        break;
+    case AttributeNames::hspaceAttr:
         addHTMLLengthToStyle(style, CSSPropertyMarginLeft, value);
         addHTMLLengthToStyle(style, CSSPropertyMarginRight, value);
-    } else if (name == alignAttr)
+        break;
+    case AttributeNames::alignAttr:
         applyAlignmentAttributeToStyle(value, style);
-    else
+        break;
+    default:
         HTMLFrameOwnerElement::collectPresentationalHintsForAttribute(name, value, style);
+        break;
+    }
 }
 
 void HTMLPlugInElement::defaultEventHandler(Event& event)

--- a/Source/WebCore/html/HTMLTableCellElement.cpp
+++ b/Source/WebCore/html/HTMLTableCellElement.cpp
@@ -31,6 +31,7 @@
 #include "HTMLNames.h"
 #include "HTMLParserIdioms.h"
 #include "HTMLTableElement.h"
+#include "NodeName.h"
 #include "RenderTableCell.h"
 #include <wtf/IsoMallocInlines.h>
 
@@ -93,23 +94,35 @@ int HTMLTableCellElement::cellIndex() const
 
 bool HTMLTableCellElement::hasPresentationalHintsForAttribute(const QualifiedName& name) const
 {
-    if (name == nowrapAttr || name == widthAttr || name == heightAttr)
+    switch (name.nodeName()) {
+    case AttributeNames::nowrapAttr:
+    case AttributeNames::widthAttr:
+    case AttributeNames::heightAttr:
         return true;
+    default:
+        break;
+    }
     return HTMLTablePartElement::hasPresentationalHintsForAttribute(name);
 }
 
 void HTMLTableCellElement::collectPresentationalHintsForAttribute(const QualifiedName& name, const AtomString& value, MutableStyleProperties& style)
 {
-    if (name == nowrapAttr)
+    switch (name.nodeName()) {
+    case AttributeNames::nowrapAttr:
         addPropertyToPresentationalHintStyle(style, CSSPropertyWhiteSpace, CSSValueNowrap);
-    else if (name == widthAttr) {
+        break;
+    case AttributeNames::widthAttr:
         // width="0" is not allowed for compatibility with WinIE.
         addHTMLLengthToStyle(style, CSSPropertyWidth, value, AllowZeroValue::No);
-    } else if (name == heightAttr) {
+        break;
+    case AttributeNames::heightAttr:
         // width="0" is not allowed for compatibility with WinIE.
         addHTMLLengthToStyle(style, CSSPropertyHeight, value, AllowZeroValue::No);
-    } else
+        break;
+    default:
         HTMLTablePartElement::collectPresentationalHintsForAttribute(name, value, style);
+        break;
+    }
 }
 
 void HTMLTableCellElement::attributeChanged(const QualifiedName& name, const AtomString& oldValue, const AtomString& newValue, AttributeModificationReason attributeModificationReason)

--- a/Source/WebCore/html/HTMLTableElement.cpp
+++ b/Source/WebCore/html/HTMLTableElement.cpp
@@ -307,28 +307,36 @@ static bool getBordersFromFrameAttributeValue(const AtomString& value, bool& bor
 
 void HTMLTableElement::collectPresentationalHintsForAttribute(const QualifiedName& name, const AtomString& value, MutableStyleProperties& style)
 {
-    if (name == widthAttr)
+    switch (name.nodeName()) {
+    case AttributeNames::widthAttr:
         addHTMLLengthToStyle(style, CSSPropertyWidth, value, AllowZeroValue::No);
-    else if (name == heightAttr)
+        break;
+    case AttributeNames::heightAttr:
         addHTMLLengthToStyle(style, CSSPropertyHeight, value);
-    else if (name == borderAttr) 
+        break;
+    case AttributeNames::borderAttr:
         addPropertyToPresentationalHintStyle(style, CSSPropertyBorderWidth, parseBorderWidthAttribute(value), CSSUnitType::CSS_PX);
-    else if (name == bordercolorAttr) {
+        break;
+    case AttributeNames::bordercolorAttr:
         if (!value.isEmpty())
             addHTMLColorToStyle(style, CSSPropertyBorderColor, value);
-    } else if (name == bgcolorAttr)
+        break;
+    case AttributeNames::bgcolorAttr:
         addHTMLColorToStyle(style, CSSPropertyBackgroundColor, value);
-    else if (name == backgroundAttr) {
-        String url = stripLeadingAndTrailingHTMLSpaces(value);
-        if (!url.isEmpty())
+        break;
+    case AttributeNames::backgroundAttr:
+        if (String url = stripLeadingAndTrailingHTMLSpaces(value); !url.isEmpty())
             style.setProperty(CSSProperty(CSSPropertyBackgroundImage, CSSImageValue::create(document().completeURL(url), LoadedFromOpaqueSource::No)));
-    } else if (name == valignAttr) {
+        break;
+    case AttributeNames::valignAttr:
         if (!value.isEmpty())
             addPropertyToPresentationalHintStyle(style, CSSPropertyVerticalAlign, value);
-    } else if (name == cellspacingAttr) {
+        break;
+    case AttributeNames::cellspacingAttr:
         if (!value.isEmpty())
             addHTMLPixelsToStyle(style, CSSPropertyBorderSpacing, value);
-    } else if (name == alignAttr) {
+        break;
+    case AttributeNames::alignAttr:
         if (!value.isEmpty()) {
             if (equalLettersIgnoringASCIICase(value, "center"_s)) {
                 addPropertyToPresentationalHintStyle(style, CSSPropertyMarginInlineStart, CSSValueAuto);
@@ -336,11 +344,13 @@ void HTMLTableElement::collectPresentationalHintsForAttribute(const QualifiedNam
             } else
                 addPropertyToPresentationalHintStyle(style, CSSPropertyFloat, value);
         }
-    } else if (name == rulesAttr) {
+        break;
+    case AttributeNames::rulesAttr:
         // The presence of a valid rules attribute causes border collapsing to be enabled.
         if (m_rulesAttr != UnsetRules)
             addPropertyToPresentationalHintStyle(style, CSSPropertyBorderCollapse, CSSValueCollapse);
-    } else if (name == frameAttr) {
+        break;
+    case AttributeNames::frameAttr: {
         bool borderTop;
         bool borderRight;
         bool borderBottom;
@@ -352,14 +362,33 @@ void HTMLTableElement::collectPresentationalHintsForAttribute(const QualifiedNam
             addPropertyToPresentationalHintStyle(style, CSSPropertyBorderLeftStyle, borderLeft ? CSSValueSolid : CSSValueHidden);
             addPropertyToPresentationalHintStyle(style, CSSPropertyBorderRightStyle, borderRight ? CSSValueSolid : CSSValueHidden);
         }
-    } else
+        break;
+    }
+    default:
         HTMLElement::collectPresentationalHintsForAttribute(name, value, style);
+        break;
+    }
 }
 
 bool HTMLTableElement::hasPresentationalHintsForAttribute(const QualifiedName& name) const
 {
-    if (name == widthAttr || name == heightAttr || name == bgcolorAttr || name == backgroundAttr || name == valignAttr || name == vspaceAttr || name == hspaceAttr || name == cellspacingAttr || name == borderAttr || name == bordercolorAttr || name == frameAttr || name == rulesAttr)
+    switch (name.nodeName()) {
+    case AttributeNames::widthAttr:
+    case AttributeNames::heightAttr:
+    case AttributeNames::bgcolorAttr:
+    case AttributeNames::backgroundAttr:
+    case AttributeNames::valignAttr:
+    case AttributeNames::vspaceAttr:
+    case AttributeNames::hspaceAttr:
+    case AttributeNames::cellspacingAttr:
+    case AttributeNames::borderAttr:
+    case AttributeNames::bordercolorAttr:
+    case AttributeNames::frameAttr:
+    case AttributeNames::rulesAttr:
         return true;
+    default:
+        break;
+    }
     return HTMLElement::hasPresentationalHintsForAttribute(name);
 }
 

--- a/Source/WebCore/html/HTMLTablePartElement.cpp
+++ b/Source/WebCore/html/HTMLTablePartElement.cpp
@@ -34,6 +34,7 @@
 #include "HTMLParserIdioms.h"
 #include "HTMLTableElement.h"
 #include "MutableStyleProperties.h"
+#include "NodeName.h"
 #include "StyleProperties.h"
 #include <wtf/IsoMallocInlines.h>
 
@@ -45,20 +46,29 @@ using namespace HTMLNames;
 
 bool HTMLTablePartElement::hasPresentationalHintsForAttribute(const QualifiedName& name) const
 {
-    if (name == bgcolorAttr || name == backgroundAttr || name == valignAttr || name == heightAttr)
+    switch (name.nodeName()) {
+    case AttributeNames::bgcolorAttr:
+    case AttributeNames::backgroundAttr:
+    case AttributeNames::valignAttr:
+    case AttributeNames::heightAttr:
         return true;
+    default:
+        break;
+    }
     return HTMLElement::hasPresentationalHintsForAttribute(name);
 }
 
 void HTMLTablePartElement::collectPresentationalHintsForAttribute(const QualifiedName& name, const AtomString& value, MutableStyleProperties& style)
 {
-    if (name == bgcolorAttr)
+    switch (name.nodeName()) {
+    case AttributeNames::bgcolorAttr:
         addHTMLColorToStyle(style, CSSPropertyBackgroundColor, value);
-    else if (name == backgroundAttr) {
-        String url = stripLeadingAndTrailingHTMLSpaces(value);
-        if (!url.isEmpty())
+        break;
+    case AttributeNames::backgroundAttr:
+        if (String url = stripLeadingAndTrailingHTMLSpaces(value); !url.isEmpty())
             style.setProperty(CSSProperty(CSSPropertyBackgroundImage, CSSImageValue::create(document().completeURL(url), LoadedFromOpaqueSource::No)));
-    } else if (name == valignAttr) {
+        break;
+    case AttributeNames::valignAttr:
         if (equalLettersIgnoringASCIICase(value, "top"_s))
             addPropertyToPresentationalHintStyle(style, CSSPropertyVerticalAlign, CSSValueTop);
         else if (equalLettersIgnoringASCIICase(value, "middle"_s))
@@ -69,7 +79,8 @@ void HTMLTablePartElement::collectPresentationalHintsForAttribute(const Qualifie
             addPropertyToPresentationalHintStyle(style, CSSPropertyVerticalAlign, CSSValueBaseline);
         else
             addPropertyToPresentationalHintStyle(style, CSSPropertyVerticalAlign, value);
-    } else if (name == alignAttr) {
+        break;
+    case AttributeNames::alignAttr:
         if (equalLettersIgnoringASCIICase(value, "middle"_s) || equalLettersIgnoringASCIICase(value, "center"_s))
             addPropertyToPresentationalHintStyle(style, CSSPropertyTextAlign, CSSValueWebkitCenter);
         else if (equalLettersIgnoringASCIICase(value, "absmiddle"_s))
@@ -80,11 +91,15 @@ void HTMLTablePartElement::collectPresentationalHintsForAttribute(const Qualifie
             addPropertyToPresentationalHintStyle(style, CSSPropertyTextAlign, CSSValueWebkitRight);
         else
             addPropertyToPresentationalHintStyle(style, CSSPropertyTextAlign, value);
-    } else if (name == heightAttr) {
+        break;
+    case AttributeNames::heightAttr:
         if (!value.isEmpty())
             addHTMLLengthToStyle(style, CSSPropertyHeight, value);
-    } else
+        break;
+    default:
         HTMLElement::collectPresentationalHintsForAttribute(name, value, style);
+        break;
+    }
 }
 
 RefPtr<const HTMLTableElement> HTMLTablePartElement::findParentTable() const

--- a/Source/WebCore/mathml/MathMLElement.cpp
+++ b/Source/WebCore/mathml/MathMLElement.cpp
@@ -112,8 +112,22 @@ void MathMLElement::attributeChanged(const QualifiedName& name, const AtomString
 
 bool MathMLElement::hasPresentationalHintsForAttribute(const QualifiedName& name) const
 {
-    if (name == backgroundAttr || name == colorAttr || name == dirAttr || name == fontfamilyAttr || name == fontsizeAttr || name == fontstyleAttr || name == fontweightAttr || name == mathbackgroundAttr || name == mathcolorAttr || name == mathsizeAttr || name == displaystyleAttr)
+    switch (name.nodeName()) {
+    case AttributeNames::backgroundAttr:
+    case AttributeNames::colorAttr:
+    case AttributeNames::dirAttr:
+    case AttributeNames::fontfamilyAttr:
+    case AttributeNames::fontsizeAttr:
+    case AttributeNames::fontstyleAttr:
+    case AttributeNames::fontweightAttr:
+    case AttributeNames::mathbackgroundAttr:
+    case AttributeNames::mathcolorAttr:
+    case AttributeNames::mathsizeAttr:
+    case AttributeNames::displaystyleAttr:
         return true;
+    default:
+        break;
+    }
     return StyledElement::hasPresentationalHintsForAttribute(name);
 }
 
@@ -155,45 +169,62 @@ static String convertMathSizeIfNeeded(const AtomString& value)
 
 void MathMLElement::collectPresentationalHintsForAttribute(const QualifiedName& name, const AtomString& value, MutableStyleProperties& style)
 {
-    if (name == mathbackgroundAttr)
+    switch (name.nodeName()) {
+    case AttributeNames::mathbackgroundAttr:
         addPropertyToPresentationalHintStyle(style, CSSPropertyBackgroundColor, value);
-    else if (name == mathsizeAttr) {
+        return;
+    case AttributeNames::mathsizeAttr:
         if (document().settings().coreMathMLEnabled()) {
             if (!isDisallowedMathSizeAttribute(value))
                 addPropertyToPresentationalHintStyle(style, CSSPropertyFontSize, value);
         } else
             addPropertyToPresentationalHintStyle(style, CSSPropertyFontSize, convertMathSizeIfNeeded(value));
-    } else if (name == mathcolorAttr)
+        return;
+    case AttributeNames::mathcolorAttr:
         addPropertyToPresentationalHintStyle(style, CSSPropertyColor, value);
-    else if (name == dirAttr)
+        return;
+    case AttributeNames::dirAttr:
         addPropertyToPresentationalHintStyle(style, CSSPropertyDirection, value);
-    else if (name == displaystyleAttr) {
+        return;
+    case AttributeNames::displaystyleAttr:
         if (equalLettersIgnoringASCIICase(value, "false"_s))
             addPropertyToPresentationalHintStyle(style, CSSPropertyMathStyle, CSSValueCompact);
         else if (equalLettersIgnoringASCIICase(value, "true"_s))
             addPropertyToPresentationalHintStyle(style, CSSPropertyMathStyle, CSSValueNormal);
-    } else {
-        if (document().settings().coreMathMLEnabled()) {
-            StyledElement::collectPresentationalHintsForAttribute(name, value, style);
-            return;
-        }
-        // FIXME: The following are deprecated attributes that should lose if there is a conflict with a non-deprecated attribute.
-        if (name == fontsizeAttr)
-            addPropertyToPresentationalHintStyle(style, CSSPropertyFontSize, value);
-        else if (name == backgroundAttr)
-            addPropertyToPresentationalHintStyle(style, CSSPropertyBackgroundColor, value);
-        else if (name == colorAttr)
-            addPropertyToPresentationalHintStyle(style, CSSPropertyColor, value);
-        else if (name == fontstyleAttr)
-            addPropertyToPresentationalHintStyle(style, CSSPropertyFontStyle, value);
-        else if (name == fontweightAttr)
-            addPropertyToPresentationalHintStyle(style, CSSPropertyFontWeight, value);
-        else if (name == fontfamilyAttr)
-            addPropertyToPresentationalHintStyle(style, CSSPropertyFontFamily, value);
-        else {
-            ASSERT(!hasPresentationalHintsForAttribute(name));
-            StyledElement::collectPresentationalHintsForAttribute(name, value, style);
-        }
+        return;
+    default:
+        break;
+    }
+
+    if (document().settings().coreMathMLEnabled()) {
+        StyledElement::collectPresentationalHintsForAttribute(name, value, style);
+        return;
+    }
+
+    // FIXME: The following are deprecated attributes that should lose if there is a conflict with a non-deprecated attribute.
+    switch (name.nodeName()) {
+    case AttributeNames::fontsizeAttr:
+        addPropertyToPresentationalHintStyle(style, CSSPropertyFontSize, value);
+        break;
+    case AttributeNames::backgroundAttr:
+        addPropertyToPresentationalHintStyle(style, CSSPropertyBackgroundColor, value);
+        break;
+    case AttributeNames::colorAttr:
+        addPropertyToPresentationalHintStyle(style, CSSPropertyColor, value);
+        break;
+    case AttributeNames::fontstyleAttr:
+        addPropertyToPresentationalHintStyle(style, CSSPropertyFontStyle, value);
+        break;
+    case AttributeNames::fontweightAttr:
+        addPropertyToPresentationalHintStyle(style, CSSPropertyFontWeight, value);
+        break;
+    case AttributeNames::fontfamilyAttr:
+        addPropertyToPresentationalHintStyle(style, CSSPropertyFontFamily, value);
+        break;
+    default:
+        ASSERT(!hasPresentationalHintsForAttribute(name));
+        StyledElement::collectPresentationalHintsForAttribute(name, value, style);
+        break;
     }
 }
 


### PR DESCRIPTION
#### 6785bbb80e0194cf9b04a569e17fbc54a70f5b57
<pre>
Adopt new NodeName enumeration in hasPresentationalHintsForAttribute() &amp; collectPresentationalHintsForAttribute()
<a href="https://bugs.webkit.org/show_bug.cgi?id=255490">https://bugs.webkit.org/show_bug.cgi?id=255490</a>

Reviewed by Darin Adler.

* Source/WebCore/html/HTMLFontElement.cpp:
(WebCore::HTMLFontElement::hasPresentationalHintsForAttribute const):
(WebCore::HTMLFontElement::collectPresentationalHintsForAttribute):
* Source/WebCore/html/HTMLHRElement.cpp:
(WebCore::HTMLHRElement::hasPresentationalHintsForAttribute const):
(WebCore::HTMLHRElement::collectPresentationalHintsForAttribute):
* Source/WebCore/html/HTMLIFrameElement.cpp:
(WebCore::HTMLIFrameElement::hasPresentationalHintsForAttribute const):
(WebCore::HTMLIFrameElement::collectPresentationalHintsForAttribute):
* Source/WebCore/html/HTMLImageElement.cpp:
(WebCore::HTMLImageElement::hasPresentationalHintsForAttribute const):
(WebCore::HTMLImageElement::collectPresentationalHintsForAttribute):
* Source/WebCore/html/HTMLMarqueeElement.cpp:
(WebCore::HTMLMarqueeElement::hasPresentationalHintsForAttribute const):
(WebCore::HTMLMarqueeElement::collectPresentationalHintsForAttribute):
* Source/WebCore/html/HTMLPlugInElement.cpp:
(WebCore::HTMLPlugInElement::hasPresentationalHintsForAttribute const):
(WebCore::HTMLPlugInElement::collectPresentationalHintsForAttribute):
* Source/WebCore/html/HTMLTableCellElement.cpp:
(WebCore::HTMLTableCellElement::hasPresentationalHintsForAttribute const):
(WebCore::HTMLTableCellElement::collectPresentationalHintsForAttribute):
* Source/WebCore/html/HTMLTableElement.cpp:
(WebCore::HTMLTableElement::collectPresentationalHintsForAttribute):
(WebCore::HTMLTableElement::hasPresentationalHintsForAttribute const):
* Source/WebCore/html/HTMLTablePartElement.cpp:
(WebCore::HTMLTablePartElement::hasPresentationalHintsForAttribute const):
(WebCore::HTMLTablePartElement::collectPresentationalHintsForAttribute):
* Source/WebCore/mathml/MathMLElement.cpp:
(WebCore::MathMLElement::hasPresentationalHintsForAttribute const):
(WebCore::MathMLElement::collectPresentationalHintsForAttribute):

Canonical link: <a href="https://commits.webkit.org/263010@main">https://commits.webkit.org/263010@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c1303c2393947f9db6ef51c6884ed21736b88090

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/3307 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/3366 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/3482 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/4724 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/3638 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/3284 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/3429 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/3389 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/2872 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/3347 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/15/builds/3635 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/2982 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/4546 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/1138 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/2947 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/2863 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/2920 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/3001 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/4282 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/3380 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/2703 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/2942 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/2948 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/807 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/2944 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/3217 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->