### PR TITLE
[bmalloc] Add Windows implementation of VMAllocate

### DIFF
--- a/Source/bmalloc/bmalloc/Deallocator.cpp
+++ b/Source/bmalloc/bmalloc/Deallocator.cpp
@@ -33,7 +33,10 @@
 #include "PerProcess.h"
 #include <algorithm>
 #include <cstdlib>
+
+#if !BPLATFORM(WIN)
 #include <sys/mman.h>
+#endif
 
 #if !BUSE(LIBPAS)
 

--- a/Source/bmalloc/bmalloc/DebugHeap.h
+++ b/Source/bmalloc/bmalloc/DebugHeap.h
@@ -29,6 +29,7 @@
 #include "FailureAction.h"
 #include "Mutex.h"
 #include "StaticPerProcess.h"
+#include "VMAllocate.h"
 #include <mutex>
 #include <unordered_map>
 
@@ -73,7 +74,7 @@ private:
     
     // This is the debug heap. We can use whatever data structures we like. It doesn't matter.
     size_t m_pageSize { 0 };
-    std::unordered_map<void*, size_t> m_sizeMap;
+    std::unordered_map<void*, VMAllocation> m_largeAlignedMap;
 };
 DECLARE_STATIC_PER_PROCESS_STORAGE(DebugHeap);
 

--- a/Source/bmalloc/bmalloc/Gigacage.cpp
+++ b/Source/bmalloc/bmalloc/Gigacage.cpp
@@ -161,14 +161,15 @@ void ensureGigacage()
 
             // FIXME: Randomize where this goes.
             // https://bugs.webkit.org/show_bug.cgi?id=175245
-            void* base = tryVMAllocate(maxAlignment, totalSize, VMTag::JSGigacage);
-            if (!base) {
+            auto result = tryVMAllocateAligned(maxAlignment, totalSize, VMTag::JSGigacage);
+            if (!result) {
                 if (GIGACAGE_ALLOCATION_CAN_FAIL)
                     return;
                 fprintf(stderr, "FATAL: Could not allocate gigacage memory with maxAlignment = %lu, totalSize = %lu.\n", maxAlignment, totalSize);
                 fprintf(stderr, "(Make sure you have not set a virtual memory limit.)\n");
                 BCRASH();
             }
+            void* base = result->aligned;
 
             size_t nextCage = 0;
             for (Kind kind : shuffledKinds) {

--- a/Source/bmalloc/bmalloc/Heap.cpp
+++ b/Source/bmalloc/bmalloc/Heap.cpp
@@ -609,7 +609,14 @@ LargeRange Heap::tryAllocateLargeChunk(size_t alignment, size_t size)
         return LargeRange();
     size = roundedSize;
 
-    void* memory = tryVMAllocate(alignment, size);
+    // Not use VMAllocateAligned(alignment, size) but calculate them here.
+    // Remaining memory regions are not returned to kernel but added to FreeLarge.
+    size_t mappedSize = alignment + size;
+    if (mappedSize < alignment || mappedSize < size) // Check for overflow
+        return LargeRange();
+    size = mappedSize;
+
+    void* memory = tryVMAllocate(size);
     if (!memory)
         return LargeRange();
     

--- a/Source/bmalloc/bmalloc/IsoPage.cpp
+++ b/Source/bmalloc/bmalloc/IsoPage.cpp
@@ -34,7 +34,8 @@ namespace bmalloc {
 
 void* IsoPageBase::allocatePageMemory()
 {
-    return tryVMAllocate(pageSize, pageSize, VMTag::IsoHeap);
+    auto result = tryVMAllocateAligned(pageSize, pageSize, VMTag::IsoHeap);
+    return result ? result->aligned : nullptr;
 }
 
 } // namespace bmalloc


### PR DESCRIPTION
https://bugs.webkit.org/show_bug.cgi?id=255968

Reviewed by NOBODY (OOPS!).

This is the patch for Windows bmalloc implementation part 5 of N.

VMAllocate.h is the core of memory allocation/commit/decommit operation using mmap API. This patch will add Windows native implementation, VirtualAlloc, to that.

There's a key conceptual difference between mmap and Windows VirtualAlloc. Partial address region allocated by mmap can be deallocated freely. But in VirtualAlloc world, the region must be exactly same for alloc and dealloc. In bmalloc, the design is based on that mmap characteristic so that we cannot replace mmap/munmap directly with VirtualAlloc APIs.

Looking into the code, actual deallocation won't happen often. The chances are:

A) bmalloc::vector's resize and deallocation
B) IsoTLS's resize
C) PerThread's deallocation of storage
D) allocation of aligned VMAllocate() to trim pre and post remainings.
E) deallocation of aligned VMAllocate()

