### PR TITLE
Fix debug build with assertions disabled

### DIFF
--- a/Source/JavaScriptCore/bytecode/CodeBlock.h
+++ b/Source/JavaScriptCore/bytecode/CodeBlock.h
@@ -996,7 +996,7 @@ private:
     HashSet<UniquedStringImpl*> m_cachedIdentifierUids;
 #endif
 };
-#if !ASSERT_ENABLED && COMPILER(GCC_COMPATIBLE)
+#if defined(NDEBUG) && COMPILER(GCC_COMPATIBLE)
 static_assert(sizeof(CodeBlock) <= 240, "Keep it small for memory saving");
 #endif
 

--- a/Source/WTF/wtf/RefCountedLeakCounter.cpp
+++ b/Source/WTF/wtf/RefCountedLeakCounter.cpp
@@ -59,9 +59,14 @@ void RefCountedLeakCounter::cancelMessageSuppression(const char* reason)
 }
 
 RefCountedLeakCounter::RefCountedLeakCounter(const char* description)
+#if !LOG_DISABLED
     : m_description(description)
+#endif
 {
-}    
+#if LOG_DISABLED
+    UNUSED_PARAM(description);
+#endif
+}
 
 RefCountedLeakCounter::~RefCountedLeakCounter()
 {

--- a/Source/WTF/wtf/RefCountedLeakCounter.h
+++ b/Source/WTF/wtf/RefCountedLeakCounter.h
@@ -38,7 +38,9 @@ struct RefCountedLeakCounter {
 #ifndef NDEBUG
 private:
     std::atomic<int> m_count;
+#if !LOG_DISABLED
     const char* m_description;
+#endif
 #endif
 };
 

--- a/Source/WebCore/animation/KeyframeEffect.cpp
+++ b/Source/WebCore/animation/KeyframeEffect.cpp
@@ -2701,7 +2701,7 @@ KeyframeEffect::CanBeAcceleratedMutationScope::~CanBeAcceleratedMutationScope()
 #if ENABLE(THREADED_ANIMATION_RESOLUTION)
 static bool acceleratedPropertyDidChange(AnimatableProperty property, const RenderStyle& previousStyle, const RenderStyle& currentStyle, const Settings& settings)
 {
-#if !defined(NDEBUG)
+#if ASSERT_ENABLED
     ASSERT(CSSPropertyAnimation::animationOfPropertyIsAccelerated(property, settings));
 #else
     UNUSED_PARAM(settings);

--- a/Source/WebCore/layout/Verification.cpp
+++ b/Source/WebCore/layout/Verification.cpp
@@ -26,7 +26,7 @@
 #include "config.h"
 #include "LayoutState.h"
 
-#ifndef NDEBUG
+#if ASSERT_ENABLED
 #include "BlockFormattingState.h"
 #include "InlineFormattingState.h"
 #include "LayoutBox.h"
@@ -351,5 +351,5 @@ void LayoutContext::verifyAndOutputMismatchingLayoutTree(const LayoutState& layo
 }
 }
 
-#endif
+#endif // ASSERT_ENABLED
 

--- a/Source/WebCore/loader/archive/cf/LegacyWebArchive.cpp
+++ b/Source/WebCore/loader/archive/cf/LegacyWebArchive.cpp
@@ -267,7 +267,7 @@ RefPtr<LegacyWebArchive> LegacyWebArchive::create(const URL&, FragmentedSharedBu
 
     RetainPtr<CFDictionaryRef> plist = adoptCF(static_cast<CFDictionaryRef>(CFPropertyListCreateWithData(0, cfData.get(), kCFPropertyListImmutable, 0, &error)));
     if (!plist) {
-#ifndef NDEBUG
+#if !LOG_DISABLED
         RetainPtr<CFStringRef> errorString = error ? adoptCF(CFErrorCopyDescription(error)) : 0;
         const char* cError = errorString ? CFStringGetCStringPtr(errorString.get(), kCFStringEncodingUTF8) : "unknown error";
         LOG(Archives, "LegacyWebArchive - Error parsing PropertyList from archive data - %s", cError);

--- a/Source/WebCore/page/LocalFrameViewLayoutContext.cpp
+++ b/Source/WebCore/page/LocalFrameViewLayoutContext.cpp
@@ -78,7 +78,7 @@ void LocalFrameViewLayoutContext::layoutUsingFormattingContext()
             descendant.clearNeedsLayout();
         renderView.clearNeedsLayout();
     }
-#ifndef NDEBUG
+#if ASSERT_ENABLED
     Layout::LayoutContext::verifyAndOutputMismatchingLayoutTree(*m_layoutState, renderView);
 #endif
 }

--- a/Source/WebCore/platform/animation/AcceleratedEffect.cpp
+++ b/Source/WebCore/platform/animation/AcceleratedEffect.cpp
@@ -61,7 +61,7 @@ WTF_MAKE_ISO_ALLOCATED_IMPL(AcceleratedEffect);
 
 static AcceleratedEffectProperty acceleratedPropertyFromCSSProperty(AnimatableProperty property, const Settings& settings)
 {
-#if !defined(NDEBUG)
+#if ASSERT_ENABLED
     ASSERT(CSSPropertyAnimation::animationOfPropertyIsAccelerated(property, settings));
 #else
     UNUSED_PARAM(settings);

--- a/Source/WebCore/platform/mediastream/MediaConstraints.h
+++ b/Source/WebCore/platform/mediastream/MediaConstraints.h
@@ -666,7 +666,7 @@ public:
         iterator(const FlattenedConstraint* constraint, size_t index)
             : m_constraint(constraint)
             , m_index(index)
-#ifndef NDEBUG
+#if ASSERT_ENABLED
             , m_generation(constraint->m_generation)
 #endif
         {
@@ -679,7 +679,7 @@ public:
 
         iterator& operator++()
         {
-#ifndef NDEBUG
+#if ASSERT_ENABLED
             ASSERT(m_generation == m_constraint->m_generation);
 #endif
             m_index++;
@@ -692,7 +692,7 @@ public:
     private:
         const FlattenedConstraint* m_constraint { nullptr };
         size_t m_index { 0 };
-#ifndef NDEBUG
+#if ASSERT_ENABLED
         int m_generation { 0 };
 #endif
     };

--- a/Source/WebKit/UIProcess/WebAuthentication/Cocoa/LocalAuthenticator.mm
+++ b/Source/WebKit/UIProcess/WebAuthentication/Cocoa/LocalAuthenticator.mm
@@ -516,7 +516,7 @@ void LocalAuthenticator::continueMakeCredentialAfterUserVerification(SecAccessCo
         credentialId = digest->computeHash();
         m_provisionalCredentialId = toNSData(credentialId);
 
-#ifndef NDEBUG
+#if ASSERT_ENABLED
         auto query = adoptNS([[NSMutableDictionary alloc] init]);
         [query setDictionary:@{
             (id)kSecClass: (id)kSecClassKey,


### PR DESCRIPTION
#### ccccc554960d2ca04f3a7ae5c9dac542682af585
<pre>
Fix debug build with assertions disabled
<a href="https://bugs.webkit.org/show_bug.cgi?id=256199">https://bugs.webkit.org/show_bug.cgi?id=256199</a>
rdar://108773614

Reviewed by Chris Dumez.

There are some inconsistent uses of NDEBUG, LOG_DISABLED, and ASSERT_ENABLED.
If I change the definition of ASSERT_ENABLED to always be 0, this fixes the debug build.

* Source/JavaScriptCore/bytecode/CodeBlock.h:
* Source/WTF/wtf/RefCountedLeakCounter.cpp:
(WTF::RefCountedLeakCounter::RefCountedLeakCounter):
* Source/WTF/wtf/RefCountedLeakCounter.h:
* Source/WebCore/animation/KeyframeEffect.cpp:
(WebCore::acceleratedPropertyDidChange):
* Source/WebCore/layout/Verification.cpp:
* Source/WebCore/loader/archive/cf/LegacyWebArchive.cpp:
(WebCore::LegacyWebArchive::create):
* Source/WebCore/page/LocalFrameViewLayoutContext.cpp:
(WebCore::LocalFrameViewLayoutContext::layoutUsingFormattingContext):
* Source/WebCore/platform/animation/AcceleratedEffect.cpp:
(WebCore::acceleratedPropertyFromCSSProperty):
* Source/WebCore/platform/mediastream/MediaConstraints.h:
(WebCore::FlattenedConstraint::iterator::iterator):
(WebCore::FlattenedConstraint::iterator::operator++):
* Source/WebKit/UIProcess/WebAuthentication/Cocoa/LocalAuthenticator.mm:
(WebKit::LocalAuthenticator::continueMakeCredentialAfterUserVerification):

Canonical link: <a href="https://commits.webkit.org/263591@main">https://commits.webkit.org/263591@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f7da6e3e3aeb78ed80db89b17d58807778ca9c0b

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/5110 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/5241 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/5418 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/6631 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/5193 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/5104 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/5442 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/5217 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/5439 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/5197 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/5284 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/4585 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/6647 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/2770 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/4583 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/9854 "Passed tests") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/4230 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/4634 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/4656 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/6267 "Passed tests") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/4701 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/5075 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/4165 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/5205 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/4558 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/1308 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/8638 "Built successfully") | | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/24/builds/5350 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/579 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/4923 "Built successfully") | | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/3/builds/1423 "Passed tests") | 
<!--EWS-Status-Bubble-End-->