### PR TITLE
REGRESSION(262632@main?): [ iOS ] 2X imported/w3c/web-platform-tests/screen-orientation (layout-tests) are consistent text failures

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/screen-orientation/nested-documents-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/screen-orientation/nested-documents-expected.txt
@@ -1,8 +1,7 @@
-CONSOLE MESSAGE: Unhandled Promise Rejection: SecurityError: Locking the screen orientation is only allowed when in fullscreen
 
 
 Harness Error (FAIL), message = Test named 'Requesting orientation lock from one document cancels the lock request from another document' specified 1 'cleanup' function, and 1 failed.
 
-FAIL Requesting orientation lock from one document cancels the lock request from another document promise_rejects_dom: function "function () { throw e }" threw object "NotSupportedError: Screen orientation locking is not supported" that is not a DOMException AbortError: property "code" is equal to 9, expected 20
+FAIL Requesting orientation lock from one document cancels the lock request from another document promise_rejects_dom: function "function () { throw e }" threw object "SecurityError: Locking the screen orientation is only allowed when in fullscreen" that is not a DOMException AbortError: property "code" is equal to 18, expected 20
 NOTRUN The orientation lock from one document affects lock requests from other documents
 

--- a/LayoutTests/imported/w3c/web-platform-tests/screen-orientation/nested-documents.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/screen-orientation/nested-documents.html
@@ -18,7 +18,7 @@
 
       // Go full screen
       await test_driver.bless("request full screen");
-      await iframe.contentDocument.documentElement.requestFullscreen();
+      await document.body.requestFullscreen();
 
       // Lock the orientation from the iframe
       const opposite = getOppositeOrientation();
@@ -48,7 +48,11 @@
       const iframes = [outerIframe, innerIframe];
 
       // Go full screen
-      await test_driver.bless("request full screen");
+      await test_driver.bless(
+        "request full screen",
+        null,
+        innerIframe.contentWindow
+      );
       await innerIframe.contentDocument.documentElement.requestFullscreen();
       const opposite = getOppositeOrientation();
 

--- a/LayoutTests/imported/w3c/web-platform-tests/screen-orientation/onchange-event-subframe.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/screen-orientation/onchange-event-subframe.html
@@ -58,8 +58,8 @@
     ).wait_for("change");
 
     // Lock from the iframe
