### PR TITLE
[GTK][WPE] Ensure the right GPU is used by GBM for WebGL

### DIFF
--- a/Source/WebCore/platform/graphics/PlatformDisplay.cpp
+++ b/Source/WebCore/platform/graphics/PlatformDisplay.cpp
@@ -81,11 +81,7 @@
 #endif
 
 #if USE(EGL) && USE(GBM)
-#include <fcntl.h>
-#include <gbm.h>
-#include <unistd.h>
-#include <wtf/SafeStrerror.h>
-#include <wtf/StdLibExtras.h>
+#include "GBMDevice.h"
 #include <xf86drm.h>
 #ifndef EGL_DRM_RENDER_NODE_FILE_EXT
 #define EGL_DRM_RENDER_NODE_FILE_EXT 0x3377
@@ -233,10 +229,6 @@ PlatformDisplay::~PlatformDisplay()
 #if PLATFORM(GTK)
     if (m_sharedDisplay)
         g_signal_handlers_disconnect_by_data(m_sharedDisplay.get(), this);
-#endif
-#if USE(EGL) && USE(GBM)
-    if (m_gbm.device.has_value() && m_gbm.device.value())
-        gbm_device_destroy(m_gbm.device.value());
 #endif
     if (s_sharedDisplayForCompositing == this)
         s_sharedDisplayForCompositing = nullptr;
