### PR TITLE
Attachment (wide-layout): Use semantic color for the save icon background on iOS

### DIFF
--- a/LayoutTests/platform/ios-wk2/fast/attachment/cocoa/wide-attachment-rendering-expected.txt
+++ b/LayoutTests/platform/ios-wk2/fast/attachment/cocoa/wide-attachment-rendering-expected.txt
@@ -49,7 +49,7 @@ layer at (0,0) size 800x600
             RenderGrid {DIV} at (76,0) size 262x92
               RenderGrid {DIV} at (6,26) size 230x40
                 RenderBlock {DIV} at (190,0) size 40x40
-                  RenderButton {BUTTON} at (0,0) size 40x40 [bgcolor=#EEEEEF]
+                  RenderButton {BUTTON} at (0,0) size 40x40 [bgcolor=#7676801F]
                     RenderBlock (anonymous) at (0,9) size 40x22
                       RenderBlock {DIV} at (9,0) size 22x22
 layer at (128,131) size 230x17

--- a/Source/WebCore/css/CSSValueKeywords.in
+++ b/Source/WebCore/css/CSSValueKeywords.in
@@ -273,6 +273,7 @@ accentcolortext
 -apple-system-label enable-if=WTF_PLATFORM_COCOA
 -apple-system-secondary-label enable-if=WTF_PLATFORM_COCOA
 -apple-system-tertiary-label enable-if=WTF_PLATFORM_COCOA
+-apple-system-tertiary-fill enable-if=WTF_PLATFORM_COCOA
 -apple-system-quaternary-label enable-if=WTF_PLATFORM_COCOA
 -apple-system-grid enable-if=WTF_PLATFORM_COCOA
 -apple-system-separator enable-if=WTF_PLATFORM_COCOA
@@ -305,7 +306,6 @@ accentcolortext
 -apple-system-selected-text-background enable-if=WTF_PLATFORM_MAC
 -apple-system-unemphasized-selected-text-background enable-if=WTF_PLATFORM_MAC
 -apple-system-find-highlight-background enable-if=WTF_PLATFORM_MAC
--apple-system-tertiary-fill enable-if=WTF_PLATFORM_MAC
 -apple-system-indigo enable-if=WTF_PLATFORM_IOS_FAMILY
 -apple-system-teal enable-if=WTF_PLATFORM_IOS_FAMILY
 -apple-system-opaque-fill enable-if=WTF_PLATFORM_IOS_FAMILY

--- a/Source/WebCore/css/parser/CSSParserIdioms.cpp
+++ b/Source/WebCore/css/parser/CSSParserIdioms.cpp
@@ -39,7 +39,7 @@ bool isValueAllowedInMode(unsigned short id, CSSParserMode mode)
     switch (id) {
     case CSSValueWebkitFocusRingColor:
         return isUASheetBehavior(mode) || isQuirksModeBehavior(mode);
-#if PLATFORM(MAC)
+#if PLATFORM(COCOA)
     case CSSValueAppleSystemTertiaryFill:
 #endif
 #if PLATFORM(IOS_FAMILY)

--- a/Source/WebCore/html/shadow/attachmentElementShadow.css
+++ b/Source/WebCore/html/shadow/attachmentElementShadow.css
@@ -182,7 +182,7 @@ button#attachment-save-button {
 #if (defined(WTF_PLATFORM_IOS_FAMILY) && WTF_PLATFORM_IOS_FAMILY)
     width: 40px;
     height: 40px;
-    background-color: -apple-system-opaque-tertiary-fill;
+    background-color: -apple-system-tertiary-fill;
     border: 0;
 #else
     width: 28px;

--- a/Source/WebCore/rendering/RenderThemeIOS.mm
+++ b/Source/WebCore/rendering/RenderThemeIOS.mm
@@ -1425,6 +1425,7 @@ static const Vector<CSSValueSystemColorInformation>& cssValueSystemColorInformat
             // FIXME: <rdar://problem/75538507> UIKit should expose this color so that we maintain parity with system buttons.
             { CSSValueAppleSystemOpaqueSecondaryFillDisabled, @selector(secondarySystemFillColor), true, 0.75f },
             { CSSValueAppleSystemOpaqueTertiaryFill, @selector(tertiarySystemFillColor), true },
+            { CSSValueAppleSystemTertiaryFill, @selector(tertiarySystemFillColor) },
             { CSSValueAppleSystemQuaternaryFill, @selector(quaternarySystemFillColor) },
             { CSSValueAppleSystemGroupedBackground, @selector(systemGroupedBackgroundColor) },
             { CSSValueAppleSystemSecondaryGroupedBackground, @selector(secondarySystemGroupedBackgroundColor) },


### PR DESCRIPTION
#### 35779e4c19aee3f6468b45c518530166a599159e
<pre>
Attachment (wide-layout): Use semantic color for the save icon background on iOS
<a href="https://bugs.webkit.org/show_bug.cgi?id=255849">https://bugs.webkit.org/show_bug.cgi?id=255849</a>
rdar://107157550

Reviewed by Aditya Keerthi.

Without a proper semantic color, the color doesn&apos;t get updated when switching between light and dark modes.
The &quot;-apple-system-opaque-tertiary-fill&quot; color is not semantic, instead &quot;-apple-system-tertiary-fill&quot; should be used (as was already done on macOS).

* LayoutTests/platform/ios-wk2/fast/attachment/cocoa/wide-attachment-rendering-expected.txt:
* Source/WebCore/css/CSSValueKeywords.in:
* Source/WebCore/css/parser/CSSParserIdioms.cpp:
(WebCore::isValueAllowedInMode):
* Source/WebCore/html/shadow/attachmentElementShadow.css:
(button#attachment-save-button):
* Source/WebCore/rendering/RenderThemeIOS.mm:
(WebCore::cssValueSystemColorInformationList):

Canonical link: <a href="https://commits.webkit.org/263340@main">https://commits.webkit.org/263340@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e6fd89258254af7497cbc61dcee51d2ae797c6bf

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/4195 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/4313 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/4431 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/5663 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/4441 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/4187 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/4419 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/4278 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/4661 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/4256 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/4430 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/3782 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/5656 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/1925 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/3759 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/5943 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/3752 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/3825 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/5344 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/4233 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/3433 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/3744 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/3757 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/1057 "Built successfully and passed tests") | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/4/builds/7844 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/4064 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->