### PR TITLE
Implement @font-face size-adjust descriptor (253062)

### DIFF
--- a/LayoutTests/TestExpectations
+++ b/LayoutTests/TestExpectations
@@ -3721,12 +3721,10 @@ webkit.org/b/219735 imported/w3c/web-platform-tests/css/css-fonts/line-gap-overr
 webkit.org/b/219735 imported/w3c/web-platform-tests/css/css-fonts/font-face-unicode-range-nbsp.html [ ImageOnlyFailure ]
 webkit.org/b/219735 imported/w3c/web-platform-tests/css/css-font-loading/fontface-override-descriptors.html [ ImageOnlyFailure ]
 
-# @font-face: size-adjust
-webkit.org/b/206881 imported/w3c/web-platform-tests/css/css-fonts/size-adjust-01.html [ ImageOnlyFailure ]
+# @font-face: size-adjust and text-decoration
 webkit.org/b/206881 imported/w3c/web-platform-tests/css/css-fonts/size-adjust-text-decoration.tentative.html [ ImageOnlyFailure ]
-webkit.org/b/206881 imported/w3c/web-platform-tests/css/css-fonts/size-adjust.tentative.html [ ImageOnlyFailure ]
-webkit.org/b/206881 imported/w3c/web-platform-tests/css/css-fonts/variations/variable-opsz-size-adjust.html [ ImageOnlyFailure ]
-webkit.org/b/206881 imported/w3c/web-platform-tests/css/css-font-loading/fontface-size-adjust-descriptor.html [ ImageOnlyFailure ]
+# @font-face: size-adjust and optical-size
+webkit.org/b/255862 imported/w3c/web-platform-tests/css/css-fonts/variations/variable-opsz-size-adjust.html [ ImageOnlyFailure ]
 
 # We intentionally do not want to allow disabling required ligatures, so we don't honor this optional test.
 imported/w3c/web-platform-tests/css/css-fonts/font-variant-ligatures-11.optional.html [ ImageOnlyFailure ]

--- a/LayoutTests/platform/ios/size-adjust-interacts-with-text-size-adjust-auto-expected-mismatch.html
+++ b/LayoutTests/platform/ios/size-adjust-interacts-with-text-size-adjust-auto-expected-mismatch.html
@@ -1,0 +1,22 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>Tests -webkit-text-size-adjust (auto value) interaction with @font-face size-adjust.</title>
+<style>
+@font-face {
+  font-family: adjusted-font;
+  src: local(Ahem), url(/fonts/Ahem.ttf), local(Times);
+}
+span {
+  font-size: 60px;
+}
+.ffsa {
+  font-family: adjusted-font;
+}
+.tsa {
+    -webkit-text-size-adjust: auto;
+}
+</style>
+
+<div>
+  <span class="ffsa tsa">x</span>
+</div>

--- a/LayoutTests/platform/ios/size-adjust-interacts-with-text-size-adjust-auto-notref.html
+++ b/LayoutTests/platform/ios/size-adjust-interacts-with-text-size-adjust-auto-notref.html
@@ -1,0 +1,22 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>Tests -webkit-text-size-adjust (auto value) interaction with @font-face size-adjust.</title>
+<style>
+@font-face {
+  font-family: adjusted-font;
+  src: local(Ahem), url(/fonts/Ahem.ttf), local(Times);
+}
+span {
+  font-size: 60px;
+}
+.ffsa {
+  font-family: adjusted-font;
+}
+.tsa {
+    -webkit-text-size-adjust: auto;
+}
+</style>
+
+<div>
+  <span class="ffsa tsa">x</span>
+</div>

