### PR TITLE
[GLib] Arrange to call malloc_trim on process suspension

### DIFF
--- a/Source/WebKit/WebProcess/WebProcess.cpp
+++ b/Source/WebKit/WebProcess/WebProcess.cpp
@@ -1703,8 +1703,10 @@ void WebProcess::nonVisibleProcessEarlyMemoryCleanupTimerFired()
 
     destroyDecodedDataForAllImages();
 
+#if PLATFORM(COCOA) || PLATFORM(WPE) || PLATFORM(GTK)
 #if PLATFORM(COCOA)
     destroyRenderingResources();
+#endif
     releaseSystemMallocMemory();
 #endif
 }

--- a/Source/WebKit/WebProcess/WebProcess.h
+++ b/Source/WebKit/WebProcess/WebProcess.h
@@ -282,9 +282,12 @@ public:
 #if PLATFORM(COCOA)
     RetainPtr<CFDataRef> sourceApplicationAuditData() const;
     void destroyRenderingResources();
-    void releaseSystemMallocMemory();
     void getProcessDisplayName(CompletionHandler<void(String&&)>&&);
     std::optional<audit_token_t> auditTokenForSelf();
+#endif
+
+#if PLATFORM(COCOA) || PLATFORM(WPE) || PLATFORM(GTK)
+    void releaseSystemMallocMemory();
 #endif
 
     const String& uiProcessBundleIdentifier() const { return m_uiProcessBundleIdentifier; }


### PR DESCRIPTION
#### 4d11cf4168d7abf139506605c081b3aaaf33afbb
<pre>
[GLib] Arrange to call malloc_trim on process suspension
<a href="https://bugs.webkit.org/show_bug.cgi?id=255919">https://bugs.webkit.org/show_bug.cgi?id=255919</a>

Reviewed by Carlos Garcia Campos.

* Source/WebKit/WebProcess/WebProcess.cpp:
(WebKit::WebProcess::nonVisibleProcessEarlyMemoryCleanupTimerFired):
Also call releaseSystemMallocMemory() for the WPE and GTK ports.
* Source/WebKit/WebProcess/WebProcess.h: Declare
releaseSystemMallocMemory() for the WPE and GTK ports.
* Source/WebKit/WebProcess/glib/WebProcessGLib.cpp:
(WebKit::WebProcess::releaseSystemMallocMemory): Call malloc_trim(0)
where the function is available.

Canonical link: <a href="https://commits.webkit.org/263373@main">https://commits.webkit.org/263373@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2f32960f07128d5d9f8866bb8eb07fb649719a0d

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/4372 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/4489 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/4619 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/5848 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/4586 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/4611 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/4455 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/4811 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/4435 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/4583 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/3933 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/5848 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/2078 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/3910 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/7436 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/3908 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/3977 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/5518 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/4387 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/3569 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/3908 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/3908 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/1087 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/7963 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/4263 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->