### PR TITLE
[Cocoa] Add plumbing for a couple more platform flags on ResourceRequest

### DIFF
--- a/Source/WebCore/platform/network/ResourceRequestBase.cpp
+++ b/Source/WebCore/platform/network/ResourceRequestBase.cpp
@@ -97,6 +97,8 @@ void ResourceRequestBase::setAsIsolatedCopy(const ResourceRequest& other)
         setHTTPBody(other.m_httpBody->isolatedCopy());
     setAllowCookies(other.m_requestData.m_allowCookies);
     setIsAppInitiated(other.isAppInitiated());
+    setPrivacyProxyFailClosedForUnreachableNonMainHosts(other.privacyProxyFailClosedForUnreachableNonMainHosts());
+    setUseNetworkConnectionIntegrity(other.useNetworkConnectionIntegrity());
 }
 
 bool ResourceRequestBase::isEmpty() const
@@ -630,7 +632,31 @@ void ResourceRequestBase::setIsAppInitiated(bool isAppInitiated)
     m_requestData.m_isAppInitiated = isAppInitiated;
 
     m_platformRequestUpdated = false;
-};
+}
+
+void ResourceRequestBase::setPrivacyProxyFailClosedForUnreachableNonMainHosts(bool privacyProxyFailClosedForUnreachableNonMainHosts)
+{
+    updateResourceRequest();
+
+    if (m_requestData.m_privacyProxyFailClosedForUnreachableNonMainHosts == privacyProxyFailClosedForUnreachableNonMainHosts)
+        return;
+
+    m_requestData.m_privacyProxyFailClosedForUnreachableNonMainHosts = privacyProxyFailClosedForUnreachableNonMainHosts;
+
+    m_platformRequestUpdated = false;
+}
+
+void ResourceRequestBase::setUseNetworkConnectionIntegrity(bool useNetworkConnectionIntegrity)
+{
+    updateResourceRequest();
+
+    if (m_requestData.m_useNetworkConnectionIntegrity == useNetworkConnectionIntegrity)
+        return;
+
+    m_requestData.m_useNetworkConnectionIntegrity = useNetworkConnectionIntegrity;
+
+    m_platformRequestUpdated = false;
+}
 
 #if USE(SYSTEM_PREVIEW)
 

--- a/Source/WebCore/platform/network/ResourceRequestBase.h
+++ b/Source/WebCore/platform/network/ResourceRequestBase.h
@@ -66,7 +66,7 @@ public:
     struct RequestData {
         RequestData() { }
         
-        RequestData(const URL& url, const URL& firstPartyForCookies, double timeoutInterval, const String& httpMethod, const HTTPHeaderMap& httpHeaderFields, const Vector<String>& responseContentDispositionEncodingFallbackArray, const ResourceRequestCachePolicy& cachePolicy, const SameSiteDisposition& sameSiteDisposition, const ResourceLoadPriority& priority, const ResourceRequestRequester& requester, bool allowCookies, bool isTopSite, bool isAppInitiated = true)
+        RequestData(const URL& url, const URL& firstPartyForCookies, double timeoutInterval, const String& httpMethod, const HTTPHeaderMap& httpHeaderFields, const Vector<String>& responseContentDispositionEncodingFallbackArray, const ResourceRequestCachePolicy& cachePolicy, const SameSiteDisposition& sameSiteDisposition, const ResourceLoadPriority& priority, const ResourceRequestRequester& requester, bool allowCookies, bool isTopSite, bool isAppInitiated = true, bool privacyProxyFailClosedForUnreachableNonMainHosts = false, bool useNetworkConnectionIntegrity = false)
             : m_url(url)
             , m_firstPartyForCookies(firstPartyForCookies)
             , m_timeoutInterval(timeoutInterval)
@@ -80,6 +80,8 @@ public:
             , m_isTopSite(isTopSite)
             , m_allowCookies(allowCookies)
             , m_isAppInitiated(isAppInitiated)
+            , m_privacyProxyFailClosedForUnreachableNonMainHosts(privacyProxyFailClosedForUnreachableNonMainHosts)
+            , m_useNetworkConnectionIntegrity(useNetworkConnectionIntegrity)
         {
         }
         
@@ -102,6 +104,8 @@ public:
         bool m_isTopSite : 1 { false };
         bool m_allowCookies : 1 { false };
         bool m_isAppInitiated : 1 { true };
+        bool m_privacyProxyFailClosedForUnreachableNonMainHosts : 1 { false };
+        bool m_useNetworkConnectionIntegrity : 1 { false };
     };
 
     ResourceRequestBase(RequestData&& requestData)
