### PR TITLE
[CSS Nesting] Fix parsing of nested at-rules with CSSOM

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-nesting/cssom-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-nesting/cssom-expected.txt
@@ -6,8 +6,8 @@ PASS Simple CSSOM manipulation of subrules 3
 PASS Simple CSSOM manipulation of subrules 4
 PASS Simple CSSOM manipulation of subrules 5
 PASS Simple CSSOM manipulation of subrules 6
-FAIL Simple CSSOM manipulation of subrules 7 assert_equals: @supports is added expected ".a {\n  color: red;\n  & .b { color: green; }\n  @supports selector(&) {\n  & div { font-size: 10px; }\n}\n  & .c { color: blue; }\n}" but got ".a {\n  color: red;\n  & .b { color: green; }\n  @supports selector(&) {\n}\n  & .c { color: blue; }\n}"
-FAIL Simple CSSOM manipulation of subrules 8 assert_equals: color is changed, new rule is ignored expected ".a {\n  color: olivedrab;\n  & .b { color: green; }\n  & .c { color: blue; }\n}" but got ".a {\n  color: olivedrab;\n  & .b { color: green; }\n  @supports selector(&) {\n}\n  & .c { color: blue; }\n}"
+PASS Simple CSSOM manipulation of subrules 7
+PASS Simple CSSOM manipulation of subrules 8
 PASS Simple CSSOM manipulation of subrules 9
 PASS Simple CSSOM manipulation of subrules 10
 FAIL Simple CSSOM manipulation of subrules 11 assert_equals: invalid rule containing ampersand is kept in serialization expected ".a {\n  :is(!& .foo, .b) { color: green; }\n}" but got ".a {\n  :is(.b) { color: green; }\n}"

--- a/Source/WebCore/css/parser/CSSParserImpl.cpp
+++ b/Source/WebCore/css/parser/CSSParserImpl.cpp
@@ -416,7 +416,7 @@ RefPtr<StyleRuleBase> CSSParserImpl::consumeAtRule(CSSParserTokenRange& range, A
 // https://drafts.csswg.org/css-syntax/#consume-a-qualified-rule
 RefPtr<StyleRuleBase> CSSParserImpl::consumeQualifiedRule(CSSParserTokenRange& range, AllowedRulesType allowedRules)
 {
-    auto isNestedStyleRule = [&]() {
+    auto isNestedStyleRule = [&] {
         return isNestedContext() && allowedRules <= RegularRules;
     };
 
@@ -581,7 +581,7 @@ Vector<RefPtr<StyleRuleBase>> CSSParserImpl::consumeRegularRuleList(CSSParserTok
 {
     Vector<RefPtr<StyleRuleBase>> rules;
     if (isNestedContext()) {
-        runInNewNestingContext([&]() {
+        runInNewNestingContext([&] {
             consumeStyleBlock(block, StyleRuleType::Style, ParsingStyleDeclarationsInRuleList::Yes);
             if (!topContext().m_parsedProperties.isEmpty()) {
                 // This at-rule contains orphan declarations, we attach them to an implicit parent nesting rule. Web
@@ -1105,7 +1105,7 @@ RefPtr<StyleRuleBase> CSSParserImpl::consumeStyleRule(CSSParserTokenRange prelud
 void CSSParserImpl::consumeDeclarationListOrStyleBlockHelper(CSSParserTokenRange range, StyleRuleType ruleType, OnlyDeclarations onlyDeclarations, ParsingStyleDeclarationsInRuleList isParsingStyleDeclarationsInRuleList)
 {
     auto nestedRulesAllowed = [&]() {
-        return m_styleRuleNestingDepth && context().cssNestingEnabled && onlyDeclarations == OnlyDeclarations::No;        
+        return isNestedContext() && onlyDeclarations == OnlyDeclarations::No;        
     };
     
     ASSERT(topContext().m_parsedProperties.isEmpty());


### PR DESCRIPTION
#### ab88221743a99d533cee3c21c2b4de51cbf87d6b
<pre>
[CSS Nesting] Fix parsing of nested at-rules with CSSOM
<a href="https://bugs.webkit.org/show_bug.cgi?id=255530">https://bugs.webkit.org/show_bug.cgi?id=255530</a>
rdar://107760234

Reviewed by Antti Koivisto.

CSS OM insertion can &quot;bypass&quot; the normal stack by inserting at an arbitrarily
deeply nested context.
We already have isNestedContext() function to check for this, but it was
not used here unfortunately.

* LayoutTests/imported/w3c/web-platform-tests/css/css-nesting/cssom-expected.txt:
* Source/WebCore/css/parser/CSSParserImpl.cpp:
(WebCore::CSSParserImpl::consumeQualifiedRule):
(WebCore::CSSParserImpl::consumeRegularRuleList):
(WebCore::CSSParserImpl::consumeDeclarationListOrStyleBlockHelper):

Canonical link: <a href="https://commits.webkit.org/263028@main">https://commits.webkit.org/263028@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/08332131baf156f109dbff9a7775ecd29fc39a05

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/3398 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/3457 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/3584 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/4826 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/3719 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/3377 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/3531 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/3488 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/2961 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/3440 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/15/builds/3714 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/3065 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/4646 "Built successfully") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/39/builds/1222 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/3034 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/2952 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/3006 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/3092 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/4394 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/3469 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/2788 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/3025 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/3033 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/821 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/3037 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/3301 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->