### PR TITLE
Web Inspector: Console: timestamps are always wrong

### DIFF
--- a/LayoutTests/inspector/console/timestamp-expected.txt
+++ b/LayoutTests/inspector/console/timestamp-expected.txt
@@ -1,0 +1,9 @@
+CONSOLE MESSAGE: 42
+Test for the ConsoleMessage.timestamp event.
+
+
+== Running test suite: ConsoleMessage.Timestamp
+-- Running test case: ConsoleMessage.Timestamp.Basic
+PASS: Should be after pre-captured timestamp.
+PASS: Should be before post-captured timestamp.
+

--- a/LayoutTests/inspector/console/timestamp.html
+++ b/LayoutTests/inspector/console/timestamp.html
@@ -1,0 +1,34 @@
+<!DOCTYPE html>
+<html>
+<head>
+<script src="../../http/tests/inspector/resources/inspector-test.js"></script>
+<script>
+function test()
+{
+    let suite = InspectorTest.createAsyncSuite("ConsoleMessage.Timestamp");
+
+    suite.addTestCase({
+        name: "ConsoleMessage.Timestamp.Basic",
+        async test() {
+            let before = Date.now();
+            let [event] = await Promise.all([
+                WI.consoleManager.awaitEvent(WI.ConsoleManager.Event.MessageAdded),
+                InspectorTest.evaluateInPage(`console.log(42)`),
+            ]);
+            let after = Date.now();
+
+            let {message} = event.data;
+
+            InspectorTest.expectGreaterThanOrEqual(message.timestamp * 1000, before, "Should be after pre-captured timestamp.");
+            InspectorTest.expectLessThanOrEqual(message.timestamp * 1000, after, "Should be before post-captured timestamp.");
+        },
+    });
+
+    suite.runTestCasesAndFinish();
+}
+</script>
+</head>
+<body onload="runTest()">
+    <p>Test for the ConsoleMessage.timestamp event.</p>
+</body>
+</html>

--- a/Source/JavaScriptCore/inspector/ConsoleMessage.h
+++ b/Source/JavaScriptCore/inspector/ConsoleMessage.h
@@ -56,12 +56,12 @@ class JS_EXPORT_PRIVATE ConsoleMessage {
     WTF_MAKE_NONCOPYABLE(ConsoleMessage);
     WTF_MAKE_FAST_ALLOCATED;
 public:
-    ConsoleMessage(MessageSource, MessageType, MessageLevel, const String& message, unsigned long requestIdentifier = 0, Seconds timestamp = { });
-    ConsoleMessage(MessageSource, MessageType, MessageLevel, const String& message, const String& url, unsigned line, unsigned column, JSC::JSGlobalObject* = nullptr, unsigned long requestIdentifier = 0, Seconds timestamp = { });
-    ConsoleMessage(MessageSource, MessageType, MessageLevel, const String& message, Ref<ScriptCallStack>&&, unsigned long requestIdentifier = 0, Seconds timestamp = { });
-    ConsoleMessage(MessageSource, MessageType, MessageLevel, const String& message, Ref<ScriptArguments>&&, Ref<ScriptCallStack>&&, unsigned long requestIdentifier = 0, Seconds timestamp = { });
-    ConsoleMessage(MessageSource, MessageType, MessageLevel, const String& message, Ref<ScriptArguments>&&, JSC::JSGlobalObject* = nullptr, unsigned long requestIdentifier = 0, Seconds timestamp = { });
-    ConsoleMessage(MessageSource, MessageType, MessageLevel, Vector<JSONLogValue>&&, JSC::JSGlobalObject*, unsigned long requestIdentifier = 0, Seconds timestamp = { });
+    ConsoleMessage(MessageSource, MessageType, MessageLevel, const String& message, unsigned long requestIdentifier = 0, WallTime timestamp = { });
+    ConsoleMessage(MessageSource, MessageType, MessageLevel, const String& message, const String& url, unsigned line, unsigned column, JSC::JSGlobalObject* = nullptr, unsigned long requestIdentifier = 0, WallTime timestamp = { });
+    ConsoleMessage(MessageSource, MessageType, MessageLevel, const String& message, Ref<ScriptCallStack>&&, unsigned long requestIdentifier = 0, WallTime timestamp = { });
+    ConsoleMessage(MessageSource, MessageType, MessageLevel, const String& message, Ref<ScriptArguments>&&, Ref<ScriptCallStack>&&, unsigned long requestIdentifier = 0, WallTime timestamp = { });
+    ConsoleMessage(MessageSource, MessageType, MessageLevel, const String& message, Ref<ScriptArguments>&&, JSC::JSGlobalObject* = nullptr, unsigned long requestIdentifier = 0, WallTime timestamp = { });
+    ConsoleMessage(MessageSource, MessageType, MessageLevel, Vector<JSONLogValue>&&, JSC::JSGlobalObject*, unsigned long requestIdentifier = 0, WallTime timestamp = { });
     ~ConsoleMessage();
 
     void addToFrontend(ConsoleFrontendDispatcher&, InjectedScriptManager&, bool generatePreview);
@@ -74,7 +74,7 @@ public:
     const String& url() const { return m_url; }
     unsigned line() const { return m_line; }
     unsigned column() const { return m_column; }
-    Seconds timestamp() const { return m_timestamp; }
+    WallTime timestamp() const { return m_timestamp; }
 
     JSC::JSGlobalObject* globalObject() const;
 
@@ -105,7 +105,7 @@ private:
     unsigned m_column { 0 };
     unsigned m_repeatCount { 1 };
     String m_requestId;
-    Seconds m_timestamp;
+    WallTime m_timestamp;
 };
 
 } // namespace Inspector