--- a/LayoutTests/platform/ios/size-adjust-interacts-with-text-size-adjust-auto.html
+++ b/LayoutTests/platform/ios/size-adjust-interacts-with-text-size-adjust-auto.html
@@ -1,0 +1,24 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<link rel="mismatch" href="size-adjust-interacts-with-text-size-adjust-auto-notref.html">
+<title>Tests -webkit-text-size-adjust (auto value) interaction with @font-face size-adjust.</title>
+<style>
+@font-face {
+  font-family: adjusted-font;
+  src: local(Times);
+  size-adjust: 200%;
+}
+span {
+  font-size: 60px;
+}
+.ffsa {
+  font-family: adjusted-font;
+}
+.tsa {
+    -webkit-text-size-adjust: 200%;
+}
+</style>
+
+<div>
+  <span class="ffsa tsa">x</span>
+</div>

--- a/LayoutTests/platform/ios/size-adjust-interacts-with-text-size-adjust-percentage-expected.html
+++ b/LayoutTests/platform/ios/size-adjust-interacts-with-text-size-adjust-percentage-expected.html
@@ -1,0 +1,39 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>Tests -webkit-text-size-adjust (percentage value) interaction with @font-face size-adjust.</title>
+<script>
+  if (window.internals) {
+      internals.settings.setTextAutosizingEnabled(true);
+  }
+</script>
+<style>
+@font-face {
+  font-family: base-font;
+  src: local(Ahem), url(/fonts/Ahem.ttf), local(Times);
+}
+span {
+  font-size: 60px;
+  font-family: base-font;
+}
+.tsa-200 {
+  -webkit-text-size-adjust: 200%;
+}
+.tsa-400 {
+  -webkit-text-size-adjust: 400%;
+}
+</style>
+
+<p>Without size-adjust or -webkit-text-size-adjust applied.</p>
+<div>
+  <span>x</span>
+</div>
+
+<p>With size-adjust applied and -webkit-text-size-adjust not applied.</p>
+<div>
+  <span class="tsa-200">x</span>
+</div>
+
+<p>With both size-adjust and -webkit-text-size-adjust applied.</p>
+<div>
+  <span class="tsa-400">x</span>
+</div>

--- a/LayoutTests/platform/ios/size-adjust-interacts-with-text-size-adjust-percentage-ref.html
+++ b/LayoutTests/platform/ios/size-adjust-interacts-with-text-size-adjust-percentage-ref.html
@@ -1,0 +1,39 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>Tests -webkit-text-size-adjust (percentage value) interaction with @font-face size-adjust.</title>
+<script>
+  if (window.internals) {
+      internals.settings.setTextAutosizingEnabled(true);
+  }
+</script>
+<style>
+@font-face {
+  font-family: base-font;
+  src: local(Ahem), url(/fonts/Ahem.ttf), local(Times);
+}
+span {
+  font-size: 60px;
+  font-family: base-font;
+}
+.tsa-200 {
+  -webkit-text-size-adjust: 200%;
+}
+.tsa-400 {
+  -webkit-text-size-adjust: 400%;
+}
+</style>
+
+<p>Without size-adjust or -webkit-text-size-adjust applied.</p>
+<div>
+  <span>x</span>
+</div>
+
+<p>With size-adjust applied and -webkit-text-size-adjust not applied.</p>
+<div>
+  <span class="tsa-200">x</span>
+</div>
+
+<p>With both size-adjust and -webkit-text-size-adjust applied.</p>
+<div>
+  <span class="tsa-400">x</span>
+</div>

