### PR TITLE
[ews-build.webkit.org] Set committer for multi-commit PRs

### DIFF
--- a/Tools/CISupport/ews-build/steps.py
+++ b/Tools/CISupport/ews-build/steps.py
@@ -5801,7 +5801,7 @@ class Canonicalize(steps.ShellSequence, ShellMixin, AddToLogMixin):
         commands.append([
             'git', 'filter-branch', '-f',
             '--env-filter', f"GIT_AUTHOR_DATE='{date}';GIT_COMMITTER_DATE='{date}';GIT_COMMITTER_NAME='{committer_name}';GIT_COMMITTER_EMAIL='{committer_email}'",
-            f'HEAD...HEAD~1',
+            f"HEAD...HEAD~{self.getProperty('commit_count', 1)}",
         ])
 
         username, access_token = GitHub.credentials(user=GitHub.user_for_queue(self.getProperty('buildername', '')))

--- a/Tools/CISupport/ews-build/steps_unittest.py
+++ b/Tools/CISupport/ews-build/steps_unittest.py
@@ -7471,7 +7471,7 @@ class TestCanonicalize(BuildStepMixinAdditions, unittest.TestCase):
                 command=[
                     'git', 'filter-branch', '-f',
                     '--env-filter', "GIT_AUTHOR_DATE='{date}';GIT_COMMITTER_DATE='{date}';GIT_COMMITTER_NAME='WebKit Committer';GIT_COMMITTER_EMAIL='committer@webkit.org'".format(date=date),
-                    'HEAD...HEAD~1',
+                    'HEAD...HEAD~4',
                 ],
             ) + 0,
         )


### PR DESCRIPTION
#### dfa7e20546b6771eccbefc6432fcff245307f8b9
<pre>
[ews-build.webkit.org] Set committer for multi-commit PRs
<a href="https://bugs.webkit.org/show_bug.cgi?id=256257">https://bugs.webkit.org/show_bug.cgi?id=256257</a>
rdar://108842902

Reviewed by Aakash Jain.

* Tools/CISupport/ews-build/steps.py:
(Canonicalize.run): Set committer for all commits we&apos;re pushing.
* Tools/CISupport/ews-build/steps_unittest.py:

Canonical link: <a href="https://commits.webkit.org/263634@main">https://commits.webkit.org/263634@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2527cd504adf494acd393540c685894d7b3d37ae

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/5306 "Passed style check") | [  ~~🛠 ios~~](https://ews-build.webkit.org/#/builders/26/builds/5442 "Build was cancelled. Recent messages:OS: Ventura (13.3), Xcode: 14.3; Skipping applying patch since patch_id isn't provided; Checked out pull request; Compiled WebKit (cancelled)") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/14/builds/5630 "Build was cancelled. Recent messages:OS: Monterey (12.6.3), Xcode: 13.4.1; Skipping applying patch since patch_id isn't provided; Checked out pull request; Compiled WebKit (cancelled)") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/6839 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/5348 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/5305 "Passed tests") | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/23/builds/5662 "Build was cancelled. Recent messages:OS: Ventura (13.3), Xcode: 14.3; Skipping applying patch since patch_id isn't provided; Checked out pull request; Compiled WebKit (cancelled)") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/5421 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/5870 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/5404 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/23/builds/5662 "Build was cancelled. Recent messages:OS: Ventura (13.3), Xcode: 14.3; Skipping applying patch since patch_id isn't provided; Checked out pull request; Compiled WebKit (cancelled)") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/14/builds/5630 "Build was cancelled. Recent messages:OS: Monterey (12.6.3), Xcode: 13.4.1; Skipping applying patch since patch_id isn't provided; Checked out pull request; Compiled WebKit (cancelled)") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/6864 "Built successfully") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/23/builds/5662 "Build was cancelled. Recent messages:OS: Ventura (13.3), Xcode: 14.3; Skipping applying patch since patch_id isn't provided; Checked out pull request; Compiled WebKit (cancelled)") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/14/builds/5630 "Build was cancelled. Recent messages:OS: Monterey (12.6.3), Xcode: 13.4.1; Skipping applying patch since patch_id isn't provided; Checked out pull request; Compiled WebKit (cancelled)") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/11456 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/23/builds/5662 "Build was cancelled. Recent messages:OS: Ventura (13.3), Xcode: 14.3; Skipping applying patch since patch_id isn't provided; Checked out pull request; Compiled WebKit (cancelled)") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/14/builds/5630 "Build was cancelled. Recent messages:OS: Monterey (12.6.3), Xcode: 13.4.1; Skipping applying patch since patch_id isn't provided; Checked out pull request; Compiled WebKit (cancelled)") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/6449 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/5260 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/4320 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| [✅ 🧪 services](https://ews-build.webkit.org/#/builders/28/builds/5255 "Passed tests") | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/30/builds/4728 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/14/builds/5630 "Build was cancelled. Recent messages:OS: Monterey (12.6.3), Xcode: 13.4.1; Skipping applying patch since patch_id isn't provided; Checked out pull request; Compiled WebKit (cancelled)") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/8822 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/593 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/5088 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->