### PR TITLE
[css-counter-styles] Port ethiopic counter styles to new codepath

### DIFF
--- a/Source/WebCore/css/CSSCounterStyleRegistry.cpp
+++ b/Source/WebCore/css/CSSCounterStyleRegistry.cpp
@@ -166,45 +166,6 @@ bool CSSCounterStyleRegistry::operator==(const CSSCounterStyleRegistry& other) c
     return m_authorCounterStyles == other.m_authorCounterStyles;
 }
 
-bool isCounterStyleUnsupportedByUserAgent(CSSValueID valueID)
-{
-    // This list has to be in sync with styles defined in counterStyles.css, once a style is added there, remove it from here.
-    switch (valueID) {
-    // FIXME: Review correctness of Ethiopian counter styles (rdar://108704382).
-    case CSSValueAmharic:
-    case CSSValueAmharicAbegede:
-    case CSSValueAfar:
-    case CSSValueEthiopic:
-    case CSSValueEthiopicAbegede:
-    case CSSValueEthiopicAbegedeAmEt:
-    case CSSValueEthiopicAbegedeGez:
-    case CSSValueEthiopicAbegedeTiEr:
-    case CSSValueEthiopicAbegedeTiEt:
-    case CSSValueEthiopicHalehameAaEr:
-    case CSSValueEthiopicHalehameAaEt:
-    case CSSValueEthiopicHalehameAmEt:
-    case CSSValueEthiopicHalehameGez:
-    case CSSValueEthiopicHalehameOmEt:
-    case CSSValueEthiopicHalehameSidEt:
-    case CSSValueEthiopicHalehameSoEt:
-    case CSSValueEthiopicHalehameTiEr:
-    case CSSValueEthiopicHalehameTiEt:
-    case CSSValueEthiopicHalehameTig:
-    case CSSValueOromo:
-    case CSSValueSidama:
-    case CSSValueSomali:
-    case CSSValueTigre:
-    case CSSValueTigrinyaEr:
-    case CSSValueTigrinyaErAbegede:
-    case CSSValueTigrinyaEt:
-    case CSSValueTigrinyaEtAbegede:
-    case CSSValueNone:
-        return true;
-    default:
-        return false;
-    }
-}
-
 void CSSCounterStyleRegistry::clearAuthorCounterStyles()
 {
     if (m_authorCounterStyles.isEmpty())

--- a/Source/WebCore/css/CSSCounterStyleRegistry.h
+++ b/Source/WebCore/css/CSSCounterStyleRegistry.h
@@ -64,6 +64,4 @@ private:
     bool m_hasUnresolvedReferences { true };
 };
 
-bool isCounterStyleUnsupportedByUserAgent(CSSValueID);
-
 } // namespace WebCore

