### PR TITLE
run-minibrowser: document how to pass extra parameters to the minibrowser

### DIFF
--- a/Tools/Scripts/webkitpy/minibrowser/run_webkit_app.py
+++ b/Tools/Scripts/webkitpy/minibrowser/run_webkit_app.py
@@ -26,7 +26,10 @@ from webkitpy.port import configuration_options, platform_options, factory
 from webkitcorepy.string_utils import decode
 
 def main(argv):
-    option_parser = argparse.ArgumentParser(usage="%(prog)s [options] [url]", add_help=False)
+    option_parser = argparse.ArgumentParser(formatter_class=argparse.RawDescriptionHelpFormatter,
+                                            usage="%(prog)s [options] [url] [-- [minibrowser_options]]",
+                                            epilog="MiniBrowser options:    Pass them after two dashes.\n  Example:"
+                                                   "{spaces}run-minibrowser --wpe -- --platform=drm http://url.com".format(spaces=" " * 14))
     groups = [("Platform options", platform_options()), ("Configuration options", configuration_options())]
 
     # Convert options to argparse, so that we can use parse_known_args() which is not supported in optparse.


### PR DESCRIPTION
#### 63d0be648fd8f20ec94cadbb884a358bc6eba18b
<pre>
run-minibrowser: document how to pass extra parameters to the minibrowser
<a href="https://bugs.webkit.org/show_bug.cgi?id=256086">https://bugs.webkit.org/show_bug.cgi?id=256086</a>

Reviewed by Adrian Perez de Castro.

This patch adds some notes documenting how to pass extra parameters to the
minibrowser (after two dashes --) and also changes the code to show the
help of the &quot;run-minibrowser&quot; script itself instead of the help of the
minibrowser binary. Printing the help of the minibrowser binary is
still possible by passing &quot;-- --help&quot; (that is: after the two dashes).

* Tools/Scripts/webkitpy/minibrowser/run_webkit_app.py:
(main):

Canonical link: <a href="https://commits.webkit.org/263500@main">https://commits.webkit.org/263500@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/8eabb27d1c34dffb5d6c25845b11daa2c3b3e05d

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/4794 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/4914 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/5080 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/6305 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/4922 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/4786 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/5073 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/4884 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/5163 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/4875 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/4954 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/4292 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/6318 "Built successfully") | 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/4875 "Passed tests") | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/2442 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/4287 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/9256 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/4304 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/4362 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/5936 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/4770 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/3884 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/4280 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/8340 "Built successfully") | | | 
| [❌ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/549 "Failed to push commit to Webkit repository") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/4641 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->