### PR TITLE
[GStreamer] Improvements regarding track configuration updates

### DIFF
--- a/LayoutTests/platform/glib/TestExpectations
+++ b/LayoutTests/platform/glib/TestExpectations
@@ -1098,9 +1098,6 @@ imported/w3c/web-platform-tests/video-rvfc/request-video-frame-callback-webrtc.h
 imported/w3c/web-platform-tests/video-rvfc/request-video-frame-callback-before-xr-session.https.html [ Skip ]
 imported/w3c/web-platform-tests/video-rvfc/request-video-frame-callback-during-xr-session.https.html [ Skip ]
 
-# Expected to pass when we enable playbin3 by default and update the SDK to GStreamer 1.20.
-webkit.org/b/234084 media/track/audio-track-configuration.html [ Failure ]
-
 # Expected to pass when we enable playbin3 by default.
 webkit.org/b/131546 media/track/track-in-band-cues-added-once.html [ Timeout Crash ]
 webkit.org/b/131546 webkit.org/b/198830 media/track/track-in-band-legacy-api.html [ Failure Crash ]

--- a/Source/WebCore/platform/graphics/gstreamer/AudioTrackPrivateGStreamer.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/AudioTrackPrivateGStreamer.cpp
@@ -31,70 +31,91 @@
 
 #include "GStreamerCommon.h"
 #include "MediaPlayerPrivateGStreamer.h"
