### PR TITLE
[JSC] Stringifier should quickly get names even if it involves accessors

### DIFF
--- a/JSTests/stress/json-stringify-getter-call-complex.js
+++ b/JSTests/stress/json-stringify-getter-call-complex.js
@@ -1,0 +1,74 @@
+function shouldBe(actual, expected) {
+    if (actual !== expected)
+        throw new Error('bad value: ' + actual);
+}
+
+{
+    let a = {
+        get cocoa() {
+            return "Cocoa";
+        },
+
+        get cappuccino() {
+            return "Cappuccino";
+        }
+    }
+
+    shouldBe(JSON.stringify(a), `{"cocoa":"Cocoa","cappuccino":"Cappuccino"}`);
+    shouldBe(JSON.stringify(a, ["cocoa", "cappuccino"]), `{"cocoa":"Cocoa","cappuccino":"Cappuccino"}`);
+}
+{
+    let a = {
+        get cocoa() {
+            Reflect.defineProperty(a, "cappuccino", { value: 42 });
+            return "Cocoa";
+        },
+
+        get cappuccino() {
+            throw new Error("out");
+        }
+    }
+
+    shouldBe(JSON.stringify(a), `{"cocoa":"Cocoa","cappuccino":42}`);
+}
+{
+    let a = {
+        get cocoa() {
+            Reflect.defineProperty(a, "next", { value: 42 });
+            return "Cocoa";
+        },
+
+        get cappuccino() {
+            return "Cappuccino";
+        }
+    }
+
+    shouldBe(JSON.stringify(a), `{"cocoa":"Cocoa","cappuccino":"Cappuccino"}`);
+}
+{
+    let a = {
+        get cocoa() {
+            Reflect.deleteProperty(a, "cappuccino");
+            return "Cocoa";
+        },
+
+        get cappuccino() {
+            return "Cappuccino";
+        }
+    }
+
+    shouldBe(JSON.stringify(a), `{"cocoa":"Cocoa"}`);
+}
+{
+    let a = {
+        get cocoa() {
+            return "Cocoa";
+        },
+
+        set cappuccino(value) {
+            throw new Error("out");
+        }
+    }
+
+    shouldBe(JSON.stringify(a), `{"cocoa":"Cocoa"}`);
+}

--- a/Source/JavaScriptCore/runtime/JSObject.cpp
+++ b/Source/JavaScriptCore/runtime/JSObject.cpp
@@ -2204,7 +2204,7 @@ bool JSObject::deleteProperty(JSCell* cell, JSGlobalObject* globalObject, Proper
 
     unsigned attributes;
 
-    if (!thisObject->staticPropertiesReified()) {
+    if (thisObject->hasNonReifiedStaticProperties()) {
         if (auto entry = thisObject->findPropertyHashEntry(propertyName)) {
             // If the static table contains a non-configurable (DontDelete) property then we can return early;
             // if there is a property in the storage array it too must be non-configurable (the language does

--- a/Source/JavaScriptCore/runtime/JSObjectInlines.h
+++ b/Source/JavaScriptCore/runtime/JSObjectInlines.h
@@ -222,7 +222,7 @@ inline bool JSObject::noSideEffectMayHaveNonIndexProperty(VM& vm, PropertyName p
         unsigned attributes;
         if (UNLIKELY(isValidOffset(structure.get(vm, propertyName, attributes))))
             return true;
-        if (TypeInfo::hasStaticPropertyTable(inlineTypeFlags) && !structure.staticPropertiesReified()) {
+        if (hasNonReifiedStaticProperties()) {
             for (auto* ancestorClass = object->classInfo(); ancestorClass; ancestorClass = ancestorClass->parentClass) {
                 if (auto* table = ancestorClass->staticPropHashTable; UNLIKELY(table && table->entry(propertyName)))
                     return true;
@@ -827,7 +827,7 @@ inline void JSObject::setPrivateBrand(JSGlobalObject* globalObject, JSValue bran
 template<typename Functor>
 bool JSObject::fastForEachPropertyWithSideEffectFreeFunctor(VM& vm, const Functor& functor)
 {
-    if (!staticPropertiesReified())
+    if (hasNonReifiedStaticProperties())
         return false;
 
     Structure* structure = this->structure();

--- a/Source/JavaScriptCore/runtime/ObjectConstructorInlines.h
+++ b/Source/JavaScriptCore/runtime/ObjectConstructorInlines.h
@@ -29,6 +29,22 @@
 
 namespace JSC {
 
+ALWAYS_INLINE bool canPerformFastPropertyNameEnumerationForJSONStringifyWithSideEffect(Structure* structure)
+{
+    // We do not check GetterSetter, CustomGetterSetter. GetterSetter and CustomGetterSetter will be invoked, and we fall back to the a bit more generic mode when we detect structure transition.
+    if (structure->typeInfo().overridesGetOwnPropertySlot())
+        return false;
+    if (structure->typeInfo().overridesAnyFormOfGetOwnPropertyNames())
+        return false;
+    if (hasIndexedProperties(structure->indexingType()))
+        return false;
+    if (structure->isUncacheableDictionary())
+        return false;
+    if (structure->hasNonReifiedStaticProperties())
+        return false;
+    return true;
+}
+
 ALWAYS_INLINE bool objectAssignFast(VM& vm, JSObject* target, JSObject* source, Vector<RefPtr<UniquedStringImpl>, 8>& properties, MarkedArgumentBuffer& values)
 {
     // |source| Structure does not have any getters. And target can perform fast put.


### PR DESCRIPTION
#### fa309035221a7368ed9d2e4b4a139a3169c5c36a
<pre>
[JSC] Stringifier should quickly get names even if it involves accessors
<a href="https://bugs.webkit.org/show_bug.cgi?id=256231">https://bugs.webkit.org/show_bug.cgi?id=256231</a>
rdar://108812378

Reviewed by Justin Michaud.

Even though the object has accessors, we can still enumerate properties quickly unless
structure is the same. This patch adds a fast path for object including accessors to
collect property names and offsets. Then we can use these information to get GetterSetter,
and even continue using these information so long as structure is not changed.

* Source/JavaScriptCore/runtime/JSONObject.cpp:
(JSC::Stringifier::Holder::isArray const):
(JSC::Stringifier::Holder::appendNextProperty):
(JSC::Stringifier::Holder::hasFastObjectProperties const): Deleted.
* Source/JavaScriptCore/runtime/JSObjectInlines.h:
(JSC::JSObject::fastForEachPropertyWithSideEffectFreeFunctor):
* Source/JavaScriptCore/runtime/ObjectConstructorInlines.h:
(JSC::canPerformFastPropertyNameEnumerationForJSONStringifyWithSideEffect):
(JSC::canPerformFastPropertyNameAndOffsetEnumerationForJSONStringifyWithSideEffect):

Canonical link: <a href="https://commits.webkit.org/263619@main">https://commits.webkit.org/263619@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ce6ed24b6f01fe4f24a390a9d22ca2d9e44cb754

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/5244 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/5380 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/5564 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/6773 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/5291 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/5593 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/5358 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/5761 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/5339 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/5414 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/4697 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/6794 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/2896 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/4699 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/10895 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [  ~~🛠 🧪 jsc~~](https://ews-build.webkit.org/#/builders/20/builds/4341 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/4760 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/4774 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/6379 "Passed tests") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/4829 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/5196 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/4270 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/5345 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/4665 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/1344 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/8757 "Built successfully") | | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/24/builds/5495 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/588 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/5027 "Built successfully") | | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/3/builds/1459 "Passed tests") | 
<!--EWS-Status-Bubble-End-->