### PR TITLE
[popover] Use dialog focus algorithm for dialog popovers

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/popovers/popover-dialog-initial-focus-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/popovers/popover-dialog-initial-focus-expected.txt
@@ -1,0 +1,5 @@
+button
+
+PASS Opening dialogs as popovers should use dialog initial focus algorithm.
+PASS Opening dialogs as popovers which have autofocus should use dialog initial focus algorithm.
+

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/popovers/popover-dialog-initial-focus.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/popovers/popover-dialog-initial-focus.html
@@ -1,0 +1,25 @@
+<!DOCTYPE html>
+<link rel=author href="mailto:jarhar@chromium.org">
+<link rel=help href="http://crbug.com/1430405">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+
+<dialog id=dialog popover=auto>
+  <button id=button>button</button>
+</dialog>
+
+<dialog id=dialog2 popover=auto autofocus>
+  <button id=button2>button</button>
+</dialog>
+
+<script>
+test(() => {
+  dialog.showPopover();
+  assert_equals(document.activeElement, button);
+}, 'Opening dialogs as popovers should use dialog initial focus algorithm.');
+
+test(() => {
+  dialog2.showPopover();
+  assert_equals(document.activeElement, button2);
+}, 'Opening dialogs as popovers which have autofocus should use dialog initial focus algorithm.');
+</script>

--- a/LayoutTests/platform/ios/fast/dom/focus-dialog-blur-input-type-change-crash-expected.txt
+++ b/LayoutTests/platform/ios/fast/dom/focus-dialog-blur-input-type-change-crash-expected.txt
@@ -1,3 +1,2 @@
 CONSOLE MESSAGE: RangeError: Maximum call stack size exceeded.
-CONSOLE MESSAGE: RangeError: Maximum call stack size exceeded.
 PASS

--- a/Source/WebCore/html/HTMLDialogElement.cpp
+++ b/Source/WebCore/html/HTMLDialogElement.cpp
@@ -63,6 +63,8 @@ ExceptionOr<void> HTMLDialogElement::show()
 
     m_previouslyFocusedElement = document().focusedElement();
 
+    document().hideAllPopoversUntil(nullptr, FocusPreviousElement::No, FireEvents::No);
+
     runFocusingSteps();
     return { };
 }
@@ -91,6 +93,8 @@ ExceptionOr<void> HTMLDialogElement::showModal()
         addToTopLayer();
 
     m_previouslyFocusedElement = document().focusedElement();
+
+    document().hideAllPopoversUntil(nullptr, FocusPreviousElement::No, FireEvents::No);
 
     runFocusingSteps();
 
@@ -134,9 +138,11 @@ void HTMLDialogElement::queueCancelTask()
 // https://html.spec.whatwg.org/multipage/interactive-elements.html#dialog-focusing-steps
 void HTMLDialogElement::runFocusingSteps()
 {
-    document().hideAllPopoversUntil(nullptr, FocusPreviousElement::No, FireEvents::No);
-
-    RefPtr control = findFocusDelegate();
+    RefPtr<Element> control;
+    if (m_isModal && hasAttributeWithoutSynchronization(HTMLNames::autofocusAttr))
+        control = this;
+    if (!control)
+        control = findFocusDelegate();
 
     if (!control)
         control = this;

--- a/Source/WebCore/html/HTMLElement.cpp
+++ b/Source/WebCore/html/HTMLElement.cpp
@@ -1333,6 +1333,11 @@ void HTMLElement::checkAndPossiblyClosePopoverStackInternal()
 // https://html.spec.whatwg.org/#popover-focusing-steps
 static void runPopoverFocusingSteps(HTMLElement& popover)
 {
+    if (auto* dialog = dynamicDowncast<HTMLDialogElement>(popover)) {
+        dialog->runFocusingSteps();
+        return;
+    }
+
     RefPtr control = popover.hasAttribute(autofocusAttr) ? &popover : popover.findAutofocusDelegate();
 
     if (!control)


### PR DESCRIPTION
#### db3c1dec69db0000cc3f5f3661d86c28bc67e28b
<pre>
[popover] Use dialog focus algorithm for dialog popovers
<a href="https://bugs.webkit.org/show_bug.cgi?id=256208">https://bugs.webkit.org/show_bug.cgi?id=256208</a>

Reviewed by Tim Nguyen.

Implement the spec changes outlines here:
<a href="https://github.com/whatwg/html/pull/9121">https://github.com/whatwg/html/pull/9121</a>

* LayoutTests/imported/w3c/web-platform-tests/html/semantics/popovers/popover-dialog-initial-focus-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/popovers/popover-dialog-initial-focus.html: Added.
* LayoutTests/platform/ios/fast/dom/focus-dialog-blur-input-type-change-crash-expected.txt:
* Source/WebCore/html/HTMLDialogElement.cpp:
(WebCore::HTMLDialogElement::show):
(WebCore::HTMLDialogElement::showModal):
(WebCore::HTMLDialogElement::runFocusingSteps):
* Source/WebCore/html/HTMLElement.cpp:
(WebCore::runPopoverFocusingSteps):

Canonical link: <a href="https://commits.webkit.org/263749@main">https://commits.webkit.org/263749@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9ef0a1f9e77757b3f5505ba3f09b654851a8f257

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/5594 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/5747 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/5935 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/7146 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/5593 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/5594 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/5972 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/5720 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/7357 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/5697 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/5757 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/5013 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/7185 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/3235 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/5032 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/12150 "4 flakes 165 failures") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/5101 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/5111 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/6919 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/5549 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/4541 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/5002 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/4963 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/1337 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/9107 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/5363 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->