### PR TITLE
[css-counter-styles] Implement complex predefined counter styles

### DIFF
--- a/LayoutTests/TestExpectations
+++ b/LayoutTests/TestExpectations
@@ -6158,11 +6158,9 @@ http/wpt/loading/early-hints [ Skip ]
 
 # Most ports don't have a HEIC decoder.
 http/tests/misc/heic-accept-header.html [ Pass Failure ]
-# Missing complex predefined counter-style at-rule rdar://103021467
-imported/w3c/web-platform-tests/css/css-counter-styles/counter-style-at-rule/dependent-builtin.html [ ImageOnlyFailure ]
 
-# Missing counter-style integration with counter() rdar://106084053
-imported/w3c/web-platform-tests/css/css-counter-styles/counter-style-at-rule/disclosure-styles.html [ ImageOnlyFailure ]
+# Needs proper bidi algorithm.
+webkit.org/b/256153 imported/w3c/web-platform-tests/css/css-counter-styles/counter-style-at-rule/disclosure-styles.html [ ImageOnlyFailure ]
 
 # WPT seems to be wrong regarding prefix/suffix fallback (https://github.com/web-platform-tests/wpt/issues/38772)
 imported/w3c/web-platform-tests/css/css-counter-styles/counter-style-at-rule/system-additive.html [ ImageOnlyFailure ]

--- a/Source/WebCore/css/CSSCounterStyle.h
+++ b/Source/WebCore/css/CSSCounterStyle.h
@@ -78,6 +78,12 @@ public:
     bool isExtendsSystem() const { return system() == CSSCounterStyleDescriptors::System::Extends; }
     void extendAndResolve(const CSSCounterStyle&);
 
+    static String counterForSystemSimplifiedChineseInformal(int);
+    static String counterForSystemSimplifiedChineseFormal(int);
+    static String counterForSystemTraditionalChineseInformal(int);
+    static String counterForSystemTraditionalChineseFormal(int);
+    static String counterForSystemEthiopicNumeric(unsigned);
+
 private:
     CSSCounterStyle(const CSSCounterStyleDescriptors&, bool isPredefinedCounterStyle);
 

