### PR TITLE
clang-cl reports "error: reference to 'UUID' is ambiguous" for Windows port

### DIFF
--- a/Source/WTF/wtf/Forward.h
+++ b/Source/WTF/wtf/Forward.h
@@ -251,3 +251,20 @@ template<class E> using Unexpected = std::experimental::unexpected<E>;
 #define WTF_LAZY_HAS_REST_8 WTF_LAZY_EXPAND
 #define WTF_LAZY_HAS_REST(...) \
     WTF_LAZY_JOIN(WTF_LAZY_HAS_REST_, WTF_LAZY_NUM_ARGS(__VA_ARGS__))
+
+// <windows.h> contains ::UUID. Define UUID in each namespace that is using it.
+namespace IPC {
+using WTF::UUID;
+}
+namespace Messages {
+using WTF::UUID;
+}
+namespace WTR {
+using WTF::UUID;
+}
+namespace WebCore {
+using WTF::UUID;
+}
+namespace WebKit {
+using WTF::UUID;
+}

--- a/Source/WebKit/UIProcess/API/APIUserInitiatedAction.h
+++ b/Source/WebKit/UIProcess/API/APIUserInitiatedAction.h
@@ -43,12 +43,12 @@ public:
     void setConsumed() { m_consumed = true; }
     bool consumed() const { return m_consumed; }
 
-    void setAuthorizationToken(UUID authorizationToken) { m_authorizationToken = authorizationToken; }
-    std::optional<UUID> authorizationToken() const { return m_authorizationToken; }
+    void setAuthorizationToken(WTF::UUID authorizationToken) { m_authorizationToken = authorizationToken; }
+    std::optional<WTF::UUID> authorizationToken() const { return m_authorizationToken; }
 
 private:
     bool m_consumed { false };
-    std::optional<UUID> m_authorizationToken;
+    std::optional<WTF::UUID> m_authorizationToken;
 };
 
 } // namespace API

--- a/Source/WebKit/UIProcess/API/C/WKNotificationManager.cpp
+++ b/Source/WebKit/UIProcess/API/C/WKNotificationManager.cpp
@@ -61,7 +61,7 @@ void WKNotificationManagerProviderDidClickNotification_b(WKNotificationManagerRe
     if (span.size() != 16)
         return;
 
-    toImpl(managerRef)->providerDidClickNotification(UUID { Span<const uint8_t, 16> { span.data(), 16 } });
+    toImpl(managerRef)->providerDidClickNotification(WTF::UUID { Span<const uint8_t, 16> { span.data(), 16 } });
 }
 
 void WKNotificationManagerProviderDidCloseNotifications(WKNotificationManagerRef managerRef, WKArrayRef notificationIDs)


### PR DESCRIPTION
#### 16e36e6bc5e6ba586ec78fcb05297928fdba0eaa
<pre>
clang-cl reports &quot;error: reference to &apos;UUID&apos; is ambiguous&quot; for Windows port
<a href="https://bugs.webkit.org/show_bug.cgi?id=234696">https://bugs.webkit.org/show_bug.cgi?id=234696</a>

Reviewed by Yusuke Suzuki.

Including &lt;windows.h&gt; defines `UUID` in the global scope. This
conflicted with &quot;using WTF::UUID;&quot; in &lt;wtf/Forward.h&gt;. For the
workaround, define `UUID` in each namespace that is using it in
&lt;wtf/Forward.h&gt;.

* Source/WTF/wtf/Forward.h:
* Source/WebKit/UIProcess/API/APIUserInitiatedAction.h:
* Source/WebKit/UIProcess/API/C/WKNotificationManager.cpp:
(WKNotificationManagerProviderDidClickNotification_b):

Canonical link: <a href="https://commits.webkit.org/263042@main">https://commits.webkit.org/263042@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/38abdacdafd39115e35c21c66658871a8be6bffa

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/3330 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/3389 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/3505 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/4747 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/3660 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/3452 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/3412 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/2896 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/3370 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/3654 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/3004 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/4569 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/1157 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/2965 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/2884 "4 flakes 141 failures") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/2742 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/2939 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/3019 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/4313 "Passed tests") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/3135 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/3403 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/2722 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/3402 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/2965 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/2966 "Passed tests") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/842 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/834 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/2967 "Built successfully") | | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/24/builds/3490 "Built successfully") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/3241 "Built successfully") | | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/3/builds/964 "Passed tests") | 
<!--EWS-Status-Bubble-End-->