### PR TITLE
[Cocoa] Read protected sample key requrements from sample's CMFormatDescription

### DIFF
--- a/Source/WebCore/platform/MediaSample.h
+++ b/Source/WebCore/platform/MediaSample.h
@@ -97,6 +97,7 @@ public:
         IsNonDisplaying = 1 << 1,
         HasAlpha = 1 << 2,
         HasSyncInfo = 1 << 3,
+        IsProtected = 1 << 4,
     };
     virtual SampleFlags flags() const = 0;
     virtual PlatformSample platformSample() const = 0;
@@ -112,6 +113,7 @@ public:
     bool isNonDisplaying() const { return flags() & IsNonDisplaying; }
     bool hasAlpha() const { return flags() & HasAlpha; }
     bool hasSyncInfo() const { return flags() & HasSyncInfo; }
+    bool isProtected() const { return flags() & IsProtected; }
 
     virtual void dump(PrintStream& out) const
     {

--- a/Source/WebCore/platform/graphics/avfoundation/objc/MediaSampleAVFObjC.h
+++ b/Source/WebCore/platform/graphics/avfoundation/objc/MediaSampleAVFObjC.h
@@ -81,7 +81,7 @@ protected:
     WEBCORE_EXPORT MediaSampleAVFObjC(CMSampleBufferRef, uint64_t trackID);
     WEBCORE_EXPORT virtual ~MediaSampleAVFObjC();
     
-    void initializeTimes();
+    void commonInit();
 
     RetainPtr<CMSampleBufferRef> m_sample;
     AtomString m_id;

--- a/Source/WebCore/platform/graphics/avfoundation/objc/MediaSampleAVFObjC.mm
+++ b/Source/WebCore/platform/graphics/avfoundation/objc/MediaSampleAVFObjC.mm
@@ -27,6 +27,7 @@
 #import "MediaSampleAVFObjC.h"
 
 #import "CVUtilities.h"
+#import "ISOTrackEncryptionBox.h"
 #import "PixelBuffer.h"
 #import "PixelBufferConformerCV.h"
 #import "ProcessIdentity.h"
@@ -51,32 +52,32 @@ namespace WebCore {
 MediaSampleAVFObjC::MediaSampleAVFObjC(RetainPtr<CMSampleBufferRef>&& sample)
     : m_sample(WTFMove(sample))
 {
-    initializeTimes();
+    commonInit();
 }
 
 MediaSampleAVFObjC::MediaSampleAVFObjC(CMSampleBufferRef sample)
     : m_sample(sample)
 {
-    initializeTimes();
+    commonInit();
 }
 
 MediaSampleAVFObjC::MediaSampleAVFObjC(CMSampleBufferRef sample, AtomString trackID)
     : m_sample(sample)
     , m_id(trackID)
 {
-    initializeTimes();
+    commonInit();
 }
 
 MediaSampleAVFObjC::MediaSampleAVFObjC(CMSampleBufferRef sample, uint64_t trackID)
     : m_sample(sample)
     , m_id(AtomString::number(trackID))
 {
-    initializeTimes();
+    commonInit();
 }
 
 MediaSampleAVFObjC::~MediaSampleAVFObjC() = default;
 
-void MediaSampleAVFObjC::initializeTimes()
+void MediaSampleAVFObjC::commonInit()
 {
     auto presentationTime = PAL::CMSampleBufferGetOutputPresentationTimeStamp(m_sample.get());
     if (CMTIME_IS_INVALID(presentationTime))
@@ -90,6 +91,31 @@ void MediaSampleAVFObjC::initializeTimes()
     if (CMTIME_IS_INVALID(duration))
         duration = PAL::CMSampleBufferGetDuration(m_sample.get());
     m_duration = PAL::toMediaTime(duration);
+
+#if ENABLE(ENCRYPTED_MEDIA) && HAVE(AVCONTENTKEYSESSION)
+    auto getKeyIDs = [](CMFormatDescriptionRef description) -> Vector<Ref<SharedBuffer>> {
+        if (!description)
+            return { };
+        auto trackEncryptionData = static_cast<CFDataRef>(PAL::CMFormatDescriptionGetExtension(description, CFSTR("CommonEncryptionTrackEncryptionBox")));
+        if (!trackEncryptionData)
+            return { };
+
+        // AVStreamDataParser will attach the 'tenc' box to each sample, not including the leading
+        // size and boxType data. Extract the 'tenc' box and use that box to derive the sample's
+        // keyID.
+        auto length = CFDataGetLength(trackEncryptionData);
+        auto ptr = (void*)(CFDataGetBytePtr(trackEncryptionData));
+        auto destructorFunction = createSharedTask<void(void*)>([data = WTFMove(trackEncryptionData)] (void*) { UNUSED_PARAM(data); });
+        auto trackEncryptionDataBuffer = ArrayBuffer::create(JSC::ArrayBufferContents(ptr, length, std::nullopt, WTFMove(destructorFunction)));
+
+        ISOTrackEncryptionBox trackEncryptionBox;
+        auto trackEncryptionView = JSC::DataView::create(WTFMove(trackEncryptionDataBuffer), 0, length);
+        if (!trackEncryptionBox.parseWithoutTypeAndSize(trackEncryptionView))
+            return { };
+        return { SharedBuffer::create(trackEncryptionBox.defaultKID()) };
+    };
+    m_keyIDs = getKeyIDs(PAL::CMSampleBufferGetFormatDescription(m_sample.get()));
+#endif
 }
 
 MediaTime MediaSampleAVFObjC::presentationTime() const
@@ -172,6 +198,11 @@ MediaSample::SampleFlags MediaSampleAVFObjC::flags() const
 
     if (isCMSampleBufferNonDisplaying(m_sample.get()))
         returnValue |= MediaSample::IsNonDisplaying;
+
+#if ENABLE(ENCRYPTED_MEDIA) && HAVE(AVCONTENTKEYSESSION)
+    if (!m_keyIDs.isEmpty())
+        returnValue |= MediaSample::IsProtected;
+#endif
 
     return SampleFlags(returnValue);
 }

--- a/Source/WebCore/platform/graphics/avfoundation/objc/SourceBufferPrivateAVFObjC.mm
+++ b/Source/WebCore/platform/graphics/avfoundation/objc/SourceBufferPrivateAVFObjC.mm
@@ -1172,12 +1172,12 @@ void SourceBufferPrivateAVFObjC::keyStatusesChanged()
 bool SourceBufferPrivateAVFObjC::canEnqueueSample(uint64_t trackID, const MediaSampleAVFObjC& sample)
 {
 #if ENABLE(ENCRYPTED_MEDIA) && HAVE(AVCONTENTKEYSESSION)
-    // If sample buffers don't support AVContentKeySession: enqueue sample
-    if (!sampleBufferRenderersSupportKeySession())
+    // if sample is unencrytped: enqueue sample
+    if (!sample.isProtected())
         return true;
 
-    // if sample is unencrytped: enqueue sample
-    if (sample.keyIDs().isEmpty())
+    // If sample buffers don't support AVContentKeySession: enqueue sample
+    if (!sampleBufferRenderersSupportKeySession())
         return true;
 
     // if sample is encrypted, but we are not attached to a CDM: do not enqueue sample.
@@ -1216,7 +1216,7 @@ void SourceBufferPrivateAVFObjC::enqueueSample(Ref<MediaSample>&& sample, const 
         return;
 
     Ref<MediaSampleAVFObjC> sampleAVFObjC = static_reference_cast<MediaSampleAVFObjC>(WTFMove(sample));
-    if (!sampleAVFObjC->keyIDs().isEmpty() && !canEnqueueSample(trackID, sampleAVFObjC)) {
+    if (!canEnqueueSample(trackID, sampleAVFObjC)) {
         m_blockedSamples.append({ trackID, WTFMove(sampleAVFObjC) });
         return;
     }

--- a/Source/WebCore/platform/graphics/iso/ISOBox.cpp
+++ b/Source/WebCore/platform/graphics/iso/ISOBox.cpp
@@ -108,6 +108,11 @@ bool ISOFullBox::parse(DataView& view, unsigned& offset)
     if (!ISOBox::parse(view, offset))
         return false;
 
+    return parseVersionAndFlags(view, offset);
+}
+
+bool ISOFullBox::parseVersionAndFlags(DataView& view, unsigned& offset)
+{
     uint32_t versionAndFlags = 0;
     if (!checkedRead<uint32_t>(versionAndFlags, view, offset, BigEndian))
         return false;

--- a/Source/WebCore/platform/graphics/iso/ISOBox.h
+++ b/Source/WebCore/platform/graphics/iso/ISOBox.h
@@ -94,6 +94,7 @@ public:
 
 protected:
     bool parse(JSC::DataView&, unsigned& offset) override;
+    bool parseVersionAndFlags(JSC::DataView&, unsigned& offset);
 
     uint8_t m_version { 0 };
     uint32_t m_flags { 0 };

--- a/Source/WebCore/platform/graphics/iso/ISOTrackEncryptionBox.cpp
+++ b/Source/WebCore/platform/graphics/iso/ISOTrackEncryptionBox.cpp
@@ -32,12 +32,25 @@ using JSC::DataView;
 
 namespace WebCore {
 
+bool ISOTrackEncryptionBox::parseWithoutTypeAndSize(DataView& view)
+{
+    // Clients may want to parse the contents of a `tenc` box without the
+    // leading size and name fields.
+    unsigned offset = 0;
+    return parseVersionAndFlags(view, offset) && parsePayload(view, offset);
+}
+
 bool ISOTrackEncryptionBox::parse(DataView& view, unsigned& offset)
 {
     // ISO/IEC 23001-7-2015 Section 8.2.2
     if (!ISOFullBox::parse(view, offset))
         return false;
 
+    return parsePayload(view, offset);
+}
+
+bool ISOTrackEncryptionBox::parsePayload(DataView& view, unsigned& offset)
+{
     // unsigned int(8) reserved = 0;
     offset += 1;
 

--- a/Source/WebCore/platform/graphics/iso/ISOTrackEncryptionBox.h
+++ b/Source/WebCore/platform/graphics/iso/ISOTrackEncryptionBox.h
@@ -40,8 +40,11 @@ public:
     Vector<uint8_t> defaultKID() const { return m_defaultKID; }
     Vector<uint8_t> defaultConstantIV() const { return m_defaultConstantIV; }
 
+    bool parseWithoutTypeAndSize(JSC::DataView&);
+
 private:
     bool parse(JSC::DataView&, unsigned& offset) override;
+    bool parsePayload(JSC::DataView&, unsigned& offset);
 
     std::optional<int8_t> m_defaultCryptByteBlock;
     std::optional<int8_t> m_defaultSkipByteBlock;


### PR DESCRIPTION
#### c748ef5450bde560ea8741cc04c15266865bc7b1
<pre>
[Cocoa] Read protected sample key requrements from sample&apos;s CMFormatDescription
<a href="https://bugs.webkit.org/show_bug.cgi?id=255553">https://bugs.webkit.org/show_bug.cgi?id=255553</a>
rdar://108162777

Reviewed by Eric Carlson.

Rather than extract keyIDs from the track in the initialization segment, extract the
keyIDs from the CMFormatDescription associated with each sample. The parser has already
done the association already at the point where it created the CMFormatDescription.

Modify the ISO box parsing methods to allow their parsers to operate on just the payload
portion of the relevent boxes, as the CMFormatDescription just stores the payload rather
than the full box.

* Source/WebCore/platform/MediaSample.h:
(WebCore::MediaSample::isProtected const):
* Source/WebCore/platform/graphics/avfoundation/objc/MediaSampleAVFObjC.h:
* Source/WebCore/platform/graphics/avfoundation/objc/MediaSampleAVFObjC.mm:
(WebCore::MediaSampleAVFObjC::MediaSampleAVFObjC):
(WebCore::MediaSampleAVFObjC::commonInit):
(WebCore::MediaSampleAVFObjC::flags const):
(WebCore::MediaSampleAVFObjC::initializeTimes): Deleted.
* Source/WebCore/platform/graphics/avfoundation/objc/SourceBufferPrivateAVFObjC.mm:
(WebCore::SourceBufferPrivateAVFObjC::canEnqueueSample):
(WebCore::SourceBufferPrivateAVFObjC::enqueueSample):
* Source/WebCore/platform/graphics/iso/ISOBox.cpp:
(WebCore::ISOFullBox::parse):
(WebCore::ISOFullBox::parseVersionAndFlags):
* Source/WebCore/platform/graphics/iso/ISOBox.h:
* Source/WebCore/platform/graphics/iso/ISOTrackEncryptionBox.cpp:
(WebCore::ISOTrackEncryptionBox::parseWithoutTypeAndSize):
(WebCore::ISOTrackEncryptionBox::parse):
(WebCore::ISOTrackEncryptionBox::parsePayload):
* Source/WebCore/platform/graphics/iso/ISOTrackEncryptionBox.h:

Canonical link: <a href="https://commits.webkit.org/263254@main">https://commits.webkit.org/263254@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0990203198e7a698eb038bf3dbe8bfca3d87babd

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/3875 "1 style error") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/3965 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/4074 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/5310 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/4134 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/3851 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/4047 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/3971 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/3791 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/3923 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/4121 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/3494 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/5146 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/1625 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/3469 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/5120 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/3444 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/3529 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/4918 "run-api-tests-without-change (failure)") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/3929 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/3182 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/3451 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/3469 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/987 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/3495 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/3729 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->