### PR TITLE
Drop unused setInactiveSchedulingPolicy function

### DIFF
--- a/Source/WebKit/UIProcess/API/Cocoa/WKPreferences.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKPreferences.mm
@@ -1662,26 +1662,6 @@ static WebCore::EditableLinkBehavior toEditableLinkBehavior(_WKEditableLinkBehav
     return _preferences->clientBadgeEnabled();
 }
 
-- (void)setInactiveSchedulingPolicy:(WKInactiveSchedulingPolicy)policy
-{
-    switch (policy) {
-    case WKInactiveSchedulingPolicySuspend:
-        _preferences->setShouldTakeSuspendedAssertions(false);
-        _preferences->setBackgroundWebContentRunningBoardThrottlingEnabled(true);
-        break;
-    case WKInactiveSchedulingPolicyThrottle:
-        _preferences->setShouldTakeSuspendedAssertions(true);
-        _preferences->setBackgroundWebContentRunningBoardThrottlingEnabled(true);
-        break;
-    case WKInactiveSchedulingPolicyNone:
-        _preferences->setShouldTakeSuspendedAssertions(true);
-        _preferences->setBackgroundWebContentRunningBoardThrottlingEnabled(false);
-        break;
-    default:
-        ASSERT_NOT_REACHED();
-    }
-}
-
 - (WKInactiveSchedulingPolicy)inactiveSchedulingPolicy
 {
     return _preferences->backgroundWebContentRunningBoardThrottlingEnabled() ? (_preferences->shouldTakeSuspendedAssertions() ? WKInactiveSchedulingPolicyThrottle : WKInactiveSchedulingPolicySuspend) : WKInactiveSchedulingPolicyNone;


### PR DESCRIPTION
#### 1f75adca23c208c36163b2be106ec730dfcd5c58
<pre>
Drop unused setInactiveSchedulingPolicy function
<a href="https://bugs.webkit.org/show_bug.cgi?id=256063">https://bugs.webkit.org/show_bug.cgi?id=256063</a>
rdar://108633001

Reviewed by NOBODY (OOPS!).

* Source/WebKit/UIProcess/API/Cocoa/WKPreferences.mm:
(-[WKPreferences setInactiveSchedulingPolicy:]): Deleted.
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1f75adca23c208c36163b2be106ec730dfcd5c58

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [  ~~🧪 style~~](https://ews-build.webkit.org/#/builders/38/builds/4745 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 ios~~](https://ews-build.webkit.org/#/builders/26/builds/4863 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/5025 "Built successfully") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/6251 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/32/builds/4881 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/5014 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/4830 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/6251 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [❌ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/4822 "Failed to checkout and rebase branch from PR 13252") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/15/builds/4902 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/4246 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/6261 "Failed to checkout and rebase branch from PR 13252") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/39/builds/2391 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/2/builds/6261 "Failed to checkout and rebase branch from PR 13252") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/4252 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/4312 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/2/builds/6261 "Failed to checkout and rebase branch from PR 13252") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/7/builds/4720 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/3843 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/30/builds/4238 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/4/builds/8290 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/31/builds/4596 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->