### PR TITLE
Safari is not using the intended AudioSession

### DIFF
--- a/LayoutTests/media/audio-session-category-at-most-recent-playback-expected.txt
+++ b/LayoutTests/media/audio-session-category-at-most-recent-playback-expected.txt
@@ -3,14 +3,17 @@ RUN(video.muted = true)
 RUN(video.src = findMediaFile("video", "content/audio-tracks"))
 EVENT(canplaythrough)
 EXPECTED (internals.categoryAtMostRecentPlayback(video) == 'None') OK
+EXPECTED (internals.modeAtMostRecentPlayback(video) == 'Default') OK
 RUN(video.play())
 EVENT(playing)
 EXPECTED (internals.categoryAtMostRecentPlayback(video) == 'None') OK
+EXPECTED (internals.modeAtMostRecentPlayback(video) == 'Default') OK
 RUN(video.pause())
 EVENT(pause)
 RUN(video.muted = false)
 RUN(video.play())
 EVENT(playing)
 EXPECTED (internals.categoryAtMostRecentPlayback(video) == 'MediaPlayback') OK
+EXPECTED (internals.modeAtMostRecentPlayback(video) == 'MoviePlayback') OK
 END OF TEST
 

--- a/LayoutTests/media/audio-session-category-at-most-recent-playback.html
+++ b/LayoutTests/media/audio-session-category-at-most-recent-playback.html
@@ -16,12 +16,14 @@
         await waitFor(video, 'canplaythrough');
 
         testExpected('internals.categoryAtMostRecentPlayback(video)', 'None');
+        testExpected('internals.modeAtMostRecentPlayback(video)', 'Default');
 
         run('video.play()');
         await waitFor(video, 'playing');
         await sleepFor(500);
 
         testExpected('internals.categoryAtMostRecentPlayback(video)', 'None');
+        testExpected('internals.modeAtMostRecentPlayback(video)', 'Default');
 
         run('video.pause()');
         await waitFor(video, 'pause');
@@ -31,6 +33,7 @@
         await waitFor(video, 'playing');
         await sleepFor(500);
         testExpected('internals.categoryAtMostRecentPlayback(video)', 'MediaPlayback');
+        testExpected('internals.modeAtMostRecentPlayback(video)', 'MoviePlayback');
 
         endTest();
     });

--- a/LayoutTests/media/audio-session-category-expected.txt
+++ b/LayoutTests/media/audio-session-category-expected.txt
@@ -9,11 +9,13 @@ EXPECTED (internals.audioSessionCategory() == 'None') OK
 ** Check category when a muted, paused, element has loaded.
 EVENT(canplaythrough)
 EXPECTED (internals.audioSessionCategory() == 'None') OK
+EXPECTED (internals.audioSessionMode() == 'Default') OK
 
 ** Check category when a muted element is playing.
 RUN(video.play())
 EVENT(playing)
 EXPECTED (internals.audioSessionCategory() == 'None') OK
+EXPECTED (internals.audioSessionMode() == 'Default') OK
 EXPECTED (internals.routeSharingPolicy() == 'Default') OK
 
 ** Check category when an unmuted element is playing.
@@ -21,12 +23,14 @@ RUN(video.muted = false)
 EVENT(volumechange)
 
 EXPECTED (internals.audioSessionCategory() == 'MediaPlayback') OK
+EXPECTED (internals.audioSessionMode() == 'Default') OK
 EXPECTED (internals.routeSharingPolicy() == 'LongFormAudio') OK
 
 ** Mute the element, check again after 500ms.
 RUN(video.pause())
 RUN(video.muted = true)
 EXPECTED (internals.audioSessionCategory() == 'MediaPlayback') OK
+EXPECTED (internals.audioSessionMode() == 'Default') OK
 EXPECTED (internals.routeSharingPolicy() == 'LongFormAudio') OK
 
 ** And check again after 3 seconds.

--- a/LayoutTests/media/audio-session-category.html
+++ b/LayoutTests/media/audio-session-category.html
@@ -31,17 +31,20 @@
 
             await waitFor(video, 'canplaythrough');
             testExpected('internals.audioSessionCategory()', 'None');
+            testExpected('internals.audioSessionMode()', 'Default');
 
             consoleWrite('<br>** Check category when a muted element is playing.');
             runWithKeyDown(() => { run('video.play()') });
             await waitFor(video, 'playing');
             testExpected('internals.audioSessionCategory()', 'None');
+            testExpected('internals.audioSessionMode()', 'Default');
             testExpected('internals.routeSharingPolicy()', 'Default');
-            
+
             consoleWrite('<br>** Check category when an unmuted element is playing.');
             runWithKeyDown(() => { run('video.muted = false') });
             await waitFor(video, 'volumechange');
             await waitForCategory('MediaPlayback', 1, '');
+            testExpected('internals.audioSessionMode()', 'Default');
             testExpected('internals.routeSharingPolicy()', 'LongFormAudio');
 
             consoleWrite('<br>** Mute the element, check again after 500ms.');
@@ -49,6 +52,7 @@
             runWithKeyDown(() => { run('video.muted = true') });
             await sleepFor(500);
             testExpected('internals.audioSessionCategory()', 'MediaPlayback');
+            testExpected('internals.audioSessionMode()', 'Default');
             testExpected('internals.routeSharingPolicy()', 'LongFormAudio');
 
             await waitForCategory('None', 3, '<br>** And check again after 3 seconds.');

