### PR TITLE
[JSC] definePropertyOnReceiver() doesn't account for put_by_val_with_this bytecode op

### DIFF
--- a/JSTests/stress/define-property-on-receiver-slow-proxy-set-missing-trap.js
+++ b/JSTests/stress/define-property-on-receiver-slow-proxy-set-missing-trap.js
@@ -1,0 +1,10 @@
+(function() {
+    var target = {};
+    var proxy = new Proxy(target, {});
+
+    for (var i = 0; i < 1e6; i++)
+        proxy.foo = i;
+
+    if (target.foo !== i - 1)
+        throw new Error("Bad value!");
+})();

--- a/JSTests/stress/define-property-on-receiver-slow-super-set-property-2.js
+++ b/JSTests/stress/define-property-on-receiver-slow-super-set-property-2.js
@@ -1,0 +1,11 @@
+(function() {
+    var target = {};
+    var proxy = new Proxy(target, {});
+
+    var { method } = { method(i) { super.foo = i; } };
+    for (var i = 0; i < 1e6; i++)
+        method.call(proxy, i);
+
+    if (target.foo !== i - 1)
+        throw new Error("Bad value!");
+})();

--- a/JSTests/stress/define-property-on-receiver-slow-super-set-property.js
+++ b/JSTests/stress/define-property-on-receiver-slow-super-set-property.js
@@ -1,0 +1,16 @@
+(function() {
+    var trapCalls = 0;
+    var proxy = new Proxy({}, {
+        defineProperty() {
+            trapCalls++;
+            return true;
+        }
+    });
+
+    var { method } = { method() { super.foo = 1; } };
+    for (var i = 0; i < 1e6; i++)
+        method.call(proxy);
+
+    if (trapCalls !== i)
+        throw new Error("Bad value!");
+})();

--- a/JSTests/stress/ordinary-set-exceptions.js
+++ b/JSTests/stress/ordinary-set-exceptions.js
@@ -63,7 +63,7 @@ shouldThrow(function () {
         value: 42,
     }), true);
     receiver.cocoa = 'NG';
