### PR TITLE
ManagedMediaSource should stop tagging network operations as media if player is not following guidance

### DIFF
--- a/Source/WebCore/Modules/mediasource/ManagedMediaSource.cpp
+++ b/Source/WebCore/Modules/mediasource/ManagedMediaSource.cpp
@@ -47,10 +47,14 @@ Ref<ManagedMediaSource> ManagedMediaSource::create(ScriptExecutionContext& conte
 
 ManagedMediaSource::ManagedMediaSource(ScriptExecutionContext& context)
     : MediaSource(context)
+    , m_streamingTimer(*this, &ManagedMediaSource::streamingTimerFired)
 {
 }
 
-ManagedMediaSource::~ManagedMediaSource() = default;
+ManagedMediaSource::~ManagedMediaSource()
+{
+    m_streamingTimer.stop();
+}
 
 ExceptionOr<ManagedMediaSource::PreferredQuality> ManagedMediaSource::quality() const
 {
@@ -67,10 +71,18 @@ void ManagedMediaSource::setStreaming(bool streaming)
     if (m_streaming == streaming)
         return;
     m_streaming = streaming;
-    if (streaming)
+    if (streaming) {
         scheduleEvent(eventNames().startstreamingEvent);
-    else
+        if (m_streamingAllowed) {
+            ensurePrefsRead();
+            Seconds delay { *m_highThreshold };
+            m_streamingTimer.startOneShot(delay);
+        }
+    } else {
+        if (m_streamingTimer.isActive())
+            m_streamingTimer.stop();
         scheduleEvent(eventNames().endstreamingEvent);
+    }
     notifyElementUpdateMediaState();
 }
 
@@ -108,6 +120,14 @@ bool ManagedMediaSource::isBuffered(const PlatformTimeRanges& ranges) const
     return true;
 }
 
+void ManagedMediaSource::ensurePrefsRead()
+{
+    if (m_lowThreshold && m_highThreshold)
+        return;
+    m_lowThreshold = mediaElement()->document().settings().managedMediaSourceLowThreshold();
+    m_highThreshold = mediaElement()->document().settings().managedMediaSourceHighThreshold();
+}
+
 void ManagedMediaSource::monitorSourceBuffers()
 {
     if (isClosed()) {
@@ -123,10 +143,7 @@ void ManagedMediaSource::monitorSourceBuffers()
     }
     auto currentTime = this->currentTime();
 
-    if (!m_lowThreshold || !m_highThreshold) {
-        m_lowThreshold = mediaElement()->document().settings().managedMediaSourceLowThreshold();
-        m_highThreshold = mediaElement()->document().settings().managedMediaSourceHighThreshold();
-    }
+    ensurePrefsRead();
 
     if (!m_streaming) {
         MediaTime aheadTime = std::min(duration(), currentTime + MediaTime::createWithDouble(*m_lowThreshold));
@@ -140,6 +157,12 @@ void ManagedMediaSource::monitorSourceBuffers()
     PlatformTimeRanges neededBufferedRange { currentTime, aheadTime };
     if (isBuffered(neededBufferedRange))
         setStreaming(false);
+}
+
+void ManagedMediaSource::streamingTimerFired()
+{
+    m_streamingAllowed = false;
+    notifyElementUpdateMediaState();
 }
 
 }

--- a/Source/WebCore/Modules/mediasource/ManagedMediaSource.h
+++ b/Source/WebCore/Modules/mediasource/ManagedMediaSource.h
@@ -28,6 +28,7 @@
 #if ENABLE(MANAGED_MEDIA_SOURCE) && ENABLE(MEDIA_SOURCE)
 
 #include "MediaSource.h"
+#include "Timer.h"
 #include <optional>
 
 namespace WebCore {
@@ -44,6 +45,7 @@ public:
     static bool isTypeSupported(ScriptExecutionContext&, const String& type);
 
     bool streaming() const { return m_streaming; }
+    bool streamingAllowed() const { return m_streamingAllowed; }
 
     bool isManaged() const final { return true; }
 
@@ -52,9 +54,14 @@ private:
     void monitorSourceBuffers() final;
     bool isBuffered(const PlatformTimeRanges&) const;
     void setStreaming(bool);
+    void streamingTimerFired();
+    void ensurePrefsRead();
+
     bool m_streaming { false };
     std::optional<double> m_lowThreshold;
     std::optional<double> m_highThreshold;
+    Timer m_streamingTimer;
+    bool m_streamingAllowed { true };
 };
 
 } // namespace WebCore

