### PR TITLE
[GStreamer][WebRTC] Tighten EndPoint pipeline with playback pipeline

### DIFF
--- a/Source/WebCore/platform/graphics/gstreamer/MediaPlayerPrivateGStreamer.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/MediaPlayerPrivateGStreamer.cpp
@@ -2169,11 +2169,6 @@ void MediaPlayerPrivateGStreamer::configureElement(GstElement* element)
         return;
     }
 
-    if (classifiers.contains("Depayloader"_s)) {
-        configureDepayloader(element);
-        return;
-    }
-
     if (isMediaStreamPlayer())
         return;
 
@@ -2930,17 +2925,6 @@ void MediaPlayerPrivateGStreamer::createGSTPlayBin(const URL& url)
     if (m_videoSink)
         configureElementPlatformQuirks(m_videoSink.get());
 #endif
-}
-
-void MediaPlayerPrivateGStreamer::configureDepayloader(GstElement* depayloader)
-{
-    if (!isMediaStreamPlayer())
-        return;
-
-    if (gstObjectHasProperty(depayloader, "request-keyframe"))
-        g_object_set(depayloader, "request-keyframe", TRUE, nullptr);
-    if (gstObjectHasProperty(depayloader, "wait-for-keyframe"))
-        g_object_set(depayloader, "wait-for-keyframe", TRUE, nullptr);
 }
 
 void MediaPlayerPrivateGStreamer::configureVideoDecoder(GstElement* decoder)

--- a/Source/WebCore/platform/graphics/gstreamer/MediaPlayerPrivateGStreamer.h
+++ b/Source/WebCore/platform/graphics/gstreamer/MediaPlayerPrivateGStreamer.h
@@ -485,7 +485,6 @@ private:
     void configureDownloadBuffer(GstElement*);
     static void downloadBufferFileCreatedCallback(MediaPlayerPrivateGStreamer*);
 
-    void configureDepayloader(GstElement*);
     void configureVideoDecoder(GstElement*);
     void configureElement(GstElement*);
 #if PLATFORM(BROADCOM) || USE(WESTEROS_SINK) || PLATFORM(AMLOGIC) || PLATFORM(REALTEK)

--- a/Source/WebCore/platform/mediastream/gstreamer/RealtimeIncomingSourceGStreamer.cpp
+++ b/Source/WebCore/platform/mediastream/gstreamer/RealtimeIncomingSourceGStreamer.cpp
@@ -41,10 +41,34 @@ RealtimeIncomingSourceGStreamer::RealtimeIncomingSourceGStreamer(const CaptureDe
     m_bin = gst_bin_new(nullptr);
     m_valve = gst_element_factory_make("valve", nullptr);
     m_tee = gst_element_factory_make("tee", nullptr);
-    g_object_set(m_tee.get(), "allow-not-linked", true, nullptr);
+    g_object_set(m_tee.get(), "allow-not-linked", TRUE, nullptr);
 
-    gst_bin_add_many(GST_BIN_CAST(m_bin.get()), m_valve.get(), m_tee.get(), nullptr);
-    gst_element_link(m_valve.get(), m_tee.get());
+    auto* parsebin = makeGStreamerElement("parsebin", nullptr);
+
+    g_signal_connect(parsebin, "element-added", G_CALLBACK(+[](GstBin*, GstElement* element, gpointer) {
+        auto elementClass = makeString(gst_element_get_metadata(element, GST_ELEMENT_METADATA_KLASS));
+        auto classifiers = elementClass.split('/');
+        if (!classifiers.contains("Depayloader"_s))
+            return;
+
+        if (gstObjectHasProperty(element, "request-keyframe"))
+            g_object_set(element, "request-keyframe", TRUE, nullptr);
+        if (gstObjectHasProperty(element, "wait-for-keyframe"))
+            g_object_set(element, "wait-for-keyframe", TRUE, nullptr);
+        g_object_set(element, "auto-header-extension", FALSE, nullptr);
+    }),
+        nullptr);
+
+    g_signal_connect_swapped(parsebin, "pad-added", G_CALLBACK(+[](RealtimeIncomingSourceGStreamer* source, GstPad* pad) {
+        auto sinkPad = adoptGRef(gst_element_get_static_pad(source->m_tee.get(), "sink"));
+        gst_pad_link(pad, sinkPad.get());
+
+        gst_bin_sync_children_states(GST_BIN_CAST(source->m_bin.get()));
+        GST_DEBUG_BIN_TO_DOT_FILE_WITH_TS(GST_BIN_CAST(source->m_bin.get()), GST_DEBUG_GRAPH_SHOW_ALL, GST_OBJECT_NAME(source->m_bin.get()));
+    }), this);
+
+    gst_bin_add_many(GST_BIN_CAST(m_bin.get()), m_valve.get(), parsebin, m_tee.get(), nullptr);
+    gst_element_link(m_valve.get(), parsebin);
 
     auto sinkPad = adoptGRef(gst_element_get_static_pad(m_valve.get(), "sink"));
     gst_element_add_pad(m_bin.get(), gst_ghost_pad_new("sink", sinkPad.get()));
@@ -69,36 +93,82 @@ const RealtimeMediaSourceCapabilities& RealtimeIncomingSourceGStreamer::capabili
     return RealtimeMediaSourceCapabilities::emptyCapabilities();
 }
 
