### PR TITLE
Remove draggable elements default presentational CSS of -webkit-user-select: none

### DIFF
--- a/LayoutTests/fast/css/style-change-draggable-text-expected.txt
+++ b/LayoutTests/fast/css/style-change-draggable-text-expected.txt
@@ -1,1 +1,4 @@
-Test changing style with draggable text. The test passes if WebKit doesn't crash or hit an assertiona
+Test changing style with draggable text. The test passes if WebKit doesn't crash or hit an assertion
+
+a
+a

--- a/LayoutTests/fast/html/find-selects-draggable-element-expected.txt
+++ b/LayoutTests/fast/html/find-selects-draggable-element-expected.txt
@@ -1,0 +1,2 @@
+PASS window.getSelection().toString() == 'Something' is true
+Something

--- a/LayoutTests/fast/html/find-selects-draggable-element.html
+++ b/LayoutTests/fast/html/find-selects-draggable-element.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<head>
+  <script src="../../resources/js-test-pre.js"></script>
+  <script>
+    function findText() {
+      window.find("Something");
+      shouldBeTrue("window.getSelection().toString() == 'Something'");
+    }
+  </script>
+<body onload="findText()">
+  <p draggable="true">Something</p>
+</body>

--- a/LayoutTests/fast/inline/contenteditable-with-leading-whitespace-crash-expected.txt
+++ b/LayoutTests/fast/inline/contenteditable-with-leading-whitespace-crash-expected.txt
@@ -1,3 +1,2 @@
 PASS if no crash.
 
-

--- a/Source/WebCore/html/HTMLElement.cpp
+++ b/Source/WebCore/html/HTMLElement.cpp
@@ -270,11 +270,9 @@ void HTMLElement::collectPresentationalHintsForAttribute(const QualifiedName& na
         addPropertyToPresentationalHintStyle(style, CSSPropertyDisplay, CSSValueNone);
         break;
     case AttributeNames::draggableAttr:
-        if (equalLettersIgnoringASCIICase(value, "true"_s)) {
+        if (equalLettersIgnoringASCIICase(value, "true"_s))
             addPropertyToPresentationalHintStyle(style, CSSPropertyWebkitUserDrag, CSSValueElement);
-            if (!isDraggableIgnoringAttributes())
-                addPropertyToPresentationalHintStyle(style, CSSPropertyWebkitUserSelect, CSSValueNone);
-        } else if (equalLettersIgnoringASCIICase(value, "false"_s))
+        else if (equalLettersIgnoringASCIICase(value, "false"_s))
             addPropertyToPresentationalHintStyle(style, CSSPropertyWebkitUserDrag, CSSValueNone);
         break;
     case AttributeNames::dirAttr:


### PR DESCRIPTION
#### 1605f4df0c4bbf4b276dd70343a3f1026a72e3d6
<pre>
Remove draggable elements default presentational CSS of -webkit-user-select: none
<a href="https://bugs.webkit.org/show_bug.cgi?id=234716">https://bugs.webkit.org/show_bug.cgi?id=234716</a>

Reviewed by Tim Nguyen.

This behaves similar to both Firefox and Chromium. Draggable elements do not make them
un-selectable. When selected, dragging still takes priority also like other browsers.

* LayoutTests/fast/html/find-selects-draggable-element-expected.txt: Added.
* LayoutTests/fast/html/find-selects-draggable-element.html: Added.
* Source/WebCore/html/HTMLElement.cpp:
  (WebCore::HTMLElement::collectPresentationalHintsForAttribute):

Canonical link: <a href="https://commits.webkit.org/264448@main">https://commits.webkit.org/264448@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/64aea20f80c8c2729f8fcd0f1d187b199a2bd4e4

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/6640 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/6856 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/7038 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/8231 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/6922 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/6639 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/7926 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/6804 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/9820 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/6758 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/7271 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/6076 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/8318 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/4741 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/6005 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/14502 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/6550 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/6085 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/10193 "7 api tests failed or timed out") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/6574 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/5384 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/5970 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/5933 "Passed tests") | | 
| [  ~~🛠 🧪 merge~~](https://ews-build.webkit.org/#/builders/19/builds/1823 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/10142 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/925 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/6343 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->