### PR TITLE
[WGSL] Use arena allocation for AST nodes

### DIFF
--- a/Source/WebGPU/WGSL/AST/ASTBuilder.cpp
+++ b/Source/WebGPU/WGSL/AST/ASTBuilder.cpp
@@ -1,0 +1,62 @@
+/*
+ * Copyright (c) 2023 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "ASTBuilder.h"
+
+namespace WGSL::AST {
+
+DEFINE_ALLOCATOR_WITH_HEAP_IDENTIFIER(WGSLAST);
+
+Builder::Builder(Builder&& other)
+{
+    m_arena = std::exchange(other.m_arena, nullptr);
+    m_arenaEnd = std::exchange(other.m_arenaEnd, nullptr);
+    m_arenas = WTFMove(other.m_arenas);
+    m_nodes = WTFMove(other.m_nodes);
+}
+
+inline uint8_t* Builder::arena()
+{
+    ASSERT(m_arenaEnd);
+    return m_arenaEnd - arenaSize;
+}
+
+Builder::~Builder()
+{
+    size_t size = m_nodes.size();
+    for (size_t i = 0; i < size; ++i)
+        m_nodes[i]->~Node();
+}
+
+void Builder::allocateArena()
+{
+    m_arenas.append(MallocPtr<uint8_t, WGSLASTMalloc>::malloc(arenaSize));
+    m_arena = m_arenas.last().get();
+    m_arenaEnd = m_arena + arenaSize;
+    ASSERT(arena() == m_arena);
+}
+
+} // namespace WGSL::AST

--- a/Source/WebGPU/WGSL/AST/ASTBuilder.h
+++ b/Source/WebGPU/WGSL/AST/ASTBuilder.h
@@ -1,0 +1,83 @@
+/*
+ * Copyright (c) 2023 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include "ASTNode.h"
+#include <wtf/MallocPtr.h>
+#include <wtf/Noncopyable.h>
+#include <wtf/Nonmovable.h>
+#include <wtf/Vector.h>
+
+#define WGSL_AST_BUILDER_NODE(Node) \
+    WTF_MAKE_NONCOPYABLE(Node); \
+    WTF_MAKE_NONMOVABLE(Node); \
+    friend class Builder; \
+
+namespace WGSL::AST {
+
+DECLARE_ALLOCATOR_WITH_HEAP_IDENTIFIER(WGSLAST);
+
+class Builder {
+    WTF_MAKE_NONCOPYABLE(Builder);
+
+public:
+    static constexpr size_t arenaSize = 0x4000;
+
+    Builder() = default;
+    Builder(Builder&&);
+    ~Builder();
+
+    template<typename T, typename... Arguments, typename = std::enable_if_t<std::is_base_of_v<Node, T>>>
+    T& construct(Arguments&&... arguments)
+    {
+        constexpr size_t size = sizeof(T);
+        constexpr size_t alignedSize = alignSize(size);
+        static_assert(alignedSize <= arenaSize);
+        if (UNLIKELY(static_cast<size_t>(m_arenaEnd - m_arena) < alignedSize))
+            allocateArena();
+
+        auto* node = new (m_arena) T(std::forward<Arguments>(arguments)...);
+        m_arena += alignedSize;
+        m_nodes.append(node);
+        return *node;
+    }
+
+private:
+    static constexpr size_t alignSize(size_t size)
+    {
+        return (size + sizeof(WTF::AllocAlignmentInteger) - 1) & ~(sizeof(WTF::AllocAlignmentInteger) - 1);
+    }
+
+    uint8_t* arena();
+    void allocateArena();
+
+    uint8_t* m_arena { nullptr };
+    uint8_t* m_arenaEnd { nullptr };
+    Vector<MallocPtr<uint8_t, WGSLASTMalloc>> m_arenas;
+    Vector<Node*> m_nodes;
+};
+
+} // namespace WGSL::AST

--- a/Source/WebGPU/WGSL/AST/ASTStructureMember.h
+++ b/Source/WebGPU/WGSL/AST/ASTStructureMember.h
@@ -26,22 +26,17 @@
 #pragma once
 
 #include "ASTAttribute.h"
+#include "ASTBuilder.h"
 #include "ASTIdentifier.h"
 #include "ASTTypeName.h"
 
 namespace WGSL::AST {
 
 class StructureMember final : public Node {
-    WTF_MAKE_FAST_ALLOCATED;
-public:
-    using List = UniqueRefVector<StructureMember>;
+    WGSL_AST_BUILDER_NODE(StructureMember);
 
-    StructureMember(SourceSpan span, Identifier&& name, TypeName::Ref&& type, Attribute::List&& attributes)
-        : Node(span)
-        , m_name(WTFMove(name))
-        , m_attributes(WTFMove(attributes))
-        , m_type(WTFMove(type))
-    { }
+public:
+    using List = Vector<std::reference_wrapper<StructureMember>>;
 
     NodeKind kind() const final;
     Identifier& name() { return m_name; }
@@ -49,6 +44,13 @@ public:
     Attribute::List& attributes() { return m_attributes; }
 
 private:
+    StructureMember(SourceSpan span, Identifier&& name, TypeName::Ref&& type, Attribute::List&& attributes)
+        : Node(span)
+        , m_name(WTFMove(name))
+        , m_attributes(WTFMove(attributes))
+        , m_type(WTFMove(type))
+    { }
+
     Identifier m_name;
     Attribute::List m_attributes;
     TypeName::Ref m_type;

--- a/Source/WebGPU/WGSL/EntryPointRewriter.cpp
+++ b/Source/WebGPU/WGSL/EntryPointRewriter.cpp
@@ -159,7 +159,7 @@ void EntryPointRewriter::constructInputStruct()
     // insert `var ${parameter.name()} = ${structName}.${parameter.name()}`
     AST::StructureMember::List structMembers;
     for (auto& parameter : m_parameters) {
-        structMembers.append(makeUniqueRef<AST::StructureMember>(
+        structMembers.append(m_shaderModule.astBuilder().construct<AST::StructureMember>(
             SourceSpan::empty(),
             WTFMove(parameter.name),
             WTFMove(parameter.type),
@@ -253,7 +253,7 @@ void EntryPointRewriter::visit(Vector<String>& path, MemberOrParameter&& data)
             )
         ));
         path.append(data.name);
-        for (auto& member : structType->structure.members())
+        for (AST::StructureMember& member : structType->structure.members())
             visit(path, MemberOrParameter { member.name(), member.type(), member.attributes() });
         path.removeLast();
         return;

--- a/Source/WebGPU/WGSL/GlobalVariableRewriter.cpp
+++ b/Source/WebGPU/WGSL/GlobalVariableRewriter.cpp
@@ -312,7 +312,7 @@ void RewriteGlobalVariables::insertStructs(const UsedGlobals& usedGlobals)
             AST::TypeName::Ref memberType = *global->declaration->maybeTypeName();
             if (shouldBeReference)
                 memberType = adoptRef(*new AST::ReferenceTypeName(span, WTFMove(memberType)));
-            structMembers.append(makeUniqueRef<AST::StructureMember>(
+            structMembers.append(m_callGraph.ast().astBuilder().construct<AST::StructureMember>(
                 span,
                 AST::Identifier::make(global->declaration->name()),
                 WTFMove(memberType),

--- a/Source/WebGPU/WGSL/MangleNames.cpp
+++ b/Source/WebGPU/WGSL/MangleNames.cpp
@@ -148,7 +148,7 @@ void NameManglerVisitor::visit(AST::Structure& structure)
     introduceVariable(structure.name(), MangledName::Type);
 
     NameMap fieldMap;
-    for (auto& member : structure.members()) {
+    for (AST::StructureMember& member : structure.members()) {
         AST::Visitor::visit(member.type());
         auto mangledName = makeMangledName(member.name(), MangledName::Field);
         fieldMap.add(member.name(), mangledName);

--- a/Source/WebGPU/WGSL/Metal/MetalFunctionWriter.cpp
+++ b/Source/WebGPU/WGSL/Metal/MetalFunctionWriter.cpp
@@ -168,7 +168,7 @@ void FunctionDefinitionWriter::visit(AST::Structure& structDecl)
     m_stringBuilder.append(m_indent, "struct ", structDecl.name(), " {\n");
     {
         IndentationScope scope(m_indent);
-        for (auto& member : structDecl.members()) {
+        for (AST::StructureMember& member : structDecl.members()) {
             m_stringBuilder.append(m_indent);
             visit(member.type());
             m_stringBuilder.append(" ", member.name());

--- a/Source/WebGPU/WGSL/ParserPrivate.h
+++ b/Source/WebGPU/WGSL/ParserPrivate.h
@@ -26,6 +26,7 @@
 #pragma once
 
 #include "ASTAttribute.h"
+#include "ASTBuilder.h"
 #include "ASTExpression.h"
 #include "ASTForward.h"
 #include "ASTStatement.h"
@@ -34,6 +35,7 @@
 #include "ASTVariable.h"
 #include "CompilationMessage.h"
 #include "Lexer.h"
+#include "WGSLShaderModule.h"
 #include <wtf/Ref.h>
 
 namespace WGSL {
@@ -45,6 +47,7 @@ class Parser {
 public:
     Parser(ShaderModule& shaderModule, Lexer& lexer)
         : m_shaderModule(shaderModule)
+        , m_builder(shaderModule.astBuilder())
         , m_lexer(lexer)
         , m_current(lexer.lex())
     {
@@ -58,7 +61,7 @@ public:
     Result<AST::Attribute::List> parseAttributes();
     Result<AST::Attribute::Ref> parseAttribute();
     Result<AST::Structure::Ref> parseStructure(AST::Attribute::List&&);
-    Result<AST::StructureMember> parseStructureMember();
+    Result<std::reference_wrapper<AST::StructureMember>> parseStructureMember();
     Result<AST::TypeName::Ref> parseTypeName();
     Result<AST::TypeName::Ref> parseTypeNameAfterIdentifier(AST::Identifier&&, SourcePosition start);
     Result<AST::TypeName::Ref> parseArrayType();
@@ -101,6 +104,7 @@ private:
     Token& current() { return m_current; }
 
     ShaderModule& m_shaderModule;
+    AST::Builder& m_builder;
     Lexer& m_lexer;
     Token m_current;
 };

--- a/Source/WebGPU/WGSL/TypeCheck.cpp
+++ b/Source/WebGPU/WGSL/TypeCheck.cpp
@@ -178,7 +178,7 @@ void TypeChecker::visitStructMembers(AST::Structure& structure)
     ASSERT(std::holds_alternative<Types::Struct>(**type));
 
     auto& structType = std::get<Types::Struct>(**type);
-    for (auto& member : structure.members()) {
+    for (AST::StructureMember& member : structure.members()) {
         auto* memberType = resolve(member.type());
         auto result = structType.fields.add(member.name().id(), memberType);
         ASSERT_UNUSED(result, result.isNewEntry);

--- a/Source/WebGPU/WGSL/WGSLShaderModule.h
+++ b/Source/WebGPU/WGSL/WGSLShaderModule.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 Apple Inc. All rights reserved.
+ * Copyright (c) 2021-2023 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -25,6 +25,7 @@
 
 #pragma once
 
+#include "ASTBuilder.h"
 #include "ASTDirective.h"
 #include "ASTFunction.h"
 #include "ASTStructure.h"
@@ -56,6 +57,7 @@ public:
     AST::Structure::List& structures() { return m_structures; }
     AST::Variable::List& variables() { return m_variables; }
     TypeStore& types() { return m_types; }
+    AST::Builder& astBuilder() { return m_astBuilder; }
 
     template<typename T>
     std::enable_if_t<std::is_base_of_v<AST::Node, T>, void> replace(T* current, T&& replacement)
@@ -136,6 +138,7 @@ private:
     AST::Structure::List m_structures;
     AST::Variable::List m_variables;
     TypeStore m_types;
+    AST::Builder m_astBuilder;
     Vector<std::function<void()>> m_replacements;
 };
 

--- a/Source/WebGPU/WebGPU.xcodeproj/project.pbxproj
+++ b/Source/WebGPU/WebGPU.xcodeproj/project.pbxproj
@@ -123,6 +123,8 @@
 		9776BE732992A236002D6D93 /* Overload.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 9776BE712992A236002D6D93 /* Overload.cpp */; };
 		9776BE742992A236002D6D93 /* Overload.h in Headers */ = {isa = PBXBuildFile; fileRef = 9776BE722992A236002D6D93 /* Overload.h */; };
 		9776BE7629957E12002D6D93 /* WGSLShaderModule.h in Headers */ = {isa = PBXBuildFile; fileRef = 9776BE7529957E12002D6D93 /* WGSLShaderModule.h */; };
