### PR TITLE
[JSC] Convert GetByVal + StringIdent constant to GetById to encourage megamorphic IC

### DIFF
--- a/JSTests/microbenchmarks/megamorphic-dfg.js
+++ b/JSTests/microbenchmarks/megamorphic-dfg.js
@@ -1,0 +1,25 @@
+//@ skip if $model == "Apple Watch Series 3" # added by mark-jsc-stress-test.py
+(function() {
+    var array = [];
+    for (var i = 0; i < 1000; ++i) {
+        var o = {};
+        o["i" + i] = i;
+        o.f = 42;
+        array.push(o);
+    }
+
+    function test(array, index) {
+        return test2(array, index, 'f');
+    }
+
+    function test2(array, index, name) {
+        return array[index][name];
+    }
+    noInline(test);
+
+    for (var i = 0; i < 1000000; ++i) {
+        var result = test(array, i % array.length);
+        if (result != 42)
+            throw "Error: bad result: " + result;
+    }
+})();

--- a/Source/JavaScriptCore/dfg/DFGNode.cpp
+++ b/Source/JavaScriptCore/dfg/DFGNode.cpp
@@ -353,6 +353,22 @@ void Node::convertToRegExpTestInline(FrozenValue* globalObject, FrozenValue* reg
     m_opInfo2 = regExp;
 }
 
+void Node::convertToGetById(Graph& graph, CacheableIdentifier identifier)
+{
+    ASSERT(op() == GetByVal);
+    Edge base = graph.varArgChild(this, 0);
+    ASSERT(base.useKind() == ObjectUse);
+    for (unsigned i = 0; i < numChildren(); ++i) {
+        Edge& edge = graph.varArgChild(this, i);
+        edge = Edge();
+    }
+    setOpAndDefaultFlags(GetById);
+    children.child1() = Edge(base.node(), CellUse);
+    children.child2() = Edge();
+    children.child3() = Edge();
+    m_opInfo = identifier;
+}
+
 String Node::tryGetString(Graph& graph)
 {
     if (hasConstant())

--- a/Source/JavaScriptCore/dfg/DFGNode.h
+++ b/Source/JavaScriptCore/dfg/DFGNode.h
@@ -517,6 +517,8 @@ public:
     void convertToIdentity();
     void convertToIdentityOn(Node*);
 
+    void convertToGetById(Graph&, CacheableIdentifier);
+
     bool mustGenerate() const
     {
         return m_flags & NodeMustGenerate;


### PR DESCRIPTION
#### d77ef3a80e9c9809eb75d531ede8be8b95712ae5
<pre>
[JSC] Convert GetByVal + StringIdent constant to GetById to encourage megamorphic IC
<a href="https://bugs.webkit.org/show_bug.cgi?id=255709">https://bugs.webkit.org/show_bug.cgi?id=255709</a>
rdar://108302994

Reviewed by Alexey Shvayka.

This patch converts DFG/FTL GetByVal + StringIdent constant to GetById. The main benefit of this is that
we can use megamorphic IC from GetById.

                                ToT                     Patched

    megamorphic-dfg       10.9843+-0.0357     ^      7.3780+-0.0332        ^ definitely 1.4888x faster

* JSTests/microbenchmarks/megamorphic-dfg.js: Added.
(test):
(test2):
* Source/JavaScriptCore/dfg/DFGAbstractInterpreterInlines.h:
(JSC::DFG::AbstractInterpreter&lt;AbstractStateType&gt;::executeEffects):
* Source/JavaScriptCore/dfg/DFGConstantFoldingPhase.cpp:
(JSC::DFG::ConstantFoldingPhase::foldConstants):
* Source/JavaScriptCore/dfg/DFGNode.cpp:
(JSC::DFG::Node::convertToGetById):
* Source/JavaScriptCore/dfg/DFGNode.h:

Canonical link: <a href="https://commits.webkit.org/263200@main">https://commits.webkit.org/263200@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ddc6c7ec3352b7137a873a43025eeb59d0a37f33

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/3838 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/3926 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/4034 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/5270 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/4096 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/4005 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/3931 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/3678 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/3884 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/4083 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/3457 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/5104 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/1587 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/3432 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/4777 "Passed tests") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/3152 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/3406 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/3492 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/4870 "Passed tests") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/3610 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/3889 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/3147 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/3914 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/3414 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/3432 "Passed tests") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/981 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/3455 "Built successfully") | | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/24/builds/4006 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/445 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/3691 "Built successfully") | | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/3/builds/1092 "Passed tests") | 
<!--EWS-Status-Bubble-End-->