### PR TITLE
REGRESSION (262243@main): LFC enters a broken, semi-enabled state after rendering scrollbars

### DIFF
--- a/Source/WebCore/page/LocalFrameView.cpp
+++ b/Source/WebCore/page/LocalFrameView.cpp
@@ -5939,6 +5939,7 @@ Display::View* LocalFrameView::existingDisplayView() const
 
 Display::View& LocalFrameView::displayView()
 {
+    ASSERT(m_frame->settings().layoutFormattingContextEnabled());
     if (!m_displayView)
         m_displayView = makeUnique<Display::View>(*this);
     return *m_displayView;
@@ -6309,6 +6310,13 @@ LayoutRect LocalFrameView::getPossiblyFixedRectToExpose(const LayoutRect& visibl
     requiredVisualViewport.scale(frameScaleFactor());
     requiredVisualViewport.move(0, headerHeight());
     return requiredVisualViewport;
+}
+
+float LocalFrameView::deviceScaleFactor() const
+{
+    if (auto* page = m_frame->page())
+        return page->deviceScaleFactor();
+    return 1;
 }
 
 } // namespace WebCore

--- a/Source/WebCore/page/LocalFrameView.h
+++ b/Source/WebCore/page/LocalFrameView.h
@@ -921,6 +921,8 @@ private:
     void scrollRectToVisibleInTopLevelView(const LayoutRect& absoluteRect, bool insideFixed, const ScrollRectToVisibleOptions&);
     LayoutRect getPossiblyFixedRectToExpose(const LayoutRect& visibleRect, const LayoutRect& exposeRect, bool insideFixed, const ScrollAlignment& alignX, const ScrollAlignment& alignY) const;
 
+    float deviceScaleFactor() const final;
+
     const Ref<LocalFrame> m_frame;
     LocalFrameViewLayoutContext m_layoutContext;
 

--- a/Source/WebCore/platform/ScrollableArea.h
+++ b/Source/WebCore/platform/ScrollableArea.h
@@ -389,6 +389,8 @@ public:
         return 1.0f;
     }
 
+    virtual float deviceScaleFactor() const { return 1; }
+
     virtual void didStartScrollAnimation() { }
     
     bool horizontalOverscrollBehaviorPreventsPropagation() const { return horizontalOverscrollBehavior() != OverscrollBehavior::Auto; }

--- a/Source/WebCore/platform/Scrollbar.cpp
+++ b/Source/WebCore/platform/Scrollbar.cpp
@@ -27,7 +27,6 @@
 #include "Scrollbar.h"
 
 #include "DeprecatedGlobalSettings.h"
-#include "DisplayView.h"
 #include "GraphicsContext.h"
 #include "LocalFrameView.h"
 #include "PlatformMouseEvent.h"
@@ -509,9 +508,7 @@ NativeScrollbarVisibility Scrollbar::nativeScrollbarVisibility(const Scrollbar* 
 
 float Scrollbar::deviceScaleFactor() const
 {
-    if (RefPtr root = this->root())
-        return root->displayView().deviceScaleFactor();
-    return 1;
+    return m_scrollableArea.deviceScaleFactor();
 }
 
 } // namespace WebCore

--- a/Source/WebCore/rendering/RenderLayerCompositor.cpp
+++ b/Source/WebCore/rendering/RenderLayerCompositor.cpp
@@ -3815,7 +3815,7 @@ void RenderLayerCompositor::resetTrackedRepaintRects()
 
 float RenderLayerCompositor::deviceScaleFactor() const
 {
-    return m_renderView.document().deviceScaleFactor();
+    return page().deviceScaleFactor();
 }
 
 float RenderLayerCompositor::pageScaleFactor() const

--- a/Source/WebCore/rendering/RenderLayerScrollableArea.cpp
+++ b/Source/WebCore/rendering/RenderLayerScrollableArea.cpp
@@ -1971,4 +1971,9 @@ void RenderLayerScrollableArea::animatedScrollDidEnd()
     }
 }
 
+float RenderLayerScrollableArea::deviceScaleFactor() const
+{
+    return m_layer.renderer().document().deviceScaleFactor();
+}
+
 } // namespace WebCore

