### PR TITLE
[macOS] Performing layout when scroll snapping with a physical mouse wheel snaps to the last snap position

### DIFF
--- a/LayoutTests/css3/scroll-snap/scroll-snap-discrete-wheel-events-with-layout-expected.txt
+++ b/LayoutTests/css3/scroll-snap/scroll-snap-discrete-wheel-events-with-layout-expected.txt
@@ -1,0 +1,10 @@
+This test verifies that discrete wheel events trigger scroll snapping in overflow areas, even if layout occurs during scrolling. To manually run the test, scroll using a physical mouse wheel and verify that a single scroll tick animates to the next snap point, such that only the green box is visible.
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+PASS container.scrollTop became 300
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/css3/scroll-snap/scroll-snap-discrete-wheel-events-with-layout.html
+++ b/LayoutTests/css3/scroll-snap/scroll-snap-discrete-wheel-events-with-layout.html
@@ -1,0 +1,64 @@
+<!DOCTYPE html>
+<html>
+<head>
+<style>
+body, html {
+    margin: 0;
+}
+
+.container {
+    height: 300px;
+    width: 300px;
+    overflow: auto;
+    scroll-snap-type: y mandatory;
+}
+
+.block {
+    height: 100%;
+    width: 300px;
+    scroll-snap-align: start;
+}
+</style>
+<script src="../../resources/js-test.js"></script>
+<script src="../../resources/ui-helper.js"></script>
+<script>
+jsTestIsAsync = true;
+
+let frameCount = 0;
+function runWidthAnimation() {
+    frameCount++;
+    const blocks = Array.from(document.querySelectorAll(".block"));
+    for (let i = 0; i < blocks.length; ++i) {
+        let frameWidth = 10 * Math.sin(frameCount * 2 * Math.PI / 100) + 50;
+        blocks[i].style.width = frameWidth + "%";
+    }
+    requestAnimationFrame(runWidthAnimation);
+}
+
+addEventListener("load", async () => {
+    description(`This test verifies that discrete wheel events trigger scroll snapping in overflow
+        areas, even if layout occurs during scrolling. To manually run the test, scroll using a
+        physical mouse wheel and verify that a single scroll tick animates to the next snap point,
+        such that only the green box is visible.`);
+
+    runWidthAnimation();
+
+    if (window.testRunner)
+       await UIHelper.statelessMouseWheelScrollAt(150, 150, 0, -1);
+
+    container = document.querySelector(".container");
+    await shouldBecomeEqual("container.scrollTop", "300");
+    finishJSTest();
+});
+</script>
+</head>
+<body>
+    <div class="container">
+        <div class="block" style="background: red;"></div>
+        <div class="block" style="background: green;"></div>
+        <div class="block" style="background: red;"></div>
+    </div>
+    <p id="description"></p>
+    <p id="console"></p>
+</body>
+</html>

--- a/LayoutTests/platform/glib/TestExpectations
+++ b/LayoutTests/platform/glib/TestExpectations
@@ -1357,6 +1357,7 @@ webkit.org/b/212202 fast/scrolling/overflow-scrollable-after-back.html [ Skip ]
 webkit.org/b/212202 css3/scroll-snap/scroll-snap-wheel-event.html [ Skip ]
 
 css3/scroll-snap/scroll-snap-discrete-wheel-event-in-mainframe.html [ Skip ]
+css3/scroll-snap/scroll-snap-discrete-wheel-events-with-layout.html [ Skip ]
 
 webkit.org/b/213921 fast/visual-viewport/scroll-event-fired-during-scroll-alone.html [ Crash ]
 

--- a/LayoutTests/platform/ios-wk2/TestExpectations
+++ b/LayoutTests/platform/ios-wk2/TestExpectations
@@ -967,6 +967,7 @@ editing/selection/select-out-of-floated-non-editable-12.html [ Skip ]
 css3/scroll-snap/scroll-snap-click-scrollbar-gutter.html [ Skip ]
 css3/scroll-snap/scroll-snap-wheel-event.html [ Skip ]
 css3/scroll-snap/scroll-snap-discrete-wheel-event-in-mainframe.html [ Skip ]
+css3/scroll-snap/scroll-snap-discrete-wheel-events-with-layout.html [ Skip ]
 css3/scroll-snap/resnap-after-layout.html [ Skip ]
 
 webkit.org/b/192088 media/no-fullscreen-when-hidden.html [ Failure Pass ]

--- a/Source/WebCore/page/scrolling/ScrollingTree.cpp
+++ b/Source/WebCore/page/scrolling/ScrollingTree.cpp
@@ -711,15 +711,19 @@ bool ScrollingTree::isScrollSnapInProgressForNode(ScrollingNodeID nodeID)
     Locker locker { m_treeStateLock };
     return m_treeState.nodesWithActiveScrollSnap.contains(nodeID);
 }
