### PR TITLE
REGRESSION (Safari 16.4): PostMessage with transfer object is broken between contexts

### DIFF
--- a/LayoutTests/fast/events/message-event-data-isolated-world-expected.txt
+++ b/LayoutTests/fast/events/message-event-data-isolated-world-expected.txt
@@ -1,0 +1,3 @@
+CONSOLE MESSAGE: Tests that MessageEvent.data works as expected from isolated worlds.
+CONSOLE MESSAGE: PASS: The isolated world was able to read the MessagePort sent via postMessage()
+

--- a/LayoutTests/fast/events/message-event-data-isolated-world.html
+++ b/LayoutTests/fast/events/message-event-data-isolated-world.html
@@ -1,0 +1,35 @@
+<!DOCTYPE html>
+<html>
+<body>
+<script>
+console.log("Tests that MessageEvent.data works as expected from isolated worlds.");
+
+if (window.testRunner) {
+    testRunner.dumpAsText();
+    testRunner.waitUntilDone();
+}
+
+testRunner.evaluateScriptInIsolatedWorld(1,
+    "window.onmessage = (ev) => {" +
+    "    if (ev.data && ev.data.port instanceof MessagePort)" +
+    "        console.log('PASS: The isolated world was able to read the MessagePort sent via postMessage()');" +
+    "    else" +
+    "        console.log('FAIL: The isolated world was not able to read the MessagePort sent via postMessage()');" +
+    "    window.onmessage = null;" +
+    "};"
+);
+
+onmessage = (ev) => {
+    if (ev.data === "DONE") {
+        if (window.testRunner)
+            testRunner.notifyDone();
+    }
+};
+
+const ch = new MessageChannel();
+const port = ch.port2;
+window.postMessage({ port }, "*", [port]);
+window.postMessage("DONE", "*");
+</script>
+</body>
+</html>

--- a/Source/WebCore/dom/MessageEvent.cpp
+++ b/Source/WebCore/dom/MessageEvent.cpp
@@ -74,9 +74,11 @@ auto MessageEvent::create(JSC::JSGlobalObject& globalObject, Ref<SerializedScrip
     JSC::Strong<JSC::Unknown> strongData(vm, deserialized);
 
     auto& eventType = didFail ? eventNames().messageerrorEvent : eventNames().messageEvent;
-    auto event = adoptRef(*new MessageEvent(eventType, MessageEvent::JSValueTag { }, origin, lastEventId, WTFMove(source), WTFMove(ports)));
+    auto event = adoptRef(*new MessageEvent(eventType, WTFMove(data), origin, lastEventId, WTFMove(source), WTFMove(ports)));
     JSC::Strong<JSC::JSObject> strongWrapper(vm, JSC::jsCast<JSC::JSObject*>(toJS(&globalObject, JSC::jsCast<JSDOMGlobalObject*>(&globalObject), event.get())));
-    event->jsData().set(vm, strongWrapper.get(), deserialized);
+    // Since we've already deserialized the SerializedScriptValue, cache the result so we don't have to deserialize
+    // again the next time JSMessageEvent::data() gets called by the main world.
+    event->cachedData().set(vm, strongWrapper.get(), deserialized);
 
     return MessageEventWithStrongData { event, WTFMove(strongWrapper) };
 }


### PR DESCRIPTION
#### ca6ca7d1895d58cb5d2b54563cda04c0c7945b12
<pre>
REGRESSION (Safari 16.4): PostMessage with transfer object is broken between contexts
<a href="https://bugs.webkit.org/show_bug.cgi?id=254777">https://bugs.webkit.org/show_bug.cgi?id=254777</a>
rdar://107538083

Reviewed by Geoffrey Garen.

Before 256896@main, we would construct MessageEvents and give them a
SerializedScriptValue to store internally. Then, the deserialization of this
SerializedScriptValue would happen lazily when the JS accesses
MessageEvent.data. We would then cache the result of the deserialization
inside MessageEvent::m_cachedData to avoid repeated deserializations.
Also note that we would make sure that the cachedData&apos;s world matches the
current world before using it. We would deserialize again if the worlds
don&apos;t match.

After 256896@main, we now deserialize the SerializedScriptValue eagerly, so
that we know whether to fire a `message` event or a `messageerror` one.
This deserialization would happen in the main JS world and we would pass
the resulting JSValue to the MessageEvent to store instead of the
SerializedScriptValue. This would work fine for main worlds and regressed
isolated worlds since JSMessageEvent::data() would not have a
SerializedScriptValue to re-deserialize for isolated worlds.

To address the issue, we now construct MessageEvents with a
SerializedScriptValue, like we did before 256896@main. For performance reasons
we also store the deserialized JSValue in MessageEvent::cachedData so that
later calls to JSMessageEvent::data() don&apos;t end up deserializing the
SerializedScriptValue again if called from the main world. However, if the
call for JSMessageEvent::data() comes from an isolated world, the
implementation will properly deserialize the SerializedScriptValue again,
like it did before 256896@main.

This was tested manually on strava.com.

Test: fast/events/message-event-data-isolated-world.html

* Source/WebCore/dom/MessageEvent.cpp:
(WebCore::MessageEvent::create):

Canonical link: <a href="https://commits.webkit.org/263155@main">https://commits.webkit.org/263155@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/159c4ee34029ca05b1dbe6adad1a2391c81673d3

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/3764 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/3849 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/3957 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/5193 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/4034 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/3736 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/3927 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/3854 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/3258 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/3808 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/4021 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/3392 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/5026 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/1526 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/3364 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/3822 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/3339 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/3423 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/4802 "267 api tests failed or timed out") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/3814 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/3088 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/3341 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/3364 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/923 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/3380 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/3619 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->