### PR TITLE
Sanitize email input when multiple attribute is set

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-input-element/email-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-input-element/email-expected.txt
@@ -7,4 +7,5 @@ PASS When the multiple attribute is removed, the user agent must run the value s
 PASS multiple_email has the multiple attribute
 PASS run the value sanitization algorithm after setting a new value
 PASS valid value is a set of valid email addresses separated by a single ','
+PASS When the multiple attribute is set, the user agent must run the value sanitization algorithm
 

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-input-element/email.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-input-element/email.html
@@ -55,4 +55,12 @@
     mult.value = 'u,ser1@example.com,user2@test.com,user3@test.com';
     assert_false(mult.validity.valid);
   }, "valid value is a set of valid email addresses separated by a single ','");
+    
+  test(function(){
+    mult.removeAttribute('multiple');
+    mult.value = 'user1@example.com , user2@example.com';
+    assert_equals(mult.value, 'user1@example.com , user2@example.com');
+    mult.setAttribute('multiple', true);
+    assert_equals(mult.value, 'user1@example.com,user2@example.com');
+  }, 'When the multiple attribute is set, the user agent must run the value sanitization algorithm');
 </script>

--- a/Source/WebCore/html/EmailInputType.cpp
+++ b/Source/WebCore/html/EmailInputType.cpp
@@ -26,6 +26,7 @@
 #include "EmailInputType.h"
 
 #include "HTMLInputElement.h"
+#include "HTMLNames.h"
 #include "HTMLParserIdioms.h"
 #include "InputTypeNames.h"
 #include "LocalizedStrings.h"
@@ -34,6 +35,8 @@
 #include <wtf/text/StringBuilder.h>
 
 namespace WebCore {
+
+using namespace HTMLNames;
 
 // From https://html.spec.whatwg.org/#valid-e-mail-address.
 static constexpr ASCIILiteral emailPattern = "^[a-zA-Z0-9.!#$%&'*+\\/=?^_`{|}~-]+@[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?(?:\\.[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?)*$"_s;
@@ -86,6 +89,14 @@ String EmailInputType::typeMismatchText() const
 bool EmailInputType::supportsSelectionAPI() const
 {
     return false;
+}
+
+void EmailInputType::attributeChanged(const QualifiedName& name)
+{
+    if (name == multipleAttr)
+        element()->setValueFromRenderer(sanitizeValue(element()->value()));
+
+    BaseTextInputType::attributeChanged(name);
 }
 
 String EmailInputType::sanitizeValue(const String& proposedValue) const

--- a/Source/WebCore/html/EmailInputType.h
+++ b/Source/WebCore/html/EmailInputType.h
@@ -54,6 +54,7 @@ private:
     String typeMismatchText() const final;
     bool supportsSelectionAPI() const final;
     String sanitizeValue(const String&) const final;
+    void attributeChanged(const QualifiedName&) final;
 };
 
 } // namespace WebCore


### PR DESCRIPTION
#### 6ae622978d28c12e50253fab9c4cfc08bcffff1c
<pre>
Sanitize email input when multiple attribute is set
<a href="https://bugs.webkit.org/show_bug.cgi?id=256137">https://bugs.webkit.org/show_bug.cgi?id=256137</a>

Reviewed by Tim Nguyen and Chris Dumez.

The sanitizeValue function is now called when the multiple attribute is
changed. As per the spec <a href="https://html.spec.whatwg.org/#email-state-(type=email)">https://html.spec.whatwg.org/#email-state-(type=email)</a>

* LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-input-element/email-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-input-element/email.html:
* Source/WebCore/html/EmailInputType.cpp:
(WebCore::EmailInputType::attributeChanged):
* Source/WebCore/html/EmailInputType.h:

Canonical link: <a href="https://commits.webkit.org/263555@main">https://commits.webkit.org/263555@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c2aa2af7e2d240acc92af6693fd8ec0e773e1d31

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/5050 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/5180 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/5357 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/6570 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/5140 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/5043 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/5374 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/5155 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/5389 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/5136 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/5219 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/4531 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/6586 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/2706 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/4529 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/9542 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/4569 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/4602 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/6209 "Passed tests") | 
| [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/4654 "Build is in progress. Recent messages:") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/5015 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/4114 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/4501 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/4525 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/1213 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/8578 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/4867 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->