### PR TITLE
Use the XPCConnectionTerminationWatchdog on macOS too

### DIFF
--- a/Source/WebKit/UIProcess/Cocoa/AuxiliaryProcessProxyCocoa.mm
+++ b/Source/WebKit/UIProcess/Cocoa/AuxiliaryProcessProxyCocoa.mm
@@ -29,7 +29,7 @@
 #import <WebCore/WebMAudioUtilitiesCocoa.h>
 #import <wtf/cocoa/VectorCocoa.h>
 
-#if PLATFORM(IOS_FAMILY) 
+#if USE(RUNNINGBOARD)
 #include "XPCConnectionTerminationWatchdog.h"
 #endif
 
@@ -65,8 +65,8 @@ Vector<String> AuxiliaryProcessProxy::platformOverrideLanguages() const
 
 void AuxiliaryProcessProxy::platformStartConnectionTerminationWatchdog()
 {
-#if PLATFORM(IOS_FAMILY)
-    // On iOS deploy a watchdog in the UI process, since the child process may be suspended.
+#if USE(RUNNINGBOARD)
+    // Deploy a watchdog in the UI process, since the child process may be suspended.
     // If 30s is insufficient for any outstanding activity to complete cleanly, then it will be killed.
     ASSERT(m_connection && m_connection->xpcConnection());
     XPCConnectionTerminationWatchdog::startConnectionTerminationWatchdog(m_connection->xpcConnection(), 30_s);

--- a/Source/WebKit/UIProcess/Cocoa/XPCConnectionTerminationWatchdog.h
+++ b/Source/WebKit/UIProcess/Cocoa/XPCConnectionTerminationWatchdog.h
@@ -52,9 +52,7 @@ private:
 
     OSObjectPtr<xpc_connection_t> m_xpcConnection;
     RunLoop::Timer m_watchdogTimer;
-#if PLATFORM(IOS_FAMILY)
     Ref<ProcessAndUIAssertion> m_assertion;
-#endif
 };
 
 }

--- a/Source/WebKit/UIProcess/Cocoa/XPCConnectionTerminationWatchdog.mm
+++ b/Source/WebKit/UIProcess/Cocoa/XPCConnectionTerminationWatchdog.mm
@@ -26,11 +26,8 @@
 #import "config.h"
 #import "XPCConnectionTerminationWatchdog.h"
 
-#import "XPCUtilities.h"
-
-#if PLATFORM(IOS_FAMILY)
 #import "ProcessAssertion.h"
-#endif
+#import "XPCUtilities.h"
 
 namespace WebKit {
 
@@ -42,9 +39,7 @@ void XPCConnectionTerminationWatchdog::startConnectionTerminationWatchdog(OSObje
 XPCConnectionTerminationWatchdog::XPCConnectionTerminationWatchdog(OSObjectPtr<xpc_connection_t>&& xpcConnection, Seconds interval)
     : m_xpcConnection(WTFMove(xpcConnection))
     , m_watchdogTimer(RunLoop::main(), this, &XPCConnectionTerminationWatchdog::watchdogTimerFired)
-#if PLATFORM(IOS_FAMILY)
     , m_assertion(ProcessAndUIAssertion::create(xpc_connection_get_pid(m_xpcConnection.get()), "XPCConnectionTerminationWatchdog"_s, ProcessAssertionType::Background))
-#endif
 {
     m_watchdogTimer.startOneShot(interval);
 }


### PR DESCRIPTION
#### 256bf3a7dde702f607491a3c1bfd3bae5c359036
<pre>
Use the XPCConnectionTerminationWatchdog on macOS too
<a href="https://bugs.webkit.org/show_bug.cgi?id=256096">https://bugs.webkit.org/show_bug.cgi?id=256096</a>

Reviewed by Ben Nham.

Use the XPCConnectionTerminationWatchdog on macOS too now that process
suspension is no longer specific to iOS.

* Source/WebKit/UIProcess/Cocoa/AuxiliaryProcessProxyCocoa.mm:
(WebKit::AuxiliaryProcessProxy::platformStartConnectionTerminationWatchdog):
* Source/WebKit/UIProcess/Cocoa/XPCConnectionTerminationWatchdog.h:
* Source/WebKit/UIProcess/Cocoa/XPCConnectionTerminationWatchdog.mm:
(WebKit::XPCConnectionTerminationWatchdog::XPCConnectionTerminationWatchdog):

Canonical link: <a href="https://commits.webkit.org/263514@main">https://commits.webkit.org/263514@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f90b83ae5fe27e376d828f81cdd4316dfcb229e6

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/4824 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/4945 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/5116 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/6338 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/4951 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/5111 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/4917 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/5189 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/4905 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/4989 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/4323 "Passed tests") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/2/builds/6376 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/2477 "Passed tests") | | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/9294 "layout-tests (failure)") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/4339 "Passed tests") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/4393 "3 failures") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/5981 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/4801 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/3911 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/4308 "Built successfully") | | | 
| [  ~~🛠 🧪 merge~~](https://ews-build.webkit.org/#/builders/19/builds/1187 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/8371 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/4670 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->