### PR TITLE
[iOS] Mainframe scroll snap jumps to unpredictable offsets when pinch zooming

### DIFF
--- a/LayoutTests/css3/scroll-snap/ios/scroll-snap-mainframe-pinch-out-expected.txt
+++ b/LayoutTests/css3/scroll-snap/ios/scroll-snap-mainframe-pinch-out-expected.txt
@@ -1,0 +1,13 @@
+This test verifies that pinching out below the minimum scale in a root scroll
+        snapping container while triggering layout passes does not cause us to snap to an incorrect
+        position upon finishing the zoom animation. To manually test, pinch out to zoom on this page
+        and verify that the final scroll position is the same as the initial position (marked 4),
+        and the scroll position does not flicker in the process.
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+PASS finalOffsetY is originalOffsetY
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/css3/scroll-snap/ios/scroll-snap-mainframe-pinch-out.html
+++ b/LayoutTests/css3/scroll-snap/ios/scroll-snap-mainframe-pinch-out.html
@@ -1,0 +1,98 @@
+<!DOCTYPE html> <!-- webkit-test-runner [ useFlexibleViewport=true ] -->
+<html>
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<head>
+<style>
+body {
+    margin: 0;
+    overflow-x: hidden;
+    overflow-y: scroll;
+}
+
+:root {
+    scroll-snap-type: y mandatory;
+}
+
+body, html {
+    width: 100%;
+    height: 100%;
+}
+
+.child {
+    height: 100vh;
+    width: 50%;
+    scroll-snap-align: start;
+    font-family: system-ui;
+    font-size: 50px;
+    line-height: 100vh;
+    color: white;
+    text-align: center;
+}
+
+.fixed-output {
+    position: fixed;
+    top: 0;
+    right: 0;
+}
+</style>
+<script src="../../../resources/js-test.js"></script>
+<script src="../../../resources/ui-helper.js"></script>
+<script>
+let frameCount = 0;
+jsTestIsAsync = true;
+
+function oscillateBarWidth() {
+    frameCount++;
+    const snapChildren = [...document.getElementsByClassName("child")];
+    for (var i = 0; i < snapChildren.length; ++i) {
+        var framewidth = 10 * Math.sin(frameCount * 2 * Math.PI / 100) + 50;
+        snapChildren[i].style.width = framewidth + "%";
+    }
+    requestAnimationFrame(oscillateBarWidth);
+}
+
+addEventListener("load", async () => {
+    description(`This test verifies that pinching out below the minimum scale in a root scroll
+        snapping container while triggering layout passes does not cause us to snap to an incorrect
+        position upon finishing the zoom animation. To manually test, pinch out to zoom on this page
+        and verify that the final scroll position is the same as the initial position (marked 4),
+        and the scroll position does not flicker in the process.`);
+
+    await UIHelper.renderingUpdate();
+
+    const childHeight = document.querySelector(".child").offsetHeight;
+    scrollTo(0, 4 * childHeight);
+    oscillateBarWidth();
+
+    originalOffsetY = (await UIHelper.contentOffset()).y;
+    await UIHelper.pinch(
+        250, pageYOffset + 100,
+        50, pageYOffset + 400,
+        150, pageYOffset + 250,
+        150,  pageYOffset + 300
+    );
+    await UIHelper.ensureStablePresentationUpdate();
+
+    finalOffsetY = (await UIHelper.contentOffset()).y;
+    shouldBe("finalOffsetY", "originalOffsetY");
+    finishJSTest();
+});
+</script>
+</head>
+<body>
+    <div class="child" style="background-color: black;"></div>
+    <div class="child" style="background-color: darkred;"></div>
+    <div class="child" style="background-color: red;"></div>
+    <div class="child" style="background-color: darkorange;"></div>
+    <div class="child" style="background-color: darkgreen;"></div>
+    <div class="child" style="background-color: darkorange;"></div>
+    <div class="child" style="background-color: red;"></div>
+    <div class="child" style="background-color: darkred;"></div>
+    <div class="child" style="background-color: black;"></div>
+    <div class="fixed-output">
+        <pre id="description"></pre>
+        <pre id="console"></pre>
+    </div>
+</body>
+</html>
+

