### PR TITLE
[WPE] Test gardening after 263291@main

### DIFF
--- a/LayoutTests/platform/wpe/fast/css/resize-corner-tracking-expected.txt
+++ b/LayoutTests/platform/wpe/fast/css/resize-corner-tracking-expected.txt
@@ -15,13 +15,11 @@ layer at (0,0) size 800x600
             text run at (403,0) width 318: "Resize corner does not track the mouse accurately"
         RenderText {#text} at (720,0) size 5x17
           text run at (720,0) width 5: "."
-      RenderBlock (anonymous) at (0,187) size 784x374
-        RenderText {#text} at (173,111) size 4x17
-          text run at (173,111) width 4: " "
-        RenderBR {BR} at (177,111) size 0x17
-        RenderText {#text} at (203,181) size 4x17
-          text run at (203,181) width 4: " "
-        RenderBR {BR} at (207,181) size 0x17
+      RenderBlock (anonymous) at (0,187) size 784x366
+        RenderText {#text} at (0,0) size 0x0
+        RenderBR {BR} at (173,111) size 0x17
+        RenderText {#text} at (0,0) size 0x0
+        RenderBR {BR} at (203,177) size 0x17
         RenderText {#text} at (0,0) size 0x0
 layer at (8,8) size 784x2 clip at (0,0) size 0x0
   RenderBlock {HR} at (0,0) size 784x2 [border: (1px inset #000000)]
@@ -32,11 +30,11 @@ layer at (8,70) size 173x125 clip at (10,72) size 169x121
 layer at (8,195) size 173x125 clip at (10,197) size 169x121
   RenderTextControl {TEXTAREA} at (0,0) size 173x125 [bgcolor=#FFFFFF] [border: (2px solid #0000FF)]
     RenderBlock {DIV} at (4,4) size 165x18
-layer at (8,324) size 203x66 clip at (9,325) size 201x64
-  RenderTextControl {TEXTAREA} at (0,129) size 203x66 [bgcolor=#FFFFFF] [border: (1px solid #000000)]
+layer at (8,320) size 203x66 clip at (9,321) size 201x64
+  RenderTextControl {TEXTAREA} at (0,125) size 203x66 [bgcolor=#FFFFFF] [border: (1px solid #000000)]
     RenderBlock {DIV} at (3,3) size 197x18
-layer at (8,394) size 323x175
-  RenderIFrame {IFRAME} at (0,199) size 323x175 [border: (2px inset #000000)]
+layer at (8,386) size 323x175
+  RenderIFrame {IFRAME} at (0,191) size 323x175 [border: (2px inset #000000)]
     layer at (0,0) size 319x171
       RenderView at (0,0) size 319x171
     layer at (0,0) size 319x171

--- a/LayoutTests/platform/wpe/fast/encoding/utf-16-big-endian-expected.txt
+++ b/LayoutTests/platform/wpe/fast/encoding/utf-16-big-endian-expected.txt
@@ -43,8 +43,8 @@ layer at (0,0) size 785x1077
           RenderText {#text} at (0,0) size 0x0
       RenderBlock (anonymous) at (0,77) size 769x3
       RenderBlock (anonymous) at (0,86) size 769x51
-        RenderInline {SPAN} at (0,0) size 574x49
-          RenderInline {SPAN} at (0,0) size 574x49
+        RenderInline {SPAN} at (0,0) size 570x49
+          RenderInline {SPAN} at (0,0) size 570x49
             RenderText {#text} at (0,0) size 0x0
             RenderImage {IMG} at (0,1) size 66x19
             RenderText {#text} at (66,2) size 4x15
@@ -58,16 +58,16 @@ layer at (0,0) size 785x1077
           RenderText {#text} at (0,0) size 0x0
       RenderBlock (anonymous) at (0,143) size 769x3
       RenderBlock (anonymous) at (0,152) size 769x25
-        RenderInline {SPAN} at (0,0) size 130x25
-          RenderInline {SPAN} at (0,0) size 130x25
+        RenderInline {SPAN} at (0,0) size 126x25
+          RenderInline {SPAN} at (0,0) size 126x25
             RenderText {#text} at (0,0) size 0x0
-            RenderInline {SPAN} at (0,0) size 130x17
+            RenderInline {SPAN} at (0,0) size 126x17
               RenderText {#text} at (0,0) size 0x0
               RenderImage {IMG} at (0,0) size 63x21
-              RenderText {#text} at (63,1) size 67x17
+              RenderText {#text} at (63,1) size 63x17
                 text run at (63,1) width 4: " "
-                text run at (67,1) width 63: "Phones "
-              RenderBR {BR} at (130,1) size 0x17
+                text run at (67,1) width 59: "Phones"
+              RenderBR {BR} at (126,1) size 0x17
             RenderText {#text} at (0,0) size 0x0
       RenderBlock (anonymous) at (0,237) size 769x0
         RenderInline {SPAN} at (0,0) size 0x0
@@ -132,9 +132,9 @@ layer at (0,0) size 785x1077
                 RenderText {#text} at (0,0) size 0x0
               RenderTableCell {TD} at (106,2) size 606x192 [r=0 c=3 rs=1 cs=1]
                 RenderBlock (anonymous) at (1,1) size 604x126
-                  RenderText {#text} at (0,0) size 24x17
-                    text run at (0,0) width 24: "Air "
-                  RenderBR {BR} at (24,0) size 0x17
+                  RenderText {#text} at (0,0) size 20x17
+                    text run at (0,0) width 20: "Air"
+                  RenderBR {BR} at (20,0) size 0x17
                   RenderText {#text} at (0,18) size 484x17
                     text run at (0,18) width 51: "United "
                     text run at (51,18) width 83: "Flight 1187 "
@@ -154,13 +154,12 @@ layer at (0,0) size 785x1077
                   RenderBR {BR} at (244,72) size 0x17
                   RenderText {#text} at (0,90) size 49x17
                     text run at (0,90) width 49: "Status:"
-                  RenderInline {SPACE} at (0,0) size 127x35
+                  RenderInline {SPACE} at (0,0) size 123x35
                     RenderText {#text} at (49,90) size 74x17
                       text run at (49,90) width 74: " confirmed"
-                    RenderInline {SPACE} at (0,0) size 127x35
-                      RenderText {#text} at (123,90) size 4x17
-                        text run at (123,90) width 4: " "
-                      RenderBR {BR} at (127,90) size 0x17
+                    RenderInline {SPACE} at (0,0) size 123x35
+                      RenderText {#text} at (0,0) size 0x0
+                      RenderBR {BR} at (123,90) size 0x17
                       RenderText {#text} at (0,108) size 45x17
                         text run at (0,108) width 45: "Seats:"
                       RenderBR {BR} at (45,108) size 0x17
@@ -227,9 +226,9 @@ layer at (0,0) size 785x1077
                 RenderText {#text} at (0,0) size 0x0
               RenderTableCell {TD} at (106,2) size 495x192 [r=0 c=3 rs=1 cs=1]
                 RenderBlock (anonymous) at (1,1) size 493x126
-                  RenderText {#text} at (0,0) size 24x17
-                    text run at (0,0) width 24: "Air "
-                  RenderBR {BR} at (24,0) size 0x17
+                  RenderText {#text} at (0,0) size 20x17
+                    text run at (0,0) width 20: "Air"
+                  RenderBR {BR} at (20,0) size 0x17
                   RenderText {#text} at (0,18) size 465x17
                     text run at (0,18) width 51: "United "
                     text run at (51,18) width 75: "Flight 480 "
@@ -249,13 +248,12 @@ layer at (0,0) size 785x1077
                   RenderBR {BR} at (244,72) size 0x17
                   RenderText {#text} at (0,90) size 49x17
                     text run at (0,90) width 49: "Status:"
-                  RenderInline {SPACE} at (0,0) size 127x35
+                  RenderInline {SPACE} at (0,0) size 123x35
                     RenderText {#text} at (49,90) size 74x17
                       text run at (49,90) width 74: " confirmed"
-                    RenderInline {SPACE} at (0,0) size 127x35
-                      RenderText {#text} at (123,90) size 4x17
-                        text run at (123,90) width 4: " "
-                      RenderBR {BR} at (127,90) size 0x17
+                    RenderInline {SPACE} at (0,0) size 123x35
+                      RenderText {#text} at (0,0) size 0x0
+                      RenderBR {BR} at (123,90) size 0x17
                       RenderText {#text} at (0,108) size 45x17
                         text run at (0,108) width 45: "Seats:"
                       RenderBR {BR} at (45,108) size 0x17
@@ -321,9 +319,9 @@ layer at (0,0) size 785x1077
                 RenderImage {IMG} at (1,1) size 92x21
                 RenderText {#text} at (0,0) size 0x0
               RenderTableCell {TD} at (106,2) size 509x110 [r=0 c=3 rs=1 cs=1]
-                RenderText {#text} at (1,1) size 24x17
-                  text run at (1,1) width 24: "Air "
-                RenderBR {BR} at (25,1) size 0x17
+                RenderText {#text} at (1,1) size 20x17
+                  text run at (1,1) width 20: "Air"
+                RenderBR {BR} at (21,1) size 0x17
                 RenderText {#text} at (1,19) size 507x17
                   text run at (1,19) width 90: "UNKNOWN "
                   text run at (91,19) width 75: "Flight 123 "
@@ -343,13 +341,12 @@ layer at (0,0) size 785x1077
                 RenderBR {BR} at (171,73) size 0x17
                 RenderText {#text} at (1,91) size 49x17
                   text run at (1,91) width 49: "Status:"
-                RenderInline {SPACE} at (0,0) size 195x17
+                RenderInline {SPACE} at (0,0) size 191x17
                   RenderText {#text} at (50,91) size 191x17
                     text run at (50,91) width 191: " requested, await response"
-                  RenderInline {SPACE} at (0,0) size 4x17
-                    RenderText {#text} at (241,91) size 4x17
-                      text run at (241,91) width 4: " "
-                    RenderBR {BR} at (245,91) size 0x17
+                  RenderInline {SPACE} at (0,0) size 0x17
+                    RenderText {#text} at (0,0) size 0x0
+                    RenderBR {BR} at (241,91) size 0x17
       RenderBlock (anonymous) at (0,885) size 769x0
         RenderInline {SPAN} at (0,0) size 0x0
           RenderInline {SPAN} at (0,0) size 0x0
@@ -380,8 +377,8 @@ layer at (0,0) size 785x1077
           RenderText {#text} at (0,0) size 0x0
       RenderBlock (anonymous) at (0,955) size 769x3
       RenderBlock (anonymous) at (0,963) size 769x22
-        RenderInline {SPAN} at (0,0) size 186x15
-          RenderInline {SPAN} at (0,0) size 186x17
+        RenderInline {SPAN} at (0,0) size 182x15
+          RenderInline {SPAN} at (0,0) size 182x17
             RenderText {#text} at (0,0) size 0x0
             RenderImage {IMG} at (0,0) size 66x21
             RenderText {#text} at (66,1) size 4x17
@@ -389,10 +386,9 @@ layer at (0,0) size 785x1077
             RenderInline {B} at (0,0) size 112x17
               RenderText {#text} at (70,1) size 112x17
                 text run at (70,1) width 112: "Web Bookings"
-            RenderText {#text} at (181,1) size 5x17
-              text run at (181,1) width 5: " "
+            RenderText {#text} at (0,0) size 0x0
             RenderInline {SPAN} at (0,0) size 0x17
-              RenderBR {BR} at (185,1) size 1x17
+              RenderBR {BR} at (181,1) size 1x17
               RenderInline {SPAN} at (0,0) size 0x14
             RenderText {#text} at (0,0) size 0x0
           RenderText {#text} at (0,0) size 0x0
@@ -459,15 +455,15 @@ layer at (23,43) size 88x15
         RenderText {#text} at (0,0) size 0x0
       RenderText {#text} at (0,0) size 0x0
     RenderText {#text} at (0,0) size 0x0
-layer at (23,95) size 574x31
-  RenderInline (relative positioned) {SPAN} at (0,0) size 574x31
+layer at (23,95) size 570x31
+  RenderInline (relative positioned) {SPAN} at (0,0) size 570x31
     RenderText {#text} at (0,0) size 0x0
     RenderImage {IMG} at (0,28) size 4x5
-    RenderText {#text} at (4,20) size 570x16
+    RenderText {#text} at (4,20) size 566x16
       text run at (4,20) width 4: " "
       text run at (8,20) width 56: "Address: "
-      text run at (64,20) width 510: "ST. JUDE MEDICAL, 21700 OXNARD ST SUITE 800, WOODLAND HILLS CA Z/91367 "
-    RenderBR {BR} at (573,20) size 1x16
+      text run at (64,20) width 506: "ST. JUDE MEDICAL, 21700 OXNARD ST SUITE 800, WOODLAND HILLS CA Z/91367"
+    RenderBR {BR} at (569,20) size 1x16
     RenderImage {IMG} at (0,43) size 4x5
     RenderText {#text} at (4,35) size 405x16
       text run at (4,35) width 4: " "

--- a/LayoutTests/platform/wpe/fast/encoding/utf-16-little-endian-expected.txt
+++ b/LayoutTests/platform/wpe/fast/encoding/utf-16-little-endian-expected.txt
@@ -43,8 +43,8 @@ layer at (0,0) size 785x1077
           RenderText {#text} at (0,0) size 0x0
       RenderBlock (anonymous) at (0,77) size 769x3
       RenderBlock (anonymous) at (0,86) size 769x51
-        RenderInline {SPAN} at (0,0) size 574x49
-          RenderInline {SPAN} at (0,0) size 574x49
+        RenderInline {SPAN} at (0,0) size 570x49
+          RenderInline {SPAN} at (0,0) size 570x49
             RenderText {#text} at (0,0) size 0x0
             RenderImage {IMG} at (0,1) size 66x19
             RenderText {#text} at (66,2) size 4x15
@@ -58,16 +58,16 @@ layer at (0,0) size 785x1077
           RenderText {#text} at (0,0) size 0x0
       RenderBlock (anonymous) at (0,143) size 769x3
       RenderBlock (anonymous) at (0,152) size 769x25
-        RenderInline {SPAN} at (0,0) size 130x25
-          RenderInline {SPAN} at (0,0) size 130x25
+        RenderInline {SPAN} at (0,0) size 126x25
+          RenderInline {SPAN} at (0,0) size 126x25
             RenderText {#text} at (0,0) size 0x0
-            RenderInline {SPAN} at (0,0) size 130x17
+            RenderInline {SPAN} at (0,0) size 126x17
               RenderText {#text} at (0,0) size 0x0
               RenderImage {IMG} at (0,0) size 63x21
-              RenderText {#text} at (63,1) size 67x17
+              RenderText {#text} at (63,1) size 63x17
                 text run at (63,1) width 4: " "
-                text run at (67,1) width 63: "Phones "
-              RenderBR {BR} at (130,1) size 0x17
+                text run at (67,1) width 59: "Phones"
+              RenderBR {BR} at (126,1) size 0x17
             RenderText {#text} at (0,0) size 0x0
       RenderBlock (anonymous) at (0,237) size 769x0
         RenderInline {SPAN} at (0,0) size 0x0
@@ -132,9 +132,9 @@ layer at (0,0) size 785x1077
                 RenderText {#text} at (0,0) size 0x0
               RenderTableCell {TD} at (106,2) size 606x192 [r=0 c=3 rs=1 cs=1]
                 RenderBlock (anonymous) at (1,1) size 604x126
-                  RenderText {#text} at (0,0) size 24x17
-                    text run at (0,0) width 24: "Air "
-                  RenderBR {BR} at (24,0) size 0x17
+                  RenderText {#text} at (0,0) size 20x17
+                    text run at (0,0) width 20: "Air"
+                  RenderBR {BR} at (20,0) size 0x17
                   RenderText {#text} at (0,18) size 484x17
                     text run at (0,18) width 51: "United "
                     text run at (51,18) width 83: "Flight 1187 "
@@ -154,13 +154,12 @@ layer at (0,0) size 785x1077
                   RenderBR {BR} at (244,72) size 0x17
                   RenderText {#text} at (0,90) size 49x17
                     text run at (0,90) width 49: "Status:"
-                  RenderInline {SPACE} at (0,0) size 127x35
+                  RenderInline {SPACE} at (0,0) size 123x35
                     RenderText {#text} at (49,90) size 74x17
                       text run at (49,90) width 74: " confirmed"
-                    RenderInline {SPACE} at (0,0) size 127x35
-                      RenderText {#text} at (123,90) size 4x17
-                        text run at (123,90) width 4: " "
-                      RenderBR {BR} at (127,90) size 0x17
+                    RenderInline {SPACE} at (0,0) size 123x35
+                      RenderText {#text} at (0,0) size 0x0
+                      RenderBR {BR} at (123,90) size 0x17
                       RenderText {#text} at (0,108) size 45x17
                         text run at (0,108) width 45: "Seats:"
                       RenderBR {BR} at (45,108) size 0x17
@@ -227,9 +226,9 @@ layer at (0,0) size 785x1077
                 RenderText {#text} at (0,0) size 0x0
               RenderTableCell {TD} at (106,2) size 495x192 [r=0 c=3 rs=1 cs=1]
                 RenderBlock (anonymous) at (1,1) size 493x126
-                  RenderText {#text} at (0,0) size 24x17
-                    text run at (0,0) width 24: "Air "
-                  RenderBR {BR} at (24,0) size 0x17
+                  RenderText {#text} at (0,0) size 20x17
+                    text run at (0,0) width 20: "Air"
+                  RenderBR {BR} at (20,0) size 0x17
                   RenderText {#text} at (0,18) size 465x17
                     text run at (0,18) width 51: "United "
                     text run at (51,18) width 75: "Flight 480 "
@@ -249,13 +248,12 @@ layer at (0,0) size 785x1077
                   RenderBR {BR} at (244,72) size 0x17
                   RenderText {#text} at (0,90) size 49x17
                     text run at (0,90) width 49: "Status:"
-                  RenderInline {SPACE} at (0,0) size 127x35
+                  RenderInline {SPACE} at (0,0) size 123x35
                     RenderText {#text} at (49,90) size 74x17
                       text run at (49,90) width 74: " confirmed"
-                    RenderInline {SPACE} at (0,0) size 127x35
-                      RenderText {#text} at (123,90) size 4x17
-                        text run at (123,90) width 4: " "
-                      RenderBR {BR} at (127,90) size 0x17
+                    RenderInline {SPACE} at (0,0) size 123x35
+                      RenderText {#text} at (0,0) size 0x0
+                      RenderBR {BR} at (123,90) size 0x17
                       RenderText {#text} at (0,108) size 45x17
                         text run at (0,108) width 45: "Seats:"
                       RenderBR {BR} at (45,108) size 0x17
@@ -321,9 +319,9 @@ layer at (0,0) size 785x1077
                 RenderImage {IMG} at (1,1) size 92x21
                 RenderText {#text} at (0,0) size 0x0
               RenderTableCell {TD} at (106,2) size 509x110 [r=0 c=3 rs=1 cs=1]
-                RenderText {#text} at (1,1) size 24x17
-                  text run at (1,1) width 24: "Air "
-                RenderBR {BR} at (25,1) size 0x17
+                RenderText {#text} at (1,1) size 20x17
+                  text run at (1,1) width 20: "Air"
+                RenderBR {BR} at (21,1) size 0x17
                 RenderText {#text} at (1,19) size 507x17
                   text run at (1,19) width 90: "UNKNOWN "
                   text run at (91,19) width 75: "Flight 123 "
@@ -343,13 +341,12 @@ layer at (0,0) size 785x1077
                 RenderBR {BR} at (171,73) size 0x17
                 RenderText {#text} at (1,91) size 49x17
                   text run at (1,91) width 49: "Status:"
-                RenderInline {SPACE} at (0,0) size 195x17
+                RenderInline {SPACE} at (0,0) size 191x17
                   RenderText {#text} at (50,91) size 191x17
                     text run at (50,91) width 191: " requested, await response"
-                  RenderInline {SPACE} at (0,0) size 4x17
-                    RenderText {#text} at (241,91) size 4x17
-                      text run at (241,91) width 4: " "
-                    RenderBR {BR} at (245,91) size 0x17
+                  RenderInline {SPACE} at (0,0) size 0x17
+                    RenderText {#text} at (0,0) size 0x0
+                    RenderBR {BR} at (241,91) size 0x17
       RenderBlock (anonymous) at (0,885) size 769x0
         RenderInline {SPAN} at (0,0) size 0x0
           RenderInline {SPAN} at (0,0) size 0x0
@@ -380,8 +377,8 @@ layer at (0,0) size 785x1077
           RenderText {#text} at (0,0) size 0x0
       RenderBlock (anonymous) at (0,955) size 769x3
       RenderBlock (anonymous) at (0,963) size 769x22
-        RenderInline {SPAN} at (0,0) size 186x15
-          RenderInline {SPAN} at (0,0) size 186x17
+        RenderInline {SPAN} at (0,0) size 182x15
+          RenderInline {SPAN} at (0,0) size 182x17
             RenderText {#text} at (0,0) size 0x0
             RenderImage {IMG} at (0,0) size 66x21
             RenderText {#text} at (66,1) size 4x17
@@ -389,10 +386,9 @@ layer at (0,0) size 785x1077
             RenderInline {B} at (0,0) size 112x17
               RenderText {#text} at (70,1) size 112x17
                 text run at (70,1) width 112: "Web Bookings"
-            RenderText {#text} at (181,1) size 5x17
-              text run at (181,1) width 5: " "
+            RenderText {#text} at (0,0) size 0x0
             RenderInline {SPAN} at (0,0) size 0x17
-              RenderBR {BR} at (185,1) size 1x17
+              RenderBR {BR} at (181,1) size 1x17
               RenderInline {SPAN} at (0,0) size 0x14
             RenderText {#text} at (0,0) size 0x0
           RenderText {#text} at (0,0) size 0x0
@@ -459,15 +455,15 @@ layer at (23,43) size 88x15
         RenderText {#text} at (0,0) size 0x0
       RenderText {#text} at (0,0) size 0x0
     RenderText {#text} at (0,0) size 0x0
-layer at (23,95) size 574x31
-  RenderInline (relative positioned) {SPAN} at (0,0) size 574x31
+layer at (23,95) size 570x31
+  RenderInline (relative positioned) {SPAN} at (0,0) size 570x31
     RenderText {#text} at (0,0) size 0x0
     RenderImage {IMG} at (0,28) size 4x5
-    RenderText {#text} at (4,20) size 570x16
+    RenderText {#text} at (4,20) size 566x16
       text run at (4,20) width 4: " "
       text run at (8,20) width 56: "Address: "
-      text run at (64,20) width 510: "ST. JUDE MEDICAL, 21700 OXNARD ST SUITE 800, WOODLAND HILLS CA Z/91367 "
-    RenderBR {BR} at (573,20) size 1x16
+      text run at (64,20) width 506: "ST. JUDE MEDICAL, 21700 OXNARD ST SUITE 800, WOODLAND HILLS CA Z/91367"
+    RenderBR {BR} at (569,20) size 1x16
     RenderImage {IMG} at (0,43) size 4x5
     RenderText {#text} at (4,35) size 405x16
       text run at (4,35) width 4: " "

--- a/LayoutTests/platform/wpe/fast/layers/layer-visibility-sublayer-expected.txt
+++ b/LayoutTests/platform/wpe/fast/layers/layer-visibility-sublayer-expected.txt
@@ -7,21 +7,21 @@ layer at (0,0) size 800x600
       RenderBR {BR} at (0,18) size 0x17
       RenderBR {BR} at (0,36) size 0x17
       RenderBR {BR} at (0,54) size 0x17
-      RenderText {#text} at (0,72) size 180x17
-        text run at (0,72) width 180: "24 green box with word ok: "
-      RenderBR {BR} at (180,72) size 0x17
+      RenderText {#text} at (0,72) size 176x17
+        text run at (0,72) width 176: "24 green box with word ok:"
+      RenderBR {BR} at (176,72) size 0x17
       RenderBR {BR} at (0,90) size 0x17
       RenderBR {BR} at (0,108) size 0x17
       RenderBR {BR} at (0,126) size 0x17
-      RenderText {#text} at (0,144) size 180x17
-        text run at (0,144) width 180: "25 green box with word ok: "
-      RenderBR {BR} at (180,144) size 0x17
+      RenderText {#text} at (0,144) size 176x17
+        text run at (0,144) width 176: "25 green box with word ok:"
+      RenderBR {BR} at (176,144) size 0x17
       RenderBR {BR} at (0,162) size 0x17
       RenderBR {BR} at (0,180) size 0x17
       RenderBR {BR} at (0,198) size 0x17
-      RenderText {#text} at (0,216) size 180x17
-        text run at (0,216) width 180: "26 green box with word ok: "
-      RenderBR {BR} at (180,216) size 0x17
+      RenderText {#text} at (0,216) size 176x17
+        text run at (0,216) width 176: "26 green box with word ok:"
+      RenderBR {BR} at (176,216) size 0x17
       RenderBR {BR} at (0,234) size 0x17
       RenderBR {BR} at (0,252) size 0x17
       RenderBR {BR} at (0,270) size 0x17

--- a/LayoutTests/platform/wpe/tables/mozilla/bugs/bug28928-expected.txt
+++ b/LayoutTests/platform/wpe/tables/mozilla/bugs/bug28928-expected.txt
@@ -18,9 +18,8 @@ layer at (0,0) size 800x600
                   RenderBlock (anonymous) at (8,4) size 28x18
                     RenderText at (0,0) size 28x17
                       text run at (0,0) width 28: " Go "
-                RenderText {#text} at (165,4) size 4x17
-                  text run at (165,4) width 4: " "
-                RenderBR {BR} at (169,4) size 0x17
+                RenderText {#text} at (0,0) size 0x0
+                RenderBR {BR} at (165,4) size 0x17
                 RenderText {#text} at (0,27) size 188x17
                   text run at (0,27) width 188: "Enter City Name or Zip Code"
           RenderTableRow {TR} at (0,67) size 194x0
@@ -39,9 +38,8 @@ layer at (0,0) size 800x600
                   RenderBlock (anonymous) at (8,4) size 28x18
                     RenderText at (0,0) size 28x17
                       text run at (0,0) width 28: " Go "
-                RenderText {#text} at (165,4) size 4x17
-                  text run at (165,4) width 4: " "
-                RenderBR {BR} at (169,4) size 0x17
+                RenderText {#text} at (0,0) size 0x0
+                RenderBR {BR} at (165,4) size 0x17
                 RenderText {#text} at (0,27) size 188x17
                   text run at (0,27) width 188: "Enter City Name or Zip Code"
           RenderTableRow {TR} at (0,67) size 194x0

--- a/LayoutTests/platform/wpe/transforms/3d/point-mapping/3d-point-mapping-origins-expected.txt
+++ b/LayoutTests/platform/wpe/transforms/3d/point-mapping/3d-point-mapping-origins-expected.txt
@@ -7,9 +7,8 @@ layer at (0,0) size 785x600
       RenderText {#text} at (243,229) size 4x17
         text run at (243,229) width 4: " "
       RenderBlock {DIV} at (267,21) size 202x202 [border: (1px solid #000000)]
-      RenderText {#text} at (489,229) size 4x17
-        text run at (489,229) width 4: " "
-      RenderBR {BR} at (493,229) size 0x17
+      RenderText {#text} at (0,0) size 0x0
+      RenderBR {BR} at (489,229) size 0x17
       RenderBlock {DIV} at (21,267) size 202x202 [border: (1px solid #000000)]
       RenderText {#text} at (243,475) size 4x17
         text run at (243,475) width 4: " "


### PR DESCRIPTION
#### d525adf8cad1f69e88cfb3a44433ce8c21e8b022
<pre>
[WPE] Test gardening after 263291@main

Unreviewed test gardening.

Update baselines after after 263291@main, (in which we removed a legacy
quirk that kept trailing whitespace for inline layout formatting if the
whitespace was followed by a line break; now we are in parity with
blink and gecko).

* LayoutTests/platform/wpe/fast/css/resize-corner-tracking-expected.txt:
* LayoutTests/platform/wpe/fast/encoding/utf-16-big-endian-expected.txt:
* LayoutTests/platform/wpe/fast/encoding/utf-16-little-endian-expected.txt:
* LayoutTests/platform/wpe/fast/layers/layer-visibility-sublayer-expected.txt:
* LayoutTests/platform/wpe/tables/mozilla/bugs/bug28928-expected.txt:
* LayoutTests/platform/wpe/transforms/3d/point-mapping/3d-point-mapping-origins-expected.txt:

Canonical link: <a href="https://commits.webkit.org/263409@main">https://commits.webkit.org/263409@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1fa59984565b95b771e0f901417a0b63ad965e3a

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/4434 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/4554 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/4691 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/5913 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/4631 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/4680 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/4518 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/4859 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/4498 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/4631 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/3989 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/5915 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/2126 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/3968 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/8177 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/3968 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/4037 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/5573 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/4440 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/3617 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/3965 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/3967 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/1110 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/8015 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/4319 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->