--- a/Source/WebCore/page/PageConsoleClient.cpp
+++ b/Source/WebCore/page/PageConsoleClient.cpp
@@ -318,7 +318,7 @@ void PageConsoleClient::screenshot(JSC::JSGlobalObject* lexicalGlobalObject, Ref
     String dataURL;
     JSC::JSValue target;
 
-    auto timestamp = m_page.inspectorController().executionStopwatch().elapsedTime();
+    auto timestamp = WallTime::now();
 
     if (arguments->argumentCount()) {
         auto possibleTarget = arguments->argumentAt(0);


### PR DESCRIPTION
#### 1eb0aa379232623c10a39b940d5e2ddf594ed5d2
<pre>
Web Inspector: Console: timestamps are always wrong
<a href="https://bugs.webkit.org/show_bug.cgi?id=255033">https://bugs.webkit.org/show_bug.cgi?id=255033</a>

Reviewed by Patrick Angle.

Use `WallTime` instead of `Monotonic` time since this is a timestamp we expect to display rather than something for comparison (i.e. &quot;was this before that?&quot;).

* Source/JavaScriptCore/inspector/ConsoleMessage.h:
* Source/JavaScriptCore/inspector/ConsoleMessage.cpp:
(Inspector::ConsoleMessage::ConsoleMessage):
(Inspector::ConsoleMessage::addToFrontend):
(Inspector::ConsoleMessage::updateRepeatCountInConsole):
* Source/WebCore/page/PageConsoleClient.cpp:
(WebCore::PageConsoleClient::screenshot):

* LayoutTests/inspector/console/timestamp.html: Added.
* LayoutTests/inspector/console/timestamp-expected.txt: Added.

Canonical link: <a href="https://commits.webkit.org/263261@main">https://commits.webkit.org/263261@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d449cbc771a40c653869193e4ae294cbab4a5633

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/3318 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/3377 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/3493 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/4735 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/3649 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/3295 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/3440 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/3400 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/2882 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/3358 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/3646 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/2997 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/4557 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/1149 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/2957 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/2874 "Passed tests") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/2732 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/2931 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/3011 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/4297 "Passed tests") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/3124 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/3391 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/2713 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/3390 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/2953 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/2958 "Passed tests") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/837 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/995 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/2955 "Built successfully") | | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/24/builds/3478 "Built successfully") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/3229 "Built successfully") | | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/3/builds/958 "Passed tests") | 
<!--EWS-Status-Bubble-End-->