### PR TITLE
clang-cl reports "error: reference to 'UUID' is ambiguous" for Windows port

### DIFF
--- a/Source/WTF/wtf/Forward.h
+++ b/Source/WTF/wtf/Forward.h
@@ -251,3 +251,22 @@ template<class E> using Unexpected = std::experimental::unexpected<E>;
 #define WTF_LAZY_HAS_REST_8 WTF_LAZY_EXPAND
 #define WTF_LAZY_HAS_REST(...) \
     WTF_LAZY_JOIN(WTF_LAZY_HAS_REST_, WTF_LAZY_NUM_ARGS(__VA_ARGS__))
+
+#if OS(WINDOWS)
+// <windows.h> contains ::UUID. Define UUID in each namespace that is using it.
+namespace IPC {
+using WTF::UUID;
+}
+namespace Messages {
+using WTF::UUID;
+}
+namespace WTR {
+using WTF::UUID;
+}
+namespace WebCore {
+using WTF::UUID;
+}
+namespace WebKit {
+using WTF::UUID;
+}
+#endif

--- a/Source/WebKit/UIProcess/API/APIUserInitiatedAction.h
+++ b/Source/WebKit/UIProcess/API/APIUserInitiatedAction.h
@@ -43,12 +43,12 @@ public:
     void setConsumed() { m_consumed = true; }
     bool consumed() const { return m_consumed; }
 
-    void setAuthorizationToken(UUID authorizationToken) { m_authorizationToken = authorizationToken; }
-    std::optional<UUID> authorizationToken() const { return m_authorizationToken; }
+    void setAuthorizationToken(WTF::UUID authorizationToken) { m_authorizationToken = authorizationToken; }
+    std::optional<WTF::UUID> authorizationToken() const { return m_authorizationToken; }
 
 private:
     bool m_consumed { false };
-    std::optional<UUID> m_authorizationToken;
+    std::optional<WTF::UUID> m_authorizationToken;
 };
 
 } // namespace API

--- a/Source/WebKit/UIProcess/API/C/WKNotificationManager.cpp
+++ b/Source/WebKit/UIProcess/API/C/WKNotificationManager.cpp
@@ -61,7 +61,7 @@ void WKNotificationManagerProviderDidClickNotification_b(WKNotificationManagerRe
     if (span.size() != 16)
         return;
 
-    toImpl(managerRef)->providerDidClickNotification(UUID { Span<const uint8_t, 16> { span.data(), 16 } });
+    toImpl(managerRef)->providerDidClickNotification(WTF::UUID { Span<const uint8_t, 16> { span.data(), 16 } });
 }
 
 void WKNotificationManagerProviderDidCloseNotifications(WKNotificationManagerRef managerRef, WKArrayRef notificationIDs)


### PR DESCRIPTION
#### ee81fa18a490a4867239de7706918102b04b0da6
<pre>
clang-cl reports &quot;error: reference to &apos;UUID&apos; is ambiguous&quot; for Windows port
<a href="https://bugs.webkit.org/show_bug.cgi?id=234696">https://bugs.webkit.org/show_bug.cgi?id=234696</a>

Reviewed by NOBODY (OOPS!).

Including &lt;windows.h&gt; defines `UUID` in the global scope. This
conflicted with &quot;using WTF::UUID;&quot; in &lt;wtf/Forward.h&gt;. For the
workaround, define `UUID` in each namespace that is using it in
&lt;wtf/Forward.h&gt; for OS(WINDOWS).

* Source/WTF/wtf/Forward.h:
* Source/WebKit/UIProcess/API/APIUserInitiatedAction.h:
* Source/WebKit/UIProcess/API/C/WKNotificationManager.cpp:
(WKNotificationManagerProviderDidClickNotification_b):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ee81fa18a490a4867239de7706918102b04b0da6

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/3504 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/3553 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/3689 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/4926 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/3784 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/3638 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/3592 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/3045 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/3546 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/3802 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/3156 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/4747 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/1311 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/3133 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/3032 "Passed tests") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/2866 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/3106 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/3192 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/4497 "run-api-tests-without-change (failure)") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/3285 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/3565 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/2874 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/3575 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/3107 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/3131 "Passed tests") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/908 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/3132 "Built successfully") | | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/24/builds/3667 "Built successfully") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/3385 "Built successfully") | | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/3/builds/1019 "Passed tests") | 
<!--EWS-Status-Bubble-End-->