### PR TITLE
[GStreamer][WebRTC] Duplicate state change notifications in DataChannel handler

### DIFF
--- a/Source/WebCore/Modules/mediastream/gstreamer/GStreamerDataChannelHandler.h
+++ b/Source/WebCore/Modules/mediastream/gstreamer/GStreamerDataChannelHandler.h
@@ -66,7 +66,7 @@ private:
 
     void readyStateChanged();
     void bufferedAmountChanged();
-    void checkState();
+    bool checkState();
     void postTask(Function<void()>&&);
 
     struct StateChange {


### PR DESCRIPTION
#### 954e6ee42148be3c05dde3571bad5a92f9f6aade
<pre>
[GStreamer][WebRTC] Duplicate state change notifications in DataChannel handler
<a href="https://bugs.webkit.org/show_bug.cgi?id=256163">https://bugs.webkit.org/show_bug.cgi?id=256163</a>

Reviewed by Xabier Rodriguez-Calvar.

The `checkState()` might dispatch a ready-state-change notification, so there&apos;s no need to dispatch
another one when processing pending messages.

* Source/WebCore/Modules/mediastream/gstreamer/GStreamerDataChannelHandler.cpp:
(WebCore::GStreamerDataChannelHandler::setClient):
(WebCore::GStreamerDataChannelHandler::checkState):
* Source/WebCore/Modules/mediastream/gstreamer/GStreamerDataChannelHandler.h:

Canonical link: <a href="https://commits.webkit.org/263584@main">https://commits.webkit.org/263584@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/18743675aa1c25522a2d2d0c4705c66f5bff8132

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/5030 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/5160 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/5337 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/6549 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/5121 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/5023 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/5351 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/5135 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/5369 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/5116 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/5197 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/4509 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/6566 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/2685 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/4507 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/9503 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/4548 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/4580 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/6187 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/4996 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/4092 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/4482 "Built successfully") | | | 
| [❌ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/1228 "Failed to push commit to Webkit repository") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/8559 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/4848 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->