### PR TITLE
Update counters at the end of render tree update

### DIFF
--- a/LayoutTests/TestExpectations
+++ b/LayoutTests/TestExpectations
@@ -2730,7 +2730,6 @@ imported/w3c/web-platform-tests/html/semantics/scripting-1/the-script-element/mo
 
 # Clean layout tree after FrameView::layout
 webkit.org/b/164856 [ Debug ] editing/execCommand/indent-block-in-list.html [ Skip ]
-webkit.org/b/162828 [ Debug ] tables/table-section-overflow-clip-crash.html  [ Skip ]
 
 webkit.org/b/164797 js/dom/domjit-function-get-element-by-id-licm.html [ Pass Timeout ]
 webkit.org/b/164797 js/dom/domjit-function-get-element-by-id-changed.html [ Pass Timeout ]

--- a/LayoutTests/platform/mac-ventura-wk2/imported/w3c/web-platform-tests/css/css-cascade/layer-counter-style-override-expected.txt
+++ b/LayoutTests/platform/mac-ventura-wk2/imported/w3c/web-platform-tests/css/css-cascade/layer-counter-style-override-expected.txt
@@ -2,5 +2,5 @@
 PASS @counter-style unlayered overrides layered
 PASS @counter-style override between layers
 PASS @counter-style override update with appended sheet 1
-FAIL @counter-style override update with appended sheet 2 assert_equals: expected "31.21875px" but got "23.40625px"
+PASS @counter-style override update with appended sheet 2
 

