### PR TITLE
[WebGPU] Shader module shouldn't try to read constants if there's no library

### DIFF
--- a/Source/WebGPU/WebGPU/ShaderModule.mm
+++ b/Source/WebGPU/WebGPU/ShaderModule.mm
@@ -244,6 +244,9 @@ void ShaderModule::setLabel(String&& label)
 
 id<MTLFunction> ShaderModule::getNamedFunction(const String& originalName, const HashMap<String, double>& keyValueReplacements) const
 {
+    if (!m_library)
+        return nil;
+
     const auto* information = entryPointInformation(originalName);
     const String& name = information ? information->mangledName : originalName;
     auto originalFunction = [m_library newFunctionWithName:name];


### PR DESCRIPTION
#### 219a3d11b718f56768d5bd56b44a79cc67317bef
<pre>
[WebGPU] Shader module shouldn&apos;t try to read constants if there&apos;s no library
<a href="https://bugs.webkit.org/show_bug.cgi?id=255599">https://bugs.webkit.org/show_bug.cgi?id=255599</a>
rdar://108197471

Reviewed by Mike Wyrzykowski.

We currently crash when creating a render pipeline and providing constant overrides
unless the module was early compiled (which is currently disabled). This is a trivial
change to check if we have a successfully compiled library before trying to read
the constants from it.

* Source/WebGPU/WebGPU/ShaderModule.mm:
(WebGPU::ShaderModule::getNamedFunction const):

Canonical link: <a href="https://commits.webkit.org/263120@main">https://commits.webkit.org/263120@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d7fa15f61fa2ca1278bd3bb7830434a19be24bad

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/3554 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/3601 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/3740 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/4978 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/3829 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/3693 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/3642 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/3086 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/3597 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/3847 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/3201 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/4800 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/1354 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/3176 "Passed tests") | [💥 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/3076 "An unexpected error occured. Recent messages:Printed configuration; Skipping applying patch since patch_id isn't provided; Checked out pull request") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/3154 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/3235 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/4567 "268 api tests failed or timed out") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/3613 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/2918 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/3154 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/3174 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/895 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/3181 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/3432 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->