### PR TITLE
Assert that the scrolling tree is valid, and fix issues with negative z-index layers

### DIFF
--- a/Source/WebCore/page/scrolling/ScrollingStateTree.h
+++ b/Source/WebCore/page/scrolling/ScrollingStateTree.h
@@ -97,6 +97,9 @@ private:
 
     void recursiveNodeWillBeRemoved(ScrollingStateNode&);
     void willRemoveNode(ScrollingStateNode&);
+    
+    bool isValid() const;
+    void traverse(const ScrollingStateNode&, const Function<void(const ScrollingStateNode&)>&) const;
 
     AsyncScrollingCoordinator* m_scrollingCoordinator;
     // Contains all the nodes we know about (those in the m_rootStateNode tree, and in m_unparentedNodes subtrees).

--- a/Source/WebCore/rendering/RenderLayerCompositor.h
+++ b/Source/WebCore/rendering/RenderLayerCompositor.h
@@ -530,6 +530,9 @@ private:
 
     void detachScrollCoordinatedLayer(RenderLayer&, OptionSet<ScrollCoordinationRole>);
     void detachScrollCoordinatedLayerWithRole(RenderLayer&, ScrollingCoordinator&, ScrollCoordinationRole);
+    
+    void resolveScrollingTreeRelationships();
+    bool setupScrollProxyRelatedOverflowScrollingNode(ScrollingCoordinator&, ScrollingNodeID, RenderLayer&);
 
     void updateSynchronousScrollingNodes();
 
@@ -635,6 +638,7 @@ private:
     Color m_rootExtendedBackgroundColor;
 
     HashMap<ScrollingNodeID, WeakPtr<RenderLayer>> m_scrollingNodeToLayerMap;
+    WeakHashSet<RenderLayer> m_layersWithUnresolvedRelations;
 #if PLATFORM(IOS_FAMILY)
     std::unique_ptr<LegacyWebKitScrollingLayerCoordinator> m_legacyScrollingLayerCoordinator;
 #endif


### PR DESCRIPTION
#### 46572d8428cba7c77d2ea1182c7a1c9502b12ab8
<pre>
Assert that the scrolling tree is valid, and fix issues with negative z-index layers
<a href="https://bugs.webkit.org/show_bug.cgi?id=256193">https://bugs.webkit.org/show_bug.cgi?id=256193</a>
rdar://108769471

Reviewed by Tim Horton.

To make it easier to detect invalid scrolling trees which can result in MESSAGE_CHECKs
(rdar://108204370) add code to check the validity of the scrolling tree in the web process, and
assert when not valid. This code checks that nodes that have cross-references to other scrolling
tree nodes actually point to live nodes.

This detected a case where we have incorrect behavior (tested by
scrollingcoordinator/scrolling-tree/scroller-with-negative-z-child.html and two similar tests); when
an overflow:scroll has composited descendant which is not a paint-order child, the child gets an
&quot;ancestor clipping stack&quot; which points to ScrollingStateOverflowScrollProxyNodes, which reference
the actual overflow scrolling node. However, if the child has negative z-index, we encounter the
child before the overflow scroller so fail to find its scrolling tree node.

Fix this by keeping track of RenderLayers with unresolved scrolling tree references in
m_layersWithUnresolvedRelations, and updating them at the end of the &quot;update backing and hierarchy&quot;
compositing phase.

* Source/WebCore/page/scrolling/ScrollingStateTree.cpp:
(WebCore::ScrollingStateTree::commit):
(WebCore::ScrollingStateTree::traverse const):
(WebCore::ScrollingStateTree::isValid const):
* Source/WebCore/page/scrolling/ScrollingStateTree.h:
* Source/WebCore/rendering/RenderLayerCompositor.cpp:
(WebCore::RenderLayerCompositor::updateCompositingLayers):
(WebCore::RenderLayerCompositor::setupScrollProxyRelatedOverflowScrollingNode):
(WebCore::RenderLayerCompositor::updateScrollingNodeForScrollingProxyRole):
(WebCore::RenderLayerCompositor::resolveScrollingTreeRelationships):
* Source/WebCore/rendering/RenderLayerCompositor.h:

Canonical link: <a href="https://commits.webkit.org/263620@main">https://commits.webkit.org/263620@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/28044e4afb331d02d502dad3b692f90c765a3e68

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/5106 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/5237 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/5414 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/6627 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/5189 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/5100 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/5438 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/5213 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/5434 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/5193 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/5277 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/4580 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/6643 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/2763 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/4578 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/9847 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/4627 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/4651 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/6262 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/5071 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/4161 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/4554 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/1257 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/8634 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/4919 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->