### PR TITLE
[WGSL] WorkgroupSize should accept 3 expressions

### DIFF
--- a/Source/WebGPU/WGSL/AST/ASTStringDumper.cpp
+++ b/Source/WebGPU/WGSL/AST/ASTStringDumper.cpp
@@ -131,7 +131,17 @@ void StringDumper::visit(StageAttribute& stage)
 
 void StringDumper::visit(WorkgroupSizeAttribute& workgroupSize)
 {
-    m_out.print("@workgroup_size(", workgroupSize.size(), ")");
+    m_out.print("@workgroup_size(");
+    visit(workgroupSize.x());
+    if (auto* y = workgroupSize.maybeY()) {
+        m_out.print(", ");
+        visit(*y);
+        if (auto* z = workgroupSize.maybeZ()) {
+            m_out.print(", ");
+            visit(*z);
+        }
+    }
+    m_out.print(")");
 }
 
 // Declaration

--- a/Source/WebGPU/WGSL/AST/ASTVisitor.cpp
+++ b/Source/WebGPU/WGSL/AST/ASTVisitor.cpp
@@ -149,8 +149,11 @@ void Visitor::visit(AST::StageAttribute&)
 {
 }
 
-void Visitor::visit(AST::WorkgroupSizeAttribute&)
+void Visitor::visit(AST::WorkgroupSizeAttribute& attribute)
 {
+    checkErrorAndVisit(attribute.x());
+    maybeCheckErrorAndVisit(attribute.maybeY());
+    maybeCheckErrorAndVisit(attribute.maybeZ());
 }
 
 // Expression

--- a/Source/WebGPU/WGSL/AST/ASTWorkgroupSizeAttribute.h
+++ b/Source/WebGPU/WGSL/AST/ASTWorkgroupSizeAttribute.h
@@ -32,16 +32,22 @@ namespace WGSL::AST {
 class WorkgroupSizeAttribute final : public Attribute {
     WTF_MAKE_FAST_ALLOCATED;
 public:
-    WorkgroupSizeAttribute(SourceSpan span, unsigned size)
+    WorkgroupSizeAttribute(SourceSpan span, Expression::Ref&& x, Expression::Ptr&& maybeY, Expression::Ptr&& maybeZ)
         : Attribute(span)
-        , m_size(size)
+        , m_x(WTFMove(x))
+        , m_y(WTFMove(maybeY))
+        , m_z(WTFMove(maybeZ))
     { }
 
     NodeKind kind() const override;
-    unsigned size() const { return m_size; }
+    Expression& x() { return m_x.get(); }
+    Expression* maybeY() { return m_y.get(); }
+    Expression* maybeZ() { return m_z.get(); }
 
 private:
-    unsigned m_size;
+    Expression::Ref m_x;
+    Expression::Ptr m_y;
+    Expression::Ptr m_z;
 };
 
 } // namespace WGSL::AST

--- a/Source/WebGPU/WGSL/Parser.cpp
+++ b/Source/WebGPU/WGSL/Parser.cpp
@@ -458,9 +458,29 @@ Result<Ref<AST::Attribute>> Parser<Lexer>::parseAttribute()
     if (ident.ident == "workgroup_size"_s) {
         CONSUME_TYPE(ParenLeft);
         // FIXME: should more kinds of literals be accepted here?
-        CONSUME_TYPE_NAMED(id, IntegerLiteralUnsigned);
+        PARSE(x, Expression);
+        AST::Expression::Ptr maybeY = nullptr;
+        AST::Expression::Ptr maybeZ = nullptr;
+        if (current().type == TokenType::Comma) {
+            consume();
+            if (current().type != TokenType::ParenRight) {
+                PARSE(y, Expression);
+                maybeY = y.moveToUniquePtr();
+
+                if (current().type == TokenType::Comma) {
+                    consume();
+                    if (current().type != TokenType::ParenRight) {
+                        PARSE(z, Expression);
+                        maybeZ = z.moveToUniquePtr();
+
+                        if (current().type == TokenType::Comma)
+                            consume();
+                    }
+                }
+            }
+        }
         CONSUME_TYPE(ParenRight);
-        RETURN_NODE_REF(WorkgroupSizeAttribute, id.literalValue);
+        RETURN_NODE_REF(WorkgroupSizeAttribute, WTFMove(x), WTFMove(maybeY), WTFMove(maybeZ));
     }
 
     // https://gpuweb.github.io/gpuweb/wgsl/#pipeline-stage-attributes


### PR DESCRIPTION
#### 209831d6c57289146269aaf2354108f41288ba62
<pre>
[WGSL] WorkgroupSize should accept 3 expressions
<a href="https://bugs.webkit.org/show_bug.cgi?id=255523">https://bugs.webkit.org/show_bug.cgi?id=255523</a>
rdar://108139235

Reviewed by Mike Wyrzykowski.

The implementation assumed a single unsigned literal would be passed into the
`@workgroup_size` annotation, but it takes 3 arguments, a required `x` and
optionals `y` and `z`. They must also be (const) expressions, so we can&apos;t assume
literals will be passed in.

* Source/WebGPU/WGSL/AST/ASTStringDumper.cpp:
(WGSL::AST::StringDumper::visit):
* Source/WebGPU/WGSL/AST/ASTVisitor.cpp:
(WGSL::AST::Visitor::visit):
* Source/WebGPU/WGSL/AST/ASTWorkgroupSizeAttribute.h:
* Source/WebGPU/WGSL/Parser.cpp:
(WGSL::Parser&lt;Lexer&gt;::parseAttribute):

Canonical link: <a href="https://commits.webkit.org/263063@main">https://commits.webkit.org/263063@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b797ac3ad353439a6088da70eb2e1eb2bad2750d

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/3379 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/3439 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/3563 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/4810 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/3710 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/3509 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/3467 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/2946 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/3420 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/3700 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/3068 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/4628 "Built successfully") | 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/1208 "2 failures") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/3016 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/2937 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/2988 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/3074 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/4380 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/3452 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/2776 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/3014 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/3015 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/850 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/3021 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/3290 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->