### PR TITLE
[GLib] Add introspectable API to configure experimental features at runtime

### DIFF
--- a/Source/WebKit/PlatformGTK.cmake
+++ b/Source/WebKit/PlatformGTK.cmake
@@ -136,6 +136,7 @@ set(WebKitGTK_HEADER_TEMPLATES
     ${WEBKIT_DIR}/UIProcess/API/glib/WebKitEditorState.h.in
     ${WEBKIT_DIR}/UIProcess/API/glib/WebKitError.h.in
     ${WEBKIT_DIR}/UIProcess/API/glib/WebKitFaviconDatabase.h.in
+    ${WEBKIT_DIR}/UIProcess/API/glib/WebKitFeature.h.in
     ${WEBKIT_DIR}/UIProcess/API/glib/WebKitFileChooserRequest.h.in
     ${WEBKIT_DIR}/UIProcess/API/glib/WebKitFindController.h.in
     ${WEBKIT_DIR}/UIProcess/API/glib/WebKitFormSubmissionRequest.h.in

--- a/Source/WebKit/PlatformWPE.cmake
+++ b/Source/WebKit/PlatformWPE.cmake
@@ -145,6 +145,7 @@ set(WPE_API_HEADER_TEMPLATES
     ${WEBKIT_DIR}/UIProcess/API/glib/WebKitEditingCommands.h.in
     ${WEBKIT_DIR}/UIProcess/API/glib/WebKitEditorState.h.in
     ${WEBKIT_DIR}/UIProcess/API/glib/WebKitError.h.in
+    ${WEBKIT_DIR}/UIProcess/API/glib/WebKitFeature.h.in
     ${WEBKIT_DIR}/UIProcess/API/glib/WebKitFileChooserRequest.h.in
     ${WEBKIT_DIR}/UIProcess/API/glib/WebKitFindController.h.in
     ${WEBKIT_DIR}/UIProcess/API/glib/WebKitFormSubmissionRequest.h.in

--- a/Source/WebKit/SourcesGTK.txt
+++ b/Source/WebKit/SourcesGTK.txt
@@ -144,6 +144,7 @@ UIProcess/API/glib/WebKitDownloadClient.cpp @no-unify
 UIProcess/API/glib/WebKitEditorState.cpp @no-unify
 UIProcess/API/glib/WebKitError.cpp @no-unify
 UIProcess/API/glib/WebKitFaviconDatabase.cpp @no-unify
+UIProcess/API/glib/WebKitFeature.cpp @no-unify
 UIProcess/API/glib/WebKitFileChooserRequest.cpp @no-unify
 UIProcess/API/glib/WebKitFindController.cpp @no-unify
 UIProcess/API/glib/WebKitFormClient.cpp @no-unify

--- a/Source/WebKit/SourcesWPE.txt
+++ b/Source/WebKit/SourcesWPE.txt
@@ -134,6 +134,7 @@ UIProcess/API/glib/WebKitDownload.cpp @no-unify
 UIProcess/API/glib/WebKitDownloadClient.cpp @no-unify
 UIProcess/API/glib/WebKitEditorState.cpp @no-unify
 UIProcess/API/glib/WebKitError.cpp @no-unify
+UIProcess/API/glib/WebKitFeature.cpp @no-unify
 UIProcess/API/glib/WebKitFileChooserRequest.cpp @no-unify
 UIProcess/API/glib/WebKitFindController.cpp @no-unify
 UIProcess/API/glib/WebKitFormClient.cpp @no-unify

--- a/Source/WebKit/UIProcess/API/glib/WebKitFeature.cpp
+++ b/Source/WebKit/UIProcess/API/glib/WebKitFeature.cpp
@@ -1,0 +1,431 @@
+/*
+ * Copyright (C) 2023 Igalia S.L.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Library General Public
+ * License as published by the Free Software Foundation; either
+ * version 2 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Library General Public License for more details.
+ *
+ * You should have received a copy of the GNU Library General Public License
+ * along with this library; see the file COPYING.LIB.  If not, write to
+ * the Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor,
+ * Boston, MA 02110-1301, USA.
+ */
+
+#include "config.h"
+#include "WebKitFeature.h"
+
+#include "APIFeature.h"
+#include "WebKitFeaturePrivate.h"
+#include <wtf/Algorithms.h>
+#include <wtf/RefPtr.h>
+
+static inline WebKitFeatureStatus toFeatureStatus(API::FeatureStatus status)
+{
+    switch (status) {
+    case API::FeatureStatus::Embedder:
+        return WEBKIT_FEATURE_STATUS_EMBEDDER;
+    case API::FeatureStatus::Unstable:
+        return WEBKIT_FEATURE_STATUS_UNSTABLE;
+    case API::FeatureStatus::Internal:
+        return WEBKIT_FEATURE_STATUS_INTERNAL;
+    case API::FeatureStatus::Developer:
+        return WEBKIT_FEATURE_STATUS_DEVELOPER;
+    case API::FeatureStatus::Testable:
+        return WEBKIT_FEATURE_STATUS_TESTABLE;
+    case API::FeatureStatus::Preview:
+        return WEBKIT_FEATURE_STATUS_PREVIEW;
+    case API::FeatureStatus::Stable:
+        return WEBKIT_FEATURE_STATUS_STABLE;
+    case API::FeatureStatus::Mature:
+        return WEBKIT_FEATURE_STATUS_MATURE;
+    }
+    RELEASE_ASSERT_NOT_REACHED();
+}
+
+static inline const char* toFeatureCategory(API::FeatureCategory category)
+{
+    switch (category) {
+    case API::FeatureCategory::None:
+        return "Other";
+    case API::FeatureCategory::Animation:
+        return "Animation";
+    case API::FeatureCategory::CSS:
+        return "CSS";
+    case API::FeatureCategory::DOM:
+        return "DOM";
+    case API::FeatureCategory::HTML:
+        return "HTML";
+    case API::FeatureCategory::Javascript:
+        return "JavaScript";
+    case API::FeatureCategory::Media:
+        return "Media";
+    case API::FeatureCategory::Networking:
+        return "Network";
+    case API::FeatureCategory::Privacy:
+        return "Privacy";
+    case API::FeatureCategory::Security:
+        return "Security";
+    }
+    RELEASE_ASSERT_NOT_REACHED();
+}
+
+/**
+ * WebKitFeature: (ref-func webkit_feature_ref) (unref-func webkit_feature_unref)
+ *
+ * Describes a web engine feature that may be toggled at runtime.
+ *
+ * The WebKit web engine includes a set of features which may be toggled
+ * programmatically, each one represented by a #WebKitFeature that provides
+ * information about it:
+ *
+ * - A unique “identifier”: [method@Feature.get_identifier].
+ * - A “default value”, which indicates whether the option is enabled
+ *   automatically: [method@Feature.get_default_value].
+ * - Its “status”, which determines whether it should be considered
+ *   user-settable and its development stage (see [enum@FeatureStatus]
+ *   for details): [method@Feature.get_status].
+ * - A category, which may be used to group features together:
+ *   [method@Feature.get_category].
+ * - An optional short “name” which can be presented to an user:
+ *   [method@Feature.get_name].
+ * - An optional longer “detailed” description:
+ *   [method@Feature.get_details].
+ *
+ * The lists of available features can be obtained with
+ * [func@Settings.get_all_features], [func@Settings.get_experimental_features],
+ * and [func@Settings.get_development_features]). As a rule of thumb,
+ * applications which may want to allow users (i.e. web developers) to test
+ * WebKit features should use the list of experimental features. Additionally,
+ * applications might want to expose development features *when targeting
+ * technically inclined users* for early testing of in-development features
+ * (i.e. in “technology preview” or “canary” builds).
+ *
+ * Applications **must not** expose the list of all features to end users
+ * because they often lack descriptions and control parts of the web engine
+ * which are either intended to be used during development of WebKit itself,
+ * or in specific scenarios to tweak how WebKit integrates with the
+ * application.
+ *
+ * Since: 2.42
+ */
+struct _WebKitFeature {
+    _WebKitFeature(RefPtr<API::Feature>&& feature)
+        : feature(WTFMove(feature))
+    {
+    }
+
+    RefPtr<API::Feature> feature;
+    CString identifier { toIdentifier(feature->key()) };
+    CString name { feature->name().utf8() };
+    CString details { feature->details().utf8() };
+    int referenceCount { 1 };
+
+    static CString toIdentifier(const String& key)
+    {
+        if (key.endsWith("Enabled"_s))
+            return StringView(key).left(key.length() - (sizeof("Enabled") - 1)).utf8();
+        return key.utf8();
+    }
+};
+
+G_DEFINE_BOXED_TYPE(WebKitFeature, webkit_feature, webkit_feature_ref, webkit_feature_unref)
+
+static WebKitFeature* webkitFeatureCreate(const RefPtr<API::Object>& apiFeature)
+{
+    ASSERT(apiFeature->type() == API::Object::Type::Feature);
+    WebKitFeature* feature = static_cast<WebKitFeature*>(fastMalloc(sizeof(WebKitFeature)));
+    new (feature) WebKitFeature(static_pointer_cast<API::Feature>(apiFeature));
+    return feature;
+}
+
+API::Feature& webkitFeatureGetFeature(WebKitFeature* feature)
+{
+    ASSERT(feature);
+    return *feature->feature;
+}
+
+/**
+ * webkit_feature_ref:
+ * @feature: a #WebKitFeature
+ *
+ * Atomically acquires a reference on the given @feature.
+ *
+ * This function is MT-safe and may be called from any thread.
+ *
+ * Returns: The same @feature with an additional reference.
+ *
+ * Since: 2.42
+ */
+WebKitFeature* webkit_feature_ref(WebKitFeature* feature)
+{
+    g_return_val_if_fail(feature, nullptr);
+    g_atomic_int_inc(&feature->referenceCount);
+    return feature;
+}
+
+/**
+ * webkit_feature_unref:
+ * @feature: a #WebKitFeature
+ *
+ * Atomically releases a reference on the given @feature.
+ *
+ * If the reference was the last, the resources associated to the
+ * @feature are freed. This function is MT-safe and may be called from
+ * any thread.
+ *
+ * Since: 2.42
+ */
+void webkit_feature_unref(WebKitFeature* feature)
+{
+    g_return_if_fail(feature);
+    if (g_atomic_int_dec_and_test(&feature->referenceCount)) {
+        feature->~WebKitFeature();
+        fastFree(feature);
+    }
+}
+
+/**
+ * webkit_feature_get_identifier:
+ * @feature: a #WebKitFeature
+ *
+ * Gets a string that uniquely identifies the @feature.
+ *
+ * Returns: (transfer none): The identifier string for the feature.
+ *
+ * Since: 2.42
+ */
+const char* webkit_feature_get_identifier(WebKitFeature* feature)
+{
+    g_return_val_if_fail(feature, nullptr);
+    return feature->identifier.data();
+}
+
+/**
+ * webkit_feature_get_name:
+ * @feature: a #WebKitFeature
+ *
+ * Gets a short name for the @feature.
+ *
+ * The returned string is suitable to be displayed to end users, but it
+ * should not be relied upon being localized.
+ *
+ * Note that some *features may not* have a short name, and @NULL
+ * is returned in this case.
+ *
+ * Returns: (transfer none) (nullable): Short feature name.
+ *
+ * Since: 2.42
+ */
+const char* webkit_feature_get_name(WebKitFeature* feature)
+{
+    g_return_val_if_fail(feature, nullptr);
+    return feature->name.length() ? feature->name.data() : nullptr;
+}
+
+/**
+ * webkit_feature_get_details:
+ * @feature: a #WebKitFeature
+ *
+ * Gets a description for the @feature.
+ *
+ * The detailed description should be considered an additional clarification
+ * on the purpose of the feature, to be used as complementary aid to be
+ * displayed along the feature name returned by [method@Feature.get_name].
+ * The returned string is suitable to be displayed to end users, but it
+ * should not be relied upon being localized.
+ *
+ * Note that some *features may not* have a detailed description, and @NULL
+ * is returned in this case.
+ *
+ * Returns: (transfer none) (nullable): Feature description.
+ *
+ * Since: 2.42
+ */
+const char* webkit_feature_get_details(WebKitFeature* feature)
+{
+    g_return_val_if_fail(feature, nullptr);
+    return feature->details.length() ? feature->details.data() : nullptr;
+}
+
+/**
+ * webkit_feature_get_status:
+ * @feature: a #WebKitFeature
+ *
+ * Gets the status of the feature.
+ *
+ * Returns: Feature status.
+ *
+ * Since: 2.42
+ */
+WebKitFeatureStatus webkit_feature_get_status(WebKitFeature* feature)
+{
+    g_return_val_if_fail(feature, WEBKIT_FEATURE_STATUS_EMBEDDER);
+    return toFeatureStatus(feature->feature->status());
+}
+
+/**
+ * webkit_feature_get_category:
+ * @feature: a #WebKitFeature
+ *
+ * Gets the category of the feature.
+ *
+ * Applications which include user interface to toggle features may want
+ * to use the category to group related features together.
+ *
+ * Returns: Feature category.
+ *
+ * Since: 2.42
+ */
+const char* webkit_feature_get_category(WebKitFeature* feature)
+{
+    g_return_val_if_fail(feature, "None");
+    return toFeatureCategory(feature->feature->category());
+}
+
+/**
+ * webkit_feature_get_default_value:
+ * @feature: a #WebKitFeature
+ *
+ * Gets whether the feature is enabled by default.
+ *
+ * The default value may be used by applications which include user interface
+ * to toggle features to restore its settings to their defaults. Note that
+ * whether a feature is actually enabled must be checked with
+ * [method@Settings.get_feature_enabled].
+ *
+ * Returns: Whether the feature is enabled by default.
+ *
+ * Since: 2.42
+ */
+gboolean webkit_feature_get_default_value(WebKitFeature* feature)
+{
+    g_return_val_if_fail(feature, FALSE);
+    return feature->feature->defaultValue() ? TRUE : FALSE;
+}
+
+/**
+ * WebKitFeatureList: (ref-func webkit_feature_list_ref) (unref-func webkit_feature_list_unref)
+ *
+ * Contains a set of toggle-able web engine features.
+ *
+ * The list supports passing around a set of [struct@Feature] objects and
+ * iterating over them:
+ *
+ * ```c
+ * g_autoptr(WebKitFeatureList) list = webkit_settings_get_experimental_features();
+ * for (gsize i = 0; i < webkit_feature_list_get_length(list): i++) {
+ *     WebKitFeature *feature = webkit_feature_list_get(list, i);
+ *     // Do something with "feature".
+ * }
+ * ```
+ *
+ * Lists of features can be obtained with
+ * [func@Settings.get_experimental_features],
+ * [func@Settings.get_development_features], and
+ * [func@Settings.get_all_features].
+ *
+ * Since: 2.42
+ */
+struct _WebKitFeatureList {
+    _WebKitFeatureList(const Vector<RefPtr<API::Object>>& features)
+        : items(features.map(webkitFeatureCreate))
+    {
+    }
+
+    ~_WebKitFeatureList()
+    {
+        forEach(items, webkit_feature_unref);
+    }
+
+    Vector<WebKitFeature*> items;
+    int referenceCount { 1 };
+};
+
+G_DEFINE_BOXED_TYPE(WebKitFeatureList, webkit_feature_list, webkit_feature_list_ref, webkit_feature_list_unref)
+
+WebKitFeatureList* webkitFeatureListCreate(const Vector<RefPtr<API::Object>>& features)
+{
+    WebKitFeatureList* featureList = static_cast<WebKitFeatureList*>(fastMalloc(sizeof(WebKitFeatureList)));
+    new (featureList) WebKitFeatureList(features);
+    return featureList;
+}
+
+/**
+ * webkit_feature_list_ref:
+ * @feature_list: a #WebKitFeatureList
+ *
+ * Atomically acquires a reference on the given @feature_list.
+ *
+ * This function is MT-safe and may be called from any thread.
+ *
+ * Returns: The same @feature_list with an additional reference.
+ *
+ * Since: 2.42
+ */
+WebKitFeatureList* webkit_feature_list_ref(WebKitFeatureList* featureList)
+{
+    g_return_val_if_fail(featureList, nullptr);
+    g_atomic_int_inc(&featureList->referenceCount);
+    return featureList;
+}
+
+/**
+ * webkit_feature_list_unref:
+ * @feature_list: a #WebKitFeatureList
+ *
+ * Atomically releases a reference on the given @feature_list.
+ *
+ * If the reference was the last, the resources associated to the
+ * @feature_list are freed. This function is MT-safe and may be called
+ * from any thread.
+ *
+ * Since: 2.42
+ */
+void webkit_feature_list_unref(WebKitFeatureList* featureList)
+{
+    g_return_if_fail(featureList);
+    if (g_atomic_int_dec_and_test(&featureList->referenceCount)) {
+        featureList->~WebKitFeatureList();
+        fastFree(featureList);
+    }
+}
+
+/**
+ * webkit_feature_list_get_length:
+ * @feature_list: a #WebKitFeatureList
+ *
+ * Gets the number of elements in the feature list.
+ *
+ * Returns: number of elements.
+ *
+ * Since 2.42
+ */
+gsize webkit_feature_list_get_length(WebKitFeatureList* featureList)
+{
+    g_return_val_if_fail(featureList, 0);
+    return featureList->items.size();
+}
+
+/**
+ * webkit_feature_list_get:
+ * @feature_list: a #WebKitFeatureList
+ * @index: index of the feature
+ *
+ * Gets a feature given its index.
+ *
+ * Returns: (transfer none): The feature at @index.
+ *
+ * Since: 2.42
+ */
+WebKitFeature* webkit_feature_list_get(WebKitFeatureList* featureList, gsize index)
+{
+    g_return_val_if_fail(featureList, nullptr);
+    g_return_val_if_fail(index < featureList->items.size(), nullptr);
+    return featureList->items[index];
+}

--- a/Source/WebKit/UIProcess/API/glib/WebKitFeature.h.in
+++ b/Source/WebKit/UIProcess/API/glib/WebKitFeature.h.in
@@ -1,0 +1,131 @@
+/*
+ * Copyright (C) 2023 Igalia S.L.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Library General Public
+ * License as published by the Free Software Foundation; either
+ * version 2 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Library General Public License for more details.
+ *
+ * You should have received a copy of the GNU Library General Public License
+ * along with this library; see the file COPYING.LIB.  If not, write to
+ * the Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor,
+ * Boston, MA 02110-1301, USA.
+ */
+
+@API_SINGLE_HEADER_GUARD@
+
+#ifndef WebKitFeature_h
+#define WebKitFeature_h
+
+#include <glib-object.h>
+#include <@API_INCLUDE_PREFIX@/WebKitDefines.h>
+
+G_BEGIN_DECLS
+
+/**
+ * WebKitFeatureStatus:
+ * @WEBKIT_FEATURE_STATUS_EMBEDDER: Feature that adjust behaviour for
+ *   specific application needs. The feature is not part of a Web platform
+ *   feature, not a mature feature intended to be always on.
+ * @WEBKIT_FEATURE_STATUS_UNSTABLE: Feature in development. The feature
+ *   may be unfinished, and there are no guarantees about its safety and
+ *   stability.
+ * @WEBKIT_FEATURE_STATUS_INTERNAL: Feature for debugging the WebKit engine.
+ *   The feature is not generally useful for user or web developers, and
+ *   always disabled by default.
+ * @WEBKIT_FEATURE_STATUS_DEVELOPER: Feature for web developers. The feature
+ *   is not generally useful for end users, and always disabled by default.
+ * @WEBKIT_FEATURE_STATUS_TESTABLE: Feature in active development and
+ *   complete enough for testing. The feature may not be yet ready to
+ *   ship and is disabled by default.
+ * @WEBKIT_FEATURE_STATUS_PREVIEW: Feature ready to be tested by users.
+ *   The feature is disabled by default, but may be enabled by applications
+ *   automatically e.g. in their “technology preview” or “beta” versions.
+ * @WEBKIT_FEATURE_STATUS_STABLE: Feature ready for general use. The
+ *   feature is enabled by default, but it may still be toggled to support
+ *   debugging and testing.
+ * @WEBKIT_FEATURE_STATUS_MATURE: Feature in general use. The feature is
+ *   always enabled and in general there should be no user-facing interface
+ *   to toggle it.
+ *
+ * Describes the status of a [struct@WebKitFeature].
+ *
+ * The status for a given feature can be obtained with
+ * [id@webkit_feature_get_status].
+ *
+ * Since: 2.42
+ */
+typedef enum {
+    WEBKIT_FEATURE_STATUS_EMBEDDER,
+    WEBKIT_FEATURE_STATUS_UNSTABLE,
+    WEBKIT_FEATURE_STATUS_INTERNAL,
+    WEBKIT_FEATURE_STATUS_DEVELOPER,
+    WEBKIT_FEATURE_STATUS_TESTABLE,
+    WEBKIT_FEATURE_STATUS_PREVIEW,
+    WEBKIT_FEATURE_STATUS_STABLE,
+    WEBKIT_FEATURE_STATUS_MATURE,
+} WebKitFeatureStatus;
+
+#define WEBKIT_TYPE_FEATURE (webkit_feature_get_type())
+
+typedef struct _WebKitFeature WebKitFeature;
+
+WEBKIT_API GType
+webkit_feature_get_type          (void) G_GNUC_CONST;
+
+WEBKIT_API WebKitFeature *
+webkit_feature_ref               (WebKitFeature *feature);
+
+WEBKIT_API void
+webkit_feature_unref             (WebKitFeature *feature);
+
+WEBKIT_API const char *
+webkit_feature_get_identifier    (WebKitFeature *feature);
+
+WEBKIT_API const char *
+webkit_feature_get_name          (WebKitFeature *feature);
+
+WEBKIT_API const char *
+webkit_feature_get_details       (WebKitFeature *feature);
+
+WEBKIT_API const char *
+webkit_feature_get_category      (WebKitFeature *feature);
+
+WEBKIT_API WebKitFeatureStatus
+webkit_feature_get_status        (WebKitFeature *feature);
+
+WEBKIT_API gboolean
+webkit_feature_get_default_value (WebKitFeature *feature);
+
+G_DEFINE_AUTOPTR_CLEANUP_FUNC(WebKitFeature, webkit_feature_unref)
+
+#define WEBKIT_TYPE_FEATURE_LIST (webkit_feature_list_get_type())
+
+typedef struct _WebKitFeatureList WebKitFeatureList;
+
+WEBKIT_API GType
+webkit_feature_list_get_type     (void) G_GNUC_CONST;
+
+WEBKIT_API WebKitFeatureList *
+webkit_feature_list_ref          (WebKitFeatureList *feature_list);
+
+WEBKIT_API void
+webkit_feature_list_unref        (WebKitFeatureList *feature_list);
+
+WEBKIT_API gsize
+webkit_feature_list_get_length   (WebKitFeatureList *feature_list);
+
+WEBKIT_API WebKitFeature *
+webkit_feature_list_get          (WebKitFeatureList *feature_list,
+                                  gsize              index);
+
+G_DEFINE_AUTOPTR_CLEANUP_FUNC(WebKitFeatureList, webkit_feature_list_unref)
+
+G_END_DECLS
+
+#endif /* WebKitFeature_h */

--- a/Source/WebKit/UIProcess/API/glib/WebKitFeaturePrivate.h
+++ b/Source/WebKit/UIProcess/API/glib/WebKitFeaturePrivate.h
@@ -1,0 +1,34 @@
+/*
+ * Copyright (C) 2023 Igalia S.L.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Library General Public
+ * License as published by the Free Software Foundation; either
+ * version 2 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Library General Public License for more details.
+ *
+ * You should have received a copy of the GNU Library General Public License
+ * along with this library; see the file COPYING.LIB.  If not, write to
+ * the Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor,
+ * Boston, MA 02110-1301, USA.
+ */
+
+#pragma once
+
+#include "WebKitFeature.h"
+#include <wtf/RefPtr.h>
+
+namespace API {
+class Feature;
+class Object;
+};
+
+typedef struct _WebKitFeature WebKitFeature;
+typedef struct _WebKitFeatureList WebKitFeatureList;
+
+API::Feature& webkitFeatureGetFeature(WebKitFeature*);
+WebKitFeatureList* webkitFeatureListCreate(const Vector<RefPtr<API::Object>>&);

--- a/Source/WebKit/UIProcess/API/glib/WebKitSettings.cpp
+++ b/Source/WebKit/UIProcess/API/glib/WebKitSettings.cpp
@@ -32,6 +32,7 @@
 #include "WebKitSettings.h"
 
 #include "WebKitEnumTypes.h"
+#include "WebKitFeaturePrivate.h"
 #include "WebKitInitialize.h"
 #include "WebKitSettingsPrivate.h"
 #include "WebPageProxy.h"
@@ -4031,4 +4032,107 @@ void webkit_settings_set_disable_web_security(WebKitSettings* settings, gboolean
 
     priv->preferences->setWebSecurityEnabled(!disabled);
     g_object_notify_by_pspec(G_OBJECT(settings), sObjProperties[PROP_DISABLE_WEB_SECURITY]);
+}
+
+/**
+ * webkit_settings_set_feature_enabled:
+ * @settings: a #WebKitSettings
+ * @feature: the feature to toggle.
+ * @enabled: whether the feature will be enabled.
+ *
+ * Enables or disables a feature.
+ *
+ * The current status of the feature can be determined with
+ * [id@webkit_settings_get_feature_enabled]. To reset a feature to its
+ * initial status, pass the value returned by
+ * [id@webkit_feature_get_default_value] as the @enabled parameter.
+ *
+ * Since: 2.42
+ */
+void webkit_settings_set_feature_enabled(WebKitSettings* settings, WebKitFeature* feature, gboolean enabled)
+{
+    g_return_if_fail(WEBKIT_IS_SETTINGS(settings));
+    g_return_if_fail(feature);
+
+    settings->priv->preferences->setFeatureEnabled(webkitFeatureGetFeature(feature), !!enabled);
+}
+
+/**
+ * webkit_settings_get_feature_enabled:
+ * @settings: a #WebKitSettings
+ * @feature: the feature to toggle.
+ *
+ * Gets whether a feature is enabled.
+ *
+ * Returns: Whether the feature is enabled.
+ *
+ * Since: 2.42
+ */
+gboolean webkit_settings_get_feature_enabled(WebKitSettings* settings, WebKitFeature* feature)
+{
+    g_return_val_if_fail(WEBKIT_IS_SETTINGS(settings), FALSE);
+    g_return_val_if_fail(feature, FALSE);
+
+    return settings->priv->preferences->isFeatureEnabled(webkitFeatureGetFeature(feature)) ? TRUE : FALSE;
+}
+
+/**
+ * webkit_settings_get_all_features:
+ *
+ * Gets the list of all available WebKit features.
+ *
+ * Features can be toggled with [method@Settings.set_feature_enabled],
+ * and their current state determined with
+ * [method@Settings.get_feature_enabled].
+ *
+ * Note that most applications should use
+ * [func@Settings.get_development_features] and
+ * [func@Settings.get_experimental_features] instead.
+ *
+ * Returns: (transfer full): List of all features.
+ *
+ * Since: 2.42
+ */
+WebKitFeatureList* webkit_settings_get_all_features(void)
+{
+    return webkitFeatureListCreate(WebPreferences::features());
+}
+
+/**
+ * webkit_settings_get_experimental_features:
+ *
+ * Gets the list of available experimental WebKit features.
+ *
+ * The returned features are a subset of those returned by
+ * [func@Settings.get_all_features], and includes those which
+ * certain applications may want to expose to end users; see
+ * [enum@FeatureStatus] for more details.
+ *
+ * Returns: (transfer full): List of experimental features.
+ *
+ * Since: 2.42
+ */
+WebKitFeatureList* webkit_settings_get_experimental_features(void)
+{
+    return webkitFeatureListCreate(WebPreferences::experimentalFeatures());
+}
+
+/**
+ * webkit_settings_get_development_features:
+ *
+ * Gets the list of available development WebKit features.
+ *
+ * The returned features are a subset of those returned by
+ * [func@Settings.get_all_features], and includes those which
+ * web and WebKit developers might find useful, but in general should
+ * *not* be exposed to end users; see [enum@FeatureStatus] for
+ * more details.
+ *
+ * Returns: (transfer full): List of development features.
+ *
+ * Since: 2.42
+ */
+WebKitFeatureList* webkit_settings_get_development_features(void)
+{
+    return webkitFeatureListCreate(WebPreferences::internalDebugFeatures());
 }

--- a/Source/WebKit/UIProcess/API/glib/WebKitSettings.h.in
+++ b/Source/WebKit/UIProcess/API/glib/WebKitSettings.h.in
@@ -540,6 +540,28 @@ webkit_settings_get_disable_web_security                       (WebKitSettings *
 WEBKIT_API void
 webkit_settings_set_disable_web_security                       (WebKitSettings *settings,
                                                                 gboolean        disabled);
+
+typedef struct _WebKitFeature WebKitFeature;
+typedef struct _WebKitFeatureList WebKitFeatureList;
+
+WEBKIT_API void
+webkit_settings_set_feature_enabled                            (WebKitSettings *settings,
+                                                                WebKitFeature  *feature,
+                                                                gboolean        enabled);
+
+WEBKIT_API gboolean
+webkit_settings_get_feature_enabled                            (WebKitSettings *settings,
+                                                                WebKitFeature  *feature);
+
+WEBKIT_API WebKitFeatureList *
+webkit_settings_get_all_features                               (void);
+
+WEBKIT_API WebKitFeatureList *
+webkit_settings_get_experimental_features                      (void);
+
+WEBKIT_API WebKitFeatureList *
+webkit_settings_get_development_features                       (void);
+
 G_END_DECLS
 
 #endif /* WebKitSettings_h */

--- a/Source/WebKit/UIProcess/API/glib/webkit.h.in
+++ b/Source/WebKit/UIProcess/API/glib/webkit.h.in
@@ -64,6 +64,7 @@
 #if PLATFORM(GTK) || (PLATFORM(WPE) && !ENABLE(2022_GLIB_API))
 #include <@API_INCLUDE_PREFIX@/WebKitFaviconDatabase.h>
 #endif
+#include <@API_INCLUDE_PREFIX@/WebKitFeature.h>
 #if PLATFORM(GTK)
 #include <@API_INCLUDE_PREFIX@/WebKitFileChooserRequest.h>
 #endif

--- a/Tools/MiniBrowser/gtk/main.c
+++ b/Tools/MiniBrowser/gtk/main.c
@@ -244,6 +244,72 @@ static gboolean isValidParameterType(GType gParamType)
             || gParamType == G_TYPE_FLOAT);
 }
 
+static WebKitFeature* findFeature(WebKitFeatureList *featureList, const char *identifier)
+{
+    for (gsize i = 0; i < webkit_feature_list_get_length(featureList); i++) {
+        WebKitFeature *feature = webkit_feature_list_get(featureList, i);
+        if (!g_ascii_strcasecmp(identifier, webkit_feature_get_identifier(feature)))
+            return feature;
+    }
+    return NULL;
+}
+
+static gboolean parseFeaturesOptionCallback(const gchar *option, const gchar *value, WebKitSettings *webSettings, GError **error)
+{
+    g_autoptr(WebKitFeatureList) featureList = webkit_settings_get_all_features();
+
+    if (!strcmp(value, "help")) {
+        g_print("Multiple feature names may be specified separated by commas. No prefix or '+' enable\n"
+                "features, prefixes '-' and '!' disable features. Names are case-insensitive. Example:\n"
+                "\n    %s --features='!DirPseudo,+WebAnimationsCustomEffects,webgl'\n\n"
+                "Available features (+/- = enabled/disabled by default):\n\n", g_get_prgname());
+        g_autoptr(GEnumClass) statusEnum = g_type_class_ref(WEBKIT_TYPE_FEATURE_STATUS);
+        for (gsize i = 0; i < webkit_feature_list_get_length(featureList); i++) {
+            WebKitFeature *feature = webkit_feature_list_get(featureList, i);
+            g_print("  %c %s (%s)",
+                    webkit_feature_get_default_value(feature) ? '+' : '-',
+                    webkit_feature_get_identifier(feature),
+                    g_enum_get_value(statusEnum, webkit_feature_get_status(feature))->value_nick);
+            if (webkit_feature_get_name(feature))
+                g_print(": %s", webkit_feature_get_name(feature));
+            g_print("\n");
+        }
+        exit(EXIT_SUCCESS);
+    }
+
+    g_auto(GStrv) items = g_strsplit(value, ",", -1);
+    for (gsize i = 0; items[i]; i++) {
+        char *item = g_strchomp(items[i]);
+        gboolean enabled = TRUE;
+        switch (item[0]) {
+        case '!':
+        case '-':
+            enabled = FALSE;
+            [[fallthrough]];
+        case '+':
+            item++;
+            [[fallthrough]];
+        default:
+            break;
+        }
+
+        if (item[0] == '\0') {
+            g_set_error_literal(error, G_OPTION_ERROR, G_OPTION_ERROR_FAILED, "Empty feature name specified");
+            return FALSE;
+        }
+
+        WebKitFeature *feature = findFeature(featureList, item);
+        if (!feature) {
+            g_set_error(error, G_OPTION_ERROR, G_OPTION_ERROR_FAILED, "Feature '%s' is not available", item);
+            return FALSE;
+        }
+
+        webkit_settings_set_feature_enabled(webSettings, feature, enabled);
+    }
+
+    return TRUE;
+}
+
 static GOptionEntry* getOptionEntriesFromWebKitSettings(WebKitSettings *webSettings)
 {
     GParamSpec **propertySpecs;
@@ -298,6 +364,19 @@ static gboolean addSettingsGroupToContext(GOptionContext *context, WebKitSetting
                                                         NULL);
     g_option_group_add_entries(webSettingsGroup, optionEntries);
     g_free(optionEntries);
+
+    GOptionEntry featureEntries[] = {
+        {
+            .short_name = 'F',
+            .long_name = "features",
+            .description = "Enable or disable WebKit features (hint: pass 'help' for a list)",
+            .arg = G_OPTION_ARG_CALLBACK,
+            .arg_data = parseFeaturesOptionCallback,
+            .arg_description = "FEATURE-LIST",
+        },
+        G_OPTION_ENTRY_NULL
+    };
+    g_option_group_add_entries(webSettingsGroup, featureEntries);
 
     /* Option context takes ownership of the group. */
     g_option_context_add_group(context, webSettingsGroup);

--- a/Tools/MiniBrowser/wpe/main.cpp
+++ b/Tools/MiniBrowser/wpe/main.cpp
@@ -51,6 +51,7 @@ static const char* cookiesPolicy;
 static const char* proxy;
 const char* bgColor;
 static char* timeZone;
+static const char* featureList = nullptr;
 static gboolean enableITP;
 static gboolean printVersion;
 static GHashTable* openViews;
@@ -69,6 +70,7 @@ static const GOptionEntry commandLineOptions[] =
     { "bg-color", 0, 0, G_OPTION_ARG_STRING, &bgColor, "Window background color. Default: white", "COLOR" },
     { "enable-itp", 0, 0, G_OPTION_ARG_NONE, &enableITP, "Enable Intelligent Tracking Prevention (ITP)", nullptr },
     { "time-zone", 't', 0, G_OPTION_ARG_STRING, &timeZone, "Set time zone", "TIMEZONE" },
+    { "features", 'F', 0, G_OPTION_ARG_STRING, &featureList, "Enable or disable WebKit features (hint: pass 'help' for a list)", "FEATURE-LIST" },
     { "version", 'v', 0, G_OPTION_ARG_NONE, &printVersion, "Print the WPE version", nullptr },
     { G_OPTION_REMAINING, 0, 0, G_OPTION_ARG_FILENAME_ARRAY, &uriArguments, nullptr, "[URL]" },
     { nullptr, 0, 0, G_OPTION_ARG_NONE, nullptr, nullptr, nullptr }
@@ -187,6 +189,16 @@ static WebKitWebView* createWebView(WebKitWebView* webView, WebKitNavigationActi
     return newWebView;
 }
 
+static WebKitFeature* findFeature(WebKitFeatureList* featureList, const char* identifier)
+{
+    for (gsize i = 0; i < webkit_feature_list_get_length(featureList); i++) {
+        WebKitFeature* feature = webkit_feature_list_get(featureList, i);
+        if (!g_ascii_strcasecmp(identifier, webkit_feature_get_identifier(feature)))
+            return feature;
+    }
+    return nullptr;
+}
+
 static void activate(GApplication* application, WPEToolingBackends::ViewBackend* backend)
 {
     g_application_hold(application);
@@ -287,6 +299,36 @@ static void activate(GApplication* application, WPEToolingBackends::ViewBackend*
         "enable-encrypted-media", TRUE,
         nullptr);
 
+    if (featureList) {
+        g_autoptr(WebKitFeatureList) features = webkit_settings_get_all_features();
+        g_auto(GStrv) items = g_strsplit(featureList, ",", -1);
+        for (gsize i = 0; items[i]; i++) {
+            char* item = g_strchomp(items[i]);
+            gboolean enabled = TRUE;
+            switch (item[0]) {
+            case '!':
+            case '-':
+                enabled = FALSE;
+                [[fallthrough]];
+            case '+':
+                item++;
+                [[fallthrough]];
+            default:
+                break;
+            }
+
+            if (item[0] == '\0') {
+                g_printerr("Empty feature name specified, skipped.");
+                continue;
+            }
+
+            if (auto* feature = findFeature(features, item))
+                webkit_settings_set_feature_enabled(settings, feature, enabled);
+            else
+                g_printerr("Feature '%s' is not available.", item);
+        }
+    }
+
     auto* viewBackend = webkit_web_view_backend_new(backend->backend(), [](gpointer data) {
         delete static_cast<WPEToolingBackends::ViewBackend*>(data);
     }, backend);
@@ -375,6 +417,26 @@ int main(int argc, char *argv[])
         if (g_strcmp0(BUILD_REVISION, "tarball"))
             g_print(" (%s)", BUILD_REVISION);
         g_print("\n");
+        return 0;
+    }
+
+    if (!g_strcmp0(featureList, "help")) {
+        g_print("Multiple feature names may be specified separated by commas. No prefix or '+' enable\n"
+                "features, prefixes '-' and '!' disable features. Names are case-insensitive. Example:\n"
+                "\n    %s --features='!DirPseudo,+WebAnimationsCustomEffects,webgl'\n\n"
+                "Available features (+/- = enabled/disabled by default):\n\n", g_get_prgname());
+        g_autoptr(GEnumClass) statusEnum = static_cast<GEnumClass*>(g_type_class_ref(WEBKIT_TYPE_FEATURE_STATUS));
+        g_autoptr(WebKitFeatureList) features = webkit_settings_get_all_features();
+        for (gsize i = 0; i < webkit_feature_list_get_length(features); i++) {
+            WebKitFeature* feature = webkit_feature_list_get(features, i);
+            g_print("  %c %s (%s)",
+                    webkit_feature_get_default_value(feature) ? '+' : '-',
+                    webkit_feature_get_identifier(feature),
+                    g_enum_get_value(statusEnum, webkit_feature_get_status(feature))->value_nick);
+            if (webkit_feature_get_name(feature))
+                g_print(": %s", webkit_feature_get_name(feature));
+            g_print("\n");
+        }
         return 0;
     }
 

--- a/Tools/Scripts/webkitpy/style/checker.py
+++ b/Tools/Scripts/webkitpy/style/checker.py
@@ -318,6 +318,13 @@ _PATH_RULES_SPECIFIER = [
      ["-readability/naming/underscores",
       "-whitespace/tab"]),
 
+    ([  # The GTK/WPE MiniBrowser uses public API and GLib-style conventions and indentation.
+     os.path.join('Tools', 'MiniBrowser', 'gtk'),
+     os.path.join('Tools', 'MiniBrowser', 'wpe')],
+     ["-readability/enum_casing",
+      "-readability/naming/underscores",
+      "-whitespace/indent"]),
+
     ([  # MiniBrowser doesn't use WTF, but only public WebKit API.
      os.path.join('Tools', 'MiniBrowser')],
      ["-runtime/wtf_make_unique",

--- a/Tools/TestWebKitAPI/Tests/WebKitGLib/TestWebKitSettings.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebKitGLib/TestWebKitSettings.cpp
@@ -34,6 +34,7 @@
 #include "WebKitTestServer.h"
 #include "WebViewTest.h"
 #include <WebCore/SoupVersioning.h>
+#include <wtf/HashSet.h>
 #include <wtf/glib/GRefPtr.h>
 
 static WebKitTestServer* gServer;
@@ -400,6 +401,56 @@ void testWebKitSettingsNewWithSettings(Test* test, gconstpointer)
     g_assert_false(webkit_settings_get_load_icons_ignoring_image_load_setting(settings.get()));
 }
 
+void testWebKitFeatures(Test* test, gconstpointer)
+{
+    g_autoptr(WebKitFeatureList) allFeatures = webkit_settings_get_all_features();
+    g_assert_nonnull(allFeatures);
+
+    auto allFeaturesCount = webkit_feature_list_get_length(allFeatures);
+
+    {
+        // Keep a set of identifiers to validate their uniqueness.
+        HashSet<String> featureIdentifiers;
+        featureIdentifiers.reserveInitialCapacity(allFeaturesCount);
+        for (gsize i = 0; i < allFeaturesCount; i++) {
+            auto* feature = webkit_feature_list_get(allFeatures, i);
+            g_assert_nonnull(webkit_feature_get_identifier(feature));
+            g_assert_nonnull(webkit_feature_get_category(feature));
+
+            auto identifier = String::fromUTF8(webkit_feature_get_identifier(feature));
+            g_assert_false(featureIdentifiers.contains(identifier));
+            featureIdentifiers.add(WTFMove(identifier));
+        }
+
+        g_assert_cmpuint(featureIdentifiers.size(), ==, allFeaturesCount);
+    }
+
+    // These are subsets of the list of all features.
+    g_autoptr(WebKitFeatureList) experimentalFeatures = webkit_settings_get_experimental_features();
+    g_assert_nonnull(experimentalFeatures);
+    g_assert_cmpuint(allFeaturesCount, >=, webkit_feature_list_get_length(experimentalFeatures));
+
+    g_autoptr(WebKitFeatureList) developmentFeatures = webkit_settings_get_development_features();
+    g_assert_nonnull(developmentFeatures);
+    g_assert_cmpuint(allFeaturesCount, >=, webkit_feature_list_get_length(developmentFeatures));
+
+    // Try toggling a feature.
+    GRefPtr<WebKitSettings> settings = adoptGRef(webkit_settings_new());
+    auto* feature = webkit_feature_list_get(experimentalFeatures, 0);
+    auto wasEnabled = webkit_settings_get_feature_enabled(settings.get(), feature);
+    webkit_settings_set_feature_enabled(settings.get(), feature, !wasEnabled);
+    g_assert(wasEnabled != webkit_settings_get_feature_enabled(settings.get(), feature));
+
+    // Check that enabled status is the same as the declared default.
+    // FIXME(255779): Some defaults are overriden in code and out of sync with UnifiedWebPreferences.yaml
+#if 0
+    for (gsize i = 0; i < allFeaturesCount; i++) {
+        auto* feature = webkit_feature_list_get(allFeatures, i);
+        g_assert(webkit_settings_get_feature_enabled(settings.get(), feature) == webkit_feature_get_default_value(feature));
+    }
+#endif
+}
+
 #if PLATFORM(GTK)
 static CString convertWebViewMainResourceDataToCString(WebViewTest* test)
 {
@@ -507,6 +558,7 @@ void beforeAll()
 
     Test::add("WebKitSettings", "webkit-settings", testWebKitSettings);
     Test::add("WebKitSettings", "new-with-settings", testWebKitSettingsNewWithSettings);
+    Test::add("WebKitSettings", "features", testWebKitFeatures);
 #if PLATFORM(GTK)
     WebViewTest::add("WebKitSettings", "user-agent", testWebKitSettingsUserAgent);
 #endif


### PR DESCRIPTION
#### 760e6a2591cf8cb0e8bc40af0caaccce3bc64f28
<pre>
[GLib] Add introspectable API to configure experimental features at runtime
<a href="https://bugs.webkit.org/show_bug.cgi?id=255518">https://bugs.webkit.org/show_bug.cgi?id=255518</a>

Reviewed by Carlos Garcia Campos.

Adds a WebKitFeature boxed type that wraps API::Feature, and new
functions in WebKitSettings to change their values and retrieve the
lists of available features. The structure loosely follows what the
Cocoa port does, with a few notable differences:

- Some feature identifiers have an &quot;Enabled&quot; suffix, and others do
  not, as declared in UnifiedWebPreferences.yaml. The identifiers
  exposed though the API remove the suffix for consistency.
- Whether a feature is hidden is not exposed. There is currently only
  one hidden feature (fullscreen API) so it seems moot to make the
  distinction. Might be added in the future if needed.
- The feature category is a string, to avoid committing a set of fixed
  enum values to the public API. This way it will not be needed to
  map values if there are changes in the future, and also transmits the
  idea that the category for a given feature is informative, and may
  change across versions.
- There is a helper WebKitFeatureList boxed type that groups features,
  to avoid using GPtrArray (which is bad for GObject Introspection
  bindings) or GList (poor match given the sizes of each set are fixed
  and well known).

The GTK MiniBrowser gets two new pages in its settings dialog, one for
experimental features and the other for development features. This
needed a switcher added, so at the same time the dialog gets changed to
use a header bar where to place a stack switcher. The existing page
with the settings gets tweaked to allow type-to-search, as it was done
also for the two new pages.

Both the GTK and WPE MiniBrowser get a new -F/--features= command line
option which can be used to toggle a set of features given their
identifiers.

* Source/WebKit/PlatformGTK.cmake: Add WebKitFeature.h.in to the list of
  generated API headers.
* Source/WebKit/PlatformWPE.cmake: Ditto.
* Source/WebKit/SourcesGTK.txt: Add WebKitFeature.cpp to the list of
  sources.
* Source/WebKit/SourcesWPE.txt: Ditto.
* Source/WebKit/UIProcess/API/glib/WebKitFeature.cpp: Added.
(toFeatureStatus):
(toFeatureCategory):
(_WebKitFeature::_WebKitFeature):
(_WebKitFeature::toIdentifier):
(webkitFeatureCreate):
(webkitFeatureGetFeature):
(webkit_feature_ref):
(webkit_feature_unref):
(webkit_feature_get_identifier):
(webkit_feature_get_name):
(webkit_feature_get_details):
(webkit_feature_get_status):
(webkit_feature_get_category):
(webkit_feature_get_default_value):
(_WebKitFeatureList::_WebKitFeatureList):
(_WebKitFeatureList::~_WebKitFeatureList):
(webkitFeatureListCreate):
(webkit_feature_list_ref):
(webkit_feature_list_unref):
(webkit_feature_list_get_length):
(webkit_feature_list_get):
* Source/WebKit/UIProcess/API/glib/WebKitFeature.h.in: Added.
* Source/WebKit/UIProcess/API/glib/WebKitFeaturePrivate.h: Added.
* Source/WebKit/UIProcess/API/glib/WebKitSettings.cpp:
(webkit_settings_set_feature_enabled):
(webkit_settings_get_feature_enabled):
(webkit_settings_get_all_features):
(webkit_settings_get_experimental_features):
(webkit_settings_get_development_features):
* Source/WebKit/UIProcess/API/glib/WebKitSettings.h.in:
* Source/WebKit/UIProcess/API/glib/webkit.h.in:
* Tools/MiniBrowser/gtk/BrowserSettingsDialog.c:
(featureTreeViewRowActivated):
(cellRendererToggled):
(featureTreeViewRenderEnabledData):
(featureTreeViewRenderStatusData):
(featureTreeViewRenderCategoryData):
(featureTreeViewSearchMatchSubstring):
(createFeatureTreeView):
(settingsTreeViewSearchMatchSubstring):
(browser_settings_dialog_init):
(browserSettingsDialogConstructed):
(browser_settings_dialog_new):
* Tools/MiniBrowser/gtk/main.c:
(findFeature):
(parseFeaturesOptionCallback):
(addSettingsGroupToContext):
* Tools/MiniBrowser/wpe/main.cpp:
(findFeature):
(activate):
(main):
* Tools/Scripts/webkitpy/style/checker.py:
* Tools/TestWebKitAPI/Tests/WebKitGLib/TestWebKitSettings.cpp:
(testWebKitFeatures):
(beforeAll):

Canonical link: <a href="https://commits.webkit.org/263331@main">https://commits.webkit.org/263331@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/45366a445d25047a28a67d25427c997bf90111bf

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/4218 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/4339 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/4457 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/5688 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/4464 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/4211 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/4446 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/4304 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/4683 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/4279 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/4456 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/3804 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/5682 "Built successfully") | 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/4272 "Passed tests") | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/1951 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/3781 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/5963 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/3778 "Passed tests") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/3847 "3 failures") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/5373 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/4258 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/3455 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/3768 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/3779 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/1049 "Built successfully and passed tests") | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/4/builds/7861 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/4112 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->