### PR TITLE
Repaint issues with currentColor & color-mix()

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-backgrounds/color-mix-currentcolor-border-repaint-expected.xht
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-backgrounds/color-mix-currentcolor-border-repaint-expected.xht
@@ -1,0 +1,19 @@
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml">
+ <head>
+  <title>CSS Reftest Reference</title>
+  <link rel="author" title="Gérard Talbot" href="http://www.gtalbot.org/BrowserBugsSection/css21testsuite/" />
+  <style type="text/css"><![CDATA[
+  div
+  {
+  background-color: green;
+  height: 100px;
+  width: 100px;
+  }
+  ]]></style>
+ </head>
+ <body>
+  <p>Test passes if there is a filled green square and <strong>no red</strong>.</p>
+  <div></div>
+ </body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-backgrounds/color-mix-currentcolor-border-repaint-parent-expected.xht
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-backgrounds/color-mix-currentcolor-border-repaint-parent-expected.xht
@@ -1,0 +1,19 @@
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml">
+ <head>
+  <title>CSS Reftest Reference</title>
+  <link rel="author" title="Gérard Talbot" href="http://www.gtalbot.org/BrowserBugsSection/css21testsuite/" />
+  <style type="text/css"><![CDATA[
+  div
+  {
+  background-color: green;
+  height: 100px;
+  width: 100px;
+  }
+  ]]></style>
+ </head>
+ <body>
+  <p>Test passes if there is a filled green square and <strong>no red</strong>.</p>
+  <div></div>
+ </body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-backgrounds/color-mix-currentcolor-border-repaint-parent.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-backgrounds/color-mix-currentcolor-border-repaint-parent.html
@@ -1,0 +1,38 @@
+<!DOCTYPE html>
+<html class="reftest-wait">
+<title>currentColor in color-mix() used in border repaints properly when parent color changes</title>
+<link rel="author" title="Tim Nguyen" href="https://github.com/nt1m">
+<link rel="help" href="https://drafts.csswg.org/css-color/#currentcolor-color">
+<link rel="match" href="../reference/ref-filled-green-100px-square.xht">
+<style>
+    #container {
+        color: red;
+    }
+
+    #container.green {
+        color: green;
+    }
+
+    #target {
+        border: 50px solid color-mix(in hsl, transparent 0%, currentColor 100%);
+        width: 0;
+    }
+</style>
+
+<p>Test passes if there is a filled green square and <strong>no red</strong>.</p>
+
+<div id="container">
+    <div id="target"></div>
+</div>
+
+<script>
+    addEventListener("load", () => {
+        setTimeout(() => {
+            requestAnimationFrame(() => {
+                container.classList.add("green");
+                document.documentElement.classList.remove("reftest-wait");
+            });
+        }, 0);
+    });
+</script>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-backgrounds/color-mix-currentcolor-border-repaint.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-backgrounds/color-mix-currentcolor-border-repaint.html
@@ -1,0 +1,33 @@
+<!DOCTYPE html>
+<html class="reftest-wait">
+<title>currentColor in color-mix() used in border repaints properly when color changes</title>
+<link rel="author" title="Tim Nguyen" href="https://github.com/nt1m">
+<link rel="help" href="https://drafts.csswg.org/css-color/#currentcolor-color">
+<link rel="match" href="../reference/ref-filled-green-100px-square.xht">
+<style>
+    #target {
+        color: red;
+        border: 50px solid color-mix(in hsl, transparent 0%, currentColor 100%);
+        width: 0;
+    }
+
+    #target.green {
+        color: green;
+    }
+</style>
+
+<p>Test passes if there is a filled green square and <strong>no red</strong>.</p>
+
+<div id="target"></div>
+
+<script>
+    addEventListener("load", () => {
+        setTimeout(() => {
+            requestAnimationFrame(() => {
+                target.classList.add("green");
+                document.documentElement.classList.remove("reftest-wait");
+            });
+        }, 0);
+    });
+</script>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-backgrounds/currentcolor-border-repaint-parent-expected.xht
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-backgrounds/currentcolor-border-repaint-parent-expected.xht
@@ -1,0 +1,19 @@
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml">
+ <head>
+  <title>CSS Reftest Reference</title>
+  <link rel="author" title="Gérard Talbot" href="http://www.gtalbot.org/BrowserBugsSection/css21testsuite/" />
+  <style type="text/css"><![CDATA[
+  div
+  {
+  background-color: green;
+  height: 100px;
+  width: 100px;
+  }
+  ]]></style>
+ </head>
+ <body>
+  <p>Test passes if there is a filled green square and <strong>no red</strong>.</p>
+  <div></div>
+ </body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-backgrounds/currentcolor-border-repaint-parent.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-backgrounds/currentcolor-border-repaint-parent.html
@@ -1,0 +1,38 @@
+<!DOCTYPE html>
+<html class="reftest-wait">
+<title>currentColor used in border repaints properly when parent color changes</title>
+<link rel="author" title="Tim Nguyen" href="https://github.com/nt1m">
+<link rel="help" href="https://drafts.csswg.org/css-color/#currentcolor-color">
+<link rel="match" href="../reference/ref-filled-green-100px-square.xht">
+<style>
+    #container {
+        color: red;
+    }
+
+    #container.green {
+        color: green;
+    }
+
+    #target {
+        border: 50px solid currentColor;
+        width: 0;
+    }
+</style>
+
+<p>Test passes if there is a filled green square and <strong>no red</strong>.</p>
+
+<div id="container">
+    <div id="target"></div>
+</div>
+
+<script>
+    addEventListener("load", () => {
+        setTimeout(() => {
+            requestAnimationFrame(() => {
+                container.classList.add("green");
+                document.documentElement.classList.remove("reftest-wait");
+            });
+        }, 0);
+    });
+</script>
+</html>

