### PR TITLE
Expose C-based API for WKNotificationGetAlert

### DIFF
--- a/Source/WebKit/UIProcess/API/C/WKNotification.cpp
+++ b/Source/WebKit/UIProcess/API/C/WKNotification.cpp
@@ -106,3 +106,11 @@ bool WKNotificationGetIsPersistent(WKNotificationRef notification)
 {
     return toImpl(notification)->isPersistentNotification();
 }
+
+WKNotificationAlert WKNotificationGetAlert(WKNotificationRef notification)
+{
+    auto silent = toImpl(notification)->data().silent;
+    if (silent == std::nullopt)
+        return kWKNotificationAlertDefault;
+    return *silent ? kWKNotificationAlertSilent : kWKNotificationAlertEnabled;
+}

--- a/Source/WebKit/UIProcess/API/C/WKNotification.h
+++ b/Source/WebKit/UIProcess/API/C/WKNotification.h
@@ -32,6 +32,14 @@
 extern "C" {
 #endif
 
+
+enum {
+    kWKNotificationAlertDefault = 1 << 0,
+    kWKNotificationAlertSilent = 1 << 1,
+    kWKNotificationAlertEnabled = 1 << 2
+};
+typedef uint32_t WKNotificationAlert;
+
 WK_EXPORT WKTypeID WKNotificationGetTypeID();
 
 WK_EXPORT WKStringRef WKNotificationCopyTitle(WKNotificationRef notification);
@@ -45,6 +53,7 @@ WK_EXPORT uint64_t WKNotificationGetID(WKNotificationRef notification);
 WK_EXPORT WKStringRef WKNotificationCopyDataStoreIdentifier(WKNotificationRef notification);
 WK_EXPORT WKDataRef WKNotificationCopyCoreIDForTesting(WKNotificationRef notification);
 WK_EXPORT bool WKNotificationGetIsPersistent(WKNotificationRef notification);
+WK_EXPORT WKNotificationAlert WKNotificationGetAlert(WKNotificationRef notification);
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
#### eaa067b4e145c129f915c2a7564c3f9e67985443
<pre>
Expose C-based API for WKNotificationGetAlert
<a href="https://bugs.webkit.org/show_bug.cgi?id=255759">https://bugs.webkit.org/show_bug.cgi?id=255759</a>
rdar://108348296

Reviewed by Megan Gardner.

* Source/WebKit/UIProcess/API/C/WKNotification.cpp:
(WKNotificationGetAlert):
* Source/WebKit/UIProcess/API/C/WKNotification.h:

Canonical link: <a href="https://commits.webkit.org/263212@main">https://commits.webkit.org/263212@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f6b023d60bc12c21eebea86e317b4763b0c60baf

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/3958 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/4052 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/4164 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/5398 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/4210 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/4140 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/4027 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/4111 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/4007 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/4195 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/3568 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/5288 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/1697 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/3543 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/5619 "4 flakes 181 failures") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/3519 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/3603 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/5027 "270 api tests failed or timed out") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/4009 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/3224 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/3526 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/3543 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/964 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/3576 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/3806 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->