### PR TITLE
[ iOS ] 2x imported/w3c/web-platform-tests/screen-orientation are near-constant text failures.

### DIFF
--- a/LayoutTests/TestExpectations
+++ b/LayoutTests/TestExpectations
@@ -6262,3 +6262,6 @@ webkit.org/b/255101 imported/w3c/web-platform-tests/css/css-backgrounds/box-shad
 webkit.org/b/255101 imported/w3c/web-platform-tests/css/css-backgrounds/box-shadow/slice-inline-fragmentation-001.html [ ImageOnlyFailure ]
 webkit.org/b/255101 imported/w3c/web-platform-tests/css/css-backgrounds/box-shadow/slice-inline-fragmentation-002.html [ ImageOnlyFailure ]
 webkit.org/b/255101 imported/w3c/web-platform-tests/css/css-backgrounds/box-shadow/slice-inline-fragmentation-003.html [ ImageOnlyFailure ]
+
+# Flaky test that sometimes passes and sometimes fails.
+imported/w3c/web-platform-tests/screen-orientation/nested-documents.html [ Pass Failure ]

--- a/LayoutTests/imported/w3c/web-platform-tests/page-visibility/resources/window_state_context.js
+++ b/LayoutTests/imported/w3c/web-platform-tests/page-visibility/resources/window_state_context.js
@@ -2,12 +2,13 @@ function window_state_context(t) {
     let rect = null;
     let state = "restored";
     t.add_cleanup(async () => {
-        if (state === "minimized")
-            await restore();
+        if (state === "minimized") await restore();
     });
     async function restore() {
-        state = "restored";
+        if (state !== "minimized") return;
+        state = "restoring";
         await test_driver.set_window_rect(rect);
+        state = "restored";
     }
 
     async function minimize() {
@@ -15,5 +16,5 @@ function window_state_context(t) {
         rect = await test_driver.minimize_window();
     }
 
-    return {minimize, restore};
+    return { minimize, restore };
 }

--- a/LayoutTests/imported/w3c/web-platform-tests/resources/testdriver-vendor.js
+++ b/LayoutTests/imported/w3c/web-platform-tests/resources/testdriver-vendor.js
@@ -467,7 +467,7 @@ window.test_driver_internal.minimize_window = async function (context=null)
  */
 window.test_driver_internal.set_window_rect = async function (rect, context=null)
 {
-    if (typeof rect !== "object" || typeof rect.width !== "number" || typeof rect.height !== "number")
+    if (!rect || typeof rect !== "object" || typeof rect.width !== "number" || typeof rect.height !== "number")
         throw new Error("Invalid rect");
 
     context = context ?? window;

--- a/LayoutTests/imported/w3c/web-platform-tests/screen-orientation/active-lock-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/screen-orientation/active-lock-expected.txt
@@ -1,8 +1,6 @@
 fragment
 
-Harness Error (FAIL), message = Test named 'Performing a fragment navigation must not abort the screen orientation change' specified 1 'cleanup' function, and 1 failed.
-
 FAIL Performing a fragment navigation must not abort the screen orientation change promise_test: Unhandled rejection with value: object "NotSupportedError: Screen orientation locking is not supported"
-NOTRUN Performing a fragment navigation within an iframe must not abort the lock promise
-NOTRUN Unloading an iframe by navigating it must abort the lock promise
+FAIL Performing a fragment navigation within an iframe must not abort the lock promise promise_test: Unhandled rejection with value: object "SecurityError: Locking the screen orientation is only allowed when in fullscreen"
+FAIL Unloading an iframe by navigating it must abort the lock promise promise_rejects_dom: function "function () { throw e }" threw object "SecurityError: Locking the screen orientation is only allowed when in fullscreen" that is not a DOMException AbortError: property "code" is equal to 18, expected 20
 

--- a/LayoutTests/imported/w3c/web-platform-tests/screen-orientation/active-lock.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/screen-orientation/active-lock.html
@@ -31,7 +31,7 @@
       <p id="#fragment"></p>
       <a href="#fragment">fragment</a>
     `;
-    await test_driver.bless("request full screen");
+    await test_driver.bless("request full screen", null, iframe.contentWindow);
     await document.documentElement.requestFullscreen();
     const orientation = getOppositeOrientation();
     const p = iframe.contentWindow.screen.orientation.lock(orientation);
@@ -43,7 +43,7 @@
   promise_test(async (t) => {
     t.add_cleanup(makeCleanup());
     const iframe = await attachIframe();
-    await test_driver.bless("request full screen");
+    await test_driver.bless("request full screen", null, iframe.contentWindow);
     await document.documentElement.requestFullscreen();
     const orientation = getOppositeOrientation();
     const p = iframe.contentWindow.screen.orientation.lock(orientation);

--- a/LayoutTests/imported/w3c/web-platform-tests/screen-orientation/event-before-promise-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/screen-orientation/event-before-promise-expected.txt
@@ -1,5 +1,3 @@
 
-Harness Error (FAIL), message = Test named 'The 'change' event must fire before the [[orientationPendingPromise]] is resolved.' specified 1 'cleanup' function, and 1 failed.
-
 FAIL The 'change' event must fire before the [[orientationPendingPromise]] is resolved. promise_test: Unhandled rejection with value: object "NotSupportedError: Screen orientation locking is not supported"
 

--- a/LayoutTests/imported/w3c/web-platform-tests/screen-orientation/hidden_document-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/screen-orientation/hidden_document-expected.txt
@@ -1,8 +1,6 @@
 
-Harness Error (FAIL), message = Test named 'hidden documents must not unlock the screen orientation' specified 3 'cleanup' functions, and 2 failed.
-
 PASS hidden documents must reject went trying to call lock or unlock
 PASS hidden documents must reject went trying to call unlock
-FAIL hidden documents must not unlock the screen orientation promise_test: Unhandled rejection with value: object "SecurityError: Locking the screen orientation is only allowed when in fullscreen"
-NOTRUN Once maximized, a minimized window can lock or unlock the screen orientation again
+FAIL hidden documents must not unlock the screen orientation promise_test: Unhandled rejection with value: object "NotSupportedError: Screen orientation locking is not supported"
+FAIL Once maximized, a minimized window can lock or unlock the screen orientation again promise_test: Unhandled rejection with value: object "NotSupportedError: Screen orientation locking is not supported"
 

--- a/LayoutTests/imported/w3c/web-platform-tests/screen-orientation/hidden_document.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/screen-orientation/hidden_document.html
@@ -19,7 +19,7 @@
     await minimize();
 
     assert_equals(document.visibilityState, "hidden", "Document must be hidden");
-    await promise_rejects_dom(t, "SecurityError", screen.orientation.lock("landscape") );
+    await promise_rejects_dom(t, "SecurityError", screen.orientation.lock(getOppositeOrientation()));
   }, "hidden documents must reject went trying to call lock or unlock");
 
   promise_test(async (t) => {
@@ -34,8 +34,10 @@
 
   promise_test(async (t) => {
     const { minimize, restore } = window_state_context(t);
-    t.add_cleanup(restore);
     t.add_cleanup(makeCleanup());
+
+    await test_driver.bless("request full screen");
+    await document.documentElement.requestFullscreen();
     await screen.orientation.lock(getOppositeOrientation());
 
     await minimize();
@@ -46,8 +48,9 @@
 
   promise_test(async (t) => {
     const { minimize, restore } = window_state_context(t);
-    t.add_cleanup(restore);
     t.add_cleanup(makeCleanup());
+    await test_driver.bless("request full screen");
+    await document.documentElement.requestFullscreen();
     await screen.orientation.lock(getOppositeOrientation());
 
     await minimize();
@@ -59,6 +62,9 @@
     await restore();
 
     assert_equals(document.visibilityState, "visible");
+
+    await test_driver.bless("request full screen");
+    await document.documentElement.requestFullscreen();
     await screen.orientation.lock(getOppositeOrientation());
     screen.orientation.unlock();
   }, "Once maximized, a minimized window can lock or unlock the screen orientation again");

--- a/LayoutTests/imported/w3c/web-platform-tests/screen-orientation/lock-basic-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/screen-orientation/lock-basic-expected.txt
@@ -1,7 +1,5 @@
 
-Harness Error (FAIL), message = Test named 'Test that screen.orientation.lock returns a promise which will be fulfilled with a void value.' specified 1 'cleanup' function, and 1 failed.
-
 FAIL Test that screen.orientation.lock returns a promise which will be fulfilled with a void value. promise_test: Unhandled rejection with value: object "NotSupportedError: Screen orientation locking is not supported"
-NOTRUN Test that screen.orientation.lock returns a pending promise.
-NOTRUN Test that screen.orientation.lock() is actually async
+PASS Test that screen.orientation.lock returns a pending promise.
+FAIL Test that screen.orientation.lock() is actually async promise_test: Unhandled rejection with value: object "NotSupportedError: Screen orientation locking is not supported"
 

--- a/LayoutTests/imported/w3c/web-platform-tests/screen-orientation/nested-documents-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/screen-orientation/nested-documents-expected.txt
@@ -1,7 +1,10 @@
+CONSOLE MESSAGE: Unhandled Promise Rejection: NotSupportedError: Screen orientation locking is not supported
+CONSOLE MESSAGE: Unhandled Promise Rejection: SecurityError: Locking the screen orientation is only allowed when in fullscreen
+CONSOLE MESSAGE: Unhandled Promise Rejection: NotSupportedError: Screen orientation locking is not supported
 
 
-Harness Error (FAIL), message = Test named 'Requesting orientation lock from one document cancels the lock request from another document' specified 1 'cleanup' function, and 1 failed.
+Harness Error (FAIL), message = Unhandled rejection: Screen orientation locking is not supported
 
 FAIL Requesting orientation lock from one document cancels the lock request from another document promise_rejects_dom: function "function () { throw e }" threw object "SecurityError: Locking the screen orientation is only allowed when in fullscreen" that is not a DOMException AbortError: property "code" is equal to 18, expected 20
-NOTRUN The orientation lock from one document affects lock requests from other documents
+FAIL The orientation lock from one document affects lock requests from other documents promise_rejects_dom: Expected request to lock orientation from iframe 0 to abort function "function () { throw e }" threw object "SecurityError: Locking the screen orientation is only allowed when in fullscreen" that is not a DOMException AbortError: property "code" is equal to 18, expected 20
 

--- a/LayoutTests/imported/w3c/web-platform-tests/screen-orientation/nested-documents.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/screen-orientation/nested-documents.html
@@ -37,7 +37,7 @@
 
     promise_test(async (t) => {
       t.add_cleanup(makeCleanup());
-      // Create 3 nested iframes
+      // Create 2 nested iframes
       const src = "/screen-orientation/resources/empty.html";
       const outerIframe = await attachIframe({ src: `${src}#1` });
       const innerIframe = await attachIframe({
@@ -49,11 +49,9 @@
 
       // Go full screen
       await test_driver.bless(
-        "request full screen",
-        null,
-        innerIframe.contentWindow
+        "request full screen"
       );
-      await innerIframe.contentDocument.documentElement.requestFullscreen();
+      await document.documentElement.requestFullscreen();
       const opposite = getOppositeOrientation();
 
       // Each iframe tries to lock the orientation
@@ -68,20 +66,16 @@
       const topPromise = window.screen.orientation.lock(opposite);
 
       // Check that all promises are rejected with AbortError
-      const abortedPromises = [];
       for (let i = 0; i < requestToLock.length; i++) {
         const { promise, context } = requestToLock[i];
-        const p = promise_rejects_dom(
+        await promise_rejects_dom(
           t,
           "AbortError",
           context.DOMException,
           promise,
           `Expected request to lock orientation from iframe ${i} to abort`
         );
-        abortedPromises.push(p);
       }
-      await Promise.all(abortedPromises);
-
       // Finally, top-level promise resolves
       await topPromise;
     }, "The orientation lock from one document affects lock requests from other documents");

--- a/LayoutTests/imported/w3c/web-platform-tests/screen-orientation/onchange-event-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/screen-orientation/onchange-event-expected.txt
@@ -1,6 +1,4 @@
 
-Harness Error (FAIL), message = Test named 'Test that orientationchange event is not fired when the orientation does not change.' specified 1 'cleanup' function, and 1 failed.
-
 FAIL Test that orientationchange event is not fired when the orientation does not change. promise_test: Unhandled rejection with value: object "NotSupportedError: Screen orientation locking is not supported"
-NOTRUN Test that orientationchange event is fired when the orientation changes.
+FAIL Test that orientationchange event is fired when the orientation changes. promise_test: Unhandled rejection with value: object "NotSupportedError: Screen orientation locking is not supported"
 

--- a/LayoutTests/imported/w3c/web-platform-tests/screen-orientation/onchange-event-subframe-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/screen-orientation/onchange-event-subframe-expected.txt
@@ -1,7 +1,7 @@
 
 
-Harness Error (FAIL), message = Test named 'Test subframes receive orientation change events' specified 1 'cleanup' function, and 1 failed.
+Harness Error (FAIL), message = Timeout while running cleanup for test named "Check directly that events are fired in right order (from top to bottom)".
 
 FAIL Test subframes receive orientation change events promise_test: Unhandled rejection with value: object "NotSupportedError: Screen orientation locking is not supported"
-NOTRUN Check directly that events are fired in right order (from top to bottom)
+FAIL Check directly that events are fired in right order (from top to bottom) promise_test: Unhandled rejection with value: object "NotSupportedError: Screen orientation locking is not supported"
 

--- a/LayoutTests/imported/w3c/web-platform-tests/screen-orientation/onchange-event-subframe.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/screen-orientation/onchange-event-subframe.html
@@ -44,7 +44,14 @@
   promise_test(async (t) => {
     t.add_cleanup(makeCleanup());
     const iframe = await attachIframe();
-    const opposite = getOppositeOrientation();
+    let opposite = getOppositeOrientation();
+
+    // Fail fast in case the API is not supported
+    await test_driver.bless("request fullscreen", null, iframe.contentWindow);
+    await iframe.contentDocument.documentElement.requestFullscreen();
+    await iframe.contentWindow.screen.orientation.lock(opposite);
+    iframe.contentWindow.screen.orientation.unlock();
+    opposite = getOppositeOrientation();
 
     const topEventPromise = new EventWatcher(
       t,

--- a/LayoutTests/imported/w3c/web-platform-tests/screen-orientation/orientation-reading-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/screen-orientation/orientation-reading-expected.txt
@@ -1,10 +1,8 @@
 
-Harness Error (FAIL), message = Test named 'Test the orientations and associated angles when the natural orientation is 'portrait'' specified 1 'cleanup' function, and 1 failed.
-
 PASS screen.orientation attributes are present
 PASS Test the orientations and associated angles when the natural orientation is 'portrait'
-NOTRUN Test the orientations and associated angles when the natural orientation is 'landscape'
+PASS Test the orientations and associated angles when the natural orientation is 'landscape'
 PASS Test that ScreenOrientation properties are not writable
 PASS Test that ScreenOrientation is always the same object
-NOTRUN Test that ScreenOrientation's attribute values change after 'change' event fires
+FAIL Test that ScreenOrientation's attribute values change after 'change' event fires promise_test: Unhandled rejection with value: object "NotSupportedError: Screen orientation locking is not supported"
 

--- a/LayoutTests/imported/w3c/web-platform-tests/screen-orientation/resources/orientation-utils.js
+++ b/LayoutTests/imported/w3c/web-platform-tests/screen-orientation/resources/orientation-utils.js
@@ -35,11 +35,9 @@ export function getOppositeOrientation() {
 
 export function makeCleanup() {
   return async () => {
-    document.screen.orientation.unlock();
+    screen.orientation.unlock();
     if (document.fullscreenElement) {
-      try {
-        await document.exitFullscreen();
-      } catch {}
+      await document.fullscreenElement.ownerDocument.exitFullscreen();
     }
   };
 }

--- a/LayoutTests/imported/w3c/web-platform-tests/screen-orientation/unlock-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/screen-orientation/unlock-expected.txt
@@ -1,9 +1,8 @@
 
-Harness Error (FAIL), message = Test named 'unlock() doesn't throw when there is no lock with fullscreen' specified 1 'cleanup' function, and 1 failed.
 
 PASS unlock() doesn't throw when there is no lock
 PASS unlock() returns a void value
 PASS unlock() doesn't throw when there is no lock with fullscreen
-NOTRUN unlock() aborts a pending lock request
-NOTRUN unlock() aborts a pending lock request across documents
+FAIL unlock() aborts a pending lock request promise_rejects_dom: function "function () { throw e }" threw object "NotSupportedError: Screen orientation locking is not supported" that is not a DOMException AbortError: property "code" is equal to 9, expected 20
+FAIL unlock() aborts a pending lock request across documents promise_rejects_dom: function "function () { throw e }" threw object "SecurityError: Locking the screen orientation is only allowed when in fullscreen" that is not a DOMException AbortError: property "code" is equal to 18, expected 20
 

--- a/LayoutTests/platform/ios/TestExpectations
+++ b/LayoutTests/platform/ios/TestExpectations
@@ -2990,10 +2990,6 @@ webkit.org/b/173041 http/tests/websocket/tests/hybi/handshake-ok-with-legacy-sec
 
 webkit.org/b/230968 http/tests/websocket/tests/hybi/bad-handshake-crash.html [ Skip ]
 
-# webkit.org/b/255931 2x imported/w3c/web-platform-tests/screen-orientation are near constant failures
-imported/w3c/web-platform-tests/screen-orientation/nested-documents.html [ Failure ]
-imported/w3c/web-platform-tests/screen-orientation/unlock.html [ Failure ]
-
 # WK2 spelling dot test infrastructure isn't hooked up on iOS
 webkit.org/b/190764 editing/spelling/spelling-dots-repaint.html [ Skip ]
 webkit.org/b/190764 editing/spelling/spelling-dots-position.html [ Skip ]


### PR DESCRIPTION
#### 5eb2125a124bc60c233ce92a636f3cdf0302194d
<pre>
[ iOS ] 2x imported/w3c/web-platform-tests/screen-orientation are near-constant text failures.
<a href="https://bugs.webkit.org/show_bug.cgi?id=255931">https://bugs.webkit.org/show_bug.cgi?id=255931</a>
rdar://108508861

Reviewed by Chris Dumez.

The cleanup function was accidentally calling &quot;document.screen&quot;.
Fixing that revealed a bunch of smaller bugs in the tests.

* LayoutTests/TestExpectations:
* LayoutTests/imported/w3c/web-platform-tests/page-visibility/resources/window_state_context.js:
(window_state_context.async restore):
(window_state_context):
* LayoutTests/imported/w3c/web-platform-tests/resources/testdriver-vendor.js:
(async if):
(window.test_driver_internal.set_window_rect):
* LayoutTests/imported/w3c/web-platform-tests/screen-orientation/active-lock-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/screen-orientation/active-lock.html:
* LayoutTests/imported/w3c/web-platform-tests/screen-orientation/event-before-promise-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/screen-orientation/hidden_document-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/screen-orientation/hidden_document.html:
* LayoutTests/imported/w3c/web-platform-tests/screen-orientation/lock-basic-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/screen-orientation/nested-documents-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/screen-orientation/nested-documents.html:
* LayoutTests/imported/w3c/web-platform-tests/screen-orientation/onchange-event-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/screen-orientation/onchange-event-subframe-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/screen-orientation/onchange-event-subframe.html:
* LayoutTests/imported/w3c/web-platform-tests/screen-orientation/orientation-reading-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/screen-orientation/resources/orientation-utils.js:
* LayoutTests/imported/w3c/web-platform-tests/screen-orientation/unlock-expected.txt:
* LayoutTests/platform/ios/TestExpectations:

Canonical link: <a href="https://commits.webkit.org/263509@main">https://commits.webkit.org/263509@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/72b5d69f689a22b4b399941eae8f2e6fc8c38299

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/4631 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/4750 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/4907 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/6126 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/4780 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/4891 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/4711 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/5019 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/4701 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/4792 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/4151 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/6136 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/2280 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/4143 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/9123 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/4140 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/4217 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/5765 "run-api-tests-without-change (failure)") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/4608 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/3746 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/4134 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/4139 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/1183 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/8180 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/4494 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->