### PR TITLE
[css-tables] Percentage sizing of table cell replaced children with scrollbar

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-tables/height-distribution/percentage-sizing-of-table-cell-replaced-children-001-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-tables/height-distribution/percentage-sizing-of-table-cell-replaced-children-001-expected.html
@@ -1,0 +1,38 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>CSS Reftest Reference: Percentage sizing of table cell children with margin, border, padding and scrollbar</title>
+<link rel="author" title="Manuel Rego Casasnovas" href="mailto:rego@igalia.com">
+<style>
+.table {
+  display: block;
+  border: solid 5px black;
+  width: 150px;
+  height: 100px;
+}
+
+.td {
+  background: cyan;
+  overflow: scroll;
+  padding: 5px 15px 10px 20px;
+  border: solid magenta;
+  border-width: 12px 9px 6px 3px;
+  height: 100px;
+  box-sizing: border-box;
+}
+
+img {
+  display: block;
+  background: yellow;
+  width: 100%;
+  height: 100%;
+}
+</style>
+<link rel="stylesheet" type="text/css" href="support/scrollbars.css">
+
+<p>The test passes if you see scrollbars but there's no overflow, so you cannot actually scroll.</p>
+
+<div class="table">
+  <div class="td">
+    <img />
+  </div>
+</div>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-tables/height-distribution/percentage-sizing-of-table-cell-replaced-children-001-ref.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-tables/height-distribution/percentage-sizing-of-table-cell-replaced-children-001-ref.html
@@ -1,0 +1,38 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>CSS Reftest Reference: Percentage sizing of table cell children with margin, border, padding and scrollbar</title>
+<link rel="author" title="Manuel Rego Casasnovas" href="mailto:rego@igalia.com">
+<style>
+.table {
+  display: block;
+  border: solid 5px black;
+  width: 150px;
+  height: 100px;
+}
+
+.td {
+  background: cyan;
+  overflow: scroll;
+  padding: 5px 15px 10px 20px;
+  border: solid magenta;
+  border-width: 12px 9px 6px 3px;
+  height: 100px;
+  box-sizing: border-box;
+}
+
+img {
+  display: block;
+  background: yellow;
+  width: 100%;
+  height: 100%;
+}
+</style>
+<link rel="stylesheet" type="text/css" href="support/scrollbars.css">
+
+<p>The test passes if you see scrollbars but there's no overflow, so you cannot actually scroll.</p>
+
+<div class="table">
+  <div class="td">
+    <img />
+  </div>
+</div>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-tables/height-distribution/percentage-sizing-of-table-cell-replaced-children-001.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-tables/height-distribution/percentage-sizing-of-table-cell-replaced-children-001.html
@@ -1,0 +1,40 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>CSS Table Test: Percentage sizing of table cell replaced children with margin, border, padding and scrollbar</title>
+<link rel="author" title="Manuel Rego Casasnovas" href="mailto:rego@igalia.com">
+<link rel="help" href="https://drafts.csswg.org/css-tables-3/#content-measure">
+<link rel="match" href="percentage-sizing-of-table-cell-replaced-children-001-ref.html">
+<meta name="assert" content="Checks that table cell replaced children resolve properly their percentage sizes, even when the table cell has margin, border, padding and scrollbar.">
+<style>
+.table {
+  display: table;
+  border: solid 5px black;
+  width: 150px;
+  height: 100px;
+}
+
+.td {
+  display: table-cell;
+  background: cyan;
+  overflow: scroll;
+  padding: 5px 15px 10px 20px;
+  border: solid magenta;
+  border-width: 12px 9px 6px 3px;
+}
+
+img {
+  display: block;
+  background: yellow;
+  width: 100%;
+  height: 100%;
+}
+</style>
+<link rel="stylesheet" type="text/css" href="support/scrollbars.css">
+
+<p>The test passes if you see scrollbars but there's no overflow, so you cannot actually scroll.</p>
+
+<div class="table">
+  <div class="td">
+    <img />
+  </div>
+</div>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-tables/height-distribution/support/scrollbars.css
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-tables/height-distribution/support/scrollbars.css
@@ -1,0 +1,10 @@
+/* This makes the scrollbars visible on mac, both to humans and screenshots.*/
+
+::-webkit-scrollbar {
+    -webkit-appearance: none;
+}
+
+::-webkit-scrollbar-track {
+    background-color: #eee;
+    border-radius: 8px;
+}

--- a/Source/WebCore/rendering/RenderBox.cpp
+++ b/Source/WebCore/rendering/RenderBox.cpp
@@ -3761,7 +3761,7 @@ LayoutUnit RenderBox::availableLogicalHeightUsing(const Length& h, AvailableLogi
     // height, and then when we lay out again we'll use the calculation below.
     if (isTableCell() && (h.isAuto() || h.isPercentOrCalculated())) {
         if (hasOverridingLogicalHeight())
-            return overridingLogicalHeight() - computedCSSPaddingBefore() - computedCSSPaddingAfter() - borderBefore() - borderAfter();
+            return overridingLogicalHeight() - computedCSSPaddingBefore() - computedCSSPaddingAfter() - borderBefore() - borderAfter() - scrollbarLogicalHeight();
         return logicalHeight() - borderAndPaddingLogicalHeight();
     }
 


### PR DESCRIPTION
#### f1b46a85d1832015e14aae60079bed2e9db93f02
<pre>
[css-tables] Percentage sizing of table cell replaced children with scrollbar

<a href="https://bugs.webkit.org/show_bug.cgi?id=255854">https://bugs.webkit.org/show_bug.cgi?id=255854</a>

Reviewed by Simon Fraser.

This patch aligns Webkit with Blink / Chromium.

Merge: <a href="https://chromium.googlesource.com/chromium/src.git/+/bf802aa687ff50a9f4017376cf92da49915f6f8b">https://chromium.googlesource.com/chromium/src.git/+/bf802aa687ff50a9f4017376cf92da49915f6f8b</a>

When computing the percentage height of table cell replaced children,
if the table cell has horizontal scrollbar we have to subtract
its height from the overridingLogicalHeight().

* Source/WebCore/rendering/RenderBox.cpp:
(RenderBox::availableLogicalHeightUsing): As per commit message
* LayoutTests/imported/w3c/web-platform-tests/css/css-tables/height-distribution/support/scrollbars.css: Support file
* LayoutTests/imported/w3c/web-platform-tests/css/css-tables/height-distribution/percentage-sizing-of-table-cell-replaced-children-001.html: Add Test
* LayoutTests/imported/w3c/web-platform-tests/css/css-tables/height-distribution/percentage-sizing-of-table-cell-replaced-children-001-ref.html: Add WPT Reference File
* LayoutTests/imported/w3c/web-platform-tests/css/css-tables/height-distribution/percentage-sizing-of-table-cell-replaced-children-001-expected.html: Add Test Case Expectation

Canonical link: <a href="https://commits.webkit.org/263318@main">https://commits.webkit.org/263318@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d0d326fd63fc45a7d5e6a0bd36f0d9e76a38b946

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/4198 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/4316 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/4434 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/5666 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/4444 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/4190 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/4422 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/4281 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/4664 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/4259 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/4433 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/3785 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/5659 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/1928 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/3762 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/5944 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/3755 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/3828 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/5345 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/4236 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/3435 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/3747 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/3760 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/1039 "Built successfully and passed tests") | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/4/builds/7847 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/4069 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->