### PR TITLE
Label elements should get InteractionRegions when associated to a control

### DIFF
--- a/LayoutTests/interaction-region/labels-expected.txt
+++ b/LayoutTests/interaction-region/labels-expected.txt
@@ -1,0 +1,26 @@
+Inactive label Do you like coffee?
+And checkboxes?
+(GraphicsLayer
+  (anchor 0.00 0.00)
+  (bounds 800.00 600.00)
+  (children 1
+    (GraphicsLayer
+      (bounds 800.00 600.00)
+      (contentsOpaque 1)
+      (drawsContent 1)
+      (backgroundColor #FFFFFF)
+      (event region
+        (rect (0,0) width=800 height=600)
+
+      (interaction regions [
+        (occlusion (272,13) width=37 height=36)
+        (borderRadius 0.00),
+        (interaction (282,23) width=17 height=16)
+        (borderRadius 5.00),
+        (interaction (30,52) width=260 height=42)
+        (borderRadius 16.00)])
+      )
+    )
+  )
+)
+

--- a/LayoutTests/interaction-region/labels.html
+++ b/LayoutTests/interaction-region/labels.html
@@ -1,0 +1,37 @@
+<!DOCTYPE html>
+<html>
+<style>
+    body { margin: 20px; }
+    label {
+        padding: 10px;
+    }
+    .container {
+        display: block;
+        width: 240px;
+        margin: 10px;
+
+        text-align: center;
+        background: blue;
+        border-radius: 16px;
+    }
+</style>
+<body>
+<label>Inactive label</label>
+<label for="coffee">Do you like coffee?</label>
+<input type="checkbox" name="coffee" id="coffee">
+<label class="container">
+    And checkboxes? <input type="checkbox">
+</label>
+
+<pre id="results"></pre>
+<script>
+if (window.testRunner)
+    testRunner.dumpAsText();
+
+window.onload = function () {
+    if (window.internals)
+       results.textContent = internals.layerTreeAsText(document, internals.LAYER_TREE_INCLUDES_EVENT_REGION | internals.LAYER_TREE_INCLUDES_ROOT_LAYER_PROPERTIES);
+};
+</script>
+</body>
+</html>


### PR DESCRIPTION
#### 8c684cfbe8afa5cb7eea0e46408cbdd31e920ba1
<pre>
Label elements should get InteractionRegions when associated to a control
<a href="https://bugs.webkit.org/show_bug.cgi?id=256234">https://bugs.webkit.org/show_bug.cgi?id=256234</a>
&lt;rdar://108739137&gt;

Reviewed by Tim Horton.

Add support for `&lt;label&gt;` elements in the InteractionRegion generation
code.

* Source/WebCore/page/InteractionRegion.cpp:
(WebCore::interactionRegionForRenderedRegion):
When an element is &quot;labelable&quot;, look for label ancestors when doing
element matching.
When a label has a control associated, remove the `cursor: pointer`
requirement, like we do for the control itself.
Group label and control together by using the control&apos;s
`elementIndentifier` for both regions.

* LayoutTests/interaction-region/labels-expected.txt: Added.
* LayoutTests/interaction-region/labels.html: Added.
Add a new test file for labels.

Canonical link: <a href="https://commits.webkit.org/263621@main">https://commits.webkit.org/263621@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2d8b7b46bf00bed3a9d698ef2259555e4128da09

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/5221 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/5355 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/5538 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/6748 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/5276 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/5217 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/5567 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/5333 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/5642 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/5314 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/5391 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/4678 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/6768 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/2876 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/4676 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/11106 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/4741 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/4751 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/6390 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/5178 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/4252 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/4649 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/4673 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/1258 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/8738 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/5011 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->