### PR TITLE
[ews] Add logging when FindModifiedLayoutTests fails to access the PR content

### DIFF
--- a/Tools/CISupport/ews-build/steps.py
+++ b/Tools/CISupport/ews-build/steps.py
@@ -1345,7 +1345,8 @@ class FindModifiedLayoutTests(AnalyzeChange):
     def start(self):
         patch = self._get_patch()
         if not patch:
-            self.finished(SUCCESS)
+            self._addToLog('stdio', 'Unable to access the patch/PR content.')
+            self.finished(WARNINGS)
             return None
 
         tests = self.find_test_names_from_patch(patch)


### PR DESCRIPTION
#### d01d57322f191dedd7460d99966429bb33bf5d13
<pre>
[ews] Add logging when FindModifiedLayoutTests fails to access the PR content
<a href="https://bugs.webkit.org/show_bug.cgi?id=255740">https://bugs.webkit.org/show_bug.cgi?id=255740</a>

Reviewed by Jonathan Bedard.

* Tools/CISupport/ews-build/steps.py:
(FindModifiedLayoutTests.start):

Canonical link: <a href="https://commits.webkit.org/263193@main">https://commits.webkit.org/263193@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e478a822d8a97a5e4dfb1dce79347b74ae658eeb

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/3905 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/3995 "Built successfully") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/14/builds/4106 "Build was cancelled. Recent messages:OS: Monterey (12.6.3), Xcode: 13.4.1") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/5341 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/32/builds/4163 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [  ~~🧪 bindings~~](https://ews-build.webkit.org/#/builders/9/builds/3882 "Build was cancelled. Recent messages:OS: Unknown (10.15.7), Xcode: 11.7") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/4078 "Built successfully") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/16/builds/3990 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/3898 "Build was cancelled. Recent messages:Failed to print configuration; Skipping applying patch since patch_id isn't provided; Checked out pull request; Skipped layout-tests; 31 flakes 144 failures; Uploaded test results; layout-tests (exception)") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/3953 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/15/builds/4146 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/14/builds/4106 "Build was cancelled. Recent messages:OS: Monterey (12.6.3), Xcode: 13.4.1") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/5178 "Built successfully") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/39/builds/1650 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/14/builds/4106 "Build was cancelled. Recent messages:OS: Monterey (12.6.3), Xcode: 13.4.1") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/5438 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/3469 "Build was cancelled. Recent messages:OS: Ventura (13.3), Xcode: 14.3; Skipping applying patch since patch_id isn't provided; Checked out pull request; run-api-tests (cancelled)") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/14/builds/4106 "Build was cancelled. Recent messages:OS: Monterey (12.6.3), Xcode: 13.4.1") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/4954 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/3958 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/16/builds/3990 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🧪 services](https://ews-build.webkit.org/#/builders/28/builds/3858 "Passed tests") | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/30/builds/3478 "Build was cancelled. Recent messages:OS: Monterey (12.6.1), Xcode: 14.0; Skipping applying patch since patch_id isn't provided; Checked out pull request; Compiled WebKit (cancelled)") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/14/builds/4106 "Build was cancelled. Recent messages:OS: Monterey (12.6.3), Xcode: 13.4.1") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/3524 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/440 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/3756 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->