-    await test_driver.bless("request fullscreen");
-    await document.documentElement.requestFullscreen();
+    await test_driver.bless("request fullscreen", null, iframe.contentWindow);
+    await iframe.contentDocument.documentElement.requestFullscreen();
     const lockPromise = iframe.contentWindow.screen.orientation.lock(opposite);
 
     const winningEvent = await Promise.race([

--- a/LayoutTests/imported/w3c/web-platform-tests/screen-orientation/resources/orientation-utils.js
+++ b/LayoutTests/imported/w3c/web-platform-tests/screen-orientation/resources/orientation-utils.js
@@ -33,18 +33,13 @@ export function getOppositeOrientation() {
     : "portrait";
 }
 
-export function makeCleanup(
-  initialOrientation = screen.orientation?.type.split(/-/)[0]
-) {
+export function makeCleanup() {
   return async () => {
-    if (initialOrientation) {
-      await screen.orientation.lock(initialOrientation);
-    }
-    screen.orientation.unlock();
-    requestAnimationFrame(async () => {
+    document.screen.orientation.unlock();
+    if (document.fullscreenElement) {
       try {
         await document.exitFullscreen();
       } catch {}
-    });
+    }
   };
 }

--- a/LayoutTests/imported/w3c/web-platform-tests/screen-orientation/unlock.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/screen-orientation/unlock.html
@@ -39,9 +39,9 @@
 
   promise_test(async (t) => {
     t.add_cleanup(makeCleanup());
+    const iframe = await attachIframe();
     await test_driver.bless("request full screen");
     await document.documentElement.requestFullscreen();
-    const iframe = await attachIframe();
     const promise = iframe.contentWindow.screen.orientation.lock(
       getOppositeOrientation()
     );

--- a/LayoutTests/platform/ios/TestExpectations
+++ b/LayoutTests/platform/ios/TestExpectations
@@ -4411,9 +4411,4 @@ imported/w3c/web-platform-tests/webaudio/the-audio-api/the-audioparam-interface/
 imported/w3c/web-platform-tests/webaudio/the-audio-api/the-audioparam-interface/k-rate-dynamics-compressor-connections.html [ Failure ]
 transforms/3d/hit-testing/overlapping-layers-hit-test.html [ Failure ]
 webaudio/ScriptProcessor/scriptprocessor-offlineaudiocontext.html [ Failure ]
-
-# webkit.org/b/255631 REGRESSION(262632@main?): [ iOS ] 2X imported/w3c/web-platform-tests/screen-orientation (layout-tests) are consistent text failures
-imported/w3c/web-platform-tests/screen-orientation/nested-documents.html [ Pass Failure ]
-imported/w3c/web-platform-tests/screen-orientation/unlock.html [ Pass Failure ]
-
 webkit.org/b/255704 [ Debug ] editing/inserting/insert-img-uneditable-canonical-position-crash.html [ Skip ]

--- a/LayoutTests/platform/ios/imported/w3c/web-platform-tests/screen-orientation/nested-documents-expected.txt
+++ b/LayoutTests/platform/ios/imported/w3c/web-platform-tests/screen-orientation/nested-documents-expected.txt
@@ -1,7 +1,5 @@
 
 
-Harness Error (FAIL), message = Test named 'Requesting orientation lock from one document cancels the lock request from another document' specified 1 'cleanup' function, and 1 failed.
-
-FAIL Requesting orientation lock from one document cancels the lock request from another document promise_test: Unhandled rejection with value: object "TypeError: Type error"
-NOTRUN The orientation lock from one document affects lock requests from other documents
+FAIL Requesting orientation lock from one document cancels the lock request from another document promise_rejects_dom: function "function () { throw e }" threw object "SecurityError: Locking the screen orientation is only allowed when in fullscreen" that is not a DOMException AbortError: property "code" is equal to 18, expected 20
+FAIL The orientation lock from one document affects lock requests from other documents promise_test: Unhandled rejection with value: object "TypeError: Type error"
 

--- a/LayoutTests/platform/ios/imported/w3c/web-platform-tests/screen-orientation/onchange-event-subframe-expected.txt
+++ b/LayoutTests/platform/ios/imported/w3c/web-platform-tests/screen-orientation/onchange-event-subframe-expected.txt
@@ -1,7 +1,4 @@
 
-
-Harness Error (TIMEOUT), message = null
-
 PASS Test subframes receive orientation change events
-TIMEOUT Check directly that events are fired in right order (from top to bottom) Test timed out
+PASS Check directly that events are fired in right order (from top to bottom)
 

--- a/LayoutTests/platform/ios/imported/w3c/web-platform-tests/screen-orientation/unlock-expected.txt
+++ b/LayoutTests/platform/ios/imported/w3c/web-platform-tests/screen-orientation/unlock-expected.txt
@@ -1,9 +1,8 @@
 
-Harness Error (FAIL), message = Test named 'unlock() aborts a pending lock request across documents' specified 1 'cleanup' function, and 1 failed.
 
 PASS unlock() doesn't throw when there is no lock
 PASS unlock() returns a void value
 PASS unlock() doesn't throw when there is no lock with fullscreen
 PASS unlock() aborts a pending lock request
-FAIL unlock() aborts a pending lock request across documents promise_test: Unhandled rejection with value: object "TypeError: Type error"
+FAIL unlock() aborts a pending lock request across documents promise_rejects_dom: function "function () { throw e }" threw object "SecurityError: Locking the screen orientation is only allowed when in fullscreen" that is not a DOMException AbortError: property "code" is equal to 18, expected 20
 


### PR DESCRIPTION
#### 40235be133be2b67b2eafcbc0dc444d139c66322
<pre>
REGRESSION(262632@main?): [ iOS ] 2X imported/w3c/web-platform-tests/screen-orientation (layout-tests) are consistent text failures
<a href="https://bugs.webkit.org/show_bug.cgi?id=255631">https://bugs.webkit.org/show_bug.cgi?id=255631</a>
rdar://108231120

Reviewed by Chris Dumez.

The utils file didn&apos;t get updated, causing some tests to stall.
Additionally, some of the tests where not pressing on the correct (iframe) contexts.

* LayoutTests/imported/w3c/web-platform-tests/screen-orientation/nested-documents-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/screen-orientation/nested-documents.html:
* LayoutTests/imported/w3c/web-platform-tests/screen-orientation/onchange-event-subframe.html:
* LayoutTests/imported/w3c/web-platform-tests/screen-orientation/resources/orientation-utils.js:
* LayoutTests/imported/w3c/web-platform-tests/screen-orientation/unlock.html:
* LayoutTests/platform/ios/TestExpectations:
* LayoutTests/platform/ios/imported/w3c/web-platform-tests/screen-orientation/nested-documents-expected.txt:
* LayoutTests/platform/ios/imported/w3c/web-platform-tests/screen-orientation/onchange-event-subframe-expected.txt:
* LayoutTests/platform/ios/imported/w3c/web-platform-tests/screen-orientation/unlock-expected.txt:

Canonical link: <a href="https://commits.webkit.org/263224@main">https://commits.webkit.org/263224@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4ce2fb2ef50ef0eee29e9dd596e43a56c857b162

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/3927 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/4019 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/4130 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/5365 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/4185 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/4104 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/4007 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/3998 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/3975 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/4166 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/3540 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/5217 "Built successfully") | 
| | [⏳ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/iOS-16-Simulator-WPT-WK2-Tests-EWS "Waiting to run tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/3515 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/5556 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/3489 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/3575 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/4987 "12 api tests failed or timed out") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/3979 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/3211 "1 failures") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/3498 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/3515 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/972 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/3547 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/3778 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->