### PR TITLE
Migrate PaymentInstallmentConfiguration to generated serialization

### DIFF
--- a/LayoutTests/http/tests/paymentrequest/installment-configuration.https-expected.txt
+++ b/LayoutTests/http/tests/paymentrequest/installment-configuration.https-expected.txt
@@ -1,0 +1,2 @@
+ALERT: PASS
+

--- a/LayoutTests/http/tests/paymentrequest/installment-configuration.https.html
+++ b/LayoutTests/http/tests/paymentrequest/installment-configuration.https.html
@@ -1,0 +1,4 @@
+<script>
+    testRunner.dumpAsText()
+    internals.mockPaymentCoordinator.installmentConfigurationReturnsNil() ? alert("PASS") : alert("FAIL")
+</script>

--- a/Source/WebCore/Modules/applepay/ApplePaySetupFeatureTypeWebCore.h
+++ b/Source/WebCore/Modules/applepay/ApplePaySetupFeatureTypeWebCore.h
@@ -29,7 +29,7 @@
 
 namespace WebCore {
 
-enum class ApplePaySetupFeatureType : uint8_t {
+enum class ApplePaySetupFeatureType : bool {
     ApplePay,
     AppleCard,
 };

--- a/Source/WebCore/Modules/applepay/ApplePaySetupFeatureWebCore.h
+++ b/Source/WebCore/Modules/applepay/ApplePaySetupFeatureWebCore.h
@@ -35,7 +35,7 @@ OBJC_CLASS PKPaymentSetupFeature;
 namespace WebCore {
 
 enum class ApplePaySetupFeatureState : uint8_t;
-enum class ApplePaySetupFeatureType : uint8_t;
+enum class ApplePaySetupFeatureType : bool;
 
 class ApplePaySetupFeature : public RefCounted<ApplePaySetupFeature> {
 public:

--- a/Source/WebCore/Modules/applepay/PaymentInstallmentConfiguration.mm
+++ b/Source/WebCore/Modules/applepay/PaymentInstallmentConfiguration.mm
@@ -171,7 +171,21 @@ static std::optional<ApplePayInstallmentItem> makeVectorElement(const ApplePayIn
     };
 }
 
-static RetainPtr<PKPaymentInstallmentConfiguration> createPlatformConfiguration(const ApplePayInstallmentConfiguration& coreConfiguration, NSDictionary *applicationMetadata)
+static RetainPtr<NSDictionary> applicationMetadataDictionary(const ApplePayInstallmentConfiguration& configuration)
+{
+    if (NSData *applicationMetadata = [configuration.applicationMetadata dataUsingEncoding:NSUTF8StringEncoding])
+        return dynamic_objc_cast<NSDictionary>([NSJSONSerialization JSONObjectWithData:applicationMetadata options:0 error:nil]);
+    return { };
+}
+
+static String applicationMetadataString(NSDictionary *dictionary)
+{
+    if (NSData *applicationMetadata = dictionary ? [NSJSONSerialization dataWithJSONObject:dictionary options:NSJSONWritingSortedKeys error:nil] : nil)
+        return adoptNS([[NSString alloc] initWithData:applicationMetadata encoding:NSUTF8StringEncoding]).get();
+    return { };
+}
+
+static RetainPtr<PKPaymentInstallmentConfiguration> createPlatformConfiguration(const ApplePayInstallmentConfiguration& coreConfiguration)
 {
     if (!PAL::getPKPaymentInstallmentConfigurationClass())
         return nil;
@@ -194,7 +208,7 @@ static RetainPtr<PKPaymentInstallmentConfiguration> createPlatformConfiguration(
         return configuration;
 
     [configuration setInstallmentItems:createNSArray(coreConfiguration.items).get()];
-    [configuration setApplicationMetadata:applicationMetadata];
+    [configuration setApplicationMetadata:applicationMetadataDictionary(coreConfiguration).get()];
     [configuration setRetailChannel:platformRetailChannel(coreConfiguration.retailChannel)];
 
     return configuration;
@@ -202,66 +216,76 @@ static RetainPtr<PKPaymentInstallmentConfiguration> createPlatformConfiguration(
 
 ExceptionOr<PaymentInstallmentConfiguration> PaymentInstallmentConfiguration::create(const ApplePayInstallmentConfiguration& configuration)
 {
-    NSDictionary *applicationMetadataDictionary = nil;
-    if (!configuration.applicationMetadata.isNull()) {
-        NSData *applicationMetadata = [configuration.applicationMetadata dataUsingEncoding:NSUTF8StringEncoding];
-        applicationMetadataDictionary = dynamic_objc_cast<NSDictionary>([NSJSONSerialization JSONObjectWithData:applicationMetadata options:0 error:nil]);
-        if (!applicationMetadataDictionary)
-            return Exception { TypeError, "applicationMetadata must be a JSON object"_s };
-    }
+    auto dictionary = applicationMetadataDictionary(configuration);
+    if (!configuration.applicationMetadata.isNull() && !dictionary)
+        return Exception { TypeError, "applicationMetadata must be a JSON object"_s };
 
-    return PaymentInstallmentConfiguration(configuration, applicationMetadataDictionary);
+    return PaymentInstallmentConfiguration(ApplePayInstallmentConfiguration(configuration), WTFMove(dictionary));
 }
 
-PaymentInstallmentConfiguration::PaymentInstallmentConfiguration(const ApplePayInstallmentConfiguration& configuration, NSDictionary *applicationMetadata)
-    : m_configuration { createPlatformConfiguration(configuration, applicationMetadata) }
+static ApplePayInstallmentConfiguration addApplicationMetadata(ApplePayInstallmentConfiguration configuration, RetainPtr<NSDictionary>&& applicationMetadata)
+{
+    if (applicationMetadata)
+        configuration.applicationMetadata = applicationMetadataString(applicationMetadata.get());
+    return configuration;
+}
+
+PaymentInstallmentConfiguration::PaymentInstallmentConfiguration(const ApplePayInstallmentConfiguration& configuration, RetainPtr<NSDictionary>&& applicationMetadata)
+    : m_configuration { addApplicationMetadata(configuration, WTFMove(applicationMetadata)) }
 {
 }
 
-PaymentInstallmentConfiguration::PaymentInstallmentConfiguration(RetainPtr<PKPaymentInstallmentConfiguration>&& configuration)
+PaymentInstallmentConfiguration::PaymentInstallmentConfiguration(std::optional<ApplePayInstallmentConfiguration>&& configuration)
     : m_configuration { WTFMove(configuration) }
 {
 }
 
-PKPaymentInstallmentConfiguration *PaymentInstallmentConfiguration::platformConfiguration() const
+PaymentInstallmentConfiguration::PaymentInstallmentConfiguration(RetainPtr<PKPaymentInstallmentConfiguration>&& configuration)
+    : m_configuration { applePayInstallmentConfiguration(configuration.get()) }
 {
-    return m_configuration.get();
 }
 
-ApplePayInstallmentConfiguration PaymentInstallmentConfiguration::applePayInstallmentConfiguration() const
+const std::optional<ApplePayInstallmentConfiguration>& PaymentInstallmentConfiguration::applePayInstallmentConfiguration() const
 {
+    return m_configuration;
+}
+
+RetainPtr<PKPaymentInstallmentConfiguration> PaymentInstallmentConfiguration::platformConfiguration() const
+{
+    return m_configuration ? createPlatformConfiguration(*m_configuration) : nil;
+}
+
+std::optional<ApplePayInstallmentConfiguration> PaymentInstallmentConfiguration::applePayInstallmentConfiguration(PKPaymentInstallmentConfiguration *configuration)
+{
+    if (!configuration)
+        return std::nullopt;
+
     ApplePayInstallmentConfiguration installmentConfiguration;
     if (!PAL::getPKPaymentInstallmentConfigurationClass())
-        return installmentConfiguration;
+        return std::nullopt;
 
-    if (auto featureType = applePaySetupFeatureType([m_configuration feature]))
+    if (auto featureType = applePaySetupFeatureType([configuration feature]))
         installmentConfiguration.featureType = *featureType;
     else
-        return installmentConfiguration;
+        return std::nullopt;
 
-    installmentConfiguration.bindingTotalAmount = fromDecimalNumber([m_configuration bindingTotalAmount]);
-    installmentConfiguration.currencyCode = [m_configuration currencyCode];
-    installmentConfiguration.isInStorePurchase = [m_configuration isInStorePurchase];
-    installmentConfiguration.openToBuyThresholdAmount = fromDecimalNumber([m_configuration openToBuyThresholdAmount]);
+    installmentConfiguration.bindingTotalAmount = fromDecimalNumber([configuration bindingTotalAmount]);
+    installmentConfiguration.currencyCode = [configuration currencyCode];
+    installmentConfiguration.isInStorePurchase = [configuration isInStorePurchase];
+    installmentConfiguration.openToBuyThresholdAmount = fromDecimalNumber([configuration openToBuyThresholdAmount]);
 
-    installmentConfiguration.merchandisingImageData = [[m_configuration merchandisingImageData] base64EncodedStringWithOptions:0];
-    installmentConfiguration.merchantIdentifier = [m_configuration installmentMerchantIdentifier];
-    installmentConfiguration.referrerIdentifier = [m_configuration referrerIdentifier];
+    installmentConfiguration.merchandisingImageData = [[configuration merchandisingImageData] base64EncodedStringWithOptions:0];
+    installmentConfiguration.merchantIdentifier = [configuration installmentMerchantIdentifier];
+    installmentConfiguration.referrerIdentifier = [configuration referrerIdentifier];
 
     if (!PAL::getPKPaymentInstallmentItemClass())
-        return installmentConfiguration;
+        return WTFMove(installmentConfiguration);
 
-    RetainPtr<NSString> applicationMetadataString;
-    if (NSDictionary *applicationMetadataDictionary = [m_configuration applicationMetadata]) {
-        if (NSData *applicationMetadata = [NSJSONSerialization dataWithJSONObject:applicationMetadataDictionary options:NSJSONWritingSortedKeys error:nil])
-            applicationMetadataString = adoptNS([[NSString alloc] initWithData:applicationMetadata encoding:NSUTF8StringEncoding]);
-    }
+    installmentConfiguration.items = makeVector<ApplePayInstallmentItem>([configuration installmentItems]);
+    installmentConfiguration.applicationMetadata = applicationMetadataString([configuration applicationMetadata]);
+    installmentConfiguration.retailChannel = applePayRetailChannel([configuration retailChannel]);
 
-    installmentConfiguration.items = makeVector<ApplePayInstallmentItem>([m_configuration installmentItems]);
-    installmentConfiguration.applicationMetadata = applicationMetadataString.get();
-    installmentConfiguration.retailChannel = applePayRetailChannel([m_configuration retailChannel]);
-
-    return installmentConfiguration;
+    return WTFMove(installmentConfiguration);
 }
 
 } // namespace WebCore

--- a/Source/WebCore/Modules/applepay/PaymentInstallmentConfigurationWebCore.h
+++ b/Source/WebCore/Modules/applepay/PaymentInstallmentConfigurationWebCore.h
@@ -27,6 +27,7 @@
 
 #if HAVE(PASSKIT_INSTALLMENTS)
 
+#include "ApplePayInstallmentConfigurationWebCore.h"
 #include <wtf/RetainPtr.h>
 
 OBJC_CLASS NSDictionary;
@@ -35,7 +36,6 @@ OBJC_CLASS PKPaymentInstallmentConfiguration;
 namespace WebCore {
 
 class Document;
-struct ApplePayInstallmentConfiguration;
 template<typename> class ExceptionOr;
 
 class WEBCORE_EXPORT PaymentInstallmentConfiguration {
@@ -44,14 +44,16 @@ public:
 
     PaymentInstallmentConfiguration() = default;
     PaymentInstallmentConfiguration(RetainPtr<PKPaymentInstallmentConfiguration>&&);
+    PaymentInstallmentConfiguration(std::optional<ApplePayInstallmentConfiguration>&&);
+    PaymentInstallmentConfiguration(const ApplePayInstallmentConfiguration&, RetainPtr<NSDictionary>&&);
 
-    PKPaymentInstallmentConfiguration *platformConfiguration() const;
-    ApplePayInstallmentConfiguration applePayInstallmentConfiguration() const;
+    RetainPtr<PKPaymentInstallmentConfiguration> platformConfiguration() const;
+    const std::optional<ApplePayInstallmentConfiguration>& applePayInstallmentConfiguration() const;
 
 private:
-    PaymentInstallmentConfiguration(const ApplePayInstallmentConfiguration&, NSDictionary *applicationMetadata);
+    static std::optional<ApplePayInstallmentConfiguration> applePayInstallmentConfiguration(PKPaymentInstallmentConfiguration *);
 
-    RetainPtr<PKPaymentInstallmentConfiguration> m_configuration;
+    std::optional<ApplePayInstallmentConfiguration> m_configuration;
 };
 
 } // namespace WebCore

--- a/Source/WebCore/testing/MockPaymentCoordinator.cpp
+++ b/Source/WebCore/testing/MockPaymentCoordinator.cpp
@@ -42,6 +42,7 @@
 #include "MockPaymentMethod.h"
 #include "Page.h"
 #include "PaymentCoordinator.h"
+#include "PaymentInstallmentConfigurationWebCore.h"
 #include "PaymentSessionError.h"
 #include <wtf/CompletionHandler.h>
 #include <wtf/RunLoop.h>
@@ -115,7 +116,8 @@ bool MockPaymentCoordinator::showPaymentUI(const URL&, const Vector<URL>&, const
     m_requiredBillingContactFields = request.requiredBillingContactFields();
     m_requiredShippingContactFields = request.requiredShippingContactFields();
 #if ENABLE(APPLE_PAY_INSTALLMENTS)
-    m_installmentConfiguration = request.installmentConfiguration().applePayInstallmentConfiguration();
+    if (auto& configuration = request.installmentConfiguration().applePayInstallmentConfiguration())
+        m_installmentConfiguration = *configuration;
 #endif
 #if ENABLE(APPLE_PAY_COUPON_CODE)
     m_supportsCouponCode = request.supportsCouponCode();
@@ -349,6 +351,15 @@ void MockPaymentCoordinator::beginApplePaySetup(const ApplePaySetupConfiguration
 {
     m_setupConfiguration = configuration;
     completionHandler(true);
+}
+
+bool MockPaymentCoordinator::installmentConfigurationReturnsNil() const
+{
+#if HAVE(PASSKIT_INSTALLMENTS)
+    return !PaymentInstallmentConfiguration(nullptr).platformConfiguration();
+#else
+    return true;
+#endif
 }
 
 } // namespace WebCore

--- a/Source/WebCore/testing/MockPaymentCoordinator.h
+++ b/Source/WebCore/testing/MockPaymentCoordinator.h
@@ -107,6 +107,8 @@ public:
     const std::optional<ApplePayLaterAvailability> applePayLaterAvailability() const { return m_applePayLaterAvailability; }
 #endif
 
+    bool installmentConfigurationReturnsNil() const;
+
     void ref() const { }
     void deref() const { }
 

--- a/Source/WebCore/testing/MockPaymentCoordinator.idl
+++ b/Source/WebCore/testing/MockPaymentCoordinator.idl
@@ -63,4 +63,6 @@
     [Conditional=APPLE_PAY_DEFERRED_PAYMENTS] readonly attribute ApplePayDeferredPaymentRequest? deferredPaymentRequest;
 
     [Conditional=APPLE_PAY_LATER_AVAILABILITY] readonly attribute ApplePayLaterAvailability? applePayLaterAvailability;
+
+    boolean installmentConfigurationReturnsNil();
 };

--- a/Source/WebKit/Shared/ApplePay/cocoa/WebPaymentCoordinatorProxyCocoa.mm
+++ b/Source/WebKit/Shared/ApplePay/cocoa/WebPaymentCoordinatorProxyCocoa.mm
@@ -364,8 +364,8 @@ ALLOW_DEPRECATED_DECLARATIONS_END
 #endif
 
 #if HAVE(PASSKIT_INSTALLMENTS)
-    if (PKPaymentInstallmentConfiguration *configuration = paymentRequest.installmentConfiguration().platformConfiguration()) {
-        [result setInstallmentConfiguration:configuration];
+    if (auto configuration = paymentRequest.installmentConfiguration().platformConfiguration()) {
+        [result setInstallmentConfiguration:configuration.get()];
         [result setRequestType:PKPaymentRequestTypeInstallment];
     }
 #endif

--- a/Source/WebKit/Shared/Cocoa/ArgumentCodersCocoa.mm
+++ b/Source/WebKit/Shared/Cocoa/ArgumentCodersCocoa.mm
@@ -651,11 +651,6 @@ static bool shouldEnableStrictMode(Decoder& decoder, NSArray<Class> *allowedClas
         return false;
 #endif // PLATFORM(MAC)
 #endif // ENABLE(DATA_DETECTION)
-#if ENABLE(APPLE_PAY)
-    // Don't reintroduce rdar://108281584
-    if (supportsPassKitCore && [allowedClasses containsObject:PAL::getPKPaymentInstallmentConfigurationClass()]) 
-        return false;
-#endif
 
 #if ENABLE(REVEAL)
     // rdar://107553310 - don't re-introduce rdar://107673064

--- a/Source/WebKit/Shared/Cocoa/WebCoreArgumentCodersCocoa.mm
+++ b/Source/WebKit/Shared/Cocoa/WebCoreArgumentCodersCocoa.mm
@@ -80,24 +80,6 @@ namespace IPC {
 
 #if ENABLE(APPLE_PAY)
 
-#if HAVE(PASSKIT_INSTALLMENTS)
-
-void ArgumentCoder<WebCore::PaymentInstallmentConfiguration>::encode(Encoder& encoder, const WebCore::PaymentInstallmentConfiguration& configuration)
-{
-    encoder << configuration.platformConfiguration();
-}
-
-std::optional<WebCore::PaymentInstallmentConfiguration> ArgumentCoder<WebCore::PaymentInstallmentConfiguration>::decode(Decoder& decoder)
-{
-    auto configuration = IPC::decode<PKPaymentInstallmentConfiguration>(decoder, PAL::getPKPaymentInstallmentConfigurationClass());
-    if (!configuration)
-        return std::nullopt;
-
-    return { WTFMove(*configuration) };
-}
-
-#endif // HAVE(PASSKIT_INSTALLMENTS)
-
 void ArgumentCoder<WebCore::Payment>::encode(Encoder& encoder, const WebCore::Payment& payment)
 {
     encoder << payment.pkPayment();

--- a/Source/WebKit/Shared/WebCoreArgumentCoders.h
+++ b/Source/WebKit/Shared/WebCoreArgumentCoders.h
@@ -468,13 +468,6 @@ template<> struct ArgumentCoder<WebCore::CDMInstanceSession::Message> {
 };
 #endif
 
-#if HAVE(PASSKIT_INSTALLMENTS)
-template<> struct ArgumentCoder<WebCore::PaymentInstallmentConfiguration> {
-    static void encode(Encoder&, const WebCore::PaymentInstallmentConfiguration&);
-    static std::optional<WebCore::PaymentInstallmentConfiguration> decode(Decoder&);
-};
-#endif
-
 #if ENABLE(IMAGE_ANALYSIS) && ENABLE(DATA_DETECTION)
 
 template<> struct ArgumentCoder<WebCore::TextRecognitionDataDetector> {

--- a/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
+++ b/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
@@ -771,6 +771,49 @@ enum class WebCore::ApplePayErrorCode : uint8_t {
 };
 #endif // ENABLE(APPLE_PAY)
 
+#if ENABLE(APPLE_PAY_INSTALLMENTS)
+header: <WebCore/ApplePayInstallmentConfigurationWebCore.h>
+[CustomHeader] struct WebCore::ApplePayInstallmentConfiguration {
+    WebCore::ApplePaySetupFeatureType featureType;
+    String merchandisingImageData;
+    String openToBuyThresholdAmount;
+    String bindingTotalAmount;
+    String currencyCode;
+    bool isInStorePurchase;
+    String merchantIdentifier;
+    String referrerIdentifier;
+    Vector<WebCore::ApplePayInstallmentItem> items;
+    String applicationMetadata;
+    WebCore::ApplePayInstallmentRetailChannel retailChannel;
+};
+header: <WebCore/PaymentInstallmentConfigurationWebCore.h>
+[CustomHeader] class WebCore::PaymentInstallmentConfiguration {
+    std::optional<WebCore::ApplePayInstallmentConfiguration> applePayInstallmentConfiguration()
+}
+struct WebCore::ApplePayInstallmentItem {
+    WebCore::ApplePayInstallmentItemType type;
+    String amount;
+    String currencyCode;
+    String programIdentifier;
+    String apr;
+    String programTerms;
+};
+enum class WebCore::ApplePaySetupFeatureType : bool
+enum class WebCore::ApplePayInstallmentItemType : uint8_t {
+    Generic,
+    Phone,
+    Pad,
+    Watch,
+    Mac,
+};
+enum class WebCore::ApplePayInstallmentRetailChannel : uint8_t {
+    Unknown,
+    App,
+    Web,
+    InStore,
+};
+#endif // ENABLE(APPLE_PAY_INSTALLMENTS)
+
 #if ENABLE(APPLE_PAY_COUPON_CODE)
 struct WebCore::ApplePayCouponCodeUpdate : WebCore::ApplePayDetailsUpdateBase {
     Vector<RefPtr<WebCore::ApplePayError>> errors;


### PR DESCRIPTION
#### c9b8f3887b04ea13be9d0365da205aec3689bae3
<pre>
Migrate PaymentInstallmentConfiguration to generated serialization
<a href="https://bugs.webkit.org/show_bug.cgi?id=256264">https://bugs.webkit.org/show_bug.cgi?id=256264</a>
rdar://108849628

Reviewed by Andy Estes.

A previous attempt at doing this had PaymentInstallmentConfiguration::platformConfiguration
always return a non-null, possibly empty configuration.  That caused an issue so it was reverted.
This attempt is the same as 263335@main except for the following changes:

1. I store a std::optional&lt;ApplePayInstallmentConfiguration&gt; to capture the nullness of the
   PKPaymentInstallmentConfiguration from the constructor and use that to return null when appropriate.
2. I added a layout test that verifies that null successfully roundtrips through PaymentInstallmentConfiguration
   using an internals function to do the test and return whether it passed or not.
3. addApplicationMetadata takes a ApplePayInstallmentConfiguration instead of a const reference.
   This was feedback given on 263335@main and is small and only cosmetic.

* LayoutTests/http/tests/paymentrequest/installment-configuration.https-expected.txt: Added.
* LayoutTests/http/tests/paymentrequest/installment-configuration.https.html: Added.
* Source/WebCore/Modules/applepay/ApplePaySetupFeatureTypeWebCore.h:
* Source/WebCore/Modules/applepay/ApplePaySetupFeatureWebCore.h:
* Source/WebCore/Modules/applepay/PaymentInstallmentConfiguration.mm:
(WebCore::applicationMetadataDictionary):
(WebCore::applicationMetadataString):
(WebCore::createPlatformConfiguration):
(WebCore::PaymentInstallmentConfiguration::create):
(WebCore::addApplicationMetadata):
(WebCore::PaymentInstallmentConfiguration::PaymentInstallmentConfiguration):
(WebCore::PaymentInstallmentConfiguration::applePayInstallmentConfiguration const):
(WebCore::PaymentInstallmentConfiguration::platformConfiguration const):
(WebCore::PaymentInstallmentConfiguration::applePayInstallmentConfiguration):
* Source/WebCore/Modules/applepay/PaymentInstallmentConfigurationWebCore.h:
* Source/WebCore/WebCore.xcodeproj/project.pbxproj:
* Source/WebCore/testing/MockPaymentCoordinator.cpp:
(WebCore::MockPaymentCoordinator::showPaymentUI):
(WebCore::MockPaymentCoordinator::installmentConfigurationReturnsNil const):
* Source/WebCore/testing/MockPaymentCoordinator.h:
* Source/WebCore/testing/MockPaymentCoordinator.idl:
* Source/WebKit/Shared/ApplePay/cocoa/WebPaymentCoordinatorProxyCocoa.mm:
(WebKit::WebPaymentCoordinatorProxy::platformPaymentRequest):
* Source/WebKit/Shared/Cocoa/ArgumentCodersCocoa.mm:
(IPC::shouldEnableStrictMode):
* Source/WebKit/Shared/Cocoa/WebCoreArgumentCodersCocoa.mm:
(IPC::ArgumentCoder&lt;WebCore::PaymentInstallmentConfiguration&gt;::encode): Deleted.
(IPC::ArgumentCoder&lt;WebCore::PaymentInstallmentConfiguration&gt;::decode): Deleted.
* Source/WebKit/Shared/WebCoreArgumentCoders.h:
* Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in:

Canonical link: <a href="https://commits.webkit.org/263647@main">https://commits.webkit.org/263647@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e448c3531a7446abbe5eeb04a012813a4f934076

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/5317 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/5453 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/5641 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/6853 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/5360 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/5317 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/5676 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/5435 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/5958 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/5416 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/5492 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/4764 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/6879 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/2974 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/4767 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/11738 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/4838 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/4845 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/6464 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/5272 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/4334 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/4739 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/4764 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/8835 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/599 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/5099 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->