### PR TITLE
[CURL][SOUP] Extract common data URL logic into shared NetworkDataTaskDataURL

### DIFF
--- a/Source/WebKit/NetworkProcess/NetworkDataTask.cpp
+++ b/Source/WebKit/NetworkProcess/NetworkDataTask.cpp
@@ -28,6 +28,7 @@
 
 #include "AuthenticationManager.h"
 #include "NetworkDataTaskBlob.h"
+#include "NetworkDataTaskDataURL.h"
 #include "NetworkLoadParameters.h"
 #include "NetworkProcess.h"
 #include "NetworkSession.h"
@@ -57,6 +58,8 @@ Ref<NetworkDataTask> NetworkDataTask::create(NetworkSession& session, NetworkDat
     return NetworkDataTaskCocoa::create(session, client, parameters);
 #endif
 #if USE(SOUP)
+    if (parameters.request.url().protocolIsData())
+        return NetworkDataTaskDataURL::create(session, client, parameters);
     return NetworkDataTaskSoup::create(session, client, parameters);
 #endif
 #if USE(CURL)

--- a/Source/WebKit/NetworkProcess/NetworkDataTaskDataURL.cpp
+++ b/Source/WebKit/NetworkProcess/NetworkDataTaskDataURL.cpp
@@ -1,0 +1,203 @@
+/*
+ * Copyright (C) 2023 Microsoft Corporation. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are
+ * met:
+ *
+ *     * Redistributions of source code must retain the above copyright
+ * notice, this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above
+ * copyright notice, this list of conditions and the following disclaimer
+ * in the documentation and/or other materials provided with the
+ * distribution.
+ *     * Neither the name of Microsoft Corporation nor the names of its
+ * contributors may be used to endorse or promote products derived from
+ * this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "NetworkDataTaskDataURL.h"
+
+#if USE(CURL) || USE(SOUP)
+
+#include "AuthenticationManager.h"
+#include "Download.h"
+#include "NetworkLoadParameters.h"
+#include "NetworkProcess.h"
+#include "NetworkSession.h"
+#include <WebCore/ResourceError.h>
+#include <WebCore/ResourceRequest.h>
+#include <WebCore/ResourceResponse.h>
+#include <pal/text/TextEncoding.h>
+#include <wtf/Vector.h>
+
+#if USE(CURL)
+#include <curl/curl.h>
+#elif USE(SOUP)
+#include "WebErrors.h"
+#endif
+
+namespace WebKit {
+using namespace WebCore;
+
+Ref<NetworkDataTask> NetworkDataTaskDataURL::create(NetworkSession& session, NetworkDataTaskClient& client, const NetworkLoadParameters& parameters)
+{
+    ASSERT(parameters.request.url().protocolIsData());
+    return adoptRef(*new NetworkDataTaskDataURL(session, client, parameters));
+}
+
+NetworkDataTaskDataURL::NetworkDataTaskDataURL(NetworkSession& session, NetworkDataTaskClient& client, const NetworkLoadParameters& parameters)
+    : NetworkDataTask(session, client, parameters.request, parameters.storedCredentialsPolicy, parameters.shouldClearReferrerOnHTTPSToHTTPRedirect, parameters.isMainFrameNavigation)
+{
+    m_session->registerNetworkDataTask(*this);
+}
+
+NetworkDataTaskDataURL::~NetworkDataTaskDataURL()
+{
+    invalidateAndCancel();
+}
+
+void NetworkDataTaskDataURL::resume()
+{
+    ASSERT(m_state != State::Running);
+    if (m_state == State::Canceling || m_state == State::Completed)
+        return;
+
+    m_state = State::Running;
+
+    DataURLDecoder::decode(firstRequest().url(), { }, [this, protectedThis = Ref { *this }](auto decodeResult) mutable {
+        if (m_state == State::Canceling || m_state == State::Completed)
+            return;
+
+        didDecodeDataURL(WTFMove(decodeResult));
+    });
+}
+
+void NetworkDataTaskDataURL::cancel()
+{
+    if (m_state == State::Canceling || m_state == State::Completed)
+        return;
+
+    m_state = State::Canceling;
+}
+
+void NetworkDataTaskDataURL::invalidateAndCancel()
+{
+    cancel();
+    m_state = State::Completed;
+}
+
+NetworkDataTask::State NetworkDataTaskDataURL::state() const
+{
+    return m_state;
+}
+
+void NetworkDataTaskDataURL::setPendingDownloadLocation(const String& filename, SandboxExtension::Handle&& sandboxExtensionHandle, bool allowOverwrite)
+{
+    NetworkDataTask::setPendingDownloadLocation(filename, WTFMove(sandboxExtensionHandle), allowOverwrite);
+    m_allowOverwriteDownload = allowOverwrite;
+}
+
+String NetworkDataTaskDataURL::suggestedFilename() const
+{
+    if (!m_suggestedFilename.isEmpty())
+        return m_suggestedFilename;
+
+    String suggestedFilename = m_response.suggestedFilename();
+    if (!suggestedFilename.isEmpty())
+        return suggestedFilename;
+
+    return PAL::decodeURLEscapeSequences(m_response.url().lastPathComponent());
+}
+
+void NetworkDataTaskDataURL::didDecodeDataURL(std::optional<WebCore::DataURLDecoder::Result>&& result)
+{
+    ASSERT(m_state == State::Running);
+    if (!result) {
+        if (m_client)
+            m_client->didCompleteWithError(internalError(firstRequest().url()));
+        invalidateAndCancel();
+        return;
+    }
+
+    m_response = ResourceResponse::dataURLResponse(firstRequest().url(), result.value());
+
+    didReceiveResponse(ResourceResponse(m_response), NegotiatedLegacyTLS::No, PrivateRelayed::No, [this, protectedThis = Ref { *this }, data = WTFMove(result.value().data)](PolicyAction policyAction) mutable {
+        if (m_state == State::Canceling || m_state == State::Completed)
+            return;
+
+        switch (policyAction) {
+        case PolicyAction::Use:
+            // Should not be reached for data URLs as they are normally handled in the web process.
+            invalidateAndCancel();
+            ASSERT_NOT_REACHED();
+            break;
+        case PolicyAction::Ignore:
+            invalidateAndCancel();
+            break;
+        case PolicyAction::Download:
+            downloadDecodedData(WTFMove(data));
+            break;
+        case PolicyAction::StopAllLoads:
+            ASSERT_NOT_REACHED();
+            break;
+        }
+    });
+}
+
+void NetworkDataTaskDataURL::downloadDecodedData(Vector<uint8_t>&& data)
+{
+    FileSystem::PlatformFileHandle downloadDestinationFile = FileSystem::openFile(m_pendingDownloadLocation, FileSystem::FileOpenMode::Truncate, FileSystem::FileAccessPermission::All, !m_allowOverwriteDownload);
+    if (!FileSystem::isHandleValid(downloadDestinationFile)) {
+#if USE(CURL)
+        ResourceError error(CURLE_WRITE_ERROR, m_response.url());
+#elif USE(SOUP)
+        ResourceError error(downloadDestinationError(m_response, "Cannot write destination file."_s));
+#endif
+        if (m_client)
+            m_client->didCompleteWithError(error);
+        invalidateAndCancel();
+        return;
+    }
+
+    auto& downloadManager = m_session->networkProcess().downloadManager();
+    auto download = makeUnique<Download>(downloadManager, m_pendingDownloadID, *this, *m_session, suggestedFilename());
+    auto* downloadPtr = download.get();
+    downloadManager.dataTaskBecameDownloadTask(m_pendingDownloadID, WTFMove(download));
+    downloadPtr->didCreateDestination(m_pendingDownloadLocation);
+
+    if (-1 == FileSystem::writeToFile(downloadDestinationFile, static_cast<void*>(data.data()), data.size())) {
+        FileSystem::closeFile(downloadDestinationFile);
+        FileSystem::deleteFile(m_pendingDownloadLocation);
+#if USE(CURL)
+        ResourceError error(CURLE_WRITE_ERROR, m_response.url());
+#elif USE(SOUP)
+        ResourceError error(downloadDestinationError(m_response, "Cannot write destination file."_s));
+#endif
+        downloadPtr->didFail(error, IPC::DataReference());
+        invalidateAndCancel();
+        return;
+    }
+
+    downloadPtr->didReceiveData(data.size(), 0, 0);
+    FileSystem::closeFile(downloadDestinationFile);
+    downloadPtr->didFinish();
+    m_state = State::Completed;
+}
+
+} // namespace WebKit
+
+#endif // USE(CURL) || USE(SOUP)

--- a/Source/WebKit/NetworkProcess/NetworkDataTaskDataURL.h
+++ b/Source/WebKit/NetworkProcess/NetworkDataTaskDataURL.h
@@ -1,0 +1,72 @@
+/*
+ * Copyright (C) 2023 Microsoft Corporation. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are
+ * met:
+ *
+ *     * Redistributions of source code must retain the above copyright
+ * notice, this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above
+ * copyright notice, this list of conditions and the following disclaimer
+ * in the documentation and/or other materials provided with the
+ * distribution.
+ *     * Neither the name of Microsoft Corporation nor the names of its
+ * contributors may be used to endorse or promote products derived from
+ * this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#if USE(CURL) || USE(SOUP)
+
+#include "NetworkDataTask.h"
+#include <WebCore/DataURLDecoder.h>
+#include <WebCore/ResourceResponse.h>
+#include <wtf/FileSystem.h>
+#include <wtf/Forward.h>
+
+namespace WebKit {
+
+class Download;
+
+class NetworkDataTaskDataURL : public NetworkDataTask {
+public:
+    static Ref<NetworkDataTask> create(NetworkSession&, NetworkDataTaskClient&, const NetworkLoadParameters&);
+
+    ~NetworkDataTaskDataURL() override;
+
+private:
+    NetworkDataTaskDataURL(NetworkSession&, NetworkDataTaskClient&, const NetworkLoadParameters&);
+
+    void cancel() override;
+    void resume() override;
+    void invalidateAndCancel() override;
+    State state() const override;
+
+    void setPendingDownloadLocation(const String& filename, SandboxExtension::Handle&&, bool /*allowOverwrite*/) override;
+    String suggestedFilename() const override;
+
+    void didDecodeDataURL(std::optional<WebCore::DataURLDecoder::Result>&&);
+    void downloadDecodedData(Vector<uint8_t>&&);
+
+    State m_state { State::Suspended };
+    bool m_allowOverwriteDownload { false };
+    WebCore::ResourceResponse m_response;
+};
+
+} // namespace WebKit
+
+#endif // USE(CURL) || USE(SOUP)

