### PR TITLE
[iOS] Long-running MSE video leads to jetsam crash in WebKit.GPU process

### DIFF
--- a/Source/WebCore/Modules/mediasource/SourceBuffer.cpp
+++ b/Source/WebCore/Modules/mediasource/SourceBuffer.cpp
@@ -594,7 +594,7 @@ void SourceBuffer::sourceBufferPrivateAppendComplete(AppendResult result)
     monitorBufferingRate();
     m_private->reenqueueMediaIfNeeded(m_source->currentTime());
 
-    DEBUG_LOG(LOGIDENTIFIER, "buffered = ", m_private->buffered());
+    ALWAYS_LOG(LOGIDENTIFIER, "buffered = ", m_private->buffered(), ", totalBufferSize: ", m_private->totalTrackBufferSizeInBytes());
 }
 
 void SourceBuffer::sourceBufferPrivateDidReceiveRenderingError(int64_t error)

--- a/Source/WebCore/page/Settings.yaml
+++ b/Source/WebCore/page/Settings.yaml
@@ -291,7 +291,7 @@ MaximumSourceBufferSize:
   condition: ENABLE(MEDIA_SOURCE)
   defaultValue:
     WebCore:
-      default: 318767104
+      default: SettingsBase::defaultMaximumSourceBufferSize()
 
 MediaKeysStorageDirectory:
   type: String

--- a/Source/WebCore/page/SettingsBase.cpp
+++ b/Source/WebCore/page/SettingsBase.cpp
@@ -89,6 +89,13 @@ bool SettingsBase::platformDefaultMediaSourceEnabled()
 {
     return true;
 }
+
+uint64_t SettingsBase::defaultMaximumSourceBufferSize()
+{
+    // Allow SourceBuffers to store up to 304MB each, enough for approximately five minutes
+    // of 1080p video and stereo audio.
+    return 318767104;
+}
 #endif
 
 #endif

--- a/Source/WebCore/page/SettingsBase.h
+++ b/Source/WebCore/page/SettingsBase.h
@@ -66,6 +66,7 @@ public:
 
 #if ENABLE(MEDIA_SOURCE)
     WEBCORE_EXPORT static bool platformDefaultMediaSourceEnabled();
+    WEBCORE_EXPORT static uint64_t defaultMaximumSourceBufferSize();
 #endif
 
     static const unsigned defaultMaximumHTMLParserDOMTreeDepth = 512;

--- a/Source/WebCore/page/cocoa/SettingsBaseCocoa.mm
+++ b/Source/WebCore/page/cocoa/SettingsBaseCocoa.mm
@@ -54,11 +54,6 @@ void SettingsBase::initializeDefaultFontFamilies()
     setSansSerifFontFamily("Helvetica"_s, USCRIPT_COMMON);
 }
 
-bool SettingsBase::platformDefaultMediaSourceEnabled()
-{
-    return true;
-}
-
 #else
 
 void SettingsBase::initializeDefaultFontFamilies()
@@ -74,14 +69,31 @@ void SettingsBase::initializeDefaultFontFamilies()
     setSansSerifFontFamily("Helvetica"_s, USCRIPT_COMMON);
 }
 
+#endif
+
 #if ENABLE(MEDIA_SOURCE)
 
 bool SettingsBase::platformDefaultMediaSourceEnabled()
 {
+#if PLATFORM(MAC)
+    return true;
+#else
     return false;
+#endif
 }
 
+uint64_t SettingsBase::defaultMaximumSourceBufferSize()
+{
+#if PLATFORM(IOS_FAMILY)
+    // iOS Devices have lower memory limits, enforced by jetsam rates, and a very limited
+    // ability to swap. Allow SourceBuffers to store up to 105MB each, roughly a third of
+    // the limit on macOS, and approximately equivalent to the limit on Firefox.
+    return 110376422;
 #endif
+    // For other platforms, allow SourceBuffers to store up to 304MB each, enough for approximately five minutes
+    // of 1080p video and stereo audio.
+    return 318767104;
+}
 
 #endif
 

