### PR TITLE
Scroll snap sometimes jumps back to the wrong place on stevejobsarchive.com

### DIFF
--- a/LayoutTests/css3/scroll-snap/resnap-after-layout-expected.txt
+++ b/LayoutTests/css3/scroll-snap/resnap-after-layout-expected.txt
@@ -1,0 +1,6 @@
+layout trigger
+PASS window.scrollY is 1200
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/css3/scroll-snap/resnap-after-layout.html
+++ b/LayoutTests/css3/scroll-snap/resnap-after-layout.html
@@ -1,0 +1,90 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <style>
+        :root {
+            scroll-snap-type: block mandatory;
+            font-size: 24pt;
+        }
+        
+        * {
+            box-sizing: border-box;
+        }
+        
+        html, body {
+            width: 100%;
+            height: 100%;
+        }
+
+        body {
+            margin: 0;
+            background-image: repeating-linear-gradient(transparent, silver 400px);
+        }
+        
+        .target {
+            scroll-snap-align: start;
+            border: 1px solid black;
+        }
+        
+        body > div {
+            padding: 100px;
+            text-align: center;
+            color: white;
+            width: 80%;
+            height: 100%;
+        }
+        
+        .multiple > div {
+            height: 100%;
+            width: 50%;
+            float: left;
+        }
+        
+        body.changed .layout-trigger {
+            height: 20px;
+        }
+    </style>
+    <script src="../../resources/js-test-pre.js"></script>
+    <script src="../../resources/ui-helper.js"></script>
+    <script>
+        jsTestIsAsync = true;
+
+        async function startTest()
+        {
+            // Scroll to first "multiple" snap point at 700.
+            await UIHelper.mouseWheelScrollAt(100, 100, 0, -10, 0, -40);
+            forceLayout();
+
+            // Scroll to second "single" snap point at 1200.
+            await UIHelper.mouseWheelScrollAt(100, 100, 0, -10, 0, -40);
+            forceLayout();
+
+            await UIHelper.renderingUpdate();
+            shouldBe('window.scrollY', '1200');
+            
+            finishJSTest();
+        }
+        
+        function forceLayout()
+        {
+            document.body.classList.toggle('changed');
+            document.body.offsetHeight;
+        }
+        
+        window.addEventListener('load', () => {
+            setTimeout(startTest, 0);
+        }, false);
+    </script>
+</head>
+<body>
+    <div class="target" style='background-color: red'></div>
+    <div class="multiple" style='background-color: orange'>
+        <div class="target" style='background-color: yellow'></div>
+        <div class="target" style='background-color: fuchsia'></div>
+    </div>
+    <div class="target" style='background-color: green'></div>
+    <div class="layout-trigger">layout trigger</div>
+    <div id="console"></div>
+    <script src="../../resources/js-test-post.js"></script>
+</body>
+</html>

--- a/LayoutTests/platform/gtk/TestExpectations
+++ b/LayoutTests/platform/gtk/TestExpectations
@@ -1781,6 +1781,7 @@ Bug(GTK) fast/events/wheel/platform-wheelevent-paging-y-in-non-scrolling-div.htm
 Bug(GTK) fast/events/wheel/platform-wheelevent-paging-y-in-non-scrolling-page.html [ Failure ]
 Bug(GTK) fast/events/wheel/platform-wheelevent-paging-y-in-scrolling-div.html [ Failure ]
 Bug(GTK) fast/events/wheel/platform-wheelevent-paging-y-in-scrolling-page.html [ Failure ]
+css3/scroll-snap/resnap-after-layout.html [ Skip ]
 
 # Need to add functionality to DumpRenderTree to handle scrollbar policy changes
 Bug(GTK) fast/overflow/scrollbar-restored-and-then-locked.html [ Failure ]

--- a/LayoutTests/platform/ios-wk2/TestExpectations
+++ b/LayoutTests/platform/ios-wk2/TestExpectations
@@ -967,6 +967,7 @@ editing/selection/select-out-of-floated-non-editable-12.html [ Skip ]
 css3/scroll-snap/scroll-snap-click-scrollbar-gutter.html [ Skip ]
 css3/scroll-snap/scroll-snap-wheel-event.html [ Skip ]
 css3/scroll-snap/scroll-snap-discrete-wheel-event-in-mainframe.html [ Skip ]
