### PR TITLE
[JSC] FunctionBind should fill BoundThis

### DIFF
--- a/JSTests/stress/bind-tothis-no-args.js
+++ b/JSTests/stress/bind-tothis-no-args.js
@@ -1,0 +1,16 @@
+//@ requireOptions("--forceEagerCompilation=1", "--useConcurrentJIT=0")
+function f0(x) {
+    try {
+      anything();eval();
+    } catch (error) {
+        if (x < 1e3)
+          f0.bind()(x+1);
+    }
+}
+noInline(f0);
+try {
+  f0(1);
+} catch (error) {
+  // This test shouldn't crash or throw, but in certain configurations it might
+  // run out of stack
+}

--- a/Source/JavaScriptCore/dfg/DFGByteCodeParser.cpp
+++ b/Source/JavaScriptCore/dfg/DFGByteCodeParser.cpp
@@ -3885,6 +3885,8 @@ auto ByteCodeParser::handleIntrinsicCall(Node* callee, Operand result, CallVaria
             int index = 0;
             for (; index < argumentCountIncludingThis; ++index)
                 addVarArgChild(get(virtualRegisterForArgumentIncludingThis(index, registerOffset)));
+            for (; index < numChildren - static_cast<int>(JSBoundFunction::maxEmbeddedArgs); ++index)
+                addVarArgChild(jsConstant(jsUndefined()));
             for (; index < numChildren; ++index)
                 addVarArgChild(jsConstant(JSValue()));
             Node* resultNode = addToGraph(Node::VarArg, FunctionBind, OpInfo(0), OpInfo(static_cast<unsigned>(argumentCountIncludingThis >= 2 ? argumentCountIncludingThis - 2 : 0)));


### PR DESCRIPTION
#### 0eef1c81db08bffe7c238a8fbf0de7b59ddbe981
<pre>
[JSC] FunctionBind should fill BoundThis
<a href="https://bugs.webkit.org/show_bug.cgi?id=255582">https://bugs.webkit.org/show_bug.cgi?id=255582</a>
rdar://108199593

Reviewed by Yusuke Suzuki.

Since <a href="https://commits.webkit.org/262385@main">https://commits.webkit.org/262385@main</a> we no longer pass the number of
arguments to function#bind around explicitly in DFG/FTL, and in order to infer
the number of arguments we need to account for when undefined is explicitly passed
as an argument, so we started filling all the empty slots with the empty JSValue
instead of undefined. However, we also stopped filling the BoundThis slot. This
patch keeps the behavior filling the arguments with the empty JSValue, but ensures
that BoundThis will be undefined by default.

* JSTests/stress/bind-tothis-no-args.js: Added.
(f0):
(catch):
* Source/JavaScriptCore/dfg/DFGByteCodeParser.cpp:
(JSC::DFG::ByteCodeParser::handleIntrinsicCall):

Canonical link: <a href="https://commits.webkit.org/263312@main">https://commits.webkit.org/263312@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/401ec5b8c4570e65e8c893c3a443b88dccd46d78

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/4222 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/4343 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/4461 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/5692 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/4468 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/4450 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/4308 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/4686 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/4283 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/4460 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/3811 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/5686 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/1955 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/3788 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/6024 "Passed tests") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/3521 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/3782 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/3854 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/5372 "Passed tests") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/4018 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/4262 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/3459 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/4319 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/3772 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/3786 "Passed tests") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/1068 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/1036 "Built successfully and passed tests") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/7865 "Build is in progress. Recent messages:") | | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/24/builds/4416 "Built successfully") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/4116 "Built successfully") | | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/3/builds/1176 "Passed tests") | 
<!--EWS-Status-Bubble-End-->