### PR TITLE
LayoutTest fast/images/reset-image-animation.html is a flaky failure

### DIFF
--- a/LayoutTests/fast/images/reset-image-animation.html
+++ b/LayoutTests/fast/images/reset-image-animation.html
@@ -7,6 +7,7 @@
     <canvas id="canvas"></canvas>
     <script>
         var image = new Image;
+        document.body.appendChild(image);
                 
         function drawFrame(expectedFrame) {
             return new Promise((resolve) => {
@@ -14,14 +15,15 @@
                 let context = canvas.getContext("2d");
                 context.drawImage(image, 0, 0, canvas.width, canvas.height);
                 shouldBe("internals.imageFrameIndex(image)", expectedFrame.toString());
-                setTimeout(() => {
+                // Wait for the next image frame to finish decoding before moving foreward.
+                image.addEventListener("webkitImageFrameReady", () => {
                     resolve(expectedFrame + 1);
-                }, 30);
+                }, { once : true });
             });
         }
 
-        function drawImage(frameCount, expectedFrame) {
-            let promise = drawFrame(expectedFrame);
+        function drawImage(frameCount) {
+            let promise = drawFrame(0);
             for (let frame = 1; frame < frameCount; ++frame) {
                 promise = promise.then((expectedFrame) => {
                     return drawFrame(expectedFrame);
@@ -34,13 +36,13 @@
             return new Promise((resolve) => {
                 image.onload = (() => {
                     if (window.internals) {
-                        internals.setImageFrameDecodingDuration(image, 0.020);
+                        internals.settings.setWebkitImageReadyEventEnabled(true);
                         internals.settings.setAnimatedImageDebugCanvasDrawingEnabled(true);
                     }
-                    drawImage(Math.ceil(frameCount / 2), 0).then(() => {
+                    drawImage(Math.ceil(frameCount / 2)).then(() => {
                         internals.resetImageAnimation(image);
                         debug("The animation of the image was reset.");
-                        drawImage(frameCount, 0).then(resolve);
+                        drawImage(frameCount).then(resolve);
                     });
                 });
                 image.src = src;

--- a/LayoutTests/platform/mac/TestExpectations
+++ b/LayoutTests/platform/mac/TestExpectations
@@ -1201,8 +1201,6 @@ webkit.org/b/169838 [ Release ] fast/workers/worker-close-more.html [ Pass Timeo
 
 webkit.org/b/158420 http/tests/navigation/redirect-to-fragment2.html [ Failure ]
 
-webkit.org/b/170177 fast/images/reset-image-animation.html [ Pass Failure ]
-
 webkit.org/b/168390 fast/images/slower-animation-than-decoding-image.html [ Pass Failure ]
 
 


### PR DESCRIPTION
#### b1cc64631025e09fd181bffbb11e292604ab5ad1
<pre>
LayoutTest fast/images/reset-image-animation.html is a flaky failure
<a href="https://bugs.webkit.org/show_bug.cgi?id=170177">https://bugs.webkit.org/show_bug.cgi?id=170177</a>

Reviewed by Said Abou-Hallawa.

This test expected that the next animation frame was decoded when the
timer fired. However, the decoding frames could be delayed under heavy
CPU load.

Use webkitImageFrameReady event instead of the timer. Removed the
unnecessary second argument `expectedFrame` of `drawImage`.

* LayoutTests/fast/images/reset-image-animation.html:
* LayoutTests/platform/mac/TestExpectations:

Canonical link: <a href="https://commits.webkit.org/263478@main">https://commits.webkit.org/263478@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/819bc15d934a33e0e8b4bf1c120b8feba3958494

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/4720 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/4840 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/5000 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/6225 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/4869 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/4990 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/4806 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/5093 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/4797 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/4881 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/4224 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/6235 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/2370 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/4215 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/9195 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/4230 "Passed tests") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/4289 "3 failures") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/5856 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/4701 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/3830 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/4223 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/4211 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/1160 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/8271 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/4582 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->