+		97835C9329F7C9C600939EBA /* ASTBuilder.h in Headers */ = {isa = PBXBuildFile; fileRef = 97835C9229F7C9C600939EBA /* ASTBuilder.h */; };
+		97835C9529F7D85A00939EBA /* ASTBuilder.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 97835C9429F7D85A00939EBA /* ASTBuilder.cpp */; };
 		9789C31A297EA105009E9006 /* CallGraph.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 9789C318297EA105009E9006 /* CallGraph.cpp */; };
 		978A9125298A4E8400B37E5E /* MangleNames.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 978A9123298A4E8400B37E5E /* MangleNames.cpp */; };
 		978A9126298A4E8400B37E5E /* MangleNames.h in Headers */ = {isa = PBXBuildFile; fileRef = 978A9124298A4E8400B37E5E /* MangleNames.h */; };
@@ -363,6 +365,8 @@
 		9776BE712992A236002D6D93 /* Overload.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = Overload.cpp; sourceTree = "<group>"; };
 		9776BE722992A236002D6D93 /* Overload.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = Overload.h; sourceTree = "<group>"; };
 		9776BE7529957E12002D6D93 /* WGSLShaderModule.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = WGSLShaderModule.h; sourceTree = "<group>"; };
+		97835C9229F7C9C600939EBA /* ASTBuilder.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ASTBuilder.h; sourceTree = "<group>"; };
+		97835C9429F7D85A00939EBA /* ASTBuilder.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = ASTBuilder.cpp; sourceTree = "<group>"; };
 		9789C318297EA105009E9006 /* CallGraph.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = CallGraph.cpp; sourceTree = "<group>"; };
 		9789C319297EA105009E9006 /* CallGraph.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = CallGraph.h; sourceTree = "<group>"; };
 		978A9123298A4E8400B37E5E /* MangleNames.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = MangleNames.cpp; sourceTree = "<group>"; };
@@ -602,6 +606,8 @@
 				3A12AECB28FCFA9800C1B975 /* ASTBitcastExpression.h */,
 				3A12AED028FCFC5500C1B975 /* ASTBoolLiteral.h */,
 				3A12AE9F28FCE94B00C1B975 /* ASTBreakStatement.h */,
