### PR TITLE
[WK2] Audio playing from closed tab (facebook.com)

### DIFF
--- a/Source/WebKit/GPUProcess/GPUConnectionToWebProcess.cpp
+++ b/Source/WebKit/GPUProcess/GPUConnectionToWebProcess.cpp
@@ -344,6 +344,7 @@ void GPUConnectionToWebProcess::didClose(IPC::Connection& connection)
 #endif
 #if ENABLE(VIDEO)
     m_videoFrameObjectHeap->close();
+    m_remoteMediaPlayerManagerProxy->clear();
 #endif
     // RemoteRenderingBackend objects ref their GPUConnectionToWebProcess so we need to make sure
     // to break the reference cycle by destroying them.

--- a/Source/WebKit/GPUProcess/media/RemoteMediaPlayerManagerProxy.cpp
+++ b/Source/WebKit/GPUProcess/media/RemoteMediaPlayerManagerProxy.cpp
@@ -56,6 +56,11 @@ RemoteMediaPlayerManagerProxy::RemoteMediaPlayerManagerProxy(GPUConnectionToWebP
 
 RemoteMediaPlayerManagerProxy::~RemoteMediaPlayerManagerProxy()
 {
+    clear();
+}
+
+void RemoteMediaPlayerManagerProxy::clear()
+{
     auto proxies = std::exchange(m_proxies, { });
 
     for (auto& proxy : proxies.values())


### PR DESCRIPTION
#### 7a82d30fc628c316d55262d810c6e1becca57529
<pre>
[WK2] Audio playing from closed tab (facebook.com)
<a href="https://bugs.webkit.org/show_bug.cgi?id=256152">https://bugs.webkit.org/show_bug.cgi?id=256152</a>
rdar://106866813

Reviewed by Eric Carlson and Andy Estes.

The GPUConnectionToWebProcess&apos;s m_remoteMediaPlayerManagerProxy object is only
destroyed/cleared when the GPUConnectionToWebProcess itself is destroyed. This
may not happen for various reasons (reusing the connection, etc.) when the page
itself is closed. Rather than rely on the connection&apos;s destruction to clear
the object keeping playback alive, clear the RemoteMediaPlayerManagerProxy when
the connection receives the DidClose message, like many other objects owned by
the connection.

The RemoteMediaplayerManagerProxy had a pre-existing `clear()` method declared
but not implemented. Move the code from the destructor into a newly implemented
`clear()` method, and call it from the destructor.

* Source/WebKit/GPUProcess/GPUConnectionToWebProcess.cpp:
(WebKit::GPUConnectionToWebProcess::didClose):
* Source/WebKit/GPUProcess/media/RemoteMediaPlayerManagerProxy.cpp:
(WebKit::RemoteMediaPlayerManagerProxy::~RemoteMediaPlayerManagerProxy):
(WebKit::RemoteMediaPlayerManagerProxy::clear):

Canonical link: <a href="https://commits.webkit.org/263545@main">https://commits.webkit.org/263545@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/62a041fded11a2b16703f287b1e2c34dbe7f1eac

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/4987 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/5112 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/5285 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/6504 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/5081 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/5296 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/5085 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/5336 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/5073 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/5155 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/4472 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/6520 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/2643 "Passed tests") | | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/9460 "2 flakes 146 failures") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/4506 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/4542 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/6147 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/4951 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/4053 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/4442 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/1206 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/8514 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/4806 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->