### PR TITLE
[Cocoa] Extra transform left on video layer when UI-side compositing is disabled

### DIFF
--- a/Source/WebKit/WebProcess/GPU/media/cocoa/VideoLayerRemoteCocoa.mm
+++ b/Source/WebKit/WebProcess/GPU/media/cocoa/VideoLayerRemoteCocoa.mm
@@ -187,7 +187,7 @@ static const Seconds PostAnimationDelay { 100_ms };
     }
 
     auto* videoSublayer = [sublayers objectAtIndex:0];
-    if (!CGRectIsEmpty(self.videoLayerFrame) && CGRectEqualToRect(self.videoLayerFrame, videoSublayer.bounds) && CGAffineTransformIsIdentity(self.affineTransform))
+    if (!CGRectIsEmpty(self.videoLayerFrame) && CGRectEqualToRect(self.videoLayerFrame, videoSublayer.bounds) && CGAffineTransformIsIdentity(videoSublayer.affineTransform))
         return;
 
     [CATransaction begin];


### PR DESCRIPTION
#### 8a95a469c00c748d915029c4d703f4cb8cfb82dc
<pre>
[Cocoa] Extra transform left on video layer when UI-side compositing is disabled
<a href="https://bugs.webkit.org/show_bug.cgi?id=256027">https://bugs.webkit.org/show_bug.cgi?id=256027</a>
rdar://108109357

Reviewed by Eric Carlson.

In -resolveBounds, we bail out early if the WKVideoLayerRemote has the correct bounds and has
a identity affineTransform. But in -layoutSublayers we apply the transform directly to the
videoLayer, rather than the WKVideoLayerRemote itself, so this check will always succeed.

Leaving the transformation in place _should_ have no perceivable side effects. However power
testing has revealed that in some circumstances, this layer change may result in excess power
use when displaying video in fullscreen mode.

* Source/WebKit/WebProcess/GPU/media/cocoa/VideoLayerRemoteCocoa.mm:
(-[WKVideoLayerRemote resolveBounds]):

Canonical link: <a href="https://commits.webkit.org/263456@main">https://commits.webkit.org/263456@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/90ba62d37980686ca920c75db82df3ef7385ac43

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/4653 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/4771 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/4929 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/6148 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/4798 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/4914 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/4733 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/5036 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/4723 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/4811 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/4169 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/6157 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/2299 "Passed tests") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/9144 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/4159 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/4235 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/5786 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/4629 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/3762 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/4154 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/1146 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/8200 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/4514 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->