+				97835C9429F7D85A00939EBA /* ASTBuilder.cpp */,
+				97835C9229F7C9C600939EBA /* ASTBuilder.h */,
 				3A12AE9028FCE94A00C1B975 /* ASTBuiltinAttribute.h */,
 				33EA188527BC26DF00A1DD52 /* ASTCallExpression.h */,
 				3A12AEA328FCE94C00C1B975 /* ASTCompoundAssignmentStatement.h */,
@@ -707,6 +713,7 @@
 				3A12AECD28FCFA9800C1B975 /* ASTBitcastExpression.h in Headers */,
 				3A12AED628FCFC5600C1B975 /* ASTBoolLiteral.h in Headers */,
 				3A12AEB928FCE94C00C1B975 /* ASTBreakStatement.h in Headers */,
+				97835C9329F7C9C600939EBA /* ASTBuilder.h in Headers */,
 				3A12AEAA28FCE94C00C1B975 /* ASTBuiltinAttribute.h in Headers */,
 				33EA188627BC26DF00A1DD52 /* ASTCallExpression.h in Headers */,
 				3A12AEBD28FCE94C00C1B975 /* ASTCompoundAssignmentStatement.h in Headers */,
@@ -951,6 +958,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				3AD0D23E2988F3AB0080D728 /* ASTBinaryExpression.cpp in Sources */,
+				97835C9529F7D85A00939EBA /* ASTBuilder.cpp in Sources */,
 				3A9D02A4298390CF00888A75 /* ASTStringDumper.cpp in Sources */,
 				3AD0D23B2988ED8F0080D728 /* ASTUnaryExpression.cpp in Sources */,
 				3A1337E728FBD56400F29B73 /* ASTVisitor.cpp in Sources */,