-#include <gst/pbutils/pbutils.h>
 #include <wtf/Scope.h>
 
 namespace WebCore {
+
+GST_DEBUG_CATEGORY(webkit_audio_track_debug);
+#define GST_CAT_DEFAULT webkit_audio_track_debug
+
+static void ensureDebugCategoryInitialized()
+{
+    static std::once_flag debugRegisteredFlag;
+    std::call_once(debugRegisteredFlag, [] {
+        GST_DEBUG_CATEGORY_INIT(webkit_audio_track_debug, "webkitaudiotrack", 0, "WebKit Audio Track");
+    });
+}
 
 AudioTrackPrivateGStreamer::AudioTrackPrivateGStreamer(WeakPtr<MediaPlayerPrivateGStreamer> player, unsigned index, GRefPtr<GstPad>&& pad, bool shouldHandleStreamStartEvent)
     : TrackPrivateBaseGStreamer(TrackPrivateBaseGStreamer::TrackType::Audio, this, index, WTFMove(pad), shouldHandleStreamStartEvent)
     , m_player(player)
 {
+    ensureDebugCategoryInitialized();
 }
 
 AudioTrackPrivateGStreamer::AudioTrackPrivateGStreamer(WeakPtr<MediaPlayerPrivateGStreamer> player, unsigned index, GstStream* stream)
     : TrackPrivateBaseGStreamer(TrackPrivateBaseGStreamer::TrackType::Audio, this, index, stream)
     , m_player(player)
 {
-    int kind;
-    auto tags = adoptGRef(gst_stream_get_tags(m_stream.get()));
-
-    if (tags && gst_tag_list_get_int(tags.get(), "webkit-media-stream-kind", &kind) && kind == static_cast<int>(AudioTrackPrivate::Kind::Main)) {
-        auto streamFlags = gst_stream_get_stream_flags(m_stream.get());
-        gst_stream_set_stream_flags(m_stream.get(), static_cast<GstStreamFlags>(streamFlags | GST_STREAM_FLAG_SELECT));
-    }
-
+    ensureDebugCategoryInitialized();
     g_signal_connect_swapped(m_stream.get(), "notify::caps", G_CALLBACK(+[](AudioTrackPrivateGStreamer* track) {
         track->m_taskQueue.enqueueTask([track]() {
-            track->updateConfigurationFromCaps();
+            auto caps = adoptGRef(gst_stream_get_caps(track->m_stream.get()));
+            track->capsChanged(String::fromLatin1(gst_stream_get_stream_id(track->m_stream.get())), caps);
         });
     }), this);
     g_signal_connect_swapped(m_stream.get(), "notify::tags", G_CALLBACK(+[](AudioTrackPrivateGStreamer* track) {
         track->m_taskQueue.enqueueTask([track]() {
-            track->updateConfigurationFromTags();
+            auto tags = adoptGRef(gst_stream_get_tags(track->m_stream.get()));
+            track->updateConfigurationFromTags(tags);
         });
     }), this);
 
-    updateConfigurationFromCaps();
-    updateConfigurationFromTags();
-}
-
-void AudioTrackPrivateGStreamer::updateConfigurationFromTags()
-{
-    ASSERT(isMainThread());
-    if (!m_stream)
-        return;
+    auto caps = adoptGRef(gst_stream_get_caps(m_stream.get()));
+    updateConfigurationFromCaps(caps);
 
     auto tags = adoptGRef(gst_stream_get_tags(m_stream.get()));
-    unsigned bitrate;
-    if (!tags || !gst_tag_list_get_uint(tags.get(), GST_TAG_BITRATE, &bitrate))
+    updateConfigurationFromTags(tags);
+}
+
+void AudioTrackPrivateGStreamer::capsChanged(const String& streamId, const GRefPtr<GstCaps>& caps)
+{
+    ASSERT(isMainThread());
+    updateConfigurationFromCaps(caps);
+
+    auto codec = m_player->codecForStreamId(streamId);
+    if (codec.isEmpty())
+        return;
+    GST_DEBUG_OBJECT(objectForLogging(), "Setting codec to %s", codec.ascii().data());
+    auto configuration = this->configuration();
+    configuration.codec = WTFMove(codec);
+    setConfiguration(WTFMove(configuration));
+}
+
+void AudioTrackPrivateGStreamer::updateConfigurationFromTags(const GRefPtr<GstTagList>& tags)
+{
+    ASSERT(isMainThread());
+    GST_DEBUG_OBJECT(objectForLogging(), "Updating audio configuration from %" GST_PTR_FORMAT, tags.get());
+    if (!tags)
         return;
 
+    unsigned bitrate;
+    if (!gst_tag_list_get_uint(tags.get(), GST_TAG_BITRATE, &bitrate))
+        return;
+
+    GST_DEBUG_OBJECT(objectForLogging(), "Setting bitrate to %u", bitrate);
     auto configuration = this->configuration();
     configuration.bitrate = bitrate;
     setConfiguration(WTFMove(configuration));
 }
 
-void AudioTrackPrivateGStreamer::updateConfigurationFromCaps()
+void AudioTrackPrivateGStreamer::updateConfigurationFromCaps(const GRefPtr<GstCaps>& caps)
 {
     ASSERT(isMainThread());
-    if (!m_stream)
-        return;
-
-    auto caps = adoptGRef(gst_stream_get_caps(m_stream.get()));
     if (!caps || !gst_caps_is_fixed(caps.get()))
         return;
 
+    GST_DEBUG_OBJECT(objectForLogging(), "Updating audio configuration from %" GST_PTR_FORMAT, caps.get());
     auto configuration = this->configuration();
     auto scopeExit = makeScopeExit([&] {
         setConfiguration(WTFMove(configuration));
@@ -115,11 +136,6 @@ void AudioTrackPrivateGStreamer::updateConfigurationFromCaps()
         configuration.sampleRate = GST_AUDIO_INFO_RATE(&info);
         configuration.numberOfChannels = GST_AUDIO_INFO_CHANNELS(&info);
     }
-
-#if GST_CHECK_VERSION(1, 20, 0)
-    GUniquePtr<char> codec(gst_codec_utils_caps_get_mime_codec(caps.get()));
-    configuration.codec = String::fromLatin1(codec.get());
-#endif
 }
 
 AudioTrackPrivate::Kind AudioTrackPrivateGStreamer::kind() const

--- a/Source/WebCore/platform/graphics/gstreamer/AudioTrackPrivateGStreamer.h
+++ b/Source/WebCore/platform/graphics/gstreamer/AudioTrackPrivateGStreamer.h
@@ -27,7 +27,6 @@
 
 #if ENABLE(VIDEO) && USE(GSTREAMER)
 
-#include "AbortableTaskQueue.h"
 #include "AudioTrackPrivate.h"
 #include "TrackPrivateBaseGStreamer.h"
 
@@ -60,11 +59,13 @@ public:
     AtomString id() const final { return m_id; }
     AtomString label() const final { return m_label; }
     AtomString language() const final { return m_language; }
-    AbortableTaskQueue m_taskQueue;
 
 protected:
-    void updateConfigurationFromCaps();
-    void updateConfigurationFromTags();
+    void updateConfigurationFromCaps(const GRefPtr<GstCaps>&);
+    void updateConfigurationFromTags(const GRefPtr<GstTagList>&);
+
+    void tagsChanged(const GRefPtr<GstTagList>& tags) final { updateConfigurationFromTags(tags); }
+    void capsChanged(const String& streamId, const GRefPtr<GstCaps>&) final;
 
 private:
     AudioTrackPrivateGStreamer(WeakPtr<MediaPlayerPrivateGStreamer>, unsigned index, GRefPtr<GstPad>&&, bool shouldHandleStreamStartEvent);

--- a/Source/WebCore/platform/graphics/gstreamer/MediaPlayerPrivateGStreamer.h
+++ b/Source/WebCore/platform/graphics/gstreamer/MediaPlayerPrivateGStreamer.h
@@ -248,6 +248,8 @@ public:
     // to avoid deadlocks from threads in the playback pipeline waiting for the main thread.
     AbortableTaskQueue& sinkTaskQueue() { return m_sinkTaskQueue; }
 
+    String codecForStreamId(const String& streamId);
+
 protected:
     enum MainThreadNotification {
         VideoChanged = 1 << 0,
@@ -485,6 +487,7 @@ private:
     void configureDownloadBuffer(GstElement*);
     static void downloadBufferFileCreatedCallback(MediaPlayerPrivateGStreamer*);
 
+    void configureAudioDecoder(GstElement*);
     void configureVideoDecoder(GstElement*);
     void configureElement(GstElement*);
 #if PLATFORM(BROADCOM) || USE(WESTEROS_SINK) || PLATFORM(AMLOGIC) || PLATFORM(REALTEK)
@@ -614,6 +617,9 @@ private:
     // Specific to MediaStream playback.
     MediaTime m_startTime;
     MediaTime m_pausedTime;
+
+    void setupCodecProbe(GstElement*);
+    HashMap<String, String> m_codecs;
 };
 
 }

--- a/Source/WebCore/platform/graphics/gstreamer/TrackPrivateBaseGStreamer.h
+++ b/Source/WebCore/platform/graphics/gstreamer/TrackPrivateBaseGStreamer.h
@@ -27,6 +27,7 @@
 
 #if ENABLE(VIDEO) && USE(GSTREAMER)
 
+#include "AbortableTaskQueue.h"
 #include "GStreamerCommon.h"
 #include "MainThreadNotifier.h"
 #include <gst/gst.h>
@@ -73,6 +74,11 @@ protected:
     void notifyTrackOfTagsChanged();
     void notifyTrackOfStreamChanged();
 
+    GstObject* objectForLogging() const;
+
+    virtual void tagsChanged(const GRefPtr<GstTagList>&) { }
+    virtual void capsChanged(const String&, const GRefPtr<GstCaps>&) { }
+
     enum MainThreadNotification {
         TagsChanged = 1 << 1,
         NewSample = 1 << 2,
@@ -89,6 +95,7 @@ protected:
     GRefPtr<GstStream> m_stream;
     unsigned long m_eventProbe { 0 };
     GRefPtr<GstCaps> m_initialCaps;
+    AbortableTaskQueue m_taskQueue;
 
 private:
     bool getLanguageCode(GstTagList* tags, AtomString& value);

--- a/Source/WebCore/platform/graphics/gstreamer/VideoTrackPrivateGStreamer.h
+++ b/Source/WebCore/platform/graphics/gstreamer/VideoTrackPrivateGStreamer.h
@@ -27,7 +27,6 @@
 
 #if ENABLE(VIDEO) && USE(GSTREAMER)
 
-#include "AbortableTaskQueue.h"
 #include "GStreamerCommon.h"
 #include "TrackPrivateBaseGStreamer.h"
 #include "VideoTrackPrivate.h"
@@ -61,11 +60,13 @@ public:
     AtomString id() const final { return m_id; }
     AtomString label() const final { return m_label; }
     AtomString language() const final { return m_language; }
-    AbortableTaskQueue m_taskQueue;
 
 protected:
-    void updateConfigurationFromCaps();
-    void updateConfigurationFromTags();
+    void updateConfigurationFromCaps(const GRefPtr<GstCaps>&);
+    void updateConfigurationFromTags(const GRefPtr<GstTagList>&);
+
+    void tagsChanged(const GRefPtr<GstTagList>& tags) final { updateConfigurationFromTags(tags); }
+    void capsChanged(const String&, const GRefPtr<GstCaps>&) final;
 
 private:
     VideoTrackPrivateGStreamer(WeakPtr<MediaPlayerPrivateGStreamer>, unsigned index, GRefPtr<GstPad>&&, bool shouldHandleStreamStartEvent);


### PR DESCRIPTION
#### 6c181705f176c643952399c00565224aec8b1f14
<pre>
[GStreamer] Improvements regarding track configuration updates
<a href="https://bugs.webkit.org/show_bug.cgi?id=256147">https://bugs.webkit.org/show_bug.cgi?id=256147</a>

Reviewed by Xabier Rodriguez-Calvar.

When playbin2 is used for playback the pad associated to each track has raw caps, so the pbutils
caps-&gt;codec API is useless since it expects caps representing an encoded format. So we now monitor
the sink pad of each decoder in the player, waiting for the first caps event and we cache the
streamId and corresponding codec, that can be later on retrieved from each track in order to update
the configuration accordingly.

In practice this patch also makes the modern media controls video stats overlay actually useful. It
was nearly empty before this patch.

* LayoutTests/platform/glib/TestExpectations:
* Source/WebCore/platform/graphics/gstreamer/AudioTrackPrivateGStreamer.cpp:
(WebCore::ensureDebugCategoryInitialized):
(WebCore::AudioTrackPrivateGStreamer::AudioTrackPrivateGStreamer):
(WebCore::AudioTrackPrivateGStreamer::capsChanged):
(WebCore::AudioTrackPrivateGStreamer::updateConfigurationFromTags):
(WebCore::AudioTrackPrivateGStreamer::updateConfigurationFromCaps):
* Source/WebCore/platform/graphics/gstreamer/AudioTrackPrivateGStreamer.h:
* Source/WebCore/platform/graphics/gstreamer/MediaPlayerPrivateGStreamer.cpp:
(WebCore::MediaPlayerPrivateGStreamer::configureElement):
(WebCore::MediaPlayerPrivateGStreamer::setupCodecProbe):
(WebCore::MediaPlayerPrivateGStreamer::configureAudioDecoder):
(WebCore::MediaPlayerPrivateGStreamer::configureVideoDecoder):
(WebCore::MediaPlayerPrivateGStreamer::codecForStreamId):
* Source/WebCore/platform/graphics/gstreamer/MediaPlayerPrivateGStreamer.h:
* Source/WebCore/platform/graphics/gstreamer/TrackPrivateBaseGStreamer.cpp:
(WebCore::TrackPrivateBaseGStreamer::setPad):
(WebCore::TrackPrivateBaseGStreamer::objectForLogging const):
(WebCore::TrackPrivateBaseGStreamer::notifyTrackOfTagsChanged):
* Source/WebCore/platform/graphics/gstreamer/TrackPrivateBaseGStreamer.h:
(WebCore::TrackPrivateBaseGStreamer::tagsChanged):
(WebCore::TrackPrivateBaseGStreamer::capsChanged):
* Source/WebCore/platform/graphics/gstreamer/VideoTrackPrivateGStreamer.cpp:
(WebCore::VideoTrackPrivateGStreamer::VideoTrackPrivateGStreamer):
(WebCore::VideoTrackPrivateGStreamer::capsChanged):
(WebCore::VideoTrackPrivateGStreamer::updateConfigurationFromTags):
(WebCore::VideoTrackPrivateGStreamer::updateConfigurationFromCaps):
* Source/WebCore/platform/graphics/gstreamer/VideoTrackPrivateGStreamer.h:

Canonical link: <a href="https://commits.webkit.org/263585@main">https://commits.webkit.org/263585@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/fa14e4fda54a475b0fa5988988f3b57c8398277b

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/5135 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/5267 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/5445 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/6656 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/5210 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/5130 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/5471 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/5243 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/5453 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/5224 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/5306 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/4601 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/6674 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/2792 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/4599 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/9908 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/4656 "Passed tests") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/4672 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/6285 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/5099 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/4186 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/4577 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/1229 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/8659 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/4944 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->