### PR TITLE
Move SleepDisabler ownership from WebProcessProxy to WebPageProxy

### DIFF
--- a/Source/WebCore/Modules/screen-wake-lock/WakeLock.cpp
+++ b/Source/WebCore/Modules/screen-wake-lock/WakeLock.cpp
@@ -89,9 +89,14 @@ void WakeLock::request(WakeLockType lockType, Ref<DeferredPromise>&& promise)
                 promise->reject(Exception { NotAllowedError, "Document is hidden"_s });
                 return;
             }
+            auto pageID = document->pageID();
+            if (!pageID) {
+                promise->reject(Exception { NotAllowedError, "Document is detached"_s });
+                return;
+            }
             auto lock = WakeLockSentinel::create(document, lockType);
             promise->resolve<IDLInterface<WakeLockSentinel>>(lock.get());
-            document->wakeLockManager().addWakeLock(WTFMove(lock));
+            document->wakeLockManager().addWakeLock(WTFMove(lock), *pageID);
         });
     });
 }

--- a/Source/WebCore/Modules/screen-wake-lock/WakeLockManager.cpp
+++ b/Source/WebCore/Modules/screen-wake-lock/WakeLockManager.cpp
@@ -44,7 +44,7 @@ WakeLockManager::~WakeLockManager()
     m_document.unregisterForVisibilityStateChangedCallbacks(*this);
 }
 
-void WakeLockManager::addWakeLock(Ref<WakeLockSentinel>&& lock)
+void WakeLockManager::addWakeLock(Ref<WakeLockSentinel>&& lock, PageIdentifier pageID)
 {
     auto type = lock->type();
     auto& locks = m_wakeLocks.ensure(type, [] { return Vector<RefPtr<WakeLockSentinel>>(); }).iterator->value;
@@ -56,7 +56,7 @@ void WakeLockManager::addWakeLock(Ref<WakeLockSentinel>&& lock)
 
     switch (type) {
     case WakeLockType::Screen:
-        m_screenLockDisabler = makeUnique<SleepDisabler>("Screen Wake Lock"_s, PAL::SleepDisabler::Type::Display);
+        m_screenLockDisabler = makeUnique<SleepDisabler>("Screen Wake Lock"_s, PAL::SleepDisabler::Type::Display, pageID);
         break;
     }
 }

--- a/Source/WebCore/Modules/screen-wake-lock/WakeLockManager.h
+++ b/Source/WebCore/Modules/screen-wake-lock/WakeLockManager.h
@@ -25,6 +25,7 @@
 
 #pragma once
 
+#include "PageIdentifier.h"
 #include "VisibilityChangeClient.h"
 #include "WakeLockType.h"
 #include <wtf/HashMap.h>
@@ -43,7 +44,7 @@ public:
     explicit WakeLockManager(Document&);
     ~WakeLockManager();
 
-    void addWakeLock(Ref<WakeLockSentinel>&&);
+    void addWakeLock(Ref<WakeLockSentinel>&&, PageIdentifier);
     void removeWakeLock(WakeLockSentinel&);
 
     void releaseAllLocks(WakeLockType);