--- a/Source/WebCore/css/counterStyles.css
+++ b/Source/WebCore/css/counterStyles.css
@@ -22,8 +22,6 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-/* Once a style is added here, make sure it is not listed at isCounterStyleUnsupportedByUserAgent() */
-
 /*** Built-in the spec: https://www.w3.org/TR/css-counter-styles-3/#predefined-counters ***/
 
 @counter-style decimal {
@@ -410,7 +408,7 @@
 @counter-style binary {
     system: numeric;
     symbols: '\30' '\31';
-    /* symbols: '0' '1' */
+    /* '0' '1' */
 }
 
 @counter-style lower-hexadecimal {
@@ -441,6 +439,55 @@
     system: alphabetic;
     symbols: '\3131' '\3134' '\3137' '\3139' '\3141' '\3142' '\3145' '\3147' '\3148' '\314A' '\314B' '\314C' '\314D' '\314E';
     /* 'ㄱ' 'ㄴ' 'ㄷ' 'ㄹ' 'ㅁ' 'ㅂ' 'ㅅ' 'ㅇ' 'ㅈ' 'ㅊ' 'ㅋ' 'ㅌ' 'ㅍ' 'ㅎ' */
+}
+
+/** Ethiopic ready-made Counter Styles **/
+
+/* FIXME: The W3C definition adds '\12F8' ('ዸ') between '\12F0' ('ደ') & '\1308' ('ገ') */
+@counter-style afar {
+    system: alphabetic;
+    symbols: '\1200' '\1208' '\1210' '\1218' '\1228' '\1230' '\1260' '\1270' '\1290' '\12A0' '\12A8' '\12C8' '\12D0' '\12E8' '\12F0' '\1308' '\1338' '\1348';
+    /* 'ሀ' 'ለ' 'ሐ' 'መ' 'ረ' 'ሰ' 'በ' 'ተ' 'ነ' 'አ' 'ከ' 'ወ' 'ዐ' 'የ' 'ደ' 'ገ' 'ጸ' 'ፈ' */
+    suffix: '\1366 '; /* ፦ */
+}
+
+@counter-style ethiopic-halehame-ti-er {
+    system: alphabetic;
+    symbols: '\1200' '\1208' '\1210' '\1218' '\1228' '\1230' '\1238' '\1240' '\1250' '\1260' '\1270' '\1278' '\1290' '\1298' '\12A0' '\12A8' '\12B8' '\12C8' '\12D0' '\12D8' '\12E0' '\12E8' '\12F0' '\1300' '\1308' '\1320' '\1328' '\1330' '\1338' '\1348' '\1350';
+    /* 'ሀ' 'ለ' 'ሐ' 'መ' 'ረ' 'ሰ' 'ሸ' 'ቀ' 'ቐ' 'በ' 'ተ' 'ቸ' 'ነ' 'ኘ' 'አ' 'ከ' 'ኸ' 'ወ' 'ዐ' 'ዘ' 'ዠ' 'የ' 'ደ' 'ጀ' 'ገ' 'ጠ' 'ጨ' 'ጰ' 'ጸ' 'ፈ' 'ፐ' */
+    suffix: '\1366 '; /* ፦ */
+}
+
+/* FIXME: The W3C definition does not have a suffix */
+@counter-style ethiopic-halehame-ti-et {
+    system: alphabetic;
+    symbols: '\1200' '\1208' '\1210' '\1218' '\1220' '\1228' '\1230' '\1238' '\1240' '\1250' '\1260' '\1270' '\1278' '\1280' '\1290' '\1298' '\12A0' '\12A8' '\12B8' '\12C8' '\12D0' '\12D8' '\12E0' '\12E8' '\12F0' '\1300' '\1308' '\1320' '\1328' '\1330' '\1338' '\1340' '\1348' '\1350';
+    /* 'ሀ' 'ለ' 'ሐ' 'መ' 'ሠ' 'ረ' 'ሰ' 'ሸ' 'ቀ' 'ቐ' 'በ' 'ተ' 'ቸ' 'ኀ' 'ነ' 'ኘ' 'አ' 'ከ' 'ኸ' 'ወ' 'ዐ' 'ዘ' 'ዠ' 'የ' 'ደ' 'ጀ' 'ገ' 'ጠ' 'ጨ' 'ጰ' 'ጸ' 'ፀ' 'ፈ' 'ፐ' */
+    suffix: '\1366 '; /* ፦ */
+}
+
+/* FIXME: The W3C definition has '\1338' ('ጰ') & '\1330' ('ጸ') swapped */
+@counter-style oromo {
+    system: alphabetic;
+    symbols: '\1200' '\1208' '\1218' '\1228' '\1230' '\1238' '\1240' '\1260' '\1270' '\1278' '\1290' '\1298' '\12A0' '\12A8' '\12C8' '\12E8' '\12F0' '\12F8' '\1300' '\1308' '\1320' '\1328' '\1338' '\1330' '\1348';
+    /* 'ሀ' 'ለ' 'መ' 'ረ' 'ሰ' 'ሸ' 'ቀ' 'በ' 'ተ' 'ቸ' 'ነ' 'ኘ' 'አ' 'ከ' 'ወ' 'የ' 'ደ' 'ዸ' 'ጀ' 'ገ' 'ጠ' 'ጨ' 'ጸ' 'ጰ' 'ፈ' */
+    suffix: '\1366 '; /* ፦ */
+}
+
+/* FIXME: The W3C definition has '\1338' ('ጰ') & '\1330' ('ጸ') swapped and removes '\1210' ('ሐ') */
+@counter-style sidama {
+    system: alphabetic;
+    symbols: '\1200' '\1208' '\1210' '\1218' '\1228' '\1230' '\1238' '\1240' '\1260' '\1270' '\1278' '\1290' '\1298' '\12A0' '\12A8' '\12C8' '\12E8' '\12F0' '\12F8' '\1300' '\1308' '\1320' '\1328' '\1338' '\1330' '\1348';
+    /* 'ሀ' 'ለ' 'ሐ' 'መ' 'ረ' 'ሰ' 'ሸ' 'ቀ' 'በ' 'ተ' 'ቸ' 'ነ' 'ኘ' 'አ' 'ከ' 'ወ' 'የ' 'ደ' 'ዸ' 'ጀ' 'ገ' 'ጠ' 'ጨ' 'ጸ' 'ጰ' 'ፈ' */
+    suffix: '\1366 '; /* ፦ */
+}
+
+/* FIXME: The W3C definition has '\1338' ('ጰ') & '\1330' ('ጸ') swapped */
+@counter-style tigre {
+    system: alphabetic;
+    symbols: '\1200' '\1208' '\1210' '\1218' '\1228' '\1230' '\1238' '\1240' '\1260' '\1270' '\1278' '\1290' '\12A0' '\12A8' '\12C8' '\12D0' '\12D8' '\12E8' '\12F0' '\1300' '\1308' '\1320' '\1328' '\1338' '\1330' '\1348' '\1350';
+    /* 'ሀ' 'ለ' 'ሐ' 'መ' 'ረ' 'ሰ' 'ሸ' 'ቀ' 'በ' 'ተ' 'ቸ' 'ነ' 'አ' 'ከ' 'ወ' 'ዐ' 'ዘ' 'የ' 'ደ' 'ጀ' 'ገ' 'ጠ' 'ጨ' 'ጸ' 'ጰ' 'ፈ' 'ፐ' */
+    suffix: '\1366 '; /* ፦ */
 }
 
 /*** WebKit specific ***/
@@ -479,9 +526,115 @@
     suffix: ' ';
 }
 
