### PR TITLE
Refine the grouped InteractionRegions' geometry

### DIFF
--- a/LayoutTests/interaction-region/border-radii-expected.txt
+++ b/LayoutTests/interaction-region/border-radii-expected.txt
@@ -21,7 +21,7 @@ uniform half pill diagonal tongue degenerate changing
         (interaction (334,10) width=77 height=52)
         (borderRadius 0 0 10 10),
         (interaction (434,10) width=102 height=52)
-        (borderRadius 8.00),
+        (borderRadius 2.00),
         (interaction (559,10) width=92 height=52)
         (borderRadius 20.00)])
       )

--- a/LayoutTests/interaction-region/consolidated-nested-regions-expected.txt
+++ b/LayoutTests/interaction-region/consolidated-nested-regions-expected.txt
@@ -21,7 +21,7 @@ Nested  Nested  Nested Secondary
         (interaction (256,0) width=126 height=100)
         (borderRadius 12.00),
         (interaction (293,20) width=69 height=20)
-        (borderRadius 8.00)])
+        (borderRadius 5.00)])
       )
     )
   )

--- a/LayoutTests/interaction-region/layer-tree-expected.txt
+++ b/LayoutTests/interaction-region/layer-tree-expected.txt
@@ -67,14 +67,14 @@
                                   (sublayers
                                     (
                                       (type interaction)
-                                      (layer bounds [x: 0 y: 0 width: 284 height: 192])
-                                      (layer position [x: 152 y: 152])
-                                      (layer cornerRadius 8))
-                                    (
-                                      (type interaction)
                                       (layer bounds [x: 0 y: 0 width: 59 height: 20])
                                       (layer position [x: 29.5 y: 29.5])
                                       (layer cornerRadius 9))
+                                    (
+                                      (type interaction)
+                                      (layer bounds [x: 0 y: 0 width: 284 height: 192])
+                                      (layer position [x: 152 y: 152])
+                                      (layer cornerRadius 8))
                                     (
                                       (layer bounds [x: 0 y: 0 width: 0 height: 0])
                                       (sublayers

--- a/LayoutTests/interaction-region/overlap-expected.txt
+++ b/LayoutTests/interaction-region/overlap-expected.txt
@@ -14,7 +14,7 @@
         (occlusion (0,0) width=200 height=100)
         (borderRadius 0.00),
         (interaction (0,0) width=200 height=100)
-        (borderRadius 8.00)])
+        (borderRadius 0.00)])
       )
     )
   )

--- a/LayoutTests/interaction-region/overlap-same-group-expected.txt
+++ b/LayoutTests/interaction-region/overlap-same-group-expected.txt
@@ -11,12 +11,12 @@
         (rect (0,0) width=800 height=600)
 
       (interaction regions [
-        (interaction (46,-4) width=158 height=108)
-        (borderRadius 8.00),
-        (interaction (204,21) width=50 height=83)
-        (borderRadius 8.00),
-        (interaction (96,104) width=158 height=25)
-        (borderRadius 8.00)])
+        (interaction (50,0) width=150 height=100)
+        (borderRadius 12 12 0 12),
+        (interaction (200,25) width=50 height=75)
+        (borderRadius 0 12 0 0),
+        (interaction (100,100) width=150 height=25)
+        (borderRadius 0 0 12 12)])
       )
     )
   )

--- a/LayoutTests/interaction-region/overlap-same-group.html
+++ b/LayoutTests/interaction-region/overlap-same-group.html
@@ -9,6 +9,7 @@
         width: 150px;
         height: 100px;
         background: rgba(255, 0, 0, 0.5);
