### PR TITLE
A muted microphone track should get ended if its device disappears

### DIFF
--- a/LayoutTests/fast/mediastream/MediaDevices-addEventListener-expected.txt
+++ b/LayoutTests/fast/mediastream/MediaDevices-addEventListener-expected.txt
@@ -1,3 +1,4 @@
+CONSOLE MESSAGE: A MediaStreamTrack ended due to a capture failure
 
 PASS Testing MediaDevices addEventListener/removeEventListener
 PASS Capture 'devicechange' event with addEventListener

--- a/LayoutTests/fast/mediastream/device-change-event-2-expected.txt
+++ b/LayoutTests/fast/mediastream/device-change-event-2-expected.txt
@@ -1,3 +1,5 @@
+CONSOLE MESSAGE: A MediaStreamTrack ended due to a capture failure
+CONSOLE MESSAGE: A MediaStreamTrack ended due to a capture failure
 
 PASS 'devicechange' event fired when device list changes
 PASS 'devicechange' events fired quickly are coalesced

--- a/LayoutTests/fast/mediastream/microphone-change-while-capturing-expected.txt
+++ b/LayoutTests/fast/mediastream/microphone-change-while-capturing-expected.txt
@@ -1,3 +1,4 @@
+CONSOLE MESSAGE: A MediaStreamTrack ended due to a capture failure
 
 
 PASS Detection of missing capturing device should trigger capture to fail

--- a/LayoutTests/fast/mediastream/microphone-change-while-muted-expected.txt
+++ b/LayoutTests/fast/mediastream/microphone-change-while-muted-expected.txt
@@ -1,0 +1,5 @@
+CONSOLE MESSAGE: A MediaStreamTrack ended due to a capture failure
+
+
+PASS Detection of missing capturing device should trigger capture to fail even if track is muted
+

--- a/LayoutTests/fast/mediastream/microphone-change-while-muted.html
+++ b/LayoutTests/fast/mediastream/microphone-change-while-muted.html
@@ -35,30 +35,22 @@
         await setup(test);
 
         testRunner.addMockMicrophoneDevice("usbmic", "my USB microphone");
+
         const deviceId = await getDeviceId("my USB microphone");
         video.srcObject = await navigator.mediaDevices.getUserMedia({ audio: { deviceId } });
         await video.play();
+
+        if (window.internals)
+            internals.setPageMuted("capturedevices");
+
+        await new Promise(resolve => video.srcObject.getAudioTracks()[0].onmute = resolve);
 
         testRunner.removeMockMediaDevice("usbmic");
         return new Promise((resolve, reject) => {
             video.srcObject.getAudioTracks()[0].onended = resolve;
-            setTimeout(reject, 2000);
+            setTimeout(() => reject("track did not end"), 2000);
         });
-    }, "Detection of missing capturing device should trigger capture to fail");
-
-    promise_test(async (test) => {
-        await setup(test);
-
-        testRunner.addMockMicrophoneDevice("usbmic1", "my USB microphone");
-        testRunner.addMockMicrophoneDevice("usbmic2", "my second USB microphone");
-        const deviceId = await getDeviceId("my USB microphone");
-        video.srcObject = await navigator.mediaDevices.getUserMedia({ audio: { deviceId } });
-        await video.play();
-        testRunner.removeMockMediaDevice("usbmic2");
-        testRunner.addMockMicrophoneDevice("usbmic3", "my third USB microphone");
-        await new Promise(resolve => setTimeout(resolve, 200));
-        assert_equals(video.srcObject.getAudioTracks()[0].readyState, "live");
-    }, "Adding or removing a new device should not fail ongoing capture");
+    }, "Detection of missing capturing device should trigger capture to fail even if track is muted");
     </script>
 </body>
 </html>

