### PR TITLE
createImageBitmap using ImageData doesn't respect the premultiply flag.

### DIFF
--- a/LayoutTests/webgl/2.0.0/resources/webgl_test_files/js/tests/tex-image-and-sub-image-2d-with-image-bitmap-from-image-data.js
+++ b/LayoutTests/webgl/2.0.0/resources/webgl_test_files/js/tests/tex-image-and-sub-image-2d-with-image-bitmap-from-image-data.js
@@ -51,12 +51,12 @@ function generateTest(internalFormat, pixelFormat, pixelType, prologue, resource
 
         var imageData = new ImageData(new Uint8ClampedArray(
                                       [255, 0, 0, 255,
-                                      255, 0, 0, 0,
+                                      255, 0, 0, 128,
                                       0, 255, 0, 255,
-                                      0, 255, 0, 0]),
+                                      0, 255, 0, 128]),
                                       2, 2);
 
-        runImageBitmapTest(imageData, 0, internalFormat, pixelFormat, pixelType, gl, tiu, wtu, false)
+        runImageBitmapTest(imageData, 0.5, internalFormat, pixelFormat, pixelType, gl, tiu, wtu, false)
         .then(() => {
             finishTest();
         });

--- a/Source/WebCore/html/ImageBitmap.cpp
+++ b/Source/WebCore/html/ImageBitmap.cpp
@@ -866,9 +866,12 @@ void ImageBitmap::createPromise(ScriptExecutionContext& scriptExecutionContext, 
     auto alphaPremultiplication = alphaPremultiplicationForPremultiplyAlpha(options.premultiplyAlpha);
     if (sourceRectangle.returnValue().location().isZero() && sourceRectangle.returnValue().size() == imageData->size() && sourceRectangle.returnValue().size() == outputSize && options.orientation == ImageBitmapOptions::Orientation::None) {
         bitmapData->putPixelBuffer(imageData->pixelBuffer(), sourceRectangle.releaseReturnValue(), { }, alphaPremultiplication);
-        
-        auto imageBitmap = create(ImageBitmapBacking(WTFMove(bitmapData)));
-        // The result is implicitly origin-clean, and alpha premultiplication has already been handled.
+
+        OptionSet<SerializationState> serializationState = SerializationState::OriginClean;
+        if (alphaPremultiplication == AlphaPremultiplication::Premultiplied)
+            serializationState.add(SerializationState::PremultiplyAlpha);
+
+        auto imageBitmap = create(ImageBitmapBacking(WTFMove(bitmapData), serializationState));
         promise.resolve(WTFMove(imageBitmap));
         return;
     }
@@ -885,7 +888,12 @@ void ImageBitmap::createPromise(ScriptExecutionContext& scriptExecutionContext, 
     bitmapData->context().drawImageBuffer(*tempBitmapData, destRect, sourceRectangle.releaseReturnValue(), { interpolationQualityForResizeQuality(options.resizeQuality), options.resolvedImageOrientation(ImageOrientation::Orientation::None) });
 
     // 6.4.1. Resolve p with ImageBitmap.
-    auto imageBitmap = create({ WTFMove(bitmapData) });
+    OptionSet<SerializationState> serializationState = SerializationState::OriginClean;
+    if (alphaPremultiplication == AlphaPremultiplication::Premultiplied)
+        serializationState.add(SerializationState::PremultiplyAlpha);
+
+    auto imageBitmap = create(ImageBitmapBacking(WTFMove(bitmapData), serializationState));
+
     // The result is implicitly origin-clean, and alpha premultiplication has already been handled.
     promise.resolve(WTFMove(imageBitmap));
 }


### PR DESCRIPTION
#### aa1ea27b114e05e0d19fdb76d22c39e88600917f
<pre>
createImageBitmap using ImageData doesn&apos;t respect the premultiply flag.
<a href="https://bugs.webkit.org/show_bug.cgi?id=237082">https://bugs.webkit.org/show_bug.cgi?id=237082</a>
&lt;rdar://89382358&gt;

Reviewed by Brent Fulgham.

This path used the flag to premultiply the incoming data, but didn&apos;t mark the resulting ImageBitmap as wanting premultiplied data.
When uploading a WebGL texture we&apos;d check for the flag, and unpremultiply again since it wasn&apos;t there.

* LayoutTests/webgl/2.0.0/resources/webgl_test_files/js/tests/tex-image-and-sub-image-2d-with-image-bitmap-from-image-data.js:
(init):
(generateTest):
* Source/WebCore/html/ImageBitmap.cpp:
(WebCore::ImageBitmap::createPromise):

Canonical link: <a href="https://commits.webkit.org/263137@main">https://commits.webkit.org/263137@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/de28880f00353102ae445b17ab17ce6a3548f377

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/3646 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/3730 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/3836 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/5072 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/3933 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/3620 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/3791 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/3735 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/3162 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/3690 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/3921 "1 flakes 2 failures") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/3286 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/4897 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/1428 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/3257 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/3318 "4 flakes 141 failures") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/3230 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/3316 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/4666 "run-api-tests-without-change (failure)") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/3699 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/2992 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/3233 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/3257 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/909 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/3265 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/3510 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->