### PR TITLE
[IFC] Bail out from partial layout when intrusive float is present.

### DIFF
--- a/LayoutTests/fast/inline/inline-content-with-intrusive-float-partial-layout-crash-expected.txt
+++ b/LayoutTests/fast/inline/inline-content-with-intrusive-float-partial-layout-crash-expected.txt
@@ -1,0 +1,1 @@
+PASS If No Crash

--- a/LayoutTests/fast/inline/inline-content-with-intrusive-float-partial-layout-crash.html
+++ b/LayoutTests/fast/inline/inline-content-with-intrusive-float-partial-layout-crash.html
@@ -1,0 +1,21 @@
+<style>
+details {
+  text-transform: capitalize;
+}
+div {
+  width: 0px;
+}
+img {
+  float: right;
+  width: 100px;
+  height: 100px;
+}
+</style><div><details open="true"><img id=img>
+PASS if no crash</details></div><script>
+if (window.testRunner)
+  testRunner.dumpAsText();
+document.body.offsetHeight;
+img.style.borderWidth = "1px"; 
+document.body.offsetHeight;
+img.style.borderWidth = "2px"; 
+</script>

--- a/Source/WebCore/layout/integration/LayoutIntegrationCoverage.cpp
+++ b/Source/WebCore/layout/integration/LayoutIntegrationCoverage.cpp
@@ -472,6 +472,8 @@ bool shouldInvalidateLineLayoutPathAfterChangeFor(const RenderBlockFlow& rootBlo
         return true;
     if (lineLayout.hasOutOfFlowContent())
         return true;
+    if (rootBlockContainer.containsFloats())
+        return true;
     if (lineLayout.contentNeedsVisualReordering() || (is<RenderText>(renderer) && Layout::TextUtil::containsStrongDirectionalityText(downcast<RenderText>(renderer).text()))) {
         // FIXME: InlineItemsBuilder needs some work to support paragraph level bidi handling.
         return true;


### PR DESCRIPTION
#### 0fdc3e870daf76b979a39f943b67784b49440eb7
<pre>
[IFC] Bail out from partial layout when intrusive float is present.
<a href="https://bugs.webkit.org/show_bug.cgi?id=256058">https://bugs.webkit.org/show_bug.cgi?id=256058</a>
&lt;rdar://problem/108628958&gt;

Reviewed by Antti Koivisto.

Floats may shrink available space to 0 producing completely empty lines. This is not yet supported.

* LayoutTests/fast/inline/inline-content-with-intrusive-float-partial-layout-crash-expected.txt: Added.
* LayoutTests/fast/inline/inline-content-with-intrusive-float-partial-layout-crash.html: Added.
* Source/WebCore/layout/integration/LayoutIntegrationCoverage.cpp:
(WebCore::LayoutIntegration::shouldInvalidateLineLayoutPathAfterChangeFor):

Canonical link: <a href="https://commits.webkit.org/263564@main">https://commits.webkit.org/263564@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/3b8ec110c2e84632a866cab9a1d3418da4bc06a5

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/5067 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/5198 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/5374 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/6587 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/5156 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/5060 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/5394 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/5173 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/5402 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/5153 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/5239 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/4544 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/6603 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/2726 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/4542 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/9581 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/4589 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/4615 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/6223 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/5032 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/4129 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/4518 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/4538 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/1216 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/8595 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/4883 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->