### PR TITLE
REGRESSION (263335@main): Apple Pay is cancelled automatically

### DIFF
--- a/Source/WebCore/Modules/applepay/ApplePaySetupFeatureTypeWebCore.h
+++ b/Source/WebCore/Modules/applepay/ApplePaySetupFeatureTypeWebCore.h
@@ -29,7 +29,7 @@
 
 namespace WebCore {
 
-enum class ApplePaySetupFeatureType : bool {
+enum class ApplePaySetupFeatureType : uint8_t {
     ApplePay,
     AppleCard,
 };

--- a/Source/WebCore/Modules/applepay/ApplePaySetupFeatureWebCore.h
+++ b/Source/WebCore/Modules/applepay/ApplePaySetupFeatureWebCore.h
@@ -35,7 +35,7 @@ OBJC_CLASS PKPaymentSetupFeature;
 namespace WebCore {
 
 enum class ApplePaySetupFeatureState : uint8_t;
-enum class ApplePaySetupFeatureType : bool;
+enum class ApplePaySetupFeatureType : uint8_t;
 
 class ApplePaySetupFeature : public RefCounted<ApplePaySetupFeature> {
 public:

--- a/Source/WebCore/Modules/applepay/PaymentInstallmentConfigurationWebCore.h
+++ b/Source/WebCore/Modules/applepay/PaymentInstallmentConfigurationWebCore.h
@@ -27,7 +27,6 @@
 
 #if HAVE(PASSKIT_INSTALLMENTS)
 
-#include "ApplePayInstallmentConfigurationWebCore.h"
 #include <wtf/RetainPtr.h>
 
 OBJC_CLASS NSDictionary;
@@ -36,6 +35,7 @@ OBJC_CLASS PKPaymentInstallmentConfiguration;
 namespace WebCore {
 
 class Document;
+struct ApplePayInstallmentConfiguration;
 template<typename> class ExceptionOr;
 
 class WEBCORE_EXPORT PaymentInstallmentConfiguration {
@@ -44,16 +44,14 @@ public:
 
     PaymentInstallmentConfiguration() = default;
     PaymentInstallmentConfiguration(RetainPtr<PKPaymentInstallmentConfiguration>&&);
-    PaymentInstallmentConfiguration(ApplePayInstallmentConfiguration&&);
-    PaymentInstallmentConfiguration(const ApplePayInstallmentConfiguration&, RetainPtr<NSDictionary>&&);
 
-    RetainPtr<PKPaymentInstallmentConfiguration> platformConfiguration() const;
-    const ApplePayInstallmentConfiguration& applePayInstallmentConfiguration() const;
+    PKPaymentInstallmentConfiguration *platformConfiguration() const;
+    ApplePayInstallmentConfiguration applePayInstallmentConfiguration() const;
 
 private:
-    static ApplePayInstallmentConfiguration applePayInstallmentConfiguration(PKPaymentInstallmentConfiguration *);
+    PaymentInstallmentConfiguration(const ApplePayInstallmentConfiguration&, NSDictionary *applicationMetadata);
 
-    ApplePayInstallmentConfiguration m_configuration;
+    RetainPtr<PKPaymentInstallmentConfiguration> m_configuration;
 };
 
 } // namespace WebCore

--- a/Source/WebKit/Shared/ApplePay/cocoa/WebPaymentCoordinatorProxyCocoa.mm
+++ b/Source/WebKit/Shared/ApplePay/cocoa/WebPaymentCoordinatorProxyCocoa.mm
@@ -364,8 +364,8 @@ ALLOW_DEPRECATED_DECLARATIONS_END
 #endif
 
 #if HAVE(PASSKIT_INSTALLMENTS)
-    if (auto configuration = paymentRequest.installmentConfiguration().platformConfiguration()) {
-        [result setInstallmentConfiguration:configuration.get()];
+    if (PKPaymentInstallmentConfiguration *configuration = paymentRequest.installmentConfiguration().platformConfiguration()) {
+        [result setInstallmentConfiguration:configuration];
         [result setRequestType:PKPaymentRequestTypeInstallment];
     }
 #endif

--- a/Source/WebKit/Shared/Cocoa/ArgumentCodersCocoa.mm
+++ b/Source/WebKit/Shared/Cocoa/ArgumentCodersCocoa.mm
@@ -651,6 +651,11 @@ static bool shouldEnableStrictMode(Decoder& decoder, NSArray<Class> *allowedClas
         return false;
 #endif // PLATFORM(MAC)
 #endif // ENABLE(DATA_DETECTION)
+#if ENABLE(APPLE_PAY)
+    // Don't reintroduce rdar://108281584
+    if (supportsPassKitCore && [allowedClasses containsObject:PAL::getPKPaymentInstallmentConfigurationClass()]) 
+        return false;
+#endif
 
 #if ENABLE(REVEAL)
     // rdar://107553310 - don't re-introduce rdar://107673064

--- a/Source/WebKit/Shared/Cocoa/WebCoreArgumentCodersCocoa.mm
+++ b/Source/WebKit/Shared/Cocoa/WebCoreArgumentCodersCocoa.mm
@@ -80,6 +80,24 @@ namespace IPC {
 
 #if ENABLE(APPLE_PAY)
 
+#if HAVE(PASSKIT_INSTALLMENTS)
+
+void ArgumentCoder<WebCore::PaymentInstallmentConfiguration>::encode(Encoder& encoder, const WebCore::PaymentInstallmentConfiguration& configuration)
+{
+    encoder << configuration.platformConfiguration();
+}
+
+std::optional<WebCore::PaymentInstallmentConfiguration> ArgumentCoder<WebCore::PaymentInstallmentConfiguration>::decode(Decoder& decoder)
+{
+    auto configuration = IPC::decode<PKPaymentInstallmentConfiguration>(decoder, PAL::getPKPaymentInstallmentConfigurationClass());
+    if (!configuration)
+        return std::nullopt;
+
+    return { WTFMove(*configuration) };
+}
+
+#endif // HAVE(PASSKIT_INSTALLMENTS)
+
 void ArgumentCoder<WebCore::Payment>::encode(Encoder& encoder, const WebCore::Payment& payment)
 {
     encoder << payment.pkPayment();

--- a/Source/WebKit/Shared/WebCoreArgumentCoders.h
+++ b/Source/WebKit/Shared/WebCoreArgumentCoders.h
@@ -468,6 +468,13 @@ template<> struct ArgumentCoder<WebCore::CDMInstanceSession::Message> {
 };
 #endif
 
+#if HAVE(PASSKIT_INSTALLMENTS)
+template<> struct ArgumentCoder<WebCore::PaymentInstallmentConfiguration> {
+    static void encode(Encoder&, const WebCore::PaymentInstallmentConfiguration&);
+    static std::optional<WebCore::PaymentInstallmentConfiguration> decode(Decoder&);
+};
+#endif
+
 #if ENABLE(IMAGE_ANALYSIS) && ENABLE(DATA_DETECTION)
 
 template<> struct ArgumentCoder<WebCore::TextRecognitionDataDetector> {

--- a/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
+++ b/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
@@ -771,49 +771,6 @@ enum class WebCore::ApplePayErrorCode : uint8_t {
 };
 #endif // ENABLE(APPLE_PAY)
 
-#if ENABLE(APPLE_PAY_INSTALLMENTS)
-header: <WebCore/ApplePayInstallmentConfigurationWebCore.h>
-[CustomHeader] struct WebCore::ApplePayInstallmentConfiguration {
-    WebCore::ApplePaySetupFeatureType featureType;
-    String merchandisingImageData;
-    String openToBuyThresholdAmount;
-    String bindingTotalAmount;
-    String currencyCode;
-    bool isInStorePurchase;
-    String merchantIdentifier;
-    String referrerIdentifier;
-    Vector<WebCore::ApplePayInstallmentItem> items;
-    String applicationMetadata;
-    WebCore::ApplePayInstallmentRetailChannel retailChannel;
-};
-header: <WebCore/PaymentInstallmentConfigurationWebCore.h>
-[CustomHeader] class WebCore::PaymentInstallmentConfiguration {
-    WebCore::ApplePayInstallmentConfiguration applePayInstallmentConfiguration()
-}
-struct WebCore::ApplePayInstallmentItem {
-    WebCore::ApplePayInstallmentItemType type;
-    String amount;
-    String currencyCode;
-    String programIdentifier;
-    String apr;
-    String programTerms;
-};
-enum class WebCore::ApplePaySetupFeatureType : bool
-enum class WebCore::ApplePayInstallmentItemType : uint8_t {
-    Generic,
-    Phone,
-    Pad,
-    Watch,
-    Mac,
-};
-enum class WebCore::ApplePayInstallmentRetailChannel : uint8_t {
-    Unknown,
-    App,
-    Web,
-    InStore,
-};
-#endif // ENABLE(APPLE_PAY_INSTALLMENTS)
-
 #if ENABLE(APPLE_PAY_COUPON_CODE)
 struct WebCore::ApplePayCouponCodeUpdate : WebCore::ApplePayDetailsUpdateBase {
     Vector<RefPtr<WebCore::ApplePayError>> errors;


### PR DESCRIPTION
#### 1752fc362fb2d1fb86896c0839a7645a49253979
<pre>
REGRESSION (263335@main): Apple Pay is cancelled automatically
<a href="https://bugs.webkit.org/show_bug.cgi?id=256175">https://bugs.webkit.org/show_bug.cgi?id=256175</a>
rdar://108745891

Unreviewed, revert 263335@main.

* Source/WebCore/Modules/applepay/ApplePaySetupFeatureTypeWebCore.h:
* Source/WebCore/Modules/applepay/ApplePaySetupFeatureWebCore.h:
* Source/WebCore/Modules/applepay/PaymentInstallmentConfiguration.mm:
(WebCore::createPlatformConfiguration):
(WebCore::PaymentInstallmentConfiguration::create):
(WebCore::PaymentInstallmentConfiguration::PaymentInstallmentConfiguration):
(WebCore::PaymentInstallmentConfiguration::platformConfiguration const):
(WebCore::PaymentInstallmentConfiguration::applePayInstallmentConfiguration const):
(WebCore::applicationMetadataDictionary): Deleted.
(WebCore::applicationMetadataString): Deleted.
(WebCore::addApplicationMetadata): Deleted.
(WebCore::PaymentInstallmentConfiguration::applePayInstallmentConfiguration): Deleted.
* Source/WebCore/Modules/applepay/PaymentInstallmentConfigurationWebCore.h:
* Source/WebCore/WebCore.xcodeproj/project.pbxproj:
* Source/WebKit/Shared/ApplePay/cocoa/WebPaymentCoordinatorProxyCocoa.mm:
(WebKit::WebPaymentCoordinatorProxy::platformPaymentRequest):
* Source/WebKit/Shared/Cocoa/ArgumentCodersCocoa.mm:
(IPC::shouldEnableStrictMode):
* Source/WebKit/Shared/Cocoa/WebCoreArgumentCodersCocoa.mm:
(IPC::ArgumentCoder&lt;WebCore::PaymentInstallmentConfiguration&gt;::encode):
(IPC::ArgumentCoder&lt;WebCore::PaymentInstallmentConfiguration&gt;::decode):
* Source/WebKit/Shared/WebCoreArgumentCoders.h:
* Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in:

Canonical link: <a href="https://commits.webkit.org/263560@main">https://commits.webkit.org/263560@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b082c8b116cba3c7915fc9debd14a71bc3b2d13d

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/5062 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/5193 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/5369 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/6582 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/5152 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/5055 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/5389 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/5167 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/5400 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/5148 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/5234 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/4540 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/6598 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/2721 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/4538 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/9578 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/4584 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/4611 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/6220 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/5027 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/4124 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/4513 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/1214 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/8590 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/4879 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->