--- a/Source/WebKit/NetworkProcess/soup/NetworkDataTaskSoup.cpp
+++ b/Source/WebKit/NetworkProcess/soup/NetworkDataTaskSoup.cpp
@@ -146,8 +146,7 @@ void NetworkDataTaskSoup::createRequest(ResourceRequest&& request, WasBlockingCo
         return;
     }
 
-    if (m_currentRequest.url().protocolIsData())
-        return;
+    ASSERT(!m_currentRequest.url().protocolIsData());
 
     if (!m_currentRequest.url().protocolIsInHTTPFamily()) {
         scheduleFailure(FailureType::InvalidURL);
@@ -255,7 +254,6 @@ void NetworkDataTaskSoup::clearRequest()
 
     stopTimeout();
     m_pendingResult = nullptr;
-    m_pendingDataURLResult = std::nullopt;
     m_file = nullptr;
     m_inputStream = nullptr;
     m_multipartInputStream = nullptr;
@@ -337,25 +335,6 @@ void NetworkDataTaskSoup::resume()
         return;
     }
 
-    if (m_currentRequest.url().protocolIsData() && !m_cancellable) {
-        m_networkLoadMetrics.fetchStart = MonotonicTime::now();
-        m_cancellable = adoptGRef(g_cancellable_new());
-        DataURLDecoder::decode(m_currentRequest.url(), { }, [this, protectedThis = WTFMove(protectedThis)](auto decodeResult) mutable {
-            if (m_state == State::Canceling || m_state == State::Completed || !m_client) {
-                clearRequest();
-                return;
-            }
-
-            if (m_state == State::Suspended) {
-                m_pendingDataURLResult = WTFMove(decodeResult);
-                return;
-            }
-
-            didReadDataURL(WTFMove(decodeResult));
-        });
-        return;
-    }
-
     if (m_pendingResult) {
         GRefPtr<GAsyncResult> pendingResult = WTFMove(m_pendingResult);
         if (m_inputStream)
@@ -372,8 +351,7 @@ void NetworkDataTaskSoup::resume()
                 readFileCallback(m_file.get(), pendingResult.get(), protectedThis.leakRef());
         } else
             ASSERT_NOT_REACHED();
