### PR TITLE
Share serialization of FontCustomPlatformData

### DIFF
--- a/Source/WebKit/PlatformPlayStation.cmake
+++ b/Source/WebKit/PlatformPlayStation.cmake
@@ -70,13 +70,13 @@ list(APPEND WebKit_SOURCES
 
     Shared/curl/WebCoreArgumentCodersCurl.cpp
 
+    Shared/freetype/WebCoreArgumentCodersFreeType.cpp
+
     Shared/libwpe/NativeWebKeyboardEventLibWPE.cpp
     Shared/libwpe/NativeWebMouseEventLibWPE.cpp
     Shared/libwpe/NativeWebTouchEventLibWPE.cpp
     Shared/libwpe/NativeWebWheelEventLibWPE.cpp
     Shared/libwpe/WebEventFactory.cpp
-
-    Shared/playstation/WebCoreArgumentCodersPlayStation.cpp
 
     Shared/unix/AuxiliaryProcessMain.cpp
 

--- a/Source/WebKit/Shared/WebCoreArgumentCoders.h
+++ b/Source/WebKit/Shared/WebCoreArgumentCoders.h
@@ -217,8 +217,6 @@ template<> struct ArgumentCoder<WebCore::FontPlatformData::Attributes> {
 template<> struct ArgumentCoder<WebCore::FontCustomPlatformData> {
     static void encode(Encoder&, const WebCore::FontCustomPlatformData&);
     static std::optional<Ref<WebCore::FontCustomPlatformData>> decode(Decoder&);
-    static void encodePlatformData(Encoder&, const WebCore::FontCustomPlatformData&);
-    static std::optional<Ref<WebCore::FontCustomPlatformData>> decodePlatformData(Decoder&);
 };
 
 template<> struct ArgumentCoder<WebCore::ResourceError> {

--- a/Source/WebKit/Shared/freetype/WebCoreArgumentCodersFreeType.cpp
+++ b/Source/WebKit/Shared/freetype/WebCoreArgumentCodersFreeType.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020 Sony Interactive Entertainment Inc.
+ * Copyright (C) 2023 Sony Interactive Entertainment Inc.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -26,44 +26,34 @@
 #include "config.h"
 #include "WebCoreArgumentCoders.h"
 
+#if USE(FREETYPE)
+
 #include <WebCore/Font.h>
-#include <WebCore/FontCustomPlatformData.h>
 
 namespace IPC {
 
-using namespace WebCore;
-
-void ArgumentCoder<Font>::encodePlatformData(Encoder& encoder, const Font& font)
+void ArgumentCoder<WebCore::Font>::encodePlatformData(Encoder&, const WebCore::Font&)
 {
     ASSERT_NOT_REACHED();
 }
 
-std::optional<FontPlatformData> ArgumentCoder<Font>::decodePlatformData(Decoder& decoder)
-{
-    ASSERT_NOT_REACHED();
-    return std::nullopt;
-}
-
-void ArgumentCoder<WebCore::FontCustomPlatformData>::encodePlatformData(Encoder& encoder, const WebCore::FontCustomPlatformData& customPlatformData)
-{
-    ASSERT_NOT_REACHED();
-}
-
-std::optional<Ref<WebCore::FontCustomPlatformData>> ArgumentCoder<WebCore::FontCustomPlatformData>::decodePlatformData(Decoder& decoder)
+std::optional<WebCore::FontPlatformData> ArgumentCoder<WebCore::Font>::decodePlatformData(Decoder&)
 {
     ASSERT_NOT_REACHED();
     return std::nullopt;
 }
 
-void ArgumentCoder<WebCore::FontPlatformData::Attributes>::encodePlatformData(Encoder& encoder, const WebCore::FontPlatformData::Attributes& data)
+void ArgumentCoder<WebCore::FontPlatformData::Attributes>::encodePlatformData(Encoder&, const WebCore::FontPlatformData::Attributes&)
 {
     ASSERT_NOT_REACHED();
 }
 
-bool ArgumentCoder<WebCore::FontPlatformData::Attributes>::decodePlatformData(Decoder& decoder, WebCore::FontPlatformData::Attributes& data)
+bool ArgumentCoder<WebCore::FontPlatformData::Attributes>::decodePlatformData(Decoder&, WebCore::FontPlatformData::Attributes&)
 {
     ASSERT_NOT_REACHED();
     return false;
 }
 
 } // namespace IPC
+
+#endif // USE(FREETYPE)

--- a/Source/WebKit/Shared/soup/WebCoreArgumentCodersSoup.cpp
+++ b/Source/WebKit/Shared/soup/WebCoreArgumentCodersSoup.cpp
@@ -160,39 +160,6 @@ bool ArgumentCoder<Credential>::decodePlatformData(Decoder& decoder, Credential&
     return true;
 }
 
-void ArgumentCoder<Font>::encodePlatformData(Encoder&, const Font&)
-{
-    ASSERT_NOT_REACHED();
-}
-
-std::optional<FontPlatformData> ArgumentCoder<Font>::decodePlatformData(Decoder&)
-{
-    ASSERT_NOT_REACHED();
-    return std::nullopt;
-}
-
-void ArgumentCoder<WebCore::FontCustomPlatformData>::encodePlatformData(Encoder& encoder, const WebCore::FontCustomPlatformData& customPlatformData)
-{
-    ASSERT_NOT_REACHED();
-}
-
-std::optional<Ref<WebCore::FontCustomPlatformData>> ArgumentCoder<WebCore::FontCustomPlatformData>::decodePlatformData(Decoder& decoder)
-{
-    ASSERT_NOT_REACHED();
-    return std::nullopt;
-}
-
-void ArgumentCoder<WebCore::FontPlatformData::Attributes>::encodePlatformData(Encoder& encoder, const WebCore::FontPlatformData::Attributes& data)
-{
-    ASSERT_NOT_REACHED();
-}
-
-bool ArgumentCoder<WebCore::FontPlatformData::Attributes>::decodePlatformData(Decoder& decoder, WebCore::FontPlatformData::Attributes& data)
-{
-    ASSERT_NOT_REACHED();
-    return false;
-}
-
 #if ENABLE(VIDEO)
 void ArgumentCoder<SerializedPlatformDataCueValue>::encodePlatformData(Encoder& encoder, const SerializedPlatformDataCueValue& value)
 {

--- a/Source/WebKit/Shared/win/WebCoreArgumentCodersWin.cpp
+++ b/Source/WebKit/Shared/win/WebCoreArgumentCodersWin.cpp
@@ -121,30 +121,6 @@ std::optional<FontPlatformData> ArgumentCoder<Font>::decodePlatformData(Decoder&
     return FontPlatformData(WTFMove(gdiFont), *size, *syntheticBold, *syntheticOblique, fontCustomPlatformData.get());
 }
 
-void ArgumentCoder<WebCore::FontCustomPlatformData>::encodePlatformData(Encoder& encoder, const WebCore::FontCustomPlatformData& customPlatformData)
-{
-    encoder << customPlatformData.creationData.fontFaceData;
-    encoder << customPlatformData.creationData.itemInCollection;
-}
-
-std::optional<Ref<WebCore::FontCustomPlatformData>> ArgumentCoder<WebCore::FontCustomPlatformData>::decodePlatformData(Decoder& decoder)
-{
-    std::optional<Ref<SharedBuffer>> fontFaceData;
-    decoder >> fontFaceData;
-    if (!fontFaceData)
-        return std::nullopt;
-
-    std::optional<String> itemInCollection;
-    decoder >> itemInCollection;
-    if (!itemInCollection)
-        return std::nullopt;
-
-    auto fontCustomPlatformData = createFontCustomPlatformData(fontFaceData.value(), itemInCollection.value());
-    if (!fontCustomPlatformData)
-        return std::nullopt;
-    return fontCustomPlatformData.releaseNonNull();
-}
-
 void ArgumentCoder<WebCore::FontPlatformData::Attributes>::encodePlatformData(Encoder& encoder, const WebCore::FontPlatformData::Attributes& data)
 {
     encoder << data.m_font;

--- a/Source/WebKit/SourcesGTK.txt
+++ b/Source/WebKit/SourcesGTK.txt
@@ -82,6 +82,8 @@ Shared/CoordinatedGraphics/threadedcompositor/ThreadedCompositor.cpp
 
 Shared/cairo/ShareableBitmapCairo.cpp
 
+Shared/freetype/WebCoreArgumentCodersFreeType.cpp
+
 Shared/glib/ArgumentCodersGLib.cpp
 Shared/glib/InputMethodState.cpp
 Shared/glib/ProcessExecutablePathGLib.cpp

--- a/Source/WebKit/SourcesWPE.txt
+++ b/Source/WebKit/SourcesWPE.txt
@@ -82,6 +82,8 @@ Shared/CoordinatedGraphics/threadedcompositor/ThreadedDisplayRefreshMonitor.cpp
 
 Shared/cairo/ShareableBitmapCairo.cpp
 
+Shared/freetype/WebCoreArgumentCodersFreeType.cpp
+
 Shared/glib/ArgumentCodersGLib.cpp
 Shared/glib/InputMethodState.cpp
 Shared/glib/ProcessExecutablePathGLib.cpp


### PR DESCRIPTION
#### ffd9887f8ea5b790c4e2ec7d774832ad1330ecbc
<pre>
Share serialization of FontCustomPlatformData
<a href="https://bugs.webkit.org/show_bug.cgi?id=255615">https://bugs.webkit.org/show_bug.cgi?id=255615</a>

Reviewed by Alex Christensen.

All platforms have an implementation of `createFontCustomPlatformData`
so just use that to serialize `FontCustomPlatformData`.

* Source/WebKit/PlatformPlayStation.cmake:
* Source/WebKit/Shared/Cocoa/WebCoreArgumentCodersCocoa.mm:
(IPC::ArgumentCoder&lt;WebCore::FontCustomPlatformData&gt;::encodePlatformData): Deleted.
(IPC::ArgumentCoder&lt;WebCore::FontCustomPlatformData&gt;::decodePlatformData): Deleted.
* Source/WebKit/Shared/WebCoreArgumentCoders.cpp:
(IPC::ArgumentCoder&lt;WebCore::FontCustomPlatformData&gt;::encode):
(IPC::ArgumentCoder&lt;FontCustomPlatformData&gt;::decode):
* Source/WebKit/Shared/WebCoreArgumentCoders.h:
* Source/WebKit/Shared/freetype/WebCoreArgumentCodersFreeType.cpp: Renamed from Source/WebKit/Shared/playstation/WebCoreArgumentCodersPlayStation.cpp.
(IPC::ArgumentCoder&lt;WebCore::Font&gt;::encodePlatformData):
(IPC::ArgumentCoder&lt;WebCore::Font&gt;::decodePlatformData):
(IPC::ArgumentCoder&lt;WebCore::FontPlatformData::Attributes&gt;::encodePlatformData):
(IPC::ArgumentCoder&lt;WebCore::FontPlatformData::Attributes&gt;::decodePlatformData):
* Source/WebKit/Shared/soup/WebCoreArgumentCodersSoup.cpp:
(IPC::ArgumentCoder&lt;Font&gt;::encodePlatformData): Deleted.
(IPC::ArgumentCoder&lt;Font&gt;::decodePlatformData): Deleted.
(IPC::ArgumentCoder&lt;WebCore::FontCustomPlatformData&gt;::encodePlatformData): Deleted.
(IPC::ArgumentCoder&lt;WebCore::FontCustomPlatformData&gt;::decodePlatformData): Deleted.
(IPC::ArgumentCoder&lt;WebCore::FontPlatformData::Attributes&gt;::encodePlatformData): Deleted.
(IPC::ArgumentCoder&lt;WebCore::FontPlatformData::Attributes&gt;::decodePlatformData): Deleted.
* Source/WebKit/Shared/win/WebCoreArgumentCodersWin.cpp:
(IPC::ArgumentCoder&lt;WebCore::FontCustomPlatformData&gt;::encodePlatformData): Deleted.
(IPC::ArgumentCoder&lt;WebCore::FontCustomPlatformData&gt;::decodePlatformData): Deleted.
* Source/WebKit/SourcesGTK.txt:
* Source/WebKit/SourcesWPE.txt:

Canonical link: <a href="https://commits.webkit.org/263103@main">https://commits.webkit.org/263103@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/101b188a6ab1e51bb44e171c3911783db6c73c9a

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/3601 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/3642 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/3790 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/5027 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/3865 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/3742 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/3690 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/3123 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/3645 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/3887 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/3245 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/4879 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/1393 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/3218 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/3302 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/3194 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/3277 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/4645 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/3654 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/2956 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/3189 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/3218 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/881 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/3220 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/3469 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->