### PR TITLE
[Shape Detection] Plumb ImageBitmapSource to the GPU process

### DIFF
--- a/Source/WebCore/Modules/ShapeDetection/BarcodeDetector.h
+++ b/Source/WebCore/Modules/ShapeDetection/BarcodeDetector.h
@@ -49,7 +49,7 @@ public:
     static ExceptionOr<void> getSupportedFormats(ScriptExecutionContext&, GetSupportedFormatsPromise&&);
 
     using DetectPromise = DOMPromiseDeferred<IDLSequence<IDLDictionary<DetectedBarcode>>>;
-    void detect(const ImageBitmap::Source&, DetectPromise&&);
+    void detect(ScriptExecutionContext&, ImageBitmap::Source&&, DetectPromise&&);
 
 private:
     BarcodeDetector(Ref<ShapeDetection::BarcodeDetector>&&);

--- a/Source/WebCore/Modules/ShapeDetection/BarcodeDetector.idl
+++ b/Source/WebCore/Modules/ShapeDetection/BarcodeDetector.idl
@@ -52,5 +52,5 @@ interface BarcodeDetector {
     [CallWith=CurrentScriptExecutionContext] constructor(optional BarcodeDetectorOptions barcodeDetectorOptions = {});
     [CallWith=CurrentScriptExecutionContext] static Promise<sequence<BarcodeFormat>> getSupportedFormats();
 
-    Promise<sequence<DetectedBarcode>> detect(ImageBitmapSource image);
+    [CallWith=CurrentScriptExecutionContext] Promise<sequence<DetectedBarcode>> detect(ImageBitmapSource image);
 };

--- a/Source/WebCore/Modules/ShapeDetection/FaceDetector.h
+++ b/Source/WebCore/Modules/ShapeDetection/FaceDetector.h
@@ -45,7 +45,7 @@ public:
     ~FaceDetector();
 
     using DetectPromise = DOMPromiseDeferred<IDLSequence<IDLDictionary<DetectedFace>>>;
-    void detect(const ImageBitmap::Source&, DetectPromise&&);
+    void detect(ScriptExecutionContext&, ImageBitmap::Source&&, DetectPromise&&);
 
 private:
     FaceDetector(Ref<ShapeDetection::FaceDetector>&&);

--- a/Source/WebCore/Modules/ShapeDetection/FaceDetector.idl
+++ b/Source/WebCore/Modules/ShapeDetection/FaceDetector.idl
@@ -50,5 +50,5 @@ typedef (CanvasImageSource or Blob or ImageData) ImageBitmapSource;
 ]
 interface FaceDetector {
     [CallWith=CurrentScriptExecutionContext] constructor(optional FaceDetectorOptions faceDetectorOptions = {});
-    Promise<sequence<DetectedFace>> detect(ImageBitmapSource image);
+    [CallWith=CurrentScriptExecutionContext] Promise<sequence<DetectedFace>> detect(ImageBitmapSource image);
 };

--- a/Source/WebCore/Modules/ShapeDetection/Implementation/Cocoa/BarcodeDetectorImplementation.h
+++ b/Source/WebCore/Modules/ShapeDetection/Implementation/Cocoa/BarcodeDetectorImplementation.h
@@ -51,7 +51,7 @@ private:
     BarcodeDetectorImpl& operator=(const BarcodeDetectorImpl&) = delete;
     BarcodeDetectorImpl& operator=(BarcodeDetectorImpl&&) = delete;
 
-    void detect(CompletionHandler<void(Vector<DetectedBarcode>&&)>&&) final;
+    void detect(Ref<ImageBuffer>&&, CompletionHandler<void(Vector<DetectedBarcode>&&)>&&) final;
 };
 
 } // namespace WebCore::ShapeDetection

--- a/Source/WebCore/Modules/ShapeDetection/Implementation/Cocoa/BarcodeDetectorImplementation.mm
+++ b/Source/WebCore/Modules/ShapeDetection/Implementation/Cocoa/BarcodeDetectorImplementation.mm
@@ -42,7 +42,7 @@ void BarcodeDetectorImpl::getSupportedFormats(CompletionHandler<void(Vector<Barc
     completionHandler({ });
 }
 
-void BarcodeDetectorImpl::detect(CompletionHandler<void(Vector<DetectedBarcode>&&)>&& completionHandler)
+void BarcodeDetectorImpl::detect(Ref<ImageBuffer>&&, CompletionHandler<void(Vector<DetectedBarcode>&&)>&& completionHandler)
 {
     completionHandler({ });
 }

--- a/Source/WebCore/Modules/ShapeDetection/Implementation/Cocoa/FaceDetectorImplementation.h
+++ b/Source/WebCore/Modules/ShapeDetection/Implementation/Cocoa/FaceDetectorImplementation.h
@@ -49,7 +49,7 @@ private:
     FaceDetectorImpl& operator=(const FaceDetectorImpl&) = delete;
     FaceDetectorImpl& operator=(FaceDetectorImpl&&) = delete;
 
-    void detect(CompletionHandler<void(Vector<DetectedFace>&&)>&&) final;
+    void detect(Ref<ImageBuffer>&&, CompletionHandler<void(Vector<DetectedFace>&&)>&&) final;
 };
 
 } // namespace WebCore::ShapeDetection

