### PR TITLE
REGRESSION(263216@main): [JHbuild] Cannot build with minimal moduleset on Ubuntu 22.04

### DIFF
--- a/Tools/gstreamer/jhbuild.modules
+++ b/Tools/gstreamer/jhbuild.modules
@@ -35,7 +35,6 @@
   <repository type="tarball" name="ffmpeg" href="https://ffmpeg.org/releases/"/>
 
   <meson id="orc" mesonargs="-Dgtk_doc=disabled -Dexamples=disabled">
-    <pkg-config>orc-0.4.pc</pkg-config>
     <branch repo="gstreamer"
             module="orc/archive/refs/tags/${version}.tar.gz"
             rename-tarball="orc-${version}.tar.gz"
@@ -62,7 +61,6 @@
   </cmake>
 
   <autotools id="libsrtp">
-    <pkg-config>libsrtp2.pc</pkg-config>
     <branch repo="github-tarball"
             module="cisco/libsrtp/archive/v${version}.tar.gz"
             checkoutdir="libsrtp-${version}"
@@ -85,7 +83,6 @@
   </meson>
 
   <meson id="gst-plugins-base" mesonargs="-Dintrospection=disabled -Dexamples=disabled">
-    <pkg-config>gstreamer-plugins-base-1.0.pc</pkg-config>
     <if condition-set="wpe">
       <autogenargs value="-Dpango=disabled"/>
     </if>
@@ -103,7 +100,6 @@
   </meson>
 
   <meson id="gst-plugins-good" mesonargs="-Dexamples=disabled -Dgtk3=disabled">
-    <pkg-config>gstreamer-plugins-good-1.0.pc</pkg-config>
     <dependencies>
       <dep package="gst-plugins-base"/>
     </dependencies>
@@ -117,7 +113,6 @@
   </meson>
 
   <meson id="gst-plugins-bad" mesonargs="-Dintrospection=disabled -Dexamples=disabled -Dopenexr=disabled -Dopencv=disabled">
-    <pkg-config>gstreamer-plugins-bad-1.0.pc</pkg-config>
     <dependencies>
       <dep package="graphene"/>
       <dep package="gst-plugins-base"/>
@@ -156,7 +151,6 @@
   </meson>
 
   <meson id="libva" mesonargs="-Denable_va_messaging=false">
-    <pkg-config>libva.pc</pkg-config>
     <branch repo="github-tarball"
             module="intel/libva/archive/${version}.tar.gz"
             checkoutdir="libva-${version}"

--- a/Tools/gtk/jhbuild-minimal-plus-gstreamer.modules
+++ b/Tools/gtk/jhbuild-minimal-plus-gstreamer.modules
@@ -1,0 +1,6 @@
+<?xml version="1.0"?>
+<!DOCTYPE moduleset SYSTEM "moduleset.dtd">
+<?xml-stylesheet type="text/xsl" href="moduleset.xsl"?>
+<moduleset>
+  <include href="../jhbuild/jhbuild-minimal-plus-gstreamer.modules"/>
+</moduleset>

--- a/Tools/jhbuild/jhbuild-minimal-plus-gstreamer.modules
+++ b/Tools/jhbuild/jhbuild-minimal-plus-gstreamer.modules
@@ -1,0 +1,23 @@
+<?xml version="1.0"?>
+<!DOCTYPE moduleset SYSTEM "moduleset.dtd">
+<?xml-stylesheet type="text/xsl" href="moduleset.xsl"?>
+<moduleset>
+
+  <include href="jhbuild-minimal.modules"/>
+  <include href="../gstreamer/jhbuild.modules"/>
+
+  <metamodule id="webkitgtk-minimal-plus-gstreamer-dependencies">
+    <dependencies>
+      <dep package="webkitgtk-minimal-dependencies"/>
+      <dep package="webkit-gstreamer-testing-dependencies"/>
+    </dependencies>
+  </metamodule>
+
+  <metamodule id="webkitwpe-minimal-plus-gstreamer-dependencies">
+    <dependencies>
+      <dep package="webkitwpe-minimal-dependencies"/>
+      <dep package="webkit-gstreamer-testing-dependencies"/>
+    </dependencies>
+  </metamodule>
+
+</moduleset>

--- a/Tools/jhbuild/jhbuild-minimal.modules
+++ b/Tools/jhbuild/jhbuild-minimal.modules
@@ -16,7 +16,6 @@
       <dep package="glib-networking"/>
       <dep package="atk"/>
       <dep package="at-spi2-atk"/>
-      <dep package="webkit-gstreamer-testing-dependencies"/>
     </dependencies>
   </metamodule>
 
@@ -31,7 +30,6 @@
       <dep package="glib-networking"/>
       <dep package="atk"/>
       <dep package="at-spi2-atk"/>
-      <dep package="webkit-gstreamer-testing-dependencies"/>
     </dependencies>
   </metamodule>
 

--- a/Tools/wpe/jhbuild-minimal-plus-gstreamer.modules
+++ b/Tools/wpe/jhbuild-minimal-plus-gstreamer.modules
@@ -1,0 +1,6 @@
+<?xml version="1.0"?>
+<!DOCTYPE moduleset SYSTEM "moduleset.dtd">
+<?xml-stylesheet type="text/xsl" href="moduleset.xsl"?>
+<moduleset>
+  <include href="../jhbuild/jhbuild-minimal-plus-gstreamer.modules"/>
+</moduleset>


### PR DESCRIPTION
#### bf6ce950bacc83f9fb3dc35b9c1a632146d71047
<pre>
REGRESSION(263216@main): [JHbuild] Cannot build with minimal moduleset on Ubuntu 22.04
<a href="https://bugs.webkit.org/show_bug.cgi?id=255980">https://bugs.webkit.org/show_bug.cgi?id=255980</a>

Reviewed by Philippe Normand.

Restore former minimal moduleset, which only includes minimal
dependencies. Then, add a new minimal-plus-gstreamer module set which
includes both the minimal dependencies and gstreamer dependencies.

Systems that would like to use the minimal module but cannot satisfy
GStreamer dependencies through system libraries can use this new
minimal-plus-gstreamer moduleset.

* Tools/gstreamer/jhbuild.modules:
* Tools/gtk/jhbuild-minimal-plus-gstreamer.modules: Added.
* Tools/jhbuild/jhbuild-minimal-plus-gstreamer.modules: Added.
* Tools/jhbuild/jhbuild-minimal.modules:
* Tools/wpe/jhbuild-minimal-plus-gstreamer.modules: Added.

Canonical link: <a href="https://commits.webkit.org/263411@main">https://commits.webkit.org/263411@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/64e07bdbefeab98213f1f135d192926b5d0f899b

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/4549 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/4669 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/4818 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/6039 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/4709 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/4540 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/4803 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/4625 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/4949 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/4617 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/4719 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/4079 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/6045 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/2210 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/4069 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/9057 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/4068 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/4141 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/5673 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/4526 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/3689 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/4059 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/4068 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/1111 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/8099 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/4420 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->