### PR TITLE
WebKit needs to pass along NotificationOptions.silent to API clients

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/notifications/idlharness.https.any-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/notifications/idlharness.https.any-expected.txt
@@ -30,7 +30,7 @@ FAIL Notification interface: attribute badge assert_true: The prototype object m
 FAIL Notification interface: attribute vibrate assert_true: The prototype object must have a property "vibrate" expected true got false
 FAIL Notification interface: attribute timestamp assert_true: The prototype object must have a property "timestamp" expected true got false
 FAIL Notification interface: attribute renotify assert_true: The prototype object must have a property "renotify" expected true got false
-FAIL Notification interface: attribute silent assert_true: The prototype object must have a property "silent" expected true got false
+PASS Notification interface: attribute silent
 FAIL Notification interface: attribute requireInteraction assert_true: The prototype object must have a property "requireInteraction" expected true got false
 PASS Notification interface: attribute data
 FAIL Notification interface: attribute actions assert_true: The prototype object must have a property "actions" expected true got false
@@ -56,7 +56,7 @@ FAIL Notification interface: notification must inherit property "badge" with the
 FAIL Notification interface: notification must inherit property "vibrate" with the proper type assert_inherits: property "vibrate" not found in prototype chain
 FAIL Notification interface: notification must inherit property "timestamp" with the proper type assert_inherits: property "timestamp" not found in prototype chain
 FAIL Notification interface: notification must inherit property "renotify" with the proper type assert_inherits: property "renotify" not found in prototype chain
-FAIL Notification interface: notification must inherit property "silent" with the proper type assert_inherits: property "silent" not found in prototype chain
+PASS Notification interface: notification must inherit property "silent" with the proper type
 FAIL Notification interface: notification must inherit property "requireInteraction" with the proper type assert_inherits: property "requireInteraction" not found in prototype chain
 PASS Notification interface: notification must inherit property "data" with the proper type
 FAIL Notification interface: notification must inherit property "actions" with the proper type assert_inherits: property "actions" not found in prototype chain

--- a/LayoutTests/imported/w3c/web-platform-tests/notifications/idlharness.https.any.serviceworker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/notifications/idlharness.https.any.serviceworker-expected.txt
@@ -30,7 +30,7 @@ FAIL Notification interface: attribute badge assert_true: The prototype object m
 FAIL Notification interface: attribute vibrate assert_true: The prototype object must have a property "vibrate" expected true got false
 FAIL Notification interface: attribute timestamp assert_true: The prototype object must have a property "timestamp" expected true got false
 FAIL Notification interface: attribute renotify assert_true: The prototype object must have a property "renotify" expected true got false
-FAIL Notification interface: attribute silent assert_true: The prototype object must have a property "silent" expected true got false
+PASS Notification interface: attribute silent
 FAIL Notification interface: attribute requireInteraction assert_true: The prototype object must have a property "requireInteraction" expected true got false
 PASS Notification interface: attribute data
 FAIL Notification interface: attribute actions assert_true: The prototype object must have a property "actions" expected true got false

--- a/LayoutTests/imported/w3c/web-platform-tests/notifications/idlharness.https.any.worker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/notifications/idlharness.https.any.worker-expected.txt
@@ -30,7 +30,7 @@ FAIL Notification interface: attribute badge assert_true: The prototype object m
 FAIL Notification interface: attribute vibrate assert_true: The prototype object must have a property "vibrate" expected true got false
 FAIL Notification interface: attribute timestamp assert_true: The prototype object must have a property "timestamp" expected true got false
 FAIL Notification interface: attribute renotify assert_true: The prototype object must have a property "renotify" expected true got false
-FAIL Notification interface: attribute silent assert_true: The prototype object must have a property "silent" expected true got false
+PASS Notification interface: attribute silent
 FAIL Notification interface: attribute requireInteraction assert_true: The prototype object must have a property "requireInteraction" expected true got false
 PASS Notification interface: attribute data
 FAIL Notification interface: attribute actions assert_true: The prototype object must have a property "actions" expected true got false
@@ -55,7 +55,7 @@ FAIL Notification interface: notification must inherit property "badge" with the
 FAIL Notification interface: notification must inherit property "vibrate" with the proper type assert_inherits: property "vibrate" not found in prototype chain
 FAIL Notification interface: notification must inherit property "timestamp" with the proper type assert_inherits: property "timestamp" not found in prototype chain
 FAIL Notification interface: notification must inherit property "renotify" with the proper type assert_inherits: property "renotify" not found in prototype chain
