### PR TITLE
ProducerSharedCARingBuffer::allocate should be more robust in computing shared memory buffer size

### DIFF
--- a/Source/WebKit/Shared/Cocoa/SharedCARingBuffer.cpp
+++ b/Source/WebKit/Shared/Cocoa/SharedCARingBuffer.cpp
@@ -70,12 +70,12 @@ ProducerSharedCARingBuffer::Pair ProducerSharedCARingBuffer::allocate(const WebC
     auto bytesPerFrame = format.bytesPerFrame();
     auto numChannelStreams = format.numberOfChannelStreams();
 
-    auto checkedSizeForBuffers = computeSizeForBuffers(bytesPerFrame, frameCount, numChannelStreams);
-    if (checkedSizeForBuffers.hasOverflowed()) {
+    auto checkedSharedMemorySize = computeSizeForBuffers(bytesPerFrame, frameCount, numChannelStreams) + sizeof(TimeBoundsBuffer);
+    if (checkedSharedMemorySize.hasOverflowed()) {
         RELEASE_LOG_FAULT(Media, "ProducerSharedCARingBuffer::allocate: Overflowed when trying to compute the storage size");
         return { nullptr, { } };
     }
-    auto sharedMemory = SharedMemory::allocate(sizeof(TimeBoundsBuffer) + checkedSizeForBuffers.value());
+    auto sharedMemory = SharedMemory::allocate(checkedSharedMemorySize.value());
     if (!sharedMemory)
         return { nullptr, { } };
 


### PR DESCRIPTION
#### 18738469adb24cbfb8b2f081da83612a1ba62150
<pre>
ProducerSharedCARingBuffer::allocate should be more robust in computing shared memory buffer size
<a href="https://bugs.webkit.org/show_bug.cgi?id=255866">https://bugs.webkit.org/show_bug.cgi?id=255866</a>
rdar://102920372

Reviewed by Jean-Yves Avenard.

Harden the ProducerSharedCARingBuffer shared memory size calculation,
make the + sizeof(TimeBoundsBuffer) be part of the Checked calculation.

* Source/WebKit/Shared/Cocoa/SharedCARingBuffer.cpp:
(WebKit::ProducerSharedCARingBuffer::allocate):

Canonical link: <a href="https://commits.webkit.org/263407@main">https://commits.webkit.org/263407@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/cd841065330823359d368b1a027efce5adca0e43

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/4334 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/4451 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/4576 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/5806 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/4552 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/4564 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/4415 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/4776 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/4394 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/4546 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/3895 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/5805 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/2042 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/3872 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/7167 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/3872 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/3939 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/5477 "run-api-tests-without-change (failure)") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/4350 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/3533 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/3871 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/3870 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/1107 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/7925 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/4223 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->