### PR TITLE
WebGL: Removed unused GraphicsContextGLANGLE::readCompositedResultsForPainting

### DIFF
--- a/Source/WebCore/platform/graphics/angle/GraphicsContextGLANGLE.cpp
+++ b/Source/WebCore/platform/graphics/angle/GraphicsContextGLANGLE.cpp
@@ -3258,15 +3258,6 @@ RefPtr<PixelBuffer> GraphicsContextGLANGLE::readRenderingResultsForPainting()
     return readRenderingResults();
 }
 
-RefPtr<PixelBuffer> GraphicsContextGLANGLE::readCompositedResultsForPainting()
-{
-    if (!makeContextCurrent())
-        return nullptr;
-    if (getInternalFramebufferSize().isEmpty())
-        return nullptr;
-    return readCompositedResults();
-}
-
 void GraphicsContextGLANGLE::addError(GCGLErrorCode errorCode)
 {
     m_errors.add(errorCode);

--- a/Source/WebCore/platform/graphics/angle/GraphicsContextGLANGLE.h
+++ b/Source/WebCore/platform/graphics/angle/GraphicsContextGLANGLE.h
@@ -346,7 +346,6 @@ public:
     void paintCompositedResultsToCanvas(ImageBuffer&) override;
 
     RefPtr<PixelBuffer> readRenderingResultsForPainting();
-    RefPtr<PixelBuffer> readCompositedResultsForPainting();
 
     virtual void withDrawingBufferAsNativeImage(Function<void(NativeImage&)>);
     virtual void withDisplayBufferAsNativeImage(Function<void(NativeImage&)>);


### PR DESCRIPTION
#### 305affe116cdf68a39a3d74d9842b1548402a907
<pre>
WebGL: Removed unused GraphicsContextGLANGLE::readCompositedResultsForPainting
<a href="https://bugs.webkit.org/show_bug.cgi?id=255647">https://bugs.webkit.org/show_bug.cgi?id=255647</a>

Reviewed by Said Abou-Hallawa.

It&apos;s called nowhere after 262518@main.

* Source/WebCore/platform/graphics/angle/GraphicsContextGLANGLE.cpp:
(WebCore::GraphicsContextGLANGLE::readCompositedResultsForPainting): Deleted.
* Source/WebCore/platform/graphics/angle/GraphicsContextGLANGLE.h:

Canonical link: <a href="https://commits.webkit.org/263146@main">https://commits.webkit.org/263146@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/93cd3f3bf0b5b50a384546b935f21bb66c9da857

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/3673 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/3757 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/3863 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/5099 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/3958 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/3647 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/3833 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/3762 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/3183 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/3717 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/3948 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/3310 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/4941 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/1454 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/3280 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/3353 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/3262 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/3339 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/4711 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/3726 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/3015 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/3260 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/3280 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/918 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/3292 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/3537 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->