### PR TITLE
Selecting a link and pasting plain text changes text in the link, but not the link href

### DIFF
--- a/LayoutTests/editing/pasteboard/paste-text-in-link-expected.txt
+++ b/LayoutTests/editing/pasteboard/paste-text-in-link-expected.txt
@@ -1,0 +1,12 @@
+This test verifies that replacing all the text inside of a link by pasting does not leave the link behind with its original href.
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+PASS containsLink(editor1) is false
+PASS containsLink(editor2) is false
+PASS containsLink(editor3) is false
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/editing/pasteboard/paste-text-in-link.html
+++ b/LayoutTests/editing/pasteboard/paste-text-in-link.html
@@ -1,0 +1,54 @@
+<!DOCTYPE html>
+<html>
+<meta charset="utf-8">
+<head>
+<script src="../../resources/js-test.js"></script>
+<style>
+#editor {
+    width: 100%;
+    height: 100px;
+    border: 1px solid tomato;
+}
+</style>
+</head>
+<body>
+    <input id="copy" value="www.apple.com" />
+    <p contenteditable id="editor1">Link 1: <a href="https://webkit.org">webkit.org</a></p>
+    <p contenteditable id="editor2">Link 2: <a href="https://webkit.org">webkit.org</a></p>
+    <p contenteditable id="editor3">Link 3: <a href="https://webkit.org">webkit.org</a>&nbsp;</p>
+</body>
+<script>
+description("This test verifies that replacing all the text inside of a link by pasting does not leave the link behind with its original href.");
+
+function copyPlainText() {
+    document.getElementById("copy").select();
+    document.execCommand("Copy", true);
+}
+
+function containsLink(element) {
+    return !!element.querySelector("a");
+}
+
+if (window.testRunner) {
+    editor1 = document.getElementById("editor1");
+    copyPlainText();
+    getSelection().selectAllChildren(editor1.querySelector("a"));
+    document.execCommand("Paste", true);
+    shouldBeFalse("containsLink(editor1)");
+
+    editor2 = document.getElementById("editor2");
+    copyPlainText();
+    getSelection().setBaseAndExtent(editor2.childNodes[0], 7, editor2.querySelector("a").childNodes[0], 10);
+    document.execCommand("Paste", true);
+    shouldBeFalse("containsLink(editor2)");
+
+    editor3 = document.getElementById("editor3");
+    copyPlainText();
+    getSelection().setBaseAndExtent(editor3.querySelector("a").childNodes[0], 0, editor3, 3);
+    document.execCommand("Paste", true);
+    shouldBeFalse("containsLink(editor3)");
+
+    [editor1, editor2, editor3].forEach(container => container.remove());
+}
+</script>
+</html>


### PR DESCRIPTION
#### 2c273978ff638f8499aeae96669dab48628f472f
<pre>
Selecting a link and pasting plain text changes text in the link, but not the link href
<a href="https://bugs.webkit.org/show_bug.cgi?id=256134">https://bugs.webkit.org/show_bug.cgi?id=256134</a>
rdar://16950226

Reviewed by Ryosuke Niwa.

When copying text and pasting over a selected link (i.e. `a` element with an `href`), we currently
replace the text node underneath the link without changing any of the link&apos;s attributes (namely,
`href`) — this leads to confusing behaviors (particularly in Mail) when attempting to replace a link
by pasting a URL, since the visible text underneath the link will change (e.g. &quot;www.apple.com&quot; →
&quot;google.com&quot;) but the link itself will still take you to the original location (e.g. &quot;www.apple.com&quot;
in the previous example). While this matches Cocoa platform behavior in TextEdit, it&apos;s clearly
undesirable — see also, rdar://108701929.

This happens because we end up taking the `ReplaceSelectionCommand::performTrivialReplace` codepath
when pasting, where we simply swap out the text node&apos;s data with the pasted text.

While it might be nice to somehow keep the link element and replace the HREF to something that suits
the newly pasted text in this case, it&apos;s not clear we&apos;d be able to always choose a sensible new URL,
which might lead to more inconsistent behaviors. With respect to other browser engines&apos; behaviors in
this scenario on macOS (by pasting &quot;www.google.com&quot; over a link to &quot;<a href="https://www.apple.com&quot">https://www.apple.com&quot</a>; with text
&quot;www.apple.com&quot;):

•   Blink has the same bug as we do, except *slightly* more egregious — the visible text in the link
    gains a scheme (becoming &quot;<a href="http://www.google.com&quot">http://www.google.com&quot</a>;) when pasting, but the `href` still points to
    &quot;<a href="http://www.apple.com&quot">http://www.apple.com&quot</a>;.

•   Gecko simply replaces the link with newly inserted plain text, &quot;www.google.com&quot;.

Out of all the existing major browser behaviors, Gecko&apos;s seems like the most sensible; this patch
adjusts our logic to match Gecko&apos;s, by bailing from the `performTrivialReplace` codepath in cases
where we&apos;re fully replacing the contents of an enclosing link.

Test: editing/pasteboard/paste-text-in-link.html

* LayoutTests/editing/pasteboard/paste-text-in-link-expected.txt: Added.
* LayoutTests/editing/pasteboard/paste-text-in-link.html: Added.

Add a new layout test to exercise the change.

* Source/WebCore/editing/ReplaceSelectionCommand.cpp:
(WebCore::fullySelectsEnclosingLink):

Add a helper method to return whether or not the selection exactly encompasses the enclosing link&apos;s
content, by checking that the endpoints of the selection range are equal to the positions before and
after the link element.

(WebCore::ReplaceSelectionCommand::performTrivialReplace):

Avoid the trivial replacement codepath if the selection encloses a link.

Canonical link: <a href="https://commits.webkit.org/263539@main">https://commits.webkit.org/263539@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/45d429d1dc1d23654c00cf529b66d4ada4128538

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/4952 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/5078 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/5250 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/6469 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/5053 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/4946 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/5255 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/5050 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/5303 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/5038 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/5115 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/4438 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/6485 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/2603 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/4436 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/9424 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/4466 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/4508 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/6107 "run-api-tests-without-change (failure)") | 
| [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/4617 "Build is in progress. Recent messages:") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/4919 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/4018 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/4416 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/4430 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/1201 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/8485 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/4778 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->