### PR TITLE
fast/scrolling/ios/click-events-during-momentum-scroll-in-main-frame.html is a flaky failure

### DIFF
--- a/LayoutTests/fast/scrolling/ios/click-events-during-momentum-scroll-in-main-frame-expected.txt
+++ b/LayoutTests/fast/scrolling/ios/click-events-during-momentum-scroll-in-main-frame-expected.txt
@@ -3,7 +3,7 @@ Verifies that tapping the page during momentum scrolling does not dispatch click
 On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
 
 
-PASS document.scrollingElement.scrollTop passed 1000
+PASS document.scrollingElement.scrollTop > minimumExpectedScrollTop became true
 PASS successfullyParsed is true
 
 TEST COMPLETE

--- a/LayoutTests/fast/scrolling/ios/click-events-during-momentum-scroll-in-main-frame.html
+++ b/LayoutTests/fast/scrolling/ios/click-events-during-momentum-scroll-in-main-frame.html
@@ -19,44 +19,30 @@ html, body {
     background: linear-gradient(to bottom, red 0%, green 50%, blue 100%);
 }
 </style>
-<body onload="runTest()">
+<body>
 <div id="content"></div>
 </body>
 <script>
 jsTestIsAsync = true;
-const minimumExpectedScrollTop = 1000;
-let reachedMinimumScrollPosition = false;
+const minimumExpectedScrollTop = 1200;
 
-addEventListener("scroll", observeScrollEvent);
-document.body.addEventListener("click", () => testFailed("Observed unexpected click event."), { once: true });
-
-function noteTestProgress() {
-    if (!window.progress)
-        progress = 0;
-    if (++progress == 2)
-        finishJSTest();
-}
-
-async function observeScrollEvent() {
-    if (!window.testRunner || document.scrollingElement.scrollTop < minimumExpectedScrollTop || reachedMinimumScrollPosition)
-        return;
-
-    reachedMinimumScrollPosition = true;
-    testPassed(`document.scrollingElement.scrollTop passed ${minimumExpectedScrollTop}`);
-    removeEventListener("scroll", observeScrollEvent);
-    await UIHelper.activateAt(160, document.scrollingElement.scrollTop + 350);
-    noteTestProgress();
-}
-
-async function runTest()
-{
+addEventListener("load", async () => {
     description("Verifies that tapping the page during momentum scrolling does not dispatch click events to the page. To run the test manually, swipe up to scroll down; while the page is momentum scrolling, tap the screen to interrupt scrolling. The page should not observe any click events.");
+    document.body.addEventListener("click", () => testFailed("Observed unexpected click event."), { once: true });
 
     if (!window.testRunner)
         return;
 
-    await UIHelper.dragFromPointToPoint(160, 450, 160, 50, 0.1);
-    noteTestProgress();
-}
+    await UIHelper.dragFromPointToPoint(160, 450, 160, 0, 0.1);
+    await shouldBecomeEqual("document.scrollingElement.scrollTop > minimumExpectedScrollTop", "true");
+    await UIHelper.sendEventStream(new UIHelper.EventStreamBuilder()
+        .begin(160, document.scrollingElement.scrollTop + 350)
+        .wait(0.1)
+        .end()
+        .takeResult());
+
+    await UIHelper.ensureStablePresentationUpdate();
+    finishJSTest();
+});
 </script>
 </html>

--- a/LayoutTests/fast/scrolling/ios/click-events-during-momentum-scroll-in-overflow-expected.txt
+++ b/LayoutTests/fast/scrolling/ios/click-events-during-momentum-scroll-in-overflow-expected.txt
@@ -3,7 +3,7 @@ Verifies that tapping a subscrollable region during momentum scrolling does not 
 On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
 
 
-PASS scroller.scrollTop passed 500
+PASS scroller.scrollTop > minimumExpectedScrollTop became true
 PASS successfullyParsed is true
 
 TEST COMPLETE

