### PR TITLE
[bugs.webkit.org] Disable manual patch upload

### DIFF
--- a/Tools/Scripts/webkitpy/common/net/bugzilla/bugzilla.py
+++ b/Tools/Scripts/webkitpy/common/net/bugzilla/bugzilla.py
@@ -324,6 +324,7 @@ class Bugzilla(object):
             from mechanize import Browser
             self._browser = Browser()
             self._browser.set_handle_robots(False)
+            self._browser.addheaders = [('User-agent', 'org.webkit.webkit-patch')]
         return self._browser
 
     def _set_browser(self, value):

--- a/Websites/bugs.webkit.org/attachment.cgi
+++ b/Websites/bugs.webkit.org/attachment.cgi
@@ -530,6 +530,11 @@ sub enter {
 
 # Insert a new attachment into the database.
 sub insert {
+    my $isPatch = scalar $cgi->param('ispatch');
+    if ($isPatch && $cgi->user_agent() ne 'org.webkit.webkit-patch') {
+        ThrowUserError('invalid_user_agent');
+    }
+
     my $dbh = Bugzilla->dbh;
     my $user = Bugzilla->user;
 
@@ -564,7 +569,7 @@ sub insert {
          data          => $attach_text || $data_fh,
          description   => scalar $cgi->param('description'),
          filename      => $attach_text ? "file_$bugid.txt" : $data_fh,
-         ispatch       => scalar $cgi->param('ispatch'),
+         ispatch       => $isPatch,
          isprivate     => scalar $cgi->param('isprivate'),
          mimetype      => $content_type,
          });

--- a/Websites/bugs.webkit.org/template/en/default/global/user-error.html.tmpl
+++ b/Websites/bugs.webkit.org/template/en/default/global/user-error.html.tmpl
@@ -1947,6 +1947,10 @@
     [% END %]
     with the External Login ID "[% extern_id FILTER html %]".
 
+  [% ELSIF error == "invalid_user_agent" %]
+    [% title = "Invalid User Agent" %]
+    The WebKit project uses GitHub pull-requests to propose changes. Patches must be uploaded by 'Tools/Scripts/webkit-patch'.
+
   [% ELSE %]
 
     [%# Try to find hooked error messages %]


### PR DESCRIPTION
#### b558676afcc71ff0660314e830218fc47dc54742
<pre>
[bugs.webkit.org] Disable manual patch upload
<a href="https://bugs.webkit.org/show_bug.cgi?id=255687">https://bugs.webkit.org/show_bug.cgi?id=255687</a>
rdar://108286745

Reviewed by NOBODY (OOPS!).

Tie patch upload to User-Agent to strongly encourage using
webkit-patch to upload patches instead of manual uploads.

* Tools/Scripts/webkitpy/common/net/bugzilla/bugzilla.py:
(Bugzilla._get_browser): Set webkit-patch User-Agent.
* Websites/bugs.webkit.org/attachment.cgi:
(insert): Restrict patch upload to webkit-patch&apos;s User-Agent.
* Websites/bugs.webkit.org/template/en/default/global/user-error.html.tmpl:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b558676afcc71ff0660314e830218fc47dc54742

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/3789 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/3875 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/3983 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/5219 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/4054 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/3761 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/3953 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/3880 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/3451 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/3834 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/4044 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/3414 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/5053 "Built successfully") | 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/3822 "Passed tests") | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/1548 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/3389 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/4229 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/3364 "Passed tests") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/3448 "3 failures") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/4822 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/3839 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/3112 "16 failures") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/3363 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/3389 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/3404 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/3641 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->