### PR TITLE
[GTK] Minibrowser does not render any content

### DIFF
--- a/Source/WebCore/PlatformGTK.cmake
+++ b/Source/WebCore/PlatformGTK.cmake
@@ -47,7 +47,9 @@ list(APPEND WebCore_PRIVATE_FRAMEWORK_HEADERS
 
     platform/glib/ApplicationGLib.h
 
-    platform/graphics/egl/PlatformDisplayHeadless.h
+    platform/graphics/egl/PlatformDisplaySurfaceless.h
+
+    platform/graphics/gbm/PlatformDisplayGBM.h
 
     platform/graphics/gtk/GdkCairoUtilities.h
 

--- a/Source/WebCore/SourcesGTK.txt
+++ b/Source/WebCore/SourcesGTK.txt
@@ -74,7 +74,7 @@ platform/graphics/egl/GLContext.cpp @no-unify
 platform/graphics/egl/GLContextLibWPE.cpp @no-unify
 platform/graphics/egl/GLContextWayland.cpp @no-unify
 platform/graphics/egl/GLContextX11.cpp @no-unify
-platform/graphics/egl/PlatformDisplayHeadless.cpp
+platform/graphics/egl/PlatformDisplaySurfaceless.cpp
 
 platform/graphics/gbm/GBMBufferSwapchain.cpp
 platform/graphics/gbm/GBMDevice.cpp
@@ -82,6 +82,7 @@ platform/graphics/gbm/GraphicsContextGLANGLELinux.cpp
 platform/graphics/gbm/GraphicsContextGLFallback.cpp
 platform/graphics/gbm/GraphicsContextGLGBM.cpp
 platform/graphics/gbm/GraphicsContextGLGBMTextureMapper.cpp
+platform/graphics/gbm/PlatformDisplayGBM.cpp
 
 platform/graphics/gtk/ColorGtk.cpp
 platform/graphics/gtk/DisplayRefreshMonitorGtk.cpp

--- a/Source/WebCore/platform/graphics/egl/GLContext.cpp
+++ b/Source/WebCore/platform/graphics/egl/GLContext.cpp
@@ -146,7 +146,7 @@ bool GLContext::getEGLConfig(PlatformDisplay& platformDisplay, EGLConfig* config
 
     switch (surfaceType) {
     case GLContext::Surfaceless:
-        if (platformDisplay.type() == PlatformDisplay::Type::Headless)
+        if (platformDisplay.type() == PlatformDisplay::Type::Surfaceless)
             attributeList[13] = EGL_PBUFFER_BIT;
         else
             attributeList[13] = EGL_WINDOW_BIT;
@@ -270,7 +270,10 @@ std::unique_ptr<GLContext> GLContext::createWindowContext(GLNativeWindowType win
         surface = createWindowSurfaceWPE(display, config, window);
         break;
 #endif // USE(WPE_RENDERER)
-    case PlatformDisplay::Type::Headless:
+#if USE(GBM)
+    case PlatformDisplay::Type::GBM:
+#endif
+    case PlatformDisplay::Type::Surfaceless:
         RELEASE_ASSERT_NOT_REACHED();
     }
 
@@ -359,7 +362,7 @@ std::unique_ptr<GLContext> GLContext::create(GLNativeWindowType window, Platform
     }
 
     EGLContext eglSharingContext = platformDisplay.sharingGLContext() ? static_cast<GLContext*>(platformDisplay.sharingGLContext())->m_context : EGL_NO_CONTEXT;
-    if (platformDisplay.type() == PlatformDisplay::Type::Headless) {
+    if (platformDisplay.type() == PlatformDisplay::Type::Surfaceless) {
         auto context = createSurfacelessContext(platformDisplay, eglSharingContext);
         if (!context)
             WTFLogAlways("Could not create EGL surfaceless context: %s.", lastErrorString());
@@ -386,7 +389,10 @@ std::unique_ptr<GLContext> GLContext::create(GLNativeWindowType window, Platform
             context = createWPEContext(platformDisplay, eglSharingContext);
             break;
 #endif
-        case PlatformDisplay::Type::Headless:
+#if USE(GBM)
+        case PlatformDisplay::Type::GBM:
+#endif
+        case PlatformDisplay::Type::Surfaceless:
             RELEASE_ASSERT_NOT_REACHED();
         }
     }
@@ -443,7 +449,10 @@ std::unique_ptr<GLContext> GLContext::createSharing(PlatformDisplay& platformDis
             context = createWPEContext(platformDisplay);
             break;
 #endif
-        case PlatformDisplay::Type::Headless:
+#if USE(GBM)
+        case PlatformDisplay::Type::GBM:
+#endif
+        case PlatformDisplay::Type::Surfaceless:
             break;
         }
     }

--- a/Source/WebCore/platform/graphics/egl/PlatformDisplaySurfaceless.cpp
+++ b/Source/WebCore/platform/graphics/egl/PlatformDisplaySurfaceless.cpp
@@ -1,0 +1,61 @@
+/*
+ * Copyright (C) 2023 Igalia S.L.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE COMPUTER, INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE COMPUTER, INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "PlatformDisplaySurfaceless.h"
+
+#if USE(EGL)
+#include "GLContext.h"
+#include <epoxy/egl.h>
+
+namespace WebCore {
+
+std::unique_ptr<PlatformDisplaySurfaceless> PlatformDisplaySurfaceless::create()
+{
+    return std::unique_ptr<PlatformDisplaySurfaceless>(new PlatformDisplaySurfaceless());
+}
+
+PlatformDisplaySurfaceless::PlatformDisplaySurfaceless()
+{
+#if PLATFORM(GTK)
+    PlatformDisplay::setSharedDisplayForCompositing(*this);
+#endif
+
+    const char* extensions = eglQueryString(nullptr, EGL_EXTENSIONS);
+    if (GLContext::isExtensionSupported(extensions, "EGL_EXT_platform_base"))
+        m_eglDisplay = eglGetPlatformDisplayEXT(EGL_PLATFORM_SURFACELESS_MESA, EGL_DEFAULT_DISPLAY, nullptr);
+    else if (GLContext::isExtensionSupported(extensions, "EGL_KHR_platform_base"))
+        m_eglDisplay = eglGetPlatformDisplay(EGL_PLATFORM_SURFACELESS_MESA, EGL_DEFAULT_DISPLAY, nullptr);
+
+    PlatformDisplay::initializeEGLDisplay();
+}
+
+PlatformDisplaySurfaceless::~PlatformDisplaySurfaceless()
+{
+}
+
+} // namespace WebCore
+
+#endif // USE(EGL)

--- a/Source/WebCore/platform/graphics/egl/PlatformDisplaySurfaceless.h
+++ b/Source/WebCore/platform/graphics/egl/PlatformDisplaySurfaceless.h
@@ -30,15 +30,15 @@
 
 namespace WebCore {
 
-class PlatformDisplayHeadless final : public PlatformDisplay {
+class PlatformDisplaySurfaceless final : public PlatformDisplay {
 public:
-    static std::unique_ptr<PlatformDisplayHeadless> create();
+    static std::unique_ptr<PlatformDisplaySurfaceless> create();
 
-    virtual ~PlatformDisplayHeadless();
+    virtual ~PlatformDisplaySurfaceless();
 private:
-    PlatformDisplayHeadless();
+    PlatformDisplaySurfaceless();
 
-    Type type() const override { return PlatformDisplay::Type::Headless; }
+    Type type() const override { return PlatformDisplay::Type::Surfaceless; }
 };
 
 } // namespace WebCore

--- a/Source/WebCore/platform/graphics/gbm/PlatformDisplayGBM.cpp
+++ b/Source/WebCore/platform/graphics/gbm/PlatformDisplayGBM.cpp
@@ -24,38 +24,58 @@
  */
 
 #include "config.h"
-#include "PlatformDisplayHeadless.h"
+#include "PlatformDisplayGBM.h"
 
-#if USE(EGL)
+#if USE(EGL) && USE(GBM)
 #include "GLContext.h"
 #include <epoxy/egl.h>
+#include <fcntl.h>
+#include <gbm.h>
+#include <unistd.h>
+#include <wtf/SafeStrerror.h>
+#include <wtf/StdLibExtras.h>
+#include <wtf/unix/UnixFileDescriptor.h>
 
 namespace WebCore {
 
-std::unique_ptr<PlatformDisplayHeadless> PlatformDisplayHeadless::create()
+std::unique_ptr<PlatformDisplayGBM> PlatformDisplayGBM::create(const String& deviceFile)
 {
-    return std::unique_ptr<PlatformDisplayHeadless>(new PlatformDisplayHeadless());
+    auto fd = UnixFileDescriptor { open(deviceFile.utf8().data(), O_RDWR | O_CLOEXEC), UnixFileDescriptor::Adopt };
+    if (!fd) {
+        WTFLogAlways("Failed to open DRM render device %s: %s", deviceFile.utf8().data(), safeStrerror(errno).data());
+        return nullptr;
+    }
+
+    auto* device = gbm_create_device(fd.value());
+    if (!device) {
+        WTFLogAlways("Failed to create GBM device for render device: %s: %s", deviceFile.utf8().data(), safeStrerror(errno).data());
+        return nullptr;
+    }
+
+    return std::unique_ptr<PlatformDisplayGBM>(new PlatformDisplayGBM(WTFMove(fd), device));
 }
 
-PlatformDisplayHeadless::PlatformDisplayHeadless()
+PlatformDisplayGBM::PlatformDisplayGBM(UnixFileDescriptor&& fd, struct gbm_device* device)
 {
 #if PLATFORM(GTK)
     PlatformDisplay::setSharedDisplayForCompositing(*this);
 #endif
 
+    m_gbm = { WTFMove(fd), device };
+
     const char* extensions = eglQueryString(nullptr, EGL_EXTENSIONS);
     if (GLContext::isExtensionSupported(extensions, "EGL_EXT_platform_base"))
-        m_eglDisplay = eglGetPlatformDisplayEXT(EGL_PLATFORM_SURFACELESS_MESA, EGL_DEFAULT_DISPLAY, nullptr);
+        m_eglDisplay = eglGetPlatformDisplayEXT(EGL_PLATFORM_GBM_KHR, m_gbm.device.value(), nullptr);
     else if (GLContext::isExtensionSupported(extensions, "EGL_KHR_platform_base"))
-        m_eglDisplay = eglGetPlatformDisplay(EGL_PLATFORM_SURFACELESS_MESA, EGL_DEFAULT_DISPLAY, nullptr);
+        m_eglDisplay = eglGetPlatformDisplay(EGL_PLATFORM_GBM_KHR, m_gbm.device.value(), nullptr);
 
     PlatformDisplay::initializeEGLDisplay();
 }
 
-PlatformDisplayHeadless::~PlatformDisplayHeadless()
+PlatformDisplayGBM::~PlatformDisplayGBM()
 {
 }
 
 } // namespace WebCore
 
-#endif // USE(EGL)
+#endif // USE(EGL) && USE(GBM)

--- a/Source/WebCore/platform/graphics/gbm/PlatformDisplayGBM.h
+++ b/Source/WebCore/platform/graphics/gbm/PlatformDisplayGBM.h
@@ -1,0 +1,46 @@
+/*
+ * Copyright (C) 2023 Igalia S.L.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE COMPUTER, INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE COMPUTER, INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#if USE(EGL) && USE(GBM)
+#include "PlatformDisplay.h"
+
+namespace WebCore {
+
+class PlatformDisplayGBM final : public PlatformDisplay {
+public:
+    static std::unique_ptr<PlatformDisplayGBM> create(const String&);
+
+    virtual ~PlatformDisplayGBM();
+private:
+    PlatformDisplayGBM(UnixFileDescriptor&&, struct gbm_device*);
+
+    Type type() const override { return PlatformDisplay::Type::GBM; }
+};
+
+} // namespace WebCore
+
+#endif // USE(EGL) && USE(GBM)

--- a/Source/WebKit/Shared/WebProcessCreationParameters.cpp
+++ b/Source/WebKit/Shared/WebProcessCreationParameters.cpp
@@ -188,6 +188,7 @@ void WebProcessCreationParameters::encode(IPC::Encoder& encoder) const
 
 #if PLATFORM(GTK)
     encoder << useDMABufSurfaceForCompositing;
+    encoder << renderDeviceFile;
     encoder << useSystemAppearanceForScrollbars;
     encoder << gtkSettings;
 #endif
@@ -526,6 +527,11 @@ bool WebProcessCreationParameters::decode(IPC::Decoder& decoder, WebProcessCreat
     if (!useDMABufSurfaceForCompositing)
         return false;
     parameters.useDMABufSurfaceForCompositing = WTFMove(*useDMABufSurfaceForCompositing);
+    std::optional<String> renderDeviceFile;
+    decoder >> renderDeviceFile;
+    if (!renderDeviceFile)
+        return false;
+    parameters.renderDeviceFile = WTFMove(*renderDeviceFile);
     std::optional<bool> useSystemAppearanceForScrollbars;
     decoder >> useSystemAppearanceForScrollbars;
     if (!useSystemAppearanceForScrollbars)

--- a/Source/WebKit/Shared/WebProcessCreationParameters.h
+++ b/Source/WebKit/Shared/WebProcessCreationParameters.h
@@ -229,6 +229,7 @@ struct WebProcessCreationParameters {
 
 #if PLATFORM(GTK)
     bool useDMABufSurfaceForCompositing { false };
+    String renderDeviceFile;
     bool useSystemAppearanceForScrollbars { false };
     GtkSettingsState gtkSettings;
 #endif

--- a/Source/WebKit/UIProcess/API/glib/WebKitProtocolHandler.cpp
+++ b/Source/WebKit/UIProcess/API/glib/WebKitProtocolHandler.cpp
@@ -58,9 +58,6 @@
 
 #if USE(GBM)
 #include "AcceleratedBackingStoreDMABuf.h"
-#ifndef EGL_DRM_RENDER_NODE_FILE_EXT
-#define EGL_DRM_RENDER_NODE_FILE_EXT 0x3377
-#endif
 #endif
 
 #if PLATFORM(X11)
@@ -281,22 +278,13 @@ void WebKitProtocolHandler::handleGPU(WebKitURISchemeRequest* request)
     addTableRow(hardwareAccelerationObject, "GL_VERSION"_s, makeString(reinterpret_cast<const char*>(glGetString(GL_VERSION))));
     addTableRow(hardwareAccelerationObject, "GL_SHADING_LANGUAGE_VERSION"_s, makeString(reinterpret_cast<const char*>(glGetString(GL_SHADING_LANGUAGE_VERSION))));
 
-    auto eglDisplay = PlatformDisplay::sharedDisplay().eglDisplay();
 #if USE(GBM)
-    if (GLContext::isExtensionSupported(eglQueryString(nullptr, EGL_EXTENSIONS), "EGL_EXT_device_query")) {
-        EGLDeviceEXT eglDevice;
-        if (eglQueryDisplayAttribEXT(eglDisplay, EGL_DEVICE_EXT, reinterpret_cast<EGLAttrib*>(&eglDevice))) {
-            const char* deviceExtensions = eglQueryDeviceStringEXT(eglDevice, EGL_EXTENSIONS);
-            if (GLContext::isExtensionSupported(deviceExtensions, "EGL_EXT_device_drm")) {
-                if (const char* deviceFile = eglQueryDeviceStringEXT(eglDevice, EGL_DRM_DEVICE_FILE_EXT))
-                    addTableRow(hardwareAccelerationObject, "DRM Device"_s, makeString(deviceFile));
-            }
-            if (GLContext::isExtensionSupported(deviceExtensions, "EGL_EXT_device_drm_render_node")) {
-                if (const char* renderNode = eglQueryDeviceStringEXT(eglDevice, EGL_DRM_RENDER_NODE_FILE_EXT))
-                    addTableRow(hardwareAccelerationObject, "DRM Render Node"_s, makeString(renderNode));
-            }
-        }
-    }
+    auto deviceFile = PlatformDisplay::sharedDisplay().drmDeviceFile();
+    if (!deviceFile.isEmpty())
+        addTableRow(hardwareAccelerationObject, "DRM Device"_s, deviceFile);
+    auto renderNode = PlatformDisplay::sharedDisplay().drmRenderNodeFile();
+    if (!renderNode.isEmpty())
+        addTableRow(hardwareAccelerationObject, "DRM Render Node"_s, renderNode);
 #endif
 
 #if USE(OPENGL_ES)
@@ -313,6 +301,7 @@ void WebKitProtocolHandler::handleGPU(WebKitURISchemeRequest* request)
     addTableRow(hardwareAccelerationObject, "GL_EXTENSIONS"_s, extensionsBuilder.toString());
 #endif
 
+    auto eglDisplay = PlatformDisplay::sharedDisplay().eglDisplay();
     addTableRow(hardwareAccelerationObject, "EGL_VERSION"_s, makeString(eglQueryString(eglDisplay, EGL_VERSION)));
     addTableRow(hardwareAccelerationObject, "EGL_VENDOR"_s, makeString(eglQueryString(eglDisplay, EGL_VENDOR)));
     addTableRow(hardwareAccelerationObject, "EGL_EXTENSIONS"_s, makeString(eglQueryString(nullptr, EGL_EXTENSIONS), ' ', eglQueryString(eglDisplay, EGL_EXTENSIONS)));

--- a/Source/WebKit/UIProcess/glib/WebProcessPoolGLib.cpp
+++ b/Source/WebKit/UIProcess/glib/WebProcessPoolGLib.cpp
@@ -87,8 +87,10 @@ void WebProcessPool::platformInitializeWebProcess(const WebProcessProxy& process
 #endif
 
 #if PLATFORM(GTK) && USE(GBM)
-    if (AcceleratedBackingStoreDMABuf::checkRequirements())
+    if (AcceleratedBackingStoreDMABuf::checkRequirements()) {
         parameters.useDMABufSurfaceForCompositing = true;
+        parameters.renderDeviceFile = WebCore::PlatformDisplay::sharedDisplay().drmRenderNodeFile();
+    }
 #endif
 
 #if PLATFORM(WAYLAND)

--- a/Source/WebKit/UIProcess/gtk/AcceleratedBackingStoreDMABuf.cpp
+++ b/Source/WebKit/UIProcess/gtk/AcceleratedBackingStoreDMABuf.cpp
@@ -33,7 +33,6 @@
 #include "WebPageProxy.h"
 #include "WebProcessProxy.h"
 #include <WebCore/DMABufFormat.h>
-#include <WebCore/GBMDevice.h>
 #include <WebCore/GLContext.h>
 #include <WebCore/IntRect.h>
 #include <WebCore/PlatformDisplay.h>
@@ -219,7 +218,12 @@ void AcceleratedBackingStoreDMABuf::Texture::paint(GtkWidget* widget, cairo_t* c
 AcceleratedBackingStoreDMABuf::Surface::Surface(const UnixFileDescriptor& backFD, const UnixFileDescriptor& frontFD, const WebCore::IntSize& size, uint32_t format, uint32_t offset, uint32_t stride, float deviceScaleFactor)
     : RenderSource(size, deviceScaleFactor)
 {
-    auto* device = WebCore::GBMDevice::singleton().device();
+    auto* device = WebCore::PlatformDisplay::sharedDisplay().gbmDevice();
+    if (!device) {
+        WTFLogAlways("Failed to get GBM device");
+        return;
+    }
+
     struct gbm_import_fd_data fdData = { backFD.value(), static_cast<uint32_t>(m_size.width()), static_cast<uint32_t>(m_size.height()), stride, format };
     m_backBuffer = gbm_bo_import(device, GBM_BO_IMPORT_FD, &fdData, GBM_BO_USE_RENDERING);
     if (!m_backBuffer) {

--- a/Source/WebKit/WebProcess/WebPage/AcceleratedSurface.cpp
+++ b/Source/WebKit/WebProcess/WebPage/AcceleratedSurface.cpp
@@ -47,7 +47,8 @@ using namespace WebCore;
 std::unique_ptr<AcceleratedSurface> AcceleratedSurface::create(WebPage& webPage, Client& client)
 {
 #if USE(GBM)
-    if (PlatformDisplay::sharedDisplayForCompositing().type() == PlatformDisplay::Type::Headless)
+    if (PlatformDisplay::sharedDisplayForCompositing().type() == PlatformDisplay::Type::GBM
+        || PlatformDisplay::sharedDisplayForCompositing().type() == PlatformDisplay::Type::Surfaceless)
         return AcceleratedSurfaceDMABuf::create(webPage, client);
 #endif
 #if PLATFORM(WAYLAND)

--- a/Source/WebKit/WebProcess/WebPage/gtk/AcceleratedSurfaceDMABuf.cpp
+++ b/Source/WebKit/WebProcess/WebPage/gtk/AcceleratedSurfaceDMABuf.cpp
@@ -32,7 +32,6 @@
 #include "WebPage.h"
 #include "WebProcess.h"
 #include <WebCore/DMABufFormat.h>
-#include <WebCore/GBMDevice.h>
 #include <WebCore/PlatformDisplay.h>
 #include <array>
 #include <epoxy/egl.h>
@@ -48,7 +47,7 @@ std::unique_ptr<AcceleratedSurfaceDMABuf> AcceleratedSurfaceDMABuf::create(WebPa
 
 AcceleratedSurfaceDMABuf::AcceleratedSurfaceDMABuf(WebPage& webPage, Client& client)
     : AcceleratedSurface(webPage, client)
-    , m_isSoftwareRast(!WebCore::PlatformDisplay::sharedDisplayForCompositing().eglExtensions().EXT_image_dma_buf_import)
+    , m_isSoftwareRast(WebCore::PlatformDisplay::sharedDisplayForCompositing().type() == WebCore::PlatformDisplay::Type::Surfaceless)
 {
 }
 
@@ -101,7 +100,12 @@ std::unique_ptr<AcceleratedSurfaceDMABuf::RenderTarget> AcceleratedSurfaceDMABuf
 
     auto& display = WebCore::PlatformDisplay::sharedDisplayForCompositing();
     auto createImage = [&]() -> std::pair<UnixFileDescriptor, EGLImage> {
-        auto* bo = gbm_bo_create(WebCore::GBMDevice::singleton().device(), size.width(), size.height(), uint32_t(WebCore::DMABufFormat::FourCC::ARGB8888), 0);
+        auto* device = display.gbmDevice();
+        if (!device) {
+            WTFLogAlways("Failed to create GBM buffer of size %dx%d: no GBM device found", size.width(), size.height());
+            return { };
+        }
+        auto* bo = gbm_bo_create(device, size.width(), size.height(), uint32_t(WebCore::DMABufFormat::FourCC::ARGB8888), 0);
         if (!bo) {
             WTFLogAlways("Failed to create GBM buffer of size %dx%d: %s", size.width(), size.height(), safeStrerror(errno).data());
             return { };

--- a/Source/WebKit/WebProcess/glib/WebProcessGLib.cpp
+++ b/Source/WebKit/WebProcess/glib/WebProcessGLib.cpp
@@ -48,8 +48,9 @@
 #include <wpe/wpe.h>
 #endif
 
-#if PLATFORM(GTK) && USE(EGL)
-#include <WebCore/PlatformDisplayHeadless.h>
+#if PLATFORM(GTK) && USE(GBM)
+#include <WebCore/PlatformDisplayGBM.h>
+#include <WebCore/PlatformDisplaySurfaceless.h>
 #endif
 
 #if PLATFORM(GTK) && !USE(GTK4)
@@ -123,9 +124,13 @@ void WebProcess::platformInitializeWebProcess(WebProcessCreationParameters& para
     }
 #endif
 
-#if PLATFORM(GTK) && USE(EGL)
-    if (parameters.useDMABufSurfaceForCompositing)
-        m_displayForCompositing = WebCore::PlatformDisplayHeadless::create();
+#if PLATFORM(GTK) && USE(GBM)
+    if (parameters.useDMABufSurfaceForCompositing) {
+        if (!parameters.renderDeviceFile.isEmpty())
+            m_displayForCompositing = WebCore::PlatformDisplayGBM::create(parameters.renderDeviceFile);
+        else
+            m_displayForCompositing = WebCore::PlatformDisplaySurfaceless::create();
+    }
 #endif
 
 #if PLATFORM(WAYLAND)


### PR DESCRIPTION
#### 5fa29667e2adc5d95e3db3f9a0bcd4190ce568e2
<pre>
[GTK] Minibrowser does not render any content
<a href="https://bugs.webkit.org/show_bug.cgi?id=254807">https://bugs.webkit.org/show_bug.cgi?id=254807</a>

Reviewed by Žan Doberšek.

This might happen in systems with multiple GPUs enabled. The problem is that
we might end up using a different GPU than the one used by the
application in the UI process. This is because both GBMDevice and mesa
surfaceless platform use always the first device having a render node
returned by drmGetDevices2(). To make sure we use the right GPU
everywhere we need to get the GPU used by the UI process and send it
to the web process. Mesa surfaceless platform doesn&apos;t allow to change the
device, so we need to use GBM platform that receives the device as the
native display when initializing the EGL display. Surfaceless platform
is still used for swrast, because GBM requires a GPU device.

* Source/WebCore/PlatformGTK.cmake:
* Source/WebCore/SourcesGTK.txt:
* Source/WebCore/platform/graphics/PlatformDisplay.cpp:
(WebCore::PlatformDisplay::~PlatformDisplay):
(WebCore::PlatformDisplay::eglDevice):
(WebCore::PlatformDisplay::drmDeviceFile):
(WebCore::drmRenderNodeFromPrimaryDeviceFile):
(WebCore::PlatformDisplay::drmRenderNodeFile):
(WebCore::PlatformDisplay::gbmDevice):
* Source/WebCore/platform/graphics/PlatformDisplay.h:
* Source/WebCore/platform/graphics/egl/GLContext.cpp:
(WebCore::GLContext::getEGLConfig):
(WebCore::GLContext::createWindowContext):
(WebCore::GLContext::create):
(WebCore::GLContext::createSharing):
* Source/WebCore/platform/graphics/egl/PlatformDisplaySurfaceless.cpp: Renamed from Source/WebCore/platform/graphics/egl/PlatformDisplayHeadless.cpp.
* Source/WebCore/platform/graphics/egl/PlatformDisplaySurfaceless.h: Renamed from Source/WebCore/platform/graphics/egl/PlatformDisplayHeadless.h.
* Source/WebCore/platform/graphics/gbm/PlatformDisplayGBM.cpp: Added.
(WebCore::PlatformDisplayGBM::create):
(WebCore::PlatformDisplayGBM::PlatformDisplayGBM):
(WebCore::PlatformDisplayGBM::~PlatformDisplayGBM):
* Source/WebCore/platform/graphics/gbm/PlatformDisplayGBM.h: Added.
* Source/WebKit/Shared/WebProcessCreationParameters.cpp:
(WebKit::WebProcessCreationParameters::encode const):
(WebKit::WebProcessCreationParameters::decode):
* Source/WebKit/Shared/WebProcessCreationParameters.h:
* Source/WebKit/UIProcess/API/glib/WebKitProtocolHandler.cpp:
(WebKit::WebKitProtocolHandler::handleGPU):
* Source/WebKit/UIProcess/glib/WebProcessPoolGLib.cpp:
(WebKit::WebProcessPool::platformInitializeWebProcess):
* Source/WebKit/UIProcess/gtk/AcceleratedBackingStoreDMABuf.cpp:
(WebKit::AcceleratedBackingStoreDMABuf::Surface::Surface):
* Source/WebKit/WebProcess/WebPage/AcceleratedSurface.cpp:
(WebKit::AcceleratedSurface::create):
* Source/WebKit/WebProcess/WebPage/gtk/AcceleratedSurfaceDMABuf.cpp:
(WebKit::AcceleratedSurfaceDMABuf::AcceleratedSurfaceDMABuf):
(WebKit::AcceleratedSurfaceDMABuf::RenderTargetEGLImage::create):
* Source/WebKit/WebProcess/glib/WebProcessGLib.cpp:
(WebKit::WebProcess::platformInitializeWebProcess):

Canonical link: <a href="https://commits.webkit.org/263061@main">https://commits.webkit.org/263061@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d9b373da7b9dacf97c6ff15176526b05803781b9

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [  ~~🧪 style~~](https://ews-build.webkit.org/#/builders/38/builds/3524 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 ios~~](https://ews-build.webkit.org/#/builders/26/builds/3571 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/14/builds/3709 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/4946 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/32/builds/3798 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [  ~~🧪 bindings~~](https://ews-build.webkit.org/#/builders/9/builds/3502 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/23/builds/3660 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/16/builds/3612 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/4946 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | 
| [  ~~🧪 webkitperl~~](https://ews-build.webkit.org/#/builders/11/builds/3566 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/23/builds/3660 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/14/builds/3709 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/2/builds/4769 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/23/builds/3660 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/14/builds/3709 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/2/builds/4769 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/23/builds/3660 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/14/builds/3709 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/2/builds/4769 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/7/builds/3582 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/16/builds/3612 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/30/builds/3124 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/14/builds/3709 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/4/builds/3150 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/404 "Built successfully and passed tests") | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/31/builds/3402 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->