### PR TITLE
Early return in HTMLInputElement::attributeChanged() when the attribute value hasn't changed

### DIFF
--- a/Source/WebCore/html/HTMLInputElement.cpp
+++ b/Source/WebCore/html/HTMLInputElement.cpp
@@ -743,6 +743,9 @@ inline void HTMLInputElement::initializeInputType()
 
 void HTMLInputElement::attributeChanged(const QualifiedName& name, const AtomString& oldValue, const AtomString& newValue, AttributeModificationReason attributeModificationReason)
 {
+    if (oldValue == newValue)
+        return;
+
     ASSERT(m_inputType);
     Ref protectedInputType { *m_inputType };
 
@@ -750,8 +753,7 @@ void HTMLInputElement::attributeChanged(const QualifiedName& name, const AtomStr
 
     switch (name.nodeName()) {
     case AttributeNames::typeAttr:
-        if (oldValue != newValue)
-            updateType(newValue);
+        updateType(newValue);
         break;
     case AttributeNames::valueAttr:
         // Changes to the value attribute may change whether or not this element has a default value.

--- a/Source/WebCore/html/NumberInputType.cpp
+++ b/Source/WebCore/html/NumberInputType.cpp
@@ -295,6 +295,7 @@ void NumberInputType::attributeChanged(const QualifiedName& name)
                 renderer->setNeedsLayoutAndPrefWidthsRecalc();
         }
         break;
+    case AttributeNames::classAttr:
     case AttributeNames::stepAttr:
         if (auto* element = this->element()) {
             if (auto* renderer = element->renderer())


### PR DESCRIPTION
#### c1628ee675b75f07c8f727628d5fefeb5df200d7
<pre>
Early return in HTMLInputElement::attributeChanged() when the attribute value hasn&apos;t changed
<a href="https://bugs.webkit.org/show_bug.cgi?id=255617">https://bugs.webkit.org/show_bug.cgi?id=255617</a>

Reviewed by Ryosuke Niwa.

Early return at the beginning of HTMLInputElement::attributeChanged() if the new
attribute value is the same as the old one. HTMLInputElements do not have special
handling when setting an attribute to the same value again so they can ignore this
case.

* Source/WebCore/html/HTMLInputElement.cpp:
(WebCore::HTMLInputElement::attributeChanged):

* Source/WebCore/html/NumberInputType.cpp:
(WebCore::NumberInputType::attributeChanged):
Make sure we call setNeedsLayoutAndPrefWidthsRecalc() if the class attribute
changes. The bug was caught by fast/forms/number/number-size.html. We were
previously getting lucky. The test was changing the class attribute of a
number input element, then setting min/max attributes to the same value
and expecting the borders of the input element to change. It would previously
work because setting min/max would call setNeedsLayoutAndPrefWidthsRecalc()
even when set to the same value. However, what&apos;s really changing here
and requires a new layout is the class attribute.

Canonical link: <a href="https://commits.webkit.org/263151@main">https://commits.webkit.org/263151@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/36966d3b888f99359704f1d437f1c1d04a8280b1

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/3617 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/3658 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/3807 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/5043 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/3912 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/3591 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/3758 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/3706 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/3138 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/3661 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/3933 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/3260 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/4866 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/1406 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/3231 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/3293 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/3207 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/3290 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/4642 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/3670 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/2969 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/3204 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/3231 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/921 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/3236 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/3483 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->