### PR TITLE
Add WTF::ReferenceWrapperVector

### DIFF
--- a/Source/WTF/WTF.xcodeproj/project.pbxproj
+++ b/Source/WTF/WTF.xcodeproj/project.pbxproj
@@ -116,6 +116,7 @@
 		93B5B45122171EEA004B7AA7 /* Logger.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 93B5B45022171EE9004B7AA7 /* Logger.cpp */; };
 		93E4A13728F6B75A006AD994 /* UUIDCocoa.mm in Sources */ = {isa = PBXBuildFile; fileRef = 93E4A13628F6B75A006AD994 /* UUIDCocoa.mm */; };
 		93F1993E19D7958D00C2390B /* StringView.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 93F1993D19D7958D00C2390B /* StringView.cpp */; };
+		9785729929FAC2BB00350CBA /* ReferenceWrapperVector.h in Headers */ = {isa = PBXBuildFile; fileRef = 9785729829FAC2BB00350CBA /* ReferenceWrapperVector.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		9BC70F05176C379D00101DEC /* AtomStringTable.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 9BC70F04176C379D00101DEC /* AtomStringTable.cpp */; };
 		9BD8464C2980B6C100FAE3BD /* WeakListHashSet.h in Headers */ = {isa = PBXBuildFile; fileRef = 9BD8464B2980B6C100FAE3BD /* WeakListHashSet.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		A32D8FA521FFFAB400780662 /* ThreadingPOSIX.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A32D8FA421FFFAB400780662 /* ThreadingPOSIX.cpp */; };
@@ -1257,6 +1258,7 @@
 		93E4A13628F6B75A006AD994 /* UUIDCocoa.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = UUIDCocoa.mm; sourceTree = "<group>"; };
 		93F1993D19D7958D00C2390B /* StringView.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = StringView.cpp; sourceTree = "<group>"; };
 		974CFC8D16A4F327006D5404 /* WeakPtr.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = WeakPtr.h; sourceTree = "<group>"; };
+		9785729829FAC2BB00350CBA /* ReferenceWrapperVector.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ReferenceWrapperVector.h; sourceTree = "<group>"; };
 		996B17841EBA441C007E10EB /* DebugUtilities.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = DebugUtilities.h; sourceTree = "<group>"; };
 		9B67F3F12228D5310030DE9C /* WeakHashSet.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = WeakHashSet.h; sourceTree = "<group>"; };
 		9B96E9B324FF77B8001756C3 /* CompactUniquePtrTuple.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = CompactUniquePtrTuple.h; sourceTree = "<group>"; };
@@ -2255,6 +2257,7 @@
 				A8A47301151A825B004123FF /* RefCountedLeakCounter.cpp */,
 				A8A47302151A825B004123FF /* RefCountedLeakCounter.h */,
 				86F46F5F1A2840EE00CCBF22 /* RefCounter.h */,
+				9785729829FAC2BB00350CBA /* ReferenceWrapperVector.h */,
 				A8A47303151A825B004123FF /* RefPtr.h */,
 				3A5BCFA2298768E300E0ABB2 /* RefVector.h */,
 				FE3842342325CC80009DD445 /* ResourceUsage.h */,
@@ -3214,6 +3217,7 @@
 				DD3DC95727A4BF8E007E5B61 /* RefCountedFixedVector.h in Headers */,
 				DD3DC8BE27A4BF8E007E5B61 /* RefCountedLeakCounter.h in Headers */,
 				DD3DC8D927A4BF8E007E5B61 /* RefCounter.h in Headers */,
+				9785729929FAC2BB00350CBA /* ReferenceWrapperVector.h in Headers */,
 				DD3DC91D27A4BF8E007E5B61 /* RefPtr.h in Headers */,
 				3A5BCFA3298768E300E0ABB2 /* RefVector.h in Headers */,
 				DD3DC8C727A4BF8E007E5B61 /* ResourceUsage.h in Headers */,

