### PR TITLE
[bmalloc] Add PerThread implementation for Windows.

### DIFF
--- a/Source/bmalloc/bmalloc/Cache.cpp
+++ b/Source/bmalloc/bmalloc/Cache.cpp
@@ -53,6 +53,14 @@ Cache::Cache(HeapKind heapKind)
     BASSERT(!Environment::get()->isDebugHeapEnabled());
 }
 
+BNO_INLINE void* Cache::getSignatureForTesting()
+{
+    PerHeapKind<Cache>* caches = PerThread<PerHeapKind<Cache>>::getFastCase();
+    if (!caches)
+        caches = PerThread<PerHeapKind<Cache>>::getSlowCase();
+    return reinterpret_cast<void*>(&caches->at(mapToActiveHeapKindAfterEnsuringGigacage(HeapKind::Primary)));
+}
+
 BNO_INLINE void* Cache::tryAllocateSlowCaseNullCache(HeapKind heapKind, size_t size)
 {
     if (auto* debugHeap = DebugHeap::tryGet())

--- a/Source/bmalloc/bmalloc/Cache.h
+++ b/Source/bmalloc/bmalloc/Cache.h
@@ -54,6 +54,9 @@ public:
     Allocator& allocator() { return m_allocator; }
     Deallocator& deallocator() { return m_deallocator; }
 
+    // For testing only
+    BEXPORT static void* getSignatureForTesting();
+
 private:
     BEXPORT static void* tryAllocateSlowCaseNullCache(HeapKind, size_t);
     BEXPORT static void* allocateSlowCaseNullCache(HeapKind, size_t);

--- a/Source/bmalloc/bmalloc/Mutex.cpp
+++ b/Source/bmalloc/bmalloc/Mutex.cpp
@@ -30,6 +30,8 @@
 #if BOS(DARWIN)
 #include <mach/mach_traps.h>
 #include <mach/thread_switch.h>
+#elif BPLATFORM(WIN)
+#include <windows.h>
 #endif
 #include <thread>
 
@@ -40,6 +42,8 @@ static inline void yield()
 #if BOS(DARWIN)
     constexpr mach_msg_timeout_t timeoutInMS = 1;
     thread_switch(MACH_PORT_NULL, SWITCH_OPTION_DEPRESS, timeoutInMS);
+#elif BPLATFORM(WIN)
+    SwitchToThread();
 #else
     sched_yield();
 #endif

--- a/Tools/TestWebKitAPI/CMakeLists.txt
+++ b/Tools/TestWebKitAPI/CMakeLists.txt
@@ -125,6 +125,8 @@ set(TestWTF_SOURCES
     Tests/WTF/WeakPtr.cpp
     Tests/WTF/WorkQueue.cpp
     Tests/WTF/WorkerPool.cpp
+
+    Tests/WTF/bmalloc/PerThread.cpp
 )
 
 set(TestWTF_PRIVATE_INCLUDE_DIRECTORIES

--- a/Tools/TestWebKitAPI/Tests/WTF/bmalloc/PerThread.cpp
+++ b/Tools/TestWebKitAPI/Tests/WTF/bmalloc/PerThread.cpp
@@ -1,0 +1,63 @@
+/*
+ * Copyright (C) 2023 Sony Interactive Entertainment Inc.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+
+#if !USE(SYSTEM_MALLOC)
+
+#include <bmalloc/bmalloc.h>
+
+#if !BUSE(LIBPAS)
+
+#include <bmalloc/Cache.h>
+#include <unordered_set>
+#include <wtf/Threading.h>
+
+using namespace bmalloc;
+using namespace bmalloc::api;
+
+TEST(bmalloc_PerThread, EachCacheHasDifferentCache)
+{
+    std::mutex mutex;
+    std::unordered_set<void*> signatures;
+
+    WTF::Vector<Ref<Thread>> threads;
+    for (unsigned i = 0; i < 10; ++i) {
+        threads.append(Thread::create("PerThreadTest", [&] {
+            void* signature = Cache::getSignatureForTesting();
+
+            std::scoped_lock<std::mutex> lock { mutex };
+            EXPECT_FALSE(signatures.contains(signature));
+            signatures.insert(signature);
+        }));
+    }
+
+    for (auto& thread : threads)
+        thread->waitForCompletion();
+}
+
+#endif
+
+#endif

--- a/Tools/TestWebKitAPI/config.h
+++ b/Tools/TestWebKitAPI/config.h
@@ -42,6 +42,10 @@
 #if defined(BUILDING_WITH_CMAKE)
 
 // CMake path
+#if defined(BUILDING_TestWTF)
+#include <bmalloc/BExport.h>
+#endif
+
 #if defined(BUILDING_TestJSC) || defined(BUILDING_TestJavaScriptCore)
 #include <JavaScriptCore/JSExportMacros.h>
 #endif


### PR DESCRIPTION
<pre>
[bmalloc] Add PerThread implementation for Windows.
<a href="https://bugs.webkit.org/show_bug.cgi?id=256011">https://bugs.webkit.org/show_bug.cgi?id=256011</a>

Reviewed by NOBODY (OOPS!).

This is the patch for Windows bmalloc implementation part 6 of N.

Added Windows implementation of PerThread. It is originally based on pthread
and that's not available on Windows.

Also added test for PerThread in TestWTF to ensure PerThread is working well.
To see the result of PerThread object returning different value for each thread,
testing method is added to Cache because it uses PerThread. This was chosen
because it's difficult to export PerThread outside the bmalloc world.

* Source/bmalloc/bmalloc/Cache.cpp: Added method for test. (bmalloc::Cache::debugGetSignatureForHeapKind):
* Source/bmalloc/bmalloc/Cache.h:
* Source/bmalloc/bmalloc/Mutex.cpp: (bmalloc::yield):
* Source/bmalloc/bmalloc/PerThread.h: (bmalloc::PerThreadStorage::~PerThreadStorage):
(bmalloc::PerThreadStorage::get):
(bmalloc::PerThreadStorage::init):
* Tools/TestWebKitAPI/CMakeLists.txt:
* Tools/TestWebKitAPI/Tests/WTF/bmalloc/PerThread.cpp: Added.
* Tools/TestWebKitAPI/config.h:
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b11836b9bb4d4a5ba8232b36ec9de541a43564ba

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/5072 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/5203 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/5379 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/6592 "Built successfully") | [❌ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/5160 "Failed to compile WebKit") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/5065 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/5399 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/5178 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/5404 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/5158 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/5244 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/4550 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/6608 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/2731 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/4548 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/9584 "Passed tests") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/4196 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/4594 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/4621 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/6226 "Passed tests") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/4666 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/5037 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/4134 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/5165 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/4521 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/1299 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/8600 "Built successfully") | | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/24/builds/5309 "Built successfully") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/4886 "Built successfully") | | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/3/builds/1414 "Passed tests") | 
<!--EWS-Status-Bubble-End-->