### PR TITLE
[GTK] Try to reuse the GTK EGL display instead of always creating a new one

### DIFF
--- a/Source/WebCore/platform/graphics/PlatformDisplay.h
+++ b/Source/WebCore/platform/graphics/PlatformDisplay.h
@@ -117,6 +117,10 @@ public:
     const String& drmRenderNodeFile();
     struct gbm_device* gbmDevice();
 #endif
+
+#if PLATFORM(GTK)
+    virtual EGLDisplay gtkEGLDisplay() { return nullptr; }
+#endif
 #endif
 
 #if ENABLE(VIDEO) && USE(GSTREAMER_GL)
@@ -150,6 +154,7 @@ protected:
     virtual void initializeEGLDisplay();
 
     EGLDisplay m_eglDisplay;
+    bool m_eglDisplayOwned { true };
     std::unique_ptr<GLContext> m_sharingGLContext;
 
 #if USE(GBM)

--- a/Source/WebCore/platform/graphics/wayland/PlatformDisplayWayland.h
+++ b/Source/WebCore/platform/graphics/wayland/PlatformDisplayWayland.h
@@ -53,6 +53,9 @@ private:
     Type type() const final { return PlatformDisplay::Type::Wayland; }
 
 #if USE(EGL)
+#if PLATFORM(GTK)
+    EGLDisplay gtkEGLDisplay() override;
+#endif
     void initializeEGLDisplay() override;
 #endif
 

--- a/Source/WebCore/platform/graphics/x11/PlatformDisplayX11.h
+++ b/Source/WebCore/platform/graphics/x11/PlatformDisplayX11.h
@@ -63,6 +63,9 @@ private:
     Type type() const override { return PlatformDisplay::Type::X11; }
 
 #if USE(EGL)
+#if PLATFORM(GTK)
+    EGLDisplay gtkEGLDisplay() override;
+#endif
     void initializeEGLDisplay() override;
 #endif
 


### PR DESCRIPTION
#### 53dd1f1cd48dffd5b1f67470714e7c389a1795bb
<pre>
[GTK] Try to reuse the GTK EGL display instead of always creating a new one
<a href="https://bugs.webkit.org/show_bug.cgi?id=255721">https://bugs.webkit.org/show_bug.cgi?id=255721</a>

Reviewed by Adrian Perez de Castro.

* Source/WebCore/platform/graphics/PlatformDisplay.cpp:
(WebCore::PlatformDisplay::terminateEGLDisplay):
* Source/WebCore/platform/graphics/PlatformDisplay.h:
(WebCore::PlatformDisplay::gtkEGLDisplay):
* Source/WebCore/platform/graphics/wayland/PlatformDisplayWayland.cpp:
(WebCore::PlatformDisplayWayland::initialize):
(WebCore::PlatformDisplayWayland::gtkEGLDisplay):
(WebCore::PlatformDisplayWayland::initializeEGLDisplay):
* Source/WebCore/platform/graphics/wayland/PlatformDisplayWayland.h:
* Source/WebCore/platform/graphics/x11/PlatformDisplayX11.cpp:
(WebCore::PlatformDisplayX11::gtkEGLDisplay):
(WebCore::PlatformDisplayX11::initializeEGLDisplay):
* Source/WebCore/platform/graphics/x11/PlatformDisplayX11.h:
* Source/WebKit/UIProcess/gtk/AcceleratedBackingStoreDMABuf.cpp:
(WebKit::AcceleratedBackingStoreDMABuf::createSource):
(WebKit::AcceleratedBackingStoreDMABuf::makeContextCurrent):
(WebKit::gtkGLContextIsEGL): Deleted.

Canonical link: <a href="https://commits.webkit.org/263306@main">https://commits.webkit.org/263306@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4e2a2edf0892e78f9fb28721224799249c74af3b

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/4007 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/4103 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/4215 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/5449 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/4255 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/3984 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/4194 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/4078 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/4200 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/4057 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/4244 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/3615 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/5380 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/1745 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/3591 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/5705 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/3570 "Passed tests") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/3651 "3 failures") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/5104 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/4058 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/3265 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/3573 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/3591 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/3625 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/484 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/3853 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->