### PR TITLE
Remove storage limit on single FileSystemSyncAccessHandle

### DIFF
--- a/LayoutTests/storage/filesystemaccess/sync-access-handle-read-write-worker.html
+++ b/LayoutTests/storage/filesystemaccess/sync-access-handle-read-write-worker.html
@@ -4,6 +4,10 @@
 </head>
 <body>
 <script>
+if (window.testRunner) {
+	testRunner.setQuota(1099511627776); // 1 TB
+	testRunner.setAllowStorageQuotaIncrease(false);
+}
 worker = startWorker('resources/sync-access-handle-read-write.js');</script>
 </body>
 </html>

--- a/Source/WebKit/NetworkProcess/storage/FileSystemStorageHandle.cpp
+++ b/Source/WebKit/NetworkProcess/storage/FileSystemStorageHandle.cpp
@@ -41,7 +41,6 @@ constexpr char pathSeparator = '/';
 constexpr uint64_t defaultInitialCapacity = 1 * MB;
 constexpr uint64_t defaultMaxCapacityForExponentialGrowth = 256 * MB;
 constexpr uint64_t defaultCapacityStep = 128 * MB;
-constexpr uint64_t defaultMaxCapacity = 16 * GB;
 
 std::unique_ptr<FileSystemStorageHandle> FileSystemStorageHandle::create(FileSystemStorageManager& manager, Type type, String&& path, String&& name)
 {
@@ -301,9 +300,6 @@ void FileSystemStorageHandle::requestNewCapacityForSyncAccessHandle(WebCore::Fil
         return completionHandler(currentCapacity);
 
     if (!m_manager)
-        return completionHandler(std::nullopt);
-
-    if (newCapacity > defaultMaxCapacity)
         return completionHandler(std::nullopt);
 
     if (newCapacity < defaultInitialCapacity)


### PR DESCRIPTION
#### ff428551109230c48056178c38eb43b5d8c5ab6c
<pre>
Remove storage limit on single FileSystemSyncAccessHandle
<a href="https://bugs.webkit.org/show_bug.cgi?id=255569">https://bugs.webkit.org/show_bug.cgi?id=255569</a>
rdar://108171127

Reviewed by Youenn Fablet.

Storage size of single FileSystemSyncAccessHandle should be bounded by origin quota (OriginQuotaManager).

* LayoutTests/storage/filesystemaccess/sync-access-handle-read-write-worker.html: set a high quota limit and forbid it
to increase so we still get quota error when offset is overly big.
* Source/WebKit/NetworkProcess/storage/FileSystemStorageHandle.cpp:
(WebKit::FileSystemStorageHandle::requestNewCapacityForSyncAccessHandle):

Canonical link: <a href="https://commits.webkit.org/263196@main">https://commits.webkit.org/263196@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/38877fd4fd10bc343ac0721436a57964733ca816

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/3793 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/3879 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/3987 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/5223 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/4057 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/3957 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/3884 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/3479 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/3838 "Passed tests") | [⏳ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/iOS-16-Simulator-WK2-Tests-EWS "Waiting to run tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/3416 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/5057 "Built successfully") | 
| | [⏳ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/iOS-16-Simulator-WPT-WK2-Tests-EWS "Waiting to run tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/3392 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/4237 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/3366 "Passed tests") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/3451 "3 failures") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/4826 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/3843 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/3115 "16 failures") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/3367 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/3392 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/951 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/3408 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/3645 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->