--- a/LayoutTests/media/video-audio-session-mode-expected.txt
+++ b/LayoutTests/media/video-audio-session-mode-expected.txt
@@ -1,0 +1,40 @@
+
+
+
+** <video> element test **
+
+** Check category before anything has loaded.
+EXPECTED (internals.audioSessionCategory() == 'None') OK
+
+** Check category when a muted, paused, element has loaded.
+EVENT(canplaythrough)
+EXPECTED (internals.audioSessionCategory() == 'None') OK
+EXPECTED (internals.audioSessionMode() == 'Default') OK
+
+** Check category when a muted element is playing.
+RUN(video.play())
+EVENT(playing)
+EXPECTED (internals.audioSessionCategory() == 'None') OK
+EXPECTED (internals.audioSessionMode() == 'Default') OK
+EXPECTED (internals.routeSharingPolicy() == 'Default') OK
+
+** Check category when an unmuted element is playing.
+RUN(video.muted = false)
+EVENT(volumechange)
+
+EXPECTED (internals.audioSessionCategory() == 'MediaPlayback') OK
+EXPECTED (internals.audioSessionMode() == 'MoviePlayback') OK
+EXPECTED (internals.routeSharingPolicy() == 'LongFormAudio') OK
+
+** Mute the element, check again after 500ms.
+RUN(video.pause())
+RUN(video.muted = true)
+EXPECTED (internals.audioSessionCategory() == 'MoviePlayback'), OBSERVED 'MediaPlayback' FAIL
+EXPECTED (internals.audioSessionMode() == 'Default') OK
+EXPECTED (internals.routeSharingPolicy() == 'LongFormAudio') OK
+
+** And check again after 3 seconds.
+EXPECTED (internals.audioSessionCategory() == 'None') OK
+EXPECTED (internals.routeSharingPolicy() == 'Default') OK
+END OF TEST
+

--- a/LayoutTests/media/video-audio-session-mode.html
+++ b/LayoutTests/media/video-audio-session-mode.html
@@ -1,0 +1,85 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <title>video-audio-session-category</title>
+    <script src='video-test.js'></script>
+    <script src='media-file.js'></script>
+    <script>
+
+        async function waitForCategory(category, duration, message)
+        {
+            consoleWrite(message);
+
+            const maxTries = duration * 1000 / 10;
+            let counter = 0;
+            while (++counter < maxTries) {
+                if (internals.audioSessionCategory() == category)
+                    break;
+                await new Promise(resolve => setTimeout(resolve, 10));
+            }
+
+            testExpected('internals.audioSessionCategory()', category);
+        }
+
+        async function testVideoElement()
+        {
+            consoleWrite('<br><br>** &lt;video> element test **');
+            await waitForCategory('None', 10, '<br>** Check category before anything has loaded.');
+
+            consoleWrite('<br>** Check category when a muted, paused, element has loaded.');
+            video.src = findMediaFile('video', 'content/test');
+
+            await waitFor(video, 'canplaythrough');
+            testExpected('internals.audioSessionCategory()', 'None');
+            testExpected('internals.audioSessionMode()', 'Default');
+
+            consoleWrite('<br>** Check category when a muted element is playing.');
+            runWithKeyDown(() => { run('video.play()') });
+            await waitFor(video, 'playing');
+            testExpected('internals.audioSessionCategory()', 'None');
+            testExpected('internals.audioSessionMode()', 'Default');
+            testExpected('internals.routeSharingPolicy()', 'Default');
+
+            consoleWrite('<br>** Check category when an unmuted element is playing.');
+            runWithKeyDown(() => { run('video.muted = false') });
+            await waitFor(video, 'volumechange');
+            await waitForCategory('MediaPlayback', 1, '');
+            testExpected('internals.audioSessionMode()', 'MoviePlayback');
+            testExpected('internals.routeSharingPolicy()', 'LongFormAudio');
+
+            consoleWrite('<br>** Mute the element, check again after 500ms.');
+            run('video.pause()');
+            runWithKeyDown(() => { run('video.muted = true') });
+            await sleepFor(500);
+            testExpected('internals.audioSessionCategory()', 'MoviePlayback');
+            testExpected('internals.audioSessionMode()', 'Default');
+            testExpected('internals.routeSharingPolicy()', 'LongFormAudio');
+
+            await waitForCategory('None', 3, '<br>** And check again after 3 seconds.');
+            testExpected('internals.routeSharingPolicy()', 'Default');
+
+            video.src = '';
+            video.load();
+        }
+
+        window.addEventListener('load', async event => {
+            if (!window.internals) {
+                failTest(`<br>This test requires internals!`);
+                return;
+            }
+
+            internals.settings.setShouldManageAudioSessionCategory(true);
+
+            video = document.getElementsByTagName('video')[0];
+
+            failTestIn(20000);
+            await testVideoElement();
+
+            endTest();
+        });
+    </script>
+</head>
+<body>
+    <video muted controls></video>
+</body>
+</html>

