### PR TITLE
Add isTabOrSpace to WTF

### DIFF
--- a/Source/WTF/wtf/ASCIICType.h
+++ b/Source/WTF/wtf/ASCIICType.h
@@ -49,6 +49,7 @@ template<typename CharacterType> constexpr bool isASCIIHexDigit(CharacterType);
 template<typename CharacterType> constexpr bool isASCIILower(CharacterType);
 template<typename CharacterType> constexpr bool isASCIIOctalDigit(CharacterType);
 template<typename CharacterType> constexpr bool isASCIIPrintable(CharacterType);
+template<typename CharacterType> constexpr bool isTabOrSpace(CharacterType);
 template<typename CharacterType> constexpr bool isASCIIWhitespace(CharacterType);
 template<typename CharacterType> constexpr bool isUnicodeCompatibleASCIIWhitespace(CharacterType);
 template<typename CharacterType> constexpr bool isASCIIUpper(CharacterType);
@@ -130,6 +131,11 @@ template<typename CharacterType> constexpr bool isASCIIOctalDigit(CharacterType 
 template<typename CharacterType> constexpr bool isASCIIPrintable(CharacterType character)
 {
     return character >= ' ' && character <= '~';
+}
+
+template<typename CharacterType> constexpr bool isTabOrSpace(CharacterType character)
+{
+    return character == ' ' || character == '\t';
 }
 
 // Infra's "ASCII whitespace" <https://infra.spec.whatwg.org/#ascii-whitespace>
@@ -268,6 +274,7 @@ using WTF::isASCIIHexDigit;
 using WTF::isASCIILower;
 using WTF::isASCIIOctalDigit;
 using WTF::isASCIIPrintable;
+using WTF::isTabOrSpace;
 using WTF::isASCIIWhitespace;
 using WTF::isUnicodeCompatibleASCIIWhitespace;
 using WTF::isASCIIUpper;

--- a/Source/WebCore/Modules/fetch/FetchBodyConsumer.cpp
+++ b/Source/WebCore/Modules/fetch/FetchBodyConsumer.cpp
@@ -38,7 +38,6 @@
 #include "JSBlob.h"
 #include "JSDOMFormData.h"
 #include "JSDOMPromiseDeferred.h"
-#include "RFC7230.h"
 #include "TextResourceDecoder.h"
 #include <wtf/StringExtras.h>
 #include <wtf/URLParser.h>
@@ -68,7 +67,7 @@ static HashMap<String, String> parseParameters(StringView input, size_t position
 {
     HashMap<String, String> parameters;
     while (position < input.length()) {
-        while (position < input.length() && RFC7230::isWhitespace(input[position]))
+        while (position < input.length() && isTabOrSpace(input[position]))
             position++;
         size_t nameBegin = position;
         while (position < input.length() && input[position] != '=' && input[position] != ';')

--- a/Source/WebCore/html/track/VTTCue.cpp
+++ b/Source/WebCore/html/track/VTTCue.cpp
@@ -1131,7 +1131,7 @@ void VTTCue::setCueSettings(const String& inputString)
 
         // The WebVTT cue settings part of a WebVTT cue consists of zero or more of the following components, in any order, 
         // separated from each other by one or more U+0020 SPACE characters or U+0009 CHARACTER TABULATION (tab) characters.
-        input.skipWhile<WebVTTParser::isValidSettingDelimiter>();
+        input.skipWhile<isTabOrSpace>();
         if (input.isAtEnd())
             break;
 
@@ -1145,7 +1145,7 @@ void VTTCue::setCueSettings(const String& inputString)
         CueSetting name = settingName(input);
 
         // 3. Let value be the trailing substring of setting starting from the character immediately after the first U+003A COLON character (:) in that string.
-        VTTScanner::Run valueRun = input.collectUntil<WebVTTParser::isValidSettingDelimiter>();
+        VTTScanner::Run valueRun = input.collectUntil<isTabOrSpace>();
 
         // 4. Run the appropriate substeps that apply for the value of name, as follows:
         switch (name) {

--- a/Source/WebCore/html/track/VTTRegion.cpp
+++ b/Source/WebCore/html/track/VTTRegion.cpp
@@ -163,7 +163,7 @@ void VTTRegion::setRegionSettings(const String& inputString)
     VTTScanner input(inputString);
 
     while (!input.isAtEnd()) {
-        input.skipWhile<WebVTTParser::isValidSettingDelimiter>();
+        input.skipWhile<isTabOrSpace>();
         if (input.isAtEnd())
             break;
 

--- a/Source/WebCore/html/track/WebVTTParser.cpp
+++ b/Source/WebCore/html/track/WebVTTParser.cpp
@@ -326,7 +326,7 @@ bool WebVTTParser::checkAndCreateRegion(StringView line)
     // line starts with the substring "REGION" and remaining characters
     // zero or more U+0020 SPACE characters or U+0009 CHARACTER TABULATION
     // (tab) characters expected other than these characters it is invalid.
-    if (line.startsWith("REGION"_s) && line.substring(regionIdentifierLength).isAllSpecialCharacters<isASpace>()) {
+    if (line.startsWith("REGION"_s) && line.substring(regionIdentifierLength).isAllSpecialCharacters<isASCIIWhitespace>()) {
         m_currentRegion = VTTRegion::create(m_document);
         return true;
     }
@@ -355,7 +355,7 @@ bool WebVTTParser::checkStyleSheet(StringView line)
     // line starts with the substring "STYLE" and remaining characters
     // zero or more U+0020 SPACE characters or U+0009 CHARACTER TABULATION
     // (tab) characters expected other than these characters it is invalid.
-    if (line.startsWith("STYLE"_s) && line.substring(styleIdentifierLength).isAllSpecialCharacters<isASpace>())
+    if (line.startsWith("STYLE"_s) && line.substring(styleIdentifierLength).isAllSpecialCharacters<isASCIIWhitespace>())
         return true;
 
     return false;

--- a/Source/WebCore/html/track/WebVTTParser.h
+++ b/Source/WebCore/html/track/WebVTTParser.h
@@ -122,20 +122,6 @@ public:
             || tagName == rtTag;
     }
 
-    static inline bool isASpace(UChar c)
-    {
-        // WebVTT space characters are U+0020 SPACE, U+0009 CHARACTER
-        // TABULATION (tab), U+000A LINE FEED (LF), U+000C FORM FEED (FF), and
-        // U+000D CARRIAGE RETURN (CR).
-        return c == ' ' || c == '\t' || c == '\n' || c == '\f' || c == '\r';
-    }
-
-    static inline bool isValidSettingDelimiter(UChar c)
-    {
-        // ... a WebVTT cue consists of zero or more of the following components, in any order, separated from each other by one or more 
-        // U+0020 SPACE characters or U+0009 CHARACTER TABULATION (tab) characters.
-        return c == ' ' || c == '\t';
-    }
     static bool collectTimeStamp(const String&, MediaTime&);
 
     // Useful functions for parsing percentage settings.

--- a/Source/WebCore/loader/HTTPHeaderField.cpp
+++ b/Source/WebCore/loader/HTTPHeaderField.cpp
@@ -32,8 +32,8 @@ namespace WebCore {
 
 std::optional<HTTPHeaderField> HTTPHeaderField::create(String&& unparsedName, String&& unparsedValue)
 {
-    StringView strippedName = StringView(unparsedName).stripLeadingAndTrailingMatchedCharacters(RFC7230::isWhitespace<UChar>);
-    StringView strippedValue = StringView(unparsedValue).stripLeadingAndTrailingMatchedCharacters(RFC7230::isWhitespace<UChar>);
+    StringView strippedName = StringView(unparsedName).stripLeadingAndTrailingMatchedCharacters(isTabOrSpace<UChar>);
+    StringView strippedValue = StringView(unparsedValue).stripLeadingAndTrailingMatchedCharacters(isTabOrSpace<UChar>);
     if (!RFC7230::isValidName(strippedName) || !RFC7230::isValidValue(strippedValue))
         return std::nullopt;
 

--- a/Source/WebCore/loader/HeaderFieldTokenizer.cpp
+++ b/Source/WebCore/loader/HeaderFieldTokenizer.cpp
@@ -40,7 +40,7 @@ HeaderFieldTokenizer::HeaderFieldTokenizer(const String& headerField)
 
 bool HeaderFieldTokenizer::consume(UChar c)
 {
-    ASSERT(c != ' ' && c != '\t');
+    ASSERT(!isTabOrSpace(c));
 
     if (isConsumed() || m_input[m_index] != c)
         return false;
@@ -102,7 +102,7 @@ String HeaderFieldTokenizer::consumeTokenOrQuotedString()
 
 void HeaderFieldTokenizer::skipSpaces()
 {
-    while (!isConsumed() && RFC7230::isWhitespace(m_input[m_index]))
+    while (!isConsumed() && isTabOrSpace(m_input[m_index]))
         ++m_index;
 }
 

--- a/Source/WebCore/loader/LinkHeader.cpp
+++ b/Source/WebCore/loader/LinkHeader.cpp
@@ -32,12 +32,6 @@
 
 namespace WebCore {
 
-// LWSP definition in https://www.ietf.org/rfc/rfc0822.txt
-template<typename CharacterType> static bool isSpaceOrTab(CharacterType character)
-{
-    return character == ' ' || character == '\t';
-}
-
 template<typename CharacterType> static bool isNotURLTerminatingChar(CharacterType character)
 {
     return character != '>';
@@ -61,7 +55,7 @@ template<typename CharacterType> static bool isParameterValueEnd(CharacterType c
 
 template<typename CharacterType> static bool isParameterValueChar(CharacterType character)
 {
-    return !isSpaceOrTab(character) && !isParameterValueEnd(character);
+    return !isTabOrSpace(character) && !isParameterValueEnd(character);
 }
 
 // Verify that the parameter is a link-extension which according to spec doesn't have to have a value.
@@ -83,10 +77,10 @@ static bool isExtensionParameter(LinkHeader::LinkParameterName name)
 //          position     end
 template<typename CharacterType> static std::optional<String> findURLBoundaries(StringParsingBuffer<CharacterType>& buffer)
 {
-    skipWhile<isSpaceOrTab>(buffer);
+    skipWhile<isTabOrSpace>(buffer);
     if (!skipExactly(buffer, '<'))
         return std::nullopt;
-    skipWhile<isSpaceOrTab>(buffer);
+    skipWhile<isTabOrSpace>(buffer);
 
     auto urlStart = buffer.position();
     skipWhile<isNotURLTerminatingChar>(buffer);
@@ -122,12 +116,12 @@ template<typename CharacterType> static bool validFieldEnd(StringParsingBuffer<C
 template<typename CharacterType> static bool parseParameterDelimiter(StringParsingBuffer<CharacterType>& buffer, bool& isValid)
 {
     isValid = true;
-    skipWhile<isSpaceOrTab>(buffer);
+    skipWhile<isTabOrSpace>(buffer);
     if (invalidParameterDelimiter(buffer)) {
         isValid = false;
         return false;
     }
-    skipWhile<isSpaceOrTab>(buffer);
+    skipWhile<isTabOrSpace>(buffer);
     if (validFieldEnd(buffer))
         return false;
     return true;
@@ -182,9 +176,9 @@ template<typename CharacterType> static std::optional<LinkHeader::LinkParameterN
     auto nameStart = buffer.position();
     skipWhile<isValidParameterNameChar>(buffer);
     auto nameEnd = buffer.position();
-    skipWhile<isSpaceOrTab>(buffer);
+    skipWhile<isTabOrSpace>(buffer);
     bool hasEqual = skipExactly(buffer, '=');
-    skipWhile<isSpaceOrTab>(buffer);
+    skipWhile<isTabOrSpace>(buffer);
     auto name = parameterNameFromString(StringView { nameStart, static_cast<unsigned>(nameEnd - nameStart) });
     if (hasEqual)
         return name;
@@ -244,7 +238,7 @@ template<typename CharacterType> static bool parseParameterValue(StringParsingBu
     if (!hasQuotes)
         skipWhile<isParameterValueChar>(buffer);
     valueEnd = buffer.position();
-    skipWhile<isSpaceOrTab>(buffer);
+    skipWhile<isTabOrSpace>(buffer);
     if ((!completeQuotes && valueStart == valueEnd) || (!buffer.atEnd() && !isParameterValueEnd(*buffer))) {
         value = emptyString();
         return false;

--- a/Source/WebCore/platform/network/RFC7230.cpp
+++ b/Source/WebCore/platform/network/RFC7230.cpp
@@ -69,7 +69,7 @@ static bool isOBSText(UChar c)
 
 static bool isQuotedTextCharacter(UChar c)
 {
-    return isWhitespace(c)
+    return isTabOrSpace(c)
         || c == 0x21
         || isInRange<0x23, 0x5B>(c)
         || isInRange<0x5D, 0x7E>(c)
@@ -78,14 +78,14 @@ static bool isQuotedTextCharacter(UChar c)
 
 bool isQuotedPairSecondOctet(UChar c)
 {
-    return isWhitespace(c)
+    return isTabOrSpace(c)
         || isVisibleCharacter(c)
         || isOBSText(c);
 }
 
 bool isCommentText(UChar c)
 {
-    return isWhitespace(c)
+    return isTabOrSpace(c)
         || isInRange<0x21, 0x27>(c)
         || isInRange<0x2A, 0x5B>(c)
         || isInRange<0x5D, 0x7E>(c)
@@ -119,7 +119,7 @@ bool isValidValue(StringView value)
         UChar c = value[i];
         switch (state) {
         case State::OptionalWhitespace:
-            if (isWhitespace(c))
+            if (isTabOrSpace(c))
                 continue;
             hadNonWhitespace = true;
             if (isTokenCharacter(c)) {

--- a/Source/WebCore/platform/network/RFC7230.h
+++ b/Source/WebCore/platform/network/RFC7230.h
@@ -37,9 +37,4 @@ bool isDelimiter(UChar);
 bool isValidName(StringView);
 bool isValidValue(StringView);
 
-template<typename CharacterType> constexpr bool isWhitespace(CharacterType character)
-{
-    return character == ' ' || character == '\t';
-}
-
 } // namespace RFC7230

--- a/Source/WebCore/platform/network/RFC8941.cpp
+++ b/Source/WebCore/platform/network/RFC8941.cpp
@@ -218,12 +218,12 @@ template<typename CharType> static std::optional<HashMap<String, std::pair<ItemO
             member = std::pair { WTFMove(value), WTFMove(*parameters) };
         }
         dictionary.set(key.toString(), WTFMove(member));
-        skipWhile<RFC7230::isWhitespace>(buffer);
+        skipWhile<isTabOrSpace>(buffer);
         if (buffer.atEnd())
             return dictionary;
         if (!skipExactly(buffer, ','))
             return std::nullopt;
-        skipWhile<RFC7230::isWhitespace>(buffer);
+        skipWhile<isTabOrSpace>(buffer);
         if (buffer.atEnd())
             return std::nullopt;
     }


### PR DESCRIPTION
#### 2ae8e53cdb4a77a7b7ebf9c8a790fbe8099f60eb
<pre>
Add isTabOrSpace to WTF
<a href="https://bugs.webkit.org/show_bug.cgi?id=255842">https://bugs.webkit.org/show_bug.cgi?id=255842</a>
rdar://108426795

Reviewed by Darin Adler.

Consolidates a number of separate initiatives at defining (and inlining) tab &apos;\t&apos; or space &apos; &apos;.

* Source/WTF/wtf/ASCIICType.h:
(WTF::isASCIITabOrSpace):
* Source/WebCore/Modules/fetch/FetchBodyConsumer.cpp:
(WebCore::parseParameters):
* Source/WebCore/html/track/VTTCue.cpp:
(WebCore::VTTCue::setCueSettings):
* Source/WebCore/html/track/VTTRegion.cpp:
(WebCore::VTTRegion::setRegionSettings):
* Source/WebCore/html/track/WebVTTParser.cpp:
(WebCore::WebVTTParser::checkAndCreateRegion):
(WebCore::WebVTTParser::checkStyleSheet):

The comment here talks about tab or space, but this preserves the existing functionality for now,
modulo using isASCIIWhitespace instead of something locally defined. This might be worth following
up on.

* Source/WebCore/html/track/WebVTTParser.h:
* Source/WebCore/loader/HTTPHeaderField.cpp:
(WebCore::HTTPHeaderField::create):
* Source/WebCore/loader/HeaderFieldTokenizer.cpp:
(WebCore::HeaderFieldTokenizer::consume):
(WebCore::HeaderFieldTokenizer::skipSpaces):
* Source/WebCore/loader/LinkHeader.cpp:
(WebCore::isParameterValueChar):
(WebCore::findURLBoundaries):
(WebCore::parseParameterDelimiter):
(WebCore::parseParameterName):
(WebCore::parseParameterValue):
(WebCore::isSpaceOrTab): Deleted.
* Source/WebCore/platform/network/HTTPParsers.cpp:
(WebCore::skipWhiteSpace):
(WebCore::skipValue):
(WebCore::isValidHTTPHeaderValue):
(WebCore::extractMIMETypeFromMediaType):
(WebCore::parseRange):
(WebCore::isTabOrSpace): Deleted.
* Source/WebCore/platform/network/RFC7230.cpp:
(RFC7230::isQuotedTextCharacter):
(RFC7230::isQuotedPairSecondOctet):
(RFC7230::isCommentText):
(RFC7230::isValidValue):
* Source/WebCore/platform/network/RFC7230.h:
(RFC7230::isWhitespace): Deleted.
* Source/WebCore/platform/network/RFC8941.cpp:
(RFC8941::parseDictionary):

Canonical link: <a href="https://commits.webkit.org/263354@main">https://commits.webkit.org/263354@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c72ceeb538572c712d61f6683f9908e9abc447cd

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/4338 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/4456 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/4584 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/5812 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/4557 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/4330 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/4571 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/4421 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/4783 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/4398 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/4549 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/3904 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/5811 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/2045 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/3881 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/7179 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/3602 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/3875 "Passed tests") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/3948 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/5482 "Passed tests") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/4122 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/4355 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/3538 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/4436 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/3874 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/3879 "Passed tests") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/1104 "Passed tests") | 
| [  ~~🛠 🧪 merge~~](https://ews-build.webkit.org/#/builders/19/builds/1074 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/7930 "Built successfully") | | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/24/builds/4537 "Built successfully") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/4228 "Built successfully") | | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/3/builds/1211 "Passed tests") | 
<!--EWS-Status-Bubble-End-->