### PR TITLE
New Wake Lock API does not work in Home Screen Web Apps

### DIFF
--- a/Source/WebCore/PAL/pal/system/cocoa/SleepDisablerCocoa.h
+++ b/Source/WebCore/PAL/pal/system/cocoa/SleepDisablerCocoa.h
@@ -43,6 +43,10 @@ public:
     explicit SleepDisablerCocoa(const String&, Type);
     virtual ~SleepDisablerCocoa();
 
+#if PLATFORM(IOS_FAMILY)
+    PAL_EXPORT static void setScreenWakeLockHandler(Function<bool(bool shouldKeepScreenAwake)>&&);
+#endif
+
 private:
     void takeScreenSleepDisablingAssertion(const String& reason);
     void takeSystemSleepDisablingAssertion(const String& reason);

--- a/Source/WebKit/UIProcess/API/APIUIClient.h
+++ b/Source/WebKit/UIProcess/API/APIUIClient.h
@@ -185,6 +185,7 @@ public:
     virtual RetainPtr<NSArray> actionsForElement(_WKActivatedElementInfo *, RetainPtr<NSArray> defaultActions) { return defaultActions; }
     virtual void didNotHandleTapAsClick(const WebCore::IntPoint&) { }
     virtual void statusBarWasTapped() { }
+    virtual bool setShouldKeepScreenAwake(bool) { return false; }
 #endif
 #if PLATFORM(COCOA)
     virtual PlatformViewController *presentingViewController() { return nullptr; }

--- a/Source/WebKit/UIProcess/API/Cocoa/WKUIDelegatePrivate.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKUIDelegatePrivate.h
@@ -217,6 +217,7 @@ struct UIEdgeInsets;
 - (NSArray *)_webView:(WKWebView *)webView actionsForElement:(_WKActivatedElementInfo *)element defaultActions:(NSArray<_WKElementAction *> *)defaultActions;
 - (void)_webView:(WKWebView *)webView didNotHandleTapAsClickAtPoint:(CGPoint)point;
 - (void)_webViewStatusBarWasTapped:(WKWebView *)webView;
+- (void)_webView:(WKWebView *)webView setShouldKeepScreenAwake:(BOOL)shouldKeepScreenAwake;
 - (void)_webView:(WKWebView *)webView requestGeolocationAuthorizationForURL:(NSURL *)url frame:(WKFrameInfo *)frame decisionHandler:(void (^)(BOOL authorized))decisionHandler WK_API_AVAILABLE(ios(11.0));
 - (BOOL)_webView:(WKWebView *)webView fileUploadPanelContentIsManagedWithInitiatingFrame:(WKFrameInfo *)frame;
 

--- a/Source/WebKit/UIProcess/Cocoa/UIDelegate.h
+++ b/Source/WebKit/UIProcess/Cocoa/UIDelegate.h
@@ -159,6 +159,7 @@ private:
         RetainPtr<NSArray> actionsForElement(_WKActivatedElementInfo *, RetainPtr<NSArray> defaultActions) final;
         void didNotHandleTapAsClick(const WebCore::IntPoint&) final;
         void statusBarWasTapped() final;
+        bool setShouldKeepScreenAwake(bool) final;
 #endif // PLATFORM(IOS_FAMILY)
         PlatformViewController *presentingViewController() final;
 
@@ -264,6 +265,7 @@ private:
         bool webViewActionsForElementDefaultActions : 1;
         bool webViewDidNotHandleTapAsClickAtPoint : 1;
         bool webViewStatusBarWasTapped : 1;
+        bool webViewSetShouldKeepScreenAwake : 1;
 #endif
         bool presentingViewControllerForWebView : 1;
         bool dataDetectionContextForWebView : 1;

--- a/Source/WebKit/UIProcess/Cocoa/UIDelegate.mm
+++ b/Source/WebKit/UIProcess/Cocoa/UIDelegate.mm
@@ -172,6 +172,7 @@ void UIDelegate::setDelegate(id <WKUIDelegate> delegate)
     m_delegateMethods.webViewActionsForElementDefaultActions = [delegate respondsToSelector:@selector(_webView:actionsForElement:defaultActions:)];
     m_delegateMethods.webViewDidNotHandleTapAsClickAtPoint = [delegate respondsToSelector:@selector(_webView:didNotHandleTapAsClickAtPoint:)];
     m_delegateMethods.webViewStatusBarWasTapped = [delegate respondsToSelector:@selector(_webViewStatusBarWasTapped:)];
+    m_delegateMethods.webViewSetShouldKeepScreenAwake = [delegate respondsToSelector:@selector(_webView:setShouldKeepScreenAwake:)];
 #endif
 #if PLATFORM(IOS)
     m_delegateMethods.webViewLockScreenOrientation = [delegate respondsToSelector:@selector(_webViewLockScreenOrientation:lockType:)];
@@ -1594,6 +1595,22 @@ void UIDelegate::UIClient::statusBarWasTapped()
         return;
 
     [static_cast<id <WKUIDelegatePrivate>>(delegate) _webViewStatusBarWasTapped:m_uiDelegate->m_webView.get().get()];
+}
+
+bool UIDelegate::UIClient::setShouldKeepScreenAwake(bool shouldKeepScreenAwake)
+{
+    if (!m_uiDelegate)
+        return false;
+
+    if (!m_uiDelegate->m_delegateMethods.webViewSetShouldKeepScreenAwake)
+        return false;
+
+    auto delegate = m_uiDelegate->m_delegate.get();
+    if (!delegate)
+        return false;
+
+    [static_cast<id <WKUIDelegatePrivate>>(delegate) _webView:m_uiDelegate->m_webView.get().get() setShouldKeepScreenAwake:shouldKeepScreenAwake];
+    return true;
 }
 #endif // PLATFORM(IOS_FAMILY)
 

