### PR TITLE
Web Inspector: private symbols should not be shown in the scope chain

### DIFF
--- a/LayoutTests/inspector/debugger/paused-scopes-expected.txt
+++ b/LayoutTests/inspector/debugger/paused-scopes-expected.txt
@@ -333,4 +333,33 @@ CALLFRAME: entry
 
 
 -- Running test case: PausedCallFrameScope.Complete
+-- Running test case: PausedCallFrameScope.PrivateField
+CALLFRAME: pause
+
+---- Scope Chain ----
+  SCOPE: Name (pause) - Type (Local) - Hash (pause:<sourceID>:7:10)
+  SCOPE: Name (<global>) - Type (Block) - Hash (<global>:<sourceID>:1:1)
+  SCOPE: Name () - Type (GlobalLexicalEnvironment) - Hash ()
+    - globalLet2
+  SCOPE: Name () - Type (Global) - Hash ()
+
+---- Merged Scope Chain ----
+  SCOPE: Name (pause) - Type (Local) - Hash (pause:<sourceID>:7:10)
+  SCOPE: Name (<global>) - Type (Block) - Hash (<global>:<sourceID>:1:1)
+  SCOPE: Name () - Type (GlobalLexicalEnvironment) - Hash ()
+    - globalLet2
+  SCOPE: Name () - Type (Global) - Hash ()
+
+CALLFRAME: Global Code
+
+---- Scope Chain ----
+  SCOPE: Name () - Type (GlobalLexicalEnvironment) - Hash ()
+    - globalLet2
+  SCOPE: Name () - Type (Global) - Hash ()
+
+---- Merged Scope Chain ----
+  SCOPE: Name () - Type (GlobalLexicalEnvironment) - Hash ()
+    - globalLet2
+  SCOPE: Name () - Type (Global) - Hash ()
+
 

--- a/LayoutTests/inspector/debugger/paused-scopes.html
+++ b/LayoutTests/inspector/debugger/paused-scopes.html
@@ -123,6 +123,25 @@ function test()
         }
     });
 
+    suite.addTestCase({
+        name: "PausedCallFrameScope.PrivateField",
+        async test() {
+            let evaluatePromise = InspectorTest.evaluateInPage(`
+(new class {
+    static #SHOULD_NOT_LIST_STATIC_PROPERTY = "static";
+    static #SHOULD_NOT_LIST_STATIC_METHOD() { }
+    #SHOULD_NOT_LIST_INSTANCE_PROPERTY = "instance";
+    #SHOULD_NOT_LIST_INSTANCE_METHOD() { }
+    pause() { debugger; }
+}).pause()
+            `);
+            await WI.debuggerManager.awaitEvent(WI.DebuggerManager.Event.Paused);
+            await dumpCallFrames();
+            await WI.debuggerManager.resume();
+            await evaluatePromise;
+        },
+    });
+
     suite.runTestCasesAndFinish();
 }
 </script>

--- a/Source/JavaScriptCore/runtime/JSLexicalEnvironment.cpp
+++ b/Source/JavaScriptCore/runtime/JSLexicalEnvironment.cpp
@@ -70,17 +70,20 @@ void JSLexicalEnvironment::analyzeHeap(JSCell* cell, HeapAnalyzer& analyzer)
 void JSLexicalEnvironment::getOwnSpecialPropertyNames(JSObject* object, JSGlobalObject* globalObject, PropertyNameArray& propertyNames, DontEnumPropertiesMode mode)
 {
     JSLexicalEnvironment* thisObject = jsCast<JSLexicalEnvironment*>(object);
+    SymbolTable* symbolTable = thisObject->symbolTable();
 
     {
-        ConcurrentJSLocker locker(thisObject->symbolTable()->m_lock);
-        SymbolTable::Map::iterator end = thisObject->symbolTable()->end(locker);
+        ConcurrentJSLocker locker(symbolTable->m_lock);
+        SymbolTable::Map::iterator end = symbolTable->end(locker);
         VM& vm = globalObject->vm();
-        for (SymbolTable::Map::iterator it = thisObject->symbolTable()->begin(locker); it != end; ++it) {
+        for (SymbolTable::Map::iterator it = symbolTable->begin(locker); it != end; ++it) {
             if (mode == DontEnumPropertiesMode::Exclude && it->value.isDontEnum())
                 continue;
             if (!thisObject->isValidScopeOffset(it->value.scopeOffset()))
                 continue;
-            if (it->key->isSymbol() && !propertyNames.includeSymbolProperties())
+            if (!propertyNames.includeSymbolProperties() && it->key->isSymbol())
+                continue;
+            if (propertyNames.privateSymbolMode() == PrivateSymbolMode::Exclude && symbolTable->hasPrivateName(it->key))
                 continue;
             propertyNames.add(Identifier::fromUid(vm, it->key.get()));
         }

--- a/Source/JavaScriptCore/runtime/SymbolTable.h
+++ b/Source/JavaScriptCore/runtime/SymbolTable.h
@@ -620,6 +620,13 @@ public:
         rareData.m_privateNames.add(key, value);
     }
 
+    bool hasPrivateName(const RefPtr<UniquedStringImpl>& key) const
+    {
+        if (auto* rareData = m_rareData.get())
+            return rareData->m_privateNames.contains(key);
+        return false;
+    }
+
     template<typename Entry>
     void set(const ConcurrentJSLocker&, UniquedStringImpl* key, Entry&& entry)
     {


### PR DESCRIPTION
#### d1eb17d9b5dc2abf9d7bde49daf25d31fb62b7ef
<pre>
Web Inspector: private symbols should not be shown in the scope chain
<a href="https://bugs.webkit.org/show_bug.cgi?id=255946">https://bugs.webkit.org/show_bug.cgi?id=255946</a>

Reviewed by Patrick Angle.

The fact that private fields are implemented using a private `Symbol` is kinda sorta an implementation detail, so Web Inspector shouldn&apos;t be exposing them.

* Source/JavaScriptCore/runtime/JSLexicalEnvironment.cpp:
(JSC::JSLexicalEnvironment::getOwnSpecialPropertyNames):
* Source/JavaScriptCore/runtime/JSSymbolTableObject.cpp:
(JSC::JSSymbolTableObject::getOwnSpecialPropertyNames):
Private properties should be ignored if `PropertyNameArray::privateSymbolMode` (in addition to already ignoring them based on `PropertyNameArray::includeSymbolProperties`).

* Source/JavaScriptCore/runtime/SymbolTable.h:
(JSC::SymbolTable::hasPrivateName const): Added.
Expose a way for callers to query if a given `UniquedStringImpl` is a private field.

* LayoutTests/inspector/debugger/paused-scopes.html:
* LayoutTests/inspector/debugger/paused-scopes-expected.txt:

Canonical link: <a href="https://commits.webkit.org/263513@main">https://commits.webkit.org/263513@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/79d2f57069042dc56c31b5e4cb810ef85ab1c835

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/4509 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/4627 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/4772 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/5993 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/4677 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/4758 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/4583 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/4918 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/4574 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/4682 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/4042 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/5998 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/2178 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/4032 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/8928 "Passed tests") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/3730 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/4029 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/4162 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/5635 "Passed tests") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/4267 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/4489 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/3663 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/4601 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/4021 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/4031 "Passed tests") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/1148 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/1186 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/8063 "Built successfully") | | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/24/builds/4710 "Built successfully") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/4383 "Built successfully") | | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/3/builds/1253 "Passed tests") | 
<!--EWS-Status-Bubble-End-->