### PR TITLE
[WPE][GTK] Autoinstall version conflicts for cryptography and cffi libraries when running the run-benchmark script

### DIFF
--- a/Tools/Scripts/libraries/webkitcorepy/webkitcorepy/__init__.py
+++ b/Tools/Scripts/libraries/webkitcorepy/webkitcorepy/__init__.py
@@ -85,12 +85,14 @@ AutoInstall.register(Package('tblib', Version(1, 7, 0)))
 AutoInstall.register(Package('urllib3', Version(1, 25, 10)))
 AutoInstall.register(Package('wheel', Version(0, 35, 1)))
 AutoInstall.register(Package('whichcraft', Version(0, 6, 1)))
+AutoInstall.register(Package('cffi', Version(1, 15, 1)))
+
+if sys.version_info > (3, 0):
+    AutoInstall.register(Package('cryptography', Version(36, 0, 2), wheel=True, implicit_deps=['cffi']))
 
 if sys.version_info >= (3, 6):
     if sys.platform == 'linux':
         AutoInstall.register(Package('jeepney', Version(0, 7, 1)))
-        AutoInstall.register(Package('cffi', Version(1, 15, 0)))
-        AutoInstall.register(Package('cryptography', Version(36, 0, 1), wheel=True, implicit_deps=['cffi']))
         AutoInstall.register(Package('secretstorage', Version(3, 3, 1)))
     AutoInstall.register(Package('keyring', Version(23, 2, 1)))
 else:

--- a/Tools/Scripts/webkitpy/autoinstalled/twisted.py
+++ b/Tools/Scripts/webkitpy/autoinstalled/twisted.py
@@ -30,9 +30,7 @@ AutoInstall.install(Package('incremental', Version(21, 3, 0), pypi_name='increme
 AutoInstall.install(Package('twisted', Version(20, 3, 0), pypi_name='Twisted'))
 
 AutoInstall.install(Package('pyOpenSSL', Version(20, 0, 0)))
-AutoInstall.install(Package('cryptography', Version(36, 0, 2), wheel=True))
 AutoInstall.install(Package('bcrypt', Version(4), wheel=True))
-AutoInstall.install(Package('cffi', Version(1, 15, 1), wheel=True))
 AutoInstall.install(Package('pycparser', Version(2, 21), wheel=True))
 
 from twisted.protocols.tls import TLSMemoryBIOFactory


### PR DESCRIPTION
#### 2a0a1467f4d875dc28f18119ebf2a327cf30a1c9
<pre>
[WPE][GTK] Autoinstall version conflicts for cryptography and cffi libraries when running the run-benchmark script
<a href="https://bugs.webkit.org/show_bug.cgi?id=255519">https://bugs.webkit.org/show_bug.cgi?id=255519</a>

Reviewed by Jonathan Bedard.

Autoinstall cffi and cryptography libraries for all platforms
on webkitcorepy since now are required for twisted and use
the version that was defined on twisted.

* Tools/Scripts/libraries/webkitcorepy/webkitcorepy/__init__.py:
* Tools/Scripts/webkitpy/autoinstalled/twisted.py:

Canonical link: <a href="https://commits.webkit.org/263081@main">https://commits.webkit.org/263081@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/68a8dd5c43d85aae978dfd744e68da4b9a1f39fe

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/3390 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/3449 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/3574 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/4820 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/3714 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/3369 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/3523 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/3478 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/2956 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/3431 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/3708 "2 failures") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/3063 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/4639 "Built successfully") | 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/3421 "Passed tests") | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/1216 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/3032 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/2953 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/3000 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/3090 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/4395 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/3461 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/2782 "Passed tests") | | 
| [✅ 🧪 services](https://ews-build.webkit.org/#/builders/28/builds/3353 "Passed tests") | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/3019 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/3031 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/3029 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/409 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/3295 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->