### PR TITLE
CSS style 'filter: drop-shadow...' does not render correctly without repaint.

### DIFF
--- a/LayoutTests/compositing/filters/sw-layer-overlaps-hw-shadow-expected.txt
+++ b/LayoutTests/compositing/filters/sw-layer-overlaps-hw-shadow-expected.txt
@@ -7,9 +7,10 @@
       (contentsOpaque 1)
       (children 2
         (GraphicsLayer
-          (position 105.00 105.00)
-          (bounds 100.00 100.00)
-          (contentsOpaque 1)
+          (offsetFromRenderer width=-25 height=-25)
+          (position 80.00 80.00)
+          (anchor 0.60 0.60)
+          (bounds 125.00 125.00)
           (drawsContent 1)
         )
         (GraphicsLayer

--- a/LayoutTests/compositing/filters/sw-nested-shadow-overlaps-hw-nested-shadow-expected.txt
+++ b/LayoutTests/compositing/filters/sw-nested-shadow-overlaps-hw-nested-shadow-expected.txt
@@ -7,14 +7,14 @@
       (contentsOpaque 1)
       (children 2
         (GraphicsLayer
-          (offsetFromRenderer width=-100 height=-100)
-          (position 230.00 230.00)
-          (anchor 0.75 0.75)
-          (bounds 200.00 200.00)
+          (offsetFromRenderer width=-150 height=-150)
+          (position 180.00 180.00)
+          (anchor 0.80 0.80)
+          (bounds 250.00 250.00)
           (drawsContent 1)
         )
         (GraphicsLayer
-          (bounds 200.00 200.00)
+          (bounds 250.00 250.00)
           (drawsContent 1)
         )
       )

--- a/LayoutTests/compositing/filters/sw-shadow-overlaps-hw-layer-expected.txt
+++ b/LayoutTests/compositing/filters/sw-shadow-overlaps-hw-layer-expected.txt
@@ -12,8 +12,7 @@
           (contentsOpaque 1)
         )
         (GraphicsLayer
-          (bounds 100.00 100.00)
-          (contentsOpaque 1)
+          (bounds 125.00 125.00)
           (drawsContent 1)
         )
       )

--- a/LayoutTests/compositing/filters/sw-shadow-overlaps-hw-shadow-expected.txt
+++ b/LayoutTests/compositing/filters/sw-shadow-overlaps-hw-shadow-expected.txt
@@ -7,14 +7,14 @@
       (contentsOpaque 1)
       (children 2
         (GraphicsLayer
-          (position 130.00 130.00)
-          (bounds 100.00 100.00)
-          (contentsOpaque 1)
+          (offsetFromRenderer width=-25 height=-25)
+          (position 105.00 105.00)
+          (anchor 0.60 0.60)
+          (bounds 125.00 125.00)
           (drawsContent 1)
         )
         (GraphicsLayer
-          (bounds 100.00 100.00)
-          (contentsOpaque 1)
+          (bounds 125.00 125.00)
           (drawsContent 1)
         )
       )

--- a/LayoutTests/compositing/masks/mask-and-drop-shadow.html
+++ b/LayoutTests/compositing/masks/mask-and-drop-shadow.html
@@ -1,4 +1,5 @@
 <!DOCTYPE html>
