### PR TITLE
Drop unnecessary NodeWithIndex::m_haveIndex data member

### DIFF
--- a/Source/WebCore/dom/NodeWithIndex.h
+++ b/Source/WebCore/dom/NodeWithIndex.h
@@ -1,5 +1,6 @@
 /*
  * Copyright (C) 2008 Apple Inc. All Rights Reserved.
+ * Copyright (C) 2014 Google Inc. All Rights Reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -35,7 +36,7 @@ class NodeWithIndex {
 public:
     explicit NodeWithIndex(Node* node)
         : m_node(node)
-        , m_haveIndex(false)
+        , m_index(-1)
     {
         ASSERT(node);
     }
@@ -44,17 +45,18 @@ public:
 
     int index() const
     {
-        if (!m_haveIndex) {
+        if (!hasIndex())
             m_index = m_node->computeNodeIndex();
-            m_haveIndex = true;
-        }
+
+        ASSERT(hasIndex());
         ASSERT(m_index == static_cast<int>(m_node->computeNodeIndex()));
         return m_index;
     }
 
 private:
+    bool hasIndex() const { return m_index >= 0; }
+
     Node* m_node;
-    mutable bool m_haveIndex;
     mutable int m_index;
 };
 


### PR DESCRIPTION
<pre>
Drop unnecessary NodeWithIndex::m_haveIndex data member
<a href="https://bugs.webkit.org/show_bug.cgi?id=255829">https://bugs.webkit.org/show_bug.cgi?id=255829</a>

Reviewed by NOBODY (OOPS!).

Merge - <a href="https://chromium.googlesource.com/chromium/blink/+/4534831b29f809b7b6c6a6b1e61d716c854035ca">https://chromium.googlesource.com/chromium/blink/+/4534831b29f809b7b6c6a6b1e61d716c854035ca</a>

Drop unnecessary NodeWithIndex::m_haveIndex data member. Since
Node::computeNodeIndex() returns an unsigned integer but NodeWithIndex::m_index is
signed, we can simply set m_index to -1 until it is lazily set.

* Source/WebCore/dom/NodeWithIndex.h: As above
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/53aee6c9d8b39eb4742894b34449a22bfa11478e

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/4135 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/4246 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/4364 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/5596 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/4378 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/4123 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/4344 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/4211 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/4607 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/4192 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/4370 "4 failures") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/3731 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/5589 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/1867 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/3708 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/5881 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/3694 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/3772 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/5281 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/4170 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/3378 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/3684 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/3706 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/7815 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/3963 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->