@@ -260,6 +264,12 @@ public:
 
     bool isAppInitiated() const { return m_requestData.m_isAppInitiated; }
     WEBCORE_EXPORT void setIsAppInitiated(bool);
+
+    bool privacyProxyFailClosedForUnreachableNonMainHosts() const { return m_requestData.m_privacyProxyFailClosedForUnreachableNonMainHosts; }
+    WEBCORE_EXPORT void setPrivacyProxyFailClosedForUnreachableNonMainHosts(bool);
+
+    bool useNetworkConnectionIntegrity() const { return m_requestData.m_useNetworkConnectionIntegrity; }
+    WEBCORE_EXPORT void setUseNetworkConnectionIntegrity(bool);
 
 protected:
     // Used when ResourceRequest is initialized from a platform representation of the request

--- a/Source/WebCore/platform/network/cf/ResourceRequest.h
+++ b/Source/WebCore/platform/network/cf/ResourceRequest.h
@@ -41,6 +41,8 @@ struct ResourceRequestPlatformData {
     RetainPtr<NSURLRequest> m_urlRequest;
     std::optional<bool> m_isAppInitiated;
     std::optional<ResourceRequestRequester> m_requester;
+    bool m_privacyProxyFailClosedForUnreachableNonMainHosts { false };
+    bool m_useNetworkConnectionIntegrity { false };
 };
 
 using ResourceRequestData = std::variant<ResourceRequestBase::RequestData, ResourceRequestPlatformData>;

