### PR TITLE
[WGSL] Call graph should only contain the entrypoints being compiled

### DIFF
--- a/Source/WebGPU/WGSL/CallGraph.h
+++ b/Source/WebGPU/WGSL/CallGraph.h
@@ -34,6 +34,7 @@
 namespace WGSL {
 
 class ShaderModule;
+struct PipelineLayout;
 
 class CallGraph {
     friend class CallGraphBuilder;
@@ -61,6 +62,6 @@ private:
     HashMap<AST::Function*, Vector<Callee>> m_callees;
 };
 
-CallGraph buildCallGraph(ShaderModule&);
+CallGraph buildCallGraph(ShaderModule&, const HashMap<String, std::optional<PipelineLayout>>& pipelineLayouts);
 
 } // namespace WGSL

--- a/Source/WebGPU/WGSL/WGSL.cpp
+++ b/Source/WebGPU/WGSL/WGSL.cpp
@@ -101,7 +101,7 @@ inline PrepareResult prepareImpl(ShaderModule& ast, const HashMap<String, std::o
     {
         PhaseTimer phaseTimer("prepare total", phaseTimes);
 
-        RUN_PASS_WITH_RESULT(callGraph, buildCallGraph, ast);
+        RUN_PASS_WITH_RESULT(callGraph, buildCallGraph, ast, pipelineLayouts);
         RUN_PASS(rewriteEntryPoints, callGraph, result);
         RUN_PASS(rewriteGlobalVariables, callGraph, pipelineLayouts, result);
         RUN_PASS(mangleNames, callGraph, result);


### PR DESCRIPTION
#### 200b4f5d25137d00c52458cfffa754732840e35c
<pre>
[WGSL] Call graph should only contain the entrypoints being compiled
<a href="https://bugs.webkit.org/show_bug.cgi?id=255660">https://bugs.webkit.org/show_bug.cgi?id=255660</a>
rdar://problem/108265851

Reviewed by Mike Wyrzykowski.

The call graph is used as the source of truth to determine what needs to be
compiled, and currently it includes all the entry points. Pass down the
pipeline layouts to the call graph builder so we can determine which entry
points are actually needed.

* Source/WebGPU/WGSL/CallGraph.cpp:
(WGSL::CallGraphBuilder::CallGraphBuilder):
(WGSL::CallGraphBuilder::initializeMappings):
(WGSL::buildCallGraph):
* Source/WebGPU/WGSL/CallGraph.h:
* Source/WebGPU/WGSL/WGSL.cpp:
(WGSL::prepareImpl):

Canonical link: <a href="https://commits.webkit.org/263170@main">https://commits.webkit.org/263170@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/6dac5a4c3b29de8f2835984fedffd85154f0a5ac

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/3843 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/3932 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/4040 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/5276 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/4102 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/4011 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/3937 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/3687 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/3890 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/4089 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/3465 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/5110 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/1593 "Passed tests") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/10/builds/3440 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/4784 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/3412 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/3500 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/4877 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/3895 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/3151 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/3419 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/3440 "Passed tests") | | 
| [❌ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/934 "Failed to push commit to Webkit repository") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/3461 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/3696 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->