### PR TITLE
Keep only 'CEReactions' for 'value' in HTMLOptionElement.idl

### DIFF
--- a/Source/WebCore/html/HTMLOptionElement.idl
+++ b/Source/WebCore/html/HTMLOptionElement.idl
@@ -31,6 +31,6 @@
     attribute boolean selected;
     [CEReactions=NotNeeded] attribute [AtomString] DOMString value;
 
-    [CEReactions=NotNeeded, CEReactions] attribute DOMString text;
+    [CEReactions] attribute DOMString text;
     readonly attribute long index;
 };


### PR DESCRIPTION
#### 36b39fa88451d43c2afb6996534a13381260008e
<pre>
Keep only &apos;CEReactions&apos; for &apos;value&apos; in HTMLOptionElement.idl

<a href="https://bugs.webkit.org/show_bug.cgi?id=255998">https://bugs.webkit.org/show_bug.cgi?id=255998</a>

Reviewed by Ryosuke Niwa.

This patch just removes &apos;CEReactions=NotNeeded&apos; while &apos;CEReactions&apos; is also present for &apos;text&apos; value.
In WebKit, we need &apos;CEReactions&apos; here.

* Source/WebCore/html/HTMLOptionElement.idl: As above

Canonical link: <a href="https://commits.webkit.org/263450@main">https://commits.webkit.org/263450@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/96016c5539b86240f7f4e98a9d84da23af692b04

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/4598 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/4718 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/4871 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/6091 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/4755 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/4589 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/4857 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/4677 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/4995 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/4667 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/4761 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/4118 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/6101 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/2249 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/4110 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/9107 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/4109 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/4184 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/5729 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/4576 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/3726 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/4105 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/1140 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/8148 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/4466 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->