### PR TITLE
Wake Lock permission denied after visibilitychange

### DIFF
--- a/LayoutTests/http/wpt/screen-wake-lock/sticky-permission-after-transient-activation-expected.txt
+++ b/LayoutTests/http/wpt/screen-wake-lock/sticky-permission-after-transient-activation-expected.txt
@@ -1,0 +1,3 @@
+
+PASS sticky-permission-after-transient-activation
+

--- a/LayoutTests/http/wpt/screen-wake-lock/sticky-permission-after-transient-activation.html
+++ b/LayoutTests/http/wpt/screen-wake-lock/sticky-permission-after-transient-activation.html
@@ -1,0 +1,24 @@
+<!DOCTYPE html>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script>
+promise_test(async t => {
+    // Does not have permission, should reject.
+    await promise_rejects_dom(t, "NotAllowedError", navigator.wakeLock.request('screen'));
+
+    // Trigger transient activation.
+    internals.withUserGesture(() => { });
+
+    assert_true(internals.hasTransientActivation(), "has transient activation");
+    let lock = await navigator.wakeLock.request('screen');
+
+    // Consume transient activation.
+    assert_true(internals.consumeTransientActivation());
+
+    await lock.release();
+
+    // This document was previously authorized so it should be able to require the wake lock again.
+    assert_false(internals.hasTransientActivation(), "does not have transient activation");
+    lock = await navigator.wakeLock.request('screen');
+});
+</script>

--- a/Source/WebCore/Modules/screen-wake-lock/WakeLock.cpp
+++ b/Source/WebCore/Modules/screen-wake-lock/WakeLock.cpp
@@ -67,9 +67,15 @@ void WakeLock::request(WakeLockType lockType, Ref<DeferredPromise>&& promise)
     // FIXME: The permission check can likely be dropped once the specification gets updated to only
     // require transient activation (https://github.com/w3c/screen-wake-lock/pull/326).
     bool hasTransientActivation = document->domWindow() && document->domWindow()->hasTransientActivation();
-    PermissionController::shared().query(document->clientOrigin(), PermissionDescriptor { PermissionName::ScreenWakeLock }, *document->page(), PermissionQuerySource::Window, [protectedThis = Ref { *this }, document = Ref { *document }, hasTransientActivation, promise = WTFMove(promise), lockType](std::optional<PermissionState> permission) mutable {
-        if (!permission || *permission == PermissionState::Prompt)
-            permission = hasTransientActivation ? PermissionState::Granted : PermissionState::Denied;
+    PermissionController::shared().query(document->clientOrigin(), PermissionDescriptor { PermissionName::ScreenWakeLock }, *document->page(), PermissionQuerySource::Window, [this, protectedThis = Ref { *this }, document = Ref { *document }, hasTransientActivation, promise = WTFMove(promise), lockType](std::optional<PermissionState> permission) mutable {
+        if (!permission || *permission == PermissionState::Prompt) {
+            if (hasTransientActivation || m_wasPreviouslyAuthorizedDueToTransientActivation) {
+                m_wasPreviouslyAuthorizedDueToTransientActivation = true;
+                permission = PermissionState::Granted;
+            } else
+                permission = PermissionState::Denied;
+        } else if (*permission == PermissionState::Denied)
+            m_wasPreviouslyAuthorizedDueToTransientActivation = false;
         document->eventLoop().queueTask(TaskSource::ScreenWakelock, [protectedThis = WTFMove(protectedThis), document = WTFMove(document), promise = WTFMove(promise), lockType, permission]() mutable {
             if (permission == PermissionState::Denied) {
                 promise->reject(Exception { NotAllowedError, "Permission was denied"_s });

--- a/Source/WebCore/Modules/screen-wake-lock/WakeLock.h
+++ b/Source/WebCore/Modules/screen-wake-lock/WakeLock.h
@@ -49,6 +49,8 @@ private:
     explicit WakeLock(Document*);
 
     Document* document();
+
+    bool m_wasPreviouslyAuthorizedDueToTransientActivation { false };
 };
 
 } // namespace WebCore


### PR DESCRIPTION
#### d901ad78bdb6536b4c0bdcbf85b1c1e40b8bdfc4
<pre>
Wake Lock permission denied after visibilitychange
<a href="https://bugs.webkit.org/show_bug.cgi?id=255363">https://bugs.webkit.org/show_bug.cgi?id=255363</a>
rdar://108279602

Reviewed by Geoffrey Garen.

Unlike other browser engines, WebKit requires a transient activation to acquire
a screen wake lock. While this is fine for the initial request, this seems a
bit restrictive for follow-up requests, especially considering that the screen
wake lock gets released when the document is no longer visible. It is also
common on the web to try and re-acquire the screen wake lock when the document
becomes visible again (in the visibilitychange event), in which case the JS
doesn&apos;t have transient activation.

To address this issue, we make the authorization from transient activation
sticky. If the page has previously acquired a screen wake lock with transient
activation, we will remember this permission for the lifetime of the document.

* LayoutTests/http/wpt/screen-wake-lock/sticky-permission-after-transient-activation-expected.txt: Added.
* LayoutTests/http/wpt/screen-wake-lock/sticky-permission-after-transient-activation.html: Added.
* Source/WebCore/Modules/screen-wake-lock/WakeLock.cpp:
(WebCore::WakeLock::request):
* Source/WebCore/Modules/screen-wake-lock/WakeLock.h:

Canonical link: <a href="https://commits.webkit.org/263382@main">https://commits.webkit.org/263382@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/8b073b6c0dce9e99b7934e564b2209cbd2d554c0

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/4232 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/4353 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/4471 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/5702 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/4477 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/4225 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/4460 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/4318 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/4691 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/4293 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/4467 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/3820 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/5696 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/1962 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/3796 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/6218 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/3790 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/3863 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/5395 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/4272 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/3468 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/3782 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/3794 "Passed tests") | | 
| [❌ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/1091 "Failed to push commit to Webkit repository") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/7872 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/4126 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->