### PR TITLE
REGRESSION(262860@main): [GTK] icons broken, rendering errors on reddit.com and many other websites, flickering on cnn.com

### DIFF
--- a/Source/WebCore/platform/graphics/freetype/SimpleFontDataFreeType.cpp
+++ b/Source/WebCore/platform/graphics/freetype/SimpleFontDataFreeType.cpp
@@ -96,10 +96,11 @@ static std::optional<unsigned> fontUnitsPerEm(FT_Face freeTypeFace)
     return std::nullopt;
 }
 
-static float heightOfCharacter(cairo_scaled_font_t* scaledFont, const char character, FontOrientation orientation)
+static float heightOfCharacter(cairo_scaled_font_t* scaledFont, const char* character, FontOrientation orientation)
 {
+    ASSERT(strlen(character) == 1);
     cairo_text_extents_t textExtents;
-    cairo_scaled_font_text_extents(scaledFont, &character, &textExtents);
+    cairo_scaled_font_text_extents(scaledFont, character, &textExtents);
     return narrowPrecisionToFloat(orientation == FontOrientation::Horizontal ? textExtents.height : textExtents.width);
 }
 
@@ -158,9 +159,9 @@ void Font::platformInit()
     // We approximate capHeight and xHeight from cairo_text_extents_t unless
     // FreeType returns them above. This approach is less precise than using FreeType.
     if (!capHeight.has_value() || !capHeight.value())
-        capHeight = heightOfCharacter(m_platformData.scaledFont(), 'T', platformData().orientation());
+        capHeight = heightOfCharacter(m_platformData.scaledFont(), "T", platformData().orientation());
     if (!xHeight.has_value() || !xHeight.value())
-        xHeight = heightOfCharacter(m_platformData.scaledFont(), 'x', platformData().orientation());
+        xHeight = heightOfCharacter(m_platformData.scaledFont(), "x", platformData().orientation());
 
     m_fontMetrics.setAscent(ascent);
     m_fontMetrics.setDescent(descent);


### PR DESCRIPTION
#### 60c2559bd902b7c329a5105d389ce70beeeead01
<pre>
REGRESSION(262860@main): [GTK] icons broken, rendering errors on reddit.com and many other websites, flickering on cnn.com
<a href="https://bugs.webkit.org/show_bug.cgi?id=255488">https://bugs.webkit.org/show_bug.cgi?id=255488</a>

Reviewed by Adrian Perez de Castro.

The second parameter to cairo_scaled_font_text_extents() must be a
NUL-terminated UTF-8 string.

* Source/WebCore/platform/graphics/freetype/SimpleFontDataFreeType.cpp:
(WebCore::heightOfCharacter):
(WebCore::Font::platformInit):

Canonical link: <a href="https://commits.webkit.org/263036@main">https://commits.webkit.org/263036@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/496b2994ce4193222fc140eebde4a610e945790e

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/3385 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/3445 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/3569 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/4815 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/3712 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/3364 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/3572 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/3473 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/2958 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/3426 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/15/builds/3749 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/3060 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/4634 "Built successfully") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/39/builds/1257 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/3024 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/2942 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/3045 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/3082 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/4388 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/3457 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/2781 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/3017 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/3023 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/831 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/3025 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/3293 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->