### PR TITLE
Remove the abandoned 'LoadSiteIconsIgnoringImageLoadingPreference' setting

### DIFF
--- a/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
+++ b/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
@@ -3741,23 +3741,6 @@ LoadsImagesAutomatically:
     WebCore:
       default: false
 
-# This preference only affects site icon image loading if the LoadsImagesAutomatically preference is false and
-# this preference is true. All other permutations still heed LoadsImagesAutomatically preference.
-LoadsSiteIconsIgnoringImageLoadingPreference:
-  type: bool
-  status: stable
-  category: networking
-  humanReadableName: "Load site icons ignoring image loading preference"
-  webKitLegacyPreferenceKey: WebKitLoadSiteIconsKey
-  webcoreName: loadsSiteIconsIgnoringImageLoadingSetting
-  defaultValue:
-    WebKitLegacy:
-      default: false
-    WebKit:
-      default: false
-    WebCore:
-      default: false
-
 LocalFileContentSniffingEnabled:
   type: bool
   status: internal

--- a/Source/WebKit/UIProcess/API/C/WKPreferences.cpp
+++ b/Source/WebKit/UIProcess/API/C/WKPreferences.cpp
@@ -157,16 +157,6 @@ bool WKPreferencesGetLoadsImagesAutomatically(WKPreferencesRef preferencesRef)
     return toImpl(preferencesRef)->loadsImagesAutomatically();
 }
 
-void WKPreferencesSetLoadsSiteIconsIgnoringImageLoadingPreference(WKPreferencesRef preferencesRef, bool loadsSiteIconsIgnoringImageLoadingPreference)
-{
-    toImpl(preferencesRef)->setLoadsSiteIconsIgnoringImageLoadingPreference(loadsSiteIconsIgnoringImageLoadingPreference);
-}
-
-bool WKPreferencesGetLoadsSiteIconsIgnoringImageLoadingPreference(WKPreferencesRef preferencesRef)
-{
-    return toImpl(preferencesRef)->loadsSiteIconsIgnoringImageLoadingPreference();
-}
-
 void WKPreferencesSetOfflineWebApplicationCacheEnabled(WKPreferencesRef preferencesRef, bool offlineWebApplicationCacheEnabled)
 {
     toImpl(preferencesRef)->setOfflineWebApplicationCacheEnabled(offlineWebApplicationCacheEnabled);
@@ -2112,3 +2102,11 @@ bool WKPreferencesGetPaginateDuringLayoutEnabled(WKPreferencesRef)
     return false;
 }
 
+void WKPreferencesSetLoadsSiteIconsIgnoringImageLoadingPreference(WKPreferencesRef, bool)
+{
+}
+
+bool WKPreferencesGetLoadsSiteIconsIgnoringImageLoadingPreference(WKPreferencesRef)
+{
+    return false;
+}

