### PR TITLE
`navigator.storage.getDirectory()` fails in nested workers with an `InvalidStateError`

### DIFF
--- a/LayoutTests/TestExpectations
+++ b/LayoutTests/TestExpectations
@@ -214,6 +214,7 @@ imported/w3c/web-platform-tests/storage/ [ Skip ]
 imported/w3c/web-platform-tests/file-system-access/ [ Skip ]
 imported/w3c/web-platform-tests/fs/ [ Skip ]
 storage/filesystemaccess/ [ Skip ]
+storage/storagemanager/ [ Skip ]
 
 # app-privacy-report tests are iOS only.
 http/tests/app-privacy-report/ [ Skip ]

--- a/LayoutTests/platform/wk2/TestExpectations
+++ b/LayoutTests/platform/wk2/TestExpectations
@@ -855,7 +855,7 @@ imported/w3c/web-platform-tests/permissions/ [ Pass ]
 http/tests/notifications/permission/ [ Pass ]
 http/tests/permissions/ [ Pass ]
 imported/w3c/web-platform-tests/storage/ [ Pass ]
-
+storage/storagemanager/ [ Pass ]
 fast/canvas/large-getImageData.html [ Pass ]
 
 webkit.org/b/253533 imported/w3c/web-platform-tests/fetch/api/basic/status.h2.any.html [ Pass Failure ]

--- a/LayoutTests/storage/storagemanager/nested-dedicated-workers-expected.txt
+++ b/LayoutTests/storage/storagemanager/nested-dedicated-workers-expected.txt
@@ -1,0 +1,12 @@
+[Worker] This test ensures StorageManager API works in nested dedicated workers.
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+Starting worker: resources/nested-dedicated-workers.js
+PASS [Worker] estimate.quota is non-null.
+PASS [Worker] estimate.usage is non-null.
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/storage/storagemanager/nested-dedicated-workers.html
+++ b/LayoutTests/storage/storagemanager/nested-dedicated-workers.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html>
+<head>
+<script src="../../resources/js-test.js"></script>
+</head>
+<body>
+<script>
+jsTestIsAsync = true;
+worker = startWorker('resources/nested-dedicated-workers.js');
+</script>
+</body>
+</html>

--- a/LayoutTests/storage/storagemanager/resources/nested-dedicated-workers.js
+++ b/LayoutTests/storage/storagemanager/resources/nested-dedicated-workers.js
@@ -1,0 +1,19 @@
+if (this.importScripts) {
+    importScripts('../../../resources/js-test.js');
+}
+
+description("This test ensures StorageManager API works in nested dedicated workers.");
+
+var estimate = null;
+var nestedWorker = new Worker('nested-dedicated-workers2.js');
+nestedWorker.onmessage = (event) => {
+    estimate = event.data;
+    shouldBeNonNull("estimate.quota");
+    shouldBeNonNull("estimate.usage");
+    finishJSTest();
+};
+
+nestedWorker.onerror = (event) => {
+    testFailed('nestedWorker has error ' + event.message());
+    finishJSTest();
+}

--- a/LayoutTests/storage/storagemanager/resources/nested-dedicated-workers2.js
+++ b/LayoutTests/storage/storagemanager/resources/nested-dedicated-workers2.js
@@ -1,0 +1,9 @@
+if (navigator.storage) {
+	navigator.storage.estimate().then((estimate) => {
+		self.postMessage(estimate);
+	}).catch((error) => {
+		self.postMessage('fail');
+	}); 
+} else {
+	self.postMessage('navigator.storage is not available');
+}

