### PR TITLE
WebContent crash: Invalid message dispatched virtual void WebKit::RemoteScrollingCoordinatorProxyIOS::establishLayerTreeScrollingRelations(const RemoteLayerTreeHost &)

### DIFF
--- a/LayoutTests/scrollingcoordinator/scrolling-tree/scroller-with-proxy-nodes-loses-layer-expected.txt
+++ b/LayoutTests/scrollingcoordinator/scrolling-tree/scroller-with-proxy-nodes-loses-layer-expected.txt
@@ -1,0 +1,2 @@
+This test should not crash.
+

--- a/LayoutTests/scrollingcoordinator/scrolling-tree/scroller-with-proxy-nodes-loses-layer.html
+++ b/LayoutTests/scrollingcoordinator/scrolling-tree/scroller-with-proxy-nodes-loses-layer.html
@@ -1,0 +1,86 @@
+<!DOCTYPE html> <!-- webkit-test-runner [ AsyncOverflowScrollingEnabled=true ] -->
+<html class="fullscreen">
+<head>
+    <style>
+        html.fullscreen {
+            overflow: hidden; /* fullscreen */
+        }
+
+        html, body, main {
+            height: 100%;
+        }
+
+        body {
+            margin: 20px;
+            overflow-x: hidden;
+            border: 1px solid gray;
+        }
+        
+        html.fullscreen body {
+            border: 2px solid gray; /* hack to work around webkit.org/b/256125 */
+        }
+
+        .app {
+            width: 100%;
+            height: 5000px;
+        }
+        
+        .relative {
+            position: relative;
+            
+        }
+        
+        .filtered {
+            transition: filter 500ms;
+        }
+        
+        .carousel {
+            overflow: hidden;
+            width: 700px;
+            height: 500px;
+            border: 1px solid black;
+        }
+        
+        .contents {
+            width: 300%;
+        }
+        
+        .backdrop {
+            -webkit-backdrop-filter: blur(2px);
+            z-index: 100;
+            width: 200px;
+            height: 20px;
+            background-color: silver;
+        }
+    </style>
+    <script src="../../resources/ui-helper.js"></script>
+    <script>
+        if (window.testRunner) {
+            testRunner.dumpAsText();
+            testRunner.waitUntilDone();
+        }
+
+        window.addEventListener('load', async () => {
+            await UIHelper.renderingUpdate();
+            document.documentElement.classList.remove('fullscreen');
+            await UIHelper.ensurePresentationUpdate();
+            if (window.testRunner)
+                testRunner.notifyDone();
+        }, false);
+    </script>
+</head>
+<body>
+    <div class="app">
+        <main>
+            <div class="relative">
+                <div class="relative filtered">
+                    <div class="carousel">
+                        <div class="contents">This test should not crash.</div>
+                    </div>
+                </div>
+            </div>
+            <div class="backdrop"></div>
+        </main>
+    </div>
+</body>
+</html>

--- a/Source/WebCore/rendering/LayerAncestorClippingStack.cpp
+++ b/Source/WebCore/rendering/LayerAncestorClippingStack.cpp
@@ -71,6 +71,7 @@ void LayerAncestorClippingStack::clear(ScrollingCoordinator* scrollingCoordinato
         }
 
         GraphicsLayer::unparentAndClear(entry.clippingLayer);
+        GraphicsLayer::unparentAndClear(entry.scrollingLayer);
     }
 }
 

--- a/Source/WebCore/rendering/RenderLayerBacking.cpp
+++ b/Source/WebCore/rendering/RenderLayerBacking.cpp
@@ -2111,11 +2111,13 @@ bool RenderLayerBacking::updateAncestorClipping(bool needsAncestorClip, const Re
             layersChanged = true;
         }
     } else if (m_ancestorClippingStack) {
-        removeClippingStackLayers(*m_ancestorClippingStack);
+        auto* scrollingCoordinator = m_owningLayer.page().scrollingCoordinator();
+
+        m_ancestorClippingStack->clear(scrollingCoordinator);
         m_ancestorClippingStack = nullptr;
         
         if (m_overflowControlsHostLayerAncestorClippingStack) {
-            removeClippingStackLayers(*m_overflowControlsHostLayerAncestorClippingStack);
+            m_overflowControlsHostLayerAncestorClippingStack->clear(scrollingCoordinator);
             m_overflowControlsHostLayerAncestorClippingStack = nullptr;
         }
         


### PR DESCRIPTION
#### 77bb4783cf75a060cca04bdbe5fd780c3c39c587
<pre>
WebContent crash: Invalid message dispatched virtual void WebKit::RemoteScrollingCoordinatorProxyIOS::establishLayerTreeScrollingRelations(const RemoteLayerTreeHost &amp;)
<a href="https://bugs.webkit.org/show_bug.cgi?id=256195">https://bugs.webkit.org/show_bug.cgi?id=256195</a>
rdar://108204370

Reviewed by Tim Horton.

262413@main added two MESSAGE_CHECK() in
RemoteScrollingCoordinatorProxyIOS::establishLayerTreeScrollingRelations() that fire when the UI
process receives a scrolling tree with invalid cross-references; ScrollingTreePositionedNodes or
ScrollingTreeOverflowScrollProxyNodes with invalid references to overflow scrolling nodes.

Sites triggering this MESSAGE_CHECK() all hit a pattern where an `overflow:scroll` element became
non-scrollable, but we failed to clean up ScrollingTreeOverflowScrollProxyNodes that referenced this
overflow scroll. ScrollingTreeOverflowScrollProxyNodes are created when the overflow scroller has
non paint-order descendants (typically positioned) which need to move then the scroller scrolls;
each of these has a LayerAncestorClippingStack which tracks the layers and scrolling tree nodes for
non paint-order ancestors that affect the given layer.

The bug was that we&apos;d clear the LayerAncestorClippingStack without unregistering the
ScrollingTreeOverflowScrollProxyNodes that it referenced, so when
RenderLayerBacking::updateAncestorClipping() is removing the m_ancestorClippingStack, call
LayerAncestorClippingStack::clear() to unregister those nodes.

Also have LayerAncestorClippingStack::clear() unparent the scrolling layer as well as the clipping
layer.

* LayoutTests/scrollingcoordinator/scrolling-tree/scroller-with-proxy-nodes-loses-layer-expected.txt: Added.
* LayoutTests/scrollingcoordinator/scrolling-tree/scroller-with-proxy-nodes-loses-layer.html: Added.
* Source/WebCore/rendering/LayerAncestorClippingStack.cpp:
(WebCore::LayerAncestorClippingStack::clear):
* Source/WebCore/rendering/RenderLayerBacking.cpp:
(WebCore::RenderLayerBacking::updateAncestorClipping):

Canonical link: <a href="https://commits.webkit.org/263590@main">https://commits.webkit.org/263590@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2ea515efdb31ab1e3758b1368521f0cb44240c4c

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/5107 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/5238 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/5415 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/6628 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/5190 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/5101 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/5439 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/5214 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/5435 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/5194 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/5279 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/4582 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/6644 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/2765 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/4580 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/9849 "5 flakes 152 failures") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/4629 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/4653 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/6263 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/5072 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/4162 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/4555 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/4576 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/1235 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/8635 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/4920 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->