--- a/Source/WebKit/UIProcess/API/C/WKPreferencesRef.h
+++ b/Source/WebKit/UIProcess/API/C/WKPreferencesRef.h
@@ -75,7 +75,7 @@ WK_EXPORT bool WKPreferencesGetJavaScriptMarkupEnabled(WKPreferencesRef preferen
 WK_EXPORT void WKPreferencesSetLoadsImagesAutomatically(WKPreferencesRef preferences, bool loadsImagesAutomatically);
 WK_EXPORT bool WKPreferencesGetLoadsImagesAutomatically(WKPreferencesRef preferences);
 
-// Defaults to false.
+// Obsolete: Defaults to false.
 WK_EXPORT void WKPreferencesSetLoadsSiteIconsIgnoringImageLoadingPreference(WKPreferencesRef preferences, bool loadsSiteIconsIgnoringImageLoadingPreference);
 WK_EXPORT bool WKPreferencesGetLoadsSiteIconsIgnoringImageLoadingPreference(WKPreferencesRef preferences);
 

--- a/Source/WebKit/UIProcess/API/glib/WebKitSettings.cpp
+++ b/Source/WebKit/UIProcess/API/glib/WebKitSettings.cpp
@@ -1740,12 +1740,16 @@ void webkit_settings_set_auto_load_images(WebKitSettings* settings, gboolean ena
  * Get the #WebKitSettings:load-icons-ignoring-image-load-setting property.
  *
  * Returns: %TRUE If site icon can be loaded irrespective of image loading preference or %FALSE otherwise.
+ *
+ * Deprecated: TBA
  */
 gboolean webkit_settings_get_load_icons_ignoring_image_load_setting(WebKitSettings* settings)
 {
     g_return_val_if_fail(WEBKIT_IS_SETTINGS(settings), FALSE);
 
-    return settings->priv->preferences->loadsSiteIconsIgnoringImageLoadingPreference();
+    g_warning("webkit_settings_get_load_icons_ignoring_image_load_setting is deprecated and always returns FALSE.");
+
+    return FALSE;
 }
 
 /**
@@ -1754,18 +1758,15 @@ gboolean webkit_settings_get_load_icons_ignoring_image_load_setting(WebKitSettin
  * @enabled: Value to be set
  *
  * Set the #WebKitSettings:load-icons-ignoring-image-load-setting property.
+ *
+ * Deprecated: TBA
  */
 void webkit_settings_set_load_icons_ignoring_image_load_setting(WebKitSettings* settings, gboolean enabled)
 {
     g_return_if_fail(WEBKIT_IS_SETTINGS(settings));
 
-    WebKitSettingsPrivate* priv = settings->priv;
-    bool currentValue = priv->preferences->loadsSiteIconsIgnoringImageLoadingPreference();
-    if (currentValue == enabled)
-        return;
-
-    priv->preferences->setLoadsSiteIconsIgnoringImageLoadingPreference(enabled);
-    g_object_notify_by_pspec(G_OBJECT(settings), sObjProperties[PROP_LOAD_ICONS_IGNORING_IMAGE_LOAD_SETTING]);
+    if (enabled)
+        g_warning("webkit_settings_set_load_icons_ignoring_image_load_setting is deprecated and does nothing.");
 }
 
 /**

--- a/Source/WebKitLegacy/mac/WebCoreSupport/WebFrameLoaderClient.mm
+++ b/Source/WebKitLegacy/mac/WebCoreSupport/WebFrameLoaderClient.mm
@@ -2052,7 +2052,7 @@ void WebFrameLoaderClient::getLoadDecisionForIcons(const Vector<std::pair<WebCor
 #endif
 
     bool disallowedDueToImageLoadSettings = false;
-    if (!frame->settings().loadsImagesAutomatically() && !frame->settings().loadsSiteIconsIgnoringImageLoadingSetting())
+    if (!frame->settings().loadsImagesAutomatically())
         disallowedDueToImageLoadSettings = true;
 
     if (disallowedDueToImageLoadSettings || !frame->isMainFrame() || !documentLoader->url().protocolIsInHTTPFamily() || ![WebView _isIconLoadingEnabled]) {

--- a/Source/WebKitLegacy/mac/WebView/WebPreferenceKeysPrivate.h
+++ b/Source/WebKitLegacy/mac/WebView/WebPreferenceKeysPrivate.h
@@ -65,7 +65,6 @@
 #define WebKitAllowAnimatedImageLoopingPreferenceKey @"WebKitAllowAnimatedImageLoopingPreferenceKey"
 #define WebKitDisplayImagesKey @"WebKitDisplayImagesKey"
 #define WebKitAdditionalSupportedImageTypesKey  @"WebKitAdditionalSupportedImageTypesKey"
-#define WebKitLoadSiteIconsKey @"WebKitLoadSiteIconsKey"
 #define WebKitBackForwardCacheExpirationIntervalKey @"WebKitBackForwardCacheExpirationIntervalKey"
 #if !TARGET_OS_IPHONE
 #define WebKitTabToLinksPreferenceKey @"WebKitTabToLinksPreferenceKey"

--- a/Source/WebKitLegacy/mac/WebView/WebPreferences.mm
+++ b/Source/WebKitLegacy/mac/WebView/WebPreferences.mm
@@ -1954,16 +1954,6 @@ static RetainPtr<NSString>& classIBCreatorID()
     setWebKitLinkTimeVersion(version);
 }
 
-- (void)setLoadsSiteIconsIgnoringImageLoadingPreference: (BOOL)flag
-{
-    [self _setBoolValue: flag forKey: WebKitLoadSiteIconsKey];
-}
-
-- (BOOL)loadsSiteIconsIgnoringImageLoadingPreference
-{
-    return [self _boolValueForKey: WebKitLoadSiteIconsKey];
-}
-
 - (void)setAVFoundationEnabled:(BOOL)flag
 {
     [self _setBoolValue:flag forKey:WebKitAVFoundationEnabledKey];
@@ -3390,5 +3380,15 @@ static RetainPtr<NSString>& classIBCreatorID()
 - (void)setWebGL2Enabled:(BOOL)enabled
 {
 }
+
+- (void)setLoadsSiteIconsIgnoringImageLoadingPreference: (BOOL)flag
+{
+}
+
+- (BOOL)loadsSiteIconsIgnoringImageLoadingPreference
+{
+    return NO;
+}
+
 
 @end

--- a/Source/WebKitLegacy/mac/WebView/WebPreferencesPrivate.h
+++ b/Source/WebKitLegacy/mac/WebView/WebPreferencesPrivate.h
@@ -184,7 +184,6 @@ extern NSString *WebPreferencesCacheModelChangedInternalNotification WEBKIT_DEPR
 @property (nonatomic) BOOL fullScreenEnabled;
 @property (nonatomic) BOOL asynchronousSpellCheckingEnabled;
 @property (nonatomic) BOOL usePreHTML5ParserQuirks;
-@property (nonatomic) BOOL loadsSiteIconsIgnoringImageLoadingPreference;
 @property (nonatomic, getter=isAVFoundationEnabled) BOOL AVFoundationEnabled;
 @property (nonatomic, getter=isAVFoundationNSURLSessionEnabled) BOOL AVFoundationNSURLSessionEnabled;
 @property (nonatomic) BOOL backspaceKeyNavigationEnabled;
@@ -366,6 +365,7 @@ extern NSString *WebPreferencesCacheModelChangedInternalNotification WEBKIT_DEPR
 @property (nonatomic, getter=isXSSAuditorEnabled) BOOL XSSAuditorEnabled;
 @property (nonatomic) BOOL subpixelAntialiasedLayerTextEnabled;
 @property (nonatomic) BOOL webGL2Enabled;
+@property (nonatomic) BOOL loadsSiteIconsIgnoringImageLoadingPreference;
 
 - (void)setDiskImageCacheEnabled:(BOOL)enabled;
 

--- a/Tools/TestWebKitAPI/Tests/WebKitGLib/TestWebKitSettings.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebKitGLib/TestWebKitSettings.cpp
@@ -52,10 +52,10 @@ static void testWebKitSettings(Test*, gconstpointer)
     webkit_settings_set_auto_load_images(settings, FALSE);
     g_assert_false(webkit_settings_get_auto_load_images(settings));
 
-    // load-icons-ignoring-image-load-setting is false by default.
+    // load-icons-ignoring-image-load-setting is deprecated and always false.
     g_assert_false(webkit_settings_get_load_icons_ignoring_image_load_setting(settings));
     webkit_settings_set_load_icons_ignoring_image_load_setting(settings, TRUE);
-    g_assert_true(webkit_settings_get_load_icons_ignoring_image_load_setting(settings));
+    g_assert_false(webkit_settings_get_load_icons_ignoring_image_load_setting(settings));
     
     // Offline application cache is true by default.
     g_assert_true(webkit_settings_get_enable_offline_web_application_cache(settings));
@@ -396,7 +396,8 @@ void testWebKitSettingsNewWithSettings(Test* test, gconstpointer)
     test->assertObjectIsDeletedWhenTestFinishes(G_OBJECT(settings.get()));
     g_assert_false(webkit_settings_get_enable_javascript(settings.get()));
     g_assert_false(webkit_settings_get_auto_load_images(settings.get()));
-    g_assert_true(webkit_settings_get_load_icons_ignoring_image_load_setting(settings.get()));
+    // load-icons-ignoring-image-load-setting is deprecated and always false.
+    g_assert_false(webkit_settings_get_load_icons_ignoring_image_load_setting(settings.get()));
 }
 
 #if PLATFORM(GTK)


### PR DESCRIPTION
#### 4967181732a932f88eb3b348aa0b6fa5354560f2
<pre>
Remove the abandoned &apos;LoadSiteIconsIgnoringImageLoadingPreference&apos; setting
<a href="https://bugs.webkit.org/show_bug.cgi?id=255688">https://bugs.webkit.org/show_bug.cgi?id=255688</a>
&lt;rdar://107159912&gt;

Reviewed by Brady Eidson.

The LoadSiteIconsIgnoringImageLoadingPreference is not used any longer, and we
should remove it.

* Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml:
* Source/WebKit/UIProcess/API/C/WKPreferences.cpp:
(WKPreferencesSetLoadsSiteIconsIgnoringImageLoadingPreference):
(WKPreferencesGetLoadsSiteIconsIgnoringImageLoadingPreference):
* Source/WebKit/UIProcess/API/C/WKPreferencesRef.h:
* Source/WebKit/UIProcess/API/glib/WebKitSettings.cpp:
(webkit_settings_get_load_icons_ignoring_image_load_setting):
(webkit_settings_set_load_icons_ignoring_image_load_setting):
* Source/WebKitLegacy/mac/WebCoreSupport/WebFrameLoaderClient.mm:
(WebFrameLoaderClient::getLoadDecisionForIcons):
* Source/WebKitLegacy/mac/WebView/WebPreferenceKeysPrivate.h:
* Source/WebKitLegacy/mac/WebView/WebPreferences.mm:
(-[WebPreferences setLoadsSiteIconsIgnoringImageLoadingPreference:]):
(-[WebPreferences loadsSiteIconsIgnoringImageLoadingPreference]):
* Source/WebKitLegacy/mac/WebView/WebPreferencesPrivate.h:
* Tools/TestWebKitAPI/Tests/WebKitGLib/TestWebKitSettings.cpp:
(testWebKitSettings):
(testWebKitSettingsNewWithSettings):

Canonical link: <a href="https://commits.webkit.org/263202@main">https://commits.webkit.org/263202@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f41bff12579554f04066d81ff5181deec777457a

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/3898 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/3988 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/4097 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/5333 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/4157 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/3874 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/4070 "Built successfully") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/16/builds/3986 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/3862 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/3946 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/4142 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/3519 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/5169 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/1646 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/3494 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/5521 "Passed tests") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/3208 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/3465 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/3554 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/4951 "267 api tests failed or timed out") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/3673 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/3952 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/16/builds/3986 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/3975 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/3473 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/3494 "Passed tests") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/989 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/954 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/3518 "Built successfully") | | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/24/builds/4067 "Built successfully") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/3751 "Built successfully") | | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/3/builds/1100 "Passed tests") | 
<!--EWS-Status-Bubble-End-->