-/* identical to persian in the spec */
 @counter-style urdu {
-    system: numeric;
-    symbols: '\6F0' '\6F1' '\6F2' '\6F3' '\6F4' '\6F5' '\6F6' '\6F7' '\6F8' '\6F9';
-    /* '۰' '۱' '۲' '۳' '۴' '۵' '۶' '۷' '۸' '۹' */
+    system: extends persian;
+}
+
+/** Ethiopic WebKit-specific styles/aliases **/
+
+/* The W3C definition is named ethiopic-haleme-am */
+@counter-style amharic {
+    system: alphabetic;
+    symbols: '\1200' '\1208' '\1210' '\1218' '\1220' '\1228' '\1230' '\1238' '\1240' '\1260' '\1270' '\1278' '\1280' '\1290' '\1298' '\12A0' '\12A8' '\12B8' '\12C8' '\12D0' '\12D8' '\12E0' '\12E8' '\12F0' '\1300' '\1308' '\1320' '\1328' '\1330' '\1338' '\1340' '\1348' '\1350';
+    /* 'ሀ' 'ለ' 'ሐ' 'መ' 'ሠ' 'ረ' 'ሰ' 'ሸ' 'ቀ' 'በ' 'ተ' 'ቸ' 'ኀ' 'ነ' 'ኘ' 'አ' 'ከ' 'ኸ' 'ወ' 'ዐ' 'ዘ' 'ዠ' 'የ' 'ደ' 'ጀ' 'ገ' 'ጠ' 'ጨ' 'ጰ' 'ጸ' 'ፀ' 'ፈ' 'ፐ' */
+    suffix: '\1366 '; /* ፦ */
+}
+
+@counter-style amharic-abegede {
+    system: alphabetic;
+    symbols: '\12A0' '\1260' '\1308' '\12F0' '\1300' '\1200' '\12C8' '\12D8' '\12E0' '\1210' '\1320' '\1328' '\12E8' '\12A8' '\12B8' '\1208' '\1218' '\1290' '\1298' '\1220' '\12D0' '\1348' '\1338' '\1240' '\1228' '\1230' '\1238' '\1270' '\1278' '\1280' '\1340' '\1330' '\1350';
+    /* 'አ' 'በ' 'ገ' 'ደ' 'ጀ' 'ሀ' 'ወ' 'ዘ' 'ዠ' 'ሐ' 'ጠ' 'ጨ' 'የ' 'ከ' 'ኸ' 'ለ' 'መ' 'ነ' 'ኘ' 'ሠ' 'ዐ' 'ፈ' 'ጸ' 'ቀ' 'ረ' 'ሰ' 'ሸ' 'ተ' 'ቸ' 'ኀ' 'ፀ' 'ጰ' 'ፐ' */
+    suffix: '\1366 '; /* ፦ */
+}
+
+/* The W3C definition is named ethiopic-haleme */
+@counter-style ethiopic {
+    system: alphabetic;
+    symbols: '\1200' '\1208' '\1210' '\1218' '\1220' '\1228' '\1230' '\1240' '\1260' '\1270' '\1280' '\1290' '\12A0' '\12A8' '\12C8' '\12D0' '\12D8' '\12E8' '\12F0' '\1308' '\1320' '\1330' '\1338' '\1340' '\1348' '\1350';
+    /* 'ሀ' 'ለ' 'ሐ' 'መ' 'ሠ' 'ረ' 'ሰ' 'ቀ' 'በ' 'ተ' 'ኀ' 'ነ' 'አ' 'ከ' 'ወ' 'ዐ' 'ዘ' 'የ' 'ደ' 'ገ' 'ጠ' 'ጰ' 'ጸ' 'ፀ' 'ፈ' 'ፐ' */
+    suffix: '\1366 '; /* ፦ */
+}
+
+@counter-style ethiopic-abegede {
+    system: alphabetic;
+    symbols: '\12A0' '\1260' '\1308' '\12F0' '\1200' '\12C8' '\12D8' '\1210' '\1320' '\12E8' '\12A8' '\1208' '\1218' '\1290' '\1220' '\12D0' '\1348' '\1338' '\1240' '\1228' '\1230' '\1270' '\1280' '\1340' '\1330' '\1350';
+    /* 'አ' 'በ' 'ገ' 'ደ' 'ሀ' 'ወ' 'ዘ' 'ሐ' 'ጠ' 'የ' 'ከ' 'ለ' 'መ' 'ነ' 'ሠ' 'ዐ' 'ፈ' 'ጸ' 'ቀ' 'ረ' 'ሰ' 'ተ' 'ኀ' 'ፀ' 'ጰ' 'ፐ' */
+    suffix: '\1366 '; /* ፦ */
+}
+
+@counter-style somali {
+    system: alphabetic;
+    symbols: '\1200' '\1208' '\1210' '\1218' '\1228' '\1230' '\1238' '\1240' '\1260' '\1270' '\1290' '\12A0' '\12A8' '\12B8' '\12C8' '\12D0' '\12E8' '\12F0' '\1300' '\1308' '\1338' '\1348';
+    /* 'ሀ' 'ለ' 'ሐ' 'መ' 'ረ' 'ሰ' 'ሸ' 'ቀ' 'በ' 'ተ' 'ነ' 'አ' 'ከ' 'ኸ' 'ወ' 'ዐ' 'የ' 'ደ' 'ጀ' 'ገ' 'ጸ' 'ፈ' */
+    suffix: '\1366 '; /* ፦ */
+}
+
+@counter-style tigrinya-er-abegede {
+    system: alphabetic;
+    symbols: '\12A0' '\1260' '\1308' '\12F0' '\1300' '\1200' '\12C8' '\12D8' '\12E0' '\1210' '\1320' '\1328' '\12E8' '\12A8' '\12B8' '\1208' '\1218' '\1290' '\1298' '\12D0' '\1348' '\1338' '\1240' '\1250' '\1228' '\1230' '\1238' '\1270' '\1278' '\1330' '\1350';
+    /* 'አ' 'በ' 'ገ' 'ደ' 'ጀ' 'ሀ' 'ወ' 'ዘ' 'ዠ' 'ሐ' 'ጠ' 'ጨ' 'የ' 'ከ' 'ኸ' 'ለ' 'መ' 'ነ' 'ኘ' 'ዐ' 'ፈ' 'ጸ' 'ቀ' 'ቐ' 'ረ' 'ሰ' 'ሸ' 'ተ' 'ቸ' 'ጰ' 'ፐ' */
+    suffix: '\1366 '; /* ፦ */
+}
+
+@counter-style tigrinya-et-abegede {
+    system: alphabetic;
+    symbols: '\12A0' '\1260' '\1308' '\12F0' '\1300' '\1200' '\12C8' '\12D8' '\12E0' '\1210' '\1320' '\1328' '\12E8' '\12A8' '\12B8' '\1208' '\1218' '\1290' '\1298' '\1220' '\12D0' '\1348' '\1338' '\1240' '\1250' '\1228' '\1230' '\1238' '\1270' '\1278' '\1280' '\1340' '\1330' '\1350';
+    /* 'አ' 'በ' 'ገ' 'ደ' 'ጀ' 'ሀ' 'ወ' 'ዘ' 'ዠ' 'ሐ' 'ጠ' 'ጨ' 'የ' 'ከ' 'ኸ' 'ለ' 'መ' 'ነ' 'ኘ' 'ሠ' 'ዐ' 'ፈ' 'ጸ' 'ቀ' 'ቐ' 'ረ' 'ሰ' 'ሸ' 'ተ' 'ቸ' 'ኀ' 'ፀ' 'ጰ' 'ፐ' */
+    suffix: '\1366 '; /* ፦ */
+}
+
+@counter-style ethiopic-abegede-gez {
+    system: extends ethiopic-abegede;
+}
+
+@counter-style ethiopic-abegede-am-et {
+    system: extends amharic-abegede;
+}
+
+@counter-style ethiopic-abegede-ti-er {
+    system: extends tigrinya-er-abegede;
+}
+
+@counter-style ethiopic-abegede-ti-et {
+    system: extends tigrinya-et-abegede;
+}
+
+@counter-style ethiopic-halehame-aa-et {
+    system: extends afar;
+}
+
+@counter-style ethiopic-halehame-aa-er {
+    system: extends afar;
+}
+
+@counter-style ethiopic-halehame-am-et {
+    system: extends amharic;
+}
+
+@counter-style ethiopic-halehame-gez {
+    system: extends ethiopic;
+}
+
+@counter-style ethiopic-halehame-om-et {
+    system: extends oromo;
+}
+
+@counter-style ethiopic-halehame-sid-et {
+    system: extends sidama;
+}
+
+@counter-style ethiopic-halehame-so-et {
+    system: extends somali;
+}
+
+@counter-style ethiopic-halehame-tig {
+    system: extends tigre;
+}
+
+@counter-style tigrinya-er {
+    system: extends ethiopic-halehame-ti-er;
+}
+
+@counter-style tigrinya-et {
+    system: extends ethiopic-halehame-ti-et;
 }

