### PR TITLE
REGRESSION(259145@main): Crash when using 'currentcolor' with color-mix() in color property

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-color/color-mix-currentcolor-003-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-color/color-mix-currentcolor-003-expected.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>Reference: currentColor is inherited correctly in color-mix()</title>
+<style>
+div {
+    color: color-mix(in srgb, green 50%, white)
+}
+</style>
+<div>
+    <div>This text should be pale green</div>
+</div>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-color/color-mix-currentcolor-003-ref.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-color/color-mix-currentcolor-003-ref.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>Reference: currentColor is inherited correctly in color-mix()</title>
+<style>
+div {
+    color: color-mix(in srgb, green 50%, white);
+}
+</style>
+<div>
+    <div>This text should be pale green</div>
+</div>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-color/color-mix-currentcolor-003.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-color/color-mix-currentcolor-003.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<link rel="match" href="color-mix-currentcolor-003-ref.html">
+<title>currentColor is inherited correctly in color-mix()</title>
+<link rel="help" href="https://drafts.csswg.org/css-color-5/#color-mix">
+<link rel="author" title="Tim Nguyen" href="https://github.com/nt1m">
+<style>
+body {
+    color: green;
+}
+div {
+    color: color-mix(in srgb, currentColor 50%, white);
+}
+div > div {
+    color: inherit;
+}
+</style>
+<div>
+    <div>This text should be pale green</div>
+</div>

--- a/Source/WebCore/style/StyleBuilderCustom.h
+++ b/Source/WebCore/style/StyleBuilderCustom.h
@@ -2077,21 +2077,17 @@ inline void BuilderCustom::applyValueColor(BuilderState& builderState, CSSValue&
     auto& primitiveValue = downcast<CSSPrimitiveValue>(value);
 
     // For the color property, current color is actually the inherited computed color.
-    auto absoluteColorOrInheritColor = [&](const StyleColor& color) {
-        if (color.isCurrentColor()) {
-            auto& parentStyle = builderState.parentStyle();
-            return parentStyle.color();
-        }
-        return color.absoluteColor();
+    auto resolveColor = [&](const StyleColor& color) {
+        return color.resolveColor(builderState.parentStyle().color());
     };
-    
+
     if (builderState.applyPropertyToRegularStyle()) {
         auto color = builderState.colorFromPrimitiveValue(primitiveValue, ForVisitedLink::No);
-        builderState.style().setColor(absoluteColorOrInheritColor(color));
+        builderState.style().setColor(resolveColor(color));
     }
     if (builderState.applyPropertyToVisitedLinkStyle()) {
         auto color = builderState.colorFromPrimitiveValue(primitiveValue, ForVisitedLink::Yes);
-        builderState.style().setVisitedLinkColor(absoluteColorOrInheritColor(color));
+        builderState.style().setVisitedLinkColor(resolveColor(color));
     }
     builderState.style().setDisallowsFastPathInheritance();
 }


### PR DESCRIPTION
#### 0d0b8844e76c4d7a71f2d93de58b0c1bc49056cf
<pre>
REGRESSION(259145@main): Crash when using &apos;currentcolor&apos; with color-mix() in color property
<a href="https://bugs.webkit.org/show_bug.cgi?id=256171">https://bugs.webkit.org/show_bug.cgi?id=256171</a>
rdar://108698737

Reviewed by Darin Adler.

We were previously not handling `color-mix()` in the logic to resolve colors for `BuilderCustom::applyValueColor`.
Use StyleColor::resolveColor() which properly takes care of all cases.

* LayoutTests/imported/w3c/web-platform-tests/css/css-color/color-mix-currentcolor-003-expected.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-color/color-mix-currentcolor-003-ref.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-color/color-mix-currentcolor-003.html: Added.
* Source/WebCore/style/StyleBuilderCustom.h:
(WebCore::Style::BuilderCustom::applyValueColor):

Canonical link: <a href="https://commits.webkit.org/263556@main">https://commits.webkit.org/263556@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d98a67fd9251cbff4ac10ce0fdb3e1c7ccdf3f0e

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/5057 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/5187 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/5364 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/6577 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/5147 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/5050 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/5383 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/5162 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/5394 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/5143 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/5229 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/4535 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/6593 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/2716 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/4533 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/9573 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/4579 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/4606 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/6215 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/5022 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/4120 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/4508 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/4529 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/1212 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/8585 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/4874 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->