### PR TITLE
If a page changes its title while in the background, allow the page to run in the background

### DIFF
--- a/Source/WebKit/UIProcess/WebPageProxy.cpp
+++ b/Source/WebKit/UIProcess/WebPageProxy.cpp
@@ -486,33 +486,11 @@ void WebPageProxy::ProcessActivityState::takeCapturingActivity()
     m_isCapturingActivity = m_page.process().throttler().foregroundActivity("View is capturing media"_s).moveToUniquePtr();
 }
 
-#if PLATFORM(MAC)
-// On macOS, we opt pages out of process suspension if they used the Notification API to avoid breaking
-// some use cases.
-// In particular, we opt out if either:
-// - The page showed a notification
-// - The page called navigator.permissions.query({ name: "notifications" }) and it returned true.
-// - The page accessed Notification.permission and it returned "granted".
-// - The page requested permission via Notification.requestPermission() and it was granted.
-// This gets reset whenever a new main frame load commits inside the page.
-void WebPageProxy::ProcessActivityState::takeLikelyToUseNotificationsActivity()
-{
-    if (!m_likelyToUseNotificationsActivity)
-        m_likelyToUseNotificationsActivity = m_page.process().throttler().backgroundActivity("View is likely to use notifications"_s).moveToUniquePtr();
-}
-
-void WebPageProxy::ProcessActivityState::dropLikelyToUseNotificationsActivity()
-{
-    m_likelyToUseNotificationsActivity = nullptr;
-}
-#endif
-
 void WebPageProxy::ProcessActivityState::reset()
 {
     m_isVisibleActivity = nullptr;
 #if PLATFORM(MAC)
     *m_wasRecentlyVisibleActivity = nullptr;
-    m_likelyToUseNotificationsActivity = nullptr;
 #endif
     m_isAudibleActivity = nullptr;
     m_isCapturingActivity = nullptr;
@@ -5585,9 +5563,7 @@ void WebPageProxy::didCommitLoadForFrame(FrameIdentifier frameID, FrameInfoData&
         if (is<RemoteLayerTreeDrawingAreaProxy>(*m_drawingArea))
             internals().firstLayerTreeTransactionIdAfterDidCommitLoad = downcast<RemoteLayerTreeDrawingAreaProxy>(*drawingArea()).nextLayerTreeTransactionID();
 #endif
-#if PLATFORM(MAC)
-        m_processActivityState.dropLikelyToUseNotificationsActivity();
-#endif
+        internals().pageAllowedToRunInTheBackgroundToken = nullptr;
     }
 
     auto transaction = internals().pageLoadState.transaction();
@@ -5801,8 +5777,10 @@ void WebPageProxy::didFailLoadForFrame(FrameIdentifier frameID, FrameInfoData&& 
 
     bool isMainFrame = frame->isMainFrame();
 
-    if (isMainFrame)
+    if (isMainFrame) {
         internals().pageLoadState.didFailLoad(transaction);
+        internals().pageAllowedToRunInTheBackgroundToken = nullptr;
+    }
 
     if (m_controlledByAutomation) {
         if (auto* automationSession = process().processPool().automationSession())
@@ -5955,7 +5933,13 @@ void WebPageProxy::didReceiveTitleForFrame(FrameIdentifier frameID, const String
 
     if (frame->isMainFrame()) {
         internals().pageLoadState.setTitle(transaction, title);
-        process().throttler().delaySuspension();
+        if (!isViewVisible() && !frame->title().isNull() && frame->title() != title) {
+            WEBPAGEPROXY_RELEASE_LOG(ViewState, "didReceiveTitleForFrame: This page changes its title in the background and is allowed to run in the background");
+            // This page updates its title in the background and is thus able to communicate with
+            // the user while in the background. Allow it to run in the background.
+            if (!internals().pageAllowedToRunInTheBackgroundToken)
+                internals().pageAllowedToRunInTheBackgroundToken = process().throttler().pageAllowedToRunInTheBackgroundToken();
+        }
     }
 
     frame->didChangeTitle(title);
@@ -8943,10 +8927,9 @@ void WebPageProxy::resetStateAfterProcessExited(ProcessTerminationReason termina
     m_waitingForPostLayoutEditorStateUpdateAfterFocusingElement = false;
 #endif
 
-    m_processActivityState.reset();
-
     internals().pageIsUserObservableCount = nullptr;
     internals().visiblePageToken = nullptr;
+    internals().pageAllowedToRunInTheBackgroundToken = nullptr;
 
     m_hasRunningProcess = false;
     m_areActiveDOMObjectsAndAnimationsSuspended = false;
@@ -9784,17 +9767,17 @@ void WebPageProxy::requestNotificationPermission(const String& originString, Com
 
 void WebPageProxy::pageWillLikelyUseNotifications()
 {
-#if PLATFORM(MAC)
-    m_processActivityState.takeLikelyToUseNotificationsActivity();
-#endif
+    WEBPAGEPROXY_RELEASE_LOG(ViewState, "pageWillLikelyUseNotifications: This page is likely to use notifications and is allowed to run in the background");
+    if (!internals().pageAllowedToRunInTheBackgroundToken)
+        internals().pageAllowedToRunInTheBackgroundToken = process().throttler().pageAllowedToRunInTheBackgroundToken();
 }
 
 void WebPageProxy::showNotification(IPC::Connection& connection, const WebCore::NotificationData& notificationData, RefPtr<WebCore::NotificationResources>&& notificationResources)
 {
     m_process->processPool().supplement<WebNotificationManagerProxy>()->show(this, connection, notificationData, WTFMove(notificationResources));
-#if PLATFORM(MAC)
-    m_processActivityState.takeLikelyToUseNotificationsActivity();
-#endif
+    WEBPAGEPROXY_RELEASE_LOG(ViewState, "showNotification: This page shows notifications and is allowed to run in the background");
+    if (!internals().pageAllowedToRunInTheBackgroundToken)
+        internals().pageAllowedToRunInTheBackgroundToken = process().throttler().pageAllowedToRunInTheBackgroundToken();
 }
 
 void WebPageProxy::cancelNotification(const UUID& notificationID)

--- a/Source/WebKit/UIProcess/WebPageProxy.h
+++ b/Source/WebKit/UIProcess/WebPageProxy.h
@@ -2818,18 +2818,12 @@ private:
         bool hasValidOpeningAppLinkActivity() const;
 #endif
 
-#if PLATFORM(MAC)
-        void takeLikelyToUseNotificationsActivity();
-        void dropLikelyToUseNotificationsActivity();
-#endif
-
     private:
         WebPageProxy& m_page;
 
         std::unique_ptr<ProcessThrottlerActivity> m_isVisibleActivity;
 #if PLATFORM(MAC)
         UniqueRef<ProcessThrottlerTimedActivity> m_wasRecentlyVisibleActivity;
-        std::unique_ptr<ProcessThrottlerActivity> m_likelyToUseNotificationsActivity;
 #endif
         std::unique_ptr<ProcessThrottlerActivity> m_isAudibleActivity;
         std::unique_ptr<ProcessThrottlerActivity> m_isCapturingActivity;

--- a/Source/WebKit/UIProcess/WebPageProxyInternals.h
+++ b/Source/WebKit/UIProcess/WebPageProxyInternals.h
@@ -212,6 +212,7 @@ struct WebPageProxy::Internals final : WebPopupMenuProxy::Client
     WebCore::IntRect visibleScrollerThumbRect;
     WebCore::PageIdentifier webPageID;
     WindowKind windowKind { WindowKind::Unparented };
+    PageAllowedToRunInTheBackgroundCounter::Token pageAllowedToRunInTheBackgroundToken;
 
     HashMap<WebCore::RegistrableDomain, UniqueRef<SubframePageProxy>> domainToSubframePageProxyMap;
     HashMap<WebCore::FrameIdentifier, WebCore::RegistrableDomain> frameIdentifierToDomainMap;


### PR DESCRIPTION
#### e1f40e7ef94dc4020e1efe7f83e2d360cee11d9b
<pre>
If a page changes its title while in the background, allow the page to run in the background
<a href="https://bugs.webkit.org/show_bug.cgi?id=256259">https://bugs.webkit.org/show_bug.cgi?id=256259</a>
rdar://103388697

Reviewed by Ben Nham.

If a page changes its title while in the background, allow the page to run in the
background, as long as the app is foreground. Previously, the page changing its
title would buy its an extra 8 minutes of background running time. We are now
more permissive and allow the page to run indefinitely in the background when we
detect this (as long as the application is foreground).

* Source/WebKit/UIProcess/ProcessThrottler.cpp:
(WebKit::ProcessThrottler::ProcessThrottler):
(WebKit::ProcessThrottler::dropSuspendedAssertionTimerFired):
(WebKit::ProcessThrottler::pageAllowedToRunInTheBackgroundToken):
(WebKit::ProcessThrottler::numberOfPagesAllowedToRunInTheBackgroundChanged):
(WebKit::ProcessThrottler::delaySuspension): Deleted.
* Source/WebKit/UIProcess/ProcessThrottler.h:
* Source/WebKit/UIProcess/WebPageProxy.cpp:
(WebKit::WebPageProxy::ProcessActivityState::reset):
(WebKit::WebPageProxy::didCommitLoadForFrame):
(WebKit::WebPageProxy::didFailLoadForFrame):
(WebKit::WebPageProxy::didReceiveTitleForFrame):
(WebKit::WebPageProxy::resetStateAfterProcessExited):
(WebKit::WebPageProxy::pageWillLikelyUseNotifications):
(WebKit::WebPageProxy::showNotification):
(WebKit::WebPageProxy::ProcessActivityState::takeLikelyToUseNotificationsActivity): Deleted.
(WebKit::WebPageProxy::ProcessActivityState::dropLikelyToUseNotificationsActivity): Deleted.
* Source/WebKit/UIProcess/WebPageProxy.h:
* Source/WebKit/UIProcess/WebPageProxyInternals.h:
</pre>