### PR TITLE
[macOS] Disable suspension when local notifications are granted

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/permissions/all-permissions-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/permissions/all-permissions-expected.txt
@@ -2,7 +2,7 @@
 PASS Query "geolocation" permission
 PASS Query "notifications" permission
 FAIL Query "persistent-storage" permission promise_test: Unhandled rejection with value: object "TypeError: Type error"
-FAIL Query "push" permission promise_test: Unhandled rejection with value: object "TypeError: Type error"
+PASS Query "push" permission
 FAIL Query "accelerometer" permission promise_test: Unhandled rejection with value: object "NotSupportedError: Permissions::query does not support this API"
 FAIL Query "ambient-light-sensor" permission promise_test: Unhandled rejection with value: object "TypeError: Type error"
 FAIL Query "background-fetch" permission promise_test: Unhandled rejection with value: object "NotSupportedError: Permissions::query does not support this API"

--- a/Source/WebCore/Modules/permissions/PermissionName.h
+++ b/Source/WebCore/Modules/permissions/PermissionName.h
@@ -42,6 +42,7 @@ enum class PermissionName : uint8_t {
     Midi,
     Nfc,
     Notifications,
+    Push,
     ScreenWakeLock,
     SpeakerSelection
 };
@@ -65,6 +66,7 @@ template<> struct EnumTraits<WebCore::PermissionName> {
         WebCore::PermissionName::Midi,
         WebCore::PermissionName::Nfc,
         WebCore::PermissionName::Notifications,
+        WebCore::PermissionName::Push,
         WebCore::PermissionName::ScreenWakeLock,
         WebCore::PermissionName::SpeakerSelection
     >;

--- a/Source/WebCore/Modules/permissions/PermissionName.idl
+++ b/Source/WebCore/Modules/permissions/PermissionName.idl
@@ -39,6 +39,7 @@ enum PermissionName {
     "midi",
     "nfc",
     "notifications",
+    "push",
     "screen-wake-lock",
     "speaker-selection"
 };

--- a/Source/WebCore/Modules/permissions/Permissions.cpp
+++ b/Source/WebCore/Modules/permissions/Permissions.cpp
@@ -113,6 +113,8 @@ std::optional<PermissionName> Permissions::toPermissionName(const String& name)
         return PermissionName::Microphone;
     if (name == "notifications"_s)
         return PermissionName::Notifications;
+    if (name == "push"_s)
+        return PermissionName::Push;
     return std::nullopt;
 }
 

--- a/Source/WebKit/NetworkProcess/Notifications/NetworkNotificationManager.h
+++ b/Source/WebKit/NetworkProcess/Notifications/NetworkNotificationManager.h
@@ -76,6 +76,7 @@ private:
     void cancelNotification(const UUID& notificationID) final;
     void clearNotifications(const Vector<UUID>& notificationIDs) final;
     void didDestroyNotification(const UUID& notificationID) final;
+    void pageWasNotifiedOfNotificationPermission() final { }
 
     NetworkSession& m_networkSession;
     std::unique_ptr<WebPushD::Connection> m_connection;

--- a/Source/WebKit/Shared/Notifications/NotificationManagerMessageHandler.h
+++ b/Source/WebKit/Shared/Notifications/NotificationManagerMessageHandler.h
@@ -46,6 +46,7 @@ public:
     virtual void cancelNotification(const UUID& notificationID) = 0;
     virtual void clearNotifications(const Vector<UUID>& notificationIDs) = 0;
     virtual void didDestroyNotification(const UUID& notificationID) = 0;
+    virtual void pageWasNotifiedOfNotificationPermission() = 0;
 
 private:
     // IPC::MessageReceiver

--- a/Source/WebKit/Shared/Notifications/NotificationManagerMessageHandler.messages.in
+++ b/Source/WebKit/Shared/Notifications/NotificationManagerMessageHandler.messages.in
@@ -26,4 +26,5 @@ messages -> NotificationManagerMessageHandler NotRefCounted {
     CancelNotification(UUID notificationID)
     ClearNotifications(Vector<UUID> notificationIDs)
     DidDestroyNotification(UUID notificationID)
+    PageWasNotifiedOfNotificationPermission();
 }

