### PR TITLE
[CURL] Add support for data url link downloads

### DIFF
--- a/LayoutTests/platform/wincairo/TestExpectations
+++ b/LayoutTests/platform/wincairo/TestExpectations
@@ -936,7 +936,6 @@ http/tests/security/XFrameOptions/x-frame-options-deny.html [ Skip ] # Failure
 http/tests/security/XFrameOptions/x-frame-options-multiple-headers-conflict.html [ Skip ] # Failure
 http/tests/security/XFrameOptions/x-frame-options-multiple-headers-sameorigin-deny.html [ Skip ] # Failure
 http/tests/security/XFrameOptions/x-frame-options-parent-same-origin-deny.html [ Skip ] # Failure
-http/tests/security/anchor-download-allow-data.html [ Skip ] # Crash
 http/tests/security/bypassing-cors-checks-for-extension-urls.html [ Skip ] # Failure
 http/tests/security/canvas-remote-read-remote-video-allowed-anonymous.html [ Skip ] # Failure
 http/tests/security/canvas-remote-read-remote-video-allowed-redirect.html [ Skip ] # Crash

--- a/Source/WebCore/platform/network/DataURLDecoder.h
+++ b/Source/WebCore/platform/network/DataURLDecoder.h
@@ -51,7 +51,7 @@ struct ScheduleContext {
 #endif
 };
 
-void decode(const URL&, const ScheduleContext&, DecodeCompletionHandler&&);
+WEBCORE_EXPORT void decode(const URL&, const ScheduleContext&, DecodeCompletionHandler&&);
 WEBCORE_EXPORT std::optional<Result> decode(const URL&);
 
 }

--- a/Source/WebKit/NetworkProcess/NetworkDataTask.cpp
+++ b/Source/WebKit/NetworkProcess/NetworkDataTask.cpp
@@ -56,14 +56,15 @@ Ref<NetworkDataTask> NetworkDataTask::create(NetworkSession& session, NetworkDat
     ASSERT(!parameters.request.url().protocolIsBlob());
 #if PLATFORM(COCOA)
     return NetworkDataTaskCocoa::create(session, client, parameters);
-#endif
-#if USE(SOUP)
+#else
     if (parameters.request.url().protocolIsData())
         return NetworkDataTaskDataURL::create(session, client, parameters);
+#if USE(SOUP)
     return NetworkDataTaskSoup::create(session, client, parameters);
 #endif
 #if USE(CURL)
     return NetworkDataTaskCurl::create(session, client, parameters);
+#endif
 #endif
 }
 

--- a/Source/WebKit/PlatformPlayStation.cmake
+++ b/Source/WebKit/PlatformPlayStation.cmake
@@ -35,6 +35,8 @@ list(APPEND WebKit_SOURCES
     GPUProcess/playstation/GPUProcessMainPlayStation.cpp
     GPUProcess/playstation/GPUProcessPlayStation.cpp
 
+    NetworkProcess/NetworkDataTaskDataURL.cpp
+
     NetworkProcess/Classifier/WebResourceLoadStatisticsStore.cpp
 
     NetworkProcess/Cookies/curl/WebCookieManagerCurl.cpp

--- a/Source/WebKit/PlatformWin.cmake
+++ b/Source/WebKit/PlatformWin.cmake
@@ -19,6 +19,8 @@ list(APPEND WebKit_SOURCES
     GPUProcess/win/GPUProcessMainWin.cpp
     GPUProcess/win/GPUProcessWin.cpp
 
+    NetworkProcess/NetworkDataTaskDataURL.cpp
+
     NetworkProcess/Classifier/WebResourceLoadStatisticsStore.cpp
 
     NetworkProcess/Cookies/curl/WebCookieManagerCurl.cpp


### PR DESCRIPTION
#### 8050ec39e480cea3e8046942831a6edc31bf17d1
<pre>
[CURL] Add support for data url link downloads
<a href="https://bugs.webkit.org/show_bug.cgi?id=255696">https://bugs.webkit.org/show_bug.cgi?id=255696</a>

Reviewed by Fujii Hironori.

Curl does not support data: urls, handle them using
NetworkDataTaskDataURL.

* LayoutTests/platform/wincairo/TestExpectations:
* Source/WebCore/platform/network/DataURLDecoder.h:
* Source/WebKit/NetworkProcess/NetworkDataTask.cpp:
* Source/WebKit/PlatformPlayStation.cmake

Canonical link: <a href="https://commits.webkit.org/263434@main">https://commits.webkit.org/263434@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2519f6f259356569861004d2d7cf46fabce6964e

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/4567 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/4687 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/4838 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/6058 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/4727 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/4558 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/4829 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/4643 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/4965 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/4635 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/4736 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/4089 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/6064 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/2228 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/4081 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/9077 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/4084 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/4153 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/5692 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/4544 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/3705 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/4077 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/1133 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/8118 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/4438 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->