--- a/Source/WebCore/html/HTMLMediaElement.cpp
+++ b/Source/WebCore/html/HTMLMediaElement.cpp
@@ -8517,7 +8517,7 @@ MediaProducerMediaStateFlags HTMLMediaElement::mediaState() const
     bool streaming = false;
 #if ENABLE(MANAGED_MEDIA_SOURCE)
     RefPtr managedMediasource = is<ManagedMediaSource>(m_mediaSource) ? downcast<ManagedMediaSource>(m_mediaSource.get()) : nullptr;
-    streaming |= managedMediasource && managedMediasource->streaming();
+    streaming |= managedMediasource && managedMediasource->streamingAllowed() && managedMediasource->streaming();
     if (!managedMediasource) {
 #endif
     // We can assume that if we have active source buffers, later networking activity (such as stream or XHR requests) will be media related.

--- a/Tools/TestWebKitAPI/Tests/WebKit/file-with-managedmse.html
+++ b/Tools/TestWebKitAPI/Tests/WebKit/file-with-managedmse.html
@@ -9,15 +9,15 @@
 
       function isMP4Supported()
       {
-        return MediaSource.isTypeSupported('video/mp4;codecs="avc1.4D4001,mp4a.40.2"');
+        return ManagedMediaSource.isTypeSupported('video/mp4;codecs="avc1.4D4001,mp4a.40.2"');
       }
       function isWebMVP9Supported()
       {
-        return MediaSource.isTypeSupported('video/webm;codecs="vp9,opus"');
+        return ManagedMediaSource.isTypeSupported('video/webm;codecs="vp9,opus"');
       }
       function isWebMOpusSupported()
       {
-        return MediaSource.isTypeSupported('video/webm;codecs="opus"');
+        return ManagedMediaSource.isTypeSupported('video/webm;codecs="opus"');
       }
       function loadVideo()
       {

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/WKPageHasMediaStreamingActivity.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/WKPageHasMediaStreamingActivity.mm
@@ -32,6 +32,7 @@
 #import <WebKit/WKPagePrivate.h>
 #import <WebKit/WKPreferencesPrivate.h>
 #import <notify.h>
+#import <wtf/MonotonicTime.h>
 
 // This test loads file-with-video.html. Then it calls a JavaScript method to create a source buffer and play the video,
 // waits for WKMediaNetworkingActivity notification to be fired.
@@ -87,15 +88,12 @@ TEST(WebKit, MSEHasMediaStreamingActivity)
 TEST(WebKit, ManagedMSEHasMediaStreamingActivity)
 {
     auto configuration = adoptNS([WKWebViewConfiguration new]);
-    [[configuration preferences] _setMediaSourceEnabled:YES];
     [[configuration preferences] _setManagedMediaSourceEnabled:YES];
     [[configuration preferences] _setAllowFileAccessFromFileURLs:YES];
     auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 400, 400) configuration:configuration.get()]);
     [webView synchronouslyLoadTestPageNamed:@"file-with-managedmse"];
 
-    // Bail out of the test early if the platform does not support MSE.
-    if (![[webView objectByEvaluatingJavaScript:@"window.MediaSource !== undefined"] boolValue])
-        return;
+    // Bail out of the test early if the platform does not support Managed MSE.
     if (![[webView objectByEvaluatingJavaScript:@"window.ManagedMediaSource !== undefined"] boolValue])
         return;
     // Test is only valid if either of those format is supported.
@@ -127,6 +125,60 @@ TEST(WebKit, ManagedMSEHasMediaStreamingActivity)
     [webView objectByEvaluatingJavaScript:@"startStreaming()"];
     Util::run(&isMediaStreamingChanged);
     EXPECT_FALSE(isMediaStreaming);