--- a/Tools/TestWebKitAPI/Tests/WGSL/ParserTests.cpp
+++ b/Tools/TestWebKitAPI/Tests/WGSL/ParserTests.cpp
@@ -123,7 +123,7 @@ static void testStruct(ASCIILiteral program, const Vector<String>& fieldNames, c
 
     EXPECT_EQ(str.members().size(), fieldNames.size());
     for (unsigned i = 0; i < fieldNames.size(); ++i) {
-        auto& attributes = str.members()[i].attributes();
+        auto& attributes = str.members()[i].get().attributes();
         if (!attributeTests.size())
             EXPECT_TRUE(attributes.isEmpty());
         else {
@@ -150,9 +150,9 @@ static void testStruct(ASCIILiteral program, const Vector<String>& fieldNames, c
                 }
             }
         }
-        EXPECT_EQ(str.members()[i].name(), fieldNames[i]);
-        EXPECT_TRUE(is<WGSL::AST::NamedTypeName>(str.members()[i].type()));
-        auto& memberType = downcast<WGSL::AST::NamedTypeName>(str.members()[i].type());
+        EXPECT_EQ(str.members()[i].get().name(), fieldNames[i]);
+        EXPECT_TRUE(is<WGSL::AST::NamedTypeName>(str.members()[i].get().type()));
+        auto& memberType = downcast<WGSL::AST::NamedTypeName>(str.members()[i].get().type());
         EXPECT_EQ(memberType.name(), typeNames[i]);
     }
 }