--- a/Source/WebCore/css/CSSCounterStyleDescriptors.cpp
+++ b/Source/WebCore/css/CSSCounterStyleDescriptors.cpp
@@ -293,6 +293,11 @@ bool CSSCounterStyleDescriptors::areSymbolsValidForSystem(CSSCounterStyleDescrip
         return symbols.size() >= 2u;
     case System::Additive:
         return additiveSymbols.size();
+    case System::SimplifiedChineseInformal:
+    case System::SimplifiedChineseFormal:
+    case System::TraditionalChineseInformal:
+    case System::TraditionalChineseFormal:
+    case System::EthiopicNumeric:
     case System::Extends:
         return !symbols.size() && !additiveSymbols.size();
     default:
@@ -404,36 +409,33 @@ String CSSCounterStyleDescriptors::systemCSSText() const
 {
     if (!m_explicitlySetDescriptors.contains(ExplicitlySetDescriptors::System))
         return emptyString();
-    StringBuilder builder;
-    if (m_isExtendedResolved) {
-        builder.append(makeString("extends ", m_extendsName));
-        return builder.toString();
-    }
+    if (m_isExtendedResolved)
+        return makeString("extends ", m_extendsName);
 
     switch (m_system) {
     case System::Cyclic:
-        builder.append("cyclic");
-        break;
+        return "cyclic"_s;
     case System::Numeric:
-        builder.append("numeric");
-        break;
+        return "numeric"_s;
     case System::Alphabetic:
-        builder.append("alphabetic");
-        break;
+        return "alphabetic"_s;
     case System::Symbolic:
-        builder.append("symbolic");
-        break;
+        return "symbolic"_s;
     case System::Additive:
-        builder.append("additive");
-        break;
+        return "additive"_s;
     case System::Fixed:
-        builder.append(makeString("fixed ", m_fixedSystemFirstSymbolValue));
-        break;
+        return makeString("fixed ", m_fixedSystemFirstSymbolValue);
     case System::Extends:
-        builder.append(makeString("extends ", m_extendsName));
-        break;
+        return makeString("extends ", m_extendsName);
+    // Internal values should not be exposed.
+    case System::SimplifiedChineseInformal:
+    case System::SimplifiedChineseFormal:
+    case System::TraditionalChineseInformal:
+    case System::TraditionalChineseFormal:
+    case System::EthiopicNumeric:
+        return emptyString();
     }
-    return builder.toString();
+    return emptyString();
 }
 
 String CSSCounterStyleDescriptors::negativeCSSText() const

--- a/Source/WebCore/css/CSSCounterStyleDescriptors.h
+++ b/Source/WebCore/css/CSSCounterStyleDescriptors.h
@@ -55,6 +55,11 @@ struct CSSCounterStyleDescriptors {
         Symbolic,
         Additive,
         Fixed,
+        SimplifiedChineseInformal,
+        SimplifiedChineseFormal,
+        TraditionalChineseInformal,
+        TraditionalChineseFormal,
+        EthiopicNumeric,
         Extends
     };
     enum class SpeakAs : uint8_t {

--- a/Source/WebCore/css/CSSCounterStyleRegistry.cpp
+++ b/Source/WebCore/css/CSSCounterStyleRegistry.cpp
@@ -199,13 +199,6 @@ bool isCounterStyleUnsupportedByUserAgent(CSSValueID valueID)
     case CSSValueTigrinyaErAbegede:
     case CSSValueTigrinyaEt:
     case CSSValueTigrinyaEtAbegede:
-    // Complex styles that use custom algorithms (rdar://103021467).
-    case CSSValueCjkIdeographic:
-    case CSSValueSimpChineseInformal:
-    case CSSValueSimpChineseFormal:
-    case CSSValueTradChineseInformal:
-    case CSSValueTradChineseFormal:
-    case CSSValueEthiopicNumeric:
     case CSSValueNone:
         return true;
     default:

--- a/Source/WebCore/css/CSSCounterStyleRule.cpp
+++ b/Source/WebCore/css/CSSCounterStyleRule.cpp
@@ -76,6 +76,16 @@ CSSCounterStyleDescriptors::System toCounterStyleSystemEnum(const CSSValue* syst
         return CSSCounterStyleDescriptors::System::Numeric;
     case CSSValueAdditive:
         return CSSCounterStyleDescriptors::System::Additive;
+    case CSSValueInternalSimplifiedChineseInformal:
+        return CSSCounterStyleDescriptors::System::SimplifiedChineseInformal;
+    case CSSValueInternalSimplifiedChineseFormal:
+        return CSSCounterStyleDescriptors::System::SimplifiedChineseFormal;
+    case CSSValueInternalTraditionalChineseInformal:
+        return CSSCounterStyleDescriptors::System::TraditionalChineseInformal;
+    case CSSValueInternalTraditionalChineseFormal:
+        return CSSCounterStyleDescriptors::System::TraditionalChineseFormal;
+    case CSSValueInternalEthiopicNumeric:
+        return CSSCounterStyleDescriptors::System::EthiopicNumeric;
     case CSSValueExtends:
         return CSSCounterStyleDescriptors::System::Extends;
     default:

--- a/Source/WebCore/css/CSSProperties.json
+++ b/Source/WebCore/css/CSSProperties.json
@@ -9617,6 +9617,7 @@
                 "codegen-properties": {
                     "settings-flag": "cssCounterStyleAtRulesEnabled",
                     "parser-function": "consumeCounterStyleSystem",
+                    "parser-function-requires-context": true,
                     "parser-grammar-unused": "cyclic | numeric | alphabetic | symbolic | additive | [ fixed <integer>? ] | [ extends <counter-style-name> ]",
                     "parser-grammar-unused-reason": "Needs support for ordered groups, optionals and applying restrictions to <custom-ident>."
                 },

--- a/Source/WebCore/css/CSSValueKeywords.in
+++ b/Source/WebCore/css/CSSValueKeywords.in
@@ -1613,6 +1613,11 @@ numeric
 symbolic
 additive
 // fixed
+-internal-simplified-chinese-informal
+-internal-simplified-chinese-formal
+-internal-traditional-chinese-informal
+-internal-traditional-chinese-formal
+-internal-ethiopic-numeric
 extends
 
 // @counter-style `speak-as` descriptor values

--- a/Source/WebCore/css/counterStyles.css
+++ b/Source/WebCore/css/counterStyles.css
@@ -356,6 +356,54 @@
     /* 마이너스 (followed by a space) */
 }
 
+/*** Complex counter style systems ***/
+
+@counter-style simp-chinese-informal {
+    system: -internal-simplified-chinese-informal;
+    range: -9999 9999;
+    suffix: '\3001'; /* '、' */
+    negative: '\8D1F'; /* '负' */
+    fallback: cjk-decimal;
+}
+
+@counter-style simp-chinese-formal {
+    system: -internal-simplified-chinese-formal;
+    range: -9999 9999;
+    suffix: '\3001'; /* '、' */
+    negative: '\8D1F'; /* '负' */
+    fallback: cjk-decimal;
+}
+
+@counter-style trad-chinese-informal {
+    system: -internal-traditional-chinese-informal;
+    range: -9999 9999;
+    suffix: '\3001'; /* '、' */
+    negative: '\8CA0'; /* '負' */
+    fallback: cjk-decimal;
+}
+
+@counter-style trad-chinese-formal {
+    system: -internal-traditional-chinese-formal;
+    range: -9999 9999;
+    suffix: '\3001'; /* '、' */
+    negative: '\8CA0'; /* '負' */
+    fallback: cjk-decimal;
+}
+
+/* identical to trad-chinese-informal */
+@counter-style cjk-ideographic {
+    system: -internal-traditional-chinese-informal;
+    range: -9999 9999;
+    suffix: '\3001'; /* '、' */
+    negative: '\8CA0'; /* '負' */
+    fallback: cjk-decimal;
+}
+
+@counter-style ethiopic-numeric {
+    system: -internal-ethiopic-numeric;
+    range: 1 infinite;
+    suffix: '\002F\20'; /* '/ ' (followed by space) */
+}
 
 /*** Subset of Ready-made Counter Styles: https://www.w3.org/TR/predefined-counter-styles/ ***/
 

--- a/Source/WebCore/css/parser/CSSPropertyParserHelpers.h
+++ b/Source/WebCore/css/parser/CSSPropertyParserHelpers.h
@@ -327,7 +327,7 @@ RefPtr<CSSValue> consumeFontPaletteValuesOverrideColors(CSSParserTokenRange&, co
 
 // @counter-style descriptor consumers:
 
-RefPtr<CSSValue> consumeCounterStyleSystem(CSSParserTokenRange&);
+RefPtr<CSSValue> consumeCounterStyleSystem(CSSParserTokenRange&, const CSSParserContext&);
 RefPtr<CSSValue> consumeCounterStyleSymbol(CSSParserTokenRange&, const CSSParserContext&);
 RefPtr<CSSValue> consumeCounterStyleNegative(CSSParserTokenRange&, const CSSParserContext&);
 RefPtr<CSSValue> consumeCounterStyleRange(CSSParserTokenRange&);

--- a/Source/WebCore/rendering/RenderListMarker.cpp
+++ b/Source/WebCore/rendering/RenderListMarker.cpp
@@ -55,7 +55,6 @@ WTF_MAKE_ISO_ALLOCATED_IMPL(RenderListMarker);
 constexpr int cMarkerPadding = 7;
 
 enum class SequenceType : bool { Numeric, Alphabetic };
-enum class Formality : bool { Informal, Formal };
 
 template<SequenceType type, typename CharacterType> static String toAlphabeticOrNumeric(int number, const CharacterType* sequence, unsigned sequenceSize)
 {
@@ -135,91 +134,6 @@ template<typename CharacterType, size_t size> static String toSymbolic(int numbe
     return toSymbolic(number, alphabet, size);
 }
 
-// This table format was derived from an old draft of the CSS specification: 3 group markers, 3 digit markers, 10 digits, negative sign.
-static String toCJKIdeographic(int number, const UChar table[17], Formality formality)
-{
-    enum AbstractCJKCharacter {
-        NoChar,
-        SecondGroupMarker, ThirdGroupMarker, FourthGroupMarker,
-        SecondDigitMarker, ThirdDigitMarker, FourthDigitMarker,
-        Digit0, Digit1, Digit2, Digit3, Digit4,
-        Digit5, Digit6, Digit7, Digit8, Digit9,
-        NegativeSign
-    };
-
-    if (!number)
-        return { &table[Digit0 - 1] , 1 };
-
-    ASSERT(number != std::numeric_limits<int>::min());
-    bool needsNegativeSign = number < 0;
-    if (needsNegativeSign)
-        number = -number;
-
-    constexpr unsigned groupLength = 8; // 4 digits, 3 digit markers, and a group marker
-    constexpr unsigned bufferLength = 4 * groupLength;
-    AbstractCJKCharacter buffer[bufferLength] = { NoChar };
-
-    for (int i = 0; i < 4; ++i) {
-        int groupValue = number % 10000;
-        number /= 10000;
-
-        // Process least-significant group first, but put it in the buffer last.
-        auto group = &buffer[(3 - i) * groupLength];
-
-        if (groupValue && i)
-            group[7] = static_cast<AbstractCJKCharacter>(SecondGroupMarker - 1 + i);
-
-        // Put in the four digits and digit markers for any non-zero digits.
-        group[6] = static_cast<AbstractCJKCharacter>(Digit0 + (groupValue % 10));
-        if (number != 0 || groupValue > 9) {
-            int digitValue = ((groupValue / 10) % 10);
-            group[4] = static_cast<AbstractCJKCharacter>(Digit0 + digitValue);
-            if (digitValue)
-                group[5] = SecondDigitMarker;
-        }
-        if (number != 0 || groupValue > 99) {
-            int digitValue = ((groupValue / 100) % 10);
-            group[2] = static_cast<AbstractCJKCharacter>(Digit0 + digitValue);
-            if (digitValue)
-                group[3] = ThirdDigitMarker;
-        }
-        if (number != 0 || groupValue > 999) {
-            int digitValue = groupValue / 1000;
-            group[0] = static_cast<AbstractCJKCharacter>(Digit0 + digitValue);
-            if (digitValue)
-                group[1] = FourthDigitMarker;
-        }
-
-        if (formality == Formality::Informal && groupValue < 20) {
-            // Remove the tens digit, but leave the marker.
-            ASSERT(group[4] == NoChar || group[4] == Digit0 || group[4] == Digit1);
-            group[4] = NoChar;
-        }
-
-        if (!number)
-            break;
-    }
-
-    // Convert into characters, omitting consecutive runs of digit0 and trailing digit0.
-    unsigned length = 0;
-    UChar characters[1 + bufferLength];
-    auto last = NoChar;
-    if (needsNegativeSign)
-        characters[length++] = table[NegativeSign - 1];
-    for (unsigned i = 0; i < bufferLength; ++i) {
-        auto character = buffer[i];
-        if (character != NoChar) {
-            if (character != Digit0 || last != Digit0)
-                characters[length++] = table[character - 1];
-            last = character;
-        }
-    }
-    if (last == Digit0)
-        --length;
-
-    return { characters, length };
-}
-
 struct AdditiveSymbol {
     int value;
     std::initializer_list<UChar> characters;
@@ -256,48 +170,6 @@ static String toPredefinedAdditiveSystem(int value, const AdditiveSystem& system
     }
     ASSERT(!value);
     return result.toString();
-}
-
-static String toEthiopicNumeric(int value)
-{
-    ASSERT(value >= 1);
-
-    if (value == 1) {
-        UChar ethiopicDigitOne = 0x1369;
-        return { &ethiopicDigitOne, 1 };
-    }
-
-    // Split the number into groups of two digits, starting with the least significant decimal digit.
-    uint8_t groups[5];
-    for (auto& group : groups) {
-        group = value % 100;
-        value /= 100;
-    }
-
-    UChar buffer[std::size(groups) * 3];
-    unsigned length = 0;
-    bool isMostSignificantGroup = true;
-    for (int i = std::size(groups) - 1; i >= 0; --i) {
-        auto value = groups[i];
-        bool isOddIndex = i & 1;
-        // If the group has the value zero, or if the group is the most significant one and has the value 1,
-        // or if the group has an odd index (as given in the previous step) and has the value 1,
-        // then remove the digits (but leave the group, so it still has a separator appended below).
-        if (!(value == 1 && (isMostSignificantGroup || isOddIndex))) {
-            if (auto tens = value / 10)
-                buffer[length++] = 0x1371 + tens;
-            if (auto ones = value % 10)
-                buffer[length++] = 0x1368 + ones;
-        }
-        if (value && isOddIndex)
-            buffer[length++] = 0x137B;
-        if ((value || !isMostSignificantGroup) && !isOddIndex && i)
-            buffer[length++] = 0x137C;
-        if (value)
-            isMostSignificantGroup = false;
-    }
-
-    return { buffer, length };
 }
 
 static ListStyleType::Type effectiveListMarkerType(ListStyleType::Type type, int value)
@@ -953,49 +825,15 @@ String listMarkerText(ListStyleType::Type type, int value, CSSCounterStyle* coun
         };
         return toAlphabetic(value, upperNorwegianAlphabet);
     }
-
-    case ListStyleType::Type::SimplifiedChineseInformal: {
-        static constexpr UChar simplifiedChineseInformalTable[17] = {
-            0x842C, 0x5104, 0x5146, // These three group markers are probably wrong; OK because we don't use this on big enough numbers.
-            0x5341, 0x767E, 0x5343,
-            0x96F6, 0x4E00, 0x4E8C, 0x4E09, 0x56DB,
-            0x4E94, 0x516D, 0x4E03, 0x516B, 0x4E5D,
-            0x8D1F
-        };
-        return toCJKIdeographic(value, simplifiedChineseInformalTable, Formality::Informal);
-    }
-    case ListStyleType::Type::SimplifiedChineseFormal: {
-        static constexpr UChar simplifiedChineseFormalTable[17] = {
-            0x842C, 0x5104, 0x5146, // These three group markers are probably wrong; OK because we don't use this on big enough numbers.
-            0x62FE, 0x4F70, 0x4EDF,
-            0x96F6, 0x58F9, 0x8D30, 0x53C1, 0x8086,
-            0x4F0D, 0x9646, 0x67D2, 0x634C, 0x7396,
-            0x8D1F
-        };
-        return toCJKIdeographic(value, simplifiedChineseFormalTable, Formality::Formal);
-    }
+    case ListStyleType::Type::SimplifiedChineseInformal:
+        return CSSCounterStyle::counterForSystemSimplifiedChineseInformal(value);
+    case ListStyleType::Type::SimplifiedChineseFormal:
+        return CSSCounterStyle::counterForSystemSimplifiedChineseFormal(value);
     case ListStyleType::Type::CJKIdeographic:
-    case ListStyleType::Type::TraditionalChineseInformal: {
-        static constexpr UChar traditionalChineseInformalTable[17] = {
-            0x842C, 0x5104, 0x5146,
-            0x5341, 0x767E, 0x5343,
-            0x96F6, 0x4E00, 0x4E8C, 0x4E09, 0x56DB,
-            0x4E94, 0x516D, 0x4E03, 0x516B, 0x4E5D,
-            0x8CA0
-        };
-        return toCJKIdeographic(value, traditionalChineseInformalTable, Formality::Informal);
-    }
-    case ListStyleType::Type::TraditionalChineseFormal: {
-        static constexpr UChar traditionalChineseFormalTable[17] = {
-            0x842C, 0x5104, 0x5146, // These three group markers are probably wrong; OK because we don't use this on big enough numbers.
-            0x62FE, 0x4F70, 0x4EDF,
-            0x96F6, 0x58F9, 0x8CB3, 0x53C3, 0x8086,
-            0x4F0D, 0x9678, 0x67D2, 0x634C, 0x7396,
-            0x8CA0
-        };
-        return toCJKIdeographic(value, traditionalChineseFormalTable, Formality::Formal);
-    }
-
+    case ListStyleType::Type::TraditionalChineseInformal:
+        return CSSCounterStyle::counterForSystemTraditionalChineseInformal(value);
+    case ListStyleType::Type::TraditionalChineseFormal:
+        return CSSCounterStyle::counterForSystemTraditionalChineseFormal(value);
     case ListStyleType::Type::LowerRoman: {
         static CONSTEXPR_WITH_MSVC_INITIALIZER_LIST_WORKAROUND AdditiveSystem lowerRomanSystem {
             {
@@ -1460,7 +1298,7 @@ String listMarkerText(ListStyleType::Type type, int value, CSSCounterStyle* coun
     }
 
     case ListStyleType::Type::EthiopicNumeric:
-        return toEthiopicNumeric(value);
+        return CSSCounterStyle::counterForSystemEthiopicNumeric(value);
 
     case ListStyleType::Type::String:
         ASSERT_NOT_REACHED();


### PR DESCRIPTION
#### 231e2671c75e017d86898fcdb1f3e9c1c88de9ac
<pre>
[css-counter-styles] Implement complex predefined counter styles
<a href="https://bugs.webkit.org/show_bug.cgi?id=256154">https://bugs.webkit.org/show_bug.cgi?id=256154</a>
rdar://103021467

Reviewed by Darin Adler.

Implement the following as complex counter style systems:

simp-chinese-informal
simp-chinese-formal
trad-chinese-informal
trad-chinese-formal
ethiopic-numeric

As a result, authors can now create counter styles that extend the above.

Specification: <a href="https://drafts.csswg.org/css-counter-styles/#complex-predefined-counters">https://drafts.csswg.org/css-counter-styles/#complex-predefined-counters</a>

To implement this, we create UA sheet only values for the system descriptors.
The algorithms are just moved over from RenderListMarker, and re-used in both places as static methods on CSSCounterStyle.

* LayoutTests/TestExpectations:
* Source/WebCore/css/CSSCounterStyle.cpp: Move over code from RenderListMarker
(WebCore::counterForSystemCJK):
(WebCore::CSSCounterStyle::counterForSystemSimplifiedChineseInformal):
(WebCore::CSSCounterStyle::counterForSystemSimplifiedChineseFormal):
(WebCore::CSSCounterStyle::counterForSystemTraditionalChineseInformal):
(WebCore::CSSCounterStyle::counterForSystemTraditionalChineseFormal):
(WebCore::CSSCounterStyle::counterForSystemEthiopicNumeric):
(WebCore::CSSCounterStyle::initialRepresentation const):
(WebCore::CSSCounterStyle::isInRange const):
* Source/WebCore/css/CSSCounterStyle.h:
* Source/WebCore/css/CSSCounterStyleDescriptors.cpp: Pipe the CSS value for system descriptor
(WebCore::CSSCounterStyleDescriptors::areSymbolsValidForSystem):
(WebCore::CSSCounterStyleDescriptors::systemCSSText const):
* Source/WebCore/css/CSSCounterStyleDescriptors.h:
* Source/WebCore/css/CSSCounterStyleRegistry.cpp: Enable the new codepath for complex system
(WebCore::isCounterStyleUnsupportedByUserAgent):
* Source/WebCore/css/CSSCounterStyleRule.cpp: Pipe the CSS value for system descriptor
(WebCore::toCounterStyleSystemEnum):
* Source/WebCore/css/CSSProperties.json: Pass in the context, so the parser knows whether it&apos;s in UA sheet mode
* Source/WebCore/css/CSSValueKeywords.in: Add internal CSS values
* Source/WebCore/css/counterStyles.css: Define the new complex counter styles
(@counter-style simp-chinese-informal):
(@counter-style simp-chinese-formal):
(@counter-style trad-chinese-informal):
(@counter-style trad-chinese-formal):
(@counter-style cjk-ideographic):
(@counter-style ethiopic-numeric):
* Source/WebCore/css/parser/CSSPropertyParserHelpers.cpp: Parse the new internal CSS values
(WebCore::CSSPropertyParserHelpers::consumeCounterStyleSystem): Remove outdated FIXME that is handled by CSSCounterStyleDescriptors::areSymbolsValidForSystem
* Source/WebCore/css/parser/CSSPropertyParserHelpers.h:
* Source/WebCore/rendering/RenderListMarker.cpp: Delete code that was moved to CSSCounterStyle, and re-use the methods there
(WebCore::listMarkerText):
(WebCore::toCJKIdeographic): Deleted.
(WebCore::toEthiopicNumeric): Deleted.

Canonical link: <a href="https://commits.webkit.org/263544@main">https://commits.webkit.org/263544@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ac85cc4ae19219946c8194e59100b87d505f309d

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/4997 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/5123 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/5296 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/6515 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/5090 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/4990 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/5308 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/5096 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/5349 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/5083 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/5164 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/4480 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/6531 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/2652 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/4478 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/9479 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/4515 "Passed tests") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/4550 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/6166 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/4961 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/4061 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/4451 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/1205 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/8524 "Built successfully") | | | 
| [  ~~🛠 🧪 unsafe-merge~~](https://ews-build.webkit.org/#/builders/22/builds/563 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/4815 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->