### PR TITLE
[ews] upload-file-to-url can sometimes get stuck indefinitely

### DIFF
--- a/Tools/Scripts/upload-file-to-url
+++ b/Tools/Scripts/upload-file-to-url
@@ -40,7 +40,7 @@ def upload(filename, url):
     with open(filename, 'rb') as f:
         try:
             data = f.read()
-            response = requests.put(url, data=data)
+            response = requests.put(url, data=data, timeout=180)
         except Exception as e:
            print(f'Exception: {e}')
            sys.exit(-1)


### PR DESCRIPTION
#### 8b5fe9ed475ad9209a25ef5c045c53f269b95bd6
<pre>
[ews] upload-file-to-url can sometimes get stuck indefinitely
<a href="https://bugs.webkit.org/show_bug.cgi?id=255799">https://bugs.webkit.org/show_bug.cgi?id=255799</a>

Reviewed by Ryan Haddad.

Specify a timeout so that the requests can not get stuck indefinitely.
* Tools/Scripts/upload-file-to-url:

Canonical link: <a href="https://commits.webkit.org/263255@main">https://commits.webkit.org/263255@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/8ce706fbd812a7504732092b3d121124768e002d

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/4046 "Passed style check") | [  ~~🛠 ios~~](https://ews-build.webkit.org/#/builders/26/builds/4147 "Build was cancelled. Recent messages:OS: Ventura (13.3), Xcode: 14.3; Skipping applying patch since patch_id isn't provided; Failed to checkout and rebase branch from PR 13043") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/14/builds/4258 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/5494 "Build was cancelled. Recent messages:Failed to print configuration") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/32/builds/4297 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [  ~~🧪 bindings~~](https://ews-build.webkit.org/#/builders/9/builds/4027 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/23/builds/4240 "Build was cancelled. Recent messages:OS: Ventura (13.3), Xcode: 14.3; Skipping applying patch since patch_id isn't provided; Failed to checkout and rebase branch from PR 13043") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/16/builds/4121 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/5494 "Build was cancelled. Recent messages:Failed to print configuration") | 
| [  ~~🧪 webkitperl~~](https://ews-build.webkit.org/#/builders/11/builds/4098 "Build was cancelled. Recent messages:OS: Unknown (10.15.7), Xcode: 11.7") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/23/builds/4240 "Build was cancelled. Recent messages:OS: Ventura (13.3), Xcode: 14.3; Skipping applying patch since patch_id isn't provided; Failed to checkout and rebase branch from PR 13043") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/14/builds/4258 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/2/builds/5480 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/23/builds/4240 "Build was cancelled. Recent messages:OS: Ventura (13.3), Xcode: 14.3; Skipping applying patch since patch_id isn't provided; Failed to checkout and rebase branch from PR 13043") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/14/builds/4258 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/2/builds/5480 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/23/builds/4240 "Build was cancelled. Recent messages:OS: Ventura (13.3), Xcode: 14.3; Skipping applying patch since patch_id isn't provided; Failed to checkout and rebase branch from PR 13043") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/14/builds/4258 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/2/builds/5480 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/7/builds/4100 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/16/builds/4121 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/30/builds/3613 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/14/builds/4258 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/4/builds/3698 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/470 "Built successfully and passed tests") | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/31/builds/3891 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->