### PR TITLE
[Cocoa] Add runtime logging for PlaybackSessionMangager and VideoFullscreenMangager and their proxies

### DIFF
--- a/Source/WTF/wtf/LoggerHelper.h
+++ b/Source/WTF/wtf/LoggerHelper.h
@@ -72,6 +72,15 @@ public:
 #define DEBUG_LOG_IF_POSSIBLE(...)      if (loggerPtr()) loggerPtr()->debug(logChannel(), __VA_ARGS__)
 #define WILL_LOG_IF_POSSIBLE(_level_)   if (loggerPtr()) loggerPtr()->willLog(logChannel(), _level_)
 
+#if defined(__OBJC__)
+#define OBJC_LOGIDENTIFIER WTF::Logger::LogSiteIdentifier(__PRETTY_FUNCTION__, self.logIdentifier)
+#define OBJC_ALWAYS_LOG(...)     if (self.loggerPtr && self.logChannel) self.loggerPtr->logAlways(*self.logChannel, __VA_ARGS__)
+#define OBJC_ERROR_LOG(...)      if (self.loggerPtr && self.logChannel) self.loggerPtr->error(*self.logChannel, __VA_ARGS__)
+#define OBJC_WARNING_LOG(...)    if (self.loggerPtr && self.logChannel) self.loggerPtr->warning(*self.logChannel, __VA_ARGS__)
+#define OBJC_INFO_LOG(...)       if (self.loggerPtr && self.logChannel) self.loggerPtr->info(*self.logChannel, __VA_ARGS__)
+#define OBJC_DEBUG_LOG(...)      if (self.loggerPtr && self.logChannel) self.loggerPtr->debug(*self.logChannel, __VA_ARGS__)
+#endif
+
     static const void* childLogIdentifier(const void* parentIdentifier, uint64_t childIdentifier)
     {
         static constexpr uint64_t parentMask = 0xffffffffffff0000ull;

--- a/Source/WebCore/platform/cocoa/PlaybackSessionModel.h
+++ b/Source/WebCore/platform/cocoa/PlaybackSessionModel.h
@@ -98,6 +98,11 @@ public:
     virtual double volume() const = 0;
     virtual bool isPictureInPictureSupported() const = 0;
     virtual bool isPictureInPictureActive() const = 0;
+
+#if !RELEASE_LOG_DISABLED
+    virtual const void* logIdentifier() const { return nullptr; }
+    virtual const Logger* loggerPtr() const { return nullptr; }
+#endif
 };
 
 class PlaybackSessionModelClient {

--- a/Source/WebCore/platform/cocoa/PlaybackSessionModelMediaElement.h
+++ b/Source/WebCore/platform/cocoa/PlaybackSessionModelMediaElement.h
@@ -111,6 +111,11 @@ private:
     static const Vector<AtomString>& observedEventNames();
     const AtomString& eventNameAll();
 
+#if !RELEASE_LOG_DISABLED
+    const void* logIdentifier() const final;
+    const Logger* loggerPtr() const final;
+#endif
+
     RefPtr<HTMLMediaElement> m_mediaElement;
     bool m_isListening { false };
     HashSet<PlaybackSessionModelClient*> m_clients;

--- a/Source/WebCore/platform/cocoa/PlaybackSessionModelMediaElement.mm
+++ b/Source/WebCore/platform/cocoa/PlaybackSessionModelMediaElement.mm
@@ -635,6 +635,19 @@ bool PlaybackSessionModelMediaElement::isPictureInPictureActive() const
     return (m_mediaElement->fullscreenMode() & HTMLMediaElementEnums::VideoFullscreenModePictureInPicture) == HTMLMediaElementEnums::VideoFullscreenModePictureInPicture;
 }
 
+#if !RELEASE_LOG_DISABLED
+const void* PlaybackSessionModelMediaElement::logIdentifier() const
+{
+    return m_mediaElement ? m_mediaElement->logIdentifier() : nullptr;
+}
+
+const Logger* PlaybackSessionModelMediaElement::loggerPtr() const
+{
+    return m_mediaElement ? &m_mediaElement->logger() : nullptr;
+}
+#endif
+
+
 }
 
 #endif

--- a/Source/WebCore/platform/cocoa/VideoFullscreenModelVideoElement.h
+++ b/Source/WebCore/platform/cocoa/VideoFullscreenModelVideoElement.h
@@ -78,6 +78,13 @@ public:
 
     WEBCORE_EXPORT void requestRouteSharingPolicyAndContextUID(CompletionHandler<void(RouteSharingPolicy, String)>&&) override;
 
+#if !RELEASE_LOG_DISABLED
+    const Logger* loggerPtr() const;
+    WEBCORE_EXPORT const void* logIdentifier();
+    const char* logClassName() const { return "VideoFullscreenModelVideoElement"; }
+    WTFLogChannel& logChannel() const;
+#endif
+
 protected:
     WEBCORE_EXPORT VideoFullscreenModelVideoElement();
 

--- a/Source/WebCore/platform/graphics/FloatSize.h
+++ b/Source/WebCore/platform/graphics/FloatSize.h
@@ -153,7 +153,7 @@ public:
     operator NSSize() const;
 #endif
 
-    String toJSONString() const;
+    WEBCORE_EXPORT String toJSONString() const;
     WEBCORE_EXPORT Ref<JSON::Object> toJSONObject() const;
 
 private:

--- a/Source/WebCore/platform/ios/PlaybackSessionInterfaceAVKit.h
+++ b/Source/WebCore/platform/ios/PlaybackSessionInterfaceAVKit.h
@@ -79,6 +79,13 @@ public:
 
     WebAVPlayerController *playerController() const { return m_playerController.get(); }
 
+#if !RELEASE_LOG_DISABLED
+    const void* logIdentifier() const;
+    const Logger* loggerPtr() const;
+    const char* logClassName() const { return "PlaybackSessionInterfaceAVKit"; };
+    WTFLogChannel& logChannel() const;
+#endif
+
 private:
     PlaybackSessionInterfaceAVKit(PlaybackSessionModel&);
     RetainPtr<WebAVPlayerController> m_playerController;

--- a/Source/WebCore/platform/ios/PlaybackSessionInterfaceAVKit.mm
+++ b/Source/WebCore/platform/ios/PlaybackSessionInterfaceAVKit.mm
@@ -254,6 +254,23 @@ void PlaybackSessionInterfaceAVKit::modelDestroyed()
     ASSERT(!m_playbackSessionModel);
 }
 
+#if !RELEASE_LOG_DISABLED
+const void* PlaybackSessionInterfaceAVKit::logIdentifier() const
+{
+    return m_playbackSessionModel ? m_playbackSessionModel->logIdentifier() : nullptr;
+}
+
+const Logger* PlaybackSessionInterfaceAVKit::loggerPtr() const
+{
+    return m_playbackSessionModel ? m_playbackSessionModel->loggerPtr() : nullptr;
+}
+
+WTFLogChannel& PlaybackSessionInterfaceAVKit::logChannel() const
+{
+    return LogMedia;
+}
+#endif
+
 }
 
 #endif // PLATFORM(COCOA) && HAVE(AVKIT)

--- a/Source/WebCore/platform/ios/VideoFullscreenInterfaceAVKit.h
+++ b/Source/WebCore/platform/ios/VideoFullscreenInterfaceAVKit.h
@@ -165,6 +165,13 @@ public:
     WEBCORE_EXPORT AVPlayerViewController *avPlayerViewController() const;
     WebAVPlayerController *playerController() const;
 
+#if !RELEASE_LOG_DISABLED
+    const void* logIdentifier() const;
+    const Logger* loggerPtr() const;
+    const char* logClassName() const { return "VideoFullscreenInterfaceAVKit"; };
+    WTFLogChannel& logChannel() const;
+#endif
+
 private:
     WEBCORE_EXPORT VideoFullscreenInterfaceAVKit(PlaybackSessionInterfaceAVKit&);
 

--- a/Source/WebCore/platform/mac/PlaybackSessionInterfaceMac.h
+++ b/Source/WebCore/platform/mac/PlaybackSessionInterfaceMac.h
@@ -74,6 +74,13 @@ public:
 
     void invalidate();
 
+#if !RELEASE_LOG_DISABLED
+    const void* logIdentifier() const;
+    const Logger* loggerPtr() const;
+    const char* logClassName() const { return "PlaybackSessionInterfaceMac"; };
+    WTFLogChannel& logChannel() const;
+#endif
+
 private:
     PlaybackSessionInterfaceMac(PlaybackSessionModel&);
     WeakPtr<PlaybackSessionModel> m_playbackSessionModel;

