### PR TITLE
[popover] Update focus handling in hidePopover

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/popovers/popover-focus-2-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/popovers/popover-focus-2-expected.txt
@@ -6,5 +6,5 @@ Toggle popover Other focusable element
 PASS Popover focus navigation
 PASS Circular reference tab navigation
 PASS Popover focus returns when popover is hidden by invoker
-FAIL Popover focus only returns to invoker when focus is within the popover assert_equals: focus does not move because it was not inside the popover expected Element node <span tabindex="0">Other focusable element</span> but got Element node <button popovertarget="focus-return2-p" tabindex="0">Togg...
+PASS Popover focus only returns to invoker when focus is within the popover
 

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/popovers/popover-focus-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/popovers/popover-focus-expected.txt
@@ -1,26 +1,26 @@
 
 PASS Popover focus test: default behavior - popover is not focused
-FAIL Popover button click focus test: default behavior - popover is not focused assert_equals: focus should move to the button when clicked, and should stay there when the popover closes expected Element node <button tabindex="0" popovertarget="popover-id">Click me<... but got Element node <button tabindex="0" id="priorFocus"></button>
+PASS Popover button click focus test: default behavior - popover is not focused
 PASS Popover corner cases test: default behavior - popover is not focused
 PASS Popover focus test: autofocus popover
-FAIL Popover button click focus test: autofocus popover assert_equals: focus should move to the button when clicked, and should stay there when the popover closes expected Element node <button tabindex="0" popovertarget="popover-id">Click me<... but got Element node <button tabindex="0" id="priorFocus"></button>
+PASS Popover button click focus test: autofocus popover
 PASS Popover corner cases test: autofocus popover
 PASS Popover focus test: autofocus empty popover
-FAIL Popover button click focus test: autofocus empty popover assert_equals: focus should move to the button when clicked, and should stay there when the popover closes expected Element node <button tabindex="0" popovertarget="popover-id">Click me<... but got Element node <button tabindex="0" id="priorFocus"></button>
+PASS Popover button click focus test: autofocus empty popover
 PASS Popover corner cases test: autofocus empty popover
 PASS Popover focus test: autofocus popover with button
-FAIL Popover button click focus test: autofocus popover with button assert_equals: focus should move to the button when clicked, and should stay there when the popover closes expected Element node <button tabindex="0" popovertarget="popover-id">Click me<... but got Element node <button tabindex="0" id="priorFocus"></button>
+PASS Popover button click focus test: autofocus popover with button
 PASS Popover corner cases test: autofocus popover with button
 PASS Popover focus test: autofocus child
-FAIL Popover button click focus test: autofocus child assert_equals: focus should move to the button when clicked, and should stay there when the popover closes expected Element node <button tabindex="0" popovertarget="popover-id">Click me<... but got Element node <button tabindex="0" id="priorFocus"></button>
+PASS Popover button click focus test: autofocus child
 PASS Popover corner cases test: autofocus child
 PASS Popover focus test: autofocus on tabindex=0 element
-FAIL Popover button click focus test: autofocus on tabindex=0 element assert_equals: focus should move to the button when clicked, and should stay there when the popover closes expected Element node <button tabindex="0" popovertarget="popover-id">Click me<... but got Element node <button tabindex="0" id="priorFocus"></button>
-PASS Popover corner cases test: autofocus on tabindex=0 element
+FAIL Popover button click focus test: autofocus on tabindex=0 element assert_false: clicking button should hide the popover expected false got true
+FAIL Popover corner cases test: autofocus on tabindex=0 element assert_false: popover should start out hidden expected false got true
 PASS Popover focus test: autofocus multiple children
-FAIL Popover button click focus test: autofocus multiple children assert_equals: focus should move to the button when clicked, and should stay there when the popover closes expected Element node <button tabindex="0" popovertarget="popover-id">Click me<... but got Element node <button tabindex="0" id="priorFocus"></button>
+PASS Popover button click focus test: autofocus multiple children
 PASS Popover corner cases test: autofocus multiple children
 PASS Popover focus test: autofocus popover and multiple autofocus children
-FAIL Popover button click focus test: autofocus popover and multiple autofocus children assert_equals: focus should move to the button when clicked, and should stay there when the popover closes expected Element node <button tabindex="0" popovertarget="popover-id">Click me<... but got Element node <button tabindex="0" id="priorFocus"></button>
+PASS Popover button click focus test: autofocus popover and multiple autofocus children
 PASS Popover corner cases test: autofocus popover and multiple autofocus children
 

--- a/LayoutTests/platform/mac-wk1/imported/w3c/web-platform-tests/html/semantics/popovers/popover-focus-expected.txt
+++ b/LayoutTests/platform/mac-wk1/imported/w3c/web-platform-tests/html/semantics/popovers/popover-focus-expected.txt
@@ -1,26 +1,26 @@
 
 PASS Popover focus test: default behavior - popover is not focused
-FAIL Popover button click focus test: default behavior - popover is not focused assert_equals: focus should move to the button when clicked, and should stay there when the popover closes expected Element node <button tabindex="0" popovertarget="popover-id">Click me<... but got Element node <button tabindex="0" id="priorFocus"></button>
+PASS Popover button click focus test: default behavior - popover is not focused
 PASS Popover corner cases test: default behavior - popover is not focused
 PASS Popover focus test: autofocus popover
