### PR TITLE
[margin-trim][block layout] Trimmed block-end margins should be reflected in computed style in a horizontal writing-mode BFC.

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/computed-margin-values/block-container-block-end-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/computed-margin-values/block-container-block-end-expected.txt
@@ -1,0 +1,3 @@
+
+PASS item 1
+

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/computed-margin-values/block-container-block-end-nested-child-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/computed-margin-values/block-container-block-end-nested-child-expected.txt
@@ -1,0 +1,46 @@
+
+PASS item 1
+FAIL item 2 assert_equals:
+<item data-expected-margin-bottom="0" style="block-size: auto;">
+                <div><item data-expected-margin-bottom="10"></item></div>
+                <div>
+                    <item data-expected-margin-bottom="0" style="block-size: auto;">
+                        <div><item data-expected-margin-bottom="0"></item></div>
+                    </item>
+                    <item class="collapsed" data-expected-margin-bottom="0">
+                        <div><item class="collapsed" data-expected-margin-bottom="0"></item></div>
+                    </item>
+                </div>
+                <item class="collapsed" data-expected-margin-bottom="0">
+                    <div><item class="collapsed" data-expected-margin-bottom="0"></item></div>
+                </item>
+            </item>
+margin-bottom expected "0" but got "10"
+PASS item 3
+PASS item 4
+PASS item 5
+FAIL item 6 assert_equals:
+<item class="collapsed" data-expected-margin-bottom="0">
+                        <div><item class="collapsed" data-expected-margin-bottom="0"></item></div>
+                    </item>
+margin-bottom expected "0" but got "10"
+FAIL item 7 assert_equals:
+<item class="collapsed" data-expected-margin-bottom="0"></item>
+margin-bottom expected "0" but got "10"
+FAIL item 8 assert_equals:
+<item class="collapsed" data-expected-margin-bottom="0">
+                    <div><item class="collapsed" data-expected-margin-bottom="0"></item></div>
+                </item>
+margin-bottom expected "0" but got "10"
+FAIL item 9 assert_equals:
+<item class="collapsed" data-expected-margin-bottom="0"></item>
+margin-bottom expected "0" but got "10"
+FAIL item 10 assert_equals:
+<item class="collapsed" data-expected-margin-bottom="0">
+                <div><item class="collapsed" data-expected-margin-bottom="0"></item></div>
+            </item>
+margin-bottom expected "0" but got "10"
+FAIL item 11 assert_equals:
+<item class="collapsed" data-expected-margin-bottom="0"></item>
+margin-bottom expected "0" but got "10"
+

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/computed-margin-values/block-container-block-end-nested-child.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/computed-margin-values/block-container-block-end-nested-child.html
@@ -1,0 +1,55 @@
+<!DOCTYPE html>
+<html>
+<head>
+<link rel="author" href="mailto:sammy.gill@apple.com">
+<link rel="help" href="https://w3c.github.io/csswg-drafts/css-box-4/#margin-trim-block">
+<meta name="assert" content="Items, including self-collapsing ones, at the block-end of the container should have their margins trimmed">
+<style>
+container {
+    display: block;
+    inline-size: min-content;
+    margin-trim: block-end;
+}
+item {
+    display: block;
+    background-color: green;
+    inline-size: 50px;
+    block-size: 10px;
+    margin-block-end: 10px;
+}
+.border {
+    border: 1px solid black;
+}
+.collapsed {
+    block-size: 0px;
+}
+</style>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/resources/check-layout-th.js"></script>
+</head>
+<body onload="checkLayout('item')">
+    <div id="target">
+        <container>
+            <item data-expected-margin-bottom="10"></item>
+            <item data-expected-margin-bottom="0" style="block-size: auto;">
+                <div><item data-expected-margin-bottom="10"></item></div>
+                <div>
+                    <item data-expected-margin-bottom="0" style="block-size: auto;">
+                        <div><item data-expected-margin-bottom="0"></item></div>
+                    </item>
+                    <item class="collapsed" data-expected-margin-bottom="0">
+                        <div><item class="collapsed" data-expected-margin-bottom="0"></item></div>
+                    </item>
+                </div>
+                <item class="collapsed" data-expected-margin-bottom="0">
+                    <div><item class="collapsed" data-expected-margin-bottom="0"></item></div>
+                </item>
+            </item>
+            <item class="collapsed" data-expected-margin-bottom="0">
+                <div><item class="collapsed" data-expected-margin-bottom="0"></item></div>
+            </item>
+        </container>
+    </div>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/computed-margin-values/block-container-block-end-with-self-collapsing-children-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/computed-margin-values/block-container-block-end-with-self-collapsing-children-expected.txt
@@ -1,0 +1,93 @@
+
+PASS item 1
+PASS item 2
+FAIL item 3 assert_equals:
+<item class="collapsed" data-expected-margin-bottom="0">
+                <div><item class="collapsed" data-expected-margin-bottom="0">
+                    <div><item class="collapsed" data-expected-margin-bottom="0">
+                        <div><item class="collapsed" data-expected-margin-bottom="0"></item></div>
+                        <div><item class="collapsed" data-expected-margin-bottom="0"></item></div>
+                    </item></div>
+                </item></div>
+                <div><item class="collapsed" data-expected-margin-bottom="0"></item></div>
+            </item>
+margin-bottom expected "0" but got "10"
+FAIL item 4 assert_equals:
+<item class="collapsed" data-expected-margin-bottom="0">
+                    <div><item class="collapsed" data-expected-margin-bottom="0">
+                        <div><item class="collapsed" data-expected-margin-bottom="0"></item></div>
+                        <div><item class="collapsed" data-expected-margin-bottom="0"></item></div>
+                    </item></div>
+                </item>
+margin-bottom expected "0" but got "10"
+FAIL item 5 assert_equals:
+<item class="collapsed" data-expected-margin-bottom="0">
+                        <div><item class="collapsed" data-expected-margin-bottom="0"></item></div>
+                        <div><item class="collapsed" data-expected-margin-bottom="0"></item></div>
+                    </item>
+margin-bottom expected "0" but got "10"
+FAIL item 6 assert_equals:
+<item class="collapsed" data-expected-margin-bottom="0"></item>
+margin-bottom expected "0" but got "10"
+FAIL item 7 assert_equals:
+<item class="collapsed" data-expected-margin-bottom="0"></item>
+margin-bottom expected "0" but got "10"
+FAIL item 8 assert_equals:
+<item class="collapsed" data-expected-margin-bottom="0"></item>
+margin-bottom expected "0" but got "10"
+FAIL item 9 assert_equals:
+<item class="collapsed" data-expected-margin-bottom="0">
+                <div><item class="collapsed" data-expected-margin-bottom="0">
+                    <div><item class="collapsed" data-expected-margin-bottom="0"></item></div>
+                    <div><item class="collapsed" data-expected-margin-bottom="0">
+                        <div><item class="collapsed" data-expected-margin-bottom="0"></item></div>
+                    </item></div>
+                    <div><item class="collapsed" data-expected-margin-bottom="0"></item></div>
+                </item></div>
+                <div><item class="collapsed" data-expected-margin-bottom="0">
+                    <div><item class="collapsed" data-expected-margin-bottom="0">
+                        <div><item class="collapsed" data-expected-margin-bottom="0"></item></div>
+                    </item></div>
+                </item></div>
+            </item>
+margin-bottom expected "0" but got "10"
+FAIL item 10 assert_equals:
+<item class="collapsed" data-expected-margin-bottom="0">
+                    <div><item class="collapsed" data-expected-margin-bottom="0"></item></div>
+                    <div><item class="collapsed" data-expected-margin-bottom="0">
+                        <div><item class="collapsed" data-expected-margin-bottom="0"></item></div>
+                    </item></div>
+                    <div><item class="collapsed" data-expected-margin-bottom="0"></item></div>
+                </item>
+margin-bottom expected "0" but got "10"
+FAIL item 11 assert_equals:
+<item class="collapsed" data-expected-margin-bottom="0"></item>
+margin-bottom expected "0" but got "10"
+FAIL item 12 assert_equals:
+<item class="collapsed" data-expected-margin-bottom="0">
+                        <div><item class="collapsed" data-expected-margin-bottom="0"></item></div>
+                    </item>
+margin-bottom expected "0" but got "10"
+FAIL item 13 assert_equals:
+<item class="collapsed" data-expected-margin-bottom="0"></item>
+margin-bottom expected "0" but got "10"
+FAIL item 14 assert_equals:
+<item class="collapsed" data-expected-margin-bottom="0"></item>
+margin-bottom expected "0" but got "10"
+FAIL item 15 assert_equals:
+<item class="collapsed" data-expected-margin-bottom="0">
+                    <div><item class="collapsed" data-expected-margin-bottom="0">
+                        <div><item class="collapsed" data-expected-margin-bottom="0"></item></div>
+                    </item></div>
+                </item>
+margin-bottom expected "0" but got "10"
+FAIL item 16 assert_equals:
+<item class="collapsed" data-expected-margin-bottom="0">
+                        <div><item class="collapsed" data-expected-margin-bottom="0"></item></div>
+                    </item>
+margin-bottom expected "0" but got "10"
+FAIL item 17 assert_equals:
+<item class="collapsed" data-expected-margin-bottom="0"></item>
+margin-bottom expected "0" but got "10"
+PASS item 18
+

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/computed-margin-values/block-container-block-end-with-self-collapsing-children.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/computed-margin-values/block-container-block-end-with-self-collapsing-children.html
@@ -1,0 +1,60 @@
+<!DOCTYPE html>
+<html>
+<head>
+<link rel="author" href="mailto:sammy.gill@apple.com">
+<link rel="help" href="https://w3c.github.io/csswg-drafts/css-box-4/#margin-trim-block">
+<meta name="assert" content="Second item and all self-collapsing children at block-end should have margins trimmed">
+<style>
+container {
+    display: block;
+    inline-size: min-content;
+    margin-trim: block-end;
+}
+item {
+    display: block;
+    background-color: green;
+    inline-size: 50px;
+    block-size: 50px;
+    margin-block-end: 10px;
+}
+.collapsed {
+    block-size: 0px;
+}
+</style>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/resources/check-layout-th.js"></script>
+</head>
+<body onload="checkLayout('item')">
+    <div id="target">
+        <container>
+            <item data-expected-margin-bottom="10"></item>
+            <item data-expected-margin-bottom="0"></item>
+            <item class="collapsed" data-expected-margin-bottom="0">
+                <div><item class="collapsed" data-expected-margin-bottom="0">
+                    <div><item class="collapsed" data-expected-margin-bottom="0">
+                        <div><item class="collapsed" data-expected-margin-bottom="0"></item></div>
+                        <div><item class="collapsed" data-expected-margin-bottom="0"></item></div>
+                    </item></div>
+                </item></div>
+                <div><item class="collapsed" data-expected-margin-bottom="0"></item></div>
+            </item>
+            <item class="collapsed" data-expected-margin-bottom="0">
+                <div><item class="collapsed" data-expected-margin-bottom="0">
+                    <div><item class="collapsed" data-expected-margin-bottom="0"></item></div>
+                    <div><item class="collapsed" data-expected-margin-bottom="0">
+                        <div><item class="collapsed" data-expected-margin-bottom="0"></item></div>
+                    </item></div>
+                    <div><item class="collapsed" data-expected-margin-bottom="0"></item></div>
+                </item></div>
+                <div><item class="collapsed" data-expected-margin-bottom="0">
+                    <div><item class="collapsed" data-expected-margin-bottom="0">
+                        <div><item class="collapsed" data-expected-margin-bottom="0"></item></div>
+                    </item></div>
+                </item></div>
+            </item>
+            <item class="collapsed" data-expected-margin-bottom="0"></item>
+        </container>
+    </div>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/computed-margin-values/block-container-block-end.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/computed-margin-values/block-container-block-end.html
@@ -1,0 +1,32 @@
+<!DOCTYPE html>
+<html>
+<head>
+<link rel="author" href="mailto:sammy.gill@apple.com">
+<link rel="help" href="https://w3c.github.io/csswg-drafts/css-box-4/#margin-trim-block">
+<meta name="assert" content="block-end margin of item should be trimmed">
+<style>
+container {
+    display: block;
+    inline-size: min-content;
+    margin-trim: block-end;
+}
+item {
+    display: block;
+    background-color: green;
+    inline-size: 50px;
+    block-size: 50px;
+    margin-block-end: 10px;
+}
+</style>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/resources/check-layout-th.js"></script>
+</head>
+<body onload="checkLayout('item')">
+    <div id="target">
+        <container>
+            <item data-expected-margin-bottom="0"></item>
+        </container>
+    </div>
+</body>
+</html>