+<meta name="fuzzy" content="maxDifference=1; totalPixels=113"/>
 <style>
     div {
         width: 200px;

--- a/LayoutTests/css3/filters/effect-blur.html
+++ b/LayoutTests/css3/filters/effect-blur.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html>
 <head>
-    <meta name="fuzzy" content="maxDifference=0-50; totalPixels=0-15059">
+    <meta name="fuzzy" content="maxDifference=0-41; totalPixels=0-23441"/>
     <link rel="stylesheet" href="resources/filter-helpers.css">
     <script src="resources/filter-helpers.js"></script>
     <script>

--- a/LayoutTests/fast/hidpi/filters-drop-shadow.html
+++ b/LayoutTests/fast/hidpi/filters-drop-shadow.html
@@ -1,4 +1,4 @@
-<meta name="fuzzy" content="maxDifference=60; totalPixels=1200" />
+<meta name="fuzzy" content="maxDifference=0-60; totalPixels=0-2400"/>
 <script src="resources/ensure-hidpi.js"></script>
 <style>
     div {

--- a/LayoutTests/fast/repaint/drop-shadow-box-change-expected.txt
+++ b/LayoutTests/fast/repaint/drop-shadow-box-change-expected.txt
@@ -1,0 +1,10 @@
+Test repaint rects when a box with drop-shadow changes size
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+PASS layerTreeAsText.indexOf('(rect 192 192 206 156)') > -1 is true
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/fast/repaint/drop-shadow-box-change.html
+++ b/LayoutTests/fast/repaint/drop-shadow-box-change.html
@@ -1,0 +1,45 @@
+<html>
+<head>
+    <style>
+        .box {
+            position: absolute;
+            top: 200px;
+            left: 200px;
+            width: 100px;
+            height: 100px;
+            background-color: silver;
+            filter: drop-shadow(20px 20px 10px black);
+        }
+
+        body.changed .box {
+            width: 150px;
+        }
+    </style>
+    <script src="../../resources/js-test-pre.js"></script>
+    <script>
+        jsTestIsAsync = true;
+        description("Test repaint rects when a box with drop-shadow changes size");
+
+        var layerTreeAsText;
+        window.addEventListener('load', () => {
+            setTimeout(() => {
+                if (window.internals)
+                    internals.startTrackingRepaints();
+
+                document.body.classList.add('changed');
+
+                if (window.internals) {
+                    layerTreeAsText =  window.internals.layerTreeAsText(document, internals.LAYER_TREE_INCLUDES_REPAINT_RECTS);
+                    internals.stopTrackingRepaints();
+                }
+
+                shouldBeTrue("layerTreeAsText.indexOf('(rect 192 192 206 156)') > -1");
+                finishJSTest();
+            }, 0)
+        }, false);
+    </script>
+</head>
+<body>
+    <div class="box"></div>
+<script src="../../resources/js-test-post.js"></script>
+</html>

--- a/LayoutTests/fast/repaint/drop-shadow-change-expected.txt
+++ b/LayoutTests/fast/repaint/drop-shadow-change-expected.txt
@@ -1,0 +1,10 @@
+Test repaint rects when the drop-shadow filter property changes
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+PASS layerTreeAsText.indexOf('(rect 100 160 156 156)') > -1 is true
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/fast/repaint/drop-shadow-change.html
+++ b/LayoutTests/fast/repaint/drop-shadow-change.html
@@ -1,0 +1,42 @@
+<html>
+<head>
+    <style>
+        .box {
+            width: 100px;
+            height: 100px;
+            margin: 100px;
+            background-color: silver;
+        }
+
+        body.changed .box {
+            filter: drop-shadow(20px 20px 10px black);
+        }
+    </style>
+    <script src="../../resources/js-test-pre.js"></script>
+    <script>
+        jsTestIsAsync = true;
+        description("Test repaint rects when the drop-shadow filter property changes");
+
+        var layerTreeAsText;
+        window.addEventListener('load', () => {
+            setTimeout(() => {
+                if (window.internals)
+                    internals.startTrackingRepaints();
+
+                document.body.classList.add('changed');
+
+                if (window.internals) {
+                    layerTreeAsText =  window.internals.layerTreeAsText(document, internals.LAYER_TREE_INCLUDES_REPAINT_RECTS);
+                    internals.stopTrackingRepaints();
+                }
+
+                shouldBeTrue("layerTreeAsText.indexOf('(rect 100 160 156 156)') > -1");
+                finishJSTest();
+            }, 0)
+        }, false);
+    </script>
+</head>
+<body>
+    <div class="box"></div>
+<script src="../../resources/js-test-post.js"></script>
+</html>

--- a/LayoutTests/fast/repaint/drop-shadow-writing-modes-expected.txt
+++ b/LayoutTests/fast/repaint/drop-shadow-writing-modes-expected.txt
@@ -1,0 +1,10 @@
+Test repaint rects when the drop-shadow filter property changes
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+PASS layerTreeAsText.indexOf('(rect 60 160 156 156)') > -1 is true
+PASS successfullyParsed is true
+
+TEST COMPLETE
+here is some text

--- a/LayoutTests/fast/repaint/drop-shadow-writing-modes.html
+++ b/LayoutTests/fast/repaint/drop-shadow-writing-modes.html
@@ -1,0 +1,42 @@
+<html>
+<head>
+    <style>
+        .box {
+            writing-mode:vertical-rl;
+            width: 100px;
+            height: 100px;
+            margin: 100px;
+            background-color: silver;
+        }
+
+        body.changed .box {
+            filter: drop-shadow(-20px 20px 10px black);
+        }
+    </style>
+    <script src="../../resources/js-test-pre.js"></script>
+    <script>
+        jsTestIsAsync = true;
+        description("Test repaint rects when the drop-shadow filter property changes");
+
+        var layerTreeAsText;
+        window.addEventListener('load', () => {
+            setTimeout(() => {
+                if (window.internals)
+                    internals.startTrackingRepaints();
+
+                document.body.classList.add('changed');
+
+                if (window.internals) {
+                    layerTreeAsText =  window.internals.layerTreeAsText(document, internals.LAYER_TREE_INCLUDES_REPAINT_RECTS);
+                    internals.stopTrackingRepaints();
+                }
+                shouldBeTrue("layerTreeAsText.indexOf('(rect 60 160 156 156)') > -1");
+                finishJSTest();
+            }, 2000)
+        }, false);
+    </script>
+</head>
+<body>
+    <div class="box">here is some text</div>
+<script src="../../resources/js-test-post.js"></script>
+</html>

--- a/LayoutTests/platform/gtk/fast/repaint/drop-shadow-box-change-expected.txt
+++ b/LayoutTests/platform/gtk/fast/repaint/drop-shadow-box-change-expected.txt
@@ -1,0 +1,10 @@
+Test repaint rects when a box with drop-shadow changes size
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+FAIL layerTreeAsText.indexOf('(rect 192 192 206 156)') > -1 should be true. Was false.
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/platform/gtk/fast/repaint/drop-shadow-change-expected.txt
+++ b/LayoutTests/platform/gtk/fast/repaint/drop-shadow-change-expected.txt
@@ -1,0 +1,10 @@
+Test repaint rects when the drop-shadow filter property changes
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+FAIL layerTreeAsText.indexOf('(rect 100 160 156 156)') > -1 should be true. Was false.
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/platform/gtk/fast/repaint/drop-shadow-writing-modes-expected.txt
+++ b/LayoutTests/platform/gtk/fast/repaint/drop-shadow-writing-modes-expected.txt
@@ -1,0 +1,10 @@
+Test repaint rects when the drop-shadow filter property changes
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+FAIL layerTreeAsText.indexOf('(rect 60 160 156 156)') > -1 should be true. Was false.
+PASS successfullyParsed is true
+
+TEST COMPLETE
+here is some text

--- a/LayoutTests/platform/mac-wk1/fast/repaint/drop-shadow-box-change-expected.txt
+++ b/LayoutTests/platform/mac-wk1/fast/repaint/drop-shadow-box-change-expected.txt
@@ -1,0 +1,10 @@
+Test repaint rects when a box with drop-shadow changes size
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+FAIL layerTreeAsText.indexOf('(rect 192 192 206 156)') > -1 should be true. Was false.
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/platform/mac-wk1/fast/repaint/drop-shadow-change-expected.txt
+++ b/LayoutTests/platform/mac-wk1/fast/repaint/drop-shadow-change-expected.txt
@@ -1,0 +1,10 @@
+Test repaint rects when the drop-shadow filter property changes
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+FAIL layerTreeAsText.indexOf('(rect 100 160 156 156)') > -1 should be true. Was false.
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/platform/mac-wk1/fast/repaint/drop-shadow-with-descendants-change-expected.txt
+++ b/LayoutTests/platform/mac-wk1/fast/repaint/drop-shadow-with-descendants-change-expected.txt
@@ -1,0 +1,9 @@
+Test repaint rects when the drop-shadow filter property changes on a box with positioned children
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+FAIL layerTreeAsText.indexOf('(rect 200 200 100 100)') > -1 should be true. Was false.
+PASS successfullyParsed is true
+
+TEST COMPLETE

--- a/LayoutTests/platform/mac-wk1/fast/repaint/drop-shadow-writing-modes-expected.txt
+++ b/LayoutTests/platform/mac-wk1/fast/repaint/drop-shadow-writing-modes-expected.txt
@@ -1,0 +1,10 @@
+Test repaint rects when the drop-shadow filter property changes
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+FAIL layerTreeAsText.indexOf('(rect 60 160 156 156)') > -1 should be true. Was false.
+PASS successfullyParsed is true
+
+TEST COMPLETE
+here is some text

--- a/Source/WebCore/css/CSSProperties.json
+++ b/Source/WebCore/css/CSSProperties.json
@@ -7236,6 +7236,7 @@
                 "aliases": [
                     "-webkit-filter"
                 ],
+                "custom": "Value",
                 "conditional-converter": "FilterOperations",
                 "parser-function": "consumeFilter",
                 "parser-function-requires-context": true,

--- a/Source/WebCore/platform/graphics/filters/FilterOperations.cpp
+++ b/Source/WebCore/platform/graphics/filters/FilterOperations.cpp
@@ -101,13 +101,18 @@ IntOutsets FilterOperations::outsets() const
             break;
         }
         case FilterOperation::Type::Reference:
-            ASSERT_NOT_REACHED();
+            // FIXME: Need to compute outsets for reference filters. webkit.org/b/237538
             break;
         default:
             break;
         }
     }
     return totalOutsets;
