### PR TITLE
window.open from an iframe doesn't exit fullscreen for parent document

### DIFF
--- a/LayoutTests/fullscreen/enter-fullscreen-main-frame-window-open-iframe-expected.txt
+++ b/LayoutTests/fullscreen/enter-fullscreen-main-frame-window-open-iframe-expected.txt
@@ -1,0 +1,8 @@
+To test manually, click the "Open window" button - the page should exit fullscreen mode.
+
+EVENT(fullscreenchange)
+TEST(document.fullscreenElement===document.body) OK
+EVENT(fullscreenchange)
+TEST(document.fullscreenElement===null) OK
+END OF TEST
+

--- a/LayoutTests/fullscreen/enter-fullscreen-main-frame-window-open-iframe.html
+++ b/LayoutTests/fullscreen/enter-fullscreen-main-frame-window-open-iframe.html
@@ -1,0 +1,20 @@
+<p>To test manually, click the "Open window" button - the page should exit fullscreen mode.</p>
+<script src="full-screen-test.js"></script>
+<script>
+function runTest() {
+    waitForEventOnce(document, 'fullscreenchange', function() {
+        test("document.fullscreenElement===document.body")
+        waitForEventOnce(document, 'fullscreenchange', function() {
+            test("document.fullscreenElement===null")
+            endTest();
+        });
+        document.getElementById("frame").contentWindow.exitFullscreen();
+    });
+
+    runWithKeyDown(function() {
+        document.body.requestFullscreen();
+    });
+}
+</script>
+<iframe id="frame" src="resources/window-open-iframe.html" width="300" height="100" onload="runTest()">
+</iframe>

--- a/LayoutTests/fullscreen/resources/window-open-iframe.html
+++ b/LayoutTests/fullscreen/resources/window-open-iframe.html
@@ -1,0 +1,11 @@
+<script>
+window.exitFullscreen = function(args) {
+    if (!window.internals)
+        return;
+
+    internals.withUserGesture(function() {
+        window.open('about:blank');
+    });
+}
+</script>
+<button onclick="window.open('about:blank')">Open window</button>

--- a/LayoutTests/platform/mac-wk1/TestExpectations
+++ b/LayoutTests/platform/mac-wk1/TestExpectations
@@ -1002,6 +1002,8 @@ webkit.org/b/112533 media/auto-play-in-sandbox-with-allow-scripts.html [ Pass Ti
 
 webkit.org/b/139778 fullscreen/exit-full-screen-iframe.html [ Skip ]
 
+webkit.org/b/139778 fullscreen/enter-fullscreen-main-frame-window-open-iframe.html [ Skip ]
+
 webkit.org/b/139862 editing/spelling/grammar-edit-word.html [ Skip ]
 
 webkit.org/b/144127 compositing/scrolling/touch-scroll-to-clip.html [ Pass Failure ]

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebChromeClient.cpp
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebChromeClient.cpp
@@ -309,8 +309,8 @@ OptionSet<WebEventModifier> modifiersForNavigationAction(const NavigationAction&
 Page* WebChromeClient::createWindow(LocalFrame& frame, const WindowFeatures& windowFeatures, const NavigationAction& navigationAction)
 {
 #if ENABLE(FULLSCREEN_API)
-    if (frame.document() && frame.document()->fullscreenManager().currentFullscreenElement())
-        frame.document()->fullscreenManager().cancelFullscreen();
+    if (auto* document = frame.document())
+        document->fullscreenManager().cancelFullscreen();
 #endif
 
     auto& webProcess = WebProcess::singleton();


### PR DESCRIPTION
#### 0aa6c9026a5343e363e2375b5a14178132678913
<pre>
window.open from an iframe doesn&apos;t exit fullscreen for parent document
<a href="https://bugs.webkit.org/show_bug.cgi?id=255813">https://bugs.webkit.org/show_bug.cgi?id=255813</a>
rdar://108387151

Reviewed by Tim Nguyen.

Currently, invoking `window.open` from an `iframe` that has a parent document
is fullscreen does not exit fullscreen, while invoking `window.open` from
the main frame does.

On macOS, the user is taken to a new tab, which is made visible, while the
fullscreen content remains in its own space. On iOS, the user is taken to a new
tab, but the existing content remains in fullscreen, leaving the user unaware
of what has happened.

WebKit&apos;s existing behavior in this scenario on macOS differs from both Chrome
and Firefox, which completely exit fullscreen regardless of which frame invoked
`window.open`. Additionally, the iOS behavior is confusing, as the user will
suddenly viewing another page after they decide to exit fullscreen.

To fix, ensure any successful call to `window.open` always exits fullscreen.

* LayoutTests/fullscreen/enter-fullscreen-main-frame-window-open-iframe-expected.txt: Added.
* LayoutTests/fullscreen/enter-fullscreen-main-frame-window-open-iframe.html: Added.
* LayoutTests/fullscreen/resources/window-open-iframe.html: Added.
* LayoutTests/platform/mac-wk1/TestExpectations:

Skip test on WK1, similar to another &quot;exit fullscreen from iframe&quot; test.

* Source/WebKit/WebProcess/WebCoreSupport/WebChromeClient.cpp:
(WebKit::WebChromeClient::createWindow):

Call `FullscreenManager::cancelFullscreen` unconditionally, rather than checking
if the frame&apos;s document has a fullscreen element, which would be false if the
fullscreen element is in another document.

`cancelFullscreen` already accounts for the top document, and is a no-op if there
is no fullscreen element in any document.

Canonical link: <a href="https://commits.webkit.org/263284@main">https://commits.webkit.org/263284@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f0f09827f3e548615ffaca884ee0a88d2e5758e0

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/4130 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/4241 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/4359 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/5591 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/4373 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/4339 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/4206 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/4599 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/4187 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/4365 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/3727 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/5584 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/1862 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/3704 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/5875 "1 flakes 181 failures") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/3689 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/3768 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/5274 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/4165 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/3375 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/3679 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/3702 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/1017 "Built successfully and passed tests") | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/4/builds/7811 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/3958 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->