### PR TITLE
[SVG] Fixed invalid input values in lighting filters

### DIFF
--- a/Source/WebCore/platform/graphics/filters/FEDiffuseLighting.cpp
+++ b/Source/WebCore/platform/graphics/filters/FEDiffuseLighting.cpp
@@ -2,7 +2,8 @@
  * Copyright (C) 2004, 2005, 2006, 2007 Nikolas Zimmermann <zimmermann@kde.org>
  * Copyright (C) 2004, 2005 Rob Buis <buis@kde.org>
  * Copyright (C) 2005 Eric Seidel <eric@webkit.org>
- * Copyright (C) 2021 Apple Inc.  All rights reserved.
+ * Copyright (C) 2021 Apple Inc. All rights reserved.
+ * Copyright (C) 2014 Google Inc. All rights reserved.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Library General Public
@@ -41,6 +42,7 @@ FEDiffuseLighting::FEDiffuseLighting(const Color& lightingColor, float surfaceSc
 
 bool FEDiffuseLighting::setDiffuseConstant(float diffuseConstant)
 {
+    diffuseConstant = std::max(diffuseConstant, 0.0f);
     if (m_diffuseConstant == diffuseConstant)
         return false;
     m_diffuseConstant = diffuseConstant;

--- a/Source/WebCore/platform/graphics/filters/FELighting.cpp
+++ b/Source/WebCore/platform/graphics/filters/FELighting.cpp
@@ -1,7 +1,8 @@
 /*
  * Copyright (C) 2010 University of Szeged
  * Copyright (C) 2010 Zoltan Herczeg
- * Copyright (C) 2018-2022 Apple Inc.  All rights reserved.
+ * Copyright (C) 2018-2022 Apple Inc. All rights reserved.
+ * Copyright (C) 2014 Google Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -37,9 +38,9 @@ FELighting::FELighting(Type type, const Color& lightingColor, float surfaceScale
     : FilterEffect(type)
     , m_lightingColor(lightingColor)
     , m_surfaceScale(surfaceScale)
-    , m_diffuseConstant(diffuseConstant)
-    , m_specularConstant(specularConstant)
-    , m_specularExponent(specularExponent)
+    , m_diffuseConstant(std::max(diffuseConstant, 0.0f))
+    , m_specularConstant(std::max(specularConstant, 0.0f))
+    , m_specularExponent(clampTo<float>(specularExponent, 1.0f, 128.0f))
     , m_kernelUnitLengthX(kernelUnitLengthX)
     , m_kernelUnitLengthY(kernelUnitLengthY)
     , m_lightSource(WTFMove(lightSource))

--- a/Source/WebCore/platform/graphics/filters/FESpecularLighting.cpp
+++ b/Source/WebCore/platform/graphics/filters/FESpecularLighting.cpp
@@ -2,7 +2,8 @@
  * Copyright (C) 2004, 2005, 2006, 2007 Nikolas Zimmermann <zimmermann@kde.org>
  * Copyright (C) 2004, 2005 Rob Buis <buis@kde.org>
  * Copyright (C) 2005 Eric Seidel <eric@webkit.org>
- * Copyright (C) 2021 Apple Inc.  All rights reserved.
+ * Copyright (C) 2021-2023 Apple Inc. All rights reserved.
+ * Copyright (C) 2014 Google Inc. All rights reserved.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Library General Public
@@ -41,6 +42,7 @@ FESpecularLighting::FESpecularLighting(const Color& lightingColor, float surface
 
 bool FESpecularLighting::setSpecularConstant(float specularConstant)
 {
+    specularConstant = std::max(specularConstant, 0.0f);
     if (m_specularConstant == specularConstant)
         return false;
     m_specularConstant = specularConstant;
@@ -49,6 +51,7 @@ bool FESpecularLighting::setSpecularConstant(float specularConstant)
 
 bool FESpecularLighting::setSpecularExponent(float specularExponent)
 {
+    specularExponent = clampTo<float>(specularExponent, 1.0f, 128.0f);
     if (m_specularExponent == specularExponent)
         return false;
     m_specularExponent = specularExponent;

--- a/Source/WebCore/platform/graphics/filters/LightSource.h
+++ b/Source/WebCore/platform/graphics/filters/LightSource.h
@@ -4,7 +4,8 @@
  * Copyright (C) 2004, 2005 Rob Buis <buis@kde.org>
  * Copyright (C) 2005 Eric Seidel <eric@webkit.org>
  * Copyright (C) 2010 Zoltan Herczeg <zherczeg@webkit.org>
- * Copyright (C) 2021 Apple Inc.  All rights reserved.
+ * Copyright (C) 2021-2023 Apple Inc. All rights reserved.
+ * Copyright (C) 2014 Google Inc. All rights reserved.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Library General Public
@@ -55,7 +56,6 @@ public:
         FloatPoint3D directionVector;
         float coneCutOffLimit;
         float coneFullLight;
-        int specularExponent;
     };
 
     LightSource(LightType type)

--- a/Source/WebCore/platform/graphics/filters/SpotLightSource.cpp
+++ b/Source/WebCore/platform/graphics/filters/SpotLightSource.cpp
@@ -6,7 +6,8 @@
  * Copyright (C) 2010 Zoltan Herczeg <zherczeg@webkit.org>
  * Copyright (C) 2011 University of Szeged
  * Copyright (C) 2011 Renata Hodovan <reni@webkit.org>
- * Copyright (C) 2021-2022 Apple Inc.  All rights reserved.
+ * Copyright (C) 2021-2023 Apple Inc. All rights reserved.
+ * Copyright (C) 2014 Google Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -52,7 +53,7 @@ SpotLightSource::SpotLightSource(const FloatPoint3D& position, const FloatPoint3
     : LightSource(LS_SPOT)
     , m_position(position)
     , m_pointsAt(pointsAt)
-    , m_specularExponent(specularExponent)
+    , m_specularExponent(clampTo<float>(specularExponent, 1.0f, 128.0f))
     , m_limitingConeAngle(limitingConeAngle)
 {
 }
@@ -84,14 +85,6 @@ void SpotLightSource::initPaintingData(const Filter& filter, const FilterImage& 
         paintingData.coneCutOffLimit = cosf(deg2rad(180.0f - limitingConeAngle));
         paintingData.coneFullLight = paintingData.coneCutOffLimit - antialiasThreshold;
     }
-
-    // Optimization for common specularExponent values
-    if (!m_specularExponent)
-        paintingData.specularExponent = 0;
-    else if (m_specularExponent == 1.0f)
-        paintingData.specularExponent = 1;
-    else // It is neither 0.0f nor 1.0f
-        paintingData.specularExponent = 2;
 }
 
 LightSource::ComputedLightingData SpotLightSource::computePixelLightingData(const PaintingData& paintingData, int x, int y, float z) const
@@ -111,17 +104,10 @@ LightSource::ComputedLightingData SpotLightSource::computePixelLightingData(cons
 
     // Set the color of the pixel
     float lightStrength;
-    switch (paintingData.specularExponent) {
-    case 0:
-        lightStrength = 1.0f; // -cosineOfAngle ^ 0 == 1
-        break;
-    case 1:
+    if (1.0f == m_specularExponent)
         lightStrength = -cosineOfAngle; // -cosineOfAngle ^ 1 == -cosineOfAngle
-        break;
-    default:
+    else
         lightStrength = powf(-cosineOfAngle, m_specularExponent);
-        break;
-    }
 
     if (cosineOfAngle > paintingData.coneFullLight)
         lightStrength *= (paintingData.coneCutOffLimit - cosineOfAngle) / (paintingData.coneCutOffLimit - paintingData.coneFullLight);
@@ -186,6 +172,7 @@ bool SpotLightSource::setPointsAtZ(float pointsAtZ)
 
 bool SpotLightSource::setSpecularExponent(float specularExponent)
 {
+    specularExponent = clampTo<float>(specularExponent, 1.0f, 128.0f);
     if (m_specularExponent == specularExponent)
         return false;
     m_specularExponent = specularExponent;


### PR DESCRIPTION
#### ffe7d732d4ee3424d146053a4bec67b800f48f37
<pre>
[SVG] Fixed invalid input values in lighting filters

<a href="https://bugs.webkit.org/show_bug.cgi?id=250645">https://bugs.webkit.org/show_bug.cgi?id=250645</a>
rdar://problem/104527452

Reviewed by Simon Fraser.

Merge - <a href="https://src.chromium.org/viewvc/blink?view=revision&amp">https://src.chromium.org/viewvc/blink?view=revision&amp</a>;revision=169130

This patch aligns WebKit with Web-Specs:

Spec Link: <a href="https://drafts.fxtf.org/filter-effects/#element-attrdef-fespecularlighting-specularexponent">https://drafts.fxtf.org/filter-effects/#element-attrdef-fespecularlighting-specularexponent</a> &amp;
<a href="https://drafts.fxtf.org/filter-effects/#element-attrdef-fespotlight-specularexponent">https://drafts.fxtf.org/filter-effects/#element-attrdef-fespotlight-specularexponent</a> &amp;
<a href="https://drafts.fxtf.org/filter-effects/#element-attrdef-fediffuselighting-diffuseconstant">https://drafts.fxtf.org/filter-effects/#element-attrdef-fediffuselighting-diffuseconstant</a>

A few values have specified ranges in the W3 spec:
- specularExponent = Range 1.0 to 128.0
- specularConstant = any non-negative number
- diffuseConstant = any non-negative number

* Source/WebCore/platform/graphics/filters/FEDiffuseLighting.cpp:
(FEDiffuseLighting::setDiffuseConstant): Restrict to non-negative
* Source/WebCore/platform/graphics/filters/FELighting.cpp:
(FELighting::FELighting): Update values for &apos;diffuseConstant&apos;, &apos;specularConstant&apos; and &apos;specularExponent&apos;
* Source/WebCore/platform/graphics/filters/FESpecularLighting.cpp:
(FESpecularLighting::setSpecularConstant): Restrict &apos;specularConstant&apos; to non-negative
(FESpecularLighting::setSpecularExponent): Restrict &apos;specularExponent&apos; from 1.0f to 128.0f
* Source/WebCore/platform/graphics/filters/LightSource.h: Remove &apos;int&apos; specularExponent
* Source/WebCore/platform/graphics/filters/SpotLightSource.cpp:
(SpotLightSource::SpotLightSource): clamp value for &apos;specularExponent&apos;
(SpotLightSource::initPaintingData): Remove optimizations for common value and also update switch case for color of the pixel
(SpotLightSource::setSpecularExponent): clamp value for &apos;specularExponent&apos;

Canonical link: <a href="https://commits.webkit.org/263279@main">https://commits.webkit.org/263279@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/08d7c4f86b11bf78bddab27b56d92fbb433e3340

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/4120 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/4230 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/4348 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/5580 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/4362 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/4108 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/4328 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/4195 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/4590 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/4177 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/4355 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/3716 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/5573 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/1852 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/3693 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/5867 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/3679 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/3756 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/5265 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/4154 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/3363 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/3668 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/3691 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/1014 "Built successfully and passed tests") | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/4/builds/7803 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/3947 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->