### PR TITLE
[GLib] Choose amount of painting threads depending on available CPU cores

### DIFF
--- a/Source/WebCore/platform/graphics/nicosia/NicosiaPaintingEngine.cpp
+++ b/Source/WebCore/platform/graphics/nicosia/NicosiaPaintingEngine.cpp
@@ -31,23 +31,24 @@
 
 #include "NicosiaPaintingEngineBasic.h"
 #include "NicosiaPaintingEngineThreaded.h"
+#include <wtf/NumberOfCores.h>
+#include <wtf/text/StringToIntegerConversion.h>
 
 namespace Nicosia {
 
 std::unique_ptr<PaintingEngine> PaintingEngine::create()
 {
 #if PLATFORM(WPE) || USE(GTK4)
-    unsigned numThreads = 1;
+    unsigned numThreads = std::max(1, std::min(8, WTF::numberOfProcessorCores() / 2));
 #else
     unsigned numThreads = 0;
 #endif
     if (const char* numThreadsEnv = getenv("WEBKIT_NICOSIA_PAINTING_THREADS")) {
-        if (sscanf(numThreadsEnv, "%u", &numThreads) == 1) {
-            if (numThreads > 8) {
-                WTFLogAlways("The number of Nicosia painting threads is not between 1 and 8. Using the default value 4\n");
-                numThreads = 4;
-            }
-        }
+        auto newValue = parseInteger<unsigned>(StringView::fromLatin1(numThreadsEnv));
+        if (newValue && *newValue <= 8)
+            numThreads = *newValue;
+        else
+            WTFLogAlways("The number of Nicosia painting threads is not between 0 and 8. Using the default value %u\n", numThreads);
     }
 
     if (numThreads)


### PR DESCRIPTION
#### 3161dda2cc0ef51c2526aa3ce64d43c031990c83
<pre>
[GLib] Choose amount of painting threads depending on available CPU cores
<a href="https://bugs.webkit.org/show_bug.cgi?id=255923">https://bugs.webkit.org/show_bug.cgi?id=255923</a>

Reviewed by Michael Catanzaro.

Pick default number of painting threads between 1 and 8, depending on
the amount of CPU cores. While at it, rework the environment variable
parsing to use WTF::parseInteger() and log the actual default number of
threads when the environment variable cannot be parsed or has a value
bigger than eight.

* Source/WebCore/platform/graphics/nicosia/NicosiaPaintingEngine.cpp:
(Nicosia::PaintingEngine::create):

Canonical link: <a href="https://commits.webkit.org/263378@main">https://commits.webkit.org/263378@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/8da3d0b7f6f23ad9a26f8d95d448361cd490e05b

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/4391 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/4510 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/4640 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/5869 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/4598 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/4381 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/4633 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/4476 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/4825 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/4454 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/4596 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/3945 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/5869 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/2091 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/3922 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/7531 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/3924 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/3990 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/5529 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/4405 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/3582 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/3925 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/3920 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/1089 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/7979 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/4281 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->