### PR TITLE
[JSC] Optimize Object.assign with empty object

### DIFF
--- a/JSTests/microbenchmarks/object-assign-empty.js
+++ b/JSTests/microbenchmarks/object-assign-empty.js
@@ -1,0 +1,10 @@
+function test(options)
+{
+    var options = Object.assign({ defaultParam: 32 }, options);
+    return options;
+}
+noInline(test);
+
+for (var i = 0; i < 1e6; ++i) {
+    test({});
+}

--- a/Source/JavaScriptCore/ftl/FTLAbstractHeapRepository.h
+++ b/Source/JavaScriptCore/ftl/FTLAbstractHeapRepository.h
@@ -158,6 +158,7 @@ namespace JSC { namespace FTL {
     macro(Structure_inlineCapacity, Structure::inlineCapacityOffset()) \
     macro(Structure_outOfLineTypeFlags, Structure::outOfLineTypeFlagsOffset()) \
     macro(Structure_previousOrRareData, Structure::previousOrRareDataOffset()) \
+    macro(Structure_propertyHash, Structure::propertyHashOffset()) \
     macro(Structure_prototype, Structure::prototypeOffset()) \
     macro(StructureRareData_cachedEnumerableStrings, StructureRareData::offsetOfCachedPropertyNames(CachedPropertyNamesKind::EnumerableStrings)) \
     macro(StructureRareData_cachedStrings, StructureRareData::offsetOfCachedPropertyNames(CachedPropertyNamesKind::Strings)) \

--- a/Source/JavaScriptCore/runtime/ObjectConstructor.cpp
+++ b/Source/JavaScriptCore/runtime/ObjectConstructor.cpp
@@ -361,7 +361,10 @@ JSC_DEFINE_HOST_FUNCTION(objectConstructorAssign, (JSGlobalObject* globalObject,
                     return true;
                 });
             }
-            target->putOwnDataPropertyBatching(vm, properties.data(), values.data(), properties.size());
+
+            // Actually, assigning with empty object (option for example) is common. (`Object.assign(defaultOptions, passedOptions)` where `passedOptions` is empty object.)
+            if (properties.size())
+                target->putOwnDataPropertyBatching(vm, properties.data(), values.data(), properties.size());
             return JSValue::encode(target);
         }
     }

--- a/Source/JavaScriptCore/runtime/ObjectConstructorInlines.h
+++ b/Source/JavaScriptCore/runtime/ObjectConstructorInlines.h
@@ -63,7 +63,9 @@ ALWAYS_INLINE bool objectAssignFast(VM& vm, JSObject* target, JSObject* source, 
     if (!canUseFastPath)
         return false;
 
-    target->putOwnDataPropertyBatching(vm, properties.data(), values.data(), properties.size());
+    // Actually, assigning with empty object (option for example) is common. (`Object.assign(defaultOptions, passedOptions)` where `passedOptions` is empty object.)
+    if (properties.size())
+        target->putOwnDataPropertyBatching(vm, properties.data(), values.data(), properties.size());
     return true;
 }
 

--- a/Source/JavaScriptCore/runtime/Structure.h
+++ b/Source/JavaScriptCore/runtime/Structure.h
@@ -714,6 +714,11 @@ public:
         return OBJECT_OFFSETOF(Structure, m_bitField);
     }
 
+    static ptrdiff_t propertyHashOffset()
+    {
+        return OBJECT_OFFSETOF(Structure, m_propertyHash);
+    }
+
     static Structure* createStructure(VM&);
         
     bool transitionWatchpointSetHasBeenInvalidated() const

--- a/Source/JavaScriptCore/runtime/StructureInlines.h
+++ b/Source/JavaScriptCore/runtime/StructureInlines.h
@@ -784,6 +784,7 @@ ALWAYS_INLINE bool Structure::canPerformFastPropertyEnumeration() const
         return false;
     // FIXME: Indexed properties can be handled.
     // https://bugs.webkit.org/show_bug.cgi?id=185358
+
     if (hasIndexedProperties(indexingType()))
         return false;
     if (hasAnyKindOfGetterSetterProperties())

--- a/Source/JavaScriptCore/runtime/StructureRareData.h
+++ b/Source/JavaScriptCore/runtime/StructureRareData.h
@@ -123,6 +123,11 @@ public:
         return OBJECT_OFFSETOF(StructureRareData, m_specialPropertyCache);
     }
 
