### PR TITLE
Simplify / optimize JSC's LiteralParser

### DIFF
--- a/Source/JavaScriptCore/runtime/LiteralParser.h
+++ b/Source/JavaScriptCore/runtime/LiteralParser.h
@@ -74,17 +74,16 @@ public:
     LiteralParserToken() = default;
 
     TokenType type;
-    const CharType* start;
-    const CharType* end;
     union {
-        double numberToken;
+        double numberToken; // Only used for TokNumber.
         struct {
             union {
-                const LChar* stringToken8;
-                const UChar* stringToken16;
+                const CharType* identifierStart;
+                const LChar* stringStart8;
+                const UChar* stringStart16;
             };
-            unsigned stringIs8Bit : 1;
-            unsigned stringLength : 31;
+            unsigned stringIs8Bit : 1; // Only used for TokString.
+            unsigned stringOrIdentifierLength : 31;
         };
     };
 };


### PR DESCRIPTION
#### f6ec77d6554e5282dd6a264cdc59ab4076baa9e9
<pre>
Simplify / optimize JSC&apos;s LiteralParser
<a href="https://bugs.webkit.org/show_bug.cgi?id=255928">https://bugs.webkit.org/show_bug.cgi?id=255928</a>

Reviewed by Justin Michaud.

Simplify / optimize JSC&apos;s LiteralParser:
- Avoid storing the start/end pointers inside LiteralParserToken, as they are
  not actually needed. We already have a `stringStart + length` for strings/identifiers,
  which is all that&apos;s needed.
- Stop using LiteralParserToken::stringIs8Bit for identifiers. Unlike strings,
  identifiers always use the same character type as the LiteralParser. This also avoids
  some unnecessary branching.

This may be a small progression on Speedometer on M1.

* Source/JavaScriptCore/runtime/LiteralParser.cpp:
(JSC::LiteralParser&lt;CharType&gt;::tryJSONPParse):
(JSC::LiteralParser&lt;CharType&gt;::makeIdentifier):
(JSC::LiteralParser&lt;CharType&gt;::makeJSString):
(JSC::LiteralParser&lt;CharType&gt;::Lexer::lex):
(JSC::LiteralParser&lt;LChar&gt;::Lexer::lexIdentifier):
(JSC::LiteralParser&lt;UChar&gt;::Lexer::lexIdentifier):
(JSC::setParserTokenString&lt;LChar&gt;):
(JSC::setParserTokenString&lt;UChar&gt;):
(JSC::LiteralParser&lt;CharType&gt;::Lexer::lexString):
(JSC::LiteralParser&lt;CharType&gt;::Lexer::lexStringSlow):
(JSC::LiteralParser&lt;CharType&gt;::Lexer::lexNumber):
(JSC::LiteralParser&lt;CharType&gt;::parsePrimitiveValue):
* Source/JavaScriptCore/runtime/LiteralParser.h:

Canonical link: <a href="https://commits.webkit.org/263416@main">https://commits.webkit.org/263416@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d65d136b1af09adf1245c252b3f8263e5755009a

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/4560 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/4680 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/4831 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/6051 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/4721 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/4815 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/4636 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/4962 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/4628 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/4727 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/4087 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/6057 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/2219 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/4079 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/9074 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/3779 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/4075 "Passed tests") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/4151 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/5690 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/4323 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/4538 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/3703 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/4654 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/4070 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/1163 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/1115 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/8111 "Built successfully") | | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/24/builds/4765 "Built successfully") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/4431 "Built successfully") | | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/3/builds/1269 "Passed tests") | 
<!--EWS-Status-Bubble-End-->