### PR TITLE
DFG tuples should not be queried for their state

### DIFF
--- a/JSTests/stress/dfg-tuple-ai.js
+++ b/JSTests/stress/dfg-tuple-ai.js
@@ -1,0 +1,26 @@
+//@ runDefault("--thresholdForOptimizeAfterWarmUp=0", "--thresholdForOptimizeSoon=0", "--thresholdForFTLOptimizeAfterWarmUp=0")
+function f3(a4) {
+    const o7 = {
+        ["forEach"]: "pCGSxWy10A",
+        set e(a6) {
+        },
+    };
+    return a4;
+}
+f3("forEach");
+f3("pCGSxWy10A");
+f3("function");
+const v12 = new Int8Array();
+const v14 = new Uint8ClampedArray(v12);
+for (const v15 in "pCGSxWy10A") {
+    for (let v16 = 0; v16 < 100; v16++) {
+        for (let v18 = 0; v18 < 10; v18++) {
+            try {
+                (2147483649).toString(v16);
+            } catch(e20) {
+            }
+        }
+    }
+}
+f3(v12);
+gc();

--- a/Source/JavaScriptCore/dfg/DFGAbstractInterpreter.h
+++ b/Source/JavaScriptCore/dfg/DFGAbstractInterpreter.h
@@ -47,6 +47,11 @@ public:
     {
         return m_state.forNode(node);
     }
