### PR TITLE
Fix SEGV in ReplaceSelectionCommand::makeInsertedContentRoundTrippableWithHTMLTreeBuilder

### DIFF
--- a/LayoutTests/fast/editing/replace-selection-command-crash-expected.txt
+++ b/LayoutTests/fast/editing/replace-selection-command-crash-expected.txt
@@ -1,0 +1,1 @@
+PASS if no crash

--- a/LayoutTests/fast/editing/replace-selection-command-crash.html
+++ b/LayoutTests/fast/editing/replace-selection-command-crash.html
@@ -1,0 +1,30 @@
+<style>
+.class3 { display: list-item; }
+*:dir(ltr) { font-variant-caps: all-petite-caps }
+</style>
+<script>
+function onLoadCallback() {
+    column = document.createElement("col");
+    dataID.appendChild(column);
+    window.getSelection().collapse(column);
+    if (window.testRunner)
+        testRunner.dumpAsText();
+}
+function onFocusCallback() {
+    window.document.designMode = "on";
+    window.document.dir = "auto";
+    window.document.execCommand("insertHTML", false, ulID.outerHTML);
+    document.body.innerHTML = 'PASS if no crash';
+}
+</script>
+<body onload="onLoadCallback()">
+  <ul id="ulID" translate="no">
+    <li itemid="A">
+    </li>
+  </ul>
+  <slot contenteditable="true" class="class3" onfocusin="onFocusCallback()">
+    <data id="dataID">
+    </data>
+    A
+  </slot>
+</body>

--- a/Source/WebCore/editing/ReplaceSelectionCommand.cpp
+++ b/Source/WebCore/editing/ReplaceSelectionCommand.cpp
@@ -441,8 +441,11 @@ inline void ReplaceSelectionCommand::InsertedNodes::willRemoveNode(Node* node)
         m_lastNodeInserted = nullptr;
     } else if (m_firstNodeInserted == node)
         m_firstNodeInserted = NodeTraversal::nextSkippingChildren(*m_firstNodeInserted);
-    else if (m_lastNodeInserted == node)
+    else if (m_lastNodeInserted == node) {
         m_lastNodeInserted = NodeTraversal::previousSkippingChildren(*m_lastNodeInserted);
+        if (!m_lastNodeInserted)
+            m_lastNodeInserted = m_firstNodeInserted;
+    }
 }
 
 inline void ReplaceSelectionCommand::InsertedNodes::didReplaceNode(Node* node, Node* newNode)


### PR DESCRIPTION
#### 62a3751abfbc0bda4a9fff41c52e1f4d98e6293e
<pre>
Fix SEGV in ReplaceSelectionCommand::makeInsertedContentRoundTrippableWithHTMLTreeBuilder
<a href="https://bugs.webkit.org/show_bug.cgi?id=255510">https://bugs.webkit.org/show_bug.cgi?id=255510</a>
rdar://107979390

Reviewed by Ryosuke Niwa.

This change fixes a crash which is caused because we end up in state
where m_lastNodeInserted is NULL after a call to
ReplaceSelectionCommand::InsertedNodes::willRemoveNode, which means that
when makeInsertedContentRoundTrippableWithHTMLTreeBuilder calls
pastLastLeaf() we trip over an assertion.

* LayoutTests/fast/editing/replace-selection-command-crash-expected.txt: Added.
* LayoutTests/fast/editing/replace-selection-command-crash.html: Added.
* Source/WebCore/editing/ReplaceSelectionCommand.cpp:
(WebCore::ReplaceSelectionCommand::InsertedNodes::willRemoveNode):

Canonical link: <a href="https://commits.webkit.org/263051@main">https://commits.webkit.org/263051@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a54781e14864e329012fb6df9617edb518c08f1a

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/3340 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/3400 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/3519 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/4762 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/3672 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/3319 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/3465 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/3424 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/2902 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/3381 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/3664 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/3015 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/4583 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/1167 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/2975 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/2894 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/2949 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/3029 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/4323 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/3414 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/2732 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/2977 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/2976 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/840 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/2980 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/3252 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->