### PR TITLE
Simplify the ARM64E code because NUMBER_OF_ADDRESS_ENCODING_INSTRUCTIONS is always 4.

### DIFF
--- a/Source/JavaScriptCore/assembler/ARM64EAssembler.h
+++ b/Source/JavaScriptCore/assembler/ARM64EAssembler.h
@@ -305,8 +305,7 @@ public:
         ASSERT_UNUSED(expected, expected && sf && opc == MoveWideOp_Z && !hw);
         ASSERT(checkMovk<Datasize_64>(address[1], 1, rd));
         ASSERT(checkMovk<Datasize_64>(address[2], 2, rd));
-        if (NUMBER_OF_ADDRESS_ENCODING_INSTRUCTIONS > 3)
-            ASSERT(checkMovk<Datasize_64>(address[3], 3, rd));
+        ASSERT(checkMovk<Datasize_64>(address[3], 3, rd));
 
         setPointer(address, valuePtr, rd, flush);
     }
@@ -325,8 +324,7 @@ public:
         buffer[0] = moveWideImediate(Datasize_64, MoveWideOp_Z, 0, getHalfword(value, 0), rd);
         buffer[1] = moveWideImediate(Datasize_64, MoveWideOp_K, 1, getHalfword(value, 1), rd);
         buffer[2] = moveWideImediate(Datasize_64, MoveWideOp_K, 2, getHalfword(value, 2), rd);
-        if (NUMBER_OF_ADDRESS_ENCODING_INSTRUCTIONS > 3)
-            buffer[3] = moveWideImediate(Datasize_64, MoveWideOp_K, 3, getHalfword(value, 3), rd);
+        buffer[3] = moveWideImediate(Datasize_64, MoveWideOp_K, 3, getHalfword(value, 3), rd);
         RELEASE_ASSERT(roundUpToMultipleOf<instructionSize>(address) == address);
         performJITMemcpy(address, buffer, sizeof(int) * 4);
 
@@ -356,11 +354,9 @@ public:
         ASSERT_UNUSED(expected, expected && sf && opc == MoveWideOp_K && hw == 2 && rd == rdFirst);
         result |= static_cast<uintptr_t>(imm16) << 32;
 
-        if (NUMBER_OF_ADDRESS_ENCODING_INSTRUCTIONS > 3) {
-            expected = disassembleMoveWideImediate(address + 3, sf, opc, hw, imm16, rd);
-            ASSERT_UNUSED(expected, expected && sf && opc == MoveWideOp_K && hw == 3 && rd == rdFirst);
-            result |= static_cast<uintptr_t>(imm16) << 48;
-        }
+        expected = disassembleMoveWideImediate(address + 3, sf, opc, hw, imm16, rd);
+        ASSERT_UNUSED(expected, expected && sf && opc == MoveWideOp_K && hw == 3 && rd == rdFirst);
+        result |= static_cast<uintptr_t>(imm16) << 48;
 
         return reinterpret_cast<void*>(result);
     }
@@ -368,12 +364,9 @@ public:
     static void* readCallTarget(void* from)
     {
         constexpr ptrdiff_t callInstruction = 1;
+        static constexpr ptrdiff_t NUMBER_OF_ADDRESS_ENCODING_INSTRUCTIONS = 4;
         return readPointer(reinterpret_cast<int*>(from) - callInstruction - NUMBER_OF_ADDRESS_ENCODING_INSTRUCTIONS);
     }
-
-    static constexpr ptrdiff_t MAX_POINTER_BITS = 64;
-    static constexpr ptrdiff_t BITS_ENCODEABLE_PER_INSTRUCTION = 16;
-    static constexpr ptrdiff_t NUMBER_OF_ADDRESS_ENCODING_INSTRUCTIONS = MAX_POINTER_BITS / BITS_ENCODEABLE_PER_INSTRUCTION;
 };
 
 #undef CHECK_MEMOPSIZE_OF


### PR DESCRIPTION
#### afe8886c54aa300451471cf79f482a8b35f1874b
<pre>
Simplify the ARM64E code because NUMBER_OF_ADDRESS_ENCODING_INSTRUCTIONS is always 4.
<a href="https://bugs.webkit.org/show_bug.cgi?id=255497">https://bugs.webkit.org/show_bug.cgi?id=255497</a>
rdar://108108389

Reviewed by Alexey Shvayka.

The code doesn&apos;t need to be conditional because for ARM64E, NUMBER_OF_ADDRESS_ENCODING_INSTRUCTIONS always equals 4.

* Source/JavaScriptCore/assembler/ARM64EAssembler.h:
(JSC::ARM64EAssembler::linkPointer):
(JSC::ARM64EAssembler::setPointer):
(JSC::ARM64EAssembler::readPointer):
(JSC::ARM64EAssembler::readCallTarget):

Canonical link: <a href="https://commits.webkit.org/263029@main">https://commits.webkit.org/263029@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/207318dcaa61d8007e71f744a6d1860eeff3e589

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/3300 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/3359 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/3475 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/4717 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/3631 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/3422 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/3382 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/2865 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/3340 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/3628 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/2974 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/4539 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/1131 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/2940 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/2857 "7 flakes 146 failures") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/2714 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/2913 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/2998 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/4274 "run-api-tests-without-change (failure)") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/3106 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/3373 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/2696 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/3372 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/2935 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/2941 "Passed tests") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/828 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/822 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/2937 "Built successfully") | | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/24/builds/3460 "Built successfully") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/3210 "Built successfully") | | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/3/builds/949 "Passed tests") | 
<!--EWS-Status-Bubble-End-->