### PR TITLE
Switch WindowFeatures to isASCIIWhitespace()

### DIFF
--- a/LayoutTests/fast/viewport/viewport-122-expected.txt
+++ b/LayoutTests/fast/viewport/viewport-122-expected.txt
@@ -1,3 +1,2 @@
-CONSOLE MESSAGE: Viewport argument value "device-width" for key "width" is invalid, and has been ignored.
-ALERT: viewport size 64x70.4 scale 5 with limits [5, 5] and userScalable true
+ALERT: viewport size 320x352 scale 1 with limits [1, 5] and userScalable true
 

--- a/LayoutTests/fast/viewport/viewport-122.html
+++ b/LayoutTests/fast/viewport/viewport-122.html
@@ -1,5 +1,5 @@
 <head>
-    <title>Check that form feed is not a separator space</title>
+    <title>Check that form feed is a separator space</title>
     <meta name="viewport" content="width=&#x0c;device-width">
     <script>
         function test() {

--- a/LayoutTests/imported/w3c/web-platform-tests/html/browsers/the-window-object/open-close/resources/tokenization-noopener-noreferrer.js
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/browsers/the-window-object/open-close/resources/tokenization-noopener-noreferrer.js
@@ -142,6 +142,7 @@ function booleanTests(feature) {
       `${featureSplitBegin}\n${featureSplitEnd}`,
       `${featureSplitBegin},${featureSplitEnd}`,
       `\0${feature}`,
+      `\u000B${feature}`,
       `${feature}\u0000=yes`,
       `foo=\u000C${feature}`
     ].forEach(variant => {

--- a/Source/WebCore/page/WindowFeatures.cpp
+++ b/Source/WebCore/page/WindowFeatures.cpp
@@ -42,13 +42,9 @@ static std::optional<bool> boolFeature(const DialogFeaturesMap&, ASCIILiteral ke
 static std::optional<float> floatFeature(const DialogFeaturesMap&, ASCIILiteral key, float min, float max);
 
 // https://html.spec.whatwg.org/#feature-separator
-static bool NODELETE isSeparator(char16_t character, FeatureMode mode)
+static bool NODELETE isSeparator(char16_t character)
 {
-    if (mode == FeatureMode::Viewport)
-        return character == ' ' || character == '\t' || character == '\n' || character == '\r' || character == '=' || character == ',';
-
-    // FIXME: this should be isASCIIWhitespace
-    return isUnicodeCompatibleASCIIWhitespace(character) || character == '=' || character == ',';
+    return isASCIIWhitespace(character) || character == '=' || character == ',';
 }
 
 WindowFeatures parseWindowFeatures(StringView featuresString)
@@ -73,27 +69,27 @@ void processFeaturesString(StringView features, FeatureMode mode, NOESCAPE const
     unsigned length = features.length();
     for (unsigned i = 0; i < length; ) {
         // Skip to first non-separator.
-        while (i < length && isSeparator(features[i], mode))
+        while (i < length && isSeparator(features[i]))
             ++i;
         unsigned keyBegin = i;
 
         // Skip to first separator.
-        while (i < length && !isSeparator(features[i], mode))
+        while (i < length && !isSeparator(features[i]))
             i++;
         unsigned keyEnd = i;
 
         // Skip to first '=', but don't skip past a ',' or a non-separator.
-        while (i < length && features[i] != '=' && features[i] != ',' && (mode == FeatureMode::Viewport || isSeparator(features[i], mode)))
+        while (i < length && features[i] != '=' && features[i] != ',' && (mode == FeatureMode::Viewport || isSeparator(features[i])))
             ++i;
 
         // Skip to first non-separator, but don't skip past a ','.
-        if (mode == FeatureMode::Viewport || (i < length && isSeparator(features[i], mode))) {
-            while (i < length && isSeparator(features[i], mode) && features[i] != ',')
+        if (mode == FeatureMode::Viewport || (i < length && isSeparator(features[i]))) {
+            while (i < length && isSeparator(features[i]) && features[i] != ',')
                 ++i;
             unsigned valueBegin = i;
 
             // Skip to first separator.
-            while (i < length && !isSeparator(features[i], mode))
+            while (i < length && !isSeparator(features[i]))
                 ++i;
             unsigned valueEnd = i;
             callback(features.substring(keyBegin, keyEnd - keyBegin), features.substring(valueBegin, valueEnd - valueBegin));


### PR DESCRIPTION
#### 07a744d77e3e9edf59064f1c3e8e47f7a23b6f1d
<pre>
Switch WindowFeatures to isASCIIWhitespace()
<a href="https://bugs.webkit.org/show_bug.cgi?id=255855">https://bugs.webkit.org/show_bug.cgi?id=255855</a>
<a href="https://rdar.apple.com/108440799">rdar://108440799</a>

Reviewed by Ryosuke Niwa.

Per 188338@main it seems that using
isUnicodeCompatibleASCIIWhitespace() was an oversight. Not treating
form feed as whitespace for parsing &lt;meta name=viewport&gt; is
inconsistent with HTML and there&apos;s no real justification for it other
than an early attempt at writing down the specification not taking that
into account.

Per <a href="https://github.com/w3c/csswg-drafts/issues/8757">https://github.com/w3c/csswg-drafts/issues/8757</a> the CSS WG has
resolved to update the specification.

window.open() test change upstreamed here:

    <a href="https://github.com/web-platform-tests/wpt/pull/58392">https://github.com/web-platform-tests/wpt/pull/58392</a>

Canonical link: <a href="https://commits.webkit.org/309044@main">https://commits.webkit.org/309044@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/904766c7b486fb716fba94d7477cab3755118fc1

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/149297 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/22010 "Built successfully") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/168/builds/15580 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/157990 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/102728 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/151170 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/22464 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/21888 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/115115 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/102728 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/152257 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/17270 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/133962 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/95863 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | ⏳ 🛠 vision-apple 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/16369 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/14251 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/5840 "Built successfully") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/125969 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/167/builds/11903 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/160474 "Built successfully") | | 
| | [  ~~🛠 ios-safer-cpp~~](https://ews-build.webkit.org/#/builders/174/builds/3468 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/169/builds/13431 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/123157 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/21813 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/18290 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/123374 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/21821 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/133695 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/78021 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/22988 "Built successfully and passed tests") | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/164/builds/18608 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/10441 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/21423 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/85236 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/157/builds/21154 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/21303 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/21211 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->