### PR TITLE
[WGSL] Add typing for indexed access on vectors

### DIFF
--- a/Source/WebGPU/WGSL/TypeCheck.cpp
+++ b/Source/WebGPU/WGSL/TypeCheck.cpp
@@ -302,7 +302,7 @@ void TypeChecker::visit(AST::IndexAccessExpression& access)
         return;
     }
 
-    if (!unify(index, m_types.i32Type()) && !unify(index, m_types.u32Type()) && !unify(index, m_types.abstractIntType())) {
+    if (!unify(m_types.i32Type(), index) && !unify(m_types.u32Type(), index) && !unify(m_types.abstractIntType(), index)) {
         typeError(access.span(), "index must be of type 'i32' or 'u32', found: '", *index, "'");
         return;
     }
@@ -311,6 +311,13 @@ void TypeChecker::visit(AST::IndexAccessExpression& access)
         // FIXME: check bounds if index is constant
         auto& array = std::get<Types::Array>(*base);
         inferred(array.element);
+        return;
+    }
+
+    if (std::holds_alternative<Types::Vector>(*base)) {
+        // FIXME: check bounds if index is constant
+        auto& vector = std::get<Types::Vector>(*base);
+        inferred(vector.element);
         return;
     }
 

--- a/Source/WebGPU/WGSL/tests/invalid/vector.wgsl
+++ b/Source/WebGPU/WGSL/tests/invalid/vector.wgsl
@@ -1,0 +1,4 @@
+fn testIndexAccess() {
+  // CHECK-L: index must be of type 'i32' or 'u32', found: 'f32'
+  let x1 = vec2(0)[1f];
+}


### PR DESCRIPTION
#### 381c92243cdde79aaee748e8b8c57aac87877b56
<pre>
[WGSL] Add typing for indexed access on vectors
<a href="https://bugs.webkit.org/show_bug.cgi?id=255598">https://bugs.webkit.org/show_bug.cgi?id=255598</a>
rdar://108197306

Reviewed by Myles C. Maxfield.

So far we only supported field access on vectors (e.g. vec2.x) but not indexed
access (e.g. vec2[0]). This extends the typing to add support for that. Just
like our current support for indexed access on arrays, we still don&apos;t validate
if the access is out-of-bounds when the index is a constant.

* Source/WebGPU/WGSL/TypeCheck.cpp:
(WGSL::TypeChecker::visit):
* Source/WebGPU/WGSL/tests/invalid/vector.wgsl: Added.

Canonical link: <a href="https://commits.webkit.org/263122@main">https://commits.webkit.org/263122@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c6bfd037887d7827db221d6dc93c840f2cf69443

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/3553 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/3600 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/3739 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/4977 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/3828 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/3692 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/3641 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/3087 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/3596 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/3846 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/3202 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/4799 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/1353 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/3177 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/3075 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/3153 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/3236 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/4559 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/3612 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/2916 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/3153 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/3175 "Passed tests") | | 
| [❌ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/894 "Failed to push commit to Webkit repository") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/3180 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/3431 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->