### PR TITLE
Add a circular bit to modern media controls' Button

### DIFF
--- a/Source/WebCore/Modules/modern-media-controls/controls/button.css
+++ b/Source/WebCore/Modules/modern-media-controls/controls/button.css
@@ -87,6 +87,13 @@ button.rounded {
     height: var(--inline-controls-bar-height) !important;
 }
 
+/* Circular style */
+
+button.circular {
+    aspect-ratio: 1;
+    border-radius: 50%;
+}
+
 /* Center style */
 
 button.center,

--- a/Source/WebCore/Modules/modern-media-controls/controls/button.js
+++ b/Source/WebCore/Modules/modern-media-controls/controls/button.js
@@ -135,6 +135,17 @@ class Button extends LayoutItem
         return {};
     }
 
+    get circular()
+    {
+        return this.element.classList.contains("circular");
+    }
+
+    set circular(circular)
+    {
+        this.element.classList.toggle("circular", circular);
+        this._updateImageMetrics();
+    }
+
     // Protected
 
     handleEvent(event)
@@ -202,6 +213,9 @@ class Button extends LayoutItem
 
     _updateImageMetrics()
     {
+        if (!this._imageSource)
+            return;
+
         let width = this._imageSource.width * this._scaleFactor;
         let height = this._imageSource.height * this._scaleFactor;
 
@@ -212,6 +226,11 @@ class Button extends LayoutItem
 
         if (this.image.width === width && this.image.height === height)
             return;
+
+        if (this.circular) {
+            width = Math.max(width, height);
+            height = width;
+        }
 
         this.image.width = width;
         this.image.height = height;

--- a/Source/WebCore/Modules/modern-media-controls/controls/inline-media-controls.css
+++ b/Source/WebCore/Modules/modern-media-controls/controls/inline-media-controls.css
@@ -65,7 +65,7 @@
     bottom: auto;
 }
 
-.media-controls.inline > .controls-bar button {
+.media-controls.inline > .controls-bar button:not(.circular) {
     height: 100% !important;
 }
 


### PR DESCRIPTION
#### 4472b61acbea6174657bf7df150f2606c492c54f
<pre>
Add a circular bit to modern media controls&apos; Button
<a href="https://bugs.webkit.org/show_bug.cgi?id=255904">https://bugs.webkit.org/show_bug.cgi?id=255904</a>
rdar://108487065

Reviewed by Dean Jackson.

* Source/WebCore/Modules/modern-media-controls/controls/button.css:
(button.circular):
* Source/WebCore/Modules/modern-media-controls/controls/button.js:
(Button.prototype.get circular):
(Button.prototype.set circular):
(Button.prototype._updateImageMetrics):
(Button):
* Source/WebCore/Modules/modern-media-controls/controls/inline-media-controls.css:
(.media-controls.inline &gt; .controls-bar button:not(.circular)):
(.media-controls.inline &gt; .controls-bar button): Deleted.
Add a bit, orthogonal to the style (because we want to use it both with Bar and Rounded buttons),
indicating that a button should be fully circular, and adjust the metrics accordingly.

Canonical link: <a href="https://commits.webkit.org/263356@main">https://commits.webkit.org/263356@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/6d2dcaf17e6019b6bc5295db222048e3c560e892

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/4328 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/4445 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/4570 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/5800 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/4546 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/4320 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/4558 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/4409 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/4771 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/4388 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/4534 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/3891 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/5799 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/2030 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/3868 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/7084 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/3860 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/3935 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/5469 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/4344 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/3525 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/3865 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/3866 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/1075 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/7919 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/4217 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->