### PR TITLE
Update WPT contain tests in css/motion/

### DIFF
--- a/LayoutTests/TestExpectations
+++ b/LayoutTests/TestExpectations
@@ -5125,9 +5125,12 @@ webkit.org/b/233340 imported/w3c/web-platform-tests/css/motion/offset-anchor-tra
 # CSS motion path ray test failing due to getting wrong size from containing block.
 webkit.org/b/233344 imported/w3c/web-platform-tests/css/motion/offset-path-ray-007.html [ ImageOnlyFailure ]
 
-# CSS motion path needs to implement contain for ray: https://bugs.webkit.org/show_bug.cgi?id=240259.
-webkit.org/b/233344 imported/w3c/web-platform-tests/css/motion/offset-path-ray-contain-004.html [ ImageOnlyFailure ]
-webkit.org/b/233344 imported/w3c/web-platform-tests/css/motion/offset-path-ray-contain-005.html [ ImageOnlyFailure ]
+# CSS motion path needs to implement new spec for contain: https://bugs.webkit.org/show_bug.cgi?id=256225.
+webkit.org/b/256225 imported/w3c/web-platform-tests/css/motion/offset-path-ray-contain-001.html [ ImageOnlyFailure ]
+webkit.org/b/256225 imported/w3c/web-platform-tests/css/motion/offset-path-ray-contain-002.html [ ImageOnlyFailure ]
+webkit.org/b/256225 imported/w3c/web-platform-tests/css/motion/offset-path-ray-contain-003.html [ ImageOnlyFailure ]
+webkit.org/b/256225 imported/w3c/web-platform-tests/css/motion/offset-path-ray-contain-004.html [ ImageOnlyFailure ]
+webkit.org/b/256225 imported/w3c/web-platform-tests/css/motion/offset-path-ray-contain-005.html [ ImageOnlyFailure ]
 
 # IPC test failing in Debug mode due to assert.
 [ Debug ] ipc/send-invalid-message.html [ Skip ]

--- a/LayoutTests/imported/w3c/web-platform-tests/css/motion/offset-path-ray-contain-001-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/motion/offset-path-ray-contain-001-expected.html
@@ -9,12 +9,15 @@
       }
       #target {
         position: relative;
-        left: 150px;
-        top: 150px;
-        width: 100px;
-        height: 100px;
+        left: 30px;
+        top: 40px;
+        width: 10px;
+        height: 10px;
         background-color: lime;
-        transform: rotate(0deg) translate(50px, -150px);
+        /* ray length is sqrt(30^2 + 40^2); contain does -max(10, 10) / 2; */
+        /* the result length is 45px. angle is 180deg; */
+        /* 5 is origin shift. */
+        transform: translate(-5px, 40px);
       }
     </style>
   </head>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/motion/offset-path-ray-contain-001.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/motion/offset-path-ray-contain-001.html
@@ -12,12 +12,12 @@
       }
       #target {
         position: relative;
-        left: 150px;
-        top: 150px;
-        width: 100px;
-        height: 100px;
+        left: 30px;
+        top: 40px;
+        width: 10px;
+        height: 10px;
         background-color: lime;
-        offset-path: ray(45deg closest-corner contain);
+        offset-path: ray(180deg closest-corner contain);
         offset-rotate: 0deg;
         offset-distance: 100%;
       }

--- a/LayoutTests/imported/w3c/web-platform-tests/css/motion/offset-path-ray-contain-002-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/motion/offset-path-ray-contain-002-expected.html
@@ -14,8 +14,9 @@
         width: 100px;
         height: 100px;
         background-color: lime;
-        /* The vertical movement is about sqrt(150^2 - 50^2) - 50 */
-        transform: translateY(91.42px);
+        /* ray length is sqrt(150^2 + 0^2); contain does -max(100, 100) / 2; */
+        /* the result length is 100. sin(90deg) * length = 100; */
+        transform: translateY(100px);
       }
     </style>
   </head>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/motion/offset-path-ray-contain-003-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/motion/offset-path-ray-contain-003-expected.html
@@ -14,8 +14,9 @@
         width: 100px;
         height: 100px;
         background-color: lime;
-        /* The movement is about 150 - 50 * sqrt(2) */
-        transform: rotate(-45deg) translate(79.29px) rotate(45deg);
+        /* ray length is sqrt(150^2 + 0^2); contain does -max(100, 100) / 2; */
+        /* the result length is 100. sin(45deg) * length = 70.71; */
+        transform: rotate(-45deg) translate(100px) rotate(45deg);
       }
     </style>
   </head>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/motion/offset-path-ray-contain-004-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/motion/offset-path-ray-contain-004-expected.html
@@ -14,8 +14,9 @@
         width: 100px;
         height: 100px;
         background-color: lime;
-        /* The movement is about sqrt(150^2 - 50^2) - 50 */
-        transform: rotate(-45deg) translate(91.42px);
+        /* ray length is sqrt(150^2 + 0^2); contain does -max(100, 100) / 2; */
+        /* the result length is 100. sin(45deg) * length = 70.71; */
+        transform: rotate(-45deg) translate(100px);
       }
     </style>
   </head>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/motion/offset-path-ray-contain-005-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/motion/offset-path-ray-contain-005-expected.html