--- a/Source/WebCore/Modules/storage/WorkerStorageConnection.cpp
+++ b/Source/WebCore/Modules/storage/WorkerStorageConnection.cpp
@@ -66,12 +66,15 @@ void WorkerStorageConnection::getPersisted(ClientOrigin&& origin, StorageConnect
     auto callbackIdentifier = ++m_lastCallbackIdentifier;
     m_getPersistedCallbacks.add(callbackIdentifier, WTFMove(completionHandler));
 
-    callOnMainThread([callbackIdentifier, workerThread = Ref { m_scope->thread() }, origin = WTFMove(origin).isolatedCopy()]() mutable {
-        auto mainThreadConnection = workerThread->workerLoaderProxy().storageConnection();
-        auto mainThreadCallback = [callbackIdentifier, workerThread = WTFMove(workerThread)](bool result) mutable {
-            workerThread->runLoop().postTaskForMode([callbackIdentifier, result] (auto& scope) mutable {
+    m_scope->thread().workerLoaderProxy().postTaskToLoader([callbackIdentifier, contextIdentifier = m_scope->identifier(), origin = WTFMove(origin).isolatedCopy()](auto& context) mutable {
+        ASSERT(isMainThread());
+
+        auto& document = downcast<Document>(context);
+        auto mainThreadConnection = document.storageConnection();
+        auto mainThreadCallback = [callbackIdentifier, contextIdentifier](bool result) mutable {
+            ScriptExecutionContext::postTaskTo(contextIdentifier, [callbackIdentifier, result] (auto& scope) mutable {
                 downcast<WorkerGlobalScope>(scope).storageConnection().didGetPersisted(callbackIdentifier, result);
-            }, WorkerRunLoop::defaultMode());
+            });
         };
         if (!mainThreadConnection)
             return mainThreadCallback(false);
@@ -93,12 +96,15 @@ void WorkerStorageConnection::getEstimate(ClientOrigin&& origin, StorageConnecti
     auto callbackIdentifier = ++m_lastCallbackIdentifier;
     m_getEstimateCallbacks.add(callbackIdentifier, WTFMove(completionHandler));
 
-    callOnMainThread([callbackIdentifier, workerThread = Ref { m_scope->thread() }, origin = WTFMove(origin).isolatedCopy()]() mutable {
-        auto mainThreadConnection = workerThread->workerLoaderProxy().storageConnection();
-        auto mainThreadCallback = [callbackIdentifier, workerThread = WTFMove(workerThread)](auto&& result) mutable {
-            workerThread->runLoop().postTaskForMode([callbackIdentifier, result = crossThreadCopy(WTFMove(result))] (auto& scope) mutable {
+    m_scope->thread().workerLoaderProxy().postTaskToLoader([callbackIdentifier, contextIdentifier = m_scope->identifier(), origin = WTFMove(origin).isolatedCopy()](auto& context) mutable {
+        ASSERT(isMainThread());
+
+        auto& document = downcast<Document>(context);
+        auto mainThreadConnection = document.storageConnection();
+        auto mainThreadCallback = [callbackIdentifier, contextIdentifier](auto&& result) mutable {
+            ScriptExecutionContext::postTaskTo(contextIdentifier, [callbackIdentifier, result = crossThreadCopy(WTFMove(result))] (auto& scope) mutable {
                 downcast<WorkerGlobalScope>(scope).storageConnection().didGetEstimate(callbackIdentifier, WTFMove(result));
-            }, WorkerRunLoop::defaultMode());
+            });
         };
         if (!mainThreadConnection)
             return mainThreadCallback(Exception { InvalidStateError });
@@ -120,12 +126,15 @@ void WorkerStorageConnection::fileSystemGetDirectory(ClientOrigin&& origin, Stor
     auto callbackIdentifier = ++m_lastCallbackIdentifier;
     m_getDirectoryCallbacks.add(callbackIdentifier, WTFMove(completionHandler));
 
-    callOnMainThread([callbackIdentifier, workerThread = Ref { m_scope->thread() }, origin = WTFMove(origin).isolatedCopy()]() mutable {
-        auto mainThreadConnection = workerThread->workerLoaderProxy().storageConnection();
-        auto mainThreadCallback = [callbackIdentifier, workerThread = WTFMove(workerThread)](auto&& result) mutable {
-            workerThread->runLoop().postTaskForMode([callbackIdentifier, result = crossThreadCopy(WTFMove(result))] (auto& scope) mutable {
+    m_scope->thread().workerLoaderProxy().postTaskToLoader([callbackIdentifier, contextIdentifier = m_scope->identifier(), origin = WTFMove(origin).isolatedCopy()](auto& context) mutable {
+        ASSERT(isMainThread());
+
+        auto& document = downcast<Document>(context);
+        auto mainThreadConnection = document.storageConnection();
+        auto mainThreadCallback = [callbackIdentifier, contextIdentifier](auto&& result) mutable {
+            ScriptExecutionContext::postTaskTo(contextIdentifier, [callbackIdentifier, result = crossThreadCopy(WTFMove(result))] (auto& scope) mutable {
                 downcast<WorkerGlobalScope>(scope).storageConnection().didGetDirectory(callbackIdentifier, WTFMove(result));
-            }, WorkerRunLoop::defaultMode());
+            });
         };
         if (!mainThreadConnection)
             return mainThreadCallback(Exception { InvalidStateError });

--- a/Source/WebCore/workers/WorkerLoaderProxy.h
+++ b/Source/WebCore/workers/WorkerLoaderProxy.h
@@ -50,9 +50,6 @@ public:
     // Creates a cache storage connection to be used on the main thread. Method must be called on the main thread.
     virtual RefPtr<CacheStorageConnection> createCacheStorageConnection() = 0;
 
-    // Get the storage connection to be used on the main thread.
-    virtual StorageConnection* storageConnection() { return nullptr; };
-
     virtual RefPtr<RTCDataChannelRemoteHandlerConnection> createRTCDataChannelRemoteHandlerConnection() = 0;
 
     virtual ScriptExecutionContextIdentifier loaderContextIdentifier() const = 0;

--- a/Source/WebCore/workers/WorkerMessagingProxy.cpp
+++ b/Source/WebCore/workers/WorkerMessagingProxy.cpp
@@ -289,15 +289,6 @@ RefPtr<CacheStorageConnection> WorkerMessagingProxy::createCacheStorageConnectio
     return document->page()->cacheStorageProvider().createCacheStorageConnection();
 }
 
-StorageConnection* WorkerMessagingProxy::storageConnection()
-{
-    ASSERT(isMainThread());
-    auto* document = dynamicDowncast<Document>(*m_scriptExecutionContext);
-    ASSERT(document);
-
-    return document ? document->storageConnection() : nullptr;
-}
-
 RefPtr<RTCDataChannelRemoteHandlerConnection> WorkerMessagingProxy::createRTCDataChannelRemoteHandlerConnection()
 {
     ASSERT(isMainThread());

--- a/Source/WebCore/workers/WorkerMessagingProxy.h
+++ b/Source/WebCore/workers/WorkerMessagingProxy.h
@@ -77,7 +77,6 @@ private:
     void postTaskToLoader(ScriptExecutionContext::Task&&) final;
     ScriptExecutionContextIdentifier loaderContextIdentifier() const final;
     RefPtr<CacheStorageConnection> createCacheStorageConnection() final;
-    StorageConnection* storageConnection() final;
     RefPtr<RTCDataChannelRemoteHandlerConnection> createRTCDataChannelRemoteHandlerConnection() final;
 
     void workerThreadCreated(DedicatedWorkerThread&);


### PR DESCRIPTION
#### 808b1c7f159a61619bcf30a61a4df9b69089fc64
<pre>
`navigator.storage.getDirectory()` fails in nested workers with an `InvalidStateError`
<a href="https://bugs.webkit.org/show_bug.cgi?id=255458">https://bugs.webkit.org/show_bug.cgi?id=255458</a>
rdar://108069396

Reviewed by Chris Dumez.

WorkerStorageConnection assumes its Worker&apos;s loader is a Document, and thus posts tasks to main thread and asks for
StorageConnection from its loader (WorkerLoaderProxy) directly. This is no longer true after nested worker is enabled --
the loader might be another Worker. Therefore it should get StorageConnection from the real main thread loader (via
WorkerLoaderProxy::postTaskToLoader).

Test: storage/storagemanager/nested-dedicated-workers.html

* LayoutTests/TestExpectations:
* LayoutTests/platform/wk2/TestExpectations:
* LayoutTests/storage/storagemanager/nested-dedicated-workers-expected.txt: Added.
* LayoutTests/storage/storagemanager/nested-dedicated-workers.html: Added.
* LayoutTests/storage/storagemanager/resources/nested-dedicated-workers.js: Added.
(nestedWorker.onmessage):
(nestedWorker.onerror):
* LayoutTests/storage/storagemanager/resources/nested-dedicated-workers2.js: Added.
(navigator.storage.navigator.storage.estimate.then):
(navigator.storage.catch):
* Source/WebCore/Modules/storage/WorkerStorageConnection.cpp:
(WebCore::WorkerStorageConnection::getPersisted):
(WebCore::WorkerStorageConnection::getEstimate):
(WebCore::WorkerStorageConnection::fileSystemGetDirectory):
* Source/WebCore/workers/WorkerLoaderProxy.h:
(WebCore::WorkerLoaderProxy::storageConnection): Deleted.
* Source/WebCore/workers/WorkerMessagingProxy.cpp:
(WebCore::WorkerMessagingProxy::storageConnection): Deleted.
* Source/WebCore/workers/WorkerMessagingProxy.h:

Canonical link: <a href="https://commits.webkit.org/263075@main">https://commits.webkit.org/263075@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f160331669f301d94ad00dfb3ea7c961bfc4a8c9

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/3509 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/3558 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/3694 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/4931 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/3788 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/3487 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/3643 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/3597 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/3049 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/3551 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/3803 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/3160 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/4752 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/1312 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/3137 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/3037 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/3108 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/3196 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/4509 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/3569 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/2878 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/3111 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/3135 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/856 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/3136 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/3389 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->