### PR TITLE
Remove internals.grabNextMediaStreamTrackFrame

### DIFF
--- a/LayoutTests/fast/mediastream/captureStream/canvas3d.html
+++ b/LayoutTests/fast/mediastream/captureStream/canvas3d.html
@@ -38,42 +38,62 @@ function checkGreenPixel(value, cptr)
         return value == 255;
 }
 
-promise_test((test) => {
+promise_test(async test => {
     var stream = canvas1.captureStream();
     video1.srcObject = stream;
 
-    if (!window.internals)
-        var promise = Promise.resolve();
-    else {
-        internals.observeMediaStreamTrack(stream.getVideoTracks()[0]);
-        var promise = internals.grabNextMediaStreamTrackFrame().then((data) => {
-            data.data.forEach((value, cptr) => {
-                assert_true(checkGreenPixel(value, cptr), "expecting value " + cptr + " to be part of a green pixel");
-            });
-        })
-    }
+    const promise = new Promise((resolve, reject) => {
+        const identifier = video1.requestVideoFrameCallback((now, metadata) => {
+            resolve(new VideoFrame(video1));
+        });
+        setTimeout(() => {
+            reject("no rvfc for " + identifier);
+            video1.cancelVideoFrameCallback(identifier);
+        }, 5000);
+
+    });
 
     modifyCanvas(gl1, true);
-    return promise;
+
+    const frame = await promise;
+    test.add_cleanup(() => { frame.close(); });
+
+    const data = new Uint8Array(frame.allocationSize());
+    const layout = await frame.copyTo(data);
+
+    assert_equals(frame.format, "BGRA");
+    data.forEach((value, cptr) => {
+        assert_true(checkGreenPixel(value, cptr), "expecting value " + cptr + " to be part of a green pixel");
+    });
 }, "captureStream with 3d context drawing - not buffered initially");
 
-promise_test((test) => {
+promise_test(async test => {
     var stream = canvas2.captureStream();
     video2.srcObject = stream;
 
-    if (!window.internals)
-        var promise = Promise.resolve();
-    else {
-        internals.observeMediaStreamTrack(stream.getVideoTracks()[0]);
-        var promise = internals.grabNextMediaStreamTrackFrame().then((data) => {
-            data.data.forEach((value, cptr) => {
-                assert_true(checkGreenPixel(value, cptr), "expecting value " + cptr + " to be part of a green pixel");
-            });
-        })
-    }
+    const promise = new Promise((resolve, reject) => {
+        const identifier = video2.requestVideoFrameCallback((now, metadata) => {
+            resolve(new VideoFrame(video2));
+        });
+        setTimeout(() => {
+            reject("no rvfc for " + identifier);
+            video2.cancelVideoFrameCallback(identifier);
+        }, 5000);
+
+    });
 
     modifyCanvas(gl2, true);
-    return promise;
+
+    const frame = await promise;
+    test.add_cleanup(() => { frame.close(); });
+
+    const data = new Uint8Array(frame.allocationSize());
+    const layout = await frame.copyTo(data);
+
+    assert_equals(frame.format, "BGRA");
+    data.forEach((value, cptr) => {
+        assert_true(checkGreenPixel(value, cptr), "expecting value " + cptr + " to be part of a green pixel");
+    });
 }, "captureStream with 3d context drawing - buffered initially");
 
         </script>

--- a/Source/WebCore/platform/VideoFrame.cpp
+++ b/Source/WebCore/platform/VideoFrame.cpp
@@ -92,17 +92,6 @@ void VideoFrame::paintInContext(GraphicsContext&, const FloatRect&, const ImageO
 }
 #endif // !PLATFORM(COCOA)
 
-#if !PLATFORM(COCOA)
-RefPtr<JSC::Uint8ClampedArray> VideoFrame::getRGBAImageData() const
-{
-#if USE(GSTREAMER)
-    if (isGStreamer())
-        return static_cast<const VideoFrameGStreamer*>(this)->computeRGBAImageData();
-#endif
-    // FIXME: Add support.
-    return nullptr;
-}
-#endif
 }
 
 #endif // ENABLE(VIDEO)

--- a/Source/WebCore/platform/VideoFrame.h
+++ b/Source/WebCore/platform/VideoFrame.h
@@ -85,7 +85,6 @@ public:
 #if PLATFORM(COCOA) && USE(AVFOUNDATION)
     WEBCORE_EXPORT RefPtr<VideoFrameCV> asVideoFrameCV();
 #endif
-    WEBCORE_EXPORT RefPtr<JSC::Uint8ClampedArray> getRGBAImageData() const;
 
     using CopyCallback = CompletionHandler<void(std::optional<Vector<PlaneLayout>>&&)>;
     void copyTo(Span<uint8_t>, VideoPixelFormat, Vector<ComputedPlaneLayout>&&, CopyCallback&&);

--- a/Source/WebCore/platform/VideoFrame.mm
+++ b/Source/WebCore/platform/VideoFrame.mm
@@ -37,25 +37,6 @@
 
 namespace WebCore {
 
-RefPtr<JSC::Uint8ClampedArray> VideoFrame::getRGBAImageData() const
-{
-    PixelBufferConformerCV pixelBufferConformer((__bridge CFDictionaryRef)@{ (__bridge NSString *)kCVPixelBufferPixelFormatTypeKey: @(kCVPixelFormatType_32RGBA) });
-
-    auto pixelBuffer = this->pixelBuffer();
-    auto rgbaPixelBuffer = pixelBufferConformer.convert(pixelBuffer);
-    auto status = CVPixelBufferLockBaseAddress(rgbaPixelBuffer.get(), kCVPixelBufferLock_ReadOnly);
-    ASSERT_UNUSED(status, status == noErr);
-
-    void* data = CVPixelBufferGetBaseAddressOfPlane(rgbaPixelBuffer.get(), 0);
-    size_t byteLength = CVPixelBufferGetHeight(pixelBuffer) * CVPixelBufferGetWidth(pixelBuffer) * 4;
-    auto result = JSC::Uint8ClampedArray::tryCreate(JSC::ArrayBuffer::create(data, byteLength), 0, byteLength);
-
-    status = CVPixelBufferUnlockBaseAddress(rgbaPixelBuffer.get(), kCVPixelBufferLock_ReadOnly);
-    ASSERT(status == noErr);
-
-    return result;
-}
-
 #if USE(AVFOUNDATION)
 RefPtr<VideoFrameCV> VideoFrame::asVideoFrameCV()
 {

--- a/Source/WebCore/platform/graphics/gstreamer/VideoFrameGStreamer.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/VideoFrameGStreamer.cpp
@@ -540,39 +540,6 @@ RefPtr<VideoFrameGStreamer> VideoFrameGStreamer::resizeTo(const IntSize& destina
     return VideoFrameGStreamer::create(WTFMove(sample), destinationSize, presentationTime, rotation(), isMirrored());
 }
 
-RefPtr<JSC::Uint8ClampedArray> VideoFrameGStreamer::computeRGBAImageData() const
-{
-    auto* caps = gst_sample_get_caps(m_sample.get());
-    GstVideoInfo inputInfo;
-    if (!gst_video_info_from_caps(&inputInfo, caps))
-        return nullptr;
-
-    // We could check the input format is RGBA before attempting a conversion, but it is very
-    // unlikely to pay off. The input format is likely to be BGRA (when the samples are created as a
-    // result of mediastream captureStream) or some YUV format if the sample is from a video capture
-    // device. This method is called only by internals during layout tests, it is thus not critical
-    // to optimize this code path.
-
-    auto outputCaps = adoptGRef(gst_caps_copy(caps));
-    gst_caps_set_simple(outputCaps.get(), "format", G_TYPE_STRING, "RGBA", nullptr);
-
-    GstVideoInfo outputInfo;
-    if (!gst_video_info_from_caps(&outputInfo, outputCaps.get()))
-        return nullptr;
-
-    int width = GST_VIDEO_INFO_WIDTH(&inputInfo);
-    int height = GST_VIDEO_INFO_HEIGHT(&inputInfo);
-    unsigned byteLength = GST_VIDEO_INFO_SIZE(&inputInfo);
-    auto bufferStorage = JSC::ArrayBuffer::create(width * height, 4);
-    auto outputBuffer = adoptGRef(gst_buffer_new_wrapped_full(GST_MEMORY_FLAG_NO_SHARE, bufferStorage->data(), byteLength, 0, byteLength, nullptr, [](gpointer) { }));
-    GstMappedFrame outputFrame(outputBuffer.get(), outputInfo, GST_MAP_WRITE);
-
-    GUniquePtr<GstVideoConverter> converter(gst_video_converter_new(&inputInfo, &outputInfo, nullptr));
-    GstMappedFrame inputFrame(gst_sample_get_buffer(m_sample.get()), inputInfo, GST_MAP_READ);
-    gst_video_converter_frame(converter.get(), inputFrame.get(), outputFrame.get());
-    return JSC::Uint8ClampedArray::tryCreate(WTFMove(bufferStorage), 0, byteLength);
-}
-
 RefPtr<ImageGStreamer> VideoFrameGStreamer::convertToImage()
 {
     return GstSampleColorConverter::singleton().convertSampleToImage(m_sample);

--- a/Source/WebCore/platform/graphics/gstreamer/VideoFrameGStreamer.h
+++ b/Source/WebCore/platform/graphics/gstreamer/VideoFrameGStreamer.h
@@ -51,7 +51,6 @@ public:
     RefPtr<VideoFrameGStreamer> resizeTo(const IntSize&);
 
     GstSample* sample() const { return m_sample.get(); }
-    RefPtr<JSC::Uint8ClampedArray> computeRGBAImageData() const;
 
     RefPtr<ImageGStreamer> convertToImage();
 

--- a/Source/WebCore/testing/Internals.cpp
+++ b/Source/WebCore/testing/Internals.cpp
@@ -5819,11 +5819,6 @@ void Internals::observeMediaStreamTrack(MediaStreamTrack& track)
     }
 }
 
-void Internals::grabNextMediaStreamTrackFrame(TrackFramePromise&& promise)
-{
-    m_nextTrackFramePromise = makeUnique<TrackFramePromise>(WTFMove(promise));
-}
-
 void Internals::mediaStreamTrackVideoFrameRotation(DOMPromiseDeferred<IDLShort>&& promise)
 {
     promise.resolve(m_trackVideoRotation);
@@ -5836,23 +5831,6 @@ void Internals::videoFrameAvailable(VideoFrame& videoFrame, VideoFrameTimeMetada
             return;
         m_trackVideoSampleCount++;
         m_trackVideoRotation = static_cast<int>(videoFrame->rotation());
-        if (!m_nextTrackFramePromise)
-            return;
-
-        auto& videoSettings = m_trackSource->settings();
-        if (!videoSettings.width() || !videoSettings.height())
-            return;
-
-        auto rgba = videoFrame->getRGBAImageData();
-        if (!rgba)
-            return;
-
-        auto imageData = ImageData::create(rgba.releaseNonNull(), videoSettings.width(), videoSettings.height(), { { PredefinedColorSpace::SRGB } });
-        if (!imageData.hasException())
-            m_nextTrackFramePromise->resolve(imageData.releaseReturnValue());
-        else
-            m_nextTrackFramePromise->reject(imageData.exception().code());
-        m_nextTrackFramePromise = nullptr;
     });
 }
 

--- a/Source/WebCore/testing/Internals.h
+++ b/Source/WebCore/testing/Internals.h
@@ -926,8 +926,6 @@ public:
     unsigned long trackAudioSampleCount() const { return m_trackAudioSampleCount; }
     unsigned long trackVideoSampleCount() const { return m_trackVideoSampleCount; }
     void observeMediaStreamTrack(MediaStreamTrack&);
-    using TrackFramePromise = DOMPromiseDeferred<IDLInterface<ImageData>>;
-    void grabNextMediaStreamTrackFrame(TrackFramePromise&&);
     void mediaStreamTrackVideoFrameRotation(DOMPromiseDeferred<IDLShort>&&);
     void delayMediaStreamTrackSamples(MediaStreamTrack&, float);
     void setMediaStreamTrackMuted(MediaStreamTrack&, bool);
@@ -1428,7 +1426,6 @@ private:
     unsigned long m_trackVideoSampleCount { 0 };
     unsigned long m_trackAudioSampleCount { 0 };
     RefPtr<RealtimeMediaSource> m_trackSource;
-    std::unique_ptr<TrackFramePromise> m_nextTrackFramePromise;
     int m_trackVideoRotation { 0 };
 #endif
 #if ENABLE(MEDIA_SESSION)

--- a/Source/WebCore/testing/Internals.idl
+++ b/Source/WebCore/testing/Internals.idl
@@ -987,7 +987,6 @@ typedef (FetchRequest or FetchResponse) FetchObject;
     [Conditional=MEDIA_STREAM] undefined setShouldInterruptAudioOnPageVisibilityChange(boolean shouldInterrupt);
     [Conditional=MEDIA_STREAM] undefined setCameraMediaStreamTrackOrientation(MediaStreamTrack track, short orientation);
     [Conditional=MEDIA_STREAM] undefined observeMediaStreamTrack(MediaStreamTrack track);
-    [Conditional=MEDIA_STREAM] Promise<ImageData> grabNextMediaStreamTrackFrame();
     [Conditional=MEDIA_STREAM] Promise<short> mediaStreamTrackVideoFrameRotation();
     [Conditional=MEDIA_STREAM] readonly attribute unsigned long trackAudioSampleCount;
     [Conditional=MEDIA_STREAM] readonly attribute unsigned long trackVideoSampleCount;


### PR DESCRIPTION
#### 8ceec419005a2955682f6fe9c4cd76d73da9ecdf
<pre>
Remove internals.grabNextMediaStreamTrackFrame
<a href="https://bugs.webkit.org/show_bug.cgi?id=256204">https://bugs.webkit.org/show_bug.cgi?id=256204</a>
rdar://108289717

Reviewed by Philippe Normand.

VideoFrame::getRGBAImageData is using a converter in WebProcess which is now blocked.
We can remove this code path since we are now supporting requestVideoFrameCallback and VideoFrame.
We update LayoutTests/fast/mediastream/captureStream/canvas3d.html accordingly and remove VideoFrame::getRGBAImageData and related internals code.

* LayoutTests/fast/mediastream/captureStream/canvas3d.html:
* Source/WebCore/platform/VideoFrame.cpp:
(WebCore::VideoFrame::getRGBAImageData const): Deleted.
* Source/WebCore/platform/VideoFrame.h:
* Source/WebCore/platform/VideoFrame.mm:
(WebCore::VideoFrame::getRGBAImageData const): Deleted.
* Source/WebCore/platform/graphics/gstreamer/VideoFrameGStreamer.cpp:
(WebCore::VideoFrameGStreamer::computeRGBAImageData const): Deleted.
* Source/WebCore/platform/graphics/gstreamer/VideoFrameGStreamer.h:
* Source/WebCore/testing/Internals.cpp:
(WebCore::Internals::videoFrameAvailable):
(WebCore::Internals::grabNextMediaStreamTrackFrame): Deleted.
* Source/WebCore/testing/Internals.h:
* Source/WebCore/testing/Internals.idl:

Canonical link: <a href="https://commits.webkit.org/263628@main">https://commits.webkit.org/263628@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c1ef7fccc591f28613ce8b7ee5f0bf671f436d97

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/5129 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/5261 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/5439 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/6650 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/5208 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/5124 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/5463 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/5237 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/5451 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/5217 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/5298 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/4600 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/6668 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/2784 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/4598 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/9903 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/4648 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/4671 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/6283 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/5093 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/4180 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/4573 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/4594 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/1265 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/8655 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/4939 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->