--- a/Source/WebCore/layout/integration/LayoutIntegrationBoxTree.cpp
+++ b/Source/WebCore/layout/integration/LayoutIntegrationBoxTree.cpp
@@ -184,12 +184,6 @@ UniqueRef<Layout::Box> BoxTree::createLayoutBox(RenderObject& renderer)
     if (is<RenderText>(renderer)) {
         auto& textRenderer = downcast<RenderText>(renderer);
 
-        if (is<RenderCounter>(textRenderer) && textRenderer.preferredLogicalWidthsDirty()) {
-            // This ensures that InlineTextBox always has up-to-date counter text.
-            // Counter content is updated through preferred width computation.
-            downcast<RenderCounter>(textRenderer).updateCounter();
-        }
-
         auto style = RenderStyle::createAnonymousStyleWithDisplay(textRenderer.style(), DisplayType::Inline);
         auto isCombinedText = is<RenderCombineText>(textRenderer) && downcast<RenderCombineText>(textRenderer).isCombined();
         auto text = style.textSecurity() == TextSecurity::None

--- a/Source/WebCore/rendering/CounterNode.cpp
+++ b/Source/WebCore/rendering/CounterNode.cpp
@@ -177,17 +177,12 @@ void CounterNode::resetRenderers()
 {
     if (!m_rootRenderer)
         return;
-    bool skipLayoutAndPerfWidthsRecalc = m_rootRenderer->renderTreeBeingDestroyed();
     auto* current = m_rootRenderer;
     while (current) {
-        if (!skipLayoutAndPerfWidthsRecalc) {
-            current->setNeedsLayoutAndPrefWidthsRecalc();
-            if (auto* lineLayout = LayoutIntegration::LineLayout::containing(*current))
-                lineLayout->flow().invalidateLineLayoutPath();
-        }
         auto* next = current->m_nextForSameCounter;
         current->m_nextForSameCounter = nullptr;
         current->m_counterNode = nullptr;
+        current->view().addCounterNeedingUpdate(*current);
         current = next;
     }
     m_rootRenderer = nullptr;

--- a/Source/WebCore/rendering/LegacyLineLayout.cpp
+++ b/Source/WebCore/rendering/LegacyLineLayout.cpp
@@ -191,7 +191,6 @@ static inline void dirtyLineBoxesForRenderer(RenderObject& renderer, bool fullLa
 {
     if (is<RenderText>(renderer)) {
         RenderText& renderText = downcast<RenderText>(renderer);
-        updateCounterIfNeeded(renderText);
         renderText.dirtyLineBoxes(fullLayout);
     } else if (is<RenderLineBreak>(renderer))
         downcast<RenderLineBreak>(renderer).dirtyLineBoxes(fullLayout);

--- a/Source/WebCore/rendering/RenderBlockFlow.cpp
+++ b/Source/WebCore/rendering/RenderBlockFlow.cpp
@@ -4037,13 +4037,6 @@ void RenderBlockFlow::layoutModernLines(bool relayoutChildren, LayoutUnit& repai
         else if (!renderer.isOutOfFlowPositioned())
             renderer.clearNeedsLayout();
 
-        if (is<RenderCounter>(renderer)) {
-            // The counter content gets updated unconventionally by involving computePreferredLogicalWidths() (see RenderCounter::updateCounter())
-            // Here we assume that every time the content of a counter changes, we already handled the update by re-constructing the associated InlineTextBox (see BoxTree::buildTreeForInlineContent).
-            if (renderer.preferredLogicalWidthsDirty())
-                downcast<RenderCounter>(renderer).updateCounter();
-            continue;
-        }
         if (is<RenderCombineText>(renderer)) {
             downcast<RenderCombineText>(renderer).combineTextIfNeeded();
             continue;

--- a/Source/WebCore/rendering/RenderCounter.h
+++ b/Source/WebCore/rendering/RenderCounter.h
@@ -38,8 +38,6 @@ public:
 
     static void destroyCounterNodes(RenderElement&);
     static void destroyCounterNode(RenderElement&, const AtomString& identifier);
-    static void rendererSubtreeAttached(RenderElement&);
-    static void rendererRemovedFromTree(RenderElement&);
     static void rendererStyleChanged(RenderElement&, const RenderStyle* oldStyle, const RenderStyle& newStyle);
 
     void updateCounter();
@@ -53,8 +51,6 @@ private:
     bool isCounter() const override;
     String originalText() const override;
     
-    void computePreferredLogicalWidths(float leadWidth, bool forcedMinMaxWidthComputation = false) override;
-
     RefPtr<CSSCounterStyle> counterStyle() const;
 
     CounterContent m_counter;

--- a/Source/WebCore/rendering/RenderView.cpp
+++ b/Source/WebCore/rendering/RenderView.cpp
@@ -40,6 +40,7 @@
 #include "LocalFrameView.h"
 #include "NodeTraversal.h"
 #include "Page.h"
+#include "RenderCounter.h"
 #include "RenderDescendantIterator.h"
 #include "RenderGeometryMap.h"
 #include "RenderImage.h"
@@ -1105,6 +1106,16 @@ void RenderView::registerContainerQueryBox(const RenderBox& box)
 void RenderView::unregisterContainerQueryBox(const RenderBox& box)
 {
     m_containerQueryBoxes.remove(box);
+}
+
+void RenderView::addCounterNeedingUpdate(RenderCounter& renderer)
+{
+    m_countersNeedingUpdate.add(renderer);
+}
+
+WeakHashSet<RenderCounter> RenderView::takeCountersNeedingUpdate()
+{
+    return std::exchange(m_countersNeedingUpdate, { });
 }
 
 } // namespace WebCore

--- a/Source/WebCore/rendering/RenderView.h
+++ b/Source/WebCore/rendering/RenderView.h
@@ -36,6 +36,7 @@ namespace WebCore {
 class ImageQualityController;
 class RenderLayerCompositor;
 class RenderLayoutState;
+class RenderCounter;
 class RenderQuote;
 
 namespace Layout {
@@ -157,13 +158,8 @@ public:
     bool hasQuotesNeedingUpdate() const { return m_hasQuotesNeedingUpdate; }
     void setHasQuotesNeedingUpdate(bool b) { m_hasQuotesNeedingUpdate = b; }
 
-    // FIXME: This is a work around because the current implementation of counters
-    // requires walking the entire tree repeatedly and most pages don't actually use either
-    // feature so we shouldn't take the performance hit when not needed. Long term we should
-    // rewrite the counter code.
-    void addRenderCounter() { ++m_renderCounterCount; }
-    void removeRenderCounter() { ASSERT(m_renderCounterCount > 0); --m_renderCounterCount; }
-    bool hasRenderCounters() const { return m_renderCounterCount; }
+    void addCounterNeedingUpdate(RenderCounter&);
+    WeakHashSet<RenderCounter> takeCountersNeedingUpdate();
 
     void incrementRendersWithOutline() { ++m_renderersWithOutlineCount; }
     void decrementRendersWithOutline() { ASSERT(m_renderersWithOutlineCount > 0); --m_renderersWithOutlineCount; }
@@ -272,6 +268,7 @@ private:
 
     bool m_hasQuotesNeedingUpdate { false };
 
+    WeakHashSet<RenderCounter> m_countersNeedingUpdate;
     unsigned m_renderCounterCount { 0 };
     unsigned m_renderersWithOutlineCount { 0 };
 

--- a/Source/WebCore/rendering/line/BreakingContext.h
+++ b/Source/WebCore/rendering/line/BreakingContext.h
@@ -526,15 +526,6 @@ inline void nextCharacter(UChar& currentCharacter, UChar& lastCharacter, UChar& 
     lastCharacter = currentCharacter;
 }
 
-// FIXME: Don't let counters mark themselves as needing pref width recalcs during layout
-// so we don't need this hack.
-inline void updateCounterIfNeeded(RenderText& renderText)
-{
-    if (!renderText.preferredLogicalWidthsDirty() || !is<RenderCounter>(renderText))
-        return;
-    downcast<RenderCounter>(renderText).updateCounter();
-}
-
 inline float measureHyphenWidth(RenderText& renderer, const FontCascade& font, HashSet<const Font*>* fallbackFonts = 0)
 {
     const RenderStyle& style = renderer.style();
@@ -715,7 +706,6 @@ inline bool BreakingContext::handleText(WordMeasurements& wordMeasurements, bool
     }
 
     if (m_renderTextInfo.text != &renderer) {
-        updateCounterIfNeeded(renderer);
         m_renderTextInfo.text = &renderer;
         m_renderTextInfo.font = &font;
         m_renderTextInfo.layout = font.createLayout(renderer, m_width.currentWidth(), m_collapseWhiteSpace);

--- a/Source/WebCore/rendering/updating/RenderTreeBuilder.cpp
+++ b/Source/WebCore/rendering/updating/RenderTreeBuilder.cpp
@@ -445,9 +445,6 @@ void RenderTreeBuilder::attachToRenderElementInternal(RenderElement& parent, Ren
         if (m_internalMovesType == RenderObject::IsInternalMove::No) {
             if (auto* fragmentedFlow = newChild->enclosingFragmentedFlow(); is<RenderMultiColumnFlow>(fragmentedFlow))
                 multiColumnBuilder().multiColumnDescendantInserted(downcast<RenderMultiColumnFlow>(*fragmentedFlow), *newChild);
-
-            if (is<RenderElement>(*newChild))
-                RenderCounter::rendererSubtreeAttached(downcast<RenderElement>(*newChild));
         }
     }
 
@@ -976,11 +973,6 @@ RenderPtr<RenderObject> RenderTreeBuilder::detachFromRenderElement(RenderElement
     // This is needed to avoid race conditions where willBeRemovedFromTree() would dirty the tree's structure
     // and the code running here would force an untimely rebuilding, leaving |child| dangling.
     auto childToTake = parent.detachRendererInternal(child);
-
-    // rendererRemovedFromTree() walks the whole subtree. We can improve performance
-    // by skipping this step when destroying the entire tree.
-    if (!parent.renderTreeBeingDestroyed() && is<RenderElement>(*childToTake))
-        RenderCounter::rendererRemovedFromTree(downcast<RenderElement>(*childToTake));
 
     if (!parent.renderTreeBeingDestroyed()) {
         if (AXObjectCache* cache = parent.document().existingAXObjectCache())

--- a/Source/WebCore/rendering/updating/RenderTreeUpdater.cpp
+++ b/Source/WebCore/rendering/updating/RenderTreeUpdater.cpp
@@ -119,6 +119,7 @@ void RenderTreeUpdater::commit(std::unique_ptr<const Style::Update> styleUpdate)
     }
 
     generatedContent().updateRemainingQuotes();
+    generatedContent().updateCounters();
 
     m_builder.updateAfterDescendants(renderView());
 

--- a/Source/WebCore/rendering/updating/RenderTreeUpdaterGeneratedContent.cpp
+++ b/Source/WebCore/rendering/updating/RenderTreeUpdaterGeneratedContent.cpp
@@ -29,6 +29,7 @@
 #include "ContentData.h"
 #include "InspectorInstrumentation.h"
 #include "PseudoElement.h"
+#include "RenderCounter.h"
 #include "RenderDescendantIterator.h"
 #include "RenderElement.h"
 #include "RenderImage.h"
@@ -67,6 +68,18 @@ void RenderTreeUpdater::GeneratedContent::updateQuotesUpTo(RenderQuote* lastQuot
             return;
     }
     ASSERT(!lastQuote || m_updater.m_builder.hasBrokenContinuation());
+}
+
+void RenderTreeUpdater::GeneratedContent::updateCounters()
+{
+    auto update = [&] {
+        auto counters = m_updater.renderView().takeCountersNeedingUpdate();
+        for (auto& counter : counters)
+            counter.updateCounter();
+    };
+    // Update twice and hope it stabilizes.
+    update();
+    update();
 }
 
 static bool elementIsTargetedByKeyframeEffectRequiringPseudoElement(const Element* element, PseudoId pseudoId)

--- a/Source/WebCore/rendering/updating/RenderTreeUpdaterGeneratedContent.h
+++ b/Source/WebCore/rendering/updating/RenderTreeUpdaterGeneratedContent.h
@@ -41,6 +41,7 @@ public:
     void updateBackdropRenderer(RenderElement&);
     void updatePseudoElement(Element&, const Style::ElementUpdate&, PseudoId);
     void updateRemainingQuotes();
+    void updateCounters();
 
     static void removeBeforePseudoElement(Element&, RenderTreeBuilder&);
     static void removeAfterPseudoElement(Element&, RenderTreeBuilder&);


### PR DESCRIPTION
#### 21790649ca108abfa081988c5c8de0ec8cec7c1e
<pre>
Update counters at the end of render tree update
<a href="https://bugs.webkit.org/show_bug.cgi?id=255589">https://bugs.webkit.org/show_bug.cgi?id=255589</a>
rdar://108189324

Reviewed by Alan Baradlay.

Simplify counter updating by doing it in a single place at the end of render tree update.

* Source/WebCore/layout/integration/LayoutIntegrationBoxTree.cpp:
(WebCore::LayoutIntegration::BoxTree::createLayoutBox):

Remove layout-time update code from here and elsewhere.

* Source/WebCore/rendering/CounterNode.cpp:
(WebCore::CounterNode::resetRenderers):

Invalidate by adding the counter to a weak map.

* Source/WebCore/rendering/LegacyLineLayout.cpp:
(WebCore::dirtyLineBoxesForRenderer):
* Source/WebCore/rendering/RenderBlockFlow.cpp:
(WebCore::RenderBlockFlow::layoutModernLines):
* Source/WebCore/rendering/RenderCounter.cpp:
(WebCore::RenderCounter::RenderCounter):
(WebCore::RenderCounter::willBeDestroyed):
(WebCore::RenderCounter::originalText const):

Just generate the text here.

(WebCore::RenderCounter::updateCounter):

Use setText instead of setRenderedText so we get correct layout invalidation for free.

(WebCore::RenderCounter::computePreferredLogicalWidths): Deleted.

Updating counters is no longer tied to preferred width updates.

* Source/WebCore/rendering/RenderCounter.h:
* Source/WebCore/rendering/RenderCounter.cpp:
(WebCore::RenderCounter::rendererRemovedFromTree): Deleted.
(WebCore::updateCounters): Deleted.
(WebCore::RenderCounter::rendererSubtreeAttached): Deleted.

No need for these tree-traversing move paths anymore. Counters get recomputed using the normal update paths.

* Source/WebCore/rendering/RenderView.cpp:
(WebCore::RenderView::addCounterNeedingUpdate):
(WebCore::RenderView::takeCountersNeedingUpdate):

Track counters that need updating. This replaces the use preferred logical width bit.

* Source/WebCore/rendering/RenderView.h:
* Source/WebCore/rendering/line/BreakingContext.h:
(WebCore::BreakingContext::handleText):
(WebCore::updateCounterIfNeeded): Deleted.
* Source/WebCore/rendering/updating/RenderTreeUpdater.cpp:
(WebCore::RenderTreeUpdater::commit):
* Source/WebCore/rendering/updating/RenderTreeBuilder.cpp:
(WebCore::RenderTreeBuilder::attachToRenderElementInternal):
(WebCore::RenderTreeBuilder::detachFromRenderElement):
* Source/WebCore/rendering/updating/RenderTreeUpdaterGeneratedContent.cpp:
(WebCore::RenderTreeUpdater::GeneratedContent::updateCounters):

Do The actual updating.

* Source/WebCore/rendering/updating/RenderTreeUpdaterGeneratedContent.h:

Canonical link: <a href="https://commits.webkit.org/263127@main">https://commits.webkit.org/263127@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/21bc3e7ec3c008698de6ba5b769bb2cddba0dbba

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/3674 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/3758 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/3864 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/5100 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/3959 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/3648 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/3834 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/3763 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/3184 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/3718 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/3949 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/3312 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/4931 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/1455 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/3282 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/3344 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/3263 "Passed tests") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/3341 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/4698 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/3727 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/3016 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/3261 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/3282 "Passed tests") | | 
| [❌ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/891 "Failed to push commit to Webkit repository") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/3293 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/3538 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->