### PR TITLE
[results.webkit.org] Fix commit view with multiple emails

### DIFF
--- a/Tools/Scripts/libraries/resultsdbpy/resultsdbpy/view/templates/commit.html
+++ b/Tools/Scripts/libraries/resultsdbpy/resultsdbpy/view/templates/commit.html
@@ -77,7 +77,7 @@ let commits = [
         timestamp: {{ commit.timestamp }},
         author: {
             name: unescapeJinjaText('{{ commit.author.name }}'),
-            emails: [{% for e in commit.author.emails %} unescapeJinjaText('{{ e }}') {% endfor %}],
+            emails: [{% for e in commit.author.emails %} unescapeJinjaText('{{ e }}'), {% endfor %}],
         }, order: {{ commit.order }},
         message: unescapeJinjaText('{{ commit.message | replace("\\", "\\\\") | replace("\n", "\\n") }}'),
     }),


### PR DESCRIPTION
#### a7fe669e401f00f010211619ea5d98016395ca00
<pre>
[results.webkit.org] Fix commit view with multiple emails
<a href="https://bugs.webkit.org/show_bug.cgi?id=255959">https://bugs.webkit.org/show_bug.cgi?id=255959</a>
rdar://108529029

Reviewed by Ryan Haddad.

* Tools/Scripts/libraries/resultsdbpy/resultsdbpy/view/templates/commit.html:
Seperate multiple emails with commas.

Canonical link: <a href="https://commits.webkit.org/263394@main">https://commits.webkit.org/263394@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/aecbc3699ed188bae8ccb7243f86854938aae34c

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/4478 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/4594 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/4739 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/5961 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/32/builds/4657 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/4466 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/4726 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/4552 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/4889 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/4543 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/15/builds/4660 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/4016 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/5965 "Built successfully") | 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/4543 "Passed tests") | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/39/builds/2155 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/4001 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/8549 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/4002 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/4071 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/5601 "Passed tests") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/7/builds/4467 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/3639 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🧪 services](https://ews-build.webkit.org/#/builders/28/builds/4443 "Passed tests") | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/30/builds/3995 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/4000 "Passed tests") | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/4/builds/8042 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/515 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/4356 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->