### PR TITLE
Web Inspector: Crash when inspecting CSS Grid without defined columns or rows

### DIFF
--- a/LayoutTests/inspector/dom/showFlexOverlay.html
+++ b/LayoutTests/inspector/dom/showFlexOverlay.html
@@ -7,6 +7,10 @@ function test()
 {
     let suite = InspectorTest.createAsyncSuite("DOM.showFlexOverlay");
 
+    const allEnabledOverlayOptions = {
+        showOrderNumbers: true,
+    };
+
     async function getFlexContainerNode() {
         let doc = await WI.domManager.requestDocument();
         let nodeId = await doc.querySelector(".flex-container");
@@ -46,12 +50,12 @@ function test()
             let container = await getFlexContainerNode();
 
             InspectorTest.log("Requesting to show flex overlay for first .flex-container");
-            await container.showLayoutOverlay({color: WI.Color.fromString("magenta")});
+            await container.showLayoutOverlay({color: WI.Color.fromString("magenta"), ...allEnabledOverlayOptions});
             await checkFlexOverlayCount(1);
 
             // No error should occur if showing flex overlay for a node that already has one.
             InspectorTest.log("Requesting to show a different flex overlay for first .flex-container");
-            await container.showLayoutOverlay({color: WI.Color.fromString("green")});
+            await container.showLayoutOverlay({color: WI.Color.fromString("green"), ...allEnabledOverlayOptions});
             await checkFlexOverlayCount(1);
 
             // No error should occur when hiding the flex overlay.
@@ -69,11 +73,11 @@ function test()
             let [first, second] = await getAllFlexContainerNodes();
 
             InspectorTest.log("Requesting to show first flex overlay");
-            await first.showLayoutOverlay({color: WI.Color.fromString("magenta")});
+            await first.showLayoutOverlay({color: WI.Color.fromString("magenta"), ...allEnabledOverlayOptions});
             await checkFlexOverlayCount(1);
 
             InspectorTest.log("Requesting to show second flex overlay");
-            await second.showLayoutOverlay({color: WI.Color.fromString("green")});
+            await second.showLayoutOverlay({color: WI.Color.fromString("green"), ...allEnabledOverlayOptions});
             await checkFlexOverlayCount(2);
 
             // No error should occur when hiding the first flex overlay.
@@ -96,11 +100,11 @@ function test()
             let [first, second] = await getAllFlexContainerNodes();
 
             InspectorTest.log("Requesting to show first flex overlay");
-            await first.showLayoutOverlay({color: WI.Color.fromString("magenta")});
+            await first.showLayoutOverlay({color: WI.Color.fromString("magenta"), ...allEnabledOverlayOptions});
             await checkFlexOverlayCount(1);
 
             InspectorTest.log("Requesting to show second flex overlay");
-            await second.showLayoutOverlay({color: WI.Color.fromString("green")});
+            await second.showLayoutOverlay({color: WI.Color.fromString("green"), ...allEnabledOverlayOptions});
             await checkFlexOverlayCount(2);
 
             // No error should occur when hiding all flex overlays.
@@ -142,7 +146,7 @@ function test()
 
             InspectorTest.log("Requesting to show flex overlay for invalid nodeId -1");
             await InspectorTest.expectException(async () => {
-                await DOMAgent.showFlexOverlay(-1, { flexColor: WI.Color.fromString("magenta").toProtocol() });
+                await DOMAgent.showFlexOverlay(-1, { flexColor: WI.Color.fromString("magenta").toProtocol(), ...allEnabledOverlayOptions });
             });
 
         await checkFlexOverlayCount(0);

--- a/LayoutTests/inspector/dom/showGridOverlay.html
+++ b/LayoutTests/inspector/dom/showGridOverlay.html
@@ -7,6 +7,14 @@ function test()
 {
     let suite = InspectorTest.createAsyncSuite("DOM.showGridOverlay");
 
+    const allEnabledOverlayOptions = {
+        showLineNames: true,
+        showLineNumbers: true,
+        showExtendedGridLines: true,
+        showTrackSizes: true,
+        showAreaNames: true,
+    };
+
     async function getGridContainerNode() {
         let doc = await WI.domManager.requestDocument();
         let nodeId = await doc.querySelector(".grid-container");
@@ -46,12 +54,12 @@ function test()
             let container = await getGridContainerNode();
 
             InspectorTest.log("Requesting to show grid overlay for first .grid-container");
-            await container.showLayoutOverlay({color: WI.Color.fromString("magenta")});
+            await container.showLayoutOverlay({color: WI.Color.fromString("magenta"), ...allEnabledOverlayOptions});
             await checkGridOverlayCount(1);
 
             // No error should occur if showing grid overlay for a node that already has one.
             InspectorTest.log("Requesting to show a different grid overlay for first .grid-container");
-            await container.showLayoutOverlay({color: WI.Color.fromString("green")});
+            await container.showLayoutOverlay({color: WI.Color.fromString("green"), ...allEnabledOverlayOptions});
             await checkGridOverlayCount(1);
 
             // No error should occur when hiding the grid overlay.
@@ -69,11 +77,11 @@ function test()
             let [first, second] = await getAllGridContainerNodes();
 
             InspectorTest.log("Requesting to show first grid overlay");
-            await first.showLayoutOverlay({color: WI.Color.fromString("magenta")});
+            await first.showLayoutOverlay({color: WI.Color.fromString("magenta"), ...allEnabledOverlayOptions});
             await checkGridOverlayCount(1);
 
             InspectorTest.log("Requesting to show second grid overlay");
-            await second.showLayoutOverlay({color: WI.Color.fromString("green")});
+            await second.showLayoutOverlay({color: WI.Color.fromString("green"), ...allEnabledOverlayOptions});
             await checkGridOverlayCount(2);
 
             // No error should occur when hiding the grid overlay.
@@ -96,11 +104,11 @@ function test()
             let [first, second] = await getAllGridContainerNodes();
 
             InspectorTest.log("Requesting to show grid overlay");
-            await first.showLayoutOverlay({color: WI.Color.fromString("magenta")});
+            await first.showLayoutOverlay({color: WI.Color.fromString("magenta"), ...allEnabledOverlayOptions});
             await checkGridOverlayCount(1);
 
             InspectorTest.log("Requesting to show a different grid overlay");
-            await second.showLayoutOverlay({color: WI.Color.fromString("green")});
+            await second.showLayoutOverlay({color: WI.Color.fromString("green"), ...allEnabledOverlayOptions});
             await checkGridOverlayCount(2);
 
             // No error should occur when hiding the grid overlay.
@@ -142,7 +150,7 @@ function test()
 
             InspectorTest.log("Requesting to show grid overlay for invalid nodeId -1");
             await InspectorTest.expectException(async () => {
-                await DOMAgent.showGridOverlay(-1, { gridColor: WI.Color.fromString("magenta").toProtocol() });
+                await DOMAgent.showGridOverlay(-1, { gridColor: WI.Color.fromString("magenta").toProtocol(), ...allEnabledOverlayOptions });
             });
 
         await checkGridOverlayCount(0);
@@ -161,8 +169,8 @@ function test()
         .grid-container {
             display: grid;
             grid-gap: 10px;
-            grid-template-columns: 100px 100px 100px;
-            grid-template-rows: repeat(2, 10px) repeat(auto-fit, 50px);
+            grid-auto-columns: minmax(100px, auto);
+            grid-template-rows: 100px repeat(2, 10px) repeat(auto-fit, 50px);
             background-color: white;
             color: gray;
         }

--- a/Source/WebCore/inspector/InspectorOverlay.cpp
+++ b/Source/WebCore/inspector/InspectorOverlay.cpp
@@ -1441,7 +1441,7 @@ static Vector<String> authoredGridTrackSizes(Node* node, GridTrackSizingDirectio
         }
     }
 
-    auto* cssValueList = dynamicDowncast<CSSValueList>(*cssValue);
+    auto* cssValueList = dynamicDowncast<CSSValueList>(cssValue.get());
     if (!cssValueList)
         return { };
     


### PR DESCRIPTION
#### 05e01b57a4ecfed9f298898ed78f32bfd2456b94
<pre>
Web Inspector: Crash when inspecting CSS Grid without defined columns or rows
<a href="https://bugs.webkit.org/show_bug.cgi?id=256072">https://bugs.webkit.org/show_bug.cgi?id=256072</a>
rdar://108641874

Reviewed by Devin Rousso.

262869@main fixed issues with determining the authored grid track sizes, but in the process introduced a potential null
pointer deref due to us erroneously trying to get a reference to a RefPtr&apos;s value instead of getting its pointer for use
in a dynamic downcast.

* LayoutTests/inspector/dom/showFlexOverlay.html:
- Drive-by ensure we enable all options for flex overlays too so that those paths are exercises.

* LayoutTests/inspector/dom/showGridOverlay.html:
* Source/WebCore/inspector/InspectorOverlay.cpp:
(WebCore::authoredGridTrackSizes):

Canonical link: <a href="https://commits.webkit.org/263517@main">https://commits.webkit.org/263517@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2eb0a355f6993a7fbe459e6899d2584898c125a6

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/4814 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/4936 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/5104 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/6329 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/4942 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/4806 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/5107 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/4908 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/5183 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/4895 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/4984 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/4313 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/6342 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/2472 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/4308 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/9278 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/4334 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/4383 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/5962 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/4792 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/3906 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/4299 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/4304 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/1188 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/8362 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/4661 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->