### PR TITLE
[WGSL] Implement for-loop

### DIFF
--- a/Source/WebGPU/WGSL/AST/ASTForStatement.h
+++ b/Source/WebGPU/WGSL/AST/ASTForStatement.h
@@ -33,7 +33,7 @@ namespace WGSL::AST {
 class ForStatement final : public Statement {
     WTF_MAKE_FAST_ALLOCATED;
 public:
-    ForStatement(SourceSpan span, Statement::Ptr&& initializer, Expression::Ptr&& test, Statement::Ptr&& update, CompoundStatement::Ref&& body)
+    ForStatement(SourceSpan span, Statement::Ptr&& initializer, Expression::Ptr&& test, Statement::Ptr&& update, CompoundStatement&& body)
         : Statement(span)
         , m_initializer(WTFMove(initializer))
         , m_test(WTFMove(test))
@@ -45,13 +45,13 @@ public:
     Statement* maybeInitializer() { return m_initializer.get(); }
     Expression* maybeTest() { return m_test.get(); }
     Statement* maybeUpdate() { return m_update.get(); }
-    CompoundStatement& body() { return m_body.get(); }
+    CompoundStatement& body() { return m_body; }
 
 private:
     Statement::Ptr m_initializer;
     Expression::Ptr m_test;
     Statement::Ptr m_update;
-    CompoundStatement::Ref m_body;
+    CompoundStatement m_body;
 };
 
 } // namespace WGSL::AST

--- a/Source/WebGPU/WGSL/AST/ASTStringDumper.cpp
+++ b/Source/WebGPU/WGSL/AST/ASTStringDumper.cpp
@@ -349,6 +349,21 @@ void StringDumper::visit(VariableStatement& statement)
     visit(statement.variable());
 }
 
+void StringDumper::visit(ForStatement& statement)
+{
+    m_out.print("for (");
+    if (auto* initializer = statement.maybeInitializer())
+        visit(*initializer);
+    m_out.print(";");
+    if (auto* test = statement.maybeTest())
+        visit(*test);
+    m_out.print(";");
+    if (auto* update = statement.maybeUpdate())
+        visit(*update);
+    m_out.print(")");
+    visit(statement.body());
+}
+
 // Types
 void StringDumper::visit(ArrayTypeName& type)
 {

--- a/Source/WebGPU/WGSL/AST/ASTStringDumper.h
+++ b/Source/WebGPU/WGSL/AST/ASTStringDumper.h
@@ -81,6 +81,7 @@ public:
     void visit(IfStatement&) override;
     void visit(ReturnStatement&) override;
     void visit(VariableStatement&) override;
+    void visit(ForStatement&) override;
 
     // Types
     void visit(ArrayTypeName&) override;

--- a/Source/WebGPU/WGSL/Lexer.cpp
+++ b/Source/WebGPU/WGSL/Lexer.cpp
@@ -290,6 +290,7 @@ Token Lexer<T>::lex()
                 { "f64", TokenType::ReservedWord },
                 { "false", TokenType::LiteralFalse },
                 { "fn", TokenType::KeywordFn },
+                { "for", TokenType::KeywordFor },
                 { "function", TokenType::KeywordFunction },
                 { "handle", TokenType::ReservedWord },
                 { "i16", TokenType::ReservedWord },

--- a/Source/WebGPU/WGSL/Metal/MetalFunctionWriter.cpp
+++ b/Source/WebGPU/WGSL/Metal/MetalFunctionWriter.cpp
@@ -86,6 +86,7 @@ public:
     void visit(AST::CompoundStatement&) override;
     void visit(AST::IfStatement&) override;
     void visit(AST::ReturnStatement&) override;
+    void visit(AST::ForStatement&) override;
 
     void visit(AST::TypeName&) override;
 
@@ -697,6 +698,21 @@ void FunctionDefinitionWriter::visit(AST::ReturnStatement& statement)
         visit(*statement.maybeExpression());
     }
     m_stringBuilder.append(";\n");
+}
+
+void FunctionDefinitionWriter::visit(AST::ForStatement& statement)
+{
+    m_stringBuilder.append("for (");
+    if (auto* initializer = statement.maybeInitializer())
+        visit(*initializer);
+    m_stringBuilder.append(";");
+    if (auto* test = statement.maybeTest())
+        visit(*test);
+    m_stringBuilder.append(";");
+    if (auto* update = statement.maybeUpdate())
+        visit(*update);
+    m_stringBuilder.append(")");
+    visit(statement.body());
 }
 
 void emitMetalFunctions(StringBuilder& stringBuilder, CallGraph& callGraph)

--- a/Source/WebGPU/WGSL/ParserPrivate.h
+++ b/Source/WebGPU/WGSL/ParserPrivate.h
@@ -73,6 +73,7 @@ public:
     Result<AST::CompoundStatement> parseCompoundStatement();
     Result<AST::IfStatement> parseIfStatement();
     Result<AST::IfStatement> parseIfStatementWithAttributes(AST::Attribute::List&&, SourcePosition _startOfElementPosition);
+    Result<AST::ForStatement> parseForStatement();
     Result<AST::ReturnStatement> parseReturnStatement();
     Result<AST::Expression::Ref> parseShortCircuitExpression(AST::Expression::Ref&&, TokenType, AST::BinaryOperation);
     Result<AST::Expression::Ref> parseRelationalExpression();

--- a/Source/WebGPU/WGSL/Token.cpp
+++ b/Source/WebGPU/WGSL/Token.cpp
@@ -59,6 +59,8 @@ String toString(TokenType type)
         return "struct"_s;
     case TokenType::KeywordFn:
         return "fn"_s;
