### PR TITLE
Serialize an optional<double> instead of an NSDictionary for DataDetection reference date

### DIFF
--- a/Source/WebCore/editing/cocoa/DataDetection.h
+++ b/Source/WebCore/editing/cocoa/DataDetection.h
@@ -57,7 +57,8 @@ public:
 #if PLATFORM(MAC)
     WEBCORE_EXPORT static std::optional<DetectedItem> detectItemAroundHitTestResult(const HitTestResult&);
 #endif
-    WEBCORE_EXPORT static NSArray *detectContentInRange(const SimpleRange&, OptionSet<DataDetectorType>, NSDictionary *context);
+    WEBCORE_EXPORT static NSArray *detectContentInRange(const SimpleRange&, OptionSet<DataDetectorType>, std::optional<double> referenceDate);
+    WEBCORE_EXPORT static std::optional<double> extractReferenceDate(NSDictionary *);
     WEBCORE_EXPORT static void removeDataDetectedLinksInDocument(Document&);
 #if PLATFORM(IOS_FAMILY)
     WEBCORE_EXPORT static bool canBePresentedByDataDetectors(const URL&);

--- a/Source/WebCore/loader/FrameLoader.cpp
+++ b/Source/WebCore/loader/FrameLoader.cpp
@@ -2723,7 +2723,7 @@ void FrameLoader::checkLoadCompleteForThisFrame()
             auto document = m_frame.document();
             OptionSet<DataDetectorType> types = m_frame.settings().dataDetectorTypes();
             if (document && types) {
-                auto documentLevelResults = retainPtr(DataDetection::detectContentInRange(makeRangeSelectingNodeContents(*document), types, m_client->dataDetectionContext()));
+                auto documentLevelResults = retainPtr(DataDetection::detectContentInRange(makeRangeSelectingNodeContents(*document), types, m_client->dataDetectionReferenceDate()));
                 m_frame.dataDetectionResults().setDocumentLevelResults(documentLevelResults.get());
                 if (m_frame.isMainFrame())
                     m_client->dispatchDidFinishDataDetection(documentLevelResults.get());

--- a/Source/WebCore/loader/FrameLoaderClient.h
+++ b/Source/WebCore/loader/FrameLoaderClient.h
@@ -298,7 +298,7 @@ public:
     // Allow an accessibility object to retrieve a Frame parent if there's no PlatformWidget.
     virtual RemoteAXObjectRef accessibilityRemoteObject() = 0;
     virtual void willCacheResponse(DocumentLoader*, ResourceLoaderIdentifier, NSCachedURLResponse*, CompletionHandler<void(NSCachedURLResponse *)>&&) const = 0;
-    virtual NSDictionary *dataDetectionContext() { return nullptr; }
+    virtual std::optional<double> dataDetectionReferenceDate() { return std::nullopt; }
 #endif
 
     virtual bool shouldAlwaysUsePluginDocument(const String& /*mimeType*/) const { return false; }

--- a/Source/WebKit/Shared/Cocoa/LoadParametersCocoa.mm
+++ b/Source/WebKit/Shared/Cocoa/LoadParametersCocoa.mm
@@ -35,8 +35,7 @@ namespace WebKit {
 
 void LoadParameters::platformEncode(IPC::Encoder& encoder) const
 {
-    IPC::encode(encoder, dataDetectionContext.get());
-
+    encoder << dataDetectionReferenceDate;
 #if !ENABLE(CONTENT_FILTERING_IN_NETWORKING_PROCESS)
     encoder << networkExtensionSandboxExtensionHandles;
 #if PLATFORM(IOS)
@@ -48,8 +47,10 @@ void LoadParameters::platformEncode(IPC::Encoder& encoder) const
 
 bool LoadParameters::platformDecode(IPC::Decoder& decoder, LoadParameters& parameters)
 {
-    if (!IPC::decode(decoder, parameters.dataDetectionContext))
+    auto dataDetectionReferenceDate = decoder.decode<std::optional<double>>();
+    if (!dataDetectionReferenceDate)
         return false;
+    parameters.dataDetectionReferenceDate = WTFMove(*dataDetectionReferenceDate);
 
 #if !ENABLE(CONTENT_FILTERING_IN_NETWORKING_PROCESS)
     std::optional<Vector<SandboxExtension::Handle>> networkExtensionSandboxExtensionHandles;

--- a/Source/WebKit/Shared/LoadParameters.h
+++ b/Source/WebKit/Shared/LoadParameters.h
@@ -91,7 +91,7 @@ struct LoadParameters {
     bool isServiceWorkerLoad { false };
 
 #if PLATFORM(COCOA)
-    RetainPtr<NSDictionary> dataDetectionContext;
+    std::optional<double> dataDetectionReferenceDate;
 #if !ENABLE(CONTENT_FILTERING_IN_NETWORKING_PROCESS)
     Vector<SandboxExtension::Handle> networkExtensionSandboxExtensionHandles;
 #if PLATFORM(IOS)

--- a/Source/WebKit/UIProcess/API/APIUIClient.h
+++ b/Source/WebKit/UIProcess/API/APIUIClient.h
@@ -188,7 +188,7 @@ public:
 #endif
 #if PLATFORM(COCOA)
     virtual PlatformViewController *presentingViewController() { return nullptr; }
-    virtual NSDictionary *dataDetectionContext() { return nullptr; }
+    virtual std::optional<double> dataDetectionReferenceDate() { return std::nullopt; }
 #endif
 
 #if ENABLE(POINTER_LOCK)

--- a/Source/WebKit/UIProcess/Cocoa/UIDelegate.h
+++ b/Source/WebKit/UIProcess/Cocoa/UIDelegate.h
@@ -162,7 +162,7 @@ private:
 #endif // PLATFORM(IOS_FAMILY)
         PlatformViewController *presentingViewController() final;
 
-        NSDictionary *dataDetectionContext() final;
+        std::optional<double> dataDetectionReferenceDate() final;
 
 #if ENABLE(POINTER_LOCK)
         void requestPointerLock(WebPageProxy*) final;

--- a/Source/WebKit/UIProcess/Cocoa/UIDelegate.mm
+++ b/Source/WebKit/UIProcess/Cocoa/UIDelegate.mm
@@ -66,6 +66,7 @@
 #import <AVFoundation/AVCaptureDevice.h>
 #import <AVFoundation/AVMediaFormat.h>
 #import <WebCore/AutoplayEvent.h>
+#import <WebCore/DataDetection.h>
 #import <WebCore/FontAttributes.h>
 #import <WebCore/SecurityOrigin.h>
 #import <wtf/BlockPtr.h>
@@ -1611,19 +1612,23 @@ PlatformViewController *UIDelegate::UIClient::presentingViewController()
     return [static_cast<id <WKUIDelegatePrivate>>(delegate) _presentingViewControllerForWebView:m_uiDelegate->m_webView.get().get()];
 }
 
-NSDictionary *UIDelegate::UIClient::dataDetectionContext()
+std::optional<double> UIDelegate::UIClient::dataDetectionReferenceDate()
 {
     if (!m_uiDelegate)
-        return nullptr;
+        return std::nullopt;
 
     if (!m_uiDelegate->m_delegateMethods.dataDetectionContextForWebView)
-        return nullptr;
+        return std::nullopt;
 
     auto delegate = m_uiDelegate->m_delegate.get();
     if (!delegate)
-        return nullptr;
+        return std::nullopt;
 
-    return [static_cast<id <WKUIDelegatePrivate>>(delegate) _dataDetectionContextForWebView:m_uiDelegate->m_webView.get().get()];
+#if ENABLE(DATA_DETECTION)
+    return WebCore::DataDetection::extractReferenceDate([static_cast<id<WKUIDelegatePrivate>>(delegate) _dataDetectionContextForWebView:m_uiDelegate->m_webView.get().get()]);
+#else
+    return std::nullopt;
+#endif
 }
 
 #if ENABLE(POINTER_LOCK)

--- a/Source/WebKit/UIProcess/Cocoa/WebPageProxyCocoa.mm
+++ b/Source/WebKit/UIProcess/Cocoa/WebPageProxyCocoa.mm
@@ -241,7 +241,7 @@ void WebPageProxy::contentFilterDidBlockLoadForFrameShared(Ref<WebProcessProxy>&
 
 void WebPageProxy::addPlatformLoadParameters(WebProcessProxy& process, LoadParameters& loadParameters)
 {
-    loadParameters.dataDetectionContext = m_uiClient->dataDetectionContext();
+    loadParameters.dataDetectionReferenceDate = m_uiClient->dataDetectionReferenceDate();
 
 #if !ENABLE(CONTENT_FILTERING_IN_NETWORKING_PROCESS)
     loadParameters.networkExtensionSandboxExtensionHandles = createNetworkExtensionsSandboxExtensions(process);

--- a/Source/WebKit/WebProcess/InjectedBundle/API/Cocoa/WKWebProcessPlugInRangeHandle.mm
+++ b/Source/WebKit/WebProcess/InjectedBundle/API/Cocoa/WKWebProcessPlugInRangeHandle.mm
@@ -70,7 +70,7 @@
 - (NSArray *)detectDataWithTypes:(WKDataDetectorTypes)types context:(NSDictionary *)context
 {
 #if ENABLE(DATA_DETECTION)
-    return WebCore::DataDetection::detectContentInRange(makeSimpleRange(_rangeHandle->coreRange()), fromWKDataDetectorTypes(types), context);
+    return WebCore::DataDetection::detectContentInRange(makeSimpleRange(_rangeHandle->coreRange()), fromWKDataDetectorTypes(types), WebCore::DataDetection::extractReferenceDate(context));
 #else
     return nil;
 #endif

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebFrameLoaderClient.cpp
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebFrameLoaderClient.cpp
@@ -1913,13 +1913,13 @@ void WebFrameLoaderClient::willCacheResponse(DocumentLoader*, ResourceLoaderIden
     return completionHandler(webPage->injectedBundleResourceLoadClient().shouldCacheResponse(*webPage, m_frame, identifier) ? response : nil);
 }
 
-NSDictionary *WebFrameLoaderClient::dataDetectionContext()
+std::optional<double> WebFrameLoaderClient::dataDetectionReferenceDate()
 {
     WebPage* webPage = m_frame->page();
     if (!webPage)
-        return nil;
+        return std::nullopt;
 
-    return webPage->dataDetectionContext();
+    return webPage->dataDetectionReferenceDate();
 }
 
 #endif // PLATFORM(COCOA)

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebFrameLoaderClient.h
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebFrameLoaderClient.h
@@ -245,7 +245,7 @@ private:
     
     void willCacheResponse(WebCore::DocumentLoader*, WebCore::ResourceLoaderIdentifier, NSCachedURLResponse*, CompletionHandler<void(NSCachedURLResponse *)>&&) const final;
 
-    NSDictionary *dataDetectionContext() final;
+    std::optional<double> dataDetectionReferenceDate() final;
 #endif
 
     void didChangeScrollOffset() final;

--- a/Source/WebKit/WebProcess/WebPage/Cocoa/WebPageCocoa.mm
+++ b/Source/WebKit/WebProcess/WebPage/Cocoa/WebPageCocoa.mm
@@ -105,7 +105,7 @@ void WebPage::platformInitialize(const WebPageCreationParameters& parameters)
 
 void WebPage::platformDidReceiveLoadParameters(const LoadParameters& parameters)
 {
-    m_dataDetectionContext = parameters.dataDetectionContext;
+    m_dataDetectionReferenceDate = parameters.dataDetectionReferenceDate;
 
 #if !ENABLE(CONTENT_FILTERING_IN_NETWORKING_PROCESS)
     consumeNetworkExtensionSandboxExtensions(parameters.networkExtensionSandboxExtensionHandles);

--- a/Source/WebKit/WebProcess/WebPage/WebPage.cpp
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.cpp
@@ -4577,7 +4577,7 @@ void WebPage::detectDataInAllFrames(OptionSet<WebCore::DataDetectorType> dataDet
         RefPtr document = localFrame->document();
         if (!document)
             continue;
-        auto results = retainPtr(DataDetection::detectContentInRange(makeRangeSelectingNodeContents(*document), dataDetectorTypes, m_dataDetectionContext.get()));
+        auto results = retainPtr(DataDetection::detectContentInRange(makeRangeSelectingNodeContents(*document), dataDetectorTypes, m_dataDetectionReferenceDate));
         localFrame->dataDetectionResults().setDocumentLevelResults(results.get());
         if (localFrame->isMainFrame())
             mainFrameResult.results = WTFMove(results);

--- a/Source/WebKit/WebProcess/WebPage/WebPage.h
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.h
@@ -1218,7 +1218,7 @@ public:
     bool selectionFlippingEnabled() const { return m_selectionFlippingEnabled; }
     void setSelectionFlippingEnabled(bool enabled) { m_selectionFlippingEnabled = enabled; }
 
-    NSDictionary *dataDetectionContext() const { return m_dataDetectionContext.get(); }
+    std::optional<double> dataDetectionReferenceDate() const { return m_dataDetectionReferenceDate; }
 #endif
 
     bool mainFrameIsScrollable() const { return m_mainFrameIsScrollable; }
@@ -2189,7 +2189,7 @@ private:
 #endif
 
 #if PLATFORM(COCOA)
-    RetainPtr<NSDictionary> m_dataDetectionContext;
+    std::optional<double> m_dataDetectionReferenceDate;
 #endif
 
 #if USE(ATSPI)

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/DataDetection.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/DataDetection.mm
@@ -78,7 +78,8 @@ static bool ranScript;
         return nil;
 
     return @{
-        @"ReferenceDate": _referenceDate
+        @"ReferenceDate": _referenceDate,
+        @"unused": [NSUUID UUID]
     };
 }
 

--- a/Tools/TestWebKitAPI/Tests/ios/ActionSheetTests.mm
+++ b/Tools/TestWebKitAPI/Tests/ios/ActionSheetTests.mm
@@ -179,7 +179,7 @@ TEST(ActionSheetTests, DataDetectorsLinkIsNotPresentedAsALink)
         // We shouldn't present a normal action sheet, but instead a data detectors sheet.
         [observer setDataDetectionContextHandler:^{
             done = true;
-            return @{ };
+            return @{ @"unused" : [NSUUID UUID] };
         }];
         [observer setPresentationHandler:^(_WKActivatedElementInfo *, NSArray *) {
             done = true;


### PR DESCRIPTION
#### da253c7b2296c8a10d598a0df293db636fd52da7
<pre>
Serialize an optional&lt;double&gt; instead of an NSDictionary for DataDetection reference date
<a href="https://bugs.webkit.org/show_bug.cgi?id=255541">https://bugs.webkit.org/show_bug.cgi?id=255541</a>
rdar://108108131

Reviewed by Tim Horton.

This fixes a regression from 262558@main with a test that would hit the crash.

* Source/WebCore/editing/cocoa/DataDetection.h:
* Source/WebCore/editing/cocoa/DataDetection.mm:
(WebCore::DataDetection::extractReferenceDate):
(WebCore::DataDetection::detectContentInRange):
* Source/WebCore/loader/FrameLoader.cpp:
(WebCore::FrameLoader::checkLoadCompleteForThisFrame):
* Source/WebCore/loader/FrameLoaderClient.h:
* Source/WebKit/Shared/Cocoa/LoadParametersCocoa.mm:
(WebKit::LoadParameters::platformEncode const):
(WebKit::LoadParameters::platformDecode):
* Source/WebKit/Shared/LoadParameters.h:
* Source/WebKit/UIProcess/API/APIUIClient.h:
(API::UIClient::dataDetectionReferenceDate):
(API::UIClient::dataDetectionContext): Deleted.
* Source/WebKit/UIProcess/Cocoa/UIDelegate.h:
* Source/WebKit/UIProcess/Cocoa/UIDelegate.mm:
(WebKit::UIDelegate::UIClient::dataDetectionReferenceDate):
(WebKit::UIDelegate::UIClient::dataDetectionContext): Deleted.
* Source/WebKit/UIProcess/Cocoa/WebPageProxyCocoa.mm:
(WebKit::WebPageProxy::addPlatformLoadParameters):
* Source/WebKit/WebProcess/InjectedBundle/API/Cocoa/WKWebProcessPlugInRangeHandle.mm:
(-[WKWebProcessPlugInRangeHandle detectDataWithTypes:context:]):
* Source/WebKit/WebProcess/WebCoreSupport/WebFrameLoaderClient.cpp:
(WebKit::WebFrameLoaderClient::dataDetectionReferenceDate):
(WebKit::WebFrameLoaderClient::dataDetectionContext): Deleted.
* Source/WebKit/WebProcess/WebCoreSupport/WebFrameLoaderClient.h:
* Source/WebKit/WebProcess/WebPage/Cocoa/WebPageCocoa.mm:
(WebKit::WebPage::platformDidReceiveLoadParameters):
* Source/WebKit/WebProcess/WebPage/WebPage.cpp:
(WebKit::WebPage::detectDataInAllFrames):
* Source/WebKit/WebProcess/WebPage/WebPage.h:
(WebKit::WebPage::dataDetectionReferenceDate const):
(WebKit::WebPage::dataDetectionContext const): Deleted.
* Tools/TestWebKitAPI/Tests/WebKitCocoa/DataDetection.mm:
(-[DataDetectionUIDelegate _dataDetectionContextForWebView:]):
* Tools/TestWebKitAPI/Tests/ios/ActionSheetTests.mm:
(TestWebKitAPI::TEST):

Canonical link: <a href="https://commits.webkit.org/263037@main">https://commits.webkit.org/263037@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/94d2a7fb0d80b7e871a7ae9eb1a9d417d9215135

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/3433 "1 style error") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/3491 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/3620 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/4860 "Built successfully") | [❌ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/3739 "Failed to checkout and rebase branch from PR 12818") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/3412 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/3568 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/3523 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/2990 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/3475 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/15/builds/3744 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/3095 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/4680 "Built successfully") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/39/builds/1252 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/3069 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/2979 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/3040 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/3128 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/4434 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/3502 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/2816 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/3047 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/3067 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/828 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/3068 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/3326 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->