### PR TITLE
[WebAuthn] Enums should be DOMStrings

### DIFF
--- a/Source/WebCore/Modules/webauthn/AttestationConveyancePreference.cpp
+++ b/Source/WebCore/Modules/webauthn/AttestationConveyancePreference.cpp
@@ -1,0 +1,54 @@
+/*
+* Copyright (C) 2022 Apple Inc. All rights reserved.
+*
+* Redistribution and use in source and binary forms, with or without
+* modification, are permitted provided that the following conditions
+* are met:
+* 1. Redistributions of source code must retain the above copyright
+*    notice, this list of conditions and the following disclaimer.
+* 2. Redistributions in binary form must reproduce the above copyright
+*    notice, this list of conditions and the following disclaimer in the
+*    documentation and/or other materials provided with the distribution.
+*
+* THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+* AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+* THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+* PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+* BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+* CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+* SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+* INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+* CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+* ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+* THE POSSIBILITY OF SUCH DAMAGE.
+*/
+
+#include "config.h"
+#include "AttestationConveyancePreference.h"
+
+#if ENABLE(WEB_AUTHN)
+
+#include "JSAttestationConveyancePreference.h"
+#include <wtf/text/WTFString.h>
+
+namespace WebCore {
+
+AttestationConveyancePreference toAttestationConveyancePreference(const String& preference)
+{
+    if (preference == "indirect"_s)
+        return AttestationConveyancePreference::Indirect;
+    if (preference == "direct"_s)
+        return AttestationConveyancePreference::Direct;
+    if (preference == "enterprise"_s)
+        return AttestationConveyancePreference::Enterprise;
+    return AttestationConveyancePreference::None;
+}
+
+String toString(AttestationConveyancePreference preference)
+{
+    return convertEnumerationToString(preference);
+}
+
+}
+
+#endif

--- a/Source/WebCore/Modules/webauthn/AttestationConveyancePreference.h
+++ b/Source/WebCore/Modules/webauthn/AttestationConveyancePreference.h
@@ -38,6 +38,10 @@ enum class AttestationConveyancePreference : uint8_t {
     Enterprise,
 };
 
+WEBCORE_EXPORT AttestationConveyancePreference toAttestationConveyancePreference(const String& preference);
+
+WEBCORE_EXPORT String toString(AttestationConveyancePreference);
+
 } // namespace WebCore
 
 #endif // ENABLE(WEB_AUTHN)

