### PR TITLE
WebFrame transition from RemoteFrame to LocalFrame should use same WebFrame

### DIFF
--- a/Source/WebCore/loader/FrameLoader.h
+++ b/Source/WebCore/loader/FrameLoader.h
@@ -468,6 +468,7 @@ private:
     bool m_inStopAllLoaders;
     bool m_inClearProvisionalLoadForPolicyCheck { false };
     bool m_shouldReportResourceTimingToParentFrame { true };
+    bool m_provisionalLoadHappeningInAnotherProcess { false };
 
     String m_outgoingReferrer;
 

--- a/Source/WebCore/page/RemoteFrame.cpp
+++ b/Source/WebCore/page/RemoteFrame.cpp
@@ -73,6 +73,7 @@ RemoteDOMWindow& RemoteFrame::window() const
 
 void RemoteFrame::didFinishLoadInAnotherProcess()
 {
+    // FIXME: We also need to set this to false if the load fails in another process.
     m_preventsParentFromBeingComplete = false;
 
     if (auto* ownerElement = this->ownerElement())

--- a/Source/WebKit/Shared/WebPageCreationParameters.cpp
+++ b/Source/WebKit/Shared/WebPageCreationParameters.cpp
@@ -200,7 +200,7 @@ void WebPageCreationParameters::encode(IPC::Encoder& encoder) const
 #endif
 
     encoder << contentSecurityPolicyModeForExtension;
-    encoder << subframeProcessFrameTreeInitializationParameters;
+    encoder << subframeProcessFrameTreeCreationParameters;
 
 #if ENABLE(NETWORK_CONNECTION_INTEGRITY)
     encoder << lookalikeCharacterStrings;
@@ -646,7 +646,7 @@ std::optional<WebPageCreationParameters> WebPageCreationParameters::decode(IPC::
     if (!decoder.decode(parameters.contentSecurityPolicyModeForExtension))
         return std::nullopt;
 
-    if (!decoder.decode(parameters.subframeProcessFrameTreeInitializationParameters))
+    if (!decoder.decode(parameters.subframeProcessFrameTreeCreationParameters))
         return std::nullopt;
 
 #if ENABLE(NETWORK_CONNECTION_INTEGRITY)
@@ -672,34 +672,6 @@ std::optional<WebPageCreationParameters> WebPageCreationParameters::decode(IPC::
 #endif
 
     return { WTFMove(parameters) };
-}
-
-void WebPageCreationParameters::SubframeProcessFrameTreeInitializationParameters::encode(IPC::Encoder& encoder) const
-{
-    encoder << localFrameIdentifier;
-    encoder << treeCreationParameters;
-    encoder << layerHostingContextIdentifier;
-}
-
-auto WebPageCreationParameters::SubframeProcessFrameTreeInitializationParameters::decode(IPC::Decoder& decoder) -> std::optional<SubframeProcessFrameTreeInitializationParameters>
-{
-    auto localFrameIdentifier = decoder.decode<WebCore::FrameIdentifier>();
-    if (!localFrameIdentifier)
-        return std::nullopt;
-
-    auto treeCreationParameters = decoder.decode<FrameTreeCreationParameters>();
-    if (!treeCreationParameters)
-        return std::nullopt;
-
-    auto layerHostingContextIdentifier = decoder.decode<WebCore::LayerHostingContextIdentifier>();
-    if (!layerHostingContextIdentifier)
-        return std::nullopt;
-
-    return { {
-        WTFMove(*localFrameIdentifier),
-        WTFMove(*treeCreationParameters),
-        WTFMove(*layerHostingContextIdentifier)
-    } };
 }
 
 } // namespace WebKit

--- a/Source/WebKit/Shared/WebPageCreationParameters.h
+++ b/Source/WebKit/Shared/WebPageCreationParameters.h
@@ -289,15 +289,7 @@ struct WebPageCreationParameters {
 
     WebCore::ContentSecurityPolicyModeForExtension contentSecurityPolicyModeForExtension { WebCore::ContentSecurityPolicyModeForExtension::None };
 
-    struct SubframeProcessFrameTreeInitializationParameters {
-        WebCore::FrameIdentifier localFrameIdentifier;
-        FrameTreeCreationParameters treeCreationParameters;
-        WebCore::LayerHostingContextIdentifier layerHostingContextIdentifier;
-
-        void encode(IPC::Encoder&) const;
-        static std::optional<SubframeProcessFrameTreeInitializationParameters> decode(IPC::Decoder&);
-    };
-    std::optional<SubframeProcessFrameTreeInitializationParameters> subframeProcessFrameTreeInitializationParameters;
+    std::optional<FrameTreeCreationParameters> subframeProcessFrameTreeCreationParameters;
 
 #if ENABLE(NETWORK_CONNECTION_INTEGRITY)
     Vector<WebCore::LookalikeCharactersSanitizationData> lookalikeCharacterStrings;

--- a/Source/WebKit/UIProcess/ProvisionalFrameProxy.h
+++ b/Source/WebKit/UIProcess/ProvisionalFrameProxy.h
@@ -52,7 +52,7 @@ struct FrameInfoData;
 class ProvisionalFrameProxy : public IPC::MessageReceiver, public IPC::MessageSender {
     WTF_MAKE_FAST_ALLOCATED;
 public:
-    ProvisionalFrameProxy(WebFrameProxy&, Ref<WebProcessProxy>&&, const WebCore::ResourceRequest&, bool shouldUseNewProcess);
+    ProvisionalFrameProxy(WebFrameProxy&, Ref<WebProcessProxy>&&, const WebCore::ResourceRequest&);
     ~ProvisionalFrameProxy();
 
     WebProcessProxy& process() { return m_process.get(); }

--- a/Source/WebKit/UIProcess/SubframePageProxy.cpp
+++ b/Source/WebKit/UIProcess/SubframePageProxy.cpp
@@ -43,6 +43,15 @@ SubframePageProxy::SubframePageProxy(WebPageProxy& page, WebProcessProxy& proces
 {
     if (!m_isInSameProcessAsMainFrame)
         m_process->addMessageReceiver(Messages::WebPageProxy::messageReceiverName(), m_webPageID, *this);
+
+    auto* drawingArea = page.drawingArea();
+    auto parameters = page.creationParameters(m_process, *drawingArea);
+    parameters.subframeProcessFrameTreeCreationParameters = page.frameTreeCreationParameters();
+    parameters.isProcessSwap = true; // FIXME: This should be a parameter to creationParameters rather than doctoring up the parameters afterwards.
+    parameters.topContentInset = 0;
+    m_process->send(Messages::WebProcess::CreateWebPage(m_webPageID, parameters), 0);
+    m_process->addVisitedLinkStoreUser(page.visitedLinkStore(), page.identifier());
+    drawingArea->attachToProvisionalFrameProcess(m_process);
 }
 
 SubframePageProxy::~SubframePageProxy()

--- a/Source/WebKit/UIProcess/WebFrameProxy.cpp
+++ b/Source/WebKit/UIProcess/WebFrameProxy.cpp
@@ -382,10 +382,10 @@ void WebFrameProxy::didCreateSubframe(WebCore::FrameIdentifier frameID)
     m_childFrames.add(WTFMove(child));
 }
 
-void WebFrameProxy::swapToProcess(Ref<WebProcessProxy>&& process, const WebCore::ResourceRequest& request, bool didCreateNewProcess)
+void WebFrameProxy::swapToProcess(Ref<WebProcessProxy>&& process, const WebCore::ResourceRequest& request)
 {
     ASSERT(!isMainFrame());
-    m_provisionalFrame = makeUnique<ProvisionalFrameProxy>(*this, WTFMove(process), request, didCreateNewProcess);
+    m_provisionalFrame = makeUnique<ProvisionalFrameProxy>(*this, WTFMove(process), request);
 }
 
 IPC::Connection* WebFrameProxy::messageSenderConnection() const

--- a/Source/WebKit/UIProcess/WebFrameProxy.h
+++ b/Source/WebKit/UIProcess/WebFrameProxy.h
@@ -151,7 +151,7 @@ public:
     void disconnect();
     void didCreateSubframe(WebCore::FrameIdentifier);
     ProcessID processIdentifier() const;
-    void swapToProcess(Ref<WebProcessProxy>&&, const WebCore::ResourceRequest&, bool didCreateNewProcess);
+    void swapToProcess(Ref<WebProcessProxy>&&, const WebCore::ResourceRequest&);
 
     void didReceiveMessage(IPC::Connection&, IPC::Decoder&);
 

--- a/Source/WebKit/UIProcess/WebPageProxy.cpp
+++ b/Source/WebKit/UIProcess/WebPageProxy.cpp
@@ -3929,7 +3929,7 @@ void WebPageProxy::receivedNavigationPolicyDecision(PolicyAction policyAction, A
             if (suspendedPage && suspendedPage->pageIsClosedOrClosing())
                 suspendedPage = nullptr;
 
-            continueNavigationInNewProcess(navigation, frame.get(), WTFMove(suspendedPage), WTFMove(processForNavigation), processSwapRequestedByClient, ShouldTreatAsContinuingLoad::YesAfterNavigationPolicyDecision, std::nullopt, didCreateNewProcess == WebProcessPool::DidCreateNewProcess::Yes);
+            continueNavigationInNewProcess(navigation, frame.get(), WTFMove(suspendedPage), WTFMove(processForNavigation), processSwapRequestedByClient, ShouldTreatAsContinuingLoad::YesAfterNavigationPolicyDecision, std::nullopt);
 
             receivedPolicyDecision(policyAction, navigation.ptr(), nullptr, WTFMove(navigationAction), WTFMove(sender), WillContinueLoadInNewProcess::Yes, std::nullopt);
             return;
@@ -4038,7 +4038,7 @@ void WebPageProxy::destroyProvisionalPage()
     m_provisionalPage = nullptr;
 }
 
-void WebPageProxy::continueNavigationInNewProcess(API::Navigation& navigation, WebFrameProxy& frame, std::unique_ptr<SuspendedPageProxy>&& suspendedPage, Ref<WebProcessProxy>&& newProcess, ProcessSwapRequestedByClient processSwapRequestedByClient, ShouldTreatAsContinuingLoad shouldTreatAsContinuingLoad, std::optional<NetworkResourceLoadIdentifier> existingNetworkResourceLoadIdentifierToResume, bool didCreateNewProcess)
+void WebPageProxy::continueNavigationInNewProcess(API::Navigation& navigation, WebFrameProxy& frame, std::unique_ptr<SuspendedPageProxy>&& suspendedPage, Ref<WebProcessProxy>&& newProcess, ProcessSwapRequestedByClient processSwapRequestedByClient, ShouldTreatAsContinuingLoad shouldTreatAsContinuingLoad, std::optional<NetworkResourceLoadIdentifier> existingNetworkResourceLoadIdentifierToResume)
 {
     WEBPAGEPROXY_RELEASE_LOG(Loading, "continueNavigationInNewProcess: newProcessPID=%i, hasSuspendedPage=%i", newProcess->processIdentifier(), !!suspendedPage);
     LOG(Loading, "Continuing navigation %" PRIu64 " '%s' in a new web process", navigation.navigationID(), navigation.loggingString());
@@ -4058,11 +4058,9 @@ void WebPageProxy::continueNavigationInNewProcess(API::Navigation& navigation, W
     RefPtr websitePolicies = navigation.websitePolicies();
     bool isServerSideRedirect = shouldTreatAsContinuingLoad == ShouldTreatAsContinuingLoad::YesAfterNavigationPolicyDecision && navigation.currentRequestIsRedirect();
     bool isProcessSwappingOnNavigationResponse = shouldTreatAsContinuingLoad == ShouldTreatAsContinuingLoad::YesAfterProvisionalLoadStarted;
-    // FIXME: We should change this condition to only create a ProvisionalFrameProxy when a new process is created, but currently that fails with
-    // TestWebKitAPI.SiteIsolation.IframeNavigatesSelfWithoutChangingOrigin
     if (!frame.isMainFrame() && preferences().siteIsolationEnabled()) {
         if (newProcess->coreProcessIdentifier() != frame.process().coreProcessIdentifier())
-            frame.swapToProcess(WTFMove(newProcess), navigation.currentRequest(), didCreateNewProcess);
+            frame.swapToProcess(WTFMove(newProcess), navigation.currentRequest());
         else {
             LoadParameters loadParameters;
             loadParameters.request = navigation.currentRequest();

--- a/Source/WebKit/UIProcess/WebPageProxy.h
+++ b/Source/WebKit/UIProcess/WebPageProxy.h
@@ -2718,7 +2718,7 @@ private:
 
     void reportPageLoadResult(const WebCore::ResourceError&);
 
-    void continueNavigationInNewProcess(API::Navigation&, WebFrameProxy&, std::unique_ptr<SuspendedPageProxy>&&, Ref<WebProcessProxy>&&, ProcessSwapRequestedByClient, WebCore::ShouldTreatAsContinuingLoad, std::optional<NetworkResourceLoadIdentifier> existingNetworkResourceLoadIdentifierToResume, bool didCreateNewProcess = true);
+    void continueNavigationInNewProcess(API::Navigation&, WebFrameProxy&, std::unique_ptr<SuspendedPageProxy>&&, Ref<WebProcessProxy>&&, ProcessSwapRequestedByClient, WebCore::ShouldTreatAsContinuingLoad, std::optional<NetworkResourceLoadIdentifier> existingNetworkResourceLoadIdentifierToResume);
 
     void setNeedsFontAttributes(bool);
     void updateFontAttributesAfterEditorStateChange();

--- a/Source/WebKit/UIProcess/WebProcessPool.cpp
+++ b/Source/WebKit/UIProcess/WebProcessPool.cpp
@@ -1824,11 +1824,12 @@ void WebProcessPool::processForNavigation(WebPageProxy& page, WebFrameProxy& fra
 
     auto [process, suspendedPage, reason] = processForNavigationInternal(page, navigation, sourceProcess.copyRef(), sourceURL, processSwapRequestedByClient, lockdownMode, frameInfo, dataStore.copyRef());
 
-    if (page.preferences().siteIsolationEnabled()) {
-        auto registrableDomain = RegistrableDomain(navigation.currentRequest().url());
-        if (!registrableDomain.isEmpty()) {
+    if (!frame.isMainFrame() && page.preferences().siteIsolationEnabled()) {
+        RegistrableDomain navigationDomain(navigation.currentRequest().url());
+        RegistrableDomain mainFrameDomain(URL(page.pageLoadState().activeURL()));
+        if (!navigationDomain.isEmpty() && navigationDomain != mainFrameDomain) {
             auto subFramePageProxy = makeUniqueRef<SubframePageProxy>(page, process, frame.isMainFrame());
-            page.addSubframePageProxyForFrameID(frame.frameID(), registrableDomain, WTFMove(subFramePageProxy));
+            page.addSubframePageProxyForFrameID(frame.frameID(), navigationDomain, WTFMove(subFramePageProxy));
         }
     }
 

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebFrameLoaderClient.cpp
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebFrameLoaderClient.cpp
@@ -122,11 +122,9 @@
 namespace WebKit {
 using namespace WebCore;
 
-WebFrameLoaderClient::WebFrameLoaderClient(Ref<WebFrame>&& frame, std::optional<ScopeExit<Function<void()>>>&& invalidator)
+WebFrameLoaderClient::WebFrameLoaderClient(Ref<WebFrame>&& frame, ScopeExit<Function<void()>>&& invalidator)
     : m_frame(WTFMove(frame))
-    , m_frameInvalidator(invalidator ? WTFMove(*invalidator) : makeScopeExit<Function<void()>>([frame = m_frame] {
-        frame->invalidate();
-    }))
+    , m_frameInvalidator(WTFMove(invalidator))
 {
 }
 

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebFrameLoaderClient.h
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebFrameLoaderClient.h
@@ -40,7 +40,7 @@ struct WebsitePoliciesData;
     
 class WebFrameLoaderClient final : public WebCore::FrameLoaderClient {
 public:
-    explicit WebFrameLoaderClient(Ref<WebFrame>&&, std::optional<ScopeExit<Function<void()>>>&& = std::nullopt);
+    explicit WebFrameLoaderClient(Ref<WebFrame>&&, ScopeExit<Function<void()>>&&);
     ~WebFrameLoaderClient();
 
     WebFrame& webFrame() const { return m_frame.get(); }

--- a/Source/WebKit/WebProcess/WebPage/RemoteLayerTree/RemoteLayerTreeDrawingArea.mm
+++ b/Source/WebKit/WebProcess/WebPage/RemoteLayerTree/RemoteLayerTreeDrawingArea.mm
@@ -62,9 +62,8 @@ using namespace WebCore;
 
 static WeakPtr<WebFrame> initialRootFrame(WebPage& page, const WebPageCreationParameters& parameters)
 {
-    if (parameters.subframeProcessFrameTreeInitializationParameters) {
-        // attachToInitialRootFrame will be called once the frame exists.
-        ASSERT(!WebProcess::singleton().webFrame(parameters.subframeProcessFrameTreeInitializationParameters->localFrameIdentifier));
+    if (parameters.subframeProcessFrameTreeCreationParameters) {
+        // attachToInitialRootFrame will be called once the frame transitions to local.
         return nullptr;
     }
     return page.mainWebFrame();

--- a/Source/WebKit/WebProcess/WebPage/WebFrame.h
+++ b/Source/WebKit/WebProcess/WebPage/WebFrame.h
@@ -80,7 +80,7 @@ class WebFrame : public API::ObjectImpl<API::Object::Type::BundleFrame>, public 
 public:
     static Ref<WebFrame> create(WebPage& page) { return adoptRef(*new WebFrame(page)); }
     static Ref<WebFrame> createSubframe(WebPage&, WebFrame& parent, const AtomString& frameName, WebCore::HTMLFrameOwnerElement&);
-    static Ref<WebFrame> createLocalSubframeHostedInAnotherProcess(WebPage&, WebFrame& parent, WebCore::FrameIdentifier, WebCore::LayerHostingContextIdentifier, std::optional<ScopeExit<Function<void()>>>&&);
+    static Ref<WebFrame> createLocalSubframeHostedInAnotherProcess(WebPage&, WebFrame& parent, WebCore::FrameIdentifier, WebCore::LayerHostingContextIdentifier);
     static Ref<WebFrame> createRemoteSubframe(WebPage&, WebFrame& parent, WebCore::FrameIdentifier, WebCore::ProcessIdentifier);
     ~WebFrame();
 
@@ -88,6 +88,7 @@ public:
 
     // Called when the FrameLoaderClient (and therefore the WebCore::Frame) is being torn down.
     void invalidate();
+    ScopeExit<Function<void()>> makeInvalidator();
 
     WebPage* page() const;
 
@@ -95,6 +96,8 @@ public:
     WebCore::LocalFrame* coreFrame() const;
     WebCore::RemoteFrame* coreRemoteFrame() const;
     WebCore::Frame* coreAbstractFrame() const;
+
+    void transitionToLocal(WebCore::LayerHostingContextIdentifier);
 
     FrameInfoData info() const;
     void getFrameInfo(CompletionHandler<void(FrameInfoData&&)>&&);

--- a/Source/WebKit/WebProcess/WebPage/WebPage.h
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.h
@@ -1630,7 +1630,7 @@ public:
 private:
     WebPage(WebCore::PageIdentifier, WebPageCreationParameters&&);
 
-    void constructFrameTree(WebFrame& parent, WebCore::FrameIdentifier localFrameIdentifier, WebCore::LayerHostingContextIdentifier localFrameHostLayerIdentifier, const FrameTreeCreationParameters&);
+    void constructFrameTree(WebFrame& parent, const FrameTreeCreationParameters&);
 
     void updateThrottleState();
 


### PR DESCRIPTION
#### 786784fcad5d8b4086949b22bad554248e8d848d
<pre>
WebFrame transition from RemoteFrame to LocalFrame should use same WebFrame
<a href="https://bugs.webkit.org/show_bug.cgi?id=255765">https://bugs.webkit.org/show_bug.cgi?id=255765</a>
rdar://108354414

Reviewed by Chris Dumez.

Instead of replacing the WebFrame, just replace its m_coreFrame.
This is more symmetric with WebFrame::didCommitLoadInAnotherProcess which transitions the other way.
Also tie the WebPage lifetime more closely with the SubframePageProxy lifetime,
which requires initially creating a frame tree with all RemoteFrames, then transitioning them
to LocalFrames as ProvisionalFrameProxies are made to start loads in the frames.

In order to prevent the load event from happening early, I needed to also make
FrameLoader::subframeIsLoading return true if a provisional or committed load is happening
in another process, which can&apos;t be queried through FrameLoader::provisionalDocumentLoader
because the DocumentLoader is in another process.  I added a bool to keep track of whether
this is happening, and some further refinement is needed here so I added some FIXME comments.

* Source/WebKit/Shared/WebPageCreationParameters.cpp:
(WebKit::WebPageCreationParameters::encode const):
(WebKit::WebPageCreationParameters::decode):
(WebKit::WebPageCreationParameters::SubframeProcessFrameTreeInitializationParameters::encode const): Deleted.
(WebKit::WebPageCreationParameters::SubframeProcessFrameTreeInitializationParameters::decode): Deleted.
* Source/WebKit/Shared/WebPageCreationParameters.h:
* Source/WebKit/UIProcess/ProvisionalFrameProxy.cpp:
(WebKit::ProvisionalFrameProxy::ProvisionalFrameProxy):
* Source/WebKit/UIProcess/ProvisionalFrameProxy.h:
* Source/WebKit/UIProcess/SubframePageProxy.cpp:
(WebKit::SubframePageProxy::SubframePageProxy):
* Source/WebKit/UIProcess/WebFrameProxy.cpp:
(WebKit::WebFrameProxy::swapToProcess):
* Source/WebKit/UIProcess/WebFrameProxy.h:
* Source/WebKit/UIProcess/WebPageProxy.cpp:
(WebKit::WebPageProxy::receivedNavigationPolicyDecision):
(WebKit::WebPageProxy::continueNavigationInNewProcess):
* Source/WebKit/UIProcess/WebPageProxy.h:
* Source/WebKit/UIProcess/WebProcessPool.cpp:
(WebKit::WebProcessPool::processForNavigation):
* Source/WebKit/WebProcess/WebCoreSupport/WebFrameLoaderClient.cpp:
(WebKit::WebFrameLoaderClient::WebFrameLoaderClient):
* Source/WebKit/WebProcess/WebCoreSupport/WebFrameLoaderClient.h:
* Source/WebKit/WebProcess/WebPage/RemoteLayerTree/RemoteLayerTreeDrawingArea.mm:
(WebKit::initialRootFrame):
* Source/WebKit/WebProcess/WebPage/WebFrame.cpp:
(WebKit::WebFrame::createSubframe):
(WebKit::WebFrame::createLocalSubframeHostedInAnotherProcess):
(WebKit::WebFrame::createRemoteSubframe):
(WebKit::WebFrame::makeInvalidator):
(WebKit::WebFrame::transitionToLocal):
* Source/WebKit/WebProcess/WebPage/WebFrame.h:
* Source/WebKit/WebProcess/WebPage/WebPage.cpp:
(WebKit::clientForMainFrame):
(WebKit::m_appHighlightsVisible):
(WebKit::WebPage::constructFrameTree):
(WebKit::WebPage::loadRequestByCreatingNewLocalFrameOrConvertingRemoteFrame):
(WebKit::WebPage::loadRequest):
* Source/WebKit/WebProcess/WebPage/WebPage.h:

Canonical link: <a href="https://commits.webkit.org/263458@main">https://commits.webkit.org/263458@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b0678713be2c37e4ed7bf58881ac8c3b85d70f35

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/4654 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/4772 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/4930 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/6150 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/4800 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/4644 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/4916 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/4735 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/5039 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/4725 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/4813 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/4167 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/6159 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/2301 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/4159 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/9141 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/4161 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/4233 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/5783 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/4630 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/3766 "10 flakes 2 failures") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/4155 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/8201 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/532 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/4515 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->