### PR TITLE
CloneDeserializer::deserialize() should store cell pointers in a MarkedVector.

### DIFF
--- a/Source/JavaScriptCore/heap/Heap.cpp
+++ b/Source/JavaScriptCore/heap/Heap.cpp
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2003-2022 Apple Inc. All rights reserved.
+ *  Copyright (C) 2003-2023 Apple Inc. All rights reserved.
  *  Copyright (C) 2007 Eric Seidel <eric@webkit.org>
  *
  *  This library is free software; you can redistribute it and/or
@@ -2864,7 +2864,7 @@ void Heap::addCoreConstraints()
             
             if (!m_markListSet.isEmpty()) {
                 SetRootMarkReasonScope rootScope(visitor, RootMarkReason::ConservativeScan);
-                MarkedArgumentBufferBase::markLists(visitor, m_markListSet);
+                MarkedVectorBase::markLists(visitor, m_markListSet);
             }
 
             {

--- a/Source/JavaScriptCore/heap/Heap.h
+++ b/Source/JavaScriptCore/heap/Heap.h
@@ -1,7 +1,7 @@
 /*
  *  Copyright (C) 1999-2000 Harri Porten (porten@kde.org)
  *  Copyright (C) 2001 Peter Kelly (pmk@post.com)
- *  Copyright (C) 2003-2022 Apple Inc. All rights reserved.
+ *  Copyright (C) 2003-2023 Apple Inc. All rights reserved.
  *
  *  This library is free software; you can redistribute it and/or
  *  modify it under the terms of the GNU Lesser General Public
@@ -85,7 +85,7 @@ class MarkStackArray;
 class MarkStackMergingConstraint;
 class MarkedJSValueRefArray;
 class BlockDirectory;
-class MarkedArgumentBufferBase;
+class MarkedVectorBase;
 class MarkingConstraint;
 class MarkingConstraintSet;
 class MutatorScheduler;
@@ -413,7 +413,7 @@ public:
     JS_EXPORT_PRIVATE std::unique_ptr<TypeCountSet> protectedObjectTypeCounts();
     JS_EXPORT_PRIVATE std::unique_ptr<TypeCountSet> objectTypeCounts();
 
-    HashSet<MarkedArgumentBufferBase*>& markListSet();
+    HashSet<MarkedVectorBase*>& markListSet();
     void addMarkedJSValueRefArray(MarkedJSValueRefArray*);
     
     template<typename Functor> void forEachProtectedCell(const Functor&);
@@ -782,7 +782,7 @@ private:
     size_t m_deprecatedExtraMemorySize { 0 };
 
     ProtectCountSet m_protectedValues;
-    HashSet<MarkedArgumentBufferBase*> m_markListSet;
+    HashSet<MarkedVectorBase*> m_markListSet;
     SentinelLinkedList<MarkedJSValueRefArray, BasicRawSentinelNode<MarkedJSValueRefArray>> m_markedJSValueRefArrays;
 
     std::unique_ptr<MachineThreads> m_machineThreads;

--- a/Source/JavaScriptCore/heap/HeapInlines.h
+++ b/Source/JavaScriptCore/heap/HeapInlines.h
@@ -205,7 +205,7 @@ inline void Heap::decrementDeferralDepthAndGCIfNeeded()
     }
 }
 
-inline HashSet<MarkedArgumentBufferBase*>& Heap::markListSet()
+inline HashSet<MarkedVectorBase*>& Heap::markListSet()
 {
     return m_markListSet;
 }

--- a/Source/JavaScriptCore/runtime/ArgList.h
+++ b/Source/JavaScriptCore/runtime/ArgList.h
@@ -28,20 +28,20 @@
 
 namespace JSC {
 
-class alignas(alignof(EncodedJSValue)) MarkedArgumentBufferBase : public RecordOverflow {
-    WTF_MAKE_NONCOPYABLE(MarkedArgumentBufferBase);
-    WTF_MAKE_NONMOVABLE(MarkedArgumentBufferBase);
+class alignas(alignof(EncodedJSValue)) MarkedVectorBase {
+    WTF_MAKE_NONCOPYABLE(MarkedVectorBase);
+    WTF_MAKE_NONMOVABLE(MarkedVectorBase);
     WTF_FORBID_HEAP_ALLOCATION;
     friend class VM;
     friend class ArgList;
 
+protected:
+    enum class Status { Success, Overflowed };
 public:
-    using Base = RecordOverflow;
-    typedef HashSet<MarkedArgumentBufferBase*> ListSet;
+    typedef HashSet<MarkedVectorBase*> ListSet;
 
-    ~MarkedArgumentBufferBase()
+    ~MarkedVectorBase()
     {
-        ASSERT(!m_needsOverflowCheck);
         if (m_markSet)
             m_markSet->remove(this);
 
@@ -52,43 +52,7 @@ public:
     size_t size() const { return m_size; }
     bool isEmpty() const { return !m_size; }
 
-    JSValue at(int i) const
-    {
-        if (i >= m_size)
-            return jsUndefined();
-
-        return JSValue::decode(slotFor(i));
-    }
-
     const EncodedJSValue* data() const { return m_buffer; }
-
-    void clear()
-    {
-        ASSERT(!m_needsOverflowCheck);
-        clearOverflow();
-        m_size = 0;
-    }
-
-    enum OverflowCheckAction {
-        CrashOnOverflow,
-        WillCheckLater
-    };
-    template<OverflowCheckAction action>
-    void appendWithAction(JSValue v)
-    {
-        ASSERT(m_size <= m_capacity);
-        if (m_size == m_capacity || mallocBase()) {
-            slowAppend(v);
-            if (action == CrashOnOverflow)
-                RELEASE_ASSERT(!hasOverflowed());
-            return;
-        }
-
-        slotFor(m_size) = JSValue::encode(v);
-        ++m_size;
-    }
-    void append(JSValue v) { appendWithAction<WillCheckLater>(v); }
-    void appendWithCrashOnOverflow(JSValue v) { appendWithAction<CrashOnOverflow>(v); }
 
     void removeLast()
     { 
@@ -96,50 +60,14 @@ public:
         m_size--;
     }
 
-    JSValue last() 
-    {
-        ASSERT(m_size);
-        return JSValue::decode(slotFor(m_size - 1));
-    }
-
-    JSValue takeLast()
-    {
-        JSValue result = last();
-        removeLast();
-        return result;
-    }
-        
     template<typename Visitor> static void markLists(Visitor&, ListSet&);
 
-    void ensureCapacity(size_t requestedCapacity)
-    {
-        if (requestedCapacity > static_cast<size_t>(m_capacity))
-            slowEnsureCapacity(requestedCapacity);
-    }
-
-    bool hasOverflowed()
-    {
-        clearNeedsOverflowCheck();
-        return Base::hasOverflowed();
-    }
-
     void overflowCheckNotNeeded() { clearNeedsOverflowCheck(); }
-
-    template<typename Functor>
-    void fill(size_t count, const Functor& func)
-    {
-        ASSERT(!m_size);
-        ensureCapacity(count);
-        if (Base::hasOverflowed())
-            return;
-        m_size = count;
-        func(reinterpret_cast<JSValue*>(&slotFor(0)));
-    }
 
 protected:
     // Constructor for a read-write list, to which you may append values.
     // FIXME: Remove all clients of this API, then remove this API.
-    MarkedArgumentBufferBase(size_t capacity)
+    MarkedVectorBase(size_t capacity)
         : m_size(0)
         , m_capacity(capacity)
         , m_buffer(inlineBuffer())
@@ -149,17 +77,16 @@ protected:
 
     EncodedJSValue* inlineBuffer()
     {
-        return bitwise_cast<EncodedJSValue*>(bitwise_cast<uint8_t*>(this) + sizeof(MarkedArgumentBufferBase));
+        return bitwise_cast<EncodedJSValue*>(bitwise_cast<uint8_t*>(this) + sizeof(MarkedVectorBase));
     }
 
-private:
-    void expandCapacity();
-    void expandCapacity(int newCapacity);
-    void slowEnsureCapacity(size_t requestedCapacity);
+    Status expandCapacity();
+    Status expandCapacity(int newCapacity);
+    Status slowEnsureCapacity(size_t requestedCapacity);
 
     void addMarkSet(JSValue);
 
-    JS_EXPORT_PRIVATE void slowAppend(JSValue);
+    JS_EXPORT_PRIVATE Status slowAppend(JSValue);
 
     EncodedJSValue& slotFor(int item) const
     {
@@ -174,11 +101,14 @@ private:
     }
 
 #if ASSERT_ENABLED
-    void setNeedsOverflowCheck() { m_needsOverflowCheck = true; }
+    void disableNeedsOverflowCheck() { m_overflowCheckEnabled = false; }
+    void setNeedsOverflowCheck() { m_needsOverflowCheck = m_overflowCheckEnabled; }
     void clearNeedsOverflowCheck() { m_needsOverflowCheck = false; }
 
     bool m_needsOverflowCheck { false };
+    bool m_overflowCheckEnabled { true };
 #else
+    void disableNeedsOverflowCheck() { }
     void setNeedsOverflowCheck() { }
     void clearNeedsOverflowCheck() { }
 #endif // ASSERT_ENABLED
@@ -188,22 +118,114 @@ private:
     ListSet* m_markSet;
 };
 
-template<size_t passedInlineCapacity = 8>
-class MarkedArgumentBufferWithSize : public MarkedArgumentBufferBase {
+template<typename T, size_t passedInlineCapacity = 8, class OverflowHandler = CrashOnOverflow>
+class MarkedVector : public OverflowHandler, public MarkedVectorBase  {
 public:
     static constexpr size_t inlineCapacity = passedInlineCapacity;
 
-    MarkedArgumentBufferWithSize()
-        : MarkedArgumentBufferBase(inlineCapacity)
+    MarkedVector()
+        : MarkedVectorBase(inlineCapacity)
     {
         ASSERT(inlineBuffer() == m_inlineBuffer);
+        if constexpr (std::is_same_v<OverflowHandler, CrashOnOverflow>) {
+            // CrashOnOverflow handles overflows immediately. So, we do not
+            // need to check for it after.
+            disableNeedsOverflowCheck();
+        }
+    }
+
+    auto at(int i) const -> decltype(auto)
+    {
+        if constexpr (std::is_same_v<T, JSValue>) {
+            if (i >= m_size)
+                return jsUndefined();
+            return JSValue::decode(slotFor(i));
+        } else {
+            if (i >= m_size)
+                return static_cast<T>(nullptr);
+            return jsCast<T>(JSValue::decode(slotFor(i)).asCell());
+        }
+    }
+
+    void clear()
+    {
+        ASSERT(!m_needsOverflowCheck);
+        OverflowHandler::clearOverflow();
+        m_size = 0;
+    }
+
+    void append(T v)
+    {
+        ASSERT(m_size <= m_capacity);
+        if (m_size == m_capacity || mallocBase()) {
+            if (slowAppend(v) == Status::Overflowed)
+                this->overflowed();
+            return;
+        }
+
+        slotFor(m_size) = JSValue::encode(v);
+        ++m_size;
+    }
+
+    void appendWithCrashOnOverflow(T v)
+    {
+        append(v);
+        if constexpr (!std::is_same<OverflowHandler, CrashOnOverflow>::value)
+            RELEASE_ASSERT(!this->hasOverflowed());
+    }
+
+    auto last() const -> decltype(auto)
+    {
+        if constexpr (std::is_same_v<T, JSValue>) {
+            ASSERT(m_size);
+            return JSValue::decode(slotFor(m_size - 1));
+        } else {
+            ASSERT(m_size);
+            return jsCast<T>(JSValue::decode(slotFor(m_size - 1)).asCell());
+        }
+    }
+
+    JSValue takeLast()
+    {
+        JSValue result = last();
+        removeLast();
+        return result;
+    }
+
+    void ensureCapacity(size_t requestedCapacity)
+    {
+        if (requestedCapacity > static_cast<size_t>(m_capacity)) {
+            if (slowEnsureCapacity(requestedCapacity) == Status::Overflowed)
+                this->overflowed();
+        }
+    }
+
+    bool hasOverflowed()
+    {
+        clearNeedsOverflowCheck();
+        return OverflowHandler::hasOverflowed();
+    }
+
+    template<typename Functor>
+    void fill(size_t count, const Functor& func)
+    {
+        ASSERT(!m_size);
+        ensureCapacity(count);
+        if (OverflowHandler::hasOverflowed())
+            return;
+        m_size = count;
+        func(reinterpret_cast<JSValue*>(&slotFor(0)));
     }
 
 private:
     EncodedJSValue m_inlineBuffer[inlineCapacity] { };
 };
 
-using MarkedArgumentBuffer = MarkedArgumentBufferWithSize<>;
+template<size_t passedInlineCapacity>
+class MarkedArgumentBufferWithSize : public MarkedVector<JSValue, passedInlineCapacity, RecordOverflow> {
+};
+
+using MarkedArgumentBuffer = MarkedVector<JSValue, 8, RecordOverflow>;
 
 class ArgList {
     WTF_MAKE_FAST_ALLOCATED;

--- a/Source/WebCore/Modules/webaudio/AudioWorkletProcessor.cpp
+++ b/Source/WebCore/Modules/webaudio/AudioWorkletProcessor.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020 Apple Inc. All rights reserved.
+ * Copyright (C) 2020-2023 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -220,7 +220,7 @@ AudioWorkletProcessor::AudioWorkletProcessor(AudioWorkletGlobalScope& globalScop
     ASSERT(!isMainThread());
 }
 
-void AudioWorkletProcessor::buildJSArguments(VM& vm, JSGlobalObject& globalObject, MarkedArgumentBufferBase& args, const Vector<RefPtr<AudioBus>>& inputs, Vector<Ref<AudioBus>>& outputs, const MemoryCompactLookupOnlyRobinHoodHashMap<String, std::unique_ptr<AudioFloatArray>>& paramValuesMap)
+void AudioWorkletProcessor::buildJSArguments(VM& vm, JSGlobalObject& globalObject, MarkedArgumentBuffer& args, const Vector<RefPtr<AudioBus>>& inputs, Vector<Ref<AudioBus>>& outputs, const MemoryCompactLookupOnlyRobinHoodHashMap<String, std::unique_ptr<AudioFloatArray>>& paramValuesMap)
 {
     // For performance reasons, we cache the arrays passed to JS and reconstruct them only when the topology changes.
     if (!copyDataFromBusesToJSArray(globalObject, inputs, toJSArray(m_jsInputs)))

--- a/Source/WebCore/Modules/webaudio/AudioWorkletProcessor.h
+++ b/Source/WebCore/Modules/webaudio/AudioWorkletProcessor.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020 Apple Inc. All rights reserved.
+ * Copyright (C) 2020-2023 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -41,7 +41,8 @@
 
 namespace JSC {
 class JSArray;
-class MarkedArgumentBufferBase;
+template<typename T, size_t, class> class MarkedVector;
+using MarkedArgumentBuffer = MarkedVector<JSValue, 8, RecordOverflow>;
 }
 
 namespace WebCore {
@@ -71,7 +72,7 @@ public:
 
 private:
     explicit AudioWorkletProcessor(AudioWorkletGlobalScope&, const AudioWorkletProcessorConstructionData&);
-    void buildJSArguments(JSC::VM&, JSC::JSGlobalObject&, JSC::MarkedArgumentBufferBase&, const Vector<RefPtr<AudioBus>>& inputs, Vector<Ref<AudioBus>>& outputs, const MemoryCompactLookupOnlyRobinHoodHashMap<String, std::unique_ptr<AudioFloatArray>>& paramValuesMap);
+    void buildJSArguments(JSC::VM&, JSC::JSGlobalObject&, JSC::MarkedArgumentBuffer&, const Vector<RefPtr<AudioBus>>& inputs, Vector<Ref<AudioBus>>& outputs, const MemoryCompactLookupOnlyRobinHoodHashMap<String, std::unique_ptr<AudioFloatArray>>& paramValuesMap);
 
     AudioWorkletGlobalScope& m_globalScope;
     String m_name;

--- a/Source/WebCore/bindings/js/SerializedScriptValue.cpp
+++ b/Source/WebCore/bindings/js/SerializedScriptValue.cpp
@@ -574,6 +574,7 @@ static const unsigned StringDataIs8BitFlag = 0x80000000;
 using DeserializationResult = std::pair<JSC::JSValue, SerializationReturnCode>;
 
 class CloneBase {
+    WTF_FORBID_HEAP_ALLOCATION;
 protected:
     CloneBase(JSGlobalObject* lexicalGlobalObject)
         : m_lexicalGlobalObject(lexicalGlobalObject)
@@ -651,6 +652,7 @@ template <> bool writeLittleEndian<uint8_t>(Vector<uint8_t>& buffer, const uint8
 }
 
 class CloneSerializer : CloneBase {
+    WTF_FORBID_HEAP_ALLOCATION;
 public:
     static SerializationReturnCode serialize(JSGlobalObject* lexicalGlobalObject, JSValue value, Vector<RefPtr<MessagePort>>& messagePorts, Vector<RefPtr<JSC::ArrayBuffer>>& arrayBuffers, const Vector<RefPtr<ImageBitmap>>& imageBitmaps,
 #if ENABLE(OFFSCREEN_CANVAS_IN_WORKERS)
@@ -2319,6 +2321,7 @@ SerializationReturnCode CloneSerializer::serialize(JSValue in)
 }
 
 class CloneDeserializer : CloneBase {
+    WTF_FORBID_HEAP_ALLOCATION;
 public:
     static String deserializeString(const Vector<uint8_t>& buffer)
     {
@@ -4286,10 +4289,10 @@ DeserializationResult CloneDeserializer::deserialize()
 
     Vector<uint32_t, 16> indexStack;
     Vector<Identifier, 16> propertyNameStack;
-    Vector<JSObject*, 32> outputObjectStack;
-    Vector<JSValue, 4> mapKeyStack;
-    Vector<JSMap*, 4> mapStack;
-    Vector<JSSet*, 4> setStack;
+    MarkedVector<JSObject*, 32> outputObjectStack;
+    MarkedVector<JSValue, 4> mapKeyStack;
+    MarkedVector<JSMap*, 4> mapStack;
+    MarkedVector<JSSet*, 4> setStack;
     Vector<WalkerState, 16> stateStack;
     WalkerState state = StateUnknown;
     JSValue outValue;


### PR DESCRIPTION
#### c9880de4a28b9a64a5e1d0513dc245d61a2e6ddb
<pre>
CloneDeserializer::deserialize() should store cell pointers in a MarkedVector.
<a href="https://bugs.webkit.org/show_bug.cgi?id=254797">https://bugs.webkit.org/show_bug.cgi?id=254797</a>
rdar://107459160

Reviewed by Justin Michaud.

Previously, CloneDeserializer::deserialize() was storing pointers to newly created objects
in a few Vectors.  This is problematic because the GC is not aware of Vectors, and cannot
scan them.  In this patch, we refactor the MarkedArgumentBuffer class into a MarkedVector
template class that offer 2 enhancements:

1. It can be configured to store specific types of cell pointer types.  This avoids us
   having to constantly cast JSValues into these pointers.

2. It allows us to specify the type of OverflowHandler we want to use.  In this case,
   we want to use CrashOnOverflow.  The previous MarkedArgumentBuffer always assumes
   RecordOnOverflow.  This allows us to avoid having to manually check for overflows,
   or have to use appendWithCrashOnOverflow.  For our current needs, MarkedVector can be
   used as a drop in replacement for Vector.

And we fix the CloneDeserializer::deserialize() issue by replacing the use of Vectors
with MarkedVector instead.

* Source/JavaScriptCore/heap/Heap.cpp:
(JSC::Heap::addCoreConstraints):
* Source/JavaScriptCore/heap/Heap.h:
* Source/JavaScriptCore/heap/HeapInlines.h:
* Source/JavaScriptCore/runtime/ArgList.cpp:
(JSC::MarkedVectorBase::addMarkSet):
(JSC::MarkedVectorBase::markLists):
(JSC::MarkedVectorBase::slowEnsureCapacity):
(JSC::MarkedVectorBase::expandCapacity):
(JSC::MarkedVectorBase::slowAppend):
(JSC::MarkedArgumentBufferBase::addMarkSet): Deleted.
(JSC::MarkedArgumentBufferBase::markLists): Deleted.
(JSC::MarkedArgumentBufferBase::slowEnsureCapacity): Deleted.
(JSC::MarkedArgumentBufferBase::expandCapacity): Deleted.
(JSC::MarkedArgumentBufferBase::slowAppend): Deleted.
* Source/JavaScriptCore/runtime/ArgList.h:
(JSC::MarkedVectorWithSize::MarkedVectorWithSize):
(JSC::MarkedVectorWithSize::at const):
(JSC::MarkedVectorWithSize::clear):
(JSC::MarkedVectorWithSize::append):
(JSC::MarkedVectorWithSize::appendWithCrashOnOverflow):
(JSC::MarkedVectorWithSize::last const):
(JSC::MarkedVectorWithSize::takeLast):
(JSC::MarkedVectorWithSize::ensureCapacity):
(JSC::MarkedVectorWithSize::hasOverflowed):
(JSC::MarkedVectorWithSize::fill):
(JSC::MarkedArgumentBufferWithSize::MarkedArgumentBufferWithSize): Deleted.
* Source/WebCore/Modules/webaudio/AudioWorkletProcessor.cpp:
(WebCore::AudioWorkletProcessor::buildJSArguments):
* Source/WebCore/Modules/webaudio/AudioWorkletProcessor.h:
* Source/WebCore/bindings/js/SerializedScriptValue.cpp:
(WebCore::CloneDeserializer::deserialize):

Originally-landed-as: 259548.530@safari-7615-branch (2c49ff7b0481). rdar://108145916
Canonical link: <a href="https://commits.webkit.org/263041@main">https://commits.webkit.org/263041@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/06a86b840282ea973100447f8fd67ad180957408

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/3400 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/3459 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/3586 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/4828 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/3720 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/3379 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/3533 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/3490 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/2966 "1 flakes 110 failures") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/3442 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/3717 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/3070 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/4647 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/1225 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/3041 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/2955 "Passed tests") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/2803 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/3010 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/3099 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/4398 "260 api tests failed or timed out") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/3204 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/3470 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/2790 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/3473 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/3026 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/3039 "Passed tests") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/861 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/833 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/3038 "Built successfully") | | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/24/builds/3564 "Built successfully") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/3302 "Built successfully") | | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/3/builds/981 "Passed tests") | 
<!--EWS-Status-Bubble-End-->