### PR TITLE
@font-face size-adjust: Implement parser (255768)

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-fonts/parsing/font-face-size-adjust-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-fonts/parsing/font-face-size-adjust-expected.txt
@@ -1,0 +1,8 @@
+
+PASS Check that size-adjust: 100% is valid
+PASS Check that size-adjust: 0% is valid
+PASS Check that size-adjust: 110% is valid
+PASS Check that size-adjust: 100000000000% is valid
+PASS Check that size-adjust: -100% is invalid
+PASS Check that size-adjust: -1% is invalid
+

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-fonts/parsing/font-face-size-adjust.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-fonts/parsing/font-face-size-adjust.html
@@ -1,0 +1,31 @@
+<!DOCTYPE html>
+<title>CSS Fonts 5 test: parsing the size-adjust descriptor</title>
+<link rel="help" href="https://www.w3.org/TR/css-fonts-5/#size-adjust-desc">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<style id="testStyle">
+</style>
+<script>
+  const sheet = testStyle.sheet;
+  // size-adjust grammar : <percentage [0,∞]>
+  tests = [
+    { sizeAdjust: '100%', valid: true },
+    { sizeAdjust: '0%', valid: true },
+    { sizeAdjust: '110%', valid: true },
+    { sizeAdjust: '100000000000%', valid: true },
+    { sizeAdjust: '-100%', valid: false },
+    { sizeAdjust: '-1%', valid: false },
+  ];
+
+  for (let t of tests) {
+    test(() => {
+      assert_equals(sheet.cssRules.length, 0, "testSheet should initially be empty");
+      sheet.insertRule("@font-face { size-adjust: " + t.sizeAdjust + "}");
+      try {
+        assert_equals(sheet.cssRules[0].style.getPropertyValue("size-adjust") != "", t.valid);
+      } finally {
+        sheet.deleteRule(0);
+      }
+    }, "Check that size-adjust: " + t.sizeAdjust + " is " + (t.valid ? "valid" : "invalid"));
+  }
+</script>

--- a/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
+++ b/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
@@ -1025,6 +1025,20 @@ CSSCustomPropertiesAndValuesEnabled:
     WebCore:
       default: true
 
+CSSFontFaceSizeAdjustEnabled:
+  type: bool
+  status: testable
+  category: css
+  humanReadableName: "CSS @font-face size-adjust"
+  humanReadableDescription: "Enable size-adjust descriptor in @font-face"
+  defaultValue:
+    WebKitLegacy:
+      default: false
+    WebKit:
+      default: false
+    WebCore:
+      default: false
+
 CSSGradientInterpolationColorSpacesEnabled:
   type: bool
   status: stable

--- a/Source/WebCore/css/CSSFontFace.h
+++ b/Source/WebCore/css/CSSFontFace.h
@@ -67,6 +67,7 @@ public:
     void setStyle(CSSValue&);
     void setWeight(CSSValue&);
     void setStretch(CSSValue&);
+    void setSizeAdjust(CSSValue&);
     void setUnicodeRange(CSSValueList&);
     void setFeatureSettings(CSSValue&);
     void setDisplay(CSSPrimitiveValue&);
@@ -78,6 +79,7 @@ public:
     String unicodeRange() const;
     String featureSettings() const;
     String display() const;
+    String sizeAdjust() const;
 
     // Pending => Loading  => TimedOut
     //              ||  \\    //  ||
@@ -186,6 +188,8 @@ private:
 
     FontFeatureSettings m_featureSettings;
     FontLoadingBehavior m_loadingBehavior { FontLoadingBehavior::Auto };
+
+    float m_sizeAdjust { 1.0 };
 
     Vector<std::unique_ptr<CSSFontFaceSource>, 0, CrashOnOverflow, 0> m_sources;
     WeakHashSet<Client> m_clients;

