### PR TITLE
[WGSL] Overload resolution shouldn't eagerly promote variables

### DIFF
--- a/Source/WebGPU/WGSL/tests/valid/overload.wgsl
+++ b/Source/WebGPU/WGSL/tests/valid/overload.wgsl
@@ -1129,28 +1129,24 @@ fn testInsertBits()
     {
         _ = insertBits(0, 0, 0, 0);
         _ = insertBits(0, 0i, 0, 0);
-        // FIXME: fails to resolve overload resolution
-        // let x3 = insertBits(0, 0u, 0, 0);
+        _ = insertBits(0, 0u, 0, 0);
     }
 
     // [T < ConcreteInteger, N].(Vector[T, N], Vector[T, N], U32, U32) => Vector[T, N],
     {
         _ = insertBits(vec2(0), vec2(0), 0, 0);
         _ = insertBits(vec2(0), vec2(0i), 0, 0);
-        // FIXME: fails to resolve overload resolution
-        // let x3 = insertBits(vec2(0), vec2(0u), 0, 0);
+        _ = insertBits(vec2(0), vec2(0u), 0, 0);
     }
     {
         _ = insertBits(vec3(0), vec3(0), 0, 0);
         _ = insertBits(vec3(0), vec3(0i), 0, 0);
-        // FIXME: fails to resolve overload resolution
-        // let x3 = insertBits(vec3(0), vec3(0u), 0, 0);
+        _ = insertBits(vec3(0), vec3(0u), 0, 0);
     }
     {
         _ = insertBits(vec4(0), vec4(0), 0, 0);
         _ = insertBits(vec4(0), vec4(0i), 0, 0);
-        // FIXME: fails to resolve overload resolution
-        // let x3 = insertBits(vec4(0), vec4(0u), 0, 0);
+        _ = insertBits(vec4(0), vec4(0u), 0, 0);
     }
 }
 


### PR DESCRIPTION
#### 5186c242378cb9c03f6f0699cfd8029e5b618a07
<pre>
[WGSL] Overload resolution shouldn&apos;t eagerly promote variables
<a href="https://bugs.webkit.org/show_bug.cgi?id=255771">https://bugs.webkit.org/show_bug.cgi?id=255771</a>
rdar://108361197

Reviewed by Mike Wyrzykowski.

During overload resolution, when trying to assign a type to a variable we check
whether it satisifies the variable&apos;s constraints. In order to satisfy a constraint
we might need to promote the type being assigned to the variable. The example
from the tests is when the variable requires a concrete type but we are assigning
an abstract type to it. Originally, we would promote the type as soon as we assigned
it to the variable, but that is not always correct. The promotion algorithm will
pick the cheapest conversion, in this case it would promote an AbstractInt to an
i32, which is a valid conversion. However, later we observe that the same variable
is also being unified with an u32, which was also a valid conversion for the original
type (AbstractInt), but since we already promoted the variable to i32, we can no
longer unify the variable with u32, since we can&apos;t unify i32 and u32. The solution
is faily straightforward though: we still reject types that don&apos;t satisfy the constraints,
but hold off on promoting the type until we materialize the variable after determining
that a given overload is a viable candidate. This guarantees that there will be a
suitable promotion that will satisfy the constraints, but we delay choosing which
type we&apos;ll promote to until we have looked at all arguments.

* Source/WebGPU/WGSL/Overload.cpp:
(WGSL::OverloadResolver::materialize const):
(WGSL::OverloadResolver::assign):
* Source/WebGPU/WGSL/tests/valid/overload.wgsl:

Canonical link: <a href="https://commits.webkit.org/263355@main">https://commits.webkit.org/263355@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/37d466fd67efc114b3fa56566cb0ed39268749a4

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/4345 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/4463 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/4591 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/5819 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/4561 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/4579 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/4428 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/4788 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/4405 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/4552 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/3909 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/5818 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/2048 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/3886 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/7184 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/3878 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/3953 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/5489 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/4360 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/3543 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/3881 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/3884 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/1073 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/7936 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/4235 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->