### PR TITLE
[WGSL] Call expressions can't always use the inferred type for serialization

### DIFF
--- a/Source/WebGPU/WGSL/Metal/MetalFunctionWriter.cpp
+++ b/Source/WebGPU/WGSL/Metal/MetalFunctionWriter.cpp
@@ -468,10 +468,18 @@ void FunctionDefinitionWriter::visit(AST::CallExpression& call)
             } },
         };
         static constexpr SortedArrayMap builtins { builtinMappings };
-        if (auto mappedBuiltin = builtins.get(downcast<AST::NamedTypeName>(call.target()).name().id())) {
+        const auto& targetName = downcast<AST::NamedTypeName>(call.target()).name().id();
+        if (auto mappedBuiltin = builtins.get(targetName)) {
             mappedBuiltin(this, call);
             return;
         }
+
+        if (AST::ParameterizedTypeName::stringViewToKind(targetName).has_value())
+            visit(call.inferredType());
+        else
+            m_stringBuilder.append(targetName);
+        visitArguments(this, call);
+        return;
     }
 
     visit(call.inferredType());


### PR DESCRIPTION
#### fd6a43bbb6911e717868e413f864a3c0c0cf65c9
<pre>
[WGSL] Call expressions can&apos;t always use the inferred type for serialization
<a href="https://bugs.webkit.org/show_bug.cgi?id=255516">https://bugs.webkit.org/show_bug.cgi?id=255516</a>
rdar://108135679

Reviewed by Mike Wyrzykowski.

In <a href="https://commits.webkit.org/262528@main">https://commits.webkit.org/262528@main</a> we started using the inferred type for
call expressions&apos; targets when serializing. That was necessary when constructing
parameterized without explicitly providing the content type, since that relies on
type inference. However, the type of CallExpression::target is a bit misleading,
since it claims to be a type, but isn&apos;t always a type. In order to solve that, we
check if target is a valid type name, otherwise we write out the string value of
the target as is.

* Source/WebGPU/WGSL/Metal/MetalFunctionWriter.cpp:
(WGSL::Metal::FunctionDefinitionWriter::visit):

Canonical link: <a href="https://commits.webkit.org/263067@main">https://commits.webkit.org/263067@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/31300be2c1250653c497619ec45f9036bf070089

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/3362 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/3422 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/3542 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/4787 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/3693 "Built successfully") 
| | [❌ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/3519 "Failed to compile WebKit") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/3446 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/2930 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/3403 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/3686 "2 new passes 10 flakes 1 failures") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/3037 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/4606 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/1194 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/2996 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/2923 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/2968 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/3056 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/4356 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/3434 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/2761 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/2997 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/2997 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/853 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/3002 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/3274 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->