### PR TITLE
HTMLCanvasElement accesses ImageBufferBackend

### DIFF
--- a/Source/WebCore/html/HTMLCanvasElement.h
+++ b/Source/WebCore/html/HTMLCanvasElement.h
@@ -137,9 +137,6 @@ public:
 
     bool isControlledByOffscreen() const;
 
-#if PLATFORM(COCOA)
-    GraphicsContext* drawingContext() const final;
-#endif
     WEBCORE_EXPORT void setAvoidIOSurfaceSizeCheckInWebProcessForTesting();
 
     void queueTaskKeepingObjectAlive(TaskSource, Function<void()>&&) final;
@@ -201,9 +198,6 @@ private:
     bool m_hasRelevantWebGLEventListener { false };
 #endif
     bool m_isSnapshotting { false };
-#if PLATFORM(COCOA)
-    mutable bool m_mustGuardAgainstUseByPendingLayerTransaction { false };
-#endif
 };
 
 WebCoreOpaqueRoot root(HTMLCanvasElement*);


### PR DESCRIPTION
#### e4e4f40e8fbd6a284baf8ccbda286c2f7f680c56
<pre>
HTMLCanvasElement accesses ImageBufferBackend
<a href="https://bugs.webkit.org/show_bug.cgi?id=255984">https://bugs.webkit.org/show_bug.cgi?id=255984</a>
rdar://108555582

Reviewed by Matt Woodrow.

Remove the ad-hoc access of ImageBufferBackend in HTMLCanvasElement.

The original code in bug 231163 tried to work around the
case where Canvas was in GPUP but DOM access was in WP, and when
the RemoteImageBufferProxy, ImageBufferIOSurfaceBackend ehad bugs
related to flushing the drawing before external access.

These issues have been worked on now, and it should be safe to remove
the workaround. Also current Cocoa trunk builds are all in different
configuration (full GPUP).

* Source/WebCore/html/HTMLCanvasElement.cpp:
(WebCore::HTMLCanvasElement::paint):
(WebCore::HTMLCanvasElement::drawingContext const): Deleted.
* Source/WebCore/html/HTMLCanvasElement.h:
* Source/WebCore/platform/graphics/cg/ImageBufferIOSurfaceBackend.h:

Canonical link: <a href="https://commits.webkit.org/263798@main">https://commits.webkit.org/263798@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f7082776b6ed6b8c2ba77a7397d9daf49dcc3eb9

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/4793 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/4913 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/5079 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/6304 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/4921 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/4785 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/5072 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/4883 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/5162 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/4874 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/4955 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/4290 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/6317 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/2443 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/4285 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/9257 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/4305 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/4360 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/5937 "269 api tests failed or timed out") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/4769 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/3882 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/4279 "Built successfully") | | | 
| [❌ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/1365 "Failed to push commit to Webkit repository") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/8339 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/4640 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->