### PR TITLE
Migrate PKPaymentInstallmentConfiguration serialization to WebCoreArgumentCoders.serialization.in

### DIFF
--- a/Source/WebCore/Modules/applepay/ApplePaySetupFeatureTypeWebCore.h
+++ b/Source/WebCore/Modules/applepay/ApplePaySetupFeatureTypeWebCore.h
@@ -29,7 +29,7 @@
 
 namespace WebCore {
 
-enum class ApplePaySetupFeatureType : uint8_t {
+enum class ApplePaySetupFeatureType : bool {
     ApplePay,
     AppleCard,
 };

--- a/Source/WebCore/Modules/applepay/ApplePaySetupFeatureWebCore.h
+++ b/Source/WebCore/Modules/applepay/ApplePaySetupFeatureWebCore.h
@@ -35,7 +35,7 @@ OBJC_CLASS PKPaymentSetupFeature;
 namespace WebCore {
 
 enum class ApplePaySetupFeatureState : uint8_t;
-enum class ApplePaySetupFeatureType : uint8_t;
+enum class ApplePaySetupFeatureType : bool;
 
 class ApplePaySetupFeature : public RefCounted<ApplePaySetupFeature> {
 public:

--- a/Source/WebCore/Modules/applepay/PaymentInstallmentConfiguration.mm
+++ b/Source/WebCore/Modules/applepay/PaymentInstallmentConfiguration.mm
@@ -171,7 +171,21 @@ static std::optional<ApplePayInstallmentItem> makeVectorElement(const ApplePayIn
     };
 }
 
-static RetainPtr<PKPaymentInstallmentConfiguration> createPlatformConfiguration(const ApplePayInstallmentConfiguration& coreConfiguration, NSDictionary *applicationMetadata)
+static RetainPtr<NSDictionary> applicationMetadataDictionary(const ApplePayInstallmentConfiguration& configuration)
+{
+    if (NSData *applicationMetadata = [configuration.applicationMetadata dataUsingEncoding:NSUTF8StringEncoding])
+        return dynamic_objc_cast<NSDictionary>([NSJSONSerialization JSONObjectWithData:applicationMetadata options:0 error:nil]);
+    return { };
+}
+
+static String applicationMetadataString(NSDictionary *dictionary)
+{
+    if (NSData *applicationMetadata = dictionary ? [NSJSONSerialization dataWithJSONObject:dictionary options:NSJSONWritingSortedKeys error:nil] : nil)
+        return adoptNS([[NSString alloc] initWithData:applicationMetadata encoding:NSUTF8StringEncoding]).get();
+    return { };
+}
+
+static RetainPtr<PKPaymentInstallmentConfiguration> createPlatformConfiguration(const ApplePayInstallmentConfiguration& coreConfiguration)
 {
     if (!PAL::getPKPaymentInstallmentConfigurationClass())
         return nil;
@@ -194,7 +208,7 @@ static RetainPtr<PKPaymentInstallmentConfiguration> createPlatformConfiguration(
         return configuration;
 
     [configuration setInstallmentItems:createNSArray(coreConfiguration.items).get()];
-    [configuration setApplicationMetadata:applicationMetadata];
+    [configuration setApplicationMetadata:applicationMetadataDictionary(coreConfiguration).get()];
     [configuration setRetailChannel:platformRetailChannel(coreConfiguration.retailChannel)];
 
     return configuration;
@@ -202,64 +216,72 @@ static RetainPtr<PKPaymentInstallmentConfiguration> createPlatformConfiguration(
 
 ExceptionOr<PaymentInstallmentConfiguration> PaymentInstallmentConfiguration::create(const ApplePayInstallmentConfiguration& configuration)
 {
-    NSDictionary *applicationMetadataDictionary = nil;
-    if (!configuration.applicationMetadata.isNull()) {
-        NSData *applicationMetadata = [configuration.applicationMetadata dataUsingEncoding:NSUTF8StringEncoding];
-        applicationMetadataDictionary = dynamic_objc_cast<NSDictionary>([NSJSONSerialization JSONObjectWithData:applicationMetadata options:0 error:nil]);
-        if (!applicationMetadataDictionary)
-            return Exception { TypeError, "applicationMetadata must be a JSON object"_s };
-    }
+    auto dictionary = applicationMetadataDictionary(configuration);
+    if (!configuration.applicationMetadata.isNull() && !dictionary)
+        return Exception { TypeError, "applicationMetadata must be a JSON object"_s };
 
-    return PaymentInstallmentConfiguration(configuration, applicationMetadataDictionary);
+    return PaymentInstallmentConfiguration(ApplePayInstallmentConfiguration(configuration), WTFMove(dictionary));
 }
 
-PaymentInstallmentConfiguration::PaymentInstallmentConfiguration(const ApplePayInstallmentConfiguration& configuration, NSDictionary *applicationMetadata)
-    : m_configuration { createPlatformConfiguration(configuration, applicationMetadata) }
+static ApplePayInstallmentConfiguration addApplicationMetadata(const ApplePayInstallmentConfiguration& input, RetainPtr<NSDictionary>&& applicationMetadata)
+{
+    auto configuration = input;
+    if (applicationMetadata)
+        configuration.applicationMetadata = applicationMetadataString(applicationMetadata.get());
+    return configuration;
+}
+
+PaymentInstallmentConfiguration::PaymentInstallmentConfiguration(const ApplePayInstallmentConfiguration& configuration, RetainPtr<NSDictionary>&& applicationMetadata)
+    : m_configuration { addApplicationMetadata(configuration, WTFMove(applicationMetadata)) }
 {
 }
 
-PaymentInstallmentConfiguration::PaymentInstallmentConfiguration(RetainPtr<PKPaymentInstallmentConfiguration>&& configuration)
+PaymentInstallmentConfiguration::PaymentInstallmentConfiguration(ApplePayInstallmentConfiguration&& configuration)
     : m_configuration { WTFMove(configuration) }
 {
 }
 
-PKPaymentInstallmentConfiguration *PaymentInstallmentConfiguration::platformConfiguration() const
+PaymentInstallmentConfiguration::PaymentInstallmentConfiguration(RetainPtr<PKPaymentInstallmentConfiguration>&& configuration)
+    : m_configuration { applePayInstallmentConfiguration(configuration.get()) }
 {
-    return m_configuration.get();
 }
 
-ApplePayInstallmentConfiguration PaymentInstallmentConfiguration::applePayInstallmentConfiguration() const
+const ApplePayInstallmentConfiguration& PaymentInstallmentConfiguration::applePayInstallmentConfiguration() const
+{
+    return m_configuration;
+}
+
+RetainPtr<PKPaymentInstallmentConfiguration> PaymentInstallmentConfiguration::platformConfiguration() const
+{
+    return createPlatformConfiguration(m_configuration);
+}
+
+ApplePayInstallmentConfiguration PaymentInstallmentConfiguration::applePayInstallmentConfiguration(PKPaymentInstallmentConfiguration *configuration)
 {
     ApplePayInstallmentConfiguration installmentConfiguration;
     if (!PAL::getPKPaymentInstallmentConfigurationClass())
         return installmentConfiguration;
 
-    if (auto featureType = applePaySetupFeatureType([m_configuration feature]))
+    if (auto featureType = applePaySetupFeatureType([configuration feature]))
         installmentConfiguration.featureType = *featureType;
     else
         return installmentConfiguration;
 
-    installmentConfiguration.bindingTotalAmount = fromDecimalNumber([m_configuration bindingTotalAmount]);
-    installmentConfiguration.currencyCode = [m_configuration currencyCode];
-    installmentConfiguration.isInStorePurchase = [m_configuration isInStorePurchase];
-    installmentConfiguration.openToBuyThresholdAmount = fromDecimalNumber([m_configuration openToBuyThresholdAmount]);
+    installmentConfiguration.bindingTotalAmount = fromDecimalNumber([configuration bindingTotalAmount]);
+    installmentConfiguration.currencyCode = [configuration currencyCode];
+    installmentConfiguration.isInStorePurchase = [configuration isInStorePurchase];
+    installmentConfiguration.openToBuyThresholdAmount = fromDecimalNumber([configuration openToBuyThresholdAmount]);
 
-    installmentConfiguration.merchandisingImageData = [[m_configuration merchandisingImageData] base64EncodedStringWithOptions:0];
-    installmentConfiguration.merchantIdentifier = [m_configuration installmentMerchantIdentifier];
-    installmentConfiguration.referrerIdentifier = [m_configuration referrerIdentifier];
+    installmentConfiguration.merchandisingImageData = [[configuration merchandisingImageData] base64EncodedStringWithOptions:0];
+    installmentConfiguration.merchantIdentifier = [configuration installmentMerchantIdentifier];
+    installmentConfiguration.referrerIdentifier = [configuration referrerIdentifier];
 
     if (!PAL::getPKPaymentInstallmentItemClass())
         return installmentConfiguration;
 
-    RetainPtr<NSString> applicationMetadataString;
-    if (NSDictionary *applicationMetadataDictionary = [m_configuration applicationMetadata]) {
-        if (NSData *applicationMetadata = [NSJSONSerialization dataWithJSONObject:applicationMetadataDictionary options:NSJSONWritingSortedKeys error:nil])
-            applicationMetadataString = adoptNS([[NSString alloc] initWithData:applicationMetadata encoding:NSUTF8StringEncoding]);
-    }
-
-    installmentConfiguration.items = makeVector<ApplePayInstallmentItem>([m_configuration installmentItems]);
-    installmentConfiguration.applicationMetadata = applicationMetadataString.get();
-    installmentConfiguration.retailChannel = applePayRetailChannel([m_configuration retailChannel]);
+    installmentConfiguration.items = makeVector<ApplePayInstallmentItem>([configuration installmentItems]);
+    installmentConfiguration.applicationMetadata = applicationMetadataString([configuration applicationMetadata]);
+    installmentConfiguration.retailChannel = applePayRetailChannel([configuration retailChannel]);
 
     return installmentConfiguration;
 }

--- a/Source/WebCore/Modules/applepay/PaymentInstallmentConfigurationWebCore.h
+++ b/Source/WebCore/Modules/applepay/PaymentInstallmentConfigurationWebCore.h
@@ -27,6 +27,7 @@
 
 #if HAVE(PASSKIT_INSTALLMENTS)
 
+#include "ApplePayInstallmentConfigurationWebCore.h"
 #include <wtf/RetainPtr.h>
 
 OBJC_CLASS NSDictionary;
@@ -35,7 +36,6 @@ OBJC_CLASS PKPaymentInstallmentConfiguration;
 namespace WebCore {
 
 class Document;
-struct ApplePayInstallmentConfiguration;
 template<typename> class ExceptionOr;
 
 class WEBCORE_EXPORT PaymentInstallmentConfiguration {
@@ -44,14 +44,16 @@ public:
 
     PaymentInstallmentConfiguration() = default;
     PaymentInstallmentConfiguration(RetainPtr<PKPaymentInstallmentConfiguration>&&);
+    PaymentInstallmentConfiguration(ApplePayInstallmentConfiguration&&);
+    PaymentInstallmentConfiguration(const ApplePayInstallmentConfiguration&, RetainPtr<NSDictionary>&&);
 
-    PKPaymentInstallmentConfiguration *platformConfiguration() const;
-    ApplePayInstallmentConfiguration applePayInstallmentConfiguration() const;
+    RetainPtr<PKPaymentInstallmentConfiguration> platformConfiguration() const;
+    const ApplePayInstallmentConfiguration& applePayInstallmentConfiguration() const;
 
 private:
-    PaymentInstallmentConfiguration(const ApplePayInstallmentConfiguration&, NSDictionary *applicationMetadata);
+    static ApplePayInstallmentConfiguration applePayInstallmentConfiguration(PKPaymentInstallmentConfiguration *);
 
-    RetainPtr<PKPaymentInstallmentConfiguration> m_configuration;
+    ApplePayInstallmentConfiguration m_configuration;
 };
 
 } // namespace WebCore

--- a/Source/WebKit/Shared/ApplePay/cocoa/WebPaymentCoordinatorProxyCocoa.mm
+++ b/Source/WebKit/Shared/ApplePay/cocoa/WebPaymentCoordinatorProxyCocoa.mm
@@ -364,8 +364,8 @@ ALLOW_DEPRECATED_DECLARATIONS_END
 #endif
 
 #if HAVE(PASSKIT_INSTALLMENTS)
-    if (PKPaymentInstallmentConfiguration *configuration = paymentRequest.installmentConfiguration().platformConfiguration()) {
-        [result setInstallmentConfiguration:configuration];
+    if (auto configuration = paymentRequest.installmentConfiguration().platformConfiguration()) {
+        [result setInstallmentConfiguration:configuration.get()];
         [result setRequestType:PKPaymentRequestTypeInstallment];
     }
 #endif

--- a/Source/WebKit/Shared/Cocoa/ArgumentCodersCocoa.mm
+++ b/Source/WebKit/Shared/Cocoa/ArgumentCodersCocoa.mm
@@ -628,7 +628,6 @@ static bool shouldEnableStrictMode(Decoder& decoder, NSArray<Class> *allowedClas
         || (supportsRevealCore && [allowedClasses containsObject:PAL::getRVItemClass()]) // rdar://107553310 - relying on NSMutableArray re-write, don't re-introduce rdar://107673064
 #endif // ENABLE(REVEAL)
 #if ENABLE(APPLE_PAY)
-        || (supportsPassKitCore && [allowedClasses containsObject:PAL::getPKPaymentInstallmentConfigurationClass()]) // Don't reintroduce rdar://108281584
         || (supportsPassKitCore && [allowedClasses containsObject:PAL::getPKPaymentMethodClass()]) // rdar://107553480 Don't reintroduce rdar://108235706
         || (!strictSecureDecodingForAllObjCEnabled() && [allowedClasses containsObject:NSMutableURLRequest.class]) // rdar://107553194 Don't reintroduce rdar://108339450
 #endif

--- a/Source/WebKit/Shared/Cocoa/WebCoreArgumentCodersCocoa.mm
+++ b/Source/WebKit/Shared/Cocoa/WebCoreArgumentCodersCocoa.mm
@@ -80,24 +80,6 @@ namespace IPC {
 
 #if ENABLE(APPLE_PAY)
 
-#if HAVE(PASSKIT_INSTALLMENTS)
-
-void ArgumentCoder<WebCore::PaymentInstallmentConfiguration>::encode(Encoder& encoder, const WebCore::PaymentInstallmentConfiguration& configuration)
-{
-    encoder << configuration.platformConfiguration();
-}
-
-std::optional<WebCore::PaymentInstallmentConfiguration> ArgumentCoder<WebCore::PaymentInstallmentConfiguration>::decode(Decoder& decoder)
-{
-    auto configuration = IPC::decode<PKPaymentInstallmentConfiguration>(decoder, PAL::getPKPaymentInstallmentConfigurationClass());
-    if (!configuration)
-        return std::nullopt;
-
-    return { WTFMove(*configuration) };
-}
-
-#endif // HAVE(PASSKIT_INSTALLMENTS)
-
 void ArgumentCoder<WebCore::Payment>::encode(Encoder& encoder, const WebCore::Payment& payment)
 {
     encoder << payment.pkPayment();

--- a/Source/WebKit/Shared/WebCoreArgumentCoders.h
+++ b/Source/WebKit/Shared/WebCoreArgumentCoders.h
@@ -468,13 +468,6 @@ template<> struct ArgumentCoder<WebCore::CDMInstanceSession::Message> {
 };
 #endif
 
-#if HAVE(PASSKIT_INSTALLMENTS)
-template<> struct ArgumentCoder<WebCore::PaymentInstallmentConfiguration> {
-    static void encode(Encoder&, const WebCore::PaymentInstallmentConfiguration&);
-    static std::optional<WebCore::PaymentInstallmentConfiguration> decode(Decoder&);
-};
-#endif
-
 #if ENABLE(IMAGE_ANALYSIS) && ENABLE(DATA_DETECTION)
 
 template<> struct ArgumentCoder<WebCore::TextRecognitionDataDetector> {

--- a/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
+++ b/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
@@ -771,6 +771,49 @@ enum class WebCore::ApplePayErrorCode : uint8_t {
 };
 #endif // ENABLE(APPLE_PAY)
 
+#if ENABLE(APPLE_PAY_INSTALLMENTS)
+header: <WebCore/ApplePayInstallmentConfigurationWebCore.h>
+[CustomHeader] struct WebCore::ApplePayInstallmentConfiguration {
+    WebCore::ApplePaySetupFeatureType featureType;
+    String merchandisingImageData;
+    String openToBuyThresholdAmount;
+    String bindingTotalAmount;
+    String currencyCode;
+    bool isInStorePurchase;
+    String merchantIdentifier;
+    String referrerIdentifier;
+    Vector<WebCore::ApplePayInstallmentItem> items;
+    String applicationMetadata;
+    WebCore::ApplePayInstallmentRetailChannel retailChannel;
+};
+header: <WebCore/PaymentInstallmentConfigurationWebCore.h>
+[CustomHeader] class WebCore::PaymentInstallmentConfiguration {
+    WebCore::ApplePayInstallmentConfiguration applePayInstallmentConfiguration()
+}
+struct WebCore::ApplePayInstallmentItem {
+    WebCore::ApplePayInstallmentItemType type;
+    String amount;
+    String currencyCode;
+    String programIdentifier;
+    String apr;
+    String programTerms;
+};
+enum class WebCore::ApplePaySetupFeatureType : bool
+enum class WebCore::ApplePayInstallmentItemType : uint8_t {
+    Generic,
+    Phone,
+    Pad,
+    Watch,
+    Mac,
+};
+enum class WebCore::ApplePayInstallmentRetailChannel : uint8_t {
+    Unknown,
+    App,
+    Web,
+    InStore,
+};
+#endif // ENABLE(APPLE_PAY_INSTALLMENTS)
+
 #if ENABLE(APPLE_PAY_COUPON_CODE)
 struct WebCore::ApplePayCouponCodeUpdate : WebCore::ApplePayDetailsUpdateBase {
     Vector<RefPtr<WebCore::ApplePayError>> errors;


### PR DESCRIPTION
#### 47f42f1c9f330a410fd1c38366c485b8dabe52ed
<pre>
Migrate PKPaymentInstallmentConfiguration serialization to WebCoreArgumentCoders.serialization.in
<a href="https://bugs.webkit.org/show_bug.cgi?id=255706">https://bugs.webkit.org/show_bug.cgi?id=255706</a>
rdar://108301357

Reviewed by Andy Estes.

Instead of using NSKeyedArchiver to serialize it, just serialize the members of WebCore::PaymentInstallmentConfiguration.

* Source/WebCore/Modules/applepay/ApplePaySetupFeatureTypeWebCore.h:
* Source/WebCore/Modules/applepay/ApplePaySetupFeatureWebCore.h:
* Source/WebCore/Modules/applepay/PaymentInstallmentConfiguration.mm:
(WebCore::applicationMetadataDictionary):
(WebCore::createPlatformConfiguration):
(WebCore::PaymentInstallmentConfiguration::create):
(WebCore::PaymentInstallmentConfiguration::PaymentInstallmentConfiguration):
(WebCore::PaymentInstallmentConfiguration::platformConfiguration const):
(WebCore::PaymentInstallmentConfiguration::applePayInstallmentConfiguration):
(WebCore::PaymentInstallmentConfiguration::applePayInstallmentConfiguration const): Deleted.
* Source/WebCore/Modules/applepay/PaymentInstallmentConfigurationWebCore.h:
* Source/WebCore/WebCore.xcodeproj/project.pbxproj:
* Source/WebKit/Shared/ApplePay/cocoa/WebPaymentCoordinatorProxyCocoa.mm:
(WebKit::WebPaymentCoordinatorProxy::platformPaymentRequest):
* Source/WebKit/Shared/Cocoa/ArgumentCodersCocoa.mm:
(IPC::shouldEnableStrictMode):
* Source/WebKit/Shared/Cocoa/WebCoreArgumentCodersCocoa.mm:
(IPC::ArgumentCoder&lt;WebCore::PaymentInstallmentConfiguration&gt;::encode): Deleted.
(IPC::ArgumentCoder&lt;WebCore::PaymentInstallmentConfiguration&gt;::decode): Deleted.
* Source/WebKit/Shared/WebCoreArgumentCoders.h:
* Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in:

Canonical link: <a href="https://commits.webkit.org/263335@main">https://commits.webkit.org/263335@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d8caaa67b7bfbd3b73ce9bb62f510a515021ab6d

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/4259 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/4378 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/4499 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/5730 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/4497 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/4252 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/4487 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/4342 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/4714 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/4321 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/4485 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/3839 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/5725 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/1980 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/3815 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/6441 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/3809 "Passed tests") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/3882 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/5409 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/4292 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/3481 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/3804 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/3813 "Passed tests") | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/4/builds/7882 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/492 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/4159 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->