### PR TITLE
Adopt smart pointer for captured variables in VideoTrackPrivateAVFObjC constructor

### DIFF
--- a/Source/WebCore/platform/graphics/TrackPrivateBase.h
+++ b/Source/WebCore/platform/graphics/TrackPrivateBase.h
@@ -32,13 +32,24 @@
 #include "TrackPrivateBaseClient.h"
 #include <wtf/LoggerHelper.h>
 #include <wtf/MediaTime.h>
+#if COMPILER(MSVC)
 #include <wtf/ThreadSafeRefCounted.h>
+#else
+#include <wtf/ThreadSafeWeakPtr.h>
+#endif
 #include <wtf/text/AtomString.h>
 
 namespace WebCore {
 
 class WEBCORE_EXPORT TrackPrivateBase
-    : public ThreadSafeRefCounted<TrackPrivateBase, WTF::DestructionThread::Main>
+    :
+#if COMPILER(MSVC)
+    // FIXME: TrackPrivateBase inheriting from ThreadSafeRefCountedAndCanMakeThreadSafeWeakPtr does not
+    // compile when using MSVC
+    public ThreadSafeRefCounted<TrackPrivateBase, WTF::DestructionThread::Main>
+#else
+    public ThreadSafeRefCountedAndCanMakeThreadSafeWeakPtr<TrackPrivateBase, WTF::DestructionThread::Main>
+#endif
 #if !RELEASE_LOG_DISABLED
     , public LoggerHelper
 #endif


### PR DESCRIPTION
#### d9f9e3140f0667c21b6e0cb84ef0d3d3bbbddc04
<pre>
Adopt smart pointer for captured variables in VideoTrackPrivateAVFObjC constructor
<a href="https://bugs.webkit.org/show_bug.cgi?id=256048">https://bugs.webkit.org/show_bug.cgi?id=256048</a>
rdar://108617701

Reviewed by NOBODY (OOPS!).

In the constructor for VideoTrackPrivateAVFObjC we capture a reference to self
in a lambda and then store it in a separate object. We should adopt smart pointers
in that lambda to avoid lifetime issues.

* Source/WebCore/platform/graphics/TrackPrivateBase.h:
* Source/WebCore/platform/graphics/avfoundation/objc/VideoTrackPrivateAVFObjC.cpp:
(WebCore::VideoTrackPrivateAVFObjC::VideoTrackPrivateAVFObjC):
(WebCore::m_videoTrackConfigurationObserver):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d9f9e3140f0667c21b6e0cb84ef0d3d3bbbddc04

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/9791 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/10039 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/10283 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/11443 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/9532 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/9800 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/12024 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/9990 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/12459 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/9945 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/10760 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/8311 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/11874 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/8064 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/8883 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/16282 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/9162 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/9031 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/12362 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/9534 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/8327 "12 failures") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/8702 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/12928 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/9306 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->