--- a/LayoutTests/platform/ios/size-adjust-interacts-with-text-size-adjust-percentage.html
+++ b/LayoutTests/platform/ios/size-adjust-interacts-with-text-size-adjust-percentage.html
@@ -1,0 +1,50 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<link rel="match" href="size-adjust-interacts-with-text-size-adjust-percentage-ref.html">
+<title>Tests -webkit-text-size-adjust (percentage value) interaction with @font-face size-adjust.</title>
+<script>
+  if (window.internals) {
+      internals.settings.setTextAutosizingEnabled(true);
+  }
+</script>
+<style>
+@font-face {
+  font-family: base-font;
+  src: local(Ahem), url(/fonts/Ahem.ttf), local(Times);
+  size-adjust: 100%;
+}
+
+@font-face {
+  font-family: adjusted-font;
+  src: local(Ahem), url(/fonts/Ahem.ttf), local(Times);
+  size-adjust: 200%;
+}
+span {
+  font-size: 60px;
+}
+
+.base {
+  font-family: base-font;
+}
+.ffsa {
+  font-family: adjusted-font;
+}
+.tsa {
+    -webkit-text-size-adjust: 200%;
+}
+</style>
+
+<p>Without size-adjust or -webkit-text-size-adjust applied.</p>
+<div>
+  <span class="base">x</span>
+</div>
+
+<p>With size-adjust applied and -webkit-text-size-adjust not applied.</p>
+<div>
+  <span class="ffsa">x</span>
+</div>
+
+<p>With both size-adjust and -webkit-text-size-adjust applied.</p>
+<div>
+  <span class="ffsa tsa">x</span>
+</div>

--- a/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
+++ b/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
@@ -1027,17 +1027,17 @@ CSSCustomPropertiesAndValuesEnabled:
 
 CSSFontFaceSizeAdjustEnabled:
   type: bool
-  status: testable
+  status: stable
   category: css
   humanReadableName: "CSS @font-face size-adjust"
   humanReadableDescription: "Enable size-adjust descriptor in @font-face"
   defaultValue:
     WebKitLegacy:
-      default: false
+      default: true
     WebKit:
-      default: false
+      default: true
     WebCore:
-      default: false
+      default: true
 
 CSSGradientInterpolationColorSpacesEnabled:
   type: bool

--- a/Source/WebCore/css/FontFace.cpp
+++ b/Source/WebCore/css/FontFace.cpp
@@ -132,6 +132,11 @@ Ref<FontFace> FontFace::create(ScriptExecutionContext& context, const String& fa
         result->setErrorState();
         return result;
     }
+    auto setSizeAdjustResult = result->setSizeAdjust(context, descriptors.sizeAdjust.isEmpty() ? "100%"_s : descriptors.sizeAdjust);
+    if (setSizeAdjustResult.hasException()) {
+        result->setErrorState();
+        return result;
+    }
 
     if (!dataRequiresAsynchronousLoading) {
         result->backing().load();
@@ -233,6 +238,15 @@ ExceptionOr<void> FontFace::setDisplay(ScriptExecutionContext& context, const St
     return Exception { SyntaxError };
 }
 
+ExceptionOr<void> FontFace::setSizeAdjust(ScriptExecutionContext& context, const String& sizeAdjust)
+{
+    if (auto value = CSSPropertyParserWorkerSafe::parseFontFaceSizeAdjust(sizeAdjust, context)) {
+        m_backing->setSizeAdjust(*value);
+        return { };
+    }
+    return Exception { SyntaxError };
+}
+
 String FontFace::family() const
 {
     if (auto value = m_backing->family(); !value.isNull())
@@ -273,6 +287,13 @@ String FontFace::featureSettings() const
     if (auto value = m_backing->featureSettings(); !value.isNull())
         return value;
     return "normal"_s;
+}
+
+String FontFace::sizeAdjust() const
+{
+    if (auto value = m_backing->sizeAdjust(); !value.isNull())
+        return value;
+    return "100%"_s;
 }
 
 String FontFace::display() const

--- a/Source/WebCore/css/FontFace.h
+++ b/Source/WebCore/css/FontFace.h
@@ -52,6 +52,7 @@ public:
         String unicodeRange;
         String featureSettings;
         String display;
+        String sizeAdjust;
     };
     
     using Source = std::variant<String, RefPtr<JSC::ArrayBuffer>, RefPtr<JSC::ArrayBufferView>>;
@@ -66,6 +67,7 @@ public:
     ExceptionOr<void> setUnicodeRange(ScriptExecutionContext&, const String&);
     ExceptionOr<void> setFeatureSettings(ScriptExecutionContext&, const String&);
     ExceptionOr<void> setDisplay(ScriptExecutionContext&, const String&);
