### PR TITLE
Switch WindowFeatures.cpp to isASCIIWhitespace

### DIFF
--- a/Source/WebCore/page/WindowFeatures.cpp
+++ b/Source/WebCore/page/WindowFeatures.cpp
@@ -42,13 +42,9 @@ static std::optional<bool> boolFeature(const DialogFeaturesMap&, ASCIILiteral ke
 static std::optional<float> floatFeature(const DialogFeaturesMap&, ASCIILiteral key, float min, float max);
 
 // https://html.spec.whatwg.org/#feature-separator
-static bool isSeparator(UChar character, FeatureMode mode)
+static bool isSeparator(UChar character)
 {
-    if (mode == FeatureMode::Viewport)
-        return character == ' ' || character == '\t' || character == '\n' || character == '\r' || character == '=' || character == ',';
-
-    // FIXME: this should be isASCIIWhitespace
-    return isUnicodeCompatibleASCIIWhitespace(character) || character == '=' || character == ',';
+    return isASCIIWhitespace(character) || character == '=' || character == ',';
 }
 
 WindowFeatures parseWindowFeatures(StringView featuresString)
@@ -87,27 +83,27 @@ void processFeaturesString(StringView features, FeatureMode mode, const Function
     unsigned length = features.length();
     for (unsigned i = 0; i < length; ) {
         // Skip to first non-separator.
-        while (i < length && isSeparator(features[i], mode))
+        while (i < length && isSeparator(features[i]))
             ++i;
         unsigned keyBegin = i;
 
         // Skip to first separator.
-        while (i < length && !isSeparator(features[i], mode))
+        while (i < length && !isSeparator(features[i]))
             i++;
         unsigned keyEnd = i;
 
         // Skip to first '=', but don't skip past a ',' or a non-separator.
-        while (i < length && features[i] != '=' && features[i] != ',' && (mode == FeatureMode::Viewport || isSeparator(features[i], mode)))
+        while (i < length && features[i] != '=' && features[i] != ',' && (mode == FeatureMode::Viewport || isSeparator(features[i])))
             ++i;
 
         // Skip to first non-separator, but don't skip past a ','.
-        if (mode == FeatureMode::Viewport || (i < length && isSeparator(features[i], mode))) {
-            while (i < length && isSeparator(features[i], mode) && features[i] != ',')
+        if (mode == FeatureMode::Viewport || (i < length && isSeparator(features[i]))) {
+            while (i < length && isSeparator(features[i]) && features[i] != ',')
                 ++i;
             unsigned valueBegin = i;
 
             // Skip to first separator.
-            while (i < length && !isSeparator(features[i], mode))
+            while (i < length && !isSeparator(features[i]))
                 ++i;
             unsigned valueEnd = i;
             callback(features.substring(keyBegin, keyEnd - keyBegin), features.substring(valueBegin, valueEnd - valueBegin));


### PR DESCRIPTION
#### 805081a10655c540f3246619b698992dd91add22
<pre>
Switch WindowFeatures.cpp to isASCIIWhitespace
<a href="https://bugs.webkit.org/show_bug.cgi?id=255855">https://bugs.webkit.org/show_bug.cgi?id=255855</a>
rdar://108440799

Reviewed by NOBODY (OOPS!).

Reading e117030c4720367b0fd0a21723802b940bb67771 it seems that using
isUnicodeCompatibleASCIIWhitespace was an oversight and not treating form feed as whitespace for
parsing &lt;meta name=viewport&gt; seems overly cautious.

* Source/WebCore/page/WindowFeatures.cpp:
(WebCore::isSeparator):
(WebCore::processFeaturesString):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/805081a10655c540f3246619b698992dd91add22

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/4196 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/4314 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/4432 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/5664 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/4442 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/4188 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/4420 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/4279 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/4662 "152 failures") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/4257 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/4431 "2 failures") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/3783 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/5657 "Built successfully") | 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/1926 "2 failures") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/3760 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/5940 "224 failures") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/3753 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/3826 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/5342 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/4234 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/3432 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/3745 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/3758 "Passed tests") | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/4/builds/7845 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/4067 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->