### PR TITLE
[GTK] Test gardening for `fast/forms`

### DIFF
--- a/LayoutTests/platform/gtk/fast/forms/input-text-scroll-left-on-blur-expected.txt
+++ b/LayoutTests/platform/gtk/fast/forms/input-text-scroll-left-on-blur-expected.txt
@@ -20,7 +20,7 @@ layer at (11,11) size 186x18 scrollWidth 398
   RenderBlock {DIV} at (3,3) size 186x18
     RenderText {#text} at (0,0) size 397x17
       text run at (0,0) width 397: "this text field has a lot of text in it so that it needs to scroll"
-layer at (207,11) size 185x18 scrollX 213 scrollWidth 398
+layer at (207,11) size 185x18 scrollX 212 scrollWidth 397
   RenderBlock {DIV} at (3,3) size 185x18
     RenderText {#text} at (-212,0) size 397x17
       text run at (-212,0) width 25: "this"

--- a/LayoutTests/platform/gtk/fast/forms/search-rtl-expected.txt
+++ b/LayoutTests/platform/gtk/fast/forms/search-rtl-expected.txt
@@ -31,7 +31,7 @@ layer at (0,0) size 800x600
       RenderBlock {P} at (0,122) size 784x18
         RenderText {#text} at (0,0) size 38x17
           text run at (0,0) width 38: "PASS"
-layer at (27,45) size 153x18 scrollX 20 scrollWidth 173
+layer at (27,45) size 153x18 scrollX 19 scrollWidth 172
   RenderBlock {DIV} at (0,0) size 153x18
     RenderText {#text} at (-19,0) size 173x17
       text run at (-19,0) width 23 RTL: "\x{5D5}\x{5D6}\x{5D4}\x{5D5}"


### PR DESCRIPTION
#### 32573106669f7f0aaf816dec1c3a4c48a3b2aaaa
<pre>
[GTK] Test gardening for `fast/forms`

Unreviewed test gardening.

Update baselines after 259433@main and 259710@main.

* LayoutTests/platform/gtk/fast/forms/input-text-scroll-left-on-blur-expected.txt:
* LayoutTests/platform/gtk/fast/forms/search-rtl-expected.txt:

Canonical link: <a href="https://commits.webkit.org/263451@main">https://commits.webkit.org/263451@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/61e1f3a10b5c7b93a68e2e46674045d5130c7e04

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/4600 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/4720 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/4873 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/6093 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/4757 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/4859 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/4679 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/4998 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/4669 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/4764 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/4122 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/6103 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/2253 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/4114 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/9106 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/4112 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/4188 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/5731 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/4578 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/3730 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/4107 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/1141 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/8150 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/4468 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->