### PR TITLE
Add factory functions for InputType subclasses

### DIFF
--- a/Source/WebCore/html/ButtonInputType.h
+++ b/Source/WebCore/html/ButtonInputType.h
@@ -37,12 +37,17 @@ namespace WebCore {
 class ButtonInputType final : public BaseButtonInputType {
     template<typename DowncastedType> friend bool isInvalidInputType(const InputType&, const String&);
 public:
+    static Ref<ButtonInputType> create(HTMLInputElement& element)
+    {
+        return adoptRef(*new ButtonInputType(element));
+    }
+
+private:
     explicit ButtonInputType(HTMLInputElement& element)
         : BaseButtonInputType(Type::Button, element)
     {
     }
 
-private:
     const AtomString& formControlType() const final;
 };
 

--- a/Source/WebCore/html/CheckboxInputType.h
+++ b/Source/WebCore/html/CheckboxInputType.h
@@ -37,14 +37,19 @@ namespace WebCore {
 class CheckboxInputType final : public BaseCheckableInputType {
     template<typename DowncastedType> friend bool isInvalidInputType(const InputType&, const String&);
 public:
-    explicit CheckboxInputType(HTMLInputElement& element)
-        : BaseCheckableInputType(Type::Checkbox, element)
+    static Ref<CheckboxInputType> create(HTMLInputElement& element)
     {
+        return adoptRef(*new CheckboxInputType(element));
     }
 
     bool valueMissing(const String&) const final;
 
 private:
+    explicit CheckboxInputType(HTMLInputElement& element)
+        : BaseCheckableInputType(Type::Checkbox, element)
+    {
+    }
+
     const AtomString& formControlType() const final;
     String valueMissingText() const final;
     void handleKeyupEvent(KeyboardEvent&) final;

--- a/Source/WebCore/html/ColorInputType.h
+++ b/Source/WebCore/html/ColorInputType.h
@@ -42,10 +42,9 @@ namespace WebCore {
 class ColorInputType final : public BaseClickableWithKeyInputType, private ColorChooserClient {
     template<typename DowncastedType> friend bool isInvalidInputType(const InputType&, const String&);
 public:
-    explicit ColorInputType(HTMLInputElement& element)
-        : BaseClickableWithKeyInputType(Type::Color, element)
+    static Ref<ColorInputType> create(HTMLInputElement& element)
     {
-        ASSERT(needsShadowSubtree());
+        return adoptRef(*new ColorInputType(element));
     }
 
     Vector<Color> suggestedColors() const;
@@ -58,6 +57,12 @@ public:
     void detach() final;
 
 private:
+    explicit ColorInputType(HTMLInputElement& element)
+        : BaseClickableWithKeyInputType(Type::Color, element)
+    {
+        ASSERT(needsShadowSubtree());
+    }
+
     void didChooseColor(const Color&) final;
     void didEndChooser() final;
     IntRect elementRectRelativeToRootView() const final;

--- a/Source/WebCore/html/DateInputType.h
+++ b/Source/WebCore/html/DateInputType.h
@@ -39,9 +39,14 @@ namespace WebCore {
 class DateInputType final : public BaseDateAndTimeInputType {
     template<typename DowncastedType> friend bool isInvalidInputType(const InputType&, const String&);
 public:
-    explicit DateInputType(HTMLInputElement&);
+    static Ref<DateInputType> create(HTMLInputElement& element)
+    {
+        return adoptRef(*new DateInputType(element));
+    }
 
 private:
+    explicit DateInputType(HTMLInputElement&);
+
     const AtomString& formControlType() const final;
     DateComponentsType dateType() const final;
     StepRange createStepRange(AnyStepHandling) const final;

--- a/Source/WebCore/html/DateTimeLocalInputType.h
+++ b/Source/WebCore/html/DateTimeLocalInputType.h
@@ -39,12 +39,17 @@ namespace WebCore {
 class DateTimeLocalInputType final : public BaseDateAndTimeInputType {
     template<typename DowncastedType> friend bool isInvalidInputType(const InputType&, const String&);
 public:
+    static Ref<DateTimeLocalInputType> create(HTMLInputElement& element)
+    {
+        return adoptRef(*new DateTimeLocalInputType(element));
+    }
+
+private:
     explicit DateTimeLocalInputType(HTMLInputElement& element)
         : BaseDateAndTimeInputType(Type::DateTimeLocal, element)
     {
     }
 
-private:
     const AtomString& formControlType() const final;
     DateComponentsType dateType() const final;
     WallTime valueAsDate() const final;

--- a/Source/WebCore/html/EmailInputType.h
+++ b/Source/WebCore/html/EmailInputType.h
@@ -37,14 +37,19 @@ namespace WebCore {
 class EmailInputType final : public BaseTextInputType {
     template<typename DowncastedType> friend bool isInvalidInputType(const InputType&, const String&);
 public:
-    explicit EmailInputType(HTMLInputElement& element)
-        : BaseTextInputType(Type::Email, element)
+    static Ref<EmailInputType> create(HTMLInputElement& element)
     {
+        return adoptRef(*new EmailInputType(element));
     }
 
     bool typeMismatchFor(const String&) const final;
 
 private:
+    explicit EmailInputType(HTMLInputElement& element)
+        : BaseTextInputType(Type::Email, element)
+    {
+    }
+
     const AtomString& formControlType() const final;
     bool typeMismatch() const final;
     String typeMismatchText() const final;

--- a/Source/WebCore/html/FileInputType.h
+++ b/Source/WebCore/html/FileInputType.h
@@ -47,7 +47,11 @@ class Icon;
 class FileInputType final : public BaseClickableWithKeyInputType, private FileChooserClient, private FileIconLoaderClient, public CanMakeWeakPtr<FileInputType> {
     template<typename DowncastedType> friend bool isInvalidInputType(const InputType&, const String&);
 public:
-    explicit FileInputType(HTMLInputElement&);
+    static Ref<FileInputType> create(HTMLInputElement& element)
+    {
+        return adoptRef(*new FileInputType(element));
+    }
+
     virtual ~FileInputType();
 
     String firstElementPathForInputValue() const; // Checked first, before internal storage or the value attribute.
@@ -59,6 +63,8 @@ public:
     bool valueMissing(const String&) const final;
 
 private:
+    explicit FileInputType(HTMLInputElement&);
+
     const AtomString& formControlType() const final;
     FormControlState saveFormControlState() const final;
     void restoreFormControlState(const FormControlState&) final;

--- a/Source/WebCore/html/HTMLInputElement.cpp
+++ b/Source/WebCore/html/HTMLInputElement.cpp
@@ -75,6 +75,7 @@
 #include "StepRange.h"
 #include "StyleGradientImage.h"
 #include "TextControlInnerElements.h"
+#include "TextInputType.h"
 #include "TypedElementDescendantIteratorInlines.h"
 #include <wtf/IsoMallocInlines.h>
 #include <wtf/Language.h>
@@ -112,7 +113,7 @@ HTMLInputElement::HTMLInputElement(const QualifiedName& tagName, Document& docum
     , m_parsingInProgress(createdByParser)
     // m_inputType is lazily created when constructed by the parser to avoid constructing unnecessarily a text inputType,
     // just to destroy them when the |type| attribute gets set by the parser to something else than 'text'.
-    , m_inputType(createdByParser ? nullptr : RefPtr { InputType::createText(*this) })
+    , m_inputType(createdByParser ? nullptr : RefPtr { TextInputType::create(*this) })
 {
     ASSERT(hasTagName(inputTag));
 }
@@ -727,7 +728,7 @@ inline void HTMLInputElement::initializeInputType()
 
     auto& type = attributeWithoutSynchronization(typeAttr);
     if (type.isNull()) {
-        m_inputType = InputType::createText(*this);
+        m_inputType = TextInputType::create(*this);
         updateWillValidateAndValidity();
         return;
     }

--- a/Source/WebCore/html/HiddenInputType.h
+++ b/Source/WebCore/html/HiddenInputType.h
@@ -37,12 +37,17 @@ namespace WebCore {
 class HiddenInputType final : public InputType {
     template<typename DowncastedType> friend bool isInvalidInputType(const InputType&, const String&);
 public:
+    static Ref<HiddenInputType> create(HTMLInputElement& element)
+    {
+        return adoptRef(*new HiddenInputType(element));
+    }
+
+private:
     explicit HiddenInputType(HTMLInputElement& element)
         : InputType(Type::Hidden, element)
     {
     }
 
-private:
     const AtomString& formControlType() const final;
     FormControlState saveFormControlState() const final;
     void restoreFormControlState(const FormControlState&) final;

--- a/Source/WebCore/html/ImageInputType.h
+++ b/Source/WebCore/html/ImageInputType.h
@@ -40,9 +40,14 @@ namespace WebCore {
 class ImageInputType final : public BaseButtonInputType {
     template<typename DowncastedType> friend bool isInvalidInputType(const InputType&, const String&);
 public:
-    explicit ImageInputType(HTMLInputElement&);
+    static Ref<ImageInputType> create(HTMLInputElement& element)
+    {
+        return adoptRef(*new ImageInputType(element));
+    }
 
 private:
+    explicit ImageInputType(HTMLInputElement&);
+
     const AtomString& formControlType() const final;
     bool isFormDataAppendable() const final;
     bool appendFormData(DOMFormData&) const final;

--- a/Source/WebCore/html/InputType.cpp
+++ b/Source/WebCore/html/InputType.cpp
@@ -99,9 +99,9 @@ struct InputTypeFactory {
 
 typedef MemoryCompactLookupOnlyRobinHoodHashMap<AtomString, InputTypeFactory> InputTypeFactoryMap;
 
-template<class T> static Ref<InputType> createInputType(HTMLInputElement& element)
+template<typename T> static Ref<InputType> createInputType(HTMLInputElement& element)
 {
-    return adoptRef(*new T(element));
+    return T::create(element);
 }
 
 static InputTypeFactoryMap createInputTypeFactoryMap()
@@ -181,12 +181,7 @@ RefPtr<InputType> InputType::createIfDifferent(HTMLInputElement& element, const 
     }
     if (currentInputType && currentInputType->type() == Type::Text)
         return nullptr;
-    return adoptRef(*new TextInputType(element));
-}
-
-Ref<InputType> InputType::createText(HTMLInputElement& element)
-{
-    return adoptRef(*new TextInputType(element));
+    return TextInputType::create(element);
 }
 
 InputType::~InputType() = default;

--- a/Source/WebCore/html/InputType.h
+++ b/Source/WebCore/html/InputType.h
@@ -155,7 +155,7 @@ public:
     };
 
     static RefPtr<InputType> createIfDifferent(HTMLInputElement&, const AtomString&, InputType* currentInputType = nullptr);
-    static Ref<InputType> createText(HTMLInputElement&);
+
     virtual ~InputType();
 
     void detachFromElement() { m_element = nullptr; }

--- a/Source/WebCore/html/MonthInputType.h
+++ b/Source/WebCore/html/MonthInputType.h
@@ -39,12 +39,17 @@ namespace WebCore {
 class MonthInputType final : public BaseDateAndTimeInputType {
     template<typename DowncastedType> friend bool isInvalidInputType(const InputType&, const String&);
 public:
+    static Ref<MonthInputType> create(HTMLInputElement& element)
+    {
+        return adoptRef(*new MonthInputType(element));
+    }
+
+private:
     explicit MonthInputType(HTMLInputElement& element)
         : BaseDateAndTimeInputType(Type::Month, element)
     {
     }
 
-private:
     const AtomString& formControlType() const final;
     DateComponentsType dateType() const final;
     WallTime valueAsDate() const final;

--- a/Source/WebCore/html/NumberInputType.h
+++ b/Source/WebCore/html/NumberInputType.h
@@ -38,13 +38,19 @@ namespace WebCore {
 class NumberInputType final : public TextFieldInputType {
     template<typename DowncastedType> friend bool isInvalidInputType(const InputType&, const String&);
 public:
+    static Ref<NumberInputType> create(HTMLInputElement& element)
+    {
+        return adoptRef(*new NumberInputType(element));
+    }
+
+    bool typeMismatchFor(const String&) const final;
+
+private:
     explicit NumberInputType(HTMLInputElement& element)
         : TextFieldInputType(Type::Number, element)
     {
     }
-    bool typeMismatchFor(const String&) const final;
 
-private:
     const AtomString& formControlType() const final;
     void setValue(const String&, bool valueChanged, TextFieldEventBehavior, TextControlSetValueSelection) final;
     double valueAsDouble() const final;

--- a/Source/WebCore/html/PasswordInputType.h
+++ b/Source/WebCore/html/PasswordInputType.h
@@ -37,12 +37,17 @@ namespace WebCore {
 class PasswordInputType final : public BaseTextInputType {
     template<typename DowncastedType> friend bool isInvalidInputType(const InputType&, const String&);
 public:
+    static Ref<PasswordInputType> create(HTMLInputElement& element)
+    {
+        return adoptRef(*new PasswordInputType(element));
+    }
+
+private:
     explicit PasswordInputType(HTMLInputElement& element)
         : BaseTextInputType(Type::Password, element)
     {
     }
 
-private:
     const AtomString& formControlType() const final;
     bool shouldSaveAndRestoreFormControlState() const final;
     FormControlState saveFormControlState() const final;

--- a/Source/WebCore/html/RadioInputType.h
+++ b/Source/WebCore/html/RadioInputType.h
@@ -38,9 +38,9 @@ namespace WebCore {
 class RadioInputType final : public BaseCheckableInputType {
     template<typename DowncastedType> friend bool isInvalidInputType(const InputType&, const String&);
 public:
-    explicit RadioInputType(HTMLInputElement& element)
-        : BaseCheckableInputType(Type::Radio, element)
+    static Ref<RadioInputType> create(HTMLInputElement& element)
     {
+        return adoptRef(*new RadioInputType(element));
     }
 
     static void forEachButtonInDetachedGroup(ContainerNode& rootName, const String& groupName, const Function<bool(HTMLInputElement&)>&);
@@ -48,6 +48,11 @@ public:
     bool valueMissing(const String&) const final;
 
 private:
+    explicit RadioInputType(HTMLInputElement& element)
+        : BaseCheckableInputType(Type::Radio, element)
+    {
+    }
+
     const AtomString& formControlType() const final;
     String valueMissingText() const final;
     void handleClickEvent(MouseEvent&) final;

--- a/Source/WebCore/html/RangeInputType.h
+++ b/Source/WebCore/html/RangeInputType.h
@@ -40,10 +40,16 @@ class SliderThumbElement;
 class RangeInputType final : public InputType {
     template<typename DowncastedType> friend bool isInvalidInputType(const InputType&, const String&);
 public:
-    explicit RangeInputType(HTMLInputElement&);
+    static Ref<RangeInputType> create(HTMLInputElement& element)
+    {
+        return adoptRef(*new RangeInputType(element));
+    }
+
     bool typeMismatchFor(const String&) const final;
 
 private:
+    explicit RangeInputType(HTMLInputElement&);
+
     const AtomString& formControlType() const final;
     double valueAsDouble() const final;
     ExceptionOr<void> setValueAsDecimal(const Decimal&, TextFieldEventBehavior) const final;

--- a/Source/WebCore/html/ResetInputType.h
+++ b/Source/WebCore/html/ResetInputType.h
@@ -37,12 +37,17 @@ namespace WebCore {
 class ResetInputType final : public BaseButtonInputType {
     template<typename DowncastedType> friend bool isInvalidInputType(const InputType&, const String&);
 public:
+    static Ref<ResetInputType> create(HTMLInputElement& element)
+    {
+        return adoptRef(*new ResetInputType(element));
+    }
+
+private:
     explicit ResetInputType(HTMLInputElement& element)
         : BaseButtonInputType(Type::Reset, element)
     {
     }
 
-private:
     const AtomString& formControlType() const final;
     void handleDOMActivateEvent(Event&) final;
     String defaultValue() const final;

--- a/Source/WebCore/html/SearchInputType.h
+++ b/Source/WebCore/html/SearchInputType.h
@@ -41,11 +41,16 @@ class SearchFieldResultsButtonElement;
 class SearchInputType final : public BaseTextInputType {
     template<typename DowncastedType> friend bool isInvalidInputType(const InputType&, const String&);
 public:
-    explicit SearchInputType(HTMLInputElement&);
+    static Ref<SearchInputType> create(HTMLInputElement& element)
+    {
+        return adoptRef(*new SearchInputType(element));
+    }
 
     void stopSearchEventTimer();
 
 private:
+    explicit SearchInputType(HTMLInputElement&);
+
     void addSearchResult() final;
     void attributeChanged(const QualifiedName&) final;
     RenderPtr<RenderElement> createInputRenderer(RenderStyle&&) final;

--- a/Source/WebCore/html/SubmitInputType.h
+++ b/Source/WebCore/html/SubmitInputType.h
@@ -37,12 +37,17 @@ namespace WebCore {
 class SubmitInputType final : public BaseButtonInputType {
     template<typename DowncastedType> friend bool isInvalidInputType(const InputType&, const String&);
 public:
+    static Ref<SubmitInputType> create(HTMLInputElement& element)
+    {
+        return adoptRef(*new SubmitInputType(element));
+    }
+
+private:
     explicit SubmitInputType(HTMLInputElement& element)
         : BaseButtonInputType(Type::Submit, element)
     {
     }
 
-private:
     const AtomString& formControlType() const final;
     bool appendFormData(DOMFormData&) const final;
     bool supportsRequired() const final;

--- a/Source/WebCore/html/TelephoneInputType.h
+++ b/Source/WebCore/html/TelephoneInputType.h
@@ -37,12 +37,17 @@ namespace WebCore {
 class TelephoneInputType final : public BaseTextInputType {
     template<typename DowncastedType> friend bool isInvalidInputType(const InputType&, const String&);
 public:
+    static Ref<TelephoneInputType> create(HTMLInputElement& element)
+    {
+        return adoptRef(*new TelephoneInputType(element));
+    }
+
+private:
     explicit TelephoneInputType(HTMLInputElement& element)
         : BaseTextInputType(Type::Telephone, element)
     {
     }
 
-private:
     const AtomString& formControlType() const final;
 };
 

--- a/Source/WebCore/html/TextInputType.h
+++ b/Source/WebCore/html/TextInputType.h
@@ -37,12 +37,17 @@ namespace WebCore {
 class TextInputType final : public BaseTextInputType {
     template<typename DowncastedType> friend bool isInvalidInputType(const InputType&, const String&);
 public:
+    static Ref<TextInputType> create(HTMLInputElement& element)
+    {
+        return adoptRef(*new TextInputType(element));
+    }
+
+private:
     explicit TextInputType(HTMLInputElement& element)
         : BaseTextInputType(Type::Text, element)
     {
     }
 
-private:
     const AtomString& formControlType() const final;
 };
 

--- a/Source/WebCore/html/TimeInputType.h
+++ b/Source/WebCore/html/TimeInputType.h
@@ -39,9 +39,14 @@ namespace WebCore {
 class TimeInputType final : public BaseDateAndTimeInputType {
     template<typename DowncastedType> friend bool isInvalidInputType(const InputType&, const String&);
 public:
-    explicit TimeInputType(HTMLInputElement&);
+    static Ref<TimeInputType> create(HTMLInputElement& element)
+    {
+        return adoptRef(*new TimeInputType(element));
+    }
 
 private:
+    explicit TimeInputType(HTMLInputElement&);
+
     const AtomString& formControlType() const final;
     DateComponentsType dateType() const final;
     Decimal defaultValueForStepUp() const final;

--- a/Source/WebCore/html/URLInputType.h
+++ b/Source/WebCore/html/URLInputType.h
@@ -37,14 +37,19 @@ namespace WebCore {
 class URLInputType final : public BaseTextInputType {
     template<typename DowncastedType> friend bool isInvalidInputType(const InputType&, const String&);
 public:
-    explicit URLInputType(HTMLInputElement& element)
-        : BaseTextInputType(Type::URL, element)
+    static Ref<URLInputType> create(HTMLInputElement& element)
     {
+        return adoptRef(*new URLInputType(element));
     }
 
     bool typeMismatchFor(const String&) const final;
 
 private:
+    explicit URLInputType(HTMLInputElement& element)
+        : BaseTextInputType(Type::URL, element)
+    {
+    }
+
     const AtomString& formControlType() const final;
     bool typeMismatch() const final;
     String typeMismatchText() const final;

--- a/Source/WebCore/html/WeekInputType.h
+++ b/Source/WebCore/html/WeekInputType.h
@@ -39,12 +39,17 @@ namespace WebCore {
 class WeekInputType final : public BaseDateAndTimeInputType {
     template<typename DowncastedType> friend bool isInvalidInputType(const InputType&, const String&);
 public:
+    static Ref<WeekInputType> create(HTMLInputElement& element)
+    {
+        return adoptRef(*new WeekInputType(element));
+    }
+
+private:
     explicit WeekInputType(HTMLInputElement& element)
         : BaseDateAndTimeInputType(Type::Week, element)
     {
     }
 
-private:
     const AtomString& formControlType() const final;
     DateComponentsType dateType() const final;
     StepRange createStepRange(AnyStepHandling) const final;


### PR DESCRIPTION
#### 29010c0f998e5e582ca078f0584d621044934c5a
<pre>
Add factory functions for InputType subclasses
<a href="https://bugs.webkit.org/show_bug.cgi?id=255630">https://bugs.webkit.org/show_bug.cgi?id=255630</a>

Reviewed by Darin Adler.

Add factory functions for InputType subclasses. It is a little risky to have
RefCounted subclasses with a public constructor.

* Source/WebCore/html/ButtonInputType.h:
* Source/WebCore/html/CheckboxInputType.h:
* Source/WebCore/html/ColorInputType.h:
* Source/WebCore/html/DateInputType.h:
* Source/WebCore/html/DateTimeLocalInputType.h:
* Source/WebCore/html/EmailInputType.h:
* Source/WebCore/html/FileInputType.h:
* Source/WebCore/html/HTMLInputElement.cpp:
(WebCore::HTMLInputElement::HTMLInputElement):
(WebCore::HTMLInputElement::initializeInputType):
* Source/WebCore/html/HiddenInputType.h:
* Source/WebCore/html/ImageInputType.h:
* Source/WebCore/html/InputType.cpp:
(WebCore::createInputType):
(WebCore::InputType::createIfDifferent):
(WebCore::InputType::createText): Deleted.
* Source/WebCore/html/InputType.h:
* Source/WebCore/html/MonthInputType.h:
* Source/WebCore/html/NumberInputType.h:
* Source/WebCore/html/PasswordInputType.h:
* Source/WebCore/html/RadioInputType.h:
* Source/WebCore/html/RangeInputType.h:
* Source/WebCore/html/ResetInputType.h:
* Source/WebCore/html/SearchInputType.h:
* Source/WebCore/html/SubmitInputType.h:
* Source/WebCore/html/TelephoneInputType.h:
* Source/WebCore/html/TextInputType.h:
* Source/WebCore/html/TimeInputType.h:
* Source/WebCore/html/URLInputType.h:
* Source/WebCore/html/WeekInputType.h:

Canonical link: <a href="https://commits.webkit.org/263114@main">https://commits.webkit.org/263114@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/050c01d2e8290b6d128aeb51a414319265272cb7

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/3648 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/3700 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/3838 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/5074 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/32/builds/3935 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/3622 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/3793 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/3737 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/3163 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/3692 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/3923 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/3290 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/4899 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/1430 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/3261 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/3319 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/3232 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/3320 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/4665 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/3701 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/2993 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/3235 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/3261 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/889 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/3267 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/3512 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->