### PR TITLE
REGRESSION (263108@main): [ Ventura debug ] ASSERTION FAILED: WTF::WeakPtr<WebKit::RemoteScrollingCoordinatorProxy, WTF::DefaultWeakPtrImpl>::operator->() const

### DIFF
--- a/Source/WebKit/UIProcess/RemoteLayerTree/mac/RemoteScrollingTreeMac.h
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/mac/RemoteScrollingTreeMac.h
@@ -85,6 +85,9 @@ private:
     void scrollingTreeNodeWillStartScroll(WebCore::ScrollingNodeID) override;
     void scrollingTreeNodeDidEndScroll(WebCore::ScrollingNodeID) override;
 
+    void scrollingTreeNodeDidBeginScrollSnapping(ScrollingNodeID) override;
+    void scrollingTreeNodeDidEndScrollSnapping(ScrollingNodeID) override;
+
     Ref<WebCore::ScrollingTreeNode> createScrollingTreeNode(WebCore::ScrollingNodeType, WebCore::ScrollingNodeID) override;
 
     HashMap<WebCore::ScrollingNodeID, WebCore::RequestedScrollData> m_nodesWithPendingScrollAnimations; // Guarded by m_treeLock but used via call chains that can't be annotated.

--- a/Source/WebKit/UIProcess/RemoteLayerTree/mac/RemoteScrollingTreeMac.mm
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/mac/RemoteScrollingTreeMac.mm
@@ -73,15 +73,29 @@ void RemoteScrollingTreeMac::displayDidRefresh(PlatformDisplayID)
 
 void RemoteScrollingTreeMac::scrollingTreeNodeWillStartScroll(ScrollingNodeID nodeID)
 {
-    RunLoop::main().dispatch([this, nodeID] {
+    RunLoop::main().dispatch([protectedThis = Ref { *this }, this, nodeID] {
         RemoteScrollingTree::scrollingTreeNodeWillStartScroll(nodeID);
     });
 }
 
 void RemoteScrollingTreeMac::scrollingTreeNodeDidEndScroll(ScrollingNodeID nodeID)
 {
-    RunLoop::main().dispatch([this, nodeID] {
+    RunLoop::main().dispatch([protectedThis = Ref { *this }, this, nodeID] {
         RemoteScrollingTree::scrollingTreeNodeDidEndScroll(nodeID);
+    });
+}
+
+void RemoteScrollingTreeMac::scrollingTreeNodeDidBeginScrollSnapping(ScrollingNodeID nodeID)
+{
+    RunLoop::main().dispatch([protectedThis = Ref { *this }, this, nodeID] {
+        RemoteScrollingTree::scrollingTreeNodeDidBeginScrollSnapping(nodeID);
+    });
+}
+
+void RemoteScrollingTreeMac::scrollingTreeNodeDidEndScrollSnapping(ScrollingNodeID nodeID)
+{
+    RunLoop::main().dispatch([protectedThis = Ref { *this }, this, nodeID] {
+        RemoteScrollingTree::scrollingTreeNodeDidEndScrollSnapping(nodeID);
     });
 }
 


### PR DESCRIPTION
#### f56f38532d22a8b13af72d165f9f97eaa2975b83
<pre>
REGRESSION (263108@main): [ Ventura debug ] ASSERTION FAILED: WTF::WeakPtr&lt;WebKit::RemoteScrollingCoordinatorProxy, WTF::DefaultWeakPtrImpl&gt;::operator-&gt;() const
<a href="https://bugs.webkit.org/show_bug.cgi?id=255788">https://bugs.webkit.org/show_bug.cgi?id=255788</a>
rdar://108369779

Reviewed by Tim Horton.

Add a missing bounce to the main thread before calling `scrollingTreeNodeDidBeginScrollSnapping` or
`scrollingTreeNodeDidEndScrollSnapping` in the UI process on macOS.

* Source/WebKit/UIProcess/RemoteLayerTree/mac/RemoteScrollingTreeMac.h:
* Source/WebKit/UIProcess/RemoteLayerTree/mac/RemoteScrollingTreeMac.mm:
(WebKit::RemoteScrollingTreeMac::scrollingTreeNodeWillStartScroll):
(WebKit::RemoteScrollingTreeMac::scrollingTreeNodeDidEndScroll):

Also harden some existing logic (as well as the new methods below) so that they explicitly protect
`this` when calling out to the main thread.

(WebKit::RemoteScrollingTreeMac::scrollingTreeNodeDidBeginScrollSnapping):
(WebKit::RemoteScrollingTreeMac::scrollingTreeNodeDidEndScrollSnapping):

Canonical link: <a href="https://commits.webkit.org/263271@main">https://commits.webkit.org/263271@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/760ea0dfc0c8b4246f1aa71f7b4005006798ce74

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/4039 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/4138 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/4250 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/5485 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/4290 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/4233 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/4114 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/4414 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/4091 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/4289 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/3647 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/5487 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/1778 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/3624 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/5814 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/3605 "Passed tests") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/3694 "3 failures") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/5192 "Passed tests") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/7/builds/4095 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/3303 "Passed tests") | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/30/builds/3608 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/3622 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/1007 "Built successfully and passed tests") | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/4/builds/3664 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/3886 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->