### PR TITLE
[WGSL] Move constraints code to its own file

### DIFF
--- a/Source/WebGPU/WGSL/Constraints.cpp
+++ b/Source/WebGPU/WGSL/Constraints.cpp
@@ -1,0 +1,125 @@
+/*
+ * Copyright (c) 2023 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "Constraints.h"
+
+#include "TypeStore.h"
+
+namespace WGSL {
+
+bool satisfies(const Type* type, Constraint constraint)
+{
+    auto* primitive = std::get_if<Types::Primitive>(type);
+    if (!primitive)
+        return false;
+
+    switch (primitive->kind) {
+    case Types::Primitive::AbstractInt:
+        return constraint >= Constraints::AbstractInt;
+    case Types::Primitive::AbstractFloat:
+        return constraint & Constraints::Float;
+    case Types::Primitive::I32:
+        return constraint & Constraints::I32;
+    case Types::Primitive::U32:
+        return constraint & Constraints::U32;
+    case Types::Primitive::F32:
+        return constraint & Constraints::F32;
+    // FIXME: Add F16 support
+    // https://bugs.webkit.org/show_bug.cgi?id=254668
+    case Types::Primitive::Bool:
+        return constraint & Constraints::Bool;
+
+    case Types::Primitive::Void:
+    case Types::Primitive::Sampler:
+        return false;
+    }
+}
+
+Type* satisfyOrPromote(Type* type, Constraint constraint, const TypeStore& types)
+{
+    auto* primitive = std::get_if<Types::Primitive>(type);
+    if (!primitive)
+        return nullptr;
+
+    switch (primitive->kind) {
+    case Types::Primitive::AbstractInt:
+        if (constraint < Constraints::AbstractInt)
+            return nullptr;
+        if (constraint & Constraints::AbstractInt)
+            return type;
+        if (constraint & Constraints::I32)
+            return types.i32Type();
+        if (constraint & Constraints::U32)
+            return types.u32Type();
+        if (constraint & Constraints::AbstractFloat)
+            return types.abstractFloatType();
+        if (constraint & Constraints::F32)
+            return types.f32Type();
+        if (constraint & Constraints::F16) {
+            // FIXME: Add F16 support
+            // https://bugs.webkit.org/show_bug.cgi?id=254668
+            RELEASE_ASSERT_NOT_REACHED();
+        }
+        RELEASE_ASSERT_NOT_REACHED();
+    case Types::Primitive::AbstractFloat:
+        if (constraint < Constraints::AbstractFloat)
+            return nullptr;
+        if (constraint & Constraints::AbstractFloat)
+            return type;
+        if (constraint & Constraints::F32)
+            return types.f32Type();
+        if (constraint & Constraints::F16) {
+            // FIXME: Add F16 support
+            // https://bugs.webkit.org/show_bug.cgi?id=254668
+            RELEASE_ASSERT_NOT_REACHED();
+        }
+        RELEASE_ASSERT_NOT_REACHED();
+    case Types::Primitive::I32:
+        if (!(constraint & Constraints::I32))
+            return nullptr;
+        return type;
+    case Types::Primitive::U32:
+        if (!(constraint & Constraints::U32))
+            return nullptr;
+        return type;
+    case Types::Primitive::F32:
+        if (!(constraint & Constraints::F32))
+            return nullptr;
+        return type;
+    // FIXME: Add F16 support
+    // https://bugs.webkit.org/show_bug.cgi?id=254668
+    case Types::Primitive::Bool:
+        if (!(constraint & Constraints::Bool))
+            return nullptr;
+        return type;
+
+    case Types::Primitive::Void:
+    case Types::Primitive::Sampler:
+        return nullptr;
+    }
+}
+
+} // namespace WGSL

--- a/Source/WebGPU/WGSL/Constraints.h
+++ b/Source/WebGPU/WGSL/Constraints.h
@@ -1,0 +1,68 @@
+/*
+ * Copyright (c) 2023 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include <wtf/OptionSet.h>
+
+namespace WGSL {
+
+struct Type;
+class TypeStore;
+
+
+using Constraint = uint8_t;
+
+namespace Constraints {
+
+constexpr Constraint None = 0;
+
+constexpr Constraint Bool          = 1 << 0;
+constexpr Constraint AbstractInt   = 1 << 1;
+constexpr Constraint I32           = 1 << 2;
+constexpr Constraint U32           = 1 << 3;
+constexpr Constraint AbstractFloat = 1 << 4;
+constexpr Constraint F32           = 1 << 5;
+constexpr Constraint F16           = 1 << 6;
+
+constexpr Constraint ConcreteFloat = F16 | F32;
+constexpr Constraint Float = ConcreteFloat | AbstractFloat;
+
+constexpr Constraint ConcreteInteger = I32 | U32;
+constexpr Constraint Integer = ConcreteInteger | AbstractInt;
+constexpr Constraint SignedInteger = I32 | AbstractInt;
+
+constexpr Constraint Scalar = Bool | Integer | Float;
+constexpr Constraint ConcreteScalar = Bool | ConcreteInteger | ConcreteFloat;
+
+constexpr Constraint SignedNumber = Float | SignedInteger;
+constexpr Constraint Number = Float | Integer;
+
+}
+
+bool satisfies(const Type*, Constraint);
+Type* satisfyOrPromote(Type*, Constraint, const TypeStore&);
+
+} // namespace WGSL

--- a/Source/WebGPU/WGSL/Overload.cpp
+++ b/Source/WebGPU/WGSL/Overload.cpp
@@ -395,76 +395,9 @@ bool OverloadResolver::assign(TypeVariable variable, Type* type)
 {
     logLn("assign ", variable, " => ", *type);
     if (variable.constraints) {
-        auto* primitive = std::get_if<Types::Primitive>(type);
-        if (!primitive)
+        type = satisfyOrPromote(type, variable.constraints, m_types);
+        if (!type)
             return false;
-
-        switch (primitive->kind) {
-        case Types::Primitive::AbstractInt:
-            if (variable.constraints < TypeVariable::AbstractInt)
-                return false;
-            if (variable.constraints & TypeVariable::AbstractInt)
-                break;
-            if (variable.constraints & TypeVariable::I32) {
-                type = m_types.i32Type();
-                break;
-            }
-            if (variable.constraints & TypeVariable::U32) {
-                type = m_types.u32Type();
-                break;
-            }
-            if (variable.constraints & TypeVariable::AbstractFloat) {
-                type = m_types.abstractFloatType();
-                break;
-            }
-            if (variable.constraints & TypeVariable::F32) {
-                type = m_types.f32Type();
-                break;
-            }
-            if (variable.constraints & TypeVariable::F16) {
-                // FIXME: Add F16 support
-                // https://bugs.webkit.org/show_bug.cgi?id=254668
-                RELEASE_ASSERT_NOT_REACHED();
-            }
-            RELEASE_ASSERT_NOT_REACHED();
-        case Types::Primitive::AbstractFloat:
-            if (variable.constraints < TypeVariable::AbstractFloat)
-                return false;
-            if (variable.constraints & TypeVariable::AbstractFloat)
-                break;
-            if (variable.constraints & TypeVariable::F32) {
-                type = m_types.f32Type();
-                break;
-            }
-            if (variable.constraints & TypeVariable::F16) {
-                // FIXME: Add F16 support
-                // https://bugs.webkit.org/show_bug.cgi?id=254668
-                RELEASE_ASSERT_NOT_REACHED();
-            }
-            RELEASE_ASSERT_NOT_REACHED();
-        case Types::Primitive::I32:
-            if (!(variable.constraints & TypeVariable::I32))
-                return false;
-            break;
-        case Types::Primitive::U32:
-            if (!(variable.constraints & TypeVariable::U32))
-                return false;
-            break;
-        case Types::Primitive::F32:
-            if (!(variable.constraints & TypeVariable::F32))
-                return false;
-            break;
-        // FIXME: Add F16 support
-        // https://bugs.webkit.org/show_bug.cgi?id=254668
-        case Types::Primitive::Bool:
-            if (!(variable.constraints & TypeVariable::Bool))
-                return false;
-            break;
-
-        case Types::Primitive::Void:
-        case Types::Primitive::Sampler:
-            return false;
-        }
     }
     m_typeSubstitutions[variable.id] = type;
     return true;

--- a/Source/WebGPU/WGSL/Overload.h
+++ b/Source/WebGPU/WGSL/Overload.h
@@ -25,6 +25,7 @@
 
 #pragma once
 
+#include "Constraints.h"
 #include "TypeStore.h"
 
 namespace WGSL {
@@ -36,33 +37,8 @@ struct NumericVariable {
 using AbstractValue = std::variant<NumericVariable, unsigned>;
 
 struct TypeVariable {
-    enum Constraint : uint8_t {
-        None = 0,
-
-        Bool          = 1 << 0,
-        AbstractInt   = 1 << 1,
-        I32           = 1 << 2,
-        U32           = 1 << 3,
-        AbstractFloat = 1 << 4,
-        F32           = 1 << 5,
-        F16           = 1 << 6,
-
-        ConcreteFloat = F16 | F32,
-        Float = ConcreteFloat | AbstractFloat,
-
-        ConcreteInteger = I32 | U32,
-        Integer = ConcreteInteger | AbstractInt,
-        SignedInteger = I32 | AbstractInt,
-
-        Scalar = Bool | Integer | Float,
-        ConcreteScalar = Bool | ConcreteInteger | ConcreteFloat,
-
-        SignedNumber = Float | SignedInteger,
-        Number = Float | Integer,
-    };
-
     unsigned id;
-    Constraint constraints { None };
+    Constraint constraints { Constraints::None };
 };
 
 struct AbstractVector;

--- a/Source/WebGPU/WGSL/generator/main.rb
+++ b/Source/WebGPU/WGSL/generator/main.rb
@@ -14,7 +14,7 @@ class Constraint
     end
 
     def to_cpp
-        "TypeVariable::#{self}"
+        "Constraints::#{self}"
     end
 end
 

--- a/Source/WebGPU/WebGPU.xcodeproj/project.pbxproj
+++ b/Source/WebGPU/WebGPU.xcodeproj/project.pbxproj
@@ -142,6 +142,8 @@
 		979240C829769AC00050EA2C /* EntryPointRewriter.h in Headers */ = {isa = PBXBuildFile; fileRef = 979240C629769AC00050EA2C /* EntryPointRewriter.h */; };
 		979240C929769AC00050EA2C /* EntryPointRewriter.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 979240C729769AC00050EA2C /* EntryPointRewriter.cpp */; };
 		97BCD6AE29D7422B00A82577 /* JavaScriptCore.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 1CBAB0912718CCA0006080BB /* JavaScriptCore.framework */; };
