### PR TITLE
Fix handleRecursiveTailCall for osr exit at op_tail_call

### DIFF
--- a/JSTests/stress/osr-exit-at-tail-call-in-tail-recursion.js
+++ b/JSTests/stress/osr-exit-at-tail-call-in-tail-recursion.js
@@ -1,0 +1,30 @@
+//@ runDefault
+
+function shouldThrow(func, errorMessage) {
+    var errorThrown = false;
+    var error = null;
+    try {
+        func();
+    } catch (e) {
+        errorThrown = true;
+        error = e;
+    }
+    if (!errorThrown)
+        throw new Error('not thrown');
+    if (String(error) !== errorMessage)
+        throw new Error(`bad error: ${String(error)}`);
+}
+
+"use strict";
+
+function bar(x, y) {
+    function foo(a, b) {
+        if (a == 0) b += ',';
+        return foo(b - 1, a, 43);
+    }
+    return foo(x, y);
+}
+
+shouldThrow(() => {
+    bar(1, 1);
+}, "RangeError: Maximum call stack size exceeded.");

--- a/Source/JavaScriptCore/dfg/DFGByteCodeParser.cpp
+++ b/Source/JavaScriptCore/dfg/DFGByteCodeParser.cpp
@@ -1598,7 +1598,7 @@ bool ByteCodeParser::handleRecursiveTailCall(Node* callTargetNode, CallVariant c
         auto oldStackTop = m_inlineStackTop;
         m_inlineStackTop = stackEntry;
         static_assert(OpcodeIDWidthBySize<JSOpcodeTraits, OpcodeSize::Wide32>::opcodeIDSize == 1);
-        m_currentIndex = BytecodeIndex(opcodeLengths[op_enter] + 1);
+        m_currentIndex = BytecodeIndex(opcodeLengths[op_enter]);
         m_exitOK = true;
         processSetLocalQueue();
         m_currentIndex = oldIndex;


### PR DESCRIPTION
#### a75b74fc83c06296ff667aaaabf593697eb2fa1b
<pre>
Fix handleRecursiveTailCall for osr exit at op_tail_call
<a href="https://bugs.webkit.org/show_bug.cgi?id=254574">https://bugs.webkit.org/show_bug.cgi?id=254574</a>
rdar://107598022

Reviewed by Yusuke Suzuki.

Previously, we introduced a patch <a href="https://commits.webkit.org/260787@main">https://commits.webkit.org/260787@main</a>
which merges op_enter, op_get_scope, and op_check_traps into op_enter
for less prologue overhead. However, the patch crashes in a tail recursion
when OSR exit from FTL to Baseline at op_tail_call. This is becuase we
exit to the offset(op_enter) + 1 which would miss the execution of op_get_scope
that merged into op_enter in the previous path. In that case, program would
crash when trying to dereference an undefined scope after OSR exit. To fix this
issue we should just update the exit to  offset(op_enter) instead of
offset(op_enter) + 1.

JavaScript tail recursion foo:
function foo(n) {
    ...
    return foo(n);
}

Bytecode for foo with scope at loc4:
[  0] enter
[  1] ...
...
[ 11] resolve_scope  dst:loc10, scope:loc4
...
[ 38] tail_call ...
[...] ret       ...

DFG for foo:
...
--&gt; foo // inlined recursive tail call
    ...
    @node(..., bc#38, exit: bc#38 --&gt; bc#1, ...)
    ...
&lt;-- foo

DFG for foo:
...
--&gt; foo // inlined recursive tail call
    ...
    @node(..., bc#38, exit: bc#38 --&gt; bc#0, ...)
    ...
&lt;-- foo

* JSTests/stress/osr-exit-at-tail-call-in-tail-recursion.js: Added.
(foo):
(bar):
* Source/JavaScriptCore/dfg/DFGByteCodeParser.cpp:
(JSC::DFG::ByteCodeParser::handleRecursiveTailCall):

Canonical link: <a href="https://commits.webkit.org/263183@main">https://commits.webkit.org/263183@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0270a5cfd5d02ce4b8f542a6fbc9bc6d8c4673e0

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/3820 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/3908 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/4016 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/5252 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/4079 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/3986 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/3913 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/3663 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/3866 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/4065 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/3439 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/5086 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/1569 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/3414 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/4608 "Passed tests") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/3136 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/3388 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/3473 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/4854 "260 api tests failed or timed out") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/3592 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/3871 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/3134 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/3896 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/3396 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/3414 "Passed tests") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/978 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/942 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/3437 "Built successfully") | | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/24/builds/3988 "Built successfully") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/3673 "Built successfully") | | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/3/builds/1089 "Passed tests") | 
<!--EWS-Status-Bubble-End-->