+    ExceptionOr<void> setSizeAdjust(ScriptExecutionContext&, const String&);
 
     String family() const;
     String style() const;
@@ -74,6 +76,7 @@ public:
     String unicodeRange() const;
     String featureSettings() const;
     String display() const;
+    String sizeAdjust() const;
 
     enum class LoadStatus { Unloaded, Loading, Loaded, Error };
     LoadStatus status() const;

--- a/Source/WebCore/css/FontFace.idl
+++ b/Source/WebCore/css/FontFace.idl
@@ -39,6 +39,7 @@ dictionary FontFaceDescriptors {
     DOMString unicodeRange = "U+0-10FFFF";
     DOMString featureSettings = "normal";
     DOMString display = "auto";
+    DOMString sizeAdjust = "100%";
 };
 
 [
@@ -54,6 +55,7 @@ dictionary FontFaceDescriptors {
     [SetterCallWith=CurrentScriptExecutionContext] attribute DOMString unicodeRange;
     [SetterCallWith=CurrentScriptExecutionContext] attribute DOMString featureSettings;
     [SetterCallWith=CurrentScriptExecutionContext] attribute DOMString display;
+    [EnabledBySetting=CSSFontFaceSizeAdjustEnabled, SetterCallWith=CurrentScriptExecutionContext] attribute DOMString sizeAdjust;
 
     readonly attribute FontFaceLoadStatus status;
 

--- a/Source/WebCore/css/parser/CSSPropertyParserWorkerSafe.cpp
+++ b/Source/WebCore/css/parser/CSSPropertyParserWorkerSafe.cpp
@@ -207,6 +207,21 @@ RefPtr<CSSPrimitiveValue> CSSPropertyParserWorkerSafe::parseFontFaceDisplay(cons
     return parsedValue;
 }
 
+RefPtr<CSSValue> CSSPropertyParserWorkerSafe::parseFontFaceSizeAdjust(const String& string, ScriptExecutionContext& context)
+{
+    CSSParserContext parserContext(parserMode(context));
+    CSSParserImpl parser(parserContext, string);
+    CSSParserTokenRange range = parser.tokenizer()->tokenRange();
+    range.consumeWhitespace();
+    if (range.atEnd())
+        return nullptr;
+    auto parsedValue = CSSPropertyParserHelpers::consumePercent(range, ValueRange::NonNegative);
+    if (!parsedValue || !range.atEnd())
+        return nullptr;
+
+    return parsedValue;
+}
+
 namespace CSSPropertyParserHelpersWorkerSafe {
 
 static RefPtr<CSSFontFaceSrcResourceValue> consumeFontFaceSrcURI(CSSParserTokenRange& range, const CSSParserContext& context)

--- a/Source/WebCore/css/parser/CSSPropertyParserWorkerSafe.h
+++ b/Source/WebCore/css/parser/CSSPropertyParserWorkerSafe.h
@@ -52,6 +52,7 @@ public:
     static RefPtr<CSSValueList> parseFontFaceUnicodeRange(const String&, ScriptExecutionContext&);
     static RefPtr<CSSValue> parseFontFaceFeatureSettings(const String&, ScriptExecutionContext&);
     static RefPtr<CSSPrimitiveValue> parseFontFaceDisplay(const String&, ScriptExecutionContext&);
+    static RefPtr<CSSValue> parseFontFaceSizeAdjust(const String&, ScriptExecutionContext&);
 };
 
 namespace CSSPropertyParserHelpersWorkerSafe {

--- a/Source/WebCore/platform/graphics/FontDescription.cpp
+++ b/Source/WebCore/platform/graphics/FontDescription.cpp
@@ -117,4 +117,10 @@ AtomString FontDescription::platformResolveGenericFamily(UScriptCode, const Atom
 }
 #endif
 
+float FontDescription::adjustedSizeForFontFace(float fontFaceSizeAdjust) const
+{
+    // It is not worth modifying the used size with @font-face size-adjust if we are to re-adjust it later with font-size-adjust. This is because font-size-adjust will overrule this change, since size-adjust also modifies the font's metric values and thus, keeps the aspect-value unchanged.
+    return fontSizeAdjust().value ? computedPixelSize() : fontFaceSizeAdjust * computedPixelSize();
+
+}
 } // namespace WebCore

--- a/Source/WebCore/platform/graphics/FontDescription.h
+++ b/Source/WebCore/platform/graphics/FontDescription.h
@@ -46,6 +46,8 @@ public:
 
     float computedSize() const { return m_computedSize; }
     unsigned computedPixelSize() const { return unsigned(m_computedSize + 0.5f); }
+    // Adjusted size regarding @font-face size-adjust but not regarding font-size-adjust. The latter adjustment is done with updateSizeWithFontSizeAdjust() after the font's creation.
+    float adjustedSizeForFontFace(float) const;
     std::optional<FontSelectionValue> italic() const { return m_fontSelectionRequest.slope; }
     FontSelectionValue stretch() const { return m_fontSelectionRequest.width; }
     FontSelectionValue weight() const { return m_fontSelectionRequest.weight; }

--- a/Source/WebCore/platform/graphics/FontPlatformData.cpp
+++ b/Source/WebCore/platform/graphics/FontPlatformData.cpp
@@ -87,13 +87,13 @@ void FontPlatformData::updateSize(float size)
 }
 #endif
 
-void FontPlatformData::updateSizeWithFontSizeAdjust(const FontSizeAdjust& fontSizeAdjust)
+void FontPlatformData::updateSizeWithFontSizeAdjust(const FontSizeAdjust& fontSizeAdjust, float computedSize)
 {
     if (!fontSizeAdjust.value)
         return;
 
     auto tmpFont = FontCache::forCurrentThread().fontForPlatformData(*this);
-    auto adjustedFontSize = Style::adjustedFontSize(size(), fontSizeAdjust, tmpFont->fontMetrics());
+    auto adjustedFontSize = Style::adjustedFontSize(computedSize, fontSizeAdjust, tmpFont->fontMetrics());
 
     if (adjustedFontSize == size())
         return;

--- a/Source/WebCore/platform/graphics/FontPlatformData.h
+++ b/Source/WebCore/platform/graphics/FontPlatformData.h
@@ -165,7 +165,7 @@ public:
     static FontPlatformData cloneWithSyntheticOblique(const FontPlatformData&, bool);
 
     static FontPlatformData cloneWithSize(const FontPlatformData&, float);
-    void updateSizeWithFontSizeAdjust(const FontSizeAdjust&);
+    void updateSizeWithFontSizeAdjust(const FontSizeAdjust&, float);
 
 #if PLATFORM(WIN)
     HFONT hfont() const { return m_font ? m_font->get() : 0; }

--- a/Source/WebCore/platform/graphics/cocoa/FontCacheCoreText.cpp
+++ b/Source/WebCore/platform/graphics/cocoa/FontCacheCoreText.cpp
@@ -673,7 +673,7 @@ static void autoActivateFont(const String& name, CGFloat size)
 
 std::unique_ptr<FontPlatformData> FontCache::createFontPlatformData(const FontDescription& fontDescription, const AtomString& family, const FontCreationContext& fontCreationContext)
 {
-    float size = fontDescription.computedPixelSize();
+    auto size = fontDescription.adjustedSizeForFontFace(fontCreationContext.sizeAdjust());
     auto& fontDatabase = database(fontDescription.shouldAllowUserInstalledFonts());
     auto font = fontWithFamily(fontDatabase, family, fontDescription, fontCreationContext, size);
 
@@ -700,7 +700,7 @@ std::unique_ptr<FontPlatformData> FontCache::createFontPlatformData(const FontDe
 
     FontPlatformData platformData(font.get(), size, syntheticBold, syntheticOblique, fontDescription.orientation(), fontDescription.widthVariant(), fontDescription.textRenderingMode());
 
-    platformData.updateSizeWithFontSizeAdjust(fontDescription.fontSizeAdjust());
+    platformData.updateSizeWithFontSizeAdjust(fontDescription.fontSizeAdjust(), fontDescription.computedPixelSize());
     return makeUnique<FontPlatformData>(platformData);
 }
 

--- a/Source/WebCore/platform/graphics/cocoa/FontFamilySpecificationCoreText.cpp
+++ b/Source/WebCore/platform/graphics/cocoa/FontFamilySpecificationCoreText.cpp
@@ -61,7 +61,7 @@ FontRanges FontFamilySpecificationCoreText::fontRanges(const FontDescription& fo
         return makeUnique<FontPlatformData>(font.get(), size, false, syntheticOblique, fontDescription.orientation(), fontDescription.widthVariant(), fontDescription.textRenderingMode());
     });
 
-    originalPlatformData.updateSizeWithFontSizeAdjust(fontDescription.fontSizeAdjust());
+    originalPlatformData.updateSizeWithFontSizeAdjust(fontDescription.fontSizeAdjust(), fontDescription.computedSize());
     return FontRanges(FontCache::forCurrentThread().fontForPlatformData(originalPlatformData));
 }
 

--- a/Source/WebCore/platform/graphics/freetype/FontCacheFreeType.cpp
+++ b/Source/WebCore/platform/graphics/freetype/FontCacheFreeType.cpp
@@ -463,10 +463,10 @@ std::unique_ptr<FontPlatformData> FontCache::createFontPlatformData(const FontDe
     }
 #endif
 
-    auto size = fontDescription.computedPixelSize();
+    auto size = fontDescription.adjustedSizeForFontFace(fontCreationContext.sizeAdjust());
     FontPlatformData platformData(fontFace.get(), WTFMove(resultPattern), size, fixedWidth, syntheticBold, syntheticOblique, fontDescription.orientation());
 
-    platformData.updateSizeWithFontSizeAdjust(fontDescription.fontSizeAdjust());
+    platformData.updateSizeWithFontSizeAdjust(fontDescription.fontSizeAdjust(), fontDescription.computedPixelSize());
     auto platformDataUniquePtr = makeUnique<FontPlatformData>(platformData);
 
     // Verify that this font has an encoding compatible with Fontconfig. Fontconfig currently

--- a/Source/WebCore/platform/graphics/freetype/FontCustomPlatformDataFreeType.cpp
+++ b/Source/WebCore/platform/graphics/freetype/FontCustomPlatformDataFreeType.cpp
@@ -94,10 +94,10 @@ FontPlatformData FontCustomPlatformData::fontPlatformData(const FontDescription&
     }
 #endif
 
-    auto size = description.computedPixelSize();
+    auto size = description.adjustedSizeForFontFace(fontCreationContext.sizeAdjust());
     FontPlatformData platformData(m_fontFace.get(), WTFMove(pattern), size, freeTypeFace->face_flags & FT_FACE_FLAG_FIXED_WIDTH, bold, italic, description.orientation());
 
-    platformData.updateSizeWithFontSizeAdjust(description.fontSizeAdjust());
+    platformData.updateSizeWithFontSizeAdjust(description.fontSizeAdjust(), description.computedPixelSize());
     return platformData;
 }
 