--- a/Source/WebCore/platform/graphics/avfoundation/objc/MediaSampleAVFObjC.mm
+++ b/Source/WebCore/platform/graphics/avfoundation/objc/MediaSampleAVFObjC.mm
@@ -135,7 +135,14 @@ MediaTime MediaSampleAVFObjC::duration() const
 
 size_t MediaSampleAVFObjC::sizeInBytes() const
 {
-    return PAL::CMSampleBufferGetTotalSampleSize(m_sample.get());
+    // Per sample overhead was calculated with `leaks` on a process
+    // with MallocStackLogging enabled. This value should be occasionally
+    // re-validated and updated when OS changes occurr.
+    constexpr size_t EstimatedCMSampleBufferOverhead = 1234;
+
+    return PAL::CMSampleBufferGetTotalSampleSize(m_sample.get())
+        + sizeof(MediaSampleAVFObjC)
+        + EstimatedCMSampleBufferOverhead;
 }
 
 PlatformSample MediaSampleAVFObjC::platformSample() const


### PR DESCRIPTION
#### 69d4593edf21fe717d6f5355a5279bb1669bbf30
<pre>
[iOS] Long-running MSE video leads to jetsam crash in WebKit.GPU process
<a href="https://bugs.webkit.org/show_bug.cgi?id=256113">https://bugs.webkit.org/show_bug.cgi?id=256113</a>
rdar://108108015

Reviewed by Eric Carlson.

The GPU process has a jetsam limit of 300Mb. If this threshold is crossed (and isn&apos;t immediately
corrected), the system will kill the GPU process and reclaim the memory. Media data sent to the
GPU process for parsing by the WebContent process is sent via a shared memory handle, and that
memory is attributed to the WebContent sender, so media data itself doesn&apos;t cause an increase in
the GPU process&apos;s jetsam footprint. However, parsing media data will result in the creation of many
individual media samples, and the data structures to contain those samples. Over the course of a 50
minute video, this per-sample overhead could account for hundreds of megabytes of malloc&apos;d memory.

Tackle this problem in two separate ways:

1) Account for the overhead of individual samples by accounting for that overhead in
MediaSampleAVFObjC::sizeInBytes()

This would mean that, e.g., 50k parsed samples which have a ~60Mb overhead would count against the
maximumSourceBufferSize limit before either WebKit or the web site would have to purge existing samples
before appending more data.

Unfortunately this is not enough, alone, to fix the possibility of jetsam&apos;ing the foreground GPU process,
as a highly efficient, low resolution video stream could have a media data cost that is less than half
the cost of the sample overhead itself, and even when accounting for the per-sample overhead, enough data
could be appended to the SourceBuffer to cause the GPU process to be jetsam&apos;d.

2) Reduce the maximumSourceBufferSize on iOS.

WebKit has an unusually generous maximum SampleBuffer size among other browsers. Chrome&apos;s is 150M,
Firefox&apos;s is 100M, and WebKit&apos;s is 304M. We can safely reduce the maximum size we allow to be appended
to 100M on iOS.

Between these two changes, it should be very difficult (but not impossible if the GPU process has allocated
memory for other reasons) to reach the 300Mb jetsam limit just by appending to SourceBuffers alone.

* Source/WebCore/Modules/mediasource/SourceBuffer.cpp:
(WebCore::SourceBuffer::sourceBufferPrivateAppendComplete):
* Source/WebCore/page/Settings.yaml:
* Source/WebCore/page/SettingsBase.cpp:
(WebCore::SettingsBase::defaultMaximumSourceBufferSize):
* Source/WebCore/page/SettingsBase.h:
* Source/WebCore/page/cocoa/SettingsBaseCocoa.mm:
(WebCore::SettingsBase::platformDefaultMediaSourceEnabled):
(WebCore::SettingsBase::defaultMaximumSourceBufferSize):
* Source/WebCore/platform/graphics/avfoundation/objc/MediaSampleAVFObjC.mm:
(WebCore::MediaSampleAVFObjC::sizeInBytes const):

Canonical link: <a href="https://commits.webkit.org/263525@main">https://commits.webkit.org/263525@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/8f01d08faf2ac7add44276f1ef88aea0efb5fb82

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/4861 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/4984 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/5156 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/6376 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/4979 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/4852 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/5153 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/4956 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/5221 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/4944 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/5027 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/4359 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/6393 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/2515 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/4355 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/9315 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/4377 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/4429 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/6015 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/4837 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/3939 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/4340 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/1192 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/8404 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/4702 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->