### PR TITLE
[baseline-alignment][flex] Ascent for flex items that are scroll containers should be clamped to the border box.

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-flexbox/alignment/flex-align-baseline-line-clamp-001.tentative-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-flexbox/alignment/flex-align-baseline-line-clamp-001.tentative-expected.txt
@@ -37,7 +37,7 @@ PASS .target > * 1
 PASS .target > * 2
 FAIL .target > * 3 assert_equals:
 <div data-offset-y="110"><span></span></div>
-offsetTop expected 110 but got 190
+offsetTop expected 110 but got 120
 PASS .target > * 4
 PASS .target > * 5
 PASS .target > * 6
@@ -51,18 +51,18 @@ PASS .target > * 13
 PASS .target > * 14
 FAIL .target > * 15 assert_equals:
 <div data-offset-y="110"><span></span></div>
-offsetTop expected 110 but got 190
+offsetTop expected 110 but got 120
 PASS .target > * 16
 PASS .target > * 17
 PASS .target > * 18
 FAIL .target > * 19 assert_equals:
 <div data-offset-y="110"><span></span></div>
-offsetTop expected 110 but got 190
+offsetTop expected 110 but got 120
 PASS .target > * 20
 PASS .target > * 21
 PASS .target > * 22
 FAIL .target > * 23 assert_equals:
 <div data-offset-y="110"><span></span></div>
-offsetTop expected 110 but got 190
+offsetTop expected 110 but got 120
 PASS .target > * 24
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-flexbox/alignment/flex-align-baseline-overflow-001-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-flexbox/alignment/flex-align-baseline-overflow-001-expected.txt
@@ -16,27 +16,11 @@ PASS .target > * 2
 PASS .target > * 3
 PASS .target > * 4
 PASS .target > * 5
-FAIL .target > * 6 assert_equals:
-<div class="inner" data-offset-y="30">
-    <div style="margin-block-start: -200px;">
-      <span></span><br><span></span>
-    </div>
-  </div>
-offsetTop expected 30 but got 185
+PASS .target > * 6
 PASS .target > * 7
-FAIL .target > * 8 assert_equals:
-<div class="inner" data-offset-y="50">
-    <div style="margin-block-start: -200px;">
-      <span></span><br><span></span>
-    </div>
-  </div>
-offsetTop expected 50 but got 175
-FAIL .target > * 9 assert_equals:
-<div data-offset-y="110"><span></span><br><span></span></div>
-offsetTop expected 110 but got 245
+PASS .target > * 8
+PASS .target > * 9
 PASS .target > * 10
-FAIL .target > * 11 assert_equals:
-<div data-offset-y="90"><span></span><br><span></span></div>
-offsetTop expected 90 but got 255
+PASS .target > * 11
 PASS .target > * 12
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-flexbox/alignment/flex-align-baseline-overflow-002-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-flexbox/alignment/flex-align-baseline-overflow-002-expected.txt
@@ -15,28 +15,12 @@ PASS .target > * 1
 PASS .target > * 2
 PASS .target > * 3
 PASS .target > * 4
-FAIL .target > * 5 assert_equals:
-<div data-offset-x="100"><span></span><br><span></span></div>
-offsetLeft expected 100 but got 270
+PASS .target > * 5
 PASS .target > * 6
-FAIL .target > * 7 assert_equals:
-<div data-offset-x="120"><span></span><br><span></span></div>
-offsetLeft expected 120 but got 260
+PASS .target > * 7
 PASS .target > * 8
 PASS .target > * 9
-FAIL .target > * 10 assert_equals:
-<div class="inner" data-offset-x="40">
-    <div style="margin-block-start: 200px;">
-      <span></span><br><span></span>
-    </div>
-  </div>
-offsetLeft expected 40 but got 160
+PASS .target > * 10
 PASS .target > * 11
-FAIL .target > * 12 assert_equals:
-<div class="inner" data-offset-x="20">
-    <div style="margin-block-start: 200px;">
-      <span></span><br><span></span>
-    </div>
-  </div>
-offsetLeft expected 20 but got 170
+PASS .target > * 12
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-flexbox/alignment/flex-align-baseline-overflow-003-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-flexbox/alignment/flex-align-baseline-overflow-003-expected.txt
@@ -16,27 +16,11 @@ PASS .target > * 2
 PASS .target > * 3
 PASS .target > * 4
 PASS .target > * 5