--- a/Source/WebCore/platform/graphics/mac/FontCustomPlatformDataMac.cpp
+++ b/Source/WebCore/platform/graphics/mac/FontCustomPlatformDataMac.cpp
@@ -47,7 +47,7 @@ FontPlatformData FontCustomPlatformData::fontPlatformData(const FontDescription&
         addAttributesForWebFonts(attributes, fontDescription.shouldAllowUserInstalledFonts());
     });
 
-    int size = fontDescription.computedPixelSize();
+    auto size = fontDescription.adjustedSizeForFontFace(fontCreationContext.sizeAdjust());
     FontOrientation orientation = fontDescription.orientation();
     FontWidthVariant widthVariant = fontDescription.widthVariant();
 
@@ -55,7 +55,7 @@ FontPlatformData FontCustomPlatformData::fontPlatformData(const FontDescription&
     ASSERT(font);
     FontPlatformData platformData(font.get(), size, bold, italic, orientation, widthVariant, fontDescription.textRenderingMode(), this);
 
-    platformData.updateSizeWithFontSizeAdjust(fontDescription.fontSizeAdjust());
+    platformData.updateSizeWithFontSizeAdjust(fontDescription.fontSizeAdjust(), fontDescription.computedPixelSize());
     return platformData;
 }
 


