### PR TITLE
[JSC] Some simd operations in BBQ have the wrong size

### DIFF
--- a/JSTests/wasm/stress/simd-no-fast-mem-load-lane.js
+++ b/JSTests/wasm/stress/simd-no-fast-mem-load-lane.js
@@ -1,0 +1,31 @@
+//@ requireOptions("--useWebAssemblySIMD=1", "--useWebAssemblyFastMemory=0")
+//@ skip if !$isSIMDPlatform
+import { instantiate } from "../wabt-wrapper.js"
+import * as assert from "../assert.js"
+
+ let wat = `
+ (module
+    (memory 1)
+
+    (data (i32.const 0) "` + String.raw`\00\01\02\03\04\05\06\07\08\09\0A\0B\0C\0D\0E\0F` + `")
+    (data (i32.const 65520) "` + String.raw`\10\11\12\13\14\15\16\17\18\19\1A\1B\1C\1D\1E\1F` + `")
+
+    (func (export "v128_load8_lane") (result i32)
+        (i8x16.extract_lane_s 0 (v128.load8_lane 0 (i32.const 65535) (v128.const i8x16 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0))))
+
+ )
+ `
+
+ async function test() {
+    const instance = await instantiate(wat, { imports: { } }, { simd: true })
+
+    const {
+        v128_load8_lane,
+    } = instance.exports
+
+    for (let i = 0; i < 10000; ++i) {
+        assert.eq(v128_load8_lane(), 31)
+    }
+ }
+
+ assert.asyncTest(test())

--- a/JSTests/wasm/stress/simd-no-fast-mem-load-splat.js
+++ b/JSTests/wasm/stress/simd-no-fast-mem-load-splat.js
@@ -1,0 +1,31 @@
+//@ requireOptions("--useWebAssemblySIMD=1", "--useWebAssemblyFastMemory=0")
+//@ skip if !$isSIMDPlatform
+import { instantiate } from "../wabt-wrapper.js"
+import * as assert from "../assert.js"
+
+ let wat = `
+ (module
+    (memory 1)
+
+    (data (i32.const 0) "` + String.raw`\00\01\02\03\04\05\06\07\08\09\0A\0B\0C\0D\0E\0F` + `")
+    (data (i32.const 65520) "` + String.raw`\10\11\12\13\14\15\16\17\18\19\1A\1B\1C\1D\1E\1F` + `")
+
+    (func (export "v128_load8_splat") (result i32)
+        (i8x16.extract_lane_s 0 (v128.load8_splat (i32.const 65535))))
+
+ )
+ `
+
+ async function test() {
+    const instance = await instantiate(wat, { imports: { } }, { simd: true })
+
+    const {
+        v128_load8_splat,
+    } = instance.exports
+
+    for (let i = 0; i < 10000; ++i) {
+        assert.eq(v128_load8_splat(), 31)
+    }
+ }
+
+ assert.asyncTest(test())

--- a/JSTests/wasm/stress/simd-no-fast-mem-store-lane.js
+++ b/JSTests/wasm/stress/simd-no-fast-mem-store-lane.js
@@ -1,0 +1,33 @@
+//@ requireOptions("--useWebAssemblySIMD=1", "--useWebAssemblyFastMemory=0")
+//@ skip if !$isSIMDPlatform
+import { instantiate } from "../wabt-wrapper.js"
+import * as assert from "../assert.js"
+
+ let wat = `
+ (module
+    (memory 1)
+
+    (data (i32.const 0) "` + String.raw`\00\01\02\03\04\05\06\07\08\09\0A\0B\0C\0D\0E\0F` + `")
+    (data (i32.const 65520) "` + String.raw`\10\11\12\13\14\15\16\17\18\19\1A\1B\1C\1D\1E\1F` + `")
+
+    (func (export "v128_store8_lane") (result i32)
+        (v128.store8_lane 0 (i32.const 65535) (v128.const i8x16 7 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0))
+        (i32.load8_u (i32.const 65535))
+    )
+
+ )
+ `
+
+ async function test() {
+    const instance = await instantiate(wat, { imports: { } }, { simd: true })
+
+    const {
+        v128_store8_lane,
+    } = instance.exports
+
+    for (let i = 0; i < 10000; ++i) {
+        assert.eq(v128_store8_lane(), 7)
+    }
+ }
+
+ assert.asyncTest(test())

