### PR TITLE
Support some WebKit-only counter styles using @counter-style

### DIFF
--- a/Source/WebCore/css/CSSCounterStyleRegistry.cpp
+++ b/Source/WebCore/css/CSSCounterStyleRegistry.cpp
@@ -171,54 +171,42 @@ bool isCounterStyleUnsupportedByUserAgent(CSSValueID valueID)
 {
     // This list has to be in sync with styles defined in counterStyles.css, once a style is added there, remove it from here.
     switch (valueID) {
-    // FIXME: transform hard-coded styles into @counter-styles when possible (rdar://106708729).
-    case CSSValueBinary:
-    case CSSValueLowerHexadecimal:
-    case CSSValueOctal:
-    case CSSValueOriya:
-    case CSSValueUrdu:
-    case CSSValueUpperHexadecimal:
-    case CSSValueAfar:
-    case CSSValueEthiopicHalehameAaEt:
-    case CSSValueEthiopicHalehameAaEr:
+    // FIXME: Review correctness of Ethiopian counter styles (rdar://108704382).
     case CSSValueAmharic:
-    case CSSValueEthiopicHalehameAmEt:
     case CSSValueAmharicAbegede:
-    case CSSValueEthiopicAbegedeAmEt:
+    case CSSValueAfar:
     case CSSValueEthiopic:
-    case CSSValueEthiopicHalehameGez:
     case CSSValueEthiopicAbegede:
+    case CSSValueEthiopicAbegedeAmEt:
     case CSSValueEthiopicAbegedeGez:
-    case CSSValueHangulConsonant:
-    case CSSValueHangul:
-    case CSSValueLowerNorwegian:
-    case CSSValueOromo:
-    case CSSValueEthiopicHalehameOmEt:
-    case CSSValueSidama:
-    case CSSValueEthiopicHalehameSidEt:
-    case CSSValueSomali:
-    case CSSValueEthiopicHalehameSoEt:
-    case CSSValueTigre:
-    case CSSValueEthiopicHalehameTig:
-    case CSSValueTigrinyaEr:
-    case CSSValueEthiopicHalehameTiEr:
-    case CSSValueTigrinyaErAbegede:
     case CSSValueEthiopicAbegedeTiEr:
-    case CSSValueTigrinyaEt:
-    case CSSValueEthiopicHalehameTiEt:
-    case CSSValueTigrinyaEtAbegede:
     case CSSValueEthiopicAbegedeTiEt:
-    case CSSValueUpperGreek:
-    case CSSValueUpperNorwegian:
-    case CSSValueAsterisks:
-    case CSSValueFootnotes:
+    case CSSValueEthiopicHalehameAaEr:
+    case CSSValueEthiopicHalehameAaEt:
+    case CSSValueEthiopicHalehameAmEt:
+    case CSSValueEthiopicHalehameGez:
+    case CSSValueEthiopicHalehameOmEt:
+    case CSSValueEthiopicHalehameSidEt:
+    case CSSValueEthiopicHalehameSoEt:
+    case CSSValueEthiopicHalehameTiEr:
+    case CSSValueEthiopicHalehameTiEt:
+    case CSSValueEthiopicHalehameTig:
+    case CSSValueOromo:
+    case CSSValueSidama:
+    case CSSValueSomali:
+    case CSSValueTigre:
+    case CSSValueTigrinyaEr:
+    case CSSValueTigrinyaErAbegede:
+    case CSSValueTigrinyaEt:
+    case CSSValueTigrinyaEtAbegede:
+    // Complex styles that use custom algorithms (rdar://103021467).
     case CSSValueCjkIdeographic:
     case CSSValueSimpChineseInformal:
     case CSSValueSimpChineseFormal:
     case CSSValueTradChineseInformal:
     case CSSValueTradChineseFormal:
     case CSSValueEthiopicNumeric:
-    // FIXME: enable korean styles rdar://106193134.
+    // FIXME: Enable Korean styles (rdar://106193134).
     case CSSValueKoreanHangulFormal:
     case CSSValueKoreanHanjaFormal:
     case CSSValueKoreanHanjaInformal:

--- a/Source/WebCore/css/counterStyles.css
+++ b/Source/WebCore/css/counterStyles.css
@@ -22,9 +22,9 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
- /* https://www.w3.org/TR/css-counter-styles-3/#predefined-counters */
-
 /* Once a style is added here, make sure it is not listed at isCounterStyleUnsupportedByUserAgent() */
+
+/*** Built-in the spec: https://www.w3.org/TR/css-counter-styles-3/#predefined-counters ***/
 
 @counter-style decimal {
     system: numeric;
@@ -354,4 +354,86 @@
     suffix: ', ';
     negative: "\B9C8\C774\B108\C2A4  ";
     /* 마이너스 (followed by a space) */
+}
+
+
+/*** Subset of Ready-made Counter Styles: https://www.w3.org/TR/predefined-counter-styles/ ***/
+
+@counter-style binary {
+    system: numeric;
+    symbols: '\30' '\31';
+    /* symbols: '0' '1' */
+}
+
+@counter-style lower-hexadecimal {
+    system: numeric;
+    symbols: '\30' '\31' '\32' '\33' '\34' '\35' '\36' '\37' '\38' '\39' '\61' '\62' '\63' '\64' '\65' '\66';
+    /* '0' '1' '2' '3' '4' '5' '6' '7' '8' '9' 'a' 'b' 'c' 'd' 'e' 'f' */
+}
+
+@counter-style upper-hexadecimal {
+    system: numeric;
+    symbols: '\30' '\31' '\32' '\33' '\34' '\35' '\36' '\37' '\38' '\39' '\41' '\42' '\43' '\44' '\45' '\46';
+    /* '0' '1' '2' '3' '4' '5' '6' '7' '8' '9' 'A' 'B' 'C' 'D' 'E' 'F' */
+}
+
+@counter-style octal {
+    system: numeric;
+    symbols: '\30' '\31' '\32' '\33' '\34' '\35' '\36' '\37';
+    /* '0' '1' '2' '3' '4' '5' '6' '7' */
+}
+
+@counter-style hangul {
+    system: alphabetic;
+    symbols: '\AC00' '\B098' '\B2E4' '\B77C' '\B9C8' '\BC14' '\C0AC' '\C544' '\C790' '\CC28' '\CE74' '\D0C0' '\D30C' '\D558';
+    /* '가' '나' '다' '라' '마' '바' '사' '아' '자' '차' '카' '타' '파' '하' */
+}
+
+@counter-style hangul-consonant {
+    system: alphabetic;
+    symbols: '\3131' '\3134' '\3137' '\3139' '\3141' '\3142' '\3145' '\3147' '\3148' '\314A' '\314B' '\314C' '\314D' '\314E';
+    /* 'ㄱ' 'ㄴ' 'ㄷ' 'ㄹ' 'ㅁ' 'ㅂ' 'ㅅ' 'ㅇ' 'ㅈ' 'ㅊ' 'ㅋ' 'ㅌ' 'ㅍ' 'ㅎ' */
+}
+
+/*** WebKit specific ***/
+
+@counter-style asterisks {
+    system: symbolic;
+    symbols: '\2A';
+    /* '*' */
+    suffix: ' ';
+}
+
+@counter-style footnotes {
+    system: symbolic;
+    symbols: '\2A' '\2051' '\2020' '\2021';
+    /* '*' '⁑' '†' '‡' */
+    suffix: ' ';
+}
+
+@counter-style lower-norwegian {
+    system: alphabetic;
+    symbols: '\61' '\62' '\63' '\64' '\65' '\66' '\67' '\68' '\69' '\6A' '\6B' '\6C' '\6D' '\6E' '\6F' '\70' '\71' '\72' '\73' '\74' '\75' '\76' '\77' '\78' '\79' '\7A' '\E6' '\F8' '\E5';
+    /* 'a' 'b' 'c' 'd' 'e' 'f' 'g' 'h' 'i' 'j' 'k' 'l' 'm' 'n' 'o' 'p' 'q' 'r' 's' 't' 'u' 'v' 'w' 'x' 'y' 'z' 'æ' 'ø' 'å' */
+    suffix: ' ';
+}
+
+@counter-style upper-greek {
+    system: alphabetic;
+    symbols: '\0391' '\0392' '\0393' '\0394' '\0395' '\0396' '\0397' '\0398' '\0399' '\039A' '\039B' '\039C' '\039D' '\039E' '\039F' '\03A0' '\03A1' '\03A3' '\03A4' '\03A5' '\03A6' '\03A7' '\03A8' '\03A9';
+    /* 'Α' 'Β' 'Γ' 'Δ' 'Ε' 'Ζ' 'Η' 'Θ' 'Ι' 'Κ' 'Λ' 'Μ' 'Ν' 'Ξ' 'Ο' 'Π' 'Ρ' 'Σ' 'Τ' 'Υ' 'Φ' 'Χ' 'Ψ' 'Ω' */
+}
+
+@counter-style upper-norwegian {
+    system: alphabetic;
+    symbols: '\41' '\42' '\43' '\44' '\45' '\46' '\47' '\48' '\49' '\4A' '\4B' '\4C' '\4D' '\4E' '\4F' '\50' '\51' '\52' '\53' '\54' '\55' '\56' '\57' '\58' '\59' '\5A' '\C6' '\D8' '\C5';
+    /* 'A' 'B' 'C' 'D' 'E' 'F' 'G' 'H' 'I' 'J' 'K' 'L' 'M' 'N' 'O' 'P' 'Q' 'R' 'S' 'T' 'U' 'V' 'W' 'X' 'Y' 'Z' 'Æ' 'Ø' 'Å' */
+    suffix: ' ';
+}
+
+/* identical to persian in the spec */
+@counter-style urdu {
+    system: numeric;
+    symbols: '\6F0' '\6F1' '\6F2' '\6F3' '\6F4' '\6F5' '\6F6' '\6F7' '\6F8' '\6F9';
+    /* '۰' '۱' '۲' '۳' '۴' '۵' '۶' '۷' '۸' '۹' */
 }


### PR DESCRIPTION
#### b6e0a72bbf0a1a33ab4d3c6d6f58897dd2ba9c94
<pre>
Support some WebKit-only counter styles using @counter-style
<a href="https://bugs.webkit.org/show_bug.cgi?id=256140">https://bugs.webkit.org/show_bug.cgi?id=256140</a>
rdar://106708729

Reviewed by Myles C. Maxfield.

Add all non-ethiopian WebKit-only counter styles into counterStyles.css.
Some are sourced from <a href="https://www.w3.org/TR/predefined-counter-styles/">https://www.w3.org/TR/predefined-counter-styles/</a> , some other are sourced directly from RenderListMarker.

All the ported counter-styles are covered by layout tests in fast/lists/.

Ethiopian counter styles haven&apos;t been ported because of some inconsistencies between the W3C predefined counter styles and the WebKit implementation.
rdar://108704382 has been filed to port those.

* Source/WebCore/css/CSSCounterStyleRegistry.cpp:
(WebCore::isCounterStyleUnsupportedByUserAgent):
* Source/WebCore/css/counterStyles.css:
(@counter-style binary):
(@counter-style lower-hexadecimal):
(@counter-style upper-hexadecimal):
(@counter-style octal):
(@counter-style hangul):
(@counter-style hangul-consonant):
(@counter-style asterisks):
(@counter-style footnotes):
(@counter-style lower-norwegian):
(@counter-style upper-greek):
(@counter-style upper-norwegian):
(@counter-style urdu):

Canonical link: <a href="https://commits.webkit.org/263537@main">https://commits.webkit.org/263537@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/55306a8a61b2df18d0ce9022d0b9d061c4f03224

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/4943 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/5069 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/5241 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/6460 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/5047 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/4937 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/5244 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/5041 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/5293 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/5029 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/5106 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/4430 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/6476 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/2594 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/4428 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/9387 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/4457 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/4500 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/6095 "Passed tests") | 
| [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/4613 "Build is in progress. Recent messages:") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/4911 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/4011 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/4409 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/1200 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/8478 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/4771 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->