### PR TITLE
Add customElements.getName method

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/custom-elements/CustomElementRegistry-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/custom-elements/CustomElementRegistry-expected.txt
@@ -36,6 +36,11 @@ PASS CustomElementRegistry interface must have get as a method
 PASS customElements.get must return undefined when the registry does not contain an entry with the given name
 PASS customElements.get must return undefined when the registry does not contain an entry with the given name even if the name was not a valid custom element name
 PASS customElements.get return the constructor of the entry with the given name when there is a matching entry.
+PASS customElements.getName must return undefined when called with undefined
+PASS customElements.getName must return undefined when called with null
+PASS customElements.getName must return undefined when called with a string
+PASS customElements.getName must return undefined when the registry does not contain an entry with the given constructor
+PASS customElements.getName returns the name of the entry with the given constructor when there is a matching entry.
 PASS customElements.whenDefined must return a promise for a valid custom element name
 PASS customElements.whenDefined must return the same promise each time invoked for a valid custom element name which has not been defined
 PASS customElements.whenDefined must return an unresolved promise when the registry does not contain the entry with the given name

--- a/LayoutTests/imported/w3c/web-platform-tests/custom-elements/CustomElementRegistry.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/custom-elements/CustomElementRegistry.html
@@ -624,6 +624,29 @@ test(function () {
 }, 'customElements.get return the constructor of the entry with the given name when there is a matching entry.');
 
 test(function () {
+  assert_equals(customElements.getName(undefined), undefined);
+}, 'customElements.getName must return undefined when called with undefined');
+
+test(function () {
+  assert_equals(customElements.getName(null), undefined);
+}, 'customElements.getName must return undefined when called with null');
+
+test(function () {
+  assert_equals(customElements.getName(''), undefined);
+}, 'customElements.getName must return undefined when called with a string');
+
+test(function () {
+  assert_equals(customElements.getName(class extends HTMLElement {}), undefined);
+}, 'customElements.getName must return undefined when the registry does not contain an entry with the given constructor');
+
+test(function () {
+    class ExistingCustomElement extends HTMLElement {};
+    assert_equals(customElements.getName(ExistingCustomElement), undefined);
+    customElements.define('other-custom-element', ExistingCustomElement);
+    assert_equals(customElements.getName(ExistingCustomElement), 'other-custom-element');
+}, 'customElements.getName returns the name of the entry with the given constructor when there is a matching entry.');
+
+test(function () {
     assert_true(customElements.whenDefined('some-name') instanceof Promise);
 }, 'customElements.whenDefined must return a promise for a valid custom element name');
 

--- a/Source/WebCore/dom/CustomElementRegistry.cpp
+++ b/Source/WebCore/dom/CustomElementRegistry.cpp
@@ -128,6 +128,17 @@ JSC::JSValue CustomElementRegistry::get(const AtomString& name)
     return JSC::jsUndefined();
 }
 
+JSC::JSValue CustomElementRegistry::getName(JSC::JSGlobalObject& globalObject, JSC::JSValue constructorValue)
+{
+    auto* constructor = constructorValue.getObject();
+    if (!constructor)
+        return JSC::jsUndefined();
+    auto* elementInterface = findInterface(constructor);
+    if (!elementInterface)
+        return JSC::jsUndefined();
+    return JSC::jsString(globalObject.vm(), elementInterface->name().localName());
+}
+
 static void upgradeElementsInShadowIncludingDescendants(ContainerNode& root)
 {
     for (auto& element : descendantsOfType<Element>(root)) {

--- a/Source/WebCore/dom/CustomElementRegistry.h
+++ b/Source/WebCore/dom/CustomElementRegistry.h
@@ -35,9 +35,10 @@
 
 namespace JSC {
 
+class JSGlobalObject;
 class JSObject;
 class JSValue;
-    
+
 }
 
 namespace WebCore {
@@ -69,6 +70,7 @@ public:
     bool containsConstructor(const JSC::JSObject*) const;
 
     JSC::JSValue get(const AtomString&);
+    JSC::JSValue getName(JSC::JSGlobalObject&, JSC::JSValue);
     void upgrade(Node& root);
 
     MemoryCompactRobinHoodHashMap<AtomString, Ref<DeferredPromise>>& promiseMap() { return m_promiseMap; }

--- a/Source/WebCore/dom/CustomElementRegistry.idl
+++ b/Source/WebCore/dom/CustomElementRegistry.idl
@@ -31,6 +31,10 @@
 ] interface CustomElementRegistry {
     [CEReactions, Custom] undefined define(DOMString name, Function constructor);
     any get([AtomString] DOMString name);
+
+    // FIXME: This should return (DOMString or undefined). See webkit.org/b/232734.
+    [CallWith=CurrentGlobalObject] any getName(any constructor);
+
     [Custom, ReturnsOwnPromise] Promise<undefined> whenDefined(DOMString name);
     [CEReactions] undefined upgrade(Node root);
 };


### PR DESCRIPTION
#### e2748d7c56a29d295d71552e3d999d7b51ca037e
<pre>
Add customElements.getName method
<a href="https://bugs.webkit.org/show_bug.cgi?id=255778">https://bugs.webkit.org/show_bug.cgi?id=255778</a>

Reviewed by Alexey Shvayka and Chris Dumez.

Implement <a href="https://github.com/whatwg/html/pull/9195">https://github.com/whatwg/html/pull/9195</a> with test cases added in
<a href="https://github.com/web-platform-tests/wpt/pull/39640.">https://github.com/web-platform-tests/wpt/pull/39640.</a>

* LayoutTests/imported/w3c/web-platform-tests/custom-elements/CustomElementRegistry-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/custom-elements/CustomElementRegistry.html:
* Source/WebCore/dom/CustomElementRegistry.cpp:
(WebCore::CustomElementRegistry::getName): Added.
* Source/WebCore/dom/CustomElementRegistry.h:
* Source/WebCore/dom/CustomElementRegistry.idl:

Canonical link: <a href="https://commits.webkit.org/263281@main">https://commits.webkit.org/263281@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f21fc1a48bc8cec2c79a2e607a9f5cdc7084c439

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/4117 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/4226 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/4344 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/5576 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/4359 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/4104 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/4324 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/4191 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/4586 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/4173 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/4351 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/3713 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/5569 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/1848 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/3690 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/5863 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/3675 "Passed tests") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/3753 "1 flakes 3 failures") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/5262 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/4150 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/3360 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/3664 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/3688 "Passed tests") | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/4/builds/7801 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/477 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/3943 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->