--- a/Source/WebCore/Modules/ShapeDetection/Implementation/Cocoa/FaceDetectorImplementation.mm
+++ b/Source/WebCore/Modules/ShapeDetection/Implementation/Cocoa/FaceDetectorImplementation.mm
@@ -37,7 +37,7 @@ FaceDetectorImpl::FaceDetectorImpl(const FaceDetectorOptions&)
 
 FaceDetectorImpl::~FaceDetectorImpl() = default;
 
-void FaceDetectorImpl::detect(CompletionHandler<void(Vector<DetectedFace>&&)>&& completionHandler)
+void FaceDetectorImpl::detect(Ref<ImageBuffer>&&, CompletionHandler<void(Vector<DetectedFace>&&)>&& completionHandler)
 {
     completionHandler({ });
 }

--- a/Source/WebCore/Modules/ShapeDetection/Implementation/Cocoa/TextDetectorImplementation.h
+++ b/Source/WebCore/Modules/ShapeDetection/Implementation/Cocoa/TextDetectorImplementation.h
@@ -47,7 +47,7 @@ private:
     TextDetectorImpl& operator=(const TextDetectorImpl&) = delete;
     TextDetectorImpl& operator=(TextDetectorImpl&&) = delete;
 
-    void detect(CompletionHandler<void(Vector<DetectedText>&&)>&&) final;
+    void detect(Ref<ImageBuffer>&&, CompletionHandler<void(Vector<DetectedText>&&)>&&) final;
 };
 
 } // namespace WebCore::ShapeDetection

--- a/Source/WebCore/Modules/ShapeDetection/Implementation/Cocoa/TextDetectorImplementation.mm
+++ b/Source/WebCore/Modules/ShapeDetection/Implementation/Cocoa/TextDetectorImplementation.mm
@@ -34,7 +34,7 @@ TextDetectorImpl::TextDetectorImpl() = default;
 
 TextDetectorImpl::~TextDetectorImpl() = default;
 
-void TextDetectorImpl::detect(CompletionHandler<void(Vector<DetectedText>&&)>&& completionHandler)
+void TextDetectorImpl::detect(Ref<ImageBuffer>&&, CompletionHandler<void(Vector<DetectedText>&&)>&& completionHandler)
 {
     completionHandler({ });
 }

--- a/Source/WebCore/Modules/ShapeDetection/Interfaces/BarcodeDetectorInterface.h
+++ b/Source/WebCore/Modules/ShapeDetection/Interfaces/BarcodeDetectorInterface.h
@@ -30,6 +30,10 @@
 #include <wtf/RefCounted.h>
 #include <wtf/Vector.h>
 
