### PR TITLE
[Cocoa] Videos on store.steampowered.com play as black window with audio the first time full screened

### DIFF
--- a/Source/WebKit/UIProcess/Cocoa/VideoFullscreenManagerProxy.mm
+++ b/Source/WebKit/UIProcess/Cocoa/VideoFullscreenManagerProxy.mm
@@ -572,7 +572,12 @@ PlatformLayerContainer VideoFullscreenManagerProxy::createLayerWithID(PlaybackSe
         [playerLayer setFullscreenInterface:interface.get()];
         
         [playerLayer setVideoSublayer:[view layer]];
-        [playerLayer addSublayer:[view layer]];
+
+        // The videoView may already be reparented in fullscreen, so only parent the view
+        // if it has no existing parent:
+        if (![[view layer] superlayer])
+            [playerLayer addSublayer:[view layer]];
+
         model->setPlayerLayer(playerLayer.get());
         [playerLayer setFrame:CGRectMake(0, 0, initialSize.width(), initialSize.height())];
         [playerLayer setNeedsLayout];
@@ -622,7 +627,12 @@ RetainPtr<WebAVPlayerLayerView> VideoFullscreenManagerProxy::createViewWithID(Pl
         [playerLayer setFullscreenInterface:interface.get()];
 
         [playerLayer setVideoSublayer:[view layer]];
-        [playerLayer addSublayer:[view layer]];
+
+        // The videoView may already be reparented in fullscreen, so only parent the view
+        // if it has no existing parent:
+        if (![[view layer] superlayer])
+            [playerLayer addSublayer:[view layer]];
+
         model->setPlayerLayer(playerLayer);
         model->setPlayerView(WTFMove(playerView));
 


### PR DESCRIPTION
#### 584a1356823c7fa6be4d13ea0e927f7845e8c844
<pre>
[Cocoa] Videos on store.steampowered.com play as black window with audio the first time full screened
<a href="https://bugs.webkit.org/show_bug.cgi?id=255875">https://bugs.webkit.org/show_bug.cgi?id=255875</a>
rdar://108291733

Reviewed by Eric Carlson.

When the compositing code asks for a layer to be created for a video element, it may already be
displaying video content in fullscreen or a picture-in-picture window. In this case, the newly
created video layer shouldn&apos;t try to reparent the video content out of fullscreen/pip and into
the inline layer.

* Source/WebKit/UIProcess/Cocoa/VideoFullscreenManagerProxy.mm:
(WebKit::VideoFullscreenManagerProxy::createLayerWithID):
(WebKit::VideoFullscreenManagerProxy::createViewWithID):

Canonical link: <a href="https://commits.webkit.org/263327@main">https://commits.webkit.org/263327@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/68a6999e423fe8590cd23972918985f0450e85ea

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/4229 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/4350 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/4468 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/5699 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/4475 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/4457 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/4315 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/4690 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/4290 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/4468 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/3817 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/5693 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/1963 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/3793 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/6107 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/3791 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/3860 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/5386 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/4269 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/3466 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/3779 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/3791 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/1048 "Built successfully and passed tests") | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/4/builds/7870 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/4123 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->