### PR TITLE
Stop marking isInvalidInputType() as friend to InputType subclasses

### DIFF
--- a/Source/WebCore/html/BaseDateAndTimeInputType.h
+++ b/Source/WebCore/html/BaseDateAndTimeInputType.h
@@ -51,6 +51,7 @@ class BaseDateAndTimeInputType : public InputType, private DateTimeChooserClient
 public:
     bool typeMismatchFor(const String&) const final;
     bool valueMissing(const String&) const final;
+    bool typeMismatch() const final;
 
 protected:
     enum class DateTimeFormatValidationResults : uint8_t {
@@ -78,8 +79,6 @@ protected:
 
     bool shouldHaveSecondField(const DateComponents&) const;
     bool shouldHaveMillisecondField(const DateComponents&) const;
-
-    bool typeMismatch() const final;
 
 private:
     class DateTimeFormatValidator final : public DateTimeFormat::TokenHandler {

--- a/Source/WebCore/html/ButtonInputType.h
+++ b/Source/WebCore/html/ButtonInputType.h
@@ -35,7 +35,6 @@
 namespace WebCore {
 
 class ButtonInputType final : public BaseButtonInputType {
-    template<typename DowncastedType> friend bool isInvalidInputType(const InputType&, const String&);
 public:
     static Ref<ButtonInputType> create(HTMLInputElement& element)
     {

--- a/Source/WebCore/html/CheckboxInputType.h
+++ b/Source/WebCore/html/CheckboxInputType.h
@@ -35,7 +35,6 @@
 namespace WebCore {
 
 class CheckboxInputType final : public BaseCheckableInputType {
-    template<typename DowncastedType> friend bool isInvalidInputType(const InputType&, const String&);
 public:
     static Ref<CheckboxInputType> create(HTMLInputElement& element)
     {

--- a/Source/WebCore/html/ColorInputType.h
+++ b/Source/WebCore/html/ColorInputType.h
@@ -40,7 +40,6 @@
 namespace WebCore {
 
 class ColorInputType final : public BaseClickableWithKeyInputType, private ColorChooserClient {
-    template<typename DowncastedType> friend bool isInvalidInputType(const InputType&, const String&);
 public:
     static Ref<ColorInputType> create(HTMLInputElement& element)
     {

--- a/Source/WebCore/html/DateInputType.h
+++ b/Source/WebCore/html/DateInputType.h
@@ -37,7 +37,6 @@
 namespace WebCore {
 
 class DateInputType final : public BaseDateAndTimeInputType {
-    template<typename DowncastedType> friend bool isInvalidInputType(const InputType&, const String&);
 public:
     static Ref<DateInputType> create(HTMLInputElement& element)
     {

--- a/Source/WebCore/html/DateTimeLocalInputType.h
+++ b/Source/WebCore/html/DateTimeLocalInputType.h
@@ -37,7 +37,6 @@
 namespace WebCore {
 
 class DateTimeLocalInputType final : public BaseDateAndTimeInputType {
-    template<typename DowncastedType> friend bool isInvalidInputType(const InputType&, const String&);
 public:
     static Ref<DateTimeLocalInputType> create(HTMLInputElement& element)
     {

--- a/Source/WebCore/html/EmailInputType.h
+++ b/Source/WebCore/html/EmailInputType.h
@@ -35,7 +35,6 @@
 namespace WebCore {
 
 class EmailInputType final : public BaseTextInputType {
-    template<typename DowncastedType> friend bool isInvalidInputType(const InputType&, const String&);
 public:
     static Ref<EmailInputType> create(HTMLInputElement& element)
     {
@@ -43,6 +42,7 @@ public:
     }
 
     bool typeMismatchFor(const String&) const final;
+    bool typeMismatch() const final;
 
 private:
     explicit EmailInputType(HTMLInputElement& element)
@@ -51,7 +51,6 @@ private:
     }
 
     const AtomString& formControlType() const final;
-    bool typeMismatch() const final;
     String typeMismatchText() const final;
     bool supportsSelectionAPI() const final;
     String sanitizeValue(const String&) const final;

--- a/Source/WebCore/html/FileInputType.h
+++ b/Source/WebCore/html/FileInputType.h
@@ -45,7 +45,6 @@ class FileList;
 class Icon;
 
 class FileInputType final : public BaseClickableWithKeyInputType, private FileChooserClient, private FileIconLoaderClient, public CanMakeWeakPtr<FileInputType> {
-    template<typename DowncastedType> friend bool isInvalidInputType(const InputType&, const String&);
 public:
     static Ref<FileInputType> create(HTMLInputElement& element)
     {

--- a/Source/WebCore/html/HiddenInputType.h
+++ b/Source/WebCore/html/HiddenInputType.h
@@ -35,7 +35,6 @@
 namespace WebCore {
 
 class HiddenInputType final : public InputType {
-    template<typename DowncastedType> friend bool isInvalidInputType(const InputType&, const String&);
 public:
     static Ref<HiddenInputType> create(HTMLInputElement& element)
     {

--- a/Source/WebCore/html/ImageInputType.h
+++ b/Source/WebCore/html/ImageInputType.h
@@ -38,7 +38,6 @@
 namespace WebCore {
 
 class ImageInputType final : public BaseButtonInputType {
-    template<typename DowncastedType> friend bool isInvalidInputType(const InputType&, const String&);
 public:
     static Ref<ImageInputType> create(HTMLInputElement& element)
     {

--- a/Source/WebCore/html/InputType.cpp
+++ b/Source/WebCore/html/InputType.cpp
@@ -104,6 +104,19 @@ template<typename T> static Ref<InputType> createInputType(HTMLInputElement& ele
     return T::create(element);
 }
 
+template<typename DowncastedType>
+ALWAYS_INLINE bool isInvalidInputType(const InputType& baseInputType, const String& value)
+{
+    auto& inputType = static_cast<const DowncastedType&>(baseInputType);
+    return inputType.typeMismatch()
+        || inputType.stepMismatch(value)
+        || inputType.rangeUnderflow(value)
+        || inputType.rangeOverflow(value)
+        || inputType.patternMismatch(value)
+        || inputType.valueMissing(value)
+        || inputType.hasBadInput();
+}
+
 static InputTypeFactoryMap createInputTypeFactoryMap()
 {
     static const struct InputTypes {
@@ -328,35 +341,10 @@ ExceptionOr<void> InputType::setValueAsDecimal(const Decimal&, TextFieldEventBeh
     return Exception { InvalidStateError };
 }
 
-bool InputType::typeMismatchFor(const String&) const
-{
-    return false;
-}
-
-bool InputType::typeMismatch() const
-{
-    return false;
-}
-
 bool InputType::supportsRequired() const
 {
     // Almost all validatable types support @required.
     return supportsValidation();
-}
-
-bool InputType::valueMissing(const String&) const
-{
-    return false;
-}
-
-bool InputType::hasBadInput() const
-{
-    return false;
-}
-
-bool InputType::patternMismatch(const String&) const
-{
-    return false;
 }
 
 bool InputType::rangeUnderflow(const String& value) const

--- a/Source/WebCore/html/InputType.h
+++ b/Source/WebCore/html/InputType.h
@@ -232,11 +232,11 @@ public:
     // Validation functions.
 
     virtual String validationMessage() const;
-    virtual bool typeMismatchFor(const String&) const;
+    virtual bool typeMismatchFor(const String&) const { return false; }
     virtual bool supportsRequired() const;
-    virtual bool valueMissing(const String&) const;
-    virtual bool hasBadInput() const;
-    virtual bool patternMismatch(const String&) const;
+    virtual bool valueMissing(const String&) const { return false; }
+    virtual bool hasBadInput() const { return false; }
+    virtual bool patternMismatch(const String&) const { return false; }
     bool rangeUnderflow(const String&) const;
     bool rangeOverflow(const String&) const;
     bool isInRange(const String&) const;
@@ -261,7 +261,7 @@ public:
 
     // Type check for the current input value. We do nothing for some types
     // though typeMismatchFor() does something for them because of value sanitization.
-    virtual bool typeMismatch() const;
+    virtual bool typeMismatch() const { return false; }
 
     // Return value of null string means "use the default value".
     // This function must be called only by HTMLInputElement::sanitizeValue().
@@ -421,13 +421,6 @@ private:
     // m_element is null if this InputType is no longer associated with an element (either the element died or changed input type).
     WeakPtr<HTMLInputElement, WeakPtrImplWithEventTargetData> m_element;
 };
-
-template<typename DowncastedType>
-ALWAYS_INLINE bool isInvalidInputType(const InputType& baseInputType, const String& value)
-{
-    auto& inputType = static_cast<const DowncastedType&>(baseInputType);
-    return inputType.typeMismatch() || inputType.stepMismatch(value) || inputType.rangeUnderflow(value) || inputType.rangeOverflow(value) || inputType.patternMismatch(value) || inputType.valueMissing(value) || inputType.hasBadInput();
-}
 
 } // namespace WebCore
 

--- a/Source/WebCore/html/MonthInputType.h
+++ b/Source/WebCore/html/MonthInputType.h
@@ -37,7 +37,6 @@
 namespace WebCore {
 
 class MonthInputType final : public BaseDateAndTimeInputType {
-    template<typename DowncastedType> friend bool isInvalidInputType(const InputType&, const String&);
 public:
     static Ref<MonthInputType> create(HTMLInputElement& element)
     {

--- a/Source/WebCore/html/NumberInputType.h
+++ b/Source/WebCore/html/NumberInputType.h
@@ -36,7 +36,6 @@
 namespace WebCore {
 
 class NumberInputType final : public TextFieldInputType {
-    template<typename DowncastedType> friend bool isInvalidInputType(const InputType&, const String&);
 public:
     static Ref<NumberInputType> create(HTMLInputElement& element)
     {
@@ -44,6 +43,8 @@ public:
     }
 
     bool typeMismatchFor(const String&) const final;
+    bool typeMismatch() const final;
+    bool hasBadInput() const final;
 
 private:
     explicit NumberInputType(HTMLInputElement& element)
@@ -56,7 +57,6 @@ private:
     double valueAsDouble() const final;
     ExceptionOr<void> setValueAsDouble(double, TextFieldEventBehavior) const final;
     ExceptionOr<void> setValueAsDecimal(const Decimal&, TextFieldEventBehavior) const final;
-    bool typeMismatch() const final;
     bool sizeShouldIncludeDecoration(int defaultSize, int& preferredSize) const final;
     float decorationWidth() const final;
     StepRange createStepRange(AnyStepHandling) const final;
@@ -67,7 +67,6 @@ private:
     String visibleValue() const final;
     String convertFromVisibleValue(const String&) const final;
     String sanitizeValue(const String&) const final;
-    bool hasBadInput() const final;
     String badInputText() const final;
     bool supportsPlaceholder() const final;
     void attributeChanged(const QualifiedName&) final;

--- a/Source/WebCore/html/PasswordInputType.h
+++ b/Source/WebCore/html/PasswordInputType.h
@@ -35,7 +35,6 @@
 namespace WebCore {
 
 class PasswordInputType final : public BaseTextInputType {
-    template<typename DowncastedType> friend bool isInvalidInputType(const InputType&, const String&);
 public:
     static Ref<PasswordInputType> create(HTMLInputElement& element)
     {

--- a/Source/WebCore/html/RadioInputType.h
+++ b/Source/WebCore/html/RadioInputType.h
@@ -36,7 +36,6 @@
 namespace WebCore {
 
 class RadioInputType final : public BaseCheckableInputType {
-    template<typename DowncastedType> friend bool isInvalidInputType(const InputType&, const String&);
 public:
     static Ref<RadioInputType> create(HTMLInputElement& element)
     {

--- a/Source/WebCore/html/RangeInputType.h
+++ b/Source/WebCore/html/RangeInputType.h
@@ -38,7 +38,6 @@ namespace WebCore {
 class SliderThumbElement;
 
 class RangeInputType final : public InputType {
-    template<typename DowncastedType> friend bool isInvalidInputType(const InputType&, const String&);
 public:
     static Ref<RangeInputType> create(HTMLInputElement& element)
     {

--- a/Source/WebCore/html/ResetInputType.h
+++ b/Source/WebCore/html/ResetInputType.h
@@ -35,7 +35,6 @@
 namespace WebCore {
 
 class ResetInputType final : public BaseButtonInputType {
-    template<typename DowncastedType> friend bool isInvalidInputType(const InputType&, const String&);
 public:
     static Ref<ResetInputType> create(HTMLInputElement& element)
     {

--- a/Source/WebCore/html/SearchInputType.h
+++ b/Source/WebCore/html/SearchInputType.h
@@ -39,7 +39,6 @@ namespace WebCore {
 class SearchFieldResultsButtonElement;
 
 class SearchInputType final : public BaseTextInputType {
-    template<typename DowncastedType> friend bool isInvalidInputType(const InputType&, const String&);
 public:
     static Ref<SearchInputType> create(HTMLInputElement& element)
     {

--- a/Source/WebCore/html/SubmitInputType.h
+++ b/Source/WebCore/html/SubmitInputType.h
@@ -35,7 +35,6 @@
 namespace WebCore {
 
 class SubmitInputType final : public BaseButtonInputType {
-    template<typename DowncastedType> friend bool isInvalidInputType(const InputType&, const String&);
 public:
     static Ref<SubmitInputType> create(HTMLInputElement& element)
     {

--- a/Source/WebCore/html/TelephoneInputType.h
+++ b/Source/WebCore/html/TelephoneInputType.h
@@ -35,7 +35,6 @@
 namespace WebCore {
 
 class TelephoneInputType final : public BaseTextInputType {
-    template<typename DowncastedType> friend bool isInvalidInputType(const InputType&, const String&);
 public:
     static Ref<TelephoneInputType> create(HTMLInputElement& element)
     {

--- a/Source/WebCore/html/TextInputType.h
+++ b/Source/WebCore/html/TextInputType.h
@@ -35,7 +35,6 @@
 namespace WebCore {
 
 class TextInputType final : public BaseTextInputType {
-    template<typename DowncastedType> friend bool isInvalidInputType(const InputType&, const String&);
 public:
     static Ref<TextInputType> create(HTMLInputElement& element)
     {

--- a/Source/WebCore/html/TimeInputType.h
+++ b/Source/WebCore/html/TimeInputType.h
@@ -37,7 +37,6 @@
 namespace WebCore {
 
 class TimeInputType final : public BaseDateAndTimeInputType {
-    template<typename DowncastedType> friend bool isInvalidInputType(const InputType&, const String&);
 public:
     static Ref<TimeInputType> create(HTMLInputElement& element)
     {

--- a/Source/WebCore/html/URLInputType.h
+++ b/Source/WebCore/html/URLInputType.h
@@ -35,7 +35,6 @@
 namespace WebCore {
 
 class URLInputType final : public BaseTextInputType {
-    template<typename DowncastedType> friend bool isInvalidInputType(const InputType&, const String&);
 public:
     static Ref<URLInputType> create(HTMLInputElement& element)
     {
@@ -43,6 +42,7 @@ public:
     }
 
     bool typeMismatchFor(const String&) const final;
+    bool typeMismatch() const final;
 
 private:
     explicit URLInputType(HTMLInputElement& element)
@@ -51,7 +51,6 @@ private:
     }
 
     const AtomString& formControlType() const final;
-    bool typeMismatch() const final;
     String typeMismatchText() const final;
     String sanitizeValue(const String&) const final;
 };

--- a/Source/WebCore/html/WeekInputType.h
+++ b/Source/WebCore/html/WeekInputType.h
@@ -37,7 +37,6 @@
 namespace WebCore {
 
 class WeekInputType final : public BaseDateAndTimeInputType {
-    template<typename DowncastedType> friend bool isInvalidInputType(const InputType&, const String&);
 public:
     static Ref<WeekInputType> create(HTMLInputElement& element)
     {


### PR DESCRIPTION
#### 5b1d7c2431023876aa2cdc4035877580a48396ef
<pre>
Stop marking isInvalidInputType() as friend to InputType subclasses
<a href="https://bugs.webkit.org/show_bug.cgi?id=255731">https://bugs.webkit.org/show_bug.cgi?id=255731</a>

Reviewed by Darin Adler.

Stop marking isInvalidInputType() as friend to InputType subclasses. We just
need to make a few validation function public (which they are already in the
base class). This allows us to move isInvalidInputType() to InputType.cpp,
since this is the only place it is used.

* Source/WebCore/html/BaseDateAndTimeInputType.h:
* Source/WebCore/html/ButtonInputType.h:
* Source/WebCore/html/CheckboxInputType.h:
* Source/WebCore/html/ColorInputType.h:
* Source/WebCore/html/DateInputType.h:
* Source/WebCore/html/DateTimeLocalInputType.h:
* Source/WebCore/html/EmailInputType.h:
* Source/WebCore/html/FileInputType.h:
* Source/WebCore/html/HiddenInputType.h:
* Source/WebCore/html/ImageInputType.h:
* Source/WebCore/html/InputType.cpp:
(WebCore::isInvalidInputType):
(WebCore::InputType::typeMismatchFor const): Deleted.
(WebCore::InputType::typeMismatch const): Deleted.
(WebCore::InputType::valueMissing const): Deleted.
(WebCore::InputType::hasBadInput const): Deleted.
(WebCore::InputType::patternMismatch const): Deleted.
* Source/WebCore/html/InputType.h:
(WebCore::InputType::typeMismatchFor const):
(WebCore::InputType::valueMissing const):
(WebCore::InputType::hasBadInput const):
(WebCore::InputType::patternMismatch const):
(WebCore::InputType::typeMismatch const):
(WebCore::isInvalidInputType): Deleted.
* Source/WebCore/html/MonthInputType.h:
* Source/WebCore/html/NumberInputType.h:
* Source/WebCore/html/PasswordInputType.h:
* Source/WebCore/html/RadioInputType.h:
* Source/WebCore/html/RangeInputType.h:
* Source/WebCore/html/ResetInputType.h:
* Source/WebCore/html/SearchInputType.h:
* Source/WebCore/html/SubmitInputType.h:
* Source/WebCore/html/TelephoneInputType.h:
* Source/WebCore/html/TextInputType.h:
* Source/WebCore/html/TimeInputType.h:
* Source/WebCore/html/URLInputType.h:
* Source/WebCore/html/WeekInputType.h:

Canonical link: <a href="https://commits.webkit.org/263179@main">https://commits.webkit.org/263179@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/6eaf9f97260bf094327f0423b6e0480af2339f63

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/3871 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/3961 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/4070 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/5306 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/4130 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/3847 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/4042 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/3967 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/3777 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/3919 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/4115 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/3491 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/5142 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/1619 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/3466 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/5016 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/3438 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/3526 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/4911 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/3925 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/3186 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/3447 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/3466 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/940 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/3491 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/3725 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->