### PR TITLE
[glib] Cog doesn't launch when built/started within podman container

### DIFF
--- a/Source/WTF/wtf/glib/Sandbox.cpp
+++ b/Source/WTF/wtf/glib/Sandbox.cpp
@@ -36,9 +36,9 @@ bool isInsideFlatpak()
     return returnValue;
 }
 
-bool isInsideDocker()
+bool isInsideContainer()
 {
-    static bool returnValue = g_file_test("/.dockerenv", G_FILE_TEST_EXISTS);
+    static bool returnValue = g_file_test("/run/.containerenv", G_FILE_TEST_EXISTS);
     return returnValue;
 }
 

--- a/Source/WTF/wtf/glib/Sandbox.h
+++ b/Source/WTF/wtf/glib/Sandbox.h
@@ -24,7 +24,7 @@
 namespace WTF {
 
 WTF_EXPORT_PRIVATE bool isInsideFlatpak();
-WTF_EXPORT_PRIVATE bool isInsideDocker();
+WTF_EXPORT_PRIVATE bool isInsideContainer();
 WTF_EXPORT_PRIVATE bool isInsideSnap();
 WTF_EXPORT_PRIVATE bool shouldUsePortal();
 
@@ -34,7 +34,7 @@ WTF_EXPORT_PRIVATE void setSandboxedAccessibilityBusAddress(String&&);
 } // namespace WTF
 
 using WTF::isInsideFlatpak;
-using WTF::isInsideDocker;
+using WTF::isInsideContainer;
 using WTF::isInsideSnap;
 using WTF::shouldUsePortal;
 

--- a/Source/WebKit/UIProcess/Launcher/glib/ProcessLauncherGLib.cpp
+++ b/Source/WebKit/UIProcess/Launcher/glib/ProcessLauncherGLib.cpp
@@ -220,9 +220,9 @@ void ProcessLauncher::launchProcess()
     if (sandboxEnabled && isFlatpakSpawnUsable())
         process = flatpakSpawn(launcher.get(), m_launchOptions, argv, socketPair.client, &error.outPtr());
 #if ENABLE(BUBBLEWRAP_SANDBOX)
-    // You cannot use bubblewrap within Flatpak or Docker so lets ensure it never happens.
+    // You cannot use bubblewrap within Flatpak or Docker/podman so lets ensure it never happens.
     // Snap can allow it but has its own limitations that require workarounds.
-    else if (sandboxEnabled && !isInsideFlatpak() && !isInsideSnap() && !isInsideDocker())
+    else if (sandboxEnabled && !isInsideFlatpak() && !isInsideSnap() && !isInsideContainer())
         process = bubblewrapSpawn(launcher.get(), m_launchOptions, argv, &error.outPtr());
 #endif // ENABLE(BUBBLEWRAP_SANDBOX)
     else


### PR DESCRIPTION
#### 2364ff02346a5906d103bfc02c341ca8bc9b5ecb
<pre>
[glib] Cog doesn&apos;t launch when built/started within podman container
<a href="https://bugs.webkit.org/show_bug.cgi?id=255975">https://bugs.webkit.org/show_bug.cgi?id=255975</a>

Reviewed by Adrian Perez de Castro.

We intent to disable bubblewrap sandboxing when e.g. Cog is launched
within a container -- however we only handle docker -- extend that to
all OCI-compatible container execution engines (podman!).

No new tests -- not testable within our CI/CD environment.

* Source/WTF/wtf/glib/Sandbox.cpp:
(WTF::isInsideContainer):
(WTF::isInsideDocker): Deleted.
* Source/WTF/wtf/glib/Sandbox.h:
* Source/WebKit/UIProcess/Launcher/glib/ProcessLauncherGLib.cpp:
(WebKit::ProcessLauncher::launchProcess):

Canonical link: <a href="https://commits.webkit.org/263494@main">https://commits.webkit.org/263494@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e939a02d71983124f581eb6874fe989b5ef946a9

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/4533 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/4653 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/4799 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/6020 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/4693 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/4784 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/4609 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/4936 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/4599 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/4703 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/4065 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/6026 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/2193 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/4055 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/9045 "Passed tests") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/3746 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/4052 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/4127 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/5660 "Passed tests") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/4290 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/4509 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/3678 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/4626 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/4042 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/4054 "Passed tests") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/1154 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/1172 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/8080 "Built successfully") | | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/24/builds/4737 "Built successfully") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/4405 "Built successfully") | | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/3/builds/1259 "Passed tests") | 
<!--EWS-Status-Bubble-End-->