### PR TITLE
[iOS] YouTube playback can unexpectedly interrupt other apps playing audio

### DIFF
--- a/LayoutTests/media/audio-play-with-video-element-interrupted-expected.txt
+++ b/LayoutTests/media/audio-play-with-video-element-interrupted-expected.txt
@@ -1,0 +1,14 @@
+Test that a video element with an audio source always gets paused when audio is interrupted.
+
+
+RUN(video.src = findMediaFile("audio", "content/silence"))
+RUN(video.play())
+EVENT(playing)
+RUN(internals.beginAudioSessionInterruption())
+EVENT(pause)
+RUN(video.play())
+EVENT(playing)
+RUN(internals.beginAudioSessionInterruption())
+EVENT(pause)
+END OF TEST
+

--- a/LayoutTests/media/audio-play-with-video-element-interrupted.html
+++ b/LayoutTests/media/audio-play-with-video-element-interrupted.html
@@ -1,0 +1,37 @@
+<!DOCTYPE html> <!-- webkit-test-runner [ allowTestOnlyIPC=true ] -->
+<html>
+<head>
+    <script src="media-file.js"></script>
+    <script src="video-test.js"></script>
+    <script>
+    async function runTest() {
+        if (!window.internals)
+            return;
+
+        findMediaElement();
+        run('video.src = findMediaFile("audio", "content/silence")');
+
+        runWithKeyDown('video.play()');
+        await waitFor(video, 'playing');
+
+        run('internals.beginAudioSessionInterruption()');
+        await waitFor(video, 'pause');
+
+        // Play the video again to test an implicit end to the interruption.
+        runWithKeyDown('video.play()');
+        await waitFor(video, 'playing');
+
+        run('internals.beginAudioSessionInterruption()');
+        await waitFor(video, 'pause');
+
+        internals.endAudioSessionInterruption();
+        endTest();
+    }
+    </script>
+</head>
+
+<body onload="runTest()">
+    <p>Test that a video element with an audio source always gets paused when audio is interrupted.</p>
+    <video controls></video>
+</body>
+</html>

--- a/Source/WebCore/Modules/audiosession/DOMAudioSession.cpp
+++ b/Source/WebCore/Modules/audiosession/DOMAudioSession.cpp
@@ -153,7 +153,7 @@ void DOMAudioSession::endAudioSessionInterruption(AudioSession::MayResume)
     scheduleStateChangeEvent();
 }
 
-void DOMAudioSession::activeStateChanged()
+void DOMAudioSession::audioSessionActiveStateChanged()
 {
     scheduleStateChangeEvent();
 }

--- a/Source/WebCore/Modules/audiosession/DOMAudioSession.h
+++ b/Source/WebCore/Modules/audiosession/DOMAudioSession.h
@@ -72,7 +72,7 @@ private:
     // InterruptionObserver
     void beginAudioSessionInterruption() final;
     void endAudioSessionInterruption(AudioSession::MayResume) final;
-    void activeStateChanged() final;
+    void audioSessionActiveStateChanged() final;
 
     void scheduleStateChangeEvent();
 

--- a/Source/WebCore/platform/audio/AudioSession.cpp
+++ b/Source/WebCore/platform/audio/AudioSession.cpp
@@ -153,7 +153,7 @@ void AudioSession::endInterruption(MayResume mayResume)
 void AudioSession::activeStateChanged()
 {
     for (auto& observer : m_interruptionObservers)
-        observer.activeStateChanged();
+        observer.audioSessionActiveStateChanged();
 }
 
 void AudioSession::setCategory(CategoryType, Mode, RouteSharingPolicy)

--- a/Source/WebCore/platform/audio/AudioSession.h
+++ b/Source/WebCore/platform/audio/AudioSession.h
@@ -133,7 +133,7 @@ public:
 
         virtual void beginAudioSessionInterruption() = 0;
         virtual void endAudioSessionInterruption(MayResume) = 0;
