### PR TITLE
Fix build failure in WKPDFPageNumberIndicator.mm and WKFullScreenWindowControllerIOS.mm

### DIFF
--- a/Source/WebKit/UIProcess/ios/WKPDFPageNumberIndicator.mm
+++ b/Source/WebKit/UIProcess/ios/WKPDFPageNumberIndicator.mm
@@ -142,7 +142,9 @@ const NSTimeInterval indicatorMoveDuration = 0.3;
     point.y += indicatorMargin;
 
     void (^animations)() = ^{
-        self.frameOrigin = point;
+        CGRect frame = self.frame;
+        frame.origin = point;
+        self.frame = frame;
     };
     if (animated)
         [UIView animateWithDuration:indicatorMoveDuration animations:animations];
@@ -152,7 +154,7 @@ const NSTimeInterval indicatorMoveDuration = 0.3;
 
 - (CGSize)sizeThatFits:(CGSize)size
 {
-    CGSize labelSize = [_label sizeThatFits:[_label size]];
+    CGSize labelSize = [_label sizeThatFits:[_label bounds].size];
     labelSize.width += 2 * indicatorHorizontalPadding;
     labelSize.height += 2 * indicatorVerticalPadding;
     return labelSize;

--- a/Source/WebKit/UIProcess/ios/fullscreen/WKFullScreenWindowControllerIOS.mm
+++ b/Source/WebKit/UIProcess/ios/fullscreen/WKFullScreenWindowControllerIOS.mm
@@ -429,7 +429,7 @@ static constexpr CGFloat kFullScreenWindowCornerRadius = 12;
 @implementation WKFullScreenPlaceholderView
 - (void)willMoveToSuperview:(UIView *)newSuperview
 {
-    [super viewWillMoveToSuperview:newSuperview];
+    [super willMoveToSuperview:newSuperview];
     [self.parent placeholderWillMoveToSuperview:newSuperview];
 }
 @end


### PR DESCRIPTION
#### a79a71d67e04551f481525af5ebed975fe2dde61
<pre>
Fix build failure in WKPDFPageNumberIndicator.mm and WKFullScreenWindowControllerIOS.mm
<a href="https://bugs.webkit.org/show_bug.cgi?id=255801">https://bugs.webkit.org/show_bug.cgi?id=255801</a>
rdar://108379356

Unreviewed build fix.

* Source/WebKit/UIProcess/ios/WKPDFPageNumberIndicator.mm:
(-[WKPDFPageNumberIndicator moveToPoint:animated:]):
(-[WKPDFPageNumberIndicator sizeThatFits:]):
* Source/WebKit/UIProcess/ios/fullscreen/WKFullScreenWindowControllerIOS.mm:
(-[WKFullScreenPlaceholderView willMoveToSuperview:]):

Canonical link: <a href="https://commits.webkit.org/263259@main">https://commits.webkit.org/263259@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/075167f6a4ede861685d415818d073a6fddd8ff2

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/4050 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/4151 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/4262 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/5498 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/32/builds/4300 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/4245 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/4125 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/4528 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/4102 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/15/builds/4296 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/3655 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/5488 "Built successfully") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/39/builds/1789 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/10/builds/3632 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/5804 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/3616 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/3693 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/5190 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/7/builds/4103 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/3311 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/30/builds/3616 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/3630 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/4/builds/7668 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| [❌ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/471 "Failed to push commit to Webkit repository") | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/31/builds/3894 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->