### PR TITLE
[WPE] run-minibrowser: don't set a platform when COG_PLATFORM_NAME is on the env

### DIFF
--- a/Tools/PlatformWPE.cmake
+++ b/Tools/PlatformWPE.cmake
@@ -30,7 +30,7 @@ if (ENABLE_COG)
         set(WPE_COG_REPO "https://github.com/Igalia/cog.git")
     endif ()
     if ("${WPE_COG_TAG}" STREQUAL "")
-        set(WPE_COG_TAG "48347f3a36e6dba75bcfd4f9443730861adec5b0")
+        set(WPE_COG_TAG "49c2de4c82fe95571b95df48ec2a9319561d15b0")
     endif ()
     # TODO Use GIT_REMOTE_UPDATE_STRATEGY with 3.18 to allow switching between
     # conflicting branches without having to delete the repo

--- a/Tools/Scripts/webkitpy/port/wpe.py
+++ b/Tools/Scripts/webkitpy/port/wpe.py
@@ -27,6 +27,7 @@
 # (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
+import logging
 import os
 import shlex
 
@@ -38,6 +39,7 @@ from webkitpy.port.headlessdriver import HeadlessDriver
 
 from webkitcorepy import decorators
 
+_log = logging.getLogger(__name__)
 
 class WPEPort(GLibPort):
     port_name = "wpe"
@@ -117,7 +119,7 @@ class WPEPort(GLibPort):
             return browser
 
         if browser:
-            print("Unknown browser {}. Defaulting to Cog and MiniBrowser selection".format(browser))
+            _log.warning("Unknown browser {}. Defaulting to Cog and MiniBrowser selection".format(browser))
 
         if self._filesystem.isfile(self.cog_path_to('launcher', 'cog')):
             return "cog"
@@ -138,11 +140,11 @@ class WPEPort(GLibPort):
         if self.browser_name() == "cog":
             miniBrowser = self.cog_path_to('launcher', 'cog')
             if not self._filesystem.isfile(miniBrowser):
-                print("Cog not found 😢. If you wish to enable it, rebuild with `-DENABLE_COG=ON`. Falling back to good old MiniBrowser")
+                _log.warning("Cog not found 😢. If you wish to enable it, rebuild with `-DENABLE_COG=ON`. Falling back to good old MiniBrowser")
                 miniBrowser = None
             else:
                 print("Using Cog as MiniBrowser")
-                has_platform_arg = any((a == "-P" or a.startswith("--platform=") for a in args))
+                has_platform_arg = any((a == "-P" or a.startswith("--platform=") for a in args)) or "COG_PLATFORM_NAME" in os.environ
                 if not has_platform_arg:
                     args.insert(0, "--platform=gtk4")
 
@@ -150,7 +152,7 @@ class WPEPort(GLibPort):
             print("Using default MiniBrowser")
             miniBrowser = self._build_path('bin', 'MiniBrowser')
             if not self._filesystem.isfile(miniBrowser):
-                print("%s not found... Did you run build-webkit?" % miniBrowser)
+                _log.warning("%s not found... Did you run build-webkit?" % miniBrowser)
                 return 1
         command = [miniBrowser]
         if os.environ.get("WEBKIT_MINI_BROWSER_PREFIX"):


### PR DESCRIPTION
#### f081085077e66f9960c30e738f6b92fd896beb74
<pre>
[WPE] run-minibrowser: don&apos;t set a platform when COG_PLATFORM_NAME is on the env
<a href="https://bugs.webkit.org/show_bug.cgi?id=256043">https://bugs.webkit.org/show_bug.cgi?id=256043</a>

Reviewed by Philippe Normand.

Cog now can receive the platform plugin name via the environment variable COG_PLATFORM_NAME
This updates the version we checkout of Cog so it includes the above fix

The run-minibrowser script for WPE now checks for this environment variable before
passing any --platform parameters to Cog. Some extra tests are added also.

Also use logging module to log the errors on port/wpe.py to avoid having this errors getting
printed when running the python unit tests.

* Tools/PlatformWPE.cmake:
* Tools/Scripts/webkitpy/port/wpe.py:
(WPEPort.browser_name):
(WPEPort.run_minibrowser):
* Tools/Scripts/webkitpy/port/wpe_unittest.py:
(WPEPortTest._mock_port_cog_is_built):
(WPEPortTest.test_browser_name_default_wihout_cog_built):
(WPEPortTest.test_browser_name_default_with_cog_built):
(WPEPortTest.test_browser_name_override_minibrowser_with_cog_built):
(WPEPortTest.test_browser_name_override_unknown_without_cog_built):
(WPEPortTest):
(WPEPortTest.test_browser_name_override_unknown_with_cog_built):
(WPEPortTest.test_browser_cog_parameters_platform_default):
(WPEPortTest.test_browser_cog_parameters_platform_override_via_cmdline):
(WPEPortTest.test_browser_cog_parameters_platform_override_via_environ):
(WPEPortTest.test_browser_name_default): Deleted.
(WPEPortTest.test_browser_name_with_cog_built): Deleted.
(WPEPortTest.test_browser_name_override_unknown): Deleted.

Canonical link: <a href="https://commits.webkit.org/263463@main">https://commits.webkit.org/263463@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f9dbe751f00c79a99c84ba8e3e30a81546571420

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/4689 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/4809 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/4969 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/6191 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/4840 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/4682 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/4957 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/4774 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/5067 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/4765 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/4850 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/4203 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/6201 "Built successfully") | 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/4767 "Passed tests") | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/2339 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/4194 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/9171 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/4198 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/4268 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/5830 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/4669 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/3803 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/4193 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/8241 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/534 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/4553 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->