-    } else if (m_currentRequest.url().protocolIsData())
-        didReadDataURL(WTFMove(m_pendingDataURLResult));
+    }
 }
 
 void NetworkDataTaskSoup::cancel()
@@ -1789,24 +1767,6 @@ void NetworkDataTaskSoup::enumerateFileChildrenCallback(GFile* file, GAsyncResul
 void NetworkDataTaskSoup::didReadFile(GRefPtr<GInputStream>&& inputStream)
 {
     m_inputStream = WTFMove(inputStream);
-    dispatchDidReceiveResponse();
-}
-
-void NetworkDataTaskSoup::didReadDataURL(std::optional<DataURLDecoder::Result>&& result)
-{
-    if (g_cancellable_is_cancelled(m_cancellable.get())) {
-        didFail(cancelledError(m_currentRequest));
-        return;
-    }
-
-    if (!result) {
-        didFail(internalError(m_currentRequest.url()));
-        return;
-    }
-
-    m_response = ResourceResponse::dataURLResponse(m_currentRequest.url(), result.value());
-    auto bytes = SharedBuffer::create(WTFMove(result->data))->createGBytes();
-    m_inputStream = adoptGRef(g_memory_input_stream_new_from_bytes(bytes.get()));
     dispatchDidReceiveResponse();
 }
 

--- a/Source/WebKit/NetworkProcess/soup/NetworkDataTaskSoup.h
+++ b/Source/WebKit/NetworkProcess/soup/NetworkDataTaskSoup.h
@@ -27,7 +27,6 @@
 
 #include "NetworkDataTask.h"
 #include "NetworkLoadParameters.h"
-#include <WebCore/DataURLDecoder.h>
 #include <WebCore/FrameIdentifier.h>
 #include <WebCore/NetworkLoadMetrics.h>
 #include <WebCore/PageIdentifier.h>
@@ -179,8 +178,6 @@ private:
     static void enumerateFileChildrenCallback(GFile*, GAsyncResult*, NetworkDataTaskSoup*);
     void didReadFile(GRefPtr<GInputStream>&&);
 
-    void didReadDataURL(std::optional<WebCore::DataURLDecoder::Result>&&);
-
     WebCore::AdditionalNetworkLoadMetricsForWebInspector& additionalNetworkLoadMetricsForWebInspector();
 
     WebCore::FrameIdentifier m_frameID;
@@ -194,7 +191,6 @@ private:
     GRefPtr<SoupMultipartInputStream> m_multipartInputStream;
     GRefPtr<GCancellable> m_cancellable;
     GRefPtr<GAsyncResult> m_pendingResult;
-    std::optional<WebCore::DataURLDecoder::Result> m_pendingDataURLResult;
     WebCore::ProtectionSpace m_protectionSpaceForPersistentStorage;
     WebCore::Credential m_credentialForPersistentStorage;
     WebCore::ResourceRequest m_currentRequest;

--- a/Source/WebKit/SourcesGTK.txt
+++ b/Source/WebKit/SourcesGTK.txt
@@ -34,6 +34,8 @@ NetworkProcess/Classifier/WebResourceLoadStatisticsStore.cpp
 
 NetworkProcess/Cookies/soup/WebCookieManagerSoup.cpp
 
+NetworkProcess/NetworkDataTaskDataURL.cpp
+
 NetworkProcess/cache/NetworkCacheDataGLib.cpp
 NetworkProcess/cache/NetworkCacheIOChannelGLib.cpp
 

--- a/Source/WebKit/SourcesWPE.txt
+++ b/Source/WebKit/SourcesWPE.txt
@@ -34,6 +34,8 @@ NetworkProcess/Classifier/WebResourceLoadStatisticsStore.cpp
 
 NetworkProcess/Cookies/soup/WebCookieManagerSoup.cpp
 
+NetworkProcess/NetworkDataTaskDataURL.cpp
+
 NetworkProcess/cache/NetworkCacheDataGLib.cpp
 NetworkProcess/cache/NetworkCacheIOChannelGLib.cpp
 


### PR DESCRIPTION
#### afb1339d37f44414e98767bb0bc75cb0ab71c139
<pre>
[CURL][SOUP] Extract common data URL logic into shared NetworkDataTaskDataURL
<a href="https://bugs.webkit.org/show_bug.cgi?id=255750">https://bugs.webkit.org/show_bug.cgi?id=255750</a>

Reviewed by Fujii Hironori.

Curl and Soup don&apos;t support data: URLs and the download logic for both
of these platforms is mostly the same. This change extracts common bits
of data urls handling into NetworkDataTaskDataURL which can be shared
by both platforms.

* Source/WebKit/NetworkProcess/NetworkDataTaskDataURL.cpp: Added.
(WebKit::NetworkDataTaskDataURL::create):
(WebKit::NetworkDataTaskDataURL::NetworkDataTaskDataURL):
(WebKit::NetworkDataTaskDataURL::~NetworkDataTaskDataURL):
(WebKit::NetworkDataTaskDataURL::resume): note that this task never gets back
to the suspended state once it has been initially resumed.
(WebKit::NetworkDataTaskDataURL::cancel):
(WebKit::NetworkDataTaskDataURL::invalidateAndCancel):
(WebKit::NetworkDataTaskDataURL::state const):
(WebKit::NetworkDataTaskDataURL::setPendingDownloadLocation):
(WebKit::NetworkDataTaskDataURL::suggestedFilename const):
(WebKit::NetworkDataTaskDataURL::didDecodeDataURL):
(WebKit::NetworkDataTaskDataURL::downloadDecodedData):
* Source/WebKit/NetworkProcess/NetworkDataTaskDataURL.h: Added.
* Source/WebKit/NetworkProcess/soup/NetworkDataTaskSoup.cpp:
(WebKit::NetworkDataTaskSoup::create):
(WebKit::NetworkDataTaskSoup::createRequest):
(WebKit::NetworkDataTaskSoup::clearRequest):
(WebKit::NetworkDataTaskSoup::resume):
(WebKit::NetworkDataTaskSoup::didReadDataURL): Deleted.
* Source/WebKit/NetworkProcess/soup/NetworkDataTaskSoup.h:
* Source/WebKit/SourcesGTK.txt:
* Source/WebKit/SourcesWPE.txt:

Canonical link: <a href="https://commits.webkit.org/263349@main">https://commits.webkit.org/263349@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/45c759a19b7cabbed45dcda219ce0d3f7c48b805

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/4035 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/4134 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/4246 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/5481 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/4286 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/4229 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/4110 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/4508 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/4087 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/4276 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/3643 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/5464 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/1776 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/3619 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/5810 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/3602 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/3680 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/5180 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/4089 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/3291 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/3603 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/3619 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/1065 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/3656 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/3881 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->