### PR TITLE
Text not wrapping in nested grid

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/grid-relayout-with-nested-grid-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/grid-relayout-with-nested-grid-expected.html
@@ -1,0 +1,30 @@
+<!DOCTYPE html>
+ <html>
+ <head>
+ <meta charset="utf-8">
+ <link rel="author" title="Brandon Stewart" href="mailto:brandonstewart@apple.com">
+ <link rel="help" href="https://drafts.csswg.org/css-grid-1">
+ <meta name="assert" content="Ensure text does not overflow upon re-layout of grid">
+ </head>
+
+ <style>
+ .grid { 
+   display: grid; 
+   grid-template-columns: minmax(min-content, 100px) auto; 
+ }
+
+ .nested_grid {
+   border: 5px solid; 
+   display: grid; 
+   justify-items: baseline; 
+   overflow-wrap: break-word;
+ }
+
+ </style>
+ <body>
+ <div id="grid" class=grid>
+   <div id="nested_grid" class=nested_grid><p id="paragraph">This content will overflow.</p></div>
+ </div>
+ </body>
+
+ </html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/grid-relayout-with-nested-grid-ref.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/grid-relayout-with-nested-grid-ref.html
@@ -1,0 +1,30 @@
+<!DOCTYPE html>
+ <html>
+ <head>
+ <meta charset="utf-8">
+ <link rel="author" title="Brandon Stewart" href="mailto:brandonstewart@apple.com">
+ <link rel="help" href="https://drafts.csswg.org/css-grid-1">
+ <meta name="assert" content="Ensure text does not overflow upon re-layout of grid">
+ </head>
+
+ <style>
+ .grid { 
+   display: grid; 
+   grid-template-columns: minmax(min-content, 100px) auto; 
+ }
+
+ .nested_grid {
+   border: 5px solid; 
+   display: grid; 
+   justify-items: baseline; 
+   overflow-wrap: break-word;
+ }
+
+ </style>
+ <body>
+ <div id="grid" class=grid>
+   <div id="nested_grid" class=nested_grid><p id="paragraph">This content will overflow.</p></div>
+ </div>
+ </body>
+
+ </html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/grid-relayout-with-nested-grid.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/grid-relayout-with-nested-grid.html
@@ -1,0 +1,46 @@
+<!DOCTYPE html>
+<html class="reftest-wait">
+<head>
+<meta charset="utf-8">
+<link rel="author" title="Brandon Stewart" href="mailto:brandonstewart@apple.com">
+<link rel="help" href="https://drafts.csswg.org/css-grid-1">
+<link rel="match" href="grid-relayout-with-nested-grid-ref.html">
+<meta name="assert" content="Ensure text does not overflow upon re-layout of grid">
+</head>
+
+<style>
+.grid { 
+  display: grid; 
+  grid-template-columns: minmax(min-content, 100px) auto; 
+}
+
+.nested_grid {
+  border: 5px solid; 
+  display: grid; 
+  justify-items: baseline; 
+  overflow-wrap: break-word;
+}
+
+</style>
+<body>
+<div id="grid" class=grid>
+  <div id="extra_div1"> 
+    <div id="extra_div2">
+      <div id="nested_grid" class=nested_grid><p id="paragraph">This content will overflow.</p></div>
+    </div>
+  </div>
+</div>
+</body>
+
+<script>
+/* Force a re-layout */
+async function forceLayout() {
+  await new Promise(res => setTimeout(res, 0));
+  document.getElementById("extra_div1").appendChild(document.createElement("p"));
+  document.documentElement.classList.remove("reftest-wait");
+};
+
+forceLayout();
+</script>
+
+</html>

--- a/Source/WebCore/rendering/RenderGrid.h
+++ b/Source/WebCore/rendering/RenderGrid.h
@@ -158,7 +158,8 @@ private:
 
     std::unique_ptr<OrderedTrackIndexSet> computeEmptyTracksForAutoRepeat(GridTrackSizingDirection) const;
 
-    void performGridItemsPreLayout(const GridTrackSizingAlgorithm&) const;
+    enum class ShouldUpdateGridAreaLogicalSize : bool { No, Yes };
+    void performGridItemsPreLayout(const GridTrackSizingAlgorithm&, const ShouldUpdateGridAreaLogicalSize) const;
 
     void placeItemsOnGrid(std::optional<LayoutUnit> availableLogicalWidth);
     void populateExplicitGridAndOrderIterator();


### PR DESCRIPTION
#### 705acfb695e5f37fa7e52c7d2050e9e3151cb606
<pre>
Text not wrapping in nested grid
<a href="https://bugs.webkit.org/show_bug.cgi?id=254214">https://bugs.webkit.org/show_bug.cgi?id=254214</a>
rdar://107002717

Reviewed by Alan Baradlay.

This is a hack fix to support not re-layout text in inner grids. This is caused by the updateGridAreaLogicalSize
being called in performGridItemsPreLayout(). This causes the paragraph to re-need a layout, which should not be happening.
This re-layout ultimately the text to go out of the bounds of the grid.

* LayoutTests/imported/w3c/web-platform-tests/css/css-grid/grid-relayout-with-nested-grid-expected.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-grid/grid-relayout-with-nested-grid-ref.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-grid/grid-relayout-with-nested-grid.html: Added.
* Source/WebCore/rendering/RenderGrid.cpp:
(WebCore::RenderGrid::layoutGrid):
(WebCore::RenderGrid::layoutMasonry):
(WebCore::RenderGrid::computeIntrinsicLogicalWidths const):
(WebCore::RenderGrid::performGridItemsPreLayout const):
* Source/WebCore/rendering/RenderGrid.h:

Canonical link: <a href="https://commits.webkit.org/264252@main">https://commits.webkit.org/264252@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/6d7331eefd27575e1ca1d2f9d0e624c94f17cec5

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/7141 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/7389 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/7567 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/8758 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/7362 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/7151 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/8657 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/7321 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/10263 "101 failures") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/7268 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/7929 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/6577 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/8864 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/5283 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/6496 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/14240 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/6944 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/6595 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/9473 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/7077 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/5786 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/6437 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/6405 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/1696 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/10636 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/6820 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->