### PR TITLE
[WGSL] Make Attribute nodes arena alocated

### DIFF
--- a/Source/WebGPU/WGSL/AST/ASTAlignAttribute.h
+++ b/Source/WebGPU/WGSL/AST/ASTAlignAttribute.h
@@ -26,22 +26,23 @@
 #pragma once
 
 #include "ASTAttribute.h"
+#include "ASTBuilder.h"
 #include "ASTExpression.h"
 
 namespace WGSL::AST {
 
 class AlignAttribute final : public Attribute {
-    WTF_MAKE_FAST_ALLOCATED;
+    WGSL_AST_BUILDER_NODE(AlignAttribute);
 public:
+    NodeKind kind() const override;
+    Expression& alignment() { return m_alignment.get(); }
+
+private:
     AlignAttribute(SourceSpan span, Expression::Ref&& alignment)
         : Attribute(span)
         , m_alignment(WTFMove(alignment))
     { }
 
-    NodeKind kind() const override;
-    Expression& alignment() { return m_alignment.get(); }
-
-private:
     Expression::Ref m_alignment;
 };
 

--- a/Source/WebGPU/WGSL/AST/ASTAttribute.h
+++ b/Source/WebGPU/WGSL/AST/ASTAttribute.h
@@ -28,16 +28,16 @@
 #include "ASTNode.h"
 
 #include <wtf/RefCounted.h>
-#include <wtf/RefVector.h>
+#include <wtf/ReferenceWrapperVector.h>
 
 namespace WGSL::AST {
 
-class Attribute : public Node, public RefCounted<Attribute> {
-    WTF_MAKE_FAST_ALLOCATED;
+class Attribute : public Node {
 public:
-    using Ref = WTF::Ref<Attribute>;
-    using List = RefVector<Attribute, 2>;
+    using Ref = std::reference_wrapper<Attribute>;
+    using List = ReferenceWrapperVector<Attribute>;
 
+protected:
     Attribute(SourceSpan span)
         : Node(span)
     { }

--- a/Source/WebGPU/WGSL/AST/ASTBindingAttribute.h
+++ b/Source/WebGPU/WGSL/AST/ASTBindingAttribute.h
@@ -26,21 +26,22 @@
 #pragma once
 
 #include "ASTAttribute.h"
+#include "ASTBuilder.h"
 
 namespace WGSL::AST {
 
 class BindingAttribute final : public Attribute {
-    WTF_MAKE_FAST_ALLOCATED;
+    WGSL_AST_BUILDER_NODE(BindingAttribute);
 public:
+    NodeKind kind() const override;
+    unsigned binding() const { return m_value; }
+
+private:
     BindingAttribute(SourceSpan span, unsigned binding)
         : Attribute(span)
         , m_value(binding)
     { }
 
-    NodeKind kind() const override;
-    unsigned binding() const { return m_value; }
-
-private:
     unsigned m_value;
 };
 

--- a/Source/WebGPU/WGSL/AST/ASTBuiltinAttribute.h
+++ b/Source/WebGPU/WGSL/AST/ASTBuiltinAttribute.h
@@ -26,22 +26,23 @@
 #pragma once
 
 #include "ASTAttribute.h"
+#include "ASTBuilder.h"
 #include "ASTIdentifier.h"
 
 namespace WGSL::AST {
 
 class BuiltinAttribute final : public Attribute {
-    WTF_MAKE_FAST_ALLOCATED;
+    WGSL_AST_BUILDER_NODE(BuiltinAttribute);
 public:
+    NodeKind kind() const override;
+    Identifier& name() { return m_name; }
+
+private:
     BuiltinAttribute(SourceSpan span, Identifier&& name)
         : Attribute(span)
         , m_name(WTFMove(name))
     { }
 
-    NodeKind kind() const override;
-    Identifier& name() { return m_name; }
-
-private:
     Identifier m_name;
 };
 

--- a/Source/WebGPU/WGSL/AST/ASTConstAttribute.h
+++ b/Source/WebGPU/WGSL/AST/ASTConstAttribute.h
@@ -26,17 +26,19 @@
 #pragma once
 
 #include "ASTAttribute.h"
+#include "ASTBuilder.h"
 
 namespace WGSL::AST {
 
 class ConstAttribute final : public Attribute {
-    WTF_MAKE_FAST_ALLOCATED;
+    WGSL_AST_BUILDER_NODE(ConstAttribute);
 public:
+    NodeKind kind() const override;
+
+private:
     ConstAttribute(SourceSpan span)
         : Attribute(span)
     { }
-
-    NodeKind kind() const override;
 };
 
 } // namespace WGSL::AST

--- a/Source/WebGPU/WGSL/AST/ASTGroupAttribute.h
+++ b/Source/WebGPU/WGSL/AST/ASTGroupAttribute.h
@@ -26,21 +26,22 @@
 #pragma once
 
 #include "ASTAttribute.h"
+#include "ASTBuilder.h"
 
 namespace WGSL::AST {
 
 class GroupAttribute final : public Attribute {
-    WTF_MAKE_FAST_ALLOCATED;
+    WGSL_AST_BUILDER_NODE(GroupAttribute);
 public:
+    NodeKind kind() const override;
+    unsigned group() const { return m_value; }
+
+private:
     GroupAttribute(SourceSpan span, unsigned group)
         : Attribute(span)
         , m_value(group)
     { }
 
-    NodeKind kind() const override;
-    unsigned group() const { return m_value; }
-
-private:
     unsigned m_value;
 };
 

--- a/Source/WebGPU/WGSL/AST/ASTIdAttribute.h
+++ b/Source/WebGPU/WGSL/AST/ASTIdAttribute.h
@@ -26,22 +26,24 @@
 #pragma once
 
 #include "ASTAttribute.h"
+#include "ASTBuilder.h"
 #include "ASTExpression.h"
 
 namespace WGSL::AST {
 
 class IdAttribute final : public Attribute {
-    WTF_MAKE_FAST_ALLOCATED;
+    WGSL_AST_BUILDER_NODE(IdAttribute);
+
 public:
+    NodeKind kind() const override;
+    Expression& value() { return m_value; }
+
+private:
     IdAttribute(SourceSpan span, Expression::Ref&& value)
         : Attribute(span)
         , m_value(WTFMove(value))
     { }
 
-    NodeKind kind() const override;
-    Expression& value() { return m_value; }
-
-private:
     Expression::Ref m_value;
 };
 

--- a/Source/WebGPU/WGSL/AST/ASTInterpolateAttribute.h
+++ b/Source/WebGPU/WGSL/AST/ASTInterpolateAttribute.h
@@ -26,11 +26,12 @@
 #pragma once
 
 #include "ASTAttribute.h"
+#include "ASTBuilder.h"
 
 namespace WGSL::AST {
 
 class InterpolateAttribute final : public Attribute {
-    WTF_MAKE_FAST_ALLOCATED;
+    WGSL_AST_BUILDER_NODE(InterpolateAttribute);
 public:
     enum class Type : uint8_t {
         Flat,
@@ -44,17 +45,17 @@ public:
         Sample,
     };
 
+    NodeKind kind() const override;
+    Type type() const { return m_type; }
+    Sampling sampling() const { return m_sampling; }
+
+private:
     InterpolateAttribute(SourceSpan span, Type type, Sampling sampling)
         : Attribute(span)
         , m_type(type)
         , m_sampling(sampling)
     { }
 
-    NodeKind kind() const override;
-    Type type() const { return m_type; }
-    Sampling sampling() const { return m_sampling; }
-
-private:
     Type m_type;
     Sampling m_sampling;
 };

--- a/Source/WebGPU/WGSL/AST/ASTInvariantAttribute.h
+++ b/Source/WebGPU/WGSL/AST/ASTInvariantAttribute.h
@@ -26,17 +26,19 @@
 #pragma once
 
 #include "ASTAttribute.h"
+#include "ASTBuilder.h"
 
 namespace WGSL::AST {
 
 class InvariantAttribute final : public Attribute {
-    WTF_MAKE_FAST_ALLOCATED;
+    WGSL_AST_BUILDER_NODE(InvariantAttribute);
 public:
+    NodeKind kind() const override;
+
+private:
     InvariantAttribute(SourceSpan span)
         : Attribute(span)
     { }
-
-    NodeKind kind() const override;
 };
 
 } // namespace WGSL::AST

--- a/Source/WebGPU/WGSL/AST/ASTLocationAttribute.h
+++ b/Source/WebGPU/WGSL/AST/ASTLocationAttribute.h
@@ -26,22 +26,23 @@
 #pragma once
 
 #include "ASTAttribute.h"
+#include "ASTBuilder.h"
 #include "ASTExpression.h"
 
 namespace WGSL::AST {
 
 class LocationAttribute final : public Attribute {
-    WTF_MAKE_FAST_ALLOCATED;
+    WGSL_AST_BUILDER_NODE(LocationAttribute);
 public:
+    NodeKind kind() const override;
+    unsigned location() const { return m_value; }
+
+private:
     LocationAttribute(SourceSpan span, unsigned value)
         : Attribute(span)
         , m_value(value)
     { }
 
-    NodeKind kind() const override;
-    unsigned location() const { return m_value; }
-
-private:
     unsigned m_value;
 };
 

--- a/Source/WebGPU/WGSL/AST/ASTParameter.h
+++ b/Source/WebGPU/WGSL/AST/ASTParameter.h
@@ -29,6 +29,7 @@
 #include "ASTIdentifier.h"
 #include "ASTTypeName.h"
 #include <wtf/RefCounted.h>
+#include <wtf/RefVector.h>
 
 namespace WGSL::AST {
 

--- a/Source/WebGPU/WGSL/AST/ASTSizeAttribute.h
+++ b/Source/WebGPU/WGSL/AST/ASTSizeAttribute.h
@@ -26,22 +26,23 @@
 #pragma once
 
 #include "ASTAttribute.h"
+#include "ASTBuilder.h"
 #include "ASTExpression.h"
 
 namespace WGSL::AST {
 
 class SizeAttribute final : public Attribute {
-    WTF_MAKE_FAST_ALLOCATED;
+    WGSL_AST_BUILDER_NODE(SizeAttribute);
 public:
+    NodeKind kind() const override;
+    Expression& size() { return m_size.get(); }
+
+private:
     SizeAttribute(SourceSpan span, Expression::Ref&& size)
         : Attribute(span)
         , m_size(WTFMove(size))
     { }
 
-    NodeKind kind() const override;
-    Expression& size() { return m_size.get(); }
-
-private:
     Expression::Ref m_size;
 };
 

--- a/Source/WebGPU/WGSL/AST/ASTStageAttribute.h
+++ b/Source/WebGPU/WGSL/AST/ASTStageAttribute.h
@@ -26,11 +26,12 @@
 #pragma once
 
 #include "ASTAttribute.h"
+#include "ASTBuilder.h"
 
 namespace WGSL::AST {
 
 class StageAttribute final : public Attribute {
-    WTF_MAKE_FAST_ALLOCATED;
+    WGSL_AST_BUILDER_NODE(StageAttribute);
 public:
     enum class Stage : uint8_t {
         Compute,
@@ -38,15 +39,15 @@ public:
         Fragment
     };
 
+    NodeKind kind() const override;
+    Stage stage() const { return m_stage; }
+
+private:
     StageAttribute(SourceSpan span, Stage stage)
         : Attribute(span)
         , m_stage(stage)
     { }
 
-    NodeKind kind() const override;
-    Stage stage() const { return m_stage; }
-
-private:
     Stage m_stage;
 };
 

--- a/Source/WebGPU/WGSL/AST/ASTWorkgroupSizeAttribute.h
+++ b/Source/WebGPU/WGSL/AST/ASTWorkgroupSizeAttribute.h
@@ -30,8 +30,14 @@
 namespace WGSL::AST {
 
 class WorkgroupSizeAttribute final : public Attribute {
-    WTF_MAKE_FAST_ALLOCATED;
+    WGSL_AST_BUILDER_NODE(WorkgroupSizeAttribute);
 public:
+    NodeKind kind() const override;
+    Expression& x() { return m_x.get(); }
+    Expression* maybeY() { return m_y.get(); }
+    Expression* maybeZ() { return m_z.get(); }
+
+private:
     WorkgroupSizeAttribute(SourceSpan span, Expression::Ref&& x, Expression::Ptr&& maybeY, Expression::Ptr&& maybeZ)
         : Attribute(span)
         , m_x(WTFMove(x))
@@ -39,12 +45,6 @@ public:
         , m_z(WTFMove(maybeZ))
     { }
 
-    NodeKind kind() const override;
-    Expression& x() { return m_x.get(); }
-    Expression* maybeY() { return m_y.get(); }
-    Expression* maybeZ() { return m_z.get(); }
-
-private:
     Expression::Ref m_x;
     Expression::Ptr m_y;
     Expression::Ptr m_z;

--- a/Source/WebGPU/WGSL/GlobalVariableRewriter.cpp
+++ b/Source/WebGPU/WGSL/GlobalVariableRewriter.cpp
@@ -317,7 +317,7 @@ void RewriteGlobalVariables::insertStructs(const UsedGlobals& usedGlobals)
                 AST::Identifier::make(global->declaration->name()),
                 WTFMove(memberType),
                 AST::Attribute::List {
-                    adoptRef(*new AST::BindingAttribute(span, binding))
+                    m_callGraph.ast().astBuilder().construct<AST::BindingAttribute>(span, binding)
                 }
             ));
         }
@@ -345,7 +345,7 @@ void RewriteGlobalVariables::insertParameters(AST::Function& function, const Use
             argumentBufferParameterName(group),
             WTFMove(type),
             AST::Attribute::List {
-                adoptRef(*new AST::GroupAttribute(span, group))
+                m_callGraph.ast().astBuilder().construct<AST::GroupAttribute>(span, group)
             },
             AST::ParameterRole::BindGroup
         )));

--- a/Source/WebGPU/WGSL/Parser.cpp
+++ b/Source/WebGPU/WGSL/Parser.cpp
@@ -452,7 +452,7 @@ Result<AST::Attribute::List> Parser<Lexer>::parseAttributes()
 }
 
 template<typename Lexer>
-Result<Ref<AST::Attribute>> Parser<Lexer>::parseAttribute()
+Result<AST::Attribute::Ref> Parser<Lexer>::parseAttribute()
 {
     START_PARSE();
 
@@ -464,7 +464,7 @@ Result<Ref<AST::Attribute>> Parser<Lexer>::parseAttribute()
         // FIXME: should more kinds of literals be accepted here?
         CONSUME_TYPE_NAMED(id, IntegerLiteral);
         CONSUME_TYPE(ParenRight);
-        RETURN_NODE_REF(GroupAttribute, id.literalValue);
+        RETURN_ARENA_NODE(GroupAttribute, id.literalValue);
     }
 
     if (ident.ident == "binding"_s) {
@@ -472,7 +472,7 @@ Result<Ref<AST::Attribute>> Parser<Lexer>::parseAttribute()
         // FIXME: should more kinds of literals be accepted here?
         CONSUME_TYPE_NAMED(id, IntegerLiteral);
         CONSUME_TYPE(ParenRight);
-        RETURN_NODE_REF(BindingAttribute, id.literalValue);
+        RETURN_ARENA_NODE(BindingAttribute, id.literalValue);
     }
 
     if (ident.ident == "location"_s) {
@@ -480,14 +480,14 @@ Result<Ref<AST::Attribute>> Parser<Lexer>::parseAttribute()
         // FIXME: should more kinds of literals be accepted here?
         CONSUME_TYPE_NAMED(id, IntegerLiteral);
         CONSUME_TYPE(ParenRight);
-        RETURN_NODE_REF(LocationAttribute, id.literalValue);
+        RETURN_ARENA_NODE(LocationAttribute, id.literalValue);
     }
 
     if (ident.ident == "builtin"_s) {
         CONSUME_TYPE(ParenLeft);
         PARSE(name, Identifier);
         CONSUME_TYPE(ParenRight);
-        RETURN_NODE_REF(BuiltinAttribute, WTFMove(name));
+        RETURN_ARENA_NODE(BuiltinAttribute, WTFMove(name));
     }
 
     if (ident.ident == "workgroup_size"_s) {
@@ -515,30 +515,30 @@ Result<Ref<AST::Attribute>> Parser<Lexer>::parseAttribute()
             }
         }
         CONSUME_TYPE(ParenRight);
-        RETURN_NODE_REF(WorkgroupSizeAttribute, WTFMove(x), WTFMove(maybeY), WTFMove(maybeZ));
+        RETURN_ARENA_NODE(WorkgroupSizeAttribute, WTFMove(x), WTFMove(maybeY), WTFMove(maybeZ));
     }
 
     if (ident.ident == "align"_s) {
         CONSUME_TYPE(ParenLeft);
         PARSE(alignment, Expression);
         CONSUME_TYPE(ParenRight);
-        RETURN_NODE_REF(AlignAttribute, WTFMove(alignment));
+        RETURN_ARENA_NODE(AlignAttribute, WTFMove(alignment));
     }
 
     if (ident.ident == "size"_s) {
         CONSUME_TYPE(ParenLeft);
         PARSE(size, Expression);
         CONSUME_TYPE(ParenRight);
-        RETURN_NODE_REF(SizeAttribute, WTFMove(size));
+        RETURN_ARENA_NODE(SizeAttribute, WTFMove(size));
     }
 
     // https://gpuweb.github.io/gpuweb/wgsl/#pipeline-stage-attributes
     if (ident.ident == "vertex"_s)
-        RETURN_NODE_REF(StageAttribute, AST::StageAttribute::Stage::Vertex);
+        RETURN_ARENA_NODE(StageAttribute, AST::StageAttribute::Stage::Vertex);
     if (ident.ident == "compute"_s)
-        RETURN_NODE_REF(StageAttribute, AST::StageAttribute::Stage::Compute);
+        RETURN_ARENA_NODE(StageAttribute, AST::StageAttribute::Stage::Compute);
     if (ident.ident == "fragment"_s)
-        RETURN_NODE_REF(StageAttribute, AST::StageAttribute::Stage::Fragment);
+        RETURN_ARENA_NODE(StageAttribute, AST::StageAttribute::Stage::Fragment);
 
     FAIL("Unknown attribute. Supported attributes are 'group', 'binding', 'location', 'builtin', 'vertex', 'compute', 'fragment'."_s);
 }


### PR DESCRIPTION
#### 46529df64a0b24a4e010d8000fd78ef2280cf936
<pre>
[WGSL] Make Attribute nodes arena alocated
<a href="https://bugs.webkit.org/show_bug.cgi?id=256093">https://bugs.webkit.org/show_bug.cgi?id=256093</a>
rdar://108661951

Reviewed by Myles C. Maxfield.

Slowly convert the AST nodes to be arena allocated, starting with attributes.

* Source/WebGPU/WGSL/AST/ASTAlignAttribute.h:
* Source/WebGPU/WGSL/AST/ASTAttribute.h:
* Source/WebGPU/WGSL/AST/ASTBindingAttribute.h:
* Source/WebGPU/WGSL/AST/ASTBuiltinAttribute.h:
* Source/WebGPU/WGSL/AST/ASTConstAttribute.h:
* Source/WebGPU/WGSL/AST/ASTGroupAttribute.h:
* Source/WebGPU/WGSL/AST/ASTIdAttribute.h:
* Source/WebGPU/WGSL/AST/ASTInterpolateAttribute.h:
* Source/WebGPU/WGSL/AST/ASTInvariantAttribute.h:
* Source/WebGPU/WGSL/AST/ASTLocationAttribute.h:
* Source/WebGPU/WGSL/AST/ASTParameter.h:
* Source/WebGPU/WGSL/AST/ASTSizeAttribute.h:
* Source/WebGPU/WGSL/AST/ASTStageAttribute.h:
* Source/WebGPU/WGSL/AST/ASTWorkgroupSizeAttribute.h:
* Source/WebGPU/WGSL/GlobalVariableRewriter.cpp:
(WGSL::RewriteGlobalVariables::insertStructs):
(WGSL::RewriteGlobalVariables::insertParameters):
* Source/WebGPU/WGSL/Parser.cpp:
(WGSL::Parser&lt;Lexer&gt;::parseAttribute):

Canonical link: <a href="https://commits.webkit.org/263577@main">https://commits.webkit.org/263577@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/dcf1da1cffdee235bd0ebab2b2e26e444e636faf

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/4813 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/4934 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/5102 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/6327 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/4941 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/5097 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/4906 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/5179 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/4894 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/4978 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/4312 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/6340 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/2466 "Passed tests") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/9279 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/4328 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/4382 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/5963 "15 api tests failed or timed out") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/4791 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/3904 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/4298 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/1223 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/8361 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/4660 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->