@@ -497,25 +489,12 @@ const String& PlatformDisplay::drmRenderNodeFile()
 
 struct gbm_device* PlatformDisplay::gbmDevice()
 {
-    if (!m_gbm.device.has_value()) {
+    auto& device = GBMDevice::singleton();
+    if (!device.isInitialized()) {
         const char* envDeviceFile = getenv("WEBKIT_WEB_RENDER_DEVICE_FILE");
-        String deviceFile = envDeviceFile && *envDeviceFile ? String::fromUTF8(envDeviceFile) : drmRenderNodeFile();
-        if (!deviceFile.isEmpty()) {
-            m_gbm.deviceFD = UnixFileDescriptor { open(deviceFile.utf8().data(), O_RDWR | O_CLOEXEC), UnixFileDescriptor::Adopt };
-            if (m_gbm.deviceFD) {
-                m_gbm.device = gbm_create_device(m_gbm.deviceFD.value());
-                if (m_gbm.device.value())
-                    return m_gbm.device.value();
-
-                WTFLogAlways("Failed to create GBM device for render device: %s: %s", deviceFile.utf8().data(), safeStrerror(errno).data());
-                m_gbm.deviceFD = { };
-            } else
-                WTFLogAlways("Failed to open DRM render device %s: %s", deviceFile.utf8().data(), safeStrerror(errno).data());
-        }
-        m_gbm.device = nullptr;
+        device.initialize(envDeviceFile && *envDeviceFile ? String::fromUTF8(envDeviceFile) : drmRenderNodeFile());
     }
-
-    return m_gbm.device.value();
+    return device.device();
 }
 #endif
 

--- a/Source/WebCore/platform/graphics/PlatformDisplay.h
+++ b/Source/WebCore/platform/graphics/PlatformDisplay.h
@@ -37,7 +37,6 @@ typedef void *EGLDisplay;
 typedef void *EGLImage;
 typedef unsigned EGLenum;
 #if USE(GBM)
-#include <wtf/unix/UnixFileDescriptor.h>
 typedef void *EGLDeviceEXT;
 struct gbm_device;
 #endif
@@ -156,10 +155,6 @@ protected:
 #if USE(GBM)
     std::optional<String> m_drmDeviceFile;
     std::optional<String> m_drmRenderNodeFile;
-    struct {
-        WTF::UnixFileDescriptor deviceFD;
-        std::optional<struct gbm_device*> device;
-    } m_gbm;
 #endif
 #endif
 

--- a/Source/WebCore/platform/graphics/gbm/GBMBufferSwapchain.cpp
+++ b/Source/WebCore/platform/graphics/gbm/GBMBufferSwapchain.cpp
@@ -45,7 +45,9 @@ GBMBufferSwapchain::~GBMBufferSwapchain() = default;
 
 RefPtr<GBMBufferSwapchain::Buffer> GBMBufferSwapchain::getBuffer(const BufferDescription& description)
 {
-    auto& device = GBMDevice::singleton();
+    auto* device = GBMDevice::singleton().device();
+    if (!device)
+        return nullptr;
 
     // If the description of the requested buffers has changed, update the description to the new one and wreck the existing buffers.
     // This should handle changes in format or dimension of the buffers.
@@ -105,7 +107,7 @@ RefPtr<GBMBufferSwapchain::Buffer> GBMBufferSwapchain::getBuffer(const BufferDes
             // over the software-decoded video data), but might not be required for backing e.g. ANGLE rendering.
             for (unsigned i = 0; i < buffer->m_description.format.numPlanes; ++i) {
                 auto& plane = buffer->m_planes[i];
-                plane.bo = gbm_bo_create(device.device(), plane.width, plane.height, uint32_t(plane.fourcc), boFlags);
+                plane.bo = gbm_bo_create(device, plane.width, plane.height, uint32_t(plane.fourcc), boFlags);
                 plane.stride = gbm_bo_get_stride(plane.bo);
             }
 

--- a/Source/WebCore/platform/graphics/gbm/GBMBufferSwapchain.h
+++ b/Source/WebCore/platform/graphics/gbm/GBMBufferSwapchain.h
@@ -60,7 +60,7 @@ public:
         Eight = 8
     };
 
-    GBMBufferSwapchain(BufferSwapchainSize);
+    explicit GBMBufferSwapchain(BufferSwapchainSize);
     ~GBMBufferSwapchain();
 
     struct BufferDescription {

--- a/Source/WebCore/platform/graphics/gbm/GBMDevice.h
+++ b/Source/WebCore/platform/graphics/gbm/GBMDevice.h
@@ -28,7 +28,9 @@
 
 #if USE(GBM)
 
+#include <optional>
 #include <wtf/Noncopyable.h>
+#include <wtf/unix/UnixFileDescriptor.h>
 
 struct gbm_device;
 
@@ -38,16 +40,18 @@ class GBMDevice {
     WTF_MAKE_NONCOPYABLE(GBMDevice);
     WTF_MAKE_FAST_ALLOCATED();
 public:
-    static const GBMDevice& singleton();
+    static GBMDevice& singleton();
 
-    GBMDevice();
+    GBMDevice() = default;
     ~GBMDevice();
 
-    struct gbm_device* device() const { return m_device; }
+    bool isInitialized() const { return m_device.has_value(); }
+    void initialize(const String&);
+    struct gbm_device* device() const { RELEASE_ASSERT(m_device.has_value()); return m_device.value(); }
 
 private:
-    int m_fd { -1 };
-    struct gbm_device* m_device { nullptr };
+    WTF::UnixFileDescriptor m_fd;
+    std::optional<struct gbm_device*> m_device;
 };
 
 } // namespace WebCore

--- a/Source/WebCore/platform/graphics/gbm/GraphicsContextGLGBM.h
+++ b/Source/WebCore/platform/graphics/gbm/GraphicsContextGLGBM.h
@@ -95,7 +95,7 @@ public:
     const EGLExtensions& eglExtensions() { return m_eglExtensions; }
 
 protected:
-    GraphicsContextGLGBM(WebCore::GraphicsContextGLAttributes&&);
+    explicit GraphicsContextGLGBM(WebCore::GraphicsContextGLAttributes&&);
 
 private:
     void allocateDrawBufferObject();

--- a/Source/WebCore/platform/graphics/gbm/PlatformDisplayGBM.h
+++ b/Source/WebCore/platform/graphics/gbm/PlatformDisplayGBM.h
@@ -32,11 +32,11 @@ namespace WebCore {
 
 class PlatformDisplayGBM final : public PlatformDisplay {
 public:
-    static std::unique_ptr<PlatformDisplayGBM> create(const String&);
+    static std::unique_ptr<PlatformDisplayGBM> create(struct gbm_device*);
 
     virtual ~PlatformDisplayGBM();
 private:
-    PlatformDisplayGBM(UnixFileDescriptor&&, struct gbm_device*);
+    explicit PlatformDisplayGBM(struct gbm_device*);
 
     Type type() const override { return PlatformDisplay::Type::GBM; }
 };

--- a/Source/WebCore/platform/graphics/gstreamer/DMABufVideoSinkGStreamer.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/DMABufVideoSinkGStreamer.cpp
@@ -171,12 +171,9 @@ bool webKitDMABufVideoSinkIsEnabled()
     std::call_once(s_flag, [&] {
         const char* value = g_getenv("WEBKIT_GST_DMABUF_SINK_DISABLED");
         s_disabled = value && (equalLettersIgnoringASCIICase(value, "true"_s) || equalLettersIgnoringASCIICase(value, "1"_s));
-        if (!s_disabled) {
-            auto& gbmDevice = GBMDevice::singleton();
-            if (!gbmDevice.device()) {
-                WTFLogAlways("Unable to access the GBM device, disabling DMABuf video sink.");
-                s_disabled = true;
-            }
+        if (!s_disabled && !GBMDevice::singleton().device()) {
+            WTFLogAlways("Unable to access the GBM device, disabling DMABuf video sink.");
+            s_disabled = true;
         }
     });
 #else

--- a/Source/WebCore/platform/graphics/gstreamer/MediaPlayerPrivateGStreamer.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/MediaPlayerPrivateGStreamer.cpp
@@ -125,7 +125,6 @@
 #include "DMABufObject.h"
 #include "DMABufVideoSinkGStreamer.h"
 #include "GBMBufferSwapchain.h"
-#include "GBMDevice.h"
 #include "TextureMapperPlatformLayerProxyDMABuf.h"
 #include <gbm.h>
 #include <gst/allocators/gstdmabuf.h>

--- a/Source/WebKit/GPUProcess/GPUProcess.cpp
+++ b/Source/WebKit/GPUProcess/GPUProcess.cpp
@@ -81,6 +81,10 @@
 #include <WebCore/ScreenCaptureKitCaptureSource.h>
 #endif
 
+#if USE(GBM)
+#include <WebCore/GBMDevice.h>
+#endif
+
 namespace WebKit {
 
 // We wouldn't want the GPUProcess to repeatedly exit then relaunch when under memory pressure. In particular, we need to make sure the
@@ -258,6 +262,10 @@ void GPUProcess::initializeGPUProcess(GPUProcessCreationParameters&& parameters)
 #if HAVE(CGIMAGESOURCE_WITH_SET_ALLOWABLE_TYPES)
     auto emptyArray = adoptCF(CFArrayCreate(kCFAllocatorDefault, nullptr, 0, &kCFTypeArrayCallBacks));
     CGImageSourceSetAllowableTypes(emptyArray.get());
+#endif
+
+#if USE(GBM)
+    WebCore::GBMDevice::singleton().initialize(parameters.renderDeviceFile);
 #endif
 
     m_applicationVisibleName = WTFMove(parameters.applicationVisibleName);

--- a/Source/WebKit/GPUProcess/GPUProcessCreationParameters.cpp
+++ b/Source/WebKit/GPUProcess/GPUProcessCreationParameters.cpp
@@ -64,6 +64,10 @@ void GPUProcessCreationParameters::encode(IPC::Encoder& encoder) const
     encoder << mobileGestaltExtensionHandle;
 
     encoder << applicationVisibleName;
+
+#if USE(GBM)
+    encoder << renderDeviceFile;
+#endif
 }
 
 bool GPUProcessCreationParameters::decode(IPC::Decoder& decoder, GPUProcessCreationParameters& result)
@@ -121,6 +125,14 @@ bool GPUProcessCreationParameters::decode(IPC::Decoder& decoder, GPUProcessCreat
 
     if (!decoder.decode(result.applicationVisibleName))
         return false;
+
+#if USE(GBM)
+    std::optional<String> renderDeviceFile;
+    decoder >> renderDeviceFile;
+    if (!renderDeviceFile)
+        return false;
+    result.renderDeviceFile = WTFMove(*renderDeviceFile);
+#endif
 
     return true;
 }

--- a/Source/WebKit/GPUProcess/GPUProcessCreationParameters.h
+++ b/Source/WebKit/GPUProcess/GPUProcessCreationParameters.h
@@ -65,6 +65,10 @@ struct GPUProcessCreationParameters {
 
     String applicationVisibleName;
 
+#if USE(GBM)
+    String renderDeviceFile;
+#endif
+
     void encode(IPC::Encoder&) const;
     static WARN_UNUSED_RETURN bool decode(IPC::Decoder&, GPUProcessCreationParameters&);
 };

--- a/Source/WebKit/Shared/WebProcessCreationParameters.cpp
+++ b/Source/WebKit/Shared/WebProcessCreationParameters.cpp
@@ -186,9 +186,12 @@ void WebProcessCreationParameters::encode(IPC::Encoder& encoder) const
     encoder << contentSizeCategory;
 #endif
 
+#if USE(GBM)
+    encoder << renderDeviceFile;
+#endif
+
 #if PLATFORM(GTK)
     encoder << useDMABufSurfaceForCompositing;
-    encoder << renderDeviceFile;
     encoder << useSystemAppearanceForScrollbars;
     encoder << gtkSettings;
 #endif
@@ -521,17 +524,20 @@ bool WebProcessCreationParameters::decode(IPC::Decoder& decoder, WebProcessCreat
         return false;
 #endif
 
+#if USE(GBM)
+    std::optional<String> renderDeviceFile;
+    decoder >> renderDeviceFile;
+    if (!renderDeviceFile)
+        return false;
+    parameters.renderDeviceFile = WTFMove(*renderDeviceFile);
+#endif
+
 #if PLATFORM(GTK)
     std::optional<bool> useDMABufSurfaceForCompositing;
     decoder >> useDMABufSurfaceForCompositing;
     if (!useDMABufSurfaceForCompositing)
         return false;
     parameters.useDMABufSurfaceForCompositing = WTFMove(*useDMABufSurfaceForCompositing);
-    std::optional<String> renderDeviceFile;
-    decoder >> renderDeviceFile;
-    if (!renderDeviceFile)
-        return false;
-    parameters.renderDeviceFile = WTFMove(*renderDeviceFile);
     std::optional<bool> useSystemAppearanceForScrollbars;
     decoder >> useSystemAppearanceForScrollbars;
     if (!useSystemAppearanceForScrollbars)

--- a/Source/WebKit/Shared/WebProcessCreationParameters.h
+++ b/Source/WebKit/Shared/WebProcessCreationParameters.h
@@ -227,9 +227,12 @@ struct WebProcessCreationParameters {
     String contentSizeCategory;
 #endif
 
+#if USE(GBM)
+    String renderDeviceFile;
+#endif
+
 #if PLATFORM(GTK)
     bool useDMABufSurfaceForCompositing { false };
-    String renderDeviceFile;
     bool useSystemAppearanceForScrollbars { false };
     GtkSettingsState gtkSettings;
 #endif

--- a/Source/WebKit/UIProcess/GPU/GPUProcessProxy.cpp
+++ b/Source/WebKit/UIProcess/GPU/GPUProcessProxy.cpp
@@ -69,6 +69,10 @@
 #include <wtf/BlockPtr.h>
 #endif
 
+#if USE(GBM)
+#include <WebCore/PlatformDisplay.h>
+#endif
+
 #define MESSAGE_CHECK(assertion) MESSAGE_CHECK_BASE(assertion, this->connection())
 
 namespace WebKit {
@@ -166,6 +170,10 @@ GPUProcessProxy::GPUProcessProxy()
         parameters.compilerServiceExtensionHandles = SandboxExtension::createHandlesForMachLookup(WebCore::agxCompilerServices(), std::nullopt);
         parameters.dynamicIOKitExtensionHandles = SandboxExtension::createHandlesForIOKitClassExtensions(WebCore::agxCompilerClasses(), std::nullopt);
     }
+#endif
+
+#if USE(GBM)
+    parameters.renderDeviceFile = WebCore::PlatformDisplay::sharedDisplay().drmRenderNodeFile();
 #endif
 
     platformInitializeGPUProcessParameters(parameters);

--- a/Source/WebKit/UIProcess/glib/WebProcessPoolGLib.cpp
+++ b/Source/WebKit/UIProcess/glib/WebProcessPoolGLib.cpp
@@ -86,11 +86,12 @@ void WebProcessPool::platformInitializeWebProcess(const WebProcessProxy& process
     }
 #endif
 
+#if USE(GBM)
+    parameters.renderDeviceFile = WebCore::PlatformDisplay::sharedDisplay().drmRenderNodeFile();
+#endif
+
 #if PLATFORM(GTK) && USE(GBM)
-    if (AcceleratedBackingStoreDMABuf::checkRequirements()) {
-        parameters.useDMABufSurfaceForCompositing = true;
-        parameters.renderDeviceFile = WebCore::PlatformDisplay::sharedDisplay().drmRenderNodeFile();
-    }
+    parameters.useDMABufSurfaceForCompositing = AcceleratedBackingStoreDMABuf::checkRequirements();
 #endif
 
 #if PLATFORM(WAYLAND)

--- a/Source/WebKit/WebProcess/WebPage/gtk/AcceleratedSurfaceDMABuf.cpp
+++ b/Source/WebKit/WebProcess/WebPage/gtk/AcceleratedSurfaceDMABuf.cpp
@@ -32,6 +32,7 @@
 #include "WebPage.h"
 #include "WebProcess.h"
 #include <WebCore/DMABufFormat.h>
+#include <WebCore/GBMDevice.h>
 #include <WebCore/PlatformDisplay.h>
 #include <array>
 #include <epoxy/egl.h>
@@ -100,7 +101,7 @@ std::unique_ptr<AcceleratedSurfaceDMABuf::RenderTarget> AcceleratedSurfaceDMABuf
 
     auto& display = WebCore::PlatformDisplay::sharedDisplayForCompositing();
     auto createImage = [&]() -> std::pair<UnixFileDescriptor, EGLImage> {
-        auto* device = display.gbmDevice();
+        auto* device = WebCore::GBMDevice::singleton().device();
         if (!device) {
             WTFLogAlways("Failed to create GBM buffer of size %dx%d: no GBM device found", size.width(), size.height());
             return { };

--- a/Source/WebKit/WebProcess/glib/WebProcessGLib.cpp
+++ b/Source/WebKit/WebProcess/glib/WebProcessGLib.cpp
@@ -48,7 +48,11 @@
 #include <wpe/wpe.h>
 #endif
 
-#if PLATFORM(GTK) && USE(GBM)
+#if USE(GBM)
+#include <WebCore/GBMDevice.h>
+#endif
+
+#if PLATFORM(GTK)
 #include <WebCore/PlatformDisplayGBM.h>
 #include <WebCore/PlatformDisplaySurfaceless.h>
 #endif
@@ -124,10 +128,14 @@ void WebProcess::platformInitializeWebProcess(WebProcessCreationParameters& para
     }
 #endif
 
+#if USE(GBM)
+    WebCore::GBMDevice::singleton().initialize(parameters.renderDeviceFile);
+#endif
+
 #if PLATFORM(GTK) && USE(GBM)
     if (parameters.useDMABufSurfaceForCompositing) {
-        if (!parameters.renderDeviceFile.isEmpty())
-            m_displayForCompositing = WebCore::PlatformDisplayGBM::create(parameters.renderDeviceFile);
+        if (auto* device = WebCore::GBMDevice::singleton().device())
+            m_displayForCompositing = WebCore::PlatformDisplayGBM::create(device);
         else
             m_displayForCompositing = WebCore::PlatformDisplaySurfaceless::create();
     }


### PR DESCRIPTION
#### c02217e5b32db323e432a226b86d731a43ac2a70
<pre>
[GTK][WPE] Ensure the right GPU is used by GBM for WebGL
<a href="https://bugs.webkit.org/show_bug.cgi?id=255587">https://bugs.webkit.org/show_bug.cgi?id=255587</a>

Reviewed by Žan Doberšek.

Switch to use the GBM platform and use the GBM device from the shared
display for compositing.

* Source/WebCore/SourcesGTK.txt:
* Source/WebCore/platform/graphics/PlatformDisplay.cpp:
(WebCore::PlatformDisplay::~PlatformDisplay):
(WebCore::PlatformDisplay::gbmDevice):
* Source/WebCore/platform/graphics/PlatformDisplay.h:
* Source/WebCore/platform/graphics/gbm/GBMBufferSwapchain.cpp:
(WebCore::GBMBufferSwapchain::getBuffer):
* Source/WebCore/platform/graphics/gbm/GBMBufferSwapchain.h:
* Source/WebCore/platform/graphics/gbm/GBMDevice.cpp:
(WebCore::GBMDevice::singleton):
(WebCore::GBMDevice::~GBMDevice):
(WebCore::GBMDevice::initialize):
(WebCore::GBMDevice::GBMDevice): Deleted.
* Source/WebCore/platform/graphics/gbm/GBMDevice.h:
(WebCore::GBMDevice::isInitialized const):
(WebCore::GBMDevice::device const):
* Source/WebCore/platform/graphics/gbm/GraphicsContextGLGBM.cpp:
(WebCore::GraphicsContextGLGBM::platformInitializeContext):
* Source/WebCore/platform/graphics/gbm/GraphicsContextGLGBM.h:
* Source/WebCore/platform/graphics/gbm/PlatformDisplayGBM.cpp:
(WebCore::PlatformDisplayGBM::create):
(WebCore::PlatformDisplayGBM::PlatformDisplayGBM):
* Source/WebCore/platform/graphics/gbm/PlatformDisplayGBM.h:
* Source/WebCore/platform/graphics/gstreamer/DMABufVideoSinkGStreamer.cpp:
(webKitDMABufVideoSinkIsEnabled):
* Source/WebCore/platform/graphics/gstreamer/MediaPlayerPrivateGStreamer.cpp:
* Source/WebKit/GPUProcess/GPUProcess.cpp:
(WebKit::GPUProcess::initializeGPUProcess):
* Source/WebKit/GPUProcess/GPUProcess.h:
* Source/WebKit/GPUProcess/GPUProcessCreationParameters.cpp:
(WebKit::GPUProcessCreationParameters::encode const):
(WebKit::GPUProcessCreationParameters::decode):
* Source/WebKit/GPUProcess/GPUProcessCreationParameters.h:
* Source/WebKit/Shared/WebProcessCreationParameters.cpp:
(WebKit::WebProcessCreationParameters::encode const):
(WebKit::WebProcessCreationParameters::decode):
* Source/WebKit/Shared/WebProcessCreationParameters.h:
* Source/WebKit/UIProcess/GPU/GPUProcessProxy.cpp:
(WebKit::GPUProcessProxy::GPUProcessProxy):
* Source/WebKit/UIProcess/glib/WebProcessPoolGLib.cpp:
(WebKit::WebProcessPool::platformInitializeWebProcess):
* Source/WebKit/WebProcess/WebPage/gtk/AcceleratedSurfaceDMABuf.cpp:
(WebKit::AcceleratedSurfaceDMABuf::RenderTargetEGLImage::create):
* Source/WebKit/WebProcess/glib/WebProcessGLib.cpp:
(WebKit::WebProcess::platformInitializeWebProcess):
* Source/WebKit/WebProcess/WebPage/gtk/AcceleratedSurfaceDMABuf.cpp:
(WebKit::AcceleratedSurfaceDMABuf::RenderTargetEGLImage::create):
* Source/WebKit/WebProcess/glib/WebProcessGLib.cpp:
(WebKit::WebProcess::platformInitializeWebProcess):

Canonical link: <a href="https://commits.webkit.org/263215@main">https://commits.webkit.org/263215@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/df950f56c9609bc050d1b0254ce69619afec1245

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/3850 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/3939 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/4048 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/5284 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/4110 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/3826 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/4019 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/3945 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/3694 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/3898 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/4096 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/3471 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/5118 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/1600 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/3446 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/4818 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/3419 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/3506 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/4890 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/3903 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/3158 "16 failures") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/3426 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/3446 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/3469 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/453 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/3703 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->