### PR TITLE
[WebGPU] Consistenly initialize functions whether modules were early compiled or not

### DIFF
--- a/Source/WebGPU/WebGPU/Device.h
+++ b/Source/WebGPU/WebGPU/Device.h
@@ -130,14 +130,6 @@ private:
 
     void loseTheDevice(WGPUDeviceLostReason);
     void captureFrameIfNeeded() const;
-    auto buildKeyValueReplacements(const auto& stage) const
-    {
-        HashMap<String, decltype(WGPUConstantEntry::value)> keyValueReplacements;
-        for (auto* kvp = stage.constants, *endKvp = kvp + stage.constantCount; kvp != endKvp; ++kvp)
-            keyValueReplacements.set(String::fromUTF8(kvp->key), kvp->value);
-
-        return keyValueReplacements;
-    }
 
     struct Error {
         WGPUErrorType type;

--- a/Source/WebGPU/WebGPU/RenderPipeline.mm
+++ b/Source/WebGPU/WebGPU/RenderPipeline.mm
@@ -382,16 +382,12 @@ Ref<RenderPipeline> Device::createRenderPipeline(const WGPURenderPipelineDescrip
             return RenderPipeline::createInvalid(*this);
 
         const auto& vertexFunctionName = String::fromLatin1(descriptor.vertex.entryPoint);
+        auto libraryCreationResult = createLibrary(m_device, vertexModule, pipelineLayout, vertexFunctionName, label);
+        if (!libraryCreationResult)
+            return RenderPipeline::createInvalid(*this);
 
-        auto vertexFunction = vertexModule.getNamedFunction(vertexFunctionName, buildKeyValueReplacements(descriptor.vertex));
-        if (!vertexFunction) {
-            auto libraryCreationResult = createLibrary(m_device, vertexModule, pipelineLayout, vertexFunctionName, label);
-            if (!libraryCreationResult)
-                return RenderPipeline::createInvalid(*this);
-
-            const auto& entryPointInformation = libraryCreationResult->entryPointInformation;
-            vertexFunction = createFunction(libraryCreationResult->library, entryPointInformation, descriptor.vertex.constantCount, descriptor.vertex.constants, label);
-        }
+        const auto& entryPointInformation = libraryCreationResult->entryPointInformation;
+        auto vertexFunction = createFunction(libraryCreationResult->library, entryPointInformation, descriptor.vertex.constantCount, descriptor.vertex.constants, label);
         mtlRenderPipelineDescriptor.vertexFunction = vertexFunction;
     }
 
@@ -407,16 +403,12 @@ Ref<RenderPipeline> Device::createRenderPipeline(const WGPURenderPipelineDescrip
 
         const auto& fragmentFunctionName = String::fromLatin1(fragmentDescriptor.entryPoint);
 
-        auto fragmentFunction = fragmentModule.getNamedFunction(fragmentFunctionName, buildKeyValueReplacements(fragmentDescriptor));
+        auto libraryCreationResult = createLibrary(m_device, fragmentModule, pipelineLayout, fragmentFunctionName, label);
+        if (!libraryCreationResult)
+            return RenderPipeline::createInvalid(*this);
 
-        if (!fragmentFunction) {
-            auto libraryCreationResult = createLibrary(m_device, fragmentModule, pipelineLayout, fragmentFunctionName, label);
-            if (!libraryCreationResult)
-                return RenderPipeline::createInvalid(*this);
-
-            const auto& entryPointInformation = libraryCreationResult->entryPointInformation;
-            fragmentFunction = createFunction(libraryCreationResult->library, entryPointInformation, fragmentDescriptor.constantCount, fragmentDescriptor.constants, label);
-        }
+        const auto& entryPointInformation = libraryCreationResult->entryPointInformation;
+        auto fragmentFunction = createFunction(libraryCreationResult->library, entryPointInformation, fragmentDescriptor.constantCount, fragmentDescriptor.constants, label);
         mtlRenderPipelineDescriptor.fragmentFunction = fragmentFunction;
 
         for (uint32_t i = 0; i < fragmentDescriptor.targetCount; ++i) {

--- a/Source/WebGPU/WebGPU/ShaderModule.h
+++ b/Source/WebGPU/WebGPU/ShaderModule.h
@@ -58,8 +58,6 @@ public:
     void getCompilationInfo(CompletionHandler<void(WGPUCompilationInfoRequestStatus, const WGPUCompilationInfo&)>&& callback);
     void setLabel(String&&);
 
-    id<MTLFunction> getNamedFunction(const String& name, const HashMap<String, double>& keyValueReplacements) const;
-
     bool isValid() const { return !std::holds_alternative<std::monostate>(m_checkResult); }
 
     static WGSL::PipelineLayout convertPipelineLayout(const PipelineLayout&);

--- a/Source/WebGPU/WebGPU/ShaderModule.mm
+++ b/Source/WebGPU/WebGPU/ShaderModule.mm
@@ -250,64 +250,6 @@ void ShaderModule::setLabel(String&& label)
         m_library.label = label;
 }
 
-id<MTLFunction> ShaderModule::getNamedFunction(const String& originalName, const HashMap<String, double>& keyValueReplacements) const
-{
-    if (!m_library)
-        return nil;
-
-    const auto* information = entryPointInformation(originalName);
-    const String& name = information ? information->mangledName : originalName;
-    auto originalFunction = [m_library newFunctionWithName:name];
-
-    if (!keyValueReplacements.size())
-        return originalFunction;
-
-    NSDictionary<NSString *, MTLFunctionConstant *> *originalFunctionConstants = [originalFunction functionConstantsDictionary];
-    MTLFunctionConstantValues *constantValues = [MTLFunctionConstantValues new];
-    for (auto& kvp : keyValueReplacements) {
-        auto it = m_constantIdentifiersToNames.find(kvp.key);
-        auto& constantName = it != m_constantIdentifiersToNames.end() ? it->value : kvp.key;
-
-        // FIXME: https://bugs.webkit.org/show_bug.cgi?id=250444 - it would be preferable
-        // to get the type information from the WGSL compiler so we don't have to call
-        // -[MTLLibrary newFunctionWithName:] twice
-        MTLDataType dataType = [originalFunctionConstants objectForKey:constantName].type;
-        union {
-            bool b;
-            int32_t i;
-            uint32_t u;
-            float f;
-            __fp16 h;
-        } v;
-        if (dataType == MTLDataTypeFloat)
-            v.f = static_cast<decltype(v.f)>(kvp.value);
-        else if (dataType == MTLDataTypeHalf)
-            v.h = static_cast<decltype(v.h)>(kvp.value);
-        else if (dataType == MTLDataTypeInt)
-            v.i = static_cast<decltype(v.i)>(kvp.value);
-        else if (dataType == MTLDataTypeUInt)
-            v.u = static_cast<decltype(v.u)>(kvp.value);
-        else if (dataType == MTLDataTypeBool)
-            v.b = static_cast<decltype(v.b)>(kvp.value);
-        else {
-            ASSERT_NOT_REACHED("Unsupported MTLFunctionConstant data type");
-            return nil;
-        }
-
-        [constantValues setConstantValue:&v type:dataType withName:constantName];
-    }
-
-    NSError *error;
-    id<MTLFunction> result = [m_library newFunctionWithName:name constantValues:constantValues error:&error];
-
-    if (error) {
-        // FIXME: https://bugs.webkit.org/show_bug.cgi?id=250442
-        WTFLogAlways("MSL compilation error: %@", error);
-    }
-
-    return result;
-}
-
 static auto wgslBindingType(WGPUBufferBindingType bindingType)
 {
     switch (bindingType) {


### PR DESCRIPTION
#### fa7690e33574cf7df957d005cfde7fbaa4fe3f10
<pre>
[WebGPU] Consistenly initialize functions whether modules were early compiled or not
<a href="https://bugs.webkit.org/show_bug.cgi?id=255664">https://bugs.webkit.org/show_bug.cgi?id=255664</a>
rdar://problem/108268188

Reviewed by Myles C. Maxfield.

When creating pipelines, first we tried to load the entrypoints directly from the
pre-compiled module. This caused inconsistencies, since the pipeline layout might
have changed since the library was precompiled, and constants were also constructed
differently, by using reflaction. Instead, we delete that code path and use the
deferred compilation path instead, which already tries to use the precompiled module
if one is available and compatible.

* Source/WebGPU/WebGPU/ComputePipeline.mm:
(WebGPU::Device::createComputePipeline):
* Source/WebGPU/WebGPU/Device.h:
(WebGPU::Device::buildKeyValueReplacements const): Deleted.
* Source/WebGPU/WebGPU/RenderPipeline.mm:
(WebGPU::Device::createRenderPipeline):
* Source/WebGPU/WebGPU/ShaderModule.h:
* Source/WebGPU/WebGPU/ShaderModule.mm:
(WebGPU::ShaderModule::getNamedFunction const): Deleted.

Canonical link: <a href="https://commits.webkit.org/263236@main">https://commits.webkit.org/263236@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/6cbc466751e35e304beca28e103aa6e7b4e7f702

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/3988 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/4083 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/4195 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/5429 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/4239 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/4173 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/4058 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/4169 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/4038 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/4224 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/3598 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/5341 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/1726 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/3574 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/5668 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/3550 "Passed tests") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/3634 "3 failures") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/5070 "263 api tests failed or timed out") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/4040 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/3250 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/3556 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/3574 "Passed tests") | | 
| [  ~~🛠 🧪 merge~~](https://ews-build.webkit.org/#/builders/19/builds/979 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/3607 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/3836 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->