### PR TITLE
[GStreamer][WebRTC] Instrument the SDP ICE candidate parsing with debug logs

### DIFF
--- a/Source/WebCore/Modules/mediastream/gstreamer/GStreamerWebRTCUtils.cpp
+++ b/Source/WebCore/Modules/mediastream/gstreamer/GStreamerWebRTCUtils.cpp
@@ -206,8 +206,10 @@ std::optional<RTCIceCandidate::Fields> parseIceCandidateSDP(const String& sdp)
 {
     ensureDebugCategoryInitialized();
     GST_TRACE("Parsing ICE Candidate: %s", sdp.utf8().data());
-    if (!sdp.startsWith("candidate:"_s))
+    if (!sdp.startsWith("candidate:"_s)) {
+        GST_WARNING("Invalid SDP ICE candidate format, must start with candidate: prefix");
         return { };
+    }
 
     String foundation;
     unsigned componentId = 0;
@@ -232,8 +234,10 @@ std::optional<RTCIceCandidate::Fields> parseIceCandidateSDP(const String& sdp)
         case 1:
             if (auto value = parseInteger<unsigned>(token))
                 componentId = *value;
-            else
+            else {
+                GST_WARNING("Invalid SDP candidate component ID: %s", token.ascii().data());
                 return { };
+            }
             break;
         case 2:
             transport = token;
@@ -241,8 +245,10 @@ std::optional<RTCIceCandidate::Fields> parseIceCandidateSDP(const String& sdp)
         case 3:
             if (auto value = parseInteger<unsigned>(token))
                 priority = *value;
-            else
+            else {
+                GST_WARNING("Invalid SDP candidate priority: %s", token.ascii().data());
                 return { };
+            }
             break;
         case 4:
             address = token;
@@ -250,12 +256,16 @@ std::optional<RTCIceCandidate::Fields> parseIceCandidateSDP(const String& sdp)
         case 5:
             if (auto value = parseInteger<unsigned>(token))
                 port = *value;
-            else
+            else {
+                GST_WARNING("Invalid SDP candidate port: %s", token.ascii().data());
                 return { };
+            }
             break;
         default:
-            if (it + 1 == tokens.end())
+            if (it + 1 == tokens.end()) {
+                GST_WARNING("Incomplete SDP candidate");
                 return { };
+            }
 
             it++;
             if (token == "typ"_s)
@@ -272,8 +282,10 @@ std::optional<RTCIceCandidate::Fields> parseIceCandidateSDP(const String& sdp)
         }
     }
 
-    if (type.isEmpty())
+    if (type.isEmpty()) {
+        GST_WARNING("Unable to parse candidate type");
         return { };
+    }
 
     RTCIceCandidate::Fields fields;
     fields.foundation = foundation;


### PR DESCRIPTION
#### 633c039a48993c89b735502ef31384a00026b08d
<pre>
[GStreamer][WebRTC] Instrument the SDP ICE candidate parsing with debug logs
<a href="https://bugs.webkit.org/show_bug.cgi?id=255612">https://bugs.webkit.org/show_bug.cgi?id=255612</a>

Reviewed by Xabier Rodriguez-Calvar.

* Source/WebCore/Modules/mediastream/gstreamer/GStreamerWebRTCUtils.cpp:
(WebCore::parseIceCandidateSDP): Emit warnings when parsing fails, should be helpful when debugging.

Canonical link: <a href="https://commits.webkit.org/263123@main">https://commits.webkit.org/263123@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/114ae73281581661bcc5ef0fbcb98de8241b3227

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/3582 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/3628 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/3769 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/5007 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/3856 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/3561 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/3722 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/3670 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/3113 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/3625 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/3871 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/3230 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/4829 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/1377 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/3203 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/3263 "13 flakes 143 failures") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/3178 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/3262 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/4601 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/3639 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/2941 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/3179 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/3203 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/897 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/3207 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/3458 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->