-void RealtimeIncomingSourceGStreamer::registerClient()
+int RealtimeIncomingSourceGStreamer::registerClient(GRefPtr<GstElement>&& appsrc)
 {
-    GST_DEBUG_OBJECT(m_bin.get(), "Registering new client");
-    auto* queue = gst_element_factory_make("queue", nullptr);
-    auto* sink = makeGStreamerElement("appsink", nullptr);
-    g_object_set(sink, "enable-last-sample", FALSE, "emit-signals", TRUE, "sync", FALSE, nullptr);
-    g_signal_connect_swapped(sink, "new-sample", G_CALLBACK(+[](RealtimeIncomingSourceGStreamer* self, GstElement* sink) -> GstFlowReturn {
-        auto sample = adoptGRef(gst_app_sink_pull_sample(GST_APP_SINK(sink)));
-        self->dispatchSample(WTFMove(sample));
-        return GST_FLOW_OK;
-    }), this);
+    static Atomic<int> counter = 1;
+    auto clientId = counter.exchangeAdd(1);
 
-    g_signal_connect_swapped(sink, "new-preroll", G_CALLBACK(+[](RealtimeIncomingSourceGStreamer* self, GstElement* sink) -> GstFlowReturn {
-        auto sample = adoptGRef(gst_app_sink_pull_preroll(GST_APP_SINK(sink)));
-        self->dispatchSample(WTFMove(sample));
-        return GST_FLOW_OK;
-    }), this);
+    auto* queue = gst_element_factory_make("queue", makeString("queue-"_s, clientId).ascii().data());
+    auto* sink = makeGStreamerElement("appsink", makeString("sink-"_s, clientId).ascii().data());
+    g_object_set(sink, "enable-last-sample", FALSE, nullptr);
 
-    g_signal_connect_swapped(sink, "new-serialized-event", G_CALLBACK(+[](RealtimeIncomingSourceGStreamer* self, GstElement* sink) -> gboolean {
-        auto event = adoptGRef(GST_EVENT_CAST(gst_app_sink_pull_object(GST_APP_SINK(sink))));
-        switch (GST_EVENT_TYPE(event.get())) {
-        case GST_EVENT_STREAM_START:
-        case GST_EVENT_CAPS:
+    if (!m_clientQuark)
+        m_clientQuark = g_quark_from_static_string("client-id");
+    g_object_set_qdata(G_OBJECT(sink), m_clientQuark, GINT_TO_POINTER(clientId));
+    GST_DEBUG_OBJECT(m_bin.get(), "Client %" GST_PTR_FORMAT " associated to new sink %" GST_PTR_FORMAT, appsrc.get(), sink);
+    m_clients.add(clientId, WTFMove(appsrc));
+
+    static GstAppSinkCallbacks callbacks = {
+        nullptr, // eos
+        [](GstAppSink* sink, gpointer userData) -> GstFlowReturn {
+            auto* self = reinterpret_cast<RealtimeIncomingSourceGStreamer*>(userData);
+            auto sample = adoptGRef(gst_app_sink_pull_preroll(sink));
+            self->dispatchSample(WTFMove(sample));
+            return GST_FLOW_OK;
+        },
+        [](GstAppSink* sink, gpointer userData) -> GstFlowReturn {
+            auto* self = reinterpret_cast<RealtimeIncomingSourceGStreamer*>(userData);
+            auto sample = adoptGRef(gst_app_sink_pull_sample(sink));
+            self->dispatchSample(WTFMove(sample));
+            return GST_FLOW_OK;
+        },
+        [](GstAppSink* sink, gpointer userData) -> gboolean {
+            auto* self = reinterpret_cast<RealtimeIncomingSourceGStreamer*>(userData);
+            auto event = adoptGRef(GST_EVENT_CAST(gst_app_sink_pull_object(sink)));
+            switch (GST_EVENT_TYPE(event.get())) {
+            case GST_EVENT_STREAM_START:
+            case GST_EVENT_CAPS:
+            case GST_EVENT_SEGMENT:
+                return false;
+            case GST_EVENT_LATENCY: {
+                GstClockTime minLatency, maxLatency;
+                if (gst_base_sink_query_latency(GST_BASE_SINK(sink), nullptr, nullptr, &minLatency, &maxLatency)) {
+                    if (int clientId = GPOINTER_TO_INT(g_object_get_qdata(G_OBJECT(sink), self->m_clientQuark))) {
+                        GST_DEBUG_OBJECT(sink, "Setting client latency to min %" GST_TIME_FORMAT " max %" GST_TIME_FORMAT, GST_TIME_ARGS(minLatency), GST_TIME_ARGS(maxLatency));
+                        auto appsrc = self->m_clients.get(clientId);
+                        g_object_set(appsrc, "min-latency", minLatency, "max-latency", maxLatency, nullptr);
+                    }
+                }
+                return false;
+            }
+            default:
+                break;
+            }
+            self->handleDownstreamEvent(WTFMove(event));
             return false;
-        default:
-            break;
-        }
-        self->handleDownstreamEvent(WTFMove(event));
-        return true;
-    }), this);
+        },
+#if GST_CHECK_VERSION(1, 23, 0)
+        // propose_allocation
+        nullptr,
+#endif
+        { nullptr }
+    };
+    gst_app_sink_set_callbacks(GST_APP_SINK(sink), &callbacks, this, nullptr);
+
+    auto sinkPad = adoptGRef(gst_element_get_static_pad(sink, "sink"));
+    gst_pad_add_probe(sinkPad.get(), GST_PAD_PROBE_TYPE_QUERY_DOWNSTREAM, reinterpret_cast<GstPadProbeCallback>(+[](GstPad* pad, GstPadProbeInfo* info, RealtimeIncomingSourceGStreamer* self) -> GstPadProbeReturn {
+        auto sink = adoptGRef(gst_pad_get_parent_element(pad));
+        int clientId = GPOINTER_TO_INT(g_object_get_qdata(G_OBJECT(sink.get()), self->m_clientQuark));
+        if (!clientId)
+            return GST_PAD_PROBE_OK;
+
+        auto appsrc = self->m_clients.get(clientId);
+        auto srcSrcPad = adoptGRef(gst_element_get_static_pad(appsrc, "src"));
+        if (gst_pad_peer_query(srcSrcPad.get(), GST_QUERY_CAST(info->data)))
+            return GST_PAD_PROBE_HANDLED;
+
+        return GST_PAD_PROBE_OK;
+    }), this, nullptr);
 
     gst_bin_add_many(GST_BIN_CAST(m_bin.get()), queue, sink, nullptr);
     gst_element_link_many(m_tee.get(), queue, sink, nullptr);
@@ -106,13 +176,40 @@ void RealtimeIncomingSourceGStreamer::registerClient()
     gst_element_sync_state_with_parent(sink);
 
     GST_DEBUG_BIN_TO_DOT_FILE_WITH_TS(GST_BIN_CAST(m_bin.get()), GST_DEBUG_GRAPH_SHOW_ALL, GST_OBJECT_NAME(m_bin.get()));
+    return clientId;
 }
 
