### PR TITLE
Rename isHTMLSpace and move it to WTF

### DIFF
--- a/Source/JavaScriptCore/bytecode/ReduceWhitespace.cpp
+++ b/Source/JavaScriptCore/bytecode/ReduceWhitespace.cpp
@@ -38,8 +38,8 @@ CString reduceWhitespace(const CString& input)
     const char* data = input.data();
     
     for (unsigned i = 0; i < input.length();) {
-        if (isASCIISpace(data[i])) {
-            while (i < input.length() && isASCIISpace(data[i]))
+        if (isUnicodeCompatibleASCIIWhitespace(data[i])) {
+            while (i < input.length() && isUnicodeCompatibleASCIIWhitespace(data[i]))
                 ++i;
             out.print(CharacterDump(' '));
             continue;

--- a/Source/JavaScriptCore/runtime/ConfigFile.cpp
+++ b/Source/JavaScriptCore/runtime/ConfigFile.cpp
@@ -190,7 +190,7 @@ private:
             return false;
 
         while (true) {
-            while (m_srcPtr != m_bufferEnd && isASCIISpace(*m_srcPtr))
+            while (m_srcPtr != m_bufferEnd && isUnicodeCompatibleASCIIWhitespace(*m_srcPtr))
                 m_srcPtr++;
 
             if (m_srcPtr != m_bufferEnd)
@@ -312,12 +312,12 @@ void ConfigFile::parse()
 
                     char* optionNameStart = p;
 
-                    while (*p && !isASCIISpace(*p) && *p != '=')
+                    while (*p && !isUnicodeCompatibleASCIIWhitespace(*p) && *p != '=')
                         p++;
 
                     builder.appendCharacters(optionNameStart, p - optionNameStart);
 
-                    while (*p && isASCIISpace(*p) && *p != '=')
+                    while (*p && isUnicodeCompatibleASCIIWhitespace(*p) && *p != '=')
                         p++;
 
                     if (!*p)
@@ -326,7 +326,7 @@ void ConfigFile::parse()
 
                     builder.append('=');
 
-                    while (*p && isASCIISpace(*p))
+                    while (*p && isUnicodeCompatibleASCIIWhitespace(*p))
                         p++;
 
                     if (!*p)
@@ -334,13 +334,13 @@ void ConfigFile::parse()
 
                     char* optionValueStart = p;
 
-                    while (*p && !isASCIISpace(*p))
+                    while (*p && !isUnicodeCompatibleASCIIWhitespace(*p))
                         p++;
 
                     builder.appendCharacters(optionValueStart, p - optionValueStart);
                     builder.append('\n');
 
-                    while (*p && isASCIISpace(*p))
+                    while (*p && isUnicodeCompatibleASCIIWhitespace(*p))
                         p++;
                 } while (*p);
 

--- a/Source/JavaScriptCore/runtime/Options.cpp
+++ b/Source/JavaScriptCore/runtime/Options.cpp
@@ -883,7 +883,7 @@ void Options::finalize()
 
 static bool isSeparator(char c)
 {
-    return isASCIISpace(c) || (c == ',');
+    return isUnicodeCompatibleASCIIWhitespace(c) || (c == ',');
 }
 
 bool Options::setOptions(const char* optionsStr)

--- a/Source/JavaScriptCore/tools/FunctionOverrides.cpp
+++ b/Source/JavaScriptCore/tools/FunctionOverrides.cpp
@@ -196,7 +196,7 @@ static bool hasDisallowedCharacters(const char* str, size_t length)
         // '{' is also disallowed, but we don't need to check for it because
         // parseClause() searches for '{' as the end of the start delimiter.
         // As a result, the parsed delimiter string will never include '{'.
-        if (c == '}' || isASCIISpace(c))
+        if (c == '}' || isUnicodeCompatibleASCIIWhitespace(c))
             return true;
     }
     return false;

--- a/Source/WTF/wtf/DateMath.cpp
+++ b/Source/WTF/wtf/DateMath.cpp
@@ -423,7 +423,7 @@ inline static void skipSpacesAndComments(const char*& s)
     int nesting = 0;
     char ch;
     while ((ch = *s)) {
-        if (!isASCIISpace(ch)) {
+        if (!isUnicodeCompatibleASCIIWhitespace(ch)) {
             if (ch == '(')
                 nesting++;
             else if (ch == ')' && nesting > 0)
@@ -720,7 +720,7 @@ double parseDateFromNullTerminatedCharacters(const char* dateString, bool& isLoc
     const char *wordStart = dateString;
     // Check contents of first words if not number
     while (*dateString && !isASCIIDigit(*dateString)) {
-        if (isASCIISpace(*dateString) || *dateString == '(') {
+        if (isUnicodeCompatibleASCIIWhitespace(*dateString) || *dateString == '(') {
             if (dateString - wordStart >= 3)
                 month = findMonth(wordStart);
             skipSpacesAndComments(dateString);
@@ -795,14 +795,14 @@ double parseDateFromNullTerminatedCharacters(const char* dateString, bool& isLoc
             if (month == -1)
                 return std::numeric_limits<double>::quiet_NaN();
 
-            while (*dateString && *dateString != '-' && *dateString != ',' && !isASCIISpace(*dateString))
+            while (*dateString && *dateString != '-' && *dateString != ',' && !isUnicodeCompatibleASCIIWhitespace(*dateString))
                 dateString++;
 
             if (!*dateString)
                 return std::numeric_limits<double>::quiet_NaN();
 
             // '-99 23:12:40 GMT'
-            if (*dateString != '-' && *dateString != '/' && *dateString != ',' && !isASCIISpace(*dateString))
+            if (*dateString != '-' && *dateString != '/' && *dateString != ',' && !isUnicodeCompatibleASCIIWhitespace(*dateString))
                 return std::numeric_limits<double>::quiet_NaN();
             dateString++;
         }
@@ -827,7 +827,7 @@ double parseDateFromNullTerminatedCharacters(const char* dateString, bool& isLoc
         dateString = newPosStr;
     else {
         // ' 23:12:40 GMT'
-        if (!(isASCIISpace(*newPosStr) || *newPosStr == ',')) {
+        if (!(isUnicodeCompatibleASCIIWhitespace(*newPosStr) || *newPosStr == ',')) {
             if (*newPosStr != ':')
                 return std::numeric_limits<double>::quiet_NaN();
             // There was no year; the number was the hour.
@@ -835,7 +835,7 @@ double parseDateFromNullTerminatedCharacters(const char* dateString, bool& isLoc
         } else {
             // in the normal case (we parsed the year), advance to the next number
             // ' at 23:12:40 GMT'
-            if (isASCIISpace(newPosStr[0]) && isASCIIAlphaCaselessEqual(newPosStr[1], 'a') && isASCIIAlphaCaselessEqual(newPosStr[2], 't'))
+            if (isUnicodeCompatibleASCIIWhitespace(newPosStr[0]) && isASCIIAlphaCaselessEqual(newPosStr[1], 'a') && isASCIIAlphaCaselessEqual(newPosStr[2], 't'))
                 newPosStr += 3;
             else
                 ++newPosStr; // space or comma
@@ -870,7 +870,7 @@ double parseDateFromNullTerminatedCharacters(const char* dateString, bool& isLoc
                 return std::numeric_limits<double>::quiet_NaN();
 
             // ':40 GMT'
-            if (*dateString && *dateString != ':' && !isASCIISpace(*dateString))
+            if (*dateString && *dateString != ':' && !isUnicodeCompatibleASCIIWhitespace(*dateString))
                 return std::numeric_limits<double>::quiet_NaN();
 
             // seconds are optional in rfc822 + rfc2822

--- a/Source/WTF/wtf/text/Base64.cpp
+++ b/Source/WTF/wtf/text/Base64.cpp
@@ -193,7 +193,7 @@ template<typename T> static std::optional<Vector<uint8_t>> base64DecodeInternal(
                 if (equalsSignCount)
                     return std::nullopt;
                 destination[destinationLength++] = decodedCharacter;
-            } else if (!options.contains(Base64DecodeOptions::IgnoreSpacesAndNewLines) || (!isLatin1(ch) || !isASCIISpace(ch) || (options.contains(Base64DecodeOptions::DiscardVerticalTab) && ch == '\v'))) {
+            } else if (!options.contains(Base64DecodeOptions::IgnoreSpacesAndNewLines) || (!isLatin1(ch) || !isUnicodeCompatibleASCIIWhitespace(ch) || (options.contains(Base64DecodeOptions::DiscardVerticalTab) && ch == '\v'))) {
                 return std::nullopt;
             }
         }

--- a/Source/WTF/wtf/text/StringImpl.h
+++ b/Source/WTF/wtf/text/StringImpl.h
@@ -628,7 +628,7 @@ template<typename CharacterType1, typename CharacterType2> int codePointCompare(
 int codePointCompare(const StringImpl*, const StringImpl*);
 
 // FIXME: Should rename this to make clear it uses the Unicode definition of whitespace.
-// Most WebKit callers don't want that would use isASCIISpace or isHTMLSpace instead.
+// Most WebKit callers don't want that would use isUnicodeCompatibleASCIIWhitespace or isASCIIWhitespace instead.
 bool isSpaceOrNewline(UChar32);
 bool isNotSpaceOrNewline(UChar32);
 // FIXME: rdar://99002825 (Investigate if isSpaceOrNewline should be including 0xA0 non-breaking space in check.)
@@ -790,8 +790,8 @@ inline int codePointCompare(const StringImpl* string1, const StringImpl* string2
 
 inline bool isSpaceOrNewline(UChar32 character)
 {
-    // Use isASCIISpace() for all Latin-1 characters. This will include newlines, which aren't included in Unicode DirWS.
-    return isLatin1(character) ? isASCIISpace(character) : u_charDirection(character) == U_WHITE_SPACE_NEUTRAL;
+    // Use isUnicodeCompatibleASCIIWhitespace() for all Latin-1 characters. This will include newlines, which aren't included in Unicode DirWS.
+    return isLatin1(character) ? isUnicodeCompatibleASCIIWhitespace(character) : u_charDirection(character) == U_WHITE_SPACE_NEUTRAL;
 }
 
 inline bool isNotSpaceOrNewline(UChar32 character)
@@ -799,10 +799,10 @@ inline bool isNotSpaceOrNewline(UChar32 character)
     return !isSpaceOrNewline(character);
 }
 
-// FIXME: For LChar, isASCIISpace(character) || character == noBreakSpace would be enough
+// FIXME: For LChar, isUnicodeCompatibleASCIIWhitespace(character) || character == noBreakSpace would be enough
 inline bool isUnicodeWhitespace(UChar32 character)
 {
-    return isASCII(character) ? isASCIISpace(character) : u_isUWhiteSpace(character);
+    return isASCII(character) ? isUnicodeCompatibleASCIIWhitespace(character) : u_isUWhiteSpace(character);
 }
 
 inline StringImplShape::StringImplShape(unsigned refCount, unsigned length, const LChar* data8, unsigned hashAndFlags)

--- a/Source/WTF/wtf/text/StringToIntegerConversion.h
+++ b/Source/WTF/wtf/text/StringToIntegerConversion.h
@@ -30,11 +30,11 @@
 
 namespace WTF {
 
-// The parseInteger function template allows leading and trailing spaces as defined by isASCIISpace, and, after the leading spaces, allows a single leading "+".
+// The parseInteger function template allows leading and trailing spaces as defined by isUnicodeCompatibleASCIIWhitespace, and, after the leading spaces, allows a single leading "+".
 // The parseIntegerAllowingTrailingJunk function template is like parseInteger, but allows any characters after the integer.
 
 // FIXME: Should we add a version that does not allow "+"?
-// FIXME: Should we add a version that allows other definitions of spaces, like isHTMLSpace or isHTTPSpace?
+// FIXME: Should we add a version that allows other definitions of spaces, like isASCIIWhitespace or isHTTPSpace?
 // FIXME: Should we add a version that does not allow leading and trailing spaces?
 
 template<typename IntegralType> std::optional<IntegralType> parseInteger(StringView, uint8_t base = 10);
@@ -47,7 +47,7 @@ template<typename IntegralType, typename CharacterType> std::optional<IntegralTy
     if (!data)
         return std::nullopt;
 
-    while (length && isASCIISpace(*data)) {
+    while (length && isUnicodeCompatibleASCIIWhitespace(*data)) {
         --length;
         ++data;
     }
@@ -85,7 +85,7 @@ template<typename IntegralType, typename CharacterType> std::optional<IntegralTy
         return std::nullopt;
 
     if (policy == TrailingJunkPolicy::Disallow) {
-        while (length && isASCIISpace(*data)) {
+        while (length && isUnicodeCompatibleASCIIWhitespace(*data)) {
             --length;
             ++data;
         }

--- a/Source/WTF/wtf/text/StringView.cpp
+++ b/Source/WTF/wtf/text/StringView.cpp
@@ -373,7 +373,7 @@ bool equalRespectingNullity(StringView a, StringView b)
 
 StringView StringView::stripWhiteSpace() const
 {
-    return stripLeadingAndTrailingMatchedCharacters(isASCIISpace<UChar>);
+    return stripLeadingAndTrailingMatchedCharacters(isUnicodeCompatibleASCIIWhitespace<UChar>);
 }
 
 size_t StringView::reverseFind(StringView matchString, unsigned start) const

--- a/Source/WTF/wtf/text/WTFString.cpp
+++ b/Source/WTF/wtf/text/WTFString.cpp
@@ -574,7 +574,7 @@ template<typename CharacterType, TrailingJunkPolicy policy>
 static inline double toDoubleType(const CharacterType* data, size_t length, bool* ok, size_t& parsedLength)
 {
     size_t leadingSpacesLength = 0;
-    while (leadingSpacesLength < length && isASCIISpace(data[leadingSpacesLength]))
+    while (leadingSpacesLength < length && isUnicodeCompatibleASCIIWhitespace(data[leadingSpacesLength]))
         ++leadingSpacesLength;
 
     double number = parseDouble(data + leadingSpacesLength, length - leadingSpacesLength, parsedLength);

--- a/Source/WebCore/Modules/mediarecorder/MediaRecorderProvider.cpp
+++ b/Source/WebCore/Modules/mediarecorder/MediaRecorderProvider.cpp
@@ -29,7 +29,6 @@
 #if ENABLE(MEDIA_RECORDER)
 
 #include "ContentType.h"
-#include "HTMLParserIdioms.h"
 #include "MediaRecorderPrivate.h"
 
 #if PLATFORM(COCOA) && USE(AVFOUNDATION)
@@ -65,7 +64,7 @@ bool MediaRecorderProvider::isSupported(const String& value)
         return false;
 
     for (auto& item : mimeType.codecs()) {
-        auto codec = StringView(item).stripLeadingAndTrailingMatchedCharacters(isHTMLSpace<UChar>);
+        auto codec = StringView(item).stripLeadingAndTrailingMatchedCharacters(isASCIIWhitespace<UChar>);
         // FIXME: We should further validate parameters.
         if (!startsWithLettersIgnoringASCIICase(codec, "avc1"_s) && !startsWithLettersIgnoringASCIICase(codec, "mp4a"_s))
             return false;

--- a/Source/WebCore/accessibility/AXObjectCache.cpp
+++ b/Source/WebCore/accessibility/AXObjectCache.cpp
@@ -85,7 +85,6 @@
 #include "HTMLNames.h"
 #include "HTMLOptGroupElement.h"
 #include "HTMLOptionElement.h"
-#include "HTMLParserIdioms.h"
 #include "HTMLProgressElement.h"
 #include "HTMLSelectElement.h"
 #include "HTMLTableElement.h"
@@ -2359,7 +2358,7 @@ CharacterOffset AXObjectCache::traverseToOffsetInRange(const SimpleRange& range,
         } else {
             // Ignore space, new line, tag node.
             if (currentLength == 1) {
-                if (isHTMLSpace(iterator.text()[0])) {
+                if (isASCIIWhitespace(iterator.text()[0])) {
                     // If the node has BR tag, we want to set the currentNode to it.
                     Node* childNode = iterator.node();
                     if (childNode && childNode->renderer() && childNode->renderer()->isBR()) {

--- a/Source/WebCore/accessibility/AccessibilityList.cpp
+++ b/Source/WebCore/accessibility/AccessibilityList.cpp
@@ -32,7 +32,6 @@
 #include "AXObjectCache.h"
 #include "HTMLElement.h"
 #include "HTMLNames.h"
-#include "HTMLParserIdioms.h"
 #include "PseudoElement.h"
 #include "RenderListItem.h"
 #include "RenderObject.h"
@@ -110,7 +109,7 @@ bool AccessibilityList::childHasPseudoVisibleListItemMarkers(Node* node)
     // those renderers as "ignored" objects.
 #if USE(ATSPI)
     String text = axBeforePseudo->textUnderElement();
-    return !text.isEmpty() && !text.isAllSpecialCharacters<isHTMLSpace>();
+    return !text.isEmpty() && !text.isAllSpecialCharacters<isASCIIWhitespace>();
 #else
     return false;
 #endif

--- a/Source/WebCore/accessibility/AccessibilityRenderObject.cpp
+++ b/Source/WebCore/accessibility/AccessibilityRenderObject.cpp
@@ -58,7 +58,6 @@
 #include "HTMLNames.h"
 #include "HTMLOptionElement.h"
 #include "HTMLOptionsCollection.h"
-#include "HTMLParserIdioms.h"
 #include "HTMLSelectElement.h"
 #include "HTMLSummaryElement.h"
 #include "HTMLTableElement.h"
@@ -1138,7 +1137,7 @@ bool AccessibilityRenderObject::isAllowedChildOfTree() const
 static AccessibilityObjectInclusion objectInclusionFromAltText(const String& altText)
 {
     // Don't ignore an image that has an alt tag.
-    if (!altText.isAllSpecialCharacters<isHTMLSpace>())
+    if (!altText.isAllSpecialCharacters<isASCIIWhitespace>())
         return AccessibilityObjectInclusion::IncludeObject;
 
     // The informal standard is to ignore images with zero-length alt strings:
@@ -1262,7 +1261,7 @@ bool AccessibilityRenderObject::computeAccessibilityIsIgnored() const
         }
 
         // text elements that are just empty whitespace should not be returned
-        return renderText.text().isAllSpecialCharacters<isHTMLSpace>();
+        return renderText.text().isAllSpecialCharacters<isASCIIWhitespace>();
     }
     
     if (isHeading())

--- a/Source/WebCore/contentextensions/Term.h
+++ b/Source/WebCore/contentextensions/Term.h
@@ -248,7 +248,7 @@ inline String Term::toString() const
         builder.append('[');
         for (UChar c = 0; c < 128; c++) {
             if (m_atomData.characterSet.get(c)) {
-                if (isASCIIPrintable(c) && !isASCIISpace(c))
+                if (isASCIIPrintable(c) && !isUnicodeCompatibleASCIIWhitespace(c))
                     builder.append(c);
                 else
                     builder.append("\\u", c);

--- a/Source/WebCore/css/SelectorChecker.cpp
+++ b/Source/WebCore/css/SelectorChecker.cpp
@@ -39,7 +39,6 @@
 #include "FrameSelection.h"
 #include "HTMLDocument.h"
 #include "HTMLNames.h"
-#include "HTMLParserIdioms.h"
 #include "HTMLSlotElement.h"
 #include "InspectorInstrumentation.h"
 #include "LocalFrame.h"
@@ -478,7 +477,7 @@ static bool attributeValueMatches(const Attribute& attribute, CSSSelector::Match
     case CSSSelector::List:
         {
             // Ignore empty selectors or selectors containing spaces.
-            if (selectorValue.isEmpty() || selectorValue.find(isHTMLSpace<UChar>) != notFound)
+            if (selectorValue.isEmpty() || selectorValue.find(isASCIIWhitespace<UChar>) != notFound)
                 return false;
 
             unsigned startSearchAt = 0;
@@ -490,9 +489,9 @@ static bool attributeValueMatches(const Attribute& attribute, CSSSelector::Match
                     foundPos = value.findIgnoringASCIICase(selectorValue, startSearchAt);
                 if (foundPos == notFound)
                     return false;
-                if (!foundPos || isHTMLSpace(value[foundPos - 1])) {
+                if (!foundPos || isASCIIWhitespace(value[foundPos - 1])) {
                     unsigned endStr = foundPos + selectorValue.length();
-                    if (endStr == value.length() || isHTMLSpace(value[endStr]))
+                    if (endStr == value.length() || isASCIIWhitespace(value[endStr]))
                         break; // We found a match.
                 }
 

--- a/Source/WebCore/css/parser/CSSParserFastPaths.cpp
+++ b/Source/WebCore/css/parser/CSSParserFastPaths.cpp
@@ -41,7 +41,6 @@
 #include "CSSTransformListValue.h"
 #include "CSSValueList.h"
 #include "CSSValuePool.h"
-#include "HTMLParserIdioms.h"
 #include "HashTools.h"
 #include "StyleColor.h"
 #include "StylePropertyShorthand.h"
@@ -261,7 +260,7 @@ static std::optional<uint8_t> parseColorIntOrPercentage(const CharacterType*& st
     auto* current = string;
     double localValue = 0;
     bool negative = false;
-    while (current != end && isHTMLSpace<CharacterType>(*current))
+    while (current != end && isASCIIWhitespace<CharacterType>(*current))
         current++;
     if (current != end && *current == '-') {
         negative = true;
@@ -313,7 +312,7 @@ static std::optional<uint8_t> parseColorIntOrPercentage(const CharacterType*& st
     } else
         expect = CSSUnitType::CSS_NUMBER;
 
-    while (current != end && isHTMLSpace<CharacterType>(*current))
+    while (current != end && isASCIIWhitespace<CharacterType>(*current))
         current++;
     if (current == end || *current++ != terminator)
         return std::nullopt;
@@ -341,7 +340,7 @@ static inline bool isTenthAlpha(const CharacterType* string, int length)
 template <typename CharacterType>
 static inline std::optional<uint8_t> parseAlphaValue(const CharacterType*& string, const CharacterType* end, char terminator)
 {
-    while (string != end && isHTMLSpace<CharacterType>(*string))
+    while (string != end && isASCIIWhitespace<CharacterType>(*string))
         string++;
 
     bool negative = false;

--- a/Source/WebCore/css/parser/CSSTokenizer.cpp
+++ b/Source/WebCore/css/parser/CSSTokenizer.cpp
@@ -34,7 +34,6 @@
 #include "CSSParserObserverWrapper.h"
 #include "CSSParserTokenRange.h"
 #include "CSSTokenizerInputStream.h"
-#include "HTMLParserIdioms.h"
 #include "JSDOMConvertStrings.h"
 #include <wtf/text/StringBuilder.h>
 #include <wtf/text/StringToIntegerConversion.h>
@@ -677,7 +676,7 @@ CSSParserToken CSSTokenizer::consumeURLToken()
         if (cc == ')' || cc == kEndOfFileMarker)
             return CSSParserToken(UrlToken, registerString(result.toString()));
 
-        if (isHTMLSpace(cc)) {
+        if (isASCIIWhitespace(cc)) {
             m_input.advanceUntilNonWhitespace();
             if (consumeIfNext(')') || m_input.nextInputChar() == kEndOfFileMarker)
                 return CSSParserToken(UrlToken, registerString(result.toString()));
@@ -716,11 +715,11 @@ void CSSTokenizer::consumeBadUrlRemnants()
 
 void CSSTokenizer::consumeSingleWhitespaceIfNext()
 {
-    // We check for \r\n and HTML spaces since we don't do preprocessing
+    // We check for \r\n and ASCII whitespace since we don't do preprocessing
     UChar next = m_input.peek(0);
     if (next == '\r' && m_input.peek(1) == '\n')
         m_input.advance(2);
-    else if (isHTMLSpace(next))
+    else if (isASCIIWhitespace(next))
         m_input.advance();
 }
 

--- a/Source/WebCore/css/parser/CSSTokenizerInputStream.cpp
+++ b/Source/WebCore/css/parser/CSSTokenizerInputStream.cpp
@@ -30,8 +30,6 @@
 #include "config.h"
 #include "CSSTokenizerInputStream.h"
 
-#include "HTMLParserIdioms.h"
-
 namespace WebCore {
 
 CSSTokenizerInputStream::CSSTokenizerInputStream(const String& input)
@@ -43,14 +41,14 @@ CSSTokenizerInputStream::CSSTokenizerInputStream(const String& input)
 
 void CSSTokenizerInputStream::advanceUntilNonWhitespace()
 {
-    // Using HTML space here rather than CSS space since we don't do preprocessing
+    // Using ASCII whitespace here rather than CSS space since we don't do preprocessing
     if (m_string->is8Bit()) {
         const LChar* characters = m_string->characters8();
-        while (m_offset < m_stringLength && isHTMLSpace(characters[m_offset]))
+        while (m_offset < m_stringLength && isASCIIWhitespace(characters[m_offset]))
             ++m_offset;
     } else {
         const UChar* characters = m_string->characters16();
-        while (m_offset < m_stringLength && isHTMLSpace(characters[m_offset]))
+        while (m_offset < m_stringLength && isASCIIWhitespace(characters[m_offset]))
             ++m_offset;
     }
 }

--- a/Source/WebCore/cssjit/SelectorCompiler.cpp
+++ b/Source/WebCore/cssjit/SelectorCompiler.cpp
@@ -40,7 +40,6 @@
 #include "FunctionCall.h"
 #include "HTMLDocument.h"
 #include "HTMLNames.h"
-#include "HTMLParserIdioms.h"
 #include "InspectorInstrumentation.h"
 #include "NodeRenderStyle.h"
 #include "QualifiedName.h"
@@ -1507,7 +1506,7 @@ static FunctionType constructFragmentsInternal(const CSSSelector* rootSelector, 
             break;
         }
         case CSSSelector::List:
-            if (selector->value().find(isHTMLSpace<UChar>) != notFound)
+            if (selector->value().find(isASCIIWhitespace<UChar>) != notFound)
                 return FunctionType::CannotMatchAnything;
             FALLTHROUGH;
         case CSSSelector::Begin:
@@ -3503,9 +3502,9 @@ static bool attributeValueSpaceSeparatedListContains(const Attribute* attribute,
             foundPos = value.findIgnoringASCIICase(expectedString, startSearchAt);
         if (foundPos == notFound)
             return false;
-        if (!foundPos || isHTMLSpace(value[foundPos - 1])) {
+        if (!foundPos || isASCIIWhitespace(value[foundPos - 1])) {
             unsigned endStr = foundPos + expectedString->length();
-            if (endStr == value.length() || isHTMLSpace(value[endStr]))
+            if (endStr == value.length() || isASCIIWhitespace(value[endStr]))
                 return true;
         }
         startSearchAt = foundPos + 1;

--- a/Source/WebCore/dom/Document.cpp
+++ b/Source/WebCore/dom/Document.cpp
@@ -1748,7 +1748,7 @@ static String canonicalizedTitle(Document& document, const String& title)
 
     bool previousCharacterWasHTMLSpace = false;
     for (auto character : StringView { title }.codeUnits()) {
-        if (isHTMLSpace(character))
+        if (isASCIIWhitespace(character))
             previousCharacterWasHTMLSpace = true;
         else {
             if (character == '\\')
@@ -4159,12 +4159,12 @@ static void processColorSchemeString(StringView colorScheme, const Function<void
     unsigned length = colorScheme.length();
     for (unsigned i = 0; i < length; ) {
         // Skip to first non-separator.
-        while (i < length && isHTMLSpace(colorScheme[i]))
+        while (i < length && isASCIIWhitespace(colorScheme[i]))
             ++i;
         unsigned keyBegin = i;
 
         // Skip to first separator.
-        while (i < length && !isHTMLSpace(colorScheme[i]))
+        while (i < length && !isASCIIWhitespace(colorScheme[i]))
             ++i;
         unsigned keyEnd = i;
 

--- a/Source/WebCore/dom/Position.cpp
+++ b/Source/WebCore/dom/Position.cpp
@@ -35,7 +35,6 @@
 #include "HTMLBodyElement.h"
 #include "HTMLHtmlElement.h"
 #include "HTMLNames.h"
-#include "HTMLParserIdioms.h"
 #include "HTMLTableElement.h"
 #include "InlineIteratorLineBox.h"
 #include "InlineIteratorLogicalOrderTraversal.h"
@@ -1124,7 +1123,7 @@ Position Position::leadingWhitespacePosition(Affinity affinity, bool considerNon
     Position prev = previousCharacterPosition(affinity);
     if (prev != *this && inSameEnclosingBlockFlowElement(deprecatedNode(), prev.deprecatedNode()) && is<Text>(*prev.deprecatedNode())) {
         UChar c = downcast<Text>(*prev.deprecatedNode()).data()[prev.deprecatedEditingOffset()];
-        if (considerNonCollapsibleWhitespace ? (isHTMLSpace(c) || c == noBreakSpace) : deprecatedIsCollapsibleWhitespace(c)) {
+        if (considerNonCollapsibleWhitespace ? (isASCIIWhitespace(c) || c == noBreakSpace) : deprecatedIsCollapsibleWhitespace(c)) {
             if (isEditablePosition(prev))
                 return prev;
         }
@@ -1144,7 +1143,7 @@ Position Position::trailingWhitespacePosition(Affinity, bool considerNonCollapsi
     UChar c = v.characterAfter();
     // The space must not be in another paragraph and it must be editable.
     if (!isEndOfParagraph(v) && v.next(CannotCrossEditingBoundary).isNotNull())
-        if (considerNonCollapsibleWhitespace ? (isHTMLSpace(c) || c == noBreakSpace) : deprecatedIsCollapsibleWhitespace(c))
+        if (considerNonCollapsibleWhitespace ? (isASCIIWhitespace(c) || c == noBreakSpace) : deprecatedIsCollapsibleWhitespace(c))
             return *this;
     
     return { };

--- a/Source/WebCore/dom/SecurityContext.cpp
+++ b/Source/WebCore/dom/SecurityContext.cpp
@@ -28,7 +28,6 @@
 #include "SecurityContext.h"
 
 #include "ContentSecurityPolicy.h"
-#include "HTMLParserIdioms.h"
 #include "PolicyContainer.h"
 #include "SecurityOrigin.h"
 #include "SecurityOriginPolicy.h"
@@ -107,12 +106,12 @@ SandboxFlags SecurityContext::parseSandboxPolicy(StringView policy, String& inva
     unsigned numberOfTokenErrors = 0;
     StringBuilder tokenErrors;
     while (true) {
-        while (start < length && isHTMLSpace(policy[start]))
+        while (start < length && isASCIIWhitespace(policy[start]))
             ++start;
         if (start >= length)
             break;
         unsigned end = start + 1;
-        while (end < length && !isHTMLSpace(policy[end]))
+        while (end < length && !isASCIIWhitespace(policy[end]))
             ++end;
 
         // Turn off the corresponding sandbox flag if it's set as "allowed".

--- a/Source/WebCore/dom/ShadowRoot.cpp
+++ b/Source/WebCore/dom/ShadowRoot.cpp
@@ -32,7 +32,6 @@
 #include "ChildListMutationScope.h"
 #include "ElementInlines.h"
 #include "ElementTraversal.h"
-#include "HTMLParserIdioms.h"
 #include "HTMLSlotElement.h"
 #if ENABLE(PICTURE_IN_PICTURE_API)
 #include "NotImplemented.h"
@@ -312,13 +311,13 @@ static std::optional<std::pair<AtomString, AtomString>> parsePartMapping(StringV
     const auto end = mappingString.length();
 
     auto skipWhitespace = [&](auto position) {
-        while (position < end && isHTMLSpace(mappingString[position]))
+        while (position < end && isASCIIWhitespace(mappingString[position]))
             ++position;
         return position;
     };
 
     auto collectValue = [&](auto position) {
-        while (position < end && (!isHTMLSpace(mappingString[position]) && mappingString[position] != ':'))
+        while (position < end && (!isASCIIWhitespace(mappingString[position]) && mappingString[position] != ':'))
             ++position;
         return position;
     };

--- a/Source/WebCore/dom/SpaceSplitString.cpp
+++ b/Source/WebCore/dom/SpaceSplitString.cpp
@@ -21,7 +21,6 @@
 #include "config.h"
 #include "SpaceSplitString.h"
 
-#include "HTMLParserIdioms.h"
 #include <wtf/HashMap.h>
 #include <wtf/NeverDestroyed.h>
 #include <wtf/text/AtomStringHash.h>
@@ -34,12 +33,12 @@ template <typename CharacterType, typename TokenProcessor>
 static inline void tokenizeSpaceSplitString(TokenProcessor& tokenProcessor, const CharacterType* characters, unsigned length)
 {
     for (unsigned start = 0; ; ) {
-        while (start < length && isHTMLSpace(characters[start]))
+        while (start < length && isASCIIWhitespace(characters[start]))
             ++start;
         if (start >= length)
             break;
         unsigned end = start + 1;
-        while (end < length && isNotHTMLSpace(characters[end]))
+        while (end < length && !isASCIIWhitespace(characters[end]))
             ++end;
 
         if (!tokenProcessor.processToken(characters + start, end - start))

--- a/Source/WebCore/editing/TextManipulationController.cpp
+++ b/Source/WebCore/editing/TextManipulationController.cpp
@@ -153,7 +153,7 @@ static bool isNotSpace(UChar character)
     if (character == noBreakSpace)
         return false;
 
-    return isNotHTMLSpace(character);
+    return !isASCIIWhitespace(character);
 }
 
 class ParagraphContentIterator {
@@ -413,7 +413,7 @@ void TextManipulationController::parse(ManipulationUnit& unit, const String& tex
                 startPositionOfCurrentToken = positionOfLastNonHTMLSpace + 1;
             }
 
-            while (index < text.length() && (isHTMLSpace(text[index]) || isInPrivateUseArea(text[index])))
+            while (index < text.length() && (isASCIIWhitespace(text[index]) || isInPrivateUseArea(text[index])))
                 ++index;
 
             --index;

--- a/Source/WebCore/html/DOMTokenList.cpp
+++ b/Source/WebCore/html/DOMTokenList.cpp
@@ -26,7 +26,6 @@
 #include "config.h"
 #include "DOMTokenList.h"
 
-#include "HTMLParserIdioms.h"
 #include "SpaceSplitString.h"
 #include <wtf/HashSet.h>
 #include <wtf/SetForScope.h>
@@ -44,7 +43,7 @@ DOMTokenList::DOMTokenList(Element& element, const QualifiedName& attributeName,
 
 static inline bool tokenContainsHTMLSpace(StringView token)
 {
-    return token.find(isHTMLSpace<UChar>) != notFound;
+    return token.find(isASCIIWhitespace<UChar>) != notFound;
 }
 
 ExceptionOr<void> DOMTokenList::validateToken(StringView token)
@@ -228,12 +227,12 @@ void DOMTokenList::updateTokensFromAttributeValue(StringView value)
     HashSet<AtomString> addedTokens;
     // https://dom.spec.whatwg.org/#ordered%20sets
     for (unsigned start = 0; ; ) {
-        while (start < value.length() && isHTMLSpace(value[start]))
+        while (start < value.length() && isASCIIWhitespace(value[start]))
             ++start;
         if (start >= value.length())
             break;
         unsigned end = start + 1;
-        while (end < value.length() && !isHTMLSpace(value[end]))
+        while (end < value.length() && !isASCIIWhitespace(value[end]))
             ++end;
 
         auto tokenView = value.substring(start, end - start);

--- a/Source/WebCore/html/FeaturePolicy.cpp
+++ b/Source/WebCore/html/FeaturePolicy.cpp
@@ -30,7 +30,6 @@
 #include "ElementInlines.h"
 #include "HTMLIFrameElement.h"
 #include "HTMLNames.h"
-#include "HTMLParserIdioms.h"
 #include "LocalDOMWindow.h"
 #include "SecurityOrigin.h"
 
@@ -130,7 +129,7 @@ static inline void processOriginItem(Document& document, FeaturePolicy::AllowRul
     if (rule.type == FeaturePolicy::AllowRule::Type::None)
         return;
 
-    item = item.stripLeadingAndTrailingMatchedCharacters(isHTMLSpace<UChar>);
+    item = item.stripLeadingAndTrailingMatchedCharacters(isASCIIWhitespace<UChar>);
     // FIXME: Support 'src'.
     if (item == "'src'"_s)
         return;
@@ -162,14 +161,14 @@ static inline void updateList(Document& document, FeaturePolicy::AllowRule& rule
     }
 
     while (!value.isEmpty()) {
-        auto position = value.find(isHTMLSpace<UChar>);
+        auto position = value.find(isASCIIWhitespace<UChar>);
         if (position == notFound) {
             processOriginItem(document, rule, value);
             return;
         }
 
         processOriginItem(document, rule, value.left(position));
-        value = value.substring(position + 1).stripLeadingAndTrailingMatchedCharacters(isHTMLSpace<UChar>);
+        value = value.substring(position + 1).stripLeadingAndTrailingMatchedCharacters(isASCIIWhitespace<UChar>);
     }
 }
 
@@ -198,7 +197,7 @@ FeaturePolicy FeaturePolicy::parse(Document& document, const HTMLIFrameElement& 
     bool isXRSpatialTrackingInitialized = false;
 #endif
     for (auto allowItem : allowAttributeValue.split(';')) {
-        auto item = allowItem.stripLeadingAndTrailingMatchedCharacters(isHTMLSpace<UChar>);
+        auto item = allowItem.stripLeadingAndTrailingMatchedCharacters(isASCIIWhitespace<UChar>);
         if (item.startsWith("camera"_s)) {
             isCameraInitialized = true;
             updateList(document, policy.m_cameraRule, item.substring(7));

--- a/Source/WebCore/html/HTMLElement.cpp
+++ b/Source/WebCore/html/HTMLElement.cpp
@@ -1037,7 +1037,7 @@ std::optional<SRGBA<uint8_t>> HTMLElement::parseLegacyColorValue(StringView stri
     if (string.isEmpty())
         return std::nullopt;
 
-    string = string.stripLeadingAndTrailingMatchedCharacters(isHTMLSpace<UChar>);
+    string = string.stripLeadingAndTrailingMatchedCharacters(isASCIIWhitespace<UChar>);
     if (string.isEmpty())
         return Color::black;
 

--- a/Source/WebCore/html/HTMLFontElement.cpp
+++ b/Source/WebCore/html/HTMLFontElement.cpp
@@ -29,7 +29,6 @@
 #include "CSSValueList.h"
 #include "CSSValuePool.h"
 #include "HTMLNames.h"
-#include "HTMLParserIdioms.h"
 #include "MutableStyleProperties.h"
 #include "NodeName.h"
 #include "StyleProperties.h"
@@ -66,7 +65,7 @@ static bool parseFontSize(const CharacterType* characters, unsigned length, int&
 
     // Step 3
     while (position < end) {
-        if (!isHTMLSpace(*position))
+        if (!isASCIIWhitespace(*position))
             break;
         ++position;
     }

--- a/Source/WebCore/html/HTMLImageElement.cpp
+++ b/Source/WebCore/html/HTMLImageElement.cpp
@@ -40,7 +40,6 @@
 #include "HTMLFormElement.h"
 #include "HTMLImageLoader.h"
 #include "HTMLMapElement.h"
-#include "HTMLParserIdioms.h"
 #include "HTMLPictureElement.h"
 #include "HTMLSourceElement.h"
 #include "HTMLSrcsetParser.h"
@@ -239,7 +238,7 @@ static String extractMIMETypeFromTypeAttributeForLookup(const String& typeAttrib
     auto semicolonIndex = typeAttribute.find(';');
     if (semicolonIndex == notFound)
         return stripLeadingAndTrailingHTMLSpaces(typeAttribute);
-    return StringView(typeAttribute).left(semicolonIndex).stripLeadingAndTrailingMatchedCharacters(isHTMLSpace<UChar>).toStringWithoutCopying();
+    return StringView(typeAttribute).left(semicolonIndex).stripLeadingAndTrailingMatchedCharacters(isASCIIWhitespace<UChar>).toStringWithoutCopying();
 }
 
 ImageCandidate HTMLImageElement::bestFitSourceFromPictureElement()

--- a/Source/WebCore/html/HTMLInputElement.cpp
+++ b/Source/WebCore/html/HTMLInputElement.cpp
@@ -53,7 +53,6 @@
 #include "HTMLFormElement.h"
 #include "HTMLImageLoader.h"
 #include "HTMLOptionElement.h"
-#include "HTMLParserIdioms.h"
 #include "IdTargetObserver.h"
 #include "KeyboardEvent.h"
 #include "LocalDOMWindow.h"
@@ -1370,7 +1369,7 @@ static Vector<String> parseAcceptAttribute(StringView acceptString, bool (*predi
         return types;
 
     for (auto splitType : acceptString.split(',')) {
-        auto trimmedType = splitType.stripLeadingAndTrailingMatchedCharacters(isHTMLSpace<UChar>);
+        auto trimmedType = splitType.stripLeadingAndTrailingMatchedCharacters(isASCIIWhitespace<UChar>);
         if (trimmedType.isEmpty())
             continue;
         if (!predicate(trimmedType))

--- a/Source/WebCore/html/HTMLObjectElement.cpp
+++ b/Source/WebCore/html/HTMLObjectElement.cpp
@@ -36,7 +36,6 @@
 #include "HTMLMetaElement.h"
 #include "HTMLNames.h"
 #include "HTMLParamElement.h"
-#include "HTMLParserIdioms.h"
 #include "LocalFrame.h"
 #include "MIMETypeRegistry.h"
 #include "NodeList.h"
@@ -216,7 +215,7 @@ bool HTMLObjectElement::hasFallbackContent() const
     for (RefPtr<Node> child = firstChild(); child; child = child->nextSibling()) {
         // Ignore whitespace-only text, and <param> tags, any other content is fallback content.
         if (is<Text>(*child)) {
-            if (!downcast<Text>(*child).data().isAllSpecialCharacters<isHTMLSpace>())
+            if (!downcast<Text>(*child).data().isAllSpecialCharacters<isASCIIWhitespace>())
                 return true;
         } else if (!is<HTMLParamElement>(*child))
             return true;
@@ -376,7 +375,7 @@ static inline bool preventsParentObjectFromExposure(const Node& child)
     if (is<Element>(child))
         return preventsParentObjectFromExposure(downcast<Element>(child));
     if (is<Text>(child))
-        return !downcast<Text>(child).data().isAllSpecialCharacters<isHTMLSpace>();
+        return !downcast<Text>(child).data().isAllSpecialCharacters<isASCIIWhitespace>();
     return true;
 }
 

--- a/Source/WebCore/html/HTMLOptionElement.cpp
+++ b/Source/WebCore/html/HTMLOptionElement.cpp
@@ -34,7 +34,6 @@
 #include "HTMLDataListElement.h"
 #include "HTMLNames.h"
 #include "HTMLOptGroupElement.h"
-#include "HTMLParserIdioms.h"
 #include "HTMLSelectElement.h"
 #include "NodeName.h"
 #include "NodeRenderStyle.h"
@@ -109,7 +108,7 @@ String HTMLOptionElement::text() const
 
     // FIXME: Is displayStringModifiedByEncoding helpful here?
     // If it's correct here, then isn't it needed in the value and label functions too?
-    return stripLeadingAndTrailingHTMLSpaces(document().displayStringModifiedByEncoding(text)).simplifyWhiteSpace(isHTMLSpace);
+    return stripLeadingAndTrailingHTMLSpaces(document().displayStringModifiedByEncoding(text)).simplifyWhiteSpace(isASCIIWhitespace);
 }
 
 void HTMLOptionElement::setText(String&& text)
@@ -216,7 +215,7 @@ String HTMLOptionElement::value() const
     const AtomString& value = attributeWithoutSynchronization(valueAttr);
     if (!value.isNull())
         return value;
-    return stripLeadingAndTrailingHTMLSpaces(collectOptionInnerText()).simplifyWhiteSpace(isHTMLSpace);
+    return stripLeadingAndTrailingHTMLSpaces(collectOptionInnerText()).simplifyWhiteSpace(isASCIIWhitespace);
 }
 
 void HTMLOptionElement::setValue(const AtomString& value)
@@ -287,14 +286,14 @@ String HTMLOptionElement::label() const
     String label = attributeWithoutSynchronization(labelAttr);
     if (!label.isNull())
         return stripLeadingAndTrailingHTMLSpaces(label);
-    return stripLeadingAndTrailingHTMLSpaces(collectOptionInnerText()).simplifyWhiteSpace(isHTMLSpace);
+    return stripLeadingAndTrailingHTMLSpaces(collectOptionInnerText()).simplifyWhiteSpace(isASCIIWhitespace);
 }
 
 // Same as label() but ignores the label content attribute in quirks mode for compatibility with other browsers.
 String HTMLOptionElement::displayLabel() const
 {
     if (document().inQuirksMode())
-        return stripLeadingAndTrailingHTMLSpaces(collectOptionInnerText()).simplifyWhiteSpace(isHTMLSpace);
+        return stripLeadingAndTrailingHTMLSpaces(collectOptionInnerText()).simplifyWhiteSpace(isASCIIWhitespace);
     return label();
 }
 

--- a/Source/WebCore/html/parser/CSSPreloadScanner.cpp
+++ b/Source/WebCore/html/parser/CSSPreloadScanner.cpp
@@ -28,7 +28,6 @@
 #include "config.h"
 #include "CSSPreloadScanner.h"
 
-#include "HTMLParserIdioms.h"
 #include <wtf/SetForScope.h>
 
 namespace WebCore {
@@ -67,7 +66,7 @@ inline void CSSPreloadScanner::tokenize(UChar c)
     // Searching for other types of resources is probably low payoff.
     switch (m_state) {
     case Initial:
-        if (isHTMLSpace(c))
+        if (isASCIIWhitespace(c))
             break;
         if (c == '@')
             m_state = RuleStart;
@@ -105,7 +104,7 @@ inline void CSSPreloadScanner::tokenize(UChar c)
             m_state = Initial;
         break;
     case Rule:
-        if (isHTMLSpace(c))
+        if (isASCIIWhitespace(c))
             m_state = AfterRule;
         else if (c == ';')
             m_state = Initial;
@@ -113,7 +112,7 @@ inline void CSSPreloadScanner::tokenize(UChar c)
             m_rule.append(c);
         break;
     case AfterRule:
-        if (isHTMLSpace(c))
+        if (isASCIIWhitespace(c))
             break;
         if (c == ';')
             m_state = Initial;
@@ -125,7 +124,7 @@ inline void CSSPreloadScanner::tokenize(UChar c)
         }
         break;
     case RuleValue:
-        if (isHTMLSpace(c))
+        if (isASCIIWhitespace(c))
             m_state = AfterRuleValue;
         else if (c == ';')
             emitRule();
@@ -133,7 +132,7 @@ inline void CSSPreloadScanner::tokenize(UChar c)
             m_ruleValue.append(c);
         break;
     case AfterRuleValue:
-        if (isHTMLSpace(c))
+        if (isASCIIWhitespace(c))
             break;
         if (c == ';')
             emitRule();
@@ -164,12 +163,12 @@ static String parseCSSStringOrURL(const UChar* characters, size_t length)
     size_t reducedLength = length;
 
     // Remove whitespace from the rule start
-    while (reducedLength && isHTMLSpace(characters[offset])) {
+    while (reducedLength && isASCIIWhitespace(characters[offset])) {
         ++offset;
         --reducedLength;
     }
     // Remove whitespace from the rule end
-    while (reducedLength && isHTMLSpace(characters[offset + reducedLength - 1]))
+    while (reducedLength && isASCIIWhitespace(characters[offset + reducedLength - 1]))
         --reducedLength;
 
     // Skip the "url(" prefix and the ")" suffix
@@ -184,11 +183,11 @@ static String parseCSSStringOrURL(const UChar* characters, size_t length)
     }
 
     // Skip whitespace before and after the URL inside the "url()" parenthesis.
-    while (reducedLength && isHTMLSpace(characters[offset])) {
+    while (reducedLength && isASCIIWhitespace(characters[offset])) {
         ++offset;
         --reducedLength;
     }
-    while (reducedLength && isHTMLSpace(characters[offset + reducedLength - 1]))
+    while (reducedLength && isASCIIWhitespace(characters[offset + reducedLength - 1]))
         --reducedLength;
     
     // Remove single-quotes or double-quotes from the URL
@@ -207,7 +206,7 @@ static bool hasValidImportConditions(StringView conditions)
     if (conditions.isEmpty())
         return true;
 
-    conditions = conditions.stripLeadingAndTrailingMatchedCharacters(isHTMLSpace<UChar>);
+    conditions = conditions.stripLeadingAndTrailingMatchedCharacters(isASCIIWhitespace<UChar>);
 
     // FIXME: Support multiple conditions.
     // FIXME: Support media queries.

--- a/Source/WebCore/html/parser/HTMLMetaCharsetParser.cpp
+++ b/Source/WebCore/html/parser/HTMLMetaCharsetParser.cpp
@@ -28,7 +28,6 @@
 #include "HTMLMetaCharsetParser.h"
 
 #include "HTMLNames.h"
-#include "HTMLParserIdioms.h"
 #include <pal/text/TextCodec.h>
 #include <pal/text/TextEncodingRegistry.h>
 
@@ -118,7 +117,7 @@ PAL::TextEncoding HTMLMetaCharsetParser::encodingFromMetaAttributes(Span<const s
     }
 
     if (mode == Charset || (mode == Pragma && gotPragma))
-        return charset.stripLeadingAndTrailingMatchedCharacters(isHTMLSpace<UChar>);
+        return charset.stripLeadingAndTrailingMatchedCharacters(isASCIIWhitespace<UChar>);
 
     return PAL::TextEncoding();
 }

--- a/Source/WebCore/html/parser/HTMLParserIdioms.cpp
+++ b/Source/WebCore/html/parser/HTMLParserIdioms.cpp
@@ -48,7 +48,7 @@ static String stripLeadingAndTrailingHTMLSpaces(String string, CharType characte
     unsigned numTrailingSpaces = 0;
 
     for (; numLeadingSpaces < length; ++numLeadingSpaces) {
-        if (isNotHTMLSpace(characters[numLeadingSpaces]))
+        if (!isASCIIWhitespace(characters[numLeadingSpaces]))
             break;
     }
 
@@ -56,7 +56,7 @@ static String stripLeadingAndTrailingHTMLSpaces(String string, CharType characte
         return string.isNull() ? string : emptyAtom().string();
 
     for (; numTrailingSpaces < length; ++numTrailingSpaces) {
-        if (isNotHTMLSpace(characters[length - numTrailingSpaces - 1]))
+        if (!isASCIIWhitespace(characters[length - numTrailingSpaces - 1]))
             break;
     }
 
@@ -170,7 +170,7 @@ double parseToDoubleForNumberType(StringView string)
 template <typename CharacterType>
 static Expected<int, HTMLIntegerParsingError> parseHTMLIntegerInternal(const CharacterType* position, const CharacterType* end)
 {
-    while (position < end && isHTMLSpace(*position))
+    while (position < end && isASCIIWhitespace(*position))
         ++position;
 
     if (position == end)
@@ -296,7 +296,7 @@ std::optional<double> parseValidHTMLFloatingPointNumber(StringView input)
 
 static inline bool isHTMLSpaceOrDelimiter(UChar character)
 {
-    return isHTMLSpace(character) || character == ',' || character == ';';
+    return isASCIIWhitespace(character) || character == ',' || character == ';';
 }
 
 static inline bool isNumberStart(UChar character)
@@ -373,7 +373,7 @@ String parseCORSSettingsAttribute(const AtomString& value)
 template <typename CharacterType>
 static bool parseHTTPRefreshInternal(const CharacterType* position, const CharacterType* end, double& parsedDelay, String& parsedURL)
 {
-    while (position < end && isHTMLSpace(*position))
+    while (position < end && isASCIIWhitespace(*position))
         ++position;
 
     unsigned time = 0;
@@ -401,18 +401,18 @@ static bool parseHTTPRefreshInternal(const CharacterType* position, const Charac
         return true;
     }
 
-    if (*position != ';' && *position != ',' && !isHTMLSpace(*position))
+    if (*position != ';' && *position != ',' && !isASCIIWhitespace(*position))
         return false;
 
     parsedDelay = time;
 
-    while (position < end && isHTMLSpace(*position))
+    while (position < end && isASCIIWhitespace(*position))
         ++position;
 
     if (position < end && (*position == ';' || *position == ','))
         ++position;
 
-    while (position < end && isHTMLSpace(*position))
+    while (position < end && isASCIIWhitespace(*position))
         ++position;
 
     if (position == end)
@@ -437,7 +437,7 @@ static bool parseHTTPRefreshInternal(const CharacterType* position, const Charac
             return true;
         }
 
-        while (position < end && isHTMLSpace(*position))
+        while (position < end && isASCIIWhitespace(*position))
             ++position;
 
         if (position < end && *position == '=')
@@ -447,7 +447,7 @@ static bool parseHTTPRefreshInternal(const CharacterType* position, const Charac
             return true;
         }
 
-        while (position < end && isHTMLSpace(*position))
+        while (position < end && isASCIIWhitespace(*position))
             ++position;
     }
 
@@ -503,7 +503,7 @@ static std::optional<HTMLDimensionParsingResult> parseHTMLDimensionNumber(const 
 
     const auto* begin = position;
     const auto* end = position + length;
-    skipWhile<isHTMLSpace>(position, end);
+    skipWhile<isASCIIWhitespace>(position, end);
     if (position == end)
         return std::nullopt;
 

--- a/Source/WebCore/html/parser/HTMLParserIdioms.h
+++ b/Source/WebCore/html/parser/HTMLParserIdioms.h
@@ -33,9 +33,6 @@ namespace WebCore {
 class Decimal;
 class QualifiedName;
 
-// Space characters as defined by the HTML specification.
-template<typename CharacterType> bool isHTMLSpace(CharacterType);
-template<typename CharacterType> bool isNotHTMLSpace(CharacterType);
 template<typename CharacterType> bool isComma(CharacterType);
 template<typename CharacterType> bool isHTMLSpaceOrComma(CharacterType);
 bool isHTMLLineBreak(UChar);
@@ -97,26 +94,6 @@ std::optional<HTMLDimension> parseHTMLMultiLength(StringView);
 
 // Inline implementations of some of the functions declared above.
 
-template<typename CharacterType> inline bool isHTMLSpace(CharacterType character)
-{
-    // Histogram from Apple's page load test combined with some ad hoc browsing some other test suites.
-    //
-    //     82%: 216330 non-space characters, all > U+0020
-    //     11%:  30017 plain space characters, U+0020
-    //      5%:  12099 newline characters, U+000A
-    //      2%:   5346 tab characters, U+0009
-    //
-    // No other characters seen. No U+000C or U+000D, and no other control characters.
-    // Accordingly, we check for non-spaces first, then space, then newline, then tab, then the other characters.
-
-    return character <= ' ' && (character == ' ' || character == '\n' || character == '\t' || character == '\r' || character == '\f');
-}
-
-template<typename CharacterType> inline bool isNotHTMLSpace(CharacterType character)
-{
-    return !isHTMLSpace(character);
-}
-
 inline bool isHTMLLineBreak(UChar character)
 {
     return character <= '\r' && (character == '\n' || character == '\r');
@@ -129,12 +106,12 @@ template<typename CharacterType> inline bool isComma(CharacterType character)
 
 template<typename CharacterType> inline bool isHTMLSpaceOrComma(CharacterType character)
 {
-    return isComma(character) || isHTMLSpace(character);
+    return isComma(character) || isASCIIWhitespace(character);
 }
 
 inline bool isHTMLSpaceButNotLineBreak(UChar character)
 {
-    return isHTMLSpace(character) && !isHTMLLineBreak(character);
+    return isASCIIWhitespace(character) && !isHTMLLineBreak(character);
 }
 
 // https://html.spec.whatwg.org/multipage/infrastructure.html#limited-to-only-non-negative-numbers-greater-than-zero

--- a/Source/WebCore/html/parser/HTMLPreloadScanner.cpp
+++ b/Source/WebCore/html/parser/HTMLPreloadScanner.cpp
@@ -185,7 +185,7 @@ private:
         if (match(attributeName, srcAttr))
             setURLToLoad(attributeValue);
         else if (match(attributeName, crossoriginAttr))
-            m_crossOriginMode = attributeValue.stripLeadingAndTrailingMatchedCharacters(isHTMLSpace<UChar>).toString();
+            m_crossOriginMode = attributeValue.stripLeadingAndTrailingMatchedCharacters(isASCIIWhitespace<UChar>).toString();
         else if (match(attributeName, charsetAttr))
             m_charset = attributeValue.toString();
     }
@@ -280,7 +280,7 @@ private:
             else if (match(attributeName, charsetAttr))
                 m_charset = attributeValue.toString();
             else if (match(attributeName, crossoriginAttr))
-                m_crossOriginMode = attributeValue.stripLeadingAndTrailingMatchedCharacters(isHTMLSpace<UChar>).toString();
+                m_crossOriginMode = attributeValue.stripLeadingAndTrailingMatchedCharacters(isASCIIWhitespace<UChar>).toString();
             else if (match(attributeName, nonceAttr))
                 m_nonceAttribute = attributeValue.toString();
             else if (match(attributeName, asAttr))
@@ -331,7 +331,7 @@ private:
 
     void setURLToLoadAllowingReplacement(StringView value)
     {
-        auto strippedURL = value.stripLeadingAndTrailingMatchedCharacters(isHTMLSpace<UChar>);
+        auto strippedURL = value.stripLeadingAndTrailingMatchedCharacters(isASCIIWhitespace<UChar>);
         if (strippedURL.isEmpty())
             return;
         m_urlToLoad = strippedURL.toString();

--- a/Source/WebCore/html/parser/HTMLSrcsetParser.cpp
+++ b/Source/WebCore/html/parser/HTMLSrcsetParser.cpp
@@ -89,7 +89,7 @@ static void tokenizeDescriptors(const CharType*& position, const CharType* attri
                 ++position;
                 return;
             }
-            if (isHTMLSpace(*position)) {
+            if (isASCIIWhitespace(*position)) {
                 appendDescriptorAndReset(currentDescriptorStart, position, descriptors);
                 currentDescriptorStart = position + 1;
                 state = AfterToken;
@@ -113,7 +113,7 @@ static void tokenizeDescriptors(const CharType*& position, const CharType* attri
         case AfterToken:
             if (isEOF(position, attributeEnd))
                 return;
-            if (!isHTMLSpace(*position)) {
+            if (!isASCIIWhitespace(*position)) {
                 state = Initial;
                 currentDescriptorStart = position;
                 --position;
@@ -178,7 +178,7 @@ static Vector<ImageCandidate> parseImageCandidatesFromSrcsetAttribute(const Char
         const CharType* imageURLStart = position;
         // 6. Collect a sequence of characters that are not space characters, and let that be url.
 
-        skipUntil<isHTMLSpace>(position, attributeEnd);
+        skipUntil<isASCIIWhitespace>(position, attributeEnd);
         const CharType* imageURLEnd = position;
 
         DescriptorParsingResult result;
@@ -193,7 +193,7 @@ static Vector<ImageCandidate> parseImageCandidatesFromSrcsetAttribute(const Char
             if (imageURLStart == imageURLEnd)
                 continue;
         } else {
-            skipWhile<isHTMLSpace>(position, attributeEnd);
+            skipWhile<isASCIIWhitespace>(position, attributeEnd);
             Vector<StringView> descriptorTokens;
             tokenizeDescriptors(position, attributeEnd, descriptorTokens);
             // Contrary to spec language - descriptor parsing happens on each candidate.

--- a/Source/WebCore/html/parser/HTMLTreeBuilder.cpp
+++ b/Source/WebCore/html/parser/HTMLTreeBuilder.cpp
@@ -73,9 +73,9 @@ CustomElementConstructionData::~CustomElementConstructionData() = default;
 
 namespace {
 
-inline bool isHTMLSpaceOrReplacementCharacter(UChar character)
+inline bool isASCIIWhitespaceOrReplacementCharacter(UChar character)
 {
-    return isHTMLSpace(character) || character == replacementCharacter;
+    return isASCIIWhitespace(character) || character == replacementCharacter;
 }
 
 }
@@ -87,12 +87,12 @@ static inline TextPosition uninitializedPositionValue1()
 
 static inline bool isAllWhitespace(const String& string)
 {
-    return string.isAllSpecialCharacters<isHTMLSpace>();
+    return string.isAllSpecialCharacters<isASCIIWhitespace>();
 }
 
 static inline bool isAllWhitespaceOrReplacementCharacters(const String& string)
 {
-    return string.isAllSpecialCharacters<isHTMLSpaceOrReplacementCharacter>();
+    return string.isAllSpecialCharacters<isASCIIWhitespaceOrReplacementCharacter>();
 }
 
 #if ASSERT_ENABLED
@@ -172,17 +172,17 @@ public:
 
     void skipLeadingWhitespace()
     {
-        skipLeading<isHTMLSpace>();
+        skipLeading<isASCIIWhitespace>();
     }
 
     String takeLeadingWhitespace()
     {
-        return takeLeading<isHTMLSpace>();
+        return takeLeading<isASCIIWhitespace>();
     }
 
     void skipLeadingNonWhitespace()
     {
-        skipLeading<isNotHTMLSpace>();
+        skipLeading<isNotASCIIWhitespace>();
     }
 
     String takeRemaining()
@@ -204,7 +204,7 @@ public:
         Vector<LChar, 8> whitespace;
         do {
             UChar character = m_text[0];
-            if (isHTMLSpace(character))
+            if (isASCIIWhitespace(character))
                 whitespace.append(character);
             m_text = m_text.substring(1);
         } while (!m_text.isEmpty());

--- a/Source/WebCore/html/parser/ParsingUtilities.h
+++ b/Source/WebCore/html/parser/ParsingUtilities.h
@@ -38,7 +38,7 @@ namespace WebCore {
 
 template<typename CharacterType> inline bool isNotASCIISpace(CharacterType c)
 {
-    return !isASCIISpace(c);
+    return !isUnicodeCompatibleASCIIWhitespace(c);
 }
     
 template<typename CharacterType, typename DelimiterType> bool skipExactly(const CharacterType*& position, const CharacterType* end, DelimiterType delimiter)

--- a/Source/WebCore/html/track/VTTRegion.cpp
+++ b/Source/WebCore/html/track/VTTRegion.cpp
@@ -38,7 +38,6 @@
 #include "DOMTokenList.h"
 #include "ElementChildIteratorInlines.h"
 #include "HTMLDivElement.h"
-#include "HTMLParserIdioms.h"
 #include "Logging.h"
 #include "RenderElement.h"
 #include "ShadowPseudoIds.h"
@@ -173,7 +172,7 @@ void VTTRegion::setRegionSettings(const String& inputString)
 
         // Verify that we're looking at a ':'.
         if (name == None || !input.scan(':')) {
-            input.skipUntil<isHTMLSpace<UChar>>();
+            input.skipUntil<isASCIIWhitespace<UChar>>();
             continue;
         }
 
@@ -207,7 +206,7 @@ static inline bool parsedEntireRun(const VTTScanner& input, const VTTScanner::Ru
 
 void VTTRegion::parseSettingValue(RegionSetting setting, VTTScanner& input)
 {
-    VTTScanner::Run valueRun = input.collectUntil<isHTMLSpace<UChar>>();
+    VTTScanner::Run valueRun = input.collectUntil<isASCIIWhitespace<UChar>>();
 
     switch (setting) {
     case Id: {

--- a/Source/WebCore/html/track/WebVTTParser.cpp
+++ b/Source/WebCore/html/track/WebVTTParser.cpp
@@ -37,7 +37,6 @@
 
 #include "CommonAtomStrings.h"
 #include "Document.h"
-#include "HTMLParserIdioms.h"
 #include "ISOVTTCue.h"
 #include "ProcessingInstruction.h"
 #include "StylePropertiesInlines.h"
@@ -251,7 +250,7 @@ bool WebVTTParser::hasRequiredFileIdentifier(const String& line)
     // and any number of characters that are not line terminators ...
     if (!line.startsWith(fileIdentifier))
         return false;
-    if (line.length() > fileIdentifierLength && !isHTMLSpace(line[fileIdentifierLength]))
+    if (line.length() > fileIdentifierLength && !isASCIIWhitespace(line[fileIdentifierLength]))
         return false;
     return true;
 }
@@ -434,25 +433,25 @@ WebVTTParser::ParseState WebVTTParser::collectTimingsAndSettings(const String& l
 
     // Collect WebVTT cue timings and settings. (5.3 WebVTT cue timings and settings parsing.)
     // Steps 1 - 3 - Let input be the string being parsed and position be a pointer into input
-    input.skipWhile<isHTMLSpace<UChar>>();
+    input.skipWhile<isASCIIWhitespace<UChar>>();
 
     // Steps 4 - 5 - Collect a WebVTT timestamp. If that fails, then abort and return failure. Otherwise, let cue's text track cue start time be the collected time.
     if (!collectTimeStamp(input, m_currentStartTime))
         return BadCue;
     
-    input.skipWhile<isHTMLSpace<UChar>>();
+    input.skipWhile<isASCIIWhitespace<UChar>>();
 
     // Steps 6 - 9 - If the next three characters are not "-->", abort and return failure.
     if (!input.scan("-->"))
         return BadCue;
     
-    input.skipWhile<isHTMLSpace<UChar>>();
+    input.skipWhile<isASCIIWhitespace<UChar>>();
 
     // Steps 10 - 11 - Collect a WebVTT timestamp. If that fails, then abort and return failure. Otherwise, let cue's text track cue end time be the collected time.
     if (!collectTimeStamp(input, m_currentEndTime))
         return BadCue;
 
-    input.skipWhile<isHTMLSpace<UChar>>();
+    input.skipWhile<isASCIIWhitespace<UChar>>();
 
     // Step 12 - Parse the WebVTT settings for the cue (conducted in TextTrackCue).
     m_currentSettings = input.restOfInputAsString();

--- a/Source/WebCore/inspector/InspectorStyleSheet.cpp
+++ b/Source/WebCore/inspector/InspectorStyleSheet.cpp
@@ -52,7 +52,6 @@
 #include "FrameDestructionObserverInlines.h"
 #include "HTMLHeadElement.h"
 #include "HTMLNames.h"
-#include "HTMLParserIdioms.h"
 #include "HTMLStyleElement.h"
 #include "InspectorCSSAgent.h"
 #include "InspectorDOMAgent.h"
@@ -321,7 +320,7 @@ void StyleSheetHandler::startRuleHeader(StyleRuleType type, unsigned offset)
 template <typename CharacterType> inline void StyleSheetHandler::setRuleHeaderEnd(const CharacterType* dataStart, unsigned listEndOffset)
 {
     while (listEndOffset > m_currentRuleDataStack.last()->ruleHeaderRange.start) {
-        if (isHTMLSpace<CharacterType>(*(dataStart + listEndOffset - 1)))
+        if (isASCIIWhitespace<CharacterType>(*(dataStart + listEndOffset - 1)))
             --listEndOffset;
         else
             break;
@@ -429,7 +428,7 @@ static inline void fixUnparsedProperties(const CharacterType* characters, CSSRul
         else
             propertyEnd = styleStart + nextData->range.start - 1;
         
-        while (isHTMLSpace<CharacterType>(characters[propertyEnd]))
+        while (isASCIIWhitespace<CharacterType>(characters[propertyEnd]))
             --propertyEnd;
         
         // propertyEnd points at the last property text character.
@@ -444,7 +443,7 @@ static inline void fixUnparsedProperties(const CharacterType* characters, CSSRul
             if (valueStart < propertyEnd)
                 ++valueStart;
 
-            while (valueStart < propertyEnd && isHTMLSpace<CharacterType>(characters[valueStart]))
+            while (valueStart < propertyEnd && isASCIIWhitespace<CharacterType>(characters[valueStart]))
                 ++valueStart;
             
             // Need to exclude the trailing ';' from the property value.

--- a/Source/WebCore/inspector/agents/InspectorDOMAgent.cpp
+++ b/Source/WebCore/inspector/agents/InspectorDOMAgent.cpp
@@ -67,7 +67,6 @@
 #include "HTMLFrameOwnerElement.h"
 #include "HTMLMediaElement.h"
 #include "HTMLNames.h"
-#include "HTMLParserIdioms.h"
 #include "HTMLScriptElement.h"
 #include "HTMLStyleElement.h"
 #include "HTMLTemplateElement.h"
@@ -2497,7 +2496,7 @@ Ref<Protocol::DOM::AccessibilityProperties> InspectorDOMAgent::buildObjectForAcc
 static bool containsOnlyHTMLWhitespace(Node* node)
 {
     // FIXME: Respect ignoreWhitespace setting from inspector front end?
-    return is<Text>(node) && downcast<Text>(*node).data().isAllSpecialCharacters<isHTMLSpace>();
+    return is<Text>(node) && downcast<Text>(*node).data().isAllSpecialCharacters<isASCIIWhitespace>();
 }
 
 Node* InspectorDOMAgent::innerFirstChild(Node* node)

--- a/Source/WebCore/loader/FrameLoader.cpp
+++ b/Source/WebCore/loader/FrameLoader.cpp
@@ -75,7 +75,6 @@
 #include "HTMLInputElement.h"
 #include "HTMLNames.h"
 #include "HTMLObjectElement.h"
-#include "HTMLParserIdioms.h"
 #include "HTTPHeaderNames.h"
 #include "HTTPHeaderValues.h"
 #include "HTTPParsers.h"
@@ -763,7 +762,7 @@ static AtomString extractContentLanguageFromHeader(const String& header)
     auto commaIndex = header.find(',');
     if (commaIndex == notFound)
         return AtomString { stripLeadingAndTrailingHTMLSpaces(header) };
-    return StringView(header).left(commaIndex).stripLeadingAndTrailingMatchedCharacters(isHTMLSpace<UChar>).toAtomString();
+    return StringView(header).left(commaIndex).stripLeadingAndTrailingMatchedCharacters(isASCIIWhitespace<UChar>).toAtomString();
 }
 
 void FrameLoader::didBeginDocument(bool dispatch)

--- a/Source/WebCore/loader/SubresourceIntegrity.cpp
+++ b/Source/WebCore/loader/SubresourceIntegrity.cpp
@@ -27,7 +27,6 @@
 #include "SubresourceIntegrity.h"
 
 #include "CachedResource.h"
-#include "HTMLParserIdioms.h"
 #include "ParsingUtilities.h"
 #include "ResourceCryptographicDigest.h"
 #include "SharedBuffer.h"
@@ -71,7 +70,7 @@ public:
 
         // After the base64 value and options, the current character pointed to by position
         // should either be the end or a space.
-        if (!buffer.atEnd() && !isHTMLSpace(*buffer))
+        if (!buffer.atEnd() && !isASCIIWhitespace(*buffer))
             return false;
 
         m_digests->append(WTFMove(*digest));
@@ -87,12 +86,12 @@ private:
 template <typename CharacterType, typename Functor>
 static inline void splitOnSpaces(StringParsingBuffer<CharacterType> buffer, Functor&& functor)
 {
-    skipWhile<isHTMLSpace>(buffer);
+    skipWhile<isASCIIWhitespace>(buffer);
 
     while (buffer.hasCharactersRemaining()) {
         if (!functor(buffer))
-            skipWhile<isNotHTMLSpace>(buffer);
-        skipWhile<isHTMLSpace>(buffer);
+            skipWhile<isNotASCIIWhitespace>(buffer);
+        skipWhile<isASCIIWhitespace>(buffer);
     }
 }
 

--- a/Source/WebCore/mathml/MathMLMencloseElement.cpp
+++ b/Source/WebCore/mathml/MathMLMencloseElement.cpp
@@ -30,7 +30,6 @@
 #if ENABLE(MATHML)
 
 #include "ElementInlines.h"
-#include "HTMLParserIdioms.h"
 #include "MathMLNames.h"
 #include "RenderMathMLMenclose.h"
 #include <wtf/IsoMallocInlines.h>
@@ -114,12 +113,12 @@ void MathMLMencloseElement::parseNotationAttribute()
     unsigned length = value.length();
     unsigned start = 0;
     while (start < length) {
-        if (isHTMLSpace(value[start])) {
+        if (isASCIIWhitespace(value[start])) {
             start++;
             continue;
         }
         unsigned end = start + 1;
-        while (end < length && !isHTMLSpace(value[end]))
+        while (end < length && !isASCIIWhitespace(value[end]))
             end++;
         addNotationFlags(value.substring(start, end - start));
         start = end;

--- a/Source/WebCore/mathml/MathMLPresentationElement.cpp
+++ b/Source/WebCore/mathml/MathMLPresentationElement.cpp
@@ -35,7 +35,6 @@
 #include "HTMLHtmlElement.h"
 #include "HTMLMapElement.h"
 #include "HTMLNames.h"
-#include "HTMLParserIdioms.h"
 #include "HTTPParsers.h"
 #include "MathMLMathElement.h"
 #include "MathMLNames.h"
@@ -298,7 +297,7 @@ MathMLElement::Length MathMLPresentationElement::parseMathMLLength(const String&
     //   pattern = '\s*((-?[0-9]*([0-9]\.?|\.[0-9])[0-9]*(e[mx]|in|cm|mm|p[xtc]|%)?)|(negative)?((very){0,2}thi(n|ck)|medium)mathspace)\s*'
     //
     // We do not perform a strict verification of the syntax of whitespaces and number.
-    // Instead, we just use isHTMLSpace and toFloat to parse these parts.
+    // Instead, we just use isASCIIWhitespace and toFloat to parse these parts.
 
     // We first skip whitespace from both ends of the string.
     StringView stringView = string;

--- a/Source/WebCore/page/LocalFrameView.cpp
+++ b/Source/WebCore/page/LocalFrameView.cpp
@@ -61,7 +61,6 @@
 #include "HTMLIFrameElement.h"
 #include "HTMLNames.h"
 #include "HTMLObjectElement.h"
-#include "HTMLParserIdioms.h"
 #include "HTMLPlugInImageElement.h"
 #include "HighlightRegister.h"
 #include "ImageDocument.h"
@@ -4977,7 +4976,7 @@ void LocalFrameView::incrementVisuallyNonEmptyCharacterCount(const String& inlin
     auto nonWhitespaceLength = [](auto& inlineText) {
         auto length = inlineText.length();
         for (unsigned i = 0; i < inlineText.length(); ++i) {
-            if (isNotHTMLSpace(inlineText[i]))
+            if (!isASCIIWhitespace(inlineText[i]))
                 continue;
             --length;
         }

--- a/Source/WebCore/page/WindowFeatures.cpp
+++ b/Source/WebCore/page/WindowFeatures.cpp
@@ -47,7 +47,8 @@ static bool isSeparator(UChar character, FeatureMode mode)
     if (mode == FeatureMode::Viewport)
         return character == ' ' || character == '\t' || character == '\n' || character == '\r' || character == '=' || character == ',';
 
-    return isASCIISpace(character) || character == '=' || character == ',';
+    // FIXME: this should be isASCIIWhitespace
+    return isUnicodeCompatibleASCIIWhitespace(character) || character == '=' || character == ',';
 }
 
 WindowFeatures parseWindowFeatures(StringView featuresString)

--- a/Source/WebCore/page/csp/ContentSecurityPolicy.cpp
+++ b/Source/WebCore/page/csp/ContentSecurityPolicy.cpp
@@ -253,7 +253,7 @@ void ContentSecurityPolicy::didReceiveHeader(const String& header, ContentSecuri
     // be combined with a comma. Walk the header string, and parse each comma
     // separated chunk as a separate header.
     readCharactersForParsing(header, [&](auto buffer) {
-        skipWhile<isASCIISpace>(buffer);
+        skipWhile<isUnicodeCompatibleASCIIWhitespace>(buffer);
         auto begin = buffer.position();
 
         while (buffer.hasCharactersRemaining()) {

--- a/Source/WebCore/page/csp/ContentSecurityPolicyDirectiveList.cpp
+++ b/Source/WebCore/page/csp/ContentSecurityPolicyDirectiveList.cpp
@@ -44,7 +44,7 @@ template<typename CharacterType> static bool isDirectiveNameCharacter(CharacterT
 
 template<typename CharacterType> static bool isDirectiveValueCharacter(CharacterType c)
 {
-    return isASCIISpace(c) || (c >= 0x21 && c <= 0x7e); // Whitespace + VCHAR
+    return isUnicodeCompatibleASCIIWhitespace(c) || (c >= 0x21 && c <= 0x7e); // Whitespace + VCHAR
 }
 
 static inline bool checkEval(ContentSecurityPolicySourceListDirective* directive)
@@ -495,7 +495,7 @@ void ContentSecurityPolicyDirectiveList::parse(const String& policy, ContentSecu
 //
 template<typename CharacterType> auto ContentSecurityPolicyDirectiveList::parseDirective(StringParsingBuffer<CharacterType> buffer) -> std::optional<ParsedDirective>
 {
-    skipWhile<isASCIISpace>(buffer);
+    skipWhile<isUnicodeCompatibleASCIIWhitespace>(buffer);
 
     // Empty directive (e.g. ";;;"). Exit early.
     if (buffer.atEnd())
@@ -516,13 +516,13 @@ template<typename CharacterType> auto ContentSecurityPolicyDirectiveList::parseD
     if (buffer.atEnd())
         return ParsedDirective { WTFMove(name), { } };
 
-    if (!skipExactly<isASCIISpace>(buffer)) {
+    if (!skipExactly<isUnicodeCompatibleASCIIWhitespace>(buffer)) {
         skipWhile<isNotASCIISpace>(buffer);
         m_policy.reportUnsupportedDirective(String(nameBegin, buffer.position() - nameBegin));
         return std::nullopt;
     }
 
-    skipWhile<isASCIISpace>(buffer);
+    skipWhile<isUnicodeCompatibleASCIIWhitespace>(buffer);
 
     auto valueBegin = buffer.position();
     skipWhile<isDirectiveValueCharacter>(buffer);
@@ -550,7 +550,7 @@ void ContentSecurityPolicyDirectiveList::parseReportURI(ParsedDirective&& direct
     readCharactersForParsing(directive.value, [&](auto buffer) {
         auto begin = buffer.position();
         while (buffer.hasCharactersRemaining()) {
-            skipWhile<isASCIISpace>(buffer);
+            skipWhile<isUnicodeCompatibleASCIIWhitespace>(buffer);
 
             auto urlBegin = buffer.position();
             skipWhile<isNotASCIISpace>(buffer);
@@ -571,7 +571,7 @@ void ContentSecurityPolicyDirectiveList::parseReportTo(ParsedDirective&& directi
     readCharactersForParsing(directive.value, [&](auto buffer) {
         auto begin = buffer.position();
         while (buffer.hasCharactersRemaining()) {
-            skipWhile<isASCIISpace>(buffer);
+            skipWhile<isUnicodeCompatibleASCIIWhitespace>(buffer);
 
             auto urlBegin = buffer.position();
             skipWhile<isNotASCIISpace>(buffer);

--- a/Source/WebCore/page/csp/ContentSecurityPolicyMediaListDirective.cpp
+++ b/Source/WebCore/page/csp/ContentSecurityPolicyMediaListDirective.cpp
@@ -37,7 +37,7 @@ namespace WebCore {
 
 template<typename CharacterType> static bool isMediaTypeCharacter(CharacterType c)
 {
-    return !isASCIISpace(c) && c != '/';
+    return !isUnicodeCompatibleASCIIWhitespace(c) && c != '/';
 }
 
 ContentSecurityPolicyMediaListDirective::ContentSecurityPolicyMediaListDirective(const ContentSecurityPolicyDirectiveList& directiveList, const String& name, const String& value)
@@ -63,7 +63,7 @@ void ContentSecurityPolicyMediaListDirective::parse(const String& value)
         while (buffer.hasCharactersRemaining()) {
             // _____ OR _____mime1/mime1
             // ^        ^
-            skipWhile<isASCIISpace>(buffer);
+            skipWhile<isUnicodeCompatibleASCIIWhitespace>(buffer);
             if (buffer.atEnd())
                 return;
 
@@ -103,7 +103,7 @@ void ContentSecurityPolicyMediaListDirective::parse(const String& value)
             }
             m_pluginTypes.add(String(begin, buffer.position() - begin));
 
-            ASSERT(buffer.atEnd() || isASCIISpace(*buffer));
+            ASSERT(buffer.atEnd() || isUnicodeCompatibleASCIIWhitespace(*buffer));
         }
     });
 }

--- a/Source/WebCore/page/csp/ContentSecurityPolicySourceList.cpp
+++ b/Source/WebCore/page/csp/ContentSecurityPolicySourceList.cpp
@@ -62,7 +62,7 @@ static bool isCSPDirectiveName(StringView name)
 
 template<typename CharacterType> static bool isSourceCharacter(CharacterType c)
 {
-    return !isASCIISpace(c);
+    return !isUnicodeCompatibleASCIIWhitespace(c);
 }
 
 template<typename CharacterType> static bool isHostCharacter(CharacterType c)
@@ -87,12 +87,12 @@ template<typename CharacterType> static bool isNotColonOrSlash(CharacterType c)
 
 template<typename CharacterType> static bool isSourceListNone(StringParsingBuffer<CharacterType> buffer)
 {
-    skipWhile<isASCIISpace>(buffer);
+    skipWhile<isUnicodeCompatibleASCIIWhitespace>(buffer);
 
     if (!skipExactlyIgnoringASCIICase(buffer, "'none'"_s))
         return false;
 
-    skipWhile<isASCIISpace>(buffer);
+    skipWhile<isUnicodeCompatibleASCIIWhitespace>(buffer);
 
     return buffer.atEnd();
 }
@@ -247,7 +247,7 @@ static bool extensionModeAllowsKeywordsForDirective(ContentSecurityPolicyModeFor
 template<typename CharacterType> void ContentSecurityPolicySourceList::parse(StringParsingBuffer<CharacterType> buffer)
 {
     while (buffer.hasCharactersRemaining()) {
-        skipWhile<isASCIISpace>(buffer);
+        skipWhile<isUnicodeCompatibleASCIIWhitespace>(buffer);
         if (buffer.atEnd())
             return;
 
@@ -275,7 +275,7 @@ template<typename CharacterType> void ContentSecurityPolicySourceList::parse(Str
         } else
             m_policy.reportInvalidSourceExpression(m_directiveName, String(beginSource, buffer.position() - beginSource));
 
-        ASSERT(buffer.atEnd() || isASCIISpace(*buffer));
+        ASSERT(buffer.atEnd() || isUnicodeCompatibleASCIIWhitespace(*buffer));
     }
     
     m_list.shrinkToFit();

--- a/Source/WebCore/page/linux/ResourceUsageThreadLinux.cpp
+++ b/Source/WebCore/page/linux/ResourceUsageThreadLinux.cpp
@@ -173,7 +173,7 @@ static bool threadCPUUsage(pid_t id, float period, ThreadInfo& info)
     // Skip ppid, pgrp, sid, tty_nr, tty_pgrp, flags, min_flt, cmin_flt, maj_flt, cmaj_flt.
     unsigned tokensToSkip = 10;
     while (tokensToSkip--) {
-        while (!isASCIISpace(position[0]))
+        while (!isUnicodeCompatibleASCIIWhitespace(position[0]))
             position++;
         position++;
     }

--- a/Source/WebCore/platform/ContentType.cpp
+++ b/Source/WebCore/platform/ContentType.cpp
@@ -87,7 +87,7 @@ String ContentType::parameter(const String& parameterName) const
         start = equalSignPosition + 1;
         end = m_type.find(';', start);
     }
-    return StringView { m_type }.substring(start, end - start).stripLeadingAndTrailingMatchedCharacters(isHTMLSpace<UChar>).toString();
+    return StringView { m_type }.substring(start, end - start).stripLeadingAndTrailingMatchedCharacters(isASCIIWhitespace<UChar>).toString();
 }
 
 String ContentType::containerType() const
@@ -101,7 +101,7 @@ static inline Vector<String> splitParameters(StringView parametersView)
 {
     Vector<String> result;
     for (auto view : parametersView.split(','))
-        result.append(view.stripLeadingAndTrailingMatchedCharacters(isHTMLSpace<UChar>).toString());
+        result.append(view.stripLeadingAndTrailingMatchedCharacters(isASCIIWhitespace<UChar>).toString());
     return result;
 }
 

--- a/Source/WebCore/platform/graphics/ComplexTextController.cpp
+++ b/Source/WebCore/platform/graphics/ComplexTextController.cpp
@@ -312,7 +312,7 @@ static bool shouldSynthesize(bool dontSynthesizeSmallCaps, const Font* nextFont,
         return false;
     if (!nextFont || nextFont == Font::systemFallback())
         return false;
-    if (engageAllSmallCapsProcessing && isASCIISpace(baseCharacter))
+    if (engageAllSmallCapsProcessing && isUnicodeCompatibleASCIIWhitespace(baseCharacter))
         return false;
     if (!engageAllSmallCapsProcessing && !capitalizedBase)
         return false;

--- a/Source/WebCore/rendering/LegacyLineLayout.cpp
+++ b/Source/WebCore/rendering/LegacyLineLayout.cpp
@@ -30,7 +30,6 @@
 #include "BreakingContext.h"
 #include "DocumentInlines.h"
 #include "FloatingObjects.h"
-#include "HTMLParserIdioms.h"
 #include "InlineIteratorBox.h"
 #include "InlineIteratorTextBox.h"
 #include "InlineTextBoxStyle.h"
@@ -271,7 +270,7 @@ LegacyInlineFlowBox* LegacyLineLayout::createLineBoxes(RenderObject* obj, const 
 template<typename CharacterType> static inline bool endsWithHTMLSpaces(const CharacterType* characters, unsigned position, unsigned end)
 {
     for (unsigned i = position; i < end; ++i) {
-        if (!isHTMLSpace(characters[i]))
+        if (!isASCIIWhitespace(characters[i]))
             return false;
     }
     return true;

--- a/Source/WebCore/rendering/RenderBlockFlow.cpp
+++ b/Source/WebCore/rendering/RenderBlockFlow.cpp
@@ -31,7 +31,6 @@
 #include "FrameSelection.h"
 #include "HTMLElement.h"
 #include "HTMLInputElement.h"
-#include "HTMLParserIdioms.h"
 #include "HTMLTextAreaElement.h"
 #include "HitTestLocation.h"
 #include "InlineIteratorBox.h"
@@ -4164,7 +4163,7 @@ static inline bool isVisibleRenderText(const RenderObject& renderer)
         return false;
 
     auto& renderText = downcast<RenderText>(renderer);
-    return !renderText.linesBoundingBox().isEmpty() && !renderText.text().isAllSpecialCharacters<isHTMLSpace>();
+    return !renderText.linesBoundingBox().isEmpty() && !renderText.text().isAllSpecialCharacters<isASCIIWhitespace>();
 }
 
 static inline bool resizeTextPermitted(const RenderObject& renderer)

--- a/Source/WebCore/rendering/RenderLayer.cpp
+++ b/Source/WebCore/rendering/RenderLayer.cpp
@@ -77,7 +77,6 @@
 #include "HTMLFrameOwnerElement.h"
 #include "HTMLIFrameElement.h"
 #include "HTMLNames.h"
-#include "HTMLParserIdioms.h"
 #include "HitTestRequest.h"
 #include "HitTestResult.h"
 #include "HitTestingTransformState.h"
@@ -5264,7 +5263,7 @@ static void determineNonLayerDescendantsPaintedContent(const RenderElement& rend
             if (renderer.style().effectiveUserSelect() != UserSelect::None)
                 request.setHasPaintedContent();
 
-            if (!renderText.text().isAllSpecialCharacters<isHTMLSpace>())
+            if (!renderText.text().isAllSpecialCharacters<isASCIIWhitespace>())
                 request.setHasPaintedContent();
 
             if (request.isSatisfied())

--- a/Source/WebCore/rendering/RenderText.cpp
+++ b/Source/WebCore/rendering/RenderText.cpp
@@ -33,7 +33,6 @@
 #include "DocumentInlines.h"
 #include "DocumentMarkerController.h"
 #include "FloatQuad.h"
-#include "HTMLParserIdioms.h"
 #include "Hyphenation.h"
 #include "InlineIteratorLineBox.h"
 #include "InlineIteratorLogicalOrderTraversal.h"
@@ -834,7 +833,7 @@ RenderText::Widths RenderText::trimmedPreferredWidths(float leadWidth, bool& str
 
     unsigned length = this->length();
 
-    if (!length || (stripFrontSpaces && text().isAllSpecialCharacters<isHTMLSpace>()))
+    if (!length || (stripFrontSpaces && text().isAllSpecialCharacters<isASCIIWhitespace>()))
         return widths;
 
     widths.min = m_minWidth.value_or(-1);

--- a/Source/WebCore/rendering/TextPainter.cpp
+++ b/Source/WebCore/rendering/TextPainter.cpp
@@ -27,7 +27,6 @@
 #include "DisplayListReplayer.h"
 #include "FilterOperations.h"
 #include "GraphicsContext.h"
-#include "HTMLParserIdioms.h"
 #include "InlineIteratorTextBox.h"
 #include "LayoutIntegrationInlineContent.h"
 #include "LegacyInlineTextBox.h"
@@ -110,7 +109,7 @@ void TextPainter::paintTextOrEmphasisMarks(const FontCascade& font, const TextRu
     ASSERT(startOffset < endOffset);
 
     if (m_context.detectingContentfulPaint()) {
-        if (!textRun.text().isAllSpecialCharacters<isHTMLSpace>())
+        if (!textRun.text().isAllSpecialCharacters<isASCIIWhitespace>())
             m_context.setContentfulPaintDetected();
         return;
     }

--- a/Source/WebCore/rendering/updating/RenderTreeUpdater.cpp
+++ b/Source/WebCore/rendering/updating/RenderTreeUpdater.cpp
@@ -31,7 +31,6 @@
 #include "ComposedTreeIterator.h"
 #include "Document.h"
 #include "Element.h"
-#include "HTMLParserIdioms.h"
 #include "HTMLSlotElement.h"
 #include "LayoutState.h"
 #include "LayoutTreeBuilder.h"
@@ -163,7 +162,7 @@ void RenderTreeUpdater::updateRenderTree(ContainerNode& root)
             auto& text = downcast<Text>(node);
             auto* textUpdate = m_styleUpdate->textUpdate(text);
             bool didCreateParent = parent().update && parent().update->change == Style::Change::Renderer;
-            bool mayNeedUpdateWhitespaceOnlyRenderer = renderingParent().didCreateOrDestroyChildRenderer && text.data().isAllSpecialCharacters<isHTMLSpace>();
+            bool mayNeedUpdateWhitespaceOnlyRenderer = renderingParent().didCreateOrDestroyChildRenderer && text.data().isAllSpecialCharacters<isASCIIWhitespace>();
             if (didCreateParent || textUpdate || mayNeedUpdateWhitespaceOnlyRenderer)
                 updateTextRenderer(text, textUpdate);
 
@@ -443,7 +442,7 @@ bool RenderTreeUpdater::textRendererIsNeeded(const Text& textNode)
         return true;
     if (!textNode.length())
         return false;
-    if (!textNode.data().isAllSpecialCharacters<isHTMLSpace>())
+    if (!textNode.data().isAllSpecialCharacters<isASCIIWhitespace>())
         return true;
     if (is<RenderText>(renderingParent.previousChildRenderer))
         return true;

--- a/Source/WebCore/style/StyleTreeResolver.cpp
+++ b/Source/WebCore/style/StyleTreeResolver.cpp
@@ -33,7 +33,6 @@
 #include "HTMLInputElement.h"
 #include "HTMLMeterElement.h"
 #include "HTMLNames.h"
-#include "HTMLParserIdioms.h"
 #include "HTMLProgressElement.h"
 #include "HTMLSlotElement.h"
 #include "LoaderStrategy.h"
@@ -837,7 +836,7 @@ void TreeResolver::resolveComposedTree()
                 m_update->addText(text, parent.element, WTFMove(textUpdate));
             }
 
-            if (!text.data().isAllSpecialCharacters<isHTMLSpace>())
+            if (!text.data().isAllSpecialCharacters<isASCIIWhitespace>())
                 parent.resolvedFirstLineAndLetterChild = true;
 
             text.setHasValidStyle();

--- a/Source/WebCore/svg/SVGAnimationElement.cpp
+++ b/Source/WebCore/svg/SVGAnimationElement.cpp
@@ -156,7 +156,7 @@ bool SVGAnimationElement::attributeContainsJavaScriptURL(const Attribute& attrib
 
     if (attribute.name() == SVGNames::valuesAttr) {
         for (auto innerValue : StringView(attribute.value()).split(';')) {
-            if (WTF::protocolIsJavaScript(innerValue.stripLeadingAndTrailingMatchedCharacters(isHTMLSpace<UChar>)))
+            if (WTF::protocolIsJavaScript(innerValue.stripLeadingAndTrailingMatchedCharacters(isASCIIWhitespace<UChar>)))
                 return true;
         }
         return false;
@@ -176,7 +176,7 @@ void SVGAnimationElement::attributeChanged(const QualifiedName& name, const Atom
         // http://www.w3.org/TR/SVG11/animate.html#ValuesAttribute
         m_values.clear();
         newValue.string().split(';', [this](StringView innerValue) {
-            m_values.append(innerValue.stripLeadingAndTrailingMatchedCharacters(isHTMLSpace<UChar>).toString());
+            m_values.append(innerValue.stripLeadingAndTrailingMatchedCharacters(isASCIIWhitespace<UChar>).toString());
         });
         updateAnimationMode();
         break;

--- a/Source/WebGPU/WGSL/Lexer.cpp
+++ b/Source/WebGPU/WGSL/Lexer.cpp
@@ -461,7 +461,7 @@ template <typename T>
 void Lexer<T>::skipWhitespaceAndComments()
 {
     while (!isAtEndOfFile()) {
-        if (isASCIISpace(m_current)) {
+        if (isUnicodeCompatibleASCIIWhitespace(m_current)) {
             if (shift() == '\n')
                 newLine();
         } else if (peek(0) == '/') {

--- a/Source/WebKit/Shared/linux/WebMemorySamplerLinux.cpp
+++ b/Source/WebKit/Shared/linux/WebMemorySamplerLinux.cpp
@@ -58,9 +58,9 @@ static inline String nextToken(FILE* file)
     unsigned int index = 0;
     while (index < maxBuffer) {
         int ch = fgetc(file);
-        if (ch == EOF || (isASCIISpace(ch) && index)) // Break on non-initial ASCII space.
+        if (ch == EOF || (isUnicodeCompatibleASCIIWhitespace(ch) && index)) // Break on non-initial ASCII space.
             break;
-        if (!isASCIISpace(ch)) {
+        if (!isUnicodeCompatibleASCIIWhitespace(ch)) {
             buffer[index] = ch;
             index++;
         }

--- a/Source/WebKit/WebProcess/WebPage/ios/WebPageIOS.mm
+++ b/Source/WebKit/WebProcess/WebPage/ios/WebPageIOS.mm
@@ -360,7 +360,7 @@ void WebPage::getPlatformEditorState(LocalFrame& frame, EditorState& result) con
                 postLayoutData.selectedEditableImage = contextForElement(*imageElement);
         }
         // FIXME: We should disallow replace when the string contains only CJ characters.
-        postLayoutData.isReplaceAllowed = result.isContentEditable && !result.isInPasswordField && !selectedText.isAllSpecialCharacters<isHTMLSpace>();
+        postLayoutData.isReplaceAllowed = result.isContentEditable && !result.isInPasswordField && !selectedText.isAllSpecialCharacters<isASCIIWhitespace>();
     }
 
 #if USE(DICTATION_ALTERNATIVES)


### PR DESCRIPTION
#### 7f7aade4cf4a5c2688604f64e7b0f901771a3241
<pre>
Rename isHTMLSpace and move it to WTF
<a href="https://bugs.webkit.org/show_bug.cgi?id=255840">https://bugs.webkit.org/show_bug.cgi?id=255840</a>
rdar://108419120

Reviewed by Darin Adler.

Rename isHTMLSpace to isASCIIWhitespace to align it with the Infra standard, make it a constexpr
following precedent set in c650d41f8945032a348d7ffd4e11c9ca2dd75ea7, and move it to WTF to make it
more easily usable throughout WebKit. Put it in ASCIICType.h because based on
169adaafef454897deb4507150d2708430e4de01 it seemed like a reasonable place for ASCII-related
functionality.

Likewise for isNotHTMLSpace though non-predicate instances are replaced with !isASCIIWhitespace.

At the same time rename isASCIISpace to isUnicodeCompatibleASCIIWhitespace to make it clearer this
does not match the typical web standard usage and has to be somewhat carefully considered. Auditing
of existing usage will continue in <a href="https://bugs.webkit.org/show_bug.cgi?id=255467">https://bugs.webkit.org/show_bug.cgi?id=255467</a> and dependencies.

* Source/JavaScriptCore/bytecode/ReduceWhitespace.cpp:
(JSC::reduceWhitespace):
* Source/JavaScriptCore/runtime/ConfigFile.cpp:
(JSC::ConfigFileScanner::fillBufferIfNeeded):
(JSC::ConfigFile::parse):
* Source/JavaScriptCore/runtime/Options.cpp:
(JSC::isSeparator):
* Source/JavaScriptCore/tools/FunctionOverrides.cpp:
(JSC::hasDisallowedCharacters):
* Source/WTF/wtf/ASCIICType.h:
(WTF::isASCIIWhitespace):
(WTF::isUnicodeCompatibleASCIIWhitespace):
(WTF::isNotASCIIWhitespace):
(WTF::isASCIISpace): Deleted.
* Source/WTF/wtf/DateMath.cpp:
(WTF::skipSpacesAndComments):
(WTF::parseDateFromNullTerminatedCharacters):
* Source/WTF/wtf/text/Base64.cpp:
(WTF::base64DecodeInternal):
* Source/WTF/wtf/text/StringImpl.h:
(WTF::isSpaceOrNewline):
(WTF::isUnicodeWhitespace):
* Source/WTF/wtf/text/StringToIntegerConversion.h:
(WTF::parseInteger):
* Source/WTF/wtf/text/StringView.cpp:
(WTF::StringView::stripWhiteSpace const):
* Source/WTF/wtf/text/WTFString.cpp:
(WTF::toDoubleType):
* Source/WebCore/Modules/mediarecorder/MediaRecorderProvider.cpp:
(WebCore::MediaRecorderProvider::isSupported):
* Source/WebCore/accessibility/AXObjectCache.cpp:
(WebCore::AXObjectCache::traverseToOffsetInRange):
* Source/WebCore/accessibility/AccessibilityList.cpp:
(WebCore::AccessibilityList::childHasPseudoVisibleListItemMarkers):
* Source/WebCore/accessibility/AccessibilityRenderObject.cpp:
(WebCore::objectInclusionFromAltText):
(WebCore::AccessibilityRenderObject::computeAccessibilityIsIgnored const):
* Source/WebCore/contentextensions/Term.h:
(WebCore::ContentExtensions::Term::toString const):
* Source/WebCore/css/SelectorChecker.cpp:
(WebCore::attributeValueMatches):
* Source/WebCore/css/parser/CSSParserFastPaths.cpp:
(WebCore::parseColorIntOrPercentage):
(WebCore::parseAlphaValue):
* Source/WebCore/css/parser/CSSTokenizer.cpp:
(WebCore::CSSTokenizer::consumeURLToken):
(WebCore::CSSTokenizer::consumeSingleWhitespaceIfNext):
* Source/WebCore/css/parser/CSSTokenizerInputStream.cpp:
(WebCore::CSSTokenizerInputStream::advanceUntilNonWhitespace):
* Source/WebCore/cssjit/SelectorCompiler.cpp:
(WebCore::SelectorCompiler::constructFragmentsInternal):
(WebCore::SelectorCompiler::attributeValueSpaceSeparatedListContains):
* Source/WebCore/dom/Document.cpp:
(WebCore::canonicalizedTitle):
(WebCore::processColorSchemeString):
* Source/WebCore/dom/Position.cpp:
(WebCore::Position::leadingWhitespacePosition const):
(WebCore::Position::trailingWhitespacePosition const):
* Source/WebCore/dom/SecurityContext.cpp:
(WebCore::SecurityContext::parseSandboxPolicy):
* Source/WebCore/dom/ShadowRoot.cpp:
(WebCore::parsePartMapping):
* Source/WebCore/dom/SpaceSplitString.cpp:
(WebCore::tokenizeSpaceSplitString):
* Source/WebCore/editing/TextManipulationController.cpp:
(WebCore::isNotSpace):
(WebCore::TextManipulationController::parse):
* Source/WebCore/html/DOMTokenList.cpp:
(WebCore::tokenContainsHTMLSpace):
(WebCore::DOMTokenList::updateTokensFromAttributeValue):
* Source/WebCore/html/FeaturePolicy.cpp:
(WebCore::processOriginItem):
(WebCore::updateList):
(WebCore::FeaturePolicy::parse):
* Source/WebCore/html/HTMLElement.cpp:
(WebCore::HTMLElement::parseLegacyColorValue):
* Source/WebCore/html/HTMLFontElement.cpp:
(WebCore::parseFontSize):
* Source/WebCore/html/HTMLImageElement.cpp:
(WebCore::extractMIMETypeFromTypeAttributeForLookup):
* Source/WebCore/html/HTMLInputElement.cpp:
(WebCore::parseAcceptAttribute):
* Source/WebCore/html/HTMLObjectElement.cpp:
(WebCore::HTMLObjectElement::hasFallbackContent const):
(WebCore::preventsParentObjectFromExposure):
* Source/WebCore/html/HTMLOptionElement.cpp:
(WebCore::HTMLOptionElement::text const):
(WebCore::HTMLOptionElement::value const):
(WebCore::HTMLOptionElement::label const):
(WebCore::HTMLOptionElement::displayLabel const):
* Source/WebCore/html/parser/CSSPreloadScanner.cpp:
(WebCore::CSSPreloadScanner::tokenize):
(WebCore::parseCSSStringOrURL):
(WebCore::hasValidImportConditions):
* Source/WebCore/html/parser/HTMLDocumentParserFastPath.cpp:
(WebCore::isCharAfterTagNameOrAttribute):
(WebCore::isCharAfterUnquotedAttribute):
(WebCore::HTMLFastPathParser::scanTagName):
(WebCore::HTMLFastPathParser::scanAttributeValue):
(WebCore::HTMLFastPathParser::scanEscapedAttributeValue):
(WebCore::HTMLFastPathParser::parseAttributes):
(WebCore::HTMLFastPathParser::parseContainerElement):
* Source/WebCore/html/parser/HTMLMetaCharsetParser.cpp:
(WebCore::HTMLMetaCharsetParser::encodingFromMetaAttributes):
* Source/WebCore/html/parser/HTMLParserIdioms.cpp:
(WebCore::stripLeadingAndTrailingHTMLSpaces):
(WebCore::parseHTMLIntegerInternal):
(WebCore::isHTMLSpaceOrDelimiter):
(WebCore::parseHTTPRefreshInternal):
(WebCore::parseHTMLDimensionNumber):
* Source/WebCore/html/parser/HTMLParserIdioms.h:
(WebCore::isHTMLSpaceOrComma):
(WebCore::isHTMLSpaceButNotLineBreak):
(WebCore::isHTMLSpace): Deleted.
(WebCore::isNotHTMLSpace): Deleted.
* Source/WebCore/html/parser/HTMLPreloadScanner.cpp:
(WebCore::TokenPreloadScanner::StartTagScanner::processImageAndScriptAttribute):
(WebCore::TokenPreloadScanner::StartTagScanner::processAttribute):
(WebCore::TokenPreloadScanner::StartTagScanner::setURLToLoadAllowingReplacement):
* Source/WebCore/html/parser/HTMLSrcsetParser.cpp:
(WebCore::tokenizeDescriptors):
(WebCore::parseImageCandidatesFromSrcsetAttribute):
* Source/WebCore/html/parser/HTMLTreeBuilder.cpp:
(WebCore::isAllWhitespace):
(WebCore::isAllWhitespaceOrReplacementCharacters):
(WebCore::HTMLTreeBuilder::ExternalCharacterTokenBuffer::skipLeadingWhitespace):
(WebCore::HTMLTreeBuilder::ExternalCharacterTokenBuffer::takeLeadingWhitespace):
(WebCore::HTMLTreeBuilder::ExternalCharacterTokenBuffer::skipLeadingNonWhitespace):
(WebCore::HTMLTreeBuilder::ExternalCharacterTokenBuffer::takeRemainingWhitespace):
* Source/WebCore/html/parser/ParsingUtilities.h:
(WebCore::isNotASCIISpace):
* Source/WebCore/html/track/VTTRegion.cpp:
(WebCore::VTTRegion::setRegionSettings):
(WebCore::VTTRegion::parseSettingValue):
* Source/WebCore/html/track/WebVTTParser.cpp:
(WebCore::WebVTTParser::hasRequiredFileIdentifier):
(WebCore::WebVTTParser::collectTimingsAndSettings):
* Source/WebCore/inspector/InspectorStyleSheet.cpp:
(WebCore::StyleSheetHandler::setRuleHeaderEnd):
(WebCore::fixUnparsedProperties):
* Source/WebCore/inspector/agents/InspectorDOMAgent.cpp:
(WebCore::containsOnlyHTMLWhitespace):
* Source/WebCore/loader/FrameLoader.cpp:
(WebCore::extractContentLanguageFromHeader):
* Source/WebCore/loader/SubresourceIntegrity.cpp:
(WebCore::splitOnSpaces):
* Source/WebCore/mathml/MathMLMencloseElement.cpp:
(WebCore::MathMLMencloseElement::parseNotationAttribute):
* Source/WebCore/mathml/MathMLPresentationElement.cpp:
(WebCore::MathMLPresentationElement::parseMathMLLength):
* Source/WebCore/page/LocalFrameView.cpp:
(WebCore::LocalFrameView::incrementVisuallyNonEmptyCharacterCount):
* Source/WebCore/page/WindowFeatures.cpp:
(WebCore::isSeparator):
* Source/WebCore/page/csp/ContentSecurityPolicy.cpp:
(WebCore::ContentSecurityPolicy::didReceiveHeader):
* Source/WebCore/page/csp/ContentSecurityPolicyDirectiveList.cpp:
(WebCore::isDirectiveValueCharacter):
(WebCore::ContentSecurityPolicyDirectiveList::parseDirective):
(WebCore::ContentSecurityPolicyDirectiveList::parseReportURI):
(WebCore::ContentSecurityPolicyDirectiveList::parseReportTo):
* Source/WebCore/page/csp/ContentSecurityPolicyMediaListDirective.cpp:
(WebCore::isMediaTypeCharacter):
(WebCore::ContentSecurityPolicyMediaListDirective::parse):
* Source/WebCore/page/csp/ContentSecurityPolicySourceList.cpp:
(WebCore::isSourceCharacter):
(WebCore::isSourceListNone):
(WebCore::ContentSecurityPolicySourceList::parse):
* Source/WebCore/page/linux/ResourceUsageThreadLinux.cpp:
(WebCore::threadCPUUsage):
* Source/WebCore/platform/ContentType.cpp:
(WebCore::ContentType::parameter const):
(WebCore::splitParameters):
* Source/WebCore/platform/graphics/ComplexTextController.cpp:
(WebCore::shouldSynthesize):
* Source/WebCore/rendering/LegacyLineLayout.cpp:
(WebCore::endsWithHTMLSpaces):
* Source/WebCore/rendering/RenderBlockFlow.cpp:
(WebCore::isVisibleRenderText):
* Source/WebCore/rendering/RenderLayer.cpp:
(WebCore::RenderLayer::calculateClipRects const):
* Source/WebCore/rendering/RenderText.cpp:
(WebCore::RenderText::trimmedPreferredWidths):
* Source/WebCore/rendering/TextPainter.cpp:
(WebCore::TextPainter::paintTextOrEmphasisMarks):
* Source/WebCore/rendering/updating/RenderTreeUpdater.cpp:
(WebCore::RenderTreeUpdater::updateRenderTree):
(WebCore::RenderTreeUpdater::textRendererIsNeeded):
* Source/WebCore/style/StyleTreeResolver.cpp:
(WebCore::Style::TreeResolver::resolveComposedTree):
* Source/WebCore/svg/SVGAnimationElement.cpp:
(WebCore::SVGAnimationElement::attributeContainsJavaScriptURL const):
(WebCore::SVGAnimationElement::attributeChanged):
* Source/WebGPU/WGSL/Lexer.cpp:
(WGSL::Lexer&lt;T&gt;::skipWhitespaceAndComments):
* Source/WebKit/Shared/linux/WebMemorySamplerLinux.cpp:
(WebKit::nextToken):
* Source/WebKit/WebProcess/WebPage/ios/WebPageIOS.mm:
(WebKit::WebPage::getPlatformEditorState const):

Canonical link: <a href="https://commits.webkit.org/263290@main">https://commits.webkit.org/263290@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/bc89fd18718e034d232d73111292da0486d06942

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/4158 "3 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/4272 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/4390 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/5622 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/4403 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/4147 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/4374 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/4237 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/4626 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/4217 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/4392 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/3748 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/5615 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/1888 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/3725 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/5906 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/3452 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/3715 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/3790 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/5309 "Passed tests") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/3947 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/4193 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/3397 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/4251 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/3706 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/3723 "Passed tests") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/1041 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/1019 "Built successfully and passed tests") | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/4/builds/7828 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/24/builds/4347 "Built successfully") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/3988 "Built successfully") | | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/3/builds/1159 "Passed tests") | 
<!--EWS-Status-Bubble-End-->