### PR TITLE
[@property] Nullptr crash with calc()

### DIFF
--- a/LayoutTests/fast/css/custom-properties/at-property-calc-crash-expected.txt
+++ b/LayoutTests/fast/css/custom-properties/at-property-calc-crash-expected.txt
@@ -1,0 +1,1 @@
+This test passes it it doesn't crash.

--- a/LayoutTests/fast/css/custom-properties/at-property-calc-crash.html
+++ b/LayoutTests/fast/css/custom-properties/at-property-calc-crash.html
@@ -1,0 +1,16 @@
+<style>
+  body {
+    --v: calc(0% + 1px + 0 * max(0px, 0cqi));
+    width: var(--v);
+  }
+  @property --v {
+    syntax: '<length-percentage>';
+    inherits: false;
+    initial-value: 0;
+  }
+</style>
+<script>
+if (window.testRunner)
+  testRunner.dumpAsText();
+</script>
+This test passes it it doesn't crash.

--- a/Source/WebCore/css/CSSCustomPropertyValue.cpp
+++ b/Source/WebCore/css/CSSCustomPropertyValue.cpp
@@ -71,6 +71,14 @@ String CSSCustomPropertyValue::customCSSText() const
 {
     auto serializeSyntaxValue = [](const SyntaxValue& syntaxValue) -> String {
         return WTF::switchOn(syntaxValue, [&](const Length& value) {
+            if (value.type() == LengthType::Calculated) {
+                auto calcValue = CSSCalcValue::create(value.calculationValue(), RenderStyle::defaultStyle());
+                if (!calcValue) {
+                    ASSERT_NOT_REACHED();
+                    return emptyString();
+                }
+                return calcValue->cssText();
+            }
             return CSSPrimitiveValue::create(value, RenderStyle::defaultStyle())->cssText();
         }, [&](const NumericSyntaxValue& value) {
             return CSSPrimitiveValue::create(value.value, value.unitType)->cssText();


### PR DESCRIPTION
#### 8b62fda7097bfee9488a412c9d1f52a0393887c3
<pre>
[@property] Nullptr crash with calc()
<a href="https://bugs.webkit.org/show_bug.cgi?id=256032">https://bugs.webkit.org/show_bug.cgi?id=256032</a>
rdar://105491386

Reviewed by Alan Baradlay.

* LayoutTests/fast/css/custom-properties/at-property-calc-crash.html: Added.
* LayoutTests/fast/css/custom-properties/at-property-calc-crash-expected.txt: Added.
* Source/WebCore/css/CSSCustomPropertyValue.cpp:
(WebCore::CSSCustomPropertyValue::customCSSText const):

Ensure that we don&apos;t crash even if the calc expression building returns null.

* Source/WebCore/css/calc/CSSCalcValue.cpp:
(WebCore::createCSS):

Limit zero-length elimination when constructing CSSCalcExpressionNodes from CalcExpressionNodes to sum and substract expressions.
With other expression types eliminating zeroes can lead to miscomputing the expression unit category and
the building code returning null.

Canonical link: <a href="https://commits.webkit.org/263453@main">https://commits.webkit.org/263453@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/29c0ad72dd4f9b4ac4de327b3c5b58d9b02a3f04

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/4674 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/4793 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/4952 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/6174 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/4823 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/4666 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/4940 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/4757 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/5057 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/4748 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/4836 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/4188 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/6184 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/2324 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/4179 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/9160 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/4184 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/4253 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/5807 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/4652 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/3788 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/4176 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/4175 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/1143 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/8223 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/4537 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->