+}
+
+IntOutsets FilterOperations::accumulatedFilterOutsets(IntOutsets parentOutsets) const
+{
+    return outsets() + parentOutsets;
 }
 
 bool FilterOperations::transformColor(Color& color) const

--- a/Source/WebCore/platform/graphics/filters/FilterOperations.h
+++ b/Source/WebCore/platform/graphics/filters/FilterOperations.h
@@ -57,6 +57,7 @@ public:
 
     bool hasOutsets() const { return !outsets().isZero(); }
     IntOutsets outsets() const;
+    IntOutsets accumulatedFilterOutsets(IntOutsets parentOutsets) const;
 
     bool hasFilterThatAffectsOpacity() const;
     bool hasFilterThatMovesPixels() const;

--- a/Source/WebCore/rendering/RenderBox.cpp
+++ b/Source/WebCore/rendering/RenderBox.cpp
@@ -5117,7 +5117,8 @@ void RenderBox::addVisualEffectOverflow()
     bool hasBoxShadow = style().boxShadow();
     bool hasBorderImageOutsets = style().hasBorderImageOutsets();
     bool hasOutline = outlineStyleForRepaint().hasOutlineInVisualOverflow();
-    if (!hasBoxShadow && !hasBorderImageOutsets && !hasOutline)
+    bool hasFilterOutsets = style().hasAccumulatedFilterOutsets();
+    if (!hasBoxShadow && !hasBorderImageOutsets && !hasOutline && !hasFilterOutsets)
         return;
 
     addVisualOverflow(applyVisualEffectOverflow(borderBoxRect()));
