### PR TITLE
[ macOS ] TestWebKitAPI.WebKitLegacy.MediaPlaybackSleepAssertion is a constant failure

### DIFF
--- a/Source/WebCore/Modules/screen-wake-lock/WakeLock.cpp
+++ b/Source/WebCore/Modules/screen-wake-lock/WakeLock.cpp
@@ -89,14 +89,9 @@ void WakeLock::request(WakeLockType lockType, Ref<DeferredPromise>&& promise)
                 promise->reject(Exception { NotAllowedError, "Document is hidden"_s });
                 return;
             }
-            auto pageID = document->pageID();
-            if (!pageID) {
-                promise->reject(Exception { NotAllowedError, "Document is detached"_s });
-                return;
-            }
             auto lock = WakeLockSentinel::create(document, lockType);
             promise->resolve<IDLInterface<WakeLockSentinel>>(lock.get());
-            document->wakeLockManager().addWakeLock(WTFMove(lock), *pageID);
+            document->wakeLockManager().addWakeLock(WTFMove(lock), document->pageID());
         });
     });
 }

--- a/Source/WebCore/Modules/screen-wake-lock/WakeLockManager.cpp
+++ b/Source/WebCore/Modules/screen-wake-lock/WakeLockManager.cpp
@@ -44,7 +44,7 @@ WakeLockManager::~WakeLockManager()
     m_document.unregisterForVisibilityStateChangedCallbacks(*this);
 }
 
