### PR TITLE
REGRESSION(263338@main) [Win] JSTests/stress/settimeout-starvation.js is timing out

### DIFF
--- a/Source/WTF/wtf/win/RunLoopWin.cpp
+++ b/Source/WTF/wtf/win/RunLoopWin.cpp
@@ -81,7 +81,11 @@ void RunLoop::setWakeUpCallback(WTF::Function<void()>&& function)
 
 void RunLoop::stop()
 {
-    ::PostMessage(m_runLoopMessageWindow, WM_CLOSE, 0, 0);
+    // RunLoop::stop() can be called from threads unrelated to this RunLoop.
+    // We should post a message that call PostQuitMessage in RunLoop's thread.
+    dispatch([] {
+        ::PostQuitMessage(0);
+    });
 }
 
 void RunLoop::registerRunLoopMessageWindowClass()
@@ -103,6 +107,7 @@ RunLoop::RunLoop()
 
 RunLoop::~RunLoop()
 {
+    ::DestroyWindow(m_runLoopMessageWindow);
 }
 
 void RunLoop::wakeUp()


### PR DESCRIPTION
#### 5ce84537546780563ba28ecf43a06396eb106f9b
<pre>
REGRESSION(263338@main) [Win] JSTests/stress/settimeout-starvation.js is timing out
<a href="https://bugs.webkit.org/show_bug.cgi?id=255908">https://bugs.webkit.org/show_bug.cgi?id=255908</a>

Reviewed by Ross Kirsling.

stress/settimeout-starvation.js was timing out after 263338@main. It
changed RunLoop::stop to post WM_CLOSE to close a window.
settimeout-starvation.js does setTimeout in the timeout callback
infinitely. The WM_CLOSE message in the message queue never be
dispatched.

Reverted 263338@main. Use DestroyWindow in ~RunLoop to close the
window.

* Source/WTF/wtf/win/RunLoopWin.cpp:
(WTF::RunLoop::stop):
(WTF::RunLoop::~RunLoop):

Canonical link: <a href="https://commits.webkit.org/263401@main">https://commits.webkit.org/263401@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e13e38a47e7cbe0e2a24206c500a341e2ff1da1b

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/4440 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/4559 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/4698 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/5920 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/4635 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/4685 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/4523 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/4865 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/4504 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/4639 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/3995 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/5922 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/2134 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/3974 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/8285 "1 flakes 178 failures") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/3689 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/3976 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/4043 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/5579 "Passed tests") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/4218 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/4444 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/3619 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/4538 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/3970 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/3973 "Passed tests") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/1131 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/8019 "Built successfully") | | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/24/builds/4643 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/517 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/4324 "Built successfully") | | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/3/builds/1238 "Passed tests") | 
<!--EWS-Status-Bubble-End-->