### PR TITLE
[margin-trim][block layout] Nested self-collapsing children at block-end should also be trimmed.

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/computed-margin-values/block-container-block-end-nested-child-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/computed-margin-values/block-container-block-end-nested-child-expected.txt
@@ -1,46 +1,13 @@
 
 PASS item 1
-FAIL item 2 assert_equals:
-<item data-expected-margin-bottom="0" style="block-size: auto;">
-                <div><item data-expected-margin-bottom="10"></item></div>
-                <div>
-                    <item data-expected-margin-bottom="0" style="block-size: auto;">
-                        <div><item data-expected-margin-bottom="0"></item></div>
-                    </item>
-                    <item class="collapsed" data-expected-margin-bottom="0">
-                        <div><item class="collapsed" data-expected-margin-bottom="0"></item></div>
-                    </item>
-                </div>
-                <item class="collapsed" data-expected-margin-bottom="0">
-                    <div><item class="collapsed" data-expected-margin-bottom="0"></item></div>
-                </item>
-            </item>
-margin-bottom expected "0" but got "10"
+PASS item 2
 PASS item 3
 PASS item 4
 PASS item 5
-FAIL item 6 assert_equals:
-<item class="collapsed" data-expected-margin-bottom="0">
-                        <div><item class="collapsed" data-expected-margin-bottom="0"></item></div>
-                    </item>
-margin-bottom expected "0" but got "10"
-FAIL item 7 assert_equals:
-<item class="collapsed" data-expected-margin-bottom="0"></item>
-margin-bottom expected "0" but got "10"
-FAIL item 8 assert_equals:
-<item class="collapsed" data-expected-margin-bottom="0">
-                    <div><item class="collapsed" data-expected-margin-bottom="0"></item></div>
-                </item>
-margin-bottom expected "0" but got "10"
-FAIL item 9 assert_equals:
-<item class="collapsed" data-expected-margin-bottom="0"></item>
-margin-bottom expected "0" but got "10"
-FAIL item 10 assert_equals:
-<item class="collapsed" data-expected-margin-bottom="0">
-                <div><item class="collapsed" data-expected-margin-bottom="0"></item></div>
-            </item>
-margin-bottom expected "0" but got "10"
-FAIL item 11 assert_equals:
-<item class="collapsed" data-expected-margin-bottom="0"></item>
-margin-bottom expected "0" but got "10"
+PASS item 6
+PASS item 7
+PASS item 8
+PASS item 9
+PASS item 10
+PASS item 11
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/computed-margin-values/block-container-block-end-with-self-collapsing-children-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/computed-margin-values/block-container-block-end-with-self-collapsing-children-expected.txt
@@ -1,93 +1,20 @@
 
 PASS item 1
 PASS item 2