-    
+
 void ScrollingTree::setNodeScrollSnapInProgress(ScrollingNodeID nodeID, bool isScrollSnapping)
 {
     ASSERT(nodeID);
     Locker locker { m_treeStateLock };
-    if (isScrollSnapping)
-        m_treeState.nodesWithActiveScrollSnap.add(nodeID);
-    else
-        m_treeState.nodesWithActiveScrollSnap.remove(nodeID);
+
+    if (isScrollSnapping) {
+        if (m_treeState.nodesWithActiveScrollSnap.add(nodeID).isNewEntry)
+            scrollingTreeNodeDidBeginScrollSnapping(nodeID);
+    } else {
+        if (m_treeState.nodesWithActiveScrollSnap.remove(nodeID))
+            scrollingTreeNodeDidEndScrollSnapping(nodeID);
+    }
 }
 
 bool ScrollingTree::isScrollAnimationInProgressForNode(ScrollingNodeID nodeID)

--- a/Source/WebCore/page/scrolling/ScrollingTree.h
+++ b/Source/WebCore/page/scrolling/ScrollingTree.h
@@ -142,6 +142,9 @@ public:
     virtual void scrollingTreeNodeWillStartScroll(ScrollingNodeID) { }
     virtual void scrollingTreeNodeDidEndScroll(ScrollingNodeID) { }
 
+    virtual void scrollingTreeNodeDidBeginScrollSnapping(ScrollingNodeID) { }
+    virtual void scrollingTreeNodeDidEndScrollSnapping(ScrollingNodeID) { }
+
     WEBCORE_EXPORT TrackingType eventTrackingTypeForPoint(EventTrackingRegions::EventType, IntPoint);
 
     virtual void receivedWheelEventWithPhases(PlatformWheelEventPhase /* phase */, PlatformWheelEventPhase /* momentumPhase */) { }

--- a/Source/WebCore/platform/mac/ScrollingEffectsController.mm
+++ b/Source/WebCore/platform/mac/ScrollingEffectsController.mm
@@ -73,8 +73,10 @@ ScrollingEffectsController::~ScrollingEffectsController()
 
 void ScrollingEffectsController::stopAllTimers()
 {
-    if (m_discreteSnapTransitionTimer)
+    if (m_discreteSnapTransitionTimer) {
         m_discreteSnapTransitionTimer->stop();
+        m_client.didStopScrollSnapAnimation();
+    }
 
 #if ASSERT_ENABLED
     m_timersWereStopped = true;
@@ -395,6 +397,9 @@ bool ScrollingEffectsController::isScrollSnapInProgress() const
     if (m_inScrollGesture || m_momentumScrollInProgress || m_isAnimatingScrollSnap)
         return true;
 
+    if (m_discreteSnapTransitionTimer && m_discreteSnapTransitionTimer->isActive())
+        return true;
+
     return false;
 }
 
@@ -640,8 +645,10 @@ void ScrollingEffectsController::discreteSnapTransitionTimerFired()
 
     if (shouldStartScrollSnapAnimation)
         startScrollSnapAnimation();
-    else
+    else {
         stopDeferringWheelEventTestCompletion(WheelEventTestMonitor::ScrollSnapInProgress);
+        m_client.didStopScrollSnapAnimation();
+    }
 }
 
 bool ScrollingEffectsController::processWheelEventForScrollSnap(const PlatformWheelEvent& wheelEvent)

--- a/Source/WebKit/UIProcess/RemoteLayerTree/RemoteScrollingCoordinatorProxy.h
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/RemoteScrollingCoordinatorProxy.h
@@ -124,6 +124,9 @@ public:
     virtual void scrollingTreeNodeDidEndScroll(WebCore::ScrollingNodeID) { }
     virtual void hasNodeWithAnimatedScrollChanged(bool) { }
     virtual void setRootNodeIsInUserScroll(bool) { }
+
+    virtual void scrollingTreeNodeDidBeginScrollSnapping(WebCore::ScrollingNodeID) { }
+    virtual void scrollingTreeNodeDidEndScrollSnapping(WebCore::ScrollingNodeID) { }
     
     virtual void willCommitLayerAndScrollingTrees() { }
     virtual void didCommitLayerAndScrollingTrees() { }

--- a/Source/WebKit/UIProcess/RemoteLayerTree/RemoteScrollingTree.cpp
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/RemoteScrollingTree.cpp
@@ -119,6 +119,18 @@ void RemoteScrollingTree::scrollingTreeNodeDidEndScroll(ScrollingNodeID nodeID)
         m_scrollingCoordinatorProxy->scrollingTreeNodeDidEndScroll(nodeID);
 }
 