+
+    ALWAYS_INLINE AbstractValue& forTupleNode(NodeFlowProjection node, unsigned index)
+    {
+        return m_state.forTupleNode(node, index);
+    }
     
     ALWAYS_INLINE AbstractValue& forNode(Edge edge)
     {

--- a/Source/JavaScriptCore/dfg/DFGAtTailAbstractState.cpp
+++ b/Source/JavaScriptCore/dfg/DFGAtTailAbstractState.cpp
@@ -56,6 +56,7 @@ void AtTailAbstractState::createValueForNode(NodeFlowProjection node)
 
 AbstractValue& AtTailAbstractState::forNode(NodeFlowProjection node)
 {
+    ASSERT(!node->isTuple());
     auto& valuesAtTail = m_valuesAtTailMap.at(m_block);
     HashMap<NodeFlowProjection, AbstractValue>::iterator iter = valuesAtTail.find(node);
     DFG_ASSERT(m_graph, node.node(), iter != valuesAtTail.end());

--- a/Source/JavaScriptCore/dfg/DFGAtTailAbstractState.h
+++ b/Source/JavaScriptCore/dfg/DFGAtTailAbstractState.h
@@ -54,10 +54,15 @@ public:
     AbstractValue& fastForward(AbstractValue& value) { return value; }
     
     AbstractValue& forNode(NodeFlowProjection);
-    AbstractValue& forNode(Edge edge) { return forNode(edge.node()); }
+    AbstractValue& forNode(Edge edge)
+    {
+        ASSERT(!edge.node()->isTuple());
+        return forNode(edge.node());
+    }
     
     ALWAYS_INLINE AbstractValue& forNodeWithoutFastForward(NodeFlowProjection node)
     {
+        ASSERT(!node->isTuple());
         return forNode(node);
     }
     
@@ -73,6 +78,7 @@ public:
     
     ALWAYS_INLINE void clearForNode(NodeFlowProjection node)
     {
+        ASSERT(!node->isTuple());
         forNode(node).clear();
     }
     
@@ -84,6 +90,7 @@ public:
     template<typename... Arguments>
     ALWAYS_INLINE void setForNode(NodeFlowProjection node, Arguments&&... arguments)
     {
+        ASSERT(!node->isTuple());
         forNode(node).set(m_graph, std::forward<Arguments>(arguments)...);
     }
 
@@ -135,6 +142,11 @@ public:
     ALWAYS_INLINE void makeHeapTopForNode(Edge edge)
     {
         makeHeapTopForNode(edge.node());
+    }
+
+    ALWAYS_INLINE AbstractValue& forTupleNodeWithoutFastForward(NodeFlowProjection node, unsigned index)
+    {
+        return forTupleNode(node, index);
     }
 
     ALWAYS_INLINE AbstractValue& forTupleNode(NodeFlowProjection node, unsigned index)

--- a/Source/JavaScriptCore/dfg/DFGInPlaceAbstractState.h
+++ b/Source/JavaScriptCore/dfg/DFGInPlaceAbstractState.h
@@ -60,16 +60,19 @@ public:
     
     ALWAYS_INLINE AbstractValue& forNodeWithoutFastForward(NodeFlowProjection node)
     {
+        ASSERT(!node->isTuple());
         return m_abstractValues.at(node);
     }
     
     ALWAYS_INLINE AbstractValue& forNodeWithoutFastForward(Edge edge)
     {
+        ASSERT(!edge.node()->isTuple());
         return forNodeWithoutFastForward(edge.node());
     }
     
     ALWAYS_INLINE AbstractValue& forNode(NodeFlowProjection node)
     {
+        ASSERT(!node->isTuple());
         return fastForward(m_abstractValues.at(node));
     }
     
@@ -80,6 +83,7 @@ public:
     
     ALWAYS_INLINE void clearForNode(NodeFlowProjection node)
     {
+        ASSERT(!node->isTuple());
         AbstractValue& value = m_abstractValues.at(node);
         value.clear();
         value.m_effectEpoch = m_effectEpoch;
@@ -93,6 +97,7 @@ public:
     template<typename... Arguments>
     ALWAYS_INLINE void setForNode(NodeFlowProjection node, Arguments&&... arguments)
     {
+        ASSERT(!node->isTuple());
         AbstractValue& value = m_abstractValues.at(node);
         value.set(m_graph, std::forward<Arguments>(arguments)...);
         value.m_effectEpoch = m_effectEpoch;
@@ -107,6 +112,7 @@ public:
     template<typename... Arguments>
     ALWAYS_INLINE void setTypeForNode(NodeFlowProjection node, Arguments&&... arguments)
     {
+        ASSERT(!node->isTuple());
         AbstractValue& value = m_abstractValues.at(node);
         value.setType(m_graph, std::forward<Arguments>(arguments)...);
         value.m_effectEpoch = m_effectEpoch;
@@ -121,6 +127,7 @@ public:
     template<typename... Arguments>
     ALWAYS_INLINE void setNonCellTypeForNode(NodeFlowProjection node, Arguments&&... arguments)
     {
+        ASSERT(!node->isTuple());
         AbstractValue& value = m_abstractValues.at(node);
         value.setNonCellType(std::forward<Arguments>(arguments)...);
         value.m_effectEpoch = m_effectEpoch;
@@ -134,6 +141,7 @@ public:
     
     ALWAYS_INLINE void makeBytecodeTopForNode(NodeFlowProjection node)
     {
+        ASSERT(!node->isTuple());
         AbstractValue& value = m_abstractValues.at(node);
         value.makeBytecodeTop();
         value.m_effectEpoch = m_effectEpoch;
@@ -146,6 +154,7 @@ public:
     
     ALWAYS_INLINE void makeHeapTopForNode(NodeFlowProjection node)
     {
+        ASSERT(!node->isTuple());
         AbstractValue& value = m_abstractValues.at(node);
         value.makeHeapTop();
         value.m_effectEpoch = m_effectEpoch;
@@ -154,6 +163,13 @@ public:
     ALWAYS_INLINE void makeHeapTopForNode(Edge edge)
     {
         makeHeapTopForNode(edge.node());
+    }
+
+    ALWAYS_INLINE AbstractValue& forTupleNodeWithoutFastForward(NodeFlowProjection node, unsigned index)
+    {
+        ASSERT(node->isTuple());
+        ASSERT(index < node->tupleSize());
+        return m_tupleAbstractValues.at(node->tupleOffset() + index);
     }
     
     ALWAYS_INLINE AbstractValue& forTupleNode(NodeFlowProjection node, unsigned index)


### PR DESCRIPTION
#### 39dd6c8334a66035cb396c8593a28dfca2b50f5e
<pre>
DFG tuples should not be queried for their state
rdar://107876378
<a href="https://bugs.webkit.org/show_bug.cgi?id=255279">https://bugs.webkit.org/show_bug.cgi?id=255279</a>

Reviewed by Keith Miller.

DFG tuples don&apos;t have a type themselves, they represent a collection of
elements. We should only ask questions about the type of an element of a tuple,
never the tuple directly. Edges to a tuple should always be Untyped.

In this test case, we get garbage data when we ask for the type of EnumeratorNextUpdateIndexAndMode
from ExtractFromTuple. We remove the assert for this case and add some extra
assertions to make sure that nobody else is making the same mistake.

* JSTests/stress/dfg-tuple-ai.js: Added.
(f3.const.o7.set e):
(f3):
(const.v15.in.string_appeared_here.v16.v18.catch):
* Source/JavaScriptCore/dfg/DFGAbstractInterpreter.h:
(JSC::DFG::AbstractInterpreter::forTupleNode):
* Source/JavaScriptCore/dfg/DFGAbstractInterpreterInlines.h:
(JSC::DFG::AbstractInterpreter&lt;AbstractStateType&gt;::verifyEdge):
* Source/JavaScriptCore/dfg/DFGAtTailAbstractState.cpp:
(JSC::DFG::AtTailAbstractState::forNode):
* Source/JavaScriptCore/dfg/DFGAtTailAbstractState.h:
(JSC::DFG::AtTailAbstractState::forNode):
(JSC::DFG::AtTailAbstractState::forNodeWithoutFastForward):
(JSC::DFG::AtTailAbstractState::clearForNode):
(JSC::DFG::AtTailAbstractState::setForNode):
(JSC::DFG::AtTailAbstractState::forTupleNodeWithoutFastForward):
* Source/JavaScriptCore/dfg/DFGInPlaceAbstractState.h:
(JSC::DFG::InPlaceAbstractState::forNodeWithoutFastForward):
(JSC::DFG::InPlaceAbstractState::forNode):
(JSC::DFG::InPlaceAbstractState::clearForNode):
(JSC::DFG::InPlaceAbstractState::setForNode):
(JSC::DFG::InPlaceAbstractState::setTypeForNode):
(JSC::DFG::InPlaceAbstractState::setNonCellTypeForNode):
(JSC::DFG::InPlaceAbstractState::makeBytecodeTopForNode):
(JSC::DFG::InPlaceAbstractState::makeHeapTopForNode):
(JSC::DFG::InPlaceAbstractState::forTupleNodeWithoutFastForward):

Canonical link: <a href="https://commits.webkit.org/263433@main">https://commits.webkit.org/263433@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/99e2a19f58a9b2f863b9ab012121dde58406fa02

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/3485 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/3536 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/3670 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/4907 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/3772 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/3619 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/3573 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/3027 "110 failures") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/3527 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/3783 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/3135 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/4727 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/1292 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/3113 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/3019 "Passed tests") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/2853 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/3086 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/3172 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/4500 "Passed tests") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/3267 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/3547 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/2856 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/3556 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/3090 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/3111 "Passed tests") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/898 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/1130 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/3113 "Built successfully") | | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/24/builds/3648 "Built successfully") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/3368 "Built successfully") | | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/3/builds/1009 "Passed tests") | 
<!--EWS-Status-Bubble-End-->