### PR TITLE
run-minibrowser: improve how extra parameters are passed to the minibrowser

### DIFF
--- a/Tools/Scripts/webkitpy/port/__init__.py
+++ b/Tools/Scripts/webkitpy/port/__init__.py
@@ -30,4 +30,4 @@
 
 from webkitpy.port.base import Port  # It's possible we don't need to export this virtual baseclass outside the module.
 from webkitpy.port.driver import Driver, DriverInput, DriverOutput
-from webkitpy.port.factory import platform_options, configuration_options
+from webkitpy.port.factory import platform_options, configuration_options, minibrowser_options

--- a/Tools/Scripts/webkitpy/port/base.py
+++ b/Tools/Scripts/webkitpy/port/base.py
@@ -1357,7 +1357,7 @@ class Port(object):
         """Returns the full path to the default ImageDiff binary, or None if it is not available."""
         return self._build_path('ImageDiff')
 
-    def run_minibrowser(self, args):
+    def run_minibrowser(self, args, minibrowser_name=None):
         # FIXME: Migrate to webkitpy based run-minibrowser. https://bugs.webkit.org/show_bug.cgi?id=213464
         miniBrowser = self.path_to_script("old-run-minibrowser")
         args.append(self._config.flag_for_configuration(self.get_option('configuration')))

--- a/Tools/Scripts/webkitpy/port/factory.py
+++ b/Tools/Scripts/webkitpy/port/factory.py
@@ -91,6 +91,14 @@ def configuration_options():
     ]
 
 
+def minibrowser_options():
+    return [
+        optparse.make_option('--minibrowser-args', action="store", default=None, type=str, dest="minibrowser_args",
+                             help='List of arguments to pass to the minibrowser. Specify it inside quotes. Can be defined also via the env var WEBKIT_MINI_BROWSER_ARGS'),
+        optparse.make_option('--minibrowser-name', action='store', default=None, type=str, dest="minibrowser_name",
+                             help='Choose the minibrowser that will be run (only for platforms that have more tha one minibrowser type).'),
+    ]
+
 def _builder_options(builder_name):
     configuration = "Debug" if re.search(r"[d|D](ebu|b)g", builder_name) else "Release"
     is_webkit2 = builder_name.find("WK2") != -1

--- a/Tools/Scripts/webkitpy/port/gtk.py
+++ b/Tools/Scripts/webkitpy/port/gtk.py
@@ -182,7 +182,7 @@ class GtkPort(GLibPort):
         configuration['version_name'] = self._display_server.capitalize() if self._display_server else 'Xvfb'
         return configuration
 
-    def run_minibrowser(self, args):
+    def run_minibrowser(self, args, minibrowser_name=None):
         miniBrowser = self._build_path('bin', 'MiniBrowser')
         if not self._filesystem.isfile(miniBrowser):
             print("%s not found... Did you run build-webkit?" % miniBrowser)

--- a/Tools/Scripts/webkitpy/port/wpe_unittest.py
+++ b/Tools/Scripts/webkitpy/port/wpe_unittest.py
@@ -80,7 +80,7 @@ class WPEPortTest(port_testcase.PortTestCase):
 
     def test_browser_name_default(self):
         port = self.make_port()
-        self.assertEqual(port.browser_name(), "minibrowser")
+        self.assertEqual(port._determine_browser_name(), "minibrowser")
 
     def test_browser_name_with_cog_built(self):
         with patch('os.environ', {'WPE_BROWSER': ''}):
@@ -88,7 +88,7 @@ class WPEPortTest(port_testcase.PortTestCase):
             port._filesystem = MockFileSystem({
                 "/mock-build/Tools/cog-prefix/src/cog-build/launcher/cog": "",
             })
-            self.assertEqual(port.browser_name(), "cog")
+            self.assertEqual(port._determine_browser_name(), "cog")
 
     def test_browser_name_override_minibrowser_with_cog_built(self):
         with patch('os.environ', {'WPE_BROWSER': 'MiniBrowser'}):
