### PR TITLE
[JSC] Add IndexedProxyObjectLoad for generic keys

### DIFF
--- a/JSTests/microbenchmarks/proxy-get-by-val-miss.js
+++ b/JSTests/microbenchmarks/proxy-get-by-val-miss.js
@@ -1,0 +1,7 @@
+(function() {
+    var proxy = new Proxy({}, {});
+    var keys = [ "a", "b", "c", "d", "e", "f", "g", "h", "i", "j", "k", "l", "m", "n", "o", "p" ];
+
+    for (var i = 0; i < 1e7; ++i)
+        proxy[keys[i & 15]];
+})();

--- a/Source/JavaScriptCore/builtins/ProxyHelpers.js
+++ b/Source/JavaScriptCore/builtins/ProxyHelpers.js
@@ -77,6 +77,33 @@ function performProxyObjectGet(propertyName, receiver)
 }
 
 @linkTimeConstant
+function performProxyObjectGetByVal(propertyName, receiver)
+{
+    "use strict";
+
+    var target = @getProxyInternalField(this, @proxyFieldTarget);
+    var handler = @getProxyInternalField(this, @proxyFieldHandler);
+    var propertyName = @toPropertyKey(propertyName);
+
+    if (handler === null)
+        @throwTypeError("Proxy has already been revoked. No more operations are allowed to be performed on it");
+
+    var trap = handler.get;
+    if (@isUndefinedOrNull(trap))
+        return @getByValWithThis(target, receiver, propertyName);
+
+    if (!@isCallable(trap))
+        @throwTypeError("'get' property of a Proxy's handler should be callable");
+
+    var trapResult = trap.@call(handler, target, propertyName, receiver);
+
+    if (@mustValidateResultOfProxyGetAndSetTraps(target))
+        @handleProxyGetTrapResult(trapResult, target, propertyName);
+
+    return trapResult;
+}
+
+@linkTimeConstant
 function performProxyObjectSetSloppy(propertyName, receiver, value)
 {
     "use strict";

--- a/Source/JavaScriptCore/bytecode/AccessCase.cpp
+++ b/Source/JavaScriptCore/bytecode/AccessCase.cpp
@@ -88,6 +88,7 @@ Ref<AccessCase> AccessCase::create(VM& vm, JSCell* owner, AccessType type, Cache
     case ProxyObjectStore:
     case Replace:
     case InstanceOfGeneric:
+    case IndexedProxyObjectLoad:
     case IndexedMegamorphicLoad:
     case IndexedInt32Load:
     case IndexedDoubleLoad:
@@ -350,6 +351,7 @@ bool AccessCase::guardedByStructureCheckSkippingConstantIdentifierCheck() const
     case InstanceOfHit:
     case InstanceOfMiss:
     case InstanceOfGeneric:
+    case IndexedProxyObjectLoad:
     case IndexedMegamorphicLoad:
     case IndexedInt32Load:
     case IndexedDoubleLoad:
@@ -460,6 +462,7 @@ bool AccessCase::requiresIdentifierNameMatch() const
     case InstanceOfHit:
     case InstanceOfMiss:
     case InstanceOfGeneric:
+    case IndexedProxyObjectLoad:
     case IndexedMegamorphicLoad:
     case IndexedInt32Load:
     case IndexedDoubleLoad:
@@ -548,6 +551,7 @@ bool AccessCase::requiresInt32PropertyCheck() const
     case InstanceOfGeneric:
     case CheckPrivateBrand:
     case SetPrivateBrand:
+    case IndexedProxyObjectLoad:
     case IndexedMegamorphicLoad:
         return false;
     case IndexedInt32Load:
@@ -636,6 +640,7 @@ bool AccessCase::needsScratchFPR() const
     case InstanceOfHit:
     case InstanceOfMiss:
     case InstanceOfGeneric:
+    case IndexedProxyObjectLoad:
     case IndexedMegamorphicLoad:
     case IndexedInt32Load:
     case IndexedContiguousLoad:
@@ -735,7 +740,8 @@ void AccessCase::forEachDependentCell(VM&, const Functor& functor) const
     }
     case ProxyObjectHas:
     case ProxyObjectLoad:
-    case ProxyObjectStore: {
+    case ProxyObjectStore:
+    case IndexedProxyObjectLoad: {
         auto& accessor = this->as<ProxyObjectAccessCase>();
         if (accessor.callLinkInfo())
             accessor.callLinkInfo()->forEachDependentCell(functor);
@@ -835,6 +841,7 @@ bool AccessCase::doesCalls(VM& vm, Vector<JSCell*>* cellsToMarkIfDoesCalls) cons
     case ProxyObjectHas:
     case ProxyObjectLoad:
     case ProxyObjectStore:
+    case IndexedProxyObjectLoad:
         doesCalls = true;
         break;
     case IntrinsicGetter: {
@@ -1026,6 +1033,7 @@ bool AccessCase::canReplace(const AccessCase& other) const
     case ProxyObjectHas:
     case ProxyObjectLoad:
     case ProxyObjectStore:
+    case IndexedProxyObjectLoad:
         return other.type() == type();
 
     case ModuleNamespaceLoad: {
@@ -1277,6 +1285,7 @@ inline void AccessCase::runWithDowncast(const Func& func)
     case ProxyObjectHas:
     case ProxyObjectLoad:
     case ProxyObjectStore:
+    case IndexedProxyObjectLoad:
         func(static_cast<ProxyObjectAccessCase*>(this));
         break;
     }
@@ -1390,8 +1399,9 @@ bool AccessCase::canBeShared(const AccessCase& lhs, const AccessCase& rhs)
     case Setter:
     case ProxyObjectHas:
     case ProxyObjectLoad:
-    case ProxyObjectStore: {
-        // Getter / Setter / ProxyObjectHas / ProxyObjectLoad / ProxyObjectStore relies on CodeBlock, which makes sharing impossible.
+    case ProxyObjectStore:
+    case IndexedProxyObjectLoad: {
+        // Getter / Setter / ProxyObjectHas / ProxyObjectLoad / ProxyObjectStore / IndexedProxyObjectLoad rely on CodeBlock, which makes sharing impossible.
         return false;
     }
 

--- a/Source/JavaScriptCore/bytecode/AccessCase.h
+++ b/Source/JavaScriptCore/bytecode/AccessCase.h
@@ -123,6 +123,7 @@ DECLARE_ALLOCATOR_WITH_HEAP_IDENTIFIER(AccessCase);
     macro(InstanceOfGeneric) \
     macro(CheckPrivateBrand) \
     macro(SetPrivateBrand) \
+    macro(IndexedProxyObjectLoad) \
     macro(IndexedMegamorphicLoad) \
     macro(IndexedInt32Load) \
     macro(IndexedDoubleLoad) \

--- a/Source/JavaScriptCore/runtime/JSGlobalObject.h
+++ b/Source/JavaScriptCore/runtime/JSGlobalObject.h
@@ -669,6 +669,8 @@ public:
     JSFunction* performProxyObjectHasFunction() const;
     JSFunction* performProxyObjectGetFunction() const;
     JSFunction* performProxyObjectGetFunctionConcurrently() const;
+    JSFunction* performProxyObjectGetByValFunction() const;
+    JSFunction* performProxyObjectGetByValFunctionConcurrently() const;
     JSFunction* performProxyObjectSetSloppyFunction() const;
     JSFunction* performProxyObjectSetSloppyFunctionConcurrently() const;
     JSFunction* performProxyObjectSetStrictFunction() const;

--- a/Source/JavaScriptCore/runtime/JSGlobalObjectInlines.h
+++ b/Source/JavaScriptCore/runtime/JSGlobalObjectInlines.h
@@ -219,6 +219,8 @@ inline JSFunction* JSGlobalObject::stringProtoSubstringFunction() const { return
 inline JSFunction* JSGlobalObject::performProxyObjectHasFunction() const { return jsCast<JSFunction*>(linkTimeConstant(LinkTimeConstant::performProxyObjectHas)); }
 inline JSFunction* JSGlobalObject::performProxyObjectGetFunction() const { return jsCast<JSFunction*>(linkTimeConstant(LinkTimeConstant::performProxyObjectGet)); }
 inline JSFunction* JSGlobalObject::performProxyObjectGetFunctionConcurrently() const { return linkTimeConstantConcurrently<JSFunction*>(LinkTimeConstant::performProxyObjectGet); }
+inline JSFunction* JSGlobalObject::performProxyObjectGetByValFunction() const { return jsCast<JSFunction*>(linkTimeConstant(LinkTimeConstant::performProxyObjectGetByVal)); }
+inline JSFunction* JSGlobalObject::performProxyObjectGetByValFunctionConcurrently() const { return linkTimeConstantConcurrently<JSFunction*>(LinkTimeConstant::performProxyObjectGetByVal); }
 inline JSFunction* JSGlobalObject::performProxyObjectSetSloppyFunction() const { return jsCast<JSFunction*>(linkTimeConstant(LinkTimeConstant::performProxyObjectSetSloppy)); }
 inline JSFunction* JSGlobalObject::performProxyObjectSetSloppyFunctionConcurrently() const { return linkTimeConstantConcurrently<JSFunction*>(LinkTimeConstant::performProxyObjectSetSloppy); }
 inline JSFunction* JSGlobalObject::performProxyObjectSetStrictFunction() const { return jsCast<JSFunction*>(linkTimeConstant(LinkTimeConstant::performProxyObjectSetStrict)); }


### PR DESCRIPTION
#### 5b42d5b3a7026f0fd35f3d8e1680ec6ccb4552e9
<pre>
[JSC] Add IndexedProxyObjectLoad for generic keys
<a href="https://bugs.webkit.org/show_bug.cgi?id=256224">https://bugs.webkit.org/show_bug.cgi?id=256224</a>
rdar://108802515

Reviewed by NOBODY (OOPS!).

Let&apos;s extend the current IC to support GetByVal style generic key handling for ProxyObject get. This patch adds
IndexedProxyObjectLoad which can accept any keys. Inside performProxyObjectGetByVal, we do @toPropertyKey to
enforce stringified key and use it in the rest of the code.

                                      ToT                     Patched

    proxy-get-by-val-miss      318.8902+-2.6191     ^    111.6158+-1.9680        ^ definitely 2.8570x faster

* JSTests/microbenchmarks/proxy-get-by-val-miss.js: Added.
* Source/JavaScriptCore/builtins/ProxyHelpers.js:
(linkTimeConstant.performProxyObjectGet):
(linkTimeConstant.performProxyObjectGetByVal):
* Source/JavaScriptCore/bytecode/AccessCase.cpp:
(JSC::AccessCase::create):
(JSC::AccessCase::guardedByStructureCheckSkippingConstantIdentifierCheck const):
(JSC::AccessCase::requiresIdentifierNameMatch const):
(JSC::AccessCase::requiresInt32PropertyCheck const):
(JSC::AccessCase::needsScratchFPR const):
(JSC::AccessCase::forEachDependentCell const):
(JSC::AccessCase::doesCalls const):
(JSC::AccessCase::canReplace const):
(JSC::AccessCase::runWithDowncast):
(JSC::AccessCase::canBeShared):
* Source/JavaScriptCore/bytecode/AccessCase.h:
* Source/JavaScriptCore/bytecode/InlineCacheCompiler.cpp:
(JSC::InlineCacheCompiler::generateWithGuard):
(JSC::InlineCacheCompiler::generateImpl):
(JSC::InlineCacheCompiler::emitProxyObjectAccess):
(JSC::InlineCacheCompiler::regenerate):
* Source/JavaScriptCore/bytecode/Repatch.cpp:
(JSC::tryCacheGetBy):
* Source/JavaScriptCore/runtime/JSGlobalObject.h:
* Source/JavaScriptCore/runtime/JSGlobalObjectInlines.h:
(JSC::JSGlobalObject::performProxyObjectGetByValFunction const):
(JSC::JSGlobalObject::performProxyObjectGetByValFunctionConcurrently const):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5b42d5b3a7026f0fd35f3d8e1680ec6ccb4552e9

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/5175 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/5309 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/5489 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/6700 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/5248 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/5517 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/5286 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/5526 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/5267 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/5351 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/4643 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/6718 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/2837 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/4641 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/10242 "Passed tests") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/4286 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/4701 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/4714 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/6328 "Passed tests") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/4764 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/5139 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/4227 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/5271 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/4617 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/1329 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/8700 "Built successfully") | | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/24/builds/5420 "Built successfully") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/4982 "Built successfully") | | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/3/builds/1444 "Passed tests") | 
<!--EWS-Status-Bubble-End-->