### PR TITLE
[css-counter-styles] Various small cleanups

### DIFF
--- a/Source/WebCore/css/CSSCounterStyle.cpp
+++ b/Source/WebCore/css/CSSCounterStyle.cpp
@@ -28,9 +28,6 @@
 
 #include "CSSCounterStyleDescriptors.h"
 #include "CSSCounterStyleRegistry.h"
-#include "CSSCounterStyleRule.h"
-#include "CSSPrimitiveValue.h"
-#include "CSSValuePair.h"
 #include <cmath>
 #include <wtf/text/StringBuilder.h>
 #include <wtf/text/TextBreakIterator.h>
@@ -146,7 +143,7 @@ String CSSCounterStyle::counterForSystemAdditive(unsigned value) const
     }
 
     StringBuilder result;
-    auto appendToResult = [&](String symbol, unsigned frequency) {
+    auto appendToResult = [&](const String& symbol, unsigned frequency) {
         for (unsigned i = 0; i < frequency; ++i)
             result.append(symbol);
     };
@@ -252,7 +249,7 @@ static String counterForSystemCJK(int number, const std::array<UChar, 17>& table
 
 String CSSCounterStyle::counterForSystemSimplifiedChineseInformal(int value)
 {
-    static constexpr std::array<UChar, 17> simplifiedChineseInformalTable = {
+    static constexpr std::array<UChar, 17> simplifiedChineseInformalTable {
         0x842C, 0x5104, 0x5146, // These three group markers are probably wrong; OK because we don't use this on big enough numbers.
         0x5341, 0x767E, 0x5343,
         0x96F6, 0x4E00, 0x4E8C, 0x4E09, 0x56DB,
@@ -264,7 +261,7 @@ String CSSCounterStyle::counterForSystemSimplifiedChineseInformal(int value)
 
 String CSSCounterStyle::counterForSystemSimplifiedChineseFormal(int value)
 {
-    static constexpr std::array<UChar, 17> simplifiedChineseFormalTable = {
+    static constexpr std::array<UChar, 17> simplifiedChineseFormalTable {
         0x842C, 0x5104, 0x5146, // These three group markers are probably wrong; OK because we don't use this on big enough numbers.
         0x62FE, 0x4F70, 0x4EDF,
         0x96F6, 0x58F9, 0x8D30, 0x53C1, 0x8086,
@@ -276,7 +273,7 @@ String CSSCounterStyle::counterForSystemSimplifiedChineseFormal(int value)
 
 String CSSCounterStyle::counterForSystemTraditionalChineseInformal(int value)
 {
-    static constexpr std::array<UChar, 17> traditionalChineseInformalTable = {
+    static constexpr std::array<UChar, 17> traditionalChineseInformalTable {
         0x842C, 0x5104, 0x5146,
         0x5341, 0x767E, 0x5343,
         0x96F6, 0x4E00, 0x4E8C, 0x4E09, 0x56DB,
@@ -288,7 +285,7 @@ String CSSCounterStyle::counterForSystemTraditionalChineseInformal(int value)
 
 String CSSCounterStyle::counterForSystemTraditionalChineseFormal(int value)
 {
-    static constexpr std::array<UChar, 17> traditionalChineseFormalTable = {
+    static constexpr std::array<UChar, 17> traditionalChineseFormalTable {
         0x842C, 0x5104, 0x5146, // These three group markers are probably wrong; OK because we don't use this on big enough numbers.
         0x62FE, 0x4F70, 0x4EDF,
         0x96F6, 0x58F9, 0x8CB3, 0x53C3, 0x8086,

--- a/Source/WebCore/css/CSSCounterStyleDescriptors.cpp
+++ b/Source/WebCore/css/CSSCounterStyleDescriptors.cpp
@@ -27,7 +27,6 @@
 #include "CSSCounterStyleDescriptors.h"
 
 #include "CSSCounterStyleRule.h"
-#include "CSSMarkup.h"
 #include "CSSPrimitiveValue.h"
 #include "CSSValueList.h"
 #include "CSSValuePair.h"
@@ -410,7 +409,7 @@ String CSSCounterStyleDescriptors::systemCSSText() const
     if (!m_explicitlySetDescriptors.contains(ExplicitlySetDescriptors::System))
         return emptyString();
     if (m_isExtendedResolved)
-        return makeString("extends ", m_extendsName);
+        return makeString("extends "_s, m_extendsName);
 
     switch (m_system) {
     case System::Cyclic:
@@ -424,9 +423,9 @@ String CSSCounterStyleDescriptors::systemCSSText() const
     case System::Additive:
         return "additive"_s;
     case System::Fixed:
-        return makeString("fixed ", m_fixedSystemFirstSymbolValue);
+        return makeString("fixed "_s, m_fixedSystemFirstSymbolValue);
     case System::Extends:
-        return makeString("extends ", m_extendsName);
+        return makeString("extends "_s, m_extendsName);
     // Internal values should not be exposed.
     case System::SimplifiedChineseInformal:
     case System::SimplifiedChineseFormal:

--- a/Source/WebCore/css/CSSCounterStyleRegistry.cpp
+++ b/Source/WebCore/css/CSSCounterStyleRegistry.cpp
@@ -27,7 +27,6 @@
 #include "CSSCounterStyleRegistry.h"
 
 #include "CSSCounterStyle.h"
-#include "CSSCounterStyleRule.h"
 #include "CSSPrimitiveValue.h"
 #include "CSSValuePair.h"
 #include "ListStyleType.h"

--- a/Tools/DumpRenderTree/TestOptions.cpp
+++ b/Tools/DumpRenderTree/TestOptions.cpp
@@ -136,7 +136,6 @@ const TestFeatures& TestOptions::defaults()
             { "AttachmentWideLayoutEnabled", false },
             { "CSSContainmentEnabled", false },
             { "CSSCounterStyleAtRuleImageSymbolsEnabled", false },
-            { "CSSCounterStyleAtRulesEnabled", false },
             { "CSSGradientInterpolationColorSpacesEnabled", true },
             { "CSSGradientPremultipliedAlphaInterpolationEnabled", true },
             { "CSSInputSecurityEnabled", true },


### PR DESCRIPTION
#### e9b16603c9ebc1bf3127f49b790f0e8bb7fed87b
<pre>
[css-counter-styles] Various small cleanups
<a href="https://bugs.webkit.org/show_bug.cgi?id=256155">https://bugs.webkit.org/show_bug.cgi?id=256155</a>
rdar://108720314

Unreviewed, address Darin&apos;s comments on #13320.

- Remove unnecessary `=`
- Add _s suffix to appropriate strings
- Remove unnecessary #include
- Enable @counter-style on Windows DRT (not sure why it was disabled in the first place)

* Source/WebCore/css/CSSCounterStyle.cpp:
(WebCore::CSSCounterStyle::counterForSystemAdditive const):
(WebCore::CSSCounterStyle::counterForSystemSimplifiedChineseInformal):
(WebCore::CSSCounterStyle::counterForSystemSimplifiedChineseFormal):
(WebCore::CSSCounterStyle::counterForSystemTraditionalChineseInformal):
(WebCore::CSSCounterStyle::counterForSystemTraditionalChineseFormal):
* Source/WebCore/css/CSSCounterStyleDescriptors.cpp:
(WebCore::CSSCounterStyleDescriptors::systemCSSText const):
* Source/WebCore/css/CSSCounterStyleRegistry.cpp:
* Tools/DumpRenderTree/TestOptions.cpp:
(WTR::TestOptions::defaults):

Canonical link: <a href="https://commits.webkit.org/263546@main">https://commits.webkit.org/263546@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5db408c3cf658addfdfb3a97c17fb74c7b95e0fb

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/5011 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/5139 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/5316 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/6528 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/5102 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/5004 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/5327 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/5114 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/5358 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/5097 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/5175 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/4492 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/6545 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/2663 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/4490 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/9493 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/4526 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/4562 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/6176 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/4976 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/4075 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/4465 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/1207 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/8539 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/4830 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->