+
+    notify_cancel(token);
+}
+
+TEST(WebKit, ManagedMSEHasMediaStreamingActivityWithPolicy)
+{
+    auto configuration = adoptNS([WKWebViewConfiguration new]);
+    [[configuration preferences] _setManagedMediaSourceEnabled:YES];
+    [[configuration preferences] _setAllowFileAccessFromFileURLs:YES];
+    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 400, 400) configuration:configuration.get()]);
+    [webView synchronouslyLoadTestPageNamed:@"file-with-managedmse"];
+
+    // Bail out of the test early if the platform does not support Managed MSE.
+    if (![[webView objectByEvaluatingJavaScript:@"window.ManagedMediaSource !== undefined"] boolValue])
+        return;
+    // Test is only valid if either of those format is supported.
+    auto typeSupported = [[webView objectByEvaluatingJavaScript:@"isMP4Supported() || isWebMVP9Supported() || isWebMOpusSupported()"] boolValue];
+    if (!typeSupported)
+        return;
+    int token = NOTIFY_TOKEN_INVALID;
+    if (notify_register_check(WebKitMediaStreamingActivity, &token) != NOTIFY_STATUS_OK)
+        return;
+
+    __block bool isMediaStreamingChanged = false;
+    __block bool isMediaStreaming = false;
+
+    int status = notify_register_dispatch(WebKitMediaStreamingActivity, &token, dispatch_get_main_queue(), ^(int token) {
+        uint64_t state = 0;
+        notify_get_state(token, &state);
+        isMediaStreamingChanged = true;
+        isMediaStreaming= !!state;
+    });
+
+    if (status != NOTIFY_STATUS_OK)
+        return;
+
+    // Ensure that if it takes too long, notification is fired anyway.
+    constexpr double highThreshold = 1;
+    [[configuration preferences] _setManagedMediaSourceHighThreshold:highThreshold];
+
+    auto startTime = MonotonicTime::now();
+    [webView objectByEvaluatingJavaScript:@"loadVideo()"];
+    Util::run(&isMediaStreamingChanged);
+    EXPECT_TRUE(isMediaStreaming);
+
+    // notification should be fired after 1s.
+    isMediaStreamingChanged = false;
+    Util::run(&isMediaStreamingChanged);
+    EXPECT_FALSE(isMediaStreaming);
+
+    Seconds duration = MonotonicTime::now() - startTime;
+    Seconds expectedDuration { highThreshold };
+    EXPECT_TRUE(duration >= expectedDuration);
+
     notify_cancel(token);
 }
 #endif


### PR DESCRIPTION
#### 4b47aa217bc82f6f0dc160eeec086eac846bb651
<pre>
ManagedMediaSource should stop tagging network operations as media if player is not following guidance
<a href="https://bugs.webkit.org/show_bug.cgi?id=255584">https://bugs.webkit.org/show_bug.cgi?id=255584</a>
rdar://106091782

Reviewed by Jer Noble.

As soon as the Managed Media Source element&apos;s streaming attribute was
true, we would tag all networking activity as media related.
However, this didn&apos;t account for live playback where small buffers are
appended repeatedly without ever filling the buffered window requested.

We request from the JS player to have &quot;high threshold&quot; seconds ahead of
currentTime. If we fail to buffer that much within &quot;high threshold&quot; seconds
we can assume one of the following:
- networking is too slow to keep up with playback
- or it&apos;s a live stream where the player will continously append new data.

In either case, we don&apos;t want to keep the 5G mode on to reduce power usage.
So we stop flagging networking activity as media then.

Add API test.

* Source/WebCore/Modules/mediasource/ManagedMediaSource.cpp:
(WebCore::ManagedMediaSource::ManagedMediaSource):
(WebCore::ManagedMediaSource::~ManagedMediaSource):
(WebCore::ManagedMediaSource::setStreaming):
(WebCore::ManagedMediaSource::ensurePrefsRead):
(WebCore::ManagedMediaSource::monitorSourceBuffers):
(WebCore::ManagedMediaSource::streamingTimerFired):
* Source/WebCore/Modules/mediasource/ManagedMediaSource.h:
* Source/WebCore/html/HTMLMediaElement.cpp:
(WebCore::HTMLMediaElement::mediaState const):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/WKPageHasMediaStreamingActivity.mm:
(TestWebKitAPI::TEST):
* Tools/TestWebKitAPI/Tests/WebKit/file-with-managedmse.html:

Canonical link: <a href="https://commits.webkit.org/263105@main">https://commits.webkit.org/263105@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/344cdf0514810adfdee14e75799cc60ad94e8efd

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/3541 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/3588 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/3726 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/4963 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/3815 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/3519 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/3678 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/3629 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/3076 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/3583 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/3834 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/3188 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/4786 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/1342 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/3164 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/3065 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/3141 "Passed tests") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/3223 "3 failures") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/4546 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/3599 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/2905 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/3141 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/3162 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/883 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/3167 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/3419 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->