### PR TITLE
Ensure legend renderers are not incorrectly placed next to MultiColumnSet renderers

### DIFF
--- a/LayoutTests/fast/multicol/legend-in-fieldset-crash-expected.txt
+++ b/LayoutTests/fast/multicol/legend-in-fieldset-crash-expected.txt
@@ -1,0 +1,3 @@
+This test passes if it does not crash
+
+

--- a/LayoutTests/fast/multicol/legend-in-fieldset-crash.html
+++ b/LayoutTests/fast/multicol/legend-in-fieldset-crash.html
@@ -1,0 +1,22 @@
+<style>
+    * {
+        padding: 100% 0%;
+        -webkit-mask-position: c;
+        grid-column-gap: 18%
+    }
+
+    *:last-of-type {
+        -webkit-columns: 128;
+        transform: rotateY(0deg);
+    }
+</style>
+<script>
+if (window.testRunner)
+    testRunner.dumpAsText();
+</script>
+<p>This test passes if it does not crash</p>
+<h>
+    <fieldset>
+        <legend style="font-variant-caps: baseline;outline-style: auto">
+</h>
+<audio controls="" muted="">

--- a/Source/WebCore/rendering/updating/RenderTreeBuilderMultiColumn.cpp
+++ b/Source/WebCore/rendering/updating/RenderTreeBuilderMultiColumn.cpp
@@ -170,7 +170,7 @@ void RenderTreeBuilder::MultiColumn::createFragmentedFlow(RenderBlockFlow& flow)
         // Keep legends out of the flow thread.
         for (auto& box : childrenOfType<RenderBox>(fragmentedFlow)) {
             if (box.isLegend())
-                m_builder.move(fragmentedFlow, flow, box, RenderTreeBuilder::NormalizeAfterInsertion::Yes);
+                m_builder.move(fragmentedFlow, flow, box, &fragmentedFlow, RenderTreeBuilder::NormalizeAfterInsertion::Yes);
         }
     }
 


### PR DESCRIPTION
#### bd02bbfa78903b620974c1a94ea28e9102840a7e
<pre>
Ensure legend renderers are not incorrectly placed next to MultiColumnSet renderers
<a href="https://bugs.webkit.org/show_bug.cgi?id=256015">https://bugs.webkit.org/show_bug.cgi?id=256015</a>
rdar://108558987

Reviewed by NOBODY (OOPS!).

When we have a legend fragmented flow renderer that is a child of a fieldset
renderer we move out of the MultiColumnFlow renderer. However, this can cause us
to incorrectly place it as a sibling of a MultiColumnSet renderer. We should
specify a beforeChild when moving the legend renderer to avoid this case.

* LayoutTests/fast/multicol/legend-in-fieldset-crash-expected.txt: Added.
* LayoutTests/fast/multicol/legend-in-fieldset-crash.html: Added.
* Source/WebCore/rendering/updating/RenderTreeBuilderMultiColumn.cpp:
(WebCore::RenderTreeBuilder::MultiColumn::createFragmentedFlow):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/bd02bbfa78903b620974c1a94ea28e9102840a7e

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/4636 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/4754 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/4912 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/6131 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/4784 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/4626 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/4895 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/4716 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/5022 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/4706 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/4790 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/4149 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/6140 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/2277 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/4141 "Passed tests") | [⏳ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/GTK-WK2-Tests-EWS "Waiting to run tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/4138 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/4215 "Passed tests") | [⏳ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/API-Tests-GTK-EWS "Waiting to run tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/4612 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/3750 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/4138 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/4137 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/8184 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/4498 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->