--- a/Source/JavaScriptCore/wasm/WasmBBQJIT.cpp
+++ b/Source/JavaScriptCore/wasm/WasmBBQJIT.cpp
@@ -7629,7 +7629,24 @@ public:
 
     PartialResult WARN_UNUSED_RETURN addSIMDLoadSplat(SIMDLaneOperation op, ExpressionType pointer, uint32_t uoffset, ExpressionType& result)
     {
-        Location pointerLocation = emitCheckAndPreparePointer(pointer, uoffset, bytesForWidth(Width::Width128));
+        Width width;
+        switch (op) {
+        case SIMDLaneOperation::LoadSplat8:
+            width = Width::Width8;
+            break;
+        case SIMDLaneOperation::LoadSplat16:
+            width = Width::Width16;
+            break;
+        case SIMDLaneOperation::LoadSplat32:
+            width = Width::Width32;
+            break;
+        case SIMDLaneOperation::LoadSplat64:
+            width = Width::Width64;
+            break;
+        default:
+            RELEASE_ASSERT_NOT_REACHED();
+        }
+        Location pointerLocation = emitCheckAndPreparePointer(pointer, uoffset, bytesForWidth(width));
         Address address = materializePointer(pointerLocation, uoffset);
 
         result = topValue(TypeKind::V128);
@@ -7665,7 +7682,24 @@ public:
 
     PartialResult WARN_UNUSED_RETURN addSIMDLoadLane(SIMDLaneOperation op, ExpressionType pointer, ExpressionType vector, uint32_t uoffset, uint8_t lane, ExpressionType& result)
     {
-        Location pointerLocation = emitCheckAndPreparePointer(pointer, uoffset, bytesForWidth(Width::Width128));
+        Width width;
+        switch (op) {
+        case SIMDLaneOperation::LoadLane8:
+            width = Width::Width8;
+            break;
+        case SIMDLaneOperation::LoadLane16:
+            width = Width::Width16;
+            break;
+        case SIMDLaneOperation::LoadLane32:
+            width = Width::Width32;
+            break;
+        case SIMDLaneOperation::LoadLane64:
+            width = Width::Width64;
+            break;
+        default:
+            RELEASE_ASSERT_NOT_REACHED();
+        }
+        Location pointerLocation = emitCheckAndPreparePointer(pointer, uoffset, bytesForWidth(width));
         Address address = materializePointer(pointerLocation, uoffset);
 
         Location vectorLocation = loadIfNecessary(vector);
@@ -7699,7 +7733,24 @@ public:
 
     PartialResult WARN_UNUSED_RETURN addSIMDStoreLane(SIMDLaneOperation op, ExpressionType pointer, ExpressionType vector, uint32_t uoffset, uint8_t lane)
     {
-        Location pointerLocation = emitCheckAndPreparePointer(pointer, uoffset, bytesForWidth(Width::Width128));
+        Width width;
+        switch (op) {
+        case SIMDLaneOperation::StoreLane8:
+            width = Width::Width8;
+            break;
+        case SIMDLaneOperation::StoreLane16:
+            width = Width::Width16;
+            break;
+        case SIMDLaneOperation::StoreLane32:
+            width = Width::Width32;
+            break;
+        case SIMDLaneOperation::StoreLane64:
+            width = Width::Width64;
+            break;
+        default:
+            RELEASE_ASSERT_NOT_REACHED();
+        }
+        Location pointerLocation = emitCheckAndPreparePointer(pointer, uoffset, bytesForWidth(width));
         Address address = materializePointer(pointerLocation, uoffset);
 
         Location vectorLocation = loadIfNecessary(vector);


### PR DESCRIPTION
#### 8308719e1589f96792eba25315d7939e97f67044
<pre>
[JSC] Some simd operations in BBQ have the wrong size
<a href="https://bugs.webkit.org/show_bug.cgi?id=255859">https://bugs.webkit.org/show_bug.cgi?id=255859</a>
rdar://108148560

Reviewed by Yusuke Suzuki.

Three operations in BBQ (loadN_splat, loadN_lane and storeN_lane) were always
using Width128, but their size actually depend on the opcode.

* JSTests/wasm/stress/simd-no-fast-mem-load-lane.js: Added.
(from.string_appeared_here.import.as.assert.from.string_appeared_here.let.wat.module.memory.1.data.i32.const.0.string_appeared_here.data.i32.const.65520.string_appeared_here.func.export.string_appeared_here.result.i32.i8x16.extract_lane_s.0.v128.load8_lane.0.i32.const.65535.v128.const.i8x16.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.async test):
* JSTests/wasm/stress/simd-no-fast-mem-load-splat.js: Added.
(from.string_appeared_here.import.as.assert.from.string_appeared_here.let.wat.module.memory.1.data.i32.const.0.string_appeared_here.data.i32.const.65520.string_appeared_here.func.export.string_appeared_here.result.i32.i8x16.extract_lane_s.0.v128.load8_splat.i32.const.65535.async test):
* JSTests/wasm/stress/simd-no-fast-mem-store-lane.js: Added.
(from.string_appeared_here.import.as.assert.from.string_appeared_here.let.wat.module.memory.1.data.i32.const.0.string_appeared_here.data.i32.const.65520.string_appeared_here.func.export.string_appeared_here.result.i32.v128.store8_lane.0.i32.const.65535.v128.const.i8x16.7.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.i32.load8_u.i32.const.65535.async test):
* Source/JavaScriptCore/wasm/WasmBBQJIT.cpp:
(JSC::Wasm::BBQJIT::addSIMDLoadSplat):
(JSC::Wasm::BBQJIT::addSIMDLoadLane):
(JSC::Wasm::BBQJIT::addSIMDStoreLane):

Canonical link: <a href="https://commits.webkit.org/263329@main">https://commits.webkit.org/263329@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e0f0f2e57638e472732cc1226d129db869634ac6

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/4200 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/4318 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/4436 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/5668 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/4446 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/4436 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/4283 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/4668 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/4261 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/4447 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/3788 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/5661 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/1942 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/3765 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/5948 "Passed tests") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/3496 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/3769 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/3831 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/5355 "run-api-tests-without-change (failure)") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/3993 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/4238 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/3437 "11 flakes 3 failures") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/4296 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/3749 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/3763 "Passed tests") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/1059 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/1051 "Built successfully and passed tests") | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/4/builds/7849 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/24/builds/4393 "Built successfully") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/4075 "Built successfully") | | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/3/builds/1171 "Passed tests") | 
<!--EWS-Status-Bubble-End-->