-FAIL Popover button click focus test: autofocus popover assert_equals: focus should move to the button when clicked, and should stay there when the popover closes expected Element node <button tabindex="0" popovertarget="popover-id">Click me<... but got Element node <button tabindex="0" id="priorFocus"></button>
+PASS Popover button click focus test: autofocus popover
 PASS Popover corner cases test: autofocus popover
 PASS Popover focus test: autofocus empty popover
-FAIL Popover button click focus test: autofocus empty popover assert_equals: focus should move to the button when clicked, and should stay there when the popover closes expected Element node <button tabindex="0" popovertarget="popover-id">Click me<... but got Element node <button tabindex="0" id="priorFocus"></button>
+PASS Popover button click focus test: autofocus empty popover
 PASS Popover corner cases test: autofocus empty popover
 PASS Popover focus test: autofocus popover with button
-FAIL Popover button click focus test: autofocus popover with button assert_equals: focus should move to the button when clicked, and should stay there when the popover closes expected Element node <button tabindex="0" popovertarget="popover-id">Click me<... but got Element node <button tabindex="0" id="priorFocus"></button>
+PASS Popover button click focus test: autofocus popover with button
 PASS Popover corner cases test: autofocus popover with button
 PASS Popover focus test: autofocus child
-FAIL Popover button click focus test: autofocus child assert_equals: focus should move to the button when clicked, and should stay there when the popover closes expected Element node <button tabindex="0" popovertarget="popover-id">Click me<... but got Element node <button tabindex="0" id="priorFocus"></button>
+PASS Popover button click focus test: autofocus child
 PASS Popover corner cases test: autofocus child
 PASS Popover focus test: autofocus on tabindex=0 element
-FAIL Popover button click focus test: autofocus on tabindex=0 element assert_equals: focus should move to the button when clicked, and should stay there when the popover closes expected Element node <button tabindex="0" popovertarget="popover-id">Click me<... but got Element node <button tabindex="0" id="priorFocus"></button>
-PASS Popover corner cases test: autofocus on tabindex=0 element
+FAIL Popover button click focus test: autofocus on tabindex=0 element assert_false: clicking button should hide the popover expected false got true
+FAIL Popover corner cases test: autofocus on tabindex=0 element assert_false: popover should start out hidden expected false got true
 PASS Popover focus test: autofocus multiple children
-FAIL Popover button click focus test: autofocus multiple children assert_equals: focus should move to the button when clicked, and should stay there when the popover closes expected Element node <button tabindex="0" popovertarget="popover-id">Click me<... but got Element node <button tabindex="0" id="priorFocus"></button>
+PASS Popover button click focus test: autofocus multiple children
 PASS Popover corner cases test: autofocus multiple children
 PASS Popover focus test: autofocus popover and multiple autofocus children
-FAIL Popover button click focus test: autofocus popover and multiple autofocus children assert_equals: focus should move to the button when clicked, and should stay there when the popover closes expected Element node <button tabindex="0" popovertarget="popover-id">Click me<... but got Element node <button tabindex="0" id="priorFocus"></button>
+PASS Popover button click focus test: autofocus popover and multiple autofocus children
 PASS Popover corner cases test: autofocus popover and multiple autofocus children
 

--- a/Source/WebCore/html/HTMLElement.cpp
+++ b/Source/WebCore/html/HTMLElement.cpp
@@ -1449,7 +1449,7 @@ ExceptionOr<void> HTMLElement::hidePopoverInternal(FocusPreviousElement focusPre
         queuePopoverToggleEventTask(PopoverVisibilityState::Showing, PopoverVisibilityState::Hidden);
 
     if (RefPtr element = popoverData()->previouslyFocusedElement()) {
-        if (focusPreviousElement == FocusPreviousElement::Yes) {
+        if (focusPreviousElement == FocusPreviousElement::Yes && containsIncludingShadowDOM(document().focusedElement())) {
             FocusOptions options;
             options.preventScroll = true;
             element->focus(options);


### PR DESCRIPTION
#### fd8990a116f4cf0d6ac2e2190062d44fc656ee08
<pre>
[popover] Update focus handling in hidePopover
<a href="https://bugs.webkit.org/show_bug.cgi?id=256249">https://bugs.webkit.org/show_bug.cgi?id=256249</a>

Reviewed by Ryosuke Niwa.

Only return focus to previously focused element if focus is within the popover hierarchy, since
the user may have tabbed the focus away from the popover since showPopover was called.

* LayoutTests/imported/w3c/web-platform-tests/html/semantics/popovers/popover-focus-2-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/popovers/popover-focus-expected.txt:
* LayoutTests/platform/mac-wk1/imported/w3c/web-platform-tests/html/semantics/popovers/popover-focus-expected.txt:
* Source/WebCore/html/HTMLElement.cpp:
(WebCore::HTMLElement::hidePopoverInternal):

Canonical link: <a href="https://commits.webkit.org/263645@main">https://commits.webkit.org/263645@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9e22bd8e85eced743a2b926e95e77f9308dd1cb6

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/5295 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/5431 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/5619 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/6828 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/5337 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/5294 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/5649 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/5410 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/5856 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/5393 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/5461 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/4745 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/6853 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/2943 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/4748 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/11700 "3 flakes 141 failures") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/4807 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/4825 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/6435 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/5249 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/4308 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/4717 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/1273 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/8811 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/5077 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->