-FAIL Notification interface: notification must inherit property "silent" with the proper type assert_inherits: property "silent" not found in prototype chain
+PASS Notification interface: notification must inherit property "silent" with the proper type
 FAIL Notification interface: notification must inherit property "requireInteraction" with the proper type assert_inherits: property "requireInteraction" not found in prototype chain
 PASS Notification interface: notification must inherit property "data" with the proper type
 FAIL Notification interface: notification must inherit property "actions" with the proper type assert_inherits: property "actions" not found in prototype chain

--- a/Source/WebCore/Modules/notifications/Notification.cpp
+++ b/Source/WebCore/Modules/notifications/Notification.cpp
@@ -116,7 +116,7 @@ ExceptionOr<Ref<Notification>> Notification::createForServiceWorker(ScriptExecut
 
 Ref<Notification> Notification::create(ScriptExecutionContext& context, NotificationData&& data)
 {
-    Options options { data.direction, WTFMove(data.language), WTFMove(data.body), WTFMove(data.tag), WTFMove(data.iconURL), JSC::jsNull() };
+    Options options { data.direction, WTFMove(data.language), WTFMove(data.body), WTFMove(data.tag), WTFMove(data.iconURL), JSC::jsNull(), data.silent };
 
     auto notification = adoptRef(*new Notification(context, data.notificationID, WTFMove(data.title), WTFMove(options), SerializedScriptValue::createFromWireBytes(WTFMove(data.data))));
     notification->suspendIfNeeded();
@@ -134,6 +134,7 @@ Notification::Notification(ScriptExecutionContext& context, UUID identifier, Str
     , m_body(WTFMove(options.body).isolatedCopy())
     , m_tag(WTFMove(options.tag).isolatedCopy())
     , m_dataForBindings(WTFMove(dataForBindings))
+    , m_silent(options.silent)
     , m_state(Idle)
 {
     if (context.isDocument())
@@ -419,7 +420,8 @@ NotificationData Notification::data() const
         context.identifier(),
         *sessionID,
         MonotonicTime::now(),
-        m_dataForBindings->wireBytes()
+        m_dataForBindings->wireBytes(),
+        m_silent
     };
 }
 

--- a/Source/WebCore/Modules/notifications/Notification.h
+++ b/Source/WebCore/Modules/notifications/Notification.h
@@ -68,6 +68,7 @@ public:
         String tag;
         String icon;
         JSC::JSValue data;
+        std::optional<bool> silent;
     };
     // For JS constructor only.
     static ExceptionOr<Ref<Notification>> create(ScriptExecutionContext&, String&& title, Options&&);
@@ -87,6 +88,7 @@ public:
     const String& tag() const { return m_tag; }
     const URL& icon() const { return m_icon; }
     JSC::JSValue dataForBindings(JSC::JSGlobalObject&);
+    bool silent() const { return m_silent == std::nullopt ? false : *m_silent; }
 
     TextDirection direction() const { return m_direction == Direction::Rtl ? TextDirection::RTL : TextDirection::LTR; }
 
@@ -146,6 +148,7 @@ private:
     String m_tag;
     URL m_icon;
     Ref<SerializedScriptValue> m_dataForBindings;
+    std::optional<bool> m_silent;
 
     enum State { Idle, Showing, Closed };
     State m_state { Idle };

--- a/Source/WebCore/Modules/notifications/Notification.idl
+++ b/Source/WebCore/Modules/notifications/Notification.idl
@@ -60,7 +60,7 @@
     // [SameObject] readonly attribute FrozenArray<unsigned long> vibrate;
     // readonly attribute EpochTimeStamp timestamp;
     // readonly attribute boolean renotify;
-    // readonly attribute boolean silent;
+    readonly attribute boolean silent;
     // readonly attribute boolean requireInteraction;
     [CallWith=CurrentGlobalObject, CachedAttribute, ImplementedAs=dataForBindings] readonly attribute any data;
     // [SameObject] readonly attribute FrozenArray<NotificationAction> actions;

--- a/Source/WebCore/Modules/notifications/NotificationData.cpp
+++ b/Source/WebCore/Modules/notifications/NotificationData.cpp
@@ -30,12 +30,12 @@ namespace WebCore {
 
 NotificationData NotificationData::isolatedCopy() const &
 {
-    return { title.isolatedCopy(), body.isolatedCopy(), iconURL.isolatedCopy(), tag.isolatedCopy(), language.isolatedCopy(), direction, originString.isolatedCopy(), serviceWorkerRegistrationURL.isolatedCopy(), notificationID, contextIdentifier, sourceSession, creationTime, data };
+    return { title.isolatedCopy(), body.isolatedCopy(), iconURL.isolatedCopy(), tag.isolatedCopy(), language.isolatedCopy(), direction, originString.isolatedCopy(), serviceWorkerRegistrationURL.isolatedCopy(), notificationID, contextIdentifier, sourceSession, creationTime, data, silent };
 }
 
 NotificationData NotificationData::isolatedCopy() &&
 {
-    return { WTFMove(title).isolatedCopy(), WTFMove(body).isolatedCopy(), WTFMove(iconURL).isolatedCopy(), WTFMove(tag).isolatedCopy(), WTFMove(language).isolatedCopy(), direction, WTFMove(originString).isolatedCopy(), WTFMove(serviceWorkerRegistrationURL).isolatedCopy(), notificationID, contextIdentifier, sourceSession, creationTime, WTFMove(data) };
+    return { WTFMove(title).isolatedCopy(), WTFMove(body).isolatedCopy(), WTFMove(iconURL).isolatedCopy(), WTFMove(tag).isolatedCopy(), WTFMove(language).isolatedCopy(), direction, WTFMove(originString).isolatedCopy(), WTFMove(serviceWorkerRegistrationURL).isolatedCopy(), notificationID, contextIdentifier, sourceSession, creationTime, WTFMove(data), silent };
 }
 
 } // namespace WebCore

--- a/Source/WebCore/Modules/notifications/NotificationData.h
+++ b/Source/WebCore/Modules/notifications/NotificationData.h
@@ -63,6 +63,7 @@ struct NotificationData {
     PAL::SessionID sourceSession;
     MonotonicTime creationTime;
     Vector<uint8_t> data;
+    std::optional<bool> silent;
 };
 
 } // namespace WebCore