-FAIL .target > * 6 assert_equals:
-<div class="inner" data-offset-x="20">
-    <div style="margin-block-start: -200px;">
-      <span></span><br><span></span>
-    </div>
-  </div>
-offsetLeft expected 20 but got 190
+PASS .target > * 6
 PASS .target > * 7
-FAIL .target > * 8 assert_equals:
-<div class="inner" data-offset-x="40">
-    <div style="margin-block-start: -200px;">
-      <span></span><br><span></span>
-    </div>
-  </div>
-offsetLeft expected 40 but got 180
-FAIL .target > * 9 assert_equals:
-<div data-offset-x="120"><span></span><br><span></span></div>
-offsetLeft expected 120 but got 240
+PASS .target > * 8
+PASS .target > * 9
 PASS .target > * 10
-FAIL .target > * 11 assert_equals:
-<div data-offset-x="100"><span></span><br><span></span></div>
-offsetLeft expected 100 but got 250
+PASS .target > * 11
 PASS .target > * 12
 

--- a/Source/WebCore/rendering/RenderBox.h
+++ b/Source/WebCore/rendering/RenderBox.h
@@ -477,6 +477,9 @@ public:
     inline bool hasScrollableOverflowX() const;
     inline bool hasScrollableOverflowY() const;
 
+    bool isScrollContainerX() const { return style().overflowX() == Overflow::Scroll || style().overflowX() == Overflow::Hidden || style().overflowX() == Overflow::Auto;  }
+    bool isScrollContainerY() const { return style().overflowY() == Overflow::Scroll || style().overflowY() == Overflow::Hidden || style().overflowY() == Overflow::Auto; }
+
     LayoutBoxExtent scrollPaddingForViewportRect(const LayoutRect& viewportRect);
 
     bool usesCompositedScrolling() const;


### PR DESCRIPTION
#### 1e66b0fc954597d3d357d1c7db0c7b8373dad8b1
<pre>
[baseline-alignment][flex] Ascent for flex items that are scroll containers should be clamped to the border box.
<a href="https://bugs.webkit.org/show_bug.cgi?id=246229">https://bugs.webkit.org/show_bug.cgi?id=246229</a>
rdar://100908615

Reviewed by Alan Baradlay.

If a flex item is a scroll container (e.g. overflow scroll/hidden) then
it may provide an ascent value that is outside the visible content box
and result in a non-visible position being used for baseline alignment.

When determining the ascent of a flex item, we will check to see if it
is a scroll container by checking to see if it has an overflow value
of either scroll, hidden, or auto and then clamp the used ascent value
of the box to the bottom/top edges of its border box if it is.

<a href="https://drafts.csswg.org/css-align/#baseline-export">https://drafts.csswg.org/css-align/#baseline-export</a>

* LayoutTests/imported/w3c/web-platform-tests/css/css-flexbox/alignment/flex-align-baseline-line-clamp-001.tentative-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-flexbox/alignment/flex-align-baseline-overflow-001-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-flexbox/alignment/flex-align-baseline-overflow-002-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-flexbox/alignment/flex-align-baseline-overflow-003-expected.txt:
* Source/WebCore/rendering/RenderBox.h:
(WebCore::RenderBox::isScrollContainerX const):
(WebCore::RenderBox::isScrollContainerY const):
* Source/WebCore/rendering/RenderFlexibleBox.cpp:
(WebCore::RenderFlexibleBox::flexItemIsScrollContainerCrossAxis const):
(WebCore::RenderFlexibleBox::marginBoxAscentForChild):
(WebCore::RenderFlexibleBox::layoutAndPlaceChildren):
* Source/WebCore/rendering/RenderFlexibleBox.h:

Canonical link: <a href="https://commits.webkit.org/263974@main">https://commits.webkit.org/263974@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e5a5833047c5e2cd0ec69950f368cfdbb53d368e

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/6167 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/6355 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/6537 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/7730 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/6504 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/6167 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/6575 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/6307 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/9383 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/6277 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/6295 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/5582 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/7797 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/3769 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/5562 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/13458 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/5634 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/5641 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/7878 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/6112 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/5000 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/5529 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/1486 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/9673 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/5896 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->