+    case TokenType::KeywordFor:
+        return "for"_s;
     case TokenType::KeywordFunction:
         return "function"_s;
     case TokenType::KeywordIf:

--- a/Source/WebGPU/WGSL/Token.h
+++ b/Source/WebGPU/WGSL/Token.h
@@ -53,6 +53,7 @@ enum class TokenType: uint32_t {
     KeywordConst,
     KeywordElse,
     KeywordFn,
+    KeywordFor,
     KeywordFunction,
     KeywordIf,
     KeywordLet,

--- a/Source/WebGPU/WGSL/TypeCheck.cpp
+++ b/Source/WebGPU/WGSL/TypeCheck.cpp
@@ -57,6 +57,7 @@ public:
     void visit(AST::IfStatement&) override;
     void visit(AST::ReturnStatement&) override;
     void visit(AST::CompoundStatement&) override;
+    void visit(AST::ForStatement&) override;
 
     // Expressions
     void visit(AST::Expression&) override;
@@ -254,6 +255,23 @@ void TypeChecker::visit(AST::CompoundStatement& statement)
 {
     ContextScope blockScope(this);
     AST::Visitor::visit(statement);
+}
+
+void TypeChecker::visit(AST::ForStatement& statement)
+{
+    if (auto* initializer = statement.maybeInitializer())
+        AST::Visitor::visit(*initializer);
+
+    if (auto* test = statement.maybeTest()) {
+        auto* testType = infer(*test);
+        if (!unify(m_types.boolType(), testType))
+            typeError(test->span(), "for-loop condition must be bool, got ", *testType);
+    }
+
+    if (auto* update = statement.maybeUpdate())
+        AST::Visitor::visit(*update);
+
+    visit(statement.body());
 }
 
 // Expressions

--- a/Source/WebGPU/WGSL/tests/invalid/for.wgsl
+++ b/Source/WebGPU/WGSL/tests/invalid/for.wgsl
@@ -1,0 +1,5 @@
+fn testForStatement() {
+  // CHECK-L: for-loop condition must be bool, got <AbstractInt>
+  for (var i = 0; i;) {
+  }
+}

--- a/Source/WebGPU/WGSL/tests/valid/for.wgsl
+++ b/Source/WebGPU/WGSL/tests/valid/for.wgsl
@@ -1,0 +1,4 @@
+fn testForStatement() {
+    for (var x = -1; x <= 1;) {
+    }
+}

--- a/Tools/TestWebKitAPI/Tests/WGSL/LexerTests.cpp
+++ b/Tools/TestWebKitAPI/Tests/WGSL/LexerTests.cpp
@@ -126,6 +126,7 @@ TEST(WGSLLexerTests, KeywordTokens)
     checkSingleToken("else"_s, TokenType::KeywordElse);
     checkSingleToken("f32"_s, TokenType::KeywordF32);
     checkSingleToken("fn"_s, TokenType::KeywordFn);
+    checkSingleToken("for"_s, TokenType::KeywordFor);
     checkSingleToken("function"_s, TokenType::KeywordFunction);
     checkSingleToken("i32"_s, TokenType::KeywordI32);
     checkSingleToken("if"_s, TokenType::KeywordIf);


### PR DESCRIPTION
#### 7e62fd17e02ba347563d489dff70655596299b60
<pre>
[WGSL] Implement for-loop
<a href="https://bugs.webkit.org/show_bug.cgi?id=255723">https://bugs.webkit.org/show_bug.cgi?id=255723</a>
rdar://108317255

Reviewed by Mike Wyrzykowski.

Add parsing, type checking and codegen for for-loops. For now, we still don&apos;t
support the full syntax for the initialization and update clauses.

* Source/WebGPU/WGSL/AST/ASTForStatement.h:
* Source/WebGPU/WGSL/AST/ASTStringDumper.cpp:
(WGSL::AST::StringDumper::visit):
* Source/WebGPU/WGSL/AST/ASTStringDumper.h:
* Source/WebGPU/WGSL/Lexer.cpp:
(WGSL::Lexer&lt;T&gt;::lex):
* Source/WebGPU/WGSL/Metal/MetalFunctionWriter.cpp:
(WGSL::Metal::FunctionDefinitionWriter::visit):
* Source/WebGPU/WGSL/Parser.cpp:
(WGSL::Parser&lt;Lexer&gt;::parseStatement):
(WGSL::Parser&lt;Lexer&gt;::parseForStatement):
* Source/WebGPU/WGSL/ParserPrivate.h:
* Source/WebGPU/WGSL/Token.cpp:
(WGSL::toString):
* Source/WebGPU/WGSL/Token.h:
* Source/WebGPU/WGSL/TypeCheck.cpp:
(WGSL::TypeChecker::visit):
* Source/WebGPU/WGSL/tests/invalid/for.wgsl: Added.
* Source/WebGPU/WGSL/tests/valid/for.wgsl: Added.

Canonical link: <a href="https://commits.webkit.org/263233@main">https://commits.webkit.org/263233@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4d9389190392cb99fe9fef31d04646646ac9d5ca

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/3999 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/4095 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/4207 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/5441 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/4249 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/3976 "Passed tests") | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/23/builds/4206 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/4070 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/4182 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/4049 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/4235 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/3609 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/5364 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/1737 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/3585 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/5689 "") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/3561 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/3645 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/5084 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/4050 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/3259 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/3565 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/3585 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/978 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/3617 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/3845 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->