### PR TITLE
[JSC] Inline ProxyObject's "has" trap in DFG / FTL

### DIFF
--- a/JSTests/microbenchmarks/proxy-has-hit.js
+++ b/JSTests/microbenchmarks/proxy-has-hit.js
@@ -6,6 +6,6 @@
     });
 
     var has;
-    for (var i = 0; i < 1e6; ++i)
+    for (var i = 0; i < 1e7; ++i)
         has = "test" in proxy;
 })();

--- a/JSTests/microbenchmarks/proxy-has-miss-handler.js
+++ b/JSTests/microbenchmarks/proxy-has-miss-handler.js
@@ -2,6 +2,6 @@
     var proxy = new Proxy({}, {});
 
     var has;
-    for (var i = 0; i < 1e6; ++i)
+    for (var i = 0; i < 1e7; ++i)
         has = "test" in proxy;
 })();

--- a/JSTests/microbenchmarks/proxy-has-miss.js
+++ b/JSTests/microbenchmarks/proxy-has-miss.js
@@ -6,6 +6,6 @@
     });
 
     var has;
-    for (var i = 0; i < 1e6; ++i)
+    for (var i = 0; i < 1e7; ++i)
         has = "test" in proxy;
 })();

--- a/Source/JavaScriptCore/bytecode/InByStatus.h
+++ b/Source/JavaScriptCore/bytecode/InByStatus.h
@@ -48,6 +48,8 @@ public:
         // It's cached for a simple access to a known object property with
         // a possible structure chain and a possible specific value.
         Simple,
+        // It's cached to call ProxyObject's "has" trap.
+        ProxyObject,
         // It's known to often take slow path.
         TakesSlowPath,
     };
@@ -92,6 +94,7 @@ public:
     bool isSet() const { return m_state != NoInformation; }
     explicit operator bool() const { return isSet(); }
     bool isSimple() const { return m_state == Simple; }
+    bool isProxyObject() const { return m_state == ProxyObject; }
 
     size_t numVariants() const { return m_variants.size(); }
     const Vector<InByVariant, 1>& variants() const { return m_variants; }
@@ -115,7 +118,7 @@ public:
 
 private:
 #if ENABLE(DFG_JIT)
-    static InByStatus computeForStubInfoWithoutExitSiteFeedback(const ConcurrentJSLocker&, VM&, StructureStubInfo*);
+    static InByStatus computeForStubInfo(const ConcurrentJSLocker&, CodeBlock*, StructureStubInfo*, CallLinkStatus::ExitSiteData);
 #endif
     bool appendVariant(const InByVariant&);
     void shrinkToFit();

