### PR TITLE
[WPE] Gardening `fast/text/emphasis-vertical`

### DIFF
--- a/LayoutTests/platform/wpe/fast/text/emphasis-vertical-expected.txt
+++ b/LayoutTests/platform/wpe/fast/text/emphasis-vertical-expected.txt
@@ -74,7 +74,7 @@ layer at (25,0) size 775x600
         RenderInline {SPAN} at (0,0) size 20x72
           RenderText {#text} at (4,237) size 20x72
             text run at (4,237) width 72: "\x{8A18}\x{4E8B}\x{304C}\x{3069}"
-        RenderInline {SPAN} at (0,0) size 62x342
+        RenderInline {SPAN} at (0,0) size 51x342
           RenderText {#text} at (4,309) size 51x342
             text run at (4,309) width 36: "\x{3053}\x{306B}"
             text run at (35,3) width 36: "\x{3042}\x{3063}"


### PR DESCRIPTION
#### 99f7ecfe78103719da3374fd840b2b18c5c7aa2a
<pre>
[WPE] Gardening `fast/text/emphasis-vertical`

Unreviewed test gardening.

Update baselines after 262855@main, which corrected box position in
vertical writing-mode and included formatting context conditionals.

* LayoutTests/platform/wpe/fast/text/emphasis-vertical-expected.txt:

Canonical link: <a href="https://commits.webkit.org/263074@main">https://commits.webkit.org/263074@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/68cbaea7705c1b243b8cd8985a70d526de706b29

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/3447 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/3503 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/3634 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/4874 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/3747 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/3583 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/3537 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/3002 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/3489 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/3755 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/3104 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/4694 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/1263 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/3081 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/2988 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/3054 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/3140 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/4442 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/3514 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/2827 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/3058 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/3079 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/859 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/3080 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/3337 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->