### PR TITLE
[bmalloc] Replace ssize_t with ptrdiff_t for portability.

### DIFF
--- a/Source/bmalloc/bmalloc/Heap.cpp
+++ b/Source/bmalloc/bmalloc/Heap.cpp
@@ -91,7 +91,7 @@ size_t Heap::footprint()
     return m_footprint;
 }
 
-BINLINE void Heap::adjustStat(size_t& value, ssize_t amount)
+BINLINE void Heap::adjustStat(size_t& value, std::ptrdiff_t amount)
 {
     constexpr bool check = false;
 
@@ -103,12 +103,12 @@ BINLINE void Heap::adjustStat(size_t& value, ssize_t amount)
     value = result;
 }
 
-BINLINE void Heap::logStat(size_t value, ssize_t amount, const char* label, const char* note)
+BINLINE void Heap::logStat(size_t value, std::ptrdiff_t amount, const char* label, const char* note)
 {
     fprintf(stderr, "%s: %zu (%zd) %s\n", label, value, amount, note);
 }
 
-BINLINE void Heap::adjustFreeableMemory(UniqueLockHolder&, ssize_t amount, const char* note)
+BINLINE void Heap::adjustFreeableMemory(UniqueLockHolder&, std::ptrdiff_t amount, const char* note)
 {
     constexpr bool verbose = false;
 
@@ -118,7 +118,7 @@ BINLINE void Heap::adjustFreeableMemory(UniqueLockHolder&, ssize_t amount, const
         logStat(m_freeableMemory, amount, "freeableMemory", note);
 }
 
-BINLINE void Heap::adjustFootprint(UniqueLockHolder&, ssize_t amount, const char* note)
+BINLINE void Heap::adjustFootprint(UniqueLockHolder&, std::ptrdiff_t amount, const char* note)
 {
     constexpr bool verbose = false;
 

--- a/Source/bmalloc/bmalloc/Heap.h
+++ b/Source/bmalloc/bmalloc/Heap.h
@@ -118,10 +118,10 @@ private:
     LargeRange tryAllocateLargeChunk(size_t alignment, size_t);
     LargeRange splitAndAllocate(UniqueLockHolder&, LargeRange&, size_t alignment, size_t);
 
-    inline void adjustFootprint(UniqueLockHolder&, ssize_t, const char* note);
-    inline void adjustFreeableMemory(UniqueLockHolder&, ssize_t, const char* note);
-    inline void adjustStat(size_t& value, ssize_t);
-    inline void logStat(size_t value, ssize_t amount, const char* label, const char* note);
+    inline void adjustFootprint(UniqueLockHolder&, std::ptrdiff_t, const char* note);
+    inline void adjustFreeableMemory(UniqueLockHolder&, std::ptrdiff_t, const char* note);
+    inline void adjustStat(size_t& value, std::ptrdiff_t);
+    inline void logStat(size_t value, std::ptrdiff_t amount, const char* label, const char* note);
 
     HeapKind m_kind;
     HeapConstants& m_constants;


### PR DESCRIPTION
#### 3fca1b37291f10c1bc0b672f96542994873c8f4c
<pre>
[bmalloc] Replace ssize_t with ptrdiff_t for portability.
<a href="https://bugs.webkit.org/show_bug.cgi?id=256010">https://bugs.webkit.org/show_bug.cgi?id=256010</a>

Reviewed by Yusuke Suzuki.

This is the patch for Windows bmalloc implementation part 4 of N.

In Heap, ssize_t is used to pass +/- delta. Actually ssize_t is from posix and not portable.
Let&apos;s use ptrdiff_t instead for better portability.

* Source/bmalloc/bmalloc/Heap.cpp:
(bmalloc::Heap::adjustStat):
(bmalloc::Heap::logStat):
(bmalloc::Heap::adjustFreeableMemory):
(bmalloc::Heap::adjustFootprint):
* Source/bmalloc/bmalloc/Heap.h:

Canonical link: <a href="https://commits.webkit.org/263472@main">https://commits.webkit.org/263472@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/db8cfcd0bfba7bf7c0b8c05472c7ed48f8894554

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/4699 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/4819 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/4979 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/6202 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/4851 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/4968 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/4784 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/5081 "106 failures") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/4776 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/4864 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/4208 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/6212 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/2353 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/4199 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/9181 "Passed tests") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/3904 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/4212 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/4273 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/5841 "Passed tests") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/4467 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/4680 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/3815 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/4794 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/4204 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/1184 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/1156 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/8252 "Built successfully") | | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/24/builds/4915 "Built successfully") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/4564 "Built successfully") | | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/3/builds/1294 "Passed tests") | 
<!--EWS-Status-Bubble-End-->