### PR TITLE
[curl] Remove unused functions from CurlContext

### DIFF
--- a/Source/WebCore/platform/network/curl/CurlContext.cpp
+++ b/Source/WebCore/platform/network/curl/CurlContext.cpp
@@ -266,16 +266,6 @@ CURLMcode CurlMultiHandle::removeHandle(CURL* handle)
     return curl_multi_remove_handle(m_multiHandle, handle);
 }
 
-CURLMcode CurlMultiHandle::getFdSet(fd_set& readFdSet, fd_set& writeFdSet, fd_set& excFdSet, int& maxFd)
-{
-    FD_ZERO(&readFdSet);
-    FD_ZERO(&writeFdSet);
-    FD_ZERO(&excFdSet);
-    maxFd = 0;
-
-    return curl_multi_fdset(m_multiHandle, &readFdSet, &writeFdSet, &excFdSet, &maxFd);
-}
-
 CURLMcode CurlMultiHandle::poll(const Vector<curl_waitfd>& extraFds, int timeoutMS)
 {
     int numFds = 0;
@@ -506,12 +496,6 @@ void CurlHandle::enableHttpPostRequest()
     enableHttp();
     curl_easy_setopt(m_handle, CURLOPT_POST, 1L);
     curl_easy_setopt(m_handle, CURLOPT_POSTFIELDSIZE, 0L);
-}
-
-void CurlHandle::setPostFields(const uint8_t* data, long size)
-{
-    curl_easy_setopt(m_handle, CURLOPT_POSTFIELDS, data);
-    curl_easy_setopt(m_handle, CURLOPT_POSTFIELDSIZE, size);
 }
 
 void CurlHandle::setPostFieldLarge(curl_off_t size)
@@ -981,13 +965,6 @@ std::optional<CertificateInfo> CurlHandle::certificateInfo() const
     }
 
     return std::nullopt;
-}
-
-long long CurlHandle::maxCurlOffT()
-{
-    static const long long maxCurlOffT = (1LL << (expectedSizeOfCurlOffT() * 8 - 1)) - 1;
-
-    return maxCurlOffT;
 }
 
 int CurlHandle::expectedSizeOfCurlOffT()

--- a/Source/WebCore/platform/network/curl/CurlContext.h
+++ b/Source/WebCore/platform/network/curl/CurlContext.h
@@ -178,7 +178,6 @@ public:
     CURLMcode addHandle(CURL*);
     CURLMcode removeHandle(CURL*);
 
-    CURLMcode getFdSet(fd_set&, fd_set&, fd_set&, int&);
     CURLMcode poll(const Vector<curl_waitfd>&, int);
     CURLMcode wakeUp();
     CURLMcode perform(int&);
@@ -261,7 +260,6 @@ public:
     void enableHttpGetRequest();
     void enableHttpHeadRequest();
     void enableHttpPostRequest();
-    void setPostFields(const uint8_t*, long);
     void setPostFieldLarge(curl_off_t);
     void enableHttpPutRequest();
     void setInFileSizeLarge(curl_off_t);
@@ -312,8 +310,6 @@ public:
     void addExtraNetworkLoadMetrics(NetworkLoadMetrics&);
 
     std::optional<CertificateInfo> certificateInfo() const;
-
-    static long long maxCurlOffT();
 
     // socket
     Expected<curl_socket_t, CURLcode> getActiveSocket();


### PR DESCRIPTION
#### ab621a40b413e5f1ff2541147bd341324f80c956
<pre>
[curl] Remove unused functions from CurlContext
<a href="https://bugs.webkit.org/show_bug.cgi?id=256067">https://bugs.webkit.org/show_bug.cgi?id=256067</a>

Reviewed by Fujii Hironori.

* Source/WebCore/platform/network/curl/CurlContext.cpp:
(WebCore::CurlHandle::setPostFieldLarge):
(WebCore::CurlHandle::expectedSizeOfCurlOffT):
(WebCore::CurlMultiHandle::getFdSet): Deleted.
(WebCore::CurlHandle::setPostFields): Deleted.
(WebCore::CurlHandle::maxCurlOffT): Deleted.
* Source/WebCore/platform/network/curl/CurlContext.h:

Canonical link: <a href="https://commits.webkit.org/263480@main">https://commits.webkit.org/263480@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/282558f329901b2236714cd24fe0195f4de5c5bd

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/4762 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/4880 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/5043 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/6268 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/32/builds/4890 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/4754 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/5033 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/4848 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/5126 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/4840 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/4918 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/4259 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/6279 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/2406 "Passed tests") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/10/builds/4254 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/9223 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/4268 "Passed tests") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/4328 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/5892 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/4735 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/3853 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/4248 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/8304 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/543 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/4605 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->