### PR DESCRIPTION
#### 97f82bc0e98c7ae32a6a0b24ded9ead1400583c8
<pre>
Implement @font-face size-adjust descriptor (253062)
<a href="https://bugs.webkit.org/show_bug.cgi?id=253062">https://bugs.webkit.org/show_bug.cgi?id=253062</a>
rdar://106349717

Reviewed by Myles C. Maxfield.

Implements @font-face size-adjust descriptor according to
<a href="https://www.w3.org/TR/css-fonts-5/#size-adjust-desc">https://www.w3.org/TR/css-fonts-5/#size-adjust-desc</a>

* LayoutTests/TestExpectations:
* Source/WebCore/css/FontFace.cpp:
(WebCore::FontFace::create):
(WebCore::FontFace::setSizeAdjust):
(WebCore::FontFace::sizeAdjust const):
* Source/WebCore/css/FontFace.h:
* Source/WebCore/css/FontFace.idl:
- Integrating size-adjust descriptor to FontFace() api.

* Source/WebCore/css/parser/CSSPropertyParserWorkerSafe.cpp:
(WebCore::CSSPropertyParserWorkerSafe::parseFontFaceSizeAdjust):
* Source/WebCore/css/parser/CSSPropertyParserWorkerSafe.h:
- size-adjust parser wrapper for being used by FontFace().

