### PR TITLE
[curl] Add HTTP/3 enabling option and settings

### DIFF
--- a/Source/WebCore/platform/network/curl/CurlContext.h
+++ b/Source/WebCore/platform/network/curl/CurlContext.h
@@ -122,8 +122,9 @@ public:
     CurlSSLHandle& sslHandle() { return m_sslHandle; }
 
     // Supported features
-    bool isAltSvcEnabled() const;
-    bool isHttp2Enabled() const;
+    bool isAltSvcEnabled() const { return m_isAltSvcEnabled; }
+    bool isHttp2Enabled() const { return m_isHttp2Enabled; }
+    bool isHttp3Enabled() const { return m_isHttp3Enabled; }
 
     // Timeout
     Seconds dnsCacheTimeout() const { return m_dnsCacheTimeout; }
@@ -143,6 +144,10 @@ private:
     CurlShareHandle m_shareHandle;
     CurlSSLHandle m_sslHandle;
     std::unique_ptr<CurlRequestScheduler> m_scheduler;
+
+    bool m_isAltSvcEnabled { false };
+    bool m_isHttp2Enabled { false };
+    bool m_isHttp3Enabled { false };
 
     Seconds m_dnsCacheTimeout { Seconds::fromMinutes(5) };
     Seconds m_connectTimeout { 30.0 };

--- a/Source/WebCore/platform/network/curl/ResourceResponseCurl.cpp
+++ b/Source/WebCore/platform/network/curl/ResourceResponseCurl.cpp
@@ -98,6 +98,9 @@ ResourceResponse::ResourceResponse(CurlResponse& response)
     case CURL_HTTP_VERSION_2_0:
         setHTTPVersion("HTTP/2"_s);
         break;
+    case CURL_HTTP_VERSION_3:
+        setHTTPVersion("HTTP/3"_s);
+        break;
     case CURL_HTTP_VERSION_NONE:
     default:
         break;


### PR DESCRIPTION
#### 7327aab70ea504499e0f1a14c78f55863233afd9
<pre>
[curl] Add HTTP/3 enabling option and settings
<a href="https://bugs.webkit.org/show_bug.cgi?id=255978">https://bugs.webkit.org/show_bug.cgi?id=255978</a>

Reviewed by Don Olmstead and Fujii Hironori.

Add HTTP/3 enabling option and settings to make it easier
to check HTTP/3 behavior.

* Source/WebCore/platform/network/curl/CurlContext.cpp:
(WebCore::CurlContext::CurlContext):
(WebCore::CurlHandle::enableHttp):
(WebCore::CurlHandle::enableAltSvc):
(WebCore::CurlContext::isAltSvcEnabled const): Deleted.
(WebCore::CurlContext::isHttp2Enabled const): Deleted.
* Source/WebCore/platform/network/curl/CurlContext.h:
(WebCore::CurlContext::isAltSvcEnabled const):
(WebCore::CurlContext::isHttp2Enabled const):
(WebCore::CurlContext::isHttp3Enabled const):
* Source/WebCore/platform/network/curl/ResourceResponseCurl.cpp:
(WebCore::ResourceResponse::ResourceResponse):

Canonical link: <a href="https://commits.webkit.org/263447@main">https://commits.webkit.org/263447@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/278e2080410fe15e6ed9ab2dda9e800a98a25ea0

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/4658 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/4777 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/4935 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/6155 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/4805 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/4648 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/4921 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/4740 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/5042 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/4729 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/4816 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/4172 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/6164 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/2304 "Passed tests") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/10/builds/4164 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/9143 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/4164 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/4238 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/5784 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/4634 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/3769 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/4159 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/8205 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/530 "Built successfully and passed tests") | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/31/builds/4519 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->