--- a/Source/WebCore/rendering/RenderBlockFlow.cpp
+++ b/Source/WebCore/rendering/RenderBlockFlow.cpp
@@ -872,9 +872,9 @@ void RenderBlockFlow::trimBlockEndChildrenMargins()
         }
 
         auto* childContainingBlock = child->containingBlock();
-        childContainingBlock->setMarginAfterForChild(*child, 0_lu);
+        setTrimmedMarginForChild(*child, MarginTrimType::BlockEnd);
         if (child->isSelfCollapsingBlock()) {
-            childContainingBlock->setMarginBeforeForChild(*child, 0_lu);
+            setTrimmedMarginForChild(*child, MarginTrimType::BlockStart);
             childContainingBlock->setLogicalTopForChild(*child, childContainingBlock->logicalHeight());
             child = child->previousSiblingBox();
         }  else if (auto* nestedBlock = dynamicDowncast<RenderBlockFlow>(child); nestedBlock && nestedBlock->isBlockContainer() && !nestedBlock->childrenInline() && !nestedBlock->style().marginTrim().contains(MarginTrimType::BlockEnd)) {

--- a/Source/WebCore/rendering/RenderBox.cpp
+++ b/Source/WebCore/rendering/RenderBox.cpp
@@ -1408,14 +1408,8 @@ bool RenderBox::hasTrimmedMargin(std::optional<MarginTrimType> marginTrimType) c
     // We should assert here if this function is called with a layout system and
     // MarginTrimType combination that is not supported yet (i.e. the layout system
     // does not set the margin trim rare data bit for that margin)
-
-    // containingBlock->isBlockContainer() can return true even if the item is in a RenderFlexibleBox
-    // (e.g. buttons) so we should explicitly check that the item is not a flex item to catch block containers here
-    auto* containingBlock = this->containingBlock(); 
-    if (containingBlock && !containingBlock->isFlexibleBox() && containingBlock->isBlockContainer()) {
-        ASSERT_NOT_IMPLEMENTED_YET();
-        return false;
-    }
+    if (!isFlexItem() && !isGridItem() && isBlockLevelBox())
+        ASSERT(!marginTrimType || marginTrimType.value() == MarginTrimType::BlockEnd);
 #endif
     if (!hasRareData())
         return false;

--- a/Source/WebCore/rendering/RenderBox.h
+++ b/Source/WebCore/rendering/RenderBox.h
@@ -686,6 +686,7 @@ public:
 
     bool isGridItem() const { return parent() && parent()->isRenderGrid() && !isExcludedFromNormalLayout(); }
     bool isFlexItem() const { return parent() && parent()->isFlexibleBox() && !isExcludedFromNormalLayout(); }
+    bool isBlockLevelBox() const { return style().isDisplayBlockLevel(); }
 
     virtual void adjustBorderBoxRectForPainting(LayoutRect&) { };
 


### PR DESCRIPTION
#### e44bd7f346a1ce7ccfffd73e4192ded629c708ff
<pre>
[margin-trim][block layout] Trimmed block-end margins should be reflected in computed style in a horizontal writing-mode BFC.
<a href="https://bugs.webkit.org/show_bug.cgi?id=253610">https://bugs.webkit.org/show_bug.cgi?id=253610</a>
rdar://106454992

Reviewed by Alan Baradlay.

We currently perform margin trimming by doing some backtracking after a
block container with block-end margin trim has completed layout (261750@main).
In order to make sure that these margins are properly shown in their
computed style value, we need a way for ComputedStyleExtractor to know
that the block-end margin for the renderer has been trimmed. This can be
done by setting the margin-trim rare data bit for that renderer.

Whenever we trim a margin in RenderBlockFlow::trimBlockEndChildrenMargins,
we can replace the calls to setMarginAfterForChild with setTrimmedMarginForChild
which will both trim the margin and set the rare data bit for the renderer.

Later on when ComputedStyleExtractor tries to determine the value of
a bottom margin for a renderer it can first use hasTrimmedMargin on the
renderer in order to determine if that specific margin is trimmed.

While creating this patch and testing the logic, I found that certain
margins are not being trimmed correctly. It seems like particularly that
self collapsing children that has other nested self collapsing content
do not have the nested content trimmed properly. Whenever we have a
self collapsing child, we need to also go inside and trim the margins
of any other children (and perhaps perform this logic for any other
children that are nested inside that). For example

&lt;container&gt;
    &lt;item style=&quot;margin-bottom: 10px&quot;&gt;&lt;/item&gt;
    &lt;item style=&quot;margin-bottom: 10px; height: 0px;&quot;&gt;
        &lt;item style=&quot;margin-bottom: 10px; height: 0px;&quot;&gt;
            &lt;item style=&quot;margin-bottom: 10px; height: 0px;&quot;&gt;
                &lt;item style=&quot;margin-bottom: 10px; height: 0px;&quot;&gt;&lt;/item&gt;
                &lt;item style=&quot;margin-bottom: 10px; height: 0px;&quot;&gt;&lt;/item&gt;
            &lt;/item&gt;
        &lt;/item&gt;
    &lt;/item&gt;
&lt;/container&gt;

In this scenario the content itself looks fine as if margin-trimming
occurred correctly, however when looking at the computed margin-bottom
values of the nested self collapsing children we can see that their
margins were not trimmed. Currently we fail the tests in these scenarios
that are introduced in this patch because of this. I plan on addressing
this in a separate patch following this one.

* LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/computed-margin-values/block-container-block-end-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/computed-margin-values/block-container-block-end-nested-child-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/computed-margin-values/block-container-block-end-nested-child.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/computed-margin-values/block-container-block-end-with-self-collapsing-children-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/computed-margin-values/block-container-block-end-with-self-collapsing-children.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/computed-margin-values/block-container-block-end.html: Added.
* Source/WebCore/css/ComputedStyleExtractor.cpp:
(WebCore::rendererCanHaveTrimmedMargin):
* Source/WebCore/rendering/RenderBlockFlow.cpp:
(WebCore::RenderBlockFlow::trimBlockEndChildrenMargins):
* Source/WebCore/rendering/RenderBox.cpp:
(WebCore::RenderBox::physicalToFlowRelativeDirectionMapping const):
(WebCore::RenderBox::hasTrimmedMargin const):
(WebCore::RenderBox::hasTrimmedMargin const):
* Source/WebCore/rendering/RenderBox.h:
(WebCore::RenderBox::isBlockLevelBox const):

Canonical link: <a href="https://commits.webkit.org/263398@main">https://commits.webkit.org/263398@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/74aa172f43f873a5272de84684e66e8a3d42c3c5

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/4424 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/4544 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/4676 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/5903 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/4623 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/4413 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/4669 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/4508 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/4852 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/4488 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/4624 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/3979 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/5905 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/2119 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/3958 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/7984 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/3959 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/4027 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/5562 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/4431 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/3609 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/3955 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/3957 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/1102 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/8006 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/4310 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->