### PR TITLE
Verify non-serialized members of serialized types are not accidentally forgotten

### DIFF
--- a/Source/WebCore/Modules/reporting/DeprecationReportBody.cpp
+++ b/Source/WebCore/Modules/reporting/DeprecationReportBody.cpp
@@ -37,8 +37,7 @@ namespace WebCore {
 WTF_MAKE_ISO_ALLOCATED_IMPL(DeprecationReportBody);
 
 DeprecationReportBody::DeprecationReportBody(String&& id, WallTime anticipatedRemoval, String&& message, String&& sourceFile, std::optional<unsigned> lineNumber, std::optional<unsigned> columnNumber)
-    : ReportBody(ViolationReportType::Deprecation)
-    , m_id(WTFMove(id))
+    : m_id(WTFMove(id))
     , m_anticipatedRemoval(anticipatedRemoval)
     , m_message(WTFMove(message))
     , m_sourceFile(WTFMove(sourceFile))

--- a/Source/WebCore/Modules/reporting/DeprecationReportBody.h
+++ b/Source/WebCore/Modules/reporting/DeprecationReportBody.h
@@ -53,6 +53,8 @@ public:
 private:
     DeprecationReportBody(String&& id, WallTime anticipatedRemoval, String&& message, String&& sourceFile, std::optional<unsigned> lineNumber, std::optional<unsigned> columnNumber);
 
+    ViolationReportType reportBodyType() const final { return ViolationReportType::Deprecation; }
+
     const String m_id;
     const WallTime m_anticipatedRemoval;
     const String m_message;

--- a/Source/WebCore/Modules/reporting/ReportBody.cpp
+++ b/Source/WebCore/Modules/reporting/ReportBody.cpp
@@ -33,15 +33,6 @@ namespace WebCore {
 
 WTF_MAKE_ISO_ALLOCATED_IMPL(ReportBody);
 
-ReportBody::ReportBody(ViolationReportType type)
-    : m_reportBodyType(type)
-{ }
-
 ReportBody::~ReportBody() = default;
-
-ViolationReportType ReportBody::reportBodyType() const
-{
-    return m_reportBodyType;
-}
 
 } // namespace WebCore

--- a/Source/WebCore/Modules/reporting/ReportBody.h
+++ b/Source/WebCore/Modules/reporting/ReportBody.h
@@ -38,13 +38,7 @@ public:
     virtual ~ReportBody();
 
     virtual const String& type() const = 0;
-    ViolationReportType reportBodyType() const;
-
-protected:
-    ReportBody(ViolationReportType);
-
-private:
-    ViolationReportType m_reportBodyType;
+    virtual ViolationReportType reportBodyType() const = 0;
 };
 
 } // namespace WebCore

--- a/Source/WebCore/Modules/reporting/TestReportBody.cpp
+++ b/Source/WebCore/Modules/reporting/TestReportBody.cpp
@@ -34,8 +34,7 @@ namespace WebCore {
 WTF_MAKE_ISO_ALLOCATED_IMPL(TestReportBody);
 
 TestReportBody::TestReportBody(String&& message)
-    : ReportBody(ViolationReportType::Test)
-    , m_bodyMessage(WTFMove(message))
+    : m_bodyMessage(WTFMove(message))
 {
 }
 

--- a/Source/WebCore/Modules/reporting/TestReportBody.h
+++ b/Source/WebCore/Modules/reporting/TestReportBody.h
@@ -45,6 +45,8 @@ public:
 private:
     TestReportBody(String&& message);
 
+    ViolationReportType reportBodyType() const final { return ViolationReportType::Test; }
+
     const String m_bodyMessage;
 };
 

--- a/Source/WebCore/loader/COEPInheritenceViolationReportBody.cpp
+++ b/Source/WebCore/loader/COEPInheritenceViolationReportBody.cpp
@@ -39,8 +39,7 @@ Ref<COEPInheritenceViolationReportBody> COEPInheritenceViolationReportBody::crea
 }
 
 COEPInheritenceViolationReportBody::COEPInheritenceViolationReportBody(COEPDisposition disposition, const URL& blockedURL, const String& type)
