### PR TITLE
Container query length units use border box instead of a content box

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-contain/container-queries/container-units-content-box-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-contain/container-queries/container-units-content-box-expected.txt
@@ -1,0 +1,4 @@
+
+PASS Container units are relative to the content box of the container
+PASS Container units are relative to the content box of the container (box-sizing: border-box)
+

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-contain/container-queries/container-units-content-box.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-contain/container-queries/container-units-content-box.html
@@ -1,0 +1,58 @@
+<!doctype html>
+<title>Container Relative Units: evaluate against the content box</title>
+<link rel="help" href="https://drafts.csswg.org/css-contain-3/#container-lengths">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="support/cq-testcommon.js"></script>
+<style>
+.size {
+  container-type: size;
+  width:100px;
+  height:50px;
+  border: 10px solid green;
+  padding: 10px;
+}
+.border-box {
+  box-sizing: border-box;
+}
+</style>
+<div id=ref></div>
+<div class="size">
+  <div id=child></div>
+</div>
+<div class="size border-box">
+  <div id=child2></div>
+</div>
+<script>
+  setup(() => assert_implements_container_queries());
+
+  function assert_unit_equals(element, actual, expected) {
+    try {
+      element.style.padding = actual;
+      ref.style.padding = expected;
+      assert_equals(getComputedStyle(element).paddingLeft,
+                    getComputedStyle(ref).paddingLeft);
+    } finally {
+      element.style = '';
+      ref.style = '';
+    }
+  }
+
+  test(function() {
+    assert_unit_equals(child, '10cqi', '10px');
+    assert_unit_equals(child, '10cqw', '10px');
+    assert_unit_equals(child, '10cqb', '5px');
+    assert_unit_equals(child, '10cqh', '5px');
+    assert_unit_equals(child, '10cqmin', '5px');
+    assert_unit_equals(child, '10cqmax', '10px');
+  }, 'Container units are relative to the content box of the container');
+
+  test(function() {
+    assert_unit_equals(child2, '10cqi', '6px');
+    assert_unit_equals(child2, '10cqw', '6px');
+    assert_unit_equals(child2, '10cqb', '1px');
+    assert_unit_equals(child2, '10cqh', '1px');
+    assert_unit_equals(child2, '10cqmin', '1px');
+    assert_unit_equals(child2, '10cqmax', '6px');
+  }, 'Container units are relative to the content box of the container (box-sizing: border-box)');
+</script>

--- a/Source/WebCore/css/CSSPrimitiveValue.cpp
+++ b/Source/WebCore/css/CSSPrimitiveValue.cpp
@@ -904,25 +904,25 @@ double CSSPrimitiveValue::computeNonCalcLengthDouble(const CSSToLengthConversion
 
     case CSSUnitType::CSS_CQW: {
         if (auto* containerRenderer = selectContainerRenderer(CQ::Axis::Width))
-            return containerRenderer->width() * value / 100;
+            return containerRenderer->contentWidth() * value / 100;
         return value * conversionData.smallViewportFactor().width();
     }
 
     case CSSUnitType::CSS_CQH: {
         if (auto* containerRenderer = selectContainerRenderer(CQ::Axis::Height))
-            return containerRenderer->height() * value / 100;
+            return containerRenderer->contentHeight() * value / 100;
         return value * conversionData.smallViewportFactor().height();
     }
 
     case CSSUnitType::CSS_CQI: {
         if (auto* containerRenderer = selectContainerRenderer(CQ::Axis::Inline))
-            return containerRenderer->logicalWidth() * value / 100;
+            return containerRenderer->contentLogicalWidth() * value / 100;
         return value * lengthOfViewportPhysicalAxisForLogicalAxis(LogicalBoxAxis::Inline, conversionData.smallViewportFactor(), conversionData.rootStyle());
     }
 
     case CSSUnitType::CSS_CQB: {
         if (auto* containerRenderer = selectContainerRenderer(CQ::Axis::Block))
-            return containerRenderer->logicalHeight() * value / 100;
+            return containerRenderer->contentLogicalHeight() * value / 100;
         return value * lengthOfViewportPhysicalAxisForLogicalAxis(LogicalBoxAxis::Block, conversionData.smallViewportFactor(), conversionData.rootStyle());
     }
 


### PR DESCRIPTION
#### e31e2eb9806ebc6612c400af57b33856ec796957
<pre>
Container query length units use border box instead of a content box
<a href="https://bugs.webkit.org/show_bug.cgi?id=256178">https://bugs.webkit.org/show_bug.cgi?id=256178</a>
rdar://problem/108754549

Reviewed by Alan Baradlay.

<a href="https://www.w3.org/TR/css-contain-3/#container-query-length">https://www.w3.org/TR/css-contain-3/#container-query-length</a>:

&gt; For each element, container query length units are evaluated as container size queries on the relevant axis (or axes) described by the unit.

<a href="https://www.w3.org/TR/css-contain-3/#container-size-query">https://www.w3.org/TR/css-contain-3/#container-size-query</a>:

&gt; The width container feature queries the width of the query container’s content box.
&gt; The height container feature queries the height of the query container’s content box.
&gt; The inline-size container feature queries the size of the query container’s content box in the query container’s inline axis.
&gt; The block-size container feature queries the size of the query container’s content box in the query container’s block axis.

* LayoutTests/imported/w3c/web-platform-tests/css/css-contain/container-queries/container-units-content-box-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-contain/container-queries/container-units-content-box.html: Added.
* Source/WebCore/css/CSSPrimitiveValue.cpp:
(WebCore::CSSPrimitiveValue::computeNonCalcLengthDouble):

Resolve the container units against the correct box.

Canonical link: <a href="https://commits.webkit.org/263595@main">https://commits.webkit.org/263595@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c1e15e18d3a88dfc27a3fb59d877b431f9c2b615

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/5156 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/5289 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/5469 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/6680 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/5230 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/5153 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/5495 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/5266 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/5479 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/5247 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/5328 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/4622 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/6698 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/2814 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/4620 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/9996 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/4678 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/4693 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/6311 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/5120 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/4208 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/4599 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/4616 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/1237 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/8681 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/4964 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->