### PR TITLE
Fullscreen video size/position is incorrect on YouTube when minimumEffectiveDeviceWidth is set

### DIFF
--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebView.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebView.mm
@@ -1639,6 +1639,13 @@ inline OptionSet<WebKit::FindOptions> toFindOptions(WKFindConfiguration *configu
     });
 }
 
+- (void)_doAfterNextVisibleContentRectAndPresentationUpdate:(void (^)(void))updateBlock
+{
+    [self _doAfterNextVisibleContentRectUpdate:makeBlockPtr([strongSelf = retainPtr(self), updateBlock = makeBlockPtr(updateBlock)] {
+        [strongSelf _doAfterNextPresentationUpdate:updateBlock.get()];
+    }).get()];
+}
+
 - (void)_recalculateViewportSizesWithMinimumViewportInset:(CocoaEdgeInsets)minimumViewportInset maximumViewportInset:(CocoaEdgeInsets)maximumViewportInset throwOnInvalidInput:(BOOL)throwOnInvalidInput
 {
     auto frame = WebCore::FloatSize(self.frame.size);

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebViewInternal.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebViewInternal.h
@@ -336,6 +336,8 @@ struct PerWebProcessState {
 
 - (void)_internalDoAfterNextPresentationUpdate:(void (^)(void))updateBlock withoutWaitingForPainting:(BOOL)withoutWaitingForPainting withoutWaitingForAnimatedResize:(BOOL)withoutWaitingForAnimatedResize;
 
+- (void)_doAfterNextVisibleContentRectAndPresentationUpdate:(void (^)(void))updateBlock;
+
 - (void)_recalculateViewportSizesWithMinimumViewportInset:(CocoaEdgeInsets)minimumViewportInset maximumViewportInset:(CocoaEdgeInsets)maximumViewportInset throwOnInvalidInput:(BOOL)throwOnInvalidInput;
 
 - (void)_showSafeBrowsingWarning:(const WebKit::SafeBrowsingWarning&)warning completionHandler:(CompletionHandler<void(std::variant<WebKit::ContinueUnsafeLoad, URL>&&)>&&)completionHandler;


### PR DESCRIPTION
#### b42eaa63ce43d533c18d3ffc18ef29ef6b8f3ee1
<pre>
Fullscreen video size/position is incorrect on YouTube when minimumEffectiveDeviceWidth is set
<a href="https://bugs.webkit.org/show_bug.cgi?id=255556">https://bugs.webkit.org/show_bug.cgi?id=255556</a>
rdar://101557743

Reviewed by Tim Horton.

Entering fullscreen on youtube.com for a `WKWebView` with a non-zero
`minimumEffectiveDeviceWidth` currently results in portions of the video
becoming clipped, the top of the video being incorrectly offset from the top of
the window.

In fullscreen, YouTube explicitly sets the width/height of the video element to
the `clientWidth`/`clientHeight` of the fullscreen element, inside the
`fullscreenchange` event. The fullscreen element is a wrapper `&lt;div&gt;` containing
the video element, with width/height: 100%.

Currently, the `WKWebView`&apos;s frame is adjusted prior to dispatching the
`fullscreenchange` event, but the `minimumEffectiveDeviceWidth` is not. This
results in the viewport state continuing to incorporate the
`minimumEffectiveDeviceWidth`, which may be larger than the width of the
fullscreen window. The larger size also results in an offset from the top of the
window, as the video element has `object-fit: contain`. The video is smaller
than its element&apos;s size, and is vertically centered relative to the larger size.

To fix, ensure `minimumEffectiveDeviceWidth` is unset prior to dispatching the
`fullscreenchange` event. However, simply updating the value in the UI process
prior to dispatching `willEnterFullscreen` is not enough, as the visible content
rect update is asynchronous in both the UI and web processes. This means that
there is no guarantee that the viewport state in the web process will be correct
at the time of `fullscreenchange` event dispatch. To fix the secondary issue,
introduce `-[WKWebView _doAfterNextVisibleContentRectAndPresentationUpdate]` to
ensure the correct viewport state is reflected in the web process prior to
dispatching the `fullscreenchange` event.

* Source/WebKit/UIProcess/API/Cocoa/WKWebView.mm:
(-[WKWebView _doAfterNextVisibleContentRectAndPresentationUpdate:]):
* Source/WebKit/UIProcess/API/Cocoa/WKWebViewInternal.h:

Introduce `_doAfterNextVisibleContentRectAndPresentationUpdate`, used to ensure
ensure that the next visible content rect update is accurately reflected in
the web process, prior to performing the update block.

* Source/WebKit/UIProcess/ios/fullscreen/WKFullScreenWindowControllerIOS.mm:
(-[WKFullScreenWindowController enterFullScreen:]):

Unset `minimumEffectiveDeviceWidth` prior to dispatching the `fullscreenchange`
event, so that the viewport state accurately reflects the size of the fullscreen
window.

The original value is already stored `WKWebViewState`, and is restored on
fullscreen exit.

Canonical link: <a href="https://commits.webkit.org/263082@main">https://commits.webkit.org/263082@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9333a572ab27761242647a07d9cb533314c606c8

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/3465 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/3520 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/3652 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/4891 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/3760 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/3600 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/3554 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/3012 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/3507 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/3767 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/3123 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/4711 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/1275 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/3102 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/2998 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/3068 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/3161 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/4457 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/3531 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/2841 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/3074 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/3100 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/865 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/3097 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/3352 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->