--- a/Source/WebCore/PAL/pal/cocoa/AVFoundationSoftLink.h
+++ b/Source/WebCore/PAL/pal/cocoa/AVFoundationSoftLink.h
@@ -313,6 +313,8 @@ SOFT_LINK_CONSTANT_FOR_HEADER(PAL, AVFoundation, AVAudioSessionCategoryAudioProc
 SOFT_LINK_CONSTANT_FOR_HEADER(PAL, AVFoundation, AVAudioSessionModeDefault, NSString *)
 #define AVAudioSessionModeDefault PAL::get_AVFoundation_AVAudioSessionModeDefault()
 SOFT_LINK_CONSTANT_FOR_HEADER(PAL, AVFoundation, AVAudioSessionModeVideoChat, NSString *)
+#define AVAudioSessionModeMoviePlayback PAL::get_AVFoundation_AVAudioSessionModeMoviePlayback()
+SOFT_LINK_CONSTANT_FOR_HEADER(PAL, AVFoundation, AVAudioSessionModeMoviePlayback, NSString *)
 #define AVAudioSessionModeVideoChat PAL::get_AVFoundation_AVAudioSessionModeVideoChat()
 SOFT_LINK_CONSTANT_FOR_HEADER(PAL, AVFoundation, AVAudioSessionInterruptionNotification, NSString *)
 #define AVAudioSessionInterruptionNotification PAL::get_AVFoundation_AVAudioSessionInterruptionNotification()

--- a/Source/WebCore/PAL/pal/cocoa/AVFoundationSoftLink.mm
+++ b/Source/WebCore/PAL/pal/cocoa/AVFoundationSoftLink.mm
@@ -230,6 +230,7 @@ SOFT_LINK_CONSTANT_FOR_SOURCE_WITH_EXPORT(PAL, AVFoundation, AVAudioSessionInter
 SOFT_LINK_CONSTANT_FOR_SOURCE_WITH_EXPORT(PAL, AVFoundation, AVAudioSessionInterruptionTypeKey, NSString *, PAL_EXPORT)
 SOFT_LINK_CONSTANT_FOR_SOURCE_WITH_EXPORT(PAL, AVFoundation, AVAudioSessionMediaServicesWereResetNotification, NSString *, PAL_EXPORT)
 SOFT_LINK_CONSTANT_FOR_SOURCE_WITH_EXPORT(PAL, AVFoundation, AVAudioSessionModeDefault, NSString *, PAL_EXPORT)
+SOFT_LINK_CONSTANT_FOR_SOURCE_WITH_EXPORT(PAL, AVFoundation, AVAudioSessionModeMoviePlayback, NSString *, PAL_EXPORT)
 SOFT_LINK_CONSTANT_FOR_SOURCE_WITH_EXPORT(PAL, AVFoundation, AVAudioSessionModeVideoChat, NSString *, PAL_EXPORT)
 SOFT_LINK_CONSTANT_FOR_SOURCE_WITH_EXPORT(PAL, AVFoundation, AVCaptureSessionErrorKey, NSString *, PAL_EXPORT)
 SOFT_LINK_CONSTANT_FOR_SOURCE_WITH_EXPORT(PAL, AVFoundation, AVCaptureSessionInterruptionEndedNotification, NSString *, PAL_EXPORT)

--- a/Source/WebCore/html/HTMLMediaElement.cpp
+++ b/Source/WebCore/html/HTMLMediaElement.cpp
@@ -481,6 +481,7 @@ HTMLMediaElement::HTMLMediaElement(const QualifiedName& tagName, Document& docum
     , m_opaqueRootProvider([this] { return opaqueRoot(); })
 #if USE(AUDIO_SESSION)
     , m_categoryAtMostRecentPlayback(AudioSessionCategory::None)
+    , m_modeAtMostRecentPlayback(AudioSessionMode::Default)
 #endif
 #if !RELEASE_LOG_DISABLED
     , m_logger(&document.logger())
@@ -5999,6 +6000,7 @@ void HTMLMediaElement::playPlayer()
 
 #if USE(AUDIO_SESSION)
     m_categoryAtMostRecentPlayback = AudioSession::sharedSession().category();
+    m_modeAtMostRecentPlayback = AudioSession::sharedSession().mode();
 #endif
 
 #if ENABLE(MEDIA_SESSION) && ENABLE(MEDIA_SESSION_COORDINATOR)

--- a/Source/WebCore/html/HTMLMediaElement.h
+++ b/Source/WebCore/html/HTMLMediaElement.h
@@ -28,6 +28,7 @@
 #if ENABLE(VIDEO)
 
 #include "ActiveDOMObject.h"
+#include "AudioSession.h"
 #include "AudioTrackClient.h"
 #include "AutoplayEvent.h"
 #include "CaptionUserPreferences.h"
@@ -619,7 +620,8 @@ public:
     WEBCORE_EXPORT bool mediaPlayerRenderingCanBeAccelerated() final;
 
 #if USE(AUDIO_SESSION)
-    WEBCORE_EXPORT AudioSessionCategory categoryAtMostRecentPlayback() const { return m_categoryAtMostRecentPlayback; }
+    AudioSessionCategory categoryAtMostRecentPlayback() const { return m_categoryAtMostRecentPlayback; }
+    AudioSessionMode modeAtMostRecentPlayback() const { return m_modeAtMostRecentPlayback; }
 #endif
 
     void updateMediaPlayer(IntSize, bool);
@@ -1295,6 +1297,7 @@ private:
 
 #if USE(AUDIO_SESSION)
     AudioSessionCategory m_categoryAtMostRecentPlayback;
+    AudioSessionMode m_modeAtMostRecentPlayback;
 #endif
     bool m_wasInterruptedForInvisibleAutoplay { false };
 

--- a/Source/WebCore/platform/audio/AudioSession.cpp
+++ b/Source/WebCore/platform/audio/AudioSession.cpp
@@ -156,7 +156,7 @@ void AudioSession::activeStateChanged()
         observer.activeStateChanged();
 }
 
-void AudioSession::setCategory(CategoryType, RouteSharingPolicy)
+void AudioSession::setCategory(CategoryType, Mode, RouteSharingPolicy)
 {
     notImplemented();
 }
@@ -168,7 +168,7 @@ void AudioSession::setCategoryOverride(CategoryType category)
 
     m_categoryOverride = category;
     if (category != CategoryType::None)
-        setCategory(category, RouteSharingPolicy::Default);
+        setCategory(category, Mode::Default, RouteSharingPolicy::Default);
 }
 
 AudioSession::CategoryType AudioSession::categoryOverride() const
@@ -180,6 +180,12 @@ AudioSession::CategoryType AudioSession::category() const
 {
     notImplemented();
     return AudioSession::CategoryType::None;
+}
+
+AudioSession::Mode AudioSession::mode() const
+{
+    notImplemented();
+    return AudioSession::Mode::Default;
 }
 
 float AudioSession::sampleRate() const
@@ -287,6 +293,20 @@ String convertEnumerationToString(AudioSession::CategoryType enumerationValue)
     static_assert(static_cast<size_t>(AudioSession::CategoryType::RecordAudio) == 4, "AudioSession::CategoryType::RecordAudio is not 4 as expected");
     static_assert(static_cast<size_t>(AudioSession::CategoryType::PlayAndRecord) == 5, "AudioSession::CategoryType::PlayAndRecord is not 5 as expected");
     static_assert(static_cast<size_t>(AudioSession::CategoryType::AudioProcessing) == 6, "AudioSession::CategoryType::AudioProcessing is not 6 as expected");
+    ASSERT(static_cast<size_t>(enumerationValue) < std::size(values));
+    return values[static_cast<size_t>(enumerationValue)];
+}
+
+String convertEnumerationToString(AudioSession::Mode enumerationValue)
+{
+    static const NeverDestroyed<String> values[] = {
+        MAKE_STATIC_STRING_IMPL("Default"),
+        MAKE_STATIC_STRING_IMPL("VideoChat"),
+        MAKE_STATIC_STRING_IMPL("MoviePlayback"),
+    };
+    static_assert(!static_cast<size_t>(AudioSession::Mode::Default), "AudioSession::Mode::Default is not 0 as expected");
+    static_assert(static_cast<size_t>(AudioSession::Mode::VideoChat) == 1, "AudioSession::Mode::VideoChat is not 1 as expected");
+    static_assert(static_cast<size_t>(AudioSession::Mode::MoviePlayback) == 2, "AudioSession::Mode::MoviePlayback is not 2 as expected");
     ASSERT(static_cast<size_t>(enumerationValue) < std::size(values));
     return values[static_cast<size_t>(enumerationValue)];
 }