--- a/Source/WTF/wtf/CMakeLists.txt
+++ b/Source/WTF/wtf/CMakeLists.txt
@@ -234,6 +234,7 @@ set(WTF_PUBLIC_HEADERS
     RefCounter.h
     RefPtr.h
     RefVector.h
+    ReferenceWrapperVector.h
     ResourceUsage.h
     RetainPtr.h
     RobinHoodHashMap.h

--- a/Source/WTF/wtf/ReferenceWrapperVector.h
+++ b/Source/WTF/wtf/ReferenceWrapperVector.h
@@ -1,0 +1,165 @@
+/*
+ * Copyright (C) 2023 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include <wtf/Vector.h>
+
+namespace WTF {
+
+template<typename T>
+class ReferenceWrapperVectorIterator {
+    using Iterator = ReferenceWrapperVectorIterator<T>;
+
+public:
+    using difference_type = ptrdiff_t;
+    using value_type = T;
+    using pointer = T*;
+    using reference = T&;
+    using iterator_category = std::bidirectional_iterator_tag;
+
+    ReferenceWrapperVectorIterator(std::reference_wrapper<T>* iterator)
+        : m_iterator(iterator)
+    {
+    }
+
+    T& operator*() const { return m_iterator->get(); }
+    T* operator->() const { return m_iterator->ptr(); }
+
+    bool operator==(const Iterator& other) const { return m_iterator == other.m_iterator; }
+    bool operator!=(const Iterator& other) const { return m_iterator != other.m_iterator; }
+
+    Iterator& operator++()
+    {
+        ++m_iterator;
+        return *this;
+    }
+    Iterator& operator--()
+    {
+        --m_iterator;
+        return *this;
+    }
+
+private:
+    std::reference_wrapper<T>* m_iterator;
+};
+
+template<typename T>
+class ReferenceWrapperVectorConstIterator {
+    using Iterator = ReferenceWrapperVectorConstIterator<T>;
+
+public:
+    using difference_type = ptrdiff_t;
+    using value_type = T;
+    using pointer = T*;
+    using reference = T&;
+    using iterator_category = std::bidirectional_iterator_tag;
+
+    ReferenceWrapperVectorConstIterator(const std::reference_wrapper<T>* iterator)
+        : m_iterator(iterator)
+    {
+    }
+
+    const T& operator*() const { return m_iterator->get(); }
+    const T* operator->() const { return m_iterator->ptr(); }
+
+    bool operator==(const Iterator& other) const { return m_iterator == other.m_iterator; }
+    bool operator!=(const Iterator& other) const { return m_iterator != other.m_iterator; }
+
+    Iterator& operator++()
+    {
+        ++m_iterator;
+        return *this;
+    }
+    Iterator& operator--()
+    {
+        --m_iterator;
+        return *this;
+    }
+
+private:
+    const std::reference_wrapper<T>* m_iterator;
+};
+
+template<typename T, size_t inlineCapacity = 0>
+class ReferenceWrapperVector : public Vector<std::reference_wrapper<T>, inlineCapacity> {
+    using Base = Vector<std::reference_wrapper<T>, inlineCapacity>;
+
+public:
+    using ValueType = T;
+    using iterator = ReferenceWrapperVectorIterator<T>;
+    using const_iterator = ReferenceWrapperVectorConstIterator<T>;
+    using reverse_iterator = std::reverse_iterator<iterator>;
+    using const_reverse_iterator = std::reverse_iterator<const_iterator>;
+
+    using Base::size;
+
+    iterator begin() { return iterator { Base::begin() }; }
+    iterator end() { return iterator { Base::end() }; }
+    const_iterator begin() const { return const_iterator { Base::begin() }; }
+    const_iterator end() const { return const_iterator { Base::end() }; }
+    reverse_iterator rbegin() { return reverse_iterator(end()); }
+    reverse_iterator rend() { return reverse_iterator(begin()); }
+    const_reverse_iterator rbegin() const { return const_reverse_iterator(end()); }
+    const_reverse_iterator rend() const { return const_reverse_iterator(begin()); }
+
+    ReferenceWrapperVector() = default;
+    ReferenceWrapperVector(std::initializer_list<std::reference_wrapper<T>>);
+
+    T& at(size_t i) { return Base::at(i).get(); }
+    const T& at(size_t i) const { return Base::at(i).get(); }
+
+    T& operator[](size_t i) { return Base::at(i).get(); }
+    const T& operator[](size_t i) const { return Base::at(i).get(); }
+
+    T& first() { return Base::at(0).get(); }
+    const T& first() const { return Base::at(0).get(); }
+    T& last() { return Base::at(Base::size() - 1).get(); }
+    const T& last() const { return Base::at(Base::size() - 1).get(); }
+
+    template<typename MatchFunction> size_t findIf(const MatchFunction&) const;
+    template<typename MatchFunction> bool containsIf(const MatchFunction& matches) const { return findIf(matches) != notFound; }
+};
+
+template<typename T, size_t inlineCapacity>
+inline ReferenceWrapperVector<T, inlineCapacity>::ReferenceWrapperVector(std::initializer_list<std::reference_wrapper<T>> initializerList)
+    : Base(initializerList)
+{
+}
+
+template<typename T, size_t inlineCapacity>
+template<typename MatchFunction>
+size_t ReferenceWrapperVector<T, inlineCapacity>::findIf(const MatchFunction& matches) const
+{
+    for (size_t i = 0; i < size(); ++i) {
+        if (matches(at(i)))
+            return i;
+    }
+    return notFound;
+}
+
+} // namespace WTF
+
+using WTF::ReferenceWrapperVector;

--- a/Source/WebGPU/WGSL/AST/ASTStructureMember.h
+++ b/Source/WebGPU/WGSL/AST/ASTStructureMember.h
@@ -29,6 +29,7 @@
 #include "ASTBuilder.h"
 #include "ASTIdentifier.h"
 #include "ASTTypeName.h"
+#include <wtf/ReferenceWrapperVector.h>
 
 namespace WGSL::AST {
 
@@ -36,7 +37,7 @@ class StructureMember final : public Node {
     WGSL_AST_BUILDER_NODE(StructureMember);
 
 public:
-    using List = Vector<std::reference_wrapper<StructureMember>>;
+    using List = ReferenceWrapperVector<StructureMember>;
 
     NodeKind kind() const final;
     Identifier& name() { return m_name; }

--- a/Source/WebGPU/WGSL/EntryPointRewriter.cpp
+++ b/Source/WebGPU/WGSL/EntryPointRewriter.cpp
@@ -253,7 +253,7 @@ void EntryPointRewriter::visit(Vector<String>& path, MemberOrParameter&& data)
             )
         ));
         path.append(data.name);
-        for (AST::StructureMember& member : structType->structure.members())
+        for (auto& member : structType->structure.members())
             visit(path, MemberOrParameter { member.name(), member.type(), member.attributes() });
         path.removeLast();
         return;

--- a/Source/WebGPU/WGSL/MangleNames.cpp
+++ b/Source/WebGPU/WGSL/MangleNames.cpp
@@ -148,7 +148,7 @@ void NameManglerVisitor::visit(AST::Structure& structure)
     introduceVariable(structure.name(), MangledName::Type);
 
     NameMap fieldMap;
-    for (AST::StructureMember& member : structure.members()) {
+    for (auto& member : structure.members()) {
         AST::Visitor::visit(member.type());
         auto mangledName = makeMangledName(member.name(), MangledName::Field);
         fieldMap.add(member.name(), mangledName);

--- a/Source/WebGPU/WGSL/Metal/MetalFunctionWriter.cpp
+++ b/Source/WebGPU/WGSL/Metal/MetalFunctionWriter.cpp
@@ -168,7 +168,7 @@ void FunctionDefinitionWriter::visit(AST::Structure& structDecl)
     m_stringBuilder.append(m_indent, "struct ", structDecl.name(), " {\n");
     {
         IndentationScope scope(m_indent);
-        for (AST::StructureMember& member : structDecl.members()) {
+        for (auto& member : structDecl.members()) {
             m_stringBuilder.append(m_indent);
             visit(member.type());
             m_stringBuilder.append(" ", member.name());

--- a/Source/WebGPU/WGSL/TypeCheck.cpp
+++ b/Source/WebGPU/WGSL/TypeCheck.cpp
@@ -178,7 +178,7 @@ void TypeChecker::visitStructMembers(AST::Structure& structure)
     ASSERT(std::holds_alternative<Types::Struct>(**type));
 
     auto& structType = std::get<Types::Struct>(**type);
-    for (AST::StructureMember& member : structure.members()) {
+    for (auto& member : structure.members()) {
         auto* memberType = resolve(member.type());
         auto result = structType.fields.add(member.name().id(), memberType);
         ASSERT_UNUSED(result, result.isNewEntry);

--- a/Tools/TestWebKitAPI/Tests/WGSL/ParserTests.cpp
+++ b/Tools/TestWebKitAPI/Tests/WGSL/ParserTests.cpp
@@ -123,7 +123,7 @@ static void testStruct(ASCIILiteral program, const Vector<String>& fieldNames, c
 
     EXPECT_EQ(str.members().size(), fieldNames.size());
     for (unsigned i = 0; i < fieldNames.size(); ++i) {
-        auto& attributes = str.members()[i].get().attributes();
+        auto& attributes = str.members()[i].attributes();
         if (!attributeTests.size())
             EXPECT_TRUE(attributes.isEmpty());
         else {
@@ -150,9 +150,9 @@ static void testStruct(ASCIILiteral program, const Vector<String>& fieldNames, c
                 }
             }
         }
-        EXPECT_EQ(str.members()[i].get().name(), fieldNames[i]);
-        EXPECT_TRUE(is<WGSL::AST::NamedTypeName>(str.members()[i].get().type()));
-        auto& memberType = downcast<WGSL::AST::NamedTypeName>(str.members()[i].get().type());
+        EXPECT_EQ(str.members()[i].name(), fieldNames[i]);
+        EXPECT_TRUE(is<WGSL::AST::NamedTypeName>(str.members()[i].type()));
+        auto& memberType = downcast<WGSL::AST::NamedTypeName>(str.members()[i].type());
         EXPECT_EQ(memberType.name(), typeNames[i]);
     }
 }


### PR DESCRIPTION
#### 44decfc45440d67616d1abe20f044de27c156535
<pre>
Add WTF::ReferenceWrapperVector
<a href="https://bugs.webkit.org/show_bug.cgi?id=256045">https://bugs.webkit.org/show_bug.cgi?id=256045</a>
rdar://108610658

Reviewed by Myles C. Maxfield.

Similar to WTF::RefVector, add ReferenceWrapperVector&lt;T&gt;, which is a specialization
of Vector&lt;std::reference_wrapper&lt;T&gt;&gt; with convenience accessors and iterators. This
removes the need to use `.get()` when either accessing an element of the vector or
when using `auto&amp;` to iterate over the vector. As a first use for the new vector I
replaced the use of Vector&lt;std::reference_wrapper&gt; in the WGSL compiler.

* Source/WTF/WTF.xcodeproj/project.pbxproj:
* Source/WTF/wtf/CMakeLists.txt:
* Source/WTF/wtf/ReferenceWrapperVector.h: Added.
(WTF::ReferenceWrapperVectorIterator::ReferenceWrapperVectorIterator):
(WTF::ReferenceWrapperVectorIterator::operator* const):
(WTF::ReferenceWrapperVectorIterator::operator-&gt; const):
(WTF::ReferenceWrapperVectorIterator::operator== const):
(WTF::ReferenceWrapperVectorIterator::operator!= const):
(WTF::ReferenceWrapperVectorIterator::operator++):
(WTF::ReferenceWrapperVectorIterator::operator--):
(WTF::ReferenceWrapperVectorConstIterator::ReferenceWrapperVectorConstIterator):
(WTF::ReferenceWrapperVectorConstIterator::operator* const):
(WTF::ReferenceWrapperVectorConstIterator::operator-&gt; const):
(WTF::ReferenceWrapperVectorConstIterator::operator== const):
(WTF::ReferenceWrapperVectorConstIterator::operator!= const):
(WTF::ReferenceWrapperVectorConstIterator::operator++):
(WTF::ReferenceWrapperVectorConstIterator::operator--):
(WTF::ReferenceWrapperVector::begin):
(WTF::ReferenceWrapperVector::end):
(WTF::ReferenceWrapperVector::begin const):
(WTF::ReferenceWrapperVector::end const):
(WTF::ReferenceWrapperVector::rbegin):
(WTF::ReferenceWrapperVector::rend):
(WTF::ReferenceWrapperVector::rbegin const):
(WTF::ReferenceWrapperVector::rend const):
(WTF::ReferenceWrapperVector::at):
(WTF::ReferenceWrapperVector::at const):
(WTF::ReferenceWrapperVector::operator[]):
(WTF::ReferenceWrapperVector::operator[] const):
(WTF::ReferenceWrapperVector::first):
(WTF::ReferenceWrapperVector::first const):
(WTF::ReferenceWrapperVector::last):
(WTF::ReferenceWrapperVector::last const):
(WTF::ReferenceWrapperVector::containsIf const):
(WTF::inlineCapacity&gt;::ReferenceWrapperVector):
(WTF::inlineCapacity&gt;::findIf const):
* Source/WebGPU/WGSL/AST/ASTStructureMember.h:
* Source/WebGPU/WGSL/EntryPointRewriter.cpp:
(WGSL::EntryPointRewriter::visit):
* Source/WebGPU/WGSL/MangleNames.cpp:
(WGSL::NameManglerVisitor::visit):
* Source/WebGPU/WGSL/Metal/MetalFunctionWriter.cpp:
(WGSL::Metal::FunctionDefinitionWriter::visit):
* Source/WebGPU/WGSL/TypeCheck.cpp:
(WGSL::TypeChecker::visitStructMembers):
* Tools/TestWebKitAPI/Tests/WGSL/ParserTests.cpp:

Canonical link: <a href="https://commits.webkit.org/263489@main">https://commits.webkit.org/263489@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/de3f0a72621f69c6e0115ad585e249cf64cfa827

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/4690 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/4810 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/4970 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/6192 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/4841 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/4683 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/4958 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/4775 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/5069 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/4766 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/4854 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/4202 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/6202 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/2343 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/4193 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/9172 "Passed tests") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/3895 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/4202 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/4267 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/5827 "269 api tests failed or timed out") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/4457 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/4670 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/3806 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/4785 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/4194 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/1181 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/1169 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/8242 "Built successfully") | | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/24/builds/4905 "Built successfully") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/4554 "Built successfully") | | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/3/builds/1290 "Passed tests") | 
<!--EWS-Status-Bubble-End-->