--- a/Source/WebCore/rendering/RenderLayerScrollableArea.h
+++ b/Source/WebCore/rendering/RenderLayerScrollableArea.h
@@ -277,6 +277,8 @@ private:
     void updateScrollbarPresenceAndState(std::optional<bool> hasHorizontalOverflow = std::nullopt, std::optional<bool> hasVerticalOverflow = std::nullopt);
     void registerScrollableAreaForAnimatedScroll();
 
+    float deviceScaleFactor() const final;
+
 private:
     bool m_scrollDimensionsDirty { true };
     bool m_inOverflowRelayout { false };

--- a/Source/WebCore/rendering/RenderListBox.cpp
+++ b/Source/WebCore/rendering/RenderListBox.cpp
@@ -1039,5 +1039,10 @@ bool RenderListBox::scrolledToRight() const
     // that we are at the full extent of the scroll.
     return true;
 }
+
+float RenderListBox::deviceScaleFactor() const
+{
+    return page().deviceScaleFactor();
+}
     
 } // namespace WebCore

--- a/Source/WebCore/rendering/RenderListBox.h
+++ b/Source/WebCore/rendering/RenderListBox.h
@@ -179,6 +179,8 @@ private:
 
     std::optional<int> optionRowIndex(const HTMLOptionElement&) const;
 
+    float deviceScaleFactor() const final;
+
     void paintScrollbar(PaintInfo&, const LayoutPoint&);
     void paintItemForeground(PaintInfo&, const LayoutPoint&, int listIndex);
     void paintItemBackground(PaintInfo&, const LayoutPoint&, int listIndex);


### PR DESCRIPTION
#### 337e6bee8615c22c0fdd27f6af7481a16af57182
<pre>
REGRESSION (262243@main): LFC enters a broken, semi-enabled state after rendering scrollbars
<a href="https://bugs.webkit.org/show_bug.cgi?id=255741">https://bugs.webkit.org/show_bug.cgi?id=255741</a>
rdar://108112443

Reviewed by Simon Fraser and Alan Baradlay.

When GPU process and UI-side compositing on macOS are enabled, 262243@main had inadvertently added a
call to `LocalFrameView::displayView()` in the process of asking for the current page scale; this
instantiates a `m_displayView` in the process, the existence of which causes us to reattach or
detach the root layer in `LocalFrameView::setIsInWindow()`.

`Display::View` was not intended to be used outside of LFC, so we should avoid instantiating it
unless necessary; to fix this bug, we instead add a `deviceScaleFactor()` override hook to
`ScrollableArea`, implement it in all relevant subclasses by asking the `Page`, and then plumbing
this information at paint time to `Scrollbar`, through `ScrollableArea`. This is done (as opposed to
adding a method that reads off of the `FrameView` or `Page` directly in scrollbar) to avoid layering
violations due to accessing non-platform WebCore logic from within `platform/`.

Additionally, we enforce this moving forward by asserting that LFC is enabled when asking for
`Display::View`, which would have fired in the previous test I added in 262243@main.

* Source/WebCore/page/LocalFrameView.cpp:
(WebCore::LocalFrameView::displayView):
(WebCore::LocalFrameView::deviceScaleFactor const):
* Source/WebCore/page/LocalFrameView.h:
* Source/WebCore/platform/ScrollableArea.h:
(WebCore::ScrollableArea::deviceScaleFactor const):
* Source/WebCore/platform/Scrollbar.cpp:
(WebCore::Scrollbar::deviceScaleFactor const):
* Source/WebCore/rendering/RenderLayerCompositor.cpp:
(WebCore::RenderLayerCompositor::deviceScaleFactor const):
* Source/WebCore/rendering/RenderLayerScrollableArea.cpp:
(WebCore::RenderLayerScrollableArea::deviceScaleFactor const):
* Source/WebCore/rendering/RenderLayerScrollableArea.h:
* Source/WebCore/rendering/RenderListBox.cpp:
(WebCore::RenderListBox::deviceScaleFactor const):
* Source/WebCore/rendering/RenderListBox.h:

Canonical link: <a href="https://commits.webkit.org/263241@main">https://commits.webkit.org/263241@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4b4e5310f0059dc6892c3c6e2de40759687da8cb

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/3968 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/4062 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/4174 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/5408 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/4220 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/3945 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/4150 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/4037 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/4146 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/4017 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/4204 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/3578 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/5310 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/1706 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/3554 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/5639 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/3529 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/3614 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/5038 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/4019 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/3231 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/3536 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/3554 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/983 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/3586 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/3816 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->