### PR TITLE
REGRESSION (261793@main): [Mail] Clicking markup button causes image/attachment to go blank/disappear

### DIFF
--- a/Source/WebCore/page/ContextMenuContext.h
+++ b/Source/WebCore/page/ContextMenuContext.h
@@ -82,7 +82,7 @@ private:
     HitTestResult m_hitTestResult;
     RefPtr<Event> m_event;
     String m_selectedText;
-    bool m_hasEntireImage;
+    bool m_hasEntireImage { false };
 
 #if ENABLE(SERVICE_CONTROLS)
     RefPtr<Image> m_controlledImage;

--- a/Source/WebKit/Shared/ContextMenuContextData.h
+++ b/Source/WebKit/Shared/ContextMenuContextData.h
@@ -110,7 +110,7 @@ private:
 
     std::optional<WebHitTestResultData> m_webHitTestResultData;
     String m_selectedText;
-    bool m_hasEntireImage;
+    bool m_hasEntireImage { false };
 
 #if ENABLE(SERVICE_CONTROLS)
     void setImage(WebCore::Image&);

--- a/Source/WebKit/UIProcess/API/APIContextMenuElementInfoMac.h
+++ b/Source/WebKit/UIProcess/API/APIContextMenuElementInfoMac.h
@@ -52,7 +52,7 @@ private:
 
     WebKit::WebHitTestResultData m_hitTestResultData;
     WTF::String m_qrCodePayloadString;
-    bool m_hasEntireImage;
+    bool m_hasEntireImage { false };
 };
 
 } // namespace API


### PR DESCRIPTION
#### bbae082ce145c1e0c81fd164bbed75d93d971cb3
<pre>
REGRESSION (261793@main): [Mail] Clicking markup button causes image/attachment to go blank/disappear
<a href="https://bugs.webkit.org/show_bug.cgi?id=255627">https://bugs.webkit.org/show_bug.cgi?id=255627</a>
rdar://107635311

Reviewed by Aditya Keerthi.

After the changes in 261793@main, `WebKit::ContextMenuContextData` no longer decodes properly in the
UI process, when created via service controls codepaths (i.e. when clicking the services rollover
button over an attachment in Mail). This is because one of the new members, `m_hasEntireImage`, is
uninitialized to either `true` or `false` and ends up triggering undefined behavior; in turn, code
in the UI process expects either a value of exactly 0 or 1 when decoding `bool` types, so we
subsequently fail to decode and `MESSAGE_CHECK` the Mail web content process.

Fix this by simple initializing `m_hasEntireImage` (I&apos;ve also added a few more initial values to
harden against similar bugs in the future).

Covered by the existing API test: ImageAnalysisTests.RemoveBackgroundItemInServicesMenu, which began
timing out after 261793@main. Also, credit to Aditya for being the first to spot that
`m_hasEntireImage` is uninitialized.

* Source/WebCore/page/ContextMenuContext.h:
* Source/WebKit/Shared/ContextMenuContextData.h:
* Source/WebKit/UIProcess/API/APIContextMenuElementInfoMac.h:

Canonical link: <a href="https://commits.webkit.org/263109@main">https://commits.webkit.org/263109@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/03728dd423aa226df900cc8bec75a0ab8e79501a

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/3633 "Passed style check") | [  ~~🛠 ios~~](https://ews-build.webkit.org/#/builders/26/builds/3734 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/3823 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/5059 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/32/builds/3922 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/3607 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/3774 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/3722 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/3149 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/3677 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/15/builds/3912 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/3281 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/4883 "Built successfully") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/39/builds/1418 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/3252 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/3307 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [❌ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/3221 "4 api tests failed or timed out") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/3311 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/4649 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/3686 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/2982 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/3220 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/3252 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/887 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/3252 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/3498 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->