### PR TITLE
Bitmap-only layers sometimes get stuck with empty CG display lists

### DIFF
--- a/Source/WebCore/platform/graphics/cocoa/WebCoreCALayerExtras.h
+++ b/Source/WebCore/platform/graphics/cocoa/WebCoreCALayerExtras.h
@@ -41,6 +41,10 @@
 - (BOOL)_web_maskMayIntersectRect:(CGRect)rect;
 - (void)_web_clearContents;
 
+#if ENABLE(CG_DISPLAY_LIST_BACKED_IMAGE_BUFFER)
+- (void)_web_clearCGDisplayListIfNeeded;
+#endif
+
 @end
 
 #ifdef __cplusplus

--- a/Source/WebCore/platform/graphics/cocoa/WebCoreCALayerExtras.mm
+++ b/Source/WebCore/platform/graphics/cocoa/WebCoreCALayerExtras.mm
@@ -129,16 +129,22 @@
     self.contentsOpaque = NO;
 
 #if ENABLE(CG_DISPLAY_LIST_BACKED_IMAGE_BUFFER)
-    if ([self valueForKeyPath:WKCGDisplayListContentsKey]) {
-        // FIXME: Remove this workaround (and the -setNeedsDisplay call) once rdar://105807616 is fixed.
-        auto emptyCommandsContext = adoptCF(WKCGCommandsContextCreate(CGSizeZero, nil));
-        auto emptyCommandsData = adoptCF(RECGCommandsContextCopyEncodedData(emptyCommandsContext.get()));
-        [self setValue:(id)emptyCommandsData.get() forKeyPath:WKCGDisplayListContentsKey];
-        [self setValue:nil forKeyPath:WKCGDisplayListPortsKey];
-        [self setNeedsDisplay];
-    }
+    [self _web_clearCGDisplayListIfNeeded];
 #endif
+
 }
+
+#if ENABLE(CG_DISPLAY_LIST_BACKED_IMAGE_BUFFER)
+- (void)_web_clearCGDisplayListIfNeeded
+{
+    if (![self valueForKeyPath:WKCGDisplayListContentsKey])
+        return;
+    [self setValue:nil forKeyPath:WKCGDisplayListContentsKey];
+    [self setValue:nil forKeyPath:WKCGDisplayListPortsKey];
+    [self setValue:@NO forKeyPath:WKCGDisplayListEnabledKey];
+    [self setValue:@NO forKeyPath:WKCGDisplayListBifurcationEnabledKey];
+}
+#endif
 
 @end
 

--- a/Source/WebKit/Shared/RemoteLayerTree/RemoteLayerBackingStore.mm
+++ b/Source/WebKit/Shared/RemoteLayerTree/RemoteLayerBackingStore.mm
@@ -681,7 +681,8 @@ void RemoteLayerBackingStoreProperties::applyBackingStoreToLayer(CALayer *layer,
             layer.opaque = m_isOpaque;
         [(WKCompositingLayer *)layer _setWKContents:contents.get() withDisplayList:WTFMove(std::get<CGDisplayList>(*m_displayListBufferHandle)) replayForTesting:replayCGDisplayListsIntoBackingStore];
         return;
-    }
+    } else
+        [layer _web_clearCGDisplayListIfNeeded];
 #else
     UNUSED_PARAM(replayCGDisplayListsIntoBackingStore);
 #endif


### PR DESCRIPTION
#### 997b59a25b4cf0e265fc3d918592b9a535e9108a
<pre>
Bitmap-only layers sometimes get stuck with empty CG display lists
<a href="https://bugs.webkit.org/show_bug.cgi?id=255796">https://bugs.webkit.org/show_bug.cgi?id=255796</a>
rdar://108347964

Reviewed by Dean Jackson.

When a layer transitions from having a display list to not (e.g. a layer
/becomes/ bitmap-only), we need to actually clear the existing display list.
Also ensure that we turn off all of the related CALayer bits, not just the display list.
Also remove a stale workaround.

* Source/WebCore/platform/graphics/cocoa/WebCoreCALayerExtras.h:
* Source/WebCore/platform/graphics/cocoa/WebCoreCALayerExtras.mm:
(-[CALayer _web_clearContents]):
(-[CALayer _web_clearCGDisplayListIfNeeded]):
* Source/WebKit/Shared/RemoteLayerTree/RemoteLayerBackingStore.mm:
(WebKit::RemoteLayerBackingStoreProperties::applyBackingStoreToLayer):

Canonical link: <a href="https://commits.webkit.org/263317@main">https://commits.webkit.org/263317@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/8872188ccbecee1a709581727f82e50d2d0c375a

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/4230 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/4351 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/4469 "Built successfully") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/5700 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/32/builds/4476 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [  ~~🧪 bindings~~](https://ews-build.webkit.org/#/builders/9/builds/4223 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/4458 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/4316 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/5700 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [  ~~🧪 webkitperl~~](https://ews-build.webkit.org/#/builders/11/builds/4291 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/15/builds/4466 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/3819 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/2/builds/5694 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/39/builds/1961 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/10/builds/3795 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/2/builds/5694 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/3789 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/3862 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/2/builds/5694 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/7/builds/4270 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/3467 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/3780 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/3793 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/7871 "Build is in progress. Recent messages:") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/487 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/4124 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->