### PR TITLE
REGRESSION (262853@main): Pan gestures that scroll should not dispatch synthetic clicks

### DIFF
--- a/LayoutTests/fast/events/ios/scrolling-with-pan-gesture-should-not-trigger-click-expected.txt
+++ b/LayoutTests/fast/events/ios/scrolling-with-pan-gesture-should-not-trigger-click-expected.txt
@@ -1,0 +1,12 @@
+This test verifies that scrolling a very short distance via pan gesture on iOS does
+        not dispatch a click event. To manually test, perform a quick, short-distance pan on each of
+        the green boxes below.
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+PASS overflowScrolled became true
+PASS pageScrolled became true
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/fast/events/ios/scrolling-with-pan-gesture-should-not-trigger-click.html
+++ b/LayoutTests/fast/events/ios/scrolling-with-pan-gesture-should-not-trigger-click.html
@@ -1,0 +1,87 @@
+<!DOCTYPE html> <!-- webkit-test-runner [ useFlexibleViewport=true AsyncOverflowScrollingEnabled=true ] -->
+<html>
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<head>
+<style>
+body {
+    margin: 0;
+}
+
+.scroller {
+    width: 160px;
+    height: 160px;
+    overflow-y: scroll;
+    margin-bottom: 10px;
+}
+
+.target {
+    background: green;
+    width: 160px;
+    height: 160px;
+    box-sizing: border-box;
+    border: 1px solid lightgreen;
+}
+
+.tall {
+    height: 4096px;
+}
+</style>
+<script src="../../../resources/js-test.js"></script>
+<script src="../../../resources/ui-helper.js"></script>
+<script>
+jsTestIsAsync = true;
+pageScrolled = false;
+overflowScrolled = false;
+
+addEventListener("load", async () => {
+    description(`This test verifies that scrolling a very short distance via pan gesture on iOS does
+        not dispatch a click event. To manually test, perform a quick, short-distance pan on each of
+        the green boxes below.`);
+
+    [...document.querySelectorAll(".target")].map(target => {
+        target.addEventListener("click", () => {
+            target.style.background = "red";
+            testFailed(`Observed click over ${target.id}`)
+        });
+    });
+
+    document.querySelector(".scroller").addEventListener("scroll", () => {
+        overflowScrolled = true;
+    }, { once: true });
+
+    document.addEventListener("scroll", () => {
+        pageScrolled = true;
+    }, { once: true });
+
+    await UIHelper.sendEventStream(new UIHelper.EventStreamBuilder()
+        .begin(80, 80)
+        .wait(0.2)
+        .move(80, 40, 0.2)
+        .wait(0.2)
+        .end()
+        .takeResult());
+    await shouldBecomeEqual("overflowScrolled", "true");
+
+    await UIHelper.sendEventStream(new UIHelper.EventStreamBuilder()
+        .begin(80, 250)
+        .wait(0.2)
+        .move(80, 210, 0.2)
+        .wait(0.2)
+        .end()
+        .takeResult());
+    await shouldBecomeEqual("pageScrolled", "true");
+
+    finishJSTest();
+});
+</script>
+</head>
+<body class="tall">
+<div class="scroller">
+    <div class="target"></div>
+    <div class="tall"></div>
+</div>
+<div class="target"></div>
+<pre id="description"></pre>
+<pre id="console"></pre>
+</body>
+</html>


### PR DESCRIPTION
#### 703dabd84f9ce9f920329acd116d21c80fe7010c
<pre>
REGRESSION (262853@main): Pan gestures that scroll should not dispatch synthetic clicks
<a href="https://bugs.webkit.org/show_bug.cgi?id=256182">https://bugs.webkit.org/show_bug.cgi?id=256182</a>
rdar://108553019

Reviewed by Tim Horton.

262853@main allowed the synthetic tap gesture to recognize simultaneously with pan gestures, which
had the unintended consequence of causing synthetic clicks to be dispatched when scrolling the page
for very short distances (that is, shorter than the tap gesture&apos;s default allowable movement
distance of 45pt).

To prevent this from happening while keeping the original fix in 262853@main intact, we continue to
allow simultaneous recognition, but add explicit logic to suppress the synthetic click action from
being sent if we&apos;re actually scrolling any enclosing scroll view (including subscrollable regions in
web views).

See below for more details.

Test: fast/events/ios/scrolling-with-pan-gesture-should-not-trigger-click.html

* LayoutTests/fast/events/ios/scrolling-with-pan-gesture-should-not-trigger-click-expected.txt: Added.
* LayoutTests/fast/events/ios/scrolling-with-pan-gesture-should-not-trigger-click.html: Added.

Add a new layout test to exercise the change by verifying that scrolling for a short distance by
panning the web view does not additionally dispatch click events to the page.

* Source/WebKit/UIProcess/ios/WKContentViewInteraction.mm:
(-[WKContentView _hasEnclosingScrollView:matchingCriteria:]):

Factor out the enclosing scroll view traversal logic below into a helper method, which takes a
function and calls that function with each enclosing `UIScrollView` in the ancestor chain, starting
with the given `scrollView` (or the web view&apos;s main scroll view if none is specified), in search of
the first web view where the given function returns `YES`.

Note that we remove the restriction here that currently makes us bail upon hitting the web view&apos;s
scroller; this allows the fix to work as intended for Mail (and any other apps that embed web views
inside their own scrollers).

(-[WKContentView _isPanningScrollViewOrAncestor:]):

Use the above helper method to check whether we&apos;re actively panning any ancestor scroll view, by
returning `YES` if and only if:

•   The scroll view&apos;s `decelerating` flag is set.
•   The scroll view&apos;s `dragging` flag is set.
•   The scroll view&apos;s pan gesture recognizer is recognizing or about to begin recognizing (i.e.
    state is `Began`, `Changed` or `Ended`).

In my testing, the combination of the three checks above is required to avoid all scenarios where
it&apos;s currently possible to swipe/pan really quickly and end up with both scrolling, and a synthetic
click.

(-[WKContentView _isInterruptingDecelerationForScrollViewOrAncestor:]):

Rewrite this in terms of the `-_hasEnclosingScrollView:matchingCriteria:` helper method above.

(-[WKContentView gestureRecognizerShouldBegin:]):

Don&apos;t allow taps to begin if we&apos;re either (1) panning an enclosing scroll view, or (2) interrupting
momentum scrolling in an enclosing scroll view.

Canonical link: <a href="https://commits.webkit.org/263610@main">https://commits.webkit.org/263610@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/761fa2bb9daa04ddb064e4ef09deb3c4d14faaf6

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/5182 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/5316 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/5497 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/6708 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/5255 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/5526 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/5293 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/5531 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/5275 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/5359 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/4647 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/6726 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/2845 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/4645 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/10386 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/4709 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/4718 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/6342 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/5146 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/4232 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/4624 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/4641 "Passed tests") | | 
| [❌ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/1250 "Failed to push commit to Webkit repository") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/8707 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/4989 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->