--- a/Source/WebCore/Modules/notifications/NotificationOptions.idl
+++ b/Source/WebCore/Modules/notifications/NotificationOptions.idl
@@ -37,7 +37,7 @@
     // VibratePattern vibrate;
     // EpochTimeStamp timestamp;
     // boolean renotify = false;
-    // boolean silent = false;
+    boolean? silent;
     // boolean requireInteraction = false;
     any data = null;
     // sequence<NotificationAction> actions = [];

--- a/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
+++ b/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
@@ -905,6 +905,7 @@ struct WebCore::NotificationData {
     PAL::SessionID sourceSession;
     MonotonicTime creationTime;
     Vector<uint8_t> data;
+    std::optional<bool> silent;
 };
 
 struct WebCore::PermissionDescriptor {

--- a/Source/WebKit/UIProcess/API/Cocoa/_WKNotificationData.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKNotificationData.h
@@ -24,6 +24,12 @@
  */
 #import <WebKit/WKFoundation.h>
 
+typedef NS_ENUM(NSUInteger, _WKNotificationAlert) {
+    _WKNotificationAlertDefault,
+    _WKNotificationAlertSilent,
+    _WKNotificationAlertEnabled
+};
+
 WK_CLASS_AVAILABLE(macos(13.3), ios(16.4))
 @interface _WKNotificationData : NSObject
 @property (nonatomic, readonly, copy) NSString *title;
@@ -31,4 +37,5 @@ WK_CLASS_AVAILABLE(macos(13.3), ios(16.4))
 @property (nonatomic, readonly, copy) NSString *origin;
 @property (nonatomic, readonly, copy) NSString *identifier;
 @property (nonatomic, readonly, copy) NSDictionary *userInfo;
+@property (nonatomic, readonly) _WKNotificationAlert alert;
 @end

--- a/Source/WebKit/UIProcess/API/Cocoa/_WKNotificationData.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKNotificationData.mm
@@ -47,6 +47,10 @@ static NSString *dataKey = @"data";
     _origin = [(NSString *)coreData.originString retain];
     _identifier = [(NSString *)coreData.notificationID.toString() retain];
     _userInfo = [coreData.dictionaryRepresentation() retain];
+    if (coreData.silent == std::nullopt)
+        _alert = _WKNotificationAlertDefault;
+    else
+        _alert = *coreData.silent ? _WKNotificationAlertSilent : _WKNotificationAlertEnabled;
 
     return self;
 }

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/PushAPI.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/PushAPI.mm
@@ -288,6 +288,115 @@ TEST(PushAPI, firePushEventDataStoreDelegate)
     clearWebsiteDataStore([configuration websiteDataStore]);
 }
 