--- a/Source/WebKit/UIProcess/Cocoa/ProcessAssertionCocoa.mm
+++ b/Source/WebKit/UIProcess/Cocoa/ProcessAssertionCocoa.mm
@@ -321,7 +321,12 @@ static NSString *runningBoardNameForAssertionType(ProcessAssertionType assertion
     case ProcessAssertionType::Suspended:
         return @"Suspended";
     case ProcessAssertionType::Background:
+#if PLATFORM(MAC)
+        // The background assertions time out after 30 seconds on iOS but not macOS.
+        return @"IndefiniteBackground";
+#else
         return @"Background";
+#endif
     case ProcessAssertionType::UnboundedNetworking:
         return @"UnboundedNetworking";
     case ProcessAssertionType::Foreground:

--- a/Source/WebKit/UIProcess/Notifications/ServiceWorkerNotificationHandler.h
+++ b/Source/WebKit/UIProcess/Notifications/ServiceWorkerNotificationHandler.h
@@ -42,6 +42,7 @@ public:
     void cancelNotification(const UUID& notificationID) final;
     void clearNotifications(const Vector<UUID>& notificationIDs) final;
     void didDestroyNotification(const UUID& notificationID) final;
+    void pageWasNotifiedOfNotificationPermission() final { }
 
     bool handlesNotification(UUID value) const { return m_notificationToSessionMap.contains(value); }
 

--- a/Source/WebKit/UIProcess/Notifications/WebNotificationManagerMessageHandler.cpp
+++ b/Source/WebKit/UIProcess/Notifications/WebNotificationManagerMessageHandler.cpp
@@ -96,4 +96,9 @@ void WebNotificationManagerMessageHandler::didDestroyNotification(const UUID& no
     m_webPageProxy.didDestroyNotification(notificationID);
 }
 
+void WebNotificationManagerMessageHandler::pageWasNotifiedOfNotificationPermission()
+{
+    m_webPageProxy.pageWillLikelyUseNotifications();
+}
+
 } // namespace WebKit

--- a/Source/WebKit/UIProcess/Notifications/WebNotificationManagerMessageHandler.h
+++ b/Source/WebKit/UIProcess/Notifications/WebNotificationManagerMessageHandler.h
@@ -41,6 +41,7 @@ private:
     void cancelNotification(const UUID& notificationID) final;
     void clearNotifications(const Vector<UUID>& notificationIDs) final;
     void didDestroyNotification(const UUID& notificationID) final;
+    void pageWasNotifiedOfNotificationPermission() final;
 
     WebPageProxy& m_webPageProxy;
 };

--- a/Source/WebKit/UIProcess/WebPageProxy.h
+++ b/Source/WebKit/UIProcess/WebPageProxy.h
@@ -2159,6 +2159,7 @@ public:
     void cancelNotification(const UUID& notificationID);
     void clearNotifications(const Vector<UUID>& notificationIDs);
     void didDestroyNotification(const UUID& notificationID);
+    void pageWillLikelyUseNotifications();
 
 #if USE(SYSTEM_PREVIEW)
     void handleSystemPreview(const URL&, const WebCore::SystemPreviewInfo&);
@@ -2816,12 +2817,18 @@ private:
         bool hasValidOpeningAppLinkActivity() const;
 #endif
 
+#if PLATFORM(MAC)
+        void takeLikelyToUseNotificationsActivity();
+        void dropLikelyToUseNotificationsActivity();
+#endif
+
     private:
         WebPageProxy& m_page;
 
         std::unique_ptr<ProcessThrottlerActivity> m_isVisibleActivity;
 #if PLATFORM(MAC)
         UniqueRef<ProcessThrottlerTimedActivity> m_wasRecentlyVisibleActivity;
+        std::unique_ptr<ProcessThrottlerActivity> m_likelyToUseNotificationsActivity;
 #endif
         std::unique_ptr<ProcessThrottlerActivity> m_isAudibleActivity;
         std::unique_ptr<ProcessThrottlerActivity> m_isCapturingActivity;

--- a/Source/WebKit/WebProcess/Notifications/WebNotificationManager.h
+++ b/Source/WebKit/WebProcess/Notifications/WebNotificationManager.h
@@ -67,7 +67,7 @@ public:
     void didUpdateNotificationDecision(const String& originString, bool allowed);
 
     // Looks in local cache for permission. If not found, returns DefaultDenied.
