### PR TITLE
[GTK] Build fix for Debian Stable after 263061@main

### DIFF
--- a/Source/JavaScriptCore/runtime/Options.h
+++ b/Source/JavaScriptCore/runtime/Options.h
@@ -40,6 +40,11 @@ using WTF::StringBuilder;
 
 namespace JSC {
 
+// X11 headers define macro 'Bool' interfering with the enum defined below.
+#if defined(Bool)
+#undef Bool
+#endif
+
 class Options {
 public:
     enum class DumpLevel : uint8_t {


### PR DESCRIPTION
#### 32855b11f4251374adc2ade738d732d656b9efd8
<pre>
[GTK] Build fix for Debian Stable after 263061@main
<a href="https://bugs.webkit.org/show_bug.cgi?id=254807">https://bugs.webkit.org/show_bug.cgi?id=254807</a>

Reviewed by NOBODY (OOPS!).

Mark &apos;PlatformDisplayGBM.cpp&apos; as @no-unify to prevent unified source
build errors due to collission of symbols between X11 and other source
files.

* Source/WebCore/SourcesGTK.txt:
</pre>