### PR TITLE
Hairline pixel crack around background-clip: text

### DIFF
--- a/LayoutTests/fast/css/background-clip-text-hairline-expected.html
+++ b/LayoutTests/fast/css/background-clip-text-hairline-expected.html
@@ -1,0 +1,41 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <style>
+        body {
+            font-family: sans-serif;
+        }
+
+        .container {
+            position: absolute;
+            left: 20px;
+            top: 20px;
+        }
+
+        .text-gradient {
+            width: 500px;
+            line-height: 2em;
+            font-size: 4em;
+            box-sizing: border-box;
+            background: linear-gradient(to bottom right, blue, blue 100%);
+            -webkit-background-clip: text;
+            color: transparent;
+        }
+
+        .obscurer {
+            position: absolute;
+            left: 20px;
+            top: 30px;
+            width: 500px;
+            height: 100px;
+            background-color: gray;
+        }
+    </style>
+</head>
+<body>
+    <div class="container">
+        <div class="text-gradient">background-clip</div>
+    </div>
+    <div class="obscurer"></div>
+</body>
+</html>

--- a/LayoutTests/fast/css/background-clip-text-hairline.html
+++ b/LayoutTests/fast/css/background-clip-text-hairline.html
@@ -1,0 +1,43 @@
+<!DOCTYPE html>
+<html>
+<!--Do not add pixel tolerance -->
+<head>
+    <style>
+        body {
+            font-family: sans-serif;
+        }
+
+        .container {
+            position: absolute;
+            left: 20px;
+            top: 20px;
+            transform: translateY(0.25px);
+        }
+
+        .text-gradient {
+            width: 500px;
+            line-height: 2em;
+            font-size: 4em;
+            box-sizing: border-box;
+            background: linear-gradient(to bottom right, blue, blue 100%);
+            -webkit-background-clip: text;
+            color: transparent;
+        }
+
+        .obscurer {
+            position: absolute;
+            left: 20px;
+            top: 30px;
+            width: 500px;
+            height: 100px;
+            background-color: gray;
+        }
+    </style>
+</head>
+<body>
+    <div class="container">
+        <div class="text-gradient">background-clip</div>
+    </div>
+    <div class="obscurer"></div>
+</body>
+</html>

--- a/Source/WebCore/rendering/BackgroundPainter.cpp
+++ b/Source/WebCore/rendering/BackgroundPainter.cpp
@@ -320,6 +320,8 @@ void BackgroundPainter::paintFillLayer(const Color& color, const FillLayer& bgLa
         maskRect = snapRectToDevicePixels(rect, deviceScaleFactor);
         maskRect.intersect(snapRectToDevicePixels(m_paintInfo.rect, deviceScaleFactor));
 
+        maskRect.inflate(1);
+
         // Now create the mask.
         maskImage = context.createAlignedImageBuffer(maskRect.size());
         if (!maskImage)


### PR DESCRIPTION
#### ccbeb1e341f13f05bf4167f0f7253d8d87383da0
<pre>
Hairline pixel crack around background-clip: text
<a href="https://bugs.webkit.org/show_bug.cgi?id=179333">https://bugs.webkit.org/show_bug.cgi?id=179333</a>
rdar://54325642

Reviewed by Alan Baradlay.

When there is some non-integral transform (or a non axis-aligned transform) in the CTM, we could
show some antialiasing noise at the edge of `background-clip: text` regions. This noise was not
in the buffer used as a mask, but seemed to come from some the transparency layer operations.

We can work around it by inflating maskRect by a pixel on each size, which pads the intermediate
buffer, and the size of the transparency layer.

* LayoutTests/fast/css/background-clip-text-hairline-expected.html: Added.
* LayoutTests/fast/css/background-clip-text-hairline.html: Added.
* Source/WebCore/rendering/BackgroundPainter.cpp:
(WebCore::BackgroundPainter::paintFillLayer):

Canonical link: <a href="https://commits.webkit.org/263526@main">https://commits.webkit.org/263526@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/6a073de0d05a1536623ad793b77a53e461787647

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/4849 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/4972 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/5144 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/6364 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/4970 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/4840 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/5141 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/4944 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/5211 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/4932 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/5015 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/4349 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/6381 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/2503 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/4345 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/9309 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/4365 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/4419 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/6006 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/4825 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/3930 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/4329 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/4341 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/1193 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/8393 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/4690 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->