@@ -96,14 +96,19 @@ class WPEPortTest(port_testcase.PortTestCase):
             port._filesystem = MockFileSystem({
                 "/mock-build/Tools/cog-prefix/src/cog-build/cog": "",
             })
-            self.assertEqual(port.browser_name(), "minibrowser")
+            self.assertEqual(port._determine_browser_name(), "minibrowser")
 
     def test_browser_name_override_cog_without_cog_built(self):
         with patch('os.environ', {'WPE_BROWSER': 'Cog'}):
             port = self.make_port()
-            self.assertEqual(port.browser_name(), "cog")
+            self.assertEqual(port._determine_browser_name(), "cog")
+
+    def test_browser_name_override_minibrowser_via_parameter(self):
+        with patch('os.environ', {'WPE_BROWSER': 'Cog'}):
+            port = self.make_port()
+            self.assertEqual(port._determine_browser_name("Minibrowser"), "minibrowser")
 
     def test_browser_name_override_unknown(self):
         with patch('os.environ', {'WPE_BROWSER': 'Mosaic'}):
             port = self.make_port()
-            self.assertEqual(port.browser_name(), "minibrowser")
+            self.assertEqual(port._determine_browser_name(), "minibrowser")


### PR DESCRIPTION
#### 9625d2f962c98afb1ef454852c95e16513ad4913
<pre>
run-minibrowser: improve how extra parameters are passed to the minibrowser
<a href="https://bugs.webkit.org/show_bug.cgi?id=255962">https://bugs.webkit.org/show_bug.cgi?id=255962</a>

Reviewed by NOBODY (OOPS!).

This patch adds to optional parameters to the script run-minibrowser

`--minibrowser-args`: allows to pass random parameters to the minibrowser binary, this is
specially useful when running Cog that accepts multiple parameters, some of which can conflict
with parameters accepted by the script run-minibrowser itself (like --platform or --help).
Specifying this paramters is also possible now via the environment variable
`WEBKIT_MINI_BROWSER_ARGS`. This is useful on the bots when running performance tests to
select which Cog platoform parameters (drm/wayland/gles/etc) will be used.

`--minibrowser-name`: allows to define which minibrowser will be run in case the platform
supports more than one type (like WPE)wq

* Tools/Scripts/webkitpy/minibrowser/run_webkit_app.py:
(main):
* Tools/Scripts/webkitpy/port/__init__.py:
* Tools/Scripts/webkitpy/port/base.py:
(Port.run_minibrowser):
* Tools/Scripts/webkitpy/port/factory.py:
(minibrowser_options):
* Tools/Scripts/webkitpy/port/gtk.py:
(GtkPort.run_minibrowser):
* Tools/Scripts/webkitpy/port/wpe.py:
(WPEPort._determine_browser_name):
(WPEPort.setup_environ_for_minibrowser):
(WPEPort.run_minibrowser):
(WPEPort.browser_name): Deleted.
* Tools/Scripts/webkitpy/port/wpe_unittest.py:
(WPEPortTest.test_browser_name_default):
(WPEPortTest.test_browser_name_with_cog_built):
(WPEPortTest.test_browser_name_override_minibrowser_with_cog_built):
(WPEPortTest.test_browser_name_override_cog_without_cog_built):
(WPEPortTest):
(WPEPortTest.test_browser_name_override_minibrowser_via_parameter):
(WPEPortTest.test_browser_name_override_unknown):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9625d2f962c98afb1ef454852c95e16513ad4913

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/4501 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/4620 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/4764 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/5985 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/4674 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/4490 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/4750 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/4576 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/4910 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/4566 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/4675 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/4034 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/5990 "Built successfully") | 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/4568 "Passed tests") | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/2171 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/4020 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/8903 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/4019 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/4096 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/5622 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/4484 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/3658 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/4015 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/4019 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/8059 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/4377 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->