-        virtual void activeStateChanged() { }
+        virtual void audioSessionActiveStateChanged() { }
     };
     virtual void addInterruptionObserver(InterruptionObserver&);
     virtual void removeInterruptionObserver(InterruptionObserver&);

--- a/Source/WebKit/GPUProcess/media/RemoteAudioSessionProxy.cpp
+++ b/Source/WebKit/GPUProcess/media/RemoteAudioSessionProxy.cpp
@@ -120,12 +120,22 @@ void RemoteAudioSessionProxy::configurationChanged()
 
 void RemoteAudioSessionProxy::beginInterruption()
 {
-    connection().send(Messages::RemoteAudioSession::BeginInterruption(), { });
+    connection().send(Messages::RemoteAudioSession::BeginInterruptionRemote(), { });
 }
 
 void RemoteAudioSessionProxy::endInterruption(AudioSession::MayResume mayResume)
 {
-    connection().send(Messages::RemoteAudioSession::EndInterruption(mayResume), { });
+    connection().send(Messages::RemoteAudioSession::EndInterruptionRemote(mayResume), { });
+}
+
+void RemoteAudioSessionProxy::beginInterruptionRemote()
+{
+    audioSessionManager().beginInterruptionRemote();
+}
+
+void RemoteAudioSessionProxy::endInterruptionRemote(AudioSession::MayResume mayResume)
+{
+    audioSessionManager().endInterruptionRemote(mayResume);
 }
 
 RemoteAudioSessionProxyManager& RemoteAudioSessionProxy::audioSessionManager()

--- a/Source/WebKit/GPUProcess/media/RemoteAudioSessionProxy.h
+++ b/Source/WebKit/GPUProcess/media/RemoteAudioSessionProxy.h
@@ -81,6 +81,9 @@ private:
     void triggerBeginInterruptionForTesting();
     void triggerEndInterruptionForTesting();
 
+    void beginInterruptionRemote();
+    void endInterruptionRemote(WebCore::AudioSession::MayResume);
+
     RemoteAudioSessionProxyManager& audioSessionManager();
     IPC::Connection& connection();
 

--- a/Source/WebKit/GPUProcess/media/RemoteAudioSessionProxy.messages.in
+++ b/Source/WebKit/GPUProcess/media/RemoteAudioSessionProxy.messages.in
@@ -33,6 +33,9 @@ messages -> RemoteAudioSessionProxy NotRefCounted {
 
     TriggerBeginInterruptionForTesting()
     TriggerEndInterruptionForTesting()
+
+    BeginInterruptionRemote()
+    EndInterruptionRemote(WebCore::AudioSession::MayResume flags)
 }
 
 #endif

--- a/Source/WebKit/GPUProcess/media/RemoteAudioSessionProxyManager.cpp
+++ b/Source/WebKit/GPUProcess/media/RemoteAudioSessionProxyManager.cpp
@@ -213,6 +213,24 @@ void RemoteAudioSessionProxyManager::updatePresentingProcesses()
     AudioSession::sharedSession().setPresentingProcesses(WTFMove(presentingProcesses));
 }
 
