### PR TITLE
[JSC] Optimize Array#join's toString operation for Objects

### DIFF
--- a/JSTests/microbenchmarks/array-join-object.js
+++ b/JSTests/microbenchmarks/array-join-object.js
@@ -1,0 +1,6 @@
+var objects = [];
+for (var i = 0; i < 100; ++i)
+    objects.push({ event: true });
+
+for (var i = 0; i < 1e4; ++i)
+    String(objects);

--- a/JSTests/microbenchmarks/string-index-of-10000001-404.js
+++ b/JSTests/microbenchmarks/string-index-of-10000001-404.js
@@ -1,3 +1,4 @@
+//@ skip if $memoryLimited
 function bench(string, func)
 {
     for (var i = 0; i < 1000; ++i)

--- a/JSTests/microbenchmarks/u16-string-index-of-10000001-404.js
+++ b/JSTests/microbenchmarks/u16-string-index-of-10000001-404.js
@@ -1,3 +1,4 @@
+//@ skip if $memoryLimited
 function bench(string, func)
 {
     for (var i = 0; i < 1000; ++i)

--- a/JSTests/microbenchmarks/u16-string-index-of-10000001-beg.js
+++ b/JSTests/microbenchmarks/u16-string-index-of-10000001-beg.js
@@ -1,3 +1,4 @@
+//@ skip if $memoryLimited
 function bench(string, func)
 {
     for (var i = 0; i < 1000; ++i)

--- a/JSTests/microbenchmarks/u16-string-index-of-10000001-end.js
+++ b/JSTests/microbenchmarks/u16-string-index-of-10000001-end.js
@@ -1,3 +1,4 @@
+//@ skip if $memoryLimited
 function bench(string, func)
 {
     for (var i = 0; i < 1000; ++i)

--- a/JSTests/microbenchmarks/u16-string-index-of-10000001-mid.js
+++ b/JSTests/microbenchmarks/u16-string-index-of-10000001-mid.js
@@ -1,3 +1,4 @@
+//@ skip if $memoryLimited
 function bench(string, func)
 {
     for (var i = 0; i < 1000; ++i)

--- a/Source/JavaScriptCore/runtime/JSCast.h
+++ b/Source/JavaScriptCore/runtime/JSCast.h
@@ -124,6 +124,9 @@ using JSResizableOrGrowableSharedBigUint64Array = JSGenericResizableOrGrowableSh
 #define FOR_EACH_JS_DYNAMIC_CAST_JS_TYPE_OVERLOAD_FORWARD_DECLARED(macro) \
     macro(JSImmutableButterfly, JSType::JSImmutableButterflyType, JSType::JSImmutableButterflyType) \
     macro(JSStringIterator, JSType::JSStringIteratorType, JSType::JSStringIteratorType) \
+    macro(JSString, JSType::StringType, JSType::StringType) \
+    macro(JSBigInt, JSType::HeapBigIntType, JSType::HeapBigIntType) \
+    macro(Symbol, JSType::SymbolType, JSType::SymbolType) \
     macro(JSObject, FirstObjectType, LastObjectType) \
     macro(JSFinalObject, JSType::FinalObjectType, JSType::FinalObjectType) \
     macro(JSFunction, JSType::JSFunctionType, JSType::JSFunctionType) \

--- a/Source/JavaScriptCore/runtime/JSCell.h
+++ b/Source/JavaScriptCore/runtime/JSCell.h
@@ -179,6 +179,9 @@ public:
     JS_EXPORT_PRIVATE double toNumber(JSGlobalObject*) const;
     JSObject* toObject(JSGlobalObject*) const;
 
+    JSString* toStringInline(JSGlobalObject*) const;
+    JS_EXPORT_PRIVATE JSString* toStringSlowCase(JSGlobalObject*) const;
+
     void dump(PrintStream&) const;
     JS_EXPORT_PRIVATE static void dumpToStream(const JSCell*, PrintStream&);
 

--- a/Source/JavaScriptCore/runtime/JSCellInlines.h
+++ b/Source/JavaScriptCore/runtime/JSCellInlines.h
@@ -434,6 +434,25 @@ inline JSObject* JSCell::toObject(JSGlobalObject* globalObject) const
     return toObjectSlow(globalObject);
 }
 
+ALWAYS_INLINE JSString* JSCell::toStringInline(JSGlobalObject* globalObject) const
+{
+    Structure* structure = this->structure();
+    if (structure->hasRareData()) {
+        auto* rareData = structure->rareData();
+        if (rareData->cachedSpecialProperty(CachedSpecialPropertyKey::ToPrimitive).isUndefinedOrNull()) {
+            if (rareData->cachedSpecialProperty(CachedSpecialPropertyKey::ToString) == globalObject->objectProtoToStringFunction()) {
+                if (auto result = rareData->cachedSpecialProperty(CachedSpecialPropertyKey::ToStringTag))
+                    return asString(result);
+            }
+        }
+    }
+    if (isObject())
+        return asObject(this)->toString(globalObject);
+    if (isString())
+        return asString(this);
+    return toStringSlowCase(globalObject);
+}
+
 ALWAYS_INLINE bool JSCell::putInline(JSGlobalObject* globalObject, PropertyName propertyName, JSValue value, PutPropertySlot& slot)
 {
     auto putMethod = methodTable()->put;

--- a/Source/JavaScriptCore/runtime/JSGenericTypedArrayViewPrototypeFunctions.h
+++ b/Source/JavaScriptCore/runtime/JSGenericTypedArrayViewPrototypeFunctions.h
@@ -457,14 +457,16 @@ ALWAYS_INLINE EncodedJSValue genericTypedArrayViewProtoFuncJoin(VM& vm, JSGlobal
         IdempotentArrayBufferByteLengthGetter<std::memory_order_seq_cst> getter;
         auto updatedLength = integerIndexedObjectLength(thisObject, getter);
         if (UNLIKELY(!updatedLength)) {
-            JSStringJoiner joiner(globalObject, separator, length);
+            JSStringJoiner joiner(separator);
+            joiner.reserveCapacity(globalObject, length);
             RETURN_IF_EXCEPTION(scope, { });
             for (size_t i = 0; i < length; i++)
                 joiner.appendEmptyString();
             RELEASE_AND_RETURN(scope, JSValue::encode(joiner.join(globalObject)));
         }
 
-        JSStringJoiner joiner(globalObject, separator, length);
+        JSStringJoiner joiner(separator);
+        joiner.reserveCapacity(globalObject, length);
         RETURN_IF_EXCEPTION(scope, { });
 
         size_t accessibleLength = std::min(length, updatedLength.value());

--- a/Source/JavaScriptCore/runtime/JSObject.cpp
+++ b/Source/JavaScriptCore/runtime/JSObject.cpp
@@ -2669,8 +2669,14 @@ JSString* JSObject::toString(JSGlobalObject* globalObject) const
 {
     VM& vm = globalObject->vm();
     auto scope = DECLARE_THROW_SCOPE(vm);
-    JSValue primitive = toPrimitive(globalObject, PreferString);
+
+    JSValue primitive = callToPrimitiveFunction<CachedSpecialPropertyKey::ToPrimitive>(globalObject, this, vm.propertyNames->toPrimitiveSymbol, PreferString);
     RETURN_IF_EXCEPTION(scope, jsEmptyString(vm));
+    if (LIKELY(!primitive)) {
+        primitive = ordinaryToPrimitive(globalObject, PreferString);
+        RETURN_IF_EXCEPTION(scope, jsEmptyString(vm));
+    }
+
     RELEASE_AND_RETURN(scope, primitive.toString(globalObject));
 }
 

--- a/Source/JavaScriptCore/runtime/JSString.h
+++ b/Source/JavaScriptCore/runtime/JSString.h
@@ -240,6 +240,7 @@ public:
 
 protected:
     friend class JSValue;
+    friend class JSCell;
 
     JS_EXPORT_PRIVATE bool equalSlowCase(JSGlobalObject*, JSString* other) const;
     bool isSubstring() const;

--- a/Source/JavaScriptCore/runtime/SmallStrings.cpp
+++ b/Source/JavaScriptCore/runtime/SmallStrings.cpp
@@ -56,8 +56,18 @@ void SmallStrings::initializeCommonStrings(VM& vm)
     JSC_COMMON_STRINGS_EACH_NAME(JSC_COMMON_STRINGS_ATTRIBUTE_INITIALIZE)
 #undef JSC_COMMON_STRINGS_ATTRIBUTE_INITIALIZE
     initialize(&vm, m_objectStringStart, "[object "_s);
-    initialize(&vm, m_nullObjectString, "[object Null]"_s);
-    initialize(&vm, m_undefinedObjectString, "[object Undefined]"_s);
+    initialize(&vm, m_objectNullString, "[object Null]"_s);
+    initialize(&vm, m_objectUndefinedString, "[object Undefined]"_s);
+    initialize(&vm, m_objectObjectString, "[object Object]"_s);
+    initialize(&vm, m_objectArrayString, "[object Array]"_s);
+    initialize(&vm, m_objectFunctionString, "[object Function]"_s);
+    initialize(&vm, m_objectArgumentsString, "[object Arguments]"_s);
+    initialize(&vm, m_objectDateString, "[object Date]"_s);
+    initialize(&vm, m_objectRegExpString, "[object RegExp]"_s);
+    initialize(&vm, m_objectErrorString, "[object Error]"_s);
+    initialize(&vm, m_objectBooleanString, "[object Boolean]"_s);
+    initialize(&vm, m_objectNumberString, "[object Number]"_s);
+    initialize(&vm, m_objectStringString, "[object String]"_s);
     initialize(&vm, m_boundPrefixString, "bound "_s);
     initialize(&vm, m_notEqualString, "not-equal"_s);
     initialize(&vm, m_timedOutString, "timed-out"_s);
@@ -78,8 +88,18 @@ void SmallStrings::visitStrongReferences(Visitor& visitor)
     JSC_COMMON_STRINGS_EACH_NAME(JSC_COMMON_STRINGS_ATTRIBUTE_VISIT)
 #undef JSC_COMMON_STRINGS_ATTRIBUTE_VISIT
     visitor.appendUnbarriered(m_objectStringStart);
-    visitor.appendUnbarriered(m_nullObjectString);
-    visitor.appendUnbarriered(m_undefinedObjectString);
+    visitor.appendUnbarriered(m_objectNullString);
+    visitor.appendUnbarriered(m_objectUndefinedString);
+    visitor.appendUnbarriered(m_objectObjectString);
+    visitor.appendUnbarriered(m_objectArrayString);
+    visitor.appendUnbarriered(m_objectFunctionString);
+    visitor.appendUnbarriered(m_objectArgumentsString);
+    visitor.appendUnbarriered(m_objectDateString);
+    visitor.appendUnbarriered(m_objectRegExpString);
+    visitor.appendUnbarriered(m_objectErrorString);
+    visitor.appendUnbarriered(m_objectBooleanString);
+    visitor.appendUnbarriered(m_objectNumberString);
+    visitor.appendUnbarriered(m_objectStringString);
     visitor.appendUnbarriered(m_boundPrefixString);
     visitor.appendUnbarriered(m_notEqualString);
     visitor.appendUnbarriered(m_timedOutString);

--- a/Source/JavaScriptCore/runtime/SmallStrings.h
+++ b/Source/JavaScriptCore/runtime/SmallStrings.h
@@ -113,8 +113,18 @@ public:
     }
 
     JSString* objectStringStart() const { return m_objectStringStart; }
-    JSString* nullObjectString() const { return m_nullObjectString; }
-    JSString* undefinedObjectString() const { return m_undefinedObjectString; }
+    JSString* objectNullString() const { return m_objectNullString; }
+    JSString* objectUndefinedString() const { return m_objectUndefinedString; }
+    JSString* objectObjectString() const { return m_objectObjectString; }
+    JSString* objectArrayString() const { return m_objectArrayString; }
+    JSString* objectFunctionString() const { return m_objectFunctionString; }
+    JSString* objectArgumentsString() const { return m_objectArgumentsString; }
+    JSString* objectDateString() const { return m_objectDateString; }
+    JSString* objectRegExpString() const { return m_objectRegExpString; }
+    JSString* objectErrorString() const { return m_objectErrorString; }
+    JSString* objectBooleanString() const { return m_objectBooleanString; }
+    JSString* objectNumberString() const { return m_objectNumberString; }
+    JSString* objectStringString() const { return m_objectStringString; }
     JSString* boundPrefixString() const { return m_boundPrefixString; }
     JSString* notEqualString() const { return m_notEqualString; }
     JSString* timedOutString() const { return m_timedOutString; }
@@ -138,8 +148,19 @@ private:
     JSC_COMMON_STRINGS_EACH_NAME(JSC_COMMON_STRINGS_ATTRIBUTE_DECLARATION)
 #undef JSC_COMMON_STRINGS_ATTRIBUTE_DECLARATION
     JSString* m_objectStringStart { nullptr };
-    JSString* m_nullObjectString { nullptr };
-    JSString* m_undefinedObjectString { nullptr };
+    JSString* m_objectNullString { nullptr };
+    JSString* m_objectUndefinedString { nullptr };
+    JSString* m_objectObjectString { nullptr };
+    JSString* m_objectArrayString { nullptr };
+    JSString* m_objectFunctionString { nullptr };
+    JSString* m_objectArgumentsString { nullptr };
+    JSString* m_objectDateString { nullptr };
+    JSString* m_objectRegExpString { nullptr };
+    JSString* m_objectErrorString { nullptr };
+    JSString* m_objectBooleanString { nullptr };
+    JSString* m_objectNumberString { nullptr };
+    JSString* m_objectStringString { nullptr };
+
     JSString* m_boundPrefixString { nullptr };
     JSString* m_notEqualString { nullptr };
     JSString* m_timedOutString { nullptr };

--- a/Source/WTF/wtf/text/StringView.h
+++ b/Source/WTF/wtf/text/StringView.h
@@ -281,8 +281,13 @@ namespace WTF {
 
 struct StringViewWithUnderlyingString {
     WTF_MAKE_STRUCT_FAST_ALLOCATED;
-    StringView view;
+    StringViewWithUnderlyingString(StringView passedView, String passedUnderlyingString)
+        : underlyingString(WTFMove(passedUnderlyingString))
+        , view(WTFMove(passedView))
+    { }
+
     String underlyingString;
+    StringView view;
 
     String toString() const;
 };


### PR DESCRIPTION
#### 9d0a972fc0bfc1429382127b4ee62cbc5a7bf151
<pre>
[JSC] Optimize Array#join&apos;s toString operation for Objects
<a href="https://bugs.webkit.org/show_bug.cgi?id=255638">https://bugs.webkit.org/show_bug.cgi?id=255638</a>
rdar://108239715

Reviewed by Mark Lam.

This patch optimizes Array#join via several optimizations.

1. Borrow V8&apos;s idea. We cache the last string for Array#join, and if it is identical,
   then we just count it instead of appending it to the vector. Like, &quot;[object Object]&quot; x 100.
   Then we can keep JSStringJoiner&apos;s buffer in a reasonable size. We pre-allocate 16 for Vector
   capacity and which can cover many cases with this without Vector allocation and deallocation.
2. Our &quot;[object Object]&quot; tag string generation is too generic. We should have spec-defined ones
   in SmallStrings, and use JSString from that. This also helps (1) since now &quot;[object Object]&quot;
   will get the exact same JSString.
3. With (1), JSStringJoiner now knows the last JSString*. So if Array#join only sees one element,
   we can just return this string directly.
4. This is the last optimization having the largest effect in the 4. We revisit JSValue::toString
   and JSStringJoiner&apos;s toString operation, and optimize the fast path for Object#toString cases.
   We add JSCell::toStringInline which can handle the cached cases quickly. This also cleans up
   JSValue::toStringSlowCase by extracting JSCell related things to JSCell::toStringInline.

                                  ToT                     Patched

    array-join-object       28.6489+-0.0592     ^     16.4209+-0.1264        ^ definitely 1.7447x faster

* JSTests/microbenchmarks/array-join-object.js: Added.
* Source/JavaScriptCore/runtime/ArrayPrototype.cpp:
(JSC::fastJoin):
(JSC::JSC_DEFINE_HOST_FUNCTION):
* Source/JavaScriptCore/runtime/JSCJSValue.cpp:
(JSC::JSValue::toStringSlowCase const):
(): Deleted.
* Source/JavaScriptCore/runtime/JSCast.h:
* Source/JavaScriptCore/runtime/JSCell.cpp:
(JSC::JSCell::toStringSlowCase const):
* Source/JavaScriptCore/runtime/JSCell.h:
* Source/JavaScriptCore/runtime/JSCellInlines.h:
(JSC::JSCell::toStringInline const):
* Source/JavaScriptCore/runtime/JSGenericTypedArrayViewPrototypeFunctions.h:
(JSC::genericTypedArrayViewProtoFuncJoin):
* Source/JavaScriptCore/runtime/JSObject.cpp:
(JSC::JSObject::toString const):
* Source/JavaScriptCore/runtime/JSString.h:
* Source/JavaScriptCore/runtime/JSStringJoiner.cpp:
(JSC::joinStrings):
(JSC::JSStringJoiner::joinedLength const):
(JSC::JSStringJoiner::~JSStringJoiner): Deleted.
* Source/JavaScriptCore/runtime/JSStringJoiner.h:
(JSC::JSStringJoiner::JSStringJoiner):
(JSC::JSStringJoiner::reserveCapacity):
(JSC::JSStringJoiner::join):
(JSC::JSStringJoiner::append):
(JSC::JSStringJoiner::append8Bit):
(JSC::JSStringJoiner::appendEmptyString):
(JSC::JSStringJoiner::appendWithoutSideEffects):
* Source/JavaScriptCore/runtime/ObjectPrototypeInlines.h:
(JSC::objectPrototypeToStringSlow):
(JSC::objectPrototypeToString):
(JSC::inferBuiltinTag): Deleted.
* Source/JavaScriptCore/runtime/SmallStrings.cpp:
(JSC::SmallStrings::initializeCommonStrings):
(JSC::SmallStrings::visitStrongReferences):
* Source/JavaScriptCore/runtime/SmallStrings.h:
(JSC::SmallStrings::objectNullString const):
(JSC::SmallStrings::objectUndefinedString const):
(JSC::SmallStrings::objectObjectString const):
(JSC::SmallStrings::objectArrayString const):
(JSC::SmallStrings::objectFunctionString const):
(JSC::SmallStrings::objectArgumentsString const):
(JSC::SmallStrings::objectDateString const):
(JSC::SmallStrings::objectRegExpString const):
(JSC::SmallStrings::objectErrorString const):
(JSC::SmallStrings::objectBooleanString const):
(JSC::SmallStrings::objectNumberString const):
(JSC::SmallStrings::objectStringString const):
(JSC::SmallStrings::nullObjectString const): Deleted.
(JSC::SmallStrings::undefinedObjectString const): Deleted.
* Source/WTF/wtf/text/StringView.h:
(WTF::StringViewWithUnderlyingString::StringViewWithUnderlyingString):

Canonical link: <a href="https://commits.webkit.org/263117@main">https://commits.webkit.org/263117@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/79b13bd811a4a362574ecbae1927979f679bba2b

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/3665 "1 style error") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/3749 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/3855 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/5091 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/3950 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/3824 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/3754 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/3177 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/3709 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/3939 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/3301 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/4920 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/1445 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/3272 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/3338 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/3001 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/3253 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/3331 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/4693 "Passed tests") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/3440 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/3718 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/3007 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/3737 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/3252 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/3272 "Passed tests") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/947 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/3284 "Built successfully") | | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/24/builds/3829 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/419 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/3529 "Built successfully") | | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/3/builds/1058 "Passed tests") | 
<!--EWS-Status-Bubble-End-->