--- a/LayoutTests/css3/scroll-snap/ios/scroll-snap-mainframe-scroll-deceleration-with-obscured-inset.html
+++ b/LayoutTests/css3/scroll-snap/ios/scroll-snap-mainframe-scroll-deceleration-with-obscured-inset.html
@@ -1,9 +1,9 @@
 <!DOCTYPE html> <!-- webkit-test-runner [ useFlexibleViewport=true obscuredInset.top=50 ] -->
 <html>
 <meta name="viewport" content="width=device-width, initial-scale=1">
+<head>
 <script src="../../../resources/js-test.js"></script>
 <script src="../../../resources/ui-helper.js"></script>
-<head>
 <style>
 body, html {
     width: 100%;

--- a/LayoutTests/resources/ui-helper.js
+++ b/LayoutTests/resources/ui-helper.js
@@ -1662,6 +1662,98 @@ window.UIHelper = class UIHelper {
         });
     }
 
+    static async pinch(firstStartX, firstStartY, secondStartX, secondStartY, firstEndX, firstEndY, secondEndX, secondEndY)
+    {
+        await UIHelper.sendEventStream({
+            events: [
+                {
+                    interpolate : "linear",
+                    timestep : 0.01,
+                    coordinateSpace : "content",
+                    startEvent : {
+                        inputType : "hand",
+                        timeOffset : 0,
+                        touches : [
+                            { inputType : "finger", phase : "began", id : 1, x : firstStartX, y : firstStartY, pressure : 0 },
+                            { inputType : "finger", phase : "began", id : 2, x : secondStartX, y : secondStartY, pressure : 0 }
+                        ]
+                    },
+                    endEvent : {
+                        inputType : "hand",
+                        timeOffset : 0.01,
+                        touches : [
+                            { inputType : "finger", phase : "began", id : 1, x : firstStartX, y : firstStartY, pressure : 0 },
+                            { inputType : "finger", phase : "began", id : 2, x : secondStartX, y : secondStartY, pressure : 0 }
+                        ]
+                    }
+                },
+                {
+                    interpolate : "linear",
+                    timestep : 0.01,
+                    coordinateSpace : "content",
+                    startEvent : {
+                        inputType : "hand",
+                        timeOffset : 0.01,
+                        touches : [
+                            { inputType : "finger", phase : "moved", id : 1, x : firstStartX, y : firstStartY, pressure : 0 },
+                            { inputType : "finger", phase : "moved", id : 2, x : secondStartX, y : secondStartY, pressure : 0 }
+                        ]
+                    },
+                    endEvent : {
+                        inputType : "hand",
+                        timeOffset : 0.9,
+                        touches : [
+                            { inputType : "finger", phase : "moved", id : 1, x : firstEndX, y : firstEndY, pressure : 0 },
+                            { inputType : "finger", phase : "moved", id : 2, x : secondEndX, y : secondEndY, pressure : 0 }
+                        ]
+                    }
+                },
+                {
+                    interpolate : "linear",
+                    timestep : 0.01,
+                    coordinateSpace : "content",
+                    startEvent : {
+                        inputType : "hand",
+                        timeOffset : 0.9,
+                        touches : [
+                            { inputType : "finger", phase : "stationary", id : 1, x : firstEndX, y : firstEndY, pressure : 0 },
+                            { inputType : "finger", phase : "stationary", id : 2, x : secondEndX, y : secondEndY, pressure : 0 }
+                        ]
+                    },
+                    endEvent : {
+                        inputType : "hand",
+                        timeOffset : 0.99,
+                        touches : [
+                            { inputType : "finger", phase : "stationary", id : 1, x : firstEndX, y : firstEndY, pressure : 0 },
+                            { inputType : "finger", phase : "stationary", id : 2, x : secondEndX, y : secondEndY, pressure : 0 }
+                        ]
+                    }
+                },
+                {
+                    interpolate : "linear",
+                    timestep : 0.01,
+                    coordinateSpace : "content",
+                    startEvent : {
+                        inputType : "hand",
+                        timeOffset : 0.99,
+                        touches : [
+                            { inputType : "finger", phase : "ended", id : 1, x : firstEndX, y : firstEndY, pressure : 0 },
+                            { inputType : "finger", phase : "ended", id : 2, x : secondEndX, y : secondEndY, pressure : 0 }
+                        ]
+                    },
+                    endEvent : {
+                        inputType : "hand",
+                        timeOffset : 1,
+                        touches : [
+                            { inputType : "finger", phase : "ended", id : 1, x : firstEndX, y : firstEndY, pressure : 0 },
+                            { inputType : "finger", phase : "ended", id : 2, x : secondEndX, y : secondEndY, pressure : 0 }
+                        ]
+                    }
+                }
+            ]
+        });
+    }
+
     static setWindowIsKey(isKey)
     {
         const script = `uiController.windowIsKey = ${isKey}`;

--- a/Source/WebCore/page/ChromeClient.h
+++ b/Source/WebCore/page/ChromeClient.h
@@ -646,6 +646,8 @@ public:
 
     virtual bool isUsingUISideCompositing() const { return false; }
     
+    virtual bool isInStableState() const { return true; }
+
     WEBCORE_EXPORT virtual ~ChromeClient();
 
 protected:

--- a/Source/WebCore/page/LocalFrameView.cpp
+++ b/Source/WebCore/page/LocalFrameView.cpp
@@ -3051,6 +3051,13 @@ bool LocalFrameView::isRubberBandInProgress() const
     return false;
 }
 
