### PR TITLE
Fix type confusion in StyleBuilderCustom::ApplyValueWillChange.

### DIFF
--- a/LayoutTests/fast/css/style-builder-custom-apply-value-will-change-type-confusion-expected.txt
+++ b/LayoutTests/fast/css/style-builder-custom-apply-value-will-change-type-confusion-expected.txt
@@ -1,0 +1,1 @@
+PASS if no crash.

--- a/LayoutTests/fast/css/style-builder-custom-apply-value-will-change-type-confusion.html
+++ b/LayoutTests/fast/css/style-builder-custom-apply-value-will-change-type-confusion.html
@@ -1,0 +1,9 @@
+<script>
+  onload = () => {
+    if (window.testRunner)
+        testRunner.dumpAsText();
+     d.attributeStyleMap.set('will-change', 'A');
+};
+</script>
+<div id="d"></div>
+<p>PASS if no crash.</p>

--- a/Source/WebCore/style/StyleBuilderCustom.h
+++ b/Source/WebCore/style/StyleBuilderCustom.h
@@ -2035,9 +2035,9 @@ inline void BuilderCustom::applyValueWillChange(BuilderState& builderState, CSSV
     }
 
     auto willChange = WillChangeData::create();
-    for (auto& item : downcast<CSSValueList>(value)) {
+    auto processSingleValue = [&](const CSSValue& item) {
         if (!is<CSSPrimitiveValue>(item))
-            continue;
+            return;
         auto& primitiveValue = downcast<CSSPrimitiveValue>(item);
         switch (primitiveValue.valueID()) {
         case CSSValueScrollPosition:
@@ -2054,7 +2054,13 @@ inline void BuilderCustom::applyValueWillChange(BuilderState& builderState, CSSV
             }
             break;
         }
-    }
+    };
+    if (is<CSSValueList>(value)) {
+        for (auto& item : downcast<CSSValueList>(value))
+            processSingleValue(item);
+    } else
+        processSingleValue(value);
+
     builderState.style().setWillChange(WTFMove(willChange));
 }
 


### PR DESCRIPTION
#### 967f74508a933d74938539523c1559ff2f08147c
<pre>
Fix type confusion in StyleBuilderCustom::ApplyValueWillChange.
<a href="https://bugs.webkit.org/show_bug.cgi?id=256053.">https://bugs.webkit.org/show_bug.cgi?id=256053.</a>
rdar://108502113.

Reviewed by Antti Koivisto.

This change fixes applyValueWillChange so that it can deal with single
values instead of expecting a list of values towards the end.

* LayoutTests/fast/css/style-builder-custom-apply-value-will-change-type-confusion-expected.txt: Added.
* LayoutTests/fast/css/style-builder-custom-apply-value-will-change-type-confusion.html: Added.
* Source/WebCore/style/StyleBuilderCustom.h:
(WebCore::Style::BuilderCustom::applyValueWillChange):

Canonical link: <a href="https://commits.webkit.org/263789@main">https://commits.webkit.org/263789@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5464bd4c59ab233bc9f2ee760fbc09e39eb6693a

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/5765 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/5928 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/6117 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/7322 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/6157 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/5765 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/6150 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/5896 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/7931 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/5870 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/5916 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/5205 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/7376 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/3393 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/5192 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/12965 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/5261 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/5269 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/7403 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/5714 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/4687 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/5159 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/5122 "Passed tests") | | 
| [❌ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/1356 "Failed to push commit to Webkit repository") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/9276 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/5520 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->