--- a/LayoutTests/fast/scrolling/ios/click-events-during-momentum-scroll-in-overflow.html
+++ b/LayoutTests/fast/scrolling/ios/click-events-during-momentum-scroll-in-overflow.html
@@ -14,7 +14,7 @@ html, body {
 
 #scroller {
     width: 100%;
-    height: 75%;
+    height: 400px;
     overflow: scroll;
     border: 4px solid black;
     box-sizing: border-box;
@@ -28,7 +28,7 @@ html, body {
     background: linear-gradient(to bottom, red 0%, green 50%, blue 100%);
 }
 </style>
-<body onload="runTest()">
+<body>
     <div id="scroller">
         <div id="content"></div>
     </div>
@@ -38,40 +38,27 @@ html, body {
 <script>
 jsTestIsAsync = true;
 
-let reachedMinimumScrollPosition = false;
-const minimumExpectedScrollTop = 500;
+const minimumExpectedScrollTop = 600;
 const scroller = document.getElementById("scroller");
 
-scroller.addEventListener("scroll", observeScrollEvent);
 scroller.addEventListener("click", () => testFailed("Observed unexpected click event."), { once: true });
 
-function noteTestProgress() {
-    if (!window.progress)
-        progress = 0;
-    if (++progress == 2)
-        finishJSTest();
-}
-
-async function observeScrollEvent() {
-    if (!window.testRunner || scroller.scrollTop < minimumExpectedScrollTop || reachedMinimumScrollPosition)
-        return;
-
-    reachedMinimumScrollPosition = true;
-    testPassed(`scroller.scrollTop passed ${minimumExpectedScrollTop}`);
-    removeEventListener("scroll", observeScrollEvent);
-    await UIHelper.activateAt(160, 250);
-    noteTestProgress();
-}
-
-async function runTest()
-{
+addEventListener("load", async () => {
     description("Verifies that tapping a subscrollable region during momentum scrolling does not dispatch click events. To run the test manually, swipe up on the black box to scroll it; while scrolling, tap the scrollable area to interrupt scrolling. The scrollable area should not observe any click events.");
 
     if (!window.testRunner)
         return;
 
-    await UIHelper.dragFromPointToPoint(160, 250, 160, 50, 0.1);
-    noteTestProgress();
-}
+    await UIHelper.dragFromPointToPoint(160, 350, 160, 0, 0.1);
+    await shouldBecomeEqual("scroller.scrollTop > minimumExpectedScrollTop", "true");
+    await UIHelper.sendEventStream(new UIHelper.EventStreamBuilder()
+        .begin(160, 350)
+        .wait(0.1)
+        .end()
+        .takeResult());
+
+    await UIHelper.ensureStablePresentationUpdate();
+    finishJSTest();
+});
 </script>
 </html>


### PR DESCRIPTION
#### cc94cce0848d72816737efdb85a3d469dd7e2cc3
<pre>
fast/scrolling/ios/click-events-during-momentum-scroll-in-main-frame.html is a flaky failure
<a href="https://bugs.webkit.org/show_bug.cgi?id=256192">https://bugs.webkit.org/show_bug.cgi?id=256192</a>

Reviewed by Aditya Keerthi.

Adjust these two tests to (hopefully) be less flaky. These tests try to scroll via pan gesture, and
then tap in a web view during the deceleration phase of the scroll animation; however, it&apos;s
apparently possible for the test to synthesize the tap gesture while scrolling is still happening
(due to the pan gesture), reusing the touch identifier corresponding to the touch used for
scrolling.

Make this test more realistic (and also easier to follow) by removing the `noteTestProgress()`
counter mechanism, and instead simply wait for the scroll position to pass a certain threshold after
the event stream has ended.

Before this adjustment, I was able to reliably reproduce 1-2 test failures every 200 runs; after
this adjustment, I&apos;m no longer able to reproduce any flaky failures.

* LayoutTests/fast/scrolling/ios/click-events-during-momentum-scroll-in-main-frame-expected.txt:
* LayoutTests/fast/scrolling/ios/click-events-during-momentum-scroll-in-main-frame.html:
* LayoutTests/fast/scrolling/ios/click-events-during-momentum-scroll-in-overflow-expected.txt:
* LayoutTests/fast/scrolling/ios/click-events-during-momentum-scroll-in-overflow.html:

Canonical link: <a href="https://commits.webkit.org/263599@main">https://commits.webkit.org/263599@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d884059c0479cbed4a6f728496b34085c3b3ce8c

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/5154 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/5287 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/5467 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/6678 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/5228 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/5493 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/5264 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/5480 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/5245 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/5327 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/4620 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/6696 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/2813 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/4618 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/9949 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/4677 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/4691 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/6306 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/5118 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/4205 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/4597 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/4614 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/1240 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/8679 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/4963 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->