### PR TITLE
Resync badging tests from WPT upstream

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/badging/META.yml
+++ b/LayoutTests/imported/w3c/web-platform-tests/badging/META.yml
@@ -1,1 +1,4 @@
 spec: https://w3c.github.io/badging/
+suggested_reviewers:
+  - marcoscaceres
+  - diekus

--- a/LayoutTests/imported/w3c/web-platform-tests/badging/resources/setAppBadge_iframe.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/badging/resources/setAppBadge_iframe.html
@@ -1,0 +1,33 @@
+<!DOCTYPE html>
+<meta charset="utf-8" />
+<title>setAppBadge iframe</title>
+<script>
+  async function callSetAppBadge() {
+    const postMessageData = { message: "callSetAppBadge" };
+
+    try {
+      await navigator.setAppBadge();
+      postMessageData.status = "success";
+    } catch (e) {
+      if (e instanceof DOMException) {
+        postMessageData.status = "error";
+        postMessageData.exceptionType = e.name;
+      } else {
+        postMessageData.status = "unknown_error";
+        postMessageData.error = e.toString();
+      }
+    } finally {
+      window.parent.postMessage(postMessageData, "*");
+    }
+  }
+
+  window.addEventListener("message", async (event) => {
+    switch (event.data) {
+      case "callSetAppBadge":
+        await callSetAppBadge();
+        break;
+      default:
+        throw new Error(`Unexpected message: ${event.data}`);
+    }
+  });
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/badging/resources/w3c-import.log
+++ b/LayoutTests/imported/w3c/web-platform-tests/badging/resources/w3c-import.log
@@ -14,9 +14,4 @@ Property values requiring vendor prefixes:
 None
 ------------------------------------------------------------------------
 List of files:
-/LayoutTests/imported/w3c/web-platform-tests/badging/META.yml
-/LayoutTests/imported/w3c/web-platform-tests/badging/badge-error.https.html
-/LayoutTests/imported/w3c/web-platform-tests/badging/badge-success.https.html
-/LayoutTests/imported/w3c/web-platform-tests/badging/idlharness.https.any.js
-/LayoutTests/imported/w3c/web-platform-tests/badging/non-fully-active.https.html
-/LayoutTests/imported/w3c/web-platform-tests/badging/setAppBadge_cross_origin.sub.https.html
+/LayoutTests/imported/w3c/web-platform-tests/badging/resources/setAppBadge_iframe.html

--- a/LayoutTests/imported/w3c/web-platform-tests/badging/setAppBadge_cross_origin.sub.https-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/badging/setAppBadge_cross_origin.sub.https-expected.txt
@@ -1,0 +1,6 @@
+
+
+PASS Test that navigator.setAppBadge is available
+FAIL Test that calling setAppBadge in a cross-origin iframe throws a SecurityError assert_equals: setAppBadge should have rejected with an error expected "error" but got "success"
+PASS Test that calling setAppBadge in a same-origin iframe succeeds
+

--- a/LayoutTests/imported/w3c/web-platform-tests/badging/setAppBadge_cross_origin.sub.https.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/badging/setAppBadge_cross_origin.sub.https.html
@@ -1,0 +1,64 @@
+<!DOCTYPE html>
+<meta charset="utf-8" />
+<title>Test cross-origin and same-origin use of setAppBadge</title>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<iframe id="testIframe"></iframe>
+<script>
+  const iframe = document.getElementById("testIframe");
+
+  function sendMessageToIframe(message) {
+    return new Promise((resolve) => {
+      window.addEventListener("message", function listener(event) {
+        const { messageId } = event.data;
+        if (event.data.message !== message) return;
+        window.removeEventListener("message", listener);
+        resolve(event);
+      });
+      iframe.contentWindow.postMessage("callSetAppBadge", "*");
+    });
+  }
+
+  function loadIframe(src) {
+    return new Promise((resolve) => {
+      iframe.addEventListener("load", resolve);
+      iframe.src = src;
+    });
+  }
+
+  test(() => {
+    assert_true(
+      "setAppBadge" in navigator,
+      "navigator.setAppBadge should be available"
+    );
+  }, "Test that navigator.setAppBadge is available");
+
+  promise_test(async () => {
+    await loadIframe(
+      `https://{{hosts[][]}}:{{ports[https][1]}}/badging/resources/setAppBadge_iframe.html`
+    );
+    const event = await sendMessageToIframe("callSetAppBadge");
+    const { exceptionType, status } = event.data;
+    assert_equals(
+      status,
+      "error",
+      "setAppBadge should have rejected with an error"
+    );
+    assert_equals(
+      exceptionType,
+      "SecurityError",
+      "setAppBadge should throw a SecurityError when called in a cross-origin iframe"
+    );
+  }, "Test that calling setAppBadge in a cross-origin iframe throws a SecurityError");
+
+  promise_test(async () => {
+    await loadIframe("./resources/setAppBadge_iframe.html");
+    const event = await sendMessageToIframe("callSetAppBadge");
+    const { status } = event.data;
+    assert_equals(
+      status,
+      "success",
+      "setAppBadge should succeed when called in a same-origin iframe"
+    );
+  }, "Test that calling setAppBadge in a same-origin iframe succeeds");
+</script>


### PR DESCRIPTION
#### d02f22d0f8fe9867d408c1a7b9af3b56f90492c9
<pre>
Resync badging tests from WPT upstream
<a href="https://bugs.webkit.org/show_bug.cgi?id=256198">https://bugs.webkit.org/show_bug.cgi?id=256198</a>
rdar://108773641

Reviewed by Brady Eidson.

Resync to WPT fa9eab2eb5.

* LayoutTests/imported/w3c/web-platform-tests/badging/META.yml:
* LayoutTests/imported/w3c/web-platform-tests/badging/resources/setAppBadge_iframe.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/badging/resources/w3c-import.log: Copied from LayoutTests/imported/w3c/web-platform-tests/badging/w3c-import.log.
* LayoutTests/imported/w3c/web-platform-tests/badging/setAppBadge_cross_origin.sub.https-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/badging/setAppBadge_cross_origin.sub.https.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/badging/w3c-import.log:

Canonical link: <a href="https://commits.webkit.org/263607@main">https://commits.webkit.org/263607@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/28eca78b846327b09364a76a06777db57efdd0c7

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/5112 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/5243 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/5420 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/6633 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/5195 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/5444 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/5219 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/5438 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/5199 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/5283 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/4587 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/6663 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/2769 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/4585 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/9865 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/4633 "Passed tests") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/4658 "3 failures") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/6277 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/5076 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/4167 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/4560 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/4581 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/1244 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/8640 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/4925 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->