### PR TITLE
JSC: IA_ASSERT can use __VA_OPT__ for COMPILER(MSVC)

### DIFF
--- a/Source/JavaScriptCore/tools/Integrity.cpp
+++ b/Source/JavaScriptCore/tools/Integrity.cpp
@@ -185,7 +185,7 @@ bool Analyzer::analyzeVM(VM& vm, Analyzer::Action action)
     return true;
 }
 
-#if COMPILER(MSVC) || !VA_OPT_SUPPORTED
+#if !VA_OPT_SUPPORTED
 
 #define AUDIT_VERIFY(cond, format, ...) do { \
         IA_ASSERT_WITH_ACTION(cond, { \
@@ -197,7 +197,7 @@ bool Analyzer::analyzeVM(VM& vm, Analyzer::Action action)
         }); \
     } while (false)
 
-#else // not (COMPILER(MSVC) || !VA_OPT_SUPPORTED)
+#else // not !VA_OPT_SUPPORTED
 
 #define AUDIT_VERIFY(cond, format, ...) do { \
         IA_ASSERT_WITH_ACTION(cond, { \
@@ -209,7 +209,7 @@ bool Analyzer::analyzeVM(VM& vm, Analyzer::Action action)
         }, format __VA_OPT__(,) __VA_ARGS__); \
     } while (false)
 
-#endif // COMPILER(MSVC) || !VA_OPT_SUPPORTED
+#endif // !VA_OPT_SUPPORTED
 
 bool Analyzer::analyzeCell(VM& vm, JSCell* cell, Analyzer::Action action)
 {

--- a/Source/JavaScriptCore/tools/Integrity.h
+++ b/Source/JavaScriptCore/tools/Integrity.h
@@ -175,7 +175,7 @@ template<typename T> ALWAYS_INLINE T audit(T value) { return bitwise_cast<T>(doA
 template<typename T> ALWAYS_INLINE T audit(T value) { return value; }
 #endif
 
-#if COMPILER(MSVC) || !VA_OPT_SUPPORTED
+#if !VA_OPT_SUPPORTED
 
 #define IA_LOG(assertion, format, ...) do { \
         Integrity::logLnF("ERROR: %s @ %s:%d", #assertion, __FILE__, __LINE__); \
@@ -194,7 +194,7 @@ template<typename T> ALWAYS_INLINE T audit(T value) { return value; }
         RELEASE_ASSERT((assertion)); \
     })
 
-#else // not (COMPILER(MSVC) || !VA_OPT_SUPPORTED)
+#else // not !VA_OPT_SUPPORTED
 
 #define IA_LOG(assertion, format, ...) do { \
         Integrity::logLnF("ERROR: %s @ %s:%d", #assertion, __FILE__, __LINE__); \
@@ -214,7 +214,7 @@ template<typename T> ALWAYS_INLINE T audit(T value) { return value; }
         RELEASE_ASSERT((assertion) __VA_OPT__(,) __VA_ARGS__); \
     } __VA_OPT__(,) __VA_ARGS__)
 
-#endif // COMPILER(MSVC) || !VA_OPT_SUPPORTED
+#endif // !VA_OPT_SUPPORTED
 
 JS_EXPORT_PRIVATE WTF::PrintStream& logFile();
 JS_EXPORT_PRIVATE void logF(const char* format, ...) WTF_ATTRIBUTE_PRINTF(1, 2);


### PR DESCRIPTION
#### a40563bfe366254cad9399917bee1b691f3ecafe
<pre>
JSC: IA_ASSERT can use __VA_OPT__ for COMPILER(MSVC)
<a href="https://bugs.webkit.org/show_bug.cgi?id=255449">https://bugs.webkit.org/show_bug.cgi?id=255449</a>

Reviewed by Ross Kirsling.

We can use__VA_OPT__ for COMPILER(MSVC) now. Removed COMPILER(MSVC)
condition from IA_ASSERT. This fixes a clang-cl build problem too.

* Source/JavaScriptCore/tools/Integrity.cpp:
* Source/JavaScriptCore/tools/Integrity.h:

Canonical link: <a href="https://commits.webkit.org/263012@main">https://commits.webkit.org/263012@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/229498bc8ace099b07388f5228e8882611299669

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/3308 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/3367 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/3483 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/4725 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/3639 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/3285 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/3430 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/3390 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/2873 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/3348 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/3636 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/2983 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/4547 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/1139 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/2948 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/2865 "Passed tests") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/2722 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/2921 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/3002 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/4284 "run-api-tests-without-change (failure)") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/3114 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/3381 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/2704 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/3380 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/2943 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/2949 "Passed tests") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/831 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/2945 "Built successfully") | | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/24/builds/3468 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/388 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/3218 "Built successfully") | | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/3/builds/952 "Passed tests") | 
<!--EWS-Status-Bubble-End-->