### PR TITLE
[WTF] Avoid MonotonicTime::now / WallTime::now calls if relative seconds are infinity

### DIFF
--- a/Source/JavaScriptCore/runtime/WaiterListManager.cpp
+++ b/Source/JavaScriptCore/runtime/WaiterListManager.cpp
@@ -55,7 +55,7 @@ WaiterListManager::WaitSyncResult WaiterListManager::waitSyncImpl(VM& vm, ValueT
 {
     Ref<Waiter> syncWaiter = vm.syncWaiter();
     Ref<WaiterList> list = findOrCreateList(ptr);
-    MonotonicTime time = MonotonicTime::now() + timeout;
+    MonotonicTime time = MonotonicTime::timePointFromNow(timeout);
 
     {
         Locker listLocker { list->lock };

--- a/Source/JavaScriptCore/runtime/Watchdog.cpp
+++ b/Source/JavaScriptCore/runtime/Watchdog.cpp
@@ -70,7 +70,7 @@ bool Watchdog::shouldTerminate(JSGlobalObject* globalObject)
     // but it is a fact that only Windows is experiencing the issue.
     epsilon = Seconds::fromMilliseconds(20);
 #endif
-    if (MonotonicTime::now() + epsilon < m_deadline)
+    if (MonotonicTime::timePointFromNow(epsilon) < m_deadline)
         return false; // Just a stale timer firing. Nothing to do.
 
     // Set m_deadline to MonotonicTime::infinity() here so that we can reject all future

--- a/Source/WTF/wtf/ApproximateTime.cpp
+++ b/Source/WTF/wtf/ApproximateTime.cpp
@@ -34,11 +34,15 @@ namespace WTF {
 
 WallTime ApproximateTime::approximateWallTime() const
 {
+    if (std::isinf(*this))
+        return WallTime::fromRawSeconds(m_value);
     return *this - now() + WallTime::now();
 }
 
 MonotonicTime ApproximateTime::approximateMonotonicTime() const
 {
+    if (std::isinf(*this))
+        return MonotonicTime::fromRawSeconds(m_value);
     return *this - now() + MonotonicTime::now();
 }
 

--- a/Source/WTF/wtf/Condition.h
+++ b/Source/WTF/wtf/Condition.h
@@ -96,24 +96,24 @@ public:
     template<typename LockType, typename Functor>
     bool waitFor(LockType& lock, Seconds relativeTimeout, const Functor& predicate)
     {
-        return waitUntil(lock, MonotonicTime::now() + relativeTimeout, predicate);
+        return waitUntil(lock, MonotonicTime::timePointFromNow(relativeTimeout), predicate);
     }
 
     template<typename Functor>
     bool waitFor(Lock& lock, Seconds relativeTimeout, const Functor& predicate) WTF_REQUIRES_LOCK(lock)
     {
-        return waitUntil(lock, MonotonicTime::now() + relativeTimeout, predicate);
+        return waitUntil(lock, MonotonicTime::timePointFromNow(relativeTimeout), predicate);
     }
     
     template<typename LockType>
     bool waitFor(LockType& lock, Seconds relativeTimeout)
     {
-        return waitUntil(lock, MonotonicTime::now() + relativeTimeout);
+        return waitUntil(lock, MonotonicTime::timePointFromNow(relativeTimeout));
     }
 
     bool waitFor(Lock& lock, Seconds relativeTimeout) WTF_REQUIRES_LOCK(lock)
     {
-        return waitUntil(lock, MonotonicTime::now() + relativeTimeout);
+        return waitUntil(lock, MonotonicTime::timePointFromNow(relativeTimeout));
     }
 
     template<typename LockType>

--- a/Source/WTF/wtf/GenericTimeMixin.h
+++ b/Source/WTF/wtf/GenericTimeMixin.h
@@ -119,6 +119,13 @@ public:
         return *static_cast<const DerivedTime*>(this);
     }
 
+    static constexpr DerivedTime timePointFromNow(Seconds relativeTimeFromNow)
+    {
+        if (std::isinf(relativeTimeFromNow))
+            return DerivedTime::fromRawSeconds(relativeTimeFromNow.value());
+        return DerivedTime::now() + relativeTimeFromNow;
+    }
+
 protected:
     // This is the epoch. So, x.secondsSinceEpoch() should be the same as x - DerivedTime().
     constexpr GenericTimeMixin() = default;

--- a/Source/WTF/wtf/MessageQueue.h
+++ b/Source/WTF/wtf/MessageQueue.h
@@ -141,7 +141,7 @@ namespace WTF {
         Locker lock { m_lock };
         bool timedOut = false;
 
-        MonotonicTime absoluteTimeout = MonotonicTime::now() + relativeTimeout;
+        MonotonicTime absoluteTimeout = MonotonicTime::timePointFromNow(relativeTimeout);
         auto found = m_queue.end();
         while (!m_killed && !timedOut) {
             found = m_queue.findIf([&predicate](const std::unique_ptr<DataType>& ptr) -> bool {

--- a/Source/WTF/wtf/MonotonicTime.cpp
+++ b/Source/WTF/wtf/MonotonicTime.cpp
@@ -33,6 +33,8 @@ namespace WTF {
 
 WallTime MonotonicTime::approximateWallTime() const
 {
+    if (std::isinf(*this))
+        return WallTime::fromRawSeconds(m_value);
     return *this - now() + WallTime::now();
 }
 

--- a/Source/WTF/wtf/ParkingLot.cpp
+++ b/Source/WTF/wtf/ParkingLot.cpp
@@ -592,9 +592,8 @@ NEVER_INLINE ParkingLot::ParkResult ParkingLot::parkConditionallyImpl(
     {
         MutexLocker locker(me->parkingLock);
         while (me->address && timeout.nowWithSameClock() < timeout) {
-            me->parkingCondition.timedWait(
-                me->parkingLock, timeout.approximateWallTime());
-            
+            me->parkingCondition.timedWait(me->parkingLock, timeout.approximateWallTime());
+
             // It's possible for the OS to decide not to wait. If it does that then it will also
             // decide not to release the lock. If there's a bug in the time math, then this could
             // result in a deadlock. Flashing the lock means that at worst it's just a CPU-eating

--- a/Source/WTF/wtf/WTFSemaphore.h
+++ b/Source/WTF/wtf/WTFSemaphore.h
@@ -61,7 +61,7 @@ public:
 
     bool waitFor(Seconds relativeTimeout)
     {
-        return waitUntil(MonotonicTime::now() + relativeTimeout);
+        return waitUntil(MonotonicTime::timePointFromNow(relativeTimeout));
     }
 
     void wait()

--- a/Source/WTF/wtf/WallTime.cpp
+++ b/Source/WTF/wtf/WallTime.cpp
@@ -33,6 +33,8 @@ namespace WTF {
 
 MonotonicTime WallTime::approximateMonotonicTime() const
 {
+    if (std::isinf(*this))
+        return MonotonicTime::fromRawSeconds(m_value);
     return *this - now() + MonotonicTime::now();
 }
 

--- a/Source/WTF/wtf/posix/ThreadingPOSIX.cpp
+++ b/Source/WTF/wtf/posix/ThreadingPOSIX.cpp
@@ -606,6 +606,13 @@ void ThreadCondition::wait(Mutex& mutex)
 
 bool ThreadCondition::timedWait(Mutex& mutex, WallTime absoluteTime)
 {
+    if (std::isinf(absoluteTime)) {
+        if (absoluteTime == -WallTime::infinity())
+            return false;
+        wait(mutex);
+        return true;
+    }
+
     if (absoluteTime < WallTime::now())
         return false;
 

--- a/Source/WTF/wtf/threads/BinarySemaphore.h
+++ b/Source/WTF/wtf/threads/BinarySemaphore.h
@@ -43,7 +43,7 @@ public:
 
     bool waitFor(Seconds relativeTimeout)
     {
-        return waitUntil(MonotonicTime::now() + relativeTimeout);
+        return waitUntil(MonotonicTime::timePointFromNow(relativeTimeout));
     }
 
     void wait()

--- a/Source/WTF/wtf/win/RunLoopWin.cpp
+++ b/Source/WTF/wtf/win/RunLoopWin.cpp
@@ -147,7 +147,7 @@ void RunLoop::TimerBase::timerFired()
             m_isActive = false;
             ::KillTimer(m_runLoop->m_runLoopMessageWindow, bitwise_cast<uintptr_t>(this));
         } else
-            m_nextFireDate = MonotonicTime::now() + m_interval;
+            m_nextFireDate = MonotonicTime::timePointFromNow(m_interval);
     }
 
     fired();
@@ -169,7 +169,7 @@ void RunLoop::TimerBase::start(Seconds interval, bool repeat)
     m_isRepeating = repeat;
     m_isActive = true;
     m_interval = interval;
-    m_nextFireDate = MonotonicTime::now() + m_interval;
+    m_nextFireDate = MonotonicTime::timePointFromNow(m_interval);
     ::SetTimer(m_runLoop->m_runLoopMessageWindow, bitwise_cast<uintptr_t>(this), interval.millisecondsAs<UINT>(), nullptr);
 }
 

--- a/Source/WTF/wtf/win/ThreadingWin.cpp
+++ b/Source/WTF/wtf/win/ThreadingWin.cpp
@@ -351,6 +351,12 @@ void Mutex::unlock()
 // Returns an interval in milliseconds suitable for passing to one of the Win32 wait functions (e.g., ::WaitForSingleObject).
 static DWORD absoluteTimeToWaitTimeoutInterval(WallTime absoluteTime)
 {
+    if (std::isinf(absoluteTime)) {
+        if (absoluteTime == -WallTime::infinity())
+            return 0;
+        return INFINITE;
+    }
+
     WallTime currentTime = WallTime::now();
 
     // Time is in the past - return immediately.

--- a/Source/WebCore/platform/graphics/cocoa/WebProcessGraphicsContextGLCocoa.mm
+++ b/Source/WebCore/platform/graphics/cocoa/WebProcessGraphicsContextGLCocoa.mm
@@ -59,7 +59,7 @@ public:
     bool waitFor(Seconds timeout) final
     {
         Locker locker { m_lock };
-        auto absoluteTime = MonotonicTime::now() + timeout;
+        auto absoluteTime = MonotonicTime::timePointFromNow(timeout);
         return m_condition.waitUntil(m_lock, absoluteTime, [&] {
             assertIsHeld(m_lock);
             return m_isSet;


### PR DESCRIPTION
#### ab0f8a142a9441282025b9a77c4c37cf453a794b
<pre>
[WTF] Avoid MonotonicTime::now / WallTime::now calls if relative seconds are infinity
<a href="https://bugs.webkit.org/show_bug.cgi?id=256143">https://bugs.webkit.org/show_bug.cgi?id=256143</a>
rdar://108706987

Reviewed by Mark Lam.

This is micro-optimization. If relative seconds from now is infinity, we should not call MonotonicTime::now() / WallTime::now()
to compute the result. They involve system calls, and it is common that relative seconds are infinity (for example, just waiting
Condition without timeout is infinity).

* Source/WTF/wtf/ApproximateTime.cpp:
(WTF::ApproximateTime::approximateWallTime const):
(WTF::ApproximateTime::approximateMonotonicTime const):
* Source/WTF/wtf/Condition.h:
* Source/WTF/wtf/GenericTimeMixin.h:
(WTF::GenericTimeMixin::timePointFromNow):
* Source/WTF/wtf/MessageQueue.h:
(WTF::MessageQueue&lt;DataType&gt;::waitForMessageFilteredWithTimeout):
* Source/WTF/wtf/MonotonicTime.cpp:
(WTF::MonotonicTime::approximateWallTime const):
* Source/WTF/wtf/ParkingLot.cpp:
(WTF::ParkingLot::parkConditionallyImpl):
* Source/WTF/wtf/WTFSemaphore.h:
* Source/WTF/wtf/WallTime.cpp:
(WTF::WallTime::approximateMonotonicTime const):
* Source/WTF/wtf/threads/BinarySemaphore.h:
* Source/WTF/wtf/win/RunLoopWin.cpp:
(WTF::RunLoop::TimerBase::timerFired):
(WTF::RunLoop::TimerBase::start):

Canonical link: <a href="https://commits.webkit.org/263538@main">https://commits.webkit.org/263538@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/054b98399397c70255bdbb8d3d905df9f5c62c29

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/4957 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/5083 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/5255 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/6474 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/5056 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/4951 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/5261 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/5055 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/5305 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/5043 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/5119 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/4443 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/6490 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/2607 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/4441 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/9430 "Passed tests") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/4108 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/4470 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/4513 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/6113 "Passed tests") | 
| [  ~~🛠 🧪 jsc-arm64~~](https://ews-build.webkit.org/#/builders/12/builds/4618 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/4922 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/4023 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/5049 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/4418 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/1256 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/8488 "Built successfully") | | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/24/builds/5191 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/562 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/4781 "Built successfully") | | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/3/builds/1372 "Passed tests") | 
<!--EWS-Status-Bubble-End-->