--- a/Source/WebCore/platform/audio/AudioSession.h
+++ b/Source/WebCore/platform/audio/AudioSession.h
@@ -56,6 +56,13 @@ enum class AudioSessionCategory : uint8_t {
     AudioProcessing,
 };
 
+enum class AudioSessionMode : uint8_t {
+    // FIXME: This is not exhaustive.
+    Default,
+    VideoChat,
+    MoviePlayback,
+};
+
 class AudioSessionRoutingArbitrationClient;
 
 class WEBCORE_EXPORT AudioSession {
@@ -74,8 +81,10 @@ public:
     virtual ~AudioSession();
 
     using CategoryType = AudioSessionCategory;
-    virtual void setCategory(CategoryType, RouteSharingPolicy);
     virtual CategoryType category() const;
+    using Mode = AudioSessionMode;
+    virtual Mode mode() const;
+    virtual void setCategory(CategoryType, Mode, RouteSharingPolicy);
 
     virtual void setCategoryOverride(CategoryType);
     virtual CategoryType categoryOverride() const;
@@ -177,6 +186,7 @@ public:
 
 WEBCORE_EXPORT String convertEnumerationToString(RouteSharingPolicy);
 WEBCORE_EXPORT String convertEnumerationToString(AudioSession::CategoryType);
+WEBCORE_EXPORT String convertEnumerationToString(AudioSession::Mode);
 WEBCORE_EXPORT String convertEnumerationToString(AudioSessionRoutingArbitrationClient::RoutingArbitrationError);
 WEBCORE_EXPORT String convertEnumerationToString(AudioSessionRoutingArbitrationClient::DefaultRouteChanged);
 
@@ -200,6 +210,14 @@ struct LogArgument<WebCore::AudioSession::CategoryType> {
     static String toString(const WebCore::AudioSession::CategoryType category)
     {
         return convertEnumerationToString(category);
+    }
+};
+
+template <>
+struct LogArgument<WebCore::AudioSession::Mode> {
+    static String toString(const WebCore::AudioSession::Mode mode)
+    {
+        return convertEnumerationToString(mode);
     }
 };
 

--- a/Source/WebCore/platform/audio/ios/AudioSessionIOS.h
+++ b/Source/WebCore/platform/audio/ios/AudioSessionIOS.h
@@ -51,7 +51,8 @@ public:
 private:
     // AudioSession
     CategoryType category() const final;
-    void setCategory(CategoryType, RouteSharingPolicy) final;
+    Mode mode() const final;
+    void setCategory(CategoryType, Mode, RouteSharingPolicy) final;
     float sampleRate() const final;
     size_t bufferSize() const final;
     size_t numberOfOutputChannels() const final;

--- a/Source/WebCore/platform/audio/mac/AudioSessionMac.h
+++ b/Source/WebCore/platform/audio/mac/AudioSessionMac.h
@@ -68,7 +68,7 @@ private:
     RouteSharingPolicy routeSharingPolicy() const { return m_policy; }
     void audioOutputDeviceChanged() final;
     void setIsPlayingToBluetoothOverride(std::optional<bool>) final;
-    void setCategory(CategoryType, RouteSharingPolicy) final;
+    void setCategory(CategoryType, Mode, RouteSharingPolicy) final;
     float sampleRate() const final;
     size_t bufferSize() const final;
     size_t numberOfOutputChannels() const final;

--- a/Source/WebCore/platform/audio/mac/AudioSessionMac.mm
+++ b/Source/WebCore/platform/audio/mac/AudioSessionMac.mm
@@ -283,7 +283,7 @@ void AudioSessionMac::setIsPlayingToBluetoothOverride(std::optional<bool> value)
 #endif
 }
 
