### PR TITLE
Consider hover styles when generating InteractionRegions

### DIFF
--- a/LayoutTests/interaction-region/hover-style-expected.txt
+++ b/LayoutTests/interaction-region/hover-style-expected.txt
@@ -1,0 +1,23 @@
+not a button
+(GraphicsLayer
+  (anchor 0.00 0.00)
+  (bounds 800.00 600.00)
+  (children 1
+    (GraphicsLayer
+      (bounds 800.00 600.00)
+      (contentsOpaque 1)
+      (drawsContent 1)
+      (backgroundColor #FFFFFF)
+      (event region
+        (rect (0,0) width=800 height=600)
+
+      (interaction regions [
+        (interaction (0,0) width=100 height=100)
+        (borderRadius 10.00),
+        (interaction (0,100) width=108 height=108)
+        (borderRadius 0.00)])
+      )
+    )
+  )
+)
+

--- a/LayoutTests/interaction-region/hover-style.html
+++ b/LayoutTests/interaction-region/hover-style.html
@@ -1,0 +1,53 @@
+<!DOCTYPE html>
+<html>
+<style>
+    body { margin: 0; }
+
+    div {
+        width: 100px;
+        height: 100px;
+    }
+
+    #button {
+        background-color: green;
+        border-radius: 10px;
+    }
+    #button:hover {
+        background-color: blue;
+    }
+    #button-negation {
+        border: 4px blue solid;
+    }
+    #button-negation:not(:hover) {
+        border: 4px green solid;
+    }
+    #not-a-button:hover {
+        cursor: wait;
+    }
+    #scrollable {
+        border-right: 2px black solid;
+        height: 50px;
+        background: gray;
+        overflow-y: scroll;
+    }
+</style>
+<body>
+<div id="button" onclick="click()"></div>
+<div id="button-negation" onclick="click()"></div>
+<div id="not-a-button" onclick="click()">not a button</div>
+<div id="scrollable" onclick="click()">
+    <div></div>
+</div>
+
+<pre id="results"></pre>
+<script>
+if (window.testRunner)
+    testRunner.dumpAsText();
+
+window.onload = function () {
+    if (window.internals)
+       results.textContent = internals.layerTreeAsText(document, internals.LAYER_TREE_INCLUDES_EVENT_REGION | internals.LAYER_TREE_INCLUDES_ROOT_LAYER_PROPERTIES);
+};
+</script>
+</body>
+</html>


### PR DESCRIPTION
#### 97ea7bcbcccbf097a83ebb9416d3c12767796384
<pre>
Consider hover styles when generating InteractionRegions
<a href="https://bugs.webkit.org/show_bug.cgi?id=255940">https://bugs.webkit.org/show_bug.cgi?id=255940</a>
&lt;rdar://107265123&gt;

Reviewed by Tim Horton.

Use the presence of `:hover` styles as a signal when generating
InteractionRegions.

* Source/WebCore/page/InteractionRegion.cpp:
(WebCore::elementMatchesHoverRules):
Add a function to detect if an element potentially matches hover rules.
(WebCore::interactionRegionForRenderedRegion):
When an element looks like a likely InteractionRegion candidate, but
doesn&apos;t have `cursor: pointer`, check to see if it matches hover rules.

* LayoutTests/interaction-region/hover-style-expected.txt: Added.
* LayoutTests/interaction-region/hover-style.html: Added.
Add test covering this logic.

Canonical link: <a href="https://commits.webkit.org/263464@main">https://commits.webkit.org/263464@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/dc21342cada2e6eb99f4f3bb12817f2cc9633d34

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/4422 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/4542 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/4674 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/5901 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/4621 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/4411 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/4721 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/4506 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/4850 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/4486 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/4658 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/3974 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/5902 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/2157 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/3951 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/7932 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/3999 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/4020 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/5641 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/4429 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/3605 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/3953 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/3950 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/1149 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/8004 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/4308 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->