### PR TITLE
SVG clip-path is sometimes broken on stevejobsarchive.com

### DIFF
--- a/LayoutTests/svg/masking/masking-with-event-region-expected.html
+++ b/LayoutTests/svg/masking/masking-with-event-region-expected.html
@@ -1,0 +1,35 @@
+<!DOCTYPE html> <!-- webkit-test-runner [ AsyncOverflowScrollingEnabled=true ] -->
+<html>
+  <head>
+    <style>
+        #test-clip-text {
+            font-family: system-ui;
+            font-weight: 900;
+            font-size: 60px;
+        }
+        .clipped {
+            position: absolute;
+            width: 200px;
+            height: 100px;
+            z-index: 1;
+            top: 5px;
+            left: 50px;
+            clip-path: url("#test-clip-text");
+            background-color: blue;
+        }
+        .composited {
+            transform: translateZ(0);
+        }
+        </style>
+  </head>
+  <body>
+    <svg xmlns="http://www.w3.org/2000/svg" width="0" height="0">
+      <defs>
+        <clipPath id="test-clip-text">
+          <text x="5" y="50">TEST</text>
+        </clipPath>
+      </defs>
+    </svg>
+    <div class="composited clipped"></div>
+  </body>
+</html>

--- a/LayoutTests/svg/masking/masking-with-event-region.html
+++ b/LayoutTests/svg/masking/masking-with-event-region.html
@@ -1,0 +1,58 @@
+<!DOCTYPE html> <!-- webkit-test-runner [ AsyncOverflowScrollingEnabled=true ] -->
+<html>
+  <head>
+    <style>
+        .scroller {
+            position: absolute;
+            width: 300px;
+            height: 300px;
+            overflow: scroll;
+            background: white;
+            z-index: 3;
+            margin: 100px;
+            opacity: 0;
+        }
+        
+        .contents {
+            height: 120%;
+        }
+        
+        #test-clip-text {
+            font-family: system-ui;
+            font-weight: 900;
+            font-size: 60px;
+        }
+        .clipped {
+            position: absolute;
+            width: 200px;
+            height: 100px;
+            z-index: 1;
+            top: 5px;
+            left: 50px;
+            clip-path: url("#test-clip-text");
+            background-color: blue;
+        }
+        .composited {
+            transform: translateZ(0);
+        }
+        
+        </style>
+  </head>
+  <body>
+    <svg xmlns="http://www.w3.org/2000/svg" width="0" height="0">
+      <defs>
+        <clipPath id="test-clip-text">
+          <text x="5" y="50">TEST</text>
+        </clipPath>
+      </defs>
+    </svg>
+    <div class="composited clipped"></div>
+    
+    <!-- scroller triggers event region generation -->
+    <div class="composited scroller">
+        <div class="contents">
+            scroller
+        </div>
+    </div>
+  </body>
+</html>

--- a/Source/WebCore/rendering/svg/RenderSVGResourceClipper.cpp
+++ b/Source/WebCore/rendering/svg/RenderSVGResourceClipper.cpp
@@ -141,7 +141,7 @@ bool RenderSVGResourceClipper::pathOnlyClipping(GraphicsContext& context, const 
     return true;
 }
 
