### PR TITLE
[Win] WTF::RunLoop: RegisterClass has to be called in the main thread before creating other threads

### DIFF
--- a/Source/WTF/wtf/win/MainThreadWin.cpp
+++ b/Source/WTF/wtf/win/MainThreadWin.cpp
@@ -43,6 +43,7 @@ void initializeMainThreadPlatform()
 {
     s_mainThread = Thread::currentID();
     Thread::initializeCurrentThreadInternal("Main Thread");
+    RunLoop::registerRunLoopMessageWindowClass();
 }
 
 bool isMainThread()

--- a/Source/WTF/wtf/win/RunLoopWin.cpp
+++ b/Source/WTF/wtf/win/RunLoopWin.cpp
@@ -90,20 +90,16 @@ void RunLoop::stop()
 
 void RunLoop::registerRunLoopMessageWindowClass()
 {
-    static std::once_flag onceKey;
-    std::call_once(onceKey, [&] {
-        WNDCLASS windowClass = { };
-        windowClass.lpfnWndProc     = RunLoop::RunLoopWndProc;
-        windowClass.cbWndExtra      = sizeof(RunLoop*);
-        windowClass.lpszClassName   = kRunLoopMessageWindowClassName;
-        bool result = ::RegisterClass(&windowClass);
-        RELEASE_ASSERT(result);
-    });
+    WNDCLASS windowClass = { };
+    windowClass.lpfnWndProc = RunLoop::RunLoopWndProc;
+    windowClass.cbWndExtra = sizeof(RunLoop*);
+    windowClass.lpszClassName = kRunLoopMessageWindowClassName;
+    bool result = ::RegisterClass(&windowClass);
+    RELEASE_ASSERT(result);
 }
 
 RunLoop::RunLoop()
 {
-    registerRunLoopMessageWindowClass();
     m_runLoopMessageWindow = ::CreateWindow(kRunLoopMessageWindowClassName, nullptr, 0,
         CW_USEDEFAULT, 0, CW_USEDEFAULT, 0, HWND_MESSAGE, nullptr, nullptr, this);
     RELEASE_ASSERT(::IsWindow(m_runLoopMessageWindow));


### PR DESCRIPTION
#### a44713b31e5629dd1c3d750b74603116436bbc6b
<pre>
[Win] WTF::RunLoop: RegisterClass has to be called in the main thread before creating other threads
<a href="https://bugs.webkit.org/show_bug.cgi?id=255624">https://bugs.webkit.org/show_bug.cgi?id=255624</a>

Reviewed by Don Olmstead.

CreateWindow was randomly failing in the GPU process for WebGL tests
for Windows port. This seems to be a theading issue of calling
CreateWindow in a different thread rather than one called
RegisterClass. RegisterClass has to be called in the main thread
before creating other threads. Reverted 228617@main.

* Source/WTF/wtf/win/MainThreadWin.cpp:
(WTF::initializeMainThreadPlatform):
* Source/WTF/wtf/win/RunLoopWin.cpp:
(WTF::RunLoop::registerRunLoopMessageWindowClass):
(WTF::RunLoop::RunLoop):

Canonical link: <a href="https://commits.webkit.org/263194@main">https://commits.webkit.org/263194@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b068f783ef4fc5de1f863b0d31a4c48931fd8978

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/3824 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/3912 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/4020 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/5256 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/4083 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/3991 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/3917 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/3666 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/3870 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/4070 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/3442 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/5090 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/1574 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/3417 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/4648 "Passed tests") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/3140 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/3393 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/3476 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/4857 "Passed tests") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/3596 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/3875 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/3138 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/3900 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/3400 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/3417 "Passed tests") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/980 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/3441 "Built successfully") | | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/24/builds/3992 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/441 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/3677 "Built successfully") | | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/3/builds/1091 "Passed tests") | 
<!--EWS-Status-Bubble-End-->