### PR TITLE
Use isASCIIWhitespace for CSP

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/content-security-policy/generic/only-valid-whitespaces-are-allowed-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/content-security-policy/generic/only-valid-whitespaces-are-allowed-expected.txt
@@ -24,4 +24,8 @@ PASS U+00A0 NBSP  should not be parsed between directive name and value - meta t
 PASS U+00A0 NBSP  should not be parsed between directive name and value - HTTP header
 PASS U+00A0 NBSP  should not be parsed inside directive value - meta tag
 PASS U+00A0 NBSP  should not be parsed inside directive value - HTTP header
+PASS U+000B VT    should not be parsed between directive name and value - meta tag
+PASS U+000B VT    should not be parsed between directive name and value - HTTP header
+PASS U+000B VT    should not be parsed inside directive value - meta tag
+PASS U+000B VT    should not be parsed inside directive value - HTTP header
 

--- a/LayoutTests/imported/w3c/web-platform-tests/content-security-policy/generic/only-valid-whitespaces-are-allowed.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/content-security-policy/generic/only-valid-whitespaces-are-allowed.html
@@ -31,6 +31,11 @@
       // https://github.com/webcompat/web-bugs/issues/18902 has more details about why this particularly relevant
       { "csp": "img-src\u00A0'none';", "expected": true, "name": "U+00A0 NBSP  should not be parsed between directive name and value" },
       { "csp": "img-src http://example.com\u00A0http://example2.com;", "expected": true, "name": "U+00A0 NBSP  should not be parsed inside directive value" },