-FAIL item 3 assert_equals:
-<item class="collapsed" data-expected-margin-bottom="0">
-                <div><item class="collapsed" data-expected-margin-bottom="0">
-                    <div><item class="collapsed" data-expected-margin-bottom="0">
-                        <div><item class="collapsed" data-expected-margin-bottom="0"></item></div>
-                        <div><item class="collapsed" data-expected-margin-bottom="0"></item></div>
-                    </item></div>
-                </item></div>
-                <div><item class="collapsed" data-expected-margin-bottom="0"></item></div>
-            </item>
-margin-bottom expected "0" but got "10"
-FAIL item 4 assert_equals:
-<item class="collapsed" data-expected-margin-bottom="0">
-                    <div><item class="collapsed" data-expected-margin-bottom="0">
-                        <div><item class="collapsed" data-expected-margin-bottom="0"></item></div>
-                        <div><item class="collapsed" data-expected-margin-bottom="0"></item></div>
-                    </item></div>
-                </item>
-margin-bottom expected "0" but got "10"
-FAIL item 5 assert_equals:
-<item class="collapsed" data-expected-margin-bottom="0">
-                        <div><item class="collapsed" data-expected-margin-bottom="0"></item></div>
-                        <div><item class="collapsed" data-expected-margin-bottom="0"></item></div>
-                    </item>
-margin-bottom expected "0" but got "10"
-FAIL item 6 assert_equals:
-<item class="collapsed" data-expected-margin-bottom="0"></item>
-margin-bottom expected "0" but got "10"
-FAIL item 7 assert_equals:
-<item class="collapsed" data-expected-margin-bottom="0"></item>
-margin-bottom expected "0" but got "10"
-FAIL item 8 assert_equals:
-<item class="collapsed" data-expected-margin-bottom="0"></item>
-margin-bottom expected "0" but got "10"
-FAIL item 9 assert_equals:
-<item class="collapsed" data-expected-margin-bottom="0">
-                <div><item class="collapsed" data-expected-margin-bottom="0">
-                    <div><item class="collapsed" data-expected-margin-bottom="0"></item></div>
-                    <div><item class="collapsed" data-expected-margin-bottom="0">
-                        <div><item class="collapsed" data-expected-margin-bottom="0"></item></div>
-                    </item></div>
-                    <div><item class="collapsed" data-expected-margin-bottom="0"></item></div>
-                </item></div>
-                <div><item class="collapsed" data-expected-margin-bottom="0">
-                    <div><item class="collapsed" data-expected-margin-bottom="0">
-                        <div><item class="collapsed" data-expected-margin-bottom="0"></item></div>
-                    </item></div>
-                </item></div>
-            </item>
-margin-bottom expected "0" but got "10"
-FAIL item 10 assert_equals:
-<item class="collapsed" data-expected-margin-bottom="0">
-                    <div><item class="collapsed" data-expected-margin-bottom="0"></item></div>
-                    <div><item class="collapsed" data-expected-margin-bottom="0">
-                        <div><item class="collapsed" data-expected-margin-bottom="0"></item></div>
-                    </item></div>
-                    <div><item class="collapsed" data-expected-margin-bottom="0"></item></div>
-                </item>
-margin-bottom expected "0" but got "10"
-FAIL item 11 assert_equals:
-<item class="collapsed" data-expected-margin-bottom="0"></item>
-margin-bottom expected "0" but got "10"
-FAIL item 12 assert_equals:
-<item class="collapsed" data-expected-margin-bottom="0">
-                        <div><item class="collapsed" data-expected-margin-bottom="0"></item></div>
-                    </item>
-margin-bottom expected "0" but got "10"
-FAIL item 13 assert_equals:
-<item class="collapsed" data-expected-margin-bottom="0"></item>
-margin-bottom expected "0" but got "10"
-FAIL item 14 assert_equals:
-<item class="collapsed" data-expected-margin-bottom="0"></item>
-margin-bottom expected "0" but got "10"
-FAIL item 15 assert_equals:
-<item class="collapsed" data-expected-margin-bottom="0">
-                    <div><item class="collapsed" data-expected-margin-bottom="0">
-                        <div><item class="collapsed" data-expected-margin-bottom="0"></item></div>
-                    </item></div>
-                </item>
-margin-bottom expected "0" but got "10"
-FAIL item 16 assert_equals:
-<item class="collapsed" data-expected-margin-bottom="0">
-                        <div><item class="collapsed" data-expected-margin-bottom="0"></item></div>
-                    </item>
-margin-bottom expected "0" but got "10"
-FAIL item 17 assert_equals:
-<item class="collapsed" data-expected-margin-bottom="0"></item>
-margin-bottom expected "0" but got "10"
+PASS item 3
+PASS item 4
+PASS item 5
+PASS item 6
+PASS item 7
+PASS item 8
+PASS item 9
+PASS item 10
+PASS item 11
+PASS item 12
+PASS item 13
+PASS item 14
+PASS item 15
+PASS item 16
+PASS item 17
 PASS item 18
 


### PR DESCRIPTION
#### 809b95bb1a78dc940c38c22f885c4e16925b9945
<pre>
[margin-trim][block layout] Nested self-collapsing children at block-end should also be trimmed.
<a href="https://bugs.webkit.org/show_bug.cgi?id=255736">https://bugs.webkit.org/show_bug.cgi?id=255736</a>
rdar://108327029

Reviewed by Alan Baradlay.

When walking back up the block container for the purposes of block-end
margin trimming we may run into a self collapsing child that needs to
have both of its margins trimmed and its position adjusted. However, it
is also possible that these self-collapsing children may also have other
self-collapsing children nested arbitrarily within. If that is the case,
we need to also trim the margins of all of its descendants.

* LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/computed-margin-values/block-container-block-end-nested-child-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-box/margin-trim/computed-margin-values/block-container-block-end-with-self-collapsing-children-expected.txt:
* Source/WebCore/rendering/RenderBlockFlow.cpp:
(WebCore::RenderBlockFlow::trimBlockEndChildrenMargins):

Canonical link: <a href="https://commits.webkit.org/263439@main">https://commits.webkit.org/263439@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/133eb52ab3c299b1e46d5c922b41e33790bbec10

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/4576 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/4697 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/4848 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/6069 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/4735 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/4567 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/4834 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/4654 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/4975 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/4645 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/4740 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/4098 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/6076 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/2232 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/4090 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/9088 "4 flakes 134 failures") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/4088 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/4163 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/5705 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/4554 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/3713 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/4086 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/1134 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/8127 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/4448 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->