### PR TITLE
Remove unnecessary respondsToSelector calls for setValue:forUndefinedKey:

### DIFF
--- a/Source/WebCore/bridge/objc/objc_instance.mm
+++ b/Source/WebCore/bridge/objc/objc_instance.mm
@@ -399,28 +399,21 @@ bool ObjcInstance::setValueOfUndefinedField(JSGlobalObject* lexicalGlobalObject,
         return false;
 
     id targetObject = getObject();
-    if (![targetObject respondsToSelector:@selector(setValue:forUndefinedKey:)])
-        return false;
 
     JSLock::DropAllLocks dropAllLocks(lexicalGlobalObject); // Can't put this inside the @try scope because it unwinds incorrectly.
 
-    // This check is not really necessary because NSObject implements
-    // setValue:forUndefinedKey:, and unfortunately the default implementation
-    // throws an exception.
-    if ([targetObject respondsToSelector:@selector(setValue:forUndefinedKey:)]){
-        setGlobalException(nil);
-    
-        ObjcValue objcValue = convertValueToObjcValue(lexicalGlobalObject, aValue, ObjcObjectType);
+    setGlobalException(nil);
 
-        @try {
-            [targetObject setValue:(__bridge id)objcValue.objectValue forUndefinedKey:[NSString stringWithCString:name.ascii().data() encoding:NSASCIIStringEncoding]];
-        } @catch(NSException* localException) {
-            // Do nothing.  Class did not override valueForUndefinedKey:.
-        }
+    ObjcValue objcValue = convertValueToObjcValue(lexicalGlobalObject, aValue, ObjcObjectType);
 
-        moveGlobalExceptionToExecState(lexicalGlobalObject);
+    @try {
+        [targetObject setValue:(__bridge id)objcValue.objectValue forUndefinedKey:[NSString stringWithCString:name.ascii().data() encoding:NSASCIIStringEncoding]];
+    } @catch (NSException* localException) {
+        // Do nothing. Class did not override setValue:forUndefinedKey:.
     }
-    
+
+    moveGlobalExceptionToExecState(lexicalGlobalObject);
+
     return true;
 }
 
@@ -436,21 +429,16 @@ JSC::JSValue ObjcInstance::getValueOfUndefinedField(JSGlobalObject* lexicalGloba
 
     JSLock::DropAllLocks dropAllLocks(lexicalGlobalObject); // Can't put this inside the @try scope because it unwinds incorrectly.
 
-    // This check is not really necessary because NSObject implements
-    // valueForUndefinedKey:, and unfortunately the default implementation
-    // throws an exception.
-    if ([targetObject respondsToSelector:@selector(valueForUndefinedKey:)]){
-        setGlobalException(nil);
-    
-        @try {
-            id objcValue = [targetObject valueForUndefinedKey:[NSString stringWithCString:name.ascii().data() encoding:NSASCIIStringEncoding]];
-            result = convertObjcValueToValue(lexicalGlobalObject, &objcValue, ObjcObjectType, m_rootObject.get());
-        } @catch(NSException* localException) {
-            // Do nothing.  Class did not override valueForUndefinedKey:.
-        }
+    setGlobalException(nil);
 
-        moveGlobalExceptionToExecState(lexicalGlobalObject);
+    @try {
+        id objcValue = [targetObject valueForUndefinedKey:[NSString stringWithCString:name.ascii().data() encoding:NSASCIIStringEncoding]];
+        result = convertObjcValueToValue(lexicalGlobalObject, &objcValue, ObjcObjectType, m_rootObject.get());
+    } @catch (NSException* localException) {
+        // Do nothing. Class did not override valueForUndefinedKey:.
     }
+
+    moveGlobalExceptionToExecState(lexicalGlobalObject);
 
     return result;
 }


### PR DESCRIPTION
<pre>
Remove unnecessary respondsToSelector call for setValue:forUndefinedKey:
<a href="https://bugs.webkit.org/show_bug.cgi?id=255525">https://bugs.webkit.org/show_bug.cgi?id=255525</a>

Reviewed by NOBODY (OOPS!).

As per the comment above the checks, such a call
is not necessary, as NSObject implements setValue:forUndefinedKey:.

* Source/WebCore/bridge/objc/objc_instance.mm:
  (JSC::Bindings::ObjcInstance::setValueOfUndefinedField): Remove
  respondsToSelector call.
  (JSC::Bindings::ObjcInstance::getValueOfUndefinedField const): Ditto.
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/3a947228a65028e80668bbb0c22a0d3639b6c37c

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/3430 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/3488 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/3617 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/4857 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/3737 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/3409 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/3565 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/3520 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/2989 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/3472 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/3740 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/3090 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/4677 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/1248 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/3064 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/2977 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/3036 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/3123 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/4426 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/3499 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/2812 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/3045 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/3062 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/3065 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/3324 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->