### PR TITLE
[WebGPU] R and B channels are swapped in cube map on https://webgpu.github.io/webgpu-samples/samples/cubemap

### DIFF
--- a/Source/WebCore/Modules/WebGPU/GPUDevice.cpp
+++ b/Source/WebCore/Modules/WebGPU/GPUDevice.cpp
@@ -139,7 +139,7 @@ Ref<GPUBuffer> GPUDevice::createBuffer(const GPUBufferDescriptor& bufferDescript
 
 Ref<GPUTexture> GPUDevice::createTexture(const GPUTextureDescriptor& textureDescriptor)
 {
-    return GPUTexture::create(m_backing->createTexture(textureDescriptor.convertToBacking()));
+    return GPUTexture::create(m_backing->createTexture(textureDescriptor.convertToBacking()), textureDescriptor.format);
 }
 
 static PAL::WebGPU::SamplerDescriptor convertToBacking(const std::optional<GPUSamplerDescriptor>& samplerDescriptor)

--- a/Source/WebCore/Modules/WebGPU/GPUPresentationContext.cpp
+++ b/Source/WebCore/Modules/WebGPU/GPUPresentationContext.cpp
@@ -45,7 +45,7 @@ RefPtr<GPUTexture> GPUPresentationContext::getCurrentTexture()
 {
     if (!m_currentTexture) {
         if (auto currentTexture = m_backing->getCurrentTexture())
-            m_currentTexture = GPUTexture::create(*currentTexture).ptr();
+            m_currentTexture = GPUTexture::create(*currentTexture, GPUTextureFormat::Bgra8unorm).ptr();
     }
 
     return m_currentTexture;

--- a/Source/WebCore/Modules/WebGPU/GPUQueue.cpp
+++ b/Source/WebCore/Modules/WebGPU/GPUQueue.cpp
@@ -121,20 +121,127 @@ static ImageBuffer* imageBufferForSource(const auto& source)
     );
 }
 
