### PR TITLE
:dir pseudo class doesn't invalidate after removing dir content attribute from document element

### DIFF
--- a/LayoutTests/fast/css/dir-ltr-removal-expected.html
+++ b/LayoutTests/fast/css/dir-ltr-removal-expected.html
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<html dir="rtl">
+<body>
+<div class="box"></div>
+<style>
+body { text-align: left; }
+.box { width: 100px; height: 100px; background: green; display: inline-block; }
+</style>
+</body>
+</html>

--- a/LayoutTests/fast/css/dir-ltr-removal.html
+++ b/LayoutTests/fast/css/dir-ltr-removal.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<html dir="rtl">
+<body>
+<div id="element" dir="ltr" class="box"></div><div id="host" dir="ltr"></div>
+<style>
+body { text-align: left; }
+.box { width: 50px; height: 100px; background: green; display: inline-block; }
+.box:dir(ltr) { background: red; }
+#host { display: inline-block; }
+</style>
+<script>
+host.attachShadow({mode: 'closed'}).innerHTML = '<div class="box"></div><style>.box { width: 50px; height: 100px; background: green; } .box:dir(ltr) { background: red; }</style>';
+element.getBoundingClientRect();
+element.removeAttribute('dir');
+host.removeAttribute('dir');
+</script>
+</body>
+</html>

--- a/LayoutTests/fast/css/dir-rtl-removal-expected.html
+++ b/LayoutTests/fast/css/dir-rtl-removal-expected.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+<body>
+<div class="box"></div>
+<style>
+.box { width: 100px; height: 100px; background: green; }
+</style>
+</body>
+</html>

--- a/LayoutTests/fast/css/dir-rtl-removal.html
+++ b/LayoutTests/fast/css/dir-rtl-removal.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html>
+<body>
+<div id="element" class="box"></div>
+<div id="host" class="box"></div>
+<style>
+.box { width: 100px; height: 50px; background: green; }
+.box:dir(rtl) { background: red; }
+</style>
+<script>
+document.documentElement.setAttribute('dir', 'rtl');
+host.attachShadow({mode: 'closed'}).innerHTML = '<div class="box"></div><style>.box { width: 100px; height: 50px; background: green; } .box:dir(rtl) { background: red; }</style>'
+element.getBoundingClientRect();
+document.documentElement.removeAttribute('dir');
+</script>
+</body>
+</html>

--- a/Source/WebCore/html/HTMLElement.h
+++ b/Source/WebCore/html/HTMLElement.h
@@ -208,7 +208,7 @@ private:
     void mapLanguageAttributeToLocale(const AtomString&, MutableStyleProperties&);
 
     void dirAttributeChanged(const AtomString&);
-    void updateEffectiveDirectionality(TextDirection);
+    void updateEffectiveDirectionality(std::optional<TextDirection>);
     void adjustDirectionalityIfNeededAfterChildAttributeChanged(Element* child);
     void adjustDirectionalityIfNeededAfterChildrenChanged(Element* beforeChange, ChildChange::Type);
 


### PR DESCRIPTION
#### a3084fe071c6918f900a19156c2d9e51f1c7dc10
<pre>
:dir pseudo class doesn&apos;t invalidate after removing dir content attribute from document element
<a href="https://bugs.webkit.org/show_bug.cgi?id=255568">https://bugs.webkit.org/show_bug.cgi?id=255568</a>

Reviewed by Tim Nguyen and Antti Koivisto.

The bug was caused by dirAttributeChanged not calling HTMLElement::dirAttributeChanged not
updating the effective directionality state when removing a content attribute. Fixed the bug
by recursively invalidating the pseudo class state using updateEffectiveDirectionality,
which is now updated to take std::optional&lt;TextDirection&gt;.

Also removed redundant calls to HTMLElement::setUsesEffectiveTextDirection(true) in
HTMLElement::dirAttributeChanged.

* LayoutTests/fast/css/dir-ltr-removal-expected.html: Added.
* LayoutTests/fast/css/dir-ltr-removal.html: Added.
* LayoutTests/fast/css/dir-rtl-removal-expected.html: Added.
* LayoutTests/fast/css/dir-rtl-removal.html: Added.
* Source/WebCore/html/HTMLElement.cpp:
(WebCore::HTMLElement::dirAttributeChanged):
(WebCore::HTMLElement::updateEffectiveDirectionality):

Canonical link: <a href="https://commits.webkit.org/263357@main">https://commits.webkit.org/263357@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f4d2680298e5532163f75e97921b078650e0a15d

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/4337 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/4455 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/4582 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/5811 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/4556 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/4329 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/4570 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/4420 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/4782 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/4397 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/4544 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/3900 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/5810 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/2040 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/3877 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/7174 "5 flakes 219 failures") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/3870 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/3944 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/5478 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/4354 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/3535 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/3873 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/3875 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/7929 "Built successfully") | | | 
| [❌ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/500 "Failed to push commit to Webkit repository") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/4227 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->