### PR TITLE
Unreviewed, reverting r262665@main.

### DIFF
--- a/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
+++ b/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
@@ -5352,7 +5352,7 @@ SampleBufferContentKeySessionSupportEnabled:
     WebKitLegacy:
       default: false
     WebKit:
-      default: WebKit::defaultSampleBufferContentKeySessionSupportEnabled()
+      default: false
     WebCore:
       default: false
 

--- a/Source/WebKit/Shared/Cocoa/WebPreferencesDefaultValuesCocoa.mm
+++ b/Source/WebKit/Shared/Cocoa/WebPreferencesDefaultValuesCocoa.mm
@@ -96,20 +96,6 @@ bool defaultUseSCContentSharingPicker()
 }
 #endif
 
-#if HAVE(AVCONTENTKEYSPECIFIER)
-bool defaultSampleBufferContentKeySessionSupportEnabled()
-{
-    static bool enabled = false;
-#if ENABLE(SAMPLE_BUFFER_CONTENT_KEY_SESSION_SUPPORT)
-    static std::once_flag flag;
-    std::call_once(flag, [] {
-        enabled = os_feature_enabled(CoreMedia, EnableContentKeyBoss);
-    });
-#endif
-    return enabled;
-}
-#endif
-
 } // namespace WebKit
 
 #endif // PLATFORM(COCOA)

--- a/Source/WebKit/Shared/WebPreferencesDefaultValues.h
+++ b/Source/WebKit/Shared/WebPreferencesDefaultValues.h
@@ -110,8 +110,4 @@ bool defaultUseSCContentSharingPicker();
 bool defaultPeerConnectionEnabledAvailable();
 #endif
 
-#if HAVE(AVCONTENTKEYSPECIFIER)
-bool defaultSampleBufferContentKeySessionSupportEnabled();
-#endif
-
 } // namespace WebKit


### PR DESCRIPTION
#### 3db5312ccb75f3b264cd85e2b0a2ff2c34cc458d
<pre>
Unreviewed, reverting r262665@main.
<a href="https://bugs.webkit.org/show_bug.cgi?id=255902">https://bugs.webkit.org/show_bug.cgi?id=255902</a>
rdar://108471471

[Cocoa] Netflix videos will not play, will eventually error

Reverted changeset:

&quot;[Cocoa] Enable SampleBufferContentKeySessionSupport by default&quot;
<a href="https://bugs.webkit.org/show_bug.cgi?id=255067">https://bugs.webkit.org/show_bug.cgi?id=255067</a>
<a href="https://commits.webkit.org/262665@main">https://commits.webkit.org/262665@main</a>

Canonical link: <a href="https://commits.webkit.org/263366@main">https://commits.webkit.org/263366@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/390056df9cec59fd95016bfc8d5f57562ee69958

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/4321 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/4438 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/4563 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/5793 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/4539 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/4551 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/4402 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/4764 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/4381 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/4528 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/3883 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/5791 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/2024 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/3860 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/7073 "Passed tests") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/3583 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/3854 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/3927 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/5460 "13 api tests failed or timed out") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/4103 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/4337 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/3519 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/4419 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/3858 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/3858 "Passed tests") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/1099 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/1081 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/7913 "Built successfully") | | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/24/builds/4518 "Built successfully") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/4210 "Built successfully") | | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/3/builds/1205 "Passed tests") | 
<!--EWS-Status-Bubble-End-->