### PR TITLE
Web Inspector: Event badge popover remains visible after clicking to jump to event breakpoint

### DIFF
--- a/Source/WebInspectorUI/UserInterface/Views/Popover.js
+++ b/Source/WebInspectorUI/UserInterface/Views/Popover.js
@@ -160,6 +160,7 @@ WI.Popover = class Popover extends WI.Object
         window.removeEventListener("scroll", this, true);
         window.removeEventListener("resize", this, true);
         window.removeEventListener("keypress", this, true);
+        WI.tabBrowser.contentViewContainer.removeEventListener(WI.ContentViewContainer.Event.CurrentContentViewDidChange, this.dismiss, this);
 
         this._prefersDarkColorSchemeMediaQueryList.removeListener(this._boundUpdate);
 
@@ -609,6 +610,7 @@ WI.Popover = class Popover extends WI.Object
             window.addEventListener("scroll", this, true);
             window.addEventListener("resize", this, true);
             window.addEventListener("keypress", this, true);
+            WI.tabBrowser.contentViewContainer.addEventListener(WI.ContentViewContainer.Event.CurrentContentViewDidChange, this.dismiss, this);
 
             if (!this._boundUpdate)
                 this._boundUpdate = this._update.bind(this);

--- a/Source/WebInspectorUI/UserInterface/Views/TabBrowser.js
+++ b/Source/WebInspectorUI/UserInterface/Views/TabBrowser.js
@@ -108,6 +108,8 @@ WI.TabBrowser = class TabBrowser extends WI.View
         return this._contentViewContainer.currentContentView;
     }
 
+    get contentViewContainer() { return this._contentViewContainer; }
+
     bestTabContentViewForClass(constructor)
     {
         console.assert(!this.selectedTabContentView || this.selectedTabContentView === this._recentTabContentViews[0]);


### PR DESCRIPTION
#### 17788c3b60cf8d86de1adea98b589664ac3e1049
<pre>
Web Inspector: Event badge popover remains visible after clicking to jump to event breakpoint
<a href="https://bugs.webkit.org/show_bug.cgi?id=255795">https://bugs.webkit.org/show_bug.cgi?id=255795</a>

Reviewed by Patrick Angle and Devin Rousso.

Make `WI.Popover` auto-dismiss whenever the selected tab of the `WI.TabBrowser` changes.

A popover is usually shown inside a tab in the tab browser. If the selected tab changes,
the context changes, so it makes sense to automatically dismiss the popover.

* Source/WebInspectorUI/UserInterface/Views/Popover.js:
(WI.Popover.prototype.dismiss):
(WI.Popover.prototype._addListenersIfNeeded):
(WI.Popover):

Canonical link: <a href="https://commits.webkit.org/272140@main">https://commits.webkit.org/272140@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a1e61db98812cdd127ee833ab1285f9cf449cef9

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/30689 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/48/builds/9369 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/32352 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/33187 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/27744 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/49/builds/11669 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/51/builds/6626 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/27632 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/31001 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/47/builds/7870 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/27478 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/6739 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/42/builds/6901 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/27347 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/34524 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/27940 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/27833 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/33058 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/44/builds/6923 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/50/builds/5023 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/30885 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/46/builds/8646 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/7260 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/43/builds/7647 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/45/builds/7476 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->