### PR TITLE
Creating a transparency layer to draw a single image with opacity can be slow.

### DIFF
--- a/Source/WebCore/rendering/RenderLayerBacking.cpp
+++ b/Source/WebCore/rendering/RenderLayerBacking.cpp
@@ -3059,23 +3059,7 @@ bool RenderLayerBacking::isDirectlyCompositedImage() const
 
 bool RenderLayerBacking::isBitmapOnly() const
 {
-    if (m_owningLayer.hasVisibleBoxDecorationsOrBackground())
-        return false;
-
-    if (is<RenderHTMLCanvas>(renderer()))
-        return true;
-
-    if (is<RenderImage>(renderer())) {
-        auto& imageRenderer = downcast<RenderImage>(renderer());
-        if (auto* cachedImage = imageRenderer.cachedImage()) {
-            if (!cachedImage->hasImage())
-                return false;
-            return is<BitmapImage>(cachedImage->imageForRenderer(&imageRenderer));
-        }
-        return false;
-    }
-
-    return false;
+    return m_owningLayer.isBitmapOnly();
 }
 
 


### PR DESCRIPTION
#### 45759e33816f429a82e7b53b122abb0c579a45a8
<pre>
Creating a transparency layer to draw a single image with opacity can be slow.
<a href="https://bugs.webkit.org/show_bug.cgi?id=24438">https://bugs.webkit.org/show_bug.cgi?id=24438</a>
&lt;rdar://103334931&gt;

Reviewed by Dean Jackson.

This detects the case where we want to create a transparency layer, but the only contents that
will be drawn is a single bitmap image. We can instead just set the alpha on the GraphicsContext
and save the transparency layer (as well as the save/restore pair and the clip).

This could be extended in the future to detect more cases where we will only do a single draw call
within the transparency layer.

* Source/WebCore/rendering/RenderLayer.cpp:
(WebCore::RenderLayer::beginTransparencyLayers):
(WebCore::RenderLayer::paintLayerContents):
(WebCore::RenderLayer::calculateClipRects const):
* Source/WebCore/rendering/RenderLayer.h:
(WebCore::RenderLayer::paintsWithTransparency const):
(WebCore::RenderLayer::canPaintTransparencyWithSetOpacity const):
(WebCore::RenderLayer::hasNonOpacityTransparency const):
* Source/WebCore/rendering/RenderLayerBacking.cpp:
(WebCore::RenderLayerBacking::isBitmapOnly const):

Canonical link: <a href="https://commits.webkit.org/263035@main">https://commits.webkit.org/263035@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/8574a3b7a651c11cbd1be138cc573ed87ae6ebe3

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/3312 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/3371 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/3487 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/4729 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/3643 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/3289 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/3434 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/3394 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/2877 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/3352 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/3640 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/2988 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/4551 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/1143 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/2951 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/2869 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/2925 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/3005 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/4290 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/3385 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/2708 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/2947 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/2952 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/2949 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/395 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/3222 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->