+bool LocalFrameView::isInStableState() const
+{
+    if (auto* page = m_frame->page())
+        return page->chrome().client().isInStableState();
+    return FrameView::isInStableState();
+}
+
 bool LocalFrameView::requestStartKeyboardScrollAnimation(const KeyboardScroll& scrollData)
 {
     if (auto scrollingCoordinator = this->scrollingCoordinator())

--- a/Source/WebCore/page/LocalFrameView.h
+++ b/Source/WebCore/page/LocalFrameView.h
@@ -823,6 +823,7 @@ private:
 #if HAVE(RUBBER_BANDING)
     GraphicsLayer* layerForOverhangAreas() const final;
 #endif
+    bool isInStableState() const final;
     void contentsResized() final;
 
 #if ENABLE(DARK_MODE_CSS)

--- a/Source/WebCore/platform/ScrollableArea.cpp
+++ b/Source/WebCore/platform/ScrollableArea.cpp
@@ -545,7 +545,7 @@ void ScrollableArea::resnapAfterLayout()
     LOG_WITH_STREAM(ScrollSnap, stream << *this << " resnapAfterLayout: isScrollSnapInProgress " << isScrollSnapInProgress() << " isUserScrollInProgress " << isUserScrollInProgress());
 
     auto* scrollAnimator = existingScrollAnimator();
-    if (!scrollAnimator || isScrollSnapInProgress() || isUserScrollInProgress())
+    if (!scrollAnimator || isScrollSnapInProgress() || isUserScrollInProgress() || !isInStableState())
         return;
 
     scrollAnimator->resnapAfterLayout();

--- a/Source/WebCore/platform/ScrollableArea.h
+++ b/Source/WebCore/platform/ScrollableArea.h
@@ -347,6 +347,8 @@ public:
 
     virtual bool scrollAnimatorEnabled() const { return false; }
 
+    virtual bool isInStableState() const { return true; }
+
     // NOTE: Only called from Internals for testing.
     WEBCORE_EXPORT void setScrollOffsetFromInternals(const ScrollOffset&);
 

--- a/Source/WebKit/Platform/spi/ios/UIKitSPI.h
+++ b/Source/WebKit/Platform/spi/ios/UIKitSPI.h
@@ -1089,6 +1089,11 @@ typedef NS_ENUM(NSInteger, _UIBackdropViewStylePrivate) {
 
 @class BKSAnimationFenceHandle;
 
+@interface UIGestureRecognizer (SPI)
+- (NSSet<UITouch *> *)_activeTouchesForEvent:(UIEvent *)event;
+- (__kindof UIEvent *)_activeEventOfType:(UIEventType)type;
+@end
+
 @interface UIWindow ()
 + (BKSAnimationFenceHandle *)_synchronizedDrawingFence;
 + (mach_port_t)_synchronizeDrawingAcrossProcesses;
@@ -1534,6 +1539,8 @@ typedef NS_ENUM(NSUInteger, _UIScrollDeviceCategory) {
 - (BOOL)_canScrollWithoutBouncingY;
 - (void)_setContentOffsetWithDecelerationAnimation:(CGPoint)contentOffset;
 - (CGPoint)_adjustedContentOffsetForContentOffset:(CGPoint)contentOffset;
+- (void)handlePinch:(UIPinchGestureRecognizer *)gesture;
+- (void)handlePan:(UIPanGestureRecognizer *)gesture;
 
 @property (nonatomic) BOOL tracksImmediatelyWhileDecelerating;
 @property (nonatomic, getter=_avoidsJumpOnInterruptedBounce, setter=_setAvoidsJumpOnInterruptedBounce:) BOOL _avoidsJumpOnInterruptedBounce;

--- a/Source/WebKit/UIProcess/API/ios/WKWebViewIOS.mm
+++ b/Source/WebKit/UIProcess/API/ios/WKWebViewIOS.mm
@@ -2347,7 +2347,7 @@ static WebCore::FloatPoint constrainContentOffset(WebCore::FloatPoint contentOff
     if (scrollView.isDragging || scrollView.isZooming || scrollView._isInterruptingDeceleration)
         stabilityFlags.add(WebKit::ViewStabilityFlag::ScrollViewInteracting);
 
-    if (scrollView.isDecelerating || scrollView._isAnimatingZoom || scrollView._isScrollingToTop)
+    if (scrollView.isDecelerating || scrollView._isAnimatingZoom || scrollView._isScrollingToTop || scrollView.isZoomBouncing)
         stabilityFlags.add(WebKit::ViewStabilityFlag::ScrollViewAnimatedScrollOrZoom);
 
     if (scrollView == _scrollView.get() && _isChangingObscuredInsetsInteractively)

--- a/Source/WebKit/UIProcess/RemoteLayerTree/ios/RemoteScrollingCoordinatorProxyIOS.mm
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/ios/RemoteScrollingCoordinatorProxyIOS.mm
@@ -311,10 +311,11 @@ std::pair<float, std::optional<unsigned>> RemoteScrollingCoordinatorProxyIOS::cl
     auto* rootNode = scrollingTree()->rootNode();
     const auto& snapOffsetsInfo = rootNode->snapOffsetsInfo();
 
-    scrollDestination.scale(1.0 / webPageProxy().displayedContentScale());
-    float scaledCurrentScrollOffset = currentScrollOffset / webPageProxy().displayedContentScale();
+    auto zoomScale = [webPageProxy().cocoaView() scrollView].zoomScale;
+    scrollDestination.scale(1.0 / zoomScale);
+    float scaledCurrentScrollOffset = currentScrollOffset / zoomScale;
     auto [rawClosestSnapOffset, newIndex] = snapOffsetsInfo.closestSnapOffset(axis, rootNode->layoutViewport().size(), scrollDestination, velocity, scaledCurrentScrollOffset);
-    return std::make_pair(rawClosestSnapOffset * webPageProxy().displayedContentScale(), newIndex);
+    return std::make_pair(rawClosestSnapOffset * zoomScale, newIndex);
 }
 
 bool RemoteScrollingCoordinatorProxyIOS::hasActiveSnapPoint() const
@@ -348,13 +349,14 @@ CGPoint RemoteScrollingCoordinatorProxyIOS::nearestActiveContentInsetAdjustedSna
     auto& rootScrollingNode = downcast<ScrollingTreeFrameScrollingNode>(*root);
     const auto& horizontal = rootScrollingNode.snapOffsetsInfo().horizontalSnapOffsets;
     const auto& vertical = rootScrollingNode.snapOffsetsInfo().verticalSnapOffsets;
+    auto zoomScale = [webPageProxy().cocoaView() scrollView].zoomScale;
 
     // The bounds checking with maxScrollOffsets is to ensure that we won't interfere with rubber-banding when scrolling to the edge of the page.
     if (!horizontal.isEmpty() && m_currentHorizontalSnapPointIndex && *m_currentHorizontalSnapPointIndex < horizontal.size())
-        activePoint.x = horizontal[*m_currentHorizontalSnapPointIndex].offset * webPageProxy().displayedContentScale();
+        activePoint.x = horizontal[*m_currentHorizontalSnapPointIndex].offset * zoomScale;
 
     if (!vertical.isEmpty() && m_currentVerticalSnapPointIndex && *m_currentVerticalSnapPointIndex < vertical.size()) {
-        float potentialSnapPosition = vertical[*m_currentVerticalSnapPointIndex].offset * webPageProxy().displayedContentScale();
+        float potentialSnapPosition = vertical[*m_currentVerticalSnapPointIndex].offset * zoomScale;
         potentialSnapPosition -= topInset;
         activePoint.y = potentialSnapPosition;
     }

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebChromeClient.cpp
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebChromeClient.cpp
@@ -1715,5 +1715,14 @@ bool WebChromeClient::isUsingUISideCompositing() const
 #endif
 }
 
+bool WebChromeClient::isInStableState() const
+{
+#if PLATFORM(IOS_FAMILY)
+    return m_page.isInStableState();
+#else
+    // FIXME (255877): Implement this client hook on macOS.
+    return true;
+#endif
+}
 
 } // namespace WebKit

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebChromeClient.h
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebChromeClient.h
@@ -489,6 +489,8 @@ private:
     
     bool isUsingUISideCompositing() const;
 
+    bool isInStableState() const final;
+
     mutable bool m_cachedMainFrameHasHorizontalScrollbar { false };
     mutable bool m_cachedMainFrameHasVerticalScrollbar { false };
 

--- a/Source/WebKit/WebProcess/WebPage/WebPage.h
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.h
@@ -1623,6 +1623,10 @@ public:
     bool shouldSkipDecidePolicyForResponse(const WebCore::ResourceResponse&, const WebCore::ResourceRequest&) const;
     void setSkipDecidePolicyForResponseIfPossible(bool value) { m_skipDecidePolicyForResponseIfPossible = value; }
 
+#if PLATFORM(IOS_FAMILY)
+    bool isInStableState() const { return m_isInStableState; }
+#endif
+
 private:
     WebPage(WebCore::PageIdentifier, WebPageCreationParameters&&);
 


### PR DESCRIPTION
#### f4b2339d9e5187c28766b443ac6c29c27f59821c
<pre>
[iOS] Mainframe scroll snap jumps to unpredictable offsets when pinch zooming
<a href="https://bugs.webkit.org/show_bug.cgi?id=255848">https://bugs.webkit.org/show_bug.cgi?id=255848</a>
rdar://108008629

Reviewed by Brent Fulgham and Simon Fraser.

When pinch zooming out to less than the initial scale on book.stevejobsarchive.com (when scroll
snapping on the root element is enabled), the scroll position frequently jumps to (seemingly) random
offsets in the page, sometimes after attempting to scroll (with animation) to another wrong scroll
snap point. There are multiple root causes that trigger these symptoms, described below (along with
the changes in this patch that address each one):

(1) We occasionally use the wrong scale to compute the appropriate snap offset in
    `RemoteScrollingCoordinatorProxyIOS`. Currently, `WebPageProxy::displayedContentScale` only
    yields the latest zoom scale we sent via `VisibleContentRectUpdate`, but we scale (and
    counterscale) geometry directly on the `WKScrollView` using this scale. There&apos;s no guarantee
    that `-[UIScrollView zoomScale]` is in sync with this last sent scale, so we can end up
    computing the wrong nearest snap position in both `closestSnapOffsetForMainFrameScrolling` (when
    ending the pinch) and `nearestActiveContentInsetAdjustedSnapOffset` (when we receive the first
    stable-state commit after the bounce animation).

    To fix this, we simply use `UIScrollView`&apos;s `-zoomScale` instead so that the scale is consistent
    with the current value of `-contentOffset`, as well as the retargeted content offset.

(2) Even ignoring (1), the scroll view sometimes fails to retarget to any offset at all after
    pinching out, and instead settles back down to the current offset (as if snapping were
    disabled), before instantly jumping to a nearby snap point. Whether or not this bug happens is
    dependent on the order in which `WKScrollView`&apos;s pan gesture action fires in Ended state —
    relative to the pinch gesture — when ending the pinch. If the scroll view observes the pan
    gesture ending (`-handlePan:`) before the pinch gesture ends (`-handlePinch:`), we&apos;ll run our
    retargeting logic for scroll snapping, but then `UIScrollView` immediately stomps over the
    retargeted position due to the `-zoomScale` clamping back to `-minimumZoomScale` when ending the
    pinch. This ordering is currently non-deterministic, as it depends on hashing order of the
    scroll view&apos;s pinch and pan gesture recognizers, when sending actions to gestures after ending
    the touch.

    To work around this, we take advantage of the fact that `-handlePinch:` is idempotent when the
    pinch gesture has ended (since we&apos;ll clear the `zooming` flag and transition to `zoomBouncing`
    state only once), and directly invoke `-handlePinch:` from within `-handlePan:` here to ensure
    that we&apos;re able to use the retargeting delegate hook.

    There are other workarounds that I considered, such as detecting that this bug is about to
    happen and falling back to an animated scroll instead of retargeting; however, the above is the
    only approach I could find that results in a smooth &quot;glide&quot; animation to the correct snap
    destination (as opposed to zooming back to minimum scale and then scrolling to the final
    location).

(3) There&apos;s logic in `-_updateVisibleContentRects` that&apos;s responsible for scrolling to the active
    snap position when we&apos;re about to send a stable visible content rect update; however, this fires
    way too early in some cases (i.e. right after the pinch ends, in the middle of zooming), causing
    us to jump to the final offset. This is because we send a visible content rect update after the
    `-isZooming` flag is unset (i.e. after the pinch gesture recognizer transitions to Ended state),
    but before the zooming actually begins. Correct this gap in view stability state by additionally
    consulting the `-isZoomBouncing` flag, which is set right after zooming ends when pinching out
    and unset after the zoom animation completes.

(4) After fixing all the above, the behavior is considerably improved, but scrolling still
    occasionally jumps to the final offset in the middle of the zoom bounce animation. This is
    because `resnapAfterLayout()` triggers before the zoom animation is complete, causing a stutter
    in the scroll position as we attempt an instant scroll to the final offset while still zooming.

    Address this by avoiding `resnapAfterLayout()` in the case where the viewport is not in stable
    state; to achieve this, we add some client plumbing through `LocalFrameView` -&gt;
    `WebChromeClient` -&gt; `WebPage` to return whether or not we&apos;re in stable state. Note that we also
    rely on (3) here, otherwise the web process will enter stable state too early.

With the 4 issues above fixed, pinch zooming on book.stevejobsarchive.com no longer causes the
scroll position to visually stutter or jump, and we instead transition in one smooth animation from
the offset in the pinched-out view to the final scroll snap destination, in all cases.

Test: css3/scroll-snap/ios/scroll-snap-mainframe-pinch-out.html

* LayoutTests/css3/scroll-snap/ios/scroll-snap-mainframe-pinch-out-expected.txt: Added.
* LayoutTests/css3/scroll-snap/ios/scroll-snap-mainframe-pinch-out.html: Added.

Add a new test case to exercise this scenario; this test uses scroll snapping on the root element,
and additionally continuously triggers layout on the page by changing the widths of each of the
scroll snap children every frame. The test then programmatically scrolls to a snap point in the
middle of the page, zooms out by pinching, and verifies that after the bounce has ended (i.e. we get
a stable state presentation update), the final scroll offset matches what we started with.

* LayoutTests/css3/scroll-snap/ios/scroll-snap-mainframe-scroll-deceleration-with-obscured-inset.html:

Drive-by fix: clean up this test page by moving the `script` elements in this test under the `head`.

* LayoutTests/resources/ui-helper.js:
(window.UIHelper.async pinch):

Add a `UIHelper` method to make it easier to synthesize a pinch gesture; this helper method takes
4 points (8 x/y values total) that represent the two starting touch locations, and two ending touch
locations. It then creates and synthesizes a 2-finger gesture stream using these points.

* Source/WebCore/page/ChromeClient.h:
(WebCore::ChromeClient::isInStableState const):
* Source/WebCore/page/LocalFrameView.cpp:
(WebCore::LocalFrameView::isInStableState const):
* Source/WebCore/page/LocalFrameView.h:
* Source/WebCore/platform/ScrollableArea.cpp:
(WebCore::ScrollableArea::resnapAfterLayout):

See (4) in the above diagnosis.

* Source/WebCore/platform/ScrollableArea.h:
(WebCore::ScrollableArea::isInStableState const):
* Source/WebKit/Platform/spi/ios/UIKitSPI.h:

Add more forward declarations on `UIScrollView`.

* Source/WebKit/UIProcess/API/ios/WKWebViewIOS.mm:
(-[WKWebView _viewStabilityState:]):

See (3) in the above diagnosis.

* Source/WebKit/UIProcess/RemoteLayerTree/ios/RemoteScrollingCoordinatorProxyIOS.mm:
(WebKit::RemoteScrollingCoordinatorProxyIOS::closestSnapOffsetForMainFrameScrolling const):
(WebKit::RemoteScrollingCoordinatorProxyIOS::nearestActiveContentInsetAdjustedSnapOffset const):

See (1) in the above diagnosis.

* Source/WebKit/UIProcess/ios/WKScrollView.mm:
(-[WKScrollView _sendPinchGestureActionEarlyIfNeeded]):
(-[WKScrollView handlePan:]):

See (2) in the above diagnosis.

* Source/WebKit/WebProcess/WebCoreSupport/WebChromeClient.cpp:
(WebKit::WebChromeClient::isInStableState const):
* Source/WebKit/WebProcess/WebCoreSupport/WebChromeClient.h:
* Source/WebKit/WebProcess/WebPage/WebPage.h:
(WebKit::WebPage::isInStableState const):

Canonical link: <a href="https://commits.webkit.org/263336@main">https://commits.webkit.org/263336@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/8e3e358a614b41cf90c5c4bfffd8508be3d85ce7

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/4240 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/4362 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/4480 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/5711 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/4485 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/4234 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/4491 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/4327 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/4705 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/4302 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/4487 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/3828 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/5705 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/1982 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/3804 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/6183 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/3811 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/3871 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/5402 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/4280 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/3474 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/3790 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/3802 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/1053 "Built successfully and passed tests") | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/4/builds/7876 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/4136 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->