-void AudioSessionMac::setCategory(CategoryType category, RouteSharingPolicy policy)
+void AudioSessionMac::setCategory(CategoryType category, Mode, RouteSharingPolicy policy)
 {
 #if ENABLE(ROUTING_ARBITRATION)
     bool playingToBluetooth = defaultDeviceTransportIsBluetooth();

--- a/Source/WebCore/platform/mock/MockRealtimeAudioSource.cpp
+++ b/Source/WebCore/platform/mock/MockRealtimeAudioSource.cpp
@@ -143,6 +143,7 @@ void MockRealtimeAudioSource::startProducingData()
 #if PLATFORM(IOS_FAMILY)
     PlatformMediaSessionManager::sharedManager().sessionCanProduceAudioChanged();
     ASSERT(AudioSession::sharedSession().category() == AudioSession::CategoryType::PlayAndRecord);
+    ASSERT(AudioSession::sharedSession().mode() == AudioSession::Mode::VideoChat);
 #endif
 
     if (!sampleRate())

--- a/Source/WebCore/testing/Internals.cpp
+++ b/Source/WebCore/testing/Internals.cpp
@@ -5927,6 +5927,15 @@ auto Internals::audioSessionCategory() const -> AudioSessionCategory
 #endif
 }
 
+auto Internals::audioSessionMode() const -> AudioSessionMode
+{
+#if USE(AUDIO_SESSION)
+    return AudioSession::sharedSession().mode();
+#else
+    return AudioSessionMode::Default;
+#endif
+}
+
 auto Internals::routeSharingPolicy() const -> RouteSharingPolicy
 {
 #if USE(AUDIO_SESSION)
@@ -5944,6 +5953,17 @@ auto Internals::categoryAtMostRecentPlayback(HTMLMediaElement& element) const ->
 #else
     UNUSED_PARAM(element);
     return AudioSessionCategory::None;
+#endif
+}
+
+auto Internals::modeAtMostRecentPlayback(HTMLMediaElement& element) const -> AudioSessionMode
+{
+#if USE(AUDIO_SESSION)
+    WTFLogAlways("Internals::modeAtMostRecentPlayback");
+    return element.modeAtMostRecentPlayback();
+#else
+    UNUSED_PARAM(element);
+    return AudioSessionMode::Default;
 #endif
 }
 #endif

--- a/Source/WebCore/testing/Internals.h
+++ b/Source/WebCore/testing/Internals.h
@@ -942,6 +942,7 @@ public:
 
 #if USE(AUDIO_SESSION)
     using AudioSessionCategory = WebCore::AudioSessionCategory;
+    using AudioSessionMode = WebCore::AudioSessionMode;
     using RouteSharingPolicy = WebCore::RouteSharingPolicy;
 #else
     enum class AudioSessionCategory : uint8_t {
@@ -954,6 +955,12 @@ public:
         AudioProcessing,
     };
 
+    enum class AudioSessionMode : uint8_t {
+        Default,
+        VideoChat,
+        MoviePlayback,
+    };
+
     enum class RouteSharingPolicy : uint8_t {
         Default,
         LongFormAudio,
@@ -964,9 +971,11 @@ public:
 
     bool supportsAudioSession() const;
     AudioSessionCategory audioSessionCategory() const;
+    AudioSessionMode audioSessionMode() const;
     RouteSharingPolicy routeSharingPolicy() const;
 #if ENABLE(VIDEO)
     AudioSessionCategory categoryAtMostRecentPlayback(HTMLMediaElement&) const;
+    AudioSessionMode modeAtMostRecentPlayback(HTMLMediaElement&) const;
 #endif
     double preferredAudioBufferSize() const;
     double currentAudioBufferSize() const;

--- a/Source/WebCore/testing/Internals.idl
+++ b/Source/WebCore/testing/Internals.idl
@@ -116,6 +116,12 @@ enum AudioSessionCategory {
     "AudioProcessing"
 };
 
+enum AudioSessionMode {
+    "Default",
+    "VideoChat",
+    "MoviePlayback"
+};
+
 enum RouteSharingPolicy {
     "Default",
     "LongFormAudio",
@@ -1026,7 +1032,9 @@ typedef (FetchRequest or FetchResponse) FetchObject;
 
     readonly attribute boolean supportsAudioSession;
     AudioSessionCategory audioSessionCategory();
+    AudioSessionMode audioSessionMode();
     [Conditional=VIDEO] AudioSessionCategory categoryAtMostRecentPlayback(HTMLMediaElement element);
+    [Conditional=VIDEO] AudioSessionMode modeAtMostRecentPlayback(HTMLMediaElement element);
     RouteSharingPolicy routeSharingPolicy();
 
     double preferredAudioBufferSize();

--- a/Source/WebKit/GPUProcess/media/RemoteAudioSessionProxy.cpp
+++ b/Source/WebKit/GPUProcess/media/RemoteAudioSessionProxy.cpp
@@ -74,12 +74,13 @@ RemoteAudioSessionConfiguration RemoteAudioSessionProxy::configuration()
     };
 }
 
