### PR TITLE
Address kernel MIG sandbox telemetry

### DIFF
--- a/Source/WebKit/GPUProcess/mac/com.apple.WebKit.GPUProcess.sb.in
+++ b/Source/WebKit/GPUProcess/mac/com.apple.WebKit.GPUProcess.sb.in
@@ -1026,14 +1026,17 @@
 (when (and (equal? (param "ENABLE_SANDBOX_MESSAGE_FILTER") "YES") (defined? 'mach-kernel-endpoint))
     (allow mach-kernel-endpoint
         (apply-message-filter
-            (allow mach-message-send (with report) (with telemetry))
+            (deny mach-message-send (with telemetry))
             (allow mach-message-send (kernel-mig-routine
                 _mach_make_memory_entry
                 clock_get_time
                 host_get_io_master
+                host_get_special_port
                 host_info
                 host_request_notification
+                io_connect_add_client
                 io_connect_async_method
+                io_connect_map_memory_into_task
                 io_connect_method
                 io_connect_method_var_output
                 io_connect_set_notification_port_64
@@ -1044,11 +1047,13 @@
                 io_registry_create_iterator
                 io_registry_entry_create_iterator
                 io_registry_entry_from_path
+                io_registry_entry_get_child_iterator
                 io_registry_entry_get_name
                 io_registry_entry_get_name_in_plane
                 io_registry_entry_get_parent_iterator
                 io_registry_entry_get_properties_bin_buf
                 io_registry_entry_get_property_bin_buf
+                io_registry_entry_get_property_bytes
                 io_registry_entry_get_registry_entry_id
                 io_registry_get_root_entry
                 io_server_version
@@ -1058,17 +1063,30 @@
                 io_service_get_matching_service_bin
                 io_service_get_matching_services_bin
                 io_service_open_extended
+#if PLATFORM(MAC) && __MAC_OS_X_VERSION_MIN_REQUIRED >= 140000
+                mach_eventlink_associate
+                mach_eventlink_create
+                mach_eventlink_destroy
+#endif
+                mach_exception_raise
+                mach_memory_entry_ownership
                 mach_port_extract_right
+                mach_port_get_context_from_user
                 mach_port_get_refs
+                mach_port_is_connection_for_service
                 mach_port_request_notification
                 mach_port_set_attributes
                 mach_vm_copy
                 mach_vm_map_external
+                mach_vm_remap_external
                 semaphore_create
                 semaphore_destroy
                 task_get_special_port_from_user
                 task_info_from_user
+                task_policy_set
                 task_restartable_ranges_synchronize
+                task_set_special_port
+                thread_get_state_to_user
                 thread_info
                 thread_policy_set
                 thread_resume

--- a/Source/WebKit/NetworkProcess/mac/com.apple.WebKit.NetworkProcess.sb.in
+++ b/Source/WebKit/NetworkProcess/mac/com.apple.WebKit.NetworkProcess.sb.in
@@ -726,10 +726,11 @@
 (when (and (equal? (param "ENABLE_SANDBOX_MESSAGE_FILTER") "YES") (defined? 'mach-kernel-endpoint))
     (allow mach-kernel-endpoint
         (apply-message-filter
-            (allow mach-message-send (with report) (with telemetry))
+            (deny mach-message-send (with telemetry))
             (allow mach-message-send (kernel-mig-routine
                 _mach_make_memory_entry
                 host_get_io_master
+                host_get_special_port
                 host_info
                 host_request_notification
                 io_connect_method
@@ -739,23 +740,33 @@
                 io_registry_entry_create_iterator
                 io_registry_entry_from_path
                 io_registry_entry_get_parent_iterator
+                io_registry_entry_get_properties_bin_buf
                 io_registry_entry_get_property_bin_buf
                 io_server_version
                 io_service_add_interest_notification_64
                 io_service_get_matching_service_bin
                 io_service_open_extended
                 mach_exception_raise
+                mach_memory_entry_ownership
+                mach_port_extract_right
+                mach_port_get_context_from_user
                 mach_port_get_refs
+                mach_port_is_connection_for_service
                 mach_port_request_notification
                 mach_port_set_attributes
                 mach_vm_copy
                 mach_vm_map_external
                 mach_vm_remap_external
                 semaphore_create
+                semaphore_destroy
                 task_get_special_port_from_user
                 task_info_from_user
                 task_policy_set
                 task_restartable_ranges_synchronize
+                task_set_exc_guard_behavior
+                task_set_special_port
+                task_threads_from_user
+                thread_info
                 thread_resume
                 thread_suspend)))))
 

--- a/Source/WebKit/Resources/SandboxProfiles/ios/com.apple.WebKit.GPU.sb.in
+++ b/Source/WebKit/Resources/SandboxProfiles/ios/com.apple.WebKit.GPU.sb.in
@@ -920,9 +920,10 @@
 (when (defined? 'MSC_mach_msg2_trap)
     (allow syscall-mach (machtrap-number MSC_mach_msg2_trap)))
 
-(allow syscall-mig (with report)(with telemetry))
+(deny syscall-mig (with telemetry))
 (allow syscall-mig (kernel-mig-routine
     _mach_make_memory_entry
+    clock_get_time
     host_get_clock_service
     host_get_io_master
     host_get_special_port
@@ -933,11 +934,15 @@
     io_iterator_next
     io_registry_entry_from_path
     io_registry_entry_get_property_bin_buf
+    io_registry_entry_get_property_bytes
     io_registry_entry_get_registry_entry_id
     io_server_version
+    io_service_close
     io_service_get_matching_service_bin
     io_service_get_matching_services_bin
     io_service_open_extended
+    mach_eventlink_associate
+    mach_exception_raise
     mach_memory_entry_ownership
     mach_port_extract_right
     mach_port_get_context_from_user
@@ -947,6 +952,8 @@
     mach_port_set_attributes
     mach_vm_copy
     mach_vm_map_external
+    mach_vm_region
+    mach_vm_remap_external
     semaphore_create
     semaphore_destroy
     task_get_special_port_from_user
@@ -954,6 +961,7 @@
     task_restartable_ranges_register
     task_restartable_ranges_synchronize
     task_set_special_port
+    thread_policy
     thread_policy_set
     thread_resume
     thread_suspend))


### PR DESCRIPTION
#### 6de3806237c93f2b460208b350513503f0dc64de
<pre>
Address kernel MIG sandbox telemetry
<a href="https://bugs.webkit.org/show_bug.cgi?id=254234">https://bugs.webkit.org/show_bug.cgi?id=254234</a>
rdar://problem/106829883

Reviewed by Brent Fulgham.

Address kernel MIG sandbox telemetry in the GPU and Network process. This patch also enforces the filters.

* Source/WebKit/GPUProcess/mac/com.apple.WebKit.GPUProcess.sb.in:
* Source/WebKit/NetworkProcess/mac/com.apple.WebKit.NetworkProcess.sb.in:
* Source/WebKit/Resources/SandboxProfiles/ios/com.apple.WebKit.GPU.sb.in:

Canonical link: <a href="https://commits.webkit.org/263583@main">https://commits.webkit.org/263583@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b2bfd2b12e3fa7b2fb84c92e1a334b96d1a3597a

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/5122 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/5254 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/5431 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/6644 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/5204 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/5455 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/5230 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/5448 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/5210 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/5293 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/4595 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/6660 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/2779 "Passed tests") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/9863 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/4643 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/4666 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/6276 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/5087 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/4175 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/4569 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/1230 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/8649 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/4934 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->