+		97C36CFE29F1730100CFB379 /* Constraints.h in Headers */ = {isa = PBXBuildFile; fileRef = 97C36CFC29F1730000CFB379 /* Constraints.h */; };
+		97C36CFF29F1730100CFB379 /* Constraints.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 97C36CFD29F1730000CFB379 /* Constraints.cpp */; };
 		97F547B8298055D90011D79A /* GlobalVariableRewriter.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 97F547B6298055D90011D79A /* GlobalVariableRewriter.cpp */; };
 		97F547B9298055D90011D79A /* GlobalVariableRewriter.h in Headers */ = {isa = PBXBuildFile; fileRef = 97F547B7298055D90011D79A /* GlobalVariableRewriter.h */; };
 		97FA1A8E29C086230052D650 /* wgslc.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 97FA1A8729C085A60052D650 /* wgslc.cpp */; };
@@ -380,6 +382,8 @@
 		979240BC29753B2A0050EA2C /* PhaseTimer.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = PhaseTimer.h; sourceTree = "<group>"; };
 		979240C629769AC00050EA2C /* EntryPointRewriter.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = EntryPointRewriter.h; sourceTree = "<group>"; };
 		979240C729769AC00050EA2C /* EntryPointRewriter.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = EntryPointRewriter.cpp; sourceTree = "<group>"; };
+		97C36CFC29F1730000CFB379 /* Constraints.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = Constraints.h; sourceTree = "<group>"; };
+		97C36CFD29F1730000CFB379 /* Constraints.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = Constraints.cpp; sourceTree = "<group>"; };
 		97F547B6298055D90011D79A /* GlobalVariableRewriter.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = GlobalVariableRewriter.cpp; sourceTree = "<group>"; };
 		97F547B7298055D90011D79A /* GlobalVariableRewriter.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GlobalVariableRewriter.h; sourceTree = "<group>"; };
 		97FA1A7F29C085740052D650 /* wgslc */ = {isa = PBXFileReference; explicitFileType = "compiled.mach-o.executable"; includeInIndex = 0; path = wgslc; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -521,6 +525,8 @@
 				33EA186727BC1B1400A1DD52 /* CompilationMessage.cpp */,
 				33EA186527BC1AD500A1DD52 /* CompilationMessage.h */,
 				1CEBD8042716BFAB00A5254D /* config.h */,
+				97C36CFD29F1730000CFB379 /* Constraints.cpp */,
+				97C36CFC29F1730000CFB379 /* Constraints.h */,
 				978A9129298AB60200B37E5E /* ContextProvider.h */,
 				978A912B298AB8EE00B37E5E /* ContextProviderInlines.h */,
 				979240C729769AC00050EA2C /* EntryPointRewriter.cpp */,
@@ -752,6 +758,7 @@
 				3A12AEC828FCEEC400C1B975 /* ASTWhileStatement.h in Headers */,
 				3A12AEB228FCE94C00C1B975 /* ASTWorkgroupSizeAttribute.h in Headers */,
 				33EA186627BC1AD500A1DD52 /* CompilationMessage.h in Headers */,
+				97C36CFE29F1730100CFB379 /* Constraints.h in Headers */,
 				978A912A298AB60200B37E5E /* ContextProvider.h in Headers */,
 				978A912C298AB8EE00B37E5E /* ContextProviderInlines.h in Headers */,
 				979240C829769AC00050EA2C /* EntryPointRewriter.h in Headers */,
@@ -949,6 +956,7 @@
 				3A1337E728FBD56400F29B73 /* ASTVisitor.cpp in Sources */,
 				9789C31A297EA105009E9006 /* CallGraph.cpp in Sources */,
 				339B7B1E27D816270072BF9A /* CompilationMessage.cpp in Sources */,
+				97C36CFF29F1730100CFB379 /* Constraints.cpp in Sources */,
 				979240C929769AC00050EA2C /* EntryPointRewriter.cpp in Sources */,
 				97F547B8298055D90011D79A /* GlobalVariableRewriter.cpp in Sources */,
 				338BB2D627B6B68700E066AB /* Lexer.cpp in Sources */,


### PR DESCRIPTION
#### 2fc4c77726be4596356d9827641a6458a913a31d
<pre>
[WGSL] Move constraints code to its own file
<a href="https://bugs.webkit.org/show_bug.cgi?id=255724">https://bugs.webkit.org/show_bug.cgi?id=255724</a>
rdar://108317489

Reviewed by Mike Wyrzykowski.

The constraints-related helper functions also need to be used by other passes, so
I extracted it from Overload.h/cpp into its own file. When moving it, I converted
the enum to enum class, since it used to be nested in the TypeVariable class and
now it became a top-level declaration. Unfortunately, this breaks all the bitwise
operations, so I refactored it to use OptionSet instead of working with the enum
members directly.

* Source/WTF/wtf/OptionSet.h:
(WTF::OptionSet::OptionSet):
* Source/WebGPU/WGSL/Constraints.cpp: Added.
(WGSL::satisfies):
(WGSL::satisfyOrPromote):
* Source/WebGPU/WGSL/Constraints.h: Added.
* Source/WebGPU/WGSL/Overload.cpp:
(WGSL::OverloadResolver::assign):
* Source/WebGPU/WGSL/Overload.h:
* Source/WebGPU/WGSL/generator/main.rb:
* Source/WebGPU/WebGPU.xcodeproj/project.pbxproj:

Canonical link: <a href="https://commits.webkit.org/263232@main">https://commits.webkit.org/263232@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b17e6885b4d05afe502998f39b9ad442b9ce0518

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/3981 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/4076 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/4188 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/5422 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/4232 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/4166 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/4051 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/4163 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/4031 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/4218 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/3590 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/5325 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/1720 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/3566 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/5656 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/3544 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/3626 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/5058 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/4033 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/3244 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/3549 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/3566 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/976 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/3600 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/3829 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->