### PR TITLE
setAppBadge() should reject with SecurityError if child iframe is not same origin-domain as top-origin

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/badging/setAppBadge_cross_origin.sub.https-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/badging/setAppBadge_cross_origin.sub.https-expected.txt
@@ -1,6 +1,6 @@
 
 
 PASS Test that navigator.setAppBadge is available
-FAIL Test that calling setAppBadge in a cross-origin iframe throws a SecurityError assert_equals: setAppBadge should have rejected with an error expected "error" but got "success"
+PASS Test that calling setAppBadge in a cross-origin iframe throws a SecurityError
 PASS Test that calling setAppBadge in a same-origin iframe succeeds
 

--- a/Source/WebCore/page/Navigator.cpp
+++ b/Source/WebCore/page/Navigator.cpp
@@ -403,10 +403,16 @@ void Navigator::setAppBadge(std::optional<unsigned long long> badge, Ref<Deferre
         return;
     }
 
-    auto* document = frame->document();
-    if (document && !document->isFullyActive()) {
-        promise->reject(InvalidStateError);
-        return;
+    if (auto* document = frame->document()) {
+        if (!document->isFullyActive()) {
+            promise->reject(InvalidStateError);
+            return;
+        }
+
+        if (!frame->isMainFrame() && !document->topOrigin().isSameOriginDomain(document->securityOrigin())) {
+            promise->reject(SecurityError);
+            return;
+        }
     }
 
     page->badgeClient().setAppBadge(page, SecurityOriginData::fromFrame(frame), badge);


### PR DESCRIPTION
#### 2bd51ffa6f51161027bf50e89dcf1192e5dc8eef
<pre>
setAppBadge() should reject with SecurityError if child iframe is not same origin-domain as top-origin
<a href="https://bugs.webkit.org/show_bug.cgi?id=256241">https://bugs.webkit.org/show_bug.cgi?id=256241</a>
rdar://107109904

Reviewed by NOBODY (OOPS!).

Now does same origin-domain check against top-level origin.

Relevant spec change:
<a href="https://github.com/w3c/badging/pull/107">https://github.com/w3c/badging/pull/107</a>

* LayoutTests/imported/w3c/web-platform-tests/badging/setAppBadge_cross_origin.sub.https-expected.txt:
* Source/WebCore/page/Navigator.cpp:
(WebCore::Navigator::setAppBadge):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2bd51ffa6f51161027bf50e89dcf1192e5dc8eef

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/8748 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/9036 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/9253 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/10401 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/8736 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/8756 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/11023 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/9006 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/11601 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/8894 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/9899 "Passed tests") | [❌ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/7780 "5 api tests failed or timed out") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/10558 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/7196 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/7996 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/15503 "Passed tests") | 
| | [❌ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/8306 "4 api tests failed or timed out") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/8144 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/11481 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/8628 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/7031 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/7889 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/12102 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/8375 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->