--- a/Source/WebKit/UIProcess/WebPageProxy.cpp
+++ b/Source/WebKit/UIProcess/WebPageProxy.cpp
@@ -1320,6 +1320,7 @@ void WebPageProxy::close()
     WEBPAGEPROXY_RELEASE_LOG(Loading, "close:");
 
     m_isClosed = true;
+    m_process->willRemoveWebPage(*this);
 
     reportPageLoadResult(ResourceError { ResourceError::Type::Cancellation });
 

--- a/Source/WebKit/UIProcess/WebProcessProxy.h
+++ b/Source/WebKit/UIProcess/WebProcessProxy.h
@@ -204,6 +204,7 @@ public:
 
     enum class EndsUsingDataStore : bool { No, Yes };
     void removeWebPage(WebPageProxy&, EndsUsingDataStore);
+    void willRemoveWebPage(WebPageProxy&);
 
     void addProvisionalPageProxy(ProvisionalPageProxy&);
     void removeProvisionalPageProxy(ProvisionalPageProxy&);
@@ -524,6 +525,8 @@ private:
     using WebProcessProxyMap = HashMap<WebCore::ProcessIdentifier, WeakPtr<WebProcessProxy>>;
     static WebProcessProxyMap& allProcessMap();
     static Vector<RefPtr<WebProcessProxy>> allProcesses();
+    static WebPageProxyMap& globalPageMap();
+    static Vector<RefPtr<WebPageProxy>> globalPages();
 
     void platformInitialize();
     void platformDestroy();
@@ -731,6 +734,7 @@ private:
     std::optional<RemoteWorkerInformation> m_sharedWorkerInformation;
     bool m_hasServiceWorkerBackgroundProcessing { false };
 
+    // FIXME: We should probably move this to WebPageProxy.
     HashMap<WebCore::SleepDisablerIdentifier, std::unique_ptr<WebCore::SleepDisabler>> m_sleepDisablers;
 
     struct AudibleMediaActivity {


### PR DESCRIPTION
#### bf7f0d4d340bc8285b6223cab137fccf445d3c1a
<pre>
New Wake Lock API does not work in Home Screen Web Apps
<a href="https://bugs.webkit.org/show_bug.cgi?id=254545">https://bugs.webkit.org/show_bug.cgi?id=254545</a>
rdar://107284303

Reviewed by Geoffrey Garen.

Home screen web apps are view controllers. Unfortunately, the [UIApplication idleTimerDisabled]
API (which we rely on for the screen wake lock API) doesn&apos;t work in view controllers. I was
told that we&apos;ll need to IPC the host app and have it use the UIApplication API.

As a result, I have adding a UIDelegate SPI to ask the client to take / release the screen
wake lock. If the client doesn&apos;t implement the delegate, then we fall back to using the
UIApplication API directly.

Note that the screen wake lock is global and the UIDelegate is per WKWebView, which is a little
awkward. We make a best attempt to call the UIDelegate on a visible WKWbView when available,
and on a random view when none is visible. WebKit doesn&apos;t currently have such global app-wide
API / SPI.

* Source/WebCore/PAL/pal/system/cocoa/SleepDisablerCocoa.h:
* Source/WebCore/PAL/pal/system/ios/SleepDisablerIOS.mm:
(PAL::ScreenSleepDisabler::setScreenWakeLockHandler):
(PAL::ScreenSleepDisabler::updateState):
(PAL::SleepDisablerCocoa::setScreenWakeLockHandler):
* Source/WebKit/UIProcess/API/APIUIClient.h:
(API::UIClient::setShouldKeepScreenAwake):
* Source/WebKit/UIProcess/API/Cocoa/WKUIDelegatePrivate.h:
* Source/WebKit/UIProcess/Cocoa/UIDelegate.h:
* Source/WebKit/UIProcess/Cocoa/UIDelegate.mm:
(WebKit::UIDelegate::setDelegate):
(WebKit::UIDelegate::UIClient::setShouldKeepScreenAwake):
* Source/WebKit/UIProcess/WebPageProxy.cpp:
(WebKit::WebPageProxy::close):
* Source/WebKit/UIProcess/WebProcessProxy.cpp:
(WebKit::WebProcessProxy::globalPageMap):
(WebKit::WebProcessProxy::globalPages):
(WebKit::WebProcessProxy::willRemoveWebPage):
(WebKit::globalPageMap): Deleted.
(WebKit::globalPages): Deleted.
* Source/WebKit/UIProcess/WebProcessProxy.h:
* Source/WebKit/UIProcess/ios/WebProcessProxyIOS.mm:
(WebKit::WebProcessProxy::platformInitialize):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/UIDelegate.mm:
(-[SetShouldKeepScreenAwakeDelegate _webView:setShouldKeepScreenAwake:]):

Canonical link: <a href="https://commits.webkit.org/263419@main">https://commits.webkit.org/263419@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/6a0c9a8bbef8165e41cb0394765ecbe9715788ad

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/4486 "1 style error") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/4602 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/4747 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/5969 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/4664 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/4474 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/4734 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/4560 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/4907 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/4551 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/4665 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/4031 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/5974 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/2160 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/4017 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/8880 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/4008 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/4087 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/5627 "run-api-tests-without-change (failure)") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/4474 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/3644 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/4002 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/4016 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/1119 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/8049 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/4363 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->