### PR TITLE
Remove LegacyDownloadClient code for SystemPreview

### DIFF
--- a/Source/WebCore/html/HTMLAnchorElement.cpp
+++ b/Source/WebCore/html/HTMLAnchorElement.cpp
@@ -626,7 +626,7 @@ void HTMLAnchorElement::handleClick(Event& event)
     // Thus, URLs should be empty for now.
     ASSERT(!privateClickMeasurement || (privateClickMeasurement->attributionReportClickSourceURL().isNull() && privateClickMeasurement->attributionReportClickDestinationURL().isNull()));
     
-    frame->loader().changeLocation(completedURL, effectiveTarget, &event, referrerPolicy, document().shouldOpenExternalURLsPolicyToPropagate(), newFrameOpenerPolicy, downloadAttribute, systemPreviewInfo, WTFMove(privateClickMeasurement));
+    frame->loader().changeLocation(completedURL, effectiveTarget, &event, referrerPolicy, document().shouldOpenExternalURLsPolicyToPropagate(), newFrameOpenerPolicy, downloadAttribute, WTFMove(privateClickMeasurement));
 
     sendPings(completedURL);
 

--- a/Source/WebCore/loader/FrameLoadRequest.cpp
+++ b/Source/WebCore/loader/FrameLoadRequest.cpp
@@ -37,14 +37,13 @@
 
 namespace WebCore {
 
-FrameLoadRequest::FrameLoadRequest(Document& requester, SecurityOrigin& requesterSecurityOrigin, ResourceRequest&& resourceRequest, const AtomString& frameName, InitiatedByMainFrame initiatedByMainFrame, const AtomString& downloadAttribute, const SystemPreviewInfo& systemPreviewInfo)
+FrameLoadRequest::FrameLoadRequest(Document& requester, SecurityOrigin& requesterSecurityOrigin, ResourceRequest&& resourceRequest, const AtomString& frameName, InitiatedByMainFrame initiatedByMainFrame, const AtomString& downloadAttribute)
     : m_requester { requester }
     , m_requesterSecurityOrigin { requesterSecurityOrigin }
     , m_resourceRequest { WTFMove(resourceRequest) }
     , m_frameName { frameName }
     , m_downloadAttribute { downloadAttribute }
     , m_initiatedByMainFrame { initiatedByMainFrame }
-    , m_systemPreviewInfo { systemPreviewInfo }
 {
 }
 

--- a/Source/WebCore/loader/FrameLoadRequest.h
+++ b/Source/WebCore/loader/FrameLoadRequest.h
@@ -40,7 +40,7 @@ class SecurityOrigin;
 
 class FrameLoadRequest {
 public:
-    WEBCORE_EXPORT FrameLoadRequest(Document&, SecurityOrigin&, ResourceRequest&&, const AtomString& frameName, InitiatedByMainFrame, const AtomString& downloadAttribute = { }, const SystemPreviewInfo& = { });
+    WEBCORE_EXPORT FrameLoadRequest(Document&, SecurityOrigin&, ResourceRequest&&, const AtomString& frameName, InitiatedByMainFrame, const AtomString& downloadAttribute = { });
     WEBCORE_EXPORT FrameLoadRequest(LocalFrame&, const ResourceRequest&, const SubstituteData& = SubstituteData());
 
     WEBCORE_EXPORT ~FrameLoadRequest();
@@ -102,9 +102,6 @@ public:
 
     InitiatedByMainFrame initiatedByMainFrame() const { return m_initiatedByMainFrame; }
 
-    bool isSystemPreview() const { return m_systemPreviewInfo.isPreview; }
-    const SystemPreviewInfo& systemPreviewInfo() const { return m_systemPreviewInfo; }
-
     void setIsRequestFromClientOrUserInput() { m_isRequestFromClientOrUserInput = true; }
     bool isRequestFromClientOrUserInput() const { return m_isRequestFromClientOrUserInput; }
 
@@ -127,7 +124,6 @@ private:
     ShouldOpenExternalURLsPolicy m_shouldOpenExternalURLsPolicy { ShouldOpenExternalURLsPolicy::ShouldNotAllow };
     AtomString m_downloadAttribute;
     InitiatedByMainFrame m_initiatedByMainFrame { InitiatedByMainFrame::Unknown };
-    SystemPreviewInfo m_systemPreviewInfo;
     bool m_isRequestFromClientOrUserInput { false };
     bool m_isInitialFrameSrcLoad { false };
 };

--- a/Source/WebCore/loader/FrameLoader.cpp
+++ b/Source/WebCore/loader/FrameLoader.cpp
@@ -466,13 +466,13 @@ bool FrameLoader::upgradeRequestforHTTPSOnlyIfNeeded(const URL& originalURL, Res
     return false;
 }
 
-void FrameLoader::changeLocation(const URL& url, const AtomString& passedTarget, Event* triggeringEvent, const ReferrerPolicy& referrerPolicy, ShouldOpenExternalURLsPolicy shouldOpenExternalURLsPolicy, std::optional<NewFrameOpenerPolicy> openerPolicy, const AtomString& downloadAttribute, const SystemPreviewInfo& systemPreviewInfo, std::optional<PrivateClickMeasurement>&& privateClickMeasurement)
+void FrameLoader::changeLocation(const URL& url, const AtomString& passedTarget, Event* triggeringEvent, const ReferrerPolicy& referrerPolicy, ShouldOpenExternalURLsPolicy shouldOpenExternalURLsPolicy, std::optional<NewFrameOpenerPolicy> openerPolicy, const AtomString& downloadAttribute, std::optional<PrivateClickMeasurement>&& privateClickMeasurement)
 {
     auto* frame = lexicalFrameFromCommonVM();
     auto initiatedByMainFrame = frame && frame->isMainFrame() ? InitiatedByMainFrame::Yes : InitiatedByMainFrame::Unknown;
 
     NewFrameOpenerPolicy newFrameOpenerPolicy = openerPolicy.value_or(referrerPolicy == ReferrerPolicy::NoReferrer ? NewFrameOpenerPolicy::Suppress : NewFrameOpenerPolicy::Allow);
-    FrameLoadRequest frameLoadRequest(*m_frame.document(), m_frame.document()->securityOrigin(), { url }, passedTarget, initiatedByMainFrame, downloadAttribute, systemPreviewInfo);
+    FrameLoadRequest frameLoadRequest(*m_frame.document(), m_frame.document()->securityOrigin(), { url }, passedTarget, initiatedByMainFrame, downloadAttribute);
     frameLoadRequest.setNewFrameOpenerPolicy(newFrameOpenerPolicy);
     frameLoadRequest.setReferrerPolicy(referrerPolicy);
     frameLoadRequest.setShouldOpenExternalURLsPolicy(shouldOpenExternalURLsPolicy);
@@ -1486,11 +1486,6 @@ void FrameLoader::loadURL(FrameLoadRequest&& frameLoadRequest, const String& ref
 
     // Must grab this now, since this load may stop the previous load and clear this flag.
     bool isRedirect = m_quickRedirectComing;
-#if USE(SYSTEM_PREVIEW)
-    bool isSystemPreview = frameLoadRequest.isSystemPreview();
-    if (isSystemPreview)
-        request.setSystemPreviewInfo(frameLoadRequest.systemPreviewInfo());
-#endif
     loadWithNavigationAction(request, WTFMove(action), newLoadType, WTFMove(formState), allowNavigationToInvalidURL, frameLoadRequest.shouldTreatAsContinuingLoad(), [this, isRedirect, sameURL, newLoadType, protectedFrame = Ref { m_frame }, completionHandler = completionHandlerCaller.release()] () mutable {
         if (isRedirect) {
             m_quickRedirectComing = false;

--- a/Source/WebCore/loader/FrameLoader.h
+++ b/Source/WebCore/loader/FrameLoader.h
@@ -132,7 +132,7 @@ public:
     ResourceLoaderIdentifier loadResourceSynchronously(const ResourceRequest&, ClientCredentialPolicy, const FetchOptions&, const HTTPHeaderMap&, ResourceError&, ResourceResponse&, RefPtr<SharedBuffer>& data);
 
     bool upgradeRequestforHTTPSOnlyIfNeeded(const URL&, ResourceRequest&) const;
-    WEBCORE_EXPORT void changeLocation(const URL&, const AtomString& target, Event*, const ReferrerPolicy&, ShouldOpenExternalURLsPolicy, std::optional<NewFrameOpenerPolicy> = std::nullopt, const AtomString& downloadAttribute = nullAtom(), const SystemPreviewInfo& = { }, std::optional<PrivateClickMeasurement>&& = std::nullopt);
+    WEBCORE_EXPORT void changeLocation(const URL&, const AtomString& target, Event*, const ReferrerPolicy&, ShouldOpenExternalURLsPolicy, std::optional<NewFrameOpenerPolicy> = std::nullopt, const AtomString& downloadAttribute = nullAtom(), std::optional<PrivateClickMeasurement>&& = std::nullopt);
     void changeLocation(FrameLoadRequest&&, Event* = nullptr, std::optional<PrivateClickMeasurement>&& = std::nullopt);
     void submitForm(Ref<FormSubmission>&&);
 

--- a/Source/WebCore/loader/FrameLoaderTypes.h
+++ b/Source/WebCore/loader/FrameLoaderTypes.h
@@ -143,6 +143,7 @@ enum class LockBackForwardList : bool { No, Yes };
 enum class AllowNavigationToInvalidURL : bool { No, Yes };
 enum class HasInsecureContent : bool { No, Yes };
 
+// FIXME: This should move to somewhere else. It no longer is related to frame loading.
 struct SystemPreviewInfo {
     ElementContext element;
 

--- a/Source/WebCore/platform/network/ResourceRequestBase.cpp
+++ b/Source/WebCore/platform/network/ResourceRequestBase.cpp
@@ -658,25 +658,6 @@ void ResourceRequestBase::setUseNetworkConnectionIntegrity(bool useNetworkConnec
     m_platformRequestUpdated = false;
 }
 
-#if USE(SYSTEM_PREVIEW)
-
-bool ResourceRequestBase::isSystemPreview() const
-{
-    return m_systemPreviewInfo.has_value();
-}
-
-std::optional<SystemPreviewInfo> ResourceRequestBase::systemPreviewInfo() const
-{
-    return m_systemPreviewInfo;
-}
-
-void ResourceRequestBase::setSystemPreviewInfo(const SystemPreviewInfo& info)
-{
-    m_systemPreviewInfo = info;
-}
-
-#endif
-
 bool equalIgnoringHeaderFields(const ResourceRequestBase& a, const ResourceRequestBase& b)
 {
     if (a.url() != b.url())

--- a/Source/WebCore/platform/network/ResourceRequestBase.h
+++ b/Source/WebCore/platform/network/ResourceRequestBase.h
@@ -246,13 +246,6 @@ public:
 
     void upgradeToHTTPS();
 
-#if USE(SYSTEM_PREVIEW)
-    WEBCORE_EXPORT bool isSystemPreview() const;
-
-    WEBCORE_EXPORT std::optional<SystemPreviewInfo> systemPreviewInfo() const;
-    WEBCORE_EXPORT void setSystemPreviewInfo(const SystemPreviewInfo&);
-#endif
-
 #if !PLATFORM(COCOA) && !USE(SOUP)
     bool encodingRequiresPlatformData() const { return true; }
 #endif
@@ -310,9 +303,6 @@ protected:
     mutable bool m_resourceRequestBodyUpdated : 1;
     mutable bool m_platformRequestBodyUpdated : 1;
     bool m_hiddenFromInspector : 1;
-#if USE(SYSTEM_PREVIEW)
-    std::optional<SystemPreviewInfo> m_systemPreviewInfo;
-#endif
 
 private:
     const ResourceRequest& asResourceRequest() const;

--- a/Source/WebCore/platform/network/cf/ResourceRequest.h
+++ b/Source/WebCore/platform/network/cf/ResourceRequest.h
@@ -75,30 +75,16 @@ public:
     ResourceRequest(ResourceRequestBase&& base
         , const String& cachePartition
         , bool hiddenFromInspector
-#if USE(SYSTEM_PREVIEW)
-        , const std::optional<SystemPreviewInfo>& systemPreviewInfo
-#endif
     )
         : ResourceRequestBase(WTFMove(base))
     {
         m_cachePartition = cachePartition;
         m_hiddenFromInspector = hiddenFromInspector;
-#if USE(SYSTEM_PREVIEW)
-        m_systemPreviewInfo = systemPreviewInfo;
-#endif
     }
 
-    ResourceRequest(ResourceRequestPlatformData&&, const String& cachePartition, bool hiddenFromInspector
-#if USE(SYSTEM_PREVIEW)
-    , const std::optional<SystemPreviewInfo>&
-#endif
-    );
+    ResourceRequest(ResourceRequestPlatformData&&, const String& cachePartition, bool hiddenFromInspector);
 
-    WEBCORE_EXPORT static ResourceRequest fromResourceRequestData(ResourceRequestData, const String& cachePartition, bool hiddenFromInspector
-#if USE(SYSTEM_PREVIEW)
-    , const std::optional<SystemPreviewInfo>&
-#endif
-    );
+    WEBCORE_EXPORT static ResourceRequest fromResourceRequestData(ResourceRequestData, const String& cachePartition, bool hiddenFromInspector);
 
     WEBCORE_EXPORT void updateFromDelegatePreservingOldProperties(const ResourceRequest&);
     

--- a/Source/WebCore/platform/network/cocoa/ResourceRequestCocoa.mm
+++ b/Source/WebCore/platform/network/cocoa/ResourceRequestCocoa.mm
@@ -60,11 +60,7 @@ ResourceRequest::ResourceRequest(NSURLRequest *nsRequest)
 #endif
 }
 
-ResourceRequest::ResourceRequest(ResourceRequestPlatformData&& platformData, const String& cachePartition, bool hiddenFromInspector
-#if USE(SYSTEM_PREVIEW)
-    , const std::optional<SystemPreviewInfo>& systemPreviewInfo
-#endif
-    )
+ResourceRequest::ResourceRequest(ResourceRequestPlatformData&& platformData, const String& cachePartition, bool hiddenFromInspector)
 {
     if (platformData.m_urlRequest) {
         setRequester(*platformData.m_requester);
@@ -76,9 +72,6 @@ ResourceRequest::ResourceRequest(ResourceRequestPlatformData&& platformData, con
 
     setCachePartition(cachePartition);
     setHiddenFromInspector(hiddenFromInspector);
-#if USE(SYSTEM_PREVIEW)
-    m_systemPreviewInfo = systemPreviewInfo;
-#endif
 }
 
 ResourceRequestData ResourceRequest::getRequestDataToSerialize() const
@@ -88,25 +81,11 @@ ResourceRequestData ResourceRequest::getRequestDataToSerialize() const
     return m_requestData;
 }
 
-ResourceRequest ResourceRequest::fromResourceRequestData(ResourceRequestData requestData, const String& cachePartition, bool hiddenFromInspector
-#if USE(SYSTEM_PREVIEW)
-    , const std::optional<SystemPreviewInfo>& systemPreviewInfo
-#endif
-    )
+ResourceRequest ResourceRequest::fromResourceRequestData(ResourceRequestData requestData, const String& cachePartition, bool hiddenFromInspector)
 {
-    if (std::holds_alternative<RequestData>(requestData)) {
-        
-#if USE(SYSTEM_PREVIEW)
-        return ResourceRequest(WTFMove(std::get<RequestData>(requestData)), cachePartition, hiddenFromInspector, systemPreviewInfo);
-#else
+    if (std::holds_alternative<RequestData>(requestData))
         return ResourceRequest(WTFMove(std::get<RequestData>(requestData)), cachePartition, hiddenFromInspector);
-#endif
-    }
-#if USE(SYSTEM_PREVIEW)
-    return ResourceRequest(WTFMove(std::get<ResourceRequestPlatformData>(requestData)), cachePartition, hiddenFromInspector, systemPreviewInfo);
-#else
     return ResourceRequest(WTFMove(std::get<ResourceRequestPlatformData>(requestData)), cachePartition, hiddenFromInspector);
-#endif
 }
 
 NSURLRequest *ResourceRequest::nsURLRequest(HTTPBodyUpdatePolicy bodyPolicy) const

--- a/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
+++ b/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
@@ -1403,16 +1403,7 @@ header: <WebCore/ResourceRequest.h>
 };
 #endif
 
-#if PLATFORM(COCOA) && USE(SYSTEM_PREVIEW)
-[CreateUsing=fromResourceRequestData] class WebCore::ResourceRequest {
-    std::variant<WebCore::ResourceRequest::RequestData, WebCore::ResourceRequestPlatformData> getRequestDataToSerialize();
-    String cachePartition();
-    bool hiddenFromInspector();
-    std::optional<WebCore::SystemPreviewInfo> systemPreviewInfo();
-};
-#endif
-
-#if PLATFORM(COCOA) && !USE(SYSTEM_PREVIEW)
+#if PLATFORM(COCOA)
 [CreateUsing=fromResourceRequestData] class WebCore::ResourceRequest {
     std::variant<WebCore::ResourceRequest::RequestData, WebCore::ResourceRequestPlatformData> getRequestDataToSerialize();
     String cachePartition();

--- a/Source/WebKit/UIProcess/API/APINavigation.h
+++ b/Source/WebKit/UIProcess/API/APINavigation.h
@@ -124,15 +124,6 @@ public:
 
     bool shouldPerformDownload() const { return !m_lastNavigationAction.downloadAttribute.isNull(); }
 
-    bool isSystemPreview() const
-    {
-#if USE(SYSTEM_PREVIEW)
-        return currentRequest().isSystemPreview();
-#else
-        return false;
-#endif
-    }
-
     bool treatAsSameOriginNavigation() const { return m_lastNavigationAction.treatAsSameOriginNavigation; }
     bool hasOpenedFrames() const { return m_lastNavigationAction.hasOpenedFrames; }
     bool openedByDOMWithOpener() const { return m_lastNavigationAction.openedByDOMWithOpener; }

--- a/Source/WebKit/UIProcess/Cocoa/LegacyDownloadClient.h
+++ b/Source/WebKit/UIProcess/Cocoa/LegacyDownloadClient.h
@@ -26,7 +26,6 @@
 #pragma once
 
 #import "APIDownloadClient.h"
-#import "ProcessThrottler.h"
 #import "WKFoundation.h"
 #import <wtf/WeakObjCPtr.h>
 
@@ -58,16 +57,7 @@ private:
     void didCreateDestination(DownloadProxy&, const String&) final;
     void processDidCrash(DownloadProxy&) final;
 
-#if USE(SYSTEM_PREVIEW)
-    void takeActivityToken(DownloadProxy&);
-    void releaseActivityTokenIfNecessary(DownloadProxy&);
-#endif
-
     WeakObjCPtr<id <_WKDownloadDelegate>> m_delegate;
-
-#if PLATFORM(IOS_FAMILY) && USE(SYSTEM_PREVIEW)
-    std::unique_ptr<ProcessThrottler::BackgroundActivity> m_activity;
-#endif
 
     struct {
         bool downloadDidStart : 1;            

--- a/Source/WebKit/UIProcess/Cocoa/LegacyDownloadClient.mm
+++ b/Source/WebKit/UIProcess/Cocoa/LegacyDownloadClient.mm
@@ -32,7 +32,6 @@
 #import "CompletionHandlerCallChecker.h"
 #import "DownloadProxy.h"
 #import "Logging.h"
-#import "SystemPreviewController.h"
 #import "WKDownloadInternal.h"
 #import "WKNSURLAuthenticationChallenge.h"
 #import "WKNSURLExtras.h"
@@ -69,57 +68,20 @@ LegacyDownloadClient::LegacyDownloadClient(id <_WKDownloadDelegate> delegate)
     m_delegateMethods.downloadProcessDidCrash = [delegate respondsToSelector:@selector(_downloadProcessDidCrash:)];
 }
 
-#if USE(SYSTEM_PREVIEW)
-static SystemPreviewController* systemPreviewController(DownloadProxy& downloadProxy)
-{
-    auto* page = downloadProxy.originatingPage();
-    if (!page)
-        return nullptr;
-    return page->systemPreviewController();
-}
-#endif
-
 void LegacyDownloadClient::legacyDidStart(DownloadProxy& downloadProxy)
 {
-#if USE(SYSTEM_PREVIEW)
-    if (downloadProxy.isSystemPreviewDownload()) {
-        if (auto* webPage = downloadProxy.originatingPage()) {
-            // FIXME: Update the MIME-type once it is known in the ResourceResponse.
-            webPage->systemPreviewController()->start(URL { webPage->currentURL() }, "application/octet-stream"_s, downloadProxy.systemPreviewDownloadInfo());
-        }
-        takeActivityToken(downloadProxy);
-        return;
-    }
-#endif
-
     if (m_delegateMethods.downloadDidStart)
         [m_delegate _downloadDidStart:[_WKDownload downloadWithDownload:wrapper(downloadProxy)]];
 }
 
 void LegacyDownloadClient::didReceiveResponse(DownloadProxy& downloadProxy, const WebCore::ResourceResponse& response)
 {
-#if USE(SYSTEM_PREVIEW)
-    if (downloadProxy.isSystemPreviewDownload() && response.isSuccessful()) {
-        if (auto* controller = systemPreviewController(downloadProxy))
-            controller->updateProgress(0);
-        return;
-    }
-#endif
-
     if (m_delegateMethods.downloadDidReceiveResponse)
         [m_delegate _download:[_WKDownload downloadWithDownload:wrapper(downloadProxy)] didReceiveResponse:response.nsURLResponse()];
 }
 
 void LegacyDownloadClient::didReceiveData(DownloadProxy& downloadProxy, uint64_t bytesWritten, uint64_t totalBytesWritten, uint64_t totalBytesExpectedToWrite)
 {
-#if USE(SYSTEM_PREVIEW)
-    if (downloadProxy.isSystemPreviewDownload()) {
-        if (auto* controller = systemPreviewController(downloadProxy))
-            controller->updateProgress(static_cast<float>(totalBytesWritten) / totalBytesExpectedToWrite);
-        return;
-    }
-#endif
-
     if (m_delegateMethods.downloadDidWriteDataTotalBytesWrittenTotalBytesExpectedToWrite)
         [m_delegate _download:[_WKDownload downloadWithDownload:wrapper(downloadProxy)] didWriteData:bytesWritten totalBytesWritten:totalBytesWritten totalBytesExpectedToWrite:totalBytesExpectedToWrite];
     else if (m_delegateMethods.downloadDidReceiveData)
@@ -162,35 +124,12 @@ void LegacyDownloadClient::didReceiveAuthenticationChallenge(DownloadProxy& down
 
 void LegacyDownloadClient::didCreateDestination(DownloadProxy& downloadProxy, const String& destination)
 {
-#if USE(SYSTEM_PREVIEW)
-    if (downloadProxy.isSystemPreviewDownload()) {
-        downloadProxy.setDestinationFilename(destination);
-        if (auto* controller = systemPreviewController(downloadProxy)) {
-            auto destinationURL = URL::fileURLWithFileSystemPath(downloadProxy.destinationFilename());
-            auto& downloadURL = downloadProxy.request().url();
-            if (!destinationURL.hasFragmentIdentifier() && downloadURL.hasFragmentIdentifier())
-                destinationURL.setFragmentIdentifier(downloadURL.fragmentIdentifier());
-            controller->setDestinationURL(destinationURL);
-        }
-        return;
-    }
-#endif
-
     if (m_delegateMethods.downloadDidCreateDestination)
         [m_delegate _download:[_WKDownload downloadWithDownload:wrapper(downloadProxy)] didCreateDestination:destination];
 }
 
 void LegacyDownloadClient::processDidCrash(DownloadProxy& downloadProxy)
 {
-#if USE(SYSTEM_PREVIEW)
-    if (downloadProxy.isSystemPreviewDownload()) {
-        if (auto* controller = systemPreviewController(downloadProxy))
-            controller->cancel();
-        releaseActivityTokenIfNecessary(downloadProxy);
-        return;
-    }
-#endif
-
     if (m_delegateMethods.downloadProcessDidCrash)
         [m_delegate _downloadProcessDidCrash:[_WKDownload downloadWithDownload:wrapper(downloadProxy)]];
 }
@@ -198,15 +137,6 @@ void LegacyDownloadClient::processDidCrash(DownloadProxy& downloadProxy)
 void LegacyDownloadClient::decideDestinationWithSuggestedFilename(DownloadProxy& downloadProxy, const WebCore::ResourceResponse& response, const String& filename, CompletionHandler<void(AllowOverwrite, String)>&& completionHandler)
 {
     didReceiveResponse(downloadProxy, response);
-
-#if USE(SYSTEM_PREVIEW)
-    if (downloadProxy.isSystemPreviewDownload()) {
-        NSString *temporaryDirectory = FileSystem::createTemporaryDirectory(@"SystemPreviews");
-        NSString *destination = [temporaryDirectory stringByAppendingPathComponent:filename];
-        completionHandler(AllowOverwrite::Yes, destination);
-        return;
-    }
-#endif
 
     if (!m_delegateMethods.downloadDecideDestinationWithSuggestedFilenameAllowOverwrite && !m_delegateMethods.downloadDecideDestinationWithSuggestedFilenameCompletionHandler)
         return completionHandler(AllowOverwrite::No, { });
@@ -229,50 +159,18 @@ ALLOW_DEPRECATED_DECLARATIONS_END
 
 void LegacyDownloadClient::didFinish(DownloadProxy& downloadProxy)
 {
-#if USE(SYSTEM_PREVIEW)
-    if (downloadProxy.isSystemPreviewDownload()) {
-        if (auto* controller = systemPreviewController(downloadProxy)) {
-            auto destinationURL = URL::fileURLWithFileSystemPath(downloadProxy.destinationFilename());
-            auto& downloadURL = downloadProxy.request().url();
-            if (!destinationURL.hasFragmentIdentifier() && downloadURL.hasFragmentIdentifier())
-                destinationURL.setFragmentIdentifier(downloadURL.fragmentIdentifier());
-            controller->finish(destinationURL);
-        }
-        releaseActivityTokenIfNecessary(downloadProxy);
-        return;
-    }
-#endif
-
     if (m_delegateMethods.downloadDidFinish)
         [m_delegate _downloadDidFinish:[_WKDownload downloadWithDownload:wrapper(downloadProxy)]];
 }
 
 void LegacyDownloadClient::didFail(DownloadProxy& downloadProxy, const WebCore::ResourceError& error, API::Data*)
 {
-#if USE(SYSTEM_PREVIEW)
-    if (downloadProxy.isSystemPreviewDownload()) {
-        if (auto* controller = systemPreviewController(downloadProxy))
-            controller->fail(error);
-        releaseActivityTokenIfNecessary(downloadProxy);
-        return;
-    }
-#endif
-
     if (m_delegateMethods.downloadDidFail)
         [m_delegate _download:[_WKDownload downloadWithDownload:wrapper(downloadProxy)] didFailWithError:error.nsError()];
 }
 
 void LegacyDownloadClient::legacyDidCancel(DownloadProxy& downloadProxy)
 {
-#if USE(SYSTEM_PREVIEW)
-    if (downloadProxy.isSystemPreviewDownload()) {
-        if (auto* controller = systemPreviewController(downloadProxy))
-            controller->cancel();
-        releaseActivityTokenIfNecessary(downloadProxy);
-        return;
-    }
-#endif
-
     if (m_delegateMethods.downloadDidCancel)
         [m_delegate _downloadDidCancel:[_WKDownload downloadWithDownload:wrapper(downloadProxy)]];
 }
@@ -284,33 +182,6 @@ void LegacyDownloadClient::willSendRequest(DownloadProxy& downloadProxy, WebCore
 
     completionHandler(WTFMove(request));
 }
-
-#if USE(SYSTEM_PREVIEW)
-void LegacyDownloadClient::takeActivityToken(DownloadProxy& downloadProxy)
-{
-#if USE(RUNNINGBOARD)
-    if (auto* webPage = downloadProxy.originatingPage()) {
-        RELEASE_LOG(ProcessSuspension, "%p - UIProcess is taking a background assertion because it is downloading a system preview", this);
-        ASSERT(!m_activity);
-        m_activity = webPage->process().throttler().backgroundActivity("System preview download"_s).moveToUniquePtr();
-    }
-#else
-    UNUSED_PARAM(downloadProxy);
-#endif
-}
-
-void LegacyDownloadClient::releaseActivityTokenIfNecessary(DownloadProxy& downloadProxy)
-{
-#if PLATFORM(IOS_FAMILY)
-    if (m_activity) {
-        RELEASE_LOG(ProcessSuspension, "%p UIProcess is releasing a background assertion because a system preview download completed", this);
-        m_activity = nullptr;
-    }
-#else
-    UNUSED_PARAM(downloadProxy);
-#endif
-}
-#endif
 
 ALLOW_DEPRECATED_DECLARATIONS_END
 

--- a/Source/WebKit/UIProcess/Downloads/DownloadProxy.h
+++ b/Source/WebKit/UIProcess/Downloads/DownloadProxy.h
@@ -94,11 +94,6 @@ public:
     const String& destinationFilename() const { return m_destinationFilename; }
     void setDestinationFilename(const String& d) { m_destinationFilename = d; }
 
-#if USE(SYSTEM_PREVIEW)
-    bool isSystemPreviewDownload() const { return request().isSystemPreview(); }
-    WebCore::SystemPreviewInfo systemPreviewDownloadInfo() const { RELEASE_ASSERT(request().systemPreviewInfo().has_value()); return *request().systemPreviewInfo(); }
-#endif
-
 #if PLATFORM(COCOA)
     void publishProgress(const URL&);
     void setProgress(NSProgress *progress) { m_progress = progress; }

--- a/Source/WebKit/UIProcess/WebPageProxy.cpp
+++ b/Source/WebKit/UIProcess/WebPageProxy.cpp
@@ -3872,7 +3872,7 @@ void WebPageProxy::receivedNavigationPolicyDecision(PolicyAction policyAction, A
 #else
     static const bool forceDownloadFromDownloadAttribute = true;
 #endif
-    if (policyAction == PolicyAction::Use && navigation && (navigation->isSystemPreview() || (forceDownloadFromDownloadAttribute && navigation->shouldPerformDownload())))
+    if (policyAction == PolicyAction::Use && navigation && (forceDownloadFromDownloadAttribute && navigation->shouldPerformDownload()))
         policyAction = PolicyAction::Download;
 
     if (policyAction != PolicyAction::Use


### PR DESCRIPTION
#### 05aaf4a5692421321939630ecd0612308082ed21
<pre>
Remove LegacyDownloadClient code for SystemPreview
<a href="https://bugs.webkit.org/show_bug.cgi?id=255957">https://bugs.webkit.org/show_bug.cgi?id=255957</a>
rdar://108526852

Reviewed by Tim Horton.

<a href="https://bugs.webkit.org/show_bug.cgi?id=255954">https://bugs.webkit.org/show_bug.cgi?id=255954</a> implements a new way to trigger
this code, so the old way can be deleted. This will make Alex happy.

* Source/WebCore/html/HTMLAnchorElement.cpp:
(WebCore::HTMLAnchorElement::handleClick):
* Source/WebCore/loader/FrameLoadRequest.cpp:
(WebCore::FrameLoadRequest::FrameLoadRequest):
* Source/WebCore/loader/FrameLoadRequest.h:
(WebCore::FrameLoadRequest::FrameLoadRequest):
(WebCore::FrameLoadRequest::isSystemPreview const): Deleted.
(WebCore::FrameLoadRequest::systemPreviewInfo const): Deleted.
* Source/WebCore/loader/FrameLoader.cpp:
(WebCore::FrameLoader::changeLocation):
(WebCore::FrameLoader::loadURL):
* Source/WebCore/loader/FrameLoader.h:
* Source/WebCore/loader/FrameLoaderTypes.h:
* Source/WebCore/platform/network/ResourceRequestBase.cpp:
(WebCore::ResourceRequestBase::isSystemPreview const): Deleted.
(WebCore::ResourceRequestBase::systemPreviewInfo const): Deleted.
(WebCore::ResourceRequestBase::setSystemPreviewInfo): Deleted.
* Source/WebCore/platform/network/ResourceRequestBase.h:
* Source/WebCore/platform/network/cf/ResourceRequest.h:
(WebCore::ResourceRequest::ResourceRequest):
* Source/WebCore/platform/network/cocoa/ResourceRequestCocoa.mm:
(WebCore::ResourceRequest::ResourceRequest):
(WebCore::ResourceRequest::fromResourceRequestData):
* Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in:
* Source/WebKit/UIProcess/API/APINavigation.h:
(API::Navigation::isSystemPreview const): Deleted.
* Source/WebKit/UIProcess/Cocoa/LegacyDownloadClient.h:
* Source/WebKit/UIProcess/Cocoa/LegacyDownloadClient.mm:
(WebKit::LegacyDownloadClient::legacyDidStart):
(WebKit::LegacyDownloadClient::didReceiveResponse):
(WebKit::LegacyDownloadClient::didReceiveData):
(WebKit::LegacyDownloadClient::didCreateDestination):
(WebKit::LegacyDownloadClient::processDidCrash):
(WebKit::LegacyDownloadClient::decideDestinationWithSuggestedFilename):
(WebKit::LegacyDownloadClient::didFinish):
(WebKit::LegacyDownloadClient::didFail):
(WebKit::LegacyDownloadClient::legacyDidCancel):
(WebKit::systemPreviewController): Deleted.
(WebKit::LegacyDownloadClient::takeActivityToken): Deleted.
(WebKit::LegacyDownloadClient::releaseActivityTokenIfNecessary): Deleted.
* Source/WebKit/UIProcess/Downloads/DownloadProxy.h:
(WebKit::DownloadProxy::isSystemPreviewDownload const): Deleted.
(WebKit::DownloadProxy::systemPreviewDownloadInfo const): Deleted.
* Source/WebKit/UIProcess/WebPageProxy.cpp:
(WebKit::WebPageProxy::receivedNavigationPolicyDecision):

Canonical link: <a href="https://commits.webkit.org/263392@main">https://commits.webkit.org/263392@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1e6e96d1c2f44e7ca7e80d27d93caa99ccb8968e

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/4468 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/4586 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/4729 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/5951 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/32/builds/4650 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/4458 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/4716 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/4544 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/4890 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/4533 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/15/builds/4655 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/4010 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/5955 "Built successfully") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/39/builds/2150 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/3994 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/8466 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/3997 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/4063 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/5598 "Passed tests") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/7/builds/4460 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/3636 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/3988 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/3993 "Passed tests") | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/4/builds/8035 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/514 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/4348 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->