### PR TITLE
Crashes under SystemPreviewController::loadFailed after 263479@main

### DIFF
--- a/Source/WebKit/UIProcess/SystemPreviewController.h
+++ b/Source/WebKit/UIProcess/SystemPreviewController.h
@@ -35,6 +35,7 @@
 #include <wtf/URL.h>
 #include <wtf/WeakPtr.h>
 
+OBJC_CLASS NSArray;
 OBJC_CLASS NSString;
 #if USE(QUICK_LOOK)
 OBJC_CLASS QLPreviewController;
@@ -70,9 +71,21 @@ public:
     void setCompletionHandlerForLoadTesting(CompletionHandler<void(bool)>&&);
 
 private:
-
     void takeActivityToken();
     void releaseActivityTokenIfNecessary();
+
+    NSArray *localFileURLs() const;
+
+    enum class State : uint8_t {
+        Initial,
+        Began,
+        Loading,
+        Failed,
+        Succeeded,
+        Ended
+    };
+
+    State m_state { State::Initial };
 
     WebPageProxy& m_webPageProxy;
     WebCore::SystemPreviewInfo m_systemPreviewInfo;


### PR DESCRIPTION
#### 3582444bb21b9adfe2e203f3b1a843e79a518b3b
<pre>
Crashes under SystemPreviewController::loadFailed after 263479@main
<a href="https://bugs.webkit.org/show_bug.cgi?id=256246">https://bugs.webkit.org/show_bug.cgi?id=256246</a>
rdar://108826094

Reviewed by Wenson Hsieh.

* Source/WebKit/UIProcess/Cocoa/SystemPreviewControllerCocoa.mm:
* Source/WebKit/UIProcess/SystemPreviewController.h:
Fix a few small issues with 263479@main:

1) Don&apos;t call `cancelPreviewApplicationWithURLs` if we never called
   `beginPreviewApplicationWithURLs`, by keeping track of the current loading state.

2) Don&apos;t try to create an array of NSURLs with nil entries.

3) Allow previews by extension in addition to MIME type.

Canonical link: <a href="https://commits.webkit.org/263622@main">https://commits.webkit.org/263622@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c6e611d78c68b11789a8eca7fe1b9e829d61974b

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/5264 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/5400 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/5585 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/6794 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/5306 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/5614 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/5378 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/5826 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/5359 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/5432 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/4714 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/6816 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/2914 "Passed tests") | | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/11219 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/4778 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/4793 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/6404 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/5216 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/4283 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/4685 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/1259 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/8777 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/5047 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->