### PR TITLE
[WebGPU] Handle constants on vertex and fragment shaders

### DIFF
--- a/Source/WebGPU/WebGPU/ComputePipeline.mm
+++ b/Source/WebGPU/WebGPU/ComputePipeline.mm
@@ -88,7 +88,7 @@ Ref<ComputePipeline> Device::createComputePipeline(const WGPUComputePipelineDesc
             return ComputePipeline::createInvalid(*this);
         computeInformation = std::get<WGSL::Reflection::Compute>(entryPointInformation.typedEntryPoint);
 
-        function = createFunction(library, entryPointInformation, &descriptor.compute, label);
+        function = createFunction(library, entryPointInformation, descriptor.compute.constantCount, descriptor.compute.constants, label);
     }
 
     MTLComputePipelineReflection *reflection;

--- a/Source/WebGPU/WebGPU/Pipeline.h
+++ b/Source/WebGPU/WebGPU/Pipeline.h
@@ -35,6 +35,6 @@ std::optional<LibraryCreationResult> createLibrary(id<MTLDevice>, const ShaderMo
 
 MTLFunctionConstantValues *createConstantValues(uint32_t constantCount, const WGPUConstantEntry* constants, const WGSL::Reflection::EntryPointInformation&);
 
-id<MTLFunction> createFunction(id<MTLLibrary>, const WGSL::Reflection::EntryPointInformation&, const WGPUProgrammableStageDescriptor*, NSString *label);
+id<MTLFunction> createFunction(id<MTLLibrary>, const WGSL::Reflection::EntryPointInformation&, unsigned constantCount, const WGPUConstantEntry*, NSString *label);
 
 } // namespace WebGPU

--- a/Source/WebGPU/WebGPU/Pipeline.mm
+++ b/Source/WebGPU/WebGPU/Pipeline.mm
@@ -96,12 +96,12 @@ MTLFunctionConstantValues *createConstantValues(uint32_t constantCount, const WG
     return constantValues;
 }
 
-id<MTLFunction> createFunction(id<MTLLibrary> library, const WGSL::Reflection::EntryPointInformation& entryPointInformation, const WGPUProgrammableStageDescriptor* compute, NSString *label)
+id<MTLFunction> createFunction(id<MTLLibrary> library, const WGSL::Reflection::EntryPointInformation& entryPointInformation, unsigned constantCount, const WGPUConstantEntry* constants, NSString *label)
 {
     auto functionDescriptor = [MTLFunctionDescriptor new];
     functionDescriptor.name = entryPointInformation.mangledName;
-    if (compute && compute->constantCount) {
-        auto constantValues = createConstantValues(compute->constantCount, compute->constants, entryPointInformation);
+    if (constantCount) {
+        auto constantValues = createConstantValues(constantCount, constants, entryPointInformation);
         if (!constantValues)
             return nullptr;
         functionDescriptor.constantValues = constantValues;

--- a/Source/WebGPU/WebGPU/RenderPipeline.mm
+++ b/Source/WebGPU/WebGPU/RenderPipeline.mm
@@ -390,7 +390,7 @@ Ref<RenderPipeline> Device::createRenderPipeline(const WGPURenderPipelineDescrip
                 return RenderPipeline::createInvalid(*this);
 
             const auto& entryPointInformation = libraryCreationResult->entryPointInformation;
-            vertexFunction = createFunction(libraryCreationResult->library, entryPointInformation, nullptr, label);
+            vertexFunction = createFunction(libraryCreationResult->library, entryPointInformation, descriptor.vertex.constantCount, descriptor.vertex.constants, label);
         }
         mtlRenderPipelineDescriptor.vertexFunction = vertexFunction;
     }
@@ -415,7 +415,7 @@ Ref<RenderPipeline> Device::createRenderPipeline(const WGPURenderPipelineDescrip
                 return RenderPipeline::createInvalid(*this);
 
             const auto& entryPointInformation = libraryCreationResult->entryPointInformation;
-            fragmentFunction = createFunction(libraryCreationResult->library, entryPointInformation, nullptr, label);
+            fragmentFunction = createFunction(libraryCreationResult->library, entryPointInformation, fragmentDescriptor.constantCount, fragmentDescriptor.constants, label);
         }
         mtlRenderPipelineDescriptor.fragmentFunction = fragmentFunction;
 


### PR DESCRIPTION
#### c736295c82d42d2a749584588602348e7e2fe70c
<pre>
[WebGPU] Handle constants on vertex and fragment shaders
<a href="https://bugs.webkit.org/show_bug.cgi?id=255663">https://bugs.webkit.org/show_bug.cgi?id=255663</a>
rdar://108267496

Reviewed by Mike Wyrzykowski.

Mild refactor of the `createFunction` helper function, which used take a
`WGPUProgrammableStageDescriptor`, and therefore would only populate constants
for compute shaders. Instead we pass the relevant information (constant count and
pointer) directly, so that we can also use it with vertex and fragment descriptors.

* Source/WebGPU/WebGPU/ComputePipeline.mm:
(WebGPU::Device::createComputePipeline):
* Source/WebGPU/WebGPU/Pipeline.h:
* Source/WebGPU/WebGPU/Pipeline.mm:
(WebGPU::createFunction):
* Source/WebGPU/WebGPU/RenderPipeline.mm:
(WebGPU::Device::createRenderPipeline):

Canonical link: <a href="https://commits.webkit.org/263221@main">https://commits.webkit.org/263221@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4becdcf90993e932bd98683619c520a6664b4d5d

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/3846 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/3935 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/4043 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/5279 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/4105 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/4014 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/3940 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/3689 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/3893 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/4091 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/3464 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/5113 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/1595 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/3439 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/4798 "1 flakes 143 failures") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/3414 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/3499 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/4884 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/3898 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/3153 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/3422 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/3439 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/970 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/3464 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/3699 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->