### PR TITLE
[WebGPU] Fix invalid layout in hello-triangle demo

### DIFF
--- a/Websites/webkit.org/demos/webgpu/scripts/hello-triangle.js
+++ b/Websites/webkit.org/demos/webgpu/scripts/hello-triangle.js
@@ -23,11 +23,6 @@ async function helloTriangle() {
     const vertexBuffer = device.createBuffer(vertexDataBufferDescriptor);
     
     /*** Shader Setup ***/
-    
-    const uniformBindGroupLayout = device.createBindGroupLayout({ entries: [{binding: 0, visibility: GPUShaderStage.VERTEX, buffer: {}}] });
-    const pipelineLayoutDesc = { bindGroupLayouts: [uniformBindGroupLayout] };
-    const layout = device.createPipelineLayout(pipelineLayoutDesc);
-
     const wgslSource = `
                      struct Vertex {
                          @builtin(position) Position: vec4<f32>,
@@ -52,7 +47,7 @@ async function helloTriangle() {
                          return in.color;
                      }
     `;
-    const shaderModule = device.createShaderModule({ code: wgslSource, isWHLSL: false, hints: [ {layout: layout }, ] });
+    const shaderModule = device.createShaderModule({ code: wgslSource });
     
     /* GPUPipelineStageDescriptors */
     const vertexStageDescriptor = { module: shaderModule, entryPoint: "vsmain" };
@@ -62,7 +57,7 @@ async function helloTriangle() {
     /* GPURenderPipelineDescriptor */
 
     const renderPipelineDescriptor = {
-        layout: layout,
+        layout: 'auto',
         vertex: vertexStageDescriptor,
         fragment: fragmentStageDescriptor,
         primitive: {topology: "triangle-list" },


### PR DESCRIPTION
#### 4727cedca0d344afc7c101e7bbe1043ee10f0a0c
<pre>
[WebGPU] Fix invalid layout in hello-triangle demo
<a href="https://bugs.webkit.org/show_bug.cgi?id=255719">https://bugs.webkit.org/show_bug.cgi?id=255719</a>
rdar://108312261

Reviewed by Mike Wyrzykowski.

The layout specified that it expected one bind group, which is not actually used
and was never set, causing a validation failure. Just use the auto layout instead,
since there are no bind groups.

* Websites/webkit.org/demos/webgpu/scripts/hello-triangle.js:
(async helloTriangle):

Canonical link: <a href="https://commits.webkit.org/263222@main">https://commits.webkit.org/263222@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/3e243bf142de9b2cec7a45c663feb901d7c009a2

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/3851 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/3940 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/4049 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/5285 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/4111 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/4026 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/3946 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/3695 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/3899 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/4103 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/3472 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/5119 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/1607 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/3447 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/4822 "1 flakes 144 failures") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/3426 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/3507 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/4891 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/3904 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/3159 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/3427 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/3447 "Passed tests") | | 
| [❌ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/971 "Failed to push commit to Webkit repository") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/3470 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/3704 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->