@@ -16,15 +16,12 @@
         height: 25px;
         background-color: lime;
         /*
-         * The original path length is 50px, which is not enough to contain
-         * the element entirely, so it should be increased.
-         * "75px" is just the center of the element, which makes the path
-         * length increase minimally.
-         * Besides, -75px = (-150px * 2) + 225px, the used offset distance is
-         * -225px in this case.
-         * Note: offset-anchor is "200% -300%", and ray angle is -90deg.
+         * The original path length is 50px, contain applies
+         * decrease, so that the new length is -25px (-150px / 2).
+         * Note: offset-anchor is "200% -300%", and ray angle is -90deg
+           and offset-rotate is -90deg.
          */
-        transform: translate(calc(-75px), calc(25px * 3));
+        transform: translate(-75px, -12.5px) rotate(-90deg) translate(-225px, 87.5px);
       }
     </style>
   </head>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/motion/offset-path-ray-contain-005.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/motion/offset-path-ray-contain-005.html
@@ -22,8 +22,8 @@
         background-color: lime;
         offset-path: ray(-90deg closest-side contain);
         offset-anchor: 200% -300%;
-        offset-rotate: 0deg;
-        offset-distance: 0%;
+        offset-rotate: -90deg;
+        offset-distance: 50%;
       }
     </style>
   </head>

--- a/LayoutTests/platform/gtk/TestExpectations
+++ b/LayoutTests/platform/gtk/TestExpectations
@@ -2192,6 +2192,7 @@ webkit.org/b/160119 fast/repaint/selection-gap-flipped-fixed-child.html [ Failur
 
 webkit.org/b/240270 imported/w3c/web-platform-tests/css/motion/offset-rotate-001.html [ ImageOnlyFailure ]
 webkit.org/b/240270 imported/w3c/web-platform-tests/css/motion/offset-rotate-002.html [ ImageOnlyFailure ]
+webkit.org/b/256225 imported/w3c/web-platform-tests/css/motion/offset-path-ray-contain-004.html [ ImageOnlyFailure ]
 
 # These failures occur on GTK only (moved from LayoutTests/TestExpectations)
 webkit.org/b/200208 imported/w3c/web-platform-tests/css/css-images/gradients-with-transparent.html [ ImageOnlyFailure ]

--- a/LayoutTests/platform/wpe/TestExpectations
+++ b/LayoutTests/platform/wpe/TestExpectations
@@ -1608,6 +1608,8 @@ webkit.org/b/236926 webrtc/vp8-then-h264-gpu-process-crash.html [ Timeout Pass ]
 # UNSORTED Expectations. When in doubt, put it here.
 #////////////////////////////////////////////////////////////////////////////////////////
 
+webkit.org/b/256225 imported/w3c/web-platform-tests/css/motion/offset-path-ray-contain-004.html [ ImageOnlyFailure ]
+
 # These tests require platform support.
 
 webkit.org/b/238885 imported/w3c/web-platform-tests/WebCryptoAPI/derive_bits_keys/pbkdf2.https.any.html?1001-2000 [ Failure Timeout ]


### PR DESCRIPTION
#### 75d7fecef97ac1b7811cb97cce013bc01be53ed0
<pre>
Update WPT contain tests in css/motion/
<a href="https://bugs.webkit.org/show_bug.cgi?id=256226">https://bugs.webkit.org/show_bug.cgi?id=256226</a>
rdar://108804522

Reviewed by Tim Nguyen.

Import new WPT contain tests for &lt;ray&gt; after spec change:
<a href="https://github.com/w3c/fxtf-drafts/commit/bd9fb9b.">https://github.com/w3c/fxtf-drafts/commit/bd9fb9b.</a>

* LayoutTests/TestExpectations:
* LayoutTests/imported/w3c/web-platform-tests/css/motion/offset-path-ray-contain-001-expected.html:
* LayoutTests/imported/w3c/web-platform-tests/css/motion/offset-path-ray-contain-001.html:
* LayoutTests/imported/w3c/web-platform-tests/css/motion/offset-path-ray-contain-002-expected.html:
* LayoutTests/imported/w3c/web-platform-tests/css/motion/offset-path-ray-contain-003-expected.html:
* LayoutTests/imported/w3c/web-platform-tests/css/motion/offset-path-ray-contain-004-expected.html:
* LayoutTests/imported/w3c/web-platform-tests/css/motion/offset-path-ray-contain-005-expected.html:
* LayoutTests/imported/w3c/web-platform-tests/css/motion/offset-path-ray-contain-005.html:

Canonical link: <a href="https://commits.webkit.org/263636@main">https://commits.webkit.org/263636@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/90f02ae6347218ff70ea0c0ac8026661c3675ce3

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/5205 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/5339 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/5522 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/6732 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/5270 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/5552 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/5318 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/5631 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/5298 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/5377 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/4666 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/6751 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/2862 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/4664 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/10467 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/4727 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/4739 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/6352 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/5164 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/4246 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/4640 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/4661 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/8724 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/594 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/5005 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->