--- a/Source/WebCore/platform/network/cf/ResourceRequestCFNet.cpp
+++ b/Source/WebCore/platform/network/cf/ResourceRequestCFNet.cpp
@@ -57,6 +57,8 @@ void ResourceRequest::updateFromDelegatePreservingOldProperties(const ResourceRe
     auto oldInitiatorIdentifier = initiatorIdentifier();
     auto oldInspectorInitiatorNodeIdentifier = inspectorInitiatorNodeIdentifier();
     auto oldAppInitiatedValue = isAppInitiated();
+    auto oldPrivacyProxyFailClosedForUnreachableNonMainHosts = privacyProxyFailClosedForUnreachableNonMainHosts();
+    auto oldUseNetworkConnectionIntegrity = useNetworkConnectionIntegrity();
 
     *this = delegateProvidedRequest;
 
@@ -68,6 +70,8 @@ void ResourceRequest::updateFromDelegatePreservingOldProperties(const ResourceRe
     if (oldInspectorInitiatorNodeIdentifier)
         setInspectorInitiatorNodeIdentifier(*oldInspectorInitiatorNodeIdentifier);
     setIsAppInitiated(oldAppInitiatedValue);
+    setPrivacyProxyFailClosedForUnreachableNonMainHosts(oldPrivacyProxyFailClosedForUnreachableNonMainHosts);
+    setUseNetworkConnectionIntegrity(oldUseNetworkConnectionIntegrity);
 }
 
 bool ResourceRequest::httpPipeliningEnabled()

--- a/Source/WebKit/Shared/Cocoa/WebCoreArgumentCodersCocoa.serialization.in
+++ b/Source/WebKit/Shared/Cocoa/WebCoreArgumentCodersCocoa.serialization.in
@@ -45,7 +45,9 @@ header: <WebCore/ResourceRequest.h>
 [CustomHeader] struct WebCore::ResourceRequestPlatformData {
     [SecureCodingAllowed=[NSMutableURLRequest.class, NSURLRequest.class]] RetainPtr<NSURLRequest> m_urlRequest;
     std::optional<bool> m_isAppInitiated;
-    std::optional<WebCore::ResourceRequestRequester> m_requester
+    std::optional<WebCore::ResourceRequestRequester> m_requester;
+    bool m_privacyProxyFailClosedForUnreachableNonMainHosts;
+    bool m_useNetworkConnectionIntegrity;
 };
 
 [Nested] struct WebCore::AttributedString::AttributeValue {

--- a/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
+++ b/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
@@ -1390,6 +1390,8 @@ header: <WebCore/ResourceRequest.h>
     [BitField] bool m_allowCookies;
     [BitField] bool m_isTopSite;
     [BitField] bool m_isAppInitiated;
+    [BitField] bool m_privacyProxyFailClosedForUnreachableNonMainHosts;
+    [BitField] bool m_useNetworkConnectionIntegrity;
 };
 
 #if USE(SOUP)


### PR DESCRIPTION
#### 2092e7169114e46d8dc8ac71dad797f3c33bdc9e
<pre>
[Cocoa] Add plumbing for a couple more platform flags on ResourceRequest
<a href="https://bugs.webkit.org/show_bug.cgi?id=255927">https://bugs.webkit.org/show_bug.cgi?id=255927</a>
rdar://105895713

Reviewed by Tim Horton and Matthew Finkel.

Add plumbing for two flags on `ResourceRequest`: `PrivacyProxyFailClosedForUnreachableNonMainHosts`
and `UseNetworkConnectionIntegrity`, which both map to SPI properties on `NSURLRequest`. In a
subsequent patch, this will make it possible for WebKit clients to specify these flags on a URL
request when loading a web view, and have this state propagate to everywhere (including the resource
request used for performing preconnect).

* Source/WebCore/platform/network/ResourceRequestBase.cpp:
(WebCore::ResourceRequestBase::setAsIsolatedCopy):
(WebCore::ResourceRequestBase::setIsAppInitiated):
(WebCore::ResourceRequestBase::setPrivacyProxyFailClosedForUnreachableNonMainHosts):
(WebCore::ResourceRequestBase::setUseNetworkConnectionIntegrity):

Add support for the new flags here; this closely follows the existing pattern used to plumb whether
or not the request is app-initiated through `ResourceRequest`.

* Source/WebCore/platform/network/ResourceRequestBase.h:
(WebCore::ResourceRequestBase::RequestData::RequestData):
(WebCore::ResourceRequestBase::privacyProxyFailClosedForUnreachableNonMainHosts const):
(WebCore::ResourceRequestBase::useNetworkConnectionIntegrity const):
* Source/WebCore/platform/network/cf/ResourceRequest.h:
* Source/WebCore/platform/network/cf/ResourceRequestCFNet.cpp:
(WebCore::ResourceRequest::updateFromDelegatePreservingOldProperties):
* Source/WebCore/platform/network/cocoa/ResourceRequestCocoa.mm:
(WebCore::ResourceRequest::ResourceRequest):
(WebCore::ResourceRequest::getResourceRequestPlatformData const):
(WebCore::configureRequestWithData):

Add a new helper method to set some policy flags on the platform URL request, to avoid duplicating
this logic in the two methods below.

(WebCore::ResourceRequest::doUpdatePlatformRequest):
(WebCore::ResourceRequest::doUpdatePlatformHTTPBody):
* Source/WebKit/Shared/Cocoa/WebCoreArgumentCodersCocoa.serialization.in:
* Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in:

Add IPC encoding/decoding support for the platform flags.

Canonical link: <a href="https://commits.webkit.org/263390@main">https://commits.webkit.org/263390@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e1837a3081f1e57ddfa66616040f6f743744289a

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/4423 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/4543 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/4675 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/5902 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/4622 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/4412 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/4668 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/4507 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/4853 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/4487 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/4625 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/3980 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/5903 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/2120 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/3959 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/8032 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/3960 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/4028 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/5567 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/4430 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/3607 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/3954 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/3958 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/1095 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/8005 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/4309 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->