### PR TITLE
Async scrolling on Mac creates implicit CA transactions.

### DIFF
--- a/Source/WebKit/UIProcess/RemoteLayerTree/RemoteScrollingTree.cpp
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/RemoteScrollingTree.cpp
@@ -222,10 +222,12 @@ void RemoteScrollingTree::propagateSynchronousScrollingReasons(const HashSet<Scr
 
 void RemoteScrollingTree::tryToApplyLayerPositions()
 {
+    ASSERT(!isMainRunLoop());
     Locker locker { m_treeLock };
     if (m_hasNodesWithSynchronousScrollingReasons)
         return;
 
+    auto transaction = RemoteScrollingTreeTransactionHolder { *this };
     applyLayerPositionsInternal();
 }
 

--- a/Source/WebKit/UIProcess/RemoteLayerTree/RemoteScrollingTree.h
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/RemoteScrollingTree.h
@@ -74,6 +74,9 @@ public:
 
     void tryToApplyLayerPositions();
 
+    virtual void beginTransactionOnScrollingThread() { }
+    virtual void commitTransactionOnScrollingThread() { }
+
 protected:
     explicit RemoteScrollingTree(RemoteScrollingCoordinatorProxy&);
 
@@ -100,6 +103,23 @@ public:
     ~RemoteLayerTreeHitTestLocker()
     {
         m_scrollingTree->unlockLayersForHitTesting();
+    }
+
+private:
+    Ref<RemoteScrollingTree> m_scrollingTree;
+};
+
+class RemoteScrollingTreeTransactionHolder {
+public:
+    RemoteScrollingTreeTransactionHolder(RemoteScrollingTree& scrollingTree)
+        : m_scrollingTree(scrollingTree)
+    {
+        m_scrollingTree->beginTransactionOnScrollingThread();
+    }
+
+    ~RemoteScrollingTreeTransactionHolder()
+    {
+        m_scrollingTree->commitTransactionOnScrollingThread();
     }
 
 private:

--- a/Source/WebKit/UIProcess/RemoteLayerTree/mac/RemoteLayerTreeEventDispatcher.cpp
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/mac/RemoteLayerTreeEventDispatcher.cpp
@@ -200,6 +200,7 @@ void RemoteLayerTreeEventDispatcher::scrollingThreadHandleWheelEvent(const WebWh
         return;
 
     auto locker = RemoteLayerTreeHitTestLocker { *scrollingTree };
+    auto transaction = RemoteScrollingTreeTransactionHolder { *scrollingTree };
 
     auto platformWheelEvent = platform(webWheelEvent);
     auto processingSteps = determineWheelEventProcessing(platformWheelEvent, rubberBandableEdges);

--- a/Source/WebKit/UIProcess/RemoteLayerTree/mac/RemoteScrollingTreeMac.h
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/mac/RemoteScrollingTreeMac.h
@@ -80,6 +80,9 @@ private:
     void lockLayersForHitTesting() final WTF_ACQUIRES_LOCK(m_layerHitTestMutex);
     void unlockLayersForHitTesting() final WTF_RELEASES_LOCK(m_layerHitTestMutex);
 
+    void beginTransactionOnScrollingThread() final;
+    void commitTransactionOnScrollingThread() final;
+
     void startPendingScrollAnimations() WTF_REQUIRES_LOCK(m_treeLock);
 
     void scrollingTreeNodeWillStartScroll(WebCore::ScrollingNodeID) override;

--- a/Source/WebKit/UIProcess/RemoteLayerTree/mac/RemoteScrollingTreeMac.mm
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/mac/RemoteScrollingTreeMac.mm
@@ -347,6 +347,19 @@ void RemoteScrollingTreeMac::unlockLayersForHitTesting()
     m_layerHitTestMutex.unlock();
 }
 
+
+void RemoteScrollingTreeMac::beginTransactionOnScrollingThread()
+{
+    ASSERT(ScrollingThread::isCurrentThread());
+    [CATransaction begin];
+}
+
+void RemoteScrollingTreeMac::commitTransactionOnScrollingThread()
+{
+    ASSERT(ScrollingThread::isCurrentThread());
+    [CATransaction commit];
+}
+
 static ScrollingNodeID scrollingNodeIDForLayer(CALayer *layer)
 {
     auto* layerTreeNode = RemoteLayerTreeNode::forCALayer(layer);


### PR DESCRIPTION
#### 0c64efa347b930a2ae3dbeea7d0ad20373c1bf61
<pre>
Async scrolling on Mac creates implicit CA transactions.
<a href="https://bugs.webkit.org/show_bug.cgi?id=255960">https://bugs.webkit.org/show_bug.cgi?id=255960</a>
&lt;rdar://108174791&gt;

Reviewed by Simon Fraser.

RemoteScrollingTreeMac can mutate the layer tree on the scrolling thread, which creates implicit CA transactions. Some clients aren&apos;t expecting this, so we should instead create explicit transactions when needed.

* Source/WebKit/UIProcess/RemoteLayerTree/RemoteScrollingTree.cpp:
(WebKit::RemoteScrollingTree::tryToApplyLayerPositions):
* Source/WebKit/UIProcess/RemoteLayerTree/RemoteScrollingTree.h:
(WebKit::RemoteScrollingTree::beginTransactionOnScrollingThread):
(WebKit::RemoteScrollingTree::commitTransactionOnScrollingThread):
(WebKit::RemoteScrollingTreeTransactionHolder::RemoteScrollingTreeTransactionHolder):
(WebKit::RemoteScrollingTreeTransactionHolder::~RemoteScrollingTreeTransactionHolder):
* Source/WebKit/UIProcess/RemoteLayerTree/mac/RemoteLayerTreeEventDispatcher.cpp:
(WebKit::RemoteLayerTreeEventDispatcher::scrollingThreadHandleWheelEvent):
* Source/WebKit/UIProcess/RemoteLayerTree/mac/RemoteScrollingTreeMac.h:
* Source/WebKit/UIProcess/RemoteLayerTree/mac/RemoteScrollingTreeMac.mm:
(WebKit::RemoteScrollingTreeMac::beginTransactionOnScrollingThread):
(WebKit::RemoteScrollingTreeMac::commitTransactionOnScrollingThread):

Canonical link: <a href="https://commits.webkit.org/263400@main">https://commits.webkit.org/263400@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b750fe43776929eab8f55d5506200813b4b9c0e1

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/4475 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/4591 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/4736 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/5958 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/4654 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/4722 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/4549 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/4888 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/4540 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/4657 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/4013 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/5962 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/2153 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/3998 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/8545 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/4000 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/4068 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/5599 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/4464 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/3638 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/3992 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/3997 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/1104 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/8039 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/4353 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->