+css3/scroll-snap/resnap-after-layout.html [ Skip ]
 
 webkit.org/b/192088 media/no-fullscreen-when-hidden.html [ Failure Pass ]
 

--- a/LayoutTests/platform/wpe/TestExpectations
+++ b/LayoutTests/platform/wpe/TestExpectations
@@ -617,6 +617,7 @@ fast/events/ondrop-text-html.html
 # WTR needs an implementation for eventSender.continuousMouseScrollBy
 # https://bugs.webkit.org/show_bug.cgi?id=69417
 fast/events/wheel/wheelevent-direction-inverted-from-device.html
+css3/scroll-snap/resnap-after-layout.html [ Skip ]
 
 # These are failures that will be enabled once the relevant parts of implementation land.
 webkit.org/b/133122 crypto/workers/subtle/aes-indexeddb.html [ Skip ]

--- a/Source/WebCore/platform/ScrollSnapAnimatorState.cpp
+++ b/Source/WebCore/platform/ScrollSnapAnimatorState.cpp
@@ -141,21 +141,37 @@ HashSet<ElementIdentifier> ScrollSnapAnimatorState::currentlySnappedBoxes(const 
     return snappedBoxIDs;
 }
 
-ElementIdentifier ScrollSnapAnimatorState::chooseBoxToResnapTo(const Vector<SnapOffset<LayoutUnit>>& horizontalOffsets, const Vector<SnapOffset<LayoutUnit>>& verticalOffsets) const
+void ScrollSnapAnimatorState::setActiveSnapIndexForAxis(ScrollEventAxis axis, std::optional<unsigned> index)
 {
-    auto found = std::find_if(horizontalOffsets.begin(), horizontalOffsets.end(), [this](SnapOffset<LayoutUnit> p) -> bool {
-        return m_currentlySnappedBoxes.contains(p.snapTargetID) && p.isFocused;
+    setActiveSnapIndexForAxisInternal(axis, index);
+    updateCurrentlySnappedBoxes();
+}
+
+void ScrollSnapAnimatorState::updateCurrentlySnappedBoxes()
+{
+    auto horizontalOffsets = currentlySnappedOffsetsForAxis(ScrollEventAxis::Horizontal);
+    auto verticalOffsets = currentlySnappedOffsetsForAxis(ScrollEventAxis::Vertical);
+
+    m_currentlySnappedBoxes = currentlySnappedBoxes(horizontalOffsets, verticalOffsets);
+}
+
+static ElementIdentifier chooseBoxToResnapTo(const HashSet<ElementIdentifier>& snappedBoxes, const Vector<SnapOffset<LayoutUnit>>& horizontalOffsets, const Vector<SnapOffset<LayoutUnit>>& verticalOffsets)
+{
+    ASSERT(snappedBoxes.size());
+
+    auto found = std::find_if(horizontalOffsets.begin(), horizontalOffsets.end(), [&snappedBoxes](SnapOffset<LayoutUnit> p) -> bool {
+        return snappedBoxes.contains(p.snapTargetID) && p.isFocused;
     });
     if (found != horizontalOffsets.end())
         return found->snapTargetID;
     
-    found = std::find_if(verticalOffsets.begin(), verticalOffsets.end(), [this](SnapOffset<LayoutUnit> p) -> bool {
-        return m_currentlySnappedBoxes.contains(p.snapTargetID) && p.isFocused;
+    found = std::find_if(verticalOffsets.begin(), verticalOffsets.end(), [&snappedBoxes](SnapOffset<LayoutUnit> p) -> bool {
+        return snappedBoxes.contains(p.snapTargetID) && p.isFocused;
     });
     if (found != verticalOffsets.end())
         return found->snapTargetID;
     
-    return *m_currentlySnappedBoxes.begin();
+    return *snappedBoxes.begin();
 }
 
 bool ScrollSnapAnimatorState::resnapAfterLayout(ScrollOffset scrollOffset, const ScrollExtents& scrollExtents, float pageScale)
@@ -166,56 +182,54 @@ bool ScrollSnapAnimatorState::resnapAfterLayout(ScrollOffset scrollOffset, const
     auto snapOffsetsVertical = snapOffsetsForAxis(ScrollEventAxis::Vertical);
     auto snapOffsetsHorizontal = snapOffsetsForAxis(ScrollEventAxis::Horizontal);
     
+    auto previouslySnappedBoxes = std::exchange(m_currentlySnappedBoxes, { });
+    
     // Check if we need to set the current indices
     if (!activeVerticalIndex || *activeVerticalIndex >= snapOffsetsForAxis(ScrollEventAxis::Vertical).size()) {
-        snapPointChanged |= setNearestScrollSnapIndexForAxisAndOffset(ScrollEventAxis::Vertical, scrollOffset, scrollExtents, pageScale);
+        snapPointChanged |= setNearestScrollSnapIndexForAxisAndOffsetInternal(ScrollEventAxis::Vertical, scrollOffset, scrollExtents, pageScale);
         activeVerticalIndex = activeSnapIndexForAxis(ScrollEventAxis::Vertical);
     }
     if (!activeHorizontalIndex || *activeHorizontalIndex >= snapOffsetsForAxis(ScrollEventAxis::Horizontal).size()) {
-        snapPointChanged |= setNearestScrollSnapIndexForAxisAndOffset(ScrollEventAxis::Horizontal, scrollOffset, scrollExtents, pageScale);
+        snapPointChanged |= setNearestScrollSnapIndexForAxisAndOffsetInternal(ScrollEventAxis::Horizontal, scrollOffset, scrollExtents, pageScale);
         activeHorizontalIndex = activeSnapIndexForAxis(ScrollEventAxis::Horizontal);
     }
-    
-    auto horizontalOffsets = currentlySnappedOffsetsForAxis(ScrollEventAxis::Horizontal);
-    auto verticalOffsets = currentlySnappedOffsetsForAxis(ScrollEventAxis::Vertical);
 
-    auto currentlySnapped = currentlySnappedBoxes(horizontalOffsets, verticalOffsets);
-    
-    auto wasSnappedToMultipleBoxes = m_currentlySnappedBoxes.size() > 1;
-    auto currentlySnappedToMultipleBoxes = currentlySnapped.size() > 1;
+    updateCurrentlySnappedBoxes();
+    LOG_WITH_STREAM(ScrollSnap, stream << "ScrollSnapAnimatorState::resnapAfterLayout() - previouslySnappedBoxes " << previouslySnappedBoxes << " m_currentlySnappedBoxes " << m_currentlySnappedBoxes);
+
+    auto wasSnappedToMultipleBoxes = previouslySnappedBoxes.size() > 1;
+    auto currentlySnappedToMultipleBoxes = m_currentlySnappedBoxes.size() > 1;
     
     if (wasSnappedToMultipleBoxes && !currentlySnappedToMultipleBoxes) {
-        // Pick offset to snap to
-        auto box = chooseBoxToResnapTo(snapOffsetsHorizontal, snapOffsetsVertical);
+        auto box = chooseBoxToResnapTo(previouslySnappedBoxes, snapOffsetsHorizontal, snapOffsetsVertical);
         snapPointChanged |= preserveCurrentTargetForAxis(ScrollEventAxis::Horizontal, box);
         snapPointChanged |= preserveCurrentTargetForAxis(ScrollEventAxis::Vertical, box);
-        horizontalOffsets = currentlySnappedOffsetsForAxis(ScrollEventAxis::Horizontal);
-        verticalOffsets = currentlySnappedOffsetsForAxis(ScrollEventAxis::Vertical);
-        currentlySnapped = currentlySnappedBoxes(horizontalOffsets, verticalOffsets);
-        currentlySnappedToMultipleBoxes = currentlySnapped.size() > 1;
-        LOG_WITH_STREAM(ScrollSnap, stream << "ScrollSnapAnimatorState::resnapAfterLayout() current target: " << box << " snapPointChanged: " << snapPointChanged);
+
+        updateCurrentlySnappedBoxes();
+        LOG_WITH_STREAM(ScrollSnap, stream << "ScrollSnapAnimatorState::resnapAfterLayout() - multiple boxes snapped; chose " << box << " (changed " << snapPointChanged << ") m_currentlySnappedBoxes " << m_currentlySnappedBoxes);
     }
-    if (wasSnappedToMultipleBoxes != currentlySnappedToMultipleBoxes)
-        m_currentlySnappedBoxes = currentlySnapped;
 
     return snapPointChanged;
 }
 
-bool ScrollSnapAnimatorState::setNearestScrollSnapIndexForAxisAndOffset(ScrollEventAxis axis, ScrollOffset scrollOffset, const ScrollExtents& scrollExtents, float pageScale)
+bool ScrollSnapAnimatorState::setNearestScrollSnapIndexForAxisAndOffsetInternal(ScrollEventAxis axis, ScrollOffset scrollOffset, const ScrollExtents& scrollExtents, float pageScale)
 {
     auto activeIndex = closestSnapPointForOffset(axis, scrollOffset, scrollExtents, pageScale);
     if (activeIndex == activeSnapIndexForAxis(axis))
         return false;
 
-    setActiveSnapIndexForAxis(axis, activeIndex);
+    setActiveSnapIndexForAxisInternal(axis, activeIndex);
     return true;
 }
 
 bool ScrollSnapAnimatorState::setNearestScrollSnapIndexForOffset(ScrollOffset scrollOffset, const ScrollExtents& scrollExtents, float pageScale)
 {
     bool snapIndexChanged = false;
-    snapIndexChanged |= setNearestScrollSnapIndexForAxisAndOffset(ScrollEventAxis::Horizontal, scrollOffset, scrollExtents, pageScale);
-    snapIndexChanged |= setNearestScrollSnapIndexForAxisAndOffset(ScrollEventAxis::Vertical, scrollOffset, scrollExtents, pageScale);
+    snapIndexChanged |= setNearestScrollSnapIndexForAxisAndOffsetInternal(ScrollEventAxis::Horizontal, scrollOffset, scrollExtents, pageScale);
+    snapIndexChanged |= setNearestScrollSnapIndexForAxisAndOffsetInternal(ScrollEventAxis::Vertical, scrollOffset, scrollExtents, pageScale);
+
+    updateCurrentlySnappedBoxes();
+
     return snapIndexChanged;
 }
 

--- a/Source/WebCore/platform/ScrollSnapAnimatorState.h
+++ b/Source/WebCore/platform/ScrollSnapAnimatorState.h
@@ -74,20 +74,13 @@ public:
         return axis == ScrollEventAxis::Horizontal ? m_activeSnapIndexX : m_activeSnapIndexY;
     }
     
-    void setActiveSnapIndexForAxis(ScrollEventAxis axis, std::optional<unsigned> index)
-    {
-        if (axis == ScrollEventAxis::Horizontal)
-            m_activeSnapIndexX = index;
-        else
-            m_activeSnapIndexY = index;
-    }
+    void setActiveSnapIndexForAxis(ScrollEventAxis, std::optional<unsigned>);
 
     std::optional<unsigned> closestSnapPointForOffset(ScrollEventAxis, ScrollOffset, const ScrollExtents&, float pageScale) const;
     float adjustedScrollDestination(ScrollEventAxis, FloatPoint destinationOffset, float velocity, std::optional<float> originalOffset, const ScrollExtents&, float pageScale) const;
 
     // returns true if an active snap index changed.
     bool resnapAfterLayout(ScrollOffset, const ScrollExtents&, float pageScale);
-    bool setNearestScrollSnapIndexForAxisAndOffset(ScrollEventAxis, ScrollOffset, const ScrollExtents&, float pageScale);
 
     bool setNearestScrollSnapIndexForOffset(ScrollOffset, const ScrollExtents&, float pageScale);
 
@@ -98,14 +91,27 @@ public:
 
     void transitionToUserInteractionState();
     void transitionToDestinationReachedState();
-    bool preserveCurrentTargetForAxis(ScrollEventAxis, ElementIdentifier);
-    Vector<SnapOffset<LayoutUnit>> currentlySnappedOffsetsForAxis(ScrollEventAxis) const;
-    ElementIdentifier chooseBoxToResnapTo(const Vector<SnapOffset<LayoutUnit>>&, const Vector<SnapOffset<LayoutUnit>>&) const;
-    HashSet<ElementIdentifier> currentlySnappedBoxes(const Vector<SnapOffset<LayoutUnit>>&, const Vector<SnapOffset<LayoutUnit>>&) const;
+
 private:
     std::pair<float, std::optional<unsigned>> targetOffsetForStartOffset(ScrollEventAxis, const ScrollExtents&, float startOffset, FloatPoint predictedOffset, float pageScale, float initialDelta) const;
     bool setupAnimationForState(ScrollSnapState, const ScrollExtents&, float pageScale, const FloatPoint& initialOffset, const FloatSize& initialVelocity, const FloatSize& initialDelta);
     void teardownAnimationForState(ScrollSnapState);
+
+    bool preserveCurrentTargetForAxis(ScrollEventAxis, ElementIdentifier);
+
+    Vector<SnapOffset<LayoutUnit>> currentlySnappedOffsetsForAxis(ScrollEventAxis) const;
+    HashSet<ElementIdentifier> currentlySnappedBoxes(const Vector<SnapOffset<LayoutUnit>>& horizontalOffsets, const Vector<SnapOffset<LayoutUnit>>& verticalOffsets) const;
+
+    bool setNearestScrollSnapIndexForAxisAndOffsetInternal(ScrollEventAxis, ScrollOffset, const ScrollExtents&, float pageScale);
+    void updateCurrentlySnappedBoxes();
+
+    void setActiveSnapIndexForAxisInternal(ScrollEventAxis axis, std::optional<unsigned> index)
+    {
+        if (axis == ScrollEventAxis::Horizontal)
+            m_activeSnapIndexX = index;
+        else
+            m_activeSnapIndexY = index;
+    }
 
     ScrollingEffectsController& m_scrollController;
 

--- a/Source/WebCore/platform/ScrollableArea.cpp
+++ b/Source/WebCore/platform/ScrollableArea.cpp
@@ -542,7 +542,7 @@ void ScrollableArea::setCurrentVerticalSnapPointIndex(std::optional<unsigned> in
 
 void ScrollableArea::resnapAfterLayout()
 {
-    LOG_WITH_STREAM(ScrollSnap, stream << *this << " updateScrollSnapState: isScrollSnapInProgress " << isScrollSnapInProgress() << " isUserScrollInProgress " << isUserScrollInProgress());
+    LOG_WITH_STREAM(ScrollSnap, stream << *this << " resnapAfterLayout: isScrollSnapInProgress " << isScrollSnapInProgress() << " isUserScrollInProgress " << isUserScrollInProgress());
 
     auto* scrollAnimator = existingScrollAnimator();
     if (!scrollAnimator || isScrollSnapInProgress() || isUserScrollInProgress())
@@ -572,6 +572,7 @@ void ScrollableArea::resnapAfterLayout()
     }
 
     if (correctedOffset != currentOffset) {
+        LOG_WITH_STREAM(ScrollSnap, stream << "ScrollableArea::resnapAfterLayout - adjusting scroll position from " << currentOffset << " to " << correctedOffset << " for snap point at index " << currentVerticalSnapPointIndex());
         auto position = scrollPositionFromOffset(correctedOffset);
         if (scrollAnimationStatus() == ScrollAnimationStatus::NotAnimating)
             scrollToOffsetWithoutAnimation(correctedOffset);
@@ -595,6 +596,8 @@ void ScrollableArea::doPostThumbMoveSnapping(ScrollbarOrientation orientation)
 
     if (newOffset == currentOffset)
         return;
+
+    LOG_WITH_STREAM(ScrollSnap, stream << "ScrollableArea::doPostThumbMoveSnapping - adjusting scroll position from " << currentOffset << " to " << newOffset);
 
     auto position = scrollPositionFromOffset(newOffset);
     scrollAnimator->scrollToPositionWithAnimation(position);


### PR DESCRIPTION
#### ee03689988d70b4813d7e3db8cea577682156027
<pre>
Scroll snap sometimes jumps back to the wrong place on stevejobsarchive.com
<a href="https://bugs.webkit.org/show_bug.cgi?id=255492">https://bugs.webkit.org/show_bug.cgi?id=255492</a>
rdar://107885376

Reviewed by Wenson Hsieh.

259696@main added some logic that attempts to re-snap after layout when multiple boxes were snapped,
adding a `m_currentlySnappedBoxes` member to `ScrollSnapAnimatorState`.

However, `m_currentlySnappedBoxes` was only updated in the `resnapAfterLayout` code path, not when
scrolling moved you to a new snap point. That resulted in `resnapAfterLayout` sometimes returning
you to a stale location if you&apos;d scrolled to a new snap point since the last time
`resnapAfterLayout` was run, especially when hitting the &quot;multiple boxes were snapped&quot; clause.

It&apos;s troublesome to have both `m_currentlySnappedBoxes` and a `snapTargetID` in each SnapOffset (a
future patch will clean this up). But for now, ensure that `m_currentlySnappedBoxes` is updated on
each scroll-related snap as well as resnapping after layout.

* LayoutTests/css3/scroll-snap/resnap-after-layout-expected.txt: Added.
* LayoutTests/css3/scroll-snap/resnap-after-layout.html: Added.
* LayoutTests/platform/gtk/TestExpectations:
* LayoutTests/platform/ios-wk2/TestExpectations:
* LayoutTests/platform/wpe/TestExpectations:
* Source/WebCore/platform/ScrollSnapAnimatorState.cpp:
(WebCore::ScrollSnapAnimatorState::setActiveSnapIndexForAxis):
(WebCore::ScrollSnapAnimatorState::updateCurrentlySnappedBoxes):
(WebCore::chooseBoxToResnapTo):
(WebCore::ScrollSnapAnimatorState::resnapAfterLayout):
(WebCore::ScrollSnapAnimatorState::setNearestScrollSnapIndexForAxisAndOffsetInternal):
(WebCore::ScrollSnapAnimatorState::setNearestScrollSnapIndexForOffset):
(WebCore::ScrollSnapAnimatorState::chooseBoxToResnapTo const): Deleted.
(WebCore::ScrollSnapAnimatorState::setNearestScrollSnapIndexForAxisAndOffset): Deleted.
* Source/WebCore/platform/ScrollSnapAnimatorState.h: Some functions can be private.
(WebCore::ScrollSnapAnimatorState::setActiveSnapIndexForAxisInternal): The &quot;internal&quot; implies that it doesn&apos;t update m_currentlySnappedBoxes.
(WebCore::ScrollSnapAnimatorState::setActiveSnapIndexForAxis): Deleted.
* Source/WebCore/platform/ScrollableArea.cpp:
(WebCore::ScrollableArea::resnapAfterLayout): Improved logging.
(WebCore::ScrollableArea::doPostThumbMoveSnapping): Improved logging.

Canonical link: <a href="https://commits.webkit.org/263097@main">https://commits.webkit.org/263097@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/37ff9af9f70f4f60bc010c9a9a9f5d2f876671b5

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [  ~~🧪 style~~](https://ews-build.webkit.org/#/builders/38/builds/3629 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 ios~~](https://ews-build.webkit.org/#/builders/26/builds/3670 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/3819 "Built successfully") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/5055 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/32/builds/3919 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [  ~~🧪 bindings~~](https://ews-build.webkit.org/#/builders/9/builds/3603 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/3770 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/3718 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/5055 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [  ~~🧪 webkitperl~~](https://ews-build.webkit.org/#/builders/11/builds/3673 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/15/builds/3908 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/3272 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/2/builds/4878 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/39/builds/1414 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/10/builds/3243 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/3304 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/3217 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/3302 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/4646 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/7/builds/3682 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/2979 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/30/builds/3216 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/3243 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/4/builds/3248 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/413 "Built successfully and passed tests") | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/31/builds/3495 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->