### PR TITLE
Improve libpas PGM Enumeration

### DIFF
--- a/Source/bmalloc/libpas/libpas.xcodeproj/project.pbxproj
+++ b/Source/bmalloc/libpas/libpas.xcodeproj/project.pbxproj
@@ -546,6 +546,9 @@
 		0FF8D62722C04A7700EC72FE /* pas_segregated_page_config_kind.def in Headers */ = {isa = PBXBuildFile; fileRef = 0FF8D62622C04A6D00EC72FE /* pas_segregated_page_config_kind.def */; };
 		0FF8D62922C166F500EC72FE /* pas_segregated_page_inlines.h in Headers */ = {isa = PBXBuildFile; fileRef = 0FF8D62822C166F500EC72FE /* pas_segregated_page_inlines.h */; };
 		0FFFD515256B0FBD001EB94C /* pas_deallocation_mode.h in Headers */ = {isa = PBXBuildFile; fileRef = 0FFFD514256B0FBC001EB94C /* pas_deallocation_mode.h */; };
+		2B10EF6029FC5B9B003B84AC /* pas_report_crash.c in Sources */ = {isa = PBXBuildFile; fileRef = 2B10EF5E29FC5B9B003B84AC /* pas_report_crash.c */; };
+		2B10EF6129FC5B9B003B84AC /* pas_report_crash.h in Headers */ = {isa = PBXBuildFile; fileRef = 2B10EF5F29FC5B9B003B84AC /* pas_report_crash.h */; };
+		2B10EF6329FC5BA2003B84AC /* pas_report_crash_pgm_report.h in Headers */ = {isa = PBXBuildFile; fileRef = 2B10EF6229FC5BA2003B84AC /* pas_report_crash_pgm_report.h */; };
 		2B2A58992742D803005EE07C /* pas_probabilistic_guard_malloc_allocator.h in Headers */ = {isa = PBXBuildFile; fileRef = 2B2A58972742D802005EE07C /* pas_probabilistic_guard_malloc_allocator.h */; };
 		2B2A589A2742D803005EE07C /* pas_probabilistic_guard_malloc_allocator.c in Sources */ = {isa = PBXBuildFile; fileRef = 2B2A58982742D802005EE07C /* pas_probabilistic_guard_malloc_allocator.c */; };
 		2B2A589C2742D815005EE07C /* PGMTests.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 2B2A589B2742D815005EE07C /* PGMTests.cpp */; };
@@ -553,7 +556,6 @@
 		2B2E2FD22949A41100F85C38 /* pas_malloc_stack_logging.h in Headers */ = {isa = PBXBuildFile; fileRef = 2B2E2FD02949A41100F85C38 /* pas_malloc_stack_logging.h */; };
 		2B6055E42805368B00C8BDAC /* BmallocTests.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 2B6055E32805368B00C8BDAC /* BmallocTests.cpp */; };
 		2BDF4F4529E8B36F0056BF50 /* pas_report_crash.h in Headers */ = {isa = PBXBuildFile; fileRef = 2BDF4F4429E8B36F0056BF50 /* pas_report_crash.h */; };
-		2BDF4F4729E8B3AD0056BF50 /* pas_report_crash.c in Sources */ = {isa = PBXBuildFile; fileRef = 2BDF4F4629E8B3AD0056BF50 /* pas_report_crash.c */; };
 		2BF3F5B529A0051F005361FD /* EnumerationTests.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 2BF3F5B429A0051F005361FD /* EnumerationTests.cpp */; };
 		2C11E88E2728A783002162D0 /* bmalloc_type.h in Headers */ = {isa = PBXBuildFile; fileRef = 2C11E88C2728A783002162D0 /* bmalloc_type.h */; };
 		2C11E88F2728A783002162D0 /* pas_simple_type.c in Sources */ = {isa = PBXBuildFile; fileRef = 2C11E88D2728A783002162D0 /* pas_simple_type.c */; };