--- a/Source/WebCore/platform/mac/PlaybackSessionInterfaceMac.mm
+++ b/Source/WebCore/platform/mac/PlaybackSessionInterfaceMac.mm
@@ -29,6 +29,7 @@
 #if PLATFORM(MAC) && ENABLE(VIDEO_PRESENTATION_MODE)
 
 #import "IntRect.h"
+#import "Logging.h"
 #import "MediaSelectionOption.h"
 #import "PlaybackSessionModel.h"
 #import "TimeRanges.h"
@@ -281,6 +282,23 @@ void PlaybackSessionInterfaceMac::updatePlaybackControlsManagerTiming(double cur
 }
 
 #endif // ENABLE(WEB_PLAYBACK_CONTROLS_MANAGER)
+
+#if !RELEASE_LOG_DISABLED
+const void* PlaybackSessionInterfaceMac::logIdentifier() const
+{
+    return m_playbackSessionModel ? m_playbackSessionModel->logIdentifier() : nullptr;
+}
+
+const Logger* PlaybackSessionInterfaceMac::loggerPtr() const
+{
+    return m_playbackSessionModel ? m_playbackSessionModel->loggerPtr() : nullptr;
+}
+
+WTFLogChannel& PlaybackSessionInterfaceMac::logChannel() const
+{
+    return LogMedia;
+}
+#endif
 
 }
 

--- a/Source/WebCore/platform/mac/VideoFullscreenInterfaceMac.h
+++ b/Source/WebCore/platform/mac/VideoFullscreenInterfaceMac.h
@@ -102,6 +102,13 @@ public:
 
     std::optional<MediaPlayerIdentifier> playerIdentifier() const { return m_playerIdentifier; }
 
+#if !RELEASE_LOG_DISABLED
+    const void* logIdentifier() const;
+    const Logger* loggerPtr() const;
+    const char* logClassName() const { return "VideoFullscreenInterfaceMac"; };
+    WTFLogChannel& logChannel() const;
+#endif
+
 private:
     WEBCORE_EXPORT VideoFullscreenInterfaceMac(PlaybackSessionInterfaceMac&);
     Ref<PlaybackSessionInterfaceMac> m_playbackSessionInterface;

--- a/Source/WebCore/platform/mac/VideoFullscreenInterfaceMac.mm
+++ b/Source/WebCore/platform/mac/VideoFullscreenInterfaceMac.mm
@@ -599,6 +599,23 @@ bool VideoFullscreenInterfaceMac::isPlayingVideoInEnhancedFullscreen() const
     return hasMode(WebCore::HTMLMediaElementEnums::VideoFullscreenModePictureInPicture) && [m_webVideoFullscreenInterfaceObjC isPlaying];
 }
 
+#if !RELEASE_LOG_DISABLED
+const void* VideoFullscreenInterfaceMac::logIdentifier() const
+{
+    return m_playbackSessionInterface->logIdentifier();
+}
+
+const Logger* VideoFullscreenInterfaceMac::loggerPtr() const
+{
+    return m_playbackSessionInterface->loggerPtr();
+}
+
+WTFLogChannel& VideoFullscreenInterfaceMac::logChannel() const
+{
+    return LogFullscreen;
+}
+#endif
+
 bool supportsPictureInPicture()
 {
     return PIPLibrary() && getPIPViewControllerClass();

--- a/Source/WebKit/UIProcess/Cocoa/PlaybackSessionManagerProxy.h
+++ b/Source/WebKit/UIProcess/Cocoa/PlaybackSessionManagerProxy.h
@@ -93,11 +93,7 @@ private:
     friend class PlaybackSessionManagerProxy;
     friend class VideoFullscreenModelContext;
 
-    PlaybackSessionModelContext(PlaybackSessionManagerProxy& manager, PlaybackSessionContextIdentifier contextId)
-        : m_manager(&manager)
-        , m_contextId(contextId)
-    {
-    }
+    PlaybackSessionModelContext(PlaybackSessionManagerProxy&, PlaybackSessionContextIdentifier);
 
     // PlaybackSessionModel
     void play() final;
@@ -146,6 +142,15 @@ private:
     bool isPictureInPictureSupported() const final { return m_pictureInPictureSupported; }
     bool isPictureInPictureActive() const final { return m_pictureInPictureActive; }
 
+#if !RELEASE_LOG_DISABLED
+    void setLogIdentifier(const void* identifier) { m_logIdentifier = identifier; }
+    const void* logIdentifier() const final { return m_logIdentifier; }
+    const Logger* loggerPtr() const;
+
+    const char* logClassName() const { return "PlaybackSessionModelContext"; };
+    WTFLogChannel& logChannel() const;
+#endif
+
     PlaybackSessionManagerProxy* m_manager;
     PlaybackSessionContextIdentifier m_contextId;
     HashSet<WebCore::PlaybackSessionModelClient*> m_clients;
@@ -174,6 +179,10 @@ private:
     double m_volume { 0 };
     bool m_pictureInPictureSupported { false };
     bool m_pictureInPictureActive { false };
+
+#if !RELEASE_LOG_DISABLED
+    const void* m_logIdentifier { nullptr };
+#endif
 };
 
 class PlaybackSessionManagerProxy : public RefCounted<PlaybackSessionManagerProxy>, private IPC::MessageReceiver {
@@ -251,10 +260,24 @@ private:
     void setPlayingOnSecondScreen(PlaybackSessionContextIdentifier, bool);
     void sendRemoteCommand(PlaybackSessionContextIdentifier, WebCore::PlatformMediaSession::RemoteControlCommandType, const WebCore::PlatformMediaSession::RemoteCommandArgument&);
 
+#if !RELEASE_LOG_DISABLED
+    void setLogIdentifier(PlaybackSessionContextIdentifier, uint64_t);
+
+    const Logger& logger() const { return m_logger; }
+    const void* logIdentifier() const { return m_logIdentifier; }
+    const char* logClassName() const { return "VideoFullscreenManagerProxy"; }
+    WTFLogChannel& logChannel() const;
+#endif
+
     WebPageProxy* m_page;
     HashMap<PlaybackSessionContextIdentifier, ModelInterfaceTuple> m_contextMap;
     PlaybackSessionContextIdentifier m_controlsManagerContextId;
     HashCountedSet<PlaybackSessionContextIdentifier> m_clientCounts;
+
+#if !RELEASE_LOG_DISABLED
+    Ref<const Logger> m_logger;
+    const void* m_logIdentifier;
+#endif
 };
 
 } // namespace WebKit

--- a/Source/WebKit/UIProcess/Cocoa/PlaybackSessionManagerProxy.messages.in
+++ b/Source/WebKit/UIProcess/Cocoa/PlaybackSessionManagerProxy.messages.in
@@ -42,5 +42,9 @@ messages -> PlaybackSessionManagerProxy {
     ClearPlaybackControlsManager()
 
     HandleControlledElementIDResponse(WebKit::PlaybackSessionContextIdentifier contextId, String id)
+    
+#if !RELEASE_LOG_DISABLED
+    SetLogIdentifier(WebKit::PlaybackSessionContextIdentifier contextId, uint64_t logIdentifier)
+#endif
 }
 #endif

--- a/Source/WebKit/UIProcess/Cocoa/PlaybackSessionManagerProxy.mm
+++ b/Source/WebKit/UIProcess/Cocoa/PlaybackSessionManagerProxy.mm
@@ -33,11 +33,18 @@
 #import "PlaybackSessionManagerProxyMessages.h"
 #import "WebPageProxy.h"
 #import "WebProcessProxy.h"