-}, `TypeError: Attempting to change value of a readonly property.`);
+}, `TypeError: Attempted to assign to readonly property.`);
 
 // 9.1.9.1 4-d-ii
 shouldThrow(function () {
@@ -85,7 +85,7 @@ shouldThrow(function () {
         value: 42,
     }), true);
     receiver.cocoa = 'NG';
-}, `TypeError: Attempting to change value of a readonly property.`);
+}, `TypeError: Attempted to assign to readonly property.`);
 
 // 9.1.9.1 7
 shouldThrow(function () {

--- a/Source/JavaScriptCore/runtime/JSObject.cpp
+++ b/Source/JavaScriptCore/runtime/JSObject.cpp
@@ -859,6 +859,18 @@ bool JSObject::putInlineSlow(JSGlobalObject* globalObject, PropertyName property
     return putInlineFast(globalObject, propertyName, value, slot);
 }
 
+static bool canDefinePropertyOnReceiverFast(VM& vm, JSObject* receiver, PropertyName propertyName)
+{
+    switch (receiver->type()) {
+    case ArrayType:
+        return propertyName != vm.propertyNames->length;
+    case JSFunctionType:
+        return propertyName != vm.propertyNames->length && propertyName != vm.propertyNames->name && propertyName != vm.propertyNames->prototype;
+    default:
+        return false;
+    }
+}
+
 static NEVER_INLINE bool definePropertyOnReceiverSlow(JSGlobalObject* globalObject, PropertyName propertyName, JSValue value, JSObject* receiver, bool shouldThrow)
 {
     VM& vm = globalObject->vm();
@@ -903,8 +915,8 @@ bool JSObject::definePropertyOnReceiver(JSGlobalObject* globalObject, PropertyNa
     if (receiver->type() == GlobalProxyType)
         receiver = jsCast<JSGlobalProxy*>(receiver)->target();
 
-    if (slot.isTaintedByOpaqueObject() || slot.context() == PutPropertySlot::ReflectSet) {
-        if (receiver->methodTable()->defineOwnProperty != JSObject::defineOwnProperty)
+    if (slot.isTaintedByOpaqueObject() || receiver->methodTable()->defineOwnProperty != JSObject::defineOwnProperty) {
+        if (!canDefinePropertyOnReceiverFast(vm, receiver, propertyName))
             return definePropertyOnReceiverSlow(globalObject, propertyName, value, receiver, slot.isStrictMode());
     }
 


### PR DESCRIPTION
#### 39476b8c83f0ac6c9a06582e4d8e5aef0bb0a88f
<pre>
[JSC] definePropertyOnReceiver() doesn&apos;t account for put_by_val_with_this bytecode op
<a href="https://bugs.webkit.org/show_bug.cgi?id=256172">https://bugs.webkit.org/show_bug.cgi?id=256172</a>
&lt;rdar://problem/108750872&gt;

Reviewed by Yusuke Suzuki.

The OrdinarySet revamp in <a href="https://webkit.org/b/217916">https://webkit.org/b/217916</a> assumed that there are only 2 cases to take the slow path
for altered receivers: overriden [[Set]] in prototype chain and Reflect.set(). I thought that it&apos;s unobservable
to take the fast path otherwise since overriden methods were already called.

However, the third case was missed: put_by_val_with_this bytecode op, which is emitted for setting a property
on `super` base, and with <a href="https://webkit.org/b/252602">https://webkit.org/b/252602</a>, for ProxyObjectStore IC when the trap is missing.

Among other minor web compatibility bugs, missing that case caused properties to be put right on ProxyObject&apos;s
structure, where they are unaccessible, skipping calls to &quot;set&quot; and &quot;defineProperty&quot; traps.

This change relaxes the condition for taking the definePropertyOnReceiverSlow() while ensuring all common
[[Set]] targets like JSArray or `class X extends Y {}` are just as fast.

Regresses the Speedometer2/Flight-TodoMVC by 12-16%, which was recently falsely progressed only as a result
of skipping observable puts that other engines do perform.

* JSTests/stress/define-property-on-receiver-slow-proxy-set-missing-trap.js: Added.
* JSTests/stress/define-property-on-receiver-slow-super-set-property.js: Added.
* JSTests/stress/define-property-on-receiver-slow-super-set-property-2.js: Added.
* JSTests/stress/ordinary-set-exceptions.js: Updated error messages.
* Source/JavaScriptCore/runtime/JSObject.cpp:
(JSC::canDefinePropertyOnReceiverFast):
(JSC::JSObject::definePropertyOnReceiver):

Canonical link: <a href="https://commits.webkit.org/263559@main">https://commits.webkit.org/263559@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/edf24cd733a9de4c9c800377dab3262bdedddd46

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [  ~~🧪 style~~](https://ews-build.webkit.org/#/builders/38/builds/5073 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 ios~~](https://ews-build.webkit.org/#/builders/26/builds/5204 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/14/builds/5380 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/6593 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/32/builds/5161 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/23/builds/5400 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/16/builds/5179 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/6593 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | 
| [  ~~🧪 webkitperl~~](https://ews-build.webkit.org/#/builders/11/builds/5159 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/23/builds/5400 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/14/builds/5380 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/2/builds/6609 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/23/builds/5400 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/14/builds/5380 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/2/builds/6609 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | 
| [  ~~🛠 🧪 jsc~~](https://ews-build.webkit.org/#/builders/20/builds/4197 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/23/builds/5400 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/14/builds/5380 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/2/builds/6609 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | 
| [  ~~🛠 🧪 jsc-arm64~~](https://ews-build.webkit.org/#/builders/12/builds/4667 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/7/builds/5038 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/16/builds/5179 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 jsc-armv7~~](https://ews-build.webkit.org/#/builders/35/builds/5166 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/30/builds/4522 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/14/builds/5380 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 jsc-armv7-tests~~](https://ews-build.webkit.org/#/builders/35/builds/5166 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/4/builds/8601 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [  ~~🛠 jsc-mips~~](https://ews-build.webkit.org/#/builders/24/builds/5310 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/569 "Built successfully and passed tests") | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/31/builds/4887 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [  ~~🧪 jsc-mips-tests~~](https://ews-build.webkit.org/#/builders/24/builds/5310 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | 
<!--EWS-Status-Bubble-End-->