### PR TITLE
[GStreamer][WebRTC] Improve debug logging in RTP sender backend

### DIFF
--- a/Source/WebCore/Modules/mediastream/gstreamer/GStreamerRtpSenderBackend.h
+++ b/Source/WebCore/Modules/mediastream/gstreamer/GStreamerRtpSenderBackend.h
@@ -65,24 +65,9 @@ public:
         );
     }
 
-    void clearSource()
-    {
-        ASSERT(hasSource());
-        m_source = nullptr;
-    }
-
-    void setSource(Source&& source)
-    {
-        ASSERT(!hasSource());
-        m_source = WTFMove(source);
-        ASSERT(hasSource());
-    }
-
-    void takeSource(GStreamerRtpSenderBackend& backend)
-    {
-        ASSERT(backend.hasSource());
-        setSource(WTFMove(backend.m_source));
-    }
+    void clearSource();
+    void setSource(Source&&);
+    void takeSource(GStreamerRtpSenderBackend&);
 
     void stopSource();
 


### PR DESCRIPTION
#### c09442ed9be99b636e8db3a1eb9f42fe3bae2650
<pre>
[GStreamer][WebRTC] Improve debug logging in RTP sender backend
<a href="https://bugs.webkit.org/show_bug.cgi?id=255611">https://bugs.webkit.org/show_bug.cgi?id=255611</a>

Reviewed by Xabier Rodriguez-Calvar.

Most methods implementations were moved to the cpp file and instrumented with debug logs. Also
driving-by in the dtlsTransportBackend() method, exit early in case we don&apos;t have a rtpSender yet.

* Source/WebCore/Modules/mediastream/gstreamer/GStreamerRtpSenderBackend.cpp:
(WebCore::m_initData):
(WebCore::GStreamerRtpSenderBackend::clearSource):
(WebCore::GStreamerRtpSenderBackend::setSource):
(WebCore::GStreamerRtpSenderBackend::takeSource):
(WebCore::GStreamerRtpSenderBackend::dtlsTransportBackend):
* Source/WebCore/Modules/mediastream/gstreamer/GStreamerRtpSenderBackend.h:

Canonical link: <a href="https://commits.webkit.org/263129@main">https://commits.webkit.org/263129@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/92ccddaf0677b98285be445327e43519307de37c

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/3678 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/3762 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/3868 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/5104 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/3962 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/3652 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/3838 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/3767 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/3188 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/3722 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/3950 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/3319 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/4935 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/1456 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/3289 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/3346 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/3264 "Passed tests") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/3348 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/4700 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/3731 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/3022 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/3265 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/3289 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/898 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/3297 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/3542 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->