### PR TITLE
Web Inspector: Fonts: Holding down arrow up/down keys in the variation axis input field does not update the CSS value

### DIFF
--- a/Source/WebInspectorUI/UserInterface/Views/FontVariationDetailsSectionRow.js
+++ b/Source/WebInspectorUI/UserInterface/Views/FontVariationDetailsSectionRow.js
@@ -227,11 +227,13 @@ WI.FontVariationDetailsSectionRow = class FontVariationDetailsSectionRow extends
 
         if (event.key === "ArrowUp") {
             this.value = Number.constrain(valueAsNumber + step, this._minimumValue, this._maximumValue);
+            this.dispatchEventToListeners(WI.FontVariationDetailsSectionRow.Event.VariationValueChanged, {tag: this._tag, value: this.value});
             event.preventDefault();
         }
 
         if (event.key === "ArrowDown") {
             this.value = Number.constrain(valueAsNumber - step, this._minimumValue, this._maximumValue);
+            this.dispatchEventToListeners(WI.FontVariationDetailsSectionRow.Event.VariationValueChanged, {tag: this._tag, value: this.value});
             event.preventDefault();
         }
     }


### PR DESCRIPTION
#### c793c7c08a44ac518407dc80de56791a080cadc7
<pre>
Web Inspector: Fonts: Holding down arrow up/down keys in the variation axis input field does not update the CSS value
<a href="https://bugs.webkit.org/show_bug.cgi?id=255822">https://bugs.webkit.org/show_bug.cgi?id=255822</a>

Reviewed by Patrick Angle.

The &quot;input&quot; event handler for the variation axis input field dispatches
the `WI.FontVariationDetailsSectionRow.Event.VariationValueChanged` event.
In response to that, the variation axis value is written to the node&apos;s inline styles.

Pressing `ArrowUp` and `ArrowDown` keys in an `&lt;input type=&quot;text&quot;&gt;` field
will not dispatch &quot;input&quot; DOM events. Therefore, the handler never gets invoked.

This didn&apos;t occur when we were using `&lt;input type=&quot;number&quot;&gt;`, but we switched
away from that because it didn&apos;t reject invalid values or support the ergonomics we needed.

To fix this, we now dispatch the `WI.FontVariationDetailsSectionRow.Event.VariationValueChanged`
from the &quot;keydown&quot; event handler when the gesture indicates an action to change the value using arrow keys.

* Source/WebInspectorUI/UserInterface/Views/FontVariationDetailsSectionRow.js:
(WI.FontVariationDetailsSectionRow.prototype._handleValueTextFieldKeydown):

Canonical link: <a href="https://commits.webkit.org/263278@main">https://commits.webkit.org/263278@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/3fd1fdfe678b36c417e5c43c9b23718f4b9be87d

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/4122 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/4232 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/4350 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/5582 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/4364 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/4330 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/4197 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/4592 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/4179 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/4357 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/3718 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/5575 "Built successfully") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/39/builds/1854 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/3695 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/5869 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/3681 "Passed tests") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/3758 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/5267 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/4156 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/3365 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/3670 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/3693 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/1013 "Built successfully and passed tests") | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/4/builds/7805 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/3949 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->