--- a/LayoutTests/platform/glib/TestExpectations
+++ b/LayoutTests/platform/glib/TestExpectations
@@ -1683,7 +1683,11 @@ webkit.org/b/187603 fast/mediastream/media-stream-track-source-failure.html [ Ti
 # This ends up calling WKPageTriggerMockMicrophoneConfigurationChange which is specific to GPUProcess.
 fast/mediastream/mediastreamtrack-configurationchange.html [ Skip ]
 
-fast/mediastream/MediaDevices-addEventListener.html [ DumpJSConsoleLogInStdErr ]
+# Tests should be rebased, mock infra might need some updates.
+fast/mediastream/MediaDevices-addEventListener.html [ Failure ]
+fast/mediastream/microphone-change-while-capturing.html [ Failure ]
+fast/mediastream/microphone-change-while-muted.html [ Failure ]
+fast/mediastream/device-change-event-2.html [ Failure ]
 
 webkit.org/b/194611 http/wpt/webrtc/getUserMedia-processSwapping.html [ Failure ]
 

--- a/Source/WebCore/Modules/mediastream/MediaStreamTrack.cpp
+++ b/Source/WebCore/Modules/mediastream/MediaStreamTrack.cpp
@@ -505,7 +505,7 @@ void MediaStreamTrack::trackEnded(MediaStreamTrackPrivate&)
 
     ALWAYS_LOG(LOGIDENTIFIER);
 
-    if (m_isCaptureTrack && m_private->source().captureDidFail())
+    if (m_isCaptureTrack && m_private->source().captureDidFail() && m_readyState != State::Ended)
         scriptExecutionContext()->addConsoleMessage(MessageSource::JS, MessageLevel::Error, "A MediaStreamTrack ended due to a capture failure"_s);
 
     // http://w3c.github.io/mediacapture-main/#life-cycle

--- a/Source/WebCore/platform/mediastream/mac/BaseAudioSharedUnit.h
+++ b/Source/WebCore/platform/mediastream/mac/BaseAudioSharedUnit.h
@@ -28,6 +28,7 @@
 #if ENABLE(MEDIA_STREAM)
 
 #include "RealtimeMediaSourceCapabilities.h"
+#include "RealtimeMediaSourceCenter.h"
 #include <wtf/Function.h>
 #include <wtf/HashSet.h>
 #include <wtf/Lock.h>
@@ -42,10 +43,10 @@ class CaptureDevice;
 class CoreAudioCaptureSource;
 class PlatformAudioData;
 
-class BaseAudioSharedUnit : public CanMakeWeakPtr<BaseAudioSharedUnit, WeakPtrFactoryInitialization::Eager> {
+class BaseAudioSharedUnit : public RealtimeMediaSourceCenter::Observer {
 public:
     BaseAudioSharedUnit();
-    virtual ~BaseAudioSharedUnit() = default;
+    virtual ~BaseAudioSharedUnit();
 
     void startProducingData();
     void stopProducingData();
@@ -79,7 +80,6 @@ public:
     virtual CapabilityValueOrRange sampleRateCapacities() const = 0;
     virtual int actualSampleRate() const { return sampleRate(); }
 
-    void devicesChanged(const Vector<CaptureDevice>&);
     void whenAudioCaptureUnitIsNotRunning(Function<void()>&&);
     bool isRenderingAudio() const { return m_isRenderingAudio; }
     bool hasClients() const { return !m_clients.isEmpty(); }
@@ -118,6 +118,9 @@ protected:
 
 private:
     OSStatus startUnit();
+
+    // RealtimeMediaSourceCenter::Observer
+    void devicesChanged() final;
 
     bool m_enableEchoCancellation { true };
     double m_volume { 1 };

--- a/Source/WebCore/platform/mediastream/mac/CoreAudioCaptureDeviceManager.cpp
+++ b/Source/WebCore/platform/mediastream/mac/CoreAudioCaptureDeviceManager.cpp
@@ -375,10 +375,8 @@ void CoreAudioCaptureDeviceManager::refreshAudioCaptureDevices(NotifyIfDevicesHa
             m_speakerDevices.append(device);
     }
 
-    if (notify == NotifyIfDevicesHaveChanged::Notify) {
+    if (notify == NotifyIfDevicesHaveChanged::Notify)
         deviceChanged();
-        CoreAudioCaptureSourceFactory::singleton().devicesChanged(m_captureDevices);
-    }
 }
 
 } // namespace WebCore

--- a/Source/WebCore/platform/mediastream/mac/CoreAudioCaptureSource.cpp
+++ b/Source/WebCore/platform/mediastream/mac/CoreAudioCaptureSource.cpp
@@ -176,11 +176,6 @@ const Vector<CaptureDevice>& CoreAudioCaptureSourceFactory::speakerDevices() con
 #endif
 }
 
