### PR TITLE
Add a runtime flag for fullscreen window effects

### DIFF
--- a/Source/WebKit/UIProcess/ios/fullscreen/WKFullScreenWindowControllerIOS.mm
+++ b/Source/WebKit/UIProcess/ios/fullscreen/WKFullScreenWindowControllerIOS.mm
@@ -560,28 +560,30 @@ static constexpr CGFloat kFullScreenWindowCornerRadius = 12;
     [_window setBackgroundColor:[UIColor clearColor]];
     [_window setWindowLevel:UIWindowLevelNormal - 1];
     [_window setHidden:NO];
-#if HAVE(UIKIT_WEBKIT_INTERNALS)
-    auto screenSize = page->overrideScreenSize();
-    CGFloat preferredWidth = screenSize.width();
-    CGFloat preferredHeight = screenSize.height();
+#if ENABLE(FULLSCREEN_WINDOW_EFFECTS)
+    if (fullscreenWindowEffectsEnabled()) {
+        auto screenSize = page->overrideScreenSize();
+        CGFloat preferredWidth = screenSize.width();
+        CGFloat preferredHeight = screenSize.height();
 
-    CGFloat targetWidth = preferredWidth;
-    CGFloat targetHeight = preferredHeight;
-    if (videoDimensions.height && videoDimensions.width) {
-        CGFloat preferredAspectRatio = preferredWidth / preferredHeight;
-        CGFloat videoAspectRatio = videoDimensions.height ? (videoDimensions.width / videoDimensions.height) : preferredAspectRatio;
-        if (videoAspectRatio > preferredAspectRatio)
-            targetHeight = videoDimensions.height * preferredWidth / videoDimensions.width;
-        else
-            targetWidth = videoDimensions.width * preferredHeight / videoDimensions.height;
+        CGFloat targetWidth = preferredWidth;
+        CGFloat targetHeight = preferredHeight;
+        if (videoDimensions.height && videoDimensions.width) {
+            CGFloat preferredAspectRatio = preferredWidth / preferredHeight;
+            CGFloat videoAspectRatio = videoDimensions.height ? (videoDimensions.width / videoDimensions.height) : preferredAspectRatio;
+            if (videoAspectRatio > preferredAspectRatio)
+                targetHeight = videoDimensions.height * preferredWidth / videoDimensions.width;
+            else
+                targetWidth = videoDimensions.width * preferredHeight / videoDimensions.height;
+        }
+
+        [_window setFrame:CGRectMake(0, 0, floorf(targetWidth), floorf(targetHeight))];
+        [_window setAlpha:0];
+        [_window setClipsToBounds:YES];
+        [_window _setContinuousCornerRadius:kFullScreenWindowCornerRadius];
+        [_window setNeedsLayout];
+        [_window layoutIfNeeded];
     }
-
-    [_window setFrame:CGRectMake(0, 0, floorf(targetWidth), floorf(targetHeight))];
-    [_window setAlpha:0];
-    [_window setClipsToBounds:YES];
-    [_window _setContinuousCornerRadius:kFullScreenWindowCornerRadius];
-    [_window setNeedsLayout];
-    [_window layoutIfNeeded];
 #endif
 
     _rootViewController = adoptNS([[UIViewController alloc] init]);
@@ -719,14 +721,15 @@ static constexpr CGFloat kFullScreenWindowCornerRadius = 12;
 
     [CATransaction commit];
 
-#if ENABLE(FULLSCREEN_WINDOW_EFFECTS)
-    configureFullscreenTransition(_lastKnownParentWindow.get(), _window.get());
-    BOOL shouldAnimateEnterFullscreenTransition = NO;
-#else
     // NOTE: In this state, there is already a AVKit fullscreen presentation; we want to
     // animate into position under the AVKit fullscreen, then after that presentation
     // completes, exit AVKit fullscreen.
     BOOL shouldAnimateEnterFullscreenTransition = !_returnToFullscreenFromPictureInPicture;
+#if ENABLE(FULLSCREEN_WINDOW_EFFECTS)
+    if (fullscreenWindowEffectsEnabled()) {
+        configureFullscreenTransition(_lastKnownParentWindow.get(), _window.get());
+        shouldAnimateEnterFullscreenTransition = NO;
+    }
 #endif
 
     [_rootViewController presentViewController:_fullscreenViewController.get() animated:shouldAnimateEnterFullscreenTransition completion:^{
@@ -751,8 +754,10 @@ static constexpr CGFloat kFullScreenWindowCornerRadius = 12;
             [_fullscreenViewController showBanner];
 
 #if ENABLE(FULLSCREEN_WINDOW_EFFECTS)
-            CompletionHandler<void()> completionHandler = []() { };
-            performFullscreenTransition(self, _lastKnownParentWindow.get(), _window.get(), _parentWindowState.get(), true, WTFMove(completionHandler));
+            if (fullscreenWindowEffectsEnabled()) {
+                CompletionHandler<void()> completionHandler = []() { };
+                performFullscreenTransition(self, _lastKnownParentWindow.get(), _window.get(), _parentWindowState.get(), true, WTFMove(completionHandler));
+            }
 #endif
 
             if (auto* videoFullscreenManager = self._videoFullscreenManager) {
@@ -1092,10 +1097,12 @@ static constexpr CGFloat kFullScreenWindowCornerRadius = 12;
         page->setSuppressVisibilityUpdates(true);
 
 #if ENABLE(FULLSCREEN_WINDOW_EFFECTS)
-    [UIView performWithoutAnimation:^{
-        CompletionHandler<void()> completionHandler = []() { };
-        performFullscreenTransition(self, _lastKnownParentWindow.get(), _window.get(), _parentWindowState.get(), false, WTFMove(completionHandler));
-    }];
+    if (fullscreenWindowEffectsEnabled()) {
+        [UIView performWithoutAnimation:^{
+            CompletionHandler<void()> completionHandler = []() { };
+            performFullscreenTransition(self, _lastKnownParentWindow.get(), _window.get(), _parentWindowState.get(), false, WTFMove(completionHandler));
+        }];
+    }
 #endif
 
     [self _reinsertWebViewUnderPlaceholder];
@@ -1239,16 +1246,17 @@ static constexpr CGFloat kFullScreenWindowCornerRadius = 12;
     }
 
 #if ENABLE(FULLSCREEN_WINDOW_EFFECTS)
+    if (fullscreenWindowEffectsEnabled()) {
+        configureFullscreenTransition(_lastKnownParentWindow.get(), _window.get());
 
-    configureFullscreenTransition(_lastKnownParentWindow.get(), _window.get());
+        CompletionHandler<void()> completionHandler = [strongSelf = retainPtr(self), self] () {
+            [self _completedExitFullScreen];
+        };
 
-    CompletionHandler<void()> completionHandler = [strongSelf = retainPtr(self), self] () {
-        [self _completedExitFullScreen];
-    };
-
-    performFullscreenTransition(self, _lastKnownParentWindow.get(), _window.get(), _parentWindowState.get(), false, WTFMove(completionHandler));
-
-#else
+        performFullscreenTransition(self, _lastKnownParentWindow.get(), _window.get(), _parentWindowState.get(), false, WTFMove(completionHandler));
+        return;
+    }
+#endif // ENABLE(FULLSCREEN_WINDOW_EFFECTS)
 
     [_fullscreenViewController setAnimating:YES];
     [_fullscreenViewController dismissViewControllerAnimated:YES completion:^{
@@ -1266,8 +1274,6 @@ static constexpr CGFloat kFullScreenWindowCornerRadius = 12;
         [self _completedExitFullScreen];
 #endif
     }];
-
-#endif // ENABLE(FULLSCREEN_WINDOW_EFFECTS)
 }
 
 #if ENABLE(FULLSCREEN_DISMISSAL_GESTURES)


### PR DESCRIPTION
#### 25b7c386eb572c7f82498bc2d61f7abb44cc1146
<pre>
Add a runtime flag for fullscreen window effects
<a href="https://bugs.webkit.org/show_bug.cgi?id=256169">https://bugs.webkit.org/show_bug.cgi?id=256169</a>
rdar://107903065

Reviewed by Tim Horton.

* Source/WebKit/UIProcess/ios/fullscreen/WKFullScreenWindowControllerIOS.mm:
(-[WKFullScreenWindowController enterFullScreen:]):
(-[WKFullScreenWindowController beganEnterFullScreenWithInitialFrame:finalFrame:]):
(-[WKFullScreenWindowController _exitFullscreenImmediately]):
(-[WKFullScreenWindowController _dismissFullscreenViewController]):

Canonical link: <a href="https://commits.webkit.org/263597@main">https://commits.webkit.org/263597@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c0b2c3d05c32aec6725e760f430810384b85a4d1

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/5052 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/5182 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/5359 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/6572 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/5142 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/5377 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/5157 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/5391 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/5138 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/5221 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/4529 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/6588 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/2708 "Passed tests") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/9564 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/4571 "Passed tests") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/4600 "3 failures") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/6212 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/5017 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/4115 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/4503 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/8580 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/582 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/4869 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->