-void RemoteAudioSessionProxy::setCategory(AudioSession::CategoryType category, RouteSharingPolicy policy)
+void RemoteAudioSessionProxy::setCategory(AudioSession::CategoryType category, AudioSession::Mode mode, RouteSharingPolicy policy)
 {
-    if (m_category == category && m_routeSharingPolicy == policy && !m_isPlayingToBluetoothOverrideChanged)
+    if (m_category == category && m_mode == mode && m_routeSharingPolicy == policy && !m_isPlayingToBluetoothOverrideChanged)
         return;
 
     m_category = category;
+    m_mode = mode;
     m_routeSharingPolicy = policy;
     m_isPlayingToBluetoothOverrideChanged = false;
     audioSessionManager().updateCategory();

--- a/Source/WebKit/GPUProcess/media/RemoteAudioSessionProxy.h
+++ b/Source/WebKit/GPUProcess/media/RemoteAudioSessionProxy.h
@@ -53,6 +53,7 @@ public:
     RemoteAudioSessionConfiguration configuration();
 
     WebCore::AudioSession::CategoryType category() const { return m_category; };
+    WebCore::AudioSession::Mode mode() const { return m_mode; };
     WebCore::RouteSharingPolicy routeSharingPolicy() const { return m_routeSharingPolicy; }
     size_t preferredBufferSize() const { return m_preferredBufferSize; }
     bool isActive() const { return m_active; }
@@ -72,7 +73,7 @@ private:
     explicit RemoteAudioSessionProxy(GPUConnectionToWebProcess&);
 
     // Messages
-    void setCategory(WebCore::AudioSession::CategoryType, WebCore::RouteSharingPolicy);
+    void setCategory(WebCore::AudioSession::CategoryType, WebCore::AudioSession::Mode, WebCore::RouteSharingPolicy);
     void setPreferredBufferSize(uint64_t);
     using SetActiveCompletion = CompletionHandler<void(bool)>;
     void tryToSetActive(bool, SetActiveCompletion&&);
@@ -85,6 +86,7 @@ private:
 
     GPUConnectionToWebProcess& m_gpuConnection;
     WebCore::AudioSession::CategoryType m_category { WebCore::AudioSession::CategoryType::None };
+    WebCore::AudioSession::Mode m_mode { WebCore::AudioSession::Mode::Default };
     WebCore::RouteSharingPolicy m_routeSharingPolicy { WebCore::RouteSharingPolicy::Default };
     size_t m_preferredBufferSize { 0 };
     bool m_active { false };

--- a/Source/WebKit/GPUProcess/media/RemoteAudioSessionProxy.messages.in
+++ b/Source/WebKit/GPUProcess/media/RemoteAudioSessionProxy.messages.in
@@ -26,7 +26,7 @@
 #if ENABLE(GPU_PROCESS) && USE(AUDIO_SESSION)
 
 messages -> RemoteAudioSessionProxy NotRefCounted {
-    SetCategory(enum:uint8_t WebCore::AudioSession::CategoryType type, enum:uint8_t WebCore::RouteSharingPolicy policy)
+    SetCategory(enum:uint8_t WebCore::AudioSession::CategoryType type, enum:uint8_t WebCore::AudioSession::Mode mode, enum:uint8_t WebCore::RouteSharingPolicy policy)
     SetPreferredBufferSize(uint64_t preferredBufferSize)
     TryToSetActive(bool active) -> (bool suceeded) Synchronous
     SetIsPlayingToBluetoothOverride(std::optional<bool> value)

--- a/Source/WebKit/GPUProcess/media/RemoteAudioSessionProxyManager.cpp
+++ b/Source/WebKit/GPUProcess/media/RemoteAudioSessionProxyManager.cpp
@@ -76,16 +76,16 @@ void RemoteAudioSessionProxyManager::removeProxy(RemoteAudioSessionProxy& proxy)
 
 void RemoteAudioSessionProxyManager::updateCategory()
 {
-    AudioSession::CategoryType category = AudioSession::CategoryType::None;
-    RouteSharingPolicy policy = RouteSharingPolicy::Default;
-
     HashCountedSet<AudioSession::CategoryType, WTF::IntHash<AudioSession::CategoryType>, WTF::StrongEnumHashTraits<AudioSession::CategoryType>> categoryCounts;
+    HashCountedSet<AudioSession::Mode, WTF::IntHash<AudioSession::Mode>, WTF::StrongEnumHashTraits<AudioSession::Mode>> modeCounts;
     HashCountedSet<RouteSharingPolicy, WTF::IntHash<RouteSharingPolicy>, WTF::StrongEnumHashTraits<RouteSharingPolicy>> policyCounts;
     for (auto& otherProxy : m_proxies) {
         categoryCounts.add(otherProxy.category());
+        modeCounts.add(otherProxy.mode());
         policyCounts.add(otherProxy.routeSharingPolicy());
     }
 
+    AudioSession::CategoryType category = AudioSession::CategoryType::None;
     if (categoryCounts.contains(AudioSession::CategoryType::PlayAndRecord))
         category = AudioSession::CategoryType::PlayAndRecord;
     else if (categoryCounts.contains(AudioSession::CategoryType::RecordAudio))
@@ -98,10 +98,14 @@ void RemoteAudioSessionProxyManager::updateCategory()
         category = AudioSession::CategoryType::AmbientSound;
     else if (categoryCounts.contains(AudioSession::CategoryType::AudioProcessing))
         category = AudioSession::CategoryType::AudioProcessing;
-    else
-        category = AudioSession::CategoryType::None;
 
-    policy = RouteSharingPolicy::Default;
+    AudioSession::Mode mode = AudioSession::Mode::Default;
+    if (modeCounts.contains(AudioSession::Mode::MoviePlayback))
+        mode = AudioSession::Mode::MoviePlayback;
+    else if (modeCounts.contains(AudioSession::Mode::VideoChat))
+        mode = AudioSession::Mode::VideoChat;
+
+    RouteSharingPolicy policy = RouteSharingPolicy::Default;
     if (policyCounts.contains(RouteSharingPolicy::LongFormVideo))
         policy = RouteSharingPolicy::LongFormVideo;
     else if (policyCounts.contains(RouteSharingPolicy::LongFormAudio))
@@ -109,7 +113,7 @@ void RemoteAudioSessionProxyManager::updateCategory()
     else if (policyCounts.contains(RouteSharingPolicy::Independent))
         ASSERT_NOT_REACHED();
 
-    AudioSession::sharedSession().setCategory(category, policy);
+    AudioSession::sharedSession().setCategory(category, mode, policy);
 }
 
 void RemoteAudioSessionProxyManager::updatePreferredBufferSizeForProcess()

--- a/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
+++ b/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
@@ -3622,6 +3622,12 @@ enum class WebCore::AudioSessionCategory : uint8_t {
     AudioProcessing,
 };
 
+enum class WebCore::AudioSessionMode : uint8_t {
+    Default,
+    VideoChat,
+    MoviePlayback,
+};
+
 [Nested] enum class WebCore::AudioSession::MayResume : bool;
 
 enum class WebCore::AudioSessionRoutingArbitrationError : uint8_t {

--- a/Source/WebKit/UIProcess/Cocoa/UserMediaCaptureManagerProxy.cpp
+++ b/Source/WebKit/UIProcess/Cocoa/UserMediaCaptureManagerProxy.cpp
@@ -93,7 +93,7 @@ public:
 
     void audioUnitWillStart() final
     {
-        AudioSession::sharedSession().setCategory(AudioSession::CategoryType::PlayAndRecord, RouteSharingPolicy::Default);
+        AudioSession::sharedSession().setCategory(AudioSession::CategoryType::PlayAndRecord, AudioSession::Mode::VideoChat, RouteSharingPolicy::Default);
         AudioSession::sharedSession().tryToSetActive(true);
     }
 

--- a/Source/WebKit/WebProcess/GPU/media/RemoteAudioSession.cpp
+++ b/Source/WebKit/WebProcess/GPU/media/RemoteAudioSession.cpp
@@ -90,17 +90,18 @@ RemoteAudioSessionConfiguration& RemoteAudioSession::configuration()
     return *m_configuration;
 }
 
-void RemoteAudioSession::setCategory(CategoryType type, RouteSharingPolicy policy)
+void RemoteAudioSession::setCategory(CategoryType type, Mode mode, RouteSharingPolicy policy)
 {
 #if PLATFORM(COCOA)
-    if (type == m_category && policy == m_routeSharingPolicy && !m_isPlayingToBluetoothOverrideChanged)
+    if (type == m_category && mode == m_mode && policy == m_routeSharingPolicy && !m_isPlayingToBluetoothOverrideChanged)
         return;
 
     m_category = type;
+    m_mode = mode;
     m_routeSharingPolicy = policy;
     m_isPlayingToBluetoothOverrideChanged = false;
 
-    ensureConnection().send(Messages::RemoteAudioSessionProxy::SetCategory(type, policy), { });
+    ensureConnection().send(Messages::RemoteAudioSessionProxy::SetCategory(type, mode, policy), { });
 #else
     UNUSED_PARAM(type);
     UNUSED_PARAM(policy);
@@ -141,6 +142,11 @@ void RemoteAudioSession::setIsPlayingToBluetoothOverride(std::optional<bool> val
 AudioSession::CategoryType RemoteAudioSession::category() const
 {
     return m_category;
+}
+
+AudioSession::Mode RemoteAudioSession::mode() const
+{
+    return m_mode;
 }
 
 void RemoteAudioSession::configurationChanged(RemoteAudioSessionConfiguration&& configuration)

--- a/Source/WebKit/WebProcess/GPU/media/RemoteAudioSession.h
+++ b/Source/WebKit/WebProcess/GPU/media/RemoteAudioSession.h
@@ -65,8 +65,9 @@ private:
     void gpuProcessConnectionDidClose(GPUProcessConnection&) final;
 
     // AudioSession
-    void setCategory(CategoryType, WebCore::RouteSharingPolicy) final;
+    void setCategory(CategoryType, Mode, WebCore::RouteSharingPolicy) final;
     CategoryType category() const final;
+    Mode mode() const final;
 
     WebCore::RouteSharingPolicy routeSharingPolicy() const final { return m_routeSharingPolicy; }
     String routingContextUID() const final { return configuration().routingContextUID; }
@@ -102,6 +103,7 @@ private:
 
     WeakHashSet<ConfigurationChangeObserver> m_configurationChangeObservers;
     CategoryType m_category { CategoryType::None };
+    Mode m_mode { Mode::Default };
     WebCore::RouteSharingPolicy m_routeSharingPolicy { WebCore::RouteSharingPolicy::Default };
     bool m_isPlayingToBluetoothOverrideChanged { false };
     std::optional<RemoteAudioSessionConfiguration> m_configuration;

--- a/Source/WebKit/WebProcess/Speech/SpeechRecognitionRealtimeMediaSourceManager.cpp
+++ b/Source/WebKit/WebProcess/Speech/SpeechRecognitionRealtimeMediaSourceManager.cpp
@@ -125,7 +125,7 @@ private:
         auto bufferSize = AudioSession::sharedSession().sampleRate() / 50;
         if (AudioSession::sharedSession().preferredBufferSize() > bufferSize)
             AudioSession::sharedSession().setPreferredBufferSize(bufferSize);
-        AudioSession::sharedSession().setCategory(AudioSession::CategoryType::PlayAndRecord, RouteSharingPolicy::Default);
+        AudioSession::sharedSession().setCategory(AudioSession::CategoryType::PlayAndRecord, AudioSession::Mode::Default, RouteSharingPolicy::Default);
 #endif
     }
 


### PR DESCRIPTION
#### e0ce48fe5c2e1b20a22f817e081face321c7c541
<pre>
Safari is not using the intended AudioSession
<a href="https://bugs.webkit.org/show_bug.cgi?id=255681">https://bugs.webkit.org/show_bug.cgi?id=255681</a>
rdar://107095456

Reviewed by Jer Noble.

WebKit never sets the AudioSession mode to anything other than &quot;default&quot;, which
is not appropriate for video playback, especially in a spatial audio environment.
Fix this by exposing a way for the Media system to select an AudioSession mode,
and set it to MoviePlayback when needed.

* LayoutTests/media/audio-session-category-at-most-recent-playback-expected.txt:
* LayoutTests/media/audio-session-category-at-most-recent-playback.html:
* LayoutTests/media/audio-session-category-expected.txt:
* LayoutTests/media/audio-session-category.html:

* Source/WebCore/PAL/pal/cocoa/AVFoundationSoftLink.h: Expose the new mode constant.
* Source/WebCore/PAL/pal/cocoa/AVFoundationSoftLink.mm:

* Source/WebCore/html/HTMLMediaElement.cpp: Save the mode so that tests can query it.
(WebCore::HTMLMediaElement::playPlayer):
* Source/WebCore/html/HTMLMediaElement.h:
(WebCore::HTMLMediaElement::modeAtMostRecentPlayback const):

* Source/WebCore/platform/audio/AudioSession.h: Add a new type AudioSession::Mode that can be
set alongside the Category value.
(WTF::LogArgument&lt;WebCore::AudioSession::Mode&gt;::toString):
* Source/WebCore/platform/audio/AudioSession.cpp:
(WebCore::AudioSession::setCategory):
(WebCore::AudioSession::setCategoryOverride):
(WebCore::AudioSession::mode const):
(WebCore::convertEnumerationToString):

* Source/WebCore/platform/audio/cocoa/MediaSessionManagerCocoa.mm:
(WebCore::MediaSessionManagerCocoa::updateSessionState): Set the mode to VideoPlayback here
if `hasAudibleAudioOrVideoMediaType` is true.

* Source/WebCore/platform/audio/ios/AudioSessionIOS.h:
* Source/WebCore/platform/audio/ios/AudioSessionIOS.mm:
(WebCore::AudioSessionIOS::setCategory): Actually send the mode down to the AVAudioSession.
(WebCore::AudioSessionIOS::mode const):

* Source/WebCore/platform/audio/mac/AudioSessionMac.h:
* Source/WebCore/platform/audio/mac/AudioSessionMac.mm:
(WebCore::AudioSessionMac::setCategory): Accept the parameter, but we don&apos;t set anything on Mac.

* Source/WebCore/platform/mock/MockRealtimeAudioSource.cpp:
(WebCore::MockRealtimeAudioSource::startProducingData): Update call to setCategory.

* Source/WebCore/testing/Internals.cpp: Expose a way to test the mode.
(WebCore::Internals::audioSessionMode const):
(WebCore::Internals::modeAtMostRecentPlayback const):
* Source/WebCore/testing/Internals.h:
* Source/WebCore/testing/Internals.idl:

* Source/WebKit/GPUProcess/media/RemoteAudioSessionProxy.cpp:
(WebKit::RemoteAudioSessionProxy::setCategory):
* Source/WebKit/GPUProcess/media/RemoteAudioSessionProxy.h:
(WebKit::RemoteAudioSessionProxy::mode const):
* Source/WebKit/GPUProcess/media/RemoteAudioSessionProxy.messages.in:
* Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in:
* Source/WebKit/UIProcess/Cocoa/UserMediaCaptureManagerProxy.cpp:
* Source/WebKit/WebProcess/GPU/media/RemoteAudioSession.cpp:
(WebKit::RemoteAudioSession::setCategory):
(WebKit::RemoteAudioSession::mode const):
* Source/WebKit/WebProcess/GPU/media/RemoteAudioSession.h:
* Source/WebKit/WebProcess/Speech/SpeechRecognitionRealtimeMediaSourceManager.cpp:
    Update the call to setCategory to accept Mode.

* Source/WebKit/GPUProcess/media/RemoteAudioSessionProxyManager.cpp:
(WebKit::RemoteAudioSessionProxyManager::updateCategory):
    Iterate through the proxies to test if mode has been set.

Canonical link: <a href="https://commits.webkit.org/263201@main">https://commits.webkit.org/263201@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/199171a1db6795145f6a26150f93c1972265beb7

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/3918 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/4010 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/4121 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/5356 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/4178 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/3895 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/4094 "Built successfully") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/16/builds/4000 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/3991 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/3966 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/15/builds/4162 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/3534 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/5205 "Built successfully") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/39/builds/1665 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/10/builds/3509 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/5547 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/3485 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/3569 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/4977 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/3972 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/16/builds/4000 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/3491 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/3509 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/3539 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/446 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/3770 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->