-void RealtimeIncomingSourceGStreamer::handleUpstreamEvent(GRefPtr<GstEvent>&& event)
+void RealtimeIncomingSourceGStreamer::unregisterClient(int clientId)
+{
+    GST_DEBUG_OBJECT(m_bin.get(), "Unregistering client %d", clientId);
+    auto sink = adoptGRef(gst_bin_get_by_name(GST_BIN_CAST(m_bin.get()), makeString("sink-", clientId).ascii().data()));
+    auto queue = adoptGRef(gst_bin_get_by_name(GST_BIN_CAST(m_bin.get()), makeString("queue-", clientId).ascii().data()));
+    auto queueSinkPad = adoptGRef(gst_element_get_static_pad(queue.get(), "sink"));
+    auto teeSrcPad = adoptGRef(gst_pad_get_peer(queueSinkPad.get()));
+
+    gst_element_set_locked_state(m_bin.get(), TRUE);
+    gst_element_set_state(queue.get(), GST_STATE_NULL);
+    gst_element_set_state(sink.get(), GST_STATE_NULL);
+    gst_element_unlink_many(m_tee.get(), queue.get(), sink.get(), nullptr);
+    gst_bin_remove_many(GST_BIN_CAST(m_bin.get()), queue.get(), sink.get(), nullptr);
+    gst_element_release_request_pad(m_tee.get(), teeSrcPad.get());
+    gst_element_set_locked_state(m_bin.get(), FALSE);
+    m_clients.remove(clientId);
+}
+
+void RealtimeIncomingSourceGStreamer::handleUpstreamEvent(GRefPtr<GstEvent>&& event, int clientId)
 {
     GST_DEBUG_OBJECT(m_bin.get(), "Handling %" GST_PTR_FORMAT, event.get());
-    auto pad = adoptGRef(gst_element_get_static_pad(m_tee.get(), "sink"));
+    auto sink = adoptGRef(gst_bin_get_by_name(GST_BIN_CAST(m_bin.get()), makeString("sink-", clientId).ascii().data()));
+    auto pad = adoptGRef(gst_element_get_static_pad(sink.get(), "sink"));
     gst_pad_push_event(pad.get(), event.leakRef());
+}
+
+bool RealtimeIncomingSourceGStreamer::handleUpstreamQuery(GstQuery* query, int clientId)
+{
+    auto sink = adoptGRef(gst_bin_get_by_name(GST_BIN_CAST(m_bin.get()), makeString("sink-", clientId).ascii().data()));
+    auto pad = adoptGRef(gst_element_get_static_pad(sink.get(), "sink"));
+    return gst_pad_peer_query(pad.get(), query);
 }
 
 void RealtimeIncomingSourceGStreamer::handleDownstreamEvent(GRefPtr<GstEvent>&& event)

