### PR TITLE
Allow extension pages to set frame-specific website policies

### DIFF
--- a/Source/WebCore/page/UserContentProvider.cpp
+++ b/Source/WebCore/page/UserContentProvider.cpp
@@ -115,8 +115,12 @@ static ContentExtensions::ContentExtensionsBackend::RuleListFilter ruleListFilte
         };
     }
 
-    auto& exceptions = mainLoader->contentExtensionEnablement().second;
-    switch (mainLoader->contentExtensionEnablement().first) {
+    auto policySourceLoader = mainLoader;
+    if (!mainLoader->request().url().hasSpecialScheme() && documentLoader.request().url().protocolIsInHTTPFamily())
+        policySourceLoader = &documentLoader;
+
+    auto& exceptions = policySourceLoader->contentExtensionEnablement().second;
+    switch (policySourceLoader->contentExtensionEnablement().first) {
     case ContentExtensionDefaultEnablement::Disabled:
         return [&](auto& identifier) {
             return exceptions.contains(identifier)

--- a/Source/WebKit/WebProcess/Network/WebLoaderStrategy.cpp
+++ b/Source/WebKit/WebProcess/Network/WebLoaderStrategy.cpp
@@ -327,7 +327,11 @@ static void addParametersShared(const LocalFrame* frame, NetworkResourceLoadPara
     if (!mainFrameDocumentLoader || !isMainFrameNavigation)
         mainFrameDocumentLoader = mainFrame.loader().documentLoader();
 
-    parameters.allowPrivacyProxy = mainFrameDocumentLoader ? mainFrameDocumentLoader->allowPrivacyProxy() : true;
+    auto* policySourceDocumentLoader = mainFrameDocumentLoader;
+    if (policySourceDocumentLoader && !policySourceDocumentLoader->request().url().hasSpecialScheme() && frame->document()->url().protocolIsInHTTPFamily())
+        policySourceDocumentLoader = frame->loader().documentLoader();
+
+    parameters.allowPrivacyProxy = policySourceDocumentLoader ? policySourceDocumentLoader->allowPrivacyProxy() : true;
 
     if (auto* document = frame->document()) {
         parameters.crossOriginEmbedderPolicy = document->crossOriginEmbedderPolicy();
@@ -348,7 +352,7 @@ static void addParametersShared(const LocalFrame* frame, NetworkResourceLoadPara
         }
     }
 
-    auto networkConnectionIntegrityPolicy = mainFrameDocumentLoader ? mainFrameDocumentLoader->networkConnectionIntegrityPolicy() : OptionSet<NetworkConnectionIntegrity> { };
+    auto networkConnectionIntegrityPolicy = policySourceDocumentLoader ? policySourceDocumentLoader->networkConnectionIntegrityPolicy() : OptionSet<NetworkConnectionIntegrity> { };
     parameters.networkConnectionIntegrityPolicy = networkConnectionIntegrityPolicy;
 
     if (isMainFrameNavigation)

--- a/Source/WebKit/WebProcess/Network/WebSocketChannel.cpp
+++ b/Source/WebKit/WebProcess/Network/WebSocketChannel.cpp
@@ -137,8 +137,14 @@ WebSocketChannel::ConnectStatus WebSocketChannel::connect(const URL& url, const 
         if (!mainFrame)
             return ConnectStatus::KO; 
         if (auto* mainFrameDocumentLoader = mainFrame->document() ? mainFrame->document()->loader() : nullptr) {
-            allowPrivacyProxy = mainFrameDocumentLoader->allowPrivacyProxy();
-            networkConnectionIntegrityPolicy = mainFrameDocumentLoader->networkConnectionIntegrityPolicy();
+            auto* policySourceDocumentLoader = mainFrameDocumentLoader;
+            if (!policySourceDocumentLoader->request().url().hasSpecialScheme() && frame->document()->url().protocolIsInHTTPFamily())
+                policySourceDocumentLoader = frame->document()->loader();
+
+            if (policySourceDocumentLoader) {
+                allowPrivacyProxy = policySourceDocumentLoader->allowPrivacyProxy();
+                networkConnectionIntegrityPolicy = policySourceDocumentLoader->networkConnectionIntegrityPolicy();
+            }
         }
     }
 

--- a/Source/WebKit/WebProcess/WebPage/WebFrame.cpp
+++ b/Source/WebKit/WebProcess/WebPage/WebFrame.cpp
@@ -1127,7 +1127,11 @@ OptionSet<WebCore::NetworkConnectionIntegrity> WebFrame::networkConnectionIntegr
     if (!topDocumentLoader)
         return { };
 
-    return topDocumentLoader->networkConnectionIntegrityPolicy();
+    auto* policySourceDocumentLoader = topDocumentLoader;
+    if (!policySourceDocumentLoader->request().url().hasSpecialScheme() && document->url().protocolIsInHTTPFamily())
+        policySourceDocumentLoader = document->loader();
+
+    return policySourceDocumentLoader->networkConnectionIntegrityPolicy();
 }
 
 } // namespace WebKit

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/WebsitePolicies.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/WebsitePolicies.mm
@@ -30,6 +30,7 @@
 #import "TestNavigationDelegate.h"
 #import "TestProtocol.h"
 #import "TestUIDelegate.h"
+#import "TestURLSchemeHandler.h"
 #import "TestWKWebView.h"
 #import "WKWebViewConfigurationExtras.h"
 #import <WebKit/WKContentRuleListStorePrivate.h>
@@ -1832,4 +1833,235 @@ TEST(WebpagePreferences, ToggleNetworkConnectionIntegrity)
     EXPECT_FALSE([preferences _networkConnectionIntegrityEnabled]);
     [preferences _setNetworkConnectionIntegrityEnabled:YES];
     EXPECT_TRUE([preferences _networkConnectionIntegrityEnabled]);
+}
+
+TEST(WebpagePreferences, HttpPageContentBlockers)
+{
+    [[WKContentRuleListStore defaultStore] _removeAllContentRuleLists];
+
+    auto navigationDelegate = adoptNS([TestNavigationDelegate new]);
+    navigationDelegate.get().decidePolicyForNavigationActionWithPreferences = ^(WKNavigationAction *action, WKWebpagePreferences *preferences, void (^decisionHandler)(WKNavigationActionPolicy, WKWebpagePreferences *)) {
+        [preferences _setContentBlockersEnabled:YES];
+        if (action.targetFrame.mainFrame)
+            [preferences _setContentBlockersEnabled:NO];
+
+        decisionHandler(WKNavigationActionPolicyAllow, preferences);
+    };
+
+    TestWebKitAPI::HTTPServer server({
+        { "/index.html"_s, { 
+            R"INDEX(<script>
+                window.results = [];
+                window.addEventListener('message', function(event) {
+                    window.results.push(event.data);
+                    alert();
+                });
+            </script>
+            <script src='test:///script.js'></script>
+            <iframe src='/subframe.html'></iframe>)INDEX"_s } },
+        { "/subframe.html"_s, { "<script src='test:///script_subframe.js'></script>"_s } },
+    }, TestWebKitAPI::HTTPServer::Protocol::Http);
+
+    auto handler = adoptNS([TestURLSchemeHandler new]);
+    [handler setStartURLSchemeTaskHandler:^(WKWebView *, id<WKURLSchemeTask> task) {
+        NSString *path = task.request.URL.path;
+        NSString *type = nil;
+        NSString *result = nil;
+        if ([path hasSuffix:@"script.js"]) {
+            result = @"window.results.push(window.location.href);";
+            type = @"text/javascript";
+        } else if ([path hasSuffix:@"script_subframe.js"]) {
+            result = @"window.parent.postMessage(window.location.href, '*');";
+            type = @"text/javascript";
+        }
+
+        if (!result) {
+            [task didFailWithError:[NSError errorWithDomain:@"TestWebKitAPI" code:1 userInfo:nil]];
+            return;
+        }
+
+        auto response = adoptNS([[NSURLResponse alloc] initWithURL:task.request.URL MIMEType:type expectedContentLength:[result length] textEncodingName:nil]);
+        [task didReceiveResponse:response.get()];
+        [task didReceiveData:[result dataUsingEncoding:NSUTF8StringEncoding]];
+        [task didFinish];
+    }];
+
+    auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    [configuration setURLSchemeHandler:handler.get() forURLScheme:@"test"];
+
+    doneCompiling = false;
+    NSString* contentBlocker = @"[{\"action\":{\"type\":\"block\"},\"trigger\":{\"url-filter\":\".*\",\"resource-type\":[\"script\"]}}]";
+    [[WKContentRuleListStore defaultStore] compileContentRuleListForIdentifier:@"WebsitePoliciesTest" encodedContentRuleList:contentBlocker completionHandler:^(WKContentRuleList *list, NSError *error) {
+        EXPECT_TRUE(error == nil);
+        [[configuration userContentController] addContentRuleList:list];
+        doneCompiling = true;
+    }];
+    TestWebKitAPI::Util::run(&doneCompiling);
+
+    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 800, 600) configuration:configuration.get()]);
+    [webView setNavigationDelegate:navigationDelegate.get()];
+
+    [webView loadRequest:server.requestWithLocalhost("/index.html"_s)];
+    [webView _test_waitForAlert];
+
+    NSArray<NSString *> *results = [webView objectByEvaluatingJavaScript:@"window.results"];
+    NSString *expectedMainFrame = [NSString stringWithFormat:@"http://localhost:%d/index.html", server.port()];
+    NSString *expectedSubFrame = [NSString stringWithFormat:@"http://localhost:%d/subframe.html", server.port()];
+
+    EXPECT_EQ(2U, results.count);
+    EXPECT_WK_STREQ(expectedMainFrame, results[0]);
+    EXPECT_WK_STREQ(expectedSubFrame, results[1]);
+
+    [[WKContentRuleListStore defaultStore] _removeAllContentRuleLists];
+}
+
+TEST(WebpagePreferences, ExtensionPageContentBlockers)
+{
+    [[WKContentRuleListStore defaultStore] _removeAllContentRuleLists];
+
+    auto navigationDelegate = adoptNS([TestNavigationDelegate new]);
+    navigationDelegate.get().decidePolicyForNavigationActionWithPreferences = ^(WKNavigationAction *action, WKWebpagePreferences *preferences, void (^decisionHandler)(WKNavigationActionPolicy, WKWebpagePreferences *)) {
+        [preferences _setContentBlockersEnabled:YES];
+        if (action.targetFrame.mainFrame)
+            [preferences _setContentBlockersEnabled:NO];
+
+        decisionHandler(WKNavigationActionPolicyAllow, preferences);
+    };
+
+    TestWebKitAPI::HTTPServer server({
+        { "/subframe.html"_s, { "<script src='test:///script_subframe.js'></script>"_s } },
+    }, TestWebKitAPI::HTTPServer::Protocol::Http);
+
+    __block auto port = server.port();
+    auto handler = adoptNS([TestURLSchemeHandler new]);
+    [handler setStartURLSchemeTaskHandler:^(WKWebView *, id<WKURLSchemeTask> task) {
+        NSString *path = task.request.URL.path;
+        NSString *type = nil;
+        NSString *result = nil;
+        if ([path hasSuffix:@"index.html"]) {
+            result = [NSString stringWithFormat:@"<!DOCTYPE html>"
+                "<script>"
+                "   window.results = [];"
+                "   window.addEventListener('message', function(event) {"
+                "       window.results.push(event.data);"
+                "   });"
+                "</script>"
+                "<script src='test:///script.js'></script>"
+                "<iframe src='http://localhost:%d/subframe.html'></iframe>", port];
+            type = @"text/html";
+        } else if ([path hasSuffix:@"script.js"]) {
+            result = @"window.results.push(window.location.href);";
+            type = @"text/javascript";
+        } else if ([path hasSuffix:@"script_subframe.js"]) {
+            result = @"window.parent.postMessage(window.location.href, '*');";
+            type = @"text/javascript";
+        }
+
+        if (!result) {
+            [task didFailWithError:[NSError errorWithDomain:@"TestWebKitAPI" code:1 userInfo:nil]];
+            return;
+        }
+
+        auto response = adoptNS([[NSURLResponse alloc] initWithURL:task.request.URL MIMEType:type expectedContentLength:[result length] textEncodingName:nil]);
+        [task didReceiveResponse:response.get()];
+        [task didReceiveData:[result dataUsingEncoding:NSUTF8StringEncoding]];
+        [task didFinish];
+    }];
+
+    auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    [configuration setURLSchemeHandler:handler.get() forURLScheme:@"test"];
+
+    doneCompiling = false;
+    NSString* contentBlocker = @"[{\"action\":{\"type\":\"block\"},\"trigger\":{\"url-filter\":\".*\",\"resource-type\":[\"script\"]}}]";
+    [[WKContentRuleListStore defaultStore] compileContentRuleListForIdentifier:@"WebsitePoliciesTest" encodedContentRuleList:contentBlocker completionHandler:^(WKContentRuleList *list, NSError *error) {
+        EXPECT_TRUE(error == nil);
+        [[configuration userContentController] addContentRuleList:list];
+        doneCompiling = true;
+    }];
+    TestWebKitAPI::Util::run(&doneCompiling);
+
+    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 800, 600) configuration:configuration.get()]);
+    [webView setNavigationDelegate:navigationDelegate.get()];
+
+    auto request = [NSMutableURLRequest requestWithURL:[NSURL URLWithString:@"test:///index.html"]];
+    [webView loadRequest:request];
+    [navigationDelegate waitForDidFinishNavigation];
+
+    // Wait for an additional 0.5 seconds in case the content blocker does not block the script, and the postMessage is sent.
+    TestWebKitAPI::Util::runFor(0.5_s);
+
+    NSArray<NSString *> *results = [webView objectByEvaluatingJavaScript:@"window.results"];
+
+    EXPECT_EQ(1U, results.count);
+    EXPECT_WK_STREQ("test:///index.html", results[0]);
+
+    [[WKContentRuleListStore defaultStore] _removeAllContentRuleLists];
+}
+
+TEST(WebpagePreferences, ExtensionPageNetworkConnectionIntegrityReferrer)
+{
+    auto *store = WKWebsiteDataStore.nonPersistentDataStore;
+    store._resourceLoadStatisticsEnabled = YES;
+
+    auto navigationDelegate = adoptNS([TestNavigationDelegate new]);
+    navigationDelegate.get().decidePolicyForNavigationActionWithPreferences = ^(WKNavigationAction *action, WKWebpagePreferences *preferences, void (^decisionHandler)(WKNavigationActionPolicy, WKWebpagePreferences *)) {
+        [preferences _setNetworkConnectionIntegrityEnabled:YES];
+        if (action.targetFrame.mainFrame)
+            [preferences _setNetworkConnectionIntegrityEnabled:NO];
+
+        decisionHandler(WKNavigationActionPolicyAllow, preferences);
+    };
+
+    TestWebKitAPI::HTTPServer server({
+        { "/subframe2.html"_s, { "<script>window.top.postMessage(document.referrer, '*');</script>"_s } },
+    }, TestWebKitAPI::HTTPServer::Protocol::Http);
+
+    server.addResponse("/subframe1.html"_s, { "<iframe src='http://127.0.0.1:"_s + server.port() + "/subframe2.html'></iframe>"_s });
+
+    __block auto port = server.port();
+    auto handler = adoptNS([TestURLSchemeHandler new]);
+    [handler setStartURLSchemeTaskHandler:^(WKWebView *, id<WKURLSchemeTask> task) {
+        NSString *path = task.request.URL.path;
+        NSString *type = nil;
+        NSString *result = nil;
+        if ([path hasSuffix:@"index.html"]) {
+            result = [NSString stringWithFormat:@"<!DOCTYPE html>"
+                "<script>"
+                "   window.results = [document.referrer];"
+                "   window.addEventListener('message', function(event) {"
+                "       window.results.push(event.data);"
+                "       alert();"
+                "   });"
+                "</script>"
+                "<iframe src='http://localhost:%d/subframe1.html'></iframe>", port];
+            type = @"text/html";
+        }
+
+        if (!result) {
+            [task didFailWithError:[NSError errorWithDomain:@"TestWebKitAPI" code:1 userInfo:nil]];
+            return;
+        }
+
+        auto response = adoptNS([[NSURLResponse alloc] initWithURL:task.request.URL MIMEType:type expectedContentLength:[result length] textEncodingName:nil]);
+        [task didReceiveResponse:response.get()];
+        [task didReceiveData:[result dataUsingEncoding:NSUTF8StringEncoding]];
+        [task didFinish];
+    }];
+
+    auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    [configuration setWebsiteDataStore:store];
+    [configuration setURLSchemeHandler:handler.get() forURLScheme:@"test"];
+
+    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 800, 600) configuration:configuration.get()]);
+    [webView setNavigationDelegate:navigationDelegate.get()];
+
+    auto request = [NSMutableURLRequest requestWithURL:[NSURL URLWithString:@"test:///index.html"]];
+    [request setValue:@"http://webkit.org" forHTTPHeaderField:@"Referer"];
+    [webView loadRequest:request];
+    [webView _test_waitForAlert];
+
+    NSArray<NSString *> *results = [webView objectByEvaluatingJavaScript:@"window.results"];
+    EXPECT_EQ(2U, results.count);
+    EXPECT_WK_STREQ("http://webkit.org/", results[0]);
+    EXPECT_WK_STREQ("", results[1]);
 }