-ClipperData::Inputs RenderSVGResourceClipper::computeInputs(RenderElement& renderer, const FloatRect& objectBoundingBox, const FloatRect& clippedContentBounds, float effectiveZoom)
+ClipperData::Inputs RenderSVGResourceClipper::computeInputs(const GraphicsContext& context, const RenderElement& renderer, const FloatRect& objectBoundingBox, const FloatRect& clippedContentBounds, float effectiveZoom)
 {
     AffineTransform absoluteTransform = SVGRenderingContext::calculateTransformationToOutermostCoordinateSystem(renderer);
 
@@ -151,7 +151,7 @@ ClipperData::Inputs RenderSVGResourceClipper::computeInputs(RenderElement& rende
     // Determine scale factor for the clipper. The size of intermediate ImageBuffers shouldn't be bigger than kMaxFilterSize.
     ImageBuffer::sizeNeedsClamping(objectBoundingBox.size(), scale);
 
-    return { objectBoundingBox, clippedContentBounds, scale, effectiveZoom };
+    return { objectBoundingBox, clippedContentBounds, scale, effectiveZoom, context.paintingDisabled() };
 }
 
 bool RenderSVGResourceClipper::applyClippingToContext(GraphicsContext& context, RenderElement& renderer, const FloatRect& objectBoundingBox, const FloatRect& clippedContentBounds, float effectiveZoom)
@@ -167,7 +167,7 @@ bool RenderSVGResourceClipper::applyClippingToContext(GraphicsContext& context, 
     if (!clipperData.imageBuffer && pathOnlyClipping(context, animatedLocalTransform, objectBoundingBox, effectiveZoom))
         return true;
 
-    if (clipperData.invalidate(computeInputs(renderer, objectBoundingBox, clippedContentBounds, effectiveZoom))) {
+    if (clipperData.invalidate(computeInputs(context, renderer, objectBoundingBox, clippedContentBounds, effectiveZoom))) {
         // FIXME (149469): This image buffer should not be unconditionally unaccelerated. Making it match the context breaks nested clipping, though.
         clipperData.imageBuffer = context.createScaledImageBuffer(clippedContentBounds, clipperData.inputs.scale, DestinationColorSpace::SRGB(), RenderingMode::Unaccelerated); // FIXME
         if (!clipperData.imageBuffer)

--- a/Source/WebCore/rendering/svg/RenderSVGResourceClipper.h
+++ b/Source/WebCore/rendering/svg/RenderSVGResourceClipper.h
@@ -34,17 +34,14 @@ struct ClipperData {
     WTF_MAKE_STRUCT_FAST_ALLOCATED;
 
     struct Inputs {
-        bool operator==(const Inputs& other) const
-        {
-            return std::tie(objectBoundingBox, clippedContentBounds, scale, effectiveZoom) == std::tie(other.objectBoundingBox, other.clippedContentBounds, other.scale, other.effectiveZoom);
-        }
-
+        bool operator==(const Inputs& other) const = default;
         bool operator!=(const Inputs& other) const { return !(*this == other); }
 
         FloatRect objectBoundingBox;
         FloatRect clippedContentBounds;
         FloatSize scale;
         float effectiveZoom = 1;
+        bool paintingDisabled { false };
     };
 
     bool invalidate(const Inputs& inputs)
@@ -94,7 +91,7 @@ private:
     ASCIILiteral renderName() const override { return "RenderSVGResourceClipper"_s; }
     bool isSVGResourceClipper() const override { return true; }
 
-    ClipperData::Inputs computeInputs(RenderElement&, const FloatRect& objectBoundingBox, const FloatRect& clippedContentBounds, float effectiveZoom);
+    ClipperData::Inputs computeInputs(const GraphicsContext&, const RenderElement&, const FloatRect& objectBoundingBox, const FloatRect& clippedContentBounds, float effectiveZoom);
     bool pathOnlyClipping(GraphicsContext&, const AffineTransform&, const FloatRect&, float effectiveZoom);
     bool drawContentIntoMaskImage(ImageBuffer&, const FloatRect& objectBoundingBox, float effectiveZoom);
     void calculateClipContentRepaintRect();


### PR DESCRIPTION
#### e4d2a7474950a53bd369b91a6d7210a182c07a79
<pre>
SVG clip-path is sometimes broken on stevejobsarchive.com
<a href="https://bugs.webkit.org/show_bug.cgi?id=255577">https://bugs.webkit.org/show_bug.cgi?id=255577</a>
rdar://107885344

Reviewed by Said Abou-Hallawa.

<a href="http://book.stevejobsarchive.com/">http://book.stevejobsarchive.com/</a> uses CSS clip-path with a reference to an SVG &lt;clipPath&gt; element
which contains text.

In this configuration, RenderSVGResourceClipper::applyClippingToContext() falls back to a code path
that uses an ImageBuffer as a mask, and it caches the ImageBuffer between calls. This caused a
problem when DOM Rendering in the GPU Process was enabled; this code is first hit for a &quot;fake&quot; paint
with a NullGraphicsContext which is updating EventRegions, called out of
`RenderLayerBacking::updateEventRegion()`. The NullGraphicsContext will make a local ImageBuffer.

If we then hit this same code for actual painting with a painting GraphicsContext, we&apos;ll use that
cached ImageBuffer, rather than creating a new one with appropriate GPU Process backing.

Fix this by adding `isPaintingDisabled` to the criteria used to decide if the cached buffer can be
re-used.

* LayoutTests/svg/masking/masking-with-event-region-expected.html: Added.
* LayoutTests/svg/masking/masking-with-event-region.html: Added.
* Source/WebCore/rendering/svg/RenderSVGResourceClipper.cpp:
(WebCore::RenderSVGResourceClipper::computeInputs):
(WebCore::RenderSVGResourceClipper::applyClippingToContext):
* Source/WebCore/rendering/svg/RenderSVGResourceClipper.h:
(WebCore::ClipperData::Inputs::operator== const):

Canonical link: <a href="https://commits.webkit.org/263087@main">https://commits.webkit.org/263087@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0ad771287b1b8162a7d0dcd7c896ee4acee472c1

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/3577 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/3623 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/3764 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/5002 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/3851 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/3556 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/3717 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/3665 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/3107 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/3620 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/15/builds/3873 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/3219 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/4824 "Built successfully") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/39/builds/1379 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/3193 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/3181 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/3180 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/3252 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/4587 "268 api tests failed or timed out") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/3634 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/2934 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/3174 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/3191 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/867 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/3202 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/3453 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->