### PR TITLE
Check start after it is modified, not before RegularExpression.match()

### DIFF
--- a/Source/JavaScriptCore/inspector/ContentSearchUtilities.cpp
+++ b/Source/JavaScriptCore/inspector/ContentSearchUtilities.cpp
@@ -49,7 +49,7 @@ static String escapeStringForRegularExpressionSource(const String& text)
 {
     StringBuilder result;
 
-    for (unsigned i = 0; i < text.length(); i++) {
+    for (size_t i = 0; i < text.length(); i++) {
         UChar character = text[i];
         if (isASCII(character) && strchr(regexSpecialCharacters, character))
             result.append('\\');
@@ -154,13 +154,13 @@ int countRegularExpressionMatches(const RegularExpression& regex, const String& 
     int result = 0;
     int position;
     unsigned start = 0;
-    int matchLength;
+    int matchLength = 0;
     while ((position = regex.match(content, start, &matchLength)) != -1) {
-        if (start >= content.length())
-            break;
         if (matchLength > 0)
             ++result;
         start = position + 1;
+        if (start >= content.length())
+            break;
     }
     return result;
 }


### PR DESCRIPTION
<pre>
Check start after it is modified, not before RegularExpression.match()
<a href="https://bugs.webkit.org/show_bug.cgi?id=255529">https://bugs.webkit.org/show_bug.cgi?id=255529</a>

Reviewed by NOBODY (OOPS!).

The first iteration of regex.match is guaranteed to have start be less than content.length().
This is because of the isEmpty check at the beginning of the function,
which means that the only time start should be checked is when it changes.
This also saves us a function call when start is at the end of the content.

* Source/JavaScriptCore/inspector/ContentSearchUtilities.cpp: 
  (Inspector::ContentSearchUtilities::escapeStringForRegularExpressionSource): 
  (Inspector::ContentSearchUtilities::countRegularExpressionMatches):
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/6253d92a15e988a9caf12caa3604d8e940d57479

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/3396 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/3455 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/3582 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/4824 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/3717 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/3529 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/3486 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/2963 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/3438 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/3713 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/3069 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/4644 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/1221 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/3038 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/2948 "Passed tests") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/2800 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/3005 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/3096 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/4389 "Passed tests") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/3201 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/3467 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/2787 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/3469 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/3023 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/3037 "Passed tests") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/858 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/3035 "Built successfully") | | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/24/builds/3560 "Built successfully") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/3299 "Built successfully") | | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/3/builds/979 "Passed tests") | 
<!--EWS-Status-Bubble-End-->