### PR TITLE
[GStreamer] DMABUF sink not available for GStreamer 1.20 runtime

### DIFF
--- a/Source/WebCore/platform/graphics/gstreamer/DMABufVideoSinkGStreamer.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/DMABufVideoSinkGStreamer.cpp
@@ -184,7 +184,7 @@ bool webKitDMABufVideoSinkIsEnabled()
 
 bool webKitDMABufVideoSinkProbePlatform()
 {
-    return webkitGstCheckVersion(1, 22, 0) && isGStreamerPluginAvailable("app");
+    return webkitGstCheckVersion(1, 20, 0) && isGStreamerPluginAvailable("app");
 }
 
 void webKitDMABufVideoSinkSetMediaPlayerPrivate(WebKitDMABufVideoSink* sink, MediaPlayerPrivateGStreamer* player)


### PR DESCRIPTION
#### 4c8196fde7dad954938ee4c913c3c11807bd5a19
<pre>
[GStreamer] DMABUF sink not available for GStreamer 1.20 runtime
<a href="https://bugs.webkit.org/show_bug.cgi?id=255912">https://bugs.webkit.org/show_bug.cgi?id=255912</a>

Reviewed by Michael Catanzaro.

* Source/WebCore/platform/graphics/gstreamer/DMABufVideoSinkGStreamer.cpp:
(webKitDMABufVideoSinkProbePlatform): Enable the DMABuf sink for GStreamer 1.20 too.

Canonical link: <a href="https://commits.webkit.org/263459@main">https://commits.webkit.org/263459@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/8043d1cca31c6d7b024b9b5c706b46ab2ab195e0

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/4692 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/4812 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/4972 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/6194 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/4843 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/4685 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/4960 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/4777 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/5071 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/4768 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/4857 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/4200 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/6204 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/2346 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/4191 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/9174 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/4205 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/4265 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/5825 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/4672 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/3808 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/4196 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/1147 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/8244 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/4556 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->