### PR TITLE
[bmalloc] Add missing macros for Windows platform.

### DIFF
--- a/Source/bmalloc/bmalloc/BCompiler.h
+++ b/Source/bmalloc/bmalloc/BCompiler.h
@@ -56,14 +56,23 @@
 #define BCOMPILER_GCC_COMPATIBLE 1
 #endif
 
-/* BNO_RETURN */
-
-#if !defined(BNO_RETURN) && BCOMPILER(GCC_COMPATIBLE)
-#define BNO_RETURN __attribute((__noreturn__))
+#if defined(_MSC_VER)
+#define BCOMPILER_MSVC 1
+#if _MSC_VER < 1910
+#error "Please use a newer version of Visual Studio. WebKit requires VS2017 or newer to compile."
+#endif
 #endif
 
+/* BNO_RETURN */
+
 #if !defined(BNO_RETURN)
+#if BCOMPILER(GCC_COMPATIBLE)
+#define BNO_RETURN __attribute((__noreturn__))
+#elif BCOMPILER(MSVC)
+#define BNO_RETURN __declspec(noreturn)
+#else
 #define BNO_RETURN
+#endif
 #endif
 
 /* BFALLTHROUGH */
@@ -92,4 +101,16 @@
 
 #if !defined(BUNUSED_TYPE_ALIAS)
 #define BUNUSED_TYPE_ALIAS
+#endif
+
+/* BFUNCTION_SIGNATURE */
+
+#if !defined(BFUNCTION_SIGNATURE)
+#if BCOMPILER(GCC_COMPATIBLE)
+#define BFUNCTION_SIGNATURE __PRETTY_FUNCTION__
+#elif BCOMPILER(MSVC)
+#define BFUNCTION_SIGNATURE __FUNCSIG__
+#else
+#error "Unsupported compiler"
+#endif
 #endif

--- a/Source/bmalloc/bmalloc/BInline.h
+++ b/Source/bmalloc/bmalloc/BInline.h
@@ -25,6 +25,12 @@
 
 #pragma once
 
-#define BINLINE __attribute__((always_inline)) inline
+#include "BCompiler.h"
 
+#if BCOMPILER(GCC_COMPATIBLE)
+#define BINLINE __attribute__((always_inline)) inline
 #define BNO_INLINE __attribute__((noinline))
+#elif BCOMPILER(MSVC)
+#define BINLINE __forceinline
+#define BNO_INLINE __declspec(noinline)
+#endif

--- a/Source/bmalloc/bmalloc/BPlatform.h
+++ b/Source/bmalloc/bmalloc/BPlatform.h
@@ -270,6 +270,12 @@
 #else
 #error "Unsupported pointer width"
 #endif
+#elif BCOMPILER(MSVC)
+#if defined(_WIN64)
+#define BCPU_ADDRESS64 1
+#else
+#define BCPU_ADDRESS32 1
+#endif
 #else
 #error "Unsupported compiler for bmalloc"
 #endif
@@ -284,6 +290,8 @@
 #else
 #error "Unknown endian"
 #endif
+#elif BCOMPILER(MSVC)
+#define BCPU_LITTLE_ENDIAN 1
 #else
 #error "Unsupported compiler for bmalloc"
 #endif
@@ -299,7 +307,11 @@
 #define BOS_EFFECTIVE_ADDRESS_WIDTH 32
 #endif
 
+#if BCOMPILER(GCC_COMPATIBLE)
 #define BATTRIBUTE_PRINTF(formatStringArgument, extraArguments) __attribute__((__format__(printf, formatStringArgument, extraArguments)))
+#else
+#define BATTRIBUTE_PRINTF(formatStringArgument, extraArguments)
+#endif
 
 /* Export macro support. Detects the attributes available for shared library symbol export
    decorations. */

--- a/Source/bmalloc/bmalloc/PerProcess.h
+++ b/Source/bmalloc/bmalloc/PerProcess.h
@@ -101,7 +101,7 @@ private:
         if (s_data)
             return;
         
-        const char* disambiguator = __PRETTY_FUNCTION__;
+        const char* disambiguator = BFUNCTION_SIGNATURE;
         s_data = getPerProcessData(stringHash(disambiguator), disambiguator, sizeof(T), std::alignment_of<T>::value);
     }
     

--- a/Source/bmalloc/libpas/src/libpas/pas_platform.h
+++ b/Source/bmalloc/libpas/src/libpas/pas_platform.h
@@ -189,6 +189,8 @@
 #else
 #error "Unsupported pointer width"
 #endif
+#elif PAS_COMPILER(MSVC)
+#define PAS_CPU_ADDRESS64 1
 #else
 #error "Unsupported compiler for libpas"
 #endif


### PR DESCRIPTION
#### f462028e09b021b5d2768fee9ea0ffc056565b94
<pre>
[bmalloc] Add missing macros for Windows platform.
<a href="https://bugs.webkit.org/show_bug.cgi?id=255944">https://bugs.webkit.org/show_bug.cgi?id=255944</a>

Reviewed by Yusuke Suzuki.

This is the patch for Windows bmalloc implementation part 2 of N.

Bmalloc defines many compiler macros. Most of them are not Windows and MSVC ready.
This patch defines those for Windows API.

* Source/bmalloc/bmalloc/BCompiler.h:
* Source/bmalloc/bmalloc/BInline.h:
* Source/bmalloc/bmalloc/BPlatform.h:
* Source/bmalloc/bmalloc/OerOricess.h:
* Source/bmalloc/libpas/src/libpas/pas_platform.h:

Canonical link: <a href="https://commits.webkit.org/263404@main">https://commits.webkit.org/263404@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e994fc338b145ee02e619c9b0f15a972fbf4dbbf

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/4516 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/4634 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/4779 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/6000 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/4680 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/4765 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/4590 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/4926 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/4581 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/4692 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/4051 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/6006 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/2184 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/4041 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/9030 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [  ~~🛠 🧪 jsc~~](https://ews-build.webkit.org/#/builders/20/builds/3733 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/4041 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/4113 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/5652 "Passed tests") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/4273 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/4493 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/3667 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/4608 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/4027 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/4040 "Passed tests") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/1152 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/1105 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/8067 "Built successfully") | | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/24/builds/4717 "Built successfully") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/4390 "Built successfully") | | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/3/builds/1257 "Passed tests") | 
<!--EWS-Status-Bubble-End-->