### PR TITLE
Crash in collectStationaryLayerRelatedOverflowNodes()

### DIFF
--- a/LayoutTests/compositing/overflow/overflow-change-abspos-descendant-expected.txt
+++ b/LayoutTests/compositing/overflow/overflow-change-abspos-descendant-expected.txt
@@ -1,0 +1,3 @@
+This test passes if it does not crash.
+
+

--- a/LayoutTests/compositing/overflow/overflow-change-abspos-descendant.html
+++ b/LayoutTests/compositing/overflow/overflow-change-abspos-descendant.html
@@ -1,0 +1,42 @@
+<!DOCTYPE html> <!-- webkit-test-runner [ AsyncOverflowScrollingEnabled=true ] -->
+<html>
+<head>
+<style>
+    html, div {
+      display: flex;
+    }
+    section {
+      position: absolute;
+      width: 100px;
+      height: 100px;
+    }
+    div {
+      resize: both;
+      column-count: 1;
+    }
+    :first-child {
+      -webkit-box-reflect: left;
+    }
+    :nth-child(3) {
+      overflow-y: scroll;
+    }
+  </style>
+  <script>
+    if (window.testRunner)
+        testRunner.dumpAsText();
+
+    window.addEventListener('load', () => {
+        let div0 = document.createElement('div');
+        document.documentElement.append(div0);
+        let div1 = document.createElement('p');
+        div1.append(document.createElement('section'));
+        document.body.offsetTop;
+        div0.append(div1);
+        document.documentElement.prepend(document.createElement('h1'));
+    }, false);
+  </script>
+</head>
+<body>
+<p>This test passes if it does not crash.</p>
+</body>
+</html>

--- a/Source/WebCore/rendering/RenderLayer.cpp
+++ b/Source/WebCore/rendering/RenderLayer.cpp
@@ -5382,9 +5382,11 @@ void RenderLayer::styleChanged(StyleDifference diff, const RenderStyle* oldStyle
                 dirtyZOrderLists();
         }
 
-        // Visibility is input to canUseCompositedScrolling().
-        if (visibilityChanged && m_scrollableArea)
-            m_scrollableArea->computeHasCompositedScrollableOverflow();
+        // Visibility and scrollability are input to canUseCompositedScrolling().
+        if (m_scrollableArea) {
+            if (visibilityChanged || oldStyle->isOverflowVisible() != renderer().style().isOverflowVisible())
+                m_scrollableArea->computeHasCompositedScrollableOverflow();
+        }
     }
 
     if (m_scrollableArea) {


### PR DESCRIPTION
#### eb40daa6cd5006e841097c57d07d83e5dda55088
<pre>
Crash in collectStationaryLayerRelatedOverflowNodes()
<a href="https://bugs.webkit.org/show_bug.cgi?id=255830">https://bugs.webkit.org/show_bug.cgi?id=255830</a>
&lt;rdar://107526702&gt;

Reviewed by Alan Baradlay.

Some unusual content configurations can hit the ASSERT(overflowLayer.isComposited())
in collectStationaryLayerRelatedOverflowNodes(), which ends up in a null dereference in release builds.

The issue occurs when a RenderLayer which was using composited scrolling becomes non-scrollable,
but hasCompositedScrollableOverflow() continues to return true, leading to errors in compositing code
which relies on canUseCompositedScrolling(). RenderLayerScrollableArea caches m_hasCompositedScrollableOverflow,
and failed to recompute it in this case.

Fix by having RenderLayer::styleChanged() force hasCompositedScrollableOverflow() to be recomputed
when style scrollability changes.

The testcase is derived from rdar://88329753.

* LayoutTests/compositing/overflow/overflow-change-abspos-descendant-expected.txt: Added.
* LayoutTests/compositing/overflow/overflow-change-abspos-descendant.html: Added.
* Source/WebCore/rendering/RenderLayer.cpp:
(WebCore::RenderLayer::calculateClipRects const):

Canonical link: <a href="https://commits.webkit.org/263286@main">https://commits.webkit.org/263286@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1482ce8927875df8ef0d5488a3e127d593e5931c

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/4133 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/4244 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/4362 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/5594 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/4376 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/4121 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/4342 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/4209 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/4602 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/4190 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/4366 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/3729 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/5587 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/1863 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/3706 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/5878 "11 flakes 147 failures") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/3690 "Passed tests") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/3770 "1 flakes 3 failures") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/5277 "262 api tests failed or timed out") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/4168 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/3376 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/3682 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/3704 "Passed tests") | | 
| [❌ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/1016 "Failed to push commit to Webkit repository") | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/4/builds/7813 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/3961 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->