+    static ptrdiff_t offsetOfPrevious()
+    {
+        return OBJECT_OFFSETOF(StructureRareData, m_previous);
+    }
+
     DECLARE_EXPORT_INFO;
 
     void finalizeUnconditionally(VM&, CollectionScope);


### PR DESCRIPTION
#### 8f5016427be1a14414038b83395a443c94c10084
<pre>
[JSC] Optimize Object.assign with empty object
<a href="https://bugs.webkit.org/show_bug.cgi?id=256019">https://bugs.webkit.org/show_bug.cgi?id=256019</a>
rdar://108585195

Reviewed by Alexey Shvayka.

Actually, this is pretty common that Object.assign&apos;s source objects are empty. The reason is the pattern like this,

    function func(options = {}) {
        var options = Object.assign({ defaultOption1: true, defaultOption2: false }, options);
        ...
    }

And if we call this func with no-options, then Object.assign will see empty options object.
This patch adds a fast path for that in C++ and DFG / FTL JIT.

1. In DFG and FTL, we quickly check empty objects and skip the execution of Object.assign if source is empty.
2. In C++, we check property count before entering into putOwnDataPropertyBatching.
3. We also relax putOwnDataPropertyBatching. Transition possibility should be checked only when we cause the transition.
   Otherwise, we do not need to give up the optimization, like, just replacing properties.

                                         ToT                     Patched

    object-assign-transition       84.0831+-0.2116     ^     70.7839+-0.2697        ^ definitely 1.1879x faster
    object-assign-replace          77.5201+-0.2244     ^     72.5579+-0.1398        ^ definitely 1.0684x faster
    object-assign-empty            13.7165+-0.0783     ^      7.0465+-0.0528        ^ definitely 1.9466x faster
    object-assign-multiple        132.1961+-0.1656     ^     98.9260+-0.5316        ^ definitely 1.3363x faster

* JSTests/microbenchmarks/object-assign-empty.js: Added.
(test):
* Source/JavaScriptCore/dfg/DFGOperations.cpp:
(JSC::DFG::JSC_DEFINE_JIT_OPERATION):
* Source/JavaScriptCore/dfg/DFGSpeculativeJIT.cpp:
* Source/JavaScriptCore/ftl/FTLAbstractHeapRepository.h:
* Source/JavaScriptCore/ftl/FTLLowerDFGToB3.cpp:
(JSC::FTL::DFG::LowerDFGToB3::compileObjectAssign):
* Source/JavaScriptCore/runtime/JSObject.cpp:
(JSC::JSObject::putOwnDataPropertyBatching):
* Source/JavaScriptCore/runtime/ObjectConstructor.cpp:
(JSC::JSC_DEFINE_HOST_FUNCTION):
* Source/JavaScriptCore/runtime/ObjectConstructorInlines.h:
(JSC::objectAssignFast):
* Source/JavaScriptCore/runtime/Structure.h:
(JSC::Structure::propertyHashOffset):
* Source/JavaScriptCore/runtime/StructureInlines.h:
(JSC::Structure::canPerformFastPropertyEnumeration const):
* Source/JavaScriptCore/runtime/StructureRareData.h:

Canonical link: <a href="https://commits.webkit.org/263444@main">https://commits.webkit.org/263444@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9ae386ec8227a04d5ce936999b856dfa3b325880

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/4648 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/4766 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/4924 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/6143 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/4793 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/4909 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/4728 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/5033 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/4718 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/15/builds/4807 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/4163 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/6152 "Built successfully") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/39/builds/2295 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/10/builds/4155 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/9136 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [  ~~🛠 🧪 jsc~~](https://ews-build.webkit.org/#/builders/20/builds/3851 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/4155 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/4229 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/5778 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/4409 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/4624 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/3759 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 jsc-armv7~~](https://ews-build.webkit.org/#/builders/35/builds/4741 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/30/builds/4149 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [  ~~🧪 jsc-armv7-tests~~](https://ews-build.webkit.org/#/builders/25/builds/1178 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/8195 "Built successfully") | | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/24/builds/4856 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/527 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/4509 "Built successfully") | | [  ~~🧪 jsc-mips-tests~~](https://ews-build.webkit.org/#/builders/3/builds/1286 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
<!--EWS-Status-Bubble-End-->