### PR TITLE
getStartPositionOfChar(n) on an element with 'n' characters of text doesn't throw IndexSizeError

### DIFF
--- a/LayoutTests/svg/text/svgtextcontentelement-equality-methods-parameters-expected.txt
+++ b/LayoutTests/svg/text/svgtextcontentelement-equality-methods-parameters-expected.txt
@@ -1,0 +1,3 @@
+
+PASS SVGTextContentElement equality methods' parameters are correctly validated
+

--- a/LayoutTests/svg/text/svgtextcontentelement-equality-methods-parameters.html
+++ b/LayoutTests/svg/text/svgtextcontentelement-equality-methods-parameters.html
@@ -1,0 +1,54 @@
+<!DOCTYPE html>
+<title>SVGTextContentElement equality methods' parameters are correctly validated</title>
+<link rel="help" href="http://www.w3.org/TR/SVG2/text.html#InterfaceSVGTextContentElement">
+<script src="../../resources/testharness.js"></script>
+<script src="../../resources/testharnessreport.js"></script>
+<script>
+  test(function() {
+    var svgNS = "http://www.w3.org/2000/svg";
+    var svgRoot = document.createElementNS(svgNS, "svg");
+    document.documentElement.appendChild(svgRoot);
+  
+    var svgText = document.createElementNS(svgNS, "text");
+    svgText.style.fontFamily = "Ahem";
+    svgText.style.fontSize = "20px";
+    svgText.appendChild(document.createTextNode("abcdefg"));
+    svgRoot.appendChild(svgText);
+  
+    var emptySvgText = document.createElementNS(svgNS, "text");
+    svgRoot.appendChild(emptySvgText);
+  
+    function assert_equals_to_SVGPoint(actualPoint, expectedPoint)
+    {
+      assert_equals(actualPoint.x, expectedPoint.x);
+      assert_equals(actualPoint.y, expectedPoint.y);
+    }
+  
+    function assert_equals_to_SVGRect(actualRect, expectedRect)
+    {
+      assert_equals(actualRect.x, expectedRect.x);
+      assert_equals(actualRect.y, expectedRect.y);
+      assert_equals(actualRect.width, expectedRect.width);
+      assert_equals(actualRect.height, expectedRect.height);
+    }
+  
+    // Test the equality part of the restriction.
+    assert_throws_dom("IndexSizeError", function() { svgText.getSubStringLength(7, 2); });
+    assert_throws_dom("IndexSizeError", function() { svgText.getStartPositionOfChar(7); });
+    assert_throws_dom("IndexSizeError", function() { svgText.getEndPositionOfChar(7); });
+    assert_throws_dom("IndexSizeError", function() { svgText.getExtentOfChar(7); });
+    assert_throws_dom("IndexSizeError", function() { svgText.getRotationOfChar(7); });
+    assert_throws_dom("IndexSizeError", function() { svgText.selectSubString(7, 2); });
+  
+    // Test the equality part of the restriction for the <number of chars> == 0 case.
+    assert_throws_dom("IndexSizeError", function() { emptySvgText.getSubStringLength(0, 2); });
+    assert_throws_dom("IndexSizeError", function() { emptySvgText.getStartPositionOfChar(0); });
+    assert_throws_dom("IndexSizeError", function() { emptySvgText.getEndPositionOfChar(0); });
+    assert_throws_dom("IndexSizeError", function() { emptySvgText.getExtentOfChar(0); });
+    assert_throws_dom("IndexSizeError", function() { emptySvgText.getRotationOfChar(0); });
+    assert_throws_dom("IndexSizeError", function() { emptySvgText.selectSubString(0, 2); });
+  
+    // cleanup
+    document.documentElement.removeChild(svgRoot);
+  });
+</script>

--- a/Source/WebCore/svg/SVGTextContentElement.cpp
+++ b/Source/WebCore/svg/SVGTextContentElement.cpp
@@ -2,6 +2,7 @@
  * Copyright (C) 2004, 2005, 2007, 2008 Nikolas Zimmermann <zimmermann@kde.org>
  * Copyright (C) 2004, 2005, 2006, 2007, 2008 Rob Buis <buis@kde.org>
  * Copyright (C) 2018-2019 Apple Inc. All rights reserved.