--- a/Source/WebCore/style/StyleBuilderConverter.h
+++ b/Source/WebCore/style/StyleBuilderConverter.h
@@ -296,7 +296,9 @@ inline ListStyleType BuilderConverter::convertListStyleType(const BuilderState& 
 {
     auto& primitiveValue = downcast<CSSPrimitiveValue>(value);
     if (primitiveValue.isValueID()) {
-        if (builderState.document().settings().cssCounterStyleAtRulesEnabled() && !isCounterStyleUnsupportedByUserAgent(primitiveValue.valueID()))
+        if (primitiveValue.valueID() == CSSValueNone)
+            return { ListStyleType::Type::None, nullAtom() };
+        if (builderState.document().settings().cssCounterStyleAtRulesEnabled())
             return { ListStyleType::Type::CounterStyle, makeAtomString(primitiveValue.stringValue()) };
         return { fromCSSValue<ListStyleType::Type>(primitiveValue), nullAtom() };
     }


### PR DESCRIPTION
#### 08374bddfb52a8231e7b4876949b3c2b63822386
<pre>
[css-counter-styles] Port ethiopic counter styles to new codepath
<a href="https://bugs.webkit.org/show_bug.cgi?id=256158">https://bugs.webkit.org/show_bug.cgi?id=256158</a>
rdar://108724140

Reviewed by Myles C. Maxfield.

Use converter at <a href="https://bugs.webkit.org/attachment.cgi?id=466153">https://bugs.webkit.org/attachment.cgi?id=466153</a> to generate counter styles based on RenderListMarker data.
Note that this is supposed to be a 1:1 port from RenderListMarker, so there are places where we differ from the W3C ready-made counter styles.
rdar://108704382 has been filed to review them.

Also isCounterStyleUnsupportedByUserAgent is now removed and merged back to its call-site.

* Source/WebCore/css/CSSCounterStyleRegistry.cpp:
(WebCore::isCounterStyleUnsupportedByUserAgent): Deleted.
* Source/WebCore/css/CSSCounterStyleRegistry.h:
* Source/WebCore/css/counterStyles.css:
(@counter-style afar):
(@counter-style ethiopic-halehame-ti-er):
(@counter-style ethiopic-halehame-ti-et):
(@counter-style oromo):
(@counter-style sidama):
(@counter-style tigre):
(@counter-style urdu):
(@counter-style amharic):
(@counter-style amharic-abegede):
(@counter-style ethiopic):
(@counter-style ethiopic-abegede):
(@counter-style somali):
(@counter-style tigrinya-er-abegede):
(@counter-style tigrinya-et-abegede):
(@counter-style ethiopic-abegede-gez):
(@counter-style ethiopic-abegede-am-et):
(@counter-style ethiopic-abegede-ti-er):
(@counter-style ethiopic-abegede-ti-et):
(@counter-style ethiopic-halehame-aa-et):
(@counter-style ethiopic-halehame-aa-er):
(@counter-style ethiopic-halehame-am-et):
(@counter-style ethiopic-halehame-gez):
(@counter-style ethiopic-halehame-om-et):
(@counter-style ethiopic-halehame-sid-et):
(@counter-style ethiopic-halehame-so-et):
(@counter-style ethiopic-halehame-tig):
(@counter-style tigrinya-er):
(@counter-style tigrinya-et):
* Source/WebCore/style/StyleBuilderConverter.h:
(WebCore::Style::BuilderConverter::convertListStyleType):

Canonical link: <a href="https://commits.webkit.org/263602@main">https://commits.webkit.org/263602@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a45c5f81efc1224097b8f2701e10f013a2e9b78c

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/5191 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/5325 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/5507 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/6718 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/32/builds/5261 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/5188 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/5535 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/5303 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/5570 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/5284 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/15/builds/5373 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/4651 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/6735 "Built successfully") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/39/builds/2858 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/4649 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/10324 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/4723 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/4722 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/6341 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/7/builds/5152 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/4240 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/30/builds/4630 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| [  ~~🛠 🧪 merge~~](https://ews-build.webkit.org/#/builders/19/builds/1245 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/4/builds/8713 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/584 "Built successfully and passed tests") | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/31/builds/4995 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->