-    WebCore::NotificationClient::Permission policyForOrigin(const String& originString) const;
+    WebCore::NotificationClient::Permission policyForOrigin(const String& originString, WebPage* = nullptr) const;
 
     void removeAllPermissionsForTesting();
 
@@ -83,9 +83,6 @@ private:
     void didClickNotification(const UUID& notificationID);
     void didCloseNotifications(const Vector<UUID>& notificationIDs);
     void didRemoveNotificationDecisions(const Vector<String>& originStrings);
-
-    template<typename U> bool sendNotificationMessage(U&& message, WebPage*);
-    template<typename U> bool sendNotificationMessageWithAsyncReply(U&& message, WebPage*, CompletionHandler<void()>&&);
 
     WebProcess& m_process;
 


### PR DESCRIPTION
#### 0789169e66412b631fddd23369aa42a65592721a
<pre>
[macOS] Disable suspension when local notifications are granted
<a href="https://bugs.webkit.org/show_bug.cgi?id=256095">https://bugs.webkit.org/show_bug.cgi?id=256095</a>
rdar://107012193

Reviewed by Geoffrey Garen.

On macOS, we now disable process suspension if a tab using this process is likely
to use local notifications. In particular, we disable suspension if either:
- A notification has been shown
- The page called navigator.permissions.query({ name: &quot;notifications&quot; }) and it returned true.
- The page accessed Notification.permission and it returned &quot;granted&quot;.
- The page requested permission via Notification.requestPermission() and it was granted.

This gets reset whenever a new main frame load commits inside the page.

Before this change, our behavior was to restart the 8 minute suspension timer whenever
a local notification was shown.

* Source/WebCore/Modules/permissions/PermissionName.h:
* Source/WebCore/Modules/permissions/PermissionName.idl:
* Source/WebCore/Modules/permissions/Permissions.cpp:
(WebCore::Permissions::toPermissionName):
* Source/WebKit/NetworkProcess/Notifications/NetworkNotificationManager.h:
* Source/WebKit/Shared/Notifications/NotificationManagerMessageHandler.h:
* Source/WebKit/Shared/Notifications/NotificationManagerMessageHandler.messages.in:
* Source/WebKit/UIProcess/Notifications/ServiceWorkerNotificationHandler.h:
* Source/WebKit/UIProcess/Notifications/WebNotificationManagerMessageHandler.cpp:
(WebKit::WebNotificationManagerMessageHandler::pageWasNotifiedOfNotificationPermission):
* Source/WebKit/UIProcess/Notifications/WebNotificationManagerMessageHandler.h:
* Source/WebKit/UIProcess/WebPageProxy.cpp:
(WebKit::WebPageProxy::ProcessActivityState::takeLikelyToUseNotificationsActivity):
(WebKit::WebPageProxy::ProcessActivityState::dropLikelyToUseNotificationsActivity):
(WebKit::WebPageProxy::ProcessActivityState::reset):
(WebKit::WebPageProxy::didCommitLoadForFrame):
(WebKit::WebPageProxy::queryPermission):
(WebKit::WebPageProxy::pageWillLikelyUseNotifications):
(WebKit::WebPageProxy::showNotification):
* Source/WebKit/UIProcess/WebPageProxy.h:
* Source/WebKit/WebProcess/Notifications/WebNotificationManager.cpp:
(WebKit::sendMessage):
(WebKit::sendNotificationMessage):
(WebKit::sendNotificationMessageWithAsyncReply):
(WebKit::WebNotificationManager::policyForOrigin const):
(WebKit::WebNotificationManager::sendNotificationMessage): Deleted.
(WebKit::WebNotificationManager::sendNotificationMessageWithAsyncReply): Deleted.
* Source/WebKit/WebProcess/Notifications/WebNotificationManager.h:
* Source/WebKit/WebProcess/WebCoreSupport/WebNotificationClient.cpp:
(WebKit::WebNotificationClient::checkPermission):

Canonical link: <a href="https://commits.webkit.org/263565@main">https://commits.webkit.org/263565@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ec391ad292b8a2e25260249d3a2ab9e149eced1b

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/5081 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/5212 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/5388 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/6601 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/5168 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/5074 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/5409 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/5187 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/5411 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/5167 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/5254 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/4556 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/6617 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/2741 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/4554 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/9590 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/4604 "Passed tests") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/4627 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/6233 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/5045 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/4141 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/4529 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/1215 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/8608 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/4894 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->