### PR TITLE
Use move semantics for ShareableBitmap::create

### DIFF
--- a/Source/WebKit/Shared/ShareableBitmap.cpp
+++ b/Source/WebKit/Shared/ShareableBitmap.cpp
@@ -116,7 +116,7 @@ RefPtr<ShareableBitmap> ShareableBitmap::createFromImageDraw(NativeImage& image)
     return bitmap;
 }
 
-RefPtr<ShareableBitmap> ShareableBitmap::create(const Handle& handle, SharedMemory::Protection protection)
+RefPtr<ShareableBitmap> ShareableBitmap::create(Handle&& handle, SharedMemory::Protection protection)
 {
     auto sharedMemory = SharedMemory::map(handle.m_handle, protection);
     if (!sharedMemory)
@@ -125,7 +125,7 @@ RefPtr<ShareableBitmap> ShareableBitmap::create(const Handle& handle, SharedMemo
     return create(handle.m_configuration, sharedMemory.releaseNonNull());
 }
 
-std::optional<Ref<ShareableBitmap>> ShareableBitmap::createReadOnly(const std::optional<Handle>& handle)
+std::optional<Ref<ShareableBitmap>> ShareableBitmap::createReadOnly(std::optional<Handle>&& handle)
 {
     if (!handle)
         return std::nullopt;

--- a/Source/WebKit/Shared/ShareableBitmap.h
+++ b/Source/WebKit/Shared/ShareableBitmap.h
@@ -134,10 +134,10 @@ public:
     static RefPtr<ShareableBitmap> createFromImageDraw(WebCore::NativeImage&);
 
     // Create a shareable bitmap from a handle.
-    static RefPtr<ShareableBitmap> create(const Handle&, SharedMemory::Protection = SharedMemory::Protection::ReadWrite);
+    static RefPtr<ShareableBitmap> create(Handle&&, SharedMemory::Protection = SharedMemory::Protection::ReadWrite);
     
     // Create a shareable bitmap from a ReadOnly handle.
-    static std::optional<Ref<ShareableBitmap>> createReadOnly(const std::optional<Handle>&);
+    static std::optional<Ref<ShareableBitmap>> createReadOnly(std::optional<Handle>&&);
 
     std::optional<Handle> createHandle(SharedMemory::Protection = SharedMemory::Protection::ReadWrite) const;
     

--- a/Source/WebKit/Shared/gtk/ArgumentCodersGtk.cpp
+++ b/Source/WebKit/Shared/gtk/ArgumentCodersGtk.cpp
@@ -53,7 +53,7 @@ static WARN_UNUSED_RETURN bool decodeImage(Decoder& decoder, RefPtr<Image>& imag
     if (!handle || !*handle)
         return false;
 
-    RefPtr<ShareableBitmap> bitmap = ShareableBitmap::create(**handle);
+    RefPtr<ShareableBitmap> bitmap = ShareableBitmap::create(WTFMove(**handle));
     if (!bitmap)
         return false;
     image = bitmap->createImage();

--- a/Source/WebKit/UIProcess/BackingStore.cpp
+++ b/Source/WebKit/UIProcess/BackingStore.cpp
@@ -48,7 +48,7 @@ void BackingStore::incorporateUpdate(UpdateInfo&& updateInfo)
 {
     ASSERT(m_size == updateInfo.viewSize);
     
-    auto bitmap = ShareableBitmap::create(updateInfo.bitmapHandle);
+    auto bitmap = ShareableBitmap::create(WTFMove(updateInfo.bitmapHandle));
     if (!bitmap)
         return;
 


### PR DESCRIPTION
#### 802c13cdf46a0eb2c1f86960926c45885793132b
<pre>
Use move semantics for ShareableBitmap::create
<a href="https://bugs.webkit.org/show_bug.cgi?id=256112">https://bugs.webkit.org/show_bug.cgi?id=256112</a>

Reviewed by Kimmo Kinnunen.

Continuation of 263363@main which used move semantics for
`ShareableBitmap::Handle` to signify transferring ownership.

* Source/WebKit/Shared/ShareableBitmap.cpp:
* Source/WebKit/Shared/ShareableBitmap.h:
* Source/WebKit/Shared/gtk/ArgumentCodersGtk.cpp:
* Source/WebKit/UIProcess/BackingStore.cpp:

Canonical link: <a href="https://commits.webkit.org/263689@main">https://commits.webkit.org/263689@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c792e75a8ebcf244815ce291c9854c900f9c9bd4

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/5422 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/5561 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/5753 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/6964 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/5450 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/5790 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/5540 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/6359 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/5524 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/5588 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/4857 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/6993 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/3066 "Passed tests") | | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/12016 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/4932 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/4942 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/6648 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/5377 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/4414 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/4837 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/1302 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/8938 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/5200 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->