### PR TITLE
REGRESSION (262297@main): Cursor styles don't work in Catalyst apps that don't support indirect touches

### DIFF
--- a/Source/WebKit/UIProcess/ios/WKContentViewInteraction.mm
+++ b/Source/WebKit/UIProcess/ios/WKContentViewInteraction.mm
@@ -1868,6 +1868,9 @@ typedef NS_ENUM(NSInteger, EndEditingReason) {
     if (gestureRecognizer != _mouseGestureRecognizer && [_mouseGestureRecognizer mouseTouch] == touch && touch._isPointerTouch)
         return NO;
 
+    if (gestureRecognizer == _mouseGestureRecognizer && !touch._isPointerTouch)
+        return NO;
+
     if (gestureRecognizer == _doubleTapGestureRecognizer || gestureRecognizer == _nonBlockingDoubleTapGestureRecognizer)
         return touch.type != UITouchTypeIndirectPointer;
 #endif
@@ -10298,7 +10301,7 @@ static BOOL applicationIsKnownToIgnoreMouseEvents(const char* &warningVersion)
     [_mouseGestureRecognizer setEnabled:[self shouldUseMouseGestureRecognizer]];
 #if ENABLE(PENCIL_HOVER)
     [_pencilHoverGestureRecognizer setAllowedTouchTypes:@[ @(UITouchTypePencil)] ];
-    [_mouseGestureRecognizer setAllowedTouchTypes:@[ @(UITouchTypeIndirectPointer)] ];
+    [_mouseGestureRecognizer setAllowedTouchTypes:@[@(UITouchTypeDirect), @(UITouchTypeIndirectPointer)] ];
     [_pencilHoverGestureRecognizer setEnabled:[self shouldUseMouseGestureRecognizer]];
 #endif
 }


### PR DESCRIPTION
#### 4f0df9c94db252f1c5fe1be436f87d2bb611cec5
<pre>
REGRESSION (262297@main): Cursor styles don&apos;t work in Catalyst apps that don&apos;t support indirect touches
<a href="https://bugs.webkit.org/show_bug.cgi?id=256110">https://bugs.webkit.org/show_bug.cgi?id=256110</a>
rdar://108072867

Reviewed by Tim Horton.

262297@main removed `@(UITouchTypeDirect)` from the set of allowed touch types; however, this is
still necessary in order for tracking (and cursor styles) to work in Catalyst apps that don&apos;t have
the `UIApplicationSupportsIndirectInputEvents` application plist key set, since the mouse gesture
(which also handles hover in Catalyst) still relies on sending direct touches.

Instead, we can keep the behavior following 262297@main intact while also keeping this Catalyst case
working by:

1.  Putting `UITouchTypeDirect` back in the allowed touch types list, and…
2.  Using the `-_isPointerTouch` SPI to reject touches that aren&apos;t actually sent via trackpad, via
    the gesture recognizer delegate hook.

* Source/WebKit/UIProcess/ios/WKContentViewInteraction.mm:
(-[WKContentView gestureRecognizer:shouldReceiveTouch:]):
(-[WKContentView _configureMouseGestureRecognizer]):

Canonical link: <a href="https://commits.webkit.org/263522@main">https://commits.webkit.org/263522@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e1bccdbc5f211f6670397249d47f0286c0c32948

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/4856 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/4979 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/5151 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/6371 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/4975 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/5154 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/4951 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/5218 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/4939 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/5028 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/4354 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/6388 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/2516 "Passed tests") | | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/9311 "5 flakes 137 failures") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/4378 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/4424 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/6013 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/4832 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/3935 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/4335 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/1191 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/8400 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/4697 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->