### PR TITLE
[webkit-patch] Check issue redaction before upload

### DIFF
--- a/Tools/Scripts/webkitpy/tool/commands/commandtest.py
+++ b/Tools/Scripts/webkitpy/tool/commands/commandtest.py
@@ -54,16 +54,17 @@ class CommandsTest(TestCase):
         options.reviewer = 'MOCK reviewer'
         command.bind_to_tool(tool)
 
-        with OutputCapture(level=logging.INFO) as captured:
-            command.execute(options, args, tool)
+        try:
+            with OutputCapture(level=logging.INFO) as captured:
+                command.execute(options, args, tool)
+        finally:
+            actual_stdout = self._remove_deprecated_warning(captured.stdout.getvalue())
+            actual_stderr = self._remove_deprecated_warning(captured.stderr.getvalue())
+            actual_logs = self._remove_deprecated_warning(captured.root.log.getvalue())
 
-        actual_stdout = self._remove_deprecated_warning(captured.stdout.getvalue())
-        actual_stderr = self._remove_deprecated_warning(captured.stderr.getvalue())
-        actual_logs = self._remove_deprecated_warning(captured.root.log.getvalue())
-
-        self.assertEqual(actual_stdout, expected_stdout or '')
-        self.assertEqual(actual_stderr, expected_stderr or '')
-        self.assertEqual(actual_logs, expected_logs or '')
+            self.assertEqual(actual_stdout, expected_stdout or '')
+            self.assertEqual(actual_stderr, expected_stderr or '')
+            self.assertEqual(actual_logs, expected_logs or '')
 
     def _remove_deprecated_warning(self, s):
         lines = s.splitlines(True)  # keepends=True (PY2 doesn't accept keyword form)

--- a/Tools/Scripts/webkitpy/tool/steps/__init__.py
+++ b/Tools/Scripts/webkitpy/tool/steps/__init__.py
@@ -34,6 +34,7 @@ from webkitpy.tool.steps.applypatchwithlocalcommit import ApplyPatchWithLocalCom
 from webkitpy.tool.steps.applywatchlist import ApplyWatchList
 from webkitpy.tool.steps.attachtobug import AttachToBug
 from webkitpy.tool.steps.build import Build
+from webkitpy.tool.steps.checkforredactedissue import CheckForRedactedIssue
 from webkitpy.tool.steps.checkpatchrelevance import CheckPatchRelevance
 from webkitpy.tool.steps.checkstyle import CheckStyle
 from webkitpy.tool.steps.cleanworkingdirectory import CleanWorkingDirectory

--- a/Tools/Scripts/webkitpy/tool/steps/checkforredactedissue.py
+++ b/Tools/Scripts/webkitpy/tool/steps/checkforredactedissue.py
@@ -1,0 +1,57 @@
+# Copyright (C) 2023 Apple Inc. All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+# 1.  Redistributions of source code must retain the above copyright
+#     notice, this list of conditions and the following disclaimer.
+# 2.  Redistributions in binary form must reproduce the above copyright
+#     notice, this list of conditions and the following disclaimer in the
+#     documentation and/or other materials provided with the distribution.
+#
+# THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS "AS IS" AND
+# ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+# WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS BE LIABLE FOR
+# ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+# DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+# SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+# OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+import logging
+import sys
+
+from webkitpy.tool.steps.abstractstep import AbstractStep
+
+_log = logging.getLogger(__name__)
+
+
+class CheckForRedactedIssue(AbstractStep):
+    def run(self, state):
+        issues = state.get('issues')
+        if issues is None:
+            _log.error('Failed to populate issues from commit message')
+            sys.exit(1)
+
+        redaction_exemption = None
+        redacted_issue = None
+        for candidate in issues:
+            if getattr(candidate.redacted, 'exemption', False):
+                redaction_exemption = candidate
+            elif candidate.redacted:
+                redacted_issue = candidate
+        if redaction_exemption:
+            _log.info('The patch you are uploading references {}'.format(redaction_exemption.link))
+            _log.info("{} {}".format(redaction_exemption.link, redaction_exemption.redacted))
+            if redacted_issue:
+                _log.error("Redaction exemption overrides the redaction of {}".format(redacted_issue.link))
+                _log.error("{} {}".format(redacted_issue.link, redacted_issue.redacted))
+            redacted_issue = None
+
+        if redacted_issue:
+            _log.error('The patch you are uploading references {}'.format(redacted_issue.link))
+            _log.error("{} {}".format(redacted_issue.link, redacted_issue.redacted))
+            _log.error("Please use 'git-webkit' to upload this fix. 'webkit-patch' does not support security changes")
+            sys.exit(1)


### PR DESCRIPTION
#### dc5b85ccaaa794bae50ea2e87ba296e40d311912
<pre>
[webkit-patch] Check issue redaction before upload
<a href="https://bugs.webkit.org/show_bug.cgi?id=255565">https://bugs.webkit.org/show_bug.cgi?id=255565</a>
rdar://108169167

Rubber-stamped by Alan Baradlay.

webkit-patch should check if a patch references a redacted issue, just like git-webkit.

* Tools/Scripts/webkitpy/tool/commands/commandtest.py:
(CommandsTest.assert_execute_outputs): Check command output, even when exceptions are raised.
* Tools/Scripts/webkitpy/tool/commands/upload.py:
(AbstractPatchUploadingCommand._issues): List all issues associated with patch being uploaded.
(AbstractPatchUploadingCommand._prepare_state): Cache issues associated with patch.
(Post): Check that associated issues are not redacted.
(LandSafely): Ditto.
(Upload): Ditto.
(Upload._prepare_state): Cache issues associated with patch.
* Tools/Scripts/webkitpy/tool/commands/upload_unittest.py:
(MockIssue):
(MockRedaction):
(UploadCommandsTest.test_upload_blocked):
(UploadCommandsTest.test_upload_exempt):
* Tools/Scripts/webkitpy/tool/steps/__init__.py: Export CheckForRedactedIssue.
* Tools/Scripts/webkitpy/tool/steps/checkforredactedissue.py: Added.
(CheckForRedactedIssue): Abandon upload if associated issues are redacted.

Canonical link: <a href="https://commits.webkit.org/263104@main">https://commits.webkit.org/263104@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e50faee165b3111c902cd8fbd9e973dad5e7fe02

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/3643 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/3691 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/3833 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/5069 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/32/builds/3930 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/3617 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/3787 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/3732 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/3159 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/3687 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/15/builds/3919 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/3284 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/4894 "Built successfully") | 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/3674 "Passed tests") | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/39/builds/1426 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/10/builds/3255 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/3316 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/3228 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/3314 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/4660 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/3696 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/2990 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/3230 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/3255 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/3262 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/417 "Built successfully and passed tests") | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/31/builds/3507 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->