@@ -1253,6 +1255,9 @@
 		0FF8D62622C04A6D00EC72FE /* pas_segregated_page_config_kind.def */ = {isa = PBXFileReference; explicitFileType = sourcecode.c.h; fileEncoding = 4; path = pas_segregated_page_config_kind.def; sourceTree = "<group>"; };
 		0FF8D62822C166F500EC72FE /* pas_segregated_page_inlines.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = pas_segregated_page_inlines.h; sourceTree = "<group>"; };
 		0FFFD514256B0FBC001EB94C /* pas_deallocation_mode.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = pas_deallocation_mode.h; sourceTree = "<group>"; };
+		2B10EF5E29FC5B9B003B84AC /* pas_report_crash.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = pas_report_crash.c; sourceTree = "<group>"; };
+		2B10EF5F29FC5B9B003B84AC /* pas_report_crash.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = pas_report_crash.h; sourceTree = "<group>"; };
+		2B10EF6229FC5BA2003B84AC /* pas_report_crash_pgm_report.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = pas_report_crash_pgm_report.h; sourceTree = "<group>"; };
 		2B2A58972742D802005EE07C /* pas_probabilistic_guard_malloc_allocator.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = pas_probabilistic_guard_malloc_allocator.h; sourceTree = "<group>"; };
 		2B2A58982742D802005EE07C /* pas_probabilistic_guard_malloc_allocator.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = pas_probabilistic_guard_malloc_allocator.c; sourceTree = "<group>"; };
 		2B2A589B2742D815005EE07C /* PGMTests.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = PGMTests.cpp; sourceTree = "<group>"; };
@@ -1829,8 +1834,11 @@
 				0FF08F3122A58F1200386575 /* pas_red_black_tree.h */,
 				0FA5E4542492D5B900CE962A /* pas_redundant_local_allocator_node.c */,
 				0FA5E4522492D5B900CE962A /* pas_redundant_local_allocator_node.h */,
+				2B10EF5E29FC5B9B003B84AC /* pas_report_crash.c */,
 				2BDF4F4829E8B5510056BF50 /* pas_report_crash.c */,
+				2B10EF5F29FC5B9B003B84AC /* pas_report_crash.h */,
 				2BDF4F4429E8B36F0056BF50 /* pas_report_crash.h */,
+				2B10EF6229FC5BA2003B84AC /* pas_report_crash_pgm_report.h */,
 				0F5B608F235E88EE00CAE629 /* pas_reserved_memory_provider.c */,
 				0F5B6090235E88EE00CAE629 /* pas_reserved_memory_provider.h */,
 				0F4F60F825979BC7008B4A82 /* pas_root.c */,
@@ -2319,7 +2327,9 @@
 				0FE7EE7D22A1A31C004F4166 /* pas_reallocate_heap_teleport_rule.h in Headers */,
 				0FF08F3322A58F1200386575 /* pas_red_black_tree.h in Headers */,
 				0FA5E4572492D5BA00CE962A /* pas_redundant_local_allocator_node.h in Headers */,
+				2B10EF6129FC5B9B003B84AC /* pas_report_crash.h in Headers */,
 				2BDF4F4529E8B36F0056BF50 /* pas_report_crash.h in Headers */,
+				2B10EF6329FC5BA2003B84AC /* pas_report_crash_pgm_report.h in Headers */,
 				0F5B6092235E88EF00CAE629 /* pas_reserved_memory_provider.h in Headers */,
 				0F4F60FB25979BC8008B4A82 /* pas_root.h in Headers */,
 				0F19326C22F73E8500FBA713 /* pas_scavenger.h in Headers */,
@@ -2811,7 +2821,7 @@
 				0FD48B3023A9ABB30026C46D /* pas_random.c in Sources */,
 				0FF08F3422A58F1200386575 /* pas_red_black_tree.c in Sources */,
 				0FA5E4592492D5BA00CE962A /* pas_redundant_local_allocator_node.c in Sources */,
-				2BDF4F4729E8B3AD0056BF50 /* pas_report_crash.c in Sources */,
+				2B10EF6029FC5B9B003B84AC /* pas_report_crash.c in Sources */,
 				0F5B6091235E88EF00CAE629 /* pas_reserved_memory_provider.c in Sources */,
 				0F4F60FA25979BC8008B4A82 /* pas_root.c in Sources */,
 				0F19326D22F73E8500FBA713 /* pas_scavenger.c in Sources */,

--- a/Source/bmalloc/libpas/libpas.xcodeproj/xcshareddata/xcschemes/test_pas.xcscheme
+++ b/Source/bmalloc/libpas/libpas.xcodeproj/xcshareddata/xcschemes/test_pas.xcscheme
@@ -1,0 +1,87 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "1500"
+   version = "1.7">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "0FC681DA210FAC4B003C6A13"
+               BuildableName = "test_pas"
+               BlueprintName = "test_pas"
+               ReferencedContainer = "container:libpas.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      shouldAutocreateTestPlan = "YES">
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES"
+      viewDebuggingEnabled = "No">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "0FC681DA210FAC4B003C6A13"
+            BuildableName = "test_pas"
+            BlueprintName = "test_pas"
+            ReferencedContainer = "container:libpas.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+      <CommandLineArguments>
+         <CommandLineArgument
+            argument = "PGMEnumerationBasic"
+            isEnabled = "YES">
+         </CommandLineArgument>
+      </CommandLineArguments>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "0FC681DA210FAC4B003C6A13"
+            BuildableName = "test_pas"
+            BlueprintName = "test_pas"
+            ReferencedContainer = "container:libpas.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+   <InstallAction
+      buildConfiguration = "Release">
+   </InstallAction>
+</Scheme>