--- a/Source/WebCore/platform/mediastream/gstreamer/RealtimeIncomingSourceGStreamer.h
+++ b/Source/WebCore/platform/mediastream/gstreamer/RealtimeIncomingSourceGStreamer.h
@@ -29,9 +29,12 @@ namespace WebCore {
 class RealtimeIncomingSourceGStreamer : public RealtimeMediaSource {
 public:
     GstElement* bin() { return m_bin.get(); }
-    void registerClient();
 
-    void handleUpstreamEvent(GRefPtr<GstEvent>&&);
+    int registerClient(GRefPtr<GstElement>&&);
+    void unregisterClient(int);
+
+    void handleUpstreamEvent(GRefPtr<GstEvent>&&, int clientId);
+    bool handleUpstreamQuery(GstQuery*, int clientId);
 
 protected:
     RealtimeIncomingSourceGStreamer(const CaptureDevice&);
@@ -48,6 +51,8 @@ private:
     GRefPtr<GstElement> m_bin;
     GRefPtr<GstElement> m_valve;
     GRefPtr<GstElement> m_tee;
+    GQuark m_clientQuark { 0 };
+    HashMap<int, GRefPtr<GstElement>> m_clients;
 };
 
 } // namespace WebCore


### PR DESCRIPTION
#### 72fe39782f23fb1202e50c928b344351dc6cad7d
<pre>
[GStreamer][WebRTC] Tighten EndPoint pipeline with playback pipeline
<a href="https://bugs.webkit.org/show_bug.cgi?id=256041">https://bugs.webkit.org/show_bug.cgi?id=256041</a>

Reviewed by Xabier Rodriguez-Calvar.

The RTP depayloaders and parsers are now wrapped by the RealtimeIncomingSourceGStreamer sub-classes,
using parsebin. The relationship between the incoming source appsink and the mediastreamsrc appsrc
elements is also stronger, latency is now properly propagated and queries are relayed. This all
helps improving lip-sync of incoming WebRTC tracks.

* Source/WebCore/platform/graphics/gstreamer/MediaPlayerPrivateGStreamer.cpp:
(WebCore::MediaPlayerPrivateGStreamer::configureElement):
(WebCore::MediaPlayerPrivateGStreamer::configureDepayloader): Deleted.
* Source/WebCore/platform/graphics/gstreamer/MediaPlayerPrivateGStreamer.h:
* Source/WebCore/platform/mediastream/gstreamer/GStreamerMediaStreamSource.cpp:
(webkitMediaStreamSrcAddTrack):
* Source/WebCore/platform/mediastream/gstreamer/RealtimeIncomingSourceGStreamer.cpp:
(WebCore::RealtimeIncomingSourceGStreamer::RealtimeIncomingSourceGStreamer):
(WebCore::RealtimeIncomingSourceGStreamer::registerClient):
(WebCore::RealtimeIncomingSourceGStreamer::unregisterClient):
(WebCore::RealtimeIncomingSourceGStreamer::handleUpstreamEvent):
(WebCore::RealtimeIncomingSourceGStreamer::handleUpstreamQuery):
* Source/WebCore/platform/mediastream/gstreamer/RealtimeIncomingSourceGStreamer.h:
(WebCore::RealtimeIncomingSourceGStreamer::bin):

Canonical link: <a href="https://commits.webkit.org/263499@main">https://commits.webkit.org/263499@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/993b1318f3f28d0eb57afff8e19603602be33910

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/4799 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/4921 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/5088 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/6313 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/4929 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/4791 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/5081 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/4892 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/5169 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/4880 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/4963 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/4300 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/6326 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/2451 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/4295 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/9264 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/4313 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/4370 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/5946 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/4777 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/3892 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/4285 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/1176 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/8347 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/4648 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->