@@ -5167,6 +5168,14 @@ LayoutRect RenderBox::applyVisualEffectOverflow(const LayoutRect& borderBox) con
         overflowMaxY = std::max(overflowMaxY, borderBox.maxY() + outlineSize);
     }
     // Add in the final overflow with shadows and outsets combined.
+    auto filterOutsets = style().accumulatedFilterOutsets();
+    if (!filterOutsets.isZero()) {
+        overflowMinX = std::min(overflowMinX, overflowMinX - ((!isFlipped || isHorizontal) ? filterOutsets.left() : filterOutsets.right()));
+        overflowMaxX = std::max(overflowMaxX, overflowMaxX + ((!isFlipped || isHorizontal) ? filterOutsets.right() : filterOutsets.left()));
+        overflowMinY = std::min(overflowMinY, overflowMinY - ((!isFlipped || !isHorizontal) ? filterOutsets.top() : filterOutsets.bottom()));
+        overflowMaxY = std::max(overflowMaxY, overflowMaxY + ((!isFlipped || !isHorizontal) ? filterOutsets.bottom() : filterOutsets.top()));
+    }
+
     return LayoutRect(overflowMinX, overflowMinY, overflowMaxX - overflowMinX, overflowMaxY - overflowMinY);
 }
 

--- a/Source/WebCore/rendering/style/RenderStyle.h
+++ b/Source/WebCore/rendering/style/RenderStyle.h
@@ -264,6 +264,7 @@ public:
     LayoutBoxExtent maskBoxImageOutsets() const { return imageOutsets(maskBoxImage()); }
 
     IntOutsets filterOutsets() const { return hasFilter() ? filter().outsets() : IntOutsets(); }
