### PR TITLE
Crash in MomentumEventDispatcher::displayDidRefresh()

### DIFF
--- a/Source/WebKit/UIProcess/RemoteLayerTree/mac/RemoteLayerTreeEventDispatcher.cpp
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/mac/RemoteLayerTreeEventDispatcher.cpp
@@ -113,11 +113,14 @@ RemoteLayerTreeEventDispatcher::~RemoteLayerTreeEventDispatcher()
 // This must be called to break the cycle between RemoteLayerTreeEventDispatcherDisplayLinkClient and this.
 void RemoteLayerTreeEventDispatcher::invalidate()
 {
+    m_displayLinkClient->invalidate();
+
+    stopDisplayLinkObserver();
+
 #if ENABLE(MOMENTUM_EVENT_DISPATCHER)
     m_momentumEventDispatcher = nullptr;
 #endif
-    stopDisplayLinkObserver();
-    m_displayLinkClient->invalidate();
+
     m_displayLinkClient = nullptr;
 }
 
@@ -527,7 +530,8 @@ void RemoteLayerTreeEventDispatcher::stopDisplayDidRefreshCallbacks(PlatformDisp
 {
     ASSERT(m_momentumEventDispatcherNeedsDisplayLink);
     m_momentumEventDispatcherNeedsDisplayLink = false;
-    startOrStopDisplayLink();
+    if (m_momentumEventDispatcher)
+        startOrStopDisplayLink();
 }
 
 #if ENABLE(MOMENTUM_EVENT_DISPATCHER_TEMPORARY_LOGGING)


### PR DESCRIPTION
#### 3147f52e6d8d6c9b1ee8039f2541bf38a113eb5a
<pre>
Crash in MomentumEventDispatcher::displayDidRefresh()
<a href="https://bugs.webkit.org/show_bug.cgi?id=255831">https://bugs.webkit.org/show_bug.cgi?id=255831</a>
rdar://108105416

Reviewed by Tim Horton.

The fix done in 261404@main isn&apos;t quite right; it&apos;s possible to enter RemoteLayerTreeEventDispatcher::didRefreshDisplay()
after m_momentumEventDispatcher has been nulled out, because we cleared the m_momentumEventDispatcher before calling
stopDisplayLinkObserver().

Rather than adding a lock to use around accesses to m_momentumEventDispatcher and adding null checks, fix the
teardown order to ensure that m_momentumEventDispatcher is always non-null in the scrolling thread
code. We have to take care to consider the dispatch between the thread that `displayLinkFired()` is called
on (the CVDisplayLink thread), and the scrolling thread.

To do this, first invalidate the RemoteLayerTreeEventDispatcherDisplayLinkClient. This ensures that
if `displayLinkFired()` is called, it will early return. Then stop the display link observer.
Then we can null out the m_momentumEventDispatcher, adding a check in RemoteLayerTreeEventDispatcher::stopDisplayDidRefreshCallbacks()
to ensure that this never tries to re-start the display link. Finally we can null out the m_displayLinkClient.

* Source/WebKit/UIProcess/RemoteLayerTree/mac/RemoteLayerTreeEventDispatcher.cpp:
(WebKit::RemoteLayerTreeEventDispatcher::invalidate):
(WebKit::RemoteLayerTreeEventDispatcher::stopDisplayDidRefreshCallbacks):

Canonical link: <a href="https://commits.webkit.org/263321@main">https://commits.webkit.org/263321@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/46d87fd42fba32e0e0663f96e90ad597dab5c3b6

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/4134 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/4245 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/4363 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/5595 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/4377 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/4343 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/4210 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/4603 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/4191 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/4369 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/3730 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/5588 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/1866 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/3707 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/5880 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/3693 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/3771 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/5282 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/4169 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/3377 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/3683 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/3705 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/1040 "Built successfully and passed tests") | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/4/builds/7814 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/3962 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->