### PR TITLE
[WebGPU] Implement GPUAdapter.requestAdapterInfo

### DIFF
--- a/Source/WebCore/CMakeLists.txt
+++ b/Source/WebCore/CMakeLists.txt
@@ -1620,6 +1620,7 @@ list(APPEND WebCore_NON_SVG_IDL_FILES
     Modules/ShapeDetection/TextDetector.idl
     Modules/WebGPU/GPU.idl
     Modules/WebGPU/GPUAdapter.idl
+    Modules/WebGPU/GPUAdapterInfo.idl
     Modules/WebGPU/GPUAddressMode.idl
     Modules/WebGPU/GPUAutoLayoutMode.idl
     Modules/WebGPU/GPUBindGroup.idl

--- a/Source/WebCore/DerivedSources-input.xcfilelist
+++ b/Source/WebCore/DerivedSources-input.xcfilelist
@@ -45,6 +45,7 @@ $(PROJECT_DIR)/Modules/ShapeDetection/Point2D.idl
 $(PROJECT_DIR)/Modules/ShapeDetection/TextDetector.idl
 $(PROJECT_DIR)/Modules/WebGPU/GPU.idl
 $(PROJECT_DIR)/Modules/WebGPU/GPUAdapter.idl
+$(PROJECT_DIR)/Modules/WebGPU/GPUAdapterInfo.idl
 $(PROJECT_DIR)/Modules/WebGPU/GPUAddressMode.idl
 $(PROJECT_DIR)/Modules/WebGPU/GPUAutoLayoutMode.idl
 $(PROJECT_DIR)/Modules/WebGPU/GPUBindGroup.idl

--- a/Source/WebCore/DerivedSources-output.xcfilelist
+++ b/Source/WebCore/DerivedSources-output.xcfilelist
@@ -1023,6 +1023,8 @@ $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSGPU.cpp
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSGPU.h
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSGPUAdapter.cpp
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSGPUAdapter.h
+$(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSGPUAdapterInfo.cpp
+$(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSGPUAdapterInfo.h
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSGPUAddressMode.cpp
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSGPUAddressMode.h
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSGPUAutoLayoutMode.cpp

--- a/Source/WebCore/DerivedSources.make
+++ b/Source/WebCore/DerivedSources.make
@@ -58,6 +58,7 @@ FEATURE_AND_PLATFORM_DEFINE_DEPENDENCIES = $(WebCore)/DerivedSources.make $(PLAT
 JS_BINDING_IDLS := \
     $(WebCore)/Modules/WebGPU/GPU.idl \
     $(WebCore)/Modules/WebGPU/GPUAdapter.idl \
+    $(WebCore)/Modules/WebGPU/GPUAdapterInfo.idl \
     $(WebCore)/Modules/WebGPU/GPUAddressMode.idl \
     $(WebCore)/Modules/WebGPU/GPUAutoLayoutMode.idl \
     $(WebCore)/Modules/WebGPU/GPUBindGroup.idl \

--- a/Source/WebCore/Headers.cmake
+++ b/Source/WebCore/Headers.cmake
@@ -17,6 +17,7 @@ set(WebCore_PRIVATE_FRAMEWORK_HEADERS
 
     Modules/WebGPU/GPU.h
     Modules/WebGPU/GPUAdapter.h
+    Modules/WebGPU/GPUAdapterInfo.h
     Modules/WebGPU/GPUAddressMode.h
     Modules/WebGPU/GPUAutoLayoutMode.h
     Modules/WebGPU/GPUBindGroup.h

--- a/Source/WebCore/Modules/WebGPU/GPUAdapter.cpp
+++ b/Source/WebCore/Modules/WebGPU/GPUAdapter.cpp
@@ -28,6 +28,7 @@
 
 #include "Exception.h"
 #include "JSDOMPromiseDeferred.h"
+#include "JSGPUAdapterInfo.h"
 #include "JSGPUDevice.h"
 
 namespace WebCore {
@@ -72,8 +73,7 @@ void GPUAdapter::requestDevice(ScriptExecutionContext&, const std::optional<GPUD
 
 void GPUAdapter::requestAdapterInfo(const std::optional<Vector<String>>&, RequestAdapterInfoPromise&& promise)
 {
-    // FIXME: https://bugs.webkit.org/show_bug.cgi?id=251377 - [WebGPU] Implement GPUAdapter.requestAdapterInfo
-    promise.resolve(nullptr);
+    promise.resolve(GPUAdapterInfo::create(name()));
 }
 
 }

--- a/Source/WebCore/Modules/WebGPU/GPUAdapter.h
+++ b/Source/WebCore/Modules/WebGPU/GPUAdapter.h
@@ -25,6 +25,7 @@
 
 #pragma once
 
+#include "GPUAdapterInfo.h"
 #include "GPUDevice.h"
 #include "GPUDeviceDescriptor.h"
 #include "GPUSupportedFeatures.h"
@@ -54,7 +55,7 @@ public:
     using RequestDevicePromise = DOMPromiseDeferred<IDLInterface<GPUDevice>>;
     void requestDevice(ScriptExecutionContext&, const std::optional<GPUDeviceDescriptor>&, RequestDevicePromise&&);
 
-    using RequestAdapterInfoPromise = DOMPromiseDeferred<IDLNull>;
+    using RequestAdapterInfoPromise = DOMPromiseDeferred<IDLInterface<GPUAdapterInfo>>;
     void requestAdapterInfo(const std::optional<Vector<String>>&, RequestAdapterInfoPromise&&);
 
     PAL::WebGPU::Adapter& backing() { return m_backing; }

--- a/Source/WebCore/Modules/WebGPU/GPUAdapter.idl
+++ b/Source/WebCore/Modules/WebGPU/GPUAdapter.idl
@@ -37,5 +37,5 @@ interface GPUAdapter {
     readonly attribute boolean isFallbackAdapter;
 
     [CallWith=CurrentScriptExecutionContext] Promise<GPUDevice> requestDevice(optional GPUDeviceDescriptor descriptor);
-    Promise<undefined> requestAdapterInfo(optional sequence<DOMString> unmaskHints = []);
+    Promise<GPUAdapterInfo> requestAdapterInfo(optional sequence<DOMString> unmaskHints = []);
 };

--- a/Source/WebCore/Modules/WebGPU/GPUAdapterInfo.h
+++ b/Source/WebCore/Modules/WebGPU/GPUAdapterInfo.h
@@ -1,0 +1,55 @@
+/*
+ * Copyright (C) 2023 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include <wtf/Ref.h>
+#include <wtf/RefCounted.h>
+#include <wtf/text/WTFString.h>
+
+namespace WebCore {
+
+class GPUAdapterInfo : public RefCounted<GPUAdapterInfo> {
+public:
+    static Ref<GPUAdapterInfo> create(String&& name)
+    {
+        return adoptRef(*new GPUAdapterInfo(WTFMove(name)));
+    }
+
+    String vendor() const { auto v = m_name.split(' '); return v.size() ? v[0] : ""_s; }
+    String architecture() const { return ""_s; }
+    String device() const { return m_name; }
+    String description() const { return ""_s; }
+
+private:
+    GPUAdapterInfo(String&& name)
+        : m_name(name)
+    {
+    }
+
+    String m_name;
+};
+
+}

--- a/Source/WebCore/Modules/WebGPU/GPUAdapterInfo.idl
+++ b/Source/WebCore/Modules/WebGPU/GPUAdapterInfo.idl
@@ -1,0 +1,38 @@
+/*
+ * Copyright (C) 2023 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+// https://gpuweb.github.io/gpuweb/#gpuadapterinfo
+
+[
+    EnabledBySetting=WebGPU,
+    Exposed=(Window), /* https://bugs.webkit.org/show_bug.cgi?id=232542: DedicatedWorker */
+    SecureContext
+]
+interface GPUAdapterInfo {
+    readonly attribute DOMString vendor;
+    readonly attribute DOMString architecture;
+    readonly attribute DOMString device;
+    readonly attribute DOMString description;
+};

--- a/Source/WebCore/Sources.txt
+++ b/Source/WebCore/Sources.txt
@@ -3391,6 +3391,7 @@ JSFontFaceSet.cpp
 JSFormDataEvent.cpp
 JSGPU.cpp
 JSGPUAdapter.cpp
+JSGPUAdapterInfo.cpp
 JSGPUAddressMode.cpp
 JSGPUAutoLayoutMode.cpp
 JSGPUBindGroup.cpp

--- a/Source/WebCore/bindings/js/WebCoreBuiltinNames.h
+++ b/Source/WebCore/bindings/js/WebCoreBuiltinNames.h
@@ -191,6 +191,7 @@ namespace WebCore {
     macro(GainNode) \
     macro(GPU) \
     macro(GPUAdapter) \
+    macro(GPUAdapterInfo) \
     macro(GPUBindGroup) \
     macro(GPUBindGroupLayout) \
     macro(GPUBuffer) \


### PR DESCRIPTION
#### 1e0ff03a5f0552323e52f26820db1839dac9c864
<pre>
[WebGPU] Implement GPUAdapter.requestAdapterInfo
<a href="https://bugs.webkit.org/show_bug.cgi?id=251377">https://bugs.webkit.org/show_bug.cgi?id=251377</a>
&lt;radar://104829439&gt;

Reviewed by Myles C. Maxfield.

Minimally implement requestAdapterInfo, so <a href="https://mlc.ai/web-llm/">https://mlc.ai/web-llm/</a>
does not report an error about output.adapterInfo.description being
undefined.

* Source/WebCore/CMakeLists.txt:
* Source/WebCore/DerivedSources-input.xcfilelist:
* Source/WebCore/DerivedSources-output.xcfilelist:
* Source/WebCore/DerivedSources.make:
* Source/WebCore/Headers.cmake:
* Source/WebCore/Modules/WebGPU/GPUAdapter.cpp:
(WebCore::GPUAdapter::requestAdapterInfo):
* Source/WebCore/Modules/WebGPU/GPUAdapter.h:
* Source/WebCore/Modules/WebGPU/GPUAdapter.idl:
* Source/WebCore/Sources.txt:
* Source/WebCore/WebCore.xcodeproj/project.pbxproj:
* Source/WebCore/bindings/js/WebCoreBuiltinNames.h:

* Source/WebCore/Modules/WebGPU/GPUAdapterInfo.h: Added.
(WebCore::GPUAdapterInfo::create):
(WebCore::GPUAdapterInfo::vendor const):
(WebCore::GPUAdapterInfo::architecture const):
(WebCore::GPUAdapterInfo::device const):
(WebCore::GPUAdapterInfo::description const):
(WebCore::GPUAdapterInfo::GPUAdapterInfo):
* Source/WebCore/Modules/WebGPU/GPUAdapterInfo.idl: Added.
Add new files.

Canonical link: <a href="https://commits.webkit.org/263164@main">https://commits.webkit.org/263164@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a2b6895c1885a71a78065d1bb9bfa861f2d84626

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/3831 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/3919 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/4027 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/5263 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/4089 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/3805 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/3998 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/3924 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/3674 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/3877 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/4076 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/3450 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/5097 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/1580 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/3425 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/4709 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/3399 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/3485 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/4865 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/3882 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/3141 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/3407 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/3425 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/929 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/3448 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/3684 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->