### PR TITLE
The Document object is leaked on some pages using media (like YouTube.com)

### DIFF
--- a/LayoutTests/media/media-session/actionHandler-no-document-leak-expected.txt
+++ b/LayoutTests/media/media-session/actionHandler-no-document-leak-expected.txt
@@ -1,0 +1,11 @@
+Tests that page installed actionHandlers do not leak documents.
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+PASS internals.isDocumentAlive(frameDocumentID) is true
+PASS The iframe document didn't leak.
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/media/media-session/actionHandler-no-document-leak.html
+++ b/LayoutTests/media/media-session/actionHandler-no-document-leak.html
@@ -1,0 +1,56 @@
+<!DOCTYPE html>
+<html>
+<head>
+</head>
+<body>
+<iframe id="iframe"></iframe>
+<script src="../../resources/js-test.js"></script>
+<script>
+description("Tests that page installed actionHandlers do not leak documents.");
+
+jsTestIsAsync = true;
+frameDocumentID = 0;
+checkCount = 0;
+
+function iframeLoaded(frameDocument) {
+    if (!window.internals) {
+        testFailed("Test requires internals.");
+        return;
+    }
+
+    frameDocumentID = internals.documentIdentifier(frameDocument);
+    shouldBeTrue("internals.isDocumentAlive(frameDocumentID)");
+
+    iframe.addEventListener("load", () => {
+        handle = setInterval(() => {
+            gc();
+            if (!internals.isDocumentAlive(frameDocumentID)) {
+                clearInterval(handle);
+                testPassed("The iframe document didn't leak.");
+                finishJSTest();
+            }
+            checkCount++;
+            if (checkCount > 500) {
+                clearInterval(handle);
+                testFailed("The iframe document leaked.");
+                finishJSTest();
+            }
+        }, 10);
+    });
+
+    iframe.src = "about:blank";
+}
+
+onload = () => {
+    iframe.src = "resources/media-session-action-handler-document-leak-frame.html";
+    document.body.appendChild(iframe);
+};
+
+onmessage = (message) => {
+    if (message.data === "frameLoaded")
+        iframeLoaded(iframe.contentWindow.document);
+};
+
+</script>
+</body>
+</html>

--- a/LayoutTests/media/media-session/resources/media-session-action-handler-document-leak-frame.html
+++ b/LayoutTests/media/media-session/resources/media-session-action-handler-document-leak-frame.html
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<html>
+<body>
+<script>
+onload = () => {
+    let actions = ["play", "pause", "seekbackward", "seekforward", "previoustrack", "nexttrack", "skipad", "stop", "seekto"];
+    for (action of actions) {
+        navigator.mediaSession.setActionHandler(action, actionDetails => {
+            window.actionDetails = actionDetails;
+        });
+    }
+
+    for (mediaAction of actions) {
+        internals.sendMediaSessionAction(navigator.mediaSession, {action: mediaAction});
+    }
+
+    parent.postMessage("frameLoaded");
+};
+</script>
+</body>
+</html>

--- a/Source/WebCore/Modules/mediasession/MediaSessionActionHandler.h
+++ b/Source/WebCore/Modules/mediasession/MediaSessionActionHandler.h
@@ -40,6 +40,9 @@ public:
     using ActiveDOMCallback::ActiveDOMCallback;
 
     virtual CallbackResult<void> handleEvent(const MediaSessionActionDetails&) = 0;
+
+protected:
+    virtual bool hasCallback() const = 0;
 };
 
 } // namespace WebCore

--- a/Source/WebCore/Modules/mediasession/MediaSessionActionHandler.idl
+++ b/Source/WebCore/Modules/mediasession/MediaSessionActionHandler.idl
@@ -23,4 +23,7 @@
  * THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-[ Conditional=MEDIA_SESSION ] callback MediaSessionActionHandler = undefined (MediaSessionActionDetails details);
+[
+    Conditional=MEDIA_SESSION,
+    IsWeakCallback
+] callback MediaSessionActionHandler = undefined (MediaSessionActionDetails details);


### PR DESCRIPTION
#### 56280cdcbd8a337b7a904678c4bd955a5bbb1e31
<pre>
The Document object is leaked on some pages using media (like YouTube.com)
<a href="https://bugs.webkit.org/show_bug.cgi?id=251835">https://bugs.webkit.org/show_bug.cgi?id=251835</a>
rdar://105112595

Reviewed by Chris Dumez.

By default a callback holds a Strong&lt;&gt; reference to the JS Function
object. This has the effect of making the callback a GC root. Another
option is to annotate the callback with the IsWeakCallback extended
attribute which will hold the callback object as a Weak reference and
keep it alive via the visitJSFunction mechanism instead of making it a
root.

In the case of MediaSessionActionHandler the strong reference will
prevent an HTMLDocument from being garbage collected even after
navigating away and clearing the caches (after a low memory warning, for
example). This change adds the IsWeakCallback attribute and the
necessary virtual function to the MediaSessionActionHandler base class.

LayoutTests:
    Add a test to check that action handlers installed by the page are
    not leaked. Use an iframe to install and exercise the action
    handlers before the iframe is navigated away and a garbage
    collection is triggered (repeatedly). If after 500 attempts at GC
    the document containing the action handlers still exists we consider
    the document leaked.

* LayoutTests/media/media-session/actionHandler-no-document-leak-expected.txt: Added.
* LayoutTests/media/media-session/actionHandler-no-document-leak.html: Added.
* LayoutTests/media/media-session/resources/media-session-action-handler-document-leak-frame.html: Added.

* Source/WebCore/Modules/mediasession/MediaSessionActionHandler.h:
* Source/WebCore/Modules/mediasession/MediaSessionActionHandler.idl:

Canonical link: <a href="https://commits.webkit.org/263660@main">https://commits.webkit.org/263660@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/8464d85dccb0bcd57dabaa3c07e3855bd6468f6c

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/5338 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/5475 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/5663 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/6875 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/5379 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/5338 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/5702 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/5456 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/6004 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/5437 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/5515 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/4783 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/6901 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/2994 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/4788 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/11949 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/4860 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/4867 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/6484 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/5293 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/4348 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/4758 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/4785 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/1285 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/8855 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/5119 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->