### PR TITLE
Implement FreeType WebCoreArgumentCoders

### DIFF
--- a/Source/WebKit/Shared/freetype/WebCoreArgumentCodersFreeType.cpp
+++ b/Source/WebKit/Shared/freetype/WebCoreArgumentCodersFreeType.cpp
@@ -29,29 +29,80 @@
 #if USE(FREETYPE)
 
 #include <WebCore/Font.h>
+#include <WebCore/FontCustomPlatformData.h>
 
 namespace IPC {
 
-void ArgumentCoder<WebCore::Font>::encodePlatformData(Encoder&, const WebCore::Font&)
+void ArgumentCoder<WebCore::Font>::encodePlatformData(Encoder& encoder, const WebCore::Font& font)
 {
-    ASSERT_NOT_REACHED();
+    const auto& platformData = font.platformData();
+    encoder << platformData.size();
+    encoder << platformData.isFixedWidth();
+    encoder << platformData.syntheticBold();
+    encoder << platformData.syntheticOblique();
+    encoder << platformData.orientation();
+
+    const auto& customPlatformData = platformData.customPlatformData();
+    encoder << static_cast<bool>(customPlatformData);
+    if (customPlatformData)
+        encoder << *customPlatformData;
 }
 
-std::optional<WebCore::FontPlatformData> ArgumentCoder<WebCore::Font>::decodePlatformData(Decoder&)
+std::optional<WebCore::FontPlatformData> ArgumentCoder<WebCore::Font>::decodePlatformData(Decoder& decoder)
 {
-    ASSERT_NOT_REACHED();
-    return std::nullopt;
+    std::optional<float> size;
+    decoder >> size;
+    if (!size)
+        return std::nullopt;
+
+    std::optional<bool> fixedWidth;
+    decoder >> fixedWidth;
+    if (!fixedWidth)
+        return std::nullopt;
+
+    std::optional<bool> syntheticBold;
+    decoder >> syntheticBold;
+    if (!syntheticBold)
+        return std::nullopt;
+
+    std::optional<bool> syntheticOblique;
+    decoder >> syntheticOblique;
+    if (!syntheticOblique)
+        return std::nullopt;
+
+    std::optional<WebCore::FontOrientation> orientation;
+    decoder >> orientation;
+    if (!orientation)
+        return std::nullopt;
+
+    std::optional<bool> includesCreationData;
+    decoder >> includesCreationData;
+    if (!includesCreationData)
+        return std::nullopt;
+
+    // Currently creation data is always required
+    if (*includesCreationData)
+        return std::nullopt;
+
+    std::optional<Ref<WebCore::FontCustomPlatformData>> fontCustomPlatformData;
+    decoder >> fontCustomPlatformData;
+    if (!fontCustomPlatformData)
+        return std::nullopt;
+
+    // Need FCPattern
+
+    return WebCore::FontPlatformData((*fontCustomPlatformData)->m_fontFace.get(), nullptr, *size, *fixedWidth, *syntheticBold, *syntheticOblique, *orientation, (*fontCustomPlatformData).ptr());
 }
 
 void ArgumentCoder<WebCore::FontPlatformData::Attributes>::encodePlatformData(Encoder&, const WebCore::FontPlatformData::Attributes&)
 {
-    ASSERT_NOT_REACHED();
+    // No FreeType specific fields on Attributes
 }
 
 bool ArgumentCoder<WebCore::FontPlatformData::Attributes>::decodePlatformData(Decoder&, WebCore::FontPlatformData::Attributes&)
 {
-    ASSERT_NOT_REACHED();
-    return false;
+    // No FreeType specific fields on Attributes
+    return true;
 }
 
 } // namespace IPC


### PR DESCRIPTION
#### 4dc2cabdd2b8ac33975c6d469f184d36b20be34d
<pre>
Implement FreeType WebCoreArgumentCoders
<a href="https://bugs.webkit.org/show_bug.cgi?id=255634">https://bugs.webkit.org/show_bug.cgi?id=255634</a>

Reviewed by NOBODY (OOPS!).

Add serialization implementation for FreeType of Font and it&apos;s related
classes.

* Source/WebKit/Shared/freetype/WebCoreArgumentCodersFreeType.cpp
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/6fcf21f98735bc39f52398e57439490028f36df9

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/3731 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/3816 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/3924 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/5159 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/4011 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/3894 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/3821 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/3234 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/3775 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/3998 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/3364 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/4992 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/1503 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/3335 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/3436 "3 flakes 173 failures") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/3315 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/3394 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/4760 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/3783 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/3064 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/3315 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/3335 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/3350 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/3592 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->