--- a/Source/WebCore/animation/CSSPropertyAnimation.cpp
+++ b/Source/WebCore/animation/CSSPropertyAnimation.cpp
@@ -2492,7 +2492,7 @@ private:
         auto toStyleColor = (to.*m_getter)();
 
         // We don't animate when both are currentcolor
-        if (RenderStyle::isCurrentColor(fromStyleColor) && RenderStyle::isCurrentColor(toStyleColor))
+        if (fromStyleColor.isCurrentColor() && toStyleColor.isCurrentColor())
             return;
 
         auto fromColor = from.colorResolvingCurrentColor(fromStyleColor);
@@ -4051,7 +4051,7 @@ static std::optional<CSSCustomPropertyValue::SyntaxValue> blendSyntaxValues(cons
     if (std::holds_alternative<StyleColor>(from) && std::holds_alternative<StyleColor>(to)) {
         auto& fromStyleColor = std::get<StyleColor>(from);
         auto& toStyleColor = std::get<StyleColor>(to);
-        if (!RenderStyle::isCurrentColor(fromStyleColor) || !RenderStyle::isCurrentColor(toStyleColor))
+        if (!fromStyleColor.isCurrentColor() || !toStyleColor.isCurrentColor())
             return blendFunc(fromStyle.colorResolvingCurrentColor(fromStyleColor), toStyle.colorResolvingCurrentColor(toStyleColor), blendingContext);
     }
 

--- a/Source/WebCore/css/StyleColor.h
+++ b/Source/WebCore/css/StyleColor.h
@@ -95,6 +95,7 @@ public:
     static Color colorFromKeyword(CSSValueID, OptionSet<StyleColorOptions>);
     static Color colorFromAbsoluteKeyword(CSSValueID);
 
+    static bool containsCurrentColor(const CSSPrimitiveValue&);
     static bool isAbsoluteColorKeyword(CSSValueID);
     static bool isCurrentColorKeyword(CSSValueID id) { return id == CSSValueCurrentcolor; }
     static bool isCurrentColor(const CSSPrimitiveValue& value) { return isCurrentColorKeyword(value.valueID()); }
@@ -111,6 +112,7 @@ public:
     // https://drafts.csswg.org/css-color-4/#typedef-color
     static bool isColorKeyword(CSSValueID, OptionSet<CSSColorType> = { CSSColorType::Absolute, CSSColorType::Current, CSSColorType::System });
 
+    bool containsCurrentColor() const;
     bool isCurrentColor() const;
     bool isColorMix() const;
     bool isAbsoluteColor() const;

--- a/Source/WebCore/css/color/CSSUnresolvedColor.cpp
+++ b/Source/WebCore/css/color/CSSUnresolvedColor.cpp
@@ -25,12 +25,22 @@
 
 #include "config.h"
 #include "CSSUnresolvedColor.h"
+#include "StyleColor.h"
 
 #include "StyleBuilderState.h"
 
 namespace WebCore {
 
 CSSUnresolvedColor::~CSSUnresolvedColor() = default;
+
+bool CSSUnresolvedColor::containsCurrentColor() const
+{
+    return WTF::switchOn(m_value,
+        [&] (const CSSUnresolvedColorMix& unresolved) {
+            return StyleColor::containsCurrentColor(unresolved.mixComponents1.color) || StyleColor::containsCurrentColor(unresolved.mixComponents2.color);
+        }
+    );
+}
 
 void CSSUnresolvedColor::serializationForCSS(StringBuilder& builder) const
 {

--- a/Source/WebCore/css/color/CSSUnresolvedColor.h
+++ b/Source/WebCore/css/color/CSSUnresolvedColor.h
@@ -48,6 +48,8 @@ public:
     CSSUnresolvedColor& operator=(CSSUnresolvedColor&&) = default;
     ~CSSUnresolvedColor();
 
+    bool containsCurrentColor() const;
+
     void serializationForCSS(StringBuilder&) const;
     String serializationForCSS() const;
 

--- a/Source/WebCore/editing/EditingStyle.cpp
+++ b/Source/WebCore/editing/EditingStyle.cpp
@@ -564,9 +564,9 @@ void EditingStyle::init(Node* node, PropertiesToInclude propertiesToInclude)
 
 void EditingStyle::removeTextFillAndStrokeColorsIfNeeded(const RenderStyle* renderStyle)
 {
-    if (RenderStyle::isCurrentColor(renderStyle->textFillColor()))
+    if (renderStyle->textFillColor().isCurrentColor())
         m_mutableStyle->removeProperty(CSSPropertyWebkitTextFillColor);
-    if (RenderStyle::isCurrentColor(renderStyle->textStrokeColor()))
+    if (renderStyle->textStrokeColor().isCurrentColor())
         m_mutableStyle->removeProperty(CSSPropertyWebkitTextStrokeColor);
 }
 

--- a/Source/WebCore/rendering/style/BorderData.cpp
+++ b/Source/WebCore/rendering/style/BorderData.cpp
@@ -40,10 +40,10 @@ bool BorderData::isEquivalentForPainting(const BorderData& other, bool currentCo
     if (!currentColorDiffers)
         return true;
 
-    auto visibleBorderHasCurrentColor = (m_top.isVisible() && RenderStyle::isCurrentColor(m_top.color()))
-        || (m_right.isVisible() && RenderStyle::isCurrentColor(m_right.color()))
-        || (m_bottom.isVisible() && RenderStyle::isCurrentColor(m_bottom.color()))
-        || (m_left.isVisible() && RenderStyle::isCurrentColor(m_left.color()));
+    auto visibleBorderHasCurrentColor = (m_top.isVisible() && m_top.color().containsCurrentColor())
+        || (m_right.isVisible() && m_right.color().containsCurrentColor())
+        || (m_bottom.isVisible() && m_bottom.color().containsCurrentColor())
+        || (m_left.isVisible() && m_left.color().containsCurrentColor());
     return !visibleBorderHasCurrentColor;
 }
 

--- a/Source/WebCore/rendering/style/RenderStyle.cpp
+++ b/Source/WebCore/rendering/style/RenderStyle.cpp
@@ -1254,17 +1254,19 @@ bool RenderStyle::changeRequiresRepaint(const RenderStyle& other, OptionSet<Styl
         return true;
 
 
-    if (m_nonInheritedData.ptr() != other.m_nonInheritedData.ptr()) {
-        if (m_nonInheritedData->backgroundData.ptr() != other.m_nonInheritedData->backgroundData.ptr()) {
+    if (currentColorDiffers || m_nonInheritedData.ptr() != other.m_nonInheritedData.ptr()) {
+        if (currentColorDiffers || m_nonInheritedData->backgroundData.ptr() != other.m_nonInheritedData->backgroundData.ptr()) {
             if (!m_nonInheritedData->backgroundData->isEquivalentForPainting(*other.m_nonInheritedData->backgroundData, currentColorDiffers))
                 return true;
         }
 
-        if (m_nonInheritedData->surroundData.ptr() != other.m_nonInheritedData->surroundData.ptr()) {
+        if (currentColorDiffers || m_nonInheritedData->surroundData.ptr() != other.m_nonInheritedData->surroundData.ptr()) {
             if (!m_nonInheritedData->surroundData->border.isEquivalentForPainting(other.m_nonInheritedData->surroundData->border, currentColorDiffers))
                 return true;
         }
+    }
 
+    if (m_nonInheritedData.ptr() != other.m_nonInheritedData.ptr()) {
         if (m_nonInheritedData->miscData.ptr() != other.m_nonInheritedData->miscData.ptr()
             && miscDataChangeRequiresRepaint(*m_nonInheritedData->miscData, *other.m_nonInheritedData->miscData, changedContextSensitiveProperties))
             return true;
@@ -2329,7 +2331,7 @@ Color RenderStyle::colorResolvingCurrentColor(CSSPropertyID colorProperty, bool 
 {
     auto result = unresolvedColorForProperty(colorProperty, visitedLink);
 
-    if (isCurrentColor(result)) {
+    if (result.isCurrentColor()) {
         if (colorProperty == CSSPropertyTextDecorationColor) {
             if (hasPositiveStrokeWidth()) {
                 // Prefer stroke color if possible but not if it's fully transparent.

--- a/Source/WebCore/rendering/style/RenderStyle.h
+++ b/Source/WebCore/rendering/style/RenderStyle.h
@@ -1982,7 +1982,6 @@ public:
     void getShadowBlockDirectionExtent(const ShadowData*, LayoutUnit& logicalTop, LayoutUnit& logicalBottom) const;
 
     static StyleColor currentColor() { return StyleColor::currentColor(); }
-    static bool isCurrentColor(const StyleColor& color) { return color.isCurrentColor(); }
 
     const StyleColor& borderLeftColor() const { return m_nonInheritedData->surroundData->border.left().color(); }
     const StyleColor& borderRightColor() const { return m_nonInheritedData->surroundData->border.right().color(); }

--- a/Source/WebCore/rendering/style/SVGRenderStyle.cpp
+++ b/Source/WebCore/rendering/style/SVGRenderStyle.cpp
@@ -140,8 +140,8 @@ static bool colorChangeRequiresRepaint(const StyleColor& a, const StyleColor& b,
     if (a != b)
         return true;
 
-    if (a.isCurrentColor()) {
-        ASSERT(b.isCurrentColor());
+    if (a.containsCurrentColor()) {
+        ASSERT(b.containsCurrentColor());
         return currentColorDiffers;
     }
 

--- a/Source/WebCore/rendering/style/StyleGradientImage.cpp
+++ b/Source/WebCore/rendering/style/StyleGradientImage.cpp
@@ -91,9 +91,10 @@ static inline bool operator==(const StyleGradientImage::ConicData& a, const Styl
 static bool stopsAreCacheable(const Vector<StyleGradientImage::Stop>& stops)
 {
     for (auto& stop : stops) {
+        // FIXME: Do we need handle calc() here?
         if (stop.position && stop.position->isFontRelativeLength())
             return false;
-        if (stop.color && stop.color->isCurrentColor())
+        if (stop.color && stop.color->containsCurrentColor())
             return false;
     }
     return true;

--- a/Source/WebCore/style/ElementRuleCollector.cpp
+++ b/Source/WebCore/style/ElementRuleCollector.cpp
@@ -684,7 +684,7 @@ void ElementRuleCollector::addMatchedProperties(MatchedProperties&& matchedPrope
 
             // The value currentColor has implicitely the same side effect. It depends on the value of color,
             // which is an inherited value, making the non-inherited property implicitly inherited.
-            if (is<CSSPrimitiveValue>(value) && StyleColor::isCurrentColor(downcast<CSSPrimitiveValue>(value)))
+            if (is<CSSPrimitiveValue>(value) && StyleColor::containsCurrentColor(downcast<CSSPrimitiveValue>(value)))
                 return false;
 
             if (value.hasVariableReferences())

--- a/Source/WebCore/svg/properties/SVGAnimationAdditiveValueFunctionImpl.cpp
+++ b/Source/WebCore/svg/properties/SVGAnimationAdditiveValueFunctionImpl.cpp
@@ -48,11 +48,11 @@ Color SVGAnimationColorFunction::colorFromString(SVGElement& targetElement, cons
 std::optional<float> SVGAnimationColorFunction::calculateDistance(SVGElement&, const String& from, const String& to) const
 {
     Color fromColor = CSSParser::parseColorWithoutContext(from.stripWhiteSpace());
-    if (RenderStyle::isCurrentColor(fromColor))
+    if (!fromColor.isValid())
         return { };
 
     Color toColor = CSSParser::parseColorWithoutContext(to.stripWhiteSpace());
-    if (RenderStyle::isCurrentColor(toColor))
+    if (!toColor.isValid())
         return { };
 
     auto simpleFrom = fromColor.toColorTypeLossy<SRGBA<uint8_t>>().resolved();


### PR DESCRIPTION
#### 63a655702b0109ffa21df1c21f7307af5bc8e598
<pre>
Repaint issues with currentColor &amp; color-mix()
<a href="https://bugs.webkit.org/show_bug.cgi?id=256118">https://bugs.webkit.org/show_bug.cgi?id=256118</a>
rdar://104872702

Reviewed by Antti Koivisto.

There are 2 different issues:
1. Raw `currentColor` (even without `color-mix()`) will not repaint if the color was changed on the ancestors
2. Using `currentColor` inside `color-mix()` will not repaint if the color was changed (either on the element itself or the ancestors)

1. is fixed by taking in account currentColor changes in `RenderStyle::changeRequiresRepaint()`
2. is fixed by introducing a `containsCurrentColor()` helper taking in account nested currentColor inside `color-mix()`, and replacing appropriate `isCurrentColor()` checks.

Also remove `RenderStyle::isCurrentColor()` since it does not add much value.

* LayoutTests/imported/w3c/web-platform-tests/css/css-backgrounds/color-mix-currentcolor-border-repaint-expected.xht: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-backgrounds/color-mix-currentcolor-border-repaint-parent-expected.xht: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-backgrounds/color-mix-currentcolor-border-repaint-parent.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-backgrounds/color-mix-currentcolor-border-repaint.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-backgrounds/currentcolor-border-repaint-parent-expected.xht: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-backgrounds/currentcolor-border-repaint-parent.html: Added.
* Source/WebCore/animation/CSSPropertyAnimation.cpp:
(WebCore::blendSyntaxValues):
* Source/WebCore/css/StyleColor.cpp:
(WebCore::StyleColor::containsCurrentColor):
(WebCore::StyleColor::containsCurrentColor const):
* Source/WebCore/css/StyleColor.h:
* Source/WebCore/css/color/CSSUnresolvedColor.cpp:
(WebCore::CSSUnresolvedColor::containsCurrentColor const):
* Source/WebCore/css/color/CSSUnresolvedColor.h:
* Source/WebCore/editing/EditingStyle.cpp:
(WebCore::EditingStyle::removeTextFillAndStrokeColorsIfNeeded):
* Source/WebCore/rendering/style/BorderData.cpp:
(WebCore::BorderData::isEquivalentForPainting const):
* Source/WebCore/rendering/style/RenderStyle.cpp:
(WebCore::RenderStyle::changeRequiresRepaint const):
(WebCore::RenderStyle::colorResolvingCurrentColor const):
* Source/WebCore/rendering/style/RenderStyle.h:
(WebCore::RenderStyle::currentColor):
(WebCore::RenderStyle::isCurrentColor): Deleted.
* Source/WebCore/rendering/style/SVGRenderStyle.cpp:
(WebCore::colorChangeRequiresRepaint):
* Source/WebCore/rendering/style/StyleGradientImage.cpp:
(WebCore::stopsAreCacheable):
* Source/WebCore/style/ElementRuleCollector.cpp:
(WebCore::Style::ElementRuleCollector::addMatchedProperties):
* Source/WebCore/svg/properties/SVGAnimationAdditiveValueFunctionImpl.cpp:
(WebCore::SVGAnimationColorFunction::calculateDistance const):

Canonical link: <a href="https://commits.webkit.org/263531@main">https://commits.webkit.org/263531@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e7fe3b4bf422d80a311fd1f9ec5b5772e49e12a2

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/4876 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/5000 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/5172 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/6391 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/4991 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/4868 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/5168 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/4972 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/5235 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/4960 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/5037 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/4369 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/6407 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/2525 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/4365 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/9326 "18 flakes 134 failures") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/4387 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/4439 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/6033 "run-api-tests-without-change (failure)") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/4851 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/3945 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/4353 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/4361 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/1195 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/8418 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/4715 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->