### PR TITLE
Non-unified build fixes, mid April 2023 edition

### DIFF
--- a/Source/JavaScriptCore/b3/B3Const128Value.cpp
+++ b/Source/JavaScriptCore/b3/B3Const128Value.cpp
@@ -29,6 +29,7 @@
 #include "B3Const128Value.h"
 
 #include "B3Procedure.h"
+#include "B3ValueInlines.h"
 
 namespace JSC { namespace B3 {
 

--- a/Source/JavaScriptCore/b3/air/opcode_generator.rb
+++ b/Source/JavaScriptCore/b3/air/opcode_generator.rb
@@ -839,6 +839,7 @@ writeH("OpcodeUtils") {
 writeH("OpcodeGenerated") {
     | outp |
     outp.puts "#include \"AirInstInlines.h\""
+    outp.puts "#include \"B3ProcedureInlines.h\""
     outp.puts "#include \"CCallHelpers.h\""
     outp.puts "#include \"wtf/PrintStream.h\""
     outp.puts "namespace WTF {"

--- a/Source/JavaScriptCore/runtime/PageCount.h
+++ b/Source/JavaScriptCore/runtime/PageCount.h
@@ -25,6 +25,7 @@
 
 #pragma once
 
+#include <algorithm>
 #include <limits.h>
 
 namespace WTF {

--- a/Source/JavaScriptCore/wasm/WasmTypeDefinition.cpp
+++ b/Source/JavaScriptCore/wasm/WasmTypeDefinition.cpp
@@ -28,6 +28,7 @@
 
 #if ENABLE(WEBASSEMBLY)
 
+#include "JSCJSValueInlines.h"
 #include "JSWebAssemblyArray.h"
 #include "JSWebAssemblyStruct.h"
 #include "WasmFormat.h"

--- a/Source/WebCore/Modules/reporting/TestReportBody.cpp
+++ b/Source/WebCore/Modules/reporting/TestReportBody.cpp
@@ -28,6 +28,7 @@
 
 #include "FormData.h"
 #include <wtf/IsoMallocInlines.h>
+#include <wtf/NeverDestroyed.h>
 
 namespace WebCore {
 

--- a/Source/WebCore/Modules/storage/WorkerStorageConnection.cpp
+++ b/Source/WebCore/Modules/storage/WorkerStorageConnection.cpp
@@ -27,6 +27,7 @@
 #include "WorkerStorageConnection.h"
 
 #include "ClientOrigin.h"
+#include "Document.h"
 #include "StorageEstimate.h"
 #include "WorkerFileSystemStorageConnection.h"
 #include "WorkerGlobalScope.h"

--- a/Source/WebCore/Modules/streams/ReadableStream.cpp
+++ b/Source/WebCore/Modules/streams/ReadableStream.cpp
@@ -28,6 +28,7 @@
 
 #include "JSReadableStream.h"
 #include "JSReadableStreamSource.h"
+#include "ScriptExecutionContext.h"
 
 namespace WebCore {
 

--- a/Source/WebCore/Modules/streams/ReadableStreamSink.cpp
+++ b/Source/WebCore/Modules/streams/ReadableStreamSink.cpp
@@ -28,6 +28,7 @@
 #include "ReadableStreamSink.h"
 
 #include "DOMException.h"
+#include "JSDOMGlobalObject.h"
 #include "ReadableStream.h"
 #include "SharedBuffer.h"
 #include <JavaScriptCore/Uint8Array.h>

--- a/Source/WebCore/bindings/js/InternalReadableStream.cpp
+++ b/Source/WebCore/bindings/js/InternalReadableStream.cpp
@@ -26,9 +26,12 @@
 #include "config.h"
 #include "InternalReadableStream.h"
 
+#include "JSDOMConvertObject.h"
+#include "JSDOMConvertSequences.h"
 #include "JSDOMException.h"
 #include "JSReadableStreamSink.h"
 #include "WebCoreJSClientData.h"
+#include <JavaScriptCore/JSObjectInlines.h>
 
 namespace WebCore {
 
@@ -164,7 +167,7 @@ void InternalReadableStream::pipeTo(ReadableStreamSink& sink)
     auto* clientData = static_cast<JSVMClientData*>(globalObject->vm().clientData);
     auto& privateName = clientData->builtinFunctions().readableStreamInternalsBuiltins().readableStreamPipeToPrivateName();
 
-    MarkedArgumentBuffer arguments;
+    JSC::MarkedArgumentBuffer arguments;
     arguments.append(guardedObject());
     arguments.append(toJS(globalObject, globalObject, sink));
     ASSERT(!arguments.hasOverflowed());
@@ -270,7 +273,7 @@ JSC::JSValue InternalReadableStream::tee(JSC::JSGlobalObject& globalObject, bool
 
     JSC::MarkedArgumentBuffer arguments;
     arguments.append(guardedObject());
-    arguments.append(shouldClone ? JSValue(JSC::JSValue::JSTrue) : JSValue(JSC::JSValue::JSFalse));
+    arguments.append(shouldClone ? JSC::JSValue(JSC::JSValue::JSTrue) : JSC::JSValue(JSC::JSValue::JSFalse));
     ASSERT(!arguments.hasOverflowed());
 
     auto result = invokeReadableStreamFunction(globalObject, privateName, arguments);

--- a/Source/WebCore/bindings/scripts/CodeGenerator.pm
+++ b/Source/WebCore/bindings/scripts/CodeGenerator.pm
@@ -1110,6 +1110,7 @@ sub GetterExpression
 
     my $functionName;
     if ($attribute->extendedAttributes->{"URL"}) {
+        $implIncludes->{"ElementInlines.h"} = 1;
         $functionName = "getURLAttributeForBindings";
     } elsif ($attributeType->name eq "boolean") {
         $implIncludes->{"ElementInlines.h"} = 1;
@@ -1127,6 +1128,7 @@ sub GetterExpression
             $functionName = "getIdAttribute";
             $contentAttributeName = "";
         } elsif ($contentAttributeName eq "WebCore::HTMLNames::nameAttr") {
+            $implIncludes->{"ElementInlines.h"} = 1;
             $functionName = "getNameAttribute";
             $contentAttributeName = "";
         } elsif ($generator->IsSVGAnimatedType($attributeType)) {

--- a/Source/WebCore/loader/CORPViolationReportBody.cpp
+++ b/Source/WebCore/loader/CORPViolationReportBody.cpp
@@ -27,6 +27,7 @@
 #include "CORPViolationReportBody.h"
 
 #include <wtf/IsoMallocInlines.h>
+#include <wtf/NeverDestroyed.h>
 
 namespace WebCore {
 

--- a/Source/WebCore/page/csp/CSPViolationReportBody.cpp
+++ b/Source/WebCore/page/csp/CSPViolationReportBody.cpp
@@ -31,6 +31,7 @@
 #include "SecurityPolicyViolationEvent.h"
 #include <wtf/IsoMallocInlines.h>
 #include <wtf/JSONValues.h>
+#include <wtf/NeverDestroyed.h>
 
 namespace WebCore {
 

--- a/Source/WebCore/platform/RemoteCommandListener.cpp
+++ b/Source/WebCore/platform/RemoteCommandListener.cpp
@@ -34,6 +34,8 @@
 #include "RemoteCommandListenerGLib.h"
 #endif
 
+#include <wtf/NeverDestroyed.h>
+
 namespace WebCore {
 
 static RemoteCommandListener::CreationFunction& remoteCommandListenerCreationFunction()

--- a/Source/WebCore/platform/encryptedmedia/CDMProxy.cpp
+++ b/Source/WebCore/platform/encryptedmedia/CDMProxy.cpp
@@ -35,6 +35,7 @@
 #include "Logging.h"
 #include "MediaPlayer.h"
 #include <wtf/HexNumber.h>
+#include <wtf/NeverDestroyed.h>
 #include <wtf/Scope.h>
 #include <wtf/StringPrintStream.h>
 #include <wtf/text/StringBuilder.h>

--- a/Source/WebCore/rendering/CounterNode.cpp
+++ b/Source/WebCore/rendering/CounterNode.cpp
@@ -25,6 +25,7 @@
 #include "LayoutIntegrationLineLayout.h"
 #include "RenderCounter.h"
 #include "RenderElement.h"
+#include "RenderView.h"
 #include <stdio.h>
 
 namespace WebCore {

--- a/Source/WebCore/style/StyleFontSizeFunctions.h
+++ b/Source/WebCore/style/StyleFontSizeFunctions.h
@@ -25,6 +25,7 @@
 
 #pragma once
 
+#include "FontSizeAdjust.h"
 #include "Settings.h"
 
 namespace WebCore {

--- a/Source/WebCore/style/UserAgentStyle.cpp
+++ b/Source/WebCore/style/UserAgentStyle.cpp
@@ -55,6 +55,7 @@
 #include "MathMLElement.h"
 #include "MediaQueryEvaluator.h"
 #include "Page.h"
+#include "Quirks.h"
 #include "RenderTheme.h"
 #include "RuleSetBuilder.h"
 #include "SVGElement.h"

--- a/Source/WebCore/workers/service/server/SWRegistrationStore.h
+++ b/Source/WebCore/workers/service/server/SWRegistrationStore.h
@@ -27,9 +27,15 @@
 
 #if ENABLE(SERVICE_WORKER)
 
+#include <optional>
+#include <wtf/Forward.h>
+
 namespace WebCore {
 
 class SWServerRegistration;
+class ServiceWorkerRegistrationKey;
+
+struct ServiceWorkerContextData;
 
 class SWRegistrationStore {
     WTF_MAKE_FAST_ALLOCATED;

--- a/Source/WebKit/NetworkProcess/Cookies/WebCookieManager.cpp
+++ b/Source/WebKit/NetworkProcess/Cookies/WebCookieManager.cpp
@@ -26,6 +26,7 @@
 #include "config.h"
 #include "WebCookieManager.h"
 
+#include "MessageSenderInlines.h"
 #include "NetworkProcess.h"
 #include "NetworkProcessProxyMessages.h"
 #include "WebCookieManagerMessages.h"

--- a/Source/WebKit/NetworkProcess/Downloads/Download.cpp
+++ b/Source/WebKit/NetworkProcess/Downloads/Download.cpp
@@ -33,6 +33,7 @@
 #include "DownloadMonitor.h"
 #include "DownloadProxyMessages.h"
 #include "Logging.h"
+#include "MessageSenderInlines.h"
 #include "NetworkDataTask.h"
 #include "NetworkProcess.h"
 #include "NetworkSession.h"

--- a/Source/WebKit/NetworkProcess/NetworkResourceLoader.cpp
+++ b/Source/WebKit/NetworkProcess/NetworkResourceLoader.cpp
@@ -30,6 +30,7 @@
 #include "FormDataReference.h"
 #include "LoadedWebArchive.h"
 #include "Logging.h"
+#include "MessageSenderInlines.h"
 #include "NetworkCache.h"
 #include "NetworkCacheSpeculativeLoadManager.h"
 #include "NetworkConnectionToWebProcess.h"

--- a/Source/WebKit/NetworkProcess/ServiceWorker/WebSWRegistrationStore.cpp
+++ b/Source/WebKit/NetworkProcess/ServiceWorker/WebSWRegistrationStore.cpp
@@ -30,7 +30,6 @@
 
 #include "NetworkStorageManager.h"
 #include <WebCore/SWServer.h>
-#include <wtf/CompletionHandler.h>
 
 namespace WebKit {
 
@@ -76,13 +75,13 @@ void WebSWRegistrationStore::importRegistrations(CompletionHandler<void(std::opt
     m_manager->importServiceWorkerRegistrations(WTFMove(callback));
 }
 
-void WebSWRegistrationStore::updateRegistration(const ServiceWorkerContextData& registration)
+void WebSWRegistrationStore::updateRegistration(const WebCore::ServiceWorkerContextData& registration)
 {
     m_updates.set(registration.registration.key, registration);
     scheduleUpdateIfNecessary();
 }
 
-void WebSWRegistrationStore::removeRegistration(const ServiceWorkerRegistrationKey& key)
+void WebSWRegistrationStore::removeRegistration(const WebCore::ServiceWorkerRegistrationKey& key)
 {
     m_updates.set(key, std::nullopt);
     scheduleUpdateIfNecessary();
@@ -102,8 +101,8 @@ void WebSWRegistrationStore::updateToStorage(CompletionHandler<void()>&& callbac
 {
     ASSERT(RunLoop::isMain());
 
-    Vector<ServiceWorkerRegistrationKey> registrationsToDelete;
-    Vector<ServiceWorkerContextData> registrationsToUpdate;
+    Vector<WebCore::ServiceWorkerRegistrationKey> registrationsToDelete;
+    Vector<WebCore::ServiceWorkerContextData> registrationsToUpdate;
     for (auto& [key, registation] : m_updates) {
         if (!registation)
             registrationsToDelete.append(key);

--- a/Source/WebKit/NetworkProcess/ServiceWorker/WebSWRegistrationStore.h
+++ b/Source/WebKit/NetworkProcess/ServiceWorker/WebSWRegistrationStore.h
@@ -30,6 +30,7 @@
 #include <WebCore/SWRegistrationStore.h>
 #include <WebCore/ServiceWorkerContextData.h>
 #include <WebCore/Timer.h>
+#include <wtf/CompletionHandler.h>
 
 namespace WebCore {
 class SWServer;

--- a/Source/WebKit/NetworkProcess/SharedWorker/WebSharedWorkerServerConnection.cpp
+++ b/Source/WebKit/NetworkProcess/SharedWorker/WebSharedWorkerServerConnection.cpp
@@ -27,6 +27,7 @@
 #include "WebSharedWorkerServerConnection.h"
 
 #include "Logging.h"
+#include "MessageSenderInlines.h"
 #include "NetworkConnectionToWebProcess.h"
 #include "NetworkProcess.h"
 #include "NetworkProcessProxyMessages.h"

--- a/Source/WebKit/UIProcess/Inspector/RemoteWebInspectorUIProxy.cpp
+++ b/Source/WebKit/UIProcess/Inspector/RemoteWebInspectorUIProxy.cpp
@@ -28,6 +28,7 @@
 
 #include "APIDebuggableInfo.h"
 #include "APINavigation.h"
+#include "MessageSenderInlines.h"
 #include "RemoteWebInspectorUIMessages.h"
 #include "RemoteWebInspectorUIProxyMessages.h"
 #include "WebInspectorUIProxy.h"

--- a/Source/WebKit/UIProcess/SpeechRecognitionRemoteRealtimeMediaSource.cpp
+++ b/Source/WebKit/UIProcess/SpeechRecognitionRemoteRealtimeMediaSource.cpp
@@ -28,6 +28,7 @@
 
 #if ENABLE(MEDIA_STREAM)
 
+#include "MessageSenderInlines.h"
 #include "SpeechRecognitionRealtimeMediaSourceManagerMessages.h"
 #include "SpeechRecognitionRemoteRealtimeMediaSourceManager.h"
 

--- a/Source/WebKit/UIProcess/SpeechRecognitionServer.cpp
+++ b/Source/WebKit/UIProcess/SpeechRecognitionServer.cpp
@@ -26,6 +26,7 @@
 #include "config.h"
 #include "SpeechRecognitionServer.h"
 
+#include "MessageSenderInlines.h"
 #include "UserMediaProcessManager.h"
 #include "WebProcessProxy.h"
 #include "WebSpeechRecognitionConnectionMessages.h"

--- a/Source/WebKit/UIProcess/SubframePageProxy.cpp
+++ b/Source/WebKit/UIProcess/SubframePageProxy.cpp
@@ -26,6 +26,8 @@
 #include "config.h"
 #include "SubframePageProxy.h"
 
+#include "FrameInfoData.h"
+#include "HandleMessage.h"
 #include "WebFrameProxy.h"
 #include "WebPageProxy.h"
 #include "WebPageProxyMessages.h"

--- a/Source/WebKit/UIProcess/SubframePageProxy.h
+++ b/Source/WebKit/UIProcess/SubframePageProxy.h
@@ -27,6 +27,7 @@
 
 #include "MessageReceiver.h"
 #include "MessageSender.h"
+#include <WebCore/FrameIdentifier.h>
 #include <WebCore/PageIdentifier.h>
 
 namespace IPC {
@@ -35,11 +36,28 @@ class Decoder;
 class Encoder;
 }
 
+namespace WebCore {
+enum class FrameLoadType : uint8_t;
+enum class HasInsecureContent : bool;
+enum class MouseEventPolicy : uint8_t;
+
+class CertificateInfo;
+class ResourceResponse;
+class ResourceRequest;
+
+struct PolicyCheckIdentifierType;
+
+using PolicyCheckIdentifier = ProcessQualified<ObjectIdentifier<PolicyCheckIdentifierType>>;
+}
+
 namespace WebKit {
 
+class UserData;
 class WebFrameProxy;
 class WebPageProxy;
 class WebProcessProxy;
+
+struct FrameInfoData;
 
 class SubframePageProxy : public IPC::MessageReceiver, public IPC::MessageSender {
     WTF_MAKE_FAST_ALLOCATED;

--- a/Source/WebKit/UIProcess/SuspendedPageProxy.cpp
+++ b/Source/WebKit/UIProcess/SuspendedPageProxy.cpp
@@ -28,6 +28,7 @@
 
 #include "DrawingAreaProxy.h"
 #include "Logging.h"
+#include "MessageSenderInlines.h"
 #include "WebBackForwardCache.h"
 #include "WebFrameProxy.h"
 #include "WebPageMessages.h"

--- a/Source/WebKit/UIProcess/WebFullScreenManagerProxy.cpp
+++ b/Source/WebKit/UIProcess/WebFullScreenManagerProxy.cpp
@@ -29,6 +29,7 @@
 #if ENABLE(FULLSCREEN_API)
 
 #include "APIFullscreenClient.h"
+#include "MessageSenderInlines.h"
 #include "WebAutomationSession.h"
 #include "WebFullScreenManagerMessages.h"
 #include "WebFullScreenManagerProxyMessages.h"

--- a/Source/WebKit/WebProcess/EncryptedMedia/MediaKeySystemPermissionRequestManager.cpp
+++ b/Source/WebKit/WebProcess/EncryptedMedia/MediaKeySystemPermissionRequestManager.cpp
@@ -29,6 +29,7 @@
 #if ENABLE(ENCRYPTED_MEDIA)
 
 #include "Logging.h"
+#include "MessageSenderInlines.h"
 #include "WebCoreArgumentCoders.h"
 #include "WebFrame.h"
 #include "WebPage.h"

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebDiagnosticLoggingClient.cpp
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebDiagnosticLoggingClient.cpp
@@ -26,6 +26,7 @@
 #include "config.h"
 #include "WebDiagnosticLoggingClient.h"
 
+#include "MessageSenderInlines.h"
 #include "WebCoreArgumentCoders.h"
 #include "WebPage.h"
 #include "WebPageProxyMessages.h"

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebFrameLoaderClient.cpp
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebFrameLoaderClient.cpp
@@ -36,6 +36,7 @@
 #include "InjectedBundle.h"
 #include "InjectedBundleDOMWindowExtension.h"
 #include "Logging.h"
+#include "MessageSenderInlines.h"
 #include "NavigationActionData.h"
 #include "NetworkConnectionToWebProcessMessages.h"
 #include "NetworkProcessConnection.h"

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebRemoteFrameClient.cpp
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebRemoteFrameClient.cpp
@@ -25,6 +25,8 @@
 
 #include "config.h"
 #include "WebRemoteFrameClient.h"
+
+#include "MessageSenderInlines.h"
 #include "WebProcess.h"
 #include "WebProcessProxyMessages.h"
 

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebScreenOrientationManager.cpp
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebScreenOrientationManager.cpp
@@ -26,6 +26,7 @@
 #include "config.h"
 #include "WebScreenOrientationManager.h"
 
+#include "MessageSenderInlines.h"
 #include "WebPage.h"
 #include "WebProcess.h"
 #include "WebScreenOrientationManagerMessages.h"

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebSpeechRecognitionConnection.cpp
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebSpeechRecognitionConnection.cpp
@@ -26,6 +26,7 @@
 #include "config.h"
 #include "WebSpeechRecognitionConnection.h"
 
+#include "MessageSenderInlines.h"
 #include "SpeechRecognitionServerMessages.h"
 #include "WebFrame.h"
 #include "WebProcess.h"

--- a/Source/WebKit/WebProcess/WebPage/WebContextMenu.cpp
+++ b/Source/WebKit/WebProcess/WebPage/WebContextMenu.cpp
@@ -26,6 +26,7 @@
 #include "WebContextMenu.h"
 
 #include "ContextMenuContextData.h"
+#include "MessageSenderInlines.h"
 #include "UserData.h"
 #include "WebCoreArgumentCoders.h"
 #include "WebPage.h"


### PR DESCRIPTION
#### 35bf1a169834590160ecb5df4e711cd52b3bcdb1
<pre>
Non-unified build fixes, mid April 2023 edition
<a href="https://bugs.webkit.org/show_bug.cgi?id=255717">https://bugs.webkit.org/show_bug.cgi?id=255717</a>

Unreviewed non-unified build fixes.

* Source/JavaScriptCore/b3/B3Const128Value.cpp: Add missing
  B3ValueInlines.h inclusion.
* Source/JavaScriptCore/b3/air/opcode_generator.rb: Add missing
  B3ProcedureInlines.h inclusion in generated output.
* Source/JavaScriptCore/runtime/PageCount.h: Add missing &lt;algoithm&gt;
  inclusion.
* Source/JavaScriptCore/wasm/WasmTypeDefinition.cpp: Add missing
  JSCJSValueInlines.h inclusion.
* Source/WebCore/Modules/reporting/TestReportBody.cpp: Add missing
  wtf/NeverDestroyed.h inclusion.
* Source/WebCore/Modules/storage/WorkerStorageConnection.cpp: Add
  missing Document.h inclusion.
* Source/WebCore/Modules/streams/ReadableStream.cpp: Add missing
  ScriptExecutionContext.h inclusion.
* Source/WebCore/Modules/streams/ReadableStreamSink.cpp: Add missing
  JSDOMGlobalObject.h inclusion.
* Source/WebCore/bindings/js/InternalReadableStream.cpp: Add missing
  inclusion of the JSDOMConvertObject.h, JSDOMConvertSequences.h, and
  JavaScriptCore/JSObjectInlines.h headers.
(WebCore::InternalReadableStream::pipeTo): Add JSC:: namespace prefix to
usage of JSC::MarkedArgumentBuffer.
(WebCore::InternalReadableStream::tee): Add JSC:: namespace prefix to
usage of JSC::JSValue.
* Source/WebCore/bindings/scripts/CodeGenerator.pm:
(GetterExpression): Ensure that the ElementInlines.h header is included
in generated code that use the getURLAttributeForBindings() and
getNameAttribute() functions.
* Source/WebCore/loader/CORPViolationReportBody.cpp: Add missing
  wtf/NeverDestroyed.h inclusion.
* Source/WebCore/page/csp/CSPViolationReportBody.cpp: Ditto.
* Source/WebCore/platform/RemoteCommandListener.cpp: Ditto.
* Source/WebCore/platform/encryptedmedia/CDMProxy.cpp: Ditto.
* Source/WebCore/rendering/CounterNode.cpp: Add missing RenderView.h
  inclusion.
* Source/WebCore/style/StyleFontSizeFunctions.h: Add missing
  FontSizeAdjust.h inclusion.
* Source/WebCore/style/UserAgentStyle.cpp: Add missing Quirks.h
  inclusion.
* Source/WebCore/workers/service/server/SWRegistrationStore.h: Add
  missing forward declarations for WebCore::ServiceWorkerRegistrationKey
  and WebCore::ServiceWorkerContextData, plus missing inclusions of
  the &lt;optional&gt; and wtf/Forward.h headers.
* Source/WebKit/NetworkProcess/Cookies/WebCookieManager.cpp: Add
  missing MessageSenderInlines.h inclusion.
* Source/WebKit/NetworkProcess/Downloads/Download.cpp: Ditto.
* Source/WebKit/NetworkProcess/NetworkResourceLoader.cpp: Ditto.
* Source/WebKit/NetworkProcess/ServiceWorker/WebSWRegistrationStore.cpp:
  Remove unneeded wtf/CompletionHandler.h inclusion.
(WebKit::WebSWRegistrationStore::updateRegistration): Add WebCore::
namespace prefix to usage of WebCore::ServiceWorkerContextData.
(WebKit::WebSWRegistrationStore::removeRegistration): Add WebCore::
namespace prefix to usage of WebCore::ServiceWorkerRegistrationKey.
(WebKit::WebSWRegistrationStore::updateToStorage): Ditto.
* Source/WebKit/NetworkProcess/ServiceWorker/WebSWRegistrationStore.h:
  Add missing wtf/CompletionHandler.h inclusion.
* Source/WebKit/NetworkProcess/SharedWorker/WebSharedWorkerServerConnection.cpp:
  Add missing MessageSenderInlines.h inclusion.
* Source/WebKit/UIProcess/Inspector/RemoteWebInspectorUIProxy.cpp: Ditto.
* Source/WebKit/UIProcess/SpeechRecognitionRemoteRealtimeMediaSource.cpp: Ditto.
* Source/WebKit/UIProcess/SpeechRecognitionServer.cpp: Ditto.
* Source/WebKit/UIProcess/SubframePageProxy.cpp: Add missing
  FrameInfoData.h and HandleMessage.h inclusions.
* Source/WebKit/UIProcess/SubframePageProxy.h: Add missing
  WebCore/FrameIdentifier.h inclusion, missing forward declarations
  for WebCore types (FrameLoadType, HasInsecureContent, MouseEventPolicy,
  CertificateInfo, ResourceResponse, ResourceRequest,
  PolicyCheckIdentifierType, PolicyCheckIdentifier) and missing forward
  declarations for WebKit types (UserData, FrameInfoData).
* Source/WebKit/UIProcess/SuspendedPageProxy.cpp:
* Source/WebKit/UIProcess/WebFullScreenManagerProxy.cpp: Add missing
  MessageSenderInlines.h inclusion.
* Source/WebKit/WebProcess/EncryptedMedia/MediaKeySystemPermissionRequestManager.cpp:
  Ditto.
* Source/WebKit/WebProcess/WebCoreSupport/WebDiagnosticLoggingClient.cpp: Ditto.
* Source/WebKit/WebProcess/WebCoreSupport/WebFrameLoaderClient.cpp: Ditto.
* Source/WebKit/WebProcess/WebCoreSupport/WebRemoteFrameClient.cpp: Ditto.
* Source/WebKit/WebProcess/WebCoreSupport/WebScreenOrientationManager.cpp: Ditto.
* Source/WebKit/WebProcess/WebCoreSupport/WebSpeechRecognitionConnection.cpp:
  Ditto.
* Source/WebKit/WebProcess/WebPage/WebContextMenu.cpp: Ditto.

Canonical link: <a href="https://commits.webkit.org/263171@main">https://commits.webkit.org/263171@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a8658837845ca2f429ab043563248925462ab2b3

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/3847 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/3936 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/4044 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/5280 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/4106 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/3822 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/4015 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/3941 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/3692 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/3894 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/4093 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/3469 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/5114 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/1597 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/3444 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/4815 "4 flakes 153 failures") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/3161 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/3416 "Passed tests") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/3504 "3 failures") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/4887 "Passed tests") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/3620 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/3899 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/3156 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/3923 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/3423 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/3444 "Passed tests") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/982 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/3465 "Built successfully") | | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/24/builds/4015 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/434 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/3700 "Built successfully") | | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/3/builds/1093 "Passed tests") | 
<!--EWS-Status-Bubble-End-->