### PR TITLE
Cocoa Small RemoteLayerBackingStores should be drawn with software

### DIFF
--- a/Source/WebCore/platform/ScrollbarsController.h
+++ b/Source/WebCore/platform/ScrollbarsController.h
@@ -34,7 +34,6 @@ namespace WebCore {
 
 class Scrollbar;
 class ScrollableArea;
-class ScrollingCoordinator;
 enum class ScrollbarOrientation : uint8_t;
 
 class ScrollbarsController {

--- a/Source/WebCore/platform/graphics/cocoa/IOSurface.h
+++ b/Source/WebCore/platform/graphics/cocoa/IOSurface.h
@@ -85,34 +85,45 @@ public:
     
     class Locker {
     public:
-        enum class AccessMode {
-            ReadOnly,
-            ReadWrite
+        enum class AccessMode : uint32_t {
+            ReadOnly = kIOSurfaceLockReadOnly,
+            ReadWrite = 0
         };
 
-        Locker(IOSurface& surface, AccessMode mode = AccessMode::ReadOnly)
-            : m_surface(surface)
-            , m_flags(flagsFromMode(mode))
+        explicit Locker(IOSurface& surface, AccessMode mode = AccessMode::ReadOnly)
+            : m_surface(surface.surface())
+            , m_flags(static_cast<uint32_t>(mode))
         {
-            IOSurfaceLock(m_surface.surface(), m_flags, nullptr);
+            IOSurfaceLock(m_surface, m_flags, nullptr);
+        }
+
+        Locker(Locker&& other)
+            : m_surface(std::exchange(other.m_surface, nullptr))
+            , m_flags(other.m_flags)
+        {
         }
 
         ~Locker()
         {
-            IOSurfaceUnlock(m_surface.surface(), m_flags, nullptr);
+            if (!m_surface)
+                return;
+            IOSurfaceUnlock(m_surface, m_flags, nullptr);
+        }
+
+        Locker& operator=(Locker&& other)
+        {
+            m_surface = std::exchange(other.m_surface, nullptr);
+            m_flags = other.m_flags;
+            return *this;
         }
 
         void * surfaceBaseAddress() const
         {
-            return IOSurfaceGetBaseAddress(m_surface.surface());
+            return IOSurfaceGetBaseAddress(m_surface);
         }
 
     private:
-        static uint32_t flagsFromMode(AccessMode mode)
-        {
-            return mode == AccessMode::ReadOnly ? kIOSurfaceLockReadOnly : 0;
-        }
-        IOSurface& m_surface;
+        IOSurfaceRef m_surface;
         uint32_t m_flags;
     };
 
@@ -153,6 +164,12 @@ public:
     IOSurfaceRef surface() const { return m_surface.get(); }
 
     WEBCORE_EXPORT RetainPtr<CGContextRef> createPlatformContext(PlatformDisplayID = 0);
+
+    struct LockAndContext {
+        IOSurface::Locker lock;
+        RetainPtr<CGContextRef> context;
+    };
+    WEBCORE_EXPORT std::optional<LockAndContext> createBitmapPlatformContext();
 
     // Querying volatility can be expensive, so in cases where the surface is
     // going to be used immediately, use the return value of setVolatile to

--- a/Source/WebCore/platform/graphics/cocoa/IOSurface.mm
+++ b/Source/WebCore/platform/graphics/cocoa/IOSurface.mm
@@ -460,6 +460,17 @@ ALLOW_DEPRECATED_DECLARATIONS_END
     return cgContext;
 }
 
+std::optional<IOSurface::LockAndContext> IOSurface::createBitmapPlatformContext()
+{
+    IOSurface::Locker locker { *this, IOSurface::Locker::AccessMode::ReadWrite };
+    auto configuration = bitmapConfiguration();
+    auto size = this->size();
+    auto context = adoptCF(CGBitmapContextCreate(locker.surfaceBaseAddress(), size.width(), size.height(), configuration.bitsPerComponent, bytesPerRow(), colorSpace().platformColorSpace(), configuration.bitmapInfo));
+    if (!context)
+        return std::nullopt;
+    return LockAndContext { WTFMove(locker), WTFMove(context) };
+}
+
 SetNonVolatileResult IOSurface::state() const
 {
     uint32_t previousState = 0;

--- a/Source/WebKit/SourcesCocoa.txt
+++ b/Source/WebKit/SourcesCocoa.txt
@@ -616,6 +616,7 @@ WebProcess/Extensions/Bindings/JSWebExtensionWrapper.cpp
 
 WebProcess/GPU/graphics/cocoa/ImageBufferRemoteIOSurfaceBackend.cpp
 WebProcess/GPU/graphics/cocoa/ImageBufferShareableMappedIOSurfaceBackend.cpp
+WebProcess/GPU/graphics/cocoa/ImageBufferShareableMappedIOSurfaceBitmapBackend.cpp
 WebProcess/GPU/graphics/cocoa/RemoteGraphicsContextGLProxyCocoa.mm
 WebProcess/GPU/media/RemoteAudioSourceProvider.cpp
 WebProcess/GPU/media/RemoteAudioSourceProviderManager.cpp

--- a/Source/WebKit/WebKit.xcodeproj/project.pbxproj
+++ b/Source/WebKit/WebKit.xcodeproj/project.pbxproj
@@ -5645,6 +5645,8 @@
 		7B0DF7DC29090ACA001C2701 /* DisplayListRecorderFlushIdentifier.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = DisplayListRecorderFlushIdentifier.h; sourceTree = "<group>"; };
 		7B16191227198AA900C40EAC /* RemoteGraphicsContextGLProxyCocoa.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = RemoteGraphicsContextGLProxyCocoa.mm; sourceTree = "<group>"; };
 		7B1DB26525668CE0000E26BC /* ArrayReference.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ArrayReference.h; sourceTree = "<group>"; };
+		7B22007029B625020034C826 /* ImageBufferShareableMappedIOSurfaceBitmapBackend.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = ImageBufferShareableMappedIOSurfaceBitmapBackend.cpp; sourceTree = "<group>"; };
+		7B22007129B625020034C826 /* ImageBufferShareableMappedIOSurfaceBitmapBackend.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = ImageBufferShareableMappedIOSurfaceBitmapBackend.h; sourceTree = "<group>"; };
 		7B2DDD5E27CCD9710060ABAB /* IPCStreamTesterProxy.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = IPCStreamTesterProxy.h; sourceTree = "<group>"; };
 		7B483F1B25CDDA9B00120486 /* MessageReceiveQueueMap.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MessageReceiveQueueMap.h; sourceTree = "<group>"; };
 		7B483F1C25CDDA9B00120486 /* MessageReceiveQueue.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MessageReceiveQueue.h; sourceTree = "<group>"; };
@@ -11396,6 +11398,8 @@
 				2D25F32825758E9000231A8B /* ImageBufferRemoteIOSurfaceBackend.h */,
 				727A7F342407857D004D2931 /* ImageBufferShareableMappedIOSurfaceBackend.cpp */,
 				727A7F352407857F004D2931 /* ImageBufferShareableMappedIOSurfaceBackend.h */,
+				7B22007029B625020034C826 /* ImageBufferShareableMappedIOSurfaceBitmapBackend.cpp */,
+				7B22007129B625020034C826 /* ImageBufferShareableMappedIOSurfaceBitmapBackend.h */,
 				7B16191227198AA900C40EAC /* RemoteGraphicsContextGLProxyCocoa.mm */,
 			);
 			path = cocoa;

--- a/Source/WebKit/WebProcess/GPU/graphics/cocoa/ImageBufferShareableMappedIOSurfaceBitmapBackend.cpp
+++ b/Source/WebKit/WebProcess/GPU/graphics/cocoa/ImageBufferShareableMappedIOSurfaceBitmapBackend.cpp
@@ -1,0 +1,176 @@
+/*
+ * Copyright (C) 2020-2023 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "ImageBufferShareableMappedIOSurfaceBitmapBackend.h"
+
+#if ENABLE(GPU_PROCESS) && HAVE(IOSURFACE)
+
+#include "Logging.h"
+#include <WebCore/GraphicsContextCG.h>
+#include <WebCore/IOSurfacePool.h>
+#include <wtf/IsoMallocInlines.h>
+#include <wtf/StdLibExtras.h>
+#include <wtf/spi/cocoa/IOSurfaceSPI.h>
+
+namespace WebKit {
+using namespace WebCore;
+
+WTF_MAKE_ISO_ALLOCATED_IMPL(ImageBufferShareableMappedIOSurfaceBitmapBackend);
+
+std::unique_ptr<ImageBufferShareableMappedIOSurfaceBitmapBackend> ImageBufferShareableMappedIOSurfaceBitmapBackend::create(const Parameters& parameters, const ImageBufferCreationContext& creationContext)
+{
+    IntSize backendSize = ImageBufferIOSurfaceBackend::calculateSafeBackendSize(parameters);
+    if (backendSize.isEmpty())
+        return nullptr;
+
+    auto surface = IOSurface::create(creationContext.surfacePool, backendSize, parameters.colorSpace, IOSurface::Name::ImageBuffer, IOSurface::formatForPixelFormat(parameters.pixelFormat));
+    if (!surface)
+        return nullptr;
+
+    auto lockAndContext = surface->createBitmapPlatformContext();
+    if (!lockAndContext)
+        return nullptr;
+    CGContextClearRect(lockAndContext->context.get(), FloatRect(FloatPoint::zero(), backendSize));
+    return makeUnique<ImageBufferShareableMappedIOSurfaceBitmapBackend>(parameters, WTFMove(surface), WTFMove(*lockAndContext), creationContext.surfacePool);
+}
+
+ImageBufferShareableMappedIOSurfaceBitmapBackend::ImageBufferShareableMappedIOSurfaceBitmapBackend(const Parameters& parameters, std::unique_ptr<IOSurface> surface, IOSurface::LockAndContext&& lockAndContext, IOSurfacePool* ioSurfacePool)
+    : ImageBufferCGBackend(parameters)
+    , m_surface(WTFMove(surface))
+    , m_lock(WTFMove(lockAndContext.lock))
+    , m_ioSurfacePool(ioSurfacePool)
+{
+    m_context = makeUnique<GraphicsContextCG>(lockAndContext.context.get());
+}
+
+ImageBufferBackendHandle ImageBufferShareableMappedIOSurfaceBitmapBackend::createBackendHandle(SharedMemory::Protection) const
+{
+    return ImageBufferBackendHandle(m_surface->createSendRight());
+}
+
+GraphicsContext& ImageBufferShareableMappedIOSurfaceBitmapBackend::context()
+{
+    if (!m_context) {
+        auto lockAndContext = m_surface->createBitmapPlatformContext();
+        if (lockAndContext) {
+            m_lock = WTFMove(lockAndContext->lock);
+            m_context = makeUnique<GraphicsContextCG>(lockAndContext->context.get());
+        } else
+            m_context = makeUnique<GraphicsContextCG>(nullptr);
+        applyBaseTransform(*m_context);
+    }
+    return *m_context;
+}
+
+void ImageBufferShareableMappedIOSurfaceBitmapBackend::setOwnershipIdentity(const WebCore::ProcessIdentity& resourceOwner)
+{
+    m_surface->setOwnershipIdentity(resourceOwner);
+}
+
+IntSize ImageBufferShareableMappedIOSurfaceBitmapBackend::backendSize() const
+{
+    return m_surface->size();
+}
+
+unsigned ImageBufferShareableMappedIOSurfaceBitmapBackend::bytesPerRow() const
+{
+    return m_surface->bytesPerRow();
+}
+
+RefPtr<NativeImage> ImageBufferShareableMappedIOSurfaceBitmapBackend::copyNativeImage(BackingStoreCopy copyBehavior)
+{
+    ASSERT_NOT_REACHED(); // Not applicable for LayerBacking.
+    return nullptr;
+}
+
+RefPtr<NativeImage> ImageBufferShareableMappedIOSurfaceBitmapBackend::copyNativeImageForDrawing(GraphicsContext&)
+{
+    ASSERT_NOT_REACHED(); // Not applicable for LayerBacking.
+    return nullptr;
+}
+
+RefPtr<NativeImage> ImageBufferShareableMappedIOSurfaceBitmapBackend::sinkIntoNativeImage()
+{
+    ASSERT_NOT_REACHED(); // Not applicable for LayerBacking.
+    return nullptr;
+}
+
+bool ImageBufferShareableMappedIOSurfaceBitmapBackend::isInUse() const
+{
+    return m_surface->isInUse();
+}
+
+void ImageBufferShareableMappedIOSurfaceBitmapBackend::releaseGraphicsContext()
+{
+    m_context = nullptr;
+    m_lock = std::nullopt;
+}
+
+bool ImageBufferShareableMappedIOSurfaceBitmapBackend::setVolatile()
+{
+    if (m_surface->isInUse())
+        return false;
+
+    setVolatilityState(VolatilityState::Volatile);
+    m_surface->setVolatile(true);
+    return true;
+}
+
+SetNonVolatileResult ImageBufferShareableMappedIOSurfaceBitmapBackend::setNonVolatile()
+{
+    setVolatilityState(VolatilityState::NonVolatile);
+    return m_surface->setVolatile(false);
+}
+
+VolatilityState ImageBufferShareableMappedIOSurfaceBitmapBackend::volatilityState() const
+{
+    return m_volatilityState;
+}
+
+void ImageBufferShareableMappedIOSurfaceBitmapBackend::setVolatilityState(VolatilityState volatilityState)
+{
+    m_volatilityState = volatilityState;
+}
+
+void ImageBufferShareableMappedIOSurfaceBitmapBackend::transferToNewContext(const ImageBufferCreationContext&)
+{
+    ASSERT_NOT_REACHED(); // Not applicable for LayerBacking.
+}
+
+RefPtr<PixelBuffer> ImageBufferShareableMappedIOSurfaceBitmapBackend::getPixelBuffer(const PixelBufferFormat&, const IntRect&, const ImageBufferAllocator&)
+{
+    ASSERT_NOT_REACHED(); // Not applicable for LayerBacking.
+    return nullptr;
+}
+
+void ImageBufferShareableMappedIOSurfaceBitmapBackend::putPixelBuffer(const PixelBuffer&, const IntRect&, const IntPoint&, AlphaPremultiplication)
+{
+    ASSERT_NOT_REACHED(); // Not applicable for LayerBacking.
+}
+
+} // namespace WebKit
+
+#endif // ENABLE(GPU_PROCESS) && HAVE(IOSURFACE)

--- a/Source/WebKit/WebProcess/GPU/graphics/cocoa/ImageBufferShareableMappedIOSurfaceBitmapBackend.h
+++ b/Source/WebKit/WebProcess/GPU/graphics/cocoa/ImageBufferShareableMappedIOSurfaceBitmapBackend.h
@@ -1,0 +1,84 @@
+/*
+ * Copyright (C) 2020-2022 Apple Inc.  All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#if ENABLE(GPU_PROCESS) && HAVE(IOSURFACE)
+
+#include "ImageBufferBackendHandleSharing.h"
+#include <WebCore/IOSurface.h>
+#include <WebCore/ImageBufferIOSurfaceBackend.h>
+#include <wtf/IsoMalloc.h>
+
+namespace WebCore {
+class ProcessIdentity;
+}
+
+namespace WebKit {
+
+// ImageBufferBackend for small LayerBacking stores.
+class ImageBufferShareableMappedIOSurfaceBitmapBackend final : public WebCore::ImageBufferCGBackend, public ImageBufferBackendHandleSharing {
+    WTF_MAKE_ISO_ALLOCATED(ImageBufferShareableMappedIOSurfaceBitmapBackend);
+    WTF_MAKE_NONCOPYABLE(ImageBufferShareableMappedIOSurfaceBitmapBackend);
+public:
+    static std::unique_ptr<ImageBufferShareableMappedIOSurfaceBitmapBackend> create(const Parameters&, const WebCore::ImageBufferCreationContext&);
+    static size_t calculateMemoryCost(const Parameters& parameters) { return WebCore::ImageBufferIOSurfaceBackend::calculateMemoryCost(parameters); }
+
+    ImageBufferShareableMappedIOSurfaceBitmapBackend(const Parameters&, std::unique_ptr<WebCore::IOSurface>, WebCore::IOSurface::LockAndContext&&, WebCore::IOSurfacePool*);
+
+    static constexpr WebCore::RenderingMode renderingMode = WebCore::RenderingMode::Accelerated;
+
+    ImageBufferBackendHandle createBackendHandle(SharedMemory::Protection = SharedMemory::Protection::ReadWrite) const final;
+    void setOwnershipIdentity(const WebCore::ProcessIdentity&) final;
+    WebCore::GraphicsContext& context() final;
+private:
+    // ImageBufferBackendSharing
+    ImageBufferBackendSharing* toBackendSharing() final { return this; }
+
+    // WebCore::ImageBufferCGBackend
+    WebCore::IntSize backendSize() const final;
+    unsigned bytesPerRow() const final;
+    RefPtr<WebCore::NativeImage> copyNativeImage(WebCore::BackingStoreCopy = WebCore::CopyBackingStore) final;
+    RefPtr<WebCore::NativeImage> copyNativeImageForDrawing(WebCore::GraphicsContext&) final;
+    RefPtr<WebCore::NativeImage> sinkIntoNativeImage() final;
+    bool isInUse() const final;
+    void releaseGraphicsContext() final;
+    bool setVolatile() final;
+    WebCore::SetNonVolatileResult setNonVolatile() final;
+    WebCore::VolatilityState volatilityState() const final;
+    void setVolatilityState(WebCore::VolatilityState) final;
+    void transferToNewContext(const WebCore::ImageBufferCreationContext&) final;
+    RefPtr<WebCore::PixelBuffer> getPixelBuffer(const WebCore::PixelBufferFormat&, const WebCore::IntRect&, const WebCore::ImageBufferAllocator&) final;
+    void putPixelBuffer(const WebCore::PixelBuffer&, const WebCore::IntRect&, const WebCore::IntPoint&, WebCore::AlphaPremultiplication) final;
+
+    std::unique_ptr<WebCore::IOSurface> m_surface;
+    std::optional<WebCore::IOSurface::Locker> m_lock;
+    WebCore::VolatilityState m_volatilityState { WebCore::VolatilityState::NonVolatile };
+    RefPtr<WebCore::IOSurfacePool> m_ioSurfacePool;
+};
+
+} // namespace WebKit
+
+#endif // ENABLE(GPU_PROCESS) && HAVE(IOSURFACE)

--- a/Source/WebKit/WebProcess/WebPage/RemoteLayerTree/RemoteScrollbarsController.h
+++ b/Source/WebKit/WebProcess/WebPage/RemoteLayerTree/RemoteScrollbarsController.h
@@ -32,8 +32,9 @@
 #include <wtf/RetainPtr.h>
 #include <wtf/ThreadSafeWeakPtr.h>
 
+namespace WebCore {
 class ScrollingCoordinator;
-class Scrollbar;
+}
 
 namespace WebKit {
 
@@ -48,7 +49,7 @@ public:
     void mouseExitedScrollbar(WebCore::Scrollbar*) const final;
     bool shouldScrollbarParticipateInHitTesting(WebCore::Scrollbar*) final;
     
-    void setScrollbarVisibilityState(ScrollbarOrientation, bool) final;
+    void setScrollbarVisibilityState(WebCore::ScrollbarOrientation, bool) final;
 
 private:
     bool m_horizontalOverlayScrollbarIsVisible { false };
@@ -56,6 +57,6 @@ private:
     ThreadSafeWeakPtr<WebCore::ScrollingCoordinator> m_coordinator;
 };
 
-} // namespace WebCore
+} // namespace WebKit
 
 #endif // PLATFORM(MAC)

--- a/Source/WebKit/WebProcess/WebPage/RemoteLayerTree/RemoteScrollbarsController.mm
+++ b/Source/WebKit/WebProcess/WebPage/RemoteLayerTree/RemoteScrollbarsController.mm
@@ -76,12 +76,12 @@ bool RemoteScrollbarsController::shouldScrollbarParticipateInHitTesting(WebCore:
     ASSERT(scrollbar->isOverlayScrollbar());
 
     // Overlay scrollbars should participate in hit testing whenever they are at all visible.
-    return scrollbar->orientation() == ScrollbarOrientation::Horizontal ? m_horizontalOverlayScrollbarIsVisible :  m_verticalOverlayScrollbarIsVisible;
+    return scrollbar->orientation() == WebCore::ScrollbarOrientation::Horizontal ? m_horizontalOverlayScrollbarIsVisible :  m_verticalOverlayScrollbarIsVisible;
 }
 
-void RemoteScrollbarsController::setScrollbarVisibilityState(ScrollbarOrientation orientation, bool isVisible)
+void RemoteScrollbarsController::setScrollbarVisibilityState(WebCore::ScrollbarOrientation orientation, bool isVisible)
 {
-    if (orientation == ScrollbarOrientation::Horizontal)
+    if (orientation == WebCore::ScrollbarOrientation::Horizontal)
         m_horizontalOverlayScrollbarIsVisible = isVisible;
     else
         m_verticalOverlayScrollbarIsVisible = isVisible;


### PR DESCRIPTION
#### b9651cfb27c14c098f70dcdf312fd1ba3115a7b7
<pre>
Cocoa Small RemoteLayerBackingStores should be drawn with software
<a href="https://bugs.webkit.org/show_bug.cgi?id=253447">https://bugs.webkit.org/show_bug.cgi?id=253447</a>
Include a Radar link (OOPS!).

Reviewed by NOBODY (OOPS!).

Add a specific GPUP side backend for ImageBitmaps used for LayerBacking
purposes, e.g. RemoteLayerBackingStore buffers. The buffers are drawn
to with software rasterization.

* Source/WebCore/platform/graphics/cocoa/IOSurface.h:
* Source/WebCore/platform/graphics/cocoa/IOSurface.mm:
(WebCore::IOSurface::createBitmapPlatformContext):
* Source/WebKit/GPUProcess/graphics/RemoteRenderingBackend.cpp:
(WebKit::RemoteRenderingBackend::createImageBufferWithQualifiedIdentifier):
* Source/WebKit/SourcesCocoa.txt:
* Source/WebKit/WebKit.xcodeproj/project.pbxproj:
* Source/WebKit/WebProcess/GPU/graphics/cocoa/ImageBufferShareableMappedIOSurfaceBitmapBackend.cpp: Added.
(WebKit::ImageBufferShareableMappedIOSurfaceBitmapBackend::create):
(WebKit::ImageBufferShareableMappedIOSurfaceBitmapBackend::ImageBufferShareableMappedIOSurfaceBitmapBackend):
(WebKit::ImageBufferShareableMappedIOSurfaceBitmapBackend::createBackendHandle const):
(WebKit::ImageBufferShareableMappedIOSurfaceBitmapBackend::context):
(WebKit::ImageBufferShareableMappedIOSurfaceBitmapBackend::setOwnershipIdentity):
(WebKit::ImageBufferShareableMappedIOSurfaceBitmapBackend::bytesPerRow const):
(WebKit::ImageBufferShareableMappedIOSurfaceBitmapBackend::copyNativeImage):
(WebKit::ImageBufferShareableMappedIOSurfaceBitmapBackend::copyNativeImageForDrawing):
(WebKit::ImageBufferShareableMappedIOSurfaceBitmapBackend::sinkIntoNativeImage):
(WebKit::ImageBufferShareableMappedIOSurfaceBitmapBackend::isInUse const):
(WebKit::ImageBufferShareableMappedIOSurfaceBitmapBackend::releaseGraphicsContext):
(WebKit::ImageBufferShareableMappedIOSurfaceBitmapBackend::setVolatile):
(WebKit::ImageBufferShareableMappedIOSurfaceBitmapBackend::setNonVolatile):
(WebKit::ImageBufferShareableMappedIOSurfaceBitmapBackend::volatilityState const):
(WebKit::ImageBufferShareableMappedIOSurfaceBitmapBackend::setVolatilityState):
(WebKit::ImageBufferShareableMappedIOSurfaceBitmapBackend::transferToNewContext):
(WebKit::ImageBufferShareableMappedIOSurfaceBitmapBackend::getPixelBuffer):
(WebKit::ImageBufferShareableMappedIOSurfaceBitmapBackend::putPixelBuffer):
* Source/WebKit/WebProcess/GPU/graphics/cocoa/ImageBufferShareableMappedIOSurfaceBitmapBackend.h: Added.
* Source/WebKit/WebProcess/WebPage/EventDispatcher.cpp:

Originally-landed-as: c0b66e9581fa. https://bugs.webkit.org/show_bug.cgi?id=253447
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b9651cfb27c14c098f70dcdf312fd1ba3115a7b7

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/4360 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/4477 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/4607 "Build is in progress. Recent messages:OS: Monterey (12.6.3), Xcode: 13.4.1; Skipping applying patch since patch_id isn't provided; Checked out pull request; Running compile-webkit") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/5835 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/4575 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/4352 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/4597 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/4443 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/4802 "Build is in progress. Recent messages:Failed to print configuration; Skipping applying patch since patch_id isn't provided; Checked out pull request") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/4422 "Passed tests") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/4569 "Build is in progress. Recent messages:OS: Ventura (13.3), Xcode: 14.3; Skipping applying patch since patch_id isn't provided; Checked out pull request; Skipped layout-tests; Running layout-tests") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 api-mac](https://ews-build.webkit.org/#/builders/14/builds/4607 "Build is in progress. Recent messages:OS: Monterey (12.6.3), Xcode: 13.4.1; Skipping applying patch since patch_id isn't provided; Checked out pull request; Running compile-webkit") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/5835 "Built successfully") | 
| | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/2065 "Build is in progress. Recent messages:OS: Ventura (13.3), Xcode: 14.3; Skipping applying patch since patch_id isn't provided; Checked out pull request; Skipped layout-tests; Running layout-tests") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/14/builds/4607 "Build is in progress. Recent messages:OS: Monterey (12.6.3), Xcode: 13.4.1; Skipping applying patch since patch_id isn't provided; Checked out pull request; Running compile-webkit") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/7279 "Build is in progress. Recent messages:Running configuration") | 
| | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/3895 "Build is in progress. Recent messages:OS: Ventura (13.3), Xcode: 14.3; Skipping applying patch since patch_id isn't provided; Checked out pull request; Running run-api-tests") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/14/builds/4607 "Build is in progress. Recent messages:OS: Monterey (12.6.3), Xcode: 13.4.1; Skipping applying patch since patch_id isn't provided; Checked out pull request; Running compile-webkit") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/5501 "Build is in progress. Recent messages:Printed configuration; Skipping applying patch since patch_id isn't provided; Checked out pull request; Running run-api-tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/4376 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/3557 "Build is in progress. Recent messages:OS: Ventura (13.3.1), Xcode: 14.3; Skipping applying patch since patch_id isn't provided; Checked out pull request; Skipped layout-tests; Running layout-tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/3897 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/14/builds/4607 "Build is in progress. Recent messages:OS: Monterey (12.6.3), Xcode: 13.4.1; Skipping applying patch since patch_id isn't provided; Checked out pull request; Running compile-webkit") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/7952 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/4251 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->