+#import <wtf/LoggerHelper.h>
 
 namespace WebKit {
 using namespace WebCore;
 
 #pragma mark - PlaybackSessionModelContext
+
+PlaybackSessionModelContext::PlaybackSessionModelContext(PlaybackSessionManagerProxy& manager, PlaybackSessionContextIdentifier contextId)
+    : m_manager(&manager)
+    , m_contextId(contextId)
+{
+}
 
 void PlaybackSessionModelContext::addClient(PlaybackSessionModelClient& client)
 {
@@ -59,24 +66,28 @@ void PlaybackSessionModelContext::sendRemoteCommand(WebCore::PlatformMediaSessio
 
 void PlaybackSessionModelContext::play()
 {
+    ALWAYS_LOG_IF_POSSIBLE(LOGIDENTIFIER);
     if (m_manager)
         m_manager->play(m_contextId);
 }
 
 void PlaybackSessionModelContext::pause()
 {
+    ALWAYS_LOG_IF_POSSIBLE(LOGIDENTIFIER);
     if (m_manager)
         m_manager->pause(m_contextId);
 }
 
 void PlaybackSessionModelContext::togglePlayState()
 {
+    ALWAYS_LOG_IF_POSSIBLE(LOGIDENTIFIER);
     if (m_manager)
         m_manager->togglePlayState(m_contextId);
 }
 
 void PlaybackSessionModelContext::beginScrubbing()
 {
+    ALWAYS_LOG_IF_POSSIBLE(LOGIDENTIFIER);
     if (m_manager)
         m_manager->beginScrubbing(m_contextId);
 
@@ -85,6 +96,7 @@ void PlaybackSessionModelContext::beginScrubbing()
 
 void PlaybackSessionModelContext::endScrubbing()
 {
+    ALWAYS_LOG_IF_POSSIBLE(LOGIDENTIFIER);
     if (m_manager)
         m_manager->endScrubbing(m_contextId);
 
@@ -94,42 +106,49 @@ void PlaybackSessionModelContext::endScrubbing()
 
 void PlaybackSessionModelContext::seekToTime(double time, double toleranceBefore, double toleranceAfter)
 {
+    ALWAYS_LOG_IF_POSSIBLE(LOGIDENTIFIER, time, ", toleranceBefore: ", toleranceBefore, ", toleranceAfter: ", toleranceAfter);
     if (m_manager)
         m_manager->seekToTime(m_contextId, time, toleranceBefore, toleranceAfter);
 }
 
 void PlaybackSessionModelContext::fastSeek(double time)
 {
+    ALWAYS_LOG_IF_POSSIBLE(LOGIDENTIFIER, time);
     if (m_manager)
         m_manager->fastSeek(m_contextId, time);
 }
 
 void PlaybackSessionModelContext::beginScanningForward()
 {
+    ALWAYS_LOG_IF_POSSIBLE(LOGIDENTIFIER);
     if (m_manager)
         m_manager->beginScanningForward(m_contextId);
 }
 
 void PlaybackSessionModelContext::beginScanningBackward()
 {
+    ALWAYS_LOG_IF_POSSIBLE(LOGIDENTIFIER);
     if (m_manager)
         m_manager->beginScanningBackward(m_contextId);
 }
 
 void PlaybackSessionModelContext::endScanning()
 {
+    ALWAYS_LOG_IF_POSSIBLE(LOGIDENTIFIER);
     if (m_manager)
         m_manager->endScanning(m_contextId);
 }
 
 void PlaybackSessionModelContext::setDefaultPlaybackRate(double defaultPlaybackRate)
 {
+    ALWAYS_LOG_IF_POSSIBLE(LOGIDENTIFIER, defaultPlaybackRate);
     if (m_manager)
         m_manager->setDefaultPlaybackRate(m_contextId, defaultPlaybackRate);
 }
 
 void PlaybackSessionModelContext::setPlaybackRate(double playbackRate)
 {
+    ALWAYS_LOG_IF_POSSIBLE(LOGIDENTIFIER, playbackRate);
     if (m_manager)
         m_manager->setPlaybackRate(m_contextId, playbackRate);
 }
@@ -139,6 +158,7 @@ void PlaybackSessionModelContext::selectAudioMediaOption(uint64_t index)
     if (m_audioMediaSelectedIndex == index)
         return;
 
+    ALWAYS_LOG_IF_POSSIBLE(LOGIDENTIFIER, index);
     if (m_manager)
         m_manager->selectAudioMediaOption(m_contextId, index);
 }
@@ -148,18 +168,21 @@ void PlaybackSessionModelContext::selectLegibleMediaOption(uint64_t index)
     if (m_legibleMediaSelectedIndex == index)
         return;
 
+    ALWAYS_LOG_IF_POSSIBLE(LOGIDENTIFIER, index);
     if (m_manager)
         m_manager->selectLegibleMediaOption(m_contextId, index);
 }
 
 void PlaybackSessionModelContext::togglePictureInPicture()
 {
+    ALWAYS_LOG_IF_POSSIBLE(LOGIDENTIFIER);
     if (m_manager)
         m_manager->togglePictureInPicture(m_contextId);
 }
 
 void PlaybackSessionModelContext::toggleMuted()
 {
+    ALWAYS_LOG_IF_POSSIBLE(LOGIDENTIFIER);
     if (m_manager)
         m_manager->toggleMuted(m_contextId);
 }
@@ -169,6 +192,7 @@ void PlaybackSessionModelContext::setMuted(bool muted)
     if (muted == m_muted)
         return;
 
+    ALWAYS_LOG_IF_POSSIBLE(LOGIDENTIFIER, muted);
     if (m_manager)
         m_manager->setMuted(m_contextId, muted);
 }
@@ -178,24 +202,28 @@ void PlaybackSessionModelContext::setVolume(double volume)
     if (volume == m_volume)
         return;
 
+    ALWAYS_LOG_IF_POSSIBLE(LOGIDENTIFIER, volume);
     if (m_manager)
         m_manager->setVolume(m_contextId, volume);
 }
 
 void PlaybackSessionModelContext::setPlayingOnSecondScreen(bool value)
 {
+    ALWAYS_LOG_IF_POSSIBLE(LOGIDENTIFIER, value);
     if (m_manager)
         m_manager->setPlayingOnSecondScreen(m_contextId, value);
 }
 
 void PlaybackSessionModelContext::playbackStartedTimeChanged(double playbackStartedTime)
 {
+    ALWAYS_LOG_IF_POSSIBLE(LOGIDENTIFIER, playbackStartedTime);
     m_playbackStartedTime = playbackStartedTime;
     m_playbackStartedTimeNeedsUpdate = false;
 }
 
 void PlaybackSessionModelContext::durationChanged(double duration)
 {
+    ALWAYS_LOG_IF_POSSIBLE(LOGIDENTIFIER, duration);
     m_duration = duration;
     for (auto* client : m_clients)
         client->durationChanged(duration);
@@ -203,6 +231,7 @@ void PlaybackSessionModelContext::durationChanged(double duration)
 
 void PlaybackSessionModelContext::currentTimeChanged(double currentTime)
 {
+    INFO_LOG_IF_POSSIBLE(LOGIDENTIFIER, currentTime);
     m_currentTime = currentTime;
     auto anchorTime = [[NSProcessInfo processInfo] systemUptime];
     if (m_playbackStartedTimeNeedsUpdate)
@@ -214,6 +243,7 @@ void PlaybackSessionModelContext::currentTimeChanged(double currentTime)
 
 void PlaybackSessionModelContext::bufferedTimeChanged(double bufferedTime)
 {
+    INFO_LOG_IF_POSSIBLE(LOGIDENTIFIER, bufferedTime);
     m_bufferedTime = bufferedTime;
     for (auto* client : m_clients)
         client->bufferedTimeChanged(bufferedTime);
@@ -221,6 +251,7 @@ void PlaybackSessionModelContext::bufferedTimeChanged(double bufferedTime)
 
 void PlaybackSessionModelContext::rateChanged(OptionSet<WebCore::PlaybackSessionModel::PlaybackState> playbackState, double playbackRate, double defaultPlaybackRate)
 {
+    ALWAYS_LOG_IF_POSSIBLE(LOGIDENTIFIER, playbackRate, ", defaultPlaybackRate", defaultPlaybackRate);
     m_playbackState = playbackState;
     m_playbackRate = playbackRate;
     m_defaultPlaybackRate = defaultPlaybackRate;
@@ -230,6 +261,7 @@ void PlaybackSessionModelContext::rateChanged(OptionSet<WebCore::PlaybackSession
 
 void PlaybackSessionModelContext::seekableRangesChanged(WebCore::TimeRanges& seekableRanges, double lastModifiedTime, double liveUpdateInterval)
 {
+    INFO_LOG_IF_POSSIBLE(LOGIDENTIFIER, seekableRanges.ranges());
     m_seekableRanges = seekableRanges;
     m_seekableTimeRangesLastModifiedTime = lastModifiedTime;
     m_liveUpdateInterval = liveUpdateInterval;
@@ -322,6 +354,18 @@ void PlaybackSessionModelContext::pictureInPictureActiveChanged(bool active)
         client->pictureInPictureActiveChanged(active);
 }
 
+#if !RELEASE_LOG_DISABLED
+const Logger* PlaybackSessionModelContext::loggerPtr() const
+{
+    return m_manager ? &m_manager->logger() : nullptr;
+}
+
+WTFLogChannel& PlaybackSessionModelContext::logChannel() const
+{
+    return WebKit2LogMedia;
+}
+#endif
+
 #pragma mark - PlaybackSessionManagerProxy
 
 Ref<PlaybackSessionManagerProxy> PlaybackSessionManagerProxy::create(WebPageProxy& page)
@@ -331,12 +375,18 @@ Ref<PlaybackSessionManagerProxy> PlaybackSessionManagerProxy::create(WebPageProx
 
 PlaybackSessionManagerProxy::PlaybackSessionManagerProxy(WebPageProxy& page)
     : m_page(&page)
+#if !RELEASE_LOG_DISABLED
+    , m_logger(page.logger())
+    , m_logIdentifier(page.logIdentifier())
+#endif
 {
+    ALWAYS_LOG(LOGIDENTIFIER);
     m_page->process().addMessageReceiver(Messages::PlaybackSessionManagerProxy::messageReceiverName(), m_page->webPageID(), *this);
 }
 
 PlaybackSessionManagerProxy::~PlaybackSessionManagerProxy()
 {
+    ALWAYS_LOG(LOGIDENTIFIER);
     if (!m_page)
         return;
     invalidate();
@@ -344,6 +394,7 @@ PlaybackSessionManagerProxy::~PlaybackSessionManagerProxy()
 
 void PlaybackSessionManagerProxy::invalidate()
 {
+    ALWAYS_LOG(LOGIDENTIFIER);
     m_page->process().removeMessageReceiver(Messages::PlaybackSessionManagerProxy::messageReceiverName(), m_page->webPageID());
     m_page = nullptr;
 
@@ -667,6 +718,19 @@ bool PlaybackSessionManagerProxy::isPaused(PlaybackSessionContextIdentifier iden
     auto& model = *std::get<0>(iterator->value);
     return !model.isPlaying() && !model.isStalled();
 }
+
+#if !RELEASE_LOG_DISABLED
+void PlaybackSessionManagerProxy::setLogIdentifier(PlaybackSessionContextIdentifier identifier, uint64_t logIdentifier)
+{
+    auto& model = ensureModel(identifier);
+    model.setLogIdentifier(reinterpret_cast<const void*>(logIdentifier));
+}
+
+WTFLogChannel& PlaybackSessionManagerProxy::logChannel() const
+{
+    return WebKit2LogMedia;
+}
+#endif
 
 } // namespace WebKit
 

--- a/Source/WebKit/UIProcess/Cocoa/VideoFullscreenManagerProxy.h
+++ b/Source/WebKit/UIProcess/Cocoa/VideoFullscreenManagerProxy.h
@@ -94,6 +94,7 @@ public:
     void requestCloseAllMediaPresentations(bool finishedWithMedia, CompletionHandler<void()>&&);
 
 private:
+    friend class VideoFullscreenManagerProxy;
     VideoFullscreenModelContext(VideoFullscreenManagerProxy&, PlaybackSessionModelContext&, PlaybackSessionContextIdentifier);
 
     // VideoFullscreenModel
@@ -128,6 +129,14 @@ private:
     void didExitFullscreen() final;
     void didCleanupFullscreen() final;
     void fullscreenMayReturnToInline() final;
+
+#if !RELEASE_LOG_DISABLED
+    const void* logIdentifier() const;
+    const Logger* loggerPtr() const;
+
+    const char* logClassName() const { return "VideoFullscreenModelContext"; };
+    WTFLogChannel& logChannel() const;
+#endif
 
     VideoFullscreenManagerProxy* m_manager;
     Ref<PlaybackSessionModelContext> m_playbackSessionModel;
@@ -236,6 +245,13 @@ private:
 
     void requestCloseAllMediaPresentations(PlaybackSessionContextIdentifier, bool finishedWithMedia, CompletionHandler<void()>&&);
     void callCloseCompletionHandlers();
+
+#if !RELEASE_LOG_DISABLED
+    const Logger& logger() const;
+    const void* logIdentifier() const;
+    const char* logClassName() const;
+    WTFLogChannel& logChannel() const;
+#endif
 
     bool m_mockVideoPresentationModeEnabled { false };
     WebCore::FloatSize m_mockPictureInPictureWindowSize { DefaultMockPictureInPictureWindowWidth, DefaultMockPictureInPictureWindowHeight };

--- a/Source/WebKit/UIProcess/Cocoa/VideoFullscreenManagerProxy.mm
+++ b/Source/WebKit/UIProcess/Cocoa/VideoFullscreenManagerProxy.mm
@@ -43,6 +43,7 @@
 #import <WebCore/WebAVPlayerLayer.h>
 #import <WebCore/WebAVPlayerLayerView.h>
 #import <pal/spi/cocoa/QuartzCoreSPI.h>
+#import <wtf/LoggerHelper.h>
 #import <wtf/MachSendRight.h>
 #import <wtf/WeakObjCPtr.h>
 
@@ -193,29 +194,34 @@ void VideoFullscreenModelContext::requestCloseAllMediaPresentations(bool finishe
         return;
     }
 
+    ALWAYS_LOG_IF_POSSIBLE(LOGIDENTIFIER);
     m_manager->requestCloseAllMediaPresentations(m_contextId, finishedWithMedia, WTFMove(completionHandler));
 }
 
 void VideoFullscreenModelContext::requestFullscreenMode(HTMLMediaElementEnums::VideoFullscreenMode mode, bool finishedWithMedia)
 {
+    ALWAYS_LOG_IF_POSSIBLE(LOGIDENTIFIER, mode, ", finishedWithMedia: ", finishedWithMedia);
     if (m_manager)
         m_manager->requestFullscreenMode(m_contextId, mode, finishedWithMedia);
 }
 
 void VideoFullscreenModelContext::setVideoLayerFrame(WebCore::FloatRect frame)
 {
+    ALWAYS_LOG_IF_POSSIBLE(LOGIDENTIFIER, frame.size());
     if (m_manager)
         m_manager->setVideoLayerFrame(m_contextId, frame);
 }
 
 void VideoFullscreenModelContext::setVideoLayerGravity(WebCore::MediaPlayerEnums::VideoGravity gravity)
 {
+    ALWAYS_LOG_IF_POSSIBLE(LOGIDENTIFIER, gravity);
     if (m_manager)
         m_manager->setVideoLayerGravity(m_contextId, gravity);
 }
 
 void VideoFullscreenModelContext::fullscreenModeChanged(WebCore::HTMLMediaElementEnums::VideoFullscreenMode mode)
 {
+    ALWAYS_LOG_IF_POSSIBLE(LOGIDENTIFIER, mode);
     if (m_manager)
         m_manager->fullscreenModeChanged(m_contextId, mode);
 }
@@ -237,72 +243,84 @@ RetainPtr<UIViewController> VideoFullscreenModelContext::createVideoFullscreenVi
 
 void VideoFullscreenModelContext::requestUpdateInlineRect()
 {
+    ALWAYS_LOG_IF_POSSIBLE(LOGIDENTIFIER);
     if (m_manager)
         m_manager->requestUpdateInlineRect(m_contextId);
 }
 
 void VideoFullscreenModelContext::requestVideoContentLayer()
 {
+    ALWAYS_LOG_IF_POSSIBLE(LOGIDENTIFIER);
     if (m_manager)
         m_manager->requestVideoContentLayer(m_contextId);
 }
 
 void VideoFullscreenModelContext::returnVideoContentLayer()
 {
+    ALWAYS_LOG_IF_POSSIBLE(LOGIDENTIFIER);
     if (m_manager)
         m_manager->returnVideoContentLayer(m_contextId);
 }
 
 void VideoFullscreenModelContext::returnVideoView()
 {
+    ALWAYS_LOG_IF_POSSIBLE(LOGIDENTIFIER);
     if (m_manager)
         m_manager->returnVideoView(m_contextId);
 }
 
 void VideoFullscreenModelContext::didSetupFullscreen()
 {
+    ALWAYS_LOG_IF_POSSIBLE(LOGIDENTIFIER);
     if (m_manager)
         m_manager->didSetupFullscreen(m_contextId);
 }
 
 void VideoFullscreenModelContext::failedToEnterFullscreen()
 {
+    ALWAYS_LOG_IF_POSSIBLE(LOGIDENTIFIER);
     if (m_manager)
         m_manager->failedToEnterFullscreen(m_contextId);
 }
 
 void VideoFullscreenModelContext::didEnterFullscreen(const WebCore::FloatSize& size)
 {
+    ALWAYS_LOG_IF_POSSIBLE(LOGIDENTIFIER, size);
     if (m_manager)
         m_manager->didEnterFullscreen(m_contextId, size);
 }
 
 void VideoFullscreenModelContext::willExitFullscreen()
 {
+    ALWAYS_LOG_IF_POSSIBLE(LOGIDENTIFIER);
     if (m_manager)
         m_manager->willExitFullscreen(m_contextId);
 }
 
 void VideoFullscreenModelContext::didExitFullscreen()
 {
+    ALWAYS_LOG_IF_POSSIBLE(LOGIDENTIFIER);
     if (m_manager)
         m_manager->didExitFullscreen(m_contextId);
 }
 
 void VideoFullscreenModelContext::didCleanupFullscreen()
 {
+    ALWAYS_LOG_IF_POSSIBLE(LOGIDENTIFIER);
     if (m_manager)
         m_manager->didCleanupFullscreen(m_contextId);
 }
 
 void VideoFullscreenModelContext::fullscreenMayReturnToInline()
 {
+    ALWAYS_LOG_IF_POSSIBLE(LOGIDENTIFIER);
     if (m_manager)
         m_manager->fullscreenMayReturnToInline(m_contextId);
 }
 
 void VideoFullscreenModelContext::requestRouteSharingPolicyAndContextUID(CompletionHandler<void(WebCore::RouteSharingPolicy, String)>&& completionHandler)
 {
+    ALWAYS_LOG_IF_POSSIBLE(LOGIDENTIFIER);
     if (m_manager)
         m_manager->requestRouteSharingPolicyAndContextUID(m_contextId, WTFMove(completionHandler));
     else
@@ -311,33 +329,55 @@ void VideoFullscreenModelContext::requestRouteSharingPolicyAndContextUID(Complet
 
 void VideoFullscreenModelContext::didEnterPictureInPicture()
 {
+    ALWAYS_LOG_IF_POSSIBLE(LOGIDENTIFIER);
     if (m_manager)
         m_manager->hasVideoInPictureInPictureDidChange(true);
 }
 
 void VideoFullscreenModelContext::didExitPictureInPicture()
 {
+    ALWAYS_LOG_IF_POSSIBLE(LOGIDENTIFIER);
     if (m_manager)
         m_manager->hasVideoInPictureInPictureDidChange(false);
 }
 
 void VideoFullscreenModelContext::willEnterPictureInPicture()
 {
+    ALWAYS_LOG_IF_POSSIBLE(LOGIDENTIFIER);
     for (auto& client : copyToVector(m_clients))
         client->willEnterPictureInPicture();
 }
 
 void VideoFullscreenModelContext::failedToEnterPictureInPicture()
 {
+    ALWAYS_LOG_IF_POSSIBLE(LOGIDENTIFIER);
     for (auto& client : copyToVector(m_clients))
         client->failedToEnterPictureInPicture();
 }
 
 void VideoFullscreenModelContext::willExitPictureInPicture()
 {
+    ALWAYS_LOG_IF_POSSIBLE(LOGIDENTIFIER);
     for (auto& client : copyToVector(m_clients))
         client->willExitPictureInPicture();
 }
+
+#if !RELEASE_LOG_DISABLED
+const void* VideoFullscreenModelContext::logIdentifier() const
+{
+    return m_playbackSessionModel->logIdentifier();
+}
+
+const Logger* VideoFullscreenModelContext::loggerPtr() const
+{
+    return m_playbackSessionModel->loggerPtr();
+}
+
+WTFLogChannel& VideoFullscreenModelContext::logChannel() const
+{
+    return WebKit2LogFullscreen;
+}
+#endif
 
 #pragma mark - VideoFullscreenManagerProxy
 
@@ -350,11 +390,13 @@ VideoFullscreenManagerProxy::VideoFullscreenManagerProxy(WebPageProxy& page, Pla
     : m_page(&page)
     , m_playbackSessionManagerProxy(playbackSessionManagerProxy)
 {
+    ALWAYS_LOG(LOGIDENTIFIER);
     m_page->process().addMessageReceiver(Messages::VideoFullscreenManagerProxy::messageReceiverName(), m_page->webPageID(), *this);
 }
 
 VideoFullscreenManagerProxy::~VideoFullscreenManagerProxy()
 {
+    ALWAYS_LOG(LOGIDENTIFIER);
     callCloseCompletionHandlers();
 
     if (!m_page)
@@ -364,6 +406,7 @@ VideoFullscreenManagerProxy::~VideoFullscreenManagerProxy()
 
 void VideoFullscreenManagerProxy::invalidate()
 {
+    ALWAYS_LOG(LOGIDENTIFIER);
     m_page->process().removeMessageReceiver(Messages::VideoFullscreenManagerProxy::messageReceiverName(), m_page->webPageID());
     m_page = nullptr;
 
@@ -379,6 +422,7 @@ void VideoFullscreenManagerProxy::invalidate()
 
 void VideoFullscreenManagerProxy::requestHideAndExitFullscreen()
 {
+    ALWAYS_LOG(LOGIDENTIFIER);
     for (auto& [model, interface] : m_contextMap.values())
         interface->requestHideAndExitFullscreen();
 }
@@ -422,6 +466,7 @@ PlatformVideoFullscreenInterface* VideoFullscreenManagerProxy::controlsManagerIn
 
 void VideoFullscreenManagerProxy::applicationDidBecomeActive()
 {
+    ALWAYS_LOG(LOGIDENTIFIER);
     for (auto& [model, interface] : m_contextMap.values())
         interface->applicationDidBecomeActive();
 }
@@ -554,6 +599,7 @@ void VideoFullscreenManagerProxy::addVideoInPictureInPictureDidChangeObserver(co
 
 void VideoFullscreenManagerProxy::hasVideoInPictureInPictureDidChange(bool value)
 {
+    ALWAYS_LOG(LOGIDENTIFIER, value);
     m_page->uiClient().hasVideoInPictureInPictureDidChange(m_page, value);
     m_pipChangeObservers.forEach([value] (auto& observer) { observer(value); });
 }
@@ -566,8 +612,9 @@ PlatformLayerContainer VideoFullscreenManagerProxy::createLayerWithID(PlaybackSe
     RetainPtr<WKLayerHostView> view = createLayerHostViewWithID(contextId, videoLayerID, initialSize, hostingDeviceScaleFactor);
 
     if (!model->playerLayer()) {
+        ALWAYS_LOG(LOGIDENTIFIER, model->logIdentifier(), ", Creating AVPlayerLayer");
         auto playerLayer = adoptNS([[WebAVPlayerLayer alloc] init]);
-        
+
         [playerLayer setVideoDimensions:nativeSize];
         [playerLayer setFullscreenInterface:interface.get()];
         
@@ -619,6 +666,7 @@ RetainPtr<WebAVPlayerLayerView> VideoFullscreenManagerProxy::createViewWithID(Pl
     RetainPtr<WKLayerHostView> view = createLayerHostViewWithID(contextId, videoLayerID, initialSize, hostingDeviceScaleFactor);
 
     if (!model->playerView()) {
+        ALWAYS_LOG(LOGIDENTIFIER, model->logIdentifier(), ", Creating AVPlayerLayerView");
         auto playerView = adoptNS([allocWebAVPlayerLayerViewInstance() init]);
 
         auto *playerLayer = (WebAVPlayerLayer *)[playerView layer];
@@ -1059,6 +1107,28 @@ AVPlayerViewController *VideoFullscreenManagerProxy::playerViewController(Playba
 }
 
 #endif // PLATFORM(IOS_FAMILY)
+
+#if !RELEASE_LOG_DISABLED
+const Logger& VideoFullscreenManagerProxy::logger() const
+{
+    return m_playbackSessionManagerProxy->logger();
+}
+
+const void* VideoFullscreenManagerProxy::logIdentifier() const
+{
+    return m_playbackSessionManagerProxy->logIdentifier();
+}
+
+const char* VideoFullscreenManagerProxy::logClassName() const
+{
+    return m_playbackSessionManagerProxy->logClassName();
+}
+
+WTFLogChannel& VideoFullscreenManagerProxy::logChannel() const
+{
+    return WebKit2LogFullscreen;
+}
+#endif
 
 } // namespace WebKit
 

--- a/Source/WebKit/UIProcess/WebPageProxy.cpp
+++ b/Source/WebKit/UIProcess/WebPageProxy.cpp
@@ -11857,6 +11857,11 @@ Logger& WebPageProxy::logger()
     return *m_logger;
 }
 
+const void* WebPageProxy::logIdentifier() const
+{
+    return reinterpret_cast<const void*>(intHash(identifier().toUInt64()));
+}
+
 void WebPageProxy::configureLoggingChannel(const String& channelName, WTFLogChannelState state, WTFLogLevel level)
 {
 #if !RELEASE_LOG_DISABLED

--- a/Source/WebKit/UIProcess/WebPageProxy.h
+++ b/Source/WebKit/UIProcess/WebPageProxy.h
@@ -1936,6 +1936,7 @@ public:
 #endif
 
     Logger& logger();
+    const void* logIdentifier() const;
 
     // IPC::MessageReceiver
     // Implemented in generated WebPageProxyMessageReceiver.cpp

--- a/Source/WebKit/WebProcess/WebPage/WebPage.cpp
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.cpp
@@ -8811,6 +8811,21 @@ bool WebPage::shouldSkipDecidePolicyForResponse(const WebCore::ResourceResponse&
     return true;
 }
 
+const Logger& WebPage::logger() const
+{
+    if (!m_logger) {
+        m_logger = Logger::create(this);
+        m_logger->setEnabled(this, !sessionID().isEphemeral());
+    }
+
+    return *m_logger;
+}
+
+const void* WebPage::logIdentifier() const
+{
+    return reinterpret_cast<const void*>(intHash(m_identifier.toUInt64()));
+}
+
 } // namespace WebKit
 
 #undef WEBPAGE_RELEASE_LOG

--- a/Source/WebKit/WebProcess/WebPage/WebPage.h
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.h
@@ -660,14 +660,14 @@ public:
 
     void setEnableVerticalRubberBanding(bool);
     void setEnableHorizontalRubberBanding(bool);
-    
+
     void setBackgroundExtendsBeyondPage(bool);
 
     void setPaginationMode(uint32_t /* WebCore::Pagination::Mode */);
     void setPaginationBehavesLikeColumns(bool);
     void setPageLength(double);
     void setGapBetweenPages(double);
-    
+
     void postInjectedBundleMessage(const String& messageName, const UserData&);
 
     void setUnderPageBackgroundColorOverride(WebCore::Color&&);
@@ -754,7 +754,7 @@ public:
     WebCore::IntRect rootViewToScreen(const WebCore::IntRect&);
     WebCore::IntPoint accessibilityScreenToRootView(const WebCore::IntPoint&);
     WebCore::IntRect rootViewToAccessibilityScreen(const WebCore::IntRect&);
-    
+
     RefPtr<WebImage> scaledSnapshotWithOptions(const WebCore::IntRect&, double additionalScaleFactor, SnapshotOptions);
 
     static const WebEvent* currentEvent();
@@ -811,7 +811,7 @@ public:
     WebCore::FloatSize overrideScreenSize() const;
     WebCore::IntDegrees deviceOrientation() const { return m_deviceOrientation; }
     void didReceiveMobileDocType(bool);
-    
+
     bool screenIsBeingCaptured() const { return m_screenIsBeingCaptured; }
     void setScreenIsBeingCaptured(bool);
 
@@ -929,7 +929,7 @@ public:
     };
     void freezeLayerTree(LayerTreeFreezeReason);
     void unfreezeLayerTree(LayerTreeFreezeReason);
-    
+
     void updateFrameSize(WebCore::FrameIdentifier, WebCore::IntSize);
 
     void isLayerTreeFrozen(CompletionHandler<void(bool)>&&);
@@ -1195,7 +1195,7 @@ public:
     bool hardwareKeyboardIsAttached() const { return m_keyboardIsAttached; }
 
     void updateStringForFind(const String&);
-    
+
     bool canShowWhileLocked() const { return m_canShowWhileLocked; }
 #endif
 
@@ -1222,7 +1222,7 @@ public:
 #if PLATFORM(COCOA)
     bool pdfPluginEnabled() const { return m_pdfPluginEnabled; }
     void setPDFPluginEnabled(bool enabled) { m_pdfPluginEnabled = enabled; }
-    
+
     bool selectionFlippingEnabled() const { return m_selectionFlippingEnabled; }
     void setSelectionFlippingEnabled(bool enabled) { m_selectionFlippingEnabled = enabled; }
 
@@ -1236,7 +1236,7 @@ public:
 
     bool alwaysShowsHorizontalScroller() const { return m_alwaysShowsHorizontalScroller; };
     bool alwaysShowsVerticalScroller() const { return m_alwaysShowsVerticalScroller; };
-    
+
     void scrollToRect(const WebCore::FloatRect& targetRect, const WebCore::FloatPoint& origin);
 
     void setMinimumSizeForAutoLayout(const WebCore::IntSize&);
@@ -1280,7 +1280,7 @@ public:
 
     void getBytecodeProfile(CompletionHandler<void(const String&)>&&);
     void getSamplingProfilerOutput(CompletionHandler<void(const String&)>&&);
-    
+
 #if ENABLE(SERVICE_CONTROLS) || ENABLE(TELEPHONE_NUMBER_DETECTION)
     void handleTelephoneNumberClick(const String& number, const WebCore::IntPoint&, const WebCore::IntRect&);
     void handleSelectionServiceClick(WebCore::FrameSelection&, const Vector<String>& telephoneNumbers, const WebCore::IntPoint&);
@@ -1332,7 +1332,7 @@ public:
 #if ENABLE(GAMEPAD)
     void gamepadActivity(const Vector<std::optional<GamepadData>>&, WebCore::EventMakesGamepadsVisible);
 #endif
-    
+
 #if ENABLE(POINTER_LOCK)
     void didAcquirePointerLock();
     void didNotAcquirePointerLock();
@@ -1389,7 +1389,7 @@ public:
 
     void showShareSheet(WebCore::ShareDataWithParsedURL&, CompletionHandler<void(bool)>&& callback);
     void showContactPicker(const WebCore::ContactsRequestData&, CompletionHandler<void(std::optional<Vector<WebCore::ContactInfo>>&&)>&&);
-    
+
 #if ENABLE(ATTACHMENT_ELEMENT)
     void insertAttachment(const String& identifier, std::optional<uint64_t>&& fileSize, const String& fileName, const String& contentType, CompletionHandler<void()>&&);
     void updateAttachmentAttributes(const String& identifier, std::optional<uint64_t>&& fileSize, const String& contentType, const String& fileName, const IPC::SharedBufferReference& enclosingImageData, CompletionHandler<void()>&&);
@@ -1478,7 +1478,7 @@ public:
     static WebCore::IntRect rootViewInteractionBounds(const WebCore::Node&);
 
     InteractionInformationAtPosition positionInformation(const InteractionInformationRequest&);
-    
+
 #endif // PLATFORM(IOS_FAMILY)
 
 #if USE(QUICK_LOOK)
@@ -1617,7 +1617,7 @@ public:
 #endif
 
     void generateTestReport(String&& message, String&& group);
-    
+
     bool isUsingUISideCompositing() const;
 
 #if ENABLE(ACCESSIBILITY_ANIMATION_CONTROL)
@@ -1633,6 +1633,9 @@ public:
 #if PLATFORM(IOS_FAMILY)
     bool isInStableState() const { return m_isInStableState; }
 #endif
+
+    const Logger& logger() const;
+    const void* logIdentifier() const;
 
 private:
     WebPage(WebCore::PageIdentifier, WebPageCreationParameters&&);
@@ -1985,7 +1988,7 @@ private:
 
     bool shouldDispatchSyntheticMouseEventsWhenModifyingSelection() const;
     void platformDidSelectAll();
-    
+
     void setHasResourceLoadClient(bool);
     void setCanUseCredentialStorage(bool);
 
@@ -2105,7 +2108,7 @@ private:
     void revokeSandboxExtensions(Vector<Ref<SandboxExtension>>& sandboxExtensions);
 
     void setSelectionRange(const WebCore::IntPoint&, WebCore::TextGranularity, bool);
-    
+
 #if !ENABLE(CONTENT_FILTERING_IN_NETWORKING_PROCESS)
     void consumeNetworkExtensionSandboxExtensions(const Vector<SandboxExtension::Handle>&);
 #endif
@@ -2148,7 +2151,7 @@ private:
     bool m_isInRedo { false };
     bool m_isClosed { false };
     bool m_tabToLinks { false };
-    
+
     bool m_mainFrameIsScrollable { true };
 
     bool m_alwaysShowsHorizontalScroller { false };
@@ -2188,7 +2191,7 @@ private:
 
     // The accessibility position of the view.
     WebCore::FloatPoint m_accessibilityPosition;
-    
+
     RetainPtr<WKAccessibilityWebPageObject> m_mockAccessibilityElement;
 #endif
 
@@ -2411,7 +2414,7 @@ private:
     bool m_wasShowingInputViewForFocusedElementDuringLastPotentialTap { false };
     bool m_completingSyntheticClick { false };
     bool m_hasHandledSyntheticClick { false };
-    
+
     enum SelectionAnchor { Start, End };
     SelectionAnchor m_selectionAnchor { Start };
 
@@ -2466,7 +2469,7 @@ private:
 
     HashSet<unsigned> m_activeRenderingSuppressionTokens;
     unsigned m_maximumRenderingSuppressionToken { 0 };
-    
+
     WebCore::ScrollPinningBehavior m_scrollPinningBehavior { WebCore::ScrollPinningBehavior::DoNotPin };
     std::optional<WebCore::ScrollbarOverlayStyle> m_scrollbarOverlayStyle;
 
@@ -2589,7 +2592,7 @@ private:
 #if ENABLE(WEBXR) && !USE(OPENXR)
     std::unique_ptr<PlatformXRSystemProxy> m_xrSystemProxy;
 #endif
-    
+
 #if ENABLE(APP_HIGHLIGHTS)
     WebCore::HighlightVisibility m_appHighlightsVisible { WebCore::HighlightVisibility::Hidden };
 #endif
@@ -2603,6 +2606,8 @@ private:
 #if ENABLE(IMAGE_ANALYSIS_ENHANCEMENTS)
     WeakHashSet<WebCore::HTMLImageElement, WebCore::WeakPtrImplWithEventTargetData> m_elementsToExcludeFromRemoveBackground;
 #endif
+
+    mutable RefPtr<Logger> m_logger;
 };
 
 #if !PLATFORM(IOS_FAMILY)

--- a/Source/WebKit/WebProcess/cocoa/PlaybackSessionManager.h
+++ b/Source/WebKit/WebProcess/cocoa/PlaybackSessionManager.h
@@ -98,7 +98,7 @@ class PlaybackSessionManager : public RefCounted<PlaybackSessionManager>, privat
 public:
     static Ref<PlaybackSessionManager> create(WebPage&);
     virtual ~PlaybackSessionManager();
-    
+
     void invalidate();
 
     void didReceiveMessage(IPC::Connection&, IPC::Decoder&) final;
@@ -109,6 +109,10 @@ public:
     PlaybackSessionContextIdentifier contextIdForMediaElement(WebCore::HTMLMediaElement&);
 
     WebCore::HTMLMediaElement* currentPlaybackControlsElement() const;
+
+#if !RELEASE_LOG_DISABLED
+    void sendLogIdentifierForMediaElement(WebCore::HTMLMediaElement&);
+#endif
 
 private:
     friend class PlaybackSessionInterfaceContext;
@@ -166,11 +170,23 @@ private:
     void setPlayingOnSecondScreen(PlaybackSessionContextIdentifier, bool value);
     void sendRemoteCommand(PlaybackSessionContextIdentifier, WebCore::PlatformMediaSession::RemoteControlCommandType, const WebCore::PlatformMediaSession::RemoteCommandArgument&);
 
+#if !RELEASE_LOG_DISABLED
+    const Logger& logger() const { return m_logger; }
+    const void* logIdentifier() const { return m_logIdentifier; }
+    const char* logClassName() const { return "VideoFullscreenManager"; }
+    WTFLogChannel& logChannel() const;
+#endif
+
     WebPage* m_page;
     WeakHashSet<WebCore::HTMLMediaElement, WebCore::WeakPtrImplWithEventTargetData> m_mediaElements;
     HashMap<PlaybackSessionContextIdentifier, ModelInterfaceTuple> m_contextMap;
     PlaybackSessionContextIdentifier m_controlsManagerContextId;
     HashCountedSet<PlaybackSessionContextIdentifier> m_clientCounts;
+
+#if !RELEASE_LOG_DISABLED
+    Ref<const Logger> m_logger;
+    const void* m_logIdentifier;
+#endif
 };
 
 } // namespace WebKit

--- a/Source/WebKit/WebProcess/cocoa/VideoFullscreenManager.h
+++ b/Source/WebKit/WebProcess/cocoa/VideoFullscreenManager.h
@@ -186,6 +186,13 @@ protected:
 
     void setCurrentlyInFullscreen(VideoFullscreenInterfaceContext&, bool);
 
+#if !RELEASE_LOG_DISABLED
+    const Logger& logger() const;
+    const void* logIdentifier() const;
+    const char* logClassName() const;
+    WTFLogChannel& logChannel() const;
+#endif
+
     WebPage* m_page;
     Ref<PlaybackSessionManager> m_playbackSessionManager;
     HashMap<WebCore::HTMLVideoElement*, PlaybackSessionContextIdentifier> m_videoElements;


### PR DESCRIPTION
#### 8877cb0fb4d494b94457f9589a99da4c48efb71e
<pre>
[Cocoa] Add runtime logging for PlaybackSessionMangager and VideoFullscreenMangager and their proxies
<a href="https://bugs.webkit.org/show_bug.cgi?id=255843">https://bugs.webkit.org/show_bug.cgi?id=255843</a>
rdar://108427487

Reviewed by Eric Carlson.

Add logging to the constellation of classes that make up PlaybackSessionManager and VideoFullscreenManager.

* Source/WebCore/platform/cocoa/VideoFullscreenModelVideoElement.h:
(WebCore::VideoFullscreenModelVideoElement::logClassName const):
* Source/WebCore/platform/cocoa/VideoFullscreenModelVideoElement.mm:
(WebCore::VideoFullscreenModelVideoElement::VideoFullscreenModelVideoElement):
(WebCore::VideoFullscreenModelVideoElement::~VideoFullscreenModelVideoElement):
(WebCore::VideoFullscreenModelVideoElement::setVideoElement):
(WebCore::VideoFullscreenModelVideoElement::willExitFullscreen):
(WebCore::VideoFullscreenModelVideoElement::createVideoFullscreenLayer):
(WebCore::VideoFullscreenModelVideoElement::setVideoFullscreenLayer):
(WebCore::VideoFullscreenModelVideoElement::waitForPreparedForInlineThen):
(WebCore::VideoFullscreenModelVideoElement::requestFullscreenMode):
(WebCore::VideoFullscreenModelVideoElement::setVideoLayerFrame):
(WebCore::VideoFullscreenModelVideoElement::setVideoSizeFenced):
(WebCore::VideoFullscreenModelVideoElement::setVideoLayerGravity):
(WebCore::VideoFullscreenModelVideoElement::fullscreenModeChanged):
(WebCore::VideoFullscreenModelVideoElement::setHasVideo):
(WebCore::VideoFullscreenModelVideoElement::setVideoDimensions):
(WebCore::VideoFullscreenModelVideoElement::willEnterPictureInPicture):
(WebCore::VideoFullscreenModelVideoElement::didEnterPictureInPicture):
(WebCore::VideoFullscreenModelVideoElement::failedToEnterPictureInPicture):
(WebCore::VideoFullscreenModelVideoElement::willExitPictureInPicture):
(WebCore::VideoFullscreenModelVideoElement::didExitPictureInPicture):
(WebCore::VideoFullscreenModelVideoElement::loggerPtr):
(WebCore::VideoFullscreenModelVideoElement::logIdentifier):
(WebCore::VideoFullscreenModelVideoElement::logChannel const):
* Source/WebCore/platform/graphics/FloatSize.h:
* Source/WebKit/UIProcess/Cocoa/PlaybackSessionManagerProxy.h:
(WebKit::PlaybackSessionManagerProxy::logger const):
(WebKit::PlaybackSessionManagerProxy::logIdentifier const):
(WebKit::PlaybackSessionManagerProxy::logClassName const):
* Source/WebKit/UIProcess/Cocoa/PlaybackSessionManagerProxy.messages.in:
* Source/WebKit/UIProcess/Cocoa/PlaybackSessionManagerProxy.mm:
(WebKit::PlaybackSessionModelContext::PlaybackSessionModelContext):
(WebKit::PlaybackSessionModelContext::play):
(WebKit::PlaybackSessionModelContext::pause):
(WebKit::PlaybackSessionModelContext::togglePlayState):
(WebKit::PlaybackSessionModelContext::beginScrubbing):
(WebKit::PlaybackSessionModelContext::endScrubbing):
(WebKit::PlaybackSessionModelContext::seekToTime):
(WebKit::PlaybackSessionModelContext::fastSeek):
(WebKit::PlaybackSessionModelContext::beginScanningForward):
(WebKit::PlaybackSessionModelContext::beginScanningBackward):
(WebKit::PlaybackSessionModelContext::endScanning):
(WebKit::PlaybackSessionModelContext::setDefaultPlaybackRate):
(WebKit::PlaybackSessionModelContext::setPlaybackRate):
(WebKit::PlaybackSessionModelContext::selectAudioMediaOption):
(WebKit::PlaybackSessionModelContext::selectLegibleMediaOption):
(WebKit::PlaybackSessionModelContext::togglePictureInPicture):
(WebKit::PlaybackSessionModelContext::toggleMuted):
(WebKit::PlaybackSessionModelContext::setMuted):
(WebKit::PlaybackSessionModelContext::setVolume):
(WebKit::PlaybackSessionModelContext::setPlayingOnSecondScreen):
(WebKit::PlaybackSessionModelContext::playbackStartedTimeChanged):
(WebKit::PlaybackSessionModelContext::durationChanged):
(WebKit::PlaybackSessionModelContext::currentTimeChanged):
(WebKit::PlaybackSessionModelContext::bufferedTimeChanged):
(WebKit::PlaybackSessionModelContext::rateChanged):
(WebKit::PlaybackSessionModelContext::seekableRangesChanged):
(WebKit::PlaybackSessionModelContext::logChannel const):
(WebKit::PlaybackSessionManagerProxy::PlaybackSessionManagerProxy):
(WebKit::PlaybackSessionManagerProxy::~PlaybackSessionManagerProxy):
(WebKit::PlaybackSessionManagerProxy::invalidate):
(WebKit::PlaybackSessionManagerProxy::setLogIdentifier):
(WebKit::PlaybackSessionManagerProxy::logChannel const):
* Source/WebKit/UIProcess/Cocoa/VideoFullscreenManagerProxy.h:
* Source/WebKit/UIProcess/Cocoa/VideoFullscreenManagerProxy.mm:
(WebKit::VideoFullscreenModelContext::requestCloseAllMediaPresentations):
(WebKit::VideoFullscreenModelContext::requestFullscreenMode):
(WebKit::VideoFullscreenModelContext::setVideoLayerFrame):
(WebKit::VideoFullscreenModelContext::setVideoLayerGravity):
(WebKit::VideoFullscreenModelContext::fullscreenModeChanged):
(WebKit::VideoFullscreenModelContext::requestUpdateInlineRect):
(WebKit::VideoFullscreenModelContext::requestVideoContentLayer):
(WebKit::VideoFullscreenModelContext::returnVideoContentLayer):
(WebKit::VideoFullscreenModelContext::returnVideoView):
(WebKit::VideoFullscreenModelContext::didSetupFullscreen):
(WebKit::VideoFullscreenModelContext::failedToEnterFullscreen):
(WebKit::VideoFullscreenModelContext::didEnterFullscreen):
(WebKit::VideoFullscreenModelContext::willExitFullscreen):
(WebKit::VideoFullscreenModelContext::didExitFullscreen):
(WebKit::VideoFullscreenModelContext::didCleanupFullscreen):
(WebKit::VideoFullscreenModelContext::fullscreenMayReturnToInline):
(WebKit::VideoFullscreenModelContext::requestRouteSharingPolicyAndContextUID):
(WebKit::VideoFullscreenModelContext::didEnterPictureInPicture):
(WebKit::VideoFullscreenModelContext::didExitPictureInPicture):
(WebKit::VideoFullscreenModelContext::willEnterPictureInPicture):
(WebKit::VideoFullscreenModelContext::failedToEnterPictureInPicture):
(WebKit::VideoFullscreenModelContext::willExitPictureInPicture):
(WebKit::VideoFullscreenModelContext::logIdentifier const):
(WebKit::VideoFullscreenModelContext::logger const):
(WebKit::VideoFullscreenModelContext::logChannel const):
(WebKit::VideoFullscreenManagerProxy::VideoFullscreenManagerProxy):
(WebKit::VideoFullscreenManagerProxy::~VideoFullscreenManagerProxy):
(WebKit::VideoFullscreenManagerProxy::invalidate):
(WebKit::VideoFullscreenManagerProxy::requestHideAndExitFullscreen):
(WebKit::VideoFullscreenManagerProxy::applicationDidBecomeActive):
(WebKit::VideoFullscreenManagerProxy::hasVideoInPictureInPictureDidChange):
(WebKit::VideoFullscreenManagerProxy::logger const):
(WebKit::VideoFullscreenManagerProxy::logIdentifier const):
(WebKit::VideoFullscreenManagerProxy::logClassName const):
(WebKit::VideoFullscreenManagerProxy::logChannel const):
* Source/WebKit/UIProcess/WebPageProxy.cpp:
(WebKit::WebPageProxy::logIdentifier const):
* Source/WebKit/UIProcess/WebPageProxy.h:
* Source/WebKit/WebProcess/WebPage/WebPage.cpp:
(WebKit::WebPage::logger const):
(WebKit::WebPage::logIdentifier const):
* Source/WebKit/WebProcess/WebPage/WebPage.h:
* Source/WebKit/WebProcess/cocoa/PlaybackSessionManager.h:
(WebKit::PlaybackSessionManager::logger const):
(WebKit::PlaybackSessionManager::logIdentifier const):
(WebKit::PlaybackSessionManager::logClassName const):
* Source/WebKit/WebProcess/cocoa/PlaybackSessionManager.mm:
(WebKit::PlaybackSessionManager::PlaybackSessionManager):
(WebKit::PlaybackSessionManager::~PlaybackSessionManager):
(WebKit::PlaybackSessionManager::invalidate):
(WebKit::PlaybackSessionManager::setUpPlaybackControlsManager):
(WebKit::PlaybackSessionManager::logChannel const):
* Source/WebKit/WebProcess/cocoa/VideoFullscreenManager.h:
* Source/WebKit/WebProcess/cocoa/VideoFullscreenManager.mm:
(WebKit::VideoFullscreenManager::VideoFullscreenManager):
(WebKit::VideoFullscreenManager::~VideoFullscreenManager):
(WebKit::VideoFullscreenManager::invalidate):
(WebKit::VideoFullscreenManager::setupRemoteLayerHosting):
(WebKit::VideoFullscreenManager::enterVideoFullscreenForVideoElement):
(WebKit::VideoFullscreenManager::exitVideoFullscreenForVideoElement):
(WebKit::VideoFullscreenManager::exitVideoFullscreenToModeWithoutAnimation):
(WebKit::VideoFullscreenManager::requestVideoContentLayer):
(WebKit::VideoFullscreenManager::returnVideoContentLayer):
(WebKit::VideoFullscreenManager::didSetupFullscreen):
(WebKit::VideoFullscreenManager::willExitFullscreen):
(WebKit::VideoFullscreenManager::didEnterFullscreen):
(WebKit::VideoFullscreenManager::failedToEnterFullscreen):
(WebKit::VideoFullscreenManager::didExitFullscreen):
(WebKit::VideoFullscreenManager::didCleanupFullscreen):
(WebKit::VideoFullscreenManager::setVideoLayerGravityEnum):
(WebKit::VideoFullscreenManager::setVideoLayerFrameFenced):
(WebKit::VideoFullscreenManager::logger const):
(WebKit::VideoFullscreenManager::logIdentifier const):
(WebKit::VideoFullscreenManager::logClassName const):
(WebKit::VideoFullscreenManager::logChannel const):

Canonical link: <a href="https://commits.webkit.org/263773@main">https://commits.webkit.org/263773@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a3a2475719edd1e7f27c53335cd6ea7931f19cfa

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/5725 "2 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/5886 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/6077 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/7280 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/6118 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/5725 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/6108 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/5856 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/7879 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/5830 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/5875 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/5149 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/7333 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/3352 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/5154 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/12912 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/4767 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/5220 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/5231 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/7220 "Passed tests") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/5310 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/5672 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/4647 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/5837 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/5120 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/1427 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/1346 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/9234 "Built successfully") | | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/24/builds/6002 "Built successfully") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/5480 "Built successfully") | | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/3/builds/1547 "Passed tests") | 
<!--EWS-Status-Bubble-End-->