+        border-radius: 12px;
     }
     div:last-child {
         top: 25px;

--- a/LayoutTests/interaction-region/paused-video-regions-expected.txt
+++ b/LayoutTests/interaction-region/paused-video-regions-expected.txt
@@ -25,39 +25,26 @@
               )
               (children 1
                 (GraphicsLayer
-                  (offsetFromRenderer width=-33 height=-33)
-                  (position 143.00 111.00)
-                  (bounds 136.00 136.00)
-                  (drawsContent 1)
+                  (position 176.00 144.00)
+                  (bounds 70.00 70.00)
                   (transform [1.00 0.00 0.00 0.00] [0.00 1.00 0.00 0.00] [0.00 0.00 1.00 0.00] [-35.00 -35.00 0.00 1.00])
                   (event region
-                    (rect (51,33) width=34 height=5)
-                    (rect (38,38) width=60 height=13)
-                    (rect (33,51) width=70 height=34)
-                    (rect (38,85) width=60 height=13)
-                    (rect (51,98) width=34 height=5)
+                    (rect (18,0) width=34 height=5)
+                    (rect (5,5) width=60 height=13)
+                    (rect (0,18) width=70 height=34)
+                    (rect (5,52) width=60 height=13)
+                    (rect (18,65) width=34 height=5)
 
                   (interaction regions [
-                    (interaction (33,33) width=70 height=70)
+                    (interaction (0,0) width=70 height=70)
                     (borderRadius 35.00)])
                   )
-                  (children 3
+                  (children 1
                     (GraphicsLayer
-                      (position 33.00 33.00)
-                      (bounds 70.00 70.00)
-                      (drawsContent 1)
-                    )
-                    (GraphicsLayer
-                      (position 33.00 33.00)
-                      (bounds 70.00 70.00)
-                      (blendMode lighten)
-                      (drawsContent 1)
-                    )
-                    (GraphicsLayer
-                      (position 36.00 33.00)
+                      (position 3.00 0.00)
                       (bounds 70.00 70.00)
                       (contentsOpaque 1)
-                      (transform [0.40 0.00 0.00 0.00] [0.00 0.40 0.00 0.00] [0.00 0.00 1.00 0.00] [0.00 0.00 0.00 1.00])
+                      (transform [0.90 0.00 0.00 0.00] [0.00 0.90 0.00 0.00] [0.00 0.00 1.00 0.00] [0.00 0.00 0.00 1.00])
                       (mask layer)
                         (GraphicsLayer
                           (bounds 70.00 70.00)

--- a/LayoutTests/interaction-region/tiny-regions-expected.txt
+++ b/LayoutTests/interaction-region/tiny-regions-expected.txt
@@ -14,7 +14,7 @@
         (occlusion (-10,0) width=30 height=30)
         (borderRadius 0.00),
         (interaction (0,10) width=10 height=10)
-        (borderRadius 8.00),
+        (borderRadius 0.00),
         (occlusion (0,20) width=10 height=10)
         (borderRadius 0.00)])
       )

--- a/LayoutTests/interaction-region/wrapped-inline-link-expected.txt
+++ b/LayoutTests/interaction-region/wrapped-inline-link-expected.txt
@@ -2,6 +2,10 @@ Line
 Line
 Line
 Line
+First line
+Loooonger line
+Short line
+Line
 (GraphicsLayer
   (anchor 0.00 0.00)
   (bounds 800.00 600.00)
@@ -16,13 +20,27 @@ Line
 
       (interaction regions [
         (interaction (-4,-4) width=38 height=27)
-        (borderRadius 8.00),
+        (borderRadius 8 8 0 0),
         (interaction (-4,23) width=38 height=20)
-        (borderRadius 8.00),
+        (borderRadius 0.00),
         (interaction (-4,43) width=38 height=20)
-        (borderRadius 8.00),
+        (borderRadius 0.00),
         (interaction (-4,63) width=38 height=20)
-        (borderRadius 8.00)])
+        (borderRadius 0 0 8 8),
+        (interaction (6,82) width=66 height=27)
+        (borderRadius 8 8 0 0),
+        (interaction (72,94) width=41 height=15)
+        (borderRadius 0 8 0 0),
+        (interaction (6,109) width=107 height=12)
+        (borderRadius 0 0 8 0),
+        (occlusion (6,111) width=71 height=32)
+        (borderRadius 0.00),
+        (interaction (6,121) width=71 height=12)
+        (borderRadius 0 0 8 0),
+        (occlusion (6,123) width=38 height=32)
+        (borderRadius 0.00),
+        (interaction (6,133) width=38 height=12)
+        (borderRadius 0 0 8 8)])
       )
     )
   )

--- a/LayoutTests/interaction-region/wrapped-inline-link.html
+++ b/LayoutTests/interaction-region/wrapped-inline-link.html
@@ -2,9 +2,16 @@
 <html>
 <style>
     body { margin: 0; }
+    .dense {
+        padding: 10px;
+        line-height: 0.8em;
+    }
 </style>
 <body>
 <a href="#">Line<br/>Line<br/>Line<br/>Line</a>
+<div class="dense">
+    <a href="#">First line<br/>Loooonger line<br/>Short line<br/>Line</a>
+</div>
 
 <pre id="results"></pre>
 <script>

