### PR TITLE
[IFC][Integration][Line clamp] `LineClamp.currentLineCount` should be propagated to the parent layoutState.

### DIFF
--- a/LayoutTests/fast/block/line-clamp-nested-blocks-with-layout-state-expected.html
+++ b/LayoutTests/fast/block/line-clamp-nested-blocks-with-layout-state-expected.html
@@ -1,0 +1,15 @@
+<style>
+  .clamped {
+    font-family: Ahem;
+    display: -webkit-box;
+    -webkit-box-orient: vertical;
+    -webkit-line-clamp: 2;
+    overflow: hidden;
+  }
+</style>
+<body>
+  <div class="clamped">
+    <span>TEST<br />CASE</span>
+    <div>FAIL</div>
+  </div>
+</body>

--- a/LayoutTests/fast/block/line-clamp-nested-blocks-with-layout-state.html
+++ b/LayoutTests/fast/block/line-clamp-nested-blocks-with-layout-state.html
@@ -1,0 +1,22 @@
+<style>
+  .clamped {
+    font-family: Ahem;
+    display: -webkit-box;
+    -webkit-box-orient: vertical;
+    -webkit-line-clamp: 2;
+    overflow: hidden;
+  }
+</style>
+<body>
+  <div class="clamped">
+    <span id="test">TEST</span>
+    <div>FAIL</div>
+  </div>
+</body>
+<script>
+  if (window.testRunner) testRunner.waitUntilDone();
+  setTimeout(() => {
+    document.getElementById("test").innerHTML = "TEST<br />CASE";
+    if (window.testRunner) testRunner.notifyDone();
+  }, 0);
+</script>

--- a/Source/WebCore/page/LocalFrameViewLayoutContext.cpp
+++ b/Source/WebCore/page/LocalFrameViewLayoutContext.cpp
@@ -621,7 +621,20 @@ bool LocalFrameViewLayoutContext::pushLayoutState(RenderBox& renderer, const Lay
     
 void LocalFrameViewLayoutContext::popLayoutState()
 {
+    if (!layoutState())
+        return;
+
+    auto currentLineClamp = layoutState()->lineClamp();
+
     m_layoutStateStack.removeLast();
+
+    if (currentLineClamp) {
+        // Propagates the current line clamp state to the parent.
+        if (auto* layoutState = this->layoutState(); layoutState && layoutState->lineClamp()) {
+            ASSERT(layoutState->lineClamp()->maximumLineCount == currentLineClamp->maximumLineCount);
+            layoutState->setLineClamp(currentLineClamp);
+        }
+    }
 }
 
 #ifndef NDEBUG


### PR DESCRIPTION
#### 59088ba850576159b6e3d3bf05d2717fc6893432
<pre>
[IFC][Integration][Line clamp] `LineClamp.currentLineCount` should be propagated to the parent layoutState.
<a href="https://bugs.webkit.org/show_bug.cgi?id=255487">https://bugs.webkit.org/show_bug.cgi?id=255487</a>

Reviewed by Alan Baradlay.

Since multiple children share the same parent context for line clamp,
`LineClamp.currentLineCount` set to the individual child should be propagated to
their parent layoutState. Otherwise, subsequent children may not see the current
state of this value during layout, causing incorrect line clamp results.

* LayoutTests/fast/block/line-clamp-nested-blocks-with-layout-state-expected.html: Added.
* LayoutTests/fast/block/line-clamp-nested-blocks-with-layout-state.html: Added.
* Source/WebCore/page/LocalFrameViewLayoutContext.cpp:
(WebCore::LocalFrameViewLayoutContext::popLayoutState):

Canonical link: <a href="https://commits.webkit.org/263360@main">https://commits.webkit.org/263360@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4865a76958cded9759bec7a0d33b3f85b090ba26

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/4220 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/4341 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/4459 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/5690 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/4466 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/4213 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/4448 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/4306 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/4684 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/4281 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/4457 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/3808 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/5684 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/1952 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/3785 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/6000 "1 flakes 253 failures") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/3779 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/3851 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/5369 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/4260 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/3456 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/3770 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/3783 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/1077 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/7863 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/4114 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->