+static PixelFormat toPixelFormat(GPUTextureFormat textureFormat)
+{
+    switch (textureFormat) {
+    case GPUTextureFormat::R8unorm:
+    case GPUTextureFormat::R8snorm:
+    case GPUTextureFormat::R8uint:
+    case GPUTextureFormat::R8sint:
+    case GPUTextureFormat::R16uint:
+    case GPUTextureFormat::R16sint:
+    case GPUTextureFormat::R16float:
+    case GPUTextureFormat::Rg8unorm:
+    case GPUTextureFormat::Rg8snorm:
+    case GPUTextureFormat::Rg8uint:
+    case GPUTextureFormat::Rg8sint:
+    case GPUTextureFormat::R32uint:
+    case GPUTextureFormat::R32sint:
+    case GPUTextureFormat::R32float:
+    case GPUTextureFormat::Rg16uint:
+    case GPUTextureFormat::Rg16sint:
+    case GPUTextureFormat::Rg16float:
+    case GPUTextureFormat::Rgba8unorm:
+    case GPUTextureFormat::Rgba8unormSRGB:
+    case GPUTextureFormat::Rgba8snorm:
+    case GPUTextureFormat::Rgba8uint:
+    case GPUTextureFormat::Rgba8sint:
+        return PixelFormat::RGBA8;
+
+    case GPUTextureFormat::Bgra8unorm:
+    case GPUTextureFormat::Bgra8unormSRGB:
+        return PixelFormat::BGRA8;
+        
+    case GPUTextureFormat::Rgb9e5ufloat:
+    case GPUTextureFormat::Rgb10a2unorm:
+    case GPUTextureFormat::Rg11b10ufloat:
+    case GPUTextureFormat::Rg32uint:
+    case GPUTextureFormat::Rg32sint:
+    case GPUTextureFormat::Rg32float:
+    case GPUTextureFormat::Rgba16uint:
+    case GPUTextureFormat::Rgba16sint:
+    case GPUTextureFormat::Rgba16float:
+    case GPUTextureFormat::Rgba32uint:
+    case GPUTextureFormat::Rgba32sint:
+    case GPUTextureFormat::Rgba32float:
+    case GPUTextureFormat::Stencil8:
+    case GPUTextureFormat::Depth16unorm:
+    case GPUTextureFormat::Depth24plus:
+    case GPUTextureFormat::Depth24plusStencil8:
+    case GPUTextureFormat::Depth32float:
+    case GPUTextureFormat::Depth32floatStencil8:
+    case GPUTextureFormat::Bc1RgbaUnorm:
+    case GPUTextureFormat::Bc1RgbaUnormSRGB:
+    case GPUTextureFormat::Bc2RgbaUnorm:
+    case GPUTextureFormat::Bc2RgbaUnormSRGB:
+    case GPUTextureFormat::Bc3RgbaUnorm:
+    case GPUTextureFormat::Bc3RgbaUnormSRGB:
+    case GPUTextureFormat::Bc4RUnorm:
+    case GPUTextureFormat::Bc4RSnorm:
+    case GPUTextureFormat::Bc5RgUnorm:
+    case GPUTextureFormat::Bc5RgSnorm:
+    case GPUTextureFormat::Bc6hRgbUfloat:
+    case GPUTextureFormat::Bc6hRgbFloat:
+    case GPUTextureFormat::Bc7RgbaUnorm:
+    case GPUTextureFormat::Bc7RgbaUnormSRGB:
+    case GPUTextureFormat::Etc2Rgb8unorm:
+    case GPUTextureFormat::Etc2Rgb8unormSRGB:
+    case GPUTextureFormat::Etc2Rgb8a1unorm:
+    case GPUTextureFormat::Etc2Rgb8a1unormSRGB:
+    case GPUTextureFormat::Etc2Rgba8unorm:
+    case GPUTextureFormat::Etc2Rgba8unormSRGB:
+    case GPUTextureFormat::EacR11unorm:
+    case GPUTextureFormat::EacR11snorm:
+    case GPUTextureFormat::EacRg11unorm:
+    case GPUTextureFormat::EacRg11snorm:
+    case GPUTextureFormat::Astc4x4Unorm:
+    case GPUTextureFormat::Astc4x4UnormSRGB:
+    case GPUTextureFormat::Astc5x4Unorm:
+    case GPUTextureFormat::Astc5x4UnormSRGB:
+    case GPUTextureFormat::Astc5x5Unorm:
+    case GPUTextureFormat::Astc5x5UnormSRGB:
+    case GPUTextureFormat::Astc6x5Unorm:
+    case GPUTextureFormat::Astc6x5UnormSRGB:
+    case GPUTextureFormat::Astc6x6Unorm:
+    case GPUTextureFormat::Astc6x6UnormSRGB:
+    case GPUTextureFormat::Astc8x5Unorm:
+    case GPUTextureFormat::Astc8x5UnormSRGB:
+    case GPUTextureFormat::Astc8x6Unorm:
+    case GPUTextureFormat::Astc8x6UnormSRGB:
+    case GPUTextureFormat::Astc8x8Unorm:
+    case GPUTextureFormat::Astc8x8UnormSRGB:
+    case GPUTextureFormat::Astc10x5Unorm:
+    case GPUTextureFormat::Astc10x5UnormSRGB:
+    case GPUTextureFormat::Astc10x6Unorm:
+    case GPUTextureFormat::Astc10x6UnormSRGB:
+    case GPUTextureFormat::Astc10x8Unorm:
+    case GPUTextureFormat::Astc10x8UnormSRGB:
+    case GPUTextureFormat::Astc10x10Unorm:
+    case GPUTextureFormat::Astc10x10UnormSRGB:
+    case GPUTextureFormat::Astc12x10Unorm:
+    case GPUTextureFormat::Astc12x10UnormSRGB:
+    case GPUTextureFormat::Astc12x12Unorm:
+    case GPUTextureFormat::Astc12x12UnormSRGB:
+        return PixelFormat::RGBA8;
+    }
+
+    return PixelFormat::RGBA8;
+}
+
 void GPUQueue::copyExternalImageToTexture(
     const GPUImageCopyExternalImage& source,
     const GPUImageCopyTextureTagged& destination,
     const GPUExtent3D& copySize)
 {
     auto imageBuffer = imageBufferForSource(source.source);
-    if (!imageBuffer)
+    if (!imageBuffer || !destination.texture)
         return;
 
     auto size = imageBuffer->truncatedLogicalSize();
     if (!size.width() || !size.height())
         return;
 
-    auto pixelBuffer = imageBuffer->getPixelBuffer({ AlphaPremultiplication::Unpremultiplied, PixelFormat::BGRA8, DestinationColorSpace::SRGB() }, { { }, size });
+    auto pixelBuffer = imageBuffer->getPixelBuffer({ AlphaPremultiplication::Unpremultiplied, toPixelFormat(destination.texture->format()), DestinationColorSpace::SRGB() }, { { }, size });
     ASSERT(pixelBuffer);
 
     auto sizeInBytes = pixelBuffer->sizeInBytes();

--- a/Source/WebCore/Modules/WebGPU/GPUTexture.h
+++ b/Source/WebCore/Modules/WebGPU/GPUTexture.h
@@ -25,6 +25,7 @@
 
 #pragma once
 
+#include "GPUTextureFormat.h"
 #include <optional>
 #include <pal/graphics/WebGPU/WebGPUTexture.h>
 #include <wtf/Ref.h>
@@ -38,9 +39,9 @@ struct GPUTextureViewDescriptor;
 
 class GPUTexture : public RefCounted<GPUTexture> {
 public:
-    static Ref<GPUTexture> create(Ref<PAL::WebGPU::Texture>&& backing)
+    static Ref<GPUTexture> create(Ref<PAL::WebGPU::Texture>&& backing, GPUTextureFormat format)
     {
-        return adoptRef(*new GPUTexture(WTFMove(backing)));
+        return adoptRef(*new GPUTexture(WTFMove(backing), format));
     }
 
     String label() const;
@@ -52,14 +53,17 @@ public:
 
     PAL::WebGPU::Texture& backing() { return m_backing; }
     const PAL::WebGPU::Texture& backing() const { return m_backing; }
+    GPUTextureFormat format() const { return m_format; }
 
 private:
-    GPUTexture(Ref<PAL::WebGPU::Texture>&& backing)
+    GPUTexture(Ref<PAL::WebGPU::Texture>&& backing, GPUTextureFormat format)
         : m_backing(WTFMove(backing))
+        , m_format(format)
     {
     }
 
     Ref<PAL::WebGPU::Texture> m_backing;
+    GPUTextureFormat m_format;
 };
 
 }


