### PR TITLE
[JSC] Use memset_patternN for JSStringJoiner

### DIFF
--- a/JSTests/stress/array-join-16.js
+++ b/JSTests/stress/array-join-16.js
@@ -1,0 +1,8 @@
+function shouldBe(actual, expected) {
+    if (actual !== expected)
+        throw new Error('bad value: ' + actual);
+}
+
+shouldBe(["[Object object]", "[Object object]", "[Object object]", "[Object object]", "[Object object]", "[Object object]"].toString(), `[Object object],[Object object],[Object object],[Object object],[Object object],[Object object]`);
+shouldBe(["Object ", "Object ", "Object ", "Object ", "Object ", "Object ", "Object ", "Object ", "Object "].toString(), `Object ,Object ,Object ,Object ,Object ,Object ,Object ,Object ,Object `);
+shouldBe(["Obj", "Obj", "Obj", "Obj", "Obj", "Obj", "Obj", "Obj", "Obj", "Obj", "Obj"].toString(), `Obj,Obj,Obj,Obj,Obj,Obj,Obj,Obj,Obj,Obj,Obj`);


### PR DESCRIPTION
#### 125d5fe589bd7f8519db69abc80735a1b55280aa
<pre>
[JSC] Use memset_patternN for JSStringJoiner
<a href="https://bugs.webkit.org/show_bug.cgi?id=256196">https://bugs.webkit.org/show_bug.cgi?id=256196</a>
rdar://problem/108770718

Reviewed by Tadeu Zagallo.

Now, JSStringJoiner knows concept of counts of the same element, so let&apos;s leverage this information.
This patch adds memset_patternN optimized code to make memset fast for particular sizes.

                                  ToT                     Patched

    array-join-object       12.3455+-0.0249     ^      7.1316+-0.0285        ^ definitely 1.7311x faster

* Source/JavaScriptCore/runtime/JSStringJoiner.cpp:
(JSC::appendStringToDataWithOneCharacterSeparatorRepeatedly):
(JSC::joinStrings):

Canonical link: <a href="https://commits.webkit.org/263579@main">https://commits.webkit.org/263579@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/327d1cc3df51cc44211e598450a9cada8f4fdb39

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/5126 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/5258 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/5435 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/6648 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/32/builds/5206 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/5459 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/5234 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/5450 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/5214 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/5294 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/4598 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/6665 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/2780 "Passed tests") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/10/builds/4596 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/9867 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [  ~~🛠 🧪 jsc~~](https://ews-build.webkit.org/#/builders/20/builds/4243 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/4644 "Passed tests") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/4669 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/6279 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/4716 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/5091 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/4178 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/5220 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/4571 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/1314 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/8653 "Built successfully") | | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/24/builds/5366 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/578 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/4937 "Built successfully") | | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/3/builds/1430 "Passed tests") | 
<!--EWS-Status-Bubble-End-->