### PR TITLE
Do early returns in XPathFunctions if string is empty

### DIFF
--- a/Source/WebCore/xml/XPathFunctions.cpp
+++ b/Source/WebCore/xml/XPathFunctions.cpp
@@ -522,6 +522,8 @@ Value FunSubstring::evaluate() const
     {
         SetForScope<EvaluationContext> contextForScope(Expression::evaluationContext(), clonedContext1);
         s = argument(0).evaluate().toString();
+        if (s.isEmpty())
+            return emptyString();
     }
     {
         SetForScope<EvaluationContext> contextForScope(Expression::evaluationContext(), clonedContext2);
@@ -531,8 +533,11 @@ Value FunSubstring::evaluate() const
     if (std::isnan(doublePos))
         return emptyString();
     long pos = static_cast<long>(FunRound::round(doublePos));
+    long len = long(s.length());
+    if (pos > len)
+        return emptyString();
+
     bool haveLength = argumentCount() == 3;
-    long len = -1;
     if (haveLength) {
         double doubleLen = argument(2).evaluate().toNumber();
         if (std::isnan(doubleLen))
@@ -540,16 +545,14 @@ Value FunSubstring::evaluate() const
         len = static_cast<long>(FunRound::round(doubleLen));
     }
 
-    if (pos > long(s.length())) 
-        return emptyString();
-
     if (pos < 1) {
         if (haveLength) {
             len -= 1 - pos;
             if (len < 1)
                 return emptyString();
+            return s.substring(0, len);
         }
-        pos = 1;
+        return s;
     }
 
     return s.substring(pos - 1, len);


### PR DESCRIPTION
<pre>
Do early returns in XPathFunctions if string is empty
<a href="https://bugs.webkit.org/show_bug.cgi?id=255543">https://bugs.webkit.org/show_bug.cgi?id=255543</a>

Reviewed by NOBODY (OOPS!).

This makes the code more clear and prevents operating on empty strings.

* Source/WebCore/xml/XPathFunctions.cpp:
  (WebCore::XPath::FunSubstring::evaluate const): Return early where
  possible.
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/21828b026277f672593b51de22e64a5409b46d21

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/3436 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/3493 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/3623 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/4863 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/3741 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/3415 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/3571 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/3526 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/2993 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/3478 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/3745 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/3096 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/4683 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/1253 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/3070 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/2983 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/3041 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/3129 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/4432 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/3504 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/2821 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/3049 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/3068 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/3070 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/3328 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->