### PR TITLE
[CSS Nesting] Add WPT for each nested at-rule

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-nesting/conditional-rules-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-nesting/conditional-rules-expected.html
@@ -16,8 +16,35 @@
     }
   }
 
+  @media (min-width: 50px) {
+    .test-6 > div {
+      background-color: green;
+    }
+  }
+
   @supports (display: grid) {
     .test-10 {
+      background-color: green;
+    }
+  }
+
+  @layer {
+    .test-11 {
+      background-color: green !important;
+    }
+  }
+
+  @scope (.test-12) {
+    :scope {
+      background-color: green;
+    }
+  }
+
+  div {
+    container-type: inline-size;
+  }
+  @container (width >= 0px) {
+    .test-13 {
       background-color: green;
     }
   }
@@ -29,5 +56,9 @@
 <body>
   <p>Tests pass if <strong>block is green</strong></p>
   <div class="test test-5"><div></div></div>
+  <div class="test test-6"><div></div></div>
   <div class="test test-10"><div></div></div>
+  <div class="test test-11"><div></div></div>
+  <div class="test"><div class="test-12"></div></div>
+  <div class="test"><div class="test-13"></div></div>
 </body>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-nesting/conditional-rules-ref.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-nesting/conditional-rules-ref.html
@@ -16,8 +16,35 @@
     }
   }
 
+  @media (min-width: 50px) {
+    .test-6 > div {
+      background-color: green;
+    }
+  }
+
   @supports (display: grid) {
     .test-10 {
+      background-color: green;
+    }
+  }
+
+  @layer {
+    .test-11 {
+      background-color: green !important;
+    }
+  }
+
+  @scope (.test-12) {
+    :scope {
+      background-color: green;
+    }
+  }
+
+  div {
+    container-type: inline-size;
+  }
+  @container (width >= 0px) {
+    .test-13 {
       background-color: green;
     }
   }
@@ -29,5 +56,9 @@
 <body>
   <p>Tests pass if <strong>block is green</strong></p>
   <div class="test test-5"><div></div></div>
+  <div class="test test-6"><div></div></div>
   <div class="test test-10"><div></div></div>
+  <div class="test test-11"><div></div></div>
+  <div class="test"><div class="test-12"></div></div>
+  <div class="test"><div class="test-13"></div></div>
 </body>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-nesting/conditional-rules.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-nesting/conditional-rules.html
@@ -19,8 +19,41 @@
     }
   }
 
+  .test-6 {
+    @media (min-width: 50px) {
+      background-color: green;
+    }
+  }
+
   .test-10 {
     @supports (display: grid) {
+      & {
+        background-color: green;
+      }
+    }
+  }
+
+  .test-11 {
+    @layer {
+      & {
+        background-color: green !important;
+      }
+    }
+  }
+
+  .test-12 {
+    @scope (.test-12) {
+      :scope {
+        background-color: green;
+      }
+    }
+  }
+
+  div {
+    container-type: inline-size;
+  }
+  .test-13 {
+    @container (width >= 0px) {
       & {
         background-color: green;
       }
@@ -33,6 +66,10 @@
 </style>
 <body>
   <p>Tests pass if <strong>block is green</strong></p>
-  <div class="test test-5"><div></div></div>
-  <div class="test test-10"><div></div></div>
+  <div class="test test-5"></div>
+  <div class="test test-6"></div>
+  <div class="test test-10"></div>
+  <div class="test test-11"></div>
+  <div class="test test-12"></div>
+  <div class="test"><div class="test-13"></div></div>
 </body>


### PR DESCRIPTION
#### 829f91f40c1670fe538fd761b879f30354e496af
<pre>
[CSS Nesting] Add WPT for each nested at-rule
<a href="https://bugs.webkit.org/show_bug.cgi?id=256202">https://bugs.webkit.org/show_bug.cgi?id=256202</a>
rdar://108776084

Reviewed by Tim Nguyen.

* LayoutTests/imported/w3c/web-platform-tests/css/css-nesting/conditional-rules-expected.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-nesting/conditional-rules-ref.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-nesting/conditional-rules.html:

Canonical link: <a href="https://commits.webkit.org/263626@main">https://commits.webkit.org/263626@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4b9c65601c1af08ba00d2b7861f925b5b5a526df

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/5270 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/5406 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/5592 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/6801 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/5311 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/5621 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/5384 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/5834 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/5366 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/5441 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/4720 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/6835 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/2923 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/4723 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/11324 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/4787 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/4799 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/6424 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/5223 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/4289 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/4691 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/4720 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/1263 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/8784 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/5053 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->