### PR TITLE
[WGSL] Add type declarations for numeric built-in functions

### DIFF
--- a/Source/WebGPU/WGSL/TypeDeclarations.rb
+++ b/Source/WebGPU/WGSL/TypeDeclarations.rb
@@ -141,30 +141,6 @@ operator :vec4, {
     end
 end
 
-operator :clamp, {
-    [T < Number].(T, T, T) => T,
-    [T < Number, N].(Vector[T, N], Vector[T, N], Vector[T, N]) => Vector[T, N],
-}
-
-operator :min, {
-    [T < Number].(T, T) => T,
-    [T < Number, N].(Vector[T, N], Vector[T, N]) => Vector[T, N],
-}
-
-operator :max, {
-    [T < Number].(T, T) => T,
-    [T < Number, N].(Vector[T, N], Vector[T, N]) => Vector[T, N],
-}
-
-# Trigonometric
-["acos", "asin", "atan", "cos", "sin", "tan",
- "acosh", "asinh", "atanh", "cosh", "sinh", "tanh"].each do |op|
-    operator :"#{op}", {
-        [T < Float].(T) => T,
-        [T < Float, N].(Vector[T, N]) => Vector[T, N],
-    }
-end
-
 # 17.3. Logical Built-in Functions (https://www.w3.org/TR/WGSL/#logical-builtin-functions)
 
 # 17.3.1 & 17.3.2
@@ -180,4 +156,302 @@ operator :select, {
     [T < Scalar].(T, T, Bool) => T,
     [T < Scalar, N].(Vector[T, N], Vector[T, N], Bool) => Vector[T, N],
     [T < Scalar, N].(Vector[T, N], Vector[T, N], Vector[Bool, N]) => Vector[T, N],
+}
+
+# 17.5. Numeric Built-in Functions (https://www.w3.org/TR/WGSL/#numeric-builtin-functions)
+
+# Trigonometric
+["acos", "asin", "atan", "cos", "sin", "tan",
+ "acosh", "asinh", "atanh", "cosh", "sinh", "tanh"].each do |op|
+    operator :"#{op}", {
+        [T < Float].(T) => T,
+        [T < Float, N].(Vector[T, N]) => Vector[T, N],
+    }
+end
+
+# 17.5.1
+operator :abs, {
+    [T < Number].(T) => T,
+    [T < Number, N].(Vector[T, N]) => Vector[T, N],
+}
+
+# 17.5.2. acos
+# 17.5.3. acosh
+# 17.5.4. asin
+# 17.5.5. asinh
+# 17.5.6. atan
+# 17.5.7. atanh
+# Defined in [Trigonometric]
+
+# 17.5.8
+operator :atan2, {
+    [T < Float].(T, T) => T,
+    [T < Float, N].(Vector[T, N], Vector[T, N]) => Vector[T, N],
+}
+
+# 17.5.9
+operator :ceil, {
+    [T < Float].(T) => T,
+    [T < Float, N].(Vector[T, N]) => Vector[T, N],
+}
+
+# 17.5.10
+operator :clamp, {
+    [T < Number].(T, T, T) => T,
+    [T < Number, N].(Vector[T, N], Vector[T, N], Vector[T, N]) => Vector[T, N],
+}
+
+# 17.5.11. cos
+# 17.5.12. cosh
+# Defined in [Trigonometric]
+
+# 17.5.13-15 (Bit counting)
+["countLeadingZeros", "countOneBits", "countTrailingZeros"].each do |op|
+    operator :"#{op}", {
+        [T < ConcreteInteger].(T) => T,
+        [T < ConcreteInteger, N].(Vector[T, N]) => Vector[T, N],
+    }
+end
+
+# 17.5.16
+operator :cross, {
+    [T < Float].(Vector[T, 3], Vector[T, 3]) => Vector[T, 3],
+}
+
+# 17.5.17
+operator :degrees, {
+    [T < Float].(T) => T,
+    [T < Float, N].(Vector[T, N]) => Vector[T, N],
+}
+
+# 17.5.18
+operator :determinant, {
+    [T < Float, C].(Matrix[T, C, C]) => T,
+}
+
+# 17.5.19
+operator :distance, {
+    [T < Float].(T, T) => T,
+    [T < Float, N].(Vector[T, N], Vector[T, N]) => T,
+}
+
+# 17.5.20
+operator :dot, {
+    [T < Number, N].(Vector[T, N], Vector[T, N]) => T
+}
+
+# 17.5.21 & 17.5.22
+["exp", "exp2"].each do |op|
+    operator :"#{op}", {
+        [T < Float].(T) => T,
+        [T < Float, N].(Vector[T, N]) => Vector[T, N],
+    }
+end
+
+# 17.5.23 & 17.5.24
+operator :extractBits, {
+    # signed
+    [].(I32, U32, U32) => I32,
+    [N].(Vector[I32, N], U32, U32) => Vector[I32, N],
+
+    # unsigned
+    [].(U32, U32, U32) => U32,
+    [N].(Vector[U32, N], U32, U32) => Vector[U32, N],
+}
+
+# 17.5.25
+operator :faceForward, {
+    [T < Float, N].(Vector[T, N], Vector[T, N], Vector[T, N]) => Vector[T, N],
+}
+
+# 17.5.26 & 17.5.27
+operator :firstLeadingBit, {
+    # signed
+    [].(I32) => I32,
+    [N].(Vector[I32, N]) => Vector[I32, N],
+
+    # unsigned
+    [].(U32) => U32,
+    [N].(Vector[U32, N]) => Vector[U32, N],
+}
+
+# 17.5.28
+operator :firstTrailingBit, {
+    [T < ConcreteInteger].(T) => T,
+    [T < ConcreteInteger, N].(Vector[T, N]) => Vector[T, N],
+}
+
+# 17.5.29
+operator :floor, {
+    [T < Float].(T) => T,
+    [T < Float, N].(Vector[T, N]) => Vector[T, N],
+}
+
+# 17.5.30
+operator :fma, {
+    [T < Float].(T, T, T) => T,
+    [T < Float, N].(Vector[T, N], Vector[T, N], Vector[T, N]) => Vector[T, N],
+}
+
+# 17.5.31
+operator :fract, {
+    [T < Float].(T) => T,
+    [T < Float, N].(Vector[T, N]) => Vector[T, N],
+}
+
+# 17.5.32
+operator :frexp, {
+    # FIXME: this needs the special return types __frexp_result_*
+}
+
+# 17.5.33
+operator :insertBits, {
+    [T < ConcreteInteger].(T, T, U32, U32) => T,
+    [T < ConcreteInteger, N].(Vector[T, N], Vector[T, N], U32, U32) => Vector[T, N],
+}
+
+# 17.5.34
+operator :inverseSqrt, {
+    [T < Float].(T) => T,
+    [T < Float, N].(Vector[T, N]) => Vector[T, N],
+}
+
+# 17.5.35
+operator :ldexp, {
+    [T < ConcreteFloat].(T, I32) => T,
+    [].(AbstractFloat, AbstractInt) => AbstractFloat,
+    [T < ConcreteFloat, N].(Vector[T, N], Vector[I32, N]) => Vector[T, N],
+    [N].(Vector[AbstractFloat, N], Vector[AbstractInt, N]) => Vector[AbstractFloat, N],
+}
+
+# 17.5.36
+operator :length, {
+    [T < Float].(T) => T,
+    [T < Float, N].(Vector[T, N]) => T,
+}
+
+# 17.5.37 & 17.5.38
+["log", "log2"].each do |op|
+    operator :"#{op}", {
+        [T < Float].(T) => T,
+        [T < Float, N].(Vector[T, N]) => Vector[T, N],
+    }
+end
+
+# 17.5.39
+operator :max, {
+    [T < Number].(T, T) => T,
+    [T < Number, N].(Vector[T, N], Vector[T, N]) => Vector[T, N],
+}
+
+# 17.5.40
+operator :min, {
+    [T < Number].(T, T) => T,
+    [T < Number, N].(Vector[T, N], Vector[T, N]) => Vector[T, N],
+}
+
+# 17.5.41
+operator :mix, {
+    [T < Float].(T, T, T) => T,
+    [T < Float, N].(Vector[T, N], Vector[T, N], Vector[T, N]) => Vector[T, N],
+    [T < Float, N].(Vector[T, N], Vector[T, N], T) => Vector[T, N],
+}
+
+# 17.5.42
+operator :modf, {
+    # FIXME: this needs the special return types __modf_result_*
+}
+
+# 17.5.43
+operator :normalize, {
+    [T < Float, N].(Vector[T, N]) => Vector[T, N],
+}
+
+# 17.5.44
+operator :pow, {
+    [T < Float].(T, T) => T,
+    [T < Float, N].(Vector[T, N], Vector[T, N]) => Vector[T, N],
+}
+
+# 17.5.45
+operator :quantizeToF16, {
+    [].(F32) => F32,
+    [N].(Vector[F32, N]) => Vector[F32, N],
+}
+
+# 17.5.46
+operator :radians, {
+    [T < Float].(T) => T,
+    [T < Float, N].(Vector[T, N]) => Vector[T, N],
+}
+
+# 17.5.47
+operator :reflect, {
+    [T < Float, N].(Vector[T, N], Vector[T, N]) => Vector[T, N],
+}
+
+# 17.5.48
+operator :refract, {
+    [T < Float, N].(Vector[T, N], Vector[T, N], T) => Vector[T, N],
+}
+
+# 17.5.49
+operator :reverseBits, {
+    [T < ConcreteInteger].(T) => T,
+    [T < ConcreteInteger, N].(Vector[T, N]) => Vector[T, N],
+}
+
+# 17.5.50
+operator :round, {
+    [T < Float].(T) => T,
+    [T < Float, N].(Vector[T, N]) => Vector[T, N],
+}
+
+# 17.5.51
+operator :saturate, {
+    [T < Float].(T) => T,
+    [T < Float, N].(Vector[T, N]) => Vector[T, N],
+}
+
+# 17.5.52
+operator :sign, {
+    [T < SignedNumber].(T) => T,
+    [T < SignedNumber, N].(Vector[T, N]) => Vector[T, N],
+}
+
+# 17.5.53. sin
+# 17.5.54. sinh
+# Defined in [Trigonometric]
+
+# 17.5.55
+operator :smoothstep, {
+    [T < Float].(T, T, T) => T,
+    [T < Float, N].(Vector[T, N], Vector[T, N], Vector[T, N]) => Vector[T, N],
+}
+
+# 17.5.56
+operator :sqrt, {
+    [T < Float].(T) => T,
+    [T < Float, N].(Vector[T, N]) => Vector[T, N],
+}
+
+# 17.5.57
+operator :step, {
+    [T < Float].(T, T) => T,
+    [T < Float, N].(Vector[T, N], Vector[T, N]) => Vector[T, N],
+}
+
+# 17.5.58. tan
+# 17.5.59. tanh
+# Defined in [Trigonometric]
+
+# 17.5.60
+operator :transpose, {
+    [T < Float, C, R].(Matrix[T, C, R]) => Matrix[T, R, C],
+}
+
+# 17.5.61
+operator :trunc, {
+    [T < Float].(T) => T,
+    [T < Float, N].(Vector[T, N]) => Vector[T, N],
 }

--- a/Source/WebGPU/WGSL/generator/main.rb
+++ b/Source/WebGPU/WGSL/generator/main.rb
@@ -143,7 +143,7 @@ class PrimitiveType
     end
 
     def to_cpp
-        "m_types.#{name.downcase}Type()"
+        "m_types.#{name[0].downcase}#{name[1..]}Type()"
     end
 end
 
@@ -279,6 +279,7 @@ module DSL
         F32 = PrimitiveType.new(:F32)
         Sampler = PrimitiveType.new(:Sampler)
         AbstractInt = PrimitiveType.new(:AbstractInt)
+        AbstractFloat = PrimitiveType.new(:AbstractFloat)
 
 
         S = Variable.new(:S, @TypeVariable)

--- a/Source/WebGPU/WGSL/tests/valid/overload.wgsl
+++ b/Source/WebGPU/WGSL/tests/valid/overload.wgsl
@@ -249,127 +249,6 @@ fn testUnaryMinus() {
   let x2 = -vec2(1, 1);
 }
 
-fn testClamp() {
-   let x = clamp(0, 0, 0);
-   let x1 = clamp(0u, 0u, 0u);
-   let x2 = clamp(0i, 0i, 0i);
-   let x3 = clamp(0.0, 0.0, 0.0);
-   let x4 = clamp(0.0f, 0.0f, 0.0f);
-   let x5 = clamp(vec2(0.0, 0.0), vec2(0.0, 0.0), vec2(0.0, 0.0));
-   let x6 = clamp(vec3(0.0, 0.0, 0.0), vec3(0.0, 0.0, 0.0), vec3(0.0, 0.0, 0.0));
-   let x7 = clamp(vec4(0.0, 0.0, 0.0, 0.0), vec4(0.0, 0.0, 0.0, 0.0), vec4(0.0, 0.0, 0.0, 0.0));
-}
-
-fn testMin() {
-   let x = min(0, 0u);
-   let x1 = min(0u, 0u);
-   let x2 = min(0i, 0i);
-   let x3 = min(0.0, 0.0);
-   let x4 = min(0.0f, 0.0f);
-   let x5 = min(vec2(0.0, 0.0), vec2(0.0, 0.0));
-   let x6 = min(vec3(0.0, 0.0, 0.0), vec3(0.0, 0.0, 0.0));
-   let x7 = min(vec4(0.0, 0.0, 0.0, 0.0), vec4(0.0, 0.0, 0.0, 0.0));
-}
-
-fn testMax() {
-   let x = max(0, 0u);
-   let x1 = max(0u, 0u);
-   let x2 = max(0i, 0i);
-   let x3 = max(0.0, 0.0);
-   let x4 = max(0.0f, 0.0f);
-   let x5 = max(vec2(0.0, 0.0), vec2(0.0, 0.0));
-   let x6 = max(vec3(0.0, 0.0, 0.0), vec3(0.0, 0.0, 0.0));
-   let x7 = max(vec4(0.0, 0.0, 0.0, 0.0), vec4(0.0, 0.0, 0.0, 0.0));
-}
-
-fn testTrigonometric() {
-  {
-    let x = acos(0.0);
-    let x1 = acos(vec2(0.0, 0.0));
-    let x2 = acos(vec3(0.0, 0.0, 0.0));
-    let x3 = acos(vec4(0.0, 0.0, 0.0, 0.0));
-  }
-
-  {
-    let x = asin(0.0);
-    let x1 = asin(vec2(0.0, 0.0));
-    let x2 = asin(vec3(0.0, 0.0, 0.0));
-    let x3 = asin(vec4(0.0, 0.0, 0.0, 0.0));
-  }
-
-  {
-    let x = atan(0.0);
-    let x1 = atan(vec2(0.0, 0.0));
-    let x2 = atan(vec3(0.0, 0.0, 0.0));
-    let x3 = atan(vec4(0.0, 0.0, 0.0, 0.0));
-  }
-
-  {
-    let x = cos(0.0);
-    let x1 = cos(vec2(0.0, 0.0));
-    let x2 = cos(vec3(0.0, 0.0, 0.0));
-    let x3 = cos(vec4(0.0, 0.0, 0.0, 0.0));
-  }
-
-  {
-    let x = sin(0.0);
-    let x1 = sin(vec2(0.0, 0.0));
-    let x2 = sin(vec3(0.0, 0.0, 0.0));
-    let x3 = sin(vec4(0.0, 0.0, 0.0, 0.0));
-  }
-
-  {
-    let x = tan(0.0);
-    let x1 = tan(vec2(0.0, 0.0));
-    let x2 = tan(vec3(0.0, 0.0, 0.0));
-    let x3 = tan(vec4(0.0, 0.0, 0.0, 0.0));
-  }
-}
-
-fn testTrigonometricHyperbolic() {
-  {
-    let x = acosh(0.0);
-    let x1 = acosh(vec2(0.0, 0.0));
-    let x2 = acosh(vec3(0.0, 0.0, 0.0));
-    let x3 = acosh(vec4(0.0, 0.0, 0.0, 0.0));
-  }
-
-  {
-    let x = asinh(0.0);
-    let x1 = asinh(vec2(0.0, 0.0));
-    let x2 = asinh(vec3(0.0, 0.0, 0.0));
-    let x3 = asinh(vec4(0.0, 0.0, 0.0, 0.0));
-  }
-
-  {
-    let x = atanh(0.0);
-    let x1 = atanh(vec2(0.0, 0.0));
-    let x2 = atanh(vec3(0.0, 0.0, 0.0));
-    let x3 = atanh(vec4(0.0, 0.0, 0.0, 0.0));
-  }
-
-  {
-    let x = cosh(0.0);
-    let x1 = cosh(vec2(0.0, 0.0));
-    let x2 = cosh(vec3(0.0, 0.0, 0.0));
-    let x3 = cosh(vec4(0.0, 0.0, 0.0, 0.0));
-  }
-
-  {
-    let x = sinh(0.0);
-    let x1 = sinh(vec2(0.0, 0.0));
-    let x2 = sinh(vec3(0.0, 0.0, 0.0));
-    let x3 = sinh(vec4(0.0, 0.0, 0.0, 0.0));
-  }
-
-  {
-    let x = tanh(0.0);
-    let x1 = tanh(vec2(0.0, 0.0));
-    let x2 = tanh(vec3(0.0, 0.0, 0.0));
-    let x3 = tanh(vec4(0.0, 0.0, 0.0, 0.0));
-  }
-}
-
 fn testBinaryMinus() {
   let x1 = vec2(1, 1) - 1;
   let x2 = 1 - vec2(1, 1);
@@ -571,5 +450,1409 @@ fn testSelect()
         let x3 = select(vec4(13), vec4(42u),  vec4(true));
         let x4 = select(vec4(13), vec4(42f),  vec4(true));
         let x5 = select(vec4(13), vec4(42.0), vec4(true));
+    }
+}
+
+// 17.5. Numeric Built-in Functions (https://www.w3.org/TR/WGSL/#numeric-builtin-functions)
+
+// Trigonometric
+fn testTrigonometric()
+{
+  {
+    let x = acos(0.0);
+    let x1 = acos(vec2(0.0, 0.0));
+    let x2 = acos(vec3(0.0, 0.0, 0.0));
+    let x3 = acos(vec4(0.0, 0.0, 0.0, 0.0));
+  }
+
+  {
+    let x = asin(0.0);
+    let x1 = asin(vec2(0.0, 0.0));
+    let x2 = asin(vec3(0.0, 0.0, 0.0));
+    let x3 = asin(vec4(0.0, 0.0, 0.0, 0.0));
+  }
+
+  {
+    let x = atan(0.0);
+    let x1 = atan(vec2(0.0, 0.0));
+    let x2 = atan(vec3(0.0, 0.0, 0.0));
+    let x3 = atan(vec4(0.0, 0.0, 0.0, 0.0));
+  }
+
+  {
+    let x = cos(0.0);
+    let x1 = cos(vec2(0.0, 0.0));
+    let x2 = cos(vec3(0.0, 0.0, 0.0));
+    let x3 = cos(vec4(0.0, 0.0, 0.0, 0.0));
+  }
+
+  {
+    let x = sin(0.0);
+    let x1 = sin(vec2(0.0, 0.0));
+    let x2 = sin(vec3(0.0, 0.0, 0.0));
+    let x3 = sin(vec4(0.0, 0.0, 0.0, 0.0));
+  }
+
+  {
+    let x = tan(0.0);
+    let x1 = tan(vec2(0.0, 0.0));
+    let x2 = tan(vec3(0.0, 0.0, 0.0));
+    let x3 = tan(vec4(0.0, 0.0, 0.0, 0.0));
+  }
+}
+
+fn testTrigonometricHyperbolic()
+{
+  {
+    let x = acosh(0.0);
+    let x1 = acosh(vec2(0.0, 0.0));
+    let x2 = acosh(vec3(0.0, 0.0, 0.0));
+    let x3 = acosh(vec4(0.0, 0.0, 0.0, 0.0));
+  }
+
+  {
+    let x = asinh(0.0);
+    let x1 = asinh(vec2(0.0, 0.0));
+    let x2 = asinh(vec3(0.0, 0.0, 0.0));
+    let x3 = asinh(vec4(0.0, 0.0, 0.0, 0.0));
+  }
+
+  {
+    let x = atanh(0.0);
+    let x1 = atanh(vec2(0.0, 0.0));
+    let x2 = atanh(vec3(0.0, 0.0, 0.0));
+    let x3 = atanh(vec4(0.0, 0.0, 0.0, 0.0));
+  }
+
+  {
+    let x = cosh(0.0);
+    let x1 = cosh(vec2(0.0, 0.0));
+    let x2 = cosh(vec3(0.0, 0.0, 0.0));
+    let x3 = cosh(vec4(0.0, 0.0, 0.0, 0.0));
+  }
+
+  {
+    let x = sinh(0.0);
+    let x1 = sinh(vec2(0.0, 0.0));
+    let x2 = sinh(vec3(0.0, 0.0, 0.0));
+    let x3 = sinh(vec4(0.0, 0.0, 0.0, 0.0));
+  }
+
+  {
+    let x = tanh(0.0);
+    let x1 = tanh(vec2(0.0, 0.0));
+    let x2 = tanh(vec3(0.0, 0.0, 0.0));
+    let x3 = tanh(vec4(0.0, 0.0, 0.0, 0.0));
+  }
+}
+
+
+// 17.5.1
+fn testAbs()
+{
+    // [T < Float].(T) => T,
+    {
+        let x1 = abs(0);
+        let x2 = abs(1i);
+        let x3 = abs(1u);
+        let x4 = abs(0.0);
+        let x5 = abs(1f);
+    }
+
+    // [T < Float, N].(Vector[T, N]) => Vector[T, N],
+    {
+        let x1 = abs(vec2(0, 1));
+        let x2 = abs(vec2(1i, 2i));
+        let x3 = abs(vec2(1u, 2u));
+        let x4 = abs(vec2(0.0, 1.0));
+        let x5 = abs(vec2(1f, 2f));
+    }
+    {
+        let x1 = abs(vec3(-1, 0, 1));
+        let x2 = abs(vec3(-1i, 1i, 2i));
+        let x3 = abs(vec3(0u, 1u, 2u));
+        let x4 = abs(vec3(-1.0, 0.0, 1.0));
+        let x5 = abs(vec3(-1f, 1f, 2f));
+    }
+}
+
+// 17.5.2. acos
+// 17.5.3. acosh
+// 17.5.4. asin
+// 17.5.5. asinh
+// 17.5.6. atan
+// 17.5.7. atanh
+// Tested in testTrigonometric and testTrigonometricHyperbolic
+
+// 17.5.8
+fn testAtan2() {
+    // [T < Float].(T, T) => T,
+    {
+        let x1 = atan2(0, 1);
+        let x2 = atan2(0, 1.0);
+        let x3 = atan2(1, 2f);
+    }
+    // [T < Float, N].(Vector[T, N], Vector[T, N], Vector[T, N]) => Vector[T, N],
+    {
+        let x1 = atan2(vec2(0), vec2(0));
+        let x2 = atan2(vec2(0), vec2(0.0));
+        let x3 = atan2(vec2(0), vec2(0f));
+    }
+    {
+        let x1 = atan2(vec3(0), vec3(0));
+        let x2 = atan2(vec3(0), vec3(0.0));
+        let x3 = atan2(vec3(0), vec3(0f));
+    }
+    {
+        let x1 = atan2(vec4(0), vec4(0));
+        let x2 = atan2(vec4(0), vec4(0.0));
+        let x3 = atan2(vec4(0), vec4(0f));
+    }
+}
+
+// 17.5.9
+fn testCeil()
+{
+    // [T < Float].(T) => T,
+    {
+        let x1 = ceil(0);
+        let x2 = ceil(0.0);
+        let x3 = ceil(1f);
+    }
+
+    // [T < Float, N].(Vector[T, N]) => Vector[T, N],
+    {
+        let x1 = ceil(vec2(0, 1));
+        let x2 = ceil(vec2(0.0, 1.0));
+        let x3 = ceil(vec2(1f, 2f));
+    }
+    {
+        let x1 = ceil(vec3(-1, 0, 1));
+        let x2 = ceil(vec3(-1.0, 0.0, 1.0));
+        let x3 = ceil(vec3(-1f, 1f, 2f));
+    }
+    {
+        let x1 = ceil(vec4(-1, 0, 1, 2));
+        let x2 = ceil(vec4(-1.0, 0.0, 1.0, 2.0));
+        let x3 = ceil(vec4(-1f, 1f, 2f, 3f));
+    }
+}
+
+// 17.5.10
+fn testClamp()
+{
+    // [T < Number].(T, T, T) => T,
+    {
+        let x1 = clamp(-1, 0, 1);
+        let x2 = clamp(-1, 1, 2i);
+        let x3 = clamp(0, 1, 2u);
+        let x4 = clamp(-1, 0, 1.0);
+        let x5 = clamp(-1, 1, 2f);
+    }
+    // [T < Number, N].(Vector[T, N], Vector[T, N], Vector[T, N]) => Vector[T, N],
+    {
+        let x1 = clamp(vec2(0), vec2(0), vec2(0));
+        let x2 = clamp(vec2(0), vec2(0), vec2(0i));
+        let x3 = clamp(vec2(0), vec2(0), vec2(0u));
+        let x4 = clamp(vec2(0), vec2(0), vec2(0.0));
+        let x5 = clamp(vec2(0), vec2(0), vec2(0f));
+    }
+    {
+        let x1 = clamp(vec3(0), vec3(0), vec3(0));
+        let x2 = clamp(vec3(0), vec3(0), vec3(0i));
+        let x3 = clamp(vec3(0), vec3(0), vec3(0u));
+        let x4 = clamp(vec3(0), vec3(0), vec3(0.0));
+        let x5 = clamp(vec3(0), vec3(0), vec3(0f));
+    }
+    {
+        let x1 = clamp(vec4(0), vec4(0), vec4(0));
+        let x2 = clamp(vec4(0), vec4(0), vec4(0i));
+        let x3 = clamp(vec4(0), vec4(0), vec4(0u));
+        let x4 = clamp(vec4(0), vec4(0), vec4(0.0));
+        let x5 = clamp(vec4(0), vec4(0), vec4(0f));
+    }
+}
+
+// 17.5.11. cos
+// 17.5.12. cosh
+// Tested in testTrigonometric and testTrigonometricHyperbolic
+
+// 17.5.13-15 (Bit counting)
+fn testBitCounting()
+{
+    // [T < ConcreteInteger].(T) => T,
+    {
+        let x1 = countLeadingZeros(1);
+        let x2 = countLeadingZeros(1i);
+        let x3 = countLeadingZeros(1u);
+    }
+    {
+        let x1 = countOneBits(1);
+        let x2 = countOneBits(1i);
+        let x3 = countOneBits(1u);
+    }
+    {
+        let x1 = countTrailingZeros(1);
+        let x2 = countTrailingZeros(1i);
+        let x3 = countTrailingZeros(1u);
+    }
+    // [T < ConcreteInteger, N].(Vector[T, N]) => Vector[T, N],
+    {
+        let x1 = countLeadingZeros(vec2(1, 1));
+        let x2 = countLeadingZeros(vec2(1i, 1i));
+        let x3 = countLeadingZeros(vec2(1u, 1u));
+    }
+    {
+        let x1 = countOneBits(vec3(1, 1, 1));
+        let x2 = countOneBits(vec3(1i, 1i, 1i));
+        let x3 = countOneBits(vec3(1u, 1u, 1u));
+    }
+    {
+        let x1 = countTrailingZeros(vec4(1, 1, 1, 1));
+        let x2 = countTrailingZeros(vec4(1i, 1i, 1i, 1i));
+        let x3 = countTrailingZeros(vec4(1u, 1u, 1u, 1u));
+    }
+}
+
+// 17.5.16
+fn testCross()
+{
+    // [T < Float].(Vector[T, 3], Vector[T, 3]) => Vector[T, 3],
+    let x1 = cross(vec3(1, 1, 1), vec3(1f, 2f, 3f));
+    let x2 = cross(vec3(1.0, 1.0, 1.0), vec3(1f, 2f, 3f));
+    let x3 = cross(vec3(1f, 1f, 1f), vec3(1f, 2f, 3f));
+}
+
+// 17.5.17
+fn testDegress()
+{
+    // [T < Float].(T) => T,
+    {
+        let x1 = degrees(0);
+        let x2 = degrees(0.0);
+        let x3 = degrees(1f);
+    }
+    // [T < Float, N].(Vector[T, N]) => Vector[T, N],
+    {
+        let x1 = degrees(vec2(0, 1));
+        let x2 = degrees(vec2(0.0, 1.0));
+        let x3 = degrees(vec2(1f, 2f));
+    }
+    {
+        let x1 = degrees(vec3(-1, 0, 1));
+        let x2 = degrees(vec3(-1.0, 0.0, 1.0));
+        let x3 = degrees(vec3(-1f, 1f, 2f));
+    }
+    {
+        let x1 = degrees(vec4(-1, 0, 1, 2));
+        let x2 = degrees(vec4(-1.0, 0.0, 1.0, 2.0));
+        let x3 = degrees(vec4(-1f, 1f, 2f, 3f));
+    }
+}
+
+// 17.5.18
+fn testDeterminant()
+{
+    // [T < Float, C].(Matrix[T, C, C]) => T,
+    let x1 = determinant(mat2x2(1, 1, 1, 1));
+    let x2 = determinant(mat3x3(1, 1, 1, 1, 1, 1, 1, 1, 1));
+    let x3 = determinant(mat4x4(1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1));
+}
+
+// 17.5.19
+fn testDistance()
+{
+    // [T < Float].(T, T) => T,
+    {
+        let x1 = distance(0, 1);
+        let x2 = distance(0, 1.0);
+        let x3 = distance(0, 1f);
+        let x4 = distance(0.0, 1.0);
+        let x5 = distance(1.0, 2f);
+        let x6 = distance(1f, 2f);
+    }
+    // [T < Float, N].(Vector[T, N], Vector[T, N]) => T,
+    {
+        let x1 = distance(vec2(0),   vec2(1)  );
+        let x2 = distance(vec2(0),   vec2(0.0));
+        let x3 = distance(vec2(0),   vec2(1f) );
+        let x4 = distance(vec2(0.0), vec2(0.0));
+        let x5 = distance(vec2(0.0), vec2(0f) );
+        let x6 = distance(vec2(1f),  vec2(1f) );
+    }
+    {
+        let x1 = distance(vec3(0),   vec3(1)  );
+        let x2 = distance(vec3(0),   vec3(0.0));
+        let x3 = distance(vec3(0),   vec3(1f) );
+        let x4 = distance(vec3(0.0), vec3(0.0));
+        let x5 = distance(vec3(0.0), vec3(0f) );
+        let x6 = distance(vec3(1f),  vec3(1f) );
+    }
+    {
+        let x1 = distance(vec4(0),   vec4(1)  );
+        let x2 = distance(vec4(0),   vec4(0.0));
+        let x3 = distance(vec4(0),   vec4(1f) );
+        let x4 = distance(vec4(0.0), vec4(0.0));
+        let x5 = distance(vec4(0.0), vec4(0f) );
+        let x6 = distance(vec4(1f),  vec4(1f) );
+    }
+}
+
+// 17.5.20
+fn testDot()
+{
+    // [T < Number, N].(Vector[T, N], Vector[T, N]) => T,
+    {
+        let x1 = dot(vec2(0),   vec2(1)  );
+        let x2 = dot(vec2(0),   vec2(1f) );
+        let x3 = dot(vec2(0),   vec2(1i) );
+        let x4 = dot(vec2(0),   vec2(1u) );
+        let x5 = dot(vec2(1i),  vec2(1i) );
+        let x6 = dot(vec2(1u),  vec2(1u) );
+        let x7 = dot(vec2(0),   vec2(0.0));
+        let x8 = dot(vec2(0.0), vec2(0.0));
+        let x9 = dot(vec2(0.0), vec2(0f) );
+        let x0 = dot(vec2(1f),  vec2(1f) );
+    }
+    {
+        let x1 = dot(vec3(0),   vec3(1)  );
+        let x2 = dot(vec3(0),   vec3(1f) );
+        let x3 = dot(vec3(0),   vec3(1i) );
+        let x4 = dot(vec3(0),   vec3(1u) );
+        let x5 = dot(vec3(1i),  vec3(1i) );
+        let x6 = dot(vec3(1u),  vec3(1u) );
+        let x7 = dot(vec3(0),   vec3(0.0));
+        let x8 = dot(vec3(0.0), vec3(0.0));
+        let x9 = dot(vec3(0.0), vec3(0f) );
+        let x0 = dot(vec3(1f),  vec3(1f) );
+    }
+    {
+        let x1 = dot(vec4(0),   vec4(1)  );
+        let x2 = dot(vec4(0),   vec4(1f) );
+        let x3 = dot(vec4(0),   vec4(1i) );
+        let x4 = dot(vec4(0),   vec4(1u) );
+        let x5 = dot(vec4(1i),  vec4(1i) );
+        let x6 = dot(vec4(1u),  vec4(1u) );
+        let x7 = dot(vec4(0),   vec4(0.0));
+        let x8 = dot(vec4(0.0), vec4(0.0));
+        let x9 = dot(vec4(0.0), vec4(0f) );
+        let x0 = dot(vec4(1f),  vec4(1f) );
+    }
+}
+
+// 17.5.21 & 17.5.22
+fn testExpAndExp2() {
+    // [T < Float].(T) => T,
+    {
+        let x1 = exp(0);
+        let x2 = exp(0.0);
+        let x3 = exp(1f);
+    }
+    {
+        let x1 = exp2(0);
+        let x2 = exp2(0.0);
+        let x3 = exp2(1f);
+    }
+
+    // [T < Float, N].(Vector[T, N]) => Vector[T, N],
+    {
+        let x1 = exp(vec2(0, 1));
+        let x2 = exp(vec2(0.0, 1.0));
+        let x3 = exp(vec2(1f, 2f));
+    }
+    {
+        let x1 = exp(vec3(-1, 0, 1));
+        let x2 = exp(vec3(-1.0, 0.0, 1.0));
+        let x3 = exp(vec3(-1f, 1f, 2f));
+    }
+    {
+        let x1 = exp(vec4(-1, 0, 1, 2));
+        let x2 = exp(vec4(-1.0, 0.0, 1.0, 2.0));
+        let x3 = exp(vec4(-1f, 1f, 2f, 3f));
+    }
+
+    {
+        let x1 = exp2(vec2(0, 1));
+        let x2 = exp2(vec2(0.0, 1.0));
+        let x3 = exp2(vec2(1f, 2f));
+    }
+    {
+        let x1 = exp2(vec3(-1, 0, 1));
+        let x2 = exp2(vec3(-1.0, 0.0, 1.0));
+        let x3 = exp2(vec3(-1f, 1f, 2f));
+    }
+    {
+        let x1 = exp2(vec4(-1, 0, 1, 2));
+        let x2 = exp2(vec4(-1.0, 0.0, 1.0, 2.0));
+        let x3 = exp2(vec4(-1f, 1f, 2f, 3f));
+    }
+}
+
+// 17.5.23 & 17.5.24
+fn testExtractBits()
+{
+    // signed
+    // [].(I32, U32, U32) => I32,
+    {
+        let x1 = extractBits(0, 1, 1);
+        let x2 = extractBits(0i, 1, 1);
+        let x3 = extractBits(0i, 1u, 1u);
+    }
+    // [N].(Vector[I32, N], U32, U32) => Vector[I32, N],
+    {
+        let x1 = extractBits(vec2(0), 1, 1);
+        let x2 = extractBits(vec2(0i), 1, 1);
+        let x3 = extractBits(vec2(0i), 1u, 1u);
+    }
+    {
+        let x1 = extractBits(vec3(0), 1, 1);
+        let x2 = extractBits(vec3(0i), 1, 1);
+        let x3 = extractBits(vec3(0i), 1u, 1u);
+    }
+    {
+        let x1 = extractBits(vec4(0), 1, 1);
+        let x2 = extractBits(vec4(0i), 1, 1);
+        let x3 = extractBits(vec4(0i), 1u, 1u);
+    }
+
+    // unsigned
+    // [].(U32, U32, U32) => U32,
+    {
+        let x1 = extractBits(0, 1, 1);
+        let x2 = extractBits(0u, 1, 1);
+        let x3 = extractBits(0u, 1u, 1u);
+    }
+
+    // [N].(Vector[U32, N], U32, U32) => Vector[U32, N],
+    {
+        let x1 = extractBits(vec2(0), 1, 1);
+        let x2 = extractBits(vec2(0u), 1, 1);
+        let x3 = extractBits(vec2(0u), 1u, 1u);
+    }
+    {
+        let x1 = extractBits(vec3(0), 1, 1);
+        let x2 = extractBits(vec3(0u), 1, 1);
+        let x3 = extractBits(vec3(0u), 1u, 1u);
+    }
+    {
+        let x1 = extractBits(vec4(0), 1, 1);
+        let x2 = extractBits(vec4(0u), 1, 1);
+        let x3 = extractBits(vec4(0u), 1u, 1u);
+    }
+}
+
+// 17.5.25
+fn testFaceForward()
+{
+    // [T < Float, N].(Vector[T, N], Vector[T, N], Vector[T, N]) => Vector[T, N],
+    {
+        let x1 = faceForward(vec2(0), vec2(1),   vec2(2));
+        let x2 = faceForward(vec2(0), vec2(1),   vec2(2.0));
+        let x3 = faceForward(vec2(0), vec2(1.0), vec2(2f));
+    }
+    {
+        let x1 = faceForward(vec3(0), vec3(1),   vec3(2));
+        let x2 = faceForward(vec3(0), vec3(1),   vec3(2.0));
+        let x3 = faceForward(vec3(0), vec3(1.0), vec3(2f));
+    }
+    {
+        let x1 = faceForward(vec4(0), vec4(1),   vec4(2));
+        let x2 = faceForward(vec4(0), vec4(1),   vec4(2.0));
+        let x3 = faceForward(vec4(0), vec4(1.0), vec4(2f));
+    }
+}
+
+// 17.5.26 & 17.5.27
+fn testFirstLeadingBit()
+{
+    // signed
+    // [].(I32) => I32,
+    {
+        let x1 = firstLeadingBit(0);
+        let x2 = firstLeadingBit(0i);
+    }
+    // [N].(Vector[I32, N]) => Vector[I32, N],
+    {
+        let x1 = firstLeadingBit(vec2(0));
+        let x2 = firstLeadingBit(vec2(0i));
+    }
+    {
+        let x1 = firstLeadingBit(vec3(0));
+        let x2 = firstLeadingBit(vec3(0i));
+    }
+    {
+        let x1 = firstLeadingBit(vec4(0));
+        let x2 = firstLeadingBit(vec4(0i));
+    }
+
+    // unsigned
+    // [].(U32) => U32,
+    {
+        let x1 = firstLeadingBit(0);
+        let x2 = firstLeadingBit(0u);
+    }
+
+    // [N].(Vector[U32, N]) => Vector[U32, N],
+    {
+        let x1 = firstLeadingBit(vec2(0));
+        let x2 = firstLeadingBit(vec2(0u));
+    }
+    {
+        let x1 = firstLeadingBit(vec3(0));
+        let x2 = firstLeadingBit(vec3(0u));
+    }
+    {
+        let x1 = firstLeadingBit(vec4(0));
+        let x2 = firstLeadingBit(vec4(0u));
+    }
+}
+
+// 17.5.28
+fn testFirstTrailingBit()
+{
+    // [T < ConcreteInteger].(T) => T,
+    {
+        let x1 = firstTrailingBit(0);
+        let x2 = firstTrailingBit(0i);
+        let x3 = firstTrailingBit(0u);
+    }
+
+    // [T < ConcreteInteger, N].(Vector[T, N]) => Vector[T, N],
+    {
+        let x1 = firstTrailingBit(vec2(0));
+        let x2 = firstTrailingBit(vec2(0i));
+        let x3 = firstTrailingBit(vec2(0u));
+    }
+    {
+        let x1 = firstTrailingBit(vec3(0));
+        let x2 = firstTrailingBit(vec3(0i));
+        let x3 = firstTrailingBit(vec3(0u));
+    }
+    {
+        let x1 = firstTrailingBit(vec4(0));
+        let x2 = firstTrailingBit(vec4(0i));
+        let x3 = firstTrailingBit(vec4(0u));
+    }
+}
+
+// 17.5.29
+fn testFloor()
+{
+    // [T < Float].(T) => T,
+    {
+        let x1 = floor(0);
+        let x2 = floor(0.0);
+        let x3 = floor(1f);
+    }
+
+    // [T < Float, N].(Vector[T, N]) => Vector[T, N],
+    {
+        let x1 = floor(vec2(0, 1));
+        let x2 = floor(vec2(0.0, 1.0));
+        let x3 = floor(vec2(1f, 2f));
+    }
+    {
+        let x1 = floor(vec3(-1, 0, 1));
+        let x2 = floor(vec3(-1.0, 0.0, 1.0));
+        let x3 = floor(vec3(-1f, 1f, 2f));
+    }
+    {
+        let x1 = floor(vec4(-1, 0, 1, 2));
+        let x2 = floor(vec4(-1.0, 0.0, 1.0, 2.0));
+        let x3 = floor(vec4(-1f, 1f, 2f, 3f));
+    }
+}
+
+// 17.5.30
+fn testFma()
+{
+    // [T < Float].(T, T, T) => T,
+    {
+        let x1 = fma(-1, 0, 1);
+        let x4 = fma(-1, 0, 1.0);
+        let x5 = fma(-1, 1, 2f);
+    }
+    // [T < Float, N].(Vector[T, N], Vector[T, N], Vector[T, N]) => Vector[T, N],
+    {
+        let x1 = fma(vec2(0), vec2(0), vec2(0));
+        let x2 = fma(vec2(0), vec2(0), vec2(0.0));
+        let x3 = fma(vec2(0), vec2(0), vec2(0f));
+    }
+    {
+        let x1 = fma(vec3(0), vec3(0), vec3(0));
+        let x2 = fma(vec3(0), vec3(0), vec3(0.0));
+        let x3 = fma(vec3(0), vec3(0), vec3(0f));
+    }
+    {
+        let x1 = fma(vec4(0), vec4(0), vec4(0));
+        let x2 = fma(vec4(0), vec4(0), vec4(0.0));
+        let x3 = fma(vec4(0), vec4(0), vec4(0f));
+    }
+}
+
+// 17.5.31
+fn testFract()
+{
+    // [T < Float].(T) => T,
+    {
+        let x1 = fract(0);
+        let x2 = fract(0.0);
+        let x3 = fract(1f);
+    }
+
+    // [T < Float, N].(Vector[T, N]) => Vector[T, N],
+    {
+        let x1 = fract(vec2(0));
+        let x2 = fract(vec2(0.0));
+        let x3 = fract(vec2(1f));
+    }
+    {
+        let x1 = fract(vec3(-1));
+        let x2 = fract(vec3(-1.0));
+        let x3 = fract(vec3(-1f));
+    }
+    {
+        let x1 = fract(vec4(-1));
+        let x2 = fract(vec4(-1.0));
+        let x3 = fract(vec4(-1f));
+    }
+}
+
+// 17.5.32
+fn testFrexp()
+{
+    // FIXME: this needs the special return types __frexp_result_*
+}
+
+// 17.5.33
+fn testInsertBits()
+{
+    // [T < ConcreteInteger].(T, T, U32, U32) => T,
+    {
+        let x1 = insertBits(0, 0, 0, 0);
+        let x2 = insertBits(0, 0i, 0, 0);
+        // FIXME: fails to resolve overload resolution
+        // let x3 = insertBits(0, 0u, 0, 0);
+    }
+
+    // [T < ConcreteInteger, N].(Vector[T, N], Vector[T, N], U32, U32) => Vector[T, N],
+    {
+        let x1 = insertBits(vec2(0), vec2(0), 0, 0);
+        let x2 = insertBits(vec2(0), vec2(0i), 0, 0);
+        // FIXME: fails to resolve overload resolution
+        // let x3 = insertBits(vec2(0), vec2(0u), 0, 0);
+    }
+    {
+        let x1 = insertBits(vec3(0), vec3(0), 0, 0);
+        let x2 = insertBits(vec3(0), vec3(0i), 0, 0);
+        // FIXME: fails to resolve overload resolution
+        // let x3 = insertBits(vec3(0), vec3(0u), 0, 0);
+    }
+    {
+        let x1 = insertBits(vec4(0), vec4(0), 0, 0);
+        let x2 = insertBits(vec4(0), vec4(0i), 0, 0);
+        // FIXME: fails to resolve overload resolution
+        // let x3 = insertBits(vec4(0), vec4(0u), 0, 0);
+    }
+}
+
+// 17.5.34
+fn testInverseSqrt()
+{
+    // [T < Float].(T) => T,
+    {
+        let x1 = inverseSqrt(0);
+        let x2 = inverseSqrt(0.0);
+        let x3 = inverseSqrt(1f);
+    }
+
+    // [T < Float, N].(Vector[T, N]) => Vector[T, N],
+    {
+        let x1 = inverseSqrt(vec2(0));
+        let x2 = inverseSqrt(vec2(0.0));
+        let x3 = inverseSqrt(vec2(1f));
+    }
+    {
+        let x1 = inverseSqrt(vec3(-1));
+        let x2 = inverseSqrt(vec3(-1.0));
+        let x3 = inverseSqrt(vec3(-1f));
+    }
+    {
+        let x1 = inverseSqrt(vec4(-1));
+        let x2 = inverseSqrt(vec4(-1.0));
+        let x3 = inverseSqrt(vec4(-1f));
+    }
+}
+
+// 17.5.35
+fn testLdexp()
+{
+    // [T < ConcreteFloat].(T, I32) => T,
+    {
+        let x1 = ldexp(0f, 1);
+    }
+    // [].(AbstractFloat, AbstractInt) => AbstractFloat,
+    {
+        let x1 = ldexp(0, 1);
+        let x2 = ldexp(0.0, 1);
+    }
+    // [T < ConcreteFloat, N].(Vector[T, N], Vector[I32, N]) => Vector[T, N],
+    {
+        let x1 = ldexp(vec2(0f), vec2(1));
+        let x2 = ldexp(vec3(0f), vec3(1));
+        let x3 = ldexp(vec4(0f), vec4(1));
+    }
+    // [N].(Vector[AbstractFloat, N], Vector[AbstractInt, N]) => Vector[AbstractFloat, N],
+    {
+        let x1 = ldexp(vec2(0), vec2(1));
+        let x2 = ldexp(vec3(0), vec3(1));
+        let x3 = ldexp(vec4(0), vec4(1));
+
+        let x4 = ldexp(vec2(0.0), vec2(1));
+        let x5 = ldexp(vec3(0.0), vec3(1));
+        let x6 = ldexp(vec4(0.0), vec4(1));
+    }
+}
+
+// 17.5.36
+fn testLength()
+{
+    // [T < Float].(T) => T,
+    {
+        let x1 = length(0);
+        let x2 = length(0.0);
+        let x3 = length(1f);
+    }
+
+    // [T < Float, N].(Vector[T, N]) => Vector[T, N],
+    {
+        let x1 = length(vec2(0));
+        let x2 = length(vec2(0.0));
+        let x3 = length(vec2(1f));
+    }
+    {
+        let x1 = length(vec3(-1));
+        let x2 = length(vec3(-1.0));
+        let x3 = length(vec3(-1f));
+    }
+    {
+        let x1 = length(vec4(-1));
+        let x2 = length(vec4(-1.0));
+        let x3 = length(vec4(-1f));
+    }
+}
+
+// 17.5.37
+fn testLog()
+{
+    // [T < Float].(T) => T,
+    {
+        let x1 = log(0);
+        let x2 = log(0.0);
+        let x3 = log(1f);
+    }
+
+    // [T < Float, N].(Vector[T, N]) => Vector[T, N],
+    {
+        let x1 = log(vec2(0));
+        let x2 = log(vec2(0.0));
+        let x3 = log(vec2(1f));
+    }
+    {
+        let x1 = log(vec3(-1));
+        let x2 = log(vec3(-1.0));
+        let x3 = log(vec3(-1f));
+    }
+    {
+        let x1 = log(vec4(-1));
+        let x2 = log(vec4(-1.0));
+        let x3 = log(vec4(-1f));
+    }
+}
+
+// 17.5.38
+fn testLog2() {
+    // [T < Float].(T) => T,
+    {
+        let x1 = log2(0);
+        let x2 = log2(0.0);
+        let x3 = log2(1f);
+    }
+
+    // [T < Float, N].(Vector[T, N]) => Vector[T, N],
+    {
+        let x1 = log2(vec2(0));
+        let x2 = log2(vec2(0.0));
+        let x3 = log2(vec2(1f));
+    }
+    {
+        let x1 = log2(vec3(-1));
+        let x2 = log2(vec3(-1.0));
+        let x3 = log2(vec3(-1f));
+    }
+    {
+        let x1 = log2(vec4(-1));
+        let x2 = log2(vec4(-1.0));
+        let x3 = log2(vec4(-1f));
+    }
+}
+
+// 17.5.39
+fn testMax()
+{
+    // [T < Number].(T, T) => T,
+    {
+        let x1 = max(-1, 0);
+        let x2 = max(-1, 1);
+        let x3 = max(0, 1);
+        let x4 = max(-1, 0);
+        let x5 = max(-1, 1);
+    }
+    // [T < Number, N].(Vector[T, N], Vector[T, N]) => Vector[T, N],
+    {
+        let x1 = max(vec2(0), vec2(0));
+        let x2 = max(vec2(0), vec2(0i));
+        let x3 = max(vec2(0), vec2(0u));
+        let x4 = max(vec2(0), vec2(0.0));
+        let x5 = max(vec2(0), vec2(0f));
+    }
+    {
+        let x1 = max(vec3(0), vec3(0));
+        let x2 = max(vec3(0), vec3(0i));
+        let x3 = max(vec3(0), vec3(0u));
+        let x4 = max(vec3(0), vec3(0.0));
+        let x5 = max(vec3(0), vec3(0f));
+    }
+    {
+        let x1 = max(vec4(0), vec4(0));
+        let x2 = max(vec4(0), vec4(0i));
+        let x3 = max(vec4(0), vec4(0u));
+        let x4 = max(vec4(0), vec4(0.0));
+        let x5 = max(vec4(0), vec4(0f));
+    }
+}
+
+// 17.5.40
+fn testMin()
+{
+    // [T < Number].(T, T) => T,
+    {
+        let x1 = min(-1, 0);
+        let x2 = min(-1, 1);
+        let x3 = min(0, 1);
+        let x4 = min(-1, 0);
+        let x5 = min(-1, 1);
+    }
+    // [T < Number, N].(Vector[T, N], Vector[T, N]) => Vector[T, N],
+    {
+        let x1 = min(vec2(0), vec2(0));
+        let x2 = min(vec2(0), vec2(0i));
+        let x3 = min(vec2(0), vec2(0u));
+        let x4 = min(vec2(0), vec2(0.0));
+        let x5 = min(vec2(0), vec2(0f));
+    }
+    {
+        let x1 = min(vec3(0), vec3(0));
+        let x2 = min(vec3(0), vec3(0i));
+        let x3 = min(vec3(0), vec3(0u));
+        let x4 = min(vec3(0), vec3(0.0));
+        let x5 = min(vec3(0), vec3(0f));
+    }
+    {
+        let x1 = min(vec4(0), vec4(0));
+        let x2 = min(vec4(0), vec4(0i));
+        let x3 = min(vec4(0), vec4(0u));
+        let x4 = min(vec4(0), vec4(0.0));
+        let x5 = min(vec4(0), vec4(0f));
+    }
+}
+
+// 17.5.41
+fn testMix()
+{
+    // [T < Float].(T, T, T) => T,
+    {
+        let x1 = mix(-1, 0, 1);
+        let x2 = mix(-1, 0, 1.0);
+        let x3 = mix(-1, 1, 2f);
+    }
+    // [T < Float, N].(Vector[T, N], Vector[T, N], Vector[T, N]) => Vector[T, N],
+    {
+        let x1 = mix(vec2(0), vec2(0), vec2(0));
+        let x2 = mix(vec2(0), vec2(0), vec2(0.0));
+        let x3 = mix(vec2(0), vec2(0), vec2(0f));
+    }
+    {
+        let x1 = mix(vec3(0), vec3(0), vec3(0));
+        let x2 = mix(vec3(0), vec3(0), vec3(0.0));
+        let x3 = mix(vec3(0), vec3(0), vec3(0f));
+    }
+    {
+        let x1 = mix(vec4(0), vec4(0), vec4(0));
+        let x2 = mix(vec4(0), vec4(0), vec4(0.0));
+        let x3 = mix(vec4(0), vec4(0), vec4(0f));
+    }
+    // [T < Float, N].(Vector[T, N], Vector[T, N], T) => Vector[T, N],
+    {
+        let x1 = mix(vec2(0), vec2(0), 0);
+        let x2 = mix(vec2(0), vec2(0), 0.0);
+        let x3 = mix(vec2(0), vec2(0), 0f);
+    }
+    {
+        let x1 = mix(vec3(0), vec3(0), 0);
+        let x2 = mix(vec3(0), vec3(0), 0.0);
+        let x3 = mix(vec3(0), vec3(0), 0f);
+    }
+    {
+        let x1 = mix(vec4(0), vec4(0), 0);
+        let x2 = mix(vec4(0), vec4(0), 0.0);
+        let x3 = mix(vec4(0), vec4(0), 0f);
+    }
+}
+
+// 17.5.42
+fn testModf()
+{
+    // FIXME: this needs the special return types __modf_result_*
+}
+
+// 17.5.43
+fn testNormalize()
+{
+    // [T < Float, N].(Vector[T, N]) => Vector[T, N],
+    {
+        let x1 = normalize(vec2(0));
+        let x2 = normalize(vec2(0.0));
+        let x3 = normalize(vec2(1f));
+    }
+    {
+        let x1 = normalize(vec3(-1));
+        let x2 = normalize(vec3(-1.0));
+        let x3 = normalize(vec3(-1f));
+    }
+    {
+        let x1 = normalize(vec4(-1));
+        let x2 = normalize(vec4(-1.0));
+        let x3 = normalize(vec4(-1f));
+    }
+}
+
+// 17.5.44
+fn testPow()
+{
+    // [T < Float].(T, T) => T,
+    {
+        let x1 = pow(0, 1);
+        let x2 = pow(0, 1.0);
+        let x3 = pow(0, 1f);
+        let x4 = pow(0.0, 1.0);
+        let x5 = pow(1.0, 2f);
+        let x6 = pow(1f, 2f);
+    }
+    // [T < Float, N].(Vector[T, N], Vector[T, N]) => Vector[T, N],
+    {
+        let x1 = pow(vec2(0),   vec2(1)  );
+        let x2 = pow(vec2(0),   vec2(0.0));
+        let x3 = pow(vec2(0),   vec2(1f) );
+        let x4 = pow(vec2(0.0), vec2(0.0));
+        let x5 = pow(vec2(0.0), vec2(0f) );
+        let x6 = pow(vec2(1f),  vec2(1f) );
+    }
+    {
+        let x1 = pow(vec3(0),   vec3(1)  );
+        let x2 = pow(vec3(0),   vec3(0.0));
+        let x3 = pow(vec3(0),   vec3(1f) );
+        let x4 = pow(vec3(0.0), vec3(0.0));
+        let x5 = pow(vec3(0.0), vec3(0f) );
+        let x6 = pow(vec3(1f),  vec3(1f) );
+    }
+    {
+        let x1 = pow(vec4(0),   vec4(1)  );
+        let x2 = pow(vec4(0),   vec4(0.0));
+        let x3 = pow(vec4(0),   vec4(1f) );
+        let x4 = pow(vec4(0.0), vec4(0.0));
+        let x5 = pow(vec4(0.0), vec4(0f) );
+        let x6 = pow(vec4(1f),  vec4(1f) );
+    }
+}
+
+// 17.5.45
+fn testQuantizeToF16() {
+    // [].(F32) => F32,
+    {
+        let x1 = quantizeToF16(0);
+        let x2 = quantizeToF16(0.0);
+        let x3 = quantizeToF16(0f);
+    }
+
+    // [N].(Vector[F32, N]) => Vector[F32, N],
+    {
+        let x1 = quantizeToF16(vec2(0));
+        let x2 = quantizeToF16(vec2(0.0));
+        let x3 = quantizeToF16(vec2(0f));
+    }
+    {
+        let x1 = quantizeToF16(vec3(0));
+        let x2 = quantizeToF16(vec3(0.0));
+        let x3 = quantizeToF16(vec3(0f));
+    }
+    {
+        let x1 = quantizeToF16(vec4(0));
+        let x2 = quantizeToF16(vec4(0.0));
+        let x3 = quantizeToF16(vec4(0f));
+    }
+}
+
+// 17.5.46
+fn testRadians()
+{
+    // [T < Float].(T) => T,
+    {
+        let x1 = radians(0);
+        let x2 = radians(0.0);
+        let x3 = radians(1f);
+    }
+
+    // [T < Float, N].(Vector[T, N]) => Vector[T, N],
+    {
+        let x1 = radians(vec2(0));
+        let x2 = radians(vec2(0.0));
+        let x3 = radians(vec2(1f));
+    }
+    {
+        let x1 = radians(vec3(-1));
+        let x2 = radians(vec3(-1.0));
+        let x3 = radians(vec3(-1f));
+    }
+    {
+        let x1 = radians(vec4(-1));
+        let x2 = radians(vec4(-1.0));
+        let x3 = radians(vec4(-1f));
+    }
+}
+
+// 17.5.47
+fn testReflect()
+{
+    // [T < Float, N].(Vector[T, N], Vector[T, N]) => Vector[T, N],
+    {
+        let x1 = reflect(vec2(0),   vec2(1)  );
+        let x2 = reflect(vec2(0),   vec2(0.0));
+        let x3 = reflect(vec2(0),   vec2(1f) );
+        let x4 = reflect(vec2(0.0), vec2(0.0));
+        let x5 = reflect(vec2(0.0), vec2(0f) );
+        let x6 = reflect(vec2(1f),  vec2(1f) );
+    }
+    {
+        let x1 = reflect(vec3(0),   vec3(1)  );
+        let x2 = reflect(vec3(0),   vec3(0.0));
+        let x3 = reflect(vec3(0),   vec3(1f) );
+        let x4 = reflect(vec3(0.0), vec3(0.0));
+        let x5 = reflect(vec3(0.0), vec3(0f) );
+        let x6 = reflect(vec3(1f),  vec3(1f) );
+    }
+    {
+        let x1 = reflect(vec4(0),   vec4(1)  );
+        let x2 = reflect(vec4(0),   vec4(0.0));
+        let x3 = reflect(vec4(0),   vec4(1f) );
+        let x4 = reflect(vec4(0.0), vec4(0.0));
+        let x5 = reflect(vec4(0.0), vec4(0f) );
+        let x6 = reflect(vec4(1f),  vec4(1f) );
+    }
+}
+
+// 17.5.48
+fn testRefract()
+{
+    // [T < Float, N].(Vector[T, N], Vector[T, N], T) => Vector[T, N],
+    {
+        let x1 = refract(vec2(0), vec2(0), 1);
+        let x2 = refract(vec2(0), vec2(0), 0.0);
+        let x3 = refract(vec2(0), vec2(0), 1f);
+    }
+    {
+        let x1 = refract(vec3(0), vec3(0), 1);
+        let x2 = refract(vec3(0), vec3(0), 0.0);
+        let x3 = refract(vec3(0), vec3(0), 1f);
+    }
+    {
+        let x1 = refract(vec4(0), vec4(0), 1);
+        let x2 = refract(vec4(0), vec4(0), 0.0);
+        let x3 = refract(vec4(0), vec4(0), 1f);
+    }
+}
+
+// 17.5.49
+fn testReverseBits()
+{
+    // [T < ConcreteInteger].(T) => T,
+    {
+        let x1 = reverseBits(0);
+        let x2 = reverseBits(0i);
+        let x3 = reverseBits(0u);
+    }
+    // [T < ConcreteInteger, N].(Vector[T, N]) => Vector[T, N],
+    {
+        let x1 = reverseBits(vec2(0));
+        let x2 = reverseBits(vec2(0i));
+        let x3 = reverseBits(vec2(0u));
+    }
+    {
+        let x1 = reverseBits(vec3(0));
+        let x2 = reverseBits(vec3(0i));
+        let x3 = reverseBits(vec3(0u));
+    }
+    {
+        let x1 = reverseBits(vec4(0));
+        let x2 = reverseBits(vec4(0i));
+        let x3 = reverseBits(vec4(0u));
+    }
+}
+
+// 17.5.50
+fn testRound()
+{
+    // [T < Float].(T) => T,
+    {
+        let x1 = round(0);
+        let x2 = round(0.0);
+        let x3 = round(1f);
+    }
+
+    // [T < Float, N].(Vector[T, N]) => Vector[T, N],
+    {
+        let x1 = round(vec2(0));
+        let x2 = round(vec2(0.0));
+        let x3 = round(vec2(1f));
+    }
+    {
+        let x1 = round(vec3(-1));
+        let x2 = round(vec3(-1.0));
+        let x3 = round(vec3(-1f));
+    }
+    {
+        let x1 = round(vec4(-1));
+        let x2 = round(vec4(-1.0));
+        let x3 = round(vec4(-1f));
+    }
+}
+
+// 17.5.51
+fn testSaturate()
+{
+    // [T < Float].(T) => T,
+    {
+        let x1 = saturate(0);
+        let x2 = saturate(0.0);
+        let x3 = saturate(1f);
+    }
+
+    // [T < Float, N].(Vector[T, N]) => Vector[T, N],
+    {
+        let x1 = saturate(vec2(0));
+        let x2 = saturate(vec2(0.0));
+        let x3 = saturate(vec2(1f));
+    }
+    {
+        let x1 = saturate(vec3(-1));
+        let x2 = saturate(vec3(-1.0));
+        let x3 = saturate(vec3(-1f));
+    }
+    {
+        let x1 = saturate(vec4(-1));
+        let x2 = saturate(vec4(-1.0));
+        let x3 = saturate(vec4(-1f));
+    }
+}
+
+// 17.5.52
+fn testSign()
+{
+    // [T < SignedNumber].(T) => T,
+    {
+        let x1 = sign(0);
+        let x2 = sign(0i);
+        let x3 = sign(0.0);
+        let x4 = sign(1f);
+    }
+
+    // [T < SignedNumber, N].(Vector[T, N]) => Vector[T, N],
+    {
+        let x1 = sign(vec2(0));
+        let x2 = sign(vec2(0i));
+        let x3 = sign(vec2(0.0));
+        let x4 = sign(vec2(1f));
+    }
+    {
+        let x1 = sign(vec3(-1));
+        let x2 = sign(vec3(-1i));
+        let x3 = sign(vec3(-1.0));
+        let x4 = sign(vec3(-1f));
+    }
+    {
+        let x1 = sign(vec4(-1));
+        let x2 = sign(vec4(-1i));
+        let x3 = sign(vec4(-1.0));
+        let x4 = sign(vec4(-1f));
+    }
+}
+
+// 17.5.53. sin
+// 17.5.54. sinh
+// Tested in testTrigonometric and testTrigonometricHyperbolic
+
+// 17.5.55
+fn testSmoothstep()
+{
+    // [T < Float].(T, T, T) => T,
+    {
+        let x1 = smoothstep(-1, 0, 1);
+        let x2 = smoothstep(-1, 0, 1.0);
+        let x3 = smoothstep(-1, 1, 2f);
+    }
+    // [T < Float, N].(Vector[T, N], Vector[T, N], Vector[T, N]) => Vector[T, N],
+    {
+        let x1 = smoothstep(vec2(0), vec2(0), vec2(0));
+        let x2 = smoothstep(vec2(0), vec2(0), vec2(0.0));
+        let x3 = smoothstep(vec2(0), vec2(0), vec2(0f));
+    }
+    {
+        let x1 = smoothstep(vec3(0), vec3(0), vec3(0));
+        let x2 = smoothstep(vec3(0), vec3(0), vec3(0.0));
+        let x3 = smoothstep(vec3(0), vec3(0), vec3(0f));
+    }
+    {
+        let x1 = smoothstep(vec4(0), vec4(0), vec4(0));
+        let x2 = smoothstep(vec4(0), vec4(0), vec4(0.0));
+        let x3 = smoothstep(vec4(0), vec4(0), vec4(0f));
+    }
+}
+
+// 17.5.56
+fn testSqrt()
+{
+    // [T < Float].(T) => T,
+    {
+        let x1 = sqrt(0);
+        let x2 = sqrt(0.0);
+        let x3 = sqrt(1f);
+    }
+
+    // [T < Float, N].(Vector[T, N]) => Vector[T, N],
+    {
+        let x1 = sqrt(vec2(0));
+        let x2 = sqrt(vec2(0.0));
+        let x3 = sqrt(vec2(1f));
+    }
+    {
+        let x1 = sqrt(vec3(-1));
+        let x2 = sqrt(vec3(-1.0));
+        let x3 = sqrt(vec3(-1f));
+    }
+    {
+        let x1 = sqrt(vec4(-1));
+        let x2 = sqrt(vec4(-1.0));
+        let x3 = sqrt(vec4(-1f));
+    }
+}
+
+// 17.5.57
+fn testStep()
+{
+    // [T < Float].(T, T) => T,
+    {
+        let x1 = step(0, 1);
+        let x2 = step(0, 1.0);
+        let x3 = step(1, 2f);
+    }
+    // [T < Float, N].(Vector[T, N], Vector[T, N], Vector[T, N]) => Vector[T, N],
+    {
+        let x1 = step(vec2(0), vec2(0));
+        let x2 = step(vec2(0), vec2(0.0));
+        let x3 = step(vec2(0), vec2(0f));
+    }
+    {
+        let x1 = step(vec3(0), vec3(0));
+        let x2 = step(vec3(0), vec3(0.0));
+        let x3 = step(vec3(0), vec3(0f));
+    }
+    {
+        let x1 = step(vec4(0), vec4(0));
+        let x2 = step(vec4(0), vec4(0.0));
+        let x3 = step(vec4(0), vec4(0f));
+    }
+}
+
+// 17.5.58. tan
+// 17.5.59. tanh
+// Tested in testTrigonometric and testTrigonometricHyperbolic
+
+// 17.5.60
+fn testTranspose()
+{
+    // [T < Float, C, R].(Matrix[T, C, R]) => Matrix[T, R, C],
+    {
+        const x = 1;
+        let x1 = transpose(mat2x2(0, 0, 0, x));
+        let x2 = transpose(mat2x3(0, 0, 0, 0, 0, x));
+        let x3 = transpose(mat2x4(0, 0, 0, 0, 0, 0, 0, x));
+        let x4 = transpose(mat3x2(0, 0, 0, 0, 0, x));
+        let x5 = transpose(mat3x3(0, 0, 0, 0, 0, 0, 0, 0, x));
+        let x6 = transpose(mat3x4(0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, x));
+        let x7 = transpose(mat4x2(0, 0, 0, 0, 0, 0, 0, x));
+        let x8 = transpose(mat4x3(0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, x));
+        let x9 = transpose(mat4x4(0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, x));
+    }
+    {
+        const x = 1.0;
+        let x1 = transpose(mat2x2(0, 0, 0, x));
+        let x2 = transpose(mat2x3(0, 0, 0, 0, 0, x));
+        let x3 = transpose(mat2x4(0, 0, 0, 0, 0, 0, 0, x));
+        let x4 = transpose(mat3x2(0, 0, 0, 0, 0, x));
+        let x5 = transpose(mat3x3(0, 0, 0, 0, 0, 0, 0, 0, x));
+        let x6 = transpose(mat3x4(0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, x));
+        let x7 = transpose(mat4x2(0, 0, 0, 0, 0, 0, 0, x));
+        let x8 = transpose(mat4x3(0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, x));
+        let x9 = transpose(mat4x4(0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, x));
+    }
+    {
+        const x = 1f;
+        let x1 = transpose(mat2x2(0, 0, 0, x));
+        let x2 = transpose(mat2x3(0, 0, 0, 0, 0, x));
+        let x3 = transpose(mat2x4(0, 0, 0, 0, 0, 0, 0, x));
+        let x4 = transpose(mat3x2(0, 0, 0, 0, 0, x));
+        let x5 = transpose(mat3x3(0, 0, 0, 0, 0, 0, 0, 0, x));
+        let x6 = transpose(mat3x4(0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, x));
+        let x7 = transpose(mat4x2(0, 0, 0, 0, 0, 0, 0, x));
+        let x8 = transpose(mat4x3(0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, x));
+        let x9 = transpose(mat4x4(0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, x));
+    }
+}
+
+// 17.5.61
+fn testTrunc()
+{
+    // [T < Float].(T) => T,
+    {
+        let x1 = trunc(0);
+        let x2 = trunc(0.0);
+        let x3 = trunc(1f);
+    }
+
+    // [T < Float, N].(Vector[T, N]) => Vector[T, N],
+    {
+        let x1 = trunc(vec2(0));
+        let x2 = trunc(vec2(0.0));
+        let x3 = trunc(vec2(1f));
+    }
+    {
+        let x1 = trunc(vec3(-1));
+        let x2 = trunc(vec3(-1.0));
+        let x3 = trunc(vec3(-1f));
+    }
+    {
+        let x1 = trunc(vec4(-1));
+        let x2 = trunc(vec4(-1.0));
+        let x3 = trunc(vec4(-1f));
     }
 }


