### PR TITLE
ASSERTION FAILED: !image->size().isEmpty(): [ iOS, macOS ] imported/w3c/web-platform-tests/css/css-backgrounds/background-size/background-size-near-zero-svg.html is a constant crash.

### DIFF
--- a/Source/WebCore/svg/graphics/SVGImageCache.cpp
+++ b/Source/WebCore/svg/graphics/SVGImageCache.cpp
@@ -1,6 +1,6 @@
 /*
  * Copyright (C) 2011 Research In Motion Limited. All rights reserved.
- * Copyright (C) 2013 Apple Inc. All rights reserved.
+ * Copyright (C) 2013-2023 Apple Inc. All rights reserved.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Library General Public
@@ -53,6 +53,10 @@ void SVGImageCache::setContainerContextForClient(const CachedImageClient& client
 {
     ASSERT(!containerSize.isEmpty());
     ASSERT(containerZoom);
+
+    // SVG container has width or height less than 1 pixel.
+    if (flooredIntSize(containerSize).isEmpty())
+        return;
 
     FloatSize containerSizeWithoutZoom(containerSize);
     containerSizeWithoutZoom.scale(1 / containerZoom);


### PR DESCRIPTION
#### d142dec43f3a5bf2ca6832f1eab1df116e38e080
<pre>
ASSERTION FAILED: !image-&gt;size().isEmpty(): [ iOS, macOS ] imported/w3c/web-platform-tests/css/css-backgrounds/background-size/background-size-near-zero-svg.html is a constant crash.
<a href="https://bugs.webkit.org/show_bug.cgi?id=255662">https://bugs.webkit.org/show_bug.cgi?id=255662</a>
&lt;rdar://problem/108267097&gt;

Reviewed by Said Abou-Hallawa.

SVGImageCache::setContainerContextForClient caches an unscaled SVGImage, plus a scale factor.

It computes the size based on a LayoutSize, which is converted to a FloatSize, unscaled by
the image scaling factor, then stored for later use.

When the cached value is retrieved, it is scaled by the zoom factor, then rounded to the nearest
integer value.

This scaling and rounding process can yield an empty image, which triggers an assertion when the
image is retrieved.

Rather that store this nonsensical image, we should recognize that the image is effectively null,
and not cache it.

* Source/WebCore/svg/graphics/SVGImageCache.cpp:
(WebCore::SVGImageCache::setContainerContextForClient):

Canonical link: <a href="https://commits.webkit.org/263430@main">https://commits.webkit.org/263430@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/6c4e8ec2cc16139cd2883d11224ce1c74c6c140f

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/4572 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/4693 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/4844 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/6064 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/4731 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/4562 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/4828 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/4649 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/4972 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/4640 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/4737 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/4096 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/6070 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/2229 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/4088 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/9084 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/4085 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/4160 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/5702 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/4549 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/3710 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/4081 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/1128 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/8122 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/4443 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->