--- a/Source/JavaScriptCore/bytecode/InByVariant.cpp
+++ b/Source/JavaScriptCore/bytecode/InByVariant.cpp
@@ -31,16 +31,36 @@
 
 namespace JSC {
 
-InByVariant::InByVariant(CacheableIdentifier identifier, const StructureSet& structureSet, PropertyOffset offset, const ObjectPropertyConditionSet& conditionSet)
+InByVariant::InByVariant(CacheableIdentifier identifier, const StructureSet& structureSet, PropertyOffset offset, const ObjectPropertyConditionSet& conditionSet, std::unique_ptr<CallLinkStatus> callLinkStatus)
     : m_structureSet(structureSet)
     , m_conditionSet(conditionSet)
     , m_offset(offset)
+    , m_callLinkStatus(WTFMove(callLinkStatus))
     , m_identifier(WTFMove(identifier))
 {
     if (!structureSet.size()) {
         ASSERT(offset == invalidOffset);
         ASSERT(conditionSet.isEmpty());
     }
+}
+
+InByVariant::InByVariant(const InByVariant& other)
+    : InByVariant(other.m_identifier)
+{
+    *this = other;
+}
+
+InByVariant& InByVariant::operator=(const InByVariant& other)
+{
+    m_structureSet = other.m_structureSet;
+    m_conditionSet = other.m_conditionSet;
+    m_offset = other.m_offset;
+    m_identifier = other.m_identifier;
+    if (other.m_callLinkStatus)
+        m_callLinkStatus = makeUnique<CallLinkStatus>(*other.m_callLinkStatus);
+    else
+        m_callLinkStatus = nullptr;
+    return *this;
 }
 
 bool InByVariant::attemptToMerge(const InByVariant& other)

--- a/Source/JavaScriptCore/bytecode/InByVariant.h
+++ b/Source/JavaScriptCore/bytecode/InByVariant.h
@@ -27,6 +27,7 @@
 #pragma once
 
 #include "CacheableIdentifier.h"
+#include "CallLinkStatus.h"
 #include "ObjectPropertyConditionSet.h"
 #include "PropertyOffset.h"
 #include "StructureSet.h"
@@ -42,7 +43,10 @@ struct DumpContext;
 class InByVariant {
     WTF_MAKE_FAST_ALLOCATED;
 public:
-    InByVariant(CacheableIdentifier, const StructureSet& = StructureSet(), PropertyOffset = invalidOffset, const ObjectPropertyConditionSet& = ObjectPropertyConditionSet());
+    InByVariant(CacheableIdentifier, const StructureSet& = StructureSet(), PropertyOffset = invalidOffset, const ObjectPropertyConditionSet& = ObjectPropertyConditionSet(), std::unique_ptr<CallLinkStatus> = nullptr);
+
+    InByVariant(const InByVariant&);
+    InByVariant& operator=(const InByVariant&);
 
     bool isSet() const { return !!m_structureSet.size(); }
     explicit operator bool() const { return isSet(); }
@@ -53,6 +57,7 @@ public:
     const ObjectPropertyConditionSet& conditionSet() const { return m_conditionSet; }
 
     PropertyOffset offset() const { return m_offset; }
+    CallLinkStatus* callLinkStatus() const { return m_callLinkStatus.get(); }
 
     bool isHit() const { return offset() != invalidOffset; }
 
@@ -84,6 +89,7 @@ private:
     StructureSet m_structureSet;
     ObjectPropertyConditionSet m_conditionSet;
     PropertyOffset m_offset;
+    std::unique_ptr<CallLinkStatus> m_callLinkStatus;
     CacheableIdentifier m_identifier;
 };
 

--- a/Source/JavaScriptCore/bytecode/InlineCallFrame.cpp
+++ b/Source/JavaScriptCore/bytecode/InlineCallFrame.cpp
@@ -115,6 +115,9 @@ void printInternal(PrintStream& out, JSC::InlineCallFrame::Kind kind)
     case JSC::InlineCallFrame::SetterCall:
         out.print("SetterCall");
         return;
+    case JSC::InlineCallFrame::ProxyObjectHasCall:
+        out.print("ProxyObjectHasCall");
+        return;
     case JSC::InlineCallFrame::ProxyObjectLoadCall:
         out.print("ProxyObjectLoadCall");
         return;

--- a/Source/JavaScriptCore/bytecode/InlineCallFrame.h
+++ b/Source/JavaScriptCore/bytecode/InlineCallFrame.h
@@ -53,6 +53,7 @@ struct InlineCallFrame {
         // slot.
         GetterCall,
         SetterCall,
+        ProxyObjectHasCall,
         ProxyObjectLoadCall,
         ProxyObjectStoreCall,
         BoundFunctionCall,
@@ -67,6 +68,7 @@ struct InlineCallFrame {
         case CallVarargs:
         case GetterCall:
         case SetterCall:
+        case ProxyObjectHasCall:
         case ProxyObjectLoadCall:
         case ProxyObjectStoreCall:
         case BoundFunctionCall:
@@ -117,6 +119,7 @@ struct InlineCallFrame {
         case TailCallVarargs:
         case GetterCall:
         case SetterCall:
+        case ProxyObjectHasCall:
         case ProxyObjectLoadCall:
         case ProxyObjectStoreCall:
         case BoundFunctionCall:

--- a/Source/JavaScriptCore/dfg/DFGOSRExitCompilerCommon.cpp
+++ b/Source/JavaScriptCore/dfg/DFGOSRExitCompilerCommon.cpp
@@ -217,6 +217,7 @@ static CodePtr<JSEntryPtrTag> callerReturnPC(CodeBlock* baselineCodeBlockForCall
 
         case InlineCallFrame::GetterCall:
         case InlineCallFrame::SetterCall:
+        case InlineCallFrame::ProxyObjectHasCall:
         case InlineCallFrame::ProxyObjectLoadCall:
         case InlineCallFrame::ProxyObjectStoreCall: {
             StructureStubInfo* stubInfo = baselineCodeBlockForCaller->findStubInfo(CodeOrigin(callBytecodeIndex));

--- a/Source/JavaScriptCore/runtime/JSGlobalObject.h
+++ b/Source/JavaScriptCore/runtime/JSGlobalObject.h
@@ -667,6 +667,7 @@ public:
     JSFunction* typedArrayProtoSort() const { return m_typedArrayProtoSort.get(this); }
     JSFunction* stringProtoSubstringFunction() const;
     JSFunction* performProxyObjectHasFunction() const;
+    JSFunction* performProxyObjectHasFunctionConcurrently() const;
     JSFunction* performProxyObjectGetFunction() const;
     JSFunction* performProxyObjectGetFunctionConcurrently() const;
     JSFunction* performProxyObjectSetSloppyFunction() const;

--- a/Source/JavaScriptCore/runtime/JSGlobalObjectInlines.h
+++ b/Source/JavaScriptCore/runtime/JSGlobalObjectInlines.h
@@ -217,6 +217,7 @@ inline JSFunction* JSGlobalObject::performPromiseThenFunction() const { return j
 inline JSFunction* JSGlobalObject::regExpProtoExecFunction() const { return jsCast<JSFunction*>(linkTimeConstant(LinkTimeConstant::regExpBuiltinExec)); }
 inline JSFunction* JSGlobalObject::stringProtoSubstringFunction() const { return jsCast<JSFunction*>(linkTimeConstant(LinkTimeConstant::stringSubstring)); }
 inline JSFunction* JSGlobalObject::performProxyObjectHasFunction() const { return jsCast<JSFunction*>(linkTimeConstant(LinkTimeConstant::performProxyObjectHas)); }
+inline JSFunction* JSGlobalObject::performProxyObjectHasFunctionConcurrently() const { return linkTimeConstantConcurrently<JSFunction*>(LinkTimeConstant::performProxyObjectHas); }
 inline JSFunction* JSGlobalObject::performProxyObjectGetFunction() const { return jsCast<JSFunction*>(linkTimeConstant(LinkTimeConstant::performProxyObjectGet)); }
 inline JSFunction* JSGlobalObject::performProxyObjectGetFunctionConcurrently() const { return linkTimeConstantConcurrently<JSFunction*>(LinkTimeConstant::performProxyObjectGet); }
 inline JSFunction* JSGlobalObject::performProxyObjectSetSloppyFunction() const { return jsCast<JSFunction*>(linkTimeConstant(LinkTimeConstant::performProxyObjectSetSloppy)); }


### PR DESCRIPTION
#### de353009d843a7fd3b6719604f3da8917cd16985
<pre>
[JSC] Inline ProxyObject&apos;s &quot;has&quot; trap in DFG / FTL
<a href="https://bugs.webkit.org/show_bug.cgi?id=255583">https://bugs.webkit.org/show_bug.cgi?id=255583</a>
&lt;rdar://problem/108185228&gt;

Reviewed by NOBODY (OOPS!).

This change:
  a) makes InByVariant store CallLinkStatus, adding the now necessary explicit copy constructor;
  b) makes InByStatus handle ProxyObjectAccessCase, passing down CallLinkStatus::ExitSiteData;
  c) teaches DFG to inline ProxyObjectHas access case trap as Call, as it&apos;s already done for [[Get]] and [[Set]];
  d) adds ProxyObjectHasCall type to InlineCallFrame to handle inlined call frame correctly for DFG / FTL OSR exit.

                                   ToT                      patch

proxy-has-hit                39.0235+-0.0870     ^     12.3855+-0.0213        ^ definitely 3.1507x faster
proxy-has-miss              159.1689+-0.5865     ^    111.1327+-0.3547        ^ definitely 1.4322x faster
proxy-has-miss-handler       41.5165+-0.0694     ^     10.5006+-0.0386        ^ definitely 3.9537x faster

&lt;geometric&gt;                  63.6490+-0.0969     ^     24.3581+-0.0370        ^ definitely 2.6130x faster

* JSTests/microbenchmarks/proxy-has-hit.js:
* JSTests/microbenchmarks/proxy-has-miss-handler.js:
* JSTests/microbenchmarks/proxy-has-miss.js:
* Source/JavaScriptCore/bytecode/InByStatus.cpp:
(JSC::InByStatus::computeFor):
(JSC::InByStatus::computeForStubInfo):
(JSC::InByStatus::merge):
(JSC::InByStatus::filter):
(JSC::InByStatus::dump const):
(JSC::InByStatus::computeForStubInfoWithoutExitSiteFeedback): Deleted.
* Source/JavaScriptCore/bytecode/InByStatus.h:
* Source/JavaScriptCore/bytecode/InByVariant.cpp:
(JSC::InByVariant::InByVariant):
(JSC::InByVariant::operator=):
* Source/JavaScriptCore/bytecode/InByVariant.h:
(JSC::InByVariant::callLinkStatus const):
* Source/JavaScriptCore/bytecode/InlineCallFrame.cpp:
(WTF::printInternal):
* Source/JavaScriptCore/bytecode/InlineCallFrame.h:
(JSC::InlineCallFrame::callModeFor):
(JSC::InlineCallFrame::specializationKindFor):
* Source/JavaScriptCore/dfg/DFGByteCodeParser.cpp:
(JSC::DFG::ByteCodeParser::inlineCall):
(JSC::DFG::ByteCodeParser::handleInByForProxyObject):
(JSC::DFG::ByteCodeParser::handleInById):
* Source/JavaScriptCore/dfg/DFGOSRExitCompilerCommon.cpp:
(JSC::DFG::callerReturnPC):
* Source/JavaScriptCore/runtime/JSGlobalObject.h:
* Source/JavaScriptCore/runtime/JSGlobalObjectInlines.h:
(JSC::JSGlobalObject::performProxyObjectHasFunctionConcurrently const):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/de353009d843a7fd3b6719604f3da8917cd16985

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/3527 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/3574 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/3712 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/4949 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/3801 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/3663 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/3615 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/3063 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/3569 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/3819 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/3172 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/4772 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/1328 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/3148 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/3055 "Passed tests") | 
| [❌ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/2882 "Found 1 jsc stress test failure: stress/in-by-id-proxy.js.ftl-no-cjit-b3o0") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/3126 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/3207 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/4531 "Passed tests") | 
| [❌ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/3305 "Found 1 jsc stress test failure: stress/in-by-id-proxy.js.ftl-no-cjit-b3o0") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/3585 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/2891 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/3597 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/3127 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/3146 "Passed tests") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/917 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/3153 "Built successfully") | | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/24/builds/3689 "Built successfully") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/3405 "Built successfully") | | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/3/builds/1029 "Passed tests") | 
<!--EWS-Status-Bubble-End-->