### PR TITLE
[iOS] TestWebKitAPI.WebKit.QuotaDelegateReload and TestWebKitAPI.WebKit.QuotaDelegateNavigateFragment are flaky failure on EWS

### DIFF
--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/StorageQuota.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/StorageQuota.mm
@@ -361,12 +361,7 @@ TEST(WebKit, QuotaDelegate)
     NSLog(@"QuotaDelegate 6");
 }
 
-// FIXME: Re-enable this test for iOS once webkit.org/b/250228 is resolved
-#if PLATFORM(IOS)
-TEST(WebKit, DISABLED_QuotaDelegateReload)
-#else
 TEST(WebKit, QuotaDelegateReload)
-#endif
 {
     done = false;
     auto storeConfiguration = adoptNS([[_WKWebsiteDataStoreConfiguration alloc] init]);
@@ -392,14 +387,18 @@ TEST(WebKit, QuotaDelegateReload)
     [webView setUIDelegate:delegate.get()];
     setVisible(webView.get());
 
+    [messageHandler setExpectedMessage: @"start"];
+    receivedMessage = false;
     receivedQuotaDelegateCalled = false;
     [webView loadRequest:server.request()];
-    Util::run(&receivedQuotaDelegateCalled);
+    Util::run(&receivedMessage);
 
-    [delegate denyQuota];
-
+    while (!receivedQuotaDelegateCalled)
+        TestWebKitAPI::Util::spinRunLoop();
+    
     [messageHandler setExpectedMessage: @"fail"];
     receivedMessage = false;
+    [delegate denyQuota];
     Util::run(&receivedMessage);
 
     receivedQuotaDelegateCalled = false;
@@ -413,12 +412,7 @@ TEST(WebKit, QuotaDelegateReload)
     Util::run(&receivedMessage);
 }
 
-// FIXME: Re-enable this test for iOS once webkit.org/b/250228 is resolved
-#if PLATFORM(IOS)
-TEST(WebKit, DISABLED_QuotaDelegateNavigateFragment)
-#else
 TEST(WebKit, QuotaDelegateNavigateFragment)
-#endif
 {
     done = false;
     auto storeConfiguration = adoptNS([[_WKWebsiteDataStoreConfiguration alloc] init]);
@@ -444,14 +438,18 @@ TEST(WebKit, QuotaDelegateNavigateFragment)
     [webView setUIDelegate:delegate.get()];
     setVisible(webView.get());
 
+    [messageHandler setExpectedMessage: @"start"];
+    receivedMessage = false;
     receivedQuotaDelegateCalled = false;
     [webView loadRequest:server.request("/main.html"_s)];
-    Util::run(&receivedQuotaDelegateCalled);
+    Util::run(&receivedMessage);
 
-    [delegate denyQuota];
+    while (!receivedQuotaDelegateCalled)
+        TestWebKitAPI::Util::spinRunLoop();
 
     [messageHandler setExpectedMessage: @"fail"];
     receivedMessage = false;
+    [delegate denyQuota];
     Util::run(&receivedMessage);
 
     receivedQuotaDelegateCalled = false;


### PR DESCRIPTION
#### 2c69e0706e29b87f89ef2247dc26875b1aafb4e1
<pre>
[iOS] TestWebKitAPI.WebKit.QuotaDelegateReload and TestWebKitAPI.WebKit.QuotaDelegateNavigateFragment are flaky failure on EWS
<a href="https://bugs.webkit.org/show_bug.cgi?id=250228">https://bugs.webkit.org/show_bug.cgi?id=250228</a>
rdar://103966157

Reviewed by Youenn Fablet.

Make sure the tests wait for &quot;start&quot; message before proceeding to handle quota request.

* Tools/TestWebKitAPI/Tests/WebKitCocoa/StorageQuota.mm:

Canonical link: <a href="https://commits.webkit.org/263076@main">https://commits.webkit.org/263076@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9c4330bbcd9338d15d4e12103c93cd18ff129c49

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/3417 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/3475 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/3604 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/4844 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/3731 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/3396 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/3551 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/3507 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/2978 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/3459 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/3729 "2 failures") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/3077 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/4664 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/1237 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/3050 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/2966 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/3025 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/3108 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/4424 "270 api tests failed or timed out") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/3486 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/2803 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/3039 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/3048 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/857 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/3054 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/3317 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->