### PR TITLE
[GStreamer][WebRTC] Deadlock when closing PeerConnection

### DIFF
--- a/Source/WebCore/Modules/mediastream/gstreamer/GStreamerDtlsTransportBackend.h
+++ b/Source/WebCore/Modules/mediastream/gstreamer/GStreamerDtlsTransportBackend.h
@@ -28,11 +28,13 @@
 
 namespace WebCore {
 
-class GStreamerDtlsTransportBackend final : public RTCDtlsTransportBackend, public CanMakeWeakPtr<GStreamerDtlsTransportBackend, WeakPtrFactoryInitialization::Eager> {
+class GStreamerDtlsTransportBackendObserver;
+
+class GStreamerDtlsTransportBackend final : public RTCDtlsTransportBackend, public CanMakeWeakPtr<GStreamerDtlsTransportBackend> {
     WTF_MAKE_FAST_ALLOCATED;
 
 public:
-    explicit GStreamerDtlsTransportBackend(const GRefPtr<GstWebRTCDTLSTransport>&);
+    explicit GStreamerDtlsTransportBackend(GRefPtr<GstWebRTCDTLSTransport>&&);
     ~GStreamerDtlsTransportBackend();
 
 private:
@@ -42,10 +44,8 @@ private:
     void registerClient(Client&) final;
     void unregisterClient() final;
 
-    void stateChanged() const;
-
     GRefPtr<GstWebRTCDTLSTransport> m_backend;
-    WeakPtr<Client> m_client;
+    RefPtr<GStreamerDtlsTransportBackendObserver> m_observer;
 };
 
 } // namespace WebCore

--- a/Source/WebCore/Modules/mediastream/gstreamer/GStreamerIceTransportBackend.cpp
+++ b/Source/WebCore/Modules/mediastream/gstreamer/GStreamerIceTransportBackend.cpp
@@ -29,8 +29,8 @@
 
 namespace WebCore {
 
-GStreamerIceTransportBackend::GStreamerIceTransportBackend(const GRefPtr<GstWebRTCDTLSTransport>& transport)
-    : m_backend(transport)
+GStreamerIceTransportBackend::GStreamerIceTransportBackend(GRefPtr<GstWebRTCDTLSTransport>&& transport)
+    : m_backend(WTFMove(transport))
 {
     ASSERT(m_backend);
 

--- a/Source/WebCore/Modules/mediastream/gstreamer/GStreamerIceTransportBackend.h
+++ b/Source/WebCore/Modules/mediastream/gstreamer/GStreamerIceTransportBackend.h
@@ -31,7 +31,7 @@ class GStreamerIceTransportBackend final : public RTCIceTransportBackend, public
     WTF_MAKE_FAST_ALLOCATED;
 
 public:
-    explicit GStreamerIceTransportBackend(const GRefPtr<GstWebRTCDTLSTransport>&);
+    explicit GStreamerIceTransportBackend(GRefPtr<GstWebRTCDTLSTransport>&&);
     ~GStreamerIceTransportBackend();
 
 private:

--- a/Source/WebCore/Modules/mediastream/gstreamer/GStreamerRtpReceiverBackend.cpp
+++ b/Source/WebCore/Modules/mediastream/gstreamer/GStreamerRtpReceiverBackend.cpp
@@ -68,7 +68,9 @@ std::unique_ptr<RTCDtlsTransportBackend> GStreamerRtpReceiverBackend::dtlsTransp
 {
     GRefPtr<GstWebRTCDTLSTransport> transport;
     g_object_get(m_rtcReceiver.get(), "transport", &transport.outPtr(), nullptr);
-    return transport ? makeUnique<GStreamerDtlsTransportBackend>(transport) : nullptr;
+    if (!transport)
+        return nullptr;
+    return makeUnique<GStreamerDtlsTransportBackend>(WTFMove(transport));
 }
 
 } // namespace WebCore

--- a/Source/WebCore/Modules/mediastream/gstreamer/GStreamerRtpSenderBackend.cpp
+++ b/Source/WebCore/Modules/mediastream/gstreamer/GStreamerRtpSenderBackend.cpp
@@ -198,7 +198,9 @@ std::unique_ptr<RTCDtlsTransportBackend> GStreamerRtpSenderBackend::dtlsTranspor
 
     GRefPtr<GstWebRTCDTLSTransport> transport;
     g_object_get(m_rtcSender.get(), "transport", &transport.outPtr(), nullptr);
-    return transport ? makeUnique<GStreamerDtlsTransportBackend>(transport) : nullptr;
+    if (!transport)
+        return nullptr;
+    return makeUnique<GStreamerDtlsTransportBackend>(WTFMove(transport));
 }
 
 } // namespace WebCore

