### PR TITLE
Add Speedometer 3 support to run-benchmark

### DIFF
--- a/Tools/Scripts/webkitpy/benchmark_runner/data/patches/webserver/Speedometer3.patch
+++ b/Tools/Scripts/webkitpy/benchmark_runner/data/patches/webserver/Speedometer3.patch
@@ -59,15 +59,3 @@ index 4a71c5a..b85d066 100644
  (function () {
      if (!window.testRunner && location.search !== "?webkit" && location.hash !== "#webkit")
          return;
-diff --git a/resources/todomvc/architecture-examples/angular/dist/index.html b/resources/todomvc/architecture-examples/angular/dist/index.html
-index 6cf8576..af6fdaf 100644
---- a/resources/todomvc/architecture-examples/angular/dist/index.html
-+++ b/resources/todomvc/architecture-examples/angular/dist/index.html
-@@ -3,7 +3,6 @@
- <head>
-   <meta charset="utf-8">
-   <title>Angular</title>
--  <base href="/resources/todomvc/architecture-examples/angular/dist/">
-   <meta name="viewport" content="width=device-width, initial-scale=1">
-   <link rel="icon" type="image/x-icon" href="favicon.ico">
- <link rel="stylesheet" href="styles.5fd101737c0aaaef.css"></head>


### PR DESCRIPTION
#### a0dcbd369295e3a93b80cbc22b0988678317c18f
<pre>
Add Speedometer 3 support to run-benchmark
<a href="https://bugs.webkit.org/show_bug.cgi?id=255752">https://bugs.webkit.org/show_bug.cgi?id=255752</a>

Unreviewed; Update the Speedometer 3 patch after <a href="https://github.com/WebKit/Speedometer/pull/148.">https://github.com/WebKit/Speedometer/pull/148.</a>

* Tools/Scripts/webkitpy/benchmark_runner/data/patches/webserver/Speedometer3.patch:

Canonical link: <a href="https://commits.webkit.org/263204@main">https://commits.webkit.org/263204@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/6df84a32ae4ef9e233fbc179b58bc91085ff788b

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/3940 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/4033 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/4144 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/5378 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/32/builds/4195 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/3918 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/4120 "Built successfully") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/16/builds/4016 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/4029 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/3988 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/15/builds/4177 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/3549 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/5237 "Built successfully") | 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/3977 "Passed tests") | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/39/builds/1678 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/10/builds/3524 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/5571 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/3500 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/3584 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/5001 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/3992 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/16/builds/4016 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/3511 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/3524 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/3560 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/448 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/3791 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->