+    IntOutsets accumulatedFilterOutsets() const { return m_rareInheritedData->accumulatedFilterOutsets; }
 
     Order rtlOrdering() const { return static_cast<Order>(m_inheritedFlags.rtlOrdering); }
     void setRTLOrdering(Order ordering) { m_inheritedFlags.rtlOrdering = static_cast<unsigned>(ordering); }
@@ -918,6 +919,7 @@ public:
     const FilterOperations& filter() const { return m_nonInheritedData->miscData->filter->operations; }
     bool hasFilter() const { return !m_nonInheritedData->miscData->filter->operations.operations().isEmpty(); }
     bool hasReferenceFilterOnly() const;
+    bool hasAccumulatedFilterOutsets() const { return !accumulatedFilterOutsets().isZero(); }
 
     FilterOperations& mutableAppleColorFilter() { return m_rareInheritedData.access().appleColorFilter.access().operations; }
     const FilterOperations& appleColorFilter() const { return m_rareInheritedData->appleColorFilter->operations; }
@@ -1390,6 +1392,7 @@ public:
 
     void setFilter(const FilterOperations& ops) { SET_DOUBLY_NESTED_VAR(m_nonInheritedData, miscData, filter, operations, ops); }
     void setAppleColorFilter(const FilterOperations& ops) { SET_NESTED_VAR(m_rareInheritedData, appleColorFilter, operations, ops); }
+    void setAccumulatedFilterOutsets(IntOutsets outsets) { SET_VAR(m_rareInheritedData, accumulatedFilterOutsets, outsets); }
 
 #if ENABLE(FILTERS_LEVEL_2)
     void setBackdropFilter(const FilterOperations& ops) { SET_DOUBLY_NESTED_VAR(m_nonInheritedData, rareData, backdropFilter, operations, ops); }

--- a/Source/WebCore/rendering/style/StyleRareInheritedData.cpp
+++ b/Source/WebCore/rendering/style/StyleRareInheritedData.cpp
@@ -73,6 +73,8 @@ struct GreaterThanOrSameSizeAsStyleRareInheritedData : public RefCounted<Greater
     TextAutospace textAutospace;
 
     ListStyleType listStyleType;
