### PR TITLE
CSS hypot() function sometimes returns the result squared

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-values/hypot-pow-sqrt-computed-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-values/hypot-pow-sqrt-computed-expected.txt
@@ -18,10 +18,10 @@ PASS calc(1px * hypot(10000)) should be used-value-equivalent to 10000px
 PASS calc(2px * sqrt(100000000)) should be used-value-equivalent to 20000px
 PASS calc(3px * pow(20, 4)) should be used-value-equivalent to 480000px
 PASS calc(-2 * hypot(3px, 4px)) should be used-value-equivalent to -10px
-FAIL hypot(0% + 3px, 0% + 4px) should be used-value-equivalent to 5px assert_equals: hypot(0% + 3px, 0% + 4px) and 5px serialize to the same thing in used values. expected "5px" but got "25px"
+PASS hypot(0% + 3px, 0% + 4px) should be used-value-equivalent to 5px
 PASS hypot(0% + 772.333px) should be used-value-equivalent to calc(0% + 772.333px)
 PASS hypot(0% + 772.35px) should be used-value-equivalent to calc(0% + 772.35px)
-FAIL hypot(0% + 600px, 0% + 800px) should be used-value-equivalent to 1000px assert_equals: hypot(0% + 600px, 0% + 800px) and 1000px serialize to the same thing in used values. expected "1000px" but got "1000000px"
+PASS hypot(0% + 600px, 0% + 800px) should be used-value-equivalent to 1000px
 PASS hypot(1px) should be used-value-equivalent to 1px
 PASS hypot(1cm) should be used-value-equivalent to 1cm
 PASS hypot(1mm) should be used-value-equivalent to 1mm

--- a/Source/WebCore/platform/calc/CalcExpressionOperation.cpp
+++ b/Source/WebCore/platform/calc/CalcExpressionOperation.cpp
@@ -117,7 +117,7 @@ float CalcExpressionOperation::evaluate(float maxValue) const
             float value = child->evaluate(maxValue);
             sum += (value * value);
         }
-        return sum;
+        return std::sqrt(sum);
     }
     case CalcOperator::Sin: {
         if (m_children.size() != 1)


### PR DESCRIPTION
#### a9211716efb3a877fe390339ffccfd369c3bda46
<pre>
CSS hypot() function sometimes returns the result squared
<a href="https://bugs.webkit.org/show_bug.cgi?id=255905">https://bugs.webkit.org/show_bug.cgi?id=255905</a>
rdar://108487071

Reviewed by Tim Horton.

In cases where the result is computed by CalcExpressionOperation.cpp, the result ends up being squared, because we&apos;re missing a sqrt() operation.
The result is correct for cases computed by CSSCalcOperationNode.cpp however, ideally code should be shared to prevent these types of bugs.

* LayoutTests/imported/w3c/web-platform-tests/css/css-values/hypot-pow-sqrt-computed-expected.txt:
* Source/WebCore/platform/calc/CalcExpressionOperation.cpp:
(WebCore::CalcExpressionOperation::evaluate const):

Canonical link: <a href="https://commits.webkit.org/263351@main">https://commits.webkit.org/263351@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/58946db77d917693ce749e0744ed4d4fa4b38022

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/4330 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/4447 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/4572 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/5802 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/4548 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/4322 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/4560 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/4411 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/4772 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/4390 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/4536 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/3890 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/5801 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/2032 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/3867 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/7132 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/3862 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/3934 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/5470 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/4346 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/3527 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/3867 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/3865 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/1068 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/7921 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/4219 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->