### PR TITLE
Refactor Canvas noise injection logic and improve support for gradients in post-processed ImageData

### DIFF
--- a/Source/WebCore/Headers.cmake
+++ b/Source/WebCore/Headers.cmake
@@ -953,6 +953,7 @@ set(WebCore_PRIVATE_FRAMEWORK_HEADERS
     html/CachedHTMLCollection.h
     html/CachedHTMLCollectionInlines.h
     html/CanvasBase.h
+    html/CanvasNoiseInjection.h
     html/CanvasObserver.h
     html/CollectionTraversal.h
     html/CollectionTraversalInlines.h

--- a/Source/WebCore/Sources.txt
+++ b/Source/WebCore/Sources.txt
@@ -1259,6 +1259,7 @@ html/BaseDateAndTimeInputType.cpp
 html/BaseTextInputType.cpp
 html/ButtonInputType.cpp
 html/CanvasBase.cpp
+html/CanvasNoiseInjection.cpp
 html/CheckboxInputType.cpp
 html/ColorInputType.cpp
 html/CustomPaintCanvas.cpp

--- a/Source/WebCore/html/CanvasBase.cpp
+++ b/Source/WebCore/html/CanvasBase.cpp
@@ -109,7 +109,7 @@ void CanvasBase::makeRenderingResultsAvailable()
 {
     if (auto* context = renderingContext()) {
         context->paintRenderingResultsToCanvas();
-        postProcessDirtyCanvasBuffer();
+        m_canvasNoiseInjection.postProcessDirtyCanvasBuffer(buffer(), *scriptExecutionContext()->noiseInjectionHashSalt());
     }
 }
 
@@ -203,8 +203,12 @@ void CanvasBase::notifyObserversCanvasChanged(const std::optional<FloatRect>& re
 void CanvasBase::didDraw(const std::optional<FloatRect>& rect, ShouldApplyPostProcessingToDirtyRect shouldApplyPostProcessingToDirtyRect)
 {
     // FIXME: We should exclude rects with ShouldApplyPostProcessingToDirtyRect::No
-    if (shouldInjectNoiseBeforeReadback() && shouldApplyPostProcessingToDirtyRect == ShouldApplyPostProcessingToDirtyRect::Yes && rect)
-        m_postProcessDirtyRect.unite(*rect);
+    if (shouldInjectNoiseBeforeReadback() && shouldApplyPostProcessingToDirtyRect == ShouldApplyPostProcessingToDirtyRect::Yes) {
+        if (rect)
+            m_canvasNoiseInjection.updateDirtyRect(intersection(enclosingIntRect(*rect), { { }, size() }));
+        else
+            m_canvasNoiseInjection.updateDirtyRect({ { }, size() });
+    }
 }
 
 void CanvasBase::notifyObserversCanvasResized()
@@ -373,92 +377,12 @@ bool CanvasBase::shouldInjectNoiseBeforeReadback() const
     return scriptExecutionContext() && scriptExecutionContext()->noiseInjectionHashSalt();
 }
 
-void CanvasBase::postProcessDirtyCanvasBuffer() const
-{
-    if (!shouldInjectNoiseBeforeReadback())
-        return;
-
-    if (m_postProcessDirtyRect.isEmpty())
-        return;
-
-    ImageBuffer* imageBuffer = buffer();
-    if (!imageBuffer)
-        return;
-
-    auto imageRect = enclosingIntRect(m_postProcessDirtyRect);
-    imageRect.intersect({ { }, size() });
-    PixelBufferFormat format { AlphaPremultiplication::Unpremultiplied, PixelFormat::RGBA8, imageBuffer->colorSpace() };
-    auto pixelBuffer = imageBuffer->getPixelBuffer(format, imageRect);
-    if (!is<ByteArrayPixelBuffer>(pixelBuffer))
-        return;
-
-    if (postProcessPixelBufferResults(*pixelBuffer, { })) {
-        imageBuffer->putPixelBuffer(*pixelBuffer, imageRect, imageRect.location());
-        m_postProcessDirtyRect = { };
-    }
-}
-
-bool CanvasBase::postProcessPixelBufferResults(Ref<PixelBuffer>&& pixelBuffer, const HashSet<uint32_t>& suppliedColors) const
+bool CanvasBase::postProcessPixelBufferResults(Ref<PixelBuffer>&& pixelBuffer) const
 {
     if (!shouldInjectNoiseBeforeReadback())
         return false;
 
-    ASSERT(pixelBuffer->format().pixelFormat == PixelFormat::RGBA8);
-
-    constexpr auto contextString { "Canvas2DContextString"_s };
-    unsigned salt = computeHash<String, uint64_t>(contextString, *scriptExecutionContext()->noiseInjectionHashSalt());
-    constexpr int bytesPerPixel = 4;
-    auto* bytes = pixelBuffer->bytes();
-    HashMap<uint32_t, uint32_t> pixelColorMap;
-    bool wasPixelBufferModified { false };
-
-    for (size_t i = 0; i < pixelBuffer->sizeInBytes(); i += bytesPerPixel) {
-        auto& redChannel = bytes[i];
-        auto& greenChannel = bytes[i + 1];
-        auto& blueChannel = bytes[i + 2];
-        auto& alphaChannel = bytes[i + 3];
-        bool isBlack { !redChannel && !greenChannel && !blueChannel };
-
-        uint32_t pixel = (redChannel << 24) | (greenChannel << 16) | (blueChannel << 8) | alphaChannel;
-        // FIXME: Consider isEquivalentColor comparision instead of exact match
-        if (!pixel || !alphaChannel || !suppliedColors.isValidValue(pixel) || suppliedColors.contains(pixel))
-            continue;
-
-        if (auto color = pixelColorMap.get(pixel)) {
-            alphaChannel = static_cast<uint8_t>(color);
-            blueChannel = static_cast<uint8_t>(color >> 8);
-            greenChannel = static_cast<uint8_t>(color >> 16);
-            redChannel = static_cast<uint8_t>(color >> 24);
-            continue;
-        }
-
-        const uint64_t pixelHash = computeHash(salt, redChannel, greenChannel, blueChannel, alphaChannel);
-        // +/- ~13 is roughly 5% of the 255 max value.
-        const auto clampedFivePercent = static_cast<uint32_t>(((pixelHash * 26) / std::numeric_limits<uint32_t>::max()) - 13);
-
-        const auto clampedColorComponentOffset = [](int colorComponentOffset, int originalComponentValue) {
-            if (colorComponentOffset + originalComponentValue > std::numeric_limits<uint8_t>::max())
-                return std::numeric_limits<uint8_t>::max() - originalComponentValue;
-            if (colorComponentOffset + originalComponentValue < 0)
-                return -originalComponentValue;
-            return colorComponentOffset;
-        };
-
-        // If alpha is non-zero and the color channels are zero, then only tweak the alpha channel's value;
-        if (isBlack)
-            alphaChannel += clampedColorComponentOffset(clampedFivePercent, alphaChannel);
-        else {
-            // If alpha and any of the color channels are non-zero, then tweak all of the channels;
-            redChannel += clampedColorComponentOffset(clampedFivePercent, redChannel);
-            greenChannel += clampedColorComponentOffset(clampedFivePercent, greenChannel);
-            blueChannel += clampedColorComponentOffset(clampedFivePercent, blueChannel);
-            alphaChannel += clampedColorComponentOffset(clampedFivePercent, alphaChannel);
-        }
-        uint32_t modifiedPixel = (redChannel << 24) | (greenChannel << 16) | (blueChannel << 8) | alphaChannel;
-        pixelColorMap.set(pixel, modifiedPixel);
-        wasPixelBufferModified = true;
-    }
-    return wasPixelBufferModified;
+    return m_canvasNoiseInjection.postProcessPixelBufferResults(std::forward<Ref<PixelBuffer>>(pixelBuffer), *scriptExecutionContext()->noiseInjectionHashSalt());
 }
 
 size_t CanvasBase::activePixelMemory()

--- a/Source/WebCore/html/CanvasBase.h
+++ b/Source/WebCore/html/CanvasBase.h
@@ -25,6 +25,7 @@
 
 #pragma once
 
+#include "CanvasNoiseInjection.h"
 #include "FloatRect.h"
 #include "IntSize.h"
 #include "PixelBuffer.h"
@@ -130,7 +131,7 @@ public:
     virtual void queueTaskKeepingObjectAlive(TaskSource, Function<void()>&&) = 0;
     virtual void dispatchEvent(Event&) = 0;
 
-    bool postProcessPixelBufferResults(Ref<PixelBuffer>&&, const HashSet<uint32_t>&) const;
+    bool postProcessPixelBufferResults(Ref<PixelBuffer>&&) const;
 
 protected:
     explicit CanvasBase(IntSize);
@@ -149,16 +150,15 @@ protected:
 
 private:
     bool shouldInjectNoiseBeforeReadback() const;
-    void postProcessDirtyCanvasBuffer() const;
     virtual void createImageBuffer() const { }
 
     mutable IntSize m_size;
-    mutable FloatRect m_postProcessDirtyRect;
     mutable Lock m_imageBufferAssignmentLock;
     mutable RefPtr<ImageBuffer> m_imageBuffer;
     mutable size_t m_imageBufferCost { 0 };
     mutable std::unique_ptr<GraphicsContextStateSaver> m_contextStateSaver;
 
+    CanvasNoiseInjection m_canvasNoiseInjection;
     bool m_originClean { true };
 #if ASSERT_ENABLED
     bool m_didNotifyObserversCanvasDestroyed { false };

--- a/Source/WebCore/html/CanvasNoiseInjection.cpp
+++ b/Source/WebCore/html/CanvasNoiseInjection.cpp
@@ -1,0 +1,229 @@
+/*
+ * Copyright (c) 2023 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "CanvasNoiseInjection.h"
+
+#include "ByteArrayPixelBuffer.h"
+#include "FloatRect.h"
+#include "ImageBuffer.h"
+#include "PixelBuffer.h"
+
+namespace WebCore {
+
+void CanvasNoiseInjection::updateDirtyRect(const IntRect& rect)
+{
+    m_postProcessDirtyRect.unite(rect);
+}
+
+static inline bool isIndexInBounds(int size, int index)
+{
+    ASSERT(index < size);
+    return index < size;
+};
+
+static inline void setTightnessBounds(const std::span<uint8_t>& bytes, std::array<int, 4>& tightestBoundingDiff, int index1, int index2)
+{
+    int redDiff = bytes[index1] - bytes[index2];
+    int greenDiff = bytes[index1 + 1] - bytes[index2 + 1];
+    int blueDiff = bytes[index1 + 2] - bytes[index2 + 2];
+    int alphaDiff = bytes[index1 + 3] - bytes[index2 + 3];
+
+    if (redDiff < tightestBoundingDiff[0]
+        && greenDiff < tightestBoundingDiff[1]
+        && blueDiff < tightestBoundingDiff[2]
+        && alphaDiff < tightestBoundingDiff[3]) {
+        tightestBoundingDiff[0] = redDiff;
+        tightestBoundingDiff[1] = greenDiff;
+        tightestBoundingDiff[2] = blueDiff;
+        tightestBoundingDiff[3] = alphaDiff;
+    }
+}
+
+static std::optional<std::pair<int, int>> getGradientNeighbors(int index, const std::span<uint8_t>& bytes, const IntSize& size)
+{
+    constexpr auto bytesPerPixel = 4U;
+    auto bufferSize = bytes.size_bytes();
+    auto pixelIndex = index / bytesPerPixel;
+    bool isInTopRow = pixelIndex < static_cast<size_t>(size.width());
+    bool isInBottomRow = pixelIndex > static_cast<size_t>((size.height() - 1) * size.width());
+    bool isInLeftColumn = !(pixelIndex % size.width());
+    bool isInRightColumn = (pixelIndex % size.width()) == static_cast<unsigned>(size.width()) - 1;
+    bool isInTopLeftCorner = isInTopRow && isInLeftColumn;
+    bool isInBottomLeftCorner = isInBottomRow && isInLeftColumn;
+    bool isInTopRightCorner = isInTopRow && isInRightColumn;
+    bool isInBotomRightCorner = isInBottomRow && isInRightColumn;
+
+    if (isInTopLeftCorner || isInBottomLeftCorner || isInTopRightCorner || isInBotomRightCorner)
+        return std::nullopt;
+
+    constexpr auto leftOffset = -bytesPerPixel;
+    constexpr auto rightOffset = bytesPerPixel;
+    const auto aboveOffset = -size.width() * bytesPerPixel;
+    const auto belowOffset = size.width() * bytesPerPixel;
+    const auto aboveLeftOffset = aboveOffset + leftOffset;
+    const auto aboveRightOffset = aboveOffset + rightOffset;
+    const auto belowLeftOffset = belowOffset + leftOffset;
+    const auto belowRightOffset = belowOffset + rightOffset;
+
+    const int leftIndex = index + leftOffset;
+    const int rightIndex = index + rightOffset;
+    const int aboveIndex = index + aboveOffset;
+    const int belowIndex = index + belowOffset;
+    const int aboveLeftIndex = index + aboveLeftOffset;
+    const int aboveRightIndex = index + aboveRightOffset;
+    const int belowLeftIndex = index + belowLeftOffset;
+    const int belowRightIndex = index + belowRightOffset;
+
+    const auto areColorsDescending = [&bytes, bufferSize](int index1, int index2, int index3) {
+        if (!isIndexInBounds(bufferSize, index1) || !isIndexInBounds(bufferSize, index1 + 3))
+            return false;
+        if (!isIndexInBounds(bufferSize, index2) || !isIndexInBounds(bufferSize, index2 + 3))
+            return false;
+        if (!isIndexInBounds(bufferSize, index3) || !isIndexInBounds(bufferSize, index3 + 3))
+            return false;
+        return bytes[index1] <= bytes[index2] && bytes[index2] <= bytes[index3]
+            && bytes[index1 + 1] <= bytes[index2 + 1] && bytes[index2 + 1] <= bytes[index3 + 1]
+            && bytes[index1 + 2] <= bytes[index2 + 2] && bytes[index2 + 2] <= bytes[index3 + 2]
+            && bytes[index1 + 3] <= bytes[index2 + 3] && bytes[index2 + 3] <= bytes[index3 + 3];
+    };
+
+    const auto compareColorsAndSetBounds = [&areColorsDescending](const auto& bytes, auto& tightestBoundingIndices, auto& tightestBoundingDiff, auto colorIndex, auto neighborIndex1, auto neighborIndex2) {
+        if (areColorsDescending(neighborIndex1, colorIndex, neighborIndex2)) {
+            tightestBoundingIndices = { neighborIndex1, neighborIndex2 };
+            setTightnessBounds(bytes, tightestBoundingDiff, neighborIndex1, neighborIndex2);
+        } else if (areColorsDescending(neighborIndex2, colorIndex, neighborIndex1)) {
+            tightestBoundingIndices = { neighborIndex2, neighborIndex1 };
+            setTightnessBounds(bytes, tightestBoundingDiff, neighborIndex2, neighborIndex1);
+        }
+    };
+
+    if (isInTopRow || isInBottomRow) {
+        if (areColorsDescending(leftIndex, index, rightIndex))
+            return { { leftIndex, rightIndex } };
+        if (areColorsDescending(rightIndex, index, leftIndex))
+            return { { rightIndex, leftIndex } };
+        return std::nullopt;
+    }
+
+    if (isInLeftColumn || isInRightColumn) {
+        if (areColorsDescending(aboveIndex, index, belowIndex))
+            return { { aboveIndex, belowIndex } };
+        if (areColorsDescending(belowIndex, index, aboveIndex))
+            return { { belowIndex, aboveIndex } };
+        return std::nullopt;
+    }
+
+    std::optional<std::pair<int, int>> tightestBoundingIndices;
+    std::array<int, 4> tightestBoundingDiff { 255, 255, 255, 255 };
+
+    compareColorsAndSetBounds(bytes, tightestBoundingIndices, tightestBoundingDiff, index, leftIndex, rightIndex);
+    compareColorsAndSetBounds(bytes, tightestBoundingIndices, tightestBoundingDiff, index, aboveIndex, belowIndex);
+    compareColorsAndSetBounds(bytes, tightestBoundingIndices, tightestBoundingDiff, index, aboveLeftIndex, belowRightIndex);
+    compareColorsAndSetBounds(bytes, tightestBoundingIndices, tightestBoundingDiff, index, aboveRightIndex, belowLeftIndex);
+
+    return tightestBoundingIndices;
+}
+
+void CanvasNoiseInjection::postProcessDirtyCanvasBuffer(ImageBuffer* imageBuffer, NoiseInjectionHashSalt salt)
+{
+    if (m_postProcessDirtyRect.isEmpty())
+        return;
+
+    if (!imageBuffer)
+        return;
+
+    PixelBufferFormat format { AlphaPremultiplication::Unpremultiplied, PixelFormat::RGBA8, imageBuffer->colorSpace() };
+    auto pixelBuffer = imageBuffer->getPixelBuffer(format, m_postProcessDirtyRect);
+    if (!is<ByteArrayPixelBuffer>(pixelBuffer))
+        return;
+
+    if (postProcessPixelBufferResults(*pixelBuffer, salt)) {
+        imageBuffer->putPixelBuffer(*pixelBuffer, m_postProcessDirtyRect, m_postProcessDirtyRect.location());
+        m_postProcessDirtyRect = { };
+    }
+}
+
+bool CanvasNoiseInjection::postProcessPixelBufferResults(PixelBuffer& pixelBuffer, NoiseInjectionHashSalt salt) const
+{
+    ASSERT(pixelBuffer.format().pixelFormat == PixelFormat::RGBA8);
+
+    constexpr int bytesPerPixel = 4;
+    std::span<uint8_t> bytes = makeSpan(pixelBuffer.bytes(), pixelBuffer.sizeInBytes());
+    bool wasPixelBufferModified { false };
+
+    for (size_t i = 0; i < bytes.size_bytes(); i += bytesPerPixel) {
+        auto& redChannel = bytes[i];
+        auto& greenChannel = bytes[i + 1];
+        auto& blueChannel = bytes[i + 2];
+        auto& alphaChannel = bytes[i + 3];
+        bool isBlack { !redChannel && !greenChannel && !blueChannel };
+
+        if (!alphaChannel)
+            continue;
+
+        const uint64_t pixelHash = computeHash(salt, redChannel, greenChannel, blueChannel, alphaChannel);
+        // +/- 3 is roughly ~1% of the 255 max value.
+        const auto clampedOnePercent = static_cast<int8_t>(((pixelHash * 6) / std::numeric_limits<uint32_t>::max()) - 3);
+
+        const auto clampedColorComponentOffset = [](int colorComponentOffset, int originalComponentValue, int minBoundingColor, int maxBoundingColor) {
+            if (colorComponentOffset + originalComponentValue > maxBoundingColor)
+                return maxBoundingColor - originalComponentValue;
+            if (colorComponentOffset + originalComponentValue < minBoundingColor)
+                return minBoundingColor - originalComponentValue;
+            return colorComponentOffset;
+        };
+
+        std::array<int, 4> minNeighorColor { 0, 0, 0, 0 };
+        std::array<int, 4> maxNeighorColor { 255, 255, 255, 255 };
+        if (auto neighbors = getGradientNeighbors(i, bytes, pixelBuffer.size())) {
+            auto [minNeighorColorIndex, maxNeighorColorIndex] = *neighbors;
+            minNeighorColor[0] = bytes[minNeighorColorIndex];
+            minNeighorColor[1] = bytes[minNeighorColorIndex + 1];
+            minNeighorColor[2] = bytes[minNeighorColorIndex + 2];
+            minNeighorColor[3] = bytes[minNeighorColorIndex + 3];
+
+            maxNeighorColor[0] = bytes[maxNeighorColorIndex];
+            maxNeighorColor[1] = bytes[maxNeighorColorIndex + 1];
+            maxNeighorColor[2] = bytes[maxNeighorColorIndex + 2];
+            maxNeighorColor[3] = bytes[maxNeighorColorIndex + 3];
+        }
+
+        // If alpha is non-zero and the color channels are zero, then only tweak the alpha channel's value;
+        if (isBlack)
+            alphaChannel += clampedColorComponentOffset(clampedOnePercent, alphaChannel, minNeighorColor[3], maxNeighorColor[3]);
+        else {
+            // If alpha and any of the color channels are non-zero, then tweak all of the channels;
+            redChannel += clampedColorComponentOffset(clampedOnePercent, redChannel, minNeighorColor[0], maxNeighorColor[0]);
+            greenChannel += clampedColorComponentOffset(clampedOnePercent, greenChannel, minNeighorColor[1], maxNeighorColor[1]);
+            blueChannel += clampedColorComponentOffset(clampedOnePercent, blueChannel, minNeighorColor[2], maxNeighorColor[2]);
+            alphaChannel += clampedColorComponentOffset(clampedOnePercent, alphaChannel, minNeighorColor[3], maxNeighorColor[3]);
+        }
+        wasPixelBufferModified = true;
+    }
+    return wasPixelBufferModified;
+}
+
+} // namespace WebCore

--- a/Source/WebCore/html/CanvasNoiseInjection.h
+++ b/Source/WebCore/html/CanvasNoiseInjection.h
@@ -1,0 +1,47 @@
+/*
+ * Copyright (c) 2023 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include "IntRect.h"
+
+namespace WebCore {
+
+class CanvasBase;
+class ImageBuffer;
+class PixelBuffer;
+
+using NoiseInjectionHashSalt = uint64_t;
+
+class CanvasNoiseInjection {
+public:
+    void postProcessDirtyCanvasBuffer(ImageBuffer*, NoiseInjectionHashSalt);
+    bool postProcessPixelBufferResults(PixelBuffer&, NoiseInjectionHashSalt) const;
+    void updateDirtyRect(const IntRect&);
+
+private:
+    IntRect m_postProcessDirtyRect;
+};
+} // namespace WebCore

--- a/Source/WebCore/html/HTMLCanvasElement.cpp
+++ b/Source/WebCore/html/HTMLCanvasElement.cpp
@@ -804,7 +804,7 @@ RefPtr<ImageData> HTMLCanvasElement::getImageData()
         return nullptr;
 
     if (pixelBuffer)
-        postProcessPixelBufferResults(*pixelBuffer, { });
+        postProcessPixelBufferResults(*pixelBuffer);
 
     return ImageData::create(static_reference_cast<ByteArrayPixelBuffer>(pixelBuffer.releaseNonNull()));
 #else


### PR DESCRIPTION
#### 709720db3aff1b6405ab14f6ce9d763805f74eb1
<pre>
Refactor Canvas noise injection logic and improve support for gradients in post-processed ImageData
<a href="https://bugs.webkit.org/show_bug.cgi?id=255993">https://bugs.webkit.org/show_bug.cgi?id=255993</a>
rdar://107371244

Reviewed by NOBODY (OOPS!).

Gradients present an interesting problem when post-processing canvas ImageData
because tweaking colors result in significant visual anomalies. This change
introduces some naive gradient detection by looking at all of the immediate
neighbors of a pixel. We decide that a pixel is within a gradient if the
current color is between its opposing adjacent colors (e.g., above and below,
left and right, etc). If a color is decided to be within a gradient, then we
set those adjacent colors as bounds within which we can tweak the current
color.

In addition, within this change, we move the noise injection logic into its own
class, it removes the dependency on supplied colors for post-processing, and it
reduces the magnitude of noise from ~5% to ~1%.

* Source/WebCore/Headers.cmake:
* Source/WebCore/Sources.txt:
* Source/WebCore/WebCore.xcodeproj/project.pbxproj:
* Source/WebCore/html/CanvasBase.cpp:
(WebCore::CanvasBase::makeRenderingResultsAvailable):
(WebCore::CanvasBase::didDraw): We clip the rect before passing it into
CanvasNoiseInjection, and if the rect is std::nullopt then we pass in the
entire canvas.

(WebCore::CanvasBase::postProcessPixelBufferResults const):
(WebCore::CanvasBase::postProcessDirtyCanvasBuffer const): Deleted.
* Source/WebCore/html/CanvasBase.h:
* Source/WebCore/html/CanvasNoiseInjection.cpp: Added.
(WebCore::CanvasNoiseInjection::updateDirtyRect):
(WebCore::isIndexInBounds):
(WebCore::setTightnessBounds):
(WebCore::getGradientNeighbors):
(WebCore::CanvasNoiseInjection::postProcessDirtyCanvasBuffer):
(WebCore::CanvasNoiseInjection::postProcessPixelBufferResults const):
* Source/WebCore/html/CanvasNoiseInjection.h: Added.
* Source/WebCore/html/HTMLCanvasElement.cpp:
(WebCore::HTMLCanvasElement::getImageData):
</pre>