--- a/Source/WebCore/page/InteractionRegion.cpp
+++ b/Source/WebCore/page/InteractionRegion.cpp
@@ -200,13 +200,10 @@ std::optional<InteractionRegion> interactionRegionForRenderedRegion(RenderObject
     if (!isOriginalMatch && !isInlineNonBlock)
         return std::nullopt;
 
-    if (isInlineNonBlock)
-        bounds.inflate(regionRenderer.document().settings().interactionRegionInlinePadding());
-
     float borderRadius = 0;
     OptionSet<InteractionRegion::CornerMask> maskedCorners;
 
-    if (auto* renderBox = dynamicDowncast<RenderBox>(renderer)) {
+    if (auto* renderBox = dynamicDowncast<RenderBox>(regionRenderer)) {
         auto borderRadii = renderBox->borderRadii();
         auto minRadius = borderRadii.minimumRadius();
         auto maxRadius = borderRadii.maximumRadius();
@@ -235,8 +232,14 @@ std::optional<InteractionRegion> interactionRegionForRenderedRegion(RenderObject
             bounds.expand(IntSize(borderBoxRect.size() - contentBoxRect.size()));
         }
     }
-    borderRadius = std::max<float>(borderRadius, regionRenderer.document().settings().interactionRegionMinimumCornerRadius());
-    
+
+    bool hasNoVisualEdges = regionRenderer.style().borderAndBackgroundEqual(RenderStyle::defaultStyle());
+    if (isInlineNonBlock && hasNoVisualEdges)
+        bounds.inflate(regionRenderer.document().settings().interactionRegionInlinePadding());
+
+    if (hasNoVisualEdges)
+        borderRadius = std::max<float>(borderRadius, regionRenderer.document().settings().interactionRegionMinimumCornerRadius());
+
     return { {
         InteractionRegion::Type::Interaction,
         matchedElement->identifier(),

--- a/Source/WebCore/rendering/EventRegion.h
+++ b/Source/WebCore/rendering/EventRegion.h
@@ -63,6 +63,7 @@ public:
 #if ENABLE(INTERACTION_REGIONS_IN_EVENT_REGION)
     void uniteInteractionRegions(const Region&, RenderObject&);
     bool shouldConsolidateInteractionRegion(IntRect, RenderObject&);
+    void shrinkWrapInteractionRegions();
     void copyInteractionRegionsToEventRegion();
 #endif
 


### PR DESCRIPTION
#### ac3d70bd04ef227fb925de4019b01348654e0da0
<pre>
Refine the grouped InteractionRegions&apos; geometry
<a href="https://bugs.webkit.org/show_bug.cgi?id=255654">https://bugs.webkit.org/show_bug.cgi?id=255654</a>
&lt;rdar://107760442&gt;

Reviewed by Tim Horton.

Use masked corners to &quot;shrink wrap&quot; grouped InteractionRegions. And
make them fit the element&apos;s visual style better.

* Source/WebCore/page/InteractionRegion.cpp:
(WebCore::interactionRegionForRenderedRegion):
Lookup the `borderRadius` on the region&apos;s renderer and not the renderer of
the matched element.
Only apply inline bounds inflation and minimum border radius to
renderers without a visual edge.

* Source/WebCore/rendering/EventRegion.cpp:
* Source/WebCore/rendering/EventRegion.h:
(WebCore::EventRegionContext::shrinkWrapInteractionRegions):
(WebCore::EventRegionContext::copyInteractionRegionsToEventRegion):
Introduce a new method to edit the masked corners on grouped
InteractionRegions and make them more visually pleasing.

* LayoutTests/interaction-region/overlap-same-group-expected.txt:
* LayoutTests/interaction-region/overlap-same-group.html:
* LayoutTests/interaction-region/wrapped-inline-link-expected.txt:
* LayoutTests/interaction-region/wrapped-inline-link.html:
Test updates covering the masked corners changes.

* LayoutTests/interaction-region/border-radii-expected.txt:
* LayoutTests/interaction-region/consolidated-nested-regions-expected.txt:
* LayoutTests/interaction-region/overlap-expected.txt:
* LayoutTests/interaction-region/tiny-regions-expected.txt:
Test updates now showing the element&apos;s real border radius.

* LayoutTests/interaction-region/layer-tree-expected.txt:
* LayoutTests/interaction-region/paused-video-regions-expected.txt:
Test updates.

Canonical link: <a href="https://commits.webkit.org/263337@main">https://commits.webkit.org/263337@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2d798b77823d454922a49ed9ef42906d3080bd1e

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/3710 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/3795 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/3902 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/5138 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/3992 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/3683 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/3872 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/3800 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/3214 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/3754 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/3985 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/3345 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/4971 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/1491 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/3314 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/3379 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/3300 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/3373 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/4743 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/3762 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/3049 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/3294 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/3314 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/1054 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/3330 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/3571 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->