--- a/Source/WebCore/Modules/mediastream/gstreamer/GStreamerSctpTransportBackend.cpp
+++ b/Source/WebCore/Modules/mediastream/gstreamer/GStreamerSctpTransportBackend.cpp
@@ -64,7 +64,7 @@ UniqueRef<RTCDtlsTransportBackend> GStreamerSctpTransportBackend::dtlsTransportB
 {
     GRefPtr<GstWebRTCDTLSTransport> transport;
     g_object_get(m_backend.get(), "transport", &transport.outPtr(), nullptr);
-    return makeUniqueRef<GStreamerDtlsTransportBackend>(transport);
+    return makeUniqueRef<GStreamerDtlsTransportBackend>(WTFMove(transport));
 }
 
 void GStreamerSctpTransportBackend::registerClient(Client& client)

--- a/Source/WebCore/platform/mediastream/gstreamer/RealtimeOutgoingMediaSourceGStreamer.cpp
+++ b/Source/WebCore/platform/mediastream/gstreamer/RealtimeOutgoingMediaSourceGStreamer.cpp
@@ -68,6 +68,8 @@ RealtimeOutgoingMediaSourceGStreamer::~RealtimeOutgoingMediaSourceGStreamer()
     if (m_transceiver)
         g_signal_handlers_disconnect_by_data(m_transceiver.get(), this);
 
+    stopOutgoingSource();
+
     if (GST_IS_PAD(m_webrtcSinkPad.get())) {
         auto srcPad = adoptGRef(gst_element_get_static_pad(m_bin.get(), "src"));
         if (gst_pad_unlink(srcPad.get(), m_webrtcSinkPad.get())) {


### PR DESCRIPTION
#### 53e6c2557ae992b7f08012d57473b1a9640b4f84
<pre>
[GStreamer][WebRTC] Deadlock when closing PeerConnection
<a href="https://bugs.webkit.org/show_bug.cgi?id=256161">https://bugs.webkit.org/show_bug.cgi?id=256161</a>

Reviewed by Xabier Rodriguez-Calvar.

The main issue here was that the end-point closing from the main thread ends up waiting on the dtls
decoder sink pad to unlock its stream lock that has been locked by the DtlsTransportBackend, also from
the main thread and blocking.

This patch also aligns the DtlsTransportBackend GStreamer implementation a bit more with the
libwebrtc one and makes GstWebRTCDTLSTransport pointers ownership more explicit.

Also while debugging this I noticed outgoing sources kept being notified of buffers even after
shutdown, they weren&apos;t stopped from the source destructor.

* Source/WebCore/Modules/mediastream/gstreamer/GStreamerDtlsTransportBackend.cpp:
(WebCore::GStreamerDtlsTransportBackend::stateChanged const):
* Source/WebCore/platform/mediastream/gstreamer/RealtimeOutgoingMediaSourceGStreamer.cpp:
(WebCore::RealtimeOutgoingMediaSourceGStreamer::~RealtimeOutgoingMediaSourceGStreamer):

Canonical link: <a href="https://commits.webkit.org/263627@main">https://commits.webkit.org/263627@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/258ff5624bbbe863a64aed18c39cf31dbdfffbf5

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/5277 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/5413 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/5601 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/6810 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/5319 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/5276 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/5630 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/5392 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/5843 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/5375 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/5446 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/4728 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/6832 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/2928 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/4731 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/11271 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/4792 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/4807 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/6421 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/5231 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/4293 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/4700 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/1264 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/8793 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/5060 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->