### PR TITLE
[CSS Nesting] Rebuild rule set from original (not resolved) selector

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-nesting/invalidation-004-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-nesting/invalidation-004-expected.txt
@@ -1,4 +1,4 @@
 Test passes if color is green.
 
-FAIL CSS Selectors nested invalidation through @media by selectorText assert_equals: expected "rgb(0, 128, 0)" but got "rgb(255, 0, 0)"
+PASS CSS Selectors nested invalidation through @media by selectorText
 

--- a/Source/WebCore/style/RuleSetBuilder.cpp
+++ b/Source/WebCore/style/RuleSetBuilder.cpp
@@ -221,11 +221,11 @@ void RuleSetBuilder::resolveSelectorListWithNesting(StyleRuleWithNesting& rule)
     if (m_styleRuleStack.size()) 
         parentResolvedSelectorList =  m_styleRuleStack.last();
 
-    // If it's a top-level rule wihout a nesting parent selector, keep the selector list as is.
-    if (!rule.selectorList().hasExplicitNestingParent() && !parentResolvedSelectorList)
+    // If it's a top-level rule without a nesting parent selector, keep the selector list as is.
+    if (!rule.originalSelectorList().hasExplicitNestingParent() && !parentResolvedSelectorList)
         return;
 
-    auto resolvedSelectorList = CSSSelectorParser::resolveNestingParent(rule.selectorList(), parentResolvedSelectorList);
+    auto resolvedSelectorList = CSSSelectorParser::resolveNestingParent(rule.originalSelectorList(), parentResolvedSelectorList);
     ASSERT(!resolvedSelectorList.hasExplicitNestingParent());
     rule.wrapperAdoptSelectorList(WTFMove(resolvedSelectorList));    
 }


### PR DESCRIPTION
#### 9eba2e0de0fb4e8fb6c8f0d52252732deaeff786
<pre>
[CSS Nesting] Rebuild rule set from original (not resolved) selector
<a href="https://bugs.webkit.org/show_bug.cgi?id=255521">https://bugs.webkit.org/show_bug.cgi?id=255521</a>
rdar://108137916

Reviewed by Antti Koivisto.

When there is a modification of a selector by CSSOM,
the next resolution should work on the original user-written selector,
not on the previously resolved selector.

* LayoutTests/imported/w3c/web-platform-tests/css/css-nesting/invalidation-004-expected.txt:
* Source/WebCore/style/RuleSetBuilder.cpp:
(WebCore::Style::RuleSetBuilder::resolveSelectorListWithNesting):

Canonical link: <a href="https://commits.webkit.org/263026@main">https://commits.webkit.org/263026@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/034376587be8e035b20da252e394d2d8b452a2e5

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/3376 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/3436 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/3560 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/4807 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/3707 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/3355 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/3505 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/3464 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/2942 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/3417 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/3696 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/3047 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/4625 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/1204 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/3008 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/2935 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/2983 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/3066 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/4368 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/3449 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/2771 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/3011 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/3007 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/820 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/3018 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/3287 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->