### PR TITLE
[PlayStation] Paint to correct DrawingAreaProxy type

### DIFF
--- a/Source/WebKit/UIProcess/CoordinatedGraphics/DrawingAreaProxyCoordinatedGraphics.h
+++ b/Source/WebKit/UIProcess/CoordinatedGraphics/DrawingAreaProxyCoordinatedGraphics.h
@@ -135,3 +135,5 @@ private:
 };
 
 } // namespace WebKit
+
+SPECIALIZE_TYPE_TRAITS_DRAWING_AREA_PROXY(DrawingAreaProxyCoordinatedGraphics, DrawingAreaType::CoordinatedGraphics)

--- a/Source/WebKit/UIProcess/playstation/PageClientImpl.cpp
+++ b/Source/WebKit/UIProcess/playstation/PageClientImpl.cpp
@@ -51,12 +51,10 @@ PageClientImpl::PageClientImpl(PlayStationWebView& view)
 std::unique_ptr<DrawingAreaProxy> PageClientImpl::createDrawingAreaProxy(WebProcessProxy&)
 {
 #if USE(GRAPHICS_LAYER_WC)
-    if (m_view.page()->preferences().useGPUProcessForDOMRenderingEnabled()
-        || m_view.page()->preferences().useGPUProcessForCanvasRenderingEnabled()
-        || m_view.page()->preferences().useGPUProcessForWebGLEnabled())
-        return makeUnique<DrawingAreaProxyWC>(*m_view.page());
-#endif
+    return makeUnique<DrawingAreaProxyWC>(*m_view.page());
+#else
     return makeUnique<DrawingAreaProxyCoordinatedGraphics>(*m_view.page());
+#endif
 }
 
 void PageClientImpl::setViewNeedsDisplay(const WebCore::Region& region)

--- a/Source/WebKit/UIProcess/wc/DrawingAreaProxyWC.h
+++ b/Source/WebKit/UIProcess/wc/DrawingAreaProxyWC.h
@@ -63,4 +63,6 @@ private:
 
 } // namespace WebKit
 
+SPECIALIZE_TYPE_TRAITS_DRAWING_AREA_PROXY(DrawingAreaProxyWC, DrawingAreaType::WC)
+
 #endif // USE(GRAPHICS_LAYER_WC)


### PR DESCRIPTION
#### a63d53b024de0ae60e5571b9ba70dd74322fd75b
<pre>
[PlayStation] Paint to correct DrawingAreaProxy type
<a href="https://bugs.webkit.org/show_bug.cgi?id=255692">https://bugs.webkit.org/show_bug.cgi?id=255692</a>

Reviewed by Fujii Hironori.

Add specialized types for `DrawingAreaProxyCoordinatedGraphics` and
`DrawingAreaProxyWC` so within `WKPagePaint` the correct type can be
cast to.

* Source/WebKit/UIProcess/API/C/playstation/WKPagePrivatePlayStation.cpp:
(WKPagePaint):
* Source/WebKit/UIProcess/CoordinatedGraphics/DrawingAreaProxyCoordinatedGraphics.h:
* Source/WebKit/UIProcess/playstation/PageClientImpl.cpp:
* Source/WebKit/UIProcess/wc/DrawingAreaProxyWC.h:

Canonical link: <a href="https://commits.webkit.org/263848@main">https://commits.webkit.org/263848@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f4282ef8f0c52d3c0f7f2d2fd3145dc34fe38e1f

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/5883 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/6055 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/6242 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/7434 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/6249 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/6274 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/6016 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/8468 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/5991 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/6030 "Passed tests") | [⏳ 🧪 api-mac](https://ews-build.webkit.org/#/builders/API-Tests-macOS-EWS "Waiting to run tests") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/2/builds/7514 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/3507 "Passed tests") | | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/13244 "layout-tests (failure)") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/5372 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/5373 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/7589 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/5829 "Built successfully") | [⏳ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/macOS-AppleSilicon-Ventura-Debug-WK2-Tests-EWS "Waiting to run tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/5262 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/1393 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/9386 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/5623 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->