### PR TITLE
REGRESSION (259904@main): window.getSelection() is empty for selection inside textarea

### DIFF
--- a/LayoutTests/editing/selection/selection-toString-input-expected.txt
+++ b/LayoutTests/editing/selection/selection-toString-input-expected.txt
@@ -1,0 +1,5 @@
+PASS getSelection().toString() is "hello"
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/editing/selection/selection-toString-input.html
+++ b/LayoutTests/editing/selection/selection-toString-input.html
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<script src="../../resources/js-test.js"></script>
+<input id="inputElement" value="hello, world">
+<script>
+
+inputElement.focus();
+inputElement.setSelectionRange(0, 5);
+shouldBeEqualToString('getSelection().toString()', 'hello');
+
+</script>

--- a/LayoutTests/editing/selection/selection-toString-textarea-expected.txt
+++ b/LayoutTests/editing/selection/selection-toString-textarea-expected.txt
@@ -1,0 +1,5 @@
+PASS getSelection().toString() is "hello"
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/editing/selection/selection-toString-textarea.html
+++ b/LayoutTests/editing/selection/selection-toString-textarea.html
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<script src="../../resources/js-test.js"></script>
+<textarea id="textarea">hello, world</textarea>
+<script>
+
+textarea.focus();
+textarea.setSelectionRange(0, 5);
+shouldBeEqualToString('getSelection().toString()', 'hello');
+
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-input-element/email-set-value-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-input-element/email-set-value-expected.txt
@@ -1,4 +1,4 @@
 
 
-FAIL setValue(sanitizedValue) is reflected in visible text field content assert_equals: visible value is unsanitized expected " foo@bar   " but got ""
+PASS setValue(sanitizedValue) is reflected in visible text field content
 

--- a/Source/WebCore/page/DOMSelection.cpp
+++ b/Source/WebCore/page/DOMSelection.cpp
@@ -510,7 +510,7 @@ String DOMSelection::toString() const
     if (!frame)
         return String();
     if (frame->settings().liveRangeSelectionEnabled()) {
-        auto range = this->range();
+        auto range = frame->selection().selection().range();
         return range ? plainText(*range, TextIteratorBehavior::IgnoresUserSelectNone) : emptyString();
     }
     auto range = frame->selection().selection().firstRange();


### PR DESCRIPTION
#### b6892f51e01e4ae5859637a6cc2f615f7af92a76
<pre>
REGRESSION (259904@main): window.getSelection() is empty for selection inside textarea
<a href="https://bugs.webkit.org/show_bug.cgi?id=252281">https://bugs.webkit.org/show_bug.cgi?id=252281</a>

Reviewed by Wenson Hsieh.

Restore the pre-259904@main behavior of getSelection().toString(), which is to return
the string selected within input and textarea elements. This behavior is consistent with Chrome.

The post-259904@main behavior of not including the selected string within input and textarea
elements are consistent with Firefox but this turned out to be not Web compatible with at least
one Apple internal website.

* LayoutTests/editing/selection/selection-toString-input-expected.txt: Added.
* LayoutTests/editing/selection/selection-toString-input.html: Added.
* LayoutTests/editing/selection/selection-toString-textarea-expected.txt: Added.
* LayoutTests/editing/selection/selection-toString-textarea.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-input-element/email-set-value-expected.txt: Rebaselined.
* Source/WebCore/page/DOMSelection.cpp:
(WebCore::DOMSelection::toString const):

Canonical link: <a href="https://commits.webkit.org/263280@main">https://commits.webkit.org/263280@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d66c9e5701b66d449b7616d718718459c3dd45d5

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/4119 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/4229 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/4347 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/5579 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/4361 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/4107 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/4327 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/4194 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/4589 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/4176 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/4354 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/3715 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/5572 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/1851 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/3692 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/5866 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/3678 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/3755 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/5264 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/4153 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/3362 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/3667 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/3690 "Passed tests") | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/4/builds/7802 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/476 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/3946 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->