+void RemoteScrollingTree::scrollingTreeNodeDidBeginScrollSnapping(ScrollingNodeID nodeID)
+{
+    if (m_scrollingCoordinatorProxy)
+        m_scrollingCoordinatorProxy->scrollingTreeNodeDidBeginScrollSnapping(nodeID);
+}
+
+void RemoteScrollingTree::scrollingTreeNodeDidEndScrollSnapping(ScrollingNodeID nodeID)
+{
+    if (m_scrollingCoordinatorProxy)
+        m_scrollingCoordinatorProxy->scrollingTreeNodeDidEndScrollSnapping(nodeID);
+}
+
 Ref<ScrollingTreeNode> RemoteScrollingTree::createScrollingTreeNode(ScrollingNodeType nodeType, ScrollingNodeID nodeID)
 {
     switch (nodeType) {

--- a/Source/WebKit/UIProcess/RemoteLayerTree/RemoteScrollingTree.h
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/RemoteScrollingTree.h
@@ -65,6 +65,9 @@ public:
     void scrollingTreeNodeWillStartScroll(WebCore::ScrollingNodeID) override;
     void scrollingTreeNodeDidEndScroll(WebCore::ScrollingNodeID) override;
 
+    void scrollingTreeNodeDidBeginScrollSnapping(WebCore::ScrollingNodeID) override;
+    void scrollingTreeNodeDidEndScrollSnapping(WebCore::ScrollingNodeID) override;
+
     void currentSnapPointIndicesDidChange(WebCore::ScrollingNodeID, std::optional<unsigned> horizontal, std::optional<unsigned> vertical) override;
     void reportExposedUnfilledArea(MonotonicTime, unsigned unfilledArea) override;
     void reportSynchronousScrollingReasonsChanged(MonotonicTime, OptionSet<WebCore::SynchronousScrollingReason>) override;

--- a/Source/WebKit/UIProcess/RemoteLayerTree/mac/RemoteScrollingCoordinatorProxyMac.h
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/mac/RemoteScrollingCoordinatorProxyMac.h
@@ -53,6 +53,9 @@ private:
     void scrollingTreeNodeWillStartScroll(WebCore::ScrollingNodeID) override;
     void scrollingTreeNodeDidEndScroll(WebCore::ScrollingNodeID) override;
 
+    void scrollingTreeNodeDidBeginScrollSnapping(WebCore::ScrollingNodeID) override;
+    void scrollingTreeNodeDidEndScrollSnapping(WebCore::ScrollingNodeID) override;
+
     void connectStateNodeLayers(WebCore::ScrollingStateTree&, const RemoteLayerTreeHost&) override;
     void establishLayerTreeScrollingRelations(const RemoteLayerTreeHost&) override;
 

--- a/Source/WebKit/UIProcess/RemoteLayerTree/mac/RemoteScrollingCoordinatorProxyMac.mm
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/mac/RemoteScrollingCoordinatorProxyMac.mm
@@ -128,6 +128,18 @@ void RemoteScrollingCoordinatorProxyMac::scrollingTreeNodeDidEndScroll(Scrolling
     sendUIStateChangedIfNecessary();
 }
 
+void RemoteScrollingCoordinatorProxyMac::scrollingTreeNodeDidBeginScrollSnapping(ScrollingNodeID nodeID)
+{
+    m_uiState.addNodeWithActiveScrollSnap(nodeID);
+    sendUIStateChangedIfNecessary();
+}
+
+void RemoteScrollingCoordinatorProxyMac::scrollingTreeNodeDidEndScrollSnapping(ScrollingNodeID nodeID)
+{
+    m_uiState.removeNodeWithActiveScrollSnap(nodeID);
+    sendUIStateChangedIfNecessary();
+}
+
 void RemoteScrollingCoordinatorProxyMac::connectStateNodeLayers(ScrollingStateTree& stateTree, const RemoteLayerTreeHost& layerTreeHost)
 {
     using PlatformLayerID = PlatformLayerIdentifier;


### PR DESCRIPTION
#### 02526276204938ef6d32be0f75f1bdb076469963
<pre>
[macOS] Performing layout when scroll snapping with a physical mouse wheel snaps to the last snap position
<a href="https://bugs.webkit.org/show_bug.cgi?id=255603">https://bugs.webkit.org/show_bug.cgi?id=255603</a>

Reviewed by Tim Horton.

Currently, when `resnapAfterLayout()` is called after a layout pass while scrolling with a physical
mouse wheel in a scroll snapping container, we end up erroneously re-snapping to the last active
snap position. This doesn&apos;t happen when using a trackpad to scroll because we bail here:

```
void ScrollableArea::resnapAfterLayout()
{
…
    if (!scrollAnimator || isScrollSnapInProgress() || isUserScrollInProgress())
        return;
```

…due to the fact that `isUserScrollInProgress()` is `true`, since this flag is set over the course
of both user-driven and momentum scrolling phases. Importantly, note that `isScrollSnapInProgress()`
is only `true` in this case where UI-side compositing is *disabled* — this is because nothing
currently calls `{add|remove}NodeWithActiveScrollSnap` on `RemoteScrollingUIState`, which means that
we never end up propagating `m_nodesWithActiveScrollSnap` to the web process when UI-side
compositing is enabled, so from the web-process&apos; perspective, `isScrollSnapInProgress()` is always
`false`.

As such, in order to make physical mouse wheel scrolling work well when there are interleaved layout
passes, the fix is two-fold:

1.  Consider `isScrollSnapInProgress()` to be true if the discrete wheel event timer is scheduled.
2.  Add plumbing to deliver `isScrollSnapInProgress()` state from the UI process to the web process
    through the scrolling state tree, to ensure that this bug fix is also effective when UI-side
    compositing is enabled.

Test: css3/scroll-snap/scroll-snap-discrete-wheel-events-with-layout.html

* LayoutTests/css3/scroll-snap/scroll-snap-discrete-wheel-events-with-layout-expected.txt: Added.
* LayoutTests/css3/scroll-snap/scroll-snap-discrete-wheel-events-with-layout.html: Added.

Add a new test case to exercise the bug fix.

* LayoutTests/platform/glib/TestExpectations:
* LayoutTests/platform/ios-wk2/TestExpectations:
* Source/WebCore/page/scrolling/ScrollingTree.cpp:
(WebCore::ScrollingTree::setNodeScrollSnapInProgress):
* Source/WebCore/page/scrolling/ScrollingTree.h:
(WebCore::ScrollingTree::scrollingTreeNodeDidBeginScrollSnapping):
(WebCore::ScrollingTree::scrollingTreeNodeDidEndScrollSnapping):

Add new override hooks to allow the client layer to know when scrolling tree nodes change &quot;scroll
snap in progress&quot; state. See WebKit2 changes below for more information.

* Source/WebCore/platform/mac/ScrollingEffectsController.mm:
(WebCore::ScrollingEffectsController::stopAllTimers):
(WebCore::ScrollingEffectsController::isScrollSnapInProgress const):

Consider scroll snap in progress if we&apos;ve scheduled a scroll snap while handling discrete wheel
events.

(WebCore::ScrollingEffectsController::discreteSnapTransitionTimerFired):

Add a couple of call sites to `m_client.didStopScrollSnapAnimation()` in the case where the timer
is either stopped early or without triggering a scroll snap animation, such that we don&apos;t end up
with a node being stuck indefinitely in `nodesWithActiveScrollSnap`.

* Source/WebKit/UIProcess/RemoteLayerTree/RemoteScrollingCoordinatorProxy.h:
(WebKit::RemoteScrollingCoordinatorProxy::scrollingTreeNodeDidBeginScrollSnapping):
(WebKit::RemoteScrollingCoordinatorProxy::scrollingTreeNodeDidEndScrollSnapping):
* Source/WebKit/UIProcess/RemoteLayerTree/RemoteScrollingTree.cpp:
(WebKit::RemoteScrollingTree::scrollingTreeNodeDidBeginScrollSnapping):
(WebKit::RemoteScrollingTree::scrollingTreeNodeDidEndScrollSnapping):

Add plumbing from `RemoteScrollingTree` -&gt; `RemoteScrollingCoordinatorProxy` -&gt;
`RemoteScrollingUIState` whenever a scrolling node begins or ends scroll snapping progress.

* Source/WebKit/UIProcess/RemoteLayerTree/RemoteScrollingTree.h:
* Source/WebKit/UIProcess/RemoteLayerTree/mac/RemoteScrollingCoordinatorProxyMac.h:
* Source/WebKit/UIProcess/RemoteLayerTree/mac/RemoteScrollingCoordinatorProxyMac.mm:
(WebKit::RemoteScrollingCoordinatorProxyMac::scrollingTreeNodeDidBeginScrollSnapping):
(WebKit::RemoteScrollingCoordinatorProxyMac::scrollingTreeNodeDidEndScrollSnapping):

Canonical link: <a href="https://commits.webkit.org/263108@main">https://commits.webkit.org/263108@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c85732245bf72f3f2dbd8b0787e617b1ab521e01

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/3640 "Passed style check") | [  ~~🛠 ios~~](https://ews-build.webkit.org/#/builders/26/builds/3732 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/3830 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/5066 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/32/builds/3928 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/3614 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/3784 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/3729 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/3158 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/3684 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/15/builds/3917 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/3278 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/4891 "Built successfully") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/39/builds/1424 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/3249 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/3314 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/3226 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/3308 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/4658 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/3693 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/2988 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/3227 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/3249 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/886 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/3259 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/3504 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->