-void WakeLockManager::addWakeLock(Ref<WakeLockSentinel>&& lock, PageIdentifier pageID)
+void WakeLockManager::addWakeLock(Ref<WakeLockSentinel>&& lock, std::optional<PageIdentifier> pageID)
 {
     auto type = lock->type();
     auto& locks = m_wakeLocks.ensure(type, [] { return Vector<RefPtr<WakeLockSentinel>>(); }).iterator->value;

--- a/Source/WebCore/Modules/screen-wake-lock/WakeLockManager.h
+++ b/Source/WebCore/Modules/screen-wake-lock/WakeLockManager.h
@@ -44,7 +44,7 @@ public:
     explicit WakeLockManager(Document&);
     ~WakeLockManager();
 
-    void addWakeLock(Ref<WakeLockSentinel>&&, PageIdentifier);
+    void addWakeLock(Ref<WakeLockSentinel>&&, std::optional<PageIdentifier>);
     void removeWakeLock(WakeLockSentinel&);
 
     void releaseAllLocks(WakeLockType);

--- a/Source/WebCore/dom/Document.cpp
+++ b/Source/WebCore/dom/Document.cpp
@@ -9475,9 +9475,7 @@ void Document::updateSleepDisablerIfNeeded()
 {
     MediaProducerMediaStateFlags activeVideoCaptureMask { MediaProducerMediaState::HasActiveVideoCaptureDevice, MediaProducerMediaState::HasActiveScreenCaptureDevice, MediaProducerMediaState::HasActiveWindowCaptureDevice };
     if (m_mediaState & activeVideoCaptureMask) {
-        auto pageID = this->pageID();
-        if (!m_sleepDisabler && pageID)
-            m_sleepDisabler = makeUnique<SleepDisabler>("com.apple.WebCore: Document doing camera, screen or window capture"_s, PAL::SleepDisabler::Type::Display, *pageID);
+        m_sleepDisabler = makeUnique<SleepDisabler>("com.apple.WebCore: Document doing camera, screen or window capture"_s, PAL::SleepDisabler::Type::Display, pageID());
         return;
     }
     m_sleepDisabler = nullptr;

--- a/Source/WebCore/html/HTMLMediaElement.cpp
+++ b/Source/WebCore/html/HTMLMediaElement.cpp
@@ -7498,10 +7498,8 @@ void HTMLMediaElement::updateSleepDisabling()
         m_sleepDisabler = nullptr;
     else if (shouldDisableSleep != SleepType::None) {
         auto type = shouldDisableSleep == SleepType::Display ? PAL::SleepDisabler::Type::Display : PAL::SleepDisabler::Type::System;
-        if (!m_sleepDisabler || m_sleepDisabler->type() != type) {
-            if (auto pageID = document().pageID())
-                m_sleepDisabler = makeUnique<SleepDisabler>("com.apple.WebCore: HTMLMediaElement playback"_s, type, *pageID);
-        }
+        if (!m_sleepDisabler || m_sleepDisabler->type() != type)
+            m_sleepDisabler = makeUnique<SleepDisabler>("com.apple.WebCore: HTMLMediaElement playback"_s, type, document().pageID());
     }
 
     if (m_player)

--- a/Source/WebCore/platform/SleepDisabler.cpp
+++ b/Source/WebCore/platform/SleepDisabler.cpp
@@ -30,7 +30,7 @@
 
 namespace WebCore {
 
-SleepDisabler::SleepDisabler(const String& reason, PAL::SleepDisabler::Type type, PageIdentifier pageID)
+SleepDisabler::SleepDisabler(const String& reason, PAL::SleepDisabler::Type type, std::optional<PageIdentifier> pageID)
     : m_type(type)
     , m_pageID(pageID)
 {

--- a/Source/WebCore/platform/SleepDisabler.h
+++ b/Source/WebCore/platform/SleepDisabler.h
@@ -34,7 +34,7 @@ namespace WebCore {
 class SleepDisabler {
     WTF_MAKE_FAST_ALLOCATED;
 public:
-    WEBCORE_EXPORT SleepDisabler(const String&, PAL::SleepDisabler::Type, PageIdentifier);
+    WEBCORE_EXPORT SleepDisabler(const String&, PAL::SleepDisabler::Type, std::optional<PageIdentifier>);
     WEBCORE_EXPORT ~SleepDisabler();
 
     PAL::SleepDisabler::Type type() const { return m_type; }
@@ -43,7 +43,7 @@ private:
     std::unique_ptr<PAL::SleepDisabler> m_platformSleepDisabler;
     SleepDisablerIdentifier m_identifier;
     PAL::SleepDisabler::Type m_type;
-    PageIdentifier m_pageID;
+    std::optional<PageIdentifier> m_pageID;
 };
 
 } // namespace WebCore

--- a/Source/WebCore/platform/SleepDisablerClient.h
+++ b/Source/WebCore/platform/SleepDisablerClient.h
@@ -34,8 +34,8 @@ namespace WebCore {
 class SleepDisablerClient {
 public:
     virtual ~SleepDisablerClient() { }
-    virtual void didCreateSleepDisabler(SleepDisablerIdentifier, const String& reason, bool display, PageIdentifier) = 0;
-    virtual void didDestroySleepDisabler(SleepDisablerIdentifier, PageIdentifier) = 0;
+    virtual void didCreateSleepDisabler(SleepDisablerIdentifier, const String& reason, bool display, std::optional<PageIdentifier>) = 0;
+    virtual void didDestroySleepDisabler(SleepDisablerIdentifier, std::optional<PageIdentifier>) = 0;
 };
 
 WEBCORE_EXPORT std::unique_ptr<SleepDisablerClient>& sleepDisablerClient();

--- a/Source/WebKit/WebProcess/WebSleepDisablerClient.cpp
+++ b/Source/WebKit/WebProcess/WebSleepDisablerClient.cpp
@@ -32,15 +32,15 @@
 
 namespace WebKit {
 
-void WebSleepDisablerClient::didCreateSleepDisabler(WebCore::SleepDisablerIdentifier identifier, const String& reason, bool display, WebCore::PageIdentifier pageID)
+void WebSleepDisablerClient::didCreateSleepDisabler(WebCore::SleepDisablerIdentifier identifier, const String& reason, bool display, std::optional<WebCore::PageIdentifier> pageID)
 {
-    if (auto* webPage = WebProcess::singleton().webPage(pageID))
+    if (auto* webPage = pageID ? WebProcess::singleton().webPage(*pageID) : nullptr)
         webPage->send(Messages::WebPageProxy::DidCreateSleepDisabler(identifier, reason, display));
 }
 
-void WebSleepDisablerClient::didDestroySleepDisabler(WebCore::SleepDisablerIdentifier identifier, WebCore::PageIdentifier pageID)
+void WebSleepDisablerClient::didDestroySleepDisabler(WebCore::SleepDisablerIdentifier identifier, std::optional<WebCore::PageIdentifier> pageID)
 {
-    if (auto* webPage = WebProcess::singleton().webPage(pageID))
+    if (auto* webPage = pageID ? WebProcess::singleton().webPage(*pageID) : nullptr)
         webPage->send(Messages::WebPageProxy::DidDestroySleepDisabler(identifier));
 }
 

--- a/Source/WebKit/WebProcess/WebSleepDisablerClient.h
+++ b/Source/WebKit/WebProcess/WebSleepDisablerClient.h
@@ -32,8 +32,8 @@ namespace WebKit {
 class WebSleepDisablerClient final : public WebCore::SleepDisablerClient {
     WTF_MAKE_FAST_ALLOCATED;
 public:
-    void didCreateSleepDisabler(WebCore::SleepDisablerIdentifier, const String&, bool display, WebCore::PageIdentifier) final;
-    void didDestroySleepDisabler(WebCore::SleepDisablerIdentifier, WebCore::PageIdentifier) final;
+    void didCreateSleepDisabler(WebCore::SleepDisablerIdentifier, const String&, bool display, std::optional<WebCore::PageIdentifier>) final;
+    void didDestroySleepDisabler(WebCore::SleepDisablerIdentifier, std::optional<WebCore::PageIdentifier>) final;
 };
 
 } // namespace WebKit


### PR DESCRIPTION
#### e90882bc5116dc1e80541bfb5764d44ca722334e
<pre>
[ macOS ] TestWebKitAPI.WebKitLegacy.MediaPlaybackSleepAssertion is a constant failure
<a href="https://bugs.webkit.org/show_bug.cgi?id=256097">https://bugs.webkit.org/show_bug.cgi?id=256097</a>
rdar://108666759

Reviewed by Alex Christensen.

With WebKitLegacy, pages apparently do not have a pageID. Since SleepDisablers
should work with WebKitLegacy, we now stop requiring a pageID to construct a
SleepDisabler. The pageID is now optional and ignored when taking the sleep
disabling assertion in-process, like it is the case on WebKitLegacy. We still
require a pageID in the WebKit2 case, then we IPC to the UIProcess to take the
assertion.

* Source/WebCore/Modules/screen-wake-lock/WakeLock.cpp:
(WebCore::WakeLock::request):
* Source/WebCore/Modules/screen-wake-lock/WakeLockManager.cpp:
(WebCore::WakeLockManager::addWakeLock):
* Source/WebCore/Modules/screen-wake-lock/WakeLockManager.h:
* Source/WebCore/dom/Document.cpp:
(WebCore::Document::updateSleepDisablerIfNeeded):
* Source/WebCore/html/HTMLMediaElement.cpp:
(WebCore::HTMLMediaElement::updateSleepDisabling):
* Source/WebCore/platform/SleepDisabler.cpp:
(WebCore::SleepDisabler::SleepDisabler):
* Source/WebCore/platform/SleepDisabler.h:
* Source/WebCore/platform/SleepDisablerClient.h:
* Source/WebKit/WebProcess/WebSleepDisablerClient.cpp:
(WebKit::WebSleepDisablerClient::didCreateSleepDisabler):
(WebKit::WebSleepDisablerClient::didDestroySleepDisabler):
* Source/WebKit/WebProcess/WebSleepDisablerClient.h:

Canonical link: <a href="https://commits.webkit.org/263518@main">https://commits.webkit.org/263518@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/57f87fdb34eeb8676b9d6aede073e6b33ba395c1

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/4841 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/4963 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/5134 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/6355 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/4967 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/4833 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/5132 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/4935 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/5205 "1 flakes 110 failures") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/4923 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/5008 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/4339 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/6372 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/2496 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/4335 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/9305 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/4358 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/4409 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/6004 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/4818 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/3928 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/4325 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/8388 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/556 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/4686 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->