* Source/WebCore/platform/graphics/FontPlatformData.cpp:
(WebCore::FontPlatformData::usedFontSize):
    It is not worth modifying the used size with @font-face size-adjust if
    we are to re-adjust it later with font-size-adjust.
This is because font-size-adjust will overrule this change, since
size-adjust also modifies the font&apos;s metric values and thus, keeps the
aspect-value unchanged (see discussion at w3c/csswg-drafts#6128).

* LayoutTests/TestExpectations:
* LayoutTests/platform/ios/size-adjust-interacts-with-text-size-adjust-auto-expected-mismatch.html: Added.
* LayoutTests/platform/ios/size-adjust-interacts-with-text-size-adjust-auto-notref.html: Added.
* LayoutTests/platform/ios/size-adjust-interacts-with-text-size-adjust-auto.html: Added.
* LayoutTests/platform/ios/size-adjust-interacts-with-text-size-adjust-percentage-expected.html: Added.
* LayoutTests/platform/ios/size-adjust-interacts-with-text-size-adjust-percentage-ref.html: Added.
* LayoutTests/platform/ios/size-adjust-interacts-with-text-size-adjust-percentage.html: Added.
- Theses tests won&apos;t be exported to WPT because -webkit-text-size-adjust
is a webkit-only property.

* Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml

Canonical link: <a href="https://commits.webkit.org/263604@main">https://commits.webkit.org/263604@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e0e00d939a9385997969b75f58fa2861a6b792b1

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/5180 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/5314 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/5494 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/6705 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/32/builds/5253 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/5177 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/5523 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/5291 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/5558 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/5272 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/5357 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/4644 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/6736 "Built successfully") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/39/builds/2843 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/4642 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/10389 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/4291 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/4707 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/4715 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/6345 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/4769 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/5144 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/4234 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/5276 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/4622 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/4638 "Passed tests") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/1330 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/1242 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/8705 "Built successfully") | | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/24/builds/5425 "Built successfully") | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/31/builds/4987 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/3/builds/1445 "Passed tests") | 
<!--EWS-Status-Bubble-End-->