### PR TITLE
Do not handle context menu events when pointer is locked

### DIFF
--- a/LayoutTests/pointer-lock/mouse-event-delivery-expected.txt
+++ b/LayoutTests/pointer-lock/mouse-event-delivery-expected.txt
@@ -14,6 +14,9 @@ PASS event type: mousemove, movementX: 25, movementY: 30, target: target1, recei
      With a lock in place send a click.
 PASS event type: mousedown, target: target1, received on: target1
 PASS event type: mousedown, target: target1, received on: body
+     With a lock in place send a right click.
+PASS event type: mousedown, target: target1, received on: target1
+PASS event type: mousedown, target: target1, received on: body
 PASS document.onpointerlockchange event received.
 PASS document.pointerLockElement is targetdiv2
      With a lock in place send a wheel event.

--- a/LayoutTests/pointer-lock/mouse-event-delivery.html
+++ b/LayoutTests/pointer-lock/mouse-event-delivery.html
@@ -93,6 +93,15 @@
             doNextStepWithUserGesture();
         },
         function () {
+            debug("     With a lock in place send a right click.")
+            targetdiv1.oncontextmenu = eventNotExpected;
+            targetdiv2.oncontextmenu = eventExpected;
+            document.body.oncontextmenu = eventNotExpected;
+            if (window.eventSender)
+                window.eventSender.contextClick();
+            doNextStepWithUserGesture();
+        },
+        function () {
             targetdiv2.requestPointerLock();
             expectedTargetToBeLockedString = "targetdiv2";
             // doNextStep() called by onpointerlockchange handler.

--- a/Source/WebCore/page/EventHandler.cpp
+++ b/Source/WebCore/page/EventHandler.cpp
@@ -3295,6 +3295,12 @@ bool EventHandler::sendContextMenuEvent(const PlatformMouseEvent& event)
 {
     Ref protectedFrame(m_frame);
 
+#if ENABLE(POINTER_LOCK)
+    // Context menus should not be handled while pointer is locked.
+    if (auto* page = m_frame.page(); !page || page->pointerLockController().isLocked())
+        return false;
+#endif
+
     RefPtr doc = m_frame.document();
     RefPtr view = m_frame.view();
     if (!view)


### PR DESCRIPTION
#### 54d533997e83625142ab8063664fb21a2324d0e9
<pre>
Do not handle context menu events when pointer is locked
<a href="https://bugs.webkit.org/show_bug.cgi?id=256024">https://bugs.webkit.org/show_bug.cgi?id=256024</a>
rdar://103961310

Reviewed by Wenson Hsieh.

When pointer lock is active, we do not want to show the context menu.
This commit achieves said behavior by not handling context menu events
when the pointer is locked in a page.

* LayoutTests/pointer-lock/mouse-event-delivery-expected.txt:
* LayoutTests/pointer-lock/mouse-event-delivery.html:
* Source/WebCore/page/EventHandler.cpp:
(WebCore::EventHandler::sendContextMenuEvent):

Canonical link: <a href="https://commits.webkit.org/263475@main">https://commits.webkit.org/263475@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/64b76ff5273cc7bc80f73c848faefe2c437b7e8d

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/4714 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/4834 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/4994 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/6218 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/4865 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/4708 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/5005 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/4800 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/5090 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/4791 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/4892 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/4222 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/6228 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/2381 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/4213 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/9190 "1 flakes 140 failures") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/4241 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/4287 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/5850 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/4695 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/3828 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/4218 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/4209 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/1162 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/8266 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/4578 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->