### PR TITLE
Assertion failure in createWebViewWithRequest when running imported/w3c/web-platform-tests/shadow-dom/crashtests/move-to-new-tree-1343016.html

### DIFF
--- a/Tools/DumpRenderTree/mac/UIDelegate.mm
+++ b/Tools/DumpRenderTree/mac/UIDelegate.mm
@@ -34,6 +34,7 @@
 #import "EventSendingController.h"
 #import "MockWebNotificationProvider.h"
 #import "TestRunner.h"
+#import "WPTFunctions.h"
 
 #import <WebKit/WebApplicationCache.h>
 #import <WebKit/WebFramePrivate.h>
@@ -176,7 +177,7 @@ static NSString *addLeadingSpaceStripTrailingSpaces(NSString *string)
         return nil;
 
     // Make sure that waitUntilDone has been called.
-    ASSERT(gTestRunner->waitToDump());
+    ASSERT(gTestRunner->waitToDump() || WTR::hasTestWaitAttribute(mainFrame.globalContext));
 
     auto webView = createWebViewAndOffscreenWindow();
     [webView setPreferences:[sender preferences]];


### PR DESCRIPTION
#### 02cdac5e408458239c489b1a2c57a3b858f9041c
<pre>
Assertion failure in createWebViewWithRequest when running imported/w3c/web-platform-tests/shadow-dom/crashtests/move-to-new-tree-1343016.html
<a href="https://bugs.webkit.org/show_bug.cgi?id=255665">https://bugs.webkit.org/show_bug.cgi?id=255665</a>

Reviewed by Chris Dumez.

The assertion failure is caused by the test using &quot;test-wait&quot; attribute on the document element
to make the test keep running instead of calling waitUntilDone(). Fixed the bug by relaxing
the assertion to allow this method of waiting.

* Tools/DumpRenderTree/mac/UIDelegate.mm:
(-[UIDelegate webView:createWebViewWithRequest:]):

Canonical link: <a href="https://commits.webkit.org/263156@main">https://commits.webkit.org/263156@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/8ec368d7775311e3d6f0f1fa9f06fc99711d22f5

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/3780 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/3866 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/3974 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/5210 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/4045 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/3752 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/3944 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/3871 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/3359 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/3825 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/4035 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/3404 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/5043 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/1539 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/3379 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/3931 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/3354 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/3438 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/4810 "260 api tests failed or timed out") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/3830 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/3103 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/3354 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/3379 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/3395 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/430 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/3632 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->