### PR TITLE
XPath: Do not accept whitespace characters other than #x20, #x9, #xD, and #xA & fix normalize-space()

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/domxpath/fn-normalize-space-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/domxpath/fn-normalize-space-expected.txt
@@ -2,5 +2,5 @@ a
 b
 
 PASS normalize-space() without arguments
-FAIL normalize-space() should handle only #x20, #x9, #xD, and #xA assert_equals: expected "y\v\f\x0e\x0fz" but got "y \x0e\x0fz"
+PASS normalize-space() should handle only #x20, #x9, #xD, and #xA
 

--- a/LayoutTests/imported/w3c/web-platform-tests/domxpath/lexical-structure-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/domxpath/lexical-structure-expected.txt
@@ -1,4 +1,4 @@
 
 PASS Literal: Only ' and " should be handled as literal quotes.
-FAIL ExprWhitespace: Only #x20 #x9 #xD or #xA must be handled as a whitespace. assert_throws_dom: function "() => { parse('\x0B\x0C .'); }" did not throw
+PASS ExprWhitespace: Only #x20 #x9 #xD or #xA must be handled as a whitespace.
 

--- a/Source/WebCore/xml/XPathFunctions.cpp
+++ b/Source/WebCore/xml/XPathFunctions.cpp
@@ -1,6 +1,7 @@
 /*
  * Copyright (C) 2005 Frerich Raabe <raabe@kde.org>
  * Copyright (C) 2006, 2009, 2013 Apple Inc. All rights reserved.
+ * Copyright (C) 2019 Google Inc. All rights reserved.
  * Copyright (C) 2007 Alexey Proskuryakov <ap@webkit.org>
  *
  * Redistribution and use in source and binary forms, with or without
@@ -564,13 +565,13 @@ Value FunStringLength::evaluate() const
 
 Value FunNormalizeSpace::evaluate() const
 {
+    // https://www.w3.org/TR/1999/REC-xpath-19991116/#function-normalize-space
     if (!argumentCount()) {
         String s = Value(Expression::evaluationContext().node.get()).toString();
-        return s.simplifyWhiteSpace();
+        return s.simplifyWhiteSpace(isXMLSpace);
     }
-
     String s = argument(0).evaluate().toString();
-    return s.simplifyWhiteSpace();
+    return s.simplifyWhiteSpace(isXMLSpace);
 }
 
 Value FunTranslate::evaluate() const

--- a/Source/WebCore/xml/XPathParser.cpp
+++ b/Source/WebCore/xml/XPathParser.cpp
@@ -1,6 +1,7 @@
 /*
  * Copyright 2005 Maksim Orlovich <maksim@kde.org>
  * Copyright (C) 2006, 2013 Apple Inc. All rights reserved.
+ * Copyright (C) 2019 Google Inc. All rights reserved.
  * Copyright (C) 2007 Alexey Proskuryakov <ap@webkit.org>
  *
  * Redistribution and use in source and binary forms, with or without
@@ -32,6 +33,7 @@
 #include "XPathNSResolver.h"
 #include "XPathPath.h"
 #include "XPathStep.h"
+#include "XPathUtil.h"
 #include <wtf/NeverDestroyed.h>
 #include <wtf/RobinHoodHashMap.h>
 #include <wtf/StdLibExtras.h>
@@ -130,9 +132,10 @@ bool Parser::isBinaryOperatorContext() const
     }
 }
 
+// See https://www.w3.org/TR/1999/REC-xpath-19991116/#NT-ExprWhitespace .
 void Parser::skipWS()
 {
-    while (m_nextPos < m_data.length() && isSpaceOrNewline(m_data[m_nextPos]))
+    while (m_nextPos < m_data.length() && isXMLSpace(m_data[m_nextPos]))
         ++m_nextPos;
 }
 

--- a/Source/WebCore/xml/XPathUtil.cpp
+++ b/Source/WebCore/xml/XPathUtil.cpp
@@ -1,6 +1,7 @@
 /*
  * Copyright (C) 2005 Frerich Raabe <raabe@kde.org>
  * Copyright (C) 2006, 2009 Apple Inc.
+ * Copyright (C) 2019 Google Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -71,6 +72,11 @@ bool isValidContextNode(Node& node)
     }
     ASSERT_NOT_REACHED();
     return false;
+}
+
+bool isXMLSpace(UChar character)
+{
+    return character == ' ' || character == '\t' || character == '\r' || character == '\n';
 }
 
 }

--- a/Source/WebCore/xml/XPathUtil.h
+++ b/Source/WebCore/xml/XPathUtil.h
@@ -1,6 +1,7 @@
 /*
  * Copyright 2005 Frerich Raabe <raabe@kde.org>
  * Copyright (C) 2006 Apple Inc.
+ * Copyright (C) 2019 Google Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -42,6 +43,9 @@ namespace WebCore {
 
         /* @return whether the given node is a valid context node */
         bool isValidContextNode(Node&);
