### PR TITLE
[JSC] btoa should handle out of memory

### DIFF
--- a/JSTests/stress/btoa-string-overflow.js
+++ b/JSTests/stress/btoa-string-overflow.js
@@ -1,0 +1,19 @@
+//@ runDefault
+function shouldThrow(func, errorMessage) {
+    var errorThrown = false;
+    var error = null;
+    try {
+        func();
+    } catch (e) {
+        errorThrown = true;
+        error = e;
+    }
+    if (!errorThrown)
+        throw new Error('not thrown');
+    if (String(error) !== errorMessage)
+        throw new Error(`bad error: ${String(error)}`);
+}
+
+shouldThrow(() => {
+    btoa('a'.repeat(2 ** 31 - 1));
+}, "RangeError: Out of memory");

--- a/Source/JavaScriptCore/jsc.cpp
+++ b/Source/JavaScriptCore/jsc.cpp
@@ -1436,7 +1436,10 @@ JSC_DEFINE_HOST_FUNCTION(functionBtoa, (JSGlobalObject* globalObject, CallFrame*
     if (!stringToEncode.isAllLatin1())
         return JSValue::encode(throwException(globalObject, scope, createError(globalObject, "Invalid character in argument for btoa."_s)));
 
-    String encodedString = base64EncodeToString(stringToEncode.latin1());
+    String encodedString = base64EncodeToStringReturnNullIfOverflow(stringToEncode.latin1());
+    if (!encodedString)
+        return JSValue::encode(throwException(globalObject, scope, createOutOfMemoryError(globalObject)));
+
     return JSValue::encode(jsString(vm, encodedString));
 }
 

--- a/Source/WTF/wtf/text/Base64.cpp
+++ b/Source/WTF/wtf/text/Base64.cpp
@@ -168,6 +168,11 @@ String base64EncodeToString(Span<const std::byte> input, Base64EncodeMode mode)
     return makeString(base64Encoded(input, mode));
 }
 
+String base64EncodeToStringReturnNullIfOverflow(Span<const std::byte> input, Base64EncodeMode mode)
+{
+    return tryMakeString(base64Encoded(input, mode));
+}
+
 template<typename T> static std::optional<Vector<uint8_t>> base64DecodeInternal(Span<const T> inputDataBuffer, Base64DecodeMode mode)
 {
     if (!inputDataBuffer.size())

--- a/Source/WTF/wtf/text/Base64.h
+++ b/Source/WTF/wtf/text/Base64.h
@@ -72,6 +72,9 @@ String base64EncodeToString(Span<const char>, Base64EncodeMode = Base64EncodeMod
 String base64EncodeToString(const CString&, Base64EncodeMode = Base64EncodeMode::Default);
 String base64EncodeToString(const void*, unsigned, Base64EncodeMode = Base64EncodeMode::Default);
 
+WTF_EXPORT_PRIVATE String base64EncodeToStringReturnNullIfOverflow(Span<const std::byte>, Base64EncodeMode = Base64EncodeMode::Default);
+String base64EncodeToStringReturnNullIfOverflow(const CString&, Base64EncodeMode = Base64EncodeMode::Default);
+
 WTF_EXPORT_PRIVATE std::optional<Vector<uint8_t>> base64Decode(Span<const std::byte>, Base64DecodeMode = Base64DecodeMode::DefaultIgnorePadding);
 WTF_EXPORT_PRIVATE std::optional<Vector<uint8_t>> base64Decode(StringView, Base64DecodeMode = Base64DecodeMode::DefaultIgnorePadding);
 std::optional<Vector<uint8_t>> base64Decode(Span<const uint8_t>, Base64DecodeMode = Base64DecodeMode::DefaultIgnorePadding);
@@ -138,6 +141,11 @@ inline String base64EncodeToString(Span<const uint8_t> input, Base64EncodeMode m
     return base64EncodeToString(asBytes(input), mode);
 }
 
+inline String base64EncodeToStringReturnNullIfOverflow(Span<const uint8_t> input, Base64EncodeMode mode)
+{
+    return base64EncodeToStringReturnNullIfOverflow(asBytes(input), mode);
+}
+
 inline String base64EncodeToString(Span<const char> input, Base64EncodeMode mode)
 {
     return base64EncodeToString(asBytes(input), mode);
@@ -146,6 +154,11 @@ inline String base64EncodeToString(Span<const char> input, Base64EncodeMode mode
 inline String base64EncodeToString(const CString& input, Base64EncodeMode mode)
 {
     return base64EncodeToString(input.bytes(), mode);
+}
+
+inline String base64EncodeToStringReturnNullIfOverflow(const CString& input, Base64EncodeMode mode)
+{
+    return base64EncodeToStringReturnNullIfOverflow(input.bytes(), mode);
 }
 
 inline String base64EncodeToString(const void* input, unsigned length, Base64EncodeMode mode)


### PR DESCRIPTION
#### 25a8fed4606485426dde5ae825385c77026a72d7
<pre>
[JSC] btoa should handle out of memory
<a href="https://bugs.webkit.org/show_bug.cgi?id=256240">https://bugs.webkit.org/show_bug.cgi?id=256240</a>
rdar://108793523

Reviewed by Justin Michaud.

btoa should handle out of memory for encoded string.

* JSTests/stress/btoa-string-overflow.js: Added.
* Source/JavaScriptCore/jsc.cpp:
(JSC_DEFINE_HOST_FUNCTION):
* Source/WTF/wtf/text/Base64.cpp:
(WTF::base64EncodeToStringReturnNullIfOverflow):
* Source/WTF/wtf/text/Base64.h:
(WTF::base64EncodeToStringReturnNullIfOverflow):

Canonical link: <a href="https://commits.webkit.org/263632@main">https://commits.webkit.org/263632@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/377324c54e82cf90fc95cdfaa4ca1f2d48d5afa0

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/5245 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/5381 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/5565 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/6774 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/5292 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/5594 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/5359 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/5772 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/5340 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/5417 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/4700 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/6795 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/2899 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/4702 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/10984 "Passed tests") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/4342 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/4763 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/4777 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/6383 "Passed tests") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/4830 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/5197 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/4269 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/5346 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/4666 "Built successfully") | | [❌ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/1345 "Found 1 jsc stress test failure: stress/btoa-string-overflow.js.default") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/1267 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/8758 "Built successfully") | | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/24/builds/5496 "Built successfully") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/5028 "Built successfully") | | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/3/builds/1460 "Passed tests") | 
<!--EWS-Status-Bubble-End-->