### PR TITLE
Use move semantics for ShareableResource::map

### DIFF
--- a/Source/WebKit/NetworkProcess/cache/NetworkCacheEntry.cpp
+++ b/Source/WebKit/NetworkProcess/cache/NetworkCacheEntry.cpp
@@ -199,7 +199,7 @@ void Entry::initializeBufferFromStorageRecord() const
 {
 #if ENABLE(SHAREABLE_RESOURCE)
     if (!shareableResourceHandle().isNull()) {
-        m_buffer = m_shareableResourceHandle.tryWrapInSharedBuffer();
+        m_buffer = WTFMove(m_shareableResourceHandle).tryWrapInSharedBuffer();
         if (m_buffer)
             return;
     }

--- a/Source/WebKit/Shared/ShareableResource.cpp
+++ b/Source/WebKit/Shared/ShareableResource.cpp
@@ -70,9 +70,9 @@ RefPtr<SharedBuffer> ShareableResource::wrapInSharedBuffer()
     });
 }
 
-RefPtr<SharedBuffer> ShareableResourceHandle::tryWrapInSharedBuffer() const
+RefPtr<SharedBuffer> ShareableResourceHandle::tryWrapInSharedBuffer() &&
 {
-    RefPtr<ShareableResource> resource = ShareableResource::map(*this);
+    RefPtr<ShareableResource> resource = ShareableResource::map(WTFMove(*this));
     if (!resource) {
         LOG_ERROR("Failed to recreate ShareableResource from handle.");
         return nullptr;
@@ -95,7 +95,7 @@ RefPtr<ShareableResource> ShareableResource::create(Ref<SharedMemory>&& sharedMe
     return adoptRef(*new ShareableResource(WTFMove(sharedMemory), offset, size));
 }
 
-RefPtr<ShareableResource> ShareableResource::map(const Handle& handle)
+RefPtr<ShareableResource> ShareableResource::map(Handle&& handle)
 {
     auto sharedMemory = SharedMemory::map(handle.m_handle, SharedMemory::Protection::ReadOnly);
     if (!sharedMemory)

--- a/Source/WebKit/Shared/ShareableResource.h
+++ b/Source/WebKit/Shared/ShareableResource.h
@@ -50,7 +50,7 @@ public:
     void encode(IPC::Encoder&) const;
     static WARN_UNUSED_RETURN bool decode(IPC::Decoder&, ShareableResourceHandle&);
 
-    RefPtr<WebCore::SharedBuffer> tryWrapInSharedBuffer() const;
+    RefPtr<WebCore::SharedBuffer> tryWrapInSharedBuffer() &&;
 
 private:
     friend class ShareableResource;
@@ -68,7 +68,7 @@ public:
     static RefPtr<ShareableResource> create(Ref<SharedMemory>&&, unsigned offset, unsigned size);
 
     // Create a shareable resource from a handle.
-    static RefPtr<ShareableResource> map(const Handle&);
+    static RefPtr<ShareableResource> map(Handle&&);
 
     std::optional<Handle> createHandle();
 

--- a/Source/WebKit/Shared/WebCoreArgumentCoders.cpp
+++ b/Source/WebKit/Shared/WebCoreArgumentCoders.cpp
@@ -1425,7 +1425,7 @@ static std::optional<WebCore::ScriptBuffer> decodeScriptBufferAsShareableResourc
     ShareableResource::Handle handle;
     if (!decoder.decode(handle) || handle.isNull())
         return std::nullopt;
-    auto buffer = handle.tryWrapInSharedBuffer();
+    auto buffer = WTFMove(handle).tryWrapInSharedBuffer();
     if (!buffer)
         return std::nullopt;
     return WebCore::ScriptBuffer { WTFMove(buffer) };

--- a/Source/WebKit/UIProcess/ios/WebPageProxyIOS.mm
+++ b/Source/WebKit/UIProcess/ios/WebPageProxyIOS.mm
@@ -1244,7 +1244,7 @@ void WebPageProxy::didStartLoadForQuickLookDocumentInMainFrame(const String& fil
 
 void WebPageProxy::didFinishLoadForQuickLookDocumentInMainFrame(ShareableResource::Handle&& handle)
 {
-    auto buffer = handle.tryWrapInSharedBuffer();
+    auto buffer = WTFMove(handle).tryWrapInSharedBuffer();
     if (!buffer)
         return;
 

--- a/Source/WebKit/WebProcess/Network/NetworkProcessConnection.cpp
+++ b/Source/WebKit/WebProcess/Network/NetworkProcessConnection.cpp
@@ -293,7 +293,7 @@ void NetworkProcessConnection::didCacheResource(const ResourceRequest& request, 
     if (!resource)
         return;
     
-    auto buffer = handle.tryWrapInSharedBuffer();
+    auto buffer = WTFMove(handle).tryWrapInSharedBuffer();
     if (!buffer) {
         LOG_ERROR("Unable to create FragmentedSharedBuffer from ShareableResource handle for resource url %s", request.url().string().utf8().data());
         return;

--- a/Source/WebKit/WebProcess/Network/WebResourceLoader.cpp
+++ b/Source/WebKit/WebProcess/Network/WebResourceLoader.cpp
@@ -331,7 +331,7 @@ void WebResourceLoader::didReceiveResource(ShareableResource::Handle&& handle)
     LOG(Network, "(WebProcess) WebResourceLoader::didReceiveResource for '%s'", m_coreLoader->url().string().latin1().data());
     WEBRESOURCELOADER_RELEASE_LOG("didReceiveResource:");
 
-    RefPtr<SharedBuffer> buffer = handle.tryWrapInSharedBuffer();
+    RefPtr<SharedBuffer> buffer = WTFMove(handle).tryWrapInSharedBuffer();
 
     if (!buffer) {
         LOG_ERROR("Unable to create buffer from ShareableResource sent from the network process.");


### PR DESCRIPTION
#### c62fe5aabb3816c7590b09a775b398269c27a5e3
<pre>
Use move semantics for ShareableResource::map
<a href="https://bugs.webkit.org/show_bug.cgi?id=256062">https://bugs.webkit.org/show_bug.cgi?id=256062</a>

Reviewed by Kimmo Kinnunen.

Continuation of 263362@main which used move semantics for
`ShareableResource::Handle` to signify transferring ownership.

* Source/WebKit/NetworkProcess/cache/NetworkCacheEntry.cpp:
* Source/WebKit/Shared/ShareableResource.cpp:
* Source/WebKit/Shared/ShareableResource.h:
* Source/WebKit/Shared/WebCoreArgumentCoders.cpp:
* Source/WebKit/UIProcess/ios/WebPageProxyIOS.mm:
* Source/WebKit/WebProcess/Network/NetworkProcessConnection.cpp:
* Source/WebKit/WebProcess/Network/WebResourceLoader.cpp:

Canonical link: <a href="https://commits.webkit.org/263683@main">https://commits.webkit.org/263683@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b54d2f50797aaac2800257731b5e017f84286d47

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/5341 "1 style error") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/5478 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/5666 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/6878 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/5382 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/5705 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/5459 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/6061 "2 flakes 106 failures") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/5440 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/5519 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/4787 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/6916 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/2998 "Passed tests") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/11957 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/4864 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/4871 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/6509 "run-api-tests-without-change (failure)") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/5296 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/4353 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/4761 "Built successfully") | | | 
| [❌ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/1301 "Failed to push commit to Webkit repository") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/8858 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/5122 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->