### PR DESCRIPTION
#### 0259a9cfdd2a3983b0395fca2310bd10285d6b67
<pre>
[WebGPU] R and B channels are swapped in cube map on <a href="https://webgpu.github.io/webgpu-samples/samples/cubemap">https://webgpu.github.io/webgpu-samples/samples/cubemap</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=255657">https://bugs.webkit.org/show_bug.cgi?id=255657</a>
&lt;radar://108264195&gt;

Reviewed by Tadeu Zagallo.

copyExternalImageToTexture was assuming the destination texture was BGRA8, which
is not always the case.

Cache the texture format and use it to determine how to copy an external image
source to a destination texture.

* Source/WebCore/Modules/WebGPU/GPUDevice.cpp:
(WebCore::GPUDevice::createTexture):
Pass the format to GPUTexture::create

* Source/WebCore/Modules/WebGPU/GPUPresentationContext.cpp:
(WebCore::GPUPresentationContext::getCurrentTexture):
Presentation context always uses BGRA8

* Source/WebCore/Modules/WebGPU/GPUQueue.cpp:
(WebCore::toPixelFormat):
Use BGRA or RGBA as appropriate for the destination format.

(WebCore::GPUQueue::copyExternalImageToTexture):
Use BGRA or RGBA as appropriate for the destination format.

* Source/WebCore/Modules/WebGPU/GPUTexture.h:
(WebCore::GPUTexture::create):
(WebCore::GPUTexture::format const):
(WebCore::GPUTexture::GPUTexture):
Cache the texture format.

Canonical link: <a href="https://commits.webkit.org/263153@main">https://commits.webkit.org/263153@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b462c90ba29a4fcceeaa99965302c534192666f3

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/3742 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/3827 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/3935 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/5170 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/4020 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/3714 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/3905 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/3832 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/3244 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/3786 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/4009 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/3376 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/5003 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/1514 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/3348 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/3606 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/3357 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/3407 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/4771 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/3792 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/3074 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/3324 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/3348 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/922 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/3359 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/3601 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->