+
+static constexpr auto testSilentFlagScriptBytes = R"SWRESOURCE(
+let port;
+self.addEventListener("message", (event) => {
+    port = event.data.port;
+    port.postMessage("Ready");
+});
+self.addEventListener("push", (event) => {
+    try {
+        if (!event.data) {
+            port.postMessage("Received: null data");
+            return;
+        }
+        const value = event.data.text();
+        if (value == "nothing")
+            self.registration.showNotification("nothing");
+        else if (value == "true")
+            self.registration.showNotification("true", { silent: true });
+        else if (value == "false")
+            self.registration.showNotification("false", { silent: false });
+        port.postMessage("Done");
+    } catch (e) {
+        port.postMessage("Got exception " + e);
+    }
+});
+)SWRESOURCE"_s;
+
+TEST(PushAPI, testSilentFlag)
+{
+    TestWebKitAPI::HTTPServer server({
+        { "/"_s, { mainBytes } },
+        { "/sw.js"_s, { { { "Content-Type"_s, "application/javascript"_s } }, testSilentFlagScriptBytes } }
+    }, TestWebKitAPI::HTTPServer::Protocol::Http);
+
+    [WKWebsiteDataStore _allowWebsiteDataRecordsForAllOrigins];
+
+    auto messageHandler = adoptNS([[PushAPIMessageHandlerWithExpectedMessage alloc] init]);
+    auto configuration = createConfigurationWithNotificationsEnabled();
+    [[configuration userContentController] addScriptMessageHandler:messageHandler.get() name:@"sw"];
+
+    clearWebsiteDataStore([configuration websiteDataStore]);
+
+    RetainPtr<FirePushEventDataStoreDelegate> delegate = adoptNS([FirePushEventDataStoreDelegate new]);
+    delegate.get().permissions = @{
+        (NSString *)server.origin() : @YES
+    };
+    [configuration websiteDataStore]._delegate = delegate.get();
+
+    expectedMessage = "Ready"_s;
+    auto webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
+    [webView loadRequest:server.request()];
+
+    TestWebKitAPI::Util::run(&done);
+
+    expectedMessage = "Done"_s;
+
+    done = false;
+    pushMessageProcessed = false;
+    pushMessageSuccessful = false;
+    NSString *message = @"nothing";
+    [[configuration websiteDataStore] _processPushMessage:messageDictionary([message dataUsingEncoding:NSUTF8StringEncoding], [server.request() URL]) completionHandler:^(bool result) {
+        pushMessageSuccessful = result;
+        pushMessageProcessed = true;
+    }];
+    TestWebKitAPI::Util::run(&done);
+    TestWebKitAPI::Util::run(&pushMessageProcessed);
+
+    EXPECT_TRUE(pushMessageSuccessful);
+    EXPECT_TRUE([delegate.get().mostRecentNotification.title isEqualToString:@"nothing"]);
+    EXPECT_EQ(delegate.get().mostRecentNotification.alert, _WKNotificationAlertDefault);
+    EXPECT_TRUE([delegate.get().mostRecentNotification.userInfo[@"WebNotificationSilentKey"] isEqual:[NSNull null]]);
+
+    done = false;
+    pushMessageProcessed = false;
+    pushMessageSuccessful = false;
+    message = @"true";
+    [[configuration websiteDataStore] _processPushMessage:messageDictionary([message dataUsingEncoding:NSUTF8StringEncoding], [server.request() URL]) completionHandler:^(bool result) {
+        pushMessageSuccessful = result;
+        pushMessageProcessed = true;
+    }];
+    TestWebKitAPI::Util::run(&done);
+    TestWebKitAPI::Util::run(&pushMessageProcessed);
+
+    EXPECT_TRUE(pushMessageSuccessful);
+    EXPECT_TRUE([delegate.get().mostRecentNotification.title isEqualToString:@"true"]);
+    EXPECT_EQ(delegate.get().mostRecentNotification.alert, _WKNotificationAlertSilent);
+    EXPECT_TRUE([delegate.get().mostRecentNotification.userInfo[@"WebNotificationSilentKey"] isEqual:[NSNumber numberWithBool:YES]]);
+
+    done = false;
+    pushMessageProcessed = false;
+    pushMessageSuccessful = false;
+    message = @"false";
+    [[configuration websiteDataStore] _processPushMessage:messageDictionary([message dataUsingEncoding:NSUTF8StringEncoding], [server.request() URL]) completionHandler:^(bool result) {
+        pushMessageSuccessful = result;
+        pushMessageProcessed = true;
+    }];
+    TestWebKitAPI::Util::run(&done);
+    TestWebKitAPI::Util::run(&pushMessageProcessed);
+
+    EXPECT_TRUE(pushMessageSuccessful);
+    EXPECT_TRUE([delegate.get().mostRecentNotification.title isEqualToString:@"false"]);
+    EXPECT_EQ(delegate.get().mostRecentNotification.alert, _WKNotificationAlertEnabled);
+    EXPECT_TRUE([delegate.get().mostRecentNotification.userInfo[@"WebNotificationSilentKey"] isEqual:[NSNumber numberWithBool:NO]]);
+
+    // FIXME: Test that a click of a silent notification does in fact have silent: true
+
+    clearWebsiteDataStore([configuration websiteDataStore]);
+}
+
 static constexpr auto waitOneSecondScriptBytes = R"SWRESOURCE(
 let port;
 self.addEventListener("message", (event) => {
@@ -748,7 +857,7 @@ self.addEventListener("message", (event) => {
     port.postMessage("Ready");
 });
 self.addEventListener("push", (event) => {
-    self.registration.showNotification("notification");
+    self.registration.showNotification("notification", { silent: true });
     try {
         if (!event.data) {
             port.postMessage("Received: null data");
@@ -764,7 +873,7 @@ self.addEventListener("push", (event) => {
 });
 self.addEventListener("notificationclick", async (event) => {
     for (let client of await self.clients.matchAll({includeUncontrolled:true}))
-        client.postMessage("Received notificationclick");
+        client.postMessage("Received notificationclick: " + event.notification.silent);
 });
 self.addEventListener("notificationclose", async (event) => {
     for (let client of await self.clients.matchAll({includeUncontrolled:true}))
@@ -821,7 +930,7 @@ TEST(PushAPI, fireNotificationClickEvent)
     EXPECT_TRUE(provider.simulateNotificationClick());
 
     done = false;
-    expectedMessage = "Received notificationclick"_s;
+    expectedMessage = "Received notificationclick: true"_s;
     TestWebKitAPI::Util::run(&done);
 
     clearWebsiteDataStore([configuration websiteDataStore]);


### PR DESCRIPTION
#### c33fee9a59070e49240bca8644be011d5af78c35
<pre>
WebKit needs to pass along NotificationOptions.silent to API clients
<a href="https://bugs.webkit.org/show_bug.cgi?id=254562">https://bugs.webkit.org/show_bug.cgi?id=254562</a>
rdar://107424158

Reviewed by Megan Gardner.

WebKit doesn&apos;t display notifications itself. API clients do that.
WebKit simply passes along all of the information about the proposed notification to the client.

If a client wants to support notifications having sound, it also needs to know when a particular
notification should be silent.

JavaScript can specify in its NotificationOptions dictionary whether or not it prefers a
notification be silent.

This patch pays attention to the silent flag and passes along to the API client whether it:
- Was set to true
- Was set to false
- Was not set at all

* Source/WebCore/Modules/notifications/Notification.cpp:
(WebCore::Notification::create):
(WebCore::Notification::Notification):
(WebCore::Notification::data const):
* Source/WebCore/Modules/notifications/Notification.h:
* Source/WebCore/Modules/notifications/Notification.idl:

* Source/WebCore/Modules/notifications/NotificationData.cpp:
(WebCore::NotificationData::isolatedCopy const):
(WebCore::NotificationData::isolatedCopy):
* Source/WebCore/Modules/notifications/NotificationData.h:

* Source/WebCore/Modules/notifications/NotificationDataCocoa.mm:
(WebCore::nsValueToOptionalBool):
(WebCore::NotificationData::fromDictionary):
(WebCore::NotificationData::dictionaryRepresentation const):

* Source/WebCore/Modules/notifications/NotificationOptions.idl:

* Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in:

* Source/WebKit/UIProcess/API/Cocoa/_WKNotificationData.h:
* Source/WebKit/UIProcess/API/Cocoa/_WKNotificationData.mm:
(-[_WKNotificationData initWithCoreData:dataStore:]):

* Tools/TestWebKitAPI/Tests/WebKitCocoa/PushAPI.mm:

Canonical link: <a href="https://commits.webkit.org/263184@main">https://commits.webkit.org/263184@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/fffcc38535408ae9d2519190fc5d627e74aad59f

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/3866 "4 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/3955 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/4064 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/5300 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/4125 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/3842 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/4036 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/3961 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/3709 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/3914 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/4112 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/3486 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/5134 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/1616 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/3461 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/4888 "2 flakes 145 failures") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/3435 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/3521 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/4904 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/3919 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/3185 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/3441 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/3461 "Passed tests") | | 
| [❌ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/943 "Failed to push commit to Webkit repository") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/3485 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/3719 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->