### PR TITLE
[CoreIPC] Messages::GPUConnectionToWebProcess::SetUserPreferredLanguages is sent from WCP and not UIP

### DIFF
--- a/LayoutTests/http/tests/media/hls/hls-audio-tracks-locale-selection-expected.txt
+++ b/LayoutTests/http/tests/media/hls/hls-audio-tracks-locale-selection-expected.txt
@@ -1,5 +1,4 @@
 
-RUN(internals.setUserPreferredLanguages(["jp", "fr", "es-EN", "en"]))
 EVENT(canplaythrough)
 EXPECTED (video.audioTracks.length == '3') OK
 EXPECTED (video.audioTracks[0].enabled == 'false') OK

--- a/LayoutTests/http/tests/media/hls/hls-audio-tracks-locale-selection.html
+++ b/LayoutTests/http/tests/media/hls/hls-audio-tracks-locale-selection.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html>
+<!DOCTYPE html><!-- webkit-test-runner [ language=jp,fr,es-EN,en ] -->
 <html>
     <head>
         <script src=../../media-resources/video-test.js></script>
@@ -9,11 +9,6 @@
             }
 
             function start() {
-                if (window.internals)
-                    run('internals.setUserPreferredLanguages(["jp", "fr", "es-EN", "en"])');
-                else
-                    consoleWrite('Change your system language to French, and check that the french audio track was selected by default.');
-
                 video = document.getElementById('video');
                 waitForEvent('canplaythrough', canplaythrough);
                 video.src = "../resources/hls/audio-tracks.m3u8";

--- a/Source/WebCore/testing/Internals.idl
+++ b/Source/WebCore/testing/Internals.idl
@@ -521,6 +521,11 @@ typedef (FetchRequest or FetchResponse) FetchObject;
     undefined advanceToNextMisspelling();
 
     sequence<DOMString> userPreferredLanguages();
+
+    // This only overrides the languages inside the WebProcess, not the GPUProcess.
+    // To override the language more globally, please add something like this to
+    // your test instead:
+    // <!-- webkit-test-runner [ language=jp,fr ] -->
     undefined setUserPreferredLanguages(sequence<DOMString> languages);
 
     sequence<DOMString> userPreferredAudioCharacteristics();

--- a/Source/WebKit/GPUProcess/GPUConnectionToWebProcess.cpp
+++ b/Source/WebKit/GPUProcess/GPUConnectionToWebProcess.cpp
@@ -71,7 +71,6 @@
 #include <WebCore/MediaPlayer.h>
 #include <WebCore/MockRealtimeMediaSourceCenter.h>
 #include <WebCore/NowPlayingManager.h>
-#include <wtf/Language.h>
 
 #if PLATFORM(COCOA)
 #include "RemoteLayerTreeDrawingAreaProxyMessages.h"
@@ -279,9 +278,6 @@ GPUConnectionToWebProcess::GPUConnectionToWebProcess(GPUProcess& gpuProcess, Web
 #if ENABLE(ROUTING_ARBITRATION) && HAVE(AVAUDIO_ROUTING_ARBITER)
     gpuProcess.audioSessionManager().session().setRoutingArbitrationClient(m_routingArbitrator.get());
 #endif
-
-    if (!parameters.overrideLanguages.isEmpty())
-        overrideUserPreferredLanguages(parameters.overrideLanguages);
 
     // Use this flag to force synchronous messages to be treated as asynchronous messages in the WebProcess.
     // Otherwise, the WebProcess would process incoming synchronous IPC while waiting for a synchronous IPC
@@ -737,11 +733,6 @@ void GPUConnectionToWebProcess::setMediaOverridesForTesting(MediaOverridesForTes
     SystemBatteryStatusTestingOverrides::singleton().setHasAC(WTFMove(overrides.systemHasAC));
     SystemBatteryStatusTestingOverrides::singleton().setHasBattery(WTFMove(overrides.systemHasBattery));
 #endif
-}
-
-void GPUConnectionToWebProcess::setUserPreferredLanguages(const Vector<String>& languages)
-{
-    overrideUserPreferredLanguages(languages);
 }
 
 bool GPUConnectionToWebProcess::dispatchMessage(IPC::Connection& connection, IPC::Decoder& decoder)

--- a/Source/WebKit/GPUProcess/GPUConnectionToWebProcess.h
+++ b/Source/WebKit/GPUProcess/GPUConnectionToWebProcess.h
@@ -280,7 +280,6 @@ private:
     void createRemoteCommandListener(RemoteRemoteCommandListenerIdentifier);
     void releaseRemoteCommandListener(RemoteRemoteCommandListenerIdentifier);
     void setMediaOverridesForTesting(MediaOverridesForTesting);
-    void setUserPreferredLanguages(const Vector<String>&);
     void configureLoggingChannel(const String&, WTFLogChannelState, WTFLogLevel);
 
 #if USE(GRAPHICS_LAYER_WC)

--- a/Source/WebKit/GPUProcess/GPUConnectionToWebProcess.messages.in
+++ b/Source/WebKit/GPUProcess/GPUConnectionToWebProcess.messages.in
@@ -50,7 +50,6 @@ messages -> GPUConnectionToWebProcess WantsDispatchMessage {
     ReleaseAudioHardwareListener(WebKit::RemoteAudioHardwareListenerIdentifier identifier)
     CreateRemoteCommandListener(WebKit::RemoteRemoteCommandListenerIdentifier identifier)
     ReleaseRemoteCommandListener(WebKit::RemoteRemoteCommandListenerIdentifier identifier)
-    SetUserPreferredLanguages(Vector<String> languages)
     ConfigureLoggingChannel(String channelName, enum:uint8_t WTFLogChannelState state, enum:uint8_t WTFLogLevel level)
 #if USE(GRAPHICS_LAYER_WC)
     CreateWCLayerTreeHost(WebKit::WCLayerTreeHostIdentifier identifier, uint64_t nativeWindow, bool usesOffscreenRendering) AllowedWhenWaitingForSyncReply

--- a/Source/WebKit/GPUProcess/GPUProcess.cpp
+++ b/Source/WebKit/GPUProcess/GPUProcess.cpp
@@ -51,6 +51,7 @@
 #include <WebCore/RuntimeApplicationChecks.h>
 #include <wtf/Algorithms.h>
 #include <wtf/CallbackAggregator.h>
+#include <wtf/Language.h>
 #include <wtf/LogInitialization.h>
 #include <wtf/MemoryPressureHandler.h>
 #include <wtf/OptionSet.h>
@@ -278,6 +279,7 @@ void GPUProcess::initializeGPUProcess(GPUProcessCreationParameters&& parameters)
     WTF::Thread::setCurrentThreadIsUserInteractive(0);
 
     WebCore::setPresentingApplicationPID(parameters.parentPID);
+    overrideUserPreferredLanguages(parameters.overrideLanguages);
 
 #if USE(OS_STATE)
     registerWithStateDumper("GPUProcess state"_s);
@@ -340,6 +342,11 @@ bool GPUProcess::updatePreference(std::optional<bool>& oldPreference, std::optio
     }
     
     return false;
+}
+
+void GPUProcess::userPreferredLanguagesChanged(Vector<String>&& languages)
+{
+    overrideUserPreferredLanguages(languages);
 }
 
 void GPUProcess::prepareToSuspend(bool isSuspensionImminent, MonotonicTime, CompletionHandler<void()>&& completionHandler)

--- a/Source/WebKit/GPUProcess/GPUProcess.h
+++ b/Source/WebKit/GPUProcess/GPUProcess.h
@@ -153,6 +153,7 @@ private:
     void removeSession(PAL::SessionID);
     
     bool updatePreference(std::optional<bool>& oldPreference, std::optional<bool>& newPreference);
+    void userPreferredLanguagesChanged(Vector<String>&&);
 
 #if ENABLE(MEDIA_STREAM)
     void setMockCaptureDevicesEnabled(bool);

--- a/Source/WebKit/GPUProcess/GPUProcess.messages.in
+++ b/Source/WebKit/GPUProcess/GPUProcess.messages.in
@@ -83,6 +83,8 @@ messages -> GPUProcess LegacyReceiver {
     EnablePowerLogging(WebKit::SandboxExtension::Handle handle)
 #endif
 
+    UserPreferredLanguagesChanged(Vector<String> languages)
+
     WebProcessConnectionCountForTesting() -> (uint64_t count)
 }
 

--- a/Source/WebKit/GPUProcess/GPUProcessCreationParameters.cpp
+++ b/Source/WebKit/GPUProcess/GPUProcessCreationParameters.cpp
@@ -71,6 +71,8 @@ void GPUProcessCreationParameters::encode(IPC::Encoder& encoder) const
 #if USE(GBM)
     encoder << renderDeviceFile;
 #endif
+
+    encoder << overrideLanguages;
 }
 
 bool GPUProcessCreationParameters::decode(IPC::Decoder& decoder, GPUProcessCreationParameters& result)
@@ -141,6 +143,12 @@ bool GPUProcessCreationParameters::decode(IPC::Decoder& decoder, GPUProcessCreat
         return false;
     result.renderDeviceFile = WTFMove(*renderDeviceFile);
 #endif
+
+    std::optional<Vector<String>> overrideLanguages;
+    decoder >> overrideLanguages;
+    if (!overrideLanguages)
+        return false;
+    result.overrideLanguages = WTFMove(*overrideLanguages);
 
     return true;
 }

--- a/Source/WebKit/GPUProcess/GPUProcessCreationParameters.h
+++ b/Source/WebKit/GPUProcess/GPUProcessCreationParameters.h
@@ -71,6 +71,7 @@ struct GPUProcessCreationParameters {
 #if USE(GBM)
     String renderDeviceFile;
 #endif
+    Vector<String> overrideLanguages;
 
     void encode(IPC::Encoder&) const;
     static WARN_UNUSED_RETURN bool decode(IPC::Decoder&, GPUProcessCreationParameters&);

--- a/Source/WebKit/Shared/GPUProcessConnectionParameters.h
+++ b/Source/WebKit/Shared/GPUProcessConnectionParameters.h
@@ -35,7 +35,6 @@ namespace WebKit {
 
 struct GPUProcessConnectionParameters {
     WebCore::ProcessIdentity webProcessIdentity;
-    Vector<String> overrideLanguages;
     bool isLockdownModeEnabled { false };
 #if ENABLE(IPC_TESTING_API)
     bool ignoreInvalidMessageForTesting { false };

--- a/Source/WebKit/Shared/GPUProcessConnectionParameters.serialization.in
+++ b/Source/WebKit/Shared/GPUProcessConnectionParameters.serialization.in
@@ -24,7 +24,6 @@
 
 struct WebKit::GPUProcessConnectionParameters {
     WebCore::ProcessIdentity webProcessIdentity;
-    Vector<String> overrideLanguages;
     bool isLockdownModeEnabled;
 #if ENABLE(IPC_TESTING_API)
     bool ignoreInvalidMessageForTesting;

--- a/Source/WebKit/UIProcess/GPU/GPUProcessProxy.cpp
+++ b/Source/WebKit/UIProcess/GPU/GPUProcessProxy.cpp
@@ -36,6 +36,7 @@
 #include "GPUProcessProxyMessages.h"
 #include "GPUProcessSessionParameters.h"
 #include "Logging.h"
+#include "OverrideLanguages.h"
 #include "ProvisionalPageProxy.h"
 #include "WebPageGroup.h"
 #include "WebPageMessages.h"
@@ -136,6 +137,7 @@ GPUProcessProxy::GPUProcessProxy()
 
     GPUProcessCreationParameters parameters;
     parameters.auxiliaryProcessParameters = auxiliaryProcessParameters();
+    parameters.overrideLanguages = overrideLanguages();
 
 #if ENABLE(MEDIA_STREAM)
     parameters.useMockCaptureDevices = m_useMockCaptureDevices;

--- a/Source/WebKit/UIProcess/WebProcessPool.cpp
+++ b/Source/WebKit/UIProcess/WebProcessPool.cpp
@@ -375,6 +375,11 @@ void WebProcessPool::setOverrideLanguages(Vector<String>&& languages)
 
     LOG_WITH_STREAM(Language, stream << "WebProcessPool is setting OverrideLanguages: " << languages);
     sendToAllProcesses(Messages::WebProcess::UserPreferredLanguagesChanged(overrideLanguages()));
+
+#if ENABLE(GPU_PROCESS)
+    if (auto* gpuProcess = GPUProcessProxy::singletonIfCreated())
+        gpuProcess->send(Messages::GPUProcess::UserPreferredLanguagesChanged(overrideLanguages()), 0);
+#endif
 #if USE(SOUP)
     for (auto networkProcess : NetworkProcessProxy::allNetworkProcesses())
         networkProcess->send(Messages::NetworkProcess::UserPreferredLanguagesChanged(overrideLanguages()), 0);

--- a/Source/WebKit/WebProcess/GPU/GPUProcessConnection.cpp
+++ b/Source/WebKit/WebProcess/GPU/GPUProcessConnection.cpp
@@ -58,7 +58,6 @@
 #include "WebProcessProxyMessages.h"
 #include <WebCore/PlatformMediaSessionManager.h>
 #include <WebCore/SharedBuffer.h>
-#include <wtf/Language.h>
 
 #if ENABLE(ENCRYPTED_MEDIA)
 #include "RemoteCDMInstanceSessionMessages.h"
@@ -104,17 +103,11 @@
 namespace WebKit {
 using namespace WebCore;
 
-static void languagesChanged(void* context)
-{
-    static_cast<GPUProcessConnection*>(context)->connection().send(Messages::GPUConnectionToWebProcess::SetUserPreferredLanguages(userPreferredLanguages()), { });
-}
-
 static GPUProcessConnectionParameters getGPUProcessConnectionParameters()
 {
     GPUProcessConnectionParameters parameters;
 #if PLATFORM(COCOA)
     parameters.webProcessIdentity = ProcessIdentity { ProcessIdentity::CurrentProcess };
-    parameters.overrideLanguages = userPreferredLanguagesOverride();
 #endif
     return parameters;
 }
@@ -140,8 +133,6 @@ GPUProcessConnection::GPUProcessConnection(IPC::Connection::Identifier&& connect
 {
     m_connection->open(*this);
 
-    addLanguageChangeObserver(this, languagesChanged);
-
     if (WebProcess::singleton().shouldUseRemoteRenderingFor(RenderingPurpose::MediaPainting)) {
 #if ENABLE(VP9)
         enableVP9Decoders(PlatformMediaSessionManager::shouldEnableVP8Decoder(), PlatformMediaSessionManager::shouldEnableVP9Decoder(), PlatformMediaSessionManager::shouldEnableVP9SWDecoder());
@@ -156,7 +147,6 @@ GPUProcessConnection::~GPUProcessConnection()
     if (m_audioSourceProviderManager)
         m_audioSourceProviderManager->stopListeningForIPC();
 #endif
-    removeLanguageChangeObserver(this);
 }
 
 #if HAVE(AUDIT_TOKEN)


### PR DESCRIPTION
#### cfd1105a34372cb245b99f959ab10c8bb2a1a48d
<pre>
[CoreIPC] Messages::GPUConnectionToWebProcess::SetUserPreferredLanguages is sent from WCP and not UIP
<a href="https://bugs.webkit.org/show_bug.cgi?id=256014">https://bugs.webkit.org/show_bug.cgi?id=256014</a>
&lt;rdar://107917551&gt;

Reviewed by Alex Christensen.

The UIProcess normally knows about language overrides and is thus able to IPC
them to the GPUProcess. This is to avoid having the untrusted WebProcesses
send the languages to the GPUProcess themselves.

Note that there is one exception: internals.setUserPreferredLanguages(). Since
this is called in the WebProcess, tests calling this will only override the
languages in the current WebProcess, not more globally (e.g. in the GPUProcess).

Tests that want/need to override the language more globally now have to use the
pre-existing `&lt;!-- webkit-test-runner [ language=foo,bar ] --&gt;` test option.

* LayoutTests/http/tests/media/hls/hls-audio-tracks-locale-selection-expected.txt:
* LayoutTests/http/tests/media/hls/hls-audio-tracks-locale-selection.html:
* Source/WebCore/testing/Internals.idl:
* Source/WebKit/GPUProcess/GPUConnectionToWebProcess.cpp:
(WebKit::m_routingArbitrator):
(WebKit::GPUConnectionToWebProcess::setUserPreferredLanguages): Deleted.
* Source/WebKit/GPUProcess/GPUConnectionToWebProcess.h:
* Source/WebKit/GPUProcess/GPUConnectionToWebProcess.messages.in:
* Source/WebKit/GPUProcess/GPUProcess.cpp:
(WebKit::GPUProcess::initializeGPUProcess):
(WebKit::GPUProcess::userPreferredLanguagesChanged):
* Source/WebKit/GPUProcess/GPUProcess.h:
* Source/WebKit/GPUProcess/GPUProcess.messages.in:
* Source/WebKit/GPUProcess/GPUProcessCreationParameters.cpp:
(WebKit::GPUProcessCreationParameters::encode const):
(WebKit::GPUProcessCreationParameters::decode):
* Source/WebKit/GPUProcess/GPUProcessCreationParameters.h:
* Source/WebKit/Shared/GPUProcessConnectionParameters.h:
* Source/WebKit/Shared/GPUProcessConnectionParameters.serialization.in:
* Source/WebKit/UIProcess/GPU/GPUProcessProxy.cpp:
(WebKit::GPUProcessProxy::GPUProcessProxy):
* Source/WebKit/UIProcess/WebProcessPool.cpp:
(WebKit::WebProcessPool::setOverrideLanguages):
* Source/WebKit/WebProcess/GPU/GPUProcessConnection.cpp:
(WebKit::getGPUProcessConnectionParameters):
(WebKit::GPUProcessConnection::GPUProcessConnection):
(WebKit::GPUProcessConnection::~GPUProcessConnection):
(WebKit::languagesChanged): Deleted.

Canonical link: <a href="https://commits.webkit.org/263465@main">https://commits.webkit.org/263465@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1147db33c4070a2897d9c34eea030ec6e5069c9b

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/4614 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/4733 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/4887 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/6107 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/4769 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/4605 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/4873 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/4693 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/5009 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/4683 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/4774 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/4133 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/6117 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/2262 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/4125 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/9116 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/4122 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/4199 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/5746 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/4591 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/3739 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/4120 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/4121 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/1150 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/8163 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/4481 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->