### PR DESCRIPTION
#### 8fa47d3ff3db03b72ba4636a47b2da28e3dffb6d
<pre>
Allow extension pages to set frame-specific website policies
<a href="https://bugs.webkit.org/show_bug.cgi?id=255880">https://bugs.webkit.org/show_bug.cgi?id=255880</a>
rdar://104453529

Reviewed by Alex Christensen.

This patch makes changes to allow extensions pages to have subframes which have website
policies that are different from the main frame. For now, this only applies to the policies
allowPrivacyProxy, networkConnectionIntegrityPolicy, and contentExtensionEnablement.

* Source/WebCore/dom/Document.cpp:
(WebCore::Document::urlForBindings const):
(WebCore::Document::referrerForBindings):
* Source/WebCore/page/UserContentProvider.cpp:
(WebCore::ruleListFilter):
* Source/WebKit/WebProcess/WebPage/WebFrame.cpp:
(WebKit::WebFrame::networkConnectionIntegrityPolicy const):
* Source/WebKit/WebProcess/Network/WebLoaderStrategy.cpp:
(WebKit::addParametersShared):
* Source/WebKit/WebProcess/Network/WebSocketChannel.cpp:
(WebKit::WebSocketChannel::connect):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/WebsitePolicies.mm:

Canonical link: <a href="https://commits.webkit.org/263442@main">https://commits.webkit.org/263442@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4acb8f824d75688848fe67a2d6710e1d1b8aa5bd

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/4597 "5 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/4717 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/4870 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/6090 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/4754 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/4588 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/4856 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/4676 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/4993 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/4666 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/4759 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/4119 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/6100 "Built successfully") | 
| | [⏳ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/iOS-16-Simulator-WPT-WK2-Tests-EWS "Waiting to run tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/4111 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/9109 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/4107 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/4185 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/5735 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/4575 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/3727 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/4104 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/1138 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/8147 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/4465 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->