### PR TITLE
[GStreamer][MediaStream] Over-allocation of buffers sourced from the WebAudio bus

### DIFF
--- a/Source/WebCore/Modules/webaudio/MediaStreamAudioSourceGStreamer.cpp
+++ b/Source/WebCore/Modules/webaudio/MediaStreamAudioSourceGStreamer.cpp
@@ -59,7 +59,7 @@ void MediaStreamAudioSource::consumeAudio(AudioBus& bus, size_t numberOfFrames)
     GstAudioInfo info;
     gst_audio_info_set_format(&info, GST_AUDIO_FORMAT_F32LE, m_currentSettings.sampleRate(), bus.numberOfChannels(), nullptr);
     GST_AUDIO_INFO_LAYOUT(&info) = GST_AUDIO_LAYOUT_NON_INTERLEAVED;
-    size_t size = GST_AUDIO_INFO_BPF(&info) * bus.numberOfChannels() * numberOfFrames;
+    size_t size = GST_AUDIO_INFO_BPS(&info) * bus.numberOfChannels() * numberOfFrames;
 
     auto caps = adoptGRef(gst_audio_info_to_caps(&info));
     auto buffer = adoptGRef(gst_buffer_new_allocate(nullptr, size, nullptr));


### PR DESCRIPTION
#### eec96000efdb614b174586c139e8df8ef7d4f007
<pre>
[GStreamer][MediaStream] Over-allocation of buffers sourced from the WebAudio bus
<a href="https://bugs.webkit.org/show_bug.cgi?id=255784">https://bugs.webkit.org/show_bug.cgi?id=255784</a>

Reviewed by Xabier Rodriguez-Calvar.

The number of channels was already implied when using GST_AUDIO_INFO_BPF(), so we ended up
allocating too much in cases of bus layout other than mono.

* Source/WebCore/Modules/webaudio/MediaStreamAudioSourceGStreamer.cpp:
(WebCore::MediaStreamAudioSource::consumeAudio):

Canonical link: <a href="https://commits.webkit.org/263242@main">https://commits.webkit.org/263242@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f81a0fb4a8be9116966ed8eceb078063e2cc6cba

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/4012 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/4109 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/4221 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/5455 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/4261 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/3990 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/4200 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/4084 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/4203 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/4062 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/4248 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/3621 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/5387 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/1749 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/3597 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/5709 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/3574 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/3658 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/5118 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/4064 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/3270 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/3579 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/3597 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/984 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/3631 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/3858 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->