+
+    IntOutsets accumulatedFilterOutesets;
 };
 
 static_assert(sizeof(StyleRareInheritedData) <= sizeof(GreaterThanOrSameSizeAsStyleRareInheritedData), "StyleRareInheritedData should bit pack");
@@ -173,6 +175,7 @@ StyleRareInheritedData::StyleRareInheritedData()
     , textSpacingTrim(RenderStyle::initialTextSpacingTrim())
     , textAutospace(RenderStyle::initialTextAutospace())
     , listStyleType(RenderStyle::initialListStyleType())
+    , accumulatedFilterOutsets(IntOutsets())
 {
 }
 
@@ -280,6 +283,7 @@ inline StyleRareInheritedData::StyleRareInheritedData(const StyleRareInheritedDa
     , textSpacingTrim(o.textSpacingTrim)
     , textAutospace(o.textAutospace)
     , listStyleType(o.listStyleType)
+    , accumulatedFilterOutsets(o.accumulatedFilterOutsets)
 {
 }
 
@@ -353,6 +357,7 @@ bool StyleRareInheritedData::operator==(const StyleRareInheritedData& o) const
         && textEmphasisCustomMark == o.textEmphasisCustomMark
         && arePointingToEqualData(quotes, o.quotes)
         && appleColorFilter == o.appleColorFilter
+        && accumulatedFilterOutsets == o.accumulatedFilterOutsets
         && tabSize == o.tabSize
         && lineGrid == o.lineGrid
         && imageOrientation == o.imageOrientation

--- a/Source/WebCore/rendering/style/StyleRareInheritedData.h
+++ b/Source/WebCore/rendering/style/StyleRareInheritedData.h
@@ -214,6 +214,8 @@ public:
 
     ListStyleType listStyleType;
 
+    IntOutsets accumulatedFilterOutsets;
+
 private:
     StyleRareInheritedData();
     StyleRareInheritedData(const StyleRareInheritedData&);

--- a/Source/WebCore/style/StyleBuilderCustom.h
+++ b/Source/WebCore/style/StyleBuilderCustom.h
@@ -167,6 +167,8 @@ public:
 
     static void applyValueColor(BuilderState&, CSSValue&);
 
+    static void applyValueFilter(BuilderState&, CSSValue&);
+
 private:
     static void resetEffectiveZoom(BuilderState&);
 
@@ -2094,6 +2096,17 @@ inline void BuilderCustom::applyValueColor(BuilderState& builderState, CSSValue&
         builderState.style().setVisitedLinkColor(absoluteColorOrInheritColor(color));
     }
     builderState.style().setDisallowsFastPathInheritance();
+}
+
+inline void BuilderCustom::applyValueFilter(BuilderState& builderState, CSSValue& value)
+{
+    auto filterOperations = BuilderConverter::convertFilterOperations(builderState, value);
+    if (!filterOperations)
+        return;
+
+    builderState.style().setFilter(filterOperations.value());
+    auto accumulatedOutsets = builderState.style().filter().accumulatedFilterOutsets(builderState.parentStyle().accumulatedFilterOutsets());
+    builderState.style().setAccumulatedFilterOutsets(accumulatedOutsets);
 }
 
 inline void BuilderCustom::applyInitialCustomProperty(BuilderState& builderState, const CSSRegisteredCustomProperty* registered, const AtomString& name)


### PR DESCRIPTION
#### 9ee234dfdeeb2ab91b7c0e8124d7f981e2039918
<pre>
CSS style &apos;filter: drop-shadow...&apos; does not render correctly without repaint.
<a href="https://bugs.webkit.org/show_bug.cgi?id=207586">https://bugs.webkit.org/show_bug.cgi?id=207586</a>
rdar://59430460

Reviewed by NOBODY (OOPS!).