+ * Copyright (C) 2015 Google Inc. All rights reserved.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Library General Public
@@ -77,7 +78,7 @@ ExceptionOr<float> SVGTextContentElement::getSubStringLength(unsigned charnum, u
 
 ExceptionOr<Ref<SVGPoint>> SVGTextContentElement::getStartPositionOfChar(unsigned charnum)
 {
-    if (charnum > getNumberOfChars())
+    if (charnum >= getNumberOfChars())
         return Exception { IndexSizeError };
 
     return SVGPoint::create(SVGTextQuery(renderer()).startPositionOfCharacter(charnum));
@@ -85,7 +86,7 @@ ExceptionOr<Ref<SVGPoint>> SVGTextContentElement::getStartPositionOfChar(unsigne
 
 ExceptionOr<Ref<SVGPoint>> SVGTextContentElement::getEndPositionOfChar(unsigned charnum)
 {
-    if (charnum > getNumberOfChars())
+    if (charnum >= getNumberOfChars())
         return Exception { IndexSizeError };
 
     return SVGPoint::create(SVGTextQuery(renderer()).endPositionOfCharacter(charnum));
@@ -93,7 +94,7 @@ ExceptionOr<Ref<SVGPoint>> SVGTextContentElement::getEndPositionOfChar(unsigned 
 
 ExceptionOr<Ref<SVGRect>> SVGTextContentElement::getExtentOfChar(unsigned charnum)
 {
-    if (charnum > getNumberOfChars())
+    if (charnum >= getNumberOfChars())
         return Exception { IndexSizeError };
 
     return SVGRect::create(SVGTextQuery(renderer()).extentOfCharacter(charnum));
@@ -101,7 +102,7 @@ ExceptionOr<Ref<SVGRect>> SVGTextContentElement::getExtentOfChar(unsigned charnu
 
 ExceptionOr<float> SVGTextContentElement::getRotationOfChar(unsigned charnum)
 {
-    if (charnum > getNumberOfChars())
+    if (charnum >= getNumberOfChars())
         return Exception { IndexSizeError };
 
     return SVGTextQuery(renderer()).rotationOfCharacter(charnum);


### PR DESCRIPTION
#### 25e8d8240b8ffbd6fc44357718028b00792aea2f
<pre>
getStartPositionOfChar(n) on an element with &apos;n&apos; characters of text doesn&apos;t throw IndexSizeError

<a href="https://bugs.webkit.org/show_bug.cgi?id=255500">https://bugs.webkit.org/show_bug.cgi?id=255500</a>
rdar://problem/108115821

Reviewed by Said Abou-Hallawa.

This patch aligns WebKit to Blink / Chromium, Gecko / Firefox and Web-Spec.

Cherry-Pick: <a href="https://src.chromium.org/viewvc/blink?view=revision&amp">https://src.chromium.org/viewvc/blink?view=revision&amp</a>;revision=201411

According to the spec [1], IndexSizeError should be thrown if:

&quot;...the charnum is negative or if charnum is greater than or equal to
 the number of characters at this node.&quot;

[1] <a href="http://www.w3.org/TR/SVG11/text.html#__svg__SVGTextContentElement__getStartPositionOfChar">http://www.w3.org/TR/SVG11/text.html#__svg__SVGTextContentElement__getStartPositionOfChar</a>
    The current SVG2 draft has a different formulation:

     SVG2 - <a href="https://svgwg.org/svg2-draft/text.html#__svg__SVGTextContentElement__getStartPositionOfChar">https://svgwg.org/svg2-draft/text.html#__svg__SVGTextContentElement__getStartPositionOfChar</a>
     &quot;If cluster is null, then then throw a DOMException with code
      INDEX_SIZE_ERR.&quot;

    but will have the same result.

* Source/WebCore/svg/SVGTextContentElement.cpp:
(SVGTextContentElement::getStartPositionOfChar):
(SVGTextContentElement::getEndPositionOfChar):
(SVGTextContentElement::getExtentOfChar):
(SVGTextContentElement::getRotationOfChar):
* LayoutTests/svg/text/svgtextcontentelement-equality-methods-parameters.html: Add Test
* LayoutTests/svg/text/svgtextcontentelement-equality-methods-parameters-expected.txt: Add Test Expectation

Canonical link: <a href="https://commits.webkit.org/263049@main">https://commits.webkit.org/263049@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f5a11ebf446b22da38f36ba2b936468b998d8c96

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/3473 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/3527 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/3660 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/4898 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/32/builds/3764 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/3451 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/3609 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/3562 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/3019 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/3515 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/15/builds/3776 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/3130 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/4718 "Built successfully") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/39/builds/1284 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/3109 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/3003 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/3079 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/3168 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/4464 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/3538 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/2847 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/3081 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/3107 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/837 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/3104 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/3359 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->