+
+      // Ensure vertical tab (U+000B) is not considered a valid whitespace
+      // ASCII whitespace does not include vertical tab per https://infra.spec.whatwg.org/#ascii-whitespace
+      { "csp": "img-src\u000B'none';", "expected": true, "name": "U+000B VT    should not be parsed between directive name and value" },
+      { "csp": "img-src http://example.com\u000Bhttp://example2.com;", "expected": true, "name": "U+000B VT    should not be parsed inside directive value" },
     ];
 
     tests.forEach(test => {

--- a/Source/WTF/wtf/text/ParsingUtilities.h
+++ b/Source/WTF/wtf/text/ParsingUtilities.h
@@ -37,11 +37,6 @@
 
 namespace WTF {
 
-template<typename CharacterType> inline bool isNotASCIISpace(CharacterType c)
-{
-    return !isUnicodeCompatibleASCIIWhitespace(c);
-}
-
 template<typename CharacterType, typename DelimiterType> bool skipExactly(const CharacterType*& position, const CharacterType* end, DelimiterType delimiter)
 {
     if (position < end && *position == delimiter) {
@@ -297,7 +292,6 @@ static inline bool Latin1CharacterPredicateAdapter(Latin1Character c) { return c
 } // namespace WTF
 
 using WTF::Latin1CharacterPredicateAdapter;
-using WTF::isNotASCIISpace;
 using WTF::skipCharactersExactly;
 using WTF::skipExactly;
 using WTF::skipExactlyIgnoringASCIICase;

--- a/Source/WebCore/page/csp/ContentSecurityPolicy.cpp
+++ b/Source/WebCore/page/csp/ContentSecurityPolicy.cpp
@@ -256,7 +256,7 @@ void ContentSecurityPolicy::didReceiveHeader(const String& header, ContentSecuri
     // be combined with a comma. Walk the header string, and parse each comma
     // separated chunk as a separate header.
     readCharactersForParsing(header, [&](auto buffer) {
-        skipWhile<isUnicodeCompatibleASCIIWhitespace>(buffer);
+        skipWhile<isASCIIWhitespace>(buffer);
         auto begin = buffer.position();
 
         while (buffer.hasCharactersRemaining()) {

--- a/Source/WebCore/page/csp/ContentSecurityPolicyMediaListDirective.cpp
+++ b/Source/WebCore/page/csp/ContentSecurityPolicyMediaListDirective.cpp
@@ -40,7 +40,7 @@ WTF_MAKE_TZONE_ALLOCATED_IMPL(ContentSecurityPolicyMediaListDirective);
 
 template<typename CharacterType> static bool isMediaTypeCharacter(CharacterType c)
 {
-    return !isUnicodeCompatibleASCIIWhitespace(c) && c != '/';
+    return !isASCIIWhitespace(c) && c != '/';
 }
 
 ContentSecurityPolicyMediaListDirective::ContentSecurityPolicyMediaListDirective(const ContentSecurityPolicyDirectiveList& directiveList, const String& name, const String& value)
@@ -66,7 +66,7 @@ void ContentSecurityPolicyMediaListDirective::parse(const String& value)
         while (buffer.hasCharactersRemaining()) {
             // _____ OR _____mime1/mime1
             // ^        ^
-            skipWhile<isUnicodeCompatibleASCIIWhitespace>(buffer);
+            skipWhile<isASCIIWhitespace>(buffer);
             if (buffer.atEnd())
                 return;
 
@@ -74,7 +74,7 @@ void ContentSecurityPolicyMediaListDirective::parse(const String& value)
             // ^
             auto begin = buffer.position();
             if (!skipExactly<isMediaTypeCharacter>(buffer)) {
-                skipWhile<isNotASCIISpace>(buffer);
+                skipWhile<isNotASCIIWhitespace>(buffer);
                 directiveList().policy().reportInvalidPluginTypes(String({ begin, buffer.position() }));
                 continue;
             }
@@ -83,7 +83,7 @@ void ContentSecurityPolicyMediaListDirective::parse(const String& value)
             // mime1/mime1 mime2/mime2
             //      ^
             if (!skipExactly(buffer, '/')) {
-                skipWhile<isNotASCIISpace>(buffer);
+                skipWhile<isNotASCIIWhitespace>(buffer);
                 directiveList().policy().reportInvalidPluginTypes(String({ begin, buffer.position() }));
                 continue;
             }
@@ -91,7 +91,7 @@ void ContentSecurityPolicyMediaListDirective::parse(const String& value)
             // mime1/mime1 mime2/mime2
             //       ^
             if (!skipExactly<isMediaTypeCharacter>(buffer)) {
-                skipWhile<isNotASCIISpace>(buffer);
+                skipWhile<isNotASCIIWhitespace>(buffer);
                 directiveList().policy().reportInvalidPluginTypes(String({ begin, buffer.position() }));
                 continue;
             }
@@ -99,14 +99,14 @@ void ContentSecurityPolicyMediaListDirective::parse(const String& value)
 
             // mime1/mime1 mime2/mime2 OR mime1/mime1  OR mime1/mime1/error
             //            ^                          ^               ^
-            if (buffer.hasCharactersRemaining() && isNotASCIISpace(*buffer)) {
-                skipWhile<isNotASCIISpace>(buffer);
+            if (buffer.hasCharactersRemaining() && isNotASCIIWhitespace(*buffer)) {
+                skipWhile<isNotASCIIWhitespace>(buffer);
                 directiveList().policy().reportInvalidPluginTypes(String({ begin, buffer.position() }));
                 continue;
             }
             m_pluginTypes.add(String({ begin, buffer.position() }));
 
-            ASSERT(buffer.atEnd() || isUnicodeCompatibleASCIIWhitespace(*buffer));
+            ASSERT(buffer.atEnd() || isASCIIWhitespace(*buffer));
         }
     });
 }

--- a/Source/WebCore/page/csp/ContentSecurityPolicySourceList.cpp
+++ b/Source/WebCore/page/csp/ContentSecurityPolicySourceList.cpp
@@ -60,11 +60,6 @@ static bool isCSPDirectiveName(StringView name)
         || equalIgnoringASCIICase(name, ContentSecurityPolicyDirectiveNames::styleSrc);
 }
 
-template<typename CharacterType> static bool isSourceCharacter(CharacterType c)
-{
-    return !isUnicodeCompatibleASCIIWhitespace(c);
-}
-
 template<typename CharacterType> static bool isHostCharacter(CharacterType c)
 {
     return isASCIIAlphanumeric(c) || c == '-';
@@ -87,12 +82,12 @@ template<typename CharacterType> static bool isNotColonOrSlash(CharacterType c)
 
 template<typename CharacterType> static bool isSourceListNone(StringParsingBuffer<CharacterType> buffer)
 {
-    skipWhile<isUnicodeCompatibleASCIIWhitespace>(buffer);
+    skipWhile<isASCIIWhitespace>(buffer);
 
     if (!skipExactlyIgnoringASCIICase(buffer, "'none'"_s))
         return false;
 
-    skipWhile<isUnicodeCompatibleASCIIWhitespace>(buffer);
+    skipWhile<isASCIIWhitespace>(buffer);
 
     return buffer.atEnd();
 }
@@ -242,12 +237,12 @@ static bool extensionModeAllowsKeywordsForDirective(ContentSecurityPolicyModeFor
 template<typename CharacterType> void ContentSecurityPolicySourceList::parse(StringParsingBuffer<CharacterType> buffer)
 {
     while (buffer.hasCharactersRemaining()) {
-        skipWhile<isUnicodeCompatibleASCIIWhitespace>(buffer);
+        skipWhile<isASCIIWhitespace>(buffer);
         if (buffer.atEnd())
             return;
 
         auto beginSource = buffer.span();
-        skipWhile<isSourceCharacter>(buffer);
+        skipWhile<isNotASCIIWhitespace>(buffer);
 
         StringParsingBuffer sourceBuffer(beginSource.first(buffer.position() - beginSource.data()));
 
@@ -270,7 +265,7 @@ template<typename CharacterType> void ContentSecurityPolicySourceList::parse(Str
         } else
             m_policy->reportInvalidSourceExpression(m_directiveName, beginSource.first(buffer.position() - beginSource.data()));
 
-        ASSERT(buffer.atEnd() || isUnicodeCompatibleASCIIWhitespace(*buffer));
+        ASSERT(buffer.atEnd() || isASCIIWhitespace(*buffer));
     }
     
     m_list.shrinkToFit();


### PR DESCRIPTION
#### 37ee63b78f13433af9cf33fef225cff8380363ca
<pre>
Use isASCIIWhitespace for CSP
<a href="https://bugs.webkit.org/show_bug.cgi?id=255990">https://bugs.webkit.org/show_bug.cgi?id=255990</a>
<a href="https://rdar.apple.com/108559413">rdar://108559413</a>

Reviewed by Darin Adler.

Switch from isUnicodeCompatibleASCIIWhitespace to isASCIIWhitespace as
per:

    <a href="https://w3c.github.io/webappsec-csp/#framework-infrastructure">https://w3c.github.io/webappsec-csp/#framework-infrastructure</a>

Test changes:

    <a href="https://github.com/web-platform-tests/wpt/pull/57326">https://github.com/web-platform-tests/wpt/pull/57326</a>

Canonical link: <a href="https://commits.webkit.org/306222@main">https://commits.webkit.org/306222@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/521728ff5d4295b267a9a14437a6d89c945fe78c

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/140737 "Passed style check") | [  ~~🛠 ios~~](https://ews-build.webkit.org/#/builders/159/builds/13119 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/168/builds/2285 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/149090 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/93825 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/142610 "Passed tests") | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/155/builds/13831 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/156/builds/13273 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/149090 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/93825 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/143688 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/155/builds/13831 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/168/builds/2285 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/149090 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | ⏳ 🛠 vision-apple 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/155/builds/13831 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/168/builds/2285 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wpe-cairo-libwebrtc~~](https://ews-build.webkit.org/#/builders/166/builds/9170 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/132715 "Built successfully and passed tests") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/155/builds/13831 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/168/builds/2285 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/2/builds/151700 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [  ~~🛠 🧪 jsc-debug-arm64~~](https://ews-build.webkit.org/#/builders/171/builds/1535 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 vision~~](https://ews-build.webkit.org/#/builders/153/builds/12807 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/168/builds/2285 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/2/builds/151700 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 vision-sim~~](https://ews-build.webkit.org/#/builders/160/builds/12822 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/156/builds/13273 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/2/builds/151700 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [⏳ 🧪 vision-wk2 ](https://ews-build.webkit.org/#/builders/visionOS-26-Simulator-WK2-Tests-EWS "Waiting in queue, processing has not started yet") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/168/builds/2285 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/67947 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/21712 "Built successfully and passed tests") | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/158/builds/12849 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/168/builds/2285 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 jsc-armv7~~](https://ews-build.webkit.org/#/builders/35/builds/172029 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/157/builds/12589 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/76549 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 jsc-armv7-tests~~](https://ews-build.webkit.org/#/builders/35/builds/172029 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/163/builds/12788 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/152/builds/12633 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
<!--EWS-Status-Bubble-End-->