--- a/Source/WebCore/dom/Document.cpp
+++ b/Source/WebCore/dom/Document.cpp
@@ -9467,8 +9467,9 @@ void Document::updateSleepDisablerIfNeeded()
 {
     MediaProducerMediaStateFlags activeVideoCaptureMask { MediaProducerMediaState::HasActiveVideoCaptureDevice, MediaProducerMediaState::HasActiveScreenCaptureDevice, MediaProducerMediaState::HasActiveWindowCaptureDevice };
     if (m_mediaState & activeVideoCaptureMask) {
-        if (!m_sleepDisabler)
-            m_sleepDisabler = makeUnique<SleepDisabler>("com.apple.WebCore: Document doing camera, screen or window capture"_s, PAL::SleepDisabler::Type::Display);
+        auto pageID = this->pageID();
+        if (!m_sleepDisabler && pageID)
+            m_sleepDisabler = makeUnique<SleepDisabler>("com.apple.WebCore: Document doing camera, screen or window capture"_s, PAL::SleepDisabler::Type::Display, *pageID);
         return;
     }
     m_sleepDisabler = nullptr;

--- a/Source/WebCore/html/HTMLMediaElement.cpp
+++ b/Source/WebCore/html/HTMLMediaElement.cpp
@@ -7498,8 +7498,10 @@ void HTMLMediaElement::updateSleepDisabling()
         m_sleepDisabler = nullptr;
     else if (shouldDisableSleep != SleepType::None) {
         auto type = shouldDisableSleep == SleepType::Display ? PAL::SleepDisabler::Type::Display : PAL::SleepDisabler::Type::System;
-        if (!m_sleepDisabler || m_sleepDisabler->type() != type)
-            m_sleepDisabler = makeUnique<SleepDisabler>("com.apple.WebCore: HTMLMediaElement playback"_s, type);
+        if (!m_sleepDisabler || m_sleepDisabler->type() != type) {
+            if (auto pageID = document().pageID())
+                m_sleepDisabler = makeUnique<SleepDisabler>("com.apple.WebCore: HTMLMediaElement playback"_s, type, *pageID);
+        }
     }
 
     if (m_player)

--- a/Source/WebCore/platform/SleepDisabler.cpp
+++ b/Source/WebCore/platform/SleepDisabler.cpp
@@ -30,12 +30,13 @@
 
 namespace WebCore {
 
-SleepDisabler::SleepDisabler(const String& reason, PAL::SleepDisabler::Type type)
+SleepDisabler::SleepDisabler(const String& reason, PAL::SleepDisabler::Type type, PageIdentifier pageID)
     : m_type(type)
+    , m_pageID(pageID)
 {
     if (sleepDisablerClient()) {
         m_identifier = SleepDisablerIdentifier::generate();
-        sleepDisablerClient()->didCreateSleepDisabler(m_identifier, reason, type == PAL::SleepDisabler::Type::Display);
+        sleepDisablerClient()->didCreateSleepDisabler(m_identifier, reason, type == PAL::SleepDisabler::Type::Display, pageID);
         return;
     }
 
@@ -45,7 +46,7 @@ SleepDisabler::SleepDisabler(const String& reason, PAL::SleepDisabler::Type type
 SleepDisabler::~SleepDisabler()
 {
     if (sleepDisablerClient())
-        sleepDisablerClient()->didDestroySleepDisabler(m_identifier);
+        sleepDisablerClient()->didDestroySleepDisabler(m_identifier, m_pageID);
 }
 
 } // namespace WebCore

--- a/Source/WebCore/platform/SleepDisabler.h
+++ b/Source/WebCore/platform/SleepDisabler.h
@@ -25,6 +25,7 @@
 
 #pragma once
 
+#include "PageIdentifier.h"
 #include "SleepDisablerIdentifier.h"
 #include <pal/system/SleepDisabler.h>
 
@@ -33,7 +34,7 @@ namespace WebCore {
 class SleepDisabler {
     WTF_MAKE_FAST_ALLOCATED;
 public:
-    WEBCORE_EXPORT SleepDisabler(const String&, PAL::SleepDisabler::Type);
+    WEBCORE_EXPORT SleepDisabler(const String&, PAL::SleepDisabler::Type, PageIdentifier);
     WEBCORE_EXPORT ~SleepDisabler();
 
     PAL::SleepDisabler::Type type() const { return m_type; }
@@ -42,6 +43,7 @@ private:
     std::unique_ptr<PAL::SleepDisabler> m_platformSleepDisabler;
     SleepDisablerIdentifier m_identifier;
     PAL::SleepDisabler::Type m_type;
+    PageIdentifier m_pageID;
 };
 
 } // namespace WebCore

--- a/Source/WebCore/platform/SleepDisablerClient.h
+++ b/Source/WebCore/platform/SleepDisablerClient.h
@@ -25,6 +25,7 @@
 
 #pragma once
 
+#include "PageIdentifier.h"
 #include "SleepDisablerIdentifier.h"
 #include <wtf/Forward.h>
 
@@ -33,8 +34,8 @@ namespace WebCore {
 class SleepDisablerClient {
 public:
     virtual ~SleepDisablerClient() { }
-    virtual void didCreateSleepDisabler(SleepDisablerIdentifier, const String& reason, bool display) = 0;
-    virtual void didDestroySleepDisabler(SleepDisablerIdentifier) = 0;
+    virtual void didCreateSleepDisabler(SleepDisablerIdentifier, const String& reason, bool display, PageIdentifier) = 0;
+    virtual void didDestroySleepDisabler(SleepDisablerIdentifier, PageIdentifier) = 0;
 };
 
 WEBCORE_EXPORT std::unique_ptr<SleepDisablerClient>& sleepDisablerClient();

--- a/Source/WebCore/testing/Internals.cpp
+++ b/Source/WebCore/testing/Internals.cpp
@@ -6767,10 +6767,14 @@ String Internals::focusRingColor()
     return serializationForCSS(RenderTheme::singleton().focusRingColor({ }));
 }
 
-unsigned Internals::createSleepDisabler(const String& reason, bool display)
+ExceptionOr<unsigned> Internals::createSleepDisabler(const String& reason, bool display)
 {
+    auto* document = contextDocument();
+    if (!document || !document->pageID())
+        return Exception { InvalidAccessError };
+
     static unsigned lastUsedIdentifier = 0;
-    auto sleepDisabler = makeUnique<WebCore::SleepDisabler>(reason, display ? PAL::SleepDisabler::Type::Display : PAL::SleepDisabler::Type::System);
+    auto sleepDisabler = makeUnique<WebCore::SleepDisabler>(reason, display ? PAL::SleepDisabler::Type::Display : PAL::SleepDisabler::Type::System, *document->pageID());
     m_sleepDisablers.add(++lastUsedIdentifier, WTFMove(sleepDisabler));
     return lastUsedIdentifier;
 }

--- a/Source/WebCore/testing/Internals.h
+++ b/Source/WebCore/testing/Internals.h
@@ -1295,7 +1295,7 @@ public:
 
     bool isRemoteUIAppForAccessibility();
 
-    unsigned createSleepDisabler(const String& reason, bool display);
+    ExceptionOr<unsigned> createSleepDisabler(const String& reason, bool display);
     bool destroySleepDisabler(unsigned identifier);
         
 #if ENABLE(APP_HIGHLIGHTS)

--- a/Source/WebKit/Platform/IPC/MessageSender.h
+++ b/Source/WebKit/Platform/IPC/MessageSender.h
@@ -43,10 +43,10 @@ class MessageSender {
 public:
     virtual ~MessageSender();
 
-    template<typename T> inline bool send(T&& message);
-    template<typename T> inline bool send(T&& message, OptionSet<SendOption>);
-    template<typename T> inline bool send(T&& message, uint64_t destinationID);
-    template<typename T> inline bool send(T&& message, uint64_t destinationID, OptionSet<SendOption>);
+    template<typename T> inline bool send(T&& message); // Defined in MessageSenderInlines.h.
+    template<typename T> inline bool send(T&& message, OptionSet<SendOption>); // Defined in MessageSenderInlines.h.
+    template<typename T> inline bool send(T&& message, uint64_t destinationID); // Defined in MessageSenderInlines.h.
+    template<typename T> inline bool send(T&& message, uint64_t destinationID, OptionSet<SendOption>); // Defined in MessageSenderInlines.h.
     template<typename T, typename U, typename V> inline bool send(T&& message, ObjectIdentifierGeneric<U, V> destinationID);
     template<typename T, typename U, typename V> inline bool send(T&& message, ObjectIdentifierGeneric<U, V> destinationID, OptionSet<SendOption>);
 

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebViewTesting.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebViewTesting.mm
@@ -397,7 +397,7 @@ static void dumpCALayer(TextStream& ts, CALayer *layer, bool traverse)
 
 - (BOOL)_hasSleepDisabler
 {
-    return _page && _page->process().hasSleepDisabler();
+    return _page && _page->hasSleepDisabler();
 }
 
 - (NSString*)_scrollbarStateForScrollingNodeID:(uint64_t)scrollingNodeID isVertical:(bool)isVertical

--- a/Source/WebKit/UIProcess/WebPageProxy.h
+++ b/Source/WebKit/UIProcess/WebPageProxy.h
@@ -28,6 +28,7 @@
 #include "APIObject.h"
 #include "MessageReceiver.h"
 #include "MessageSender.h"
+#include <WebCore/SleepDisablerIdentifier.h>
 #include <wtf/CheckedRef.h>
 #include <wtf/ProcessID.h>
 #include <wtf/UniqueRef.h>
@@ -119,6 +120,7 @@ class SecurityOriginData;
 class SelectionData;
 class SelectionGeometry;
 class SharedBuffer;
+class SleepDisabler;
 class SpeechRecognitionRequest;
 class SubstituteData;
 class TextCheckingRequestData;
@@ -591,6 +593,8 @@ public:
     void loadServiceWorker(const URL&, bool usingModules, CompletionHandler<void(bool success)>&&);
 
     WebUserContentControllerProxy& userContentController() { return m_userContentController.get(); }
+
+    bool hasSleepDisabler() const;
 
 #if ENABLE(FULLSCREEN_API)
     WebFullScreenManagerProxy* fullScreenManager();
@@ -2205,6 +2209,9 @@ public:
 
     void didCommitLoadForFrame(WebCore::FrameIdentifier, FrameInfoData&&, WebCore::ResourceRequest&&, uint64_t navigationID, const String& mimeType, bool frameHasCustomContentProvider, WebCore::FrameLoadType, const WebCore::CertificateInfo&, bool usedLegacyTLS, bool wasPrivateRelayed, bool containsPluginDocument, WebCore::HasInsecureContent, WebCore::MouseEventPolicy, const UserData&);
 
+    void didCreateSleepDisabler(WebCore::SleepDisablerIdentifier, const String& reason, bool display);
+    void didDestroySleepDisabler(WebCore::SleepDisablerIdentifier);
+
 #if PLATFORM(MAC)
     void setCaretDecorationVisibility(bool);
 #endif
@@ -3278,6 +3285,7 @@ private:
 #endif
 
     RefPtr<WebPageProxy> m_pageToCloneSessionStorageFrom;
+    HashMap<WebCore::SleepDisablerIdentifier, std::unique_ptr<WebCore::SleepDisabler>> m_sleepDisablers;
 };
 
 } // namespace WebKit

--- a/Source/WebKit/UIProcess/WebPageProxy.messages.in
+++ b/Source/WebKit/UIProcess/WebPageProxy.messages.in
@@ -627,6 +627,9 @@ messages -> WebPageProxy {
     HandleSystemPreview(URL url, struct WebCore::SystemPreviewInfo systemPreviewInfo)
 #endif
 
+    DidCreateSleepDisabler(WebCore::SleepDisablerIdentifier identifier, String reason, bool display)
+    DidDestroySleepDisabler(WebCore::SleepDisablerIdentifier identifier)
+
     RequestCookieConsent() -> (enum:uint8_t WebCore::CookieConsentDecisionResult result)
     ClassifyModalContainerControls(Vector<String> texts) -> (Vector<WebCore::ModalContainerControlType> types)
     DecidePolicyForModalContainer(OptionSet<WebCore::ModalContainerControlType> types) -> (enum:uint8_t WebCore::ModalContainerDecision decision)

--- a/Source/WebKit/UIProcess/WebProcessProxy.h
+++ b/Source/WebKit/UIProcess/WebProcessProxy.h
@@ -48,7 +48,6 @@
 #include <WebCore/ProcessIdentifier.h>
 #include <WebCore/RegistrableDomain.h>
 #include <WebCore/SharedStringHash.h>
-#include <WebCore/SleepDisabler.h>
 #include <pal/SessionID.h>
 #include <wtf/Forward.h>
 #include <wtf/HashMap.h>
@@ -204,7 +203,6 @@ public:
 
     enum class EndsUsingDataStore : bool { No, Yes };
     void removeWebPage(WebPageProxy&, EndsUsingDataStore);
-    void willRemoveWebPage(WebPageProxy&);
 
     void addProvisionalPageProxy(ProvisionalPageProxy&);
     void removeProvisionalPageProxy(ProvisionalPageProxy&);
@@ -422,8 +420,6 @@ public:
     void gpuProcessExited(ProcessTerminationReason);
 #endif
 
-    bool hasSleepDisabler() const;
-
 #if PLATFORM(COCOA)
     bool hasNetworkExtensionSandboxAccess() const { return m_hasNetworkExtensionSandboxAccess; }
     void markHasNetworkExtensionSandboxAccess() { m_hasNetworkExtensionSandboxAccess = true; }
@@ -591,9 +587,6 @@ private:
     void sendMessageToWebContextWithReply(UserMessage&&, CompletionHandler<void(UserMessage&&)>&&);
 #endif
 
-    void didCreateSleepDisabler(WebCore::SleepDisablerIdentifier, const String& reason, bool display);
-    void didDestroySleepDisabler(WebCore::SleepDisablerIdentifier);
-
     void createSpeechRecognitionServer(SpeechRecognitionServerIdentifier);
     void destroySpeechRecognitionServer(SpeechRecognitionServerIdentifier);
 
@@ -733,9 +726,6 @@ private:
     std::optional<RemoteWorkerInformation> m_serviceWorkerInformation;
     std::optional<RemoteWorkerInformation> m_sharedWorkerInformation;
     bool m_hasServiceWorkerBackgroundProcessing { false };
-
-    // FIXME: We should probably move this to WebPageProxy.
-    HashMap<WebCore::SleepDisablerIdentifier, std::unique_ptr<WebCore::SleepDisabler>> m_sleepDisablers;
 
     struct AudibleMediaActivity {
         Ref<ProcessAssertion> assertion;

--- a/Source/WebKit/UIProcess/WebProcessProxy.messages.in
+++ b/Source/WebKit/UIProcess/WebProcessProxy.messages.in
@@ -70,9 +70,6 @@ messages -> WebProcessProxy LegacyReceiver {
     SendMessageToWebContextWithReply(struct WebKit::UserMessage userMessage) -> (struct WebKit::UserMessage replyMessage)
 #endif
 
-    DidCreateSleepDisabler(WebCore::SleepDisablerIdentifier identifier, String reason, bool display)
-    DidDestroySleepDisabler(WebCore::SleepDisablerIdentifier identifier)
-
     CreateSpeechRecognitionServer(WebCore::PageIdentifier identifier)
     DestroySpeechRecognitionServer(WebCore::PageIdentifier identifier)
 

--- a/Source/WebKit/WebProcess/WebSleepDisablerClient.cpp
+++ b/Source/WebKit/WebProcess/WebSleepDisablerClient.cpp
@@ -26,19 +26,22 @@
 #include "config.h"
 #include "WebSleepDisablerClient.h"
 
-#include "WebProcess.h"
-#include "WebProcessProxyMessages.h"
+#include "MessageSenderInlines.h"
+#include "WebPage.h"
+#include "WebPageProxyMessages.h"
 
 namespace WebKit {
 
-void WebSleepDisablerClient::didCreateSleepDisabler(WebCore::SleepDisablerIdentifier identifier, const String& reason, bool display)
+void WebSleepDisablerClient::didCreateSleepDisabler(WebCore::SleepDisablerIdentifier identifier, const String& reason, bool display, WebCore::PageIdentifier pageID)
 {
-    WebProcess::singleton().parentProcessConnection()->send(Messages::WebProcessProxy::DidCreateSleepDisabler(identifier, reason, display), 0);
+    if (auto* webPage = WebProcess::singleton().webPage(pageID))
+        webPage->send(Messages::WebPageProxy::DidCreateSleepDisabler(identifier, reason, display));
 }
 
-void WebSleepDisablerClient::didDestroySleepDisabler(WebCore::SleepDisablerIdentifier identifier)
+void WebSleepDisablerClient::didDestroySleepDisabler(WebCore::SleepDisablerIdentifier identifier, WebCore::PageIdentifier pageID)
 {
-    WebProcess::singleton().parentProcessConnection()->send(Messages::WebProcessProxy::DidDestroySleepDisabler(identifier), 0);
+    if (auto* webPage = WebProcess::singleton().webPage(pageID))
+        webPage->send(Messages::WebPageProxy::DidDestroySleepDisabler(identifier));
 }
 
 } // namespace WebKit

--- a/Source/WebKit/WebProcess/WebSleepDisablerClient.h
+++ b/Source/WebKit/WebProcess/WebSleepDisablerClient.h
@@ -29,11 +29,11 @@
 
 namespace WebKit {
 
-class WebSleepDisablerClient : public WebCore::SleepDisablerClient {
+class WebSleepDisablerClient final : public WebCore::SleepDisablerClient {
     WTF_MAKE_FAST_ALLOCATED;
 public:
-    void didCreateSleepDisabler(WebCore::SleepDisablerIdentifier, const String&, bool) override;
-    void didDestroySleepDisabler(WebCore::SleepDisablerIdentifier) override;
+    void didCreateSleepDisabler(WebCore::SleepDisablerIdentifier, const String&, bool display, WebCore::PageIdentifier) final;
+    void didDestroySleepDisabler(WebCore::SleepDisablerIdentifier, WebCore::PageIdentifier) final;
 };
 
 } // namespace WebKit


### PR DESCRIPTION
#### 9bfa2b8cde5b554ccb41788ee7fa0d7b302972e1
<pre>
Move SleepDisabler ownership from WebProcessProxy to WebPageProxy
<a href="https://bugs.webkit.org/show_bug.cgi?id=256056">https://bugs.webkit.org/show_bug.cgi?id=256056</a>

Reviewed by Alex Christensen.

Move SleepDisabler ownership from WebProcessProxy to WebPageProxy. Those &quot;sleep
disabling&quot; assertion are taken by paging and it thus makes sense for their
lifetime to be tired to the page rather than the process. This tighter scoping
reduces the chances of assertion leakage and fit nicely with our UIProcess-side
logic now that we rely on the UIClient to take some of these assertions.

* Source/WebCore/Modules/screen-wake-lock/WakeLock.cpp:
(WebCore::WakeLock::request):
* Source/WebCore/Modules/screen-wake-lock/WakeLockManager.cpp:
(WebCore::WakeLockManager::addWakeLock):
* Source/WebCore/Modules/screen-wake-lock/WakeLockManager.h:
* Source/WebCore/dom/Document.cpp:
(WebCore::Document::updateSleepDisablerIfNeeded):
* Source/WebCore/html/HTMLMediaElement.cpp:
(WebCore::HTMLMediaElement::updateSleepDisabling):
* Source/WebCore/platform/SleepDisabler.cpp:
(WebCore::SleepDisabler::SleepDisabler):
(WebCore::SleepDisabler::~SleepDisabler):
* Source/WebCore/platform/SleepDisabler.h:
* Source/WebCore/platform/SleepDisablerClient.h:
* Source/WebCore/testing/Internals.cpp:
(WebCore::Internals::createSleepDisabler):
* Source/WebCore/testing/Internals.h:
* Source/WebKit/UIProcess/API/Cocoa/WKWebViewTesting.mm:
(-[WKWebView _hasSleepDisabler]):
* Source/WebKit/UIProcess/WebPageProxy.cpp:
(WebKit::WebPageProxy::close):
(WebKit::WebPageProxy::resetStateAfterProcessExited):
(WebKit::WebPageProxy::didCreateSleepDisabler):
(WebKit::WebPageProxy::didDestroySleepDisabler):
(WebKit::WebPageProxy::hasSleepDisabler const):
* Source/WebKit/UIProcess/WebPageProxy.h:
* Source/WebKit/UIProcess/WebPageProxy.messages.in:
* Source/WebKit/UIProcess/WebProcessProxy.cpp:
(WebKit::WebProcessProxy::shutDown):
(WebKit::WebProcessProxy::processDidTerminateOrFailedToLaunch):
(WebKit::WebProcessProxy::willRemoveWebPage): Deleted.
(WebKit::WebProcessProxy::didCreateSleepDisabler): Deleted.
(WebKit::WebProcessProxy::didDestroySleepDisabler): Deleted.
(WebKit::WebProcessProxy::hasSleepDisabler const): Deleted.
* Source/WebKit/UIProcess/WebProcessProxy.h:
* Source/WebKit/UIProcess/WebProcessProxy.messages.in:
* Source/WebKit/WebProcess/WebSleepDisablerClient.cpp:
(WebKit::WebSleepDisablerClient::didCreateSleepDisabler):
(WebKit::WebSleepDisablerClient::didDestroySleepDisabler):
* Source/WebKit/WebProcess/WebSleepDisablerClient.h:

Canonical link: <a href="https://commits.webkit.org/263474@main">https://commits.webkit.org/263474@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/dedfd750c092d0ad93441b4927d91f36cedb8961

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/4734 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/4853 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/5015 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/6240 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/4875 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/4727 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/5004 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/4820 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/5102 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/4811 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/4896 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/4236 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/6250 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/2385 "Passed tests") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/10/builds/4227 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/9202 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/4245 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/4301 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/5864 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/4712 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/3837 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/4231 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/1161 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/8283 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/4591 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->