### PR DESCRIPTION
#### af2e0abfcb43006136e679feae74c9e61f54da56
<pre>
[WGSL] Use arena allocation for AST nodes
<a href="https://bugs.webkit.org/show_bug.cgi?id=255917">https://bugs.webkit.org/show_bug.cgi?id=255917</a>
rdar://108496324

Reviewed by Myles C. Maxfield.

The AST was originally implemented using only unique references/pointers, which
made it really difficult to transform the AST. Currently we have a mix of Ref(Ptr)
and unique references/pointers, which is unnecessary since all the nodes have the
same lifecycle. To simplify things, we switch to an arena allocator, inspired by
the JSC&apos;s ParserArena. I converted only a single leaf node, StructureMember, to
use the new AST builder as a proof of concept, but more nodes can be converted
incrementally later.

* Source/WebGPU/WGSL/AST/ASTBuilder.cpp: Added.
(WGSL::AST::Builder::arena):
(WGSL::AST::Builder::~Builder):
(WGSL::AST::Builder::allocateArena):
* Source/WebGPU/WGSL/AST/ASTBuilder.h: Added.
(WGSL::AST::Builder::construct):
(WGSL::AST::Builder::alignSize):
* Source/WebGPU/WGSL/AST/ASTStringDumper.cpp:
(WGSL::AST::StringDumper::visitPointerVector):
(WGSL::AST::StringDumper::visit):
* Source/WebGPU/WGSL/AST/ASTStringDumper.h:
* Source/WebGPU/WGSL/AST/ASTStructureMember.h:
* Source/WebGPU/WGSL/AST/ASTVisitor.cpp:
(WGSL::AST::Visitor::visit):
* Source/WebGPU/WGSL/EntryPointRewriter.cpp:
(WGSL::EntryPointRewriter::constructInputStruct):
(WGSL::EntryPointRewriter::visit):
* Source/WebGPU/WGSL/GlobalVariableRewriter.cpp:
(WGSL::RewriteGlobalVariables::insertStructs):
* Source/WebGPU/WGSL/MangleNames.cpp:
(WGSL::NameManglerVisitor::visit):
* Source/WebGPU/WGSL/Metal/MetalFunctionWriter.cpp:
(WGSL::Metal::FunctionDefinitionWriter::visit):
* Source/WebGPU/WGSL/Parser.cpp:
(WGSL::Parser&lt;Lexer&gt;::parseStructure):
(WGSL::Parser&lt;Lexer&gt;::parseStructureMember): Deleted.
* Source/WebGPU/WGSL/ParserPrivate.h:
(WGSL::Parser::Parser):
* Source/WebGPU/WGSL/TypeCheck.cpp:
(WGSL::TypeChecker::visitStructMembers):
* Source/WebGPU/WGSL/WGSLShaderModule.h:
(WGSL::ShaderModule::astBuilder):
* Source/WebGPU/WebGPU.xcodeproj/project.pbxproj:

Canonical link: <a href="https://commits.webkit.org/263452@main">https://commits.webkit.org/263452@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/84e22e7130a24aa9ca619449f6ce591a703e7457

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/4675 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/4794 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/4953 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/6175 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/4824 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/4667 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/4941 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/4758 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/5058 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/4749 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/4837 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/4189 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/6185 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/2326 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/4180 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/9161 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/4185 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/4254 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/5808 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/4653 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/3789 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/4177 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/1142 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/8225 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/4538 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->