Fix by having filter outsets contribute to visual overflow. This first patch is the simplest
case: adding to visual overflow on the element with the filter. Future patches will handle
the case where filter on some ancestor needs to contribute to visual overflow on
descendants.&quot;

The addition here is regarding &quot;handle the case where filter on some ancestor needs to contribute
to visual overflow on descendants&quot;.

We are using a internal property named &quot;accumulatedFilterOutsets&quot; to accumulate the maximum
outsets between the element&apos;s parent outsets and the element&apos;s own outsets, which is updated during
style building (StyleBuilderCustom). That way, we don&apos;t need to traverse the render tree to calculate
the maximum outsets along the path between a node and the tree&apos;s root.

At RenderBox::applyVisualEffectOverflow we will take the accumulated filters outsets in consideration
when calculating the element&apos;s visual overflow.

* LayoutTests/compositing/filters/sw-layer-overlaps-hw-shadow-expected.txt:
* LayoutTests/compositing/filters/sw-nested-shadow-overlaps-hw-nested-shadow-expected.txt:
* LayoutTests/compositing/filters/sw-shadow-overlaps-hw-layer-expected.txt:
* LayoutTests/compositing/filters/sw-shadow-overlaps-hw-shadow-expected.txt:
* LayoutTests/fast/repaint/drop-shadow-box-change-expected.txt: Added.
* LayoutTests/fast/repaint/drop-shadow-box-change.html: Added.
* LayoutTests/fast/repaint/drop-shadow-change-expected.txt: Added.
* LayoutTests/fast/repaint/drop-shadow-change.html: Added.
* LayoutTests/fast/repaint/drop-shadow-writing-modes-expected.txt: Added.
* LayoutTests/fast/repaint/drop-shadow-writing-modes.html: Added.
* LayoutTests/platform/mac-wk1/fast/repaint/drop-shadow-box-change-expected.txt: Added.
* LayoutTests/platform/mac-wk1/fast/repaint/drop-shadow-change-expected.txt: Added.
* LayoutTests/platform/mac-wk1/fast/repaint/drop-shadow-with-descendants-change-expected.txt: Added.
* LayoutTests/platform/mac-wk1/fast/repaint/drop-shadow-writing-modes-expected.txt: Added.
* Source/WebCore/css/CSSProperties.json:
* Source/WebCore/platform/graphics/filters/FilterOperations.cpp:
(WebCore::FilterOperations::outsets const):
(WebCore::FilterOperations::accumulatedFilterOutsets const):
* Source/WebCore/platform/graphics/filters/FilterOperations.h:
* Source/WebCore/rendering/RenderBox.cpp:
(WebCore::RenderBox::addVisualEffectOverflow):
(WebCore::RenderBox::applyVisualEffectOverflow const):
* Source/WebCore/rendering/style/RenderStyle.h:
(WebCore::RenderStyle::accumulatedFilterOutsets const):
(WebCore::RenderStyle::hasAccumulatedFilterOutsets const):
(WebCore::RenderStyle::setAccumulatedFilterOutsets):
* Source/WebCore/rendering/style/StyleRareInheritedData.cpp:
(WebCore::StyleRareInheritedData::StyleRareInheritedData):
(WebCore::StyleRareInheritedData::operator== const):
* Source/WebCore/rendering/style/StyleRareInheritedData.h:
* Source/WebCore/style/StyleBuilderCustom.h:
(WebCore::Style::BuilderCustom::applyValueFilter):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9ee234dfdeeb2ab91b7c0e8124d7f981e2039918

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/3616 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/3657 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/3806 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/5042 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/3911 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/3590 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/3757 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/3705 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/3140 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/3660 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/3901 "2 failures") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/3262 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/4865 "Built successfully") | 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/1407 "2 failures") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/3234 "4 failures") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/3300 "142 failures") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/3208 "Passed tests") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/3293 "3 failures") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/4652 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/3669 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/2971 "1 flakes 3 failures") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/3203 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/3234 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/3235 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/3482 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->