--- a/Source/bmalloc/libpas/src/libpas/pas_enumerate_large_heaps.c
+++ b/Source/bmalloc/libpas/src/libpas/pas_enumerate_large_heaps.c
@@ -75,7 +75,7 @@ static bool pas_hash_map_entry_callback(pas_enumerator* enumerator, pas_ptr_hash
     PAS_ASSERT_WITH_DETAIL(!arg);
 
     pas_pgm_storage* allocation = ((pas_pgm_storage*)entry->value);
-    size_t mem_to_alloc = (2 * allocation->page_size) + allocation->allocation_size_requested + allocation->mem_to_waste;
+    size_t mem_to_alloc = (2 * (size_t) getpagesize()) + allocation->allocation_size_requested + allocation->mem_to_waste;
     
     pas_enumerator_record(enumerator, (void*)((char*)entry->key - allocation->mem_to_waste - pas_page_malloc_alignment()), mem_to_alloc, pas_enumerator_object_record);
     pas_enumerator_record(enumerator, (void*)entry->value, sizeof(pas_pgm_storage), pas_enumerator_meta_record);

--- a/Source/bmalloc/libpas/src/libpas/pas_probabilistic_guard_malloc_allocator.h
+++ b/Source/bmalloc/libpas/src/libpas/pas_probabilistic_guard_malloc_allocator.h
@@ -42,11 +42,11 @@ struct pas_pgm_storage {
     uintptr_t start_of_data_pages;
 
     /*
-     * These parameter below rely on page sizes being less than 65536.
+     * This parameter relies on page sizes being less than 65536.
      * I am not aware of any platforms using more than this at the moment.
      */
     uint16_t mem_to_waste;
-    uint16_t page_size;
+    bool freed;
 
     pas_large_heap* large_heap;
 };

--- a/Source/bmalloc/libpas/src/libpas/pas_report_crash_pgm_report.h
+++ b/Source/bmalloc/libpas/src/libpas/pas_report_crash_pgm_report.h
@@ -45,14 +45,16 @@ extern "C" {
 typedef void *(*crash_reporter_memory_reader_t)(task_t task, vm_address_t address, size_t size);
 
 /* Crash Report Version number. This must be in sync between ReportCrash and libpas to generate a report. */
-const unsigned pas_crash_report_version = 1;
+const unsigned pas_crash_report_version = 2;
 
 /* Report sent back to the ReportCrash process. */
 typedef struct {
     const char *error_type;
     const char *confidence;
     vm_address_t fault_address;
+    vm_address_t nearest_allocation;
     size_t allocation_size;
+    const char* allocation_state;
 } pas_report_crash_pgm_report;
 #endif /* __APPLE__ */
 


### PR DESCRIPTION
#### 659f6ebc09bce14e109ad0f07197eee16c7d1795
<pre>
Improve libpas PGM Enumeration
<a href="https://bugs.webkit.org/show_bug.cgi?id=256103">https://bugs.webkit.org/show_bug.cgi?id=256103</a>

Reviewed by NOBODY (OOPS!).

Let&apos;s not throw away freed PGM allocated metadata on a free. Instead keep it around for enumeration.

Updated some of the enumeration paramaters to more closely align with libmalloc.

We are now tracking the free and allocated state. Next, I added the nearest allocation, which I just
point at the bottom of the guard page.

* Source/bmalloc/libpas/libpas.xcodeproj/project.pbxproj:
* Source/bmalloc/libpas/libpas.xcodeproj/xcshareddata/xcschemes/test_pas.xcscheme: Added.
* Source/bmalloc/libpas/src/libpas/pas_enumerate_large_heaps.c:
(pas_hash_map_entry_callback):
* Source/bmalloc/libpas/src/libpas/pas_probabilistic_guard_malloc_allocator.c:
(pas_probabilistic_guard_malloc_allocate):
(pas_probabilistic_guard_malloc_deallocate):
(pas_probabilistic_guard_malloc_debug_info):
* Source/bmalloc/libpas/src/libpas/pas_probabilistic_guard_malloc_allocator.h:
* Source/bmalloc/libpas/src/libpas/pas_report_crash.c:
(pas_report_crash_extract_pgm_failure):
* Source/bmalloc/libpas/src/libpas/pas_report_crash_pgm_report.h:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/659f6ebc09bce14e109ad0f07197eee16c7d1795

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/4867 "4 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/4990 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/5162 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/6382 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/4983 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/5160 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/4962 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/5228 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/4950 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/5034 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/4365 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/6399 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/2522 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/4361 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/9323 "Passed tests") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/4048 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/4384 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/4435 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/6025 "Passed tests") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/4589 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/4843 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/3943 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/4960 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/4345 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/1214 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/8410 "Built successfully") | | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/24/builds/5100 "Built successfully") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/4707 "Built successfully") | | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/3/builds/1330 "Passed tests") | 
<!--EWS-Status-Bubble-End-->