+namespace WebCore {
+class ImageBuffer;
+}
+
 namespace WebCore::ShapeDetection {
 
 enum class BarcodeFormat : uint8_t;
@@ -39,7 +43,7 @@ class BarcodeDetector : public RefCounted<BarcodeDetector> {
 public:
     virtual ~BarcodeDetector() = default;
 
-    virtual void detect(CompletionHandler<void(Vector<DetectedBarcode>&&)>&&) = 0;
+    virtual void detect(Ref<ImageBuffer>&&, CompletionHandler<void(Vector<DetectedBarcode>&&)>&&) = 0;
 
 protected:
     BarcodeDetector() = default;

--- a/Source/WebCore/Modules/ShapeDetection/Interfaces/FaceDetectorInterface.h
+++ b/Source/WebCore/Modules/ShapeDetection/Interfaces/FaceDetectorInterface.h
@@ -30,6 +30,10 @@
 #include <wtf/RefCounted.h>
 #include <wtf/Vector.h>
 
+namespace WebCore {
+class ImageBuffer;
+}
+
 namespace WebCore::ShapeDetection {
 
 struct DetectedFace;
@@ -38,7 +42,7 @@ class FaceDetector : public RefCounted<FaceDetector> {
 public:
     virtual ~FaceDetector() = default;
 
-    virtual void detect(CompletionHandler<void(Vector<DetectedFace>&&)>&&) = 0;
+    virtual void detect(Ref<ImageBuffer>&&, CompletionHandler<void(Vector<DetectedFace>&&)>&&) = 0;
 
 protected:
     FaceDetector() = default;

--- a/Source/WebCore/Modules/ShapeDetection/Interfaces/TextDetectorInterface.h
+++ b/Source/WebCore/Modules/ShapeDetection/Interfaces/TextDetectorInterface.h
@@ -30,6 +30,10 @@
 #include <wtf/RefCounted.h>
 #include <wtf/Vector.h>
 
+namespace WebCore {
+class ImageBuffer;
+}
+
 namespace WebCore::ShapeDetection {
 
 struct DetectedText;
@@ -38,7 +42,7 @@ class TextDetector : public RefCounted<TextDetector> {
 public:
     virtual ~TextDetector() = default;
 
-    virtual void detect(CompletionHandler<void(Vector<DetectedText>&&)>&&) = 0;
+    virtual void detect(Ref<ImageBuffer>&&, CompletionHandler<void(Vector<DetectedText>&&)>&&) = 0;
 
 protected:
     TextDetector() = default;

--- a/Source/WebCore/Modules/ShapeDetection/TextDetector.h
+++ b/Source/WebCore/Modules/ShapeDetection/TextDetector.h
@@ -44,7 +44,7 @@ public:
     ~TextDetector();
 
     using DetectPromise = DOMPromiseDeferred<IDLSequence<IDLDictionary<DetectedText>>>;
-    void detect(const ImageBitmap::Source&, DetectPromise&&);
+    void detect(ScriptExecutionContext&, ImageBitmap::Source&&, DetectPromise&&);
 
 private:
     TextDetector(Ref<ShapeDetection::TextDetector>&&);

--- a/Source/WebCore/Modules/ShapeDetection/TextDetector.idl
+++ b/Source/WebCore/Modules/ShapeDetection/TextDetector.idl
@@ -50,5 +50,5 @@ typedef (CanvasImageSource or Blob or ImageData) ImageBitmapSource;
 ]
 interface TextDetector {
     [CallWith=CurrentScriptExecutionContext] constructor();
-    Promise<sequence<DetectedText>> detect(ImageBitmapSource image);
+    [CallWith=CurrentScriptExecutionContext] Promise<sequence<DetectedText>> detect(ImageBitmapSource image);
 };

--- a/Source/WebKit/GPUProcess/ShapeDetection/RemoteBarcodeDetector.messages.in
+++ b/Source/WebKit/GPUProcess/ShapeDetection/RemoteBarcodeDetector.messages.in
@@ -24,7 +24,7 @@
 #if ENABLE(GPU_PROCESS)
 
 messages -> RemoteBarcodeDetector NotRefCounted Stream {
-    void Detect() -> (Vector<WebCore::ShapeDetection::DetectedBarcode> detectedBarcodes)
+    void Detect(WebCore::RenderingResourceIdentifier renderingResourceIdentifier) -> (Vector<WebCore::ShapeDetection::DetectedBarcode> detectedBarcodes)
 }
 
 #endif

--- a/Source/WebKit/GPUProcess/ShapeDetection/RemoteFaceDetector.h
+++ b/Source/WebKit/GPUProcess/ShapeDetection/RemoteFaceDetector.h
@@ -30,6 +30,8 @@
 #include "Connection.h"
 #include "ShapeDetectionIdentifier.h"
 #include "StreamMessageReceiver.h"
+#include <WebCore/ProcessIdentifier.h>
+#include <WebCore/RenderingResourceIdentifier.h>
 #include <wtf/CompletionHandler.h>
 #include <wtf/Ref.h>
 #include <wtf/Vector.h>
@@ -40,6 +42,7 @@ class FaceDetector;
 }
 
 namespace WebKit {
+class RemoteResourceCache;
 
 namespace ShapeDetection {
 class ObjectHeap;
@@ -49,15 +52,15 @@ class RemoteFaceDetector : public IPC::StreamMessageReceiver {
 public:
     WTF_MAKE_FAST_ALLOCATED;
 public:
-    static Ref<RemoteFaceDetector> create(Ref<WebCore::ShapeDetection::FaceDetector>&& faceDetector, ShapeDetection::ObjectHeap& objectHeap, ShapeDetectionIdentifier identifier)
+    static Ref<RemoteFaceDetector> create(Ref<WebCore::ShapeDetection::FaceDetector>&& faceDetector, ShapeDetection::ObjectHeap& objectHeap, RemoteResourceCache& remoteResourceCache, ShapeDetectionIdentifier identifier, WebCore::ProcessIdentifier webProcessIdentifier)
     {
-        return adoptRef(*new RemoteFaceDetector(WTFMove(faceDetector), objectHeap, identifier));
+        return adoptRef(*new RemoteFaceDetector(WTFMove(faceDetector), objectHeap, remoteResourceCache, identifier, webProcessIdentifier));
     }
 
     virtual ~RemoteFaceDetector();
 
 private:
-    RemoteFaceDetector(Ref<WebCore::ShapeDetection::FaceDetector>&&, ShapeDetection::ObjectHeap&, ShapeDetectionIdentifier);
+    RemoteFaceDetector(Ref<WebCore::ShapeDetection::FaceDetector>&&, ShapeDetection::ObjectHeap&, RemoteResourceCache&, ShapeDetectionIdentifier, WebCore::ProcessIdentifier);
 
     RemoteFaceDetector(const RemoteFaceDetector&) = delete;
     RemoteFaceDetector(RemoteFaceDetector&&) = delete;
@@ -68,11 +71,13 @@ private:
 
     void didReceiveStreamMessage(IPC::StreamServerConnection&, IPC::Decoder&) final;
 
-    void detect(CompletionHandler<void(Vector<WebCore::ShapeDetection::DetectedFace>&&)>&&);
+    void detect(WebCore::RenderingResourceIdentifier, CompletionHandler<void(Vector<WebCore::ShapeDetection::DetectedFace>&&)>&&);
 
     Ref<WebCore::ShapeDetection::FaceDetector> m_backing;
     ShapeDetection::ObjectHeap& m_objectHeap;
-    ShapeDetectionIdentifier m_identifier;
+    RemoteResourceCache& m_remoteResourceCache;
+    const ShapeDetectionIdentifier m_identifier;
+    const WebCore::ProcessIdentifier m_webProcessIdentifier;
 };
 
 } // namespace WebKit

--- a/Source/WebKit/GPUProcess/ShapeDetection/RemoteFaceDetector.messages.in
+++ b/Source/WebKit/GPUProcess/ShapeDetection/RemoteFaceDetector.messages.in
@@ -24,7 +24,7 @@
 #if ENABLE(GPU_PROCESS)
 
 messages -> RemoteFaceDetector NotRefCounted Stream {
-    void Detect() -> (Vector<WebCore::ShapeDetection::DetectedFace> detectedFaces)
+    void Detect(WebCore::RenderingResourceIdentifier renderingResourceIdentifier) -> (Vector<WebCore::ShapeDetection::DetectedFace> detectedFaces)
 }
 
 #endif

--- a/Source/WebKit/GPUProcess/ShapeDetection/RemoteTextDetector.h
+++ b/Source/WebKit/GPUProcess/ShapeDetection/RemoteTextDetector.h
@@ -30,6 +30,8 @@
 #include "Connection.h"
 #include "ShapeDetectionIdentifier.h"
 #include "StreamMessageReceiver.h"
+#include <WebCore/ProcessIdentifier.h>
+#include <WebCore/RenderingResourceIdentifier.h>
 #include <wtf/CompletionHandler.h>
 #include <wtf/Ref.h>
 #include <wtf/Vector.h>
@@ -40,6 +42,7 @@ class TextDetector;
 }
 
 namespace WebKit {
+class RemoteResourceCache;
 
 namespace ShapeDetection {
 class ObjectHeap;
@@ -49,15 +52,15 @@ class RemoteTextDetector : public IPC::StreamMessageReceiver {
 public:
     WTF_MAKE_FAST_ALLOCATED;
 public:
-    static Ref<RemoteTextDetector> create(Ref<WebCore::ShapeDetection::TextDetector>&& textDetector, ShapeDetection::ObjectHeap& objectHeap, ShapeDetectionIdentifier identifier)
+    static Ref<RemoteTextDetector> create(Ref<WebCore::ShapeDetection::TextDetector>&& textDetector, ShapeDetection::ObjectHeap& objectHeap, RemoteResourceCache& remoteResourceCache, ShapeDetectionIdentifier identifier, WebCore::ProcessIdentifier webProcessIdentifier)
     {
-        return adoptRef(*new RemoteTextDetector(WTFMove(textDetector), objectHeap, identifier));
+        return adoptRef(*new RemoteTextDetector(WTFMove(textDetector), objectHeap, remoteResourceCache, identifier, webProcessIdentifier));
     }
 
     virtual ~RemoteTextDetector();
 
 private:
-    RemoteTextDetector(Ref<WebCore::ShapeDetection::TextDetector>&&, ShapeDetection::ObjectHeap&, ShapeDetectionIdentifier);
+    RemoteTextDetector(Ref<WebCore::ShapeDetection::TextDetector>&&, ShapeDetection::ObjectHeap&, RemoteResourceCache&, ShapeDetectionIdentifier, WebCore::ProcessIdentifier);
 
     RemoteTextDetector(const RemoteTextDetector&) = delete;
     RemoteTextDetector(RemoteTextDetector&&) = delete;
@@ -68,11 +71,13 @@ private:
 
     void didReceiveStreamMessage(IPC::StreamServerConnection&, IPC::Decoder&) final;
 
-    void detect(CompletionHandler<void(Vector<WebCore::ShapeDetection::DetectedText>&&)>&&);
+    void detect(WebCore::RenderingResourceIdentifier, CompletionHandler<void(Vector<WebCore::ShapeDetection::DetectedText>&&)>&&);
 
     Ref<WebCore::ShapeDetection::TextDetector> m_backing;
     ShapeDetection::ObjectHeap& m_objectHeap;
-    ShapeDetectionIdentifier m_identifier;
+    RemoteResourceCache& m_remoteResourceCache;
+    const ShapeDetectionIdentifier m_identifier;
+    const WebCore::ProcessIdentifier m_webProcessIdentifier;
 };
 
 } // namespace WebKit

--- a/Source/WebKit/GPUProcess/ShapeDetection/RemoteTextDetector.messages.in
+++ b/Source/WebKit/GPUProcess/ShapeDetection/RemoteTextDetector.messages.in
@@ -24,7 +24,7 @@
 #if ENABLE(GPU_PROCESS)
 
 messages -> RemoteTextDetector NotRefCounted Stream {
-    void Detect() -> (Vector<WebCore::ShapeDetection::DetectedText> detectedText)
+    void Detect(WebCore::RenderingResourceIdentifier renderingResourceIdentifier) -> (Vector<WebCore::ShapeDetection::DetectedText> detectedText)
 }
 
 #endif

--- a/Source/WebKit/GPUProcess/graphics/RemoteRenderingBackend.cpp
+++ b/Source/WebKit/GPUProcess/graphics/RemoteRenderingBackend.cpp
@@ -620,7 +620,7 @@ void RemoteRenderingBackend::createRemoteBarcodeDetector(ShapeDetectionIdentifie
 {
 #if HAVE(SHAPE_DETECTION_API_IMPLEMENTATION)
     auto inner = WebCore::ShapeDetection::BarcodeDetectorImpl::create(barcodeDetectorOptions);
-    auto remoteBarcodeDetector = RemoteBarcodeDetector::create(WTFMove(inner), m_shapeDetectionObjectHeap, identifier);
+    auto remoteBarcodeDetector = RemoteBarcodeDetector::create(WTFMove(inner), m_shapeDetectionObjectHeap, remoteResourceCache(), identifier, gpuConnectionToWebProcess().webProcessIdentifier());
     m_shapeDetectionObjectHeap->addObject(identifier, remoteBarcodeDetector);
     streamConnection().startReceivingMessages(remoteBarcodeDetector, Messages::RemoteBarcodeDetector::messageReceiverName(), identifier.toUInt64());
 #else
@@ -648,7 +648,7 @@ void RemoteRenderingBackend::createRemoteFaceDetector(ShapeDetectionIdentifier i
 {
 #if HAVE(SHAPE_DETECTION_API_IMPLEMENTATION)
     auto inner = WebCore::ShapeDetection::FaceDetectorImpl::create(faceDetectorOptions);
-    auto remoteFaceDetector = RemoteFaceDetector::create(WTFMove(inner), m_shapeDetectionObjectHeap, identifier);
+    auto remoteFaceDetector = RemoteFaceDetector::create(WTFMove(inner), m_shapeDetectionObjectHeap, remoteResourceCache(), identifier, gpuConnectionToWebProcess().webProcessIdentifier());
     m_shapeDetectionObjectHeap->addObject(identifier, remoteFaceDetector);
     streamConnection().startReceivingMessages(remoteFaceDetector, Messages::RemoteFaceDetector::messageReceiverName(), identifier.toUInt64());
 #else
@@ -667,7 +667,7 @@ void RemoteRenderingBackend::createRemoteTextDetector(ShapeDetectionIdentifier i
 {
 #if HAVE(SHAPE_DETECTION_API_IMPLEMENTATION)
     auto inner = WebCore::ShapeDetection::TextDetectorImpl::create();
-    auto remoteTextDetector = RemoteTextDetector::create(WTFMove(inner), m_shapeDetectionObjectHeap, identifier);
+    auto remoteTextDetector = RemoteTextDetector::create(WTFMove(inner), m_shapeDetectionObjectHeap, remoteResourceCache(), identifier, gpuConnectionToWebProcess().webProcessIdentifier());
     m_shapeDetectionObjectHeap->addObject(identifier, remoteTextDetector);
     streamConnection().startReceivingMessages(remoteTextDetector, Messages::RemoteTextDetector::messageReceiverName(), identifier.toUInt64());
 #else

--- a/Source/WebKit/WebProcess/GPU/ShapeDetection/RemoteBarcodeDetectorProxy.cpp
+++ b/Source/WebKit/WebProcess/GPU/ShapeDetection/RemoteBarcodeDetectorProxy.cpp
@@ -34,6 +34,7 @@
 #include "RemoteRenderingBackendProxy.h"
 #include "StreamClientConnection.h"
 #include "WebProcess.h"
+#include <WebCore/ImageBuffer.h>
 
 namespace WebKit::ShapeDetection {
 
@@ -60,9 +61,9 @@ void RemoteBarcodeDetectorProxy::getSupportedFormats(Ref<IPC::StreamClientConnec
     streamClientConnection->sendWithAsyncReply(Messages::RemoteRenderingBackend::GetRemoteBarcodeDetectorSupportedFormats(), WTFMove(completionHandler), renderingBackendIdentifier, Seconds::infinity());
 }
 
-void RemoteBarcodeDetectorProxy::detect(CompletionHandler<void(Vector<WebCore::ShapeDetection::DetectedBarcode>&&)>&& completionHandler)
+void RemoteBarcodeDetectorProxy::detect(Ref<WebCore::ImageBuffer>&& imageBuffer, CompletionHandler<void(Vector<WebCore::ShapeDetection::DetectedBarcode>&&)>&& completionHandler)
 {
-    m_streamClientConnection->sendWithAsyncReply(Messages::RemoteBarcodeDetector::Detect(), WTFMove(completionHandler), m_backing, Seconds::infinity());
+    m_streamClientConnection->sendWithAsyncReply(Messages::RemoteBarcodeDetector::Detect(imageBuffer->renderingResourceIdentifier()), WTFMove(completionHandler), m_backing, Seconds::infinity());
 }
 
 } // namespace WebKit::WebGPU

--- a/Source/WebKit/WebProcess/GPU/ShapeDetection/RemoteBarcodeDetectorProxy.h
+++ b/Source/WebKit/WebProcess/GPU/ShapeDetection/RemoteBarcodeDetectorProxy.h
@@ -66,7 +66,7 @@ private:
 
     ShapeDetectionIdentifier backing() const { return m_backing; }
 
-    void detect(CompletionHandler<void(Vector<WebCore::ShapeDetection::DetectedBarcode>&&)>&&) final;
+    void detect(Ref<WebCore::ImageBuffer>&&, CompletionHandler<void(Vector<WebCore::ShapeDetection::DetectedBarcode>&&)>&&) final;
 
     ShapeDetectionIdentifier m_backing;
     Ref<IPC::StreamClientConnection> m_streamClientConnection;

--- a/Source/WebKit/WebProcess/GPU/ShapeDetection/RemoteFaceDetectorProxy.cpp
+++ b/Source/WebKit/WebProcess/GPU/ShapeDetection/RemoteFaceDetectorProxy.cpp
@@ -34,6 +34,7 @@
 #include "RemoteRenderingBackendProxy.h"
 #include "StreamClientConnection.h"
 #include "WebProcess.h"
+#include <WebCore/ImageBuffer.h>
 
 namespace WebKit::ShapeDetection {
 
@@ -55,9 +56,9 @@ RemoteFaceDetectorProxy::~RemoteFaceDetectorProxy()
     m_streamClientConnection->send(Messages::RemoteRenderingBackend::ReleaseRemoteFaceDetector(m_backing), m_renderingBackendIdentifier, Seconds::infinity());
 }
 
-void RemoteFaceDetectorProxy::detect(CompletionHandler<void(Vector<WebCore::ShapeDetection::DetectedFace>&&)>&& completionHandler)
+void RemoteFaceDetectorProxy::detect(Ref<WebCore::ImageBuffer>&& imageBuffer, CompletionHandler<void(Vector<WebCore::ShapeDetection::DetectedFace>&&)>&& completionHandler)
 {
-    m_streamClientConnection->sendWithAsyncReply(Messages::RemoteFaceDetector::Detect(), WTFMove(completionHandler), m_backing, Seconds::infinity());
+    m_streamClientConnection->sendWithAsyncReply(Messages::RemoteFaceDetector::Detect(imageBuffer->renderingResourceIdentifier()), WTFMove(completionHandler), m_backing, Seconds::infinity());
 }
 
 } // namespace WebKit::WebGPU

--- a/Source/WebKit/WebProcess/GPU/ShapeDetection/RemoteFaceDetectorProxy.h
+++ b/Source/WebKit/WebProcess/GPU/ShapeDetection/RemoteFaceDetectorProxy.h
@@ -63,7 +63,7 @@ private:
 
     ShapeDetectionIdentifier backing() const { return m_backing; }
 
-    void detect(CompletionHandler<void(Vector<WebCore::ShapeDetection::DetectedFace>&&)>&&) final;
+    void detect(Ref<WebCore::ImageBuffer>&&, CompletionHandler<void(Vector<WebCore::ShapeDetection::DetectedFace>&&)>&&) final;
 
     ShapeDetectionIdentifier m_backing;
     Ref<IPC::StreamClientConnection> m_streamClientConnection;

--- a/Source/WebKit/WebProcess/GPU/ShapeDetection/RemoteTextDetectorProxy.cpp
+++ b/Source/WebKit/WebProcess/GPU/ShapeDetection/RemoteTextDetectorProxy.cpp
@@ -34,6 +34,7 @@
 #include "RemoteTextDetectorMessages.h"
 #include "StreamClientConnection.h"
 #include "WebProcess.h"
+#include <WebCore/ImageBuffer.h>
 
 namespace WebKit::ShapeDetection {
 
@@ -55,9 +56,9 @@ RemoteTextDetectorProxy::~RemoteTextDetectorProxy()
     m_streamClientConnection->send(Messages::RemoteRenderingBackend::ReleaseRemoteTextDetector(m_backing), m_renderingBackendIdentifier, Seconds::infinity());
 }
 
-void RemoteTextDetectorProxy::detect(CompletionHandler<void(Vector<WebCore::ShapeDetection::DetectedText>&&)>&& completionHandler)
+void RemoteTextDetectorProxy::detect(Ref<WebCore::ImageBuffer>&& imageBuffer, CompletionHandler<void(Vector<WebCore::ShapeDetection::DetectedText>&&)>&& completionHandler)
 {
-    m_streamClientConnection->sendWithAsyncReply(Messages::RemoteTextDetector::Detect(), WTFMove(completionHandler), m_backing, Seconds::infinity());
+    m_streamClientConnection->sendWithAsyncReply(Messages::RemoteTextDetector::Detect(imageBuffer->renderingResourceIdentifier()), WTFMove(completionHandler), m_backing, Seconds::infinity());
 }
 
 } // namespace WebKit::WebGPU

--- a/Source/WebKit/WebProcess/GPU/ShapeDetection/RemoteTextDetectorProxy.h
+++ b/Source/WebKit/WebProcess/GPU/ShapeDetection/RemoteTextDetectorProxy.h
@@ -62,7 +62,7 @@ private:
 
     ShapeDetectionIdentifier backing() const { return m_backing; }
 
-    void detect(CompletionHandler<void(Vector<WebCore::ShapeDetection::DetectedText>&&)>&&) final;
+    void detect(Ref<WebCore::ImageBuffer>&&, CompletionHandler<void(Vector<WebCore::ShapeDetection::DetectedText>&&)>&&) final;
 
     ShapeDetectionIdentifier m_backing;
     Ref<IPC::StreamClientConnection> m_streamClientConnection;


### PR DESCRIPTION
#### 7e3bfb4cf39ac035dfec7f0d4b12384f22a3d484
<pre>
[Shape Detection] Plumb ImageBitmapSource to the GPU process
<a href="https://bugs.webkit.org/show_bug.cgi?id=255633">https://bugs.webkit.org/show_bug.cgi?id=255633</a>
rdar://108232629

Reviewed by Dean Jackson.

This patch plumbs ImageBitmapSource to the GPU process by using the same technique as ImageBitmap uses.
When you say createImageBitmap(), what that actually does is it creates a new ImageBuffer and draws the
source object into the ImageBuffer&apos;s graphics context. The ImageBitmap is backed by the ImageBuffer.
The cool part about this is that sending the ImageBuffer to the GPU process is actually free, because
the context that draw into it is a remote context that actually performs the draw in the GPU process -
so the ImageBitmap is _already_ in the GPU process. If you want to send it to a new API call in the GPU
process, all you need to send is its identifier, and have the GPU process look it up from the
RemoteRenderingBackend.

No tests because there is no behavior change - I haven&apos;t actually hooked up the Vision framework to
actually implement any of the calls yet.

* Source/WebCore/Modules/ShapeDetection/BarcodeDetector.cpp:
(WebCore::BarcodeDetector::detect):
* Source/WebCore/Modules/ShapeDetection/BarcodeDetector.h:
* Source/WebCore/Modules/ShapeDetection/BarcodeDetector.idl:
* Source/WebCore/Modules/ShapeDetection/FaceDetector.cpp:
(WebCore::FaceDetector::detect):
* Source/WebCore/Modules/ShapeDetection/FaceDetector.h:
* Source/WebCore/Modules/ShapeDetection/FaceDetector.idl:
* Source/WebCore/Modules/ShapeDetection/Implementation/Cocoa/BarcodeDetectorImplementation.h:
* Source/WebCore/Modules/ShapeDetection/Implementation/Cocoa/BarcodeDetectorImplementation.mm:
(WebCore::ShapeDetection::BarcodeDetectorImpl::detect):
* Source/WebCore/Modules/ShapeDetection/Implementation/Cocoa/FaceDetectorImplementation.h:
* Source/WebCore/Modules/ShapeDetection/Implementation/Cocoa/FaceDetectorImplementation.mm:
(WebCore::ShapeDetection::FaceDetectorImpl::detect):
* Source/WebCore/Modules/ShapeDetection/Implementation/Cocoa/TextDetectorImplementation.h:
* Source/WebCore/Modules/ShapeDetection/Implementation/Cocoa/TextDetectorImplementation.mm:
(WebCore::ShapeDetection::TextDetectorImpl::detect):
* Source/WebCore/Modules/ShapeDetection/Interfaces/BarcodeDetectorInterface.h:
* Source/WebCore/Modules/ShapeDetection/Interfaces/FaceDetectorInterface.h:
* Source/WebCore/Modules/ShapeDetection/Interfaces/TextDetectorInterface.h:
* Source/WebCore/Modules/ShapeDetection/TextDetector.cpp:
(WebCore::TextDetector::detect):
* Source/WebCore/Modules/ShapeDetection/TextDetector.h:
* Source/WebCore/Modules/ShapeDetection/TextDetector.idl:
* Source/WebCore/html/ImageBitmap.cpp:
(WebCore::ImageBitmap::createCompletionHandler):
(WebCore::ImageBitmap::createPromise):
(WebCore::ImageBitmap::createBlankImageBuffer):
(WebCore::ImageBitmap::createFromBuffer):
(WebCore::ImageBitmap::resolveWithBlankImageBuffer): Deleted.
* Source/WebCore/html/ImageBitmap.h:
* Source/WebKit/GPUProcess/ShapeDetection/RemoteBarcodeDetector.cpp:
(WebKit::RemoteBarcodeDetector::RemoteBarcodeDetector):
(WebKit::RemoteBarcodeDetector::detect):
* Source/WebKit/GPUProcess/ShapeDetection/RemoteBarcodeDetector.h:
(WebKit::RemoteBarcodeDetector::create):
* Source/WebKit/GPUProcess/ShapeDetection/RemoteBarcodeDetector.messages.in:
* Source/WebKit/GPUProcess/ShapeDetection/RemoteFaceDetector.cpp:
(WebKit::RemoteFaceDetector::RemoteFaceDetector):
(WebKit::RemoteFaceDetector::detect):
* Source/WebKit/GPUProcess/ShapeDetection/RemoteFaceDetector.h:
(WebKit::RemoteFaceDetector::create):
* Source/WebKit/GPUProcess/ShapeDetection/RemoteFaceDetector.messages.in:
* Source/WebKit/GPUProcess/ShapeDetection/RemoteTextDetector.cpp:
(WebKit::RemoteTextDetector::RemoteTextDetector):
(WebKit::RemoteTextDetector::detect):
* Source/WebKit/GPUProcess/ShapeDetection/RemoteTextDetector.h:
(WebKit::RemoteTextDetector::create):
* Source/WebKit/GPUProcess/ShapeDetection/RemoteTextDetector.messages.in:
* Source/WebKit/GPUProcess/graphics/RemoteRenderingBackend.cpp:
(WebKit::RemoteRenderingBackend::createRemoteBarcodeDetector):
(WebKit::RemoteRenderingBackend::createRemoteFaceDetector):
(WebKit::RemoteRenderingBackend::createRemoteTextDetector):
* Source/WebKit/WebProcess/GPU/ShapeDetection/RemoteBarcodeDetectorProxy.cpp:
(WebKit::ShapeDetection::RemoteBarcodeDetectorProxy::detect):
* Source/WebKit/WebProcess/GPU/ShapeDetection/RemoteBarcodeDetectorProxy.h:
* Source/WebKit/WebProcess/GPU/ShapeDetection/RemoteFaceDetectorProxy.cpp:
(WebKit::ShapeDetection::RemoteFaceDetectorProxy::detect):
* Source/WebKit/WebProcess/GPU/ShapeDetection/RemoteFaceDetectorProxy.h:
* Source/WebKit/WebProcess/GPU/ShapeDetection/RemoteTextDetectorProxy.cpp:
(WebKit::ShapeDetection::RemoteTextDetectorProxy::detect):
* Source/WebKit/WebProcess/GPU/ShapeDetection/RemoteTextDetectorProxy.h:

Canonical link: <a href="https://commits.webkit.org/263209@main">https://commits.webkit.org/263209@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d3842964b96516839f79727606e86ab7d79c1218

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/3964 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/4058 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/4170 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/5404 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/32/builds/4216 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/3941 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/4146 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/4033 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/4118 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/4013 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/15/builds/4201 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/3572 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/5297 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/1703 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/3547 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/5626 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/3526 "Passed tests") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/3607 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/5026 "run-api-tests-without-change (failure)") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/4015 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/3228 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/3532 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/3547 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/961 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/3582 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/3812 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->