### PR TITLE
6 editing/caret/ios tests consistently fail on some recent simulator versions

### DIFF
--- a/LayoutTests/editing/caret/ios/absolute-caret-position-after-scroll.html
+++ b/LayoutTests/editing/caret/ios/absolute-caret-position-after-scroll.html
@@ -38,7 +38,7 @@ jsTestIsAsync = true;
     }
 
     UIHelper.activateAndWaitForInputSessionAt(innerWidth / 2, 30)
-    .then(() => UIHelper.getUICaretRect())
+    .then(() => UIHelper.getUICaretViewRect())
     .then((rect) => {
         initialCaretRect = rect;
         shouldBe("initialCaretRect.left", "6");
@@ -46,7 +46,7 @@ jsTestIsAsync = true;
         shouldBe("initialCaretRect.width", "3");
         shouldBe("initialCaretRect.height", "15");
         document.scrollingElement.scrollTop += 5000;
-        return UIHelper.getUICaretRect();
+        return UIHelper.getUICaretViewRect();
     })
     .then((rect) => {
         finalCaretRect = rect;

--- a/LayoutTests/editing/caret/ios/caret-in-overflow-area.html
+++ b/LayoutTests/editing/caret/ios/caret-in-overflow-area.html
@@ -34,7 +34,7 @@
             await UIHelper.activateAndWaitForInputSessionAt(25, 25);
 
             await UIHelper.tapAt(25, 400);
-            const caretRect = await UIHelper.getUICaretRect();
+            const caretRect = await UIHelper.getUICaretViewRect();
 
             document.querySelector("#caret-rect").textContent = rectToString(caretRect);
 

--- a/LayoutTests/editing/caret/ios/emoji.html
+++ b/LayoutTests/editing/caret/ios/emoji.html
@@ -32,7 +32,7 @@
         function pressArrow() {
             uiController.typeCharacterUsingHardwareKeyboard("leftArrow", function() {
                 uiController.doAfterNextStablePresentationUpdate(function() {
-                    var selectionRectLeft = uiController.textSelectionCaretRect.left;
+                    var selectionRectLeft = uiController.selectionCaretViewRect.left;
                     var caretPositionsLength = caretPositions.length;
                     if (caretPositionsLength == 0 || caretPositions[caretPositionsLength - 1] != selectionRectLeft) {
                         caretPositions.push(selectionRectLeft);

--- a/LayoutTests/editing/caret/ios/fixed-caret-position-after-scroll.html
+++ b/LayoutTests/editing/caret/ios/fixed-caret-position-after-scroll.html
@@ -38,7 +38,7 @@ jsTestIsAsync = true;
     }
 
     UIHelper.activateAndWaitForInputSessionAt(innerWidth / 2, 30)
-    .then(() => UIHelper.getUICaretRect())
+    .then(() => UIHelper.getUICaretViewRect())
     .then((rect) => {
         initialCaretRect = rect;
         shouldBe("initialCaretRect.left", "6");
@@ -46,7 +46,7 @@ jsTestIsAsync = true;
         shouldBe("initialCaretRect.width", "3");
         shouldBe("initialCaretRect.height", "15");
         document.scrollingElement.scrollTop += 5000;
-        return UIHelper.getUICaretRect();
+        return UIHelper.getUICaretViewRect();
     })
     .then((rect) => {
         finalCaretRect = rect;

--- a/LayoutTests/editing/selection/character-granularity-rect.html
+++ b/LayoutTests/editing/selection/character-granularity-rect.html
@@ -22,7 +22,7 @@
         return `
         (function() {
             uiController.longPressAtPoint(30, 20, function() {
-                uiController.uiScriptComplete(JSON.stringify(uiController.textSelectionRangeRects));
+                uiController.uiScriptComplete(JSON.stringify(uiController.selectionRangeViewRects));
             });
         })();`
     }
@@ -35,12 +35,12 @@
         var target = document.getElementById('target');
         if (testRunner.runUIScript) {
             testRunner.runUIScript(getUIScript(), function(result) {
-                var textSelectionRangeRects = JSON.parse(result);
+                var selectionRangeViewRects = JSON.parse(result);
                 var output;
-                if (textSelectionRangeRects.length !== 1)
+                if (selectionRangeViewRects.length !== 1)
                     output = 'FAIL: Unexpected number of selection range views: ' + result;
                 else {
-                    var rect = textSelectionRangeRects[0];
+                    var rect = selectionRangeViewRects[0];
                     if (rect.left != 8 || rect.top != 8 || rect.width != 112 || rect.height != 17 )
                         output = 'FAIL: Unexpected selection range view frame: ' + result;
                     else

--- a/LayoutTests/editing/selection/ios/absolute-selection-after-scroll.html
+++ b/LayoutTests/editing/selection/ios/absolute-selection-after-scroll.html
@@ -46,7 +46,7 @@
         }
 
         selectTextAt(50, 50)
-        .then(() => UIHelper.getUISelectionRects())
+        .then(() => UIHelper.getUISelectionViewRects())
         .then((rects) => {
             initialSelectionRects = rects;
             shouldBe("initialSelectionRects.length", "1");
@@ -55,7 +55,7 @@
             shouldBe("initialSelectionRects[0].width", "309");
             shouldBe("initialSelectionRects[0].height", "112");
             document.scrollingElement.scrollTop += 5000;
-            return UIHelper.getUISelectionRects();
+            return UIHelper.getUISelectionViewRects();
         })
         .then((rects) => {
             finalSelectionRects = rects;

--- a/LayoutTests/editing/selection/ios/fixed-selection-after-scroll.html
+++ b/LayoutTests/editing/selection/ios/fixed-selection-after-scroll.html
@@ -46,7 +46,7 @@
         }
 
         selectTextAt(50, 50)
-        .then(() => UIHelper.getUISelectionRects())
+        .then(() => UIHelper.getUISelectionViewRects())
         .then((rects) => {
             initialSelectionRects = rects;
             shouldBe("initialSelectionRects.length", "1");
@@ -55,7 +55,7 @@
             shouldBe("initialSelectionRects[0].width", "309");
             shouldBe("initialSelectionRects[0].height", "112");
             document.scrollingElement.scrollTop += 5000;
-            return UIHelper.getUISelectionRects();
+            return UIHelper.getUISelectionViewRects();
         })
         .then((rects) => {
             finalSelectionRects = rects;

--- a/LayoutTests/editing/selection/ios/selection-extends-into-overflow-area.html
+++ b/LayoutTests/editing/selection/ios/selection-extends-into-overflow-area.html
@@ -35,7 +35,7 @@
             await UIHelper.callFunctionAndWaitForEvent(() => UIHelper.doubleTapElement(target), document, "selectionchange");
             await UIHelper.ensurePresentationUpdate();
             let rectsString = "";
-            for (let rect of await UIHelper.getUISelectionRects())
+            for (let rect of await UIHelper.getUISelectionViewRects())
                 rectsString += rectToString(rect) + ' ';
 
             document.querySelector("#selection-rects").textContent = rectsString;

--- a/LayoutTests/fast/events/touch/ios/long-press-then-drag-up-to-change-selected-text-overflow.html
+++ b/LayoutTests/fast/events/touch/ios/long-press-then-drag-up-to-change-selected-text-overflow.html
@@ -48,7 +48,7 @@
             var grabberMidpoint = UIHelper.midPointOfRect(await UIHelper.getSelectionEndGrabberViewRect());
             await touchAndDragFromPointToPoint(grabberMidpoint.x, grabberMidpoint.y , grabberMidpoint.x, grabberMidpoint.y - (fontHeight * 2));
 
-            if ((await UIHelper.getUISelectionRects()).length > 2)
+            if ((await UIHelper.getUISelectionViewRects()).length > 2)
                 output += 'FAIL: Selected outside of visible area.';
             else
                 output += 'PASS: Selection properly bounded';

--- a/LayoutTests/fast/events/touch/ios/selection-handles-after-touch-end.html
+++ b/LayoutTests/fast/events/touch/ios/selection-handles-after-touch-end.html
@@ -25,7 +25,7 @@ jsTestIsAsync = true;
 observedTouchEnd = false;
 
 document.addEventListener("touchend", async () => {
-    selectionRects = await UIHelper.getUISelectionRects();
+    selectionRects = await UIHelper.getUISelectionViewRects();
     shouldBe("selectionRects.length", "1");
     shouldBe("Math.round(selectionRects[0].left)", "0");
     shouldBe("Math.round(selectionRects[0].top)", "3");

--- a/LayoutTests/fast/forms/textarea/ios/caret-x-position-in-textarea-matches-textfield.html
+++ b/LayoutTests/fast/forms/textarea/ios/caret-x-position-in-textarea-matches-textfield.html
@@ -23,7 +23,7 @@ function computeCaretRectForElement(element)
 {
     return new Promise((resolved) => {
         async function handleFocus() {
-            let caretRect = await UIHelper.getUICaretRect();
+            let caretRect = await UIHelper.getUICaretViewRect();
             await UIHelper.deactivateFormControl(element);
             resolved(caretRect);
         }

--- a/LayoutTests/fast/visual-viewport/ios/caret-after-focus-in-fixed.html
+++ b/LayoutTests/fast/visual-viewport/ios/caret-after-focus-in-fixed.html
@@ -44,7 +44,7 @@
         {
             return `(function() {
                 uiController.doAfterNextStablePresentationUpdate(function() {
-                    uiController.uiScriptComplete(JSON.stringify(uiController.textSelectionCaretRect));
+                    uiController.uiScriptComplete(JSON.stringify(uiController.selectionCaretViewRect));
                 });
                 uiController.keyboardAccessoryBarNext();
             })();`;
@@ -53,7 +53,7 @@
         function getCaretRectScript()
         {
             return `(function() {
-                return JSON.stringify(uiController.textSelectionCaretRect);
+                return JSON.stringify(uiController.selectionCaretViewRect);
             })();`;
         }
 

--- a/LayoutTests/resources/ui-helper.js
+++ b/LayoutTests/resources/ui-helper.js
@@ -837,38 +837,6 @@ window.UIHelper = class UIHelper {
         });
     }
 
-    static getUICaretRect()
-    {
-        if (!this.isWebKit2() || !this.isIOSFamily())
-            return Promise.resolve();
-
-        return new Promise(resolve => {
-            testRunner.runUIScript(`(function() {
-                uiController.doAfterNextStablePresentationUpdate(function() {
-                    uiController.uiScriptComplete(JSON.stringify(uiController.textSelectionCaretRect));
-                });
-            })()`, jsonString => {
-                resolve(JSON.parse(jsonString));
-            });
-        });
-    }
-
-    static getUISelectionRects()
-    {
-        if (!this.isWebKit2() || !this.isIOSFamily())
-            return Promise.resolve();
-
-        return new Promise(resolve => {
-            testRunner.runUIScript(`(function() {
-                uiController.doAfterNextStablePresentationUpdate(function() {
-                    uiController.uiScriptComplete(JSON.stringify(uiController.textSelectionRangeRects));
-                });
-            })()`, jsonString => {
-                resolve(JSON.parse(jsonString));
-            });
-        });
-    }
-
     static scrollbarState(scroller, isVertical)
     {
         var internalFunctions = scroller ? scroller.ownerDocument.defaultView.internals : internals;

--- a/Source/WebCore/testing/cocoa/CocoaColorSerialization.h
+++ b/Source/WebCore/testing/cocoa/CocoaColorSerialization.h
@@ -1,0 +1,35 @@
+/*
+ * Copyright (C) 2023 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#import <WebCore/ColorCocoa.h>
+#import <wtf/Forward.h>
+
+namespace WebCoreTestSupport {
+
+String serializationForCSS(WebCore::CocoaColor *) WTF_EXPORT_PRIVATE;
+
+} // namespace WebCoreTestSupport

--- a/Source/WebCore/testing/cocoa/CocoaColorSerialization.mm
+++ b/Source/WebCore/testing/cocoa/CocoaColorSerialization.mm
@@ -1,0 +1,39 @@
+/*
+ * Copyright (C) 2023 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#import "config.h"
+#import "CocoaColorSerialization.h"
+
+#import <WebCore/ColorSerialization.h>
+#import <wtf/text/WTFString.h>
+
+namespace WebCoreTestSupport {
+
+String serializationForCSS(WebCore::CocoaColor *color)
+{
+    return WebCore::serializationForCSS(WebCore::colorFromCocoaColor(color));
+}
+
+} // namespace WebCoreTestSupport

--- a/Source/WebKit/UIProcess/API/ios/WKWebViewIOS.mm
+++ b/Source/WebKit/UIProcess/API/ios/WKWebViewIOS.mm
@@ -3475,10 +3475,8 @@ static bool isLockdownModeWarningNeeded()
 
 - (CGRect)_uiTextCaretRect
 {
-    // Force the selection view to update if needed.
-    [_contentView _updateChangedSelection];
-
-    return [[_contentView valueForKeyPath:@"interactionAssistant.selectionView.selection.caretRect"] CGRectValue];
+    // Only here to maintain binary compatibility.
+    return CGRectZero;
 }
 
 - (UIView *)_safeBrowsingWarning

--- a/Source/WebKit/UIProcess/API/ios/WKWebViewPrivateForTestingIOS.h
+++ b/Source/WebKit/UIProcess/API/ios/WKWebViewPrivateForTestingIOS.h
@@ -41,7 +41,6 @@
 @property (nonatomic, readonly) NSString *textContentTypeForTesting;
 @property (nonatomic, readonly) NSString *selectFormPopoverTitle;
 @property (nonatomic, readonly) NSString *formInputLabel;
-@property (nonatomic, readonly) NSArray<NSValue *> *_uiTextSelectionRects;
 @property (nonatomic, readonly) CGRect _inputViewBoundsInWindow;
 @property (nonatomic, readonly) NSString *_uiViewTreeAsText;
 @property (nonatomic, readonly) NSNumber *_stableStateOverride;
@@ -86,8 +85,6 @@
 - (void)_setDeviceOrientationUserPermissionHandlerForTesting:(BOOL (^)(void))handler;
 
 - (void)_setDeviceHasAGXCompilerServiceForTesting;
-
-- (NSString *)_serializedSelectionCaretBackgroundColorForTesting;
 
 - (BOOL)_hasResizeAssertion;
 - (void)_simulateSelectionStart;

--- a/Source/WebKit/UIProcess/API/ios/WKWebViewTestingIOS.mm
+++ b/Source/WebKit/UIProcess/API/ios/WKWebViewTestingIOS.mm
@@ -217,14 +217,6 @@ static void dumpSeparatedLayerProperties(TextStream&, CALayer *) { }
     return _inputViewBoundsInWindow;
 }
 
-- (NSArray<NSValue *> *)_uiTextSelectionRects
-{
-    // Force the selection view to update if needed.
-    [_contentView _updateChangedSelection];
-
-    return [_contentView _uiTextSelectionRects];
-}
-
 static String allowListedClassToString(UIView *view)
 {
     static constexpr ComparableASCIILiteral allowedClassesArray[] = {
@@ -463,15 +455,6 @@ static void dumpUIView(TextStream& ts, UIView *view)
 {
     if (_page)
         _page->setDeviceHasAGXCompilerServiceForTesting();
-}
-
-- (NSString *)_serializedSelectionCaretBackgroundColorForTesting
-{
-    UIColor *backgroundColor = [[_contentView textInteractionAssistant].selectionView valueForKeyPath:@"caretView.backgroundColor"];
-    if (!backgroundColor)
-        return nil;
-
-    return serializationForCSS(WebCore::colorFromCocoaColor(backgroundColor));
 }
 
 - (BOOL)_hasResizeAssertion

--- a/Source/WebKit/UIProcess/ios/WKContentViewInteraction.h
+++ b/Source/WebKit/UIProcess/ios/WKContentViewInteraction.h
@@ -690,7 +690,6 @@ FOR_EACH_PRIVATE_WKCONTENTVIEW_ACTION(DECLARE_WKCONTENTVIEW_ACTION_FOR_WEB_VIEW)
 #if ENABLE(DATA_DETECTION)
 - (NSArray *)_dataDetectionResults;
 #endif
-- (NSArray<NSValue *> *)_uiTextSelectionRects;
 - (void)accessibilityRetrieveSpeakSelectionContent;
 - (void)_accessibilityRetrieveRectsEnclosingSelectionOffset:(NSInteger)offset withGranularity:(UITextGranularity)granularity;
 - (void)_accessibilityRetrieveRectsAtSelectionOffset:(NSInteger)offset withText:(NSString *)text completionHandler:(void (^)(const Vector<WebCore::SelectionGeometry>& rects))completionHandler;

--- a/Source/WebKit/UIProcess/ios/WKContentViewInteraction.mm
+++ b/Source/WebKit/UIProcess/ios/WKContentViewInteraction.mm
@@ -2824,18 +2824,6 @@ ALLOW_DEPRECATED_DECLARATIONS_END
 }
 #endif
 
-- (NSArray<NSValue *> *)_uiTextSelectionRects
-{
-    NSMutableArray *textSelectionRects = [NSMutableArray array];
-
-    if (_textInteractionAssistant) {
-        for (WKTextSelectionRect *selectionRect in [_textInteractionAssistant valueForKeyPath:@"selectionView.selection.selectionRects"])
-            [textSelectionRects addObject:[NSValue valueWithCGRect:selectionRect.rect]];
-    }
-
-    return textSelectionRects;
-}
-
 - (BOOL)_pointIsInsideSelectionRect:(CGPoint)point outBoundingRect:(WebCore::FloatRect *)outBoundingRect
 {
     BOOL pointIsInSelectionRect = NO;

--- a/Tools/TestRunnerShared/UIScriptContext/Bindings/UIScriptController.idl
+++ b/Tools/TestRunnerShared/UIScriptContext/Bindings/UIScriptController.idl
@@ -322,12 +322,10 @@ interface UIScriptController {
 
     readonly attribute object contentVisibleRect; // Returned object has 'left', 'top', 'width', 'height' properties.
 
-    readonly attribute object textSelectionRangeRects; // An array of objects with 'left', 'top', 'width', and 'height' properties.
-    readonly attribute object textSelectionCaretRect; // An object with 'left', 'top', 'width', 'height' properties.
     readonly attribute object selectionStartGrabberViewRect;
     readonly attribute object selectionEndGrabberViewRect;
-    readonly attribute object selectionCaretViewRect;
-    readonly attribute object selectionRangeViewRects;
+    readonly attribute object selectionCaretViewRect; // An array of objects with 'left', 'top', 'width', and 'height' properties.
+    readonly attribute object selectionRangeViewRects; // An object with 'left', 'top', 'width', 'height' properties.
     readonly attribute object calendarType;
     undefined setDefaultCalendarType(DOMString calendarIdentifier, DOMString localeIdentifier);
     readonly attribute object inputViewBounds;

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/iOSMouseSupport.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/iOSMouseSupport.mm
@@ -473,7 +473,7 @@ TEST(iOSMouseSupport, ShowingContextMenuSelectsEditableText)
 
     TestWebKitAPI::Util::run(&done);
     EXPECT_WK_STREQ("Hello", [webView stringByEvaluatingJavaScript:@"getSelection().toString()"]);
-    EXPECT_FALSE(CGRectIsEmpty([webView _uiTextSelectionRects].firstObject.CGRectValue));
+    EXPECT_FALSE(CGRectIsEmpty([webView selectionViewRectsInContentCoordinates].firstObject.CGRectValue));
 }
 
 TEST(iOSMouseSupport, ShowingContextMenuSelectsNonEditableText)
@@ -488,7 +488,7 @@ TEST(iOSMouseSupport, ShowingContextMenuSelectsNonEditableText)
 
     TestWebKitAPI::Util::run(&done);
     EXPECT_WK_STREQ("Hello", [webView stringByEvaluatingJavaScript:@"getSelection().toString()"]);
-    EXPECT_FALSE(CGRectIsEmpty([webView _uiTextSelectionRects].firstObject.CGRectValue));
+    EXPECT_FALSE(CGRectIsEmpty([webView selectionViewRectsInContentCoordinates].firstObject.CGRectValue));
 }
 
 #if ENABLE(IOS_TOUCH_EVENTS)

--- a/Tools/TestWebKitAPI/cocoa/TestWKWebView.h
+++ b/Tools/TestWebKitAPI/cocoa/TestWKWebView.h
@@ -123,7 +123,6 @@
 @end
 
 @interface TestWKWebView (IOSOnly)
-@property (nonatomic, readonly) RetainPtr<NSArray> selectionRectsAfterPresentationUpdate;
 @property (nonatomic, readonly) CGRect caretViewRectInContentCoordinates;
 @property (nonatomic, readonly) NSArray<NSValue *> *selectionViewRectsInContentCoordinates;
 - (_WKActivatedElementInfo *)activatedElementAtPosition:(CGPoint)position;

--- a/Tools/WebKitTestRunner/ios/PlatformWebViewIOS.mm
+++ b/Tools/WebKitTestRunner/ios/PlatformWebViewIOS.mm
@@ -400,6 +400,7 @@ RetainPtr<CGImageRef> PlatformWebView::windowSnapshotImage()
     RELEASE_ASSERT(viewSize.width);
     RELEASE_ASSERT(viewSize.height);
 
+    // FIXME: Do we still require this workaround?
     UIView *selectionView = [platformView().contentView valueForKeyPath:@"interactionAssistant.selectionView"];
     UIView *startGrabberView = [selectionView valueForKeyPath:@"rangeView.startGrabber"];
     UIView *endGrabberView = [selectionView valueForKeyPath:@"rangeView.endGrabber"];

--- a/Tools/WebKitTestRunner/ios/TestControllerIOS.mm
+++ b/Tools/WebKitTestRunner/ios/TestControllerIOS.mm
@@ -135,6 +135,7 @@ static void handleMenuDidHideNotification(CFNotificationCenterRef, void*, CFStri
 void TestController::notifyDone()
 {
     UIView *contentView = mainWebView()->platformView().contentView;
+    // FIXME: Do we still require this workaround?
     UIView *selectionView = [contentView valueForKeyPath:@"interactionAssistant.selectionView"];
     [selectionView _removeAllAnimations:YES];
 }

--- a/Tools/WebKitTestRunner/ios/UIScriptControllerIOS.h
+++ b/Tools/WebKitTestRunner/ios/UIScriptControllerIOS.h
@@ -31,6 +31,7 @@
 #import <wtf/BlockPtr.h>
 
 typedef struct CGRect CGRect;
+OBJC_CLASS UITextSelectionDisplayInteraction;
 
 namespace WebCore {
 class FloatPoint;
@@ -111,8 +112,6 @@ private:
     std::optional<bool> stableStateOverride() const override;
     void setStableStateOverride(std::optional<bool> overrideValue) override;
     JSObjectRef contentVisibleRect() const override;
-    JSObjectRef textSelectionRangeRects() const override;
-    JSObjectRef textSelectionCaretRect() const override;
     JSObjectRef selectionStartGrabberViewRect() const override;
     JSObjectRef selectionEndGrabberViewRect() const override;
     JSObjectRef selectionCaretViewRect() const override;
@@ -184,6 +183,10 @@ private:
     void resignFirstResponder() override;
 
     void simulateRotation(DeviceOrientation, JSValueRef callback);
+
+#if HAVE(UI_TEXT_SELECTION_DISPLAY_INTERACTION)
+    UITextSelectionDisplayInteraction *textSelectionDisplayInteraction() const;
+#endif
 };
 
 }


### PR DESCRIPTION
#### 6723dcfd85e9413043566d211736078ffb289878
<pre>
6 editing/caret/ios tests consistently fail on some recent simulator versions
<a href="https://bugs.webkit.org/show_bug.cgi?id=256018">https://bugs.webkit.org/show_bug.cgi?id=256018</a>
rdar://108559805

Reviewed by Aditya Keerthi.

Use `UITextSelectionDisplayInteraction` to identify ranged selection views, caret views, and
selection handles when appropriate. See changes below for more details.

* LayoutTests/editing/caret/ios/absolute-caret-position-after-scroll.html:
* LayoutTests/editing/caret/ios/caret-in-overflow-area.html:
* LayoutTests/editing/caret/ios/emoji.html:
* LayoutTests/editing/caret/ios/fixed-caret-position-after-scroll.html:
* LayoutTests/editing/selection/character-granularity-rect.html:
* LayoutTests/editing/selection/ios/absolute-selection-after-scroll.html:
* LayoutTests/editing/selection/ios/fixed-selection-after-scroll.html:
* LayoutTests/editing/selection/ios/selection-extends-into-overflow-area.html:
* LayoutTests/fast/events/touch/ios/long-press-then-drag-up-to-change-selected-text-overflow.html:
* LayoutTests/fast/events/touch/ios/selection-handles-after-touch-end.html:

Refactor these existing tests, so that they use `selectionCaretViewRect` rather than
`textSelectionCaretRect` and `selectionRangeViewRects` instead of `textSelectionRangeRects`. There&apos;s
no reason to keep both versions of these testing hooks working, so I&apos;m making these tests all use
the versions that check the platform `UIView` geometry directly, which better reflects what the
user sees.

* LayoutTests/fast/forms/textarea/ios/caret-x-position-in-textarea-matches-textfield.html:
* LayoutTests/fast/visual-viewport/ios/caret-after-focus-in-fixed.html:
* LayoutTests/resources/ui-helper.js:
(window.UIHelper.getUICaretRect.return.new.Promise.): Deleted.
(window.UIHelper.getUICaretRect.return.new.Promise): Deleted.
(window.UIHelper.getUICaretRect): Deleted.
(window.UIHelper.getUISelectionRects.return.new.Promise.): Deleted.
(window.UIHelper.getUISelectionRects.return.new.Promise): Deleted.
(window.UIHelper.getUISelectionRects): Deleted.
* Source/WebKit/UIProcess/API/ios/WKWebViewIOS.mm:
(-[WKWebView _uiTextCaretRect]):

The changes above also allow us to remove this SPI hook (though, I&apos;m still leaving behind a method
stub for now, for binary compatibility).

* Source/WebKit/UIProcess/API/ios/WKWebViewPrivateForTestingIOS.h:
* Source/WebKit/UIProcess/API/ios/WKWebViewTestingIOS.mm:
(-[WKWebView _uiTextSelectionRects]): Deleted.
(-[WKWebView _serializedSelectionCaretBackgroundColorForTesting]): Deleted.

Remove these testing hooks altogether, since they&apos;re defined only in the testing header. The former
is no longer necessary since we now only use `selectionRangeViewRects` in the test runner, and the
latter has been moved into `UIScriptController`, out of engine code.

* Source/WebKit/UIProcess/ios/WKContentViewInteraction.h:
* Source/WebKit/UIProcess/ios/WKContentViewInteraction.mm:
(-[WKContentView _uiTextSelectionRects]): Deleted.
* Tools/TestRunnerShared/UIScriptContext/Bindings/UIScriptController.idl:
* Tools/TestWebKitAPI/Tests/WebKitCocoa/iOSMouseSupport.mm:

Apply a similar treatment to several API tests that run into the same issue.

* Source/WebCore/WebCore.xcodeproj/project.pbxproj:
* Source/WebCore/testing/cocoa/CocoaColorSerialization.h: Added.
* Source/WebCore/testing/cocoa/CocoaColorSerialization.mm: Added.
(WebCoreTestSupport::serializationForCSS):

Add a testing hook to convert platform Cocoa colors (`NSColor`, `UIColor`) to a serialized string
for CSS. We use this in `UIScriptControllerIOS` below.

(TEST):
* Tools/TestWebKitAPI/cocoa/TestWKWebView.h:
* Tools/TestWebKitAPI/cocoa/TestWKWebView.mm:
(-[TestWKWebView caretViewRectInContentCoordinates]):
(-[TestWKWebView selectionViewRectsInContentCoordinates]):
(-[TestWKWebView textSelectionDisplayInteraction]):
(-[TestWKWebView selectionRectsAfterPresentationUpdate]): Deleted.
* Tools/WebKitTestRunner/ios/PlatformWebViewIOS.mm:
(WTR::PlatformWebView::windowSnapshotImage):
* Tools/WebKitTestRunner/ios/TestControllerIOS.mm:
(WTR::TestController::notifyDone):
* Tools/WebKitTestRunner/ios/UIScriptControllerIOS.h:
* Tools/WebKitTestRunner/ios/UIScriptControllerIOS.mm:
(WTR::UIScriptControllerIOS::selectionStartGrabberViewRect const):
(WTR::UIScriptControllerIOS::selectionEndGrabberViewRect const):

Search for `_UITextSelectionLollipopView` in the view hierarchy, for now. `-handleViews` seems to
return an empty array, so we can&apos;t adopt it quite yet.

(WTR::UIScriptControllerIOS::selectionCaretViewRect const):
(WTR::UIScriptControllerIOS::selectionRangeViewRects const):

In the case where `selectionView` is nil but `HAVE(UI_TEXT_SELECTION_DISPLAY_INTERACTION)` is set,
fall back to asking for `-cursorView` and `-highlightView`, respectively. Note that the `-hidden`
check is necessary, since the view bounds remain at their last set value even when the selection is
deactivated; instead, the caret, selection highlights and selection handles are simply hidden when
not active.

(WTR::UIScriptControllerIOS::selectionCaretBackgroundColor const):
(WTR::UIScriptControllerIOS::textSelectionDisplayInteraction const):
(WTR::UIScriptControllerIOS::textSelectionRangeRects const): Deleted.
(WTR::UIScriptControllerIOS::textSelectionCaretRect const): Deleted.

Canonical link: <a href="https://commits.webkit.org/263460@main">https://commits.webkit.org/263460@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/8714560a12cf49173dac9d80a5b212667773ec44

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/4693 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/4813 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/4973 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/6195 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/4844 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/4686 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/4961 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/4778 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/5072 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/4769 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/4856 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/4201 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/6205 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/2345 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/4192 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/9175 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/4204 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/4266 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/5829 "run-api-tests-without-change (failure)") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/4673 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/3809 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/4197 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/4188 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/1148 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/8245 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/4557 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->