-    : ReportBody(ViolationReportType::COEPInheritenceViolation)
-    , m_disposition(disposition)
+    : m_disposition(disposition)
     , m_blockedURL(blockedURL)
     , m_type(type)
 {

--- a/Source/WebCore/loader/COEPInheritenceViolationReportBody.h
+++ b/Source/WebCore/loader/COEPInheritenceViolationReportBody.h
@@ -45,6 +45,8 @@ private:
     friend struct IPC::ArgumentCoder<COEPInheritenceViolationReportBody, void>;
     COEPInheritenceViolationReportBody(COEPDisposition, const URL& blockedURL, const String& type);
 
+    ViolationReportType reportBodyType() const final { return ViolationReportType::COEPInheritenceViolation; }
+
     COEPDisposition m_disposition;
     URL m_blockedURL;
     String m_type;

--- a/Source/WebCore/loader/CORPViolationReportBody.cpp
+++ b/Source/WebCore/loader/CORPViolationReportBody.cpp
@@ -38,8 +38,7 @@ Ref<CORPViolationReportBody> CORPViolationReportBody::create(COEPDisposition dis
 }
 
 CORPViolationReportBody::CORPViolationReportBody(COEPDisposition disposition, const URL& blockedURL, FetchOptions::Destination destination)
-    : ReportBody(ViolationReportType::CORPViolation)
-    , m_disposition(disposition)
+    : m_disposition(disposition)
     , m_blockedURL(blockedURL)
     , m_destination(destination)
 {

--- a/Source/WebCore/loader/CORPViolationReportBody.h
+++ b/Source/WebCore/loader/CORPViolationReportBody.h
@@ -47,6 +47,8 @@ private:
     friend struct IPC::ArgumentCoder<CORPViolationReportBody, void>;
     CORPViolationReportBody(COEPDisposition, const URL& blockedURL, FetchOptions::Destination);
 
+    ViolationReportType reportBodyType() const final { return ViolationReportType::CORPViolation; }
+
     COEPDisposition m_disposition;
     URL m_blockedURL;
     FetchOptions::Destination m_destination;

--- a/Source/WebCore/page/csp/CSPViolationReportBody.cpp
+++ b/Source/WebCore/page/csp/CSPViolationReportBody.cpp
@@ -39,8 +39,7 @@ using Init = SecurityPolicyViolationEventInit;
 WTF_MAKE_ISO_ALLOCATED_IMPL(CSPViolationReportBody);
 
 CSPViolationReportBody::CSPViolationReportBody(Init&& init)
-    : ReportBody(ViolationReportType::ContentSecurityPolicy)
-    , m_documentURL(WTFMove(init.documentURI))
+    : m_documentURL(WTFMove(init.documentURI))
     , m_referrer(init.referrer.isNull() ? emptyString() : WTFMove(init.referrer))
     , m_blockedURL(WTFMove(init.blockedURI))
     , m_effectiveDirective(WTFMove(init.effectiveDirective))
@@ -55,8 +54,7 @@ CSPViolationReportBody::CSPViolationReportBody(Init&& init)
 }
 
 CSPViolationReportBody::CSPViolationReportBody(String&& documentURL, String&& referrer, String&& blockedURL, String&& effectiveDirective, String&& originalPolicy, String&& sourceFile, String&& sample, SecurityPolicyViolationEventDisposition disposition, unsigned short statusCode, unsigned long lineNumber, unsigned long columnNumber)
-    : ReportBody(ViolationReportType::ContentSecurityPolicy)
-    , m_documentURL(WTFMove(documentURL))
+    : m_documentURL(WTFMove(documentURL))
     , m_referrer(WTFMove(referrer))
     , m_blockedURL(WTFMove(blockedURL))
     , m_effectiveDirective(WTFMove(effectiveDirective))

--- a/Source/WebCore/page/csp/CSPViolationReportBody.h
+++ b/Source/WebCore/page/csp/CSPViolationReportBody.h
@@ -64,6 +64,8 @@ private:
     CSPViolationReportBody(Init&&);
     CSPViolationReportBody(String&& documentURL, String&& referrer, String&& blockedURL, String&& effectiveDirective, String&& originalPolicy, String&& sourceFile, String&& sample, SecurityPolicyViolationEventDisposition, unsigned short statusCode, unsigned long lineNumber, unsigned long columnNumber);
 
+    ViolationReportType reportBodyType() const final { return ViolationReportType::ContentSecurityPolicy; }
+
     const String m_documentURL;
     const String m_referrer;
     const String m_blockedURL;

--- a/Source/WebKit/NetworkProcess/NetworkResourceLoadParameters.serialization.in
+++ b/Source/WebKit/NetworkProcess/NetworkResourceLoadParameters.serialization.in
@@ -31,6 +31,9 @@ class WebKit::NetworkLoadParameters {
     RefPtr<WebCore::SecurityOrigin> topOrigin;
     RefPtr<WebCore::SecurityOrigin> sourceOrigin;
     WTF::ProcessID parentPID;
+#if HAVE(AUDIT_TOKEN)
+    [NotSerialized] std::optional<audit_token_t> networkProcessAuditToken;
+#endif
     WebCore::ResourceRequest request;
     
     WebCore::ContentSniffingPolicy contentSniffingPolicy;
@@ -43,8 +46,9 @@ class WebKit::NetworkLoadParameters {
     bool isMainFrameNavigation;
     bool isMainResourceNavigationForAnyFrame;
     WebCore::ShouldRelaxThirdPartyCookieBlocking shouldRelaxThirdPartyCookieBlocking;
-    
+    [NotSerialized] Vector<RefPtr<WebCore::BlobDataFileReference>> blobFileReferences;
     WebKit::PreconnectOnly shouldPreconnectOnly;
+    [NotSerialized] std::optional<WebKit::NetworkActivityTracker> networkActivityTracker;
     std::optional<WebKit::NavigatingToAppBoundDomain> isNavigatingToAppBoundDomain;
     bool hadMainFrameMainResourcePrivateRelayed;
     bool allowPrivacyProxy;

--- a/Source/WebKit/Scripts/generate-serializers.py
+++ b/Source/WebKit/Scripts/generate-serializers.py
@@ -43,6 +43,7 @@ import sys
 # BitField - work around the need for http://wg21.link/P0572 and don't check that the serialization order matches the memory layout.
 # Nullable - check if the member is truthy before serializing.
 # Validator - additional C++ to validate the value when decoding
+# NotSerialized - member is present in structure but intentionally not serialized.
 
 class SerializedType(object):
     def __init__(self, struct_or_class, namespace, name, parent_class_name, members, condition, attributes, other_metadata=None):
@@ -116,6 +117,9 @@ class SerializedType(object):
             if '.' in member.name:
                 return False
         return True
+
+    def serialized_members(self):
+        return list(filter(lambda member: 'NotSerialized' not in member.attributes, self.members))
 
 
 class SerializedEnum(object):
@@ -348,10 +352,10 @@ def resolve_inheritance(serialized_types):
     return result
 
 
-def check_type_members(type):
+def check_type_members(type, checking_parent_class):
     result = []
     if type.parent_class is not None:
-        result = result + check_type_members(type.parent_class)
+        result = check_type_members(type.parent_class, True)
     for member in type.members:
         if member.condition is not None:
             result.append('#if ' + member.condition)
@@ -359,9 +363,19 @@ def check_type_members(type):
         if member.condition is not None:
             result.append('#endif')
     if type.can_assert_member_order_is_correct():
+        # FIXME: Add this check for types with parent classes, too.
+        if type.parent_class is None and not checking_parent_class:
+            result.append('    struct ShouldBeSameSizeAs' + type.name + ' : public VirtualTableAndRefCountOverhead<std::is_polymorphic_v<' + type.namespace_and_name() + '>, ' + ('true' if type.return_ref else 'false') + '> {')
+            for member in type.members:
+                if member.condition is not None:
+                    result.append('#if ' + member.condition)
+                result.append('        ' + member.type + ' ' + member.name + (' : 1' if 'BitField' in member.attributes else '') + ';')
+                if member.condition is not None:
+                    result.append('#endif')
+            result.append('    };')
+            result.append('    static_assert(sizeof(ShouldBeSameSizeAs' + type.name + ') == sizeof(' + type.namespace_and_name() + '));')
         result.append('    static_assert(MembersInCorrectOrder<0')
-        for i in range(len(type.members)):
-            member = type.members[i]
+        for member in type.members:
             if 'BitField' in member.attributes:
                 continue
             if member.condition is not None:
@@ -377,7 +391,7 @@ def encode_type(type):
     result = []
     if type.parent_class is not None:
         result = result + encode_type(type.parent_class)
-    for member in type.members:
+    for member in type.serialized_members():
         if member.condition is not None:
             result.append('#if ' + member.condition)
         if 'Nullable' in member.attributes:
@@ -409,7 +423,7 @@ def decode_type(type):
         result.append('        return std::nullopt;')
         result.append('')
 
-    for member in type.members:
+    for member in type.serialized_members():
         if member.condition is not None:
             result.append('#if ' + member.condition)
         sanitized_variable_name = sanitize_string_for_variable_name(member.name)
@@ -502,11 +516,12 @@ def construct_type(type, indentation):
         result = result + construct_type(type.parent_class, indentation + 1)
         if len(type.members) != 0:
             result[-1] += ','
-    for i in range(len(type.members)):
-        member = type.members[i]
-        if type.members[i].condition is not None:
+    serialized_members = type.serialized_members()
+    for i in range(len(serialized_members)):
+        member = serialized_members[i]
+        if member.condition is not None:
             result.append('#if ' + member.condition)
-        result.append(indent(indentation + 1) + 'WTFMove(*' + sanitize_string_for_variable_name(member.name) + ')' + ('' if i == len(type.members) - 1 else ','))
+        result.append(indent(indentation + 1) + 'WTFMove(*' + sanitize_string_for_variable_name(member.name) + ')' + ('' if i == len(serialized_members) - 1 else ','))
         if member.condition is not None:
             result.append('#endif')
     if type.create_using or type.return_ref:
@@ -528,6 +543,35 @@ def generate_impl(serialized_types, serialized_enums, headers):
     result.append('template<size_t firstOffset, size_t secondOffset, size_t... remainingOffsets> struct MembersInCorrectOrder<firstOffset, secondOffset, remainingOffsets...> {')
     result.append('    static constexpr bool value = firstOffset > secondOffset ? false : MembersInCorrectOrder<secondOffset, remainingOffsets...>::value;')
     result.append('};')
+    result.append('')
+    result.append('template<bool, bool> struct VirtualTableAndRefCountOverhead;')
+    result.append('template<> struct VirtualTableAndRefCountOverhead<true, true> {')
+    result.append('    virtual ~VirtualTableAndRefCountOverhead() { }')
+    result.append('    unsigned refCount;')
+    result.append('#if ASSERT_ENABLED')
+    result.append('    bool m_isOwnedByMainThread;')
+    result.append('    bool m_areThreadingChecksEnabled;')
+    result.append('#endif')
+    result.append('#if CHECK_REF_COUNTED_LIFECYCLE')
+    result.append('    bool m_deletionHasBegun;')
+    result.append('    bool m_adoptionIsRequired;')
+    result.append('#endif')
+    result.append('};')
+    result.append('template<> struct VirtualTableAndRefCountOverhead<false, true> {')
+    result.append('    unsigned refCount;')
+    result.append('#if ASSERT_ENABLED')
+    result.append('    bool m_isOwnedByMainThread;')
+    result.append('    bool m_areThreadingChecksEnabled;')
+    result.append('#endif')
+    result.append('#if CHECK_REF_COUNTED_LIFECYCLE')
+    result.append('    bool m_deletionHasBegun;')
+    result.append('    bool m_adoptionIsRequired;')
+    result.append('#endif')
+    result.append('};')
+    result.append('template<> struct VirtualTableAndRefCountOverhead<true, false> {')
+    result.append('    virtual ~VirtualTableAndRefCountOverhead() { }')
+    result.append('};')
+    result.append('template<> struct VirtualTableAndRefCountOverhead<false, false> { };')
     result.append('')
     # GCC is less generous with its interpretation of "Use of the offsetof macro with a
     # type other than a standard-layout class is conditionally-supported".
@@ -564,7 +608,7 @@ def generate_impl(serialized_types, serialized_enums, headers):
             result.append('void ArgumentCoder<' + type.namespace_and_name() + '>::encode(' + encoder + '& encoder, const ' + type.namespace_and_name() + '& instance)')
             result.append('{')
             if not type.members_are_subclasses:
-                result = result + check_type_members(type)
+                result = result + check_type_members(type, False)
             result = result + encode_type(type)
             result.append('}')
         result.append('')
@@ -577,7 +621,7 @@ def generate_impl(serialized_types, serialized_enums, headers):
         if not type.members_are_subclasses:
             if type.populate_from_empty_constructor:
                 result.append('    ' + type.namespace_and_name() + ' result;')
-                for member in type.members:
+                for member in type.serialized_members():
                     if member.condition is not None:
                         result.append('#if ' + member.condition)
                     result.append('    result.' + member.name + ' = WTFMove(*' + member.name + ');')
@@ -692,15 +736,18 @@ def generate_serialized_type_info(serialized_types, serialized_enums, headers, t
             result.append('            { "std::variant<' + ', '.join([member.namespace + '::' + member.name for member in type.members]) + '>"_s, "subclasses"_s }')
             result.append('        } },')
             continue
-        for i in range(len(type.members)):
+
+        serialized_members = type.serialized_members()
+        for i in range(len(serialized_members)):
+            member = type.members[i]
             if i == 0:
                 result.append('            {')
-            if 'Nullable' in type.members[i].attributes:
-                result.append('                "std::optional<' + type.members[i].type + '>"_s,')
+            if 'Nullable' in member.attributes:
+                result.append('                "std::optional<' + member.type + '>"_s,')
             else:
-                result.append('                "' + type.members[i].type + '"_s,')
-            result.append('                "' + type.members[i].name + '"_s')
-            if i == len(type.members) - 1:
+                result.append('                "' + member.type + '"_s,')
+            result.append('                "' + member.name + '"_s')
+            if i == len(serialized_members) - 1:
                 result.append('            }')
             else:
                 result.append('            }, {')

--- a/Source/WebKit/Scripts/webkit/tests/GeneratedSerializers.cpp
+++ b/Source/WebKit/Scripts/webkit/tests/GeneratedSerializers.cpp
@@ -31,13 +31,42 @@ template<size_t firstOffset, size_t secondOffset, size_t... remainingOffsets> st
     static constexpr bool value = firstOffset > secondOffset ? false : MembersInCorrectOrder<secondOffset, remainingOffsets...>::value;
 };
 
+template<bool, bool> struct VirtualTableAndRefCountOverhead;
+template<> struct VirtualTableAndRefCountOverhead<true, true> {
+    virtual ~VirtualTableAndRefCountOverhead() { }
+    unsigned refCount;
+#if ASSERT_ENABLED
+    bool m_isOwnedByMainThread;
+    bool m_areThreadingChecksEnabled;
+#endif
+#if CHECK_REF_COUNTED_LIFECYCLE
+    bool m_deletionHasBegun;
+    bool m_adoptionIsRequired;
+#endif
+};
+template<> struct VirtualTableAndRefCountOverhead<false, true> {
+    unsigned refCount;
+#if ASSERT_ENABLED
+    bool m_isOwnedByMainThread;
+    bool m_areThreadingChecksEnabled;
+#endif
+#if CHECK_REF_COUNTED_LIFECYCLE
+    bool m_deletionHasBegun;
+    bool m_adoptionIsRequired;
+#endif
+};
+template<> struct VirtualTableAndRefCountOverhead<true, false> {
+    virtual ~VirtualTableAndRefCountOverhead() { }
+};
+template<> struct VirtualTableAndRefCountOverhead<false, false> { };
+
 #if COMPILER(GCC)
 IGNORE_WARNINGS_BEGIN("invalid-offsetof")
 #endif
+#include "CommonHeader.h"
 #if ENABLE(TEST_FEATURE)
 #include "CommonHeader.h"
 #endif
-#include "CommonHeader.h"
 #if ENABLE(TEST_FEATURE)
 #include "FirstMemberType.h"
 #endif
@@ -76,6 +105,14 @@ void ArgumentCoder<Namespace::Subnamespace::StructName>::encode(Encoder& encoder
     static_assert(std::is_same_v<std::remove_cvref_t<decltype(instance.secondMemberName)>, SecondMemberType>);
 #endif
     static_assert(std::is_same_v<std::remove_cvref_t<decltype(instance.nullableTestMember)>, RetainPtr<CFTypeRef>>);
+    struct ShouldBeSameSizeAsStructName : public VirtualTableAndRefCountOverhead<std::is_polymorphic_v<Namespace::Subnamespace::StructName>, false> {
+        FirstMemberType firstMemberName;
+#if ENABLE(SECOND_MEMBER)
+        SecondMemberType secondMemberName;
+#endif
+        RetainPtr<CFTypeRef> nullableTestMember;
+    };
+    static_assert(sizeof(ShouldBeSameSizeAsStructName) == sizeof(Namespace::Subnamespace::StructName));
     static_assert(MembersInCorrectOrder<0
         , offsetof(Namespace::Subnamespace::StructName, firstMemberName)
 #if ENABLE(SECOND_MEMBER)
@@ -99,6 +136,14 @@ void ArgumentCoder<Namespace::Subnamespace::StructName>::encode(OtherEncoder& en
     static_assert(std::is_same_v<std::remove_cvref_t<decltype(instance.secondMemberName)>, SecondMemberType>);
 #endif
     static_assert(std::is_same_v<std::remove_cvref_t<decltype(instance.nullableTestMember)>, RetainPtr<CFTypeRef>>);
+    struct ShouldBeSameSizeAsStructName : public VirtualTableAndRefCountOverhead<std::is_polymorphic_v<Namespace::Subnamespace::StructName>, false> {
+        FirstMemberType firstMemberName;
+#if ENABLE(SECOND_MEMBER)
+        SecondMemberType secondMemberName;
+#endif
+        RetainPtr<CFTypeRef> nullableTestMember;
+    };
+    static_assert(sizeof(ShouldBeSameSizeAsStructName) == sizeof(Namespace::Subnamespace::StructName));
     static_assert(MembersInCorrectOrder<0
         , offsetof(Namespace::Subnamespace::StructName, firstMemberName)
 #if ENABLE(SECOND_MEMBER)
@@ -158,6 +203,13 @@ void ArgumentCoder<Namespace::OtherClass>::encode(Encoder& encoder, const Namesp
     static_assert(std::is_same_v<std::remove_cvref_t<decltype(instance.a)>, int>);
     static_assert(std::is_same_v<std::remove_cvref_t<decltype(instance.b)>, bool>);
     static_assert(std::is_same_v<std::remove_cvref_t<decltype(instance.dataDetectorResults)>, RetainPtr<NSArray>>);
+    struct ShouldBeSameSizeAsOtherClass : public VirtualTableAndRefCountOverhead<std::is_polymorphic_v<Namespace::OtherClass>, false> {
+        bool isNull;
+        int a;
+        bool b : 1;
+        RetainPtr<NSArray> dataDetectorResults;
+    };
+    static_assert(sizeof(ShouldBeSameSizeAsOtherClass) == sizeof(Namespace::OtherClass));
     static_assert(MembersInCorrectOrder<0
         , offsetof(Namespace::OtherClass, isNull)
         , offsetof(Namespace::OtherClass, a)
@@ -266,6 +318,16 @@ void ArgumentCoder<Namespace::EmptyConstructorNullable>::encode(Encoder& encoder
 #if CONDITION_AROUND_M_TYPE_AND_M_VALUE
     static_assert(std::is_same_v<std::remove_cvref_t<decltype(instance.m_value)>, OtherMemberType>);
 #endif
+    struct ShouldBeSameSizeAsEmptyConstructorNullable : public VirtualTableAndRefCountOverhead<std::is_polymorphic_v<Namespace::EmptyConstructorNullable>, false> {
+        bool m_isNull;
+#if CONDITION_AROUND_M_TYPE_AND_M_VALUE
+        MemberType m_type;
+#endif
+#if CONDITION_AROUND_M_TYPE_AND_M_VALUE
+        OtherMemberType m_value;
+#endif
+    };
+    static_assert(sizeof(ShouldBeSameSizeAsEmptyConstructorNullable) == sizeof(Namespace::EmptyConstructorNullable));
     static_assert(MembersInCorrectOrder<0
         , offsetof(Namespace::EmptyConstructorNullable, m_isNull)
 #if CONDITION_AROUND_M_TYPE_AND_M_VALUE
@@ -317,6 +379,10 @@ std::optional<Namespace::EmptyConstructorNullable> ArgumentCoder<Namespace::Empt
 void ArgumentCoder<WithoutNamespace>::encode(Encoder& encoder, const WithoutNamespace& instance)
 {
     static_assert(std::is_same_v<std::remove_cvref_t<decltype(instance.a)>, int>);
+    struct ShouldBeSameSizeAsWithoutNamespace : public VirtualTableAndRefCountOverhead<std::is_polymorphic_v<WithoutNamespace>, false> {
+        int a;
+    };
+    static_assert(sizeof(ShouldBeSameSizeAsWithoutNamespace) == sizeof(WithoutNamespace));
     static_assert(MembersInCorrectOrder<0
         , offsetof(WithoutNamespace, a)
     >::value);
@@ -340,6 +406,10 @@ std::optional<WithoutNamespace> ArgumentCoder<WithoutNamespace>::decode(Decoder&
 void ArgumentCoder<WithoutNamespaceWithAttributes>::encode(Encoder& encoder, const WithoutNamespaceWithAttributes& instance)
 {
     static_assert(std::is_same_v<std::remove_cvref_t<decltype(instance.a)>, int>);
+    struct ShouldBeSameSizeAsWithoutNamespaceWithAttributes : public VirtualTableAndRefCountOverhead<std::is_polymorphic_v<WithoutNamespaceWithAttributes>, false> {
+        int a;
+    };
+    static_assert(sizeof(ShouldBeSameSizeAsWithoutNamespaceWithAttributes) == sizeof(WithoutNamespaceWithAttributes));
     static_assert(MembersInCorrectOrder<0
         , offsetof(WithoutNamespaceWithAttributes, a)
     >::value);
@@ -349,6 +419,10 @@ void ArgumentCoder<WithoutNamespaceWithAttributes>::encode(Encoder& encoder, con
 void ArgumentCoder<WithoutNamespaceWithAttributes>::encode(OtherEncoder& encoder, const WithoutNamespaceWithAttributes& instance)
 {
     static_assert(std::is_same_v<std::remove_cvref_t<decltype(instance.a)>, int>);
+    struct ShouldBeSameSizeAsWithoutNamespaceWithAttributes : public VirtualTableAndRefCountOverhead<std::is_polymorphic_v<WithoutNamespaceWithAttributes>, false> {
+        int a;
+    };
+    static_assert(sizeof(ShouldBeSameSizeAsWithoutNamespaceWithAttributes) == sizeof(WithoutNamespaceWithAttributes));
     static_assert(MembersInCorrectOrder<0
         , offsetof(WithoutNamespaceWithAttributes, a)
     >::value);
@@ -474,6 +548,10 @@ std::optional<WTF::Seconds> ArgumentCoder<WTF::Seconds>::decode(Decoder& decoder
 void ArgumentCoder<WTF::CreateUsingClass>::encode(Encoder& encoder, const WTF::CreateUsingClass& instance)
 {
     static_assert(std::is_same_v<std::remove_cvref_t<decltype(instance.value)>, double>);
+    struct ShouldBeSameSizeAsCreateUsingClass : public VirtualTableAndRefCountOverhead<std::is_polymorphic_v<WTF::CreateUsingClass>, false> {
+        double value;
+    };
+    static_assert(sizeof(ShouldBeSameSizeAsCreateUsingClass) == sizeof(WTF::CreateUsingClass));
     static_assert(MembersInCorrectOrder<0
         , offsetof(WTF::CreateUsingClass, value)
     >::value);
@@ -539,6 +617,11 @@ void ArgumentCoder<NullableSoftLinkedMember>::encode(Encoder& encoder, const Nul
 {
     static_assert(std::is_same_v<std::remove_cvref_t<decltype(instance.firstMember)>, RetainPtr<DDActionContext>>);
     static_assert(std::is_same_v<std::remove_cvref_t<decltype(instance.secondMember)>, RetainPtr<DDActionContext>>);
+    struct ShouldBeSameSizeAsNullableSoftLinkedMember : public VirtualTableAndRefCountOverhead<std::is_polymorphic_v<NullableSoftLinkedMember>, false> {
+        RetainPtr<DDActionContext> firstMember;
+        RetainPtr<DDActionContext> secondMember;
+    };
+    static_assert(sizeof(ShouldBeSameSizeAsNullableSoftLinkedMember) == sizeof(NullableSoftLinkedMember));
     static_assert(MembersInCorrectOrder<0
         , offsetof(NullableSoftLinkedMember, firstMember)
         , offsetof(NullableSoftLinkedMember, secondMember)
@@ -649,6 +732,10 @@ std::optional<Ref<WebCore::TimingFunction>> ArgumentCoder<WebCore::TimingFunctio
 void ArgumentCoder<Namespace::ConditionalCommonClass>::encode(Encoder& encoder, const Namespace::ConditionalCommonClass& instance)
 {
     static_assert(std::is_same_v<std::remove_cvref_t<decltype(instance.value)>, int>);
+    struct ShouldBeSameSizeAsConditionalCommonClass : public VirtualTableAndRefCountOverhead<std::is_polymorphic_v<Namespace::ConditionalCommonClass>, false> {
+        int value;
+    };
+    static_assert(sizeof(ShouldBeSameSizeAsConditionalCommonClass) == sizeof(Namespace::ConditionalCommonClass));
     static_assert(MembersInCorrectOrder<0
         , offsetof(Namespace::ConditionalCommonClass, value)
     >::value);
@@ -671,48 +758,59 @@ std::optional<Namespace::ConditionalCommonClass> ArgumentCoder<Namespace::Condit
 #endif
 
 
-void ArgumentCoder<Namesapce::CommonClass>::encode(Encoder& encoder, const Namesapce::CommonClass& instance)
+void ArgumentCoder<Namespace::CommonClass>::encode(Encoder& encoder, const Namespace::CommonClass& instance)
 {
     static_assert(std::is_same_v<std::remove_cvref_t<decltype(instance.value)>, int>);
+    struct ShouldBeSameSizeAsCommonClass : public VirtualTableAndRefCountOverhead<std::is_polymorphic_v<Namespace::CommonClass>, false> {
+        int value;
+    };
+    static_assert(sizeof(ShouldBeSameSizeAsCommonClass) == sizeof(Namespace::CommonClass));
     static_assert(MembersInCorrectOrder<0
-        , offsetof(Namesapce::CommonClass, value)
+        , offsetof(Namespace::CommonClass, value)
     >::value);
     encoder << instance.value;
 }
 
-std::optional<Namesapce::CommonClass> ArgumentCoder<Namesapce::CommonClass>::decode(Decoder& decoder)
+std::optional<Namespace::CommonClass> ArgumentCoder<Namespace::CommonClass>::decode(Decoder& decoder)
 {
     auto value = decoder.decode<int>();
     if (!value)
         return std::nullopt;
 
     return {
-        Namesapce::CommonClass {
+        Namespace::CommonClass {
             WTFMove(*value)
         }
     };
 }
 
 
-void ArgumentCoder<Namesapce::AnotherCommonClass>::encode(Encoder& encoder, const Namesapce::AnotherCommonClass& instance)
+void ArgumentCoder<Namespace::AnotherCommonClass>::encode(Encoder& encoder, const Namespace::AnotherCommonClass& instance)
 {
     static_assert(std::is_same_v<std::remove_cvref_t<decltype(instance.value)>, int>);
+    static_assert(std::is_same_v<std::remove_cvref_t<decltype(instance.notSerialized)>, double>);
+    struct ShouldBeSameSizeAsAnotherCommonClass : public VirtualTableAndRefCountOverhead<std::is_polymorphic_v<Namespace::AnotherCommonClass>, true> {
+        int value;
+        double notSerialized;
+    };
+    static_assert(sizeof(ShouldBeSameSizeAsAnotherCommonClass) == sizeof(Namespace::AnotherCommonClass));
     static_assert(MembersInCorrectOrder<0
-        , offsetof(Namesapce::AnotherCommonClass, value)
+        , offsetof(Namespace::AnotherCommonClass, value)
+        , offsetof(Namespace::AnotherCommonClass, notSerialized)
     >::value);
     encoder << instance.value;
 }
 
-std::optional<Namesapce::AnotherCommonClass> ArgumentCoder<Namesapce::AnotherCommonClass>::decode(Decoder& decoder)
+std::optional<Ref<Namespace::AnotherCommonClass>> ArgumentCoder<Namespace::AnotherCommonClass>::decode(Decoder& decoder)
 {
     auto value = decoder.decode<int>();
     if (!value)
         return std::nullopt;
 
     return {
-        Namesapce::AnotherCommonClass {
+        Namespace::AnotherCommonClass::create(
             WTFMove(*value)
-        }
+        )
     };
 }
 

--- a/Source/WebKit/Scripts/webkit/tests/GeneratedSerializers.h
+++ b/Source/WebKit/Scripts/webkit/tests/GeneratedSerializers.h
@@ -59,8 +59,8 @@ namespace WebCore { class TimingFunction; }
 #if ENABLE(TEST_FEATURE)
 namespace Namespace { class ConditionalCommonClass; }
 #endif
-namespace Namesapce { class CommonClass; }
-namespace Namesapce { class AnotherCommonClass; }
+namespace Namespace { class CommonClass; }
+namespace Namespace { class AnotherCommonClass; }
 
 namespace IPC {
 
@@ -144,14 +144,14 @@ template<> struct ArgumentCoder<Namespace::ConditionalCommonClass> {
 };
 #endif
 
-template<> struct ArgumentCoder<Namesapce::CommonClass> {
-    static void encode(Encoder&, const Namesapce::CommonClass&);
-    static std::optional<Namesapce::CommonClass> decode(Decoder&);
+template<> struct ArgumentCoder<Namespace::CommonClass> {
+    static void encode(Encoder&, const Namespace::CommonClass&);
+    static std::optional<Namespace::CommonClass> decode(Decoder&);
 };
 
-template<> struct ArgumentCoder<Namesapce::AnotherCommonClass> {
-    static void encode(Encoder&, const Namesapce::AnotherCommonClass&);
-    static std::optional<Namesapce::AnotherCommonClass> decode(Decoder&);
+template<> struct ArgumentCoder<Namespace::AnotherCommonClass> {
+    static void encode(Encoder&, const Namespace::AnotherCommonClass&);
+    static std::optional<Ref<Namespace::AnotherCommonClass>> decode(Decoder&);
 };
 
 } // namespace IPC

--- a/Source/WebKit/Scripts/webkit/tests/SerializedTypeInfo.cpp
+++ b/Source/WebKit/Scripts/webkit/tests/SerializedTypeInfo.cpp
@@ -25,10 +25,10 @@
 #include "config.h"
 #include "SerializedTypeInfo.h"
 
+#include "CommonHeader.h"
 #if ENABLE(TEST_FEATURE)
 #include "CommonHeader.h"
 #endif
-#include "CommonHeader.h"
 #if ENABLE(TEST_FEATURE)
 #include "FirstMemberType.h"
 #endif
@@ -185,13 +185,13 @@ Vector<SerializedTypeInfo> allSerializedTypes()
                 "value"_s
             }
         } },
-        { "Namesapce::CommonClass"_s, {
+        { "Namespace::CommonClass"_s, {
             {
                 "int"_s,
                 "value"_s
             }
         } },
-        { "Namesapce::AnotherCommonClass"_s, {
+        { "Namespace::AnotherCommonClass"_s, {
             {
                 "int"_s,
                 "value"_s

--- a/Source/WebKit/Scripts/webkit/tests/TestSerializedType.serialization.in
+++ b/Source/WebKit/Scripts/webkit/tests/TestSerializedType.serialization.in
@@ -147,11 +147,12 @@ headers: "CommonHeader.h"
 #endif
 
 headers: "CommonHeader.h"
-[CustomHeader] class Namesapce::CommonClass {
+[CustomHeader] class Namespace::CommonClass {
     int value;
 }
 
 headers: "CommonHeader.h"
-[CustomHeader] class Namesapce::AnotherCommonClass {
+[CustomHeader, RefCounted] class Namespace::AnotherCommonClass {
     int value;
+    [NotSerialized] double notSerialized;
 }

--- a/Source/WebKit/Shared/SessionState.serialization.in
+++ b/Source/WebKit/Shared/SessionState.serialization.in
@@ -80,7 +80,9 @@ header: "SessionState.h"
 
     WebKit::PageState pageState;
     bool hasCachedPage;
-    # snapshot is not serialized.
+#if PLATFORM(COCOA) || PLATFORM(GTK)
+    [NotSerialized] RefPtr<WebKit::ViewSnapshot> snapshot;
+#endif
 };
 
 [CustomHeader] struct WebKit::BackForwardListState {

--- a/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
+++ b/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
@@ -468,6 +468,7 @@ struct WebCore::ShareData {
     String title;
     String text;
     String url;
+    [NotSerialized] Vector<RefPtr<WebCore::File>> files;
 };
 
 enum class WebCore::ShareDataOriginator : bool
@@ -562,7 +563,8 @@ class WebCore::PrivateClickMeasurement {
     std::optional<WebCore::RegistrableDomain> sourceRegistrableDomain;
     std::optional<WebCore::PCM::EphemeralNonce> ephemeralDestinationNonce;
     std::optional<WebCore::RegistrableDomain> destinationSite;
-# destinationUnlinkableToken and destinationSecretToken are not serialized.
+    [NotSerialized] std::optional<WebCore::PCM::DestinationUnlinkableToken> destinationUnlinkableToken;
+    [NotSerialized] std::optional<WebCore::PCM::DestinationSecretToken> destinationSecretToken;
 }
 
 [CustomHeader] struct WebCore::PCM::AttributionTimeToSendData {
@@ -995,6 +997,7 @@ struct WebCore::WebLockManagerSnapshot {
 
 [LegacyPopulateFromEmptyConstructor] struct WebCore::AuthenticationExtensionsClientInputs {
     String appid;
+    [NotSerialized] bool credProps;
     std::optional<WebCore::AuthenticationExtensionsClientInputs::LargeBlobInputs> largeBlob;
 }
 
@@ -1080,6 +1083,7 @@ struct WebCore::PublicKeyCredentialRequestOptions {
     Vector<WebCore::PublicKeyCredentialDescriptor> allowCredentials;
     WebCore::UserVerificationRequirement userVerification;
     std::optional<WebCore::AuthenticationExtensionsClientInputs> extensions;
+    [NotSerialized] std::optional<WebCore::AuthenticatorAttachment> authenticatorAttachment;
 #endif // ENABLE(WEB_AUTHN)
 };
 
@@ -1423,6 +1427,10 @@ struct WebCore::WindowFeatures {
 
     bool fullscreen;
     bool dialog;
+    [NotSerialized] bool noopener;
+    [NotSerialized] bool noreferrer;
+
+    [NotSerialized] Vector<String> additionalFeatures;
 };
 
 [Nested] enum class WebCore::CompositionUnderlineColor : bool
@@ -1976,6 +1984,7 @@ header: <WebCore/KeyboardScroll.h>
 };
 
 [RefCounted] class WebCore::IdentityTransformOperation {
+    [NotSerialized] WebCore::TransformOperation::Type type();
 }
 
 [RefCounted] class WebCore::TranslateTransformOperation {
@@ -2106,6 +2115,7 @@ struct WebCore::GraphicsContextGLAttributes {
     bool xrCompatible;
 #endif
     bool failPlatformContextCreationForTesting;
+    [NotSerialized] unsigned remoteIPCBufferSizeLog2ForTesting;
 };
 #endif // ENABLE(GPU_PROCESS) && ENABLE(WEBGL)
 
@@ -4395,6 +4405,8 @@ header: <WebCore/SVGFilterExpressionReference.h>
     bool madeHTTPS;
     bool blockedCookies;
     bool hasNotifications;
+    [NotSerialized] Vector<WebCore::ContentExtensions::ModifyHeadersAction> modifyHeadersActions;
+    [NotSerialized] Vector<std::pair<WebCore::ContentExtensions::RedirectAction, URL>> redirectActions;
 };
 
 struct WebCore::ContentRuleListResults {


### PR DESCRIPTION
#### be8e1cbed551b67d0203aac123801f202143abd4
<pre>
Verify non-serialized members of serialized types are not accidentally forgotten
<a href="https://bugs.webkit.org/show_bug.cgi?id=255551">https://bugs.webkit.org/show_bug.cgi?id=255551</a>
rdar://108161764

Reviewed by Chris Dumez.

I introduce the NotSerialized attribute for members that are ... not serialized.

Until we have <a href="https://wg21.link/P1240">https://wg21.link/P1240</a> in the language, we can&apos;t iterate the members
at compile time and make sure we got them all.  We already use MembersInCorrectOrder
to make sure we got them in the correct order, but we didn&apos;t have a check that we
got them all until now.  This makes a struct that has the same members in the same
order and static_asserts that it has the same size as the actual struct.

To reduce memory use and make this new sizeof trick work, I made ReportBody::type()
a virtual function call instead of using another byte to store the type.

* Source/WebCore/Modules/reporting/DeprecationReportBody.cpp:
(WebCore::DeprecationReportBody::DeprecationReportBody):
* Source/WebCore/Modules/reporting/DeprecationReportBody.h:
* Source/WebCore/Modules/reporting/ReportBody.cpp:
(WebCore::ReportBody::ReportBody): Deleted.
(WebCore::ReportBody::reportBodyType const): Deleted.
* Source/WebCore/Modules/reporting/ReportBody.h:
* Source/WebCore/Modules/reporting/TestReportBody.cpp:
(WebCore::TestReportBody::TestReportBody):
* Source/WebCore/Modules/reporting/TestReportBody.h:
* Source/WebCore/loader/COEPInheritenceViolationReportBody.cpp:
(WebCore::COEPInheritenceViolationReportBody::COEPInheritenceViolationReportBody):
* Source/WebCore/loader/COEPInheritenceViolationReportBody.h:
* Source/WebCore/loader/CORPViolationReportBody.cpp:
(WebCore::CORPViolationReportBody::CORPViolationReportBody):
* Source/WebCore/loader/CORPViolationReportBody.h:
* Source/WebCore/page/csp/CSPViolationReportBody.cpp:
(WebCore::CSPViolationReportBody::CSPViolationReportBody):
* Source/WebCore/page/csp/CSPViolationReportBody.h:
* Source/WebKit/NetworkProcess/NetworkResourceLoadParameters.serialization.in:
* Source/WebKit/Scripts/generate-serializers.py:
(SerializedType.__init__):
(SerializedType.has_bit_field):
(SerializedType):
(SerializedType.serialized_members):
(check_type_members):
(check_type_members.is):
(check_type_members.is.is):
(encode_type):
(decode_type):
(construct_type):
(generate_impl):
(generate_serialized_type_info):
* Source/WebKit/Scripts/webkit/tests/GeneratedSerializers.cpp:
(IPC::ArgumentCoder&lt;Namespace::Subnamespace::StructName&gt;::encode):
(IPC::ArgumentCoder&lt;Namespace::EmptyConstructorNullable&gt;::encode):
(IPC::ArgumentCoder&lt;WithoutNamespace&gt;::encode):
(IPC::ArgumentCoder&lt;WithoutNamespaceWithAttributes&gt;::encode):
(IPC::ArgumentCoder&lt;WTF::CreateUsingClass&gt;::encode):
(IPC::ArgumentCoder&lt;NullableSoftLinkedMember&gt;::encode):
(IPC::ArgumentCoder&lt;Namespace::ConditionalCommonClass&gt;::encode):
(IPC::ArgumentCoder&lt;Namesapce::CommonClass&gt;::encode):
(IPC::ArgumentCoder&lt;Namesapce::AnotherCommonClass&gt;::encode):
(IPC::ArgumentCoder&lt;Namesapce::AnotherCommonClass&gt;::decode):
* Source/WebKit/Scripts/webkit/tests/GeneratedSerializers.h:
* Source/WebKit/Scripts/webkit/tests/SerializedTypeInfo.cpp:
* Source/WebKit/Scripts/webkit/tests/TestSerializedType.serialization.in:
* Source/WebKit/Shared/SessionState.serialization.in:
* Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in:

Canonical link: <a href="https://commits.webkit.org/263133@main">https://commits.webkit.org/263133@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/069974c8da3d7a0d9f28e56a357409548e64e349

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/3647 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/3737 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/3837 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/5073 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/3934 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/3621 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/3792 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/3736 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/3161 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/3691 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/3922 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/3285 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/4912 "Built successfully") | 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/3678 "Passed tests") | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/1429 "1 failures") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/3256 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/3329 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/3231 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/3315 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/4679 "run-api-tests-without-change (failure)") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/3700 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/2991 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/3234 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/3256 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/3266 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/421 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/3511 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->