### PR DESCRIPTION
#### 2e1e308373225547f82eaeb507d27ef587837932
<pre>
[WGSL] Add type declarations for numeric built-in functions
<a href="https://bugs.webkit.org/show_bug.cgi?id=255514">https://bugs.webkit.org/show_bug.cgi?id=255514</a>
rdar://108134362

Reviewed by Mike Wyrzykowski.

Add type declarations for all the functions from section 17.5 (Numeric Built-in Functions) of the spec[1].

[1]: <a href="https://www.w3.org/TR/WGSL/#numeric-builtin-functions">https://www.w3.org/TR/WGSL/#numeric-builtin-functions</a>

* Source/WebGPU/WGSL/TypeDeclarations.rb:
* Source/WebGPU/WGSL/tests/valid/overload.wgsl:

Canonical link: <a href="https://commits.webkit.org/263068@main">https://commits.webkit.org/263068@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/74b5195e4c1d6230d79af217edf6c81253eac794

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/3533 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/3580 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/3718 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/4955 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/3807 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/3670 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/3621 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/3072 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/3575 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/3826 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/3180 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/4778 "Built successfully") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/39/builds/1335 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/3156 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/3057 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/3133 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/3215 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/4533 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/3591 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/2897 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/3133 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/3154 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/854 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/3159 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/3411 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->