### PR TITLE
innerHTML and outerHTML escapes <, >, &, and nbsp inside `noscript`

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/html/syntax/parsing-html-fragments/tokenizer-modes-001-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/syntax/parsing-html-fragments/tokenizer-modes-001-expected.txt
@@ -7,6 +7,6 @@ PASS </iframe> should not break out of iframe.
 PASS </noembed> should not break out of noembed.
 PASS </noframes> should not break out of noframes.
 PASS </script> should not break out of script.
-FAIL </noscript> should not break out of noscript. assert_equals: expected "</noscript><div>" but got "&lt;/noscript&gt;&lt;div&gt;"
+PASS </noscript> should not break out of noscript.
 PASS </plaintext> should not break out of plaintext.
 

--- a/LayoutTests/imported/w3c/web-platform-tests/html/syntax/serializing-html-fragments/escaping-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/syntax/serializing-html-fragments/escaping-expected.txt
@@ -1,7 +1,7 @@
 
-FAIL div.innerHTML assert_equals: Serialization should NOT re-escape <noscript> contents expected "& <>" but got "&amp;&nbsp;&lt;&gt;"
-FAIL div.insertAdjacentHTML assert_equals: Serialization should NOT re-escape <noscript> contents expected "& <>" but got "&amp;&nbsp;&lt;&gt;"
-FAIL document.write on main document assert_equals: Serialization should NOT re-escape <noscript> contents expected "& <>" but got "&amp;&nbsp;&lt;&gt;"
+PASS div.innerHTML
+PASS div.insertAdjacentHTML
+PASS document.write on main document
 PASS DOMParser.parseFromString
 PASS template.innerHTML
 PASS document.implementation.createHTMLDocument and innerHTML

--- a/LayoutTests/imported/w3c/web-platform-tests/html/syntax/serializing-html-fragments/serializing-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/syntax/serializing-html-fragments/serializing-expected.txt
@@ -24,7 +24,7 @@ PASS innerHTML 21 <xmp><&></xmp>
 PASS innerHTML 22 <iframe><&></iframe>
 PASS innerHTML 23 <noembed><&></noembed>
 PASS innerHTML 24 <noframes><&></noframes>
-FAIL innerHTML 25 <noscript><&></noscript> assert_equals: expected "<noscript><&></noscript>" but got "<noscript>&lt;&amp;&gt;</noscript>"
+PASS innerHTML 25 <noscript><&></noscript>
 PASS innerHTML 26 <!--data-->
 PASS innerHTML 27 <a><b><c></c></b><d>e</d><f><g>h</g></f></a>
 PASS innerHTML 28
@@ -53,7 +53,7 @@ PASS outerHTML 21 <span><xmp><&></xmp></span>
 PASS outerHTML 22 <span><iframe><&></iframe></span>
 PASS outerHTML 23 <span><noembed><&></noembed></span>
 PASS outerHTML 24 <span><noframes><&></noframes></span>
-FAIL outerHTML 25 <span><noscript><&></noscript></span> assert_equals: expected "<span><noscript><&></noscript></span>" but got "<span><noscript>&lt;&amp;&gt;</noscript></span>"
+PASS outerHTML 25 <span><noscript><&></noscript></span>
 PASS outerHTML 26 <span><!--data--></span>
 PASS outerHTML 27 <span><a><b><c></c></b><d>e</d><f><g>h</g></f></a></span>
 PASS outerHTML 28 <span b="c"></span>


### PR DESCRIPTION
#### b731e7a77411047016a7148725177253848a3789
<pre>
innerHTML and outerHTML escapes &lt;, &gt;, &amp;, and nbsp inside `noscript`
<a href="https://bugs.webkit.org/show_bug.cgi?id=254692">https://bugs.webkit.org/show_bug.cgi?id=254692</a>

Reviewed by Chris Dumez.

Don&apos;t escape &lt;, &gt;, &amp;, and nbsp inside noscript element when scripting is enabled.

Also use switch statements with ElementNames in elementCannotHaveEndTag and entityMaskForText.

Inspired by <a href="https://chromium-review.googlesource.com/c/chromium/src/+/886646.">https://chromium-review.googlesource.com/c/chromium/src/+/886646.</a>

* LayoutTests/imported/w3c/web-platform-tests/html/syntax/parsing-html-fragments/tokenizer-modes-001-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/html/syntax/serializing-html-fragments/escaping-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/html/syntax/serializing-html-fragments/serializing-expected.txt:
* Source/WebCore/editing/MarkupAccumulator.cpp:
(WebCore::elementCannotHaveEndTag):
(WebCore::isScriptEnabled): Added.
(WebCore::MarkupAccumulator::entityMaskForText const):

Canonical link: <a href="https://commits.webkit.org/263633@main">https://commits.webkit.org/263633@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f4687e66c733e6d31451a483138e9dcb90d5f00c

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/5266 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/5402 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/5587 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/6796 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/5307 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/5262 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/5616 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/5380 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/5828 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/5361 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/5435 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/4717 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/6818 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/2917 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/4720 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/11248 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/4781 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/4796 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/6406 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/5218 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/4294 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/4686 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/8779 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/592 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/5048 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->