### PR TITLE
Use a RunLoop Observer for RemoteLayerTreeDrawingArea.

### DIFF
--- a/Source/WebKit/WebProcess/WebPage/RemoteLayerTree/RemoteLayerTreeDrawingArea.h
+++ b/Source/WebKit/WebProcess/WebPage/RemoteLayerTree/RemoteLayerTreeDrawingArea.h
@@ -40,6 +40,7 @@
 
 namespace WebCore {
 class PlatformCALayer;
+class RunLoopObserver;
 class ThreadSafeImageBufferFlusher;
 class TiledBacking;
 }
@@ -118,7 +119,8 @@ private:
     void updateRootLayers();
 
     void addCommitHandlers();
-    void startRenderingUpdateTimer();
+    void startRenderingUpdateObserver();
+    void invalidateRenderingUpdateObserver();
     void didCompleteRenderingUpdateDisplay() override;
 
     TransactionID takeNextTransactionID() { return m_currentTransactionID.increment(); }
@@ -159,7 +161,7 @@ private:
 
     std::optional<WebCore::FloatRect> m_viewExposedRect;
 
-    WebCore::Timer m_updateRenderingTimer;
+    std::unique_ptr<WebCore::RunLoopObserver> m_renderingUpdateRunLoopObserver;
     bool m_isRenderingSuspended { false };
     bool m_hasDeferredRenderingUpdate { false };
     bool m_inUpdateRendering { false };


### PR DESCRIPTION
#### 91a6675aebd48f91d8c515fdfa723d9357aa157f
<pre>
Use a RunLoop Observer for RemoteLayerTreeDrawingArea.
<a href="https://bugs.webkit.org/show_bug.cgi?id=255769">https://bugs.webkit.org/show_bug.cgi?id=255769</a>
&lt;rdar://108390477&gt;

Reviewed by NOBODY (OOPS!).

RunLoop Observers support `breakToAllowRenderingUpdate()`, which lets us schedule a rendering update to happen without waiting for other tasks.

* Source/WebKit/WebProcess/WebPage/RemoteLayerTree/RemoteLayerTreeDrawingArea.h:
* Source/WebKit/WebProcess/WebPage/RemoteLayerTree/RemoteLayerTreeDrawingArea.mm:
(WebKit::RemoteLayerTreeDrawingArea::RemoteLayerTreeDrawingArea):
(WebKit::RemoteLayerTreeDrawingArea::~RemoteLayerTreeDrawingArea):
(WebKit::RemoteLayerTreeDrawingArea::setLayerTreeStateIsFrozen):
(WebKit::RemoteLayerTreeDrawingArea::startRenderingUpdateObserver):
(WebKit::RemoteLayerTreeDrawingArea::invalidateRenderingUpdateObserver):
(WebKit::RemoteLayerTreeDrawingArea::triggerRenderingUpdate):
(WebKit::RemoteLayerTreeDrawingArea::updateRendering):
(WebKit::RemoteLayerTreeDrawingArea::activityStateDidChange):
(WebKit::m_updateRenderingTimer): Deleted.
(WebKit::RemoteLayerTreeDrawingArea::startRenderingUpdateTimer): Deleted.
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/91a6675aebd48f91d8c515fdfa723d9357aa157f

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/4442 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/4561 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/4700 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/5922 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/4636 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/4687 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/4524 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/4867 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/4506 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/4645 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/3998 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/5924 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/2140 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/3977 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/8268 "Passed tests") | 
| | [❌ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/3982 "3 api tests failed or timed out") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/4046 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/5585 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/4445 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/3620 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/3971 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/3976 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/8020 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/4325 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->