### PR TITLE
Fix type confusion in StyleBuilderConverter::ConvertShapeValue.

### DIFF
--- a/LayoutTests/fast/css/style-converter-convert-shape-value-type-confusion-expected.txt
+++ b/LayoutTests/fast/css/style-converter-convert-shape-value-type-confusion-expected.txt
@@ -1,0 +1,1 @@
+PASS if no crash.

--- a/LayoutTests/fast/css/style-converter-convert-shape-value-type-confusion.html
+++ b/LayoutTests/fast/css/style-converter-convert-shape-value-type-confusion.html
@@ -1,0 +1,9 @@
+<script>
+  onload = () => {
+    if (window.testRunner)
+        testRunner.dumpAsText();
+    d.attributeStyleMap.set('shape-outside', 'circle()');
+  };
+</script>
+<div id="d"></div>
+<p>PASS if no crash.</p>

--- a/Source/WebCore/style/StyleBuilderConverter.h
+++ b/Source/WebCore/style/StyleBuilderConverter.h
@@ -990,13 +990,19 @@ inline RefPtr<ShapeValue> BuilderConverter::convertShapeValue(BuilderState& buil
 
     RefPtr<BasicShape> shape;
     CSSBoxType referenceBox = CSSBoxType::BoxMissing;
-    for (auto& currentValue : downcast<CSSValueList>(value)) {
+    auto processSingleValue = [&](const CSSValue& currentValue) {
         if (!currentValue.isValueID())
             shape = basicShapeForValue(builderState.cssToLengthConversionData(), currentValue);
         else
             referenceBox = fromCSSValue<CSSBoxType>(currentValue);
+    };
+    if (is<CSSValueList>(value)) {
+        for (auto& currentValue : downcast<CSSValueList>(value))
+            processSingleValue(currentValue);
+    } else {
+        processSingleValue(value);
     }
-
+    
     if (shape)
         return ShapeValue::create(shape.releaseNonNull(), referenceBox);
 


### PR DESCRIPTION
#### 0875b595b40e4c768aa706f8eb6a53f786676dd2
<pre>
Fix type confusion in StyleBuilderConverter::ConvertShapeValue.
<a href="https://bugs.webkit.org/show_bug.cgi?id=256049.">https://bugs.webkit.org/show_bug.cgi?id=256049.</a>
rdar://108502377.

Reviewed by Antti Koivisto.

This change fixes convertShapeValue so that it can deal with single
values instead of expecting a list of values towards the end.

* LayoutTests/fast/css/style-converter-convert-shape-value-type-confusion-expected.txt: Added.
* LayoutTests/fast/css/style-converter-convert-shape-value-type-confusion.html: Added.
* Source/WebCore/style/StyleBuilderConverter.h:
(WebCore::Style::BuilderConverter::convertShapeValue):

Canonical link: <a href="https://commits.webkit.org/263679@main">https://commits.webkit.org/263679@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/cb7444d19b7e23b3d15eace886352ed745fdaf75

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/4864 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/4987 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/5159 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/6379 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/4981 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/4855 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/5157 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/4959 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/5223 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/4947 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/5031 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/4362 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/6396 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/2519 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/4358 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/9319 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/4381 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/4432 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/6020 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/4840 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/3941 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/4343 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/4354 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/1299 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/8407 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/4705 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->