### PR TITLE
Remove some unused Assembler methods.

### DIFF
--- a/Source/JavaScriptCore/assembler/AbstractMacroAssembler.h
+++ b/Source/JavaScriptCore/assembler/AbstractMacroAssembler.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2008-2022 Apple Inc. All rights reserved.
+ * Copyright (C) 2008-2023 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -946,12 +946,6 @@ public:
     }
 
     template<PtrTag tag>
-    static void repatchInt32(CodeLocationDataLabel32<tag> dataLabel32, int32_t value)
-    {
-        AssemblerType::repatchInt32(dataLabel32.dataLocation(), value);
-    }
-
-    template<PtrTag tag>
     static void repatchPointer(CodeLocationDataLabelPtr<tag> dataLabelPtr, void* value)
     {
         AssemblerType::repatchPointer(dataLabelPtr.dataLocation(), value);
@@ -961,18 +955,6 @@ public:
     static void* readPointer(CodeLocationDataLabelPtr<tag> dataLabelPtr)
     {
         return AssemblerType::readPointer(dataLabelPtr.dataLocation());
-    }
-    
-    template<PtrTag tag>
-    static void replaceWithLoad(CodeLocationConvertibleLoad<tag> label)
-    {
-        AssemblerType::replaceWithLoad(label.dataLocation());
-    }
-
-    template<PtrTag tag>
-    static void replaceWithAddressComputation(CodeLocationConvertibleLoad<tag> label)
-    {
-        AssemblerType::replaceWithAddressComputation(label.dataLocation());
     }
 
     template<typename Functor>

--- a/Source/JavaScriptCore/assembler/X86Assembler.h
+++ b/Source/JavaScriptCore/assembler/X86Assembler.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2008-2020 Apple Inc. All rights reserved.
+ * Copyright (C) 2008-2023 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -6367,11 +6367,6 @@ public:
         relinkJump(from, to);
     }
 
-    static void repatchInt32(void* where, int32_t value)
-    {
-        setInt32(where, value);
-    }
-
     static void repatchPointer(void* where, void* value)
     {
         setPointer(where, value);
@@ -6482,43 +6477,7 @@ public:
         for (unsigned i = opcodeBytes + modRMBytes; i < static_cast<unsigned>(maxJumpReplacementSize()); ++i)
             ptr[i] = u.asBytes[i - opcodeBytes - modRMBytes];
     }
-    
-    static void replaceWithLoad(void* instructionStart)
-    {
-        uint8_t* ptr = reinterpret_cast<uint8_t*>(instructionStart);
-#if CPU(X86_64)
-        if ((*ptr & ~15) == PRE_REX)
-            ptr++;
-#endif
-        switch (*ptr) {
-        case OP_MOV_GvEv:
-            break;
-        case OP_LEA:
-            *ptr = OP_MOV_GvEv;
-            break;
-        default:
-            RELEASE_ASSERT_NOT_REACHED();
-        }
-    }
-    
-    static void replaceWithAddressComputation(void* instructionStart)
-    {
-        uint8_t* ptr = reinterpret_cast<uint8_t*>(instructionStart);
-#if CPU(X86_64)
-        if ((*ptr & ~15) == PRE_REX)
-            ptr++;
-#endif
-        switch (*ptr) {
-        case OP_MOV_GvEv:
-            *ptr = OP_LEA;
-            break;
-        case OP_LEA:
-            break;
-        default:
-            RELEASE_ASSERT_NOT_REACHED();
-        }
-    }
-    
+
     static unsigned getCallReturnOffset(AssemblerLabel call)
     {
         ASSERT(call.isSet());


### PR DESCRIPTION
#### 22a32809f2d43aa8c6984784fe2a53078e43a47f
<pre>
Remove some unused Assembler methods.
<a href="https://bugs.webkit.org/show_bug.cgi?id=256124">https://bugs.webkit.org/show_bug.cgi?id=256124</a>
rdar://108688852

Reviewed by Yusuke Suzuki.

Specifically, repatchInt32, replaceWithLoad, and replaceWithAddressComputation.

* Source/JavaScriptCore/assembler/ARM64Assembler.h:
* Source/JavaScriptCore/assembler/ARMv7Assembler.h:
(JSC::ARMv7Assembler::patchableJumpSize):
(JSC::ARMv7Assembler::repatchInt32): Deleted.
(JSC::ARMv7Assembler::replaceWithLoad): Deleted.
(JSC::ARMv7Assembler::replaceWithAddressComputation): Deleted.
* Source/JavaScriptCore/assembler/AbstractMacroAssembler.h:
(JSC::AbstractMacroAssembler::readPointer):
(JSC::AbstractMacroAssembler::repatchInt32): Deleted.
(JSC::AbstractMacroAssembler::replaceWithLoad): Deleted.
(JSC::AbstractMacroAssembler::replaceWithAddressComputation): Deleted.
* Source/JavaScriptCore/assembler/MIPSAssembler.h:
(JSC::MIPSAssembler::repatchPointer):
(JSC::MIPSAssembler::readInt32):
(JSC::MIPSAssembler::repatchInt32): Deleted.
(JSC::MIPSAssembler::replaceWithLoad): Deleted.
(JSC::MIPSAssembler::replaceWithAddressComputation): Deleted.
* Source/JavaScriptCore/assembler/X86Assembler.h:
(JSC::X86Assembler::repatchInt32): Deleted.
(JSC::X86Assembler::replaceWithLoad): Deleted.
(JSC::X86Assembler::replaceWithAddressComputation): Deleted.

Canonical link: <a href="https://commits.webkit.org/263533@main">https://commits.webkit.org/263533@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9ebdc012f49d546406dc1db7a91bf83b538c46c0

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/4885 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/5009 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/5181 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/6400 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/4998 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/5180 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/4981 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/5240 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/4969 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/5049 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/4376 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/6417 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/2537 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/4372 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/9334 "Passed tests") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/4064 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/4399 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/4446 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/6040 "Passed tests") | 
| [  ~~🛠 🧪 jsc-arm64~~](https://ews-build.webkit.org/#/builders/12/builds/4596 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/4860 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/3955 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/4979 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/4361 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/1221 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/8425 "Built successfully") | | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/24/builds/5119 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/561 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/4722 "Built successfully") | | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/3/builds/1337 "Passed tests") | 
<!--EWS-Status-Bubble-End-->