+
+        // https://www.w3.org/TR/REC-xml/#NT-S
+        bool isXMLSpace(UChar character);
 
     } // namespace XPath
 


### PR DESCRIPTION
#### 7e1bc9e89bee15c3828b75aa012d3d398de57ae3
<pre>
XPath: Do not accept whitespace characters other than #x20, #x9, #xD, and #xA &amp; fix normalize-space()

<a href="https://bugs.webkit.org/show_bug.cgi?id=255841">https://bugs.webkit.org/show_bug.cgi?id=255841</a>

Reviewed by Chris Dumez.

This patch aligns WebKit with Blink / Chromium and Gecko / Firefox.

Merge: <a href="https://chromium.googlesource.com/chromium/src.git/+/01fd8522eaf35abdfa468f79333b350df96e1b62">https://chromium.googlesource.com/chromium/src.git/+/01fd8522eaf35abdfa468f79333b350df96e1b62</a> &amp;
<a href="https://chromium.googlesource.com/chromium/src.git/+/66c3b1b0ce745473f6478e1fa042d71f00ee9d47">https://chromium.googlesource.com/chromium/src.git/+/66c3b1b0ce745473f6478e1fa042d71f00ee9d47</a>

This patch aligns WebKit with web-spec [1] &amp; [2] and also fixes XML white spaces handling; #x20, #x9, #xD, and #xA.
We incorrectly handled other white spaces such as U+3000.

[1] <a href="https://www.w3.org/TR/1999/REC-xpath-19991116/#function-normalize-space">https://www.w3.org/TR/1999/REC-xpath-19991116/#function-normalize-space</a>
[2] <a href="https://www.w3.org/TR/1999/REC-xpath-19991116/#NT-ExprWhitespace">https://www.w3.org/TR/1999/REC-xpath-19991116/#NT-ExprWhitespace</a>

* Source/WebCore/xml/XPathFunctions.cpp:
(FunNormalizeSpace::evaluate):
* Source/WebCore/xml/XPathUtil.cpp:
(isXMLSpace): Introduce new bool function
* Source/WebCore/xml/XPathUtil.h: new bool function definition
* Source/WebCore/xml/XPathParser.cpp:
(Parser::skipWS): Use new &apos;isXMLSpace&apos; function
* LayoutTests/imported/w3c/web-platform-tests/domxpath/lexical-structure-expected.txt: Rebaselined
* LayoutTests/imported/w3c/web-platform-tests/domxpath/fn-normalize-space-expected.txt: Rebaselined

Canonical link: <a href="https://commits.webkit.org/263311@main">https://commits.webkit.org/263311@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/6946f67af8470406ece668a3f8ba3a548a843134

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/4190 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/4307 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/4425 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/5657 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/4435 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/4181 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/4413 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/4272 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/4657 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/4251 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/4426 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/3778 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/5650 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/1921 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/3755 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/5942 "7 flakes 249 failures") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/3748 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/3821 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/5338 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/4227 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/3428 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/3739 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/3753 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/1034 "Built successfully and passed tests") | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/4/builds/7842 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/4037 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->