--- a/Source/WebCore/Modules/webauthn/AuthenticatorTransport.cpp
+++ b/Source/WebCore/Modules/webauthn/AuthenticatorTransport.cpp
@@ -1,0 +1,62 @@
+/*
+ * Copyright (C) 2023 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "AuthenticatorTransport.h"
+
+#if ENABLE(WEB_AUTHN)
+
+#include "JSAuthenticatorTransport.h"
+#include <wtf/text/WTFString.h>
+
+namespace WebCore {
+
+std::optional<AuthenticatorTransport> toAuthenticatorTransport(const String& transport)
+{
+    if (transport == "usb"_s)
+        return AuthenticatorTransport::Usb;
+    if (transport == "nfc"_s)
+        return AuthenticatorTransport::Nfc;
+    if (transport == "ble"_s)
+        return AuthenticatorTransport::Ble;
+    if (transport == "internal"_s)
+        return AuthenticatorTransport::Internal;
+    if (transport == "cable"_s)
+        return AuthenticatorTransport::Cable;
+    if (transport == "hybrid"_s)
+        return AuthenticatorTransport::Hybrid;
+    if (transport == "smart-card"_s)
+        return AuthenticatorTransport::SmartCard;
+    return std::nullopt;
+}
+
+String toString(AuthenticatorTransport transport)
+{
+    return convertEnumerationToString(transport);
+}
+
+}
+
+#endif

--- a/Source/WebCore/Modules/webauthn/AuthenticatorTransport.h
+++ b/Source/WebCore/Modules/webauthn/AuthenticatorTransport.h
@@ -25,6 +25,8 @@
 
 #pragma once
 
+#include <wtf/Forward.h>
+
 #if ENABLE(WEB_AUTHN)
 
 namespace WebCore {
@@ -38,6 +40,10 @@ enum class AuthenticatorTransport : uint8_t {
     Hybrid,
     SmartCard
 };
+
+WEBCORE_EXPORT std::optional<AuthenticatorTransport> toAuthenticatorTransport(const String& transport);
+
+WEBCORE_EXPORT String toString(AuthenticatorTransport);
 
 } // namespace WebCore
 

--- a/Source/WebCore/Modules/webauthn/PublicKeyCredentialCreationOptions.cpp
+++ b/Source/WebCore/Modules/webauthn/PublicKeyCredentialCreationOptions.cpp
@@ -1,0 +1,75 @@
+/*
+ * Copyright (C) 2023 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "PublicKeyCredentialCreationOptions.h"
+
+#include "AuthenticatorAttachment.h"
+
+#if ENABLE(WEB_AUTHN)
+
+namespace WebCore {
+
+AttestationConveyancePreference PublicKeyCredentialCreationOptions::attestation() const
+{
+    if (attestationString == "indirect"_s)
+        return AttestationConveyancePreference::Indirect;
+    if (attestationString == "direct"_s)
+        return AttestationConveyancePreference::Direct;
+    if (attestationString == "enterprise"_s)
+        return AttestationConveyancePreference::Enterprise;
+    return AttestationConveyancePreference::None;
+}
+
+std::optional<ResidentKeyRequirement> PublicKeyCredentialCreationOptions::AuthenticatorSelectionCriteria::residentKey() const
+{
+    if (residentKeyString == "required"_s)
+        return ResidentKeyRequirement::Required;
+    if (residentKeyString == "discouraged"_s)
+        return ResidentKeyRequirement::Discouraged;
+    return ResidentKeyRequirement::Preferred;
+}
+
+UserVerificationRequirement PublicKeyCredentialCreationOptions::AuthenticatorSelectionCriteria::userVerification() const
+{
+    if (userVerificationString == "required"_s)
+        return UserVerificationRequirement::Required;
+    if (userVerificationString == "preferred"_s)
+        return UserVerificationRequirement::Preferred;
+    return UserVerificationRequirement::Discouraged;
+}
+
+std::optional<AuthenticatorAttachment> PublicKeyCredentialCreationOptions::AuthenticatorSelectionCriteria::authenticatorAttachment() const
+{
+    if (authenticatorAttachmentString == "platform"_s)
+        return AuthenticatorAttachment::Platform;
+    if (authenticatorAttachmentString == "cross-platform"_s)
+        return AuthenticatorAttachment::CrossPlatform;
+    return std::nullopt;
+}
+
+}
+
+#endif

--- a/Source/WebCore/Modules/webauthn/PublicKeyCredentialCreationOptions.h
+++ b/Source/WebCore/Modules/webauthn/PublicKeyCredentialCreationOptions.h
@@ -62,11 +62,14 @@ struct PublicKeyCredentialCreationOptions {
     };
 
     struct AuthenticatorSelectionCriteria {
-        std::optional<AuthenticatorAttachment> authenticatorAttachment;
+        String authenticatorAttachmentString;
+        WEBCORE_EXPORT std::optional<AuthenticatorAttachment> authenticatorAttachment() const;
         // residentKey replaces requireResidentKey, see: https://www.w3.org/TR/webauthn-2/#dictionary-authenticatorSelection
-        std::optional<ResidentKeyRequirement> residentKey;
+        String residentKeyString;
+        WEBCORE_EXPORT std::optional<ResidentKeyRequirement> residentKey() const;
         bool requireResidentKey { false };
-        UserVerificationRequirement userVerification { UserVerificationRequirement::Preferred };
+        String userVerificationString { "preferred"_s };
+        WEBCORE_EXPORT UserVerificationRequirement userVerification() const;
     };
 
     RpEntity rp;
@@ -78,7 +81,8 @@ struct PublicKeyCredentialCreationOptions {
     std::optional<unsigned> timeout;
     Vector<PublicKeyCredentialDescriptor> excludeCredentials;
     std::optional<AuthenticatorSelectionCriteria> authenticatorSelection;
-    AttestationConveyancePreference attestation;
+    String attestationString;
+    WEBCORE_EXPORT AttestationConveyancePreference attestation() const;
     mutable std::optional<AuthenticationExtensionsClientInputs> extensions;
 #endif // ENABLE(WEB_AUTHN)
 };

--- a/Source/WebCore/Modules/webauthn/PublicKeyCredentialCreationOptions.idl
+++ b/Source/WebCore/Modules/webauthn/PublicKeyCredentialCreationOptions.idl
@@ -37,7 +37,7 @@ typedef long COSEAlgorithmIdentifier;
     unsigned long timeout;
     sequence<PublicKeyCredentialDescriptor> excludeCredentials = [];
     AuthenticatorSelectionCriteria authenticatorSelection;
-    AttestationConveyancePreference attestation = "none";
+    [ImplementedAs=attestationString] DOMString attestation = "none";
     AuthenticationExtensionsClientInputs extensions;
 };
 
@@ -71,8 +71,8 @@ typedef long COSEAlgorithmIdentifier;
 [
     Conditional=WEB_AUTHN,
 ] dictionary AuthenticatorSelectionCriteria {
-    AuthenticatorAttachment      authenticatorAttachment;
-    ResidentKeyRequirement       residentKey;
-    boolean                      requireResidentKey = false;
-    UserVerificationRequirement  userVerification = "preferred";
+    [ImplementedAs=authenticatorAttachmentString] DOMString authenticatorAttachment;
+    [ImplementedAs=residentKeyString] DOMString?            residentKey;
+    boolean                                                 requireResidentKey = false;
+    [ImplementedAs=userVerificationString] DOMString?       userVerification = "preferred";
 };

--- a/Source/WebCore/Modules/webauthn/PublicKeyCredentialDescriptor.h
+++ b/Source/WebCore/Modules/webauthn/PublicKeyCredentialDescriptor.h
@@ -36,7 +36,7 @@ namespace WebCore {
 struct PublicKeyCredentialDescriptor {
     PublicKeyCredentialType type;
     BufferSource id;
-    Vector<AuthenticatorTransport> transports;
+    Vector<String> transports;
 };
 
 } // namespace WebCore

--- a/Source/WebCore/Modules/webauthn/PublicKeyCredentialDescriptor.idl
+++ b/Source/WebCore/Modules/webauthn/PublicKeyCredentialDescriptor.idl
@@ -28,5 +28,5 @@
 ] dictionary PublicKeyCredentialDescriptor {
     required PublicKeyCredentialType type;
     required BufferSource id;
-    sequence<AuthenticatorTransport> transports;
+    sequence<DOMString> transports;
 };

--- a/Source/WebCore/Modules/webauthn/PublicKeyCredentialRequestOptions.cpp
+++ b/Source/WebCore/Modules/webauthn/PublicKeyCredentialRequestOptions.cpp
@@ -1,0 +1,55 @@
+/*
+ * Copyright (C) 2022 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "PublicKeyCredentialRequestOptions.h"
+
+#include "AuthenticatorAttachment.h"
+
+#if ENABLE(WEB_AUTHN)
+
+namespace WebCore {
+
+UserVerificationRequirement PublicKeyCredentialRequestOptions::userVerification() const
+{
+    if (userVerificationString == "required"_s)
+        return UserVerificationRequirement::Required;
+    if (userVerificationString == "preferred"_s)
+        return UserVerificationRequirement::Preferred;
+    return UserVerificationRequirement::Discouraged;
+}
+
+std::optional<AuthenticatorAttachment> PublicKeyCredentialRequestOptions::authenticatorAttachment() const
+{
+    if (authenticatorAttachmentString == "platform"_s)
+        return AuthenticatorAttachment::Platform;
+    if (authenticatorAttachmentString == "cross-platform"_s)
+        return AuthenticatorAttachment::CrossPlatform;
+    return std::nullopt;
+}
+
+}
+
+#endif

--- a/Source/WebCore/Modules/webauthn/PublicKeyCredentialRequestOptions.h
+++ b/Source/WebCore/Modules/webauthn/PublicKeyCredentialRequestOptions.h
@@ -42,9 +42,11 @@ struct PublicKeyCredentialRequestOptions {
     std::optional<unsigned> timeout;
     mutable String rpId;
     Vector<PublicKeyCredentialDescriptor> allowCredentials;
-    UserVerificationRequirement userVerification { UserVerificationRequirement::Preferred };
+    String userVerificationString { "preferred"_s };
+    WEBCORE_EXPORT UserVerificationRequirement userVerification() const;
     mutable std::optional<AuthenticationExtensionsClientInputs> extensions;
-    std::optional<AuthenticatorAttachment> authenticatorAttachment { }; // Not serialized over IPC.
+    String authenticatorAttachmentString;
+    WEBCORE_EXPORT std::optional<AuthenticatorAttachment> authenticatorAttachment() const;
 #endif // ENABLE(WEB_AUTHN)
 };
 

--- a/Source/WebCore/Modules/webauthn/PublicKeyCredentialRequestOptions.idl
+++ b/Source/WebCore/Modules/webauthn/PublicKeyCredentialRequestOptions.idl
@@ -30,6 +30,6 @@
     unsigned long timeout;
     USVString rpId;
     sequence<PublicKeyCredentialDescriptor> allowCredentials = [];
-    UserVerificationRequirement userVerification = "preferred";
+    [ImplementedAs=userVerificationString] DOMString userVerification = "preferred";
     AuthenticationExtensionsClientInputs extensions;
 };

--- a/Source/WebCore/Modules/webauthn/WebAuthenticationUtils.cpp
+++ b/Source/WebCore/Modules/webauthn/WebAuthenticationUtils.cpp
@@ -31,6 +31,9 @@
 #include "CBORReader.h"
 #include "CBORWriter.h"
 #include "FidoConstants.h"
+#include "JSAuthenticatorAttachment.h"
+#include "JSResidentKeyRequirement.h"
+#include "JSUserVerificationRequirement.h"
 #include "WebAuthenticationConstants.h"
 #include <pal/crypto/CryptoDigest.h>
 #include <wtf/JSONValues.h>
@@ -194,6 +197,21 @@ Vector<uint8_t> encodeRawPublicKey(const Vector<uint8_t>& x, const Vector<uint8_
     rawKey.appendVector(x);
     rawKey.appendVector(y);
     return rawKey;
+}
+
+String toString(AuthenticatorAttachment attachment)
+{
+    return convertEnumerationToString(attachment);
+}
+
+String toString(UserVerificationRequirement requirement)
+{
+    return convertEnumerationToString(requirement);
+}
+
+String toString(ResidentKeyRequirement requirement)
+{
+    return convertEnumerationToString(requirement);
 }
 
 } // namespace WebCore

--- a/Source/WebCore/Modules/webauthn/WebAuthenticationUtils.h
+++ b/Source/WebCore/Modules/webauthn/WebAuthenticationUtils.h
@@ -36,6 +36,10 @@
 
 namespace WebCore {
 
+enum class AuthenticatorAttachment : uint8_t;
+enum class UserVerificationRequirement : uint8_t;
+enum class ResidentKeyRequirement : uint8_t;
+
 WEBCORE_EXPORT Vector<uint8_t> convertBytesToVector(const uint8_t byteArray[], const size_t length);
 
 // Produce a SHA-256 hash of the given RP ID.
@@ -64,6 +68,12 @@ WEBCORE_EXPORT cbor::CBORValue::MapValue buildUserEntityMap(const Vector<uint8_t
 
 // encodeRawPublicKey takes X & Y and returns them as a 0x04 || X || Y byte array.
 WEBCORE_EXPORT Vector<uint8_t> encodeRawPublicKey(const Vector<uint8_t>& X, const Vector<uint8_t>& Y);
+
+WEBCORE_EXPORT String toString(AuthenticatorAttachment);
+
+WEBCORE_EXPORT String toString(UserVerificationRequirement);
+
+WEBCORE_EXPORT String toString(ResidentKeyRequirement);
 } // namespace WebCore
 
 #endif // ENABLE(WEB_AUTHN)

--- a/Source/WebCore/Modules/webauthn/fido/DeviceRequestConverter.cpp
+++ b/Source/WebCore/Modules/webauthn/fido/DeviceRequestConverter.cpp
@@ -118,16 +118,16 @@ Vector<uint8_t> encodeMakeCredentialRequestAsCBOR(const Vector<uint8_t>& hash, c
     CBORValue::MapValue optionMap;
     if (options.authenticatorSelection) {
         // Resident keys are not supported by default.
-        if (options.authenticatorSelection->residentKey) {
-            if (*options.authenticatorSelection->residentKey == ResidentKeyRequirement::Required
-                || (*options.authenticatorSelection->residentKey == ResidentKeyRequirement::Preferred && residentKeyAvailability == AuthenticatorSupportedOptions::ResidentKeyAvailability::kSupported))
+        if (options.authenticatorSelection->residentKey()) {
+            if (*options.authenticatorSelection->residentKey() == ResidentKeyRequirement::Required
+                || (*options.authenticatorSelection->residentKey() == ResidentKeyRequirement::Preferred && residentKeyAvailability == AuthenticatorSupportedOptions::ResidentKeyAvailability::kSupported))
                 optionMap[CBORValue(kResidentKeyMapKey)] = CBORValue(true);
         } else if (options.authenticatorSelection->requireResidentKey)
             optionMap[CBORValue(kResidentKeyMapKey)] = CBORValue(true);
 
         // User verification is not required by default.
         bool requireUserVerification = false;
-        switch (options.authenticatorSelection->userVerification) {
+        switch (options.authenticatorSelection->userVerification()) {
         case UserVerificationRequirement::Required:
         case UserVerificationRequirement::Preferred:
             requireUserVerification = uvCapability == UVAvailability::kSupportedAndConfigured;
@@ -189,7 +189,7 @@ Vector<uint8_t> encodeGetAssertionRequestAsCBOR(const Vector<uint8_t>& hash, con
     CBORValue::MapValue optionMap;
     // User verification is not required by default.
     bool requireUserVerification = false;
-    switch (options.userVerification) {
+    switch (options.userVerification()) {
     case UserVerificationRequirement::Required:
     case UserVerificationRequirement::Preferred:
         requireUserVerification = uvCapability == UVAvailability::kSupportedAndConfigured;

--- a/Source/WebCore/Modules/webauthn/fido/U2fCommandConstructor.cpp
+++ b/Source/WebCore/Modules/webauthn/fido/U2fCommandConstructor.cpp
@@ -85,7 +85,7 @@ static std::optional<Vector<uint8_t>> constructU2fSignCommand(const Vector<uint8
 
 bool isConvertibleToU2fRegisterCommand(const PublicKeyCredentialCreationOptions& request)
 {
-    if (request.authenticatorSelection && (request.authenticatorSelection->userVerification == UserVerificationRequirement::Required || request.authenticatorSelection->requireResidentKey))
+    if (request.authenticatorSelection && (request.authenticatorSelection->userVerification() == UserVerificationRequirement::Required || request.authenticatorSelection->requireResidentKey))
         return false;
     if (request.pubKeyCredParams.findIf([](auto& item) { return item.alg == COSE::ES256; }) == notFound)
         return false;
@@ -94,7 +94,7 @@ bool isConvertibleToU2fRegisterCommand(const PublicKeyCredentialCreationOptions&
 
 bool isConvertibleToU2fSignCommand(const PublicKeyCredentialRequestOptions& request)
 {
-    return (request.userVerification != UserVerificationRequirement::Required) && !request.allowCredentials.isEmpty();
+    return (request.userVerification() != UserVerificationRequirement::Required) && !request.allowCredentials.isEmpty();
 }
 
 std::optional<Vector<uint8_t>> convertToU2fRegisterCommand(const Vector<uint8_t>& clientDataHash, const PublicKeyCredentialCreationOptions& request)

--- a/Source/WebCore/Sources.txt
+++ b/Source/WebCore/Sources.txt
@@ -381,7 +381,10 @@ Modules/webauthn/AuthenticatorAssertionResponse.cpp
 Modules/webauthn/AuthenticatorAttestationResponse.cpp
 Modules/webauthn/AuthenticatorCoordinator.cpp
 Modules/webauthn/AuthenticatorResponse.cpp
+Modules/webauthn/AuthenticatorTransport.cpp
 Modules/webauthn/PublicKeyCredential.cpp
+Modules/webauthn/PublicKeyCredentialCreationOptions.cpp
+Modules/webauthn/PublicKeyCredentialRequestOptions.cpp
 Modules/webauthn/WebAuthenticationUtils.cpp
 Modules/webauthn/apdu/ApduCommand.cpp
 Modules/webauthn/apdu/ApduResponse.cpp

--- a/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
+++ b/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
@@ -1024,10 +1024,10 @@ struct WebCore::AuthenticationExtensionsClientOutputs {
 };
 
 [Nested] struct WebCore::PublicKeyCredentialCreationOptions::AuthenticatorSelectionCriteria {
-    std::optional<WebCore::AuthenticatorAttachment> authenticatorAttachment;
-    std::optional<WebCore::ResidentKeyRequirement> residentKey;
+    String authenticatorAttachmentString;
+    String residentKeyString;
     bool requireResidentKey;
-    WebCore::UserVerificationRequirement userVerification;
+    String userVerificationString;
 };
 
 [Nested] struct WebCore::PublicKeyCredentialCreationOptions::Entity {
@@ -1047,7 +1047,7 @@ struct WebCore::AuthenticationExtensionsClientOutputs {
 struct WebCore::PublicKeyCredentialDescriptor {
     WebCore::PublicKeyCredentialType type;
     WebCore::BufferSource id;
-    Vector<WebCore::AuthenticatorTransport> transports;
+    Vector<String> transports;
 };
 #endif // ENABLE(WEB_AUTHN)
 
@@ -1071,7 +1071,7 @@ struct WebCore::PublicKeyCredentialCreationOptions {
     std::optional<unsigned> timeout;
     Vector<WebCore::PublicKeyCredentialDescriptor> excludeCredentials;
     std::optional<WebCore::PublicKeyCredentialCreationOptions::AuthenticatorSelectionCriteria> authenticatorSelection;
-    WebCore::AttestationConveyancePreference attestation;
+    String attestationString;
     std::optional<WebCore::AuthenticationExtensionsClientInputs> extensions;
 #endif // ENABLE(WEB_AUTHN)
 };
@@ -1082,9 +1082,9 @@ struct WebCore::PublicKeyCredentialRequestOptions {
     std::optional<unsigned> timeout;
     String rpId;
     Vector<WebCore::PublicKeyCredentialDescriptor> allowCredentials;
-    WebCore::UserVerificationRequirement userVerification;
+    String userVerificationString;
     std::optional<WebCore::AuthenticationExtensionsClientInputs> extensions;
-    [NotSerialized] std::optional<WebCore::AuthenticatorAttachment> authenticatorAttachment;
+    String authenticatorAttachmentString;
 #endif // ENABLE(WEB_AUTHN)
 };
 

--- a/Source/WebKit/UIProcess/WebAuthentication/Cocoa/WebAuthenticatorCoordinatorProxy.mm
+++ b/Source/WebKit/UIProcess/WebAuthentication/Cocoa/WebAuthenticatorCoordinatorProxy.mm
@@ -147,9 +147,12 @@ static inline RetainPtr<ASCPublicKeyCredentialDescriptor> toASCDescriptor(Public
     if (transportCount) {
         transports = adoptNS([[NSMutableArray alloc] initWithCapacity:transportCount]);
 
-        for (AuthenticatorTransport transport : descriptor.transports) {
+        for (auto unparsedTransport : descriptor.transports) {
+            auto transport = toAuthenticatorTransport(unparsedTransport);
+            if (!transport)
+                continue;
             NSString *transportString = nil;
-            switch (transport) {
+            switch (*transport) {
             case AuthenticatorTransport::Usb:
                 transportString = @"usb";
                 break;
@@ -222,16 +225,16 @@ static RetainPtr<ASCCredentialRequestContext> configureRegistrationRequestContex
     std::optional<ResidentKeyRequirement> residentKeyRequirement;
     std::optional<PublicKeyCredentialCreationOptions::AuthenticatorSelectionCriteria> authenticatorSelection = options.authenticatorSelection;
     if (authenticatorSelection) {
-        std::optional<AuthenticatorAttachment> attachment = authenticatorSelection->authenticatorAttachment;
+        std::optional<AuthenticatorAttachment> attachment = authenticatorSelection->authenticatorAttachment();
         if (attachment == AuthenticatorAttachment::Platform)
             requestTypes = ASCCredentialRequestTypePlatformPublicKeyRegistration;
         else if (attachment == AuthenticatorAttachment::CrossPlatform)
             requestTypes = ASCCredentialRequestTypeSecurityKeyPublicKeyRegistration;
 
-        userVerification = toNSString(authenticatorSelection->userVerification);
+        userVerification = toNSString(authenticatorSelection->userVerification());
 
         shouldRequireResidentKey = authenticatorSelection->requireResidentKey;
-        residentKeyRequirement = authenticatorSelection->residentKey;
+        residentKeyRequirement = authenticatorSelection->residentKey();
     }
     if (!LocalService::isAvailable())
         requestTypes &= ~ASCCredentialRequestTypePlatformPublicKeyRegistration;
@@ -256,7 +259,7 @@ static RetainPtr<ASCCredentialRequestContext> configureRegistrationRequestContex
         [credentialCreationOptions setResidentKeyPreference:toASCResidentKeyPreference(residentKeyRequirement, shouldRequireResidentKey)];
     else
         [credentialCreationOptions setShouldRequireResidentKey:shouldRequireResidentKey];
-    [credentialCreationOptions setAttestationPreference:toNSString(options.attestation).get()];
+    [credentialCreationOptions setAttestationPreference:toNSString(options.attestation()).get()];
 
     RetainPtr<NSMutableArray<NSNumber *>> supportedAlgorithmIdentifiers = adoptNS([[NSMutableArray alloc] initWithCapacity:options.pubKeyCredParams.size()]);
     for (PublicKeyCredentialCreationOptions::Parameters algorithmParameter : options.pubKeyCredParams)
@@ -323,13 +326,13 @@ static RetainPtr<ASCCredentialRequestContext> configurationAssertionRequestConte
     ASCCredentialRequestTypes requestTypes = ASCCredentialRequestTypePlatformPublicKeyAssertion | ASCCredentialRequestTypeSecurityKeyPublicKeyAssertion;
 
     RetainPtr<NSString> userVerification;
-    std::optional<AuthenticatorAttachment> attachment = options.authenticatorAttachment;
+    std::optional<AuthenticatorAttachment> attachment = options.authenticatorAttachment();
     if (attachment == AuthenticatorAttachment::Platform)
         requestTypes = ASCCredentialRequestTypePlatformPublicKeyAssertion;
     else if (attachment == AuthenticatorAttachment::CrossPlatform)
         requestTypes = ASCCredentialRequestTypeSecurityKeyPublicKeyAssertion;
 
-    userVerification = toNSString(options.userVerification);
+    userVerification = toNSString(options.userVerification());
 
     size_t allowedCredentialCount = options.allowCredentials.size();
     RetainPtr<NSMutableArray<ASCPublicKeyCredentialDescriptor *>> allowedCredentials;

--- a/Source/WebKit/UIProcess/WebAuthentication/WebAuthenticationRequestData.cpp
+++ b/Source/WebKit/UIProcess/WebAuthentication/WebAuthenticationRequestData.cpp
@@ -44,11 +44,11 @@ UserVerificationRequirement getUserVerificationRequirement(const std::variant<Pu
 {
     if (std::holds_alternative<PublicKeyCredentialCreationOptions>(options)) {
         if (auto authenticatorSelection = std::get<PublicKeyCredentialCreationOptions>(options).authenticatorSelection)
-            return authenticatorSelection->userVerification;
+            return authenticatorSelection->userVerification();
         return UserVerificationRequirement::Preferred;
     }
 
-    return std::get<PublicKeyCredentialRequestOptions>(options).userVerification;
+    return std::get<PublicKeyCredentialRequestOptions>(options).userVerification();
 }
 
 } // namespace WebKit

--- a/Source/WebKit/UIProcess/WebAuthentication/fido/CtapAuthenticator.cpp
+++ b/Source/WebKit/UIProcess/WebAuthentication/fido/CtapAuthenticator.cpp
@@ -98,7 +98,7 @@ void CtapAuthenticator::makeCredential()
     auto residentKeyAvailability = m_info.options().residentKeyAvailability();
     Vector<String> authenticatorSupportedExtensions;
     // If UV is required, then either built-in uv or a pin will work.
-    if (internalUVAvailability == UVAvailability::kSupportedAndConfigured && (!options.authenticatorSelection || options.authenticatorSelection->userVerification != UserVerificationRequirement::Discouraged) && m_pinAuth.isEmpty())
+    if (internalUVAvailability == UVAvailability::kSupportedAndConfigured && (!options.authenticatorSelection || options.authenticatorSelection->userVerification() != UserVerificationRequirement::Discouraged) && m_pinAuth.isEmpty())
         cborCmd = encodeMakeCredentialRequestAsCBOR(requestData().hash, options, internalUVAvailability, residentKeyAvailability, authenticatorSupportedExtensions);
     else if (m_info.options().clientPinAvailability() == AuthenticatorSupportedOptions::ClientPinAvailability::kSupportedAndPinSet)
         cborCmd = encodeMakeCredentialRequestAsCBOR(requestData().hash, options, internalUVAvailability, residentKeyAvailability, authenticatorSupportedExtensions, PinParameters { pin::kProtocolVersion, m_pinAuth });
@@ -114,7 +114,7 @@ void CtapAuthenticator::makeCredential()
 
 void CtapAuthenticator::continueMakeCredentialAfterResponseReceived(Vector<uint8_t>&& data)
 {
-    auto response = readCTAPMakeCredentialResponse(data, AuthenticatorAttachment::CrossPlatform, transports(), std::get<PublicKeyCredentialCreationOptions>(requestData().options).attestation);
+    auto response = readCTAPMakeCredentialResponse(data, AuthenticatorAttachment::CrossPlatform, transports(), std::get<PublicKeyCredentialCreationOptions>(requestData().options).attestation());
     if (!response) {
         auto error = getResponseCode(data);
 
@@ -143,7 +143,7 @@ void CtapAuthenticator::continueMakeCredentialAfterResponseReceived(Vector<uint8
         auto extensionOutputs = response->extensions();
         
         auto rkSupported = m_info.options().residentKeyAvailability() == AuthenticatorSupportedOptions::ResidentKeyAvailability::kSupported;
-        auto rkRequested = options.authenticatorSelection && ((options.authenticatorSelection->residentKey && options.authenticatorSelection->residentKey != ResidentKeyRequirement::Discouraged) || options.authenticatorSelection->requireResidentKey);
+        auto rkRequested = options.authenticatorSelection && ((options.authenticatorSelection->residentKey() && options.authenticatorSelection->residentKey() != ResidentKeyRequirement::Discouraged) || options.authenticatorSelection->requireResidentKey);
         extensionOutputs.credProps = AuthenticationExtensionsClientOutputs::CredentialPropertiesOutput { rkSupported && rkRequested };
         response->setExtensions(WTFMove(extensionOutputs));
     }
@@ -158,9 +158,9 @@ void CtapAuthenticator::getAssertion()
     auto internalUVAvailability = m_info.options().userVerificationAvailability();
     Vector<String> authenticatorSupportedExtensions;
     // If UV is required, then either built-in uv or a pin will work.
-    if (internalUVAvailability == UVAvailability::kSupportedAndConfigured && options.userVerification != UserVerificationRequirement::Discouraged && m_pinAuth.isEmpty())
+    if (internalUVAvailability == UVAvailability::kSupportedAndConfigured && options.userVerification() != UserVerificationRequirement::Discouraged && m_pinAuth.isEmpty())
         cborCmd = encodeGetAssertionRequestAsCBOR(requestData().hash, options, internalUVAvailability, authenticatorSupportedExtensions);
-    else if (m_info.options().clientPinAvailability() == AuthenticatorSupportedOptions::ClientPinAvailability::kSupportedAndPinSet && options.userVerification != UserVerificationRequirement::Discouraged)
+    else if (m_info.options().clientPinAvailability() == AuthenticatorSupportedOptions::ClientPinAvailability::kSupportedAndPinSet && options.userVerification() != UserVerificationRequirement::Discouraged)
         cborCmd = encodeGetAssertionRequestAsCBOR(requestData().hash, options, internalUVAvailability, authenticatorSupportedExtensions, PinParameters { pin::kProtocolVersion, m_pinAuth });
     else
         cborCmd = encodeGetAssertionRequestAsCBOR(requestData().hash, options, internalUVAvailability, authenticatorSupportedExtensions);

--- a/Source/WebKit/UIProcess/WebAuthentication/fido/U2fAuthenticator.cpp
+++ b/Source/WebKit/UIProcess/WebAuthentication/fido/U2fAuthenticator.cpp
@@ -158,7 +158,7 @@ void U2fAuthenticator::continueRegisterCommandAfterResponseReceived(ApduResponse
     case ApduResponse::Status::SW_NO_ERROR: {
         auto& options = std::get<PublicKeyCredentialCreationOptions>(requestData().options);
         ASSERT(options.rp.id);
-        auto response = readU2fRegisterResponse(*options.rp.id, apduResponse.data(), AuthenticatorAttachment::CrossPlatform, { driver().transport() }, options.attestation);
+        auto response = readU2fRegisterResponse(*options.rp.id, apduResponse.data(), AuthenticatorAttachment::CrossPlatform, { driver().transport() }, options.attestation());
         if (!response) {
             receiveRespond(ExceptionData { UnknownError, "Couldn't parse the U2F register response."_s });
             return;

--- a/Tools/TestWebKitAPI/Tests/WebCore/CtapRequestTest.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebCore/CtapRequestTest.cpp
@@ -60,9 +60,9 @@ TEST(CTAPRequestTest, TestConstructMakeCredentialRequestParam)
     user.displayName = "John P. Smith"_s;
 
     Vector<PublicKeyCredentialCreationOptions::Parameters> params { { PublicKeyCredentialType::PublicKey, 7 }, { PublicKeyCredentialType::PublicKey, 257 } };
-    PublicKeyCredentialCreationOptions::AuthenticatorSelectionCriteria selection { AuthenticatorAttachment::Platform, std::nullopt, true, UserVerificationRequirement::Preferred };
+    PublicKeyCredentialCreationOptions::AuthenticatorSelectionCriteria selection { "platform"_s, nullString(), true, "preferred"_s };
 
-    PublicKeyCredentialCreationOptions options { rp, user, { }, params, std::nullopt, { }, selection, AttestationConveyancePreference::None, std::nullopt };
+    PublicKeyCredentialCreationOptions options { rp, user, { }, params, std::nullopt, { }, selection, "none"_s, std::nullopt };
     Vector<uint8_t> hash;
     Vector<String> extensions;
     hash.append(TestData::kClientDataHash, sizeof(TestData::kClientDataHash));
@@ -84,9 +84,9 @@ TEST(CTAPRequestTest, TestConstructMakeCredentialRequestParamNoUVNoRK)
     user.displayName = "John P. Smith"_s;
 
     Vector<PublicKeyCredentialCreationOptions::Parameters> params { { PublicKeyCredentialType::PublicKey, 7 }, { PublicKeyCredentialType::PublicKey, 257 } };
-    PublicKeyCredentialCreationOptions::AuthenticatorSelectionCriteria selection { AuthenticatorAttachment::Platform, std::nullopt, false, UserVerificationRequirement::Discouraged };
+    PublicKeyCredentialCreationOptions::AuthenticatorSelectionCriteria selection { "platform"_s, nullString(), false, "discouraged"_s };
 
-    PublicKeyCredentialCreationOptions options { rp, user, { }, params, std::nullopt, { }, selection, AttestationConveyancePreference::None, std::nullopt };
+    PublicKeyCredentialCreationOptions options { rp, user, { }, params, std::nullopt, { }, selection, "none"_s, std::nullopt };
     Vector<uint8_t> hash;
     Vector<String> extensions;
     hash.append(TestData::kClientDataHash, sizeof(TestData::kClientDataHash));
@@ -108,9 +108,9 @@ TEST(CTAPRequestTest, TestConstructMakeCredentialRequestParamUVRequiredButNotSup
     user.displayName = "John P. Smith"_s;
 
     Vector<PublicKeyCredentialCreationOptions::Parameters> params { { PublicKeyCredentialType::PublicKey, 7 }, { PublicKeyCredentialType::PublicKey, 257 } };
-    PublicKeyCredentialCreationOptions::AuthenticatorSelectionCriteria selection { AuthenticatorAttachment::Platform, std::nullopt, false, UserVerificationRequirement::Required };
+    PublicKeyCredentialCreationOptions::AuthenticatorSelectionCriteria selection { "platform"_s, nullString(), false, "required"_s };
 
-    PublicKeyCredentialCreationOptions options { rp, user, { }, params, std::nullopt, { }, selection, AttestationConveyancePreference::None, std::nullopt };
+    PublicKeyCredentialCreationOptions options { rp, user, { }, params, std::nullopt, { }, selection, "none"_s, std::nullopt };
     Vector<uint8_t> hash;
     Vector<String> extensions;
     hash.append(TestData::kClientDataHash, sizeof(TestData::kClientDataHash));
@@ -132,13 +132,13 @@ TEST(CTAPRequestTest, TestConstructMakeCredentialRequestParamWithPin)
     user.displayName = "John P. Smith"_s;
 
     Vector<PublicKeyCredentialCreationOptions::Parameters> params { { PublicKeyCredentialType::PublicKey, 7 }, { PublicKeyCredentialType::PublicKey, 257 } };
-    PublicKeyCredentialCreationOptions::AuthenticatorSelectionCriteria selection { AuthenticatorAttachment::Platform, std::nullopt, true, UserVerificationRequirement::Preferred };
+    PublicKeyCredentialCreationOptions::AuthenticatorSelectionCriteria selection { "platform"_s, nullString(), true, "preferred"_s };
 
     PinParameters pin;
     pin.protocol = pin::kProtocolVersion;
     pin.auth.append(TestData::kCtap2PinAuth, sizeof(TestData::kCtap2PinAuth));
 
-    PublicKeyCredentialCreationOptions options { rp, user, { }, params, std::nullopt, { }, selection, AttestationConveyancePreference::None, std::nullopt };
+    PublicKeyCredentialCreationOptions options { rp, user, { }, params, std::nullopt, { }, selection, "none"_s, std::nullopt };
     Vector<uint8_t> hash;
     Vector<String> extensions;
     hash.append(TestData::kClientDataHash, sizeof(TestData::kClientDataHash));
@@ -160,13 +160,13 @@ TEST(CTAPRequestTest, TestConstructMakeCredentialRequestRKPreferred)
     user.displayName = "John P. Smith"_s;
 
     Vector<PublicKeyCredentialCreationOptions::Parameters> params { { PublicKeyCredentialType::PublicKey, 7 }, { PublicKeyCredentialType::PublicKey, 257 } };
-    PublicKeyCredentialCreationOptions::AuthenticatorSelectionCriteria selection { AuthenticatorAttachment::Platform, ResidentKeyRequirement::Preferred, true, UserVerificationRequirement::Preferred };
+    PublicKeyCredentialCreationOptions::AuthenticatorSelectionCriteria selection { "platform"_s, "preferred"_s, true, "preferred"_s };
 
     PinParameters pin;
     pin.protocol = pin::kProtocolVersion;
     pin.auth.append(TestData::kCtap2PinAuth, sizeof(TestData::kCtap2PinAuth));
 
-    PublicKeyCredentialCreationOptions options { rp, user, { }, params, std::nullopt, { }, selection, AttestationConveyancePreference::None, std::nullopt };
+    PublicKeyCredentialCreationOptions options { rp, user, { }, params, std::nullopt, { }, selection, "none"_s, std::nullopt };
     Vector<uint8_t> hash;
     Vector<String> extensions;
     hash.append(TestData::kClientDataHash, sizeof(TestData::kClientDataHash));
@@ -188,9 +188,9 @@ TEST(CTAPRequestTest, TestConstructMakeCredentialRequestRKPreferredNotSupported)
     user.displayName = "John P. Smith"_s;
 
     Vector<PublicKeyCredentialCreationOptions::Parameters> params { { PublicKeyCredentialType::PublicKey, 7 }, { PublicKeyCredentialType::PublicKey, 257 } };
-    PublicKeyCredentialCreationOptions::AuthenticatorSelectionCriteria selection { AuthenticatorAttachment::Platform, ResidentKeyRequirement::Preferred, true, UserVerificationRequirement::Required };
+    PublicKeyCredentialCreationOptions::AuthenticatorSelectionCriteria selection { "platform"_s, "preferred"_s, true, "required"_s };
 
-    PublicKeyCredentialCreationOptions options { rp, user, { }, params, std::nullopt, { }, selection, AttestationConveyancePreference::None, std::nullopt };
+    PublicKeyCredentialCreationOptions options { rp, user, { }, params, std::nullopt, { }, selection, "none"_s, std::nullopt };
     Vector<uint8_t> hash;
     Vector<String> extensions;
     hash.append(TestData::kClientDataHash, sizeof(TestData::kClientDataHash));
@@ -212,9 +212,9 @@ TEST(CTAPRequestTest, TestConstructMakeCredentialRequestRKDiscouraged)
     user.displayName = "John P. Smith"_s;
 
     Vector<PublicKeyCredentialCreationOptions::Parameters> params { { PublicKeyCredentialType::PublicKey, 7 }, { PublicKeyCredentialType::PublicKey, 257 } };
-    PublicKeyCredentialCreationOptions::AuthenticatorSelectionCriteria selection { AuthenticatorAttachment::Platform, ResidentKeyRequirement::Discouraged, true, UserVerificationRequirement::Required };
+    PublicKeyCredentialCreationOptions::AuthenticatorSelectionCriteria selection { "platform"_s, "discouraged"_s, true, "required"_s };
 
-    PublicKeyCredentialCreationOptions options { rp, user, { }, params, std::nullopt, { }, selection, AttestationConveyancePreference::None, std::nullopt };
+    PublicKeyCredentialCreationOptions options { rp, user, { }, params, std::nullopt, { }, selection, "none"_s, std::nullopt };
     Vector<uint8_t> hash;
     Vector<String> extensions;
     hash.append(TestData::kClientDataHash, sizeof(TestData::kClientDataHash));
@@ -236,14 +236,14 @@ TEST(CTAPRequestTest, TestConstructMakeCredentialRequestWithLargeBlob)
     user.displayName = "John P. Smith"_s;
 
     Vector<PublicKeyCredentialCreationOptions::Parameters> params { { PublicKeyCredentialType::PublicKey, 7 }, { PublicKeyCredentialType::PublicKey, 257 } };
-    PublicKeyCredentialCreationOptions::AuthenticatorSelectionCriteria selection { AuthenticatorAttachment::Platform, std::nullopt, false, UserVerificationRequirement::Discouraged };
+    PublicKeyCredentialCreationOptions::AuthenticatorSelectionCriteria selection { "platform"_s, nullString(), false, "discouraged"_s };
     AuthenticationExtensionsClientInputs extensionInputs = {
         .largeBlob = AuthenticationExtensionsClientInputs::LargeBlobInputs {
             .support = "required"_s
         }
     };
 
-    PublicKeyCredentialCreationOptions options { rp, user, { }, params, std::nullopt, { }, selection, AttestationConveyancePreference::None, extensionInputs };
+    PublicKeyCredentialCreationOptions options { rp, user, { }, params, std::nullopt, { }, selection, "none"_s, extensionInputs };
     Vector<uint8_t> hash;
     Vector<String> extensions = { "largeBlob"_s };
     hash.append(TestData::kClientDataHash, sizeof(TestData::kClientDataHash));
@@ -265,14 +265,14 @@ TEST(CTAPRequestTest, TestConstructMakeCredentialRequestWithUnsupportedLargeBlob
     user.displayName = "John P. Smith"_s;
 
     Vector<PublicKeyCredentialCreationOptions::Parameters> params { { PublicKeyCredentialType::PublicKey, 7 }, { PublicKeyCredentialType::PublicKey, 257 } };
-    PublicKeyCredentialCreationOptions::AuthenticatorSelectionCriteria selection { AuthenticatorAttachment::Platform, std::nullopt, false, UserVerificationRequirement::Discouraged };
+    PublicKeyCredentialCreationOptions::AuthenticatorSelectionCriteria selection { "platform"_s, nullString(), false, "discouraged"_s };
     AuthenticationExtensionsClientInputs extensionInputs = {
         .largeBlob = AuthenticationExtensionsClientInputs::LargeBlobInputs {
             .support = "required"_s
         }
     };
 
-    PublicKeyCredentialCreationOptions options { rp, user, { }, params, std::nullopt, { }, selection, AttestationConveyancePreference::None, extensionInputs };
+    PublicKeyCredentialCreationOptions options { rp, user, { }, params, std::nullopt, { }, selection, "none"_s, extensionInputs };
     Vector<uint8_t> hash;
     Vector<String> extensions;
     hash.append(TestData::kClientDataHash, sizeof(TestData::kClientDataHash));
@@ -309,7 +309,7 @@ TEST(CTAPRequestTest, TestConstructGetAssertionRequest)
     descriptor2.id = WebCore::toBufferSource(id2, sizeof(id2));
     options.allowCredentials.append(descriptor2);
 
-    options.userVerification = UserVerificationRequirement::Required;
+    options.userVerificationString = "required"_s;
 
     Vector<uint8_t> hash;
     Vector<String> extensions;
@@ -347,7 +347,7 @@ TEST(CTAPRequestTest, TestConstructGetAssertionRequestNoUV)
     descriptor2.id = WebCore::toBufferSource(id2, sizeof(id2));
     options.allowCredentials.append(descriptor2);
 
-    options.userVerification = UserVerificationRequirement::Discouraged;
+    options.userVerificationString = "discouraged"_s;
 
     Vector<uint8_t> hash;
     Vector<String> extensions;
@@ -385,7 +385,7 @@ TEST(CTAPRequestTest, TestConstructGetAssertionRequestUVRequiredButNotSupported)
     descriptor2.id = WebCore::toBufferSource(id2, sizeof(id2));
     options.allowCredentials.append(descriptor2);
 
-    options.userVerification = UserVerificationRequirement::Required;
+    options.userVerificationString = "required"_s;
 
     Vector<uint8_t> hash;
     Vector<String> extensions;
@@ -423,7 +423,7 @@ TEST(CTAPRequestTest, TestConstructGetAssertionRequestWithPin)
     descriptor2.id = WebCore::toBufferSource(id2, sizeof(id2));
     options.allowCredentials.append(descriptor2);
 
-    options.userVerification = UserVerificationRequirement::Required;
+    options.userVerificationString = "required"_s;
 
     PinParameters pin;
     pin.protocol = pin::kProtocolVersion;
@@ -489,7 +489,7 @@ TEST(CTAPRequestTest, TestConstructGetAssertionRequestLargeBlobRead)
         }
     };
 
-    options.userVerification = UserVerificationRequirement::Required;
+    options.userVerificationString = "required"_s;
 
     Vector<uint8_t> hash;
     Vector<String> extensions = { "largeBlob"_s };
@@ -532,7 +532,7 @@ TEST(CTAPRequestTest, TestConstructGetAssertionRequestUnsupportedLargeBlobRead)
         }
     };
 
-    options.userVerification = UserVerificationRequirement::Required;
+    options.userVerificationString = "required"_s;
 
     Vector<uint8_t> hash;
     Vector<String> extensions;
@@ -579,7 +579,7 @@ TEST(CTAPRequestTest, TestConstructGetAssertionRequestLargeBlobWrite)
         }
     };
 
-    options.userVerification = UserVerificationRequirement::Required;
+    options.userVerificationString = "required"_s;
 
     Vector<uint8_t> hash;
     Vector<String> extensions;

--- a/Tools/TestWebKitAPI/Tests/WebCore/U2fCommandConstructorTest.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebCore/U2fCommandConstructorTest.cpp
@@ -147,7 +147,7 @@ TEST(U2fCommandConstructorTest, TestU2fRegisterUserVerificationRequirement)
 {
     auto makeCredentialParam = constructMakeCredentialRequest();
     PublicKeyCredentialCreationOptions::AuthenticatorSelectionCriteria selection;
-    selection.userVerification = UserVerificationRequirement::Required;
+    selection.userVerificationString = "required"_s;
     makeCredentialParam.authenticatorSelection = WTFMove(selection);
 
     EXPECT_FALSE(isConvertibleToU2fRegisterCommand(makeCredentialParam));
@@ -215,7 +215,7 @@ TEST(U2fCommandConstructorTest, TestU2fSignUserVerificationRequirement)
     Vector<PublicKeyCredentialDescriptor> allowedList;
     allowedList.append(WTFMove(credentialDescriptor));
     getAssertionReq.allowCredentials = WTFMove(allowedList);
-    getAssertionReq.userVerification = UserVerificationRequirement::Required;
+    getAssertionReq.userVerificationString = "required"_s;
 
     EXPECT_FALSE(isConvertibleToU2fSignCommand(getAssertionReq));
 }

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/_WKWebAuthenticationPanel.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/_WKWebAuthenticationPanel.mm
@@ -1510,7 +1510,7 @@ TEST(WebAuthenticationPanel, PublicKeyCredentialCreationOptionsMinimum)
     EXPECT_EQ(result.timeout, std::nullopt);
     EXPECT_EQ(result.excludeCredentials.size(), 0lu);
     EXPECT_EQ(result.authenticatorSelection, std::nullopt);
-    EXPECT_EQ(result.attestation, AttestationConveyancePreference::None);
+    EXPECT_EQ(result.attestation(), AttestationConveyancePreference::None);
     EXPECT_TRUE(result.extensions->appid.isNull());
 }
 
@@ -1559,11 +1559,11 @@ TEST(WebAuthenticationPanel, PublicKeyCredentialCreationOptionsMaximumDefault)
     EXPECT_EQ(result.excludeCredentials[0].id.length(), sizeof(identifier));
     EXPECT_EQ(memcmp(result.excludeCredentials[0].id.data(), identifier, sizeof(identifier)), 0);
 
-    EXPECT_EQ(result.authenticatorSelection->authenticatorAttachment, std::nullopt);
+    EXPECT_EQ(result.authenticatorSelection->authenticatorAttachment(), std::nullopt);
     EXPECT_EQ(result.authenticatorSelection->requireResidentKey, false);
-    EXPECT_EQ(result.authenticatorSelection->userVerification, UserVerificationRequirement::Preferred);
+    EXPECT_EQ(result.authenticatorSelection->userVerification(), UserVerificationRequirement::Preferred);
 
-    EXPECT_EQ(result.attestation, AttestationConveyancePreference::None);
+    EXPECT_EQ(result.attestation(), AttestationConveyancePreference::None);
     EXPECT_TRUE(result.extensions->appid.isNull());
 }
 
@@ -1627,16 +1627,16 @@ TEST(WebAuthenticationPanel, PublicKeyCredentialCreationOptionsMaximum1)
     EXPECT_EQ(result.excludeCredentials[0].id.length(), sizeof(identifier));
     EXPECT_EQ(memcmp(result.excludeCredentials[0].id.data(), identifier, sizeof(identifier)), 0);
     EXPECT_EQ(result.excludeCredentials[0].transports.size(), 4lu);
-    EXPECT_EQ(result.excludeCredentials[0].transports[0], AuthenticatorTransport::Usb);
-    EXPECT_EQ(result.excludeCredentials[0].transports[1], AuthenticatorTransport::Nfc);
-    EXPECT_EQ(result.excludeCredentials[0].transports[2], AuthenticatorTransport::Internal);
-    EXPECT_EQ(result.excludeCredentials[0].transports[3], AuthenticatorTransport::Hybrid);
+    EXPECT_EQ(*toAuthenticatorTransport(result.excludeCredentials[0].transports[0]), AuthenticatorTransport::Usb);
+    EXPECT_EQ(*toAuthenticatorTransport(result.excludeCredentials[0].transports[1]), AuthenticatorTransport::Nfc);
+    EXPECT_EQ(*toAuthenticatorTransport(result.excludeCredentials[0].transports[2]), AuthenticatorTransport::Internal);
+    EXPECT_EQ(*toAuthenticatorTransport(result.excludeCredentials[0].transports[3]), AuthenticatorTransport::Hybrid);
 
-    EXPECT_EQ(result.authenticatorSelection->authenticatorAttachment, AuthenticatorAttachment::Platform);
+    EXPECT_EQ(result.authenticatorSelection->authenticatorAttachment(), AuthenticatorAttachment::Platform);
     EXPECT_EQ(result.authenticatorSelection->requireResidentKey, true);
-    EXPECT_EQ(result.authenticatorSelection->userVerification, UserVerificationRequirement::Required);
+    EXPECT_EQ(result.authenticatorSelection->userVerification(), UserVerificationRequirement::Required);
 
-    EXPECT_EQ(result.attestation, AttestationConveyancePreference::Direct);
+    EXPECT_EQ(result.attestation(), AttestationConveyancePreference::Direct);
 }
 
 TEST(WebAuthenticationPanel, PublicKeyCredentialCreationOptionsMaximum2)
@@ -1698,15 +1698,15 @@ TEST(WebAuthenticationPanel, PublicKeyCredentialCreationOptionsMaximum2)
     EXPECT_EQ(result.excludeCredentials[0].id.length(), sizeof(identifier));
     EXPECT_EQ(memcmp(result.excludeCredentials[0].id.data(), identifier, sizeof(identifier)), 0);
     EXPECT_EQ(result.excludeCredentials[0].transports.size(), 3lu);
-    EXPECT_EQ(result.excludeCredentials[0].transports[0], AuthenticatorTransport::Usb);
-    EXPECT_EQ(result.excludeCredentials[0].transports[1], AuthenticatorTransport::Nfc);
-    EXPECT_EQ(result.excludeCredentials[0].transports[2], AuthenticatorTransport::Internal);
+    EXPECT_EQ(*toAuthenticatorTransport(result.excludeCredentials[0].transports[0]), AuthenticatorTransport::Usb);
+    EXPECT_EQ(*toAuthenticatorTransport(result.excludeCredentials[0].transports[1]), AuthenticatorTransport::Nfc);
+    EXPECT_EQ(*toAuthenticatorTransport(result.excludeCredentials[0].transports[2]), AuthenticatorTransport::Internal);
 
-    EXPECT_EQ(result.authenticatorSelection->authenticatorAttachment, AuthenticatorAttachment::CrossPlatform);
+    EXPECT_EQ(result.authenticatorSelection->authenticatorAttachment(), AuthenticatorAttachment::CrossPlatform);
     EXPECT_EQ(result.authenticatorSelection->requireResidentKey, true);
-    EXPECT_EQ(result.authenticatorSelection->userVerification, UserVerificationRequirement::Discouraged);
+    EXPECT_EQ(result.authenticatorSelection->userVerification(), UserVerificationRequirement::Discouraged);
 
-    EXPECT_EQ(result.attestation, AttestationConveyancePreference::Indirect);
+    EXPECT_EQ(result.attestation(), AttestationConveyancePreference::Indirect);
 }
 
 TEST(WebAuthenticationPanel, MakeCredentialSPITimeout)
@@ -1856,7 +1856,7 @@ TEST(WebAuthenticationPanel, PublicKeyCredentialRequestOptionsMinimun)
     EXPECT_EQ(result.timeout, std::nullopt);
     EXPECT_TRUE(result.rpId.isNull());
     EXPECT_EQ(result.allowCredentials.size(), 0lu);
-    EXPECT_EQ(result.userVerification, UserVerificationRequirement::Preferred);
+    EXPECT_EQ(result.userVerification(), UserVerificationRequirement::Preferred);
     EXPECT_TRUE(result.extensions->appid.isNull());
 }
 
@@ -1881,7 +1881,7 @@ TEST(WebAuthenticationPanel, PublicKeyCredentialRequestOptionsMaximumDefault)
     EXPECT_EQ(result.allowCredentials[0].id.length(), sizeof(identifier));
     EXPECT_EQ(memcmp(result.allowCredentials[0].id.data(), identifier, sizeof(identifier)), 0);
 
-    EXPECT_EQ(result.userVerification, UserVerificationRequirement::Preferred);
+    EXPECT_EQ(result.userVerification(), UserVerificationRequirement::Preferred);
     EXPECT_TRUE(result.extensions->appid.isNull());
 }
 
@@ -1915,11 +1915,11 @@ TEST(WebAuthenticationPanel, PublicKeyCredentialRequestOptionsMaximum)
     EXPECT_EQ(result.allowCredentials[0].id.length(), sizeof(identifier));
     EXPECT_EQ(memcmp(result.allowCredentials[0].id.data(), identifier, sizeof(identifier)), 0);
     EXPECT_EQ(result.allowCredentials[0].transports.size(), 3lu);
-    EXPECT_EQ(result.allowCredentials[0].transports[0], AuthenticatorTransport::Usb);
-    EXPECT_EQ(result.allowCredentials[0].transports[1], AuthenticatorTransport::Nfc);
-    EXPECT_EQ(result.allowCredentials[0].transports[2], AuthenticatorTransport::Internal);
+    EXPECT_EQ(*toAuthenticatorTransport(result.allowCredentials[0].transports[0]), AuthenticatorTransport::Usb);
+    EXPECT_EQ(*toAuthenticatorTransport(result.allowCredentials[0].transports[1]), AuthenticatorTransport::Nfc);
+    EXPECT_EQ(*toAuthenticatorTransport(result.allowCredentials[0].transports[2]), AuthenticatorTransport::Internal);
 
-    EXPECT_EQ(result.userVerification, UserVerificationRequirement::Required);
+    EXPECT_EQ(result.userVerification(), UserVerificationRequirement::Required);
     EXPECT_WK_STREQ(result.extensions->appid, "https//www.example.com/fido");
 }
 


### PR DESCRIPTION
#### 8ed776536ce98af82d1519b821e12a628503352a
<pre>
[WebAuthn] Enums should be DOMStrings
<a href="https://bugs.webkit.org/show_bug.cgi?id=255672">https://bugs.webkit.org/show_bug.cgi?id=255672</a>
rdar://108276152

Reviewed by NOBODY (OOPS!).

WebAuthn enums should be DOMStrings instead, see the discussion on the spec [1]. If a value is not valid,
it should be treated as not present (which usually means it should be converted into the default). This
applies to AuthenticatorAttachment, ResidentKeyRequirement, UserVerificationRequirement, and AttestationConveyancePreference.
w3c/webauthn#1738

* Source/WebCore/Modules/webauthn/AttestationConveyancePreference.cpp: Added.
(WebCore::toAttestationConveyancePreference):
(WebCore::toString):
* Source/WebCore/Modules/webauthn/AttestationConveyancePreference.h:
* Source/WebCore/Modules/webauthn/AuthenticatorTransport.cpp: Copied from Source/WebCore/Modules/webauthn/PublicKeyCredentialDescriptor.h.
(WebCore::toAuthenticatorTransport):
(WebCore::toString):
* Source/WebCore/Modules/webauthn/AuthenticatorTransport.h:
* Source/WebCore/Modules/webauthn/PublicKeyCredentialCreationOptions.cpp: Added.
(WebCore::PublicKeyCredentialCreationOptions::attestation const):
(WebCore::PublicKeyCredentialCreationOptions::AuthenticatorSelectionCriteria::residentKey const):
(WebCore::PublicKeyCredentialCreationOptions::AuthenticatorSelectionCriteria::userVerification const):
(WebCore::PublicKeyCredentialCreationOptions::AuthenticatorSelectionCriteria::authenticatorAttachment const):
* Source/WebCore/Modules/webauthn/PublicKeyCredentialCreationOptions.h:
* Source/WebCore/Modules/webauthn/PublicKeyCredentialCreationOptions.idl:
* Source/WebCore/Modules/webauthn/PublicKeyCredentialDescriptor.h:
* Source/WebCore/Modules/webauthn/PublicKeyCredentialDescriptor.idl:
* Source/WebCore/Modules/webauthn/PublicKeyCredentialRequestOptions.cpp: Copied from Source/WebCore/Modules/webauthn/PublicKeyCredentialRequestOptions.h.
(WebCore::PublicKeyCredentialRequestOptions::userVerification const):
(WebCore::PublicKeyCredentialRequestOptions::authenticatorAttachment const):
* Source/WebCore/Modules/webauthn/PublicKeyCredentialRequestOptions.h:
* Source/WebCore/Modules/webauthn/PublicKeyCredentialRequestOptions.idl:
* Source/WebCore/Modules/webauthn/WebAuthenticationUtils.cpp:
(WebCore::toString):
* Source/WebCore/Modules/webauthn/WebAuthenticationUtils.h:
* Source/WebCore/Modules/webauthn/fido/DeviceRequestConverter.cpp:
(fido::encodeMakeCredentialRequestAsCBOR):
(fido::encodeGetAssertionRequestAsCBOR):
* Source/WebCore/Modules/webauthn/fido/U2fCommandConstructor.cpp:
(fido::isConvertibleToU2fRegisterCommand):
(fido::isConvertibleToU2fSignCommand):
* Source/WebCore/Sources.txt:
* Source/WebCore/WebCore.xcodeproj/project.pbxproj:
* Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in:
* Source/WebKit/UIProcess/API/Cocoa/_WKWebAuthenticationPanel.mm:
(authenticatorTransports):
(authenticatorSelectionCriteria):
(+[_WKWebAuthenticationPanel convertToCoreCreationOptionsWithOptions:]):
(+[_WKWebAuthenticationPanel convertToCoreRequestOptionsWithOptions:]):
* Source/WebKit/UIProcess/WebAuthentication/AuthenticatorManager.cpp:
(WebKit::WebCore::collectTransports):
(WebKit::AuthenticatorManager::getTransports const):
* Source/WebKit/UIProcess/WebAuthentication/Cocoa/LocalAuthenticator.mm:
(WebKit::LocalAuthenticatorInternal::emptyTransportsOrContain):
(WebKit::LocalAuthenticator::continueMakeCredentialAfterUserVerification):
(WebKit::LocalAuthenticator::continueMakeCredentialAfterAttested):
* Source/WebKit/UIProcess/WebAuthentication/Cocoa/WebAuthenticatorCoordinatorProxy.mm:
(WebKit::toASCDescriptor):
(WebKit::configureRegistrationRequestContext):
(WebKit::configurationAssertionRequestContext):
* Source/WebKit/UIProcess/WebAuthentication/WebAuthenticationRequestData.cpp:
(WebKit::getUserVerificationRequirement):
* Source/WebKit/UIProcess/WebAuthentication/fido/CtapAuthenticator.cpp:
(WebKit::CtapAuthenticator::makeCredential):
(WebKit::CtapAuthenticator::continueMakeCredentialAfterResponseReceived):
(WebKit::CtapAuthenticator::getAssertion):
* Source/WebKit/UIProcess/WebAuthentication/fido/U2fAuthenticator.cpp:
(WebKit::U2fAuthenticator::continueRegisterCommandAfterResponseReceived):
* Tools/TestWebKitAPI/Tests/WebCore/CtapRequestTest.cpp:
(TestWebKitAPI::TEST):
* Tools/TestWebKitAPI/Tests/WebCore/U2fCommandConstructorTest.cpp:
(TestWebKitAPI::TEST):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/_WKWebAuthenticationPanel.mm:
(TestWebKitAPI::TEST):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/8ed776536ce98af82d1519b821e12a628503352a

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/3908 "Failed to checkout and rebase branch from PR 12926") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/3998 "Built successfully") | [❌ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/4109 "Failed to compile WebKit") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/5344 "Built successfully") | [❌ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/4166 "Failed to checkout and rebase branch from PR 12926") 
| [❌ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/3885 "Failed to checkout and rebase branch from PR 12926") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/4081 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/3992 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/3952 "Passed tests") | 
| [❌ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/3956 "Failed to checkout and rebase branch from PR 12926") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/4149 "1 failures") | [❌ 🧪 api-mac](https://ews-build.webkit.org/#/builders/14/builds/4109 "Failed to compile WebKit") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/5202 "Built successfully") | 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/1653 "2 new passes 7 flakes 2 failures") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/14/builds/4109 "Failed to compile WebKit") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/5542 "") | 
| | [❌ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/3472 "5 api tests failed or timed out") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/14/builds/4109 "Failed to compile WebKit") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/4971 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/3961 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/3207 "13 flakes 4 failures") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/3481 "Built successfully") | [❌ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/14/builds/4109 "Failed to compile WebKit") | | 
| | [❌ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/3527 "Failed to checkout and rebase branch from PR 12926") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/3759 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->