+void RemoteAudioSessionProxyManager::beginInterruptionRemote()
+{
+    auto& session = this->session();
+    // Temporarily remove as an observer to avoid a spurious IPC back to the web process.
+    session.removeInterruptionObserver(*this);
+    session.beginInterruption();
+    session.addInterruptionObserver(*this);
+}
+
+void RemoteAudioSessionProxyManager::endInterruptionRemote(AudioSession::MayResume mayResume)
+{
+    auto& session = this->session();
+    // Temporarily remove as an observer to avoid a spurious IPC back to the web process.
+    session.removeInterruptionObserver(*this);
+    session.endInterruption(mayResume);
+    session.addInterruptionObserver(*this);
+}
+
 void RemoteAudioSessionProxyManager::beginAudioSessionInterruption()
 {
     m_proxies.forEach([](auto& proxy) {

--- a/Source/WebKit/GPUProcess/media/RemoteAudioSessionProxyManager.h
+++ b/Source/WebKit/GPUProcess/media/RemoteAudioSessionProxyManager.h
@@ -52,6 +52,9 @@ public:
 
     bool tryToSetActiveForProcess(RemoteAudioSessionProxy&, bool);
 
+    void beginInterruptionRemote();
+    void endInterruptionRemote(WebCore::AudioSession::MayResume);
+
     WebCore::AudioSession& session() { return WebCore::AudioSession::sharedSession(); }
     const WebCore::AudioSession& session() const { return WebCore::AudioSession::sharedSession(); }
 

--- a/Source/WebKit/WebProcess/GPU/media/RemoteAudioSession.h
+++ b/Source/WebKit/WebProcess/GPU/media/RemoteAudioSession.h
@@ -43,6 +43,7 @@ class WebProcess;
 
 class RemoteAudioSession final
     : public WebCore::AudioSession
+    , public WebCore::AudioSession::InterruptionObserver
     , public GPUProcessConnection::Client
     , IPC::MessageReceiver {
     WTF_MAKE_FAST_ALLOCATED;
@@ -98,6 +99,12 @@ private:
     RemoteAudioSessionConfiguration& configuration();
     void initializeConfigurationIfNecessary();
 
+    void beginInterruptionRemote();
+    void endInterruptionRemote(MayResume);
+
+    // InterruptionObserver
+    void beginAudioSessionInterruption() final;
+    void endAudioSessionInterruption(WebCore::AudioSession::MayResume) final;
 
     WebProcess& m_process;
 

--- a/Source/WebKit/WebProcess/GPU/media/RemoteAudioSession.messages.in
+++ b/Source/WebKit/WebProcess/GPU/media/RemoteAudioSession.messages.in
@@ -27,8 +27,8 @@
 
 messages -> RemoteAudioSession NotRefCounted {
     ConfigurationChanged(struct WebKit::RemoteAudioSessionConfiguration configuration)
-    BeginInterruption()
-    EndInterruption(WebCore::AudioSession::MayResume flags)
+    BeginInterruptionRemote()
+    EndInterruptionRemote(WebCore::AudioSession::MayResume flags)
 }
 
 #endif


### PR DESCRIPTION
#### b300e9f2c444288175f0af13b59562609b86c24e
<pre>
[iOS] YouTube playback can unexpectedly interrupt other apps playing audio
<a href="https://bugs.webkit.org/show_bug.cgi?id=256168">https://bugs.webkit.org/show_bug.cgi?id=256168</a>
rdar://108741963

Reviewed by Jean-Yves Avenard.

Consider the following sequence of events:

1. Begin playback of a video on YouTube.
2. Open another app like Music, and play some audio while the video is playing.
3. Play the YouTube video again, as it will be paused following (2).
4. Play the audio in Music again, as it will be paused following (3).

After (4), the YouTube video does not get paused, and ends up interrupting
the content in Music. Instead, the same behavior as (2) should occur, where
the video gets paused, and the audio from Music is allowed to play uninterrupted.

The issue arises from the existing implemention of audio playback using the
GPU process. With the GPU process, there is now an `AudioSession` in both the
Web and GPU processes. After (2), the system dispatches an
`AVAudioSessionInterruptionNotification` notification, observed in the GPU
process, and used to pause playback. The interruption state is stored on the
`AudioSession` in the GPU process, and is sent to the `AudioSession` in the Web
process (`RemoteAudioSession`). Consequently, the video playback is correctly
paused following (2).

After (3), the video is resumed in the Web process, and the `RemoteAudioSession`
is marked as uninterrupted. However, the `AudioSession` is the GPU process is
not informed that the audio interruption has ended. Consequently, when the
notification is dispatched again after (4), it is ignored, as the GPU process
believes the audio session is already interrupted. This results in a failure
to correctly interrupt the audio session, and media playback in WebKit ends
up interrupting the session in another app.

To fix, ensure the GPU process is notified when interruption ends as a result
of change in the Web process.

* LayoutTests/media/audio-play-with-video-element-interrupted-expected.txt: Added.
* LayoutTests/media/audio-play-with-video-element-interrupted.html: Added.

Added a layout test to exercise the issue. Without this fix, the test times out.

* Source/WebCore/Modules/audiosession/DOMAudioSession.cpp:
(WebCore::DOMAudioSession::audioSessionActiveStateChanged):
(WebCore::DOMAudioSession::activeStateChanged): Deleted.
* Source/WebCore/Modules/audiosession/DOMAudioSession.h:
* Source/WebCore/platform/audio/AudioSession.cpp:
(WebCore::AudioSession::activeStateChanged):
* Source/WebCore/platform/audio/AudioSession.h:

Rename an `InterruptionObserver` method that has the same name as an
`AudioSession` method, so that `RemoteAudioSession` (a derived class of
`AudioSession`) can also be an `InterruptionObserver`.

* Source/WebKit/GPUProcess/media/RemoteAudioSessionProxy.cpp:
(WebKit::RemoteAudioSessionProxy::beginInterruption):
(WebKit::RemoteAudioSessionProxy::endInterruption):
(WebKit::RemoteAudioSessionProxy::beginInterruptionRemote):

Call into `RemoteAudioSessionProxyManager`, which is the actual
`InterruptionObserver`.

(WebKit::RemoteAudioSessionProxy::endInterruptionRemote):

Ditto.

* Source/WebKit/GPUProcess/media/RemoteAudioSessionProxy.h:
* Source/WebKit/GPUProcess/media/RemoteAudioSessionProxy.messages.in:

Add new IPC messages to begin/end interruptions from the Web process.

* Source/WebKit/GPUProcess/media/RemoteAudioSessionProxyManager.cpp:
(WebKit::RemoteAudioSessionProxyManager::beginInterruptionRemote):

Temporarily remove `this` as an `InterruptionObserver` to avoid sending a
spurious interruption message to the Web process, since this interruption
was triggered by the Web process.

(WebKit::RemoteAudioSessionProxyManager::endInterruptionRemote):

Ditto.

* Source/WebKit/GPUProcess/media/RemoteAudioSessionProxyManager.h:
* Source/WebKit/WebProcess/GPU/media/RemoteAudioSession.cpp:
(WebKit::RemoteAudioSession::RemoteAudioSession):
(WebKit::RemoteAudioSession::~RemoteAudioSession):
(WebKit::RemoteAudioSession::beginInterruptionRemote):

Temporarily remove `this` as an `InterruptionObserver` to avoid sending a
spurious interruption message to the GPU process, since this interruption
was triggered by the GPU process.

(WebKit::RemoteAudioSession::endInterruptionRemote):

Ditto.

(WebKit::RemoteAudioSession::beginAudioSessionInterruption):

Send IPC to the GPU process to reflect the Web process state.

(WebKit::RemoteAudioSession::endAudioSessionInterruption):
* Source/WebKit/WebProcess/GPU/media/RemoteAudioSession.h:

Make `RemoteAudioSession` an `InterruptionObserver` so that it can send IPC to
the GPU process when the Web process state is changed.

* Source/WebKit/WebProcess/GPU/media/RemoteAudioSession.messages.in:

Rename the IPC method to avoid conflicting the method on the `AudioSession` base
class that drives interruptions. This change is necessary to avoid sending a
spurious IPC to the GPU process when the interrupted state is changed in the Web
process.

Canonical link: <a href="https://commits.webkit.org/263810@main">https://commits.webkit.org/263810@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/152fd999bafe47b17a3223da328b34dd6fad9900

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/5638 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/5792 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/5982 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/7191 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/5626 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/5638 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/6017 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/5765 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/7618 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/5742 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/5793 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/5052 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/7233 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/3270 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/5077 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/12230 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/5139 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/5153 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/6972 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/5588 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/4571 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/5037 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/5007 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/1373 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/9147 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/5398 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->