### PR TITLE
[run-benchmark][WPE] Update cog and minibrowser-wpe browser drivers.

### DIFF
--- a/Tools/Scripts/webkitpy/benchmark_runner/browser_driver/linux_cog_driver.py
+++ b/Tools/Scripts/webkitpy/benchmark_runner/browser_driver/linux_cog_driver.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2019 Igalia S.L. All rights reserved.
+# Copyright (C) 2019, 2023 Igalia S.L. All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions are
@@ -29,27 +29,20 @@ from webkitpy.benchmark_runner.browser_driver.linux_browser_driver import LinuxB
 
 class CogBrowserDriver(LinuxBrowserDriver):
     browser_name = 'cog'
-    process_search_list = ['cog']
+    process_search_list = ['Tools/Scripts/run-minibrowser', 'cog']
 
+    # If you want to execute Cog with a specific platform plugin (drm, wayland, etc)
+    # Then set the environment variables COG_PLATFORM_NAME and COG_PLATFORM_PARAMS
     def launch_url(self, url, options, browser_build_path, browser_path):
-        self._browser_arguments = [url]
-        super(CogBrowserDriver, self).launch_url(url, options,
-                                                 browser_build_path,
-                                                 browser_path)
+        self._browser_arguments = []
+        if self.process_name.endswith('run-minibrowser'):
+            self._browser_arguments.append('--wpe')
+        self._browser_arguments.append(url)
+        super(CogBrowserDriver, self).launch_url(url, options, browser_build_path, browser_path)
 
     def launch_driver(self, url, options, browser_build_path):
         raise ValueError("Browser {browser} is not available with webdriver".format(browser=self.browser_name))
 
-
-class CogFdoBrowserDriver(LinuxBrowserDriver):
-    browser_name = 'cog-fdo'
-    process_search_list = ['cog']
-
-    def launch_url(self, url, options, browser_build_path, browser_path):
-        self._browser_arguments = ['--platform=fdo', url]
-        super(CogFdoBrowserDriver, self).launch_url(url, options,
-                                                    browser_build_path,
-                                                    browser_path)
-
-    def launch_driver(self, url, options, browser_build_path):
-        raise ValueError("Browser {browser} is not available with webdriver".format(browser=self.browser_name))
+    def prepare_env(self, config):
+        super(CogBrowserDriver, self).prepare_env(config)
+        self._test_environ['WPE_BROWSER'] = 'cog'

--- a/Tools/Scripts/webkitpy/benchmark_runner/browser_driver/linux_minibrowserwpe_driver.py
+++ b/Tools/Scripts/webkitpy/benchmark_runner/browser_driver/linux_minibrowserwpe_driver.py
@@ -40,3 +40,7 @@ class WPEMiniBrowserDriver(LinuxBrowserDriver):
 
     def launch_driver(self, url, options, browser_build_path):
         raise ValueError("Browser {browser} is not available with webdriver".format(browser=self.browser_name))
+
+    def prepare_env(self, config):
+        super(WPEMiniBrowserDriver, self).prepare_env(config)
+        self._test_environ['WPE_BROWSER'] = 'minibrowser'


### PR DESCRIPTION
#### 3bfd9bb7a4574965bed070cb2f7a71ab8b7f195d
<pre>
[run-benchmark][WPE] Update cog and minibrowser-wpe browser drivers.
<a href="https://bugs.webkit.org/show_bug.cgi?id=256061">https://bugs.webkit.org/show_bug.cgi?id=256061</a>

Reviewed by Philippe Normand.

Simplify the Cog browser driver to only have one browser driver for Cog.
In order to select the platform plugins for Cog the environment variables
COG_PLATFORM_NAME and COG_PLATFORM_PARAMS can be used now. Also allow to
start Cog from the run-minibrowser script.

Finally fix the driver for minibrowser-wpe to run the minibrowser binary
instead of Cog. For that the script sets the env var WPE_BROWSER=minibrowser

* Tools/Scripts/webkitpy/benchmark_runner/browser_driver/linux_cog_driver.py:
(CogBrowserDriver):
(CogBrowserDriver.launch_url):
(CogBrowserDriver.prepare_env):
(CogFdoBrowserDriver): Deleted.
(CogFdoBrowserDriver.launch_url): Deleted.
(CogFdoBrowserDriver.launch_driver): Deleted.
* Tools/Scripts/webkitpy/benchmark_runner/browser_driver/linux_minibrowserwpe_driver.py:
(WPEMiniBrowserDriver.launch_driver):
(WPEMiniBrowserDriver):
(WPEMiniBrowserDriver.prepare_env):

Canonical link: <a href="https://commits.webkit.org/263495@main">https://commits.webkit.org/263495@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/da74dd7c80f173817becc25660bb1d791ed86b18

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/4751 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/4869 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/5031 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/6257 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/4882 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/4744 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/5021 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/4836 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/5115 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/4828 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/4904 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/4249 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/6267 "Built successfully") | 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/4831 "Passed tests") | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/2393 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/4241 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/9214 "3 flakes 168 failures") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/4254 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/4315 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/5878 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/4726 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/3845 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/4240 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/8295 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/548 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/4597 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->