For case A, B and C, the region size is well-known by the code and they deallocate entire region. They are no problem.

For case D, bmalloc uses a technique to allocate region with specific alignment that:
  1. Allocate size + alignment region.
  2. It must contain specific size of region which can start with the alignment.

```
    |-- pre --|-- actual memory region --|-- post --|
              ^      <-- size -->        |
          alignment
```
  3. Deallocate pre and post if exists. mmap can do this.

And also this affects on case E. To deallocate the region allocated in case D, VirtualAlloc needs to know original allocation address, not aligned address (in the case when `pre` is not empty in case D).

To wrap up, to VirtualAlloc API:
- There's no issue to port regular usage of VMAllocate.
- We need some modification to support aligned VMAllocate.

To solve case D, we need to change the behavior of aligned VMAllocate() to decommitting `pre` and `post` instead of deallocating them.

Also for case E, we need to return not only aligned result address, but also allocated region information on top of that. We are introducing new structure which contains aligned address and (allocated address, size) pair.

The clients of aligned VMAllocate() is like this:
- Gigabage's base address
- IsoPage
- DebugHeap::memalignLarge()
- Heap::allocateLarge()

For the first two cases, they never deallocate regions so the adoption is very straightforward.

For Heap::allocateLarge, we can stop using aligned VMAllocate() and use regular VMAllocate(). The alignment can be easily handled by existing Heap logic, splitAndAllocate().

The only downside is DebugHeap. The storage is increased to keep not only size but also address.

* Source/bmalloc/bmalloc/Deallocator.cpp:
* Source/bmalloc/bmalloc/DebugHeap.cpp: (bmalloc::DebugHeap::memalignLarge):
(bmalloc::DebugHeap::freeLarge):
* Source/bmalloc/bmalloc/DebugHeap.h:
* Source/bmalloc/bmalloc/Gigacage.cpp: (Gigacage::ensureGigacage):
* Source/bmalloc/bmalloc/Heap.cpp: (bmalloc::Heap::tryAllocateLargeChunk):
* Source/bmalloc/bmalloc/IsoPage.cpp: (bmalloc::IsoPageBase::allocatePageMemory):
* Source/bmalloc/bmalloc/VMAllocate.h: (bmalloc::vmGranularity):
(bmalloc::vmPageSize):
(bmalloc::vmPageSizePhysical):
(bmalloc::tryVMAllocate):
(bmalloc::vmDeallocate):
(bmalloc::vmRevokePermissions):
(bmalloc::vmZeroAndPurge):
(bmalloc::vmDeallocatePhysicalPages):
(bmalloc::vmAllocatePhysicalPages):
(bmalloc::tryVMAllocateAligned):
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/80ff0e46c6141ec221a1a1db808b5bd4d7453352

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/4731 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/4850 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/5011 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/6236 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/4873 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/5017 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/4817 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/5101 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/4808 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/4910 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/4233 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/6246 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/2399 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/4224 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/9209 "Passed tests") | 
| [❌ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/3933 "Found 1 jsc stress test failure: wasm.yaml/wasm/stress/simple-inline-stacktrace-with-catch.js.wasm-eager") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/4260 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/4298 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/5872 "Passed tests") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/4499 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/4709 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/3835 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/4826 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/4229 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/1189 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/8280 "Built successfully") | | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/24/builds/4948 "Built successfully") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/4589 "Built successfully") | | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/3/builds/1300 "Passed tests") | 
<!--EWS-Status-Bubble-End-->