-void CoreAudioCaptureSourceFactory::devicesChanged(const Vector<CaptureDevice>& devices)
-{
-    CoreAudioSharedUnit::unit().devicesChanged(devices);
-}
-
 void CoreAudioCaptureSourceFactory::registerSpeakerSamplesProducer(CoreAudioSpeakerSamplesProducer& producer)
 {
     CoreAudioSharedUnit::unit().registerSpeakerSamplesProducer(producer);

--- a/Source/WebCore/platform/mediastream/mac/CoreAudioCaptureSource.h
+++ b/Source/WebCore/platform/mediastream/mac/CoreAudioCaptureSource.h
@@ -131,8 +131,6 @@ public:
 
     void scheduleReconfiguration();
 
-    void devicesChanged(const Vector<CaptureDevice>&);
-
     WEBCORE_EXPORT void registerSpeakerSamplesProducer(CoreAudioSpeakerSamplesProducer&);
     WEBCORE_EXPORT void unregisterSpeakerSamplesProducer(CoreAudioSpeakerSamplesProducer&);
     WEBCORE_EXPORT bool isAudioCaptureUnitRunning();


### PR DESCRIPTION
#### aa24abef3b41ed32881b1c66d61adc5a3702374e
<pre>
A muted microphone track should get ended if its device disappears
<a href="https://bugs.webkit.org/show_bug.cgi?id=255591">https://bugs.webkit.org/show_bug.cgi?id=255591</a>
rdar://problem/108194510

Reviewed by Eric Carlson.

The main change is in BaseAudioSharedUnit::devicesChanged where we no longer exit early if the shared unit is not running.
This ensures that muted tracks will be ended if their device is gone.

We do a refactoring so that mock device changes kick in the BaseAudioSharedUnit::devicesChanged logic.

We also do a small change to MediaStreamTrack::trackEnded to only log MediaStreamTrack capture failure if the track is not already ended.

Covered by added test.
Drive by fix in LayoutTests/fast/mediastream/microphone-change-while-capturing.html to ensure we use the usb fake device.
Rebasing of some tests now that some additional tracks are failing due to device changes.

* LayoutTests/fast/mediastream/MediaDevices-addEventListener-expected.txt:
* LayoutTests/fast/mediastream/device-change-event-2-expected.txt:
* LayoutTests/fast/mediastream/microphone-change-while-capturing-expected.txt:
* LayoutTests/fast/mediastream/microphone-change-while-capturing.html:
* LayoutTests/fast/mediastream/microphone-change-while-muted-expected.txt: Added.
* LayoutTests/fast/mediastream/microphone-change-while-muted.html: Copied from LayoutTests/fast/mediastream/microphone-change-while-capturing.html.
* LayoutTests/platform/glib/TestExpectations:
* Source/WebCore/Modules/mediastream/MediaStreamTrack.cpp:
(WebCore::MediaStreamTrack::trackEnded):
* Source/WebCore/platform/mediastream/mac/BaseAudioSharedUnit.cpp:
(WebCore::BaseAudioSharedUnit::BaseAudioSharedUnit):
(WebCore::BaseAudioSharedUnit::~BaseAudioSharedUnit):
(WebCore::BaseAudioSharedUnit::devicesChanged):
* Source/WebCore/platform/mediastream/mac/BaseAudioSharedUnit.h:
* Source/WebCore/platform/mediastream/mac/CoreAudioCaptureDeviceManager.cpp:
(WebCore::CoreAudioCaptureDeviceManager::refreshAudioCaptureDevices):
* Source/WebCore/platform/mediastream/mac/CoreAudioCaptureSource.cpp:
(WebCore::CoreAudioCaptureSourceFactory::devicesChanged): Deleted.
* Source/WebCore/platform/mediastream/mac/CoreAudioCaptureSource.h:

Canonical link: <a href="https://commits.webkit.org/263132@main">https://commits.webkit.org/263132@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9e99d730d688829eab256e52d75c54d57e9887bc

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/3689 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/3773 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/3879 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/5115 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/3972 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/3663 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/3849 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/3778 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/3194 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/3733 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/3961 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/3323 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/4949 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/1467 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/3293 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/3358 "145 failures") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/3275 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/3352 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/4720 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/3742 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/3028 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/3276 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/3293 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/903 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/3308 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/3553 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->