### PR TITLE
Adopt new NodeName enumeration more broadly in SVG code

### DIFF
--- a/Source/WebCore/svg/SVGFEColorMatrixElement.cpp
+++ b/Source/WebCore/svg/SVGFEColorMatrixElement.cpp
@@ -96,22 +96,25 @@ bool SVGFEColorMatrixElement::setFilterEffectAttribute(FilterEffect& effect, con
 
 void SVGFEColorMatrixElement::svgAttributeChanged(const QualifiedName& attrName)
 {
-    if (attrName == SVGNames::inAttr) {
+    switch (attrName.nodeName()) {
+    case AttributeNames::inAttr: {
         InstanceInvalidationGuard guard(*this);
         updateSVGRendererForElementChange();
-        return;
+        break;
     }
-
-    if (attrName == SVGNames::typeAttr || attrName == SVGNames::valuesAttr) {
+    case AttributeNames::typeAttr:
+    case AttributeNames::valuesAttr: {
         InstanceInvalidationGuard guard(*this);
         if (isInvalidValuesLength())
             markFilterEffectForRebuild();
         else
             primitiveAttributeChanged(attrName);
-        return;
+        break;
     }
-
-    SVGFilterPrimitiveStandardAttributes::svgAttributeChanged(attrName);
+    default:
+        SVGFilterPrimitiveStandardAttributes::svgAttributeChanged(attrName);
+        break;
+    }
 }
 
 RefPtr<FilterEffect> SVGFEColorMatrixElement::createFilterEffect(const FilterEffectVector&, const GraphicsContext&) const

--- a/Source/WebCore/svg/SVGFEComponentTransferElement.cpp
+++ b/Source/WebCore/svg/SVGFEComponentTransferElement.cpp
@@ -94,7 +94,7 @@ static bool isRelevantTransferFunctionElement(const Element& child)
     return true;
 }
 
-bool SVGFEComponentTransferElement::setFilterEffectAttributeFromChild(FilterEffect& effect, const Element& childElement, const QualifiedName& attrName)
+bool SVGFEComponentTransferElement::setFilterEffectAttributeFromChild(FilterEffect& filterEffect, const Element& childElement, const QualifiedName& attrName)
 {
     ASSERT(isRelevantTransferFunctionElement(childElement));
 
@@ -103,30 +103,27 @@ bool SVGFEComponentTransferElement::setFilterEffectAttributeFromChild(FilterEffe
         return false;
     }
 
-    auto& feComponentTransfer = downcast<FEComponentTransfer>(effect);
+    auto& effect = downcast<FEComponentTransfer>(filterEffect);
     auto& child = downcast<SVGComponentTransferFunctionElement>(childElement);
 
-    if (attrName == SVGNames::typeAttr)
-        return feComponentTransfer.setType(child.channel(), child.type());
-
-    if (attrName == SVGNames::slopeAttr)
-        return feComponentTransfer.setSlope(child.channel(), child.slope());
-
-    if (attrName == SVGNames::interceptAttr)
-        return feComponentTransfer.setIntercept(child.channel(), child.intercept());
-
-    if (attrName == SVGNames::amplitudeAttr)
-        return feComponentTransfer.setAmplitude(child.channel(), child.amplitude());
-
-    if (attrName == SVGNames::exponentAttr)
-        return feComponentTransfer.setExponent(child.channel(), child.exponent());
-
-    if (attrName == SVGNames::offsetAttr)
-        return feComponentTransfer.setOffset(child.channel(), child.offset());
-
-    if (attrName == SVGNames::tableValuesAttr)
-        return feComponentTransfer.setTableValues(child.channel(), child.tableValues());
-
+    switch (attrName.nodeName()) {
+    case AttributeNames::typeAttr:
+        return effect.setType(child.channel(), child.type());
+    case AttributeNames::slopeAttr:
+        return effect.setSlope(child.channel(), child.slope());
+    case AttributeNames::interceptAttr:
+        return effect.setIntercept(child.channel(), child.intercept());
+    case AttributeNames::amplitudeAttr:
+        return effect.setAmplitude(child.channel(), child.amplitude());
+    case AttributeNames::exponentAttr:
+        return effect.setExponent(child.channel(), child.exponent());
+    case AttributeNames::offsetAttr:
+        return effect.setOffset(child.channel(), child.offset());
+    case AttributeNames::tableValuesAttr:
+        return effect.setTableValues(child.channel(), child.tableValues());
+    default:
+        break;
+    }
     return false;
 }
 

--- a/Source/WebCore/svg/SVGFECompositeElement.cpp
+++ b/Source/WebCore/svg/SVGFECompositeElement.cpp
@@ -87,20 +87,23 @@ void SVGFECompositeElement::attributeChanged(const QualifiedName& name, const At
     }
 }
 
-bool SVGFECompositeElement::setFilterEffectAttribute(FilterEffect& effect, const QualifiedName& attrName)
+bool SVGFECompositeElement::setFilterEffectAttribute(FilterEffect& filterEffect, const QualifiedName& attrName)
 {
-    auto& feComposite = downcast<FEComposite>(effect);
-    if (attrName == SVGNames::operatorAttr)
-        return feComposite.setOperation(svgOperator());
-    if (attrName == SVGNames::k1Attr)
-        return feComposite.setK1(k1());
-    if (attrName == SVGNames::k2Attr)
-        return feComposite.setK2(k2());
-    if (attrName == SVGNames::k3Attr)
-        return feComposite.setK3(k3());
-    if (attrName == SVGNames::k4Attr)
-        return feComposite.setK4(k4());
-
+    auto& effect = downcast<FEComposite>(filterEffect);
+    switch (attrName.nodeName()) {
+    case AttributeNames::operatorAttr:
+        return effect.setOperation(svgOperator());
+    case AttributeNames::k1Attr:
+        return effect.setK1(k1());
+    case AttributeNames::k2Attr:
+        return effect.setK2(k2());
+    case AttributeNames::k3Attr:
+        return effect.setK3(k3());
+    case AttributeNames::k4Attr:
+        return effect.setK4(k4());
+    default:
+        break;
+    }
     ASSERT_NOT_REACHED();
     return false;
 }
@@ -108,19 +111,26 @@ bool SVGFECompositeElement::setFilterEffectAttribute(FilterEffect& effect, const
 
 void SVGFECompositeElement::svgAttributeChanged(const QualifiedName& attrName)
 {
-    if (attrName == SVGNames::inAttr || attrName == SVGNames::in2Attr) {
+    switch (attrName.nodeName()) {
+    case AttributeNames::inAttr:
+    case AttributeNames::in2Attr: {
         InstanceInvalidationGuard guard(*this);
         updateSVGRendererForElementChange();
-        return;
+        break;
     }
-
-    if (attrName == SVGNames::k1Attr || attrName == SVGNames::k2Attr || attrName == SVGNames::k3Attr || attrName == SVGNames::k4Attr || attrName == SVGNames::operatorAttr) {
+    case AttributeNames::k1Attr:
+    case AttributeNames::k2Attr:
+    case AttributeNames::k3Attr:
+    case AttributeNames::k4Attr:
+    case AttributeNames::operatorAttr: {
         InstanceInvalidationGuard guard(*this);
         primitiveAttributeChanged(attrName);
-        return;
+        break;
     }
-
-    SVGFilterPrimitiveStandardAttributes::svgAttributeChanged(attrName);
+    default:
+        SVGFilterPrimitiveStandardAttributes::svgAttributeChanged(attrName);
+        break;
+    }
 }
 
 RefPtr<FilterEffect> SVGFECompositeElement::createFilterEffect(const FilterEffectVector&, const GraphicsContext&) const

--- a/Source/WebCore/svg/SVGFEConvolveMatrixElement.cpp
+++ b/Source/WebCore/svg/SVGFEConvolveMatrixElement.cpp
@@ -123,24 +123,26 @@ void SVGFEConvolveMatrixElement::attributeChanged(const QualifiedName& name, con
     }
 }
 
-bool SVGFEConvolveMatrixElement::setFilterEffectAttribute(FilterEffect& effect, const QualifiedName& attrName)
+bool SVGFEConvolveMatrixElement::setFilterEffectAttribute(FilterEffect& filterEffect, const QualifiedName& attrName)
 {
-    auto& feConvolveMatrix = downcast<FEConvolveMatrix>(effect);
-    if (attrName == SVGNames::edgeModeAttr)
-        return feConvolveMatrix.setEdgeMode(edgeMode());
-    if (attrName == SVGNames::divisorAttr)
-        return feConvolveMatrix.setDivisor(divisor());
-    if (attrName == SVGNames::biasAttr)
-        return feConvolveMatrix.setBias(bias());
-    if (attrName == SVGNames::targetXAttr)
-        return feConvolveMatrix.setTargetOffset(IntPoint(targetX(), targetY()));
-    if (attrName == SVGNames::targetYAttr)
-        return feConvolveMatrix.setTargetOffset(IntPoint(targetX(), targetY()));
-    if (attrName == SVGNames::kernelUnitLengthAttr)
-        return feConvolveMatrix.setKernelUnitLength(FloatPoint(kernelUnitLengthX(), kernelUnitLengthY()));
-    if (attrName == SVGNames::preserveAlphaAttr)
-        return feConvolveMatrix.setPreserveAlpha(preserveAlpha());
-
+    auto& effect = downcast<FEConvolveMatrix>(filterEffect);
+    switch (attrName.nodeName()) {
+    case AttributeNames::edgeModeAttr:
+        return effect.setEdgeMode(edgeMode());
+    case AttributeNames::divisorAttr:
+        return effect.setDivisor(divisor());
+    case AttributeNames::biasAttr:
+        return effect.setBias(bias());
+    case AttributeNames::targetXAttr:
+    case AttributeNames::targetYAttr:
+        return effect.setTargetOffset(IntPoint(targetX(), targetY()));
+    case AttributeNames::kernelUnitLengthAttr:
+        return effect.setKernelUnitLength(FloatPoint(kernelUnitLengthX(), kernelUnitLengthY()));
+    case AttributeNames::preserveAlphaAttr:
+        return effect.setPreserveAlpha(preserveAlpha());
+    default:
+        break;
+    }
     ASSERT_NOT_REACHED();
     return false;
 }
@@ -161,21 +163,29 @@ void SVGFEConvolveMatrixElement::setKernelUnitLength(float x, float y)
 
 void SVGFEConvolveMatrixElement::svgAttributeChanged(const QualifiedName& attrName)
 {
-    if (attrName == SVGNames::inAttr || attrName == SVGNames::orderAttr || attrName == SVGNames::kernelMatrixAttr) {
+    switch (attrName.nodeName()) {
+    case AttributeNames::inAttr:
+    case AttributeNames::orderAttr:
+    case AttributeNames::kernelMatrixAttr: {
         InstanceInvalidationGuard guard(*this);
         updateSVGRendererForElementChange();
-        return;
+        break;
     }
-    
-    if (attrName == SVGNames::edgeModeAttr || attrName == SVGNames::divisorAttr || attrName == SVGNames::biasAttr
-        || attrName == SVGNames::targetXAttr || attrName == SVGNames::targetYAttr
-        || attrName == SVGNames::kernelUnitLengthAttr || attrName == SVGNames::preserveAlphaAttr) {
+    case AttributeNames::edgeModeAttr:
+    case AttributeNames::divisorAttr:
+    case AttributeNames::biasAttr:
+    case AttributeNames::targetXAttr:
+    case AttributeNames::targetYAttr:
+    case AttributeNames::kernelUnitLengthAttr:
+    case AttributeNames::preserveAlphaAttr: {
         InstanceInvalidationGuard guard(*this);
         primitiveAttributeChanged(attrName);
-        return;
+        break;
     }
-
-    SVGFilterPrimitiveStandardAttributes::svgAttributeChanged(attrName);
+    default:
+        SVGFilterPrimitiveStandardAttributes::svgAttributeChanged(attrName);
+        break;
+    }
 }
 
 RefPtr<FilterEffect> SVGFEConvolveMatrixElement::createFilterEffect(const FilterEffectVector&, const GraphicsContext&) const

--- a/Source/WebCore/svg/SVGFEDiffuseLightingElement.cpp
+++ b/Source/WebCore/svg/SVGFEDiffuseLightingElement.cpp
@@ -77,66 +77,69 @@ void SVGFEDiffuseLightingElement::attributeChanged(const QualifiedName& name, co
     }
 }
 
-bool SVGFEDiffuseLightingElement::setFilterEffectAttribute(FilterEffect& effect, const QualifiedName& attrName)
+bool SVGFEDiffuseLightingElement::setFilterEffectAttribute(FilterEffect& filterEffect, const QualifiedName& attrName)
 {
-    auto& feDiffuseLighting = downcast<FEDiffuseLighting>(effect);
+    auto& effect = downcast<FEDiffuseLighting>(filterEffect);
+    auto lightElement = [this] {
+        return SVGFELightElement::findLightElement(this);
+    };
 
-    if (attrName == SVGNames::lighting_colorAttr) {
-        RenderObject* renderer = this->renderer();
-        ASSERT(renderer);
-        auto& style = renderer->style();
-        Color color = style.colorWithColorFilter(style.svgStyle().lightingColor());
-        return feDiffuseLighting.setLightingColor(color);
+    switch (attrName.nodeName()) {
+    case AttributeNames::lighting_colorAttr: {
+        auto& style = renderer()->style();
+        auto color = style.colorWithColorFilter(style.svgStyle().lightingColor());
+        return effect.setLightingColor(color);
     }
-    if (attrName == SVGNames::surfaceScaleAttr)
-        return feDiffuseLighting.setSurfaceScale(surfaceScale());
-    if (attrName == SVGNames::diffuseConstantAttr)
-        return feDiffuseLighting.setDiffuseConstant(diffuseConstant());
-
-    auto& lightSource = feDiffuseLighting.lightSource().get();
-    const SVGFELightElement* lightElement = SVGFELightElement::findLightElement(this);
-    ASSERT(lightElement);
-
-    if (attrName == SVGNames::azimuthAttr)
-        return lightSource.setAzimuth(lightElement->azimuth());
-    if (attrName == SVGNames::elevationAttr)
-        return lightSource.setElevation(lightElement->elevation());
-    if (attrName == SVGNames::xAttr)
-        return lightSource.setX(lightElement->x());
-    if (attrName == SVGNames::yAttr)
-        return lightSource.setY(lightElement->y());
-    if (attrName == SVGNames::zAttr)
-        return lightSource.setZ(lightElement->z());
-    if (attrName == SVGNames::pointsAtXAttr)
-        return lightSource.setPointsAtX(lightElement->pointsAtX());
-    if (attrName == SVGNames::pointsAtYAttr)
-        return lightSource.setPointsAtY(lightElement->pointsAtY());
-    if (attrName == SVGNames::pointsAtZAttr)
-        return lightSource.setPointsAtZ(lightElement->pointsAtZ());
-    if (attrName == SVGNames::specularExponentAttr)
-        return lightSource.setSpecularExponent(lightElement->specularExponent());
-    if (attrName == SVGNames::limitingConeAngleAttr)
-        return lightSource.setLimitingConeAngle(lightElement->limitingConeAngle());
-
+    case AttributeNames::surfaceScaleAttr:
+        return effect.setSurfaceScale(surfaceScale());
+    case AttributeNames::diffuseConstantAttr:
+        return effect.setDiffuseConstant(diffuseConstant());
+    case AttributeNames::azimuthAttr:
+        return effect.lightSource()->setAzimuth(lightElement()->azimuth());
+    case AttributeNames::elevationAttr:
+        return effect.lightSource()->setElevation(lightElement()->elevation());
+    case AttributeNames::xAttr:
+        return effect.lightSource()->setX(lightElement()->x());
+    case AttributeNames::yAttr:
+        return effect.lightSource()->setY(lightElement()->y());
+    case AttributeNames::zAttr:
+        return effect.lightSource()->setZ(lightElement()->z());
+    case AttributeNames::pointsAtXAttr:
+        return effect.lightSource()->setPointsAtX(lightElement()->pointsAtX());
+    case AttributeNames::pointsAtYAttr:
+        return effect.lightSource()->setPointsAtY(lightElement()->pointsAtY());
+    case AttributeNames::pointsAtZAttr:
+        return effect.lightSource()->setPointsAtZ(lightElement()->pointsAtZ());
+    case AttributeNames::specularExponentAttr:
+        return effect.lightSource()->setSpecularExponent(lightElement()->specularExponent());
+    case AttributeNames::limitingConeAngleAttr:
+        return effect.lightSource()->setLimitingConeAngle(lightElement()->limitingConeAngle());
+    default:
+        break;
+    }
     ASSERT_NOT_REACHED();
     return false;
 }
 
 void SVGFEDiffuseLightingElement::svgAttributeChanged(const QualifiedName& attrName)
 {
-    if (attrName == SVGNames::inAttr) {
+    switch (attrName.nodeName()) {
+    case AttributeNames::inAttr: {
         InstanceInvalidationGuard guard(*this);
         updateSVGRendererForElementChange();
-        return;
+        break;
     }
-
-    if (attrName == SVGNames::diffuseConstantAttr || attrName == SVGNames::surfaceScaleAttr || attrName == SVGNames::kernelUnitLengthAttr) {
+    case AttributeNames::diffuseConstantAttr:
+    case AttributeNames::surfaceScaleAttr:
+    case AttributeNames::kernelUnitLengthAttr: {
         InstanceInvalidationGuard guard(*this);
         primitiveAttributeChanged(attrName);
-        return;
+        break;
     }
-
-    SVGFilterPrimitiveStandardAttributes::svgAttributeChanged(attrName);
+    default:
+        SVGFilterPrimitiveStandardAttributes::svgAttributeChanged(attrName);
+        break;
+    }
 }
 
 void SVGFEDiffuseLightingElement::lightElementAttributeChanged(const SVGFELightElement* lightElement, const QualifiedName& attrName)

--- a/Source/WebCore/svg/SVGFEDisplacementMapElement.cpp
+++ b/Source/WebCore/svg/SVGFEDisplacementMapElement.cpp
@@ -81,35 +81,43 @@ void SVGFEDisplacementMapElement::attributeChanged(const QualifiedName& name, co
     }
 }
 
-bool SVGFEDisplacementMapElement::setFilterEffectAttribute(FilterEffect& effect, const QualifiedName& attrName)
+bool SVGFEDisplacementMapElement::setFilterEffectAttribute(FilterEffect& filterEffect, const QualifiedName& attrName)
 {
-    auto& feDisplacementMap = downcast<FEDisplacementMap>(effect);
-    if (attrName == SVGNames::xChannelSelectorAttr)
-        return feDisplacementMap.setXChannelSelector(xChannelSelector());
-    if (attrName == SVGNames::yChannelSelectorAttr)
-        return feDisplacementMap.setYChannelSelector(yChannelSelector());
-    if (attrName == SVGNames::scaleAttr)
-        return feDisplacementMap.setScale(scale());
-
+    auto& effect = downcast<FEDisplacementMap>(filterEffect);
+    switch (attrName.nodeName()) {
+    case AttributeNames::xChannelSelectorAttr:
+        return effect.setXChannelSelector(xChannelSelector());
+    case AttributeNames::yChannelSelectorAttr:
+        return effect.setYChannelSelector(yChannelSelector());
+    case AttributeNames::scaleAttr:
+        return effect.setScale(scale());
+    default:
+        break;
+    }
     ASSERT_NOT_REACHED();
     return false;
 }
 
 void SVGFEDisplacementMapElement::svgAttributeChanged(const QualifiedName& attrName)
 {
-    if (attrName == SVGNames::inAttr || attrName == SVGNames::in2Attr) {
+    switch (attrName.nodeName()) {
+    case AttributeNames::inAttr:
+    case AttributeNames::in2Attr: {
         InstanceInvalidationGuard guard(*this);
         updateSVGRendererForElementChange();
-        return;
+        break;
     }
-
-    if (attrName == SVGNames::xChannelSelectorAttr || attrName == SVGNames::yChannelSelectorAttr || attrName == SVGNames::scaleAttr) {
+    case AttributeNames::xChannelSelectorAttr:
+    case AttributeNames::yChannelSelectorAttr:
+    case AttributeNames::scaleAttr: {
         InstanceInvalidationGuard guard(*this);
         primitiveAttributeChanged(attrName);
-        return;
+        break;
     }
-
-    SVGFilterPrimitiveStandardAttributes::svgAttributeChanged(attrName);
+    default:
+        SVGFilterPrimitiveStandardAttributes::svgAttributeChanged(attrName);
+        break;
+    }
 }
 
 RefPtr<FilterEffect> SVGFEDisplacementMapElement::createFilterEffect(const FilterEffectVector&, const GraphicsContext&) const

--- a/Source/WebCore/svg/SVGFEDropShadowElement.cpp
+++ b/Source/WebCore/svg/SVGFEDropShadowElement.cpp
@@ -85,51 +85,51 @@ void SVGFEDropShadowElement::attributeChanged(const QualifiedName& name, const A
 
 void SVGFEDropShadowElement::svgAttributeChanged(const QualifiedName& attrName)
 {
-    if (attrName == SVGNames::inAttr) {
+    switch (attrName.nodeName()) {
+    case AttributeNames::inAttr: {
         InstanceInvalidationGuard guard(*this);
         updateSVGRendererForElementChange();
-        return;
+        break;
     }
-
-    if (attrName == SVGNames::stdDeviationAttr && (stdDeviationX() < 0 || stdDeviationY() < 0)) {
-        InstanceInvalidationGuard guard(*this);
-        markFilterEffectForRebuild();
-        return;
+    case AttributeNames::stdDeviationAttr: {
+        if (stdDeviationX() < 0 || stdDeviationY() < 0) {
+            InstanceInvalidationGuard guard(*this);
+            markFilterEffectForRebuild();
+            return;
+        }
+        FALLTHROUGH;
     }
-
-    if (attrName == SVGNames::stdDeviationAttr || attrName == SVGNames::dxAttr || attrName == SVGNames::dyAttr) {
+    case AttributeNames::dxAttr:
+    case AttributeNames::dyAttr: {
         InstanceInvalidationGuard guard(*this);
         primitiveAttributeChanged(attrName);
-        return;
+        break;
     }
-
-    SVGFilterPrimitiveStandardAttributes::svgAttributeChanged(attrName);
+    default:
+        SVGFilterPrimitiveStandardAttributes::svgAttributeChanged(attrName);
+        break;
+    }
 }
 
-bool SVGFEDropShadowElement::setFilterEffectAttribute(FilterEffect& effect, const QualifiedName& attrName)
+bool SVGFEDropShadowElement::setFilterEffectAttribute(FilterEffect& filterEffect, const QualifiedName& attrName)
 {
-    auto& feDropShadow = downcast<FEDropShadow>(effect);
-
-    if (attrName == SVGNames::stdDeviationAttr) {
-        bool stdDeviationXChanged = feDropShadow.setStdDeviationX(stdDeviationX());
-        bool stdDeviationYChanged = feDropShadow.setStdDeviationY(stdDeviationY());
-        return stdDeviationXChanged || stdDeviationYChanged;
+    auto& effect = downcast<FEDropShadow>(filterEffect);
+    switch (attrName.nodeName()) {
+    case AttributeNames::stdDeviationAttr:
+        return effect.setStdDeviationX(stdDeviationX()) || effect.setStdDeviationY(stdDeviationY());
+    case AttributeNames::dxAttr:
+        return effect.setDx(dx());
+    case AttributeNames::dyAttr:
+        return effect.setDy(dy());
+    case AttributeNames::flood_colorAttr: {
+        auto& style = renderer()->style();
+        return effect.setShadowColor(style.colorResolvingCurrentColor(style.svgStyle().floodColor()));
     }
-
-    if (attrName == SVGNames::dxAttr)
-        return feDropShadow.setDx(dx());
-    if (attrName == SVGNames::dyAttr)
-        return feDropShadow.setDy(dy());
-
-    RenderObject* renderer = this->renderer();
-    ASSERT(renderer);
-    const RenderStyle& style = renderer->style();
-
-    if (attrName == SVGNames::flood_colorAttr)
-        return feDropShadow.setShadowColor(style.colorResolvingCurrentColor(style.svgStyle().floodColor()));
-    if (attrName == SVGNames::flood_opacityAttr)
-        return feDropShadow.setShadowOpacity(style.svgStyle().floodOpacity());
-
+    case AttributeNames::flood_opacityAttr:
+        return effect.setShadowOpacity(renderer()->style().svgStyle().floodOpacity());
+    default:
+        break;
+    }
     ASSERT_NOT_REACHED();
     return false;
 }

--- a/Source/WebCore/svg/SVGFEGaussianBlurElement.cpp
+++ b/Source/WebCore/svg/SVGFEGaussianBlurElement.cpp
@@ -86,25 +86,29 @@ void SVGFEGaussianBlurElement::attributeChanged(const QualifiedName& name, const
 
 void SVGFEGaussianBlurElement::svgAttributeChanged(const QualifiedName& attrName)
 {
-    if (attrName == SVGNames::inAttr) {
+    switch (attrName.nodeName()) {
+    case AttributeNames::inAttr: {
         InstanceInvalidationGuard guard(*this);
         updateSVGRendererForElementChange();
-        return;
+        break;
     }
-
-    if (attrName == SVGNames::stdDeviationAttr && (stdDeviationX() < 0 || stdDeviationY() < 0)) {
-        InstanceInvalidationGuard guard(*this);
-        markFilterEffectForRebuild();
-        return;
+    case AttributeNames::stdDeviationAttr: {
+        if (stdDeviationX() < 0 || stdDeviationY() < 0) {
+            InstanceInvalidationGuard guard(*this);
+            markFilterEffectForRebuild();
+            return;
+        }
+        FALLTHROUGH;
     }
-
-    if (attrName == SVGNames::stdDeviationAttr || attrName == SVGNames::edgeModeAttr) {
+    case AttributeNames::edgeModeAttr: {
         InstanceInvalidationGuard guard(*this);
         primitiveAttributeChanged(attrName);
-        return;
+        break;
     }
-
-    SVGFilterPrimitiveStandardAttributes::svgAttributeChanged(attrName);
+    default:
+        SVGFilterPrimitiveStandardAttributes::svgAttributeChanged(attrName);
+        break;
+    }
 }
 
 bool SVGFEGaussianBlurElement::setFilterEffectAttribute(FilterEffect& effect, const QualifiedName& attrName)

--- a/Source/WebCore/svg/SVGFEMorphologyElement.cpp
+++ b/Source/WebCore/svg/SVGFEMorphologyElement.cpp
@@ -93,19 +93,22 @@ bool SVGFEMorphologyElement::setFilterEffectAttribute(FilterEffect& effect, cons
 
 void SVGFEMorphologyElement::svgAttributeChanged(const QualifiedName& attrName)
 {
-    if (attrName == SVGNames::inAttr) {
+    switch (attrName.nodeName()) {
+    case AttributeNames::inAttr: {
         InstanceInvalidationGuard guard(*this);
         updateSVGRendererForElementChange();
-        return;
+        break;
     }
-
-    if (attrName == SVGNames::operatorAttr || attrName == SVGNames::radiusAttr) {
+    case AttributeNames::operatorAttr:
+    case AttributeNames::radiusAttr: {
         InstanceInvalidationGuard guard(*this);
         primitiveAttributeChanged(attrName);
-        return;
+        break;
     }
-
-    SVGFilterPrimitiveStandardAttributes::svgAttributeChanged(attrName);
+    default:
+        SVGFilterPrimitiveStandardAttributes::svgAttributeChanged(attrName);
+        break;
+    }
 }
 
 bool SVGFEMorphologyElement::isIdentity() const

--- a/Source/WebCore/svg/SVGFEOffsetElement.cpp
+++ b/Source/WebCore/svg/SVGFEOffsetElement.cpp
@@ -70,19 +70,22 @@ void SVGFEOffsetElement::attributeChanged(const QualifiedName& name, const AtomS
 
 void SVGFEOffsetElement::svgAttributeChanged(const QualifiedName& attrName)
 {
-    if (attrName == SVGNames::inAttr) {
+    switch (attrName.nodeName()) {
+    case AttributeNames::inAttr: {
         InstanceInvalidationGuard guard(*this);
         updateSVGRendererForElementChange();
-        return;
+        break;
     }
-
-    if (attrName == SVGNames::dxAttr || attrName == SVGNames::dyAttr) {
+    case AttributeNames::dxAttr:
+    case AttributeNames::dyAttr: {
         InstanceInvalidationGuard guard(*this);
         primitiveAttributeChanged(attrName);
-        return;
+        break;
     }
-
-    SVGFilterPrimitiveStandardAttributes::svgAttributeChanged(attrName);
+    default:
+        SVGFilterPrimitiveStandardAttributes::svgAttributeChanged(attrName);
+        break;
+    }
 }
 
 bool SVGFEOffsetElement::setFilterEffectAttribute(FilterEffect& effect, const QualifiedName& attrName)

--- a/Source/WebCore/svg/SVGFESpecularLightingElement.cpp
+++ b/Source/WebCore/svg/SVGFESpecularLightingElement.cpp
@@ -83,49 +83,46 @@ void SVGFESpecularLightingElement::attributeChanged(const QualifiedName& name, c
     }
 }
 
-bool SVGFESpecularLightingElement::setFilterEffectAttribute(FilterEffect& effect, const QualifiedName& attrName)
+bool SVGFESpecularLightingElement::setFilterEffectAttribute(FilterEffect& filterEffect, const QualifiedName& attrName)
 {
-    auto& feSpecularLighting = downcast<FESpecularLighting>(effect);
+    auto& effect = downcast<FESpecularLighting>(filterEffect);
+    auto lightElement = [this] {
+        return SVGFELightElement::findLightElement(this);
+    };
 
-    if (attrName == SVGNames::lighting_colorAttr) {
-        RenderObject* renderer = this->renderer();
-        ASSERT(renderer);
-        auto& style = renderer->style();
+    switch (attrName.nodeName()) {
+    case AttributeNames::lighting_colorAttr: {
+        auto& style = renderer()->style();
         auto color = style.colorWithColorFilter(style.svgStyle().lightingColor());
-        return feSpecularLighting.setLightingColor(color);
+        return effect.setLightingColor(color);
     }
-    if (attrName == SVGNames::surfaceScaleAttr)
-        return feSpecularLighting.setSurfaceScale(surfaceScale());
-    if (attrName == SVGNames::specularConstantAttr)
-        return feSpecularLighting.setSpecularConstant(specularConstant());
-    if (attrName == SVGNames::specularExponentAttr)
-        return feSpecularLighting.setSpecularExponent(specularExponent());
-
-    auto& lightSource = feSpecularLighting.lightSource().get();
-    const SVGFELightElement* lightElement = SVGFELightElement::findLightElement(this);
-    ASSERT(lightElement);
-
-    if (attrName == SVGNames::azimuthAttr)
-        return lightSource.setAzimuth(lightElement->azimuth());
-    if (attrName == SVGNames::elevationAttr)
-        return lightSource.setElevation(lightElement->elevation());
-    if (attrName == SVGNames::xAttr)
-        return lightSource.setX(lightElement->x());
-    if (attrName == SVGNames::yAttr)
-        return lightSource.setY(lightElement->y());
-    if (attrName == SVGNames::zAttr)
-        return lightSource.setZ(lightElement->z());
-    if (attrName == SVGNames::pointsAtXAttr)
-        return lightSource.setPointsAtX(lightElement->pointsAtX());
-    if (attrName == SVGNames::pointsAtYAttr)
-        return lightSource.setPointsAtY(lightElement->pointsAtY());
-    if (attrName == SVGNames::pointsAtZAttr)
-        return lightSource.setPointsAtZ(lightElement->pointsAtZ());
-    if (attrName == SVGNames::specularExponentAttr)
-        return lightSource.setSpecularExponent(lightElement->specularExponent());
-    if (attrName == SVGNames::limitingConeAngleAttr)
-        return lightSource.setLimitingConeAngle(lightElement->limitingConeAngle());
-
+    case AttributeNames::surfaceScaleAttr:
+        return effect.setSurfaceScale(surfaceScale());
+    case AttributeNames::specularConstantAttr:
+        return effect.setSpecularConstant(specularConstant());
+    case AttributeNames::specularExponentAttr:
+        return effect.setSpecularExponent(specularExponent());
+    case AttributeNames::azimuthAttr:
+        return effect.lightSource()->setAzimuth(lightElement()->azimuth());
+    case AttributeNames::elevationAttr:
+        return effect.lightSource()->setElevation(lightElement()->elevation());
+    case AttributeNames::xAttr:
+        return effect.lightSource()->setX(lightElement()->x());
+    case AttributeNames::yAttr:
+        return effect.lightSource()->setY(lightElement()->y());
+    case AttributeNames::zAttr:
+        return effect.lightSource()->setZ(lightElement()->z());
+    case AttributeNames::pointsAtXAttr:
+        return effect.lightSource()->setPointsAtX(lightElement()->pointsAtX());
+    case AttributeNames::pointsAtYAttr:
+        return effect.lightSource()->setPointsAtY(lightElement()->pointsAtY());
+    case AttributeNames::pointsAtZAttr:
+        return effect.lightSource()->setPointsAtZ(lightElement()->pointsAtZ());
+    case AttributeNames::limitingConeAngleAttr:
+        return effect.lightSource()->setLimitingConeAngle(lightElement()->limitingConeAngle());
+    default:
+        break;
+    }
     ASSERT_NOT_REACHED();
     return false;
 }

--- a/Source/WebCore/svg/SVGFETurbulenceElement.cpp
+++ b/Source/WebCore/svg/SVGFETurbulenceElement.cpp
@@ -85,23 +85,23 @@ void SVGFETurbulenceElement::attributeChanged(const QualifiedName& name, const A
     SVGFilterPrimitiveStandardAttributes::attributeChanged(name, oldValue, newValue, attributeModificationReason);
 }
 
-bool SVGFETurbulenceElement::setFilterEffectAttribute(FilterEffect& effect, const QualifiedName& attrName)
+bool SVGFETurbulenceElement::setFilterEffectAttribute(FilterEffect& filterEffect, const QualifiedName& attrName)
 {
-    auto& feTurbulence = downcast<FETurbulence>(effect);
-    if (attrName == SVGNames::typeAttr)
-        return feTurbulence.setType(type());
-    if (attrName == SVGNames::stitchTilesAttr)
-        return feTurbulence.setStitchTiles(stitchTiles());
-    if (attrName == SVGNames::baseFrequencyAttr) {
-        bool baseFrequencyXChanged = feTurbulence.setBaseFrequencyX(baseFrequencyX());
-        bool baseFrequencyYChanged = feTurbulence.setBaseFrequencyY(baseFrequencyY());
-        return baseFrequencyXChanged || baseFrequencyYChanged;
+    auto& effect = downcast<FETurbulence>(filterEffect);
+    switch (attrName.nodeName()) {
+    case AttributeNames::typeAttr:
+        return effect.setType(type());
+    case AttributeNames::stitchTilesAttr:
+        return effect.setStitchTiles(stitchTiles());
+    case AttributeNames::baseFrequencyAttr:
+        return effect.setBaseFrequencyX(baseFrequencyX()) || effect.setBaseFrequencyY(baseFrequencyY());
+    case AttributeNames::seedAttr:
+        return effect.setSeed(seed());
+    case AttributeNames::numOctavesAttr:
+        return effect.setNumOctaves(numOctaves());
+    default:
+        break;
     }
-    if (attrName == SVGNames::seedAttr)
-        return feTurbulence.setSeed(seed());
-    if (attrName == SVGNames::numOctavesAttr)
-        return feTurbulence.setNumOctaves(numOctaves());
-
     ASSERT_NOT_REACHED();
     return false;
 }

--- a/Source/WebCore/svg/SVGTests.cpp
+++ b/Source/WebCore/svg/SVGTests.cpp
@@ -24,6 +24,7 @@
 
 #include "DOMImplementation.h"
 #include "HTMLNames.h"
+#include "NodeName.h"
 #include "SVGElement.h"
 #include "SVGNames.h"
 #include "SVGStringList.h"
@@ -141,12 +142,19 @@ bool SVGTests::isValid() const
 
 void SVGTests::parseAttribute(const QualifiedName& attributeName, const AtomString& value)
 {
-    if (attributeName == SVGNames::requiredFeaturesAttr)
+    switch (attributeName.nodeName()) {
+    case AttributeNames::requiredFeaturesAttr:
         requiredFeatures().reset(value);
-    if (attributeName == SVGNames::requiredExtensionsAttr)
+        break;
+    case AttributeNames::requiredExtensionsAttr:
         requiredExtensions().reset(value);
-    if (attributeName == SVGNames::systemLanguageAttr)
+        break;
+    case AttributeNames::systemLanguageAttr:
         systemLanguage().reset(value);
+        break;
+    default:
+        break;
+    }
 }
 
 void SVGTests::svgAttributeChanged(const QualifiedName& attrName)

--- a/Source/WebCore/svg/animation/SVGSMILElement.cpp
+++ b/Source/WebCore/svg/animation/SVGSMILElement.cpp
@@ -519,28 +519,42 @@ void SVGSMILElement::svgAttributeChanged(const QualifiedName& attrName)
         return;
     }
 
-    if (attrName == SVGNames::durAttr)
+    switch (attrName.nodeName()) {
+    case AttributeNames::durAttr:
         m_cachedDur = invalidCachedTime;
-    else if (attrName == SVGNames::repeatDurAttr)
+        break;
+    case AttributeNames::repeatDurAttr:
         m_cachedRepeatDur = invalidCachedTime;
-    else if (attrName == SVGNames::repeatCountAttr)
+        break;
+    case AttributeNames::repeatCountAttr:
         m_cachedRepeatCount = invalidCachedTime;
-    else if (attrName == SVGNames::minAttr)
+        break;
+    case AttributeNames::minAttr:
         m_cachedMin = invalidCachedTime;
-    else if (attrName == SVGNames::maxAttr)
+        break;
+    case AttributeNames::maxAttr:
         m_cachedMax = invalidCachedTime;
-    else if (attrName == SVGNames::attributeNameAttr)
+        break;
+    case AttributeNames::attributeNameAttr:
         updateAttributeName();
-    else if (attrName.matches(SVGNames::hrefAttr) || attrName.matches(XLinkNames::hrefAttr)) {
+        break;
+    case AttributeNames::hrefAttr:
+    case AttributeNames::XLink::hrefAttr: {
         InstanceInvalidationGuard guard(*this);
         buildPendingResource();
-    } else if (isConnected()) {
-        if (attrName == SVGNames::beginAttr)
-            beginListChanged(elapsed());
-        else if (attrName == SVGNames::endAttr)
-            endListChanged(elapsed());
+        break;
     }
-
+    case AttributeNames::beginAttr:
+        if (isConnected())
+            beginListChanged(elapsed());
+        break;
+    case AttributeNames::endAttr:
+        if (isConnected())
+            endListChanged(elapsed());
+        break;
+    default:
+        break;
+    }
     animationAttributeChanged();
 }
 


### PR DESCRIPTION
#### d0ed0824740bddbcd4a112de942c8f7a256018ff
<pre>
Adopt new NodeName enumeration more broadly in SVG code
<a href="https://bugs.webkit.org/show_bug.cgi?id=255494">https://bugs.webkit.org/show_bug.cgi?id=255494</a>

Reviewed by Darin Adler.

* Source/WebCore/svg/SVGFEColorMatrixElement.cpp:
(WebCore::SVGFEColorMatrixElement::svgAttributeChanged):
* Source/WebCore/svg/SVGFEComponentTransferElement.cpp:
(WebCore::SVGFEComponentTransferElement::setFilterEffectAttributeFromChild):
* Source/WebCore/svg/SVGFECompositeElement.cpp:
(SVGFECompositeElement::setFilterEffectAttribute):
(SVGFECompositeElement::svgAttributeChanged):
(SVGFECompositeElement::createFilterEffect const): Deleted.
* Source/WebCore/svg/SVGFEConvolveMatrixElement.cpp:
(WebCore::SVGFEConvolveMatrixElement::setFilterEffectAttribute):
(WebCore::SVGFEConvolveMatrixElement::svgAttributeChanged):
* Source/WebCore/svg/SVGFEDiffuseLightingElement.cpp:
(WebCore::SVGFEDiffuseLightingElement::setFilterEffectAttribute):
(WebCore::SVGFEDiffuseLightingElement::svgAttributeChanged):
* Source/WebCore/svg/SVGFEDisplacementMapElement.cpp:
(WebCore::SVGFEDisplacementMapElement::setFilterEffectAttribute):
(WebCore::SVGFEDisplacementMapElement::svgAttributeChanged):
* Source/WebCore/svg/SVGFEDropShadowElement.cpp:
(WebCore::SVGFEDropShadowElement::svgAttributeChanged):
(WebCore::SVGFEDropShadowElement::setFilterEffectAttribute):
* Source/WebCore/svg/SVGFEGaussianBlurElement.cpp:
(WebCore::SVGFEGaussianBlurElement::svgAttributeChanged):
* Source/WebCore/svg/SVGFEMorphologyElement.cpp:
(SVGFEMorphologyElement::svgAttributeChanged):
* Source/WebCore/svg/SVGFEOffsetElement.cpp:
(WebCore::SVGFEOffsetElement::svgAttributeChanged):
* Source/WebCore/svg/SVGFESpecularLightingElement.cpp:
(WebCore::SVGFESpecularLightingElement::setFilterEffectAttribute):
* Source/WebCore/svg/SVGFETurbulenceElement.cpp:
(WebCore::SVGFETurbulenceElement::setFilterEffectAttribute):
* Source/WebCore/svg/SVGTests.cpp:
(WebCore::SVGTests::parseAttribute):
* Source/WebCore/svg/animation/SVGSMILElement.cpp:
(WebCore::SVGSMILElement::svgAttributeChanged):

Canonical link: <a href="https://commits.webkit.org/263011@main">https://commits.webkit.org/263011@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/142ea3abeb906546e39fe6157cc5699fe48e33cc

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/3305 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/3364 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/3480 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/4722 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/3636 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/3282 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/3427 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/3387 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/2870 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/3345 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/3633 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/2980 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/4544 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/1136 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/2945 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/2862 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/2918 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/2999 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/4281 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/3378 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/2701 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/2940 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/2946 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/809 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/2942 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/3215 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->