### PR TITLE
[Cocoa] Temporarily wake up remote process if outgoing IPC message queue becomes too large

### DIFF
--- a/Source/WebKit/Platform/IPC/Connection.h
+++ b/Source/WebKit/Platform/IPC/Connection.h
@@ -265,6 +265,9 @@ public:
     typedef void (*DidCloseOnConnectionWorkQueueCallback)(Connection*);
     void setDidCloseOnConnectionWorkQueueCallback(DidCloseOnConnectionWorkQueueCallback);
 
+    using OutgoingMessageQueueIsGrowingLargeCallback = Function<void()>;
+    void setOutgoingMessageQueueIsGrowingLargeCallback(OutgoingMessageQueueIsGrowingLargeCallback&&);
+
     // Adds a message receive queue. The client should make sure the instance is removed before it goes
     // out of scope.
     // std::nullopt ReceiverMatchSpec matches all receivers.
@@ -465,6 +468,8 @@ private:
     bool m_onlySendMessagesAsDispatchWhenWaitingForSyncReplyWhenProcessingSuchAMessage { false };
     bool m_shouldExitOnSyncMessageSendFailure { false };
     DidCloseOnConnectionWorkQueueCallback m_didCloseOnConnectionWorkQueueCallback { nullptr };
+    OutgoingMessageQueueIsGrowingLargeCallback m_outgoingMessageQueueIsGrowingLargeCallback;
+    MonotonicTime m_lastOutgoingMessageQueueIsGrowingLargeCallbackCallTime WTF_GUARDED_BY_LOCK(m_outgoingMessagesLock);
 
     Ref<WorkQueue> m_connectionQueue;
     bool m_isConnected { false };

--- a/Source/WebKit/UIProcess/AuxiliaryProcessProxy.h
+++ b/Source/WebKit/UIProcess/AuxiliaryProcessProxy.h
@@ -200,6 +200,7 @@ protected:
 private:
     virtual void connectionWillOpen(IPC::Connection&);
     virtual void processWillShutDown(IPC::Connection&) = 0;
+    void outgoingMessageQueueIsGrowingLarge();
 
     void populateOverrideLanguagesLaunchOptions(ProcessLauncher::LaunchOptions&) const;
     Vector<String> platformOverrideLanguages() const;
@@ -215,9 +216,12 @@ private:
     WebCore::ProcessIdentifier m_processIdentifier { WebCore::ProcessIdentifier::generate() };
     std::optional<UseLazyStop> m_delayedResponsivenessCheck;
     MonotonicTime m_processStart;
-#if PLATFORM(MAC) && USE(RUNNINGBOARD)
+#if USE(RUNNINGBOARD)
+    ProcessThrottler::TimedActivity m_timedActivityForIPC;
+#if PLATFORM(MAC)
     std::unique_ptr<ProcessThrottler::ForegroundActivity> m_lifetimeActivity;
     RefPtr<ProcessAssertion> m_boostedJetsamAssertion;
+#endif
 #endif
 };
 


### PR DESCRIPTION
#### 51833439139b0bb53857d4342ce05b61dfde1683
<pre>
[Cocoa] Temporarily wake up remote process if outgoing IPC message queue becomes too large
<a href="https://bugs.webkit.org/show_bug.cgi?id=256181">https://bugs.webkit.org/show_bug.cgi?id=256181</a>

Reviewed by Ben Nham.

Temporarily wake up remote process if outgoing IPC message queue becomes too
large, to avoid potentially bad memory growth when the remote process is
suspended.

This currently only works for AuxiliaryProcessProxy, so IPC from the UIProcess
to child processes. However, we may want to consider extending this to IPC
from the network process to WebProcesses in a follow-up.

In the current proposal, we wake up the destination process for 3 seconds when
its outgoing message queue has reached 1024 messages. We do so at most once
every 30 seconds.

* Source/WebKit/Platform/IPC/Connection.cpp:
(IPC::Connection::setOutgoingMessageQueueIsGrowingLargeCallback):
(IPC::Connection::invalidate):
(IPC::Connection::sendMessage):
* Source/WebKit/Platform/IPC/Connection.h:
* Source/WebKit/UIProcess/AuxiliaryProcessProxy.cpp:
(WebKit::AuxiliaryProcessProxy::AuxiliaryProcessProxy):
(WebKit::AuxiliaryProcessProxy::didFinishLaunching):
(WebKit::AuxiliaryProcessProxy::outgoingMessageQueueIsGrowingLarge):
* Source/WebKit/UIProcess/AuxiliaryProcessProxy.h:

Canonical link: <a href="https://commits.webkit.org/263570@main">https://commits.webkit.org/263570@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/966aea09d368713f0511210d348725363b8f1913

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/5086 "2 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/5217 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/5394 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/6607 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/5173 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/5424 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/5193 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/5420 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/5173 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/5267 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/4561 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/6623 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/2754 "Passed tests") | | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/9700 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/4617 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/4633 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/6241 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/5051 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/4146 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/4534 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/1218 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/8614 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/4899 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->