### PR TITLE
[popover] Improve popover-focus-2.html

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/popovers/popover-focus-2-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/popovers/popover-focus-2-expected.txt
@@ -3,7 +3,7 @@ Invoker  after
 Show popover
 Toggle popover Other focusable element
 
-FAIL Popover focus navigation assert_equals: Focus should move from invoker into the open popover expected Element node <button id="inside_popover1" tabindex="0">Inside1</button> but got Element node <button id="button3" tabindex="0">Button3</button>
+PASS Popover focus navigation
 PASS Circular reference tab navigation
 PASS Popover focus returns when popover is hidden by invoker
 FAIL Popover focus only returns to invoker when focus is within the popover assert_equals: focus does not move because it was not inside the popover expected Element node <span tabindex="0">Other focusable element</span> but got Element node <button popovertarget="focus-return2-p" tabindex="0">Togg...


### PR DESCRIPTION
#### d8c15ed26f95a54f6136b94ac284cda4f4a451ec
<pre>
[popover] Improve popover-focus-2.html
<a href="https://bugs.webkit.org/show_bug.cgi?id=255730">https://bugs.webkit.org/show_bug.cgi?id=255730</a>

Reviewed by Ryosuke Niwa.

This implements the following focus behavior [see 1]:
1. Moves focus from an invoking element to its invoked popover, regardless of where in the DOM that popover lives.
2. Moves focus back to the next focusable element after the invoking element once focus leaves the invoked popover.
3. Skips over an open invoked popover otherwise.

[1] <a href="https://html.spec.whatwg.org/#focus-navigation-scope-owner">https://html.spec.whatwg.org/#focus-navigation-scope-owner</a>

* LayoutTests/imported/w3c/web-platform-tests/html/semantics/popovers/popover-focus-2-expected.txt:
* Source/WebCore/page/FocusController.cpp:
(WebCore::isOpenPopoverWithInvoker):
(WebCore::openPopoverInvokerCast):
(WebCore::FocusNavigationScope::firstChildInScope const):
(WebCore::FocusNavigationScope::lastChildInScope const):
(WebCore::FocusNavigationScope::nextSiblingInScope const):
(WebCore::FocusNavigationScope::previousSiblingInScope const):
(WebCore::FocusNavigationScope::FocusNavigationScope):
(WebCore::FocusNavigationScope::owner const):
(WebCore::FocusNavigationScope::scopeOf):
(WebCore::FocusNavigationScope::scopeOwnedByPopoverInvoker):
(WebCore::FocusController::findFocusableElementAcrossFocusScope):

Canonical link: <a href="https://commits.webkit.org/263532@main">https://commits.webkit.org/263532@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ec1c577e3f476da80e8be17d500b28ce17ac2ed7

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/4894 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/5019 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/5191 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/6410 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/5008 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/4887 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/5193 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/4991 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/5247 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/4979 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/5059 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/4382 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/6427 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/2547 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/4378 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/9341 "1 flakes 179 failures") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/4409 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/4452 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/6048 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/4870 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/3962 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/4370 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/1197 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/8435 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/4731 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->