### PR TITLE
Regression(255052@main) Some streaming sites fail with an Embedded Video Sandbox Browser Error

### DIFF
--- a/LayoutTests/fast/dom/object-load-pdf-data-url-expected.txt
+++ b/LayoutTests/fast/dom/object-load-pdf-data-url-expected.txt
@@ -1,0 +1,10 @@
+Tests that loading a data URL with a PDF MIME type inside an does not dispatch an error event.
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+
+PASS No error event dispatched
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/fast/dom/object-load-pdf-data-url.html
+++ b/LayoutTests/fast/dom/object-load-pdf-data-url.html
@@ -1,0 +1,24 @@
+<!DOCTYPE html>
+<html>
+<body>
+<script src="../../resources/js-test.js"></script>
+<script>
+description("Tests that loading a data URL with a PDF MIME type inside an <object> does not dispatch an error event.");
+jsTestIsAsync = true;
+
+let object = document.createElement("object");
+object.data = "data:application/pdf;base64,aG1t";
+object.onerror = () => {
+    testFailed("Error event dispatched");
+    finishJSTest();
+};
+
+document.body.append(object);
+setTimeout(() => {
+    object.remove();
+    testPassed("No error event dispatched");
+    finishJSTest();
+}, 1000);
+</script>
+</body>
+</html>

--- a/Source/WebKit/WebProcess/Plugins/PDF/PDFPlugin.mm
+++ b/Source/WebKit/WebProcess/Plugins/PDF/PDFPlugin.mm
@@ -796,6 +796,9 @@ void PDFPlugin::receivedNonLinearizedPDFSentinel()
         return;
 
     m_pdfDocument = adoptNS([allocPDFDocumentInstance() initWithData:rawData()]);
+    if (!m_pdfDocument)
+        return;
+
     installPDFDocument();
     tryRunScriptsInPDFDocument();
 }
@@ -1644,7 +1647,8 @@ void PDFPlugin::streamDidFinishLoading()
 #endif
     {
         m_pdfDocument = adoptNS([allocPDFDocumentInstance() initWithData:rawData()]);
-        installPDFDocument();
+        if (m_pdfDocument)
+            installPDFDocument();
     }
 
     tryRunScriptsInPDFDocument();


### PR DESCRIPTION
#### 2c5a97645ec0a3eb6a9bf8d1c64888c47cca5c6c
<pre>
Regression(255052@main) Some streaming sites fail with an Embedded Video Sandbox Browser Error
<a href="https://bugs.webkit.org/show_bug.cgi?id=255900">https://bugs.webkit.org/show_bug.cgi?id=255900</a>
&lt;rdar://107795151&gt;

Reviewed by Tim Horton and Darin Adler.

Some streaming sites fail with an Embedded Video Sandbox Browser Error since
255052@main. 255052@main seems correct per the specification but exposing the
&quot;Chrome PDF Viewer&quot; caused those sites to use a different code path for
validating iframe sandboxing.

They now try to load a data URL with a pdf MIME type inside an &lt;object&gt; element
and this was firing an error event on iOS, which was causing the site&apos;s logic
to display the sandbox error.

There is logic inside WebFrameLoaderClient::objectContentType() that is iOS
specific and causes us  to try to load PDF as an image when inside an &lt;object&gt;.
This is because we don&apos;t support loadings such PDFs as plugins on iOS.

However, WebKit, in general, doesn&apos;t fire load/error events on &lt;object&gt; elements
that are loaded as plugins. It only does so when loading the &lt;object&gt; as an image.
I propose that we stop firing the load/error events for &lt;object&gt; loads of PDFs on
iOS, to make it look like they were loaded as plugins and avoid firing events that
could confuse sites such as the ones in the radar.

* LayoutTests/fast/dom/object-load-pdf-data-url-expected.txt: Added.
* LayoutTests/fast/dom/object-load-pdf-data-url.html: Added.
* Source/WebCore/html/HTMLImageLoader.cpp:
(WebCore::HTMLImageLoader::dispatchLoadEvent():

Canonical link: <a href="https://commits.webkit.org/263377@main">https://commits.webkit.org/263377@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/49ff29b4f7d12abf69f106dc0db61f15baf98eed

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/4375 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/4492 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/4622 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/5851 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/4588 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/4367 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/4614 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/4458 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/4813 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/4438 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/4586 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/3932 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/5850 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/2081 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/3909 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/7429 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/3912 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/3976 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/5524 "run-api-tests-without-change (failure)") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/4390 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/3572 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/3911 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/3907 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/1090 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/7965 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/4266 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->