### PR TITLE
[git-webkit] Allow alternative publication account

### DIFF
--- a/Tools/Scripts/libraries/webkitscmpy/setup.py
+++ b/Tools/Scripts/libraries/webkitscmpy/setup.py
@@ -29,7 +29,7 @@ def readme():
 
 setup(
     name='webkitscmpy',
-    version='6.2.5',
+    version='6.3.0',
     description='Library designed to interact with git and svn repositories.',
     long_description=readme(),
     classifiers=[

--- a/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/__init__.py
+++ b/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/__init__.py
@@ -46,7 +46,7 @@ except ImportError:
         "Please install webkitcorepy with `pip install webkitcorepy --extra-index-url <package index URL>`"
     )
 
-version = Version(6, 2, 5)
+version = Version(6, 3, 0)
 
 AutoInstall.register(Package('fasteners', Version(0, 15, 0)))
 AutoInstall.register(Package('jinja2', Version(2, 11, 3)))

--- a/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/program/setup.py
+++ b/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/program/setup.py
@@ -382,7 +382,7 @@ class Setup(Command):
         http_remote = local.Git.HTTP_REMOTE.match(repository.url())
         can_push = not http_remote
         rmt = repository.remote()
-        if not can_push and rmt and getattr(rmt, 'credentials', None):
+        if rmt and getattr(rmt, 'credentials', None):
             username, password = rmt.credentials()
             if username and password and not run([
                 repository.executable(), 'config',

--- a/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/remote/bitbucket.py
+++ b/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/remote/bitbucket.py
@@ -347,6 +347,13 @@ class BitBucket(Scm):
     def is_git(self):
         return True
 
+    def checkout_url(self, ssh=False, http=False):
+        if ssh and http:
+            raise ValueError('Cannot specify request both a ssh and http URL')
+        if http:
+            return 'https://{}/scm/{}/{}.git'.format(self.domain, self.project, self.name)
+        return 'git@{}/{}/{}.git'.format(self.domain, self.project, self.name)
+
     def request(self, path=None, params=None, headers=None, api=None, ignore_errors=False):
         headers = {key: value for key, value in headers.items()} if headers else dict()
 

--- a/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/remote/git_hub.py
+++ b/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/remote/git_hub.py
@@ -362,6 +362,7 @@ class GitHub(Scm):
         if not match:
             raise self.Exception("'{}' is not a valid GitHub project".format(url))
         self.api_url = 'https://api.github.{}'.format(match.group('domain'))
+        self.domain = 'github.{}'.format(match.group('domain'))
         self.owner = match.group('owner')
         self.name = match.group('repository')
         self.session = requests.Session()
@@ -394,6 +395,13 @@ class GitHub(Scm):
     @property
     def is_git(self):
         return True
+
+    def checkout_url(self, ssh=False, http=False):
+        if ssh and http:
+            raise ValueError('Cannot specify request both a ssh and http URL')
+        if http:
+            return 'https://{}/{}/{}.git'.format(self.domain, self.owner, self.name)
+        return 'git@{}:{}/{}.git'.format(self.domain, self.owner, self.name)
 
     def request(self, path=None, params=None, headers=None, authenticated=None, paginate=True, json=None, method='GET', endpoint_url=None, files=None, data=None, stream=False):
         headers = {key: value for key, value in headers.items()} if headers else dict()

--- a/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/remote/scm.py
+++ b/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/remote/scm.py
@@ -90,3 +90,6 @@ class Scm(ScmBase):
             raise ValueError("Expected 'url' to be a string type, not '{}'".format(type(url)))
         self.url = url
         self.pull_requests = None
+
+    def checkout_url(self, ssh=False, http=False):
+        raise NotImplementedError()

--- a/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/remote/svn.py
+++ b/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/remote/svn.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2020 Apple Inc. All rights reserved.
+# Copyright (C) 2020-2023 Apple Inc. All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -78,6 +78,11 @@ class Svn(Scm):
     @property
     def is_svn(self):
         return True
+
+    def checkout_url(self, ssh=False, http=False):
+        if ssh:
+            raise ValueError('Subversion does not support an ssh checkout')
+        return '{}{}'.format(self.url, self.default_branch)
 
     @decorators.Memoize(timeout=60)
     def _latest(self):

--- a/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/test/git_unittest.py
+++ b/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/test/git_unittest.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2020-2022 Apple Inc. All rights reserved.
+# Copyright (C) 2020-2023 Apple Inc. All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -746,6 +746,13 @@ class TestGitHub(testing.TestCase):
                 ['Source/main.cpp', 'Source/main.h'],
             )
 
+    def test_checkout_url(self):
+        self.assertEqual(remote.GitHub(self.remote).checkout_url(), 'git@github.example.com:WebKit/WebKit.git')
+        self.assertEqual(remote.GitHub(self.remote).checkout_url(http=True), 'https://github.example.com/WebKit/WebKit.git')
+        self.assertEqual(remote.GitHub(self.remote).checkout_url(ssh=True), 'git@github.example.com:WebKit/WebKit.git')
+        with self.assertRaises(ValueError):
+            remote.GitHub(self.remote).checkout_url(http=True, ssh=True)
+
 
 class TestBitBucket(testing.TestCase):
     remote = 'https://bitbucket.example.com/projects/WEBKIT/repos/webkit'
@@ -884,3 +891,10 @@ class TestBitBucket(testing.TestCase):
                 remote.BitBucket(self.remote).files_changed('4@main'),
                 ['Source/main.cpp', 'Source/main.h'],
             )
+
+    def test_checkout_url(self):
+        self.assertEqual(remote.BitBucket(self.remote).checkout_url(), 'git@bitbucket.example.com/WEBKIT/webkit.git')
+        self.assertEqual(remote.BitBucket(self.remote).checkout_url(http=True), 'https://bitbucket.example.com/scm/WEBKIT/webkit.git')
+        self.assertEqual(remote.BitBucket(self.remote).checkout_url(ssh=True), 'git@bitbucket.example.com/WEBKIT/webkit.git')
+        with self.assertRaises(ValueError):
+            remote.BitBucket(self.remote).checkout_url(http=True, ssh=True)

--- a/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/test/svn_unittest.py
+++ b/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/test/svn_unittest.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2020-2021 Apple Inc. All rights reserved.
+# Copyright (C) 2020-2023 Apple Inc. All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -384,3 +384,11 @@ class TestRemoteSvn(testing.TestCase):
                 svn.commit(revision='r2'),
                 svn.commit(revision='r1'),
             ]), Commit.Encoder().default(list(svn.commits(begin=dict(argument='r1'), end=dict(argument='r7')))))