--- a/Source/WebCore/css/CSSFontSelector.cpp
+++ b/Source/WebCore/css/CSSFontSelector.cpp
@@ -183,6 +183,7 @@ void CSSFontSelector::addFontFaceRule(StyleRuleFontFace& fontFaceRule, bool isIn
     RefPtr<CSSValue> unicodeRange = style.getPropertyCSSValue(CSSPropertyUnicodeRange);
     RefPtr<CSSValue> featureSettings = style.getPropertyCSSValue(CSSPropertyFontFeatureSettings);
     RefPtr<CSSValue> display = style.getPropertyCSSValue(CSSPropertyFontDisplay);
+    RefPtr<CSSValue> sizeAdjust = style.getPropertyCSSValue(CSSPropertySizeAdjust);
     if (!is<CSSValueList>(fontFamily) || !is<CSSValueList>(src) || (unicodeRange && !is<CSSValueList>(*unicodeRange)))
         return;
 
@@ -212,6 +213,8 @@ void CSSFontSelector::addFontFaceRule(StyleRuleFontFace& fontFaceRule, bool isIn
         fontFace->setFeatureSettings(*featureSettings);
     if (display)
         fontFace->setDisplay(downcast<CSSPrimitiveValue>(*display));
+    if (sizeAdjust)
+        fontFace->setSizeAdjust(*sizeAdjust);
 
     CSSFontFace::appendSources(fontFace, srcList, m_context.get(), isInitiatingElementInUserAgentShadowTree);
 
@@ -393,7 +396,7 @@ FontRanges CSSFontSelector::fontRangesForFamily(const FontDescription& fontDescr
     if (!resolveGenericFamilyFirst)
         resolveAndAssignGenericFamily();
 
-    auto font = FontCache::forCurrentThread().fontForFamily(*fontDescriptionForLookup, familyForLookup, { { }, { }, fontPaletteValues, fontFeatureValues });
+    auto font = FontCache::forCurrentThread().fontForFamily(*fontDescriptionForLookup, familyForLookup, { { }, { }, fontPaletteValues, fontFeatureValues, 1.0 });
     if (document && document->settings().webAPIStatisticsEnabled())
         ResourceLoadObserver::shared().logFontLoad(*document, familyForLookup.string(), !!font);
     return FontRanges { WTFMove(font) };

--- a/Source/WebCore/css/CSSProperties.json
+++ b/Source/WebCore/css/CSSProperties.json
@@ -9923,6 +9923,16 @@
                     "url": "https://www.w3.org/TR/css-fonts-4/#src-desc"
                 }
             },
+            "size-adjust": {
+                "codegen-properties": {
+                    "settings-flag": "cssFontFaceSizeAdjustEnabled",
+                    "parser-grammar": "<percentage [0,inf]>"
+                },
+                "specification": {
+                    "category": "css-fonts-5",
+                    "url": "https://www.w3.org/TR/css-fonts-5/#size-adjust-desc"
+                }
+            },
             "unicode-range": {
                 "codegen-properties": {
                     "parser-function": "consumeFontFaceUnicodeRange",

--- a/Source/WebCore/css/ComputedStyleExtractor.cpp
+++ b/Source/WebCore/css/ComputedStyleExtractor.cpp
@@ -4179,6 +4179,7 @@ RefPtr<CSSValue> ComputedStyleExtractor::valueForPropertyInStyle(const RenderSty
     case CSSPropertySrc:
     case CSSPropertyUnicodeRange:
     case CSSPropertyFontDisplay:
+    case CSSPropertySizeAdjust:
         return nullptr;
 
     // Unimplemented @font-palette-values properties


### PR DESCRIPTION
#### 2148febf9f0ee349f1c85c9c61f018a11e61fd92
<pre>
@font-face size-adjust: Implement parser (255768)
<a href="https://bugs.webkit.org/show_bug.cgi?id=255768">https://bugs.webkit.org/show_bug.cgi?id=255768</a>
rdar://108357839

Reviewed by Tim Nguyen.

Implement parser for @font-face size-adjust descriptor according to
 <a href="https://www.w3.org/TR/css-fonts-5/#size-adjust-desc">https://www.w3.org/TR/css-fonts-5/#size-adjust-desc</a>

* LayoutTests/imported/w3c/web-platform-tests/css/css-fonts/parsing/font-face-size-adjust-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-fonts/parsing/font-face-size-adjust.html: Added.
* Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml:
* Source/WebCore/css/CSSFontFace.cpp:
(WebCore::CSSFontFace::setSizeAdjust):
(WebCore::CSSFontFace::sizeAdjust const):
(WebCore::CSSFontFace::font):
* Source/WebCore/css/CSSFontFace.h:
* Source/WebCore/css/CSSFontSelector.cpp:
(WebCore::CSSFontSelector::addFontFaceRule):
(WebCore::CSSFontSelector::fontRangesForFamily):
* Source/WebCore/css/CSSProperties.json:
* Source/WebCore/css/ComputedStyleExtractor.cpp:
(WebCore::ComputedStyleExtractor::valueForPropertyInStyle):
* Source/WebCore/platform/graphics/FontCreationContext.h:
(WebCore::FontCreationContextRareData::create):
(WebCore::FontCreationContextRareData::sizeAdjust const):
(WebCore::FontCreationContextRareData::operator== const):
(WebCore::FontCreationContextRareData::FontCreationContextRareData):
(WebCore::FontCreationContext::FontCreationContext):
(WebCore::FontCreationContext::sizeAdjust const):
(WebCore::add):

Canonical link: <a href="https://commits.webkit.org/263248@main">https://commits.webkit.org/263248@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0d832fdc82413022ea4b167c8c61b09176e8d8a7

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/4028 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/4126 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/4238 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/5472 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/4278 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/4006 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/4220 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/4101 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/4354 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/4078 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/4267 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/3634 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/5435 "Built successfully") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/39/builds/1767 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/3610 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/5778 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/3331 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/3592 "Passed tests") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/3671 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/5167 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/3807 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/4080 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/3283 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/4110 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/3595 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/3610 "Passed tests") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/1011 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/985 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/3647 "Built successfully") | | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/24/builds/4203 "Built successfully") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/3874 "Built successfully") | | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/3/builds/1127 "Passed tests") | 
<!--EWS-Status-Bubble-End-->