+
+    def test_checkout_url(self):
+        self.assertEqual(remote.Svn(self.remote).checkout_url(), 'https://svn.example.org/repository/webkit/trunk')
+        self.assertEqual(remote.Svn(self.remote).checkout_url(http=True), 'https://svn.example.org/repository/webkit/trunk')
+        with self.assertRaises(ValueError):
+            remote.Svn(self.remote).checkout_url(ssh=True)
+        with self.assertRaises(ValueError):
+            remote.Svn(self.remote).checkout_url(http=True, ssh=True)


### PR DESCRIPTION
#### 0756acde44477062e7240b9ea1556be6835c32b4
<pre>
[git-webkit] Allow alternative publication account
<a href="https://bugs.webkit.org/show_bug.cgi?id=255934">https://bugs.webkit.org/show_bug.cgi?id=255934</a>
rdar://108510545

Reviewed by Elliott Williams.

Support a --user option in `git-webkit publish` to allow an alternative account
from a user&apos;s regular development account to perform the push.

* Tools/Scripts/libraries/webkitscmpy/setup.py: Bump version.
* Tools/Scripts/libraries/webkitscmpy/webkitscmpy/__init__.py: Ditto.
* Tools/Scripts/libraries/webkitscmpy/webkitscmpy/program/publish.py:
(Publish.parser): Add --user option.
(Publish.main): Prompt user for password if --user specified, pass that password via
environment variable to `git push` commands.
* Tools/Scripts/libraries/webkitscmpy/webkitscmpy/program/setup.py:
(Setup.git): Add credential helper, event if the checkout is not a HTTPs checkout.
* Tools/Scripts/libraries/webkitscmpy/webkitscmpy/remote/bitbucket.py:
(BitBucket.checkout_url): Return ssh and http checkout URL.
* Tools/Scripts/libraries/webkitscmpy/webkitscmpy/remote/git_hub.py:
(GitHub.checkout_url): Return ssh and http checkout URL.
* Tools/Scripts/libraries/webkitscmpy/webkitscmpy/remote/scm.py:
(Scm.checkout_url): Added.
* Tools/Scripts/libraries/webkitscmpy/webkitscmpy/remote/svn.py:
(Svn.checkout_url): Return http checkout URL.
* Tools/Scripts/libraries/webkitscmpy/webkitscmpy/test/git_unittest.py:
(TestGitHub.test_checkout_url):
(TestBitBucket.test_checkout_url):
* Tools/Scripts/libraries/webkitscmpy/webkitscmpy/test/svn_unittest.py:
(TestRemoteSvn.test_checkout_url):

Canonical link: <a href="https://commits.webkit.org/263389@main">https://commits.webkit.org/263389@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a07f6c93ae475f931e25583cd090b7f7639db28b

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [  ~~🧪 style~~](https://ews-build.webkit.org/#/builders/38/builds/4469 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 ios~~](https://ews-build.webkit.org/#/builders/26/builds/4587 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/14/builds/4730 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/5952 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/32/builds/4651 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [  ~~🧪 bindings~~](https://ews-build.webkit.org/#/builders/9/builds/4459 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/23/builds/4717 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/16/builds/4545 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/5952 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | 
| [  ~~🧪 webkitperl~~](https://ews-build.webkit.org/#/builders/11/builds/4534 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/23/builds/4717 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/14/builds/4730 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/2/builds/5956 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | 
| [  ~~🧪 webkitpy~~](https://ews-build.webkit.org/#/builders/6/builds/4534 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/23/builds/4717 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/14/builds/4730 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/2/builds/5956 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/23/builds/4717 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/14/builds/4730 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/2/builds/5956 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/7/builds/4461 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/16/builds/4545 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [  ~~🧪 services~~](https://ews-build.webkit.org/#/builders/28/builds/4434 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/30/builds/3989 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/14/builds/4730 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/4/builds/8036 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/512 "Built successfully and passed tests") | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/31/builds/4349 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->