### PR TITLE
[GTK][WPE] Test gardening for `fast/text/` control characters spec

### DIFF
--- a/LayoutTests/fast/text/nbsp-no-space.html
+++ b/LayoutTests/fast/text/nbsp-no-space.html
@@ -15,6 +15,6 @@
 <body>
 This test makes sure that the nbsp glyph is used in a font if the space glyph is unavailable. The test passes if this text you're reading right now is the only text on the page.
 <div style="font: 48px 'WebFont';">&nbsp;</div>
-<div style="font: 48px 'WebFont2'; white-space: pre;">&#x9;</div>
+<div style="font: 48px 'WebFont2'; white-space: normal;">&#x20;</div>
 </body>
 </html>

--- a/LayoutTests/platform/glib/TestExpectations
+++ b/LayoutTests/platform/glib/TestExpectations
@@ -3226,7 +3226,6 @@ webkit.org/b/236298 fast/text/combining-character-sequence-vertical.html [ Image
 webkit.org/b/236298 fast/text/fallback-font-and-zero-width-glyph.html [ ImageOnlyFailure ]
 webkit.org/b/236298 fast/text/simple-line-layout-with-justified-punctuation.html [ ImageOnlyFailure ]
 webkit.org/b/236298 fast/text/simple-lines-text-transform.html [ ImageOnlyFailure ]
-webkit.org/b/236298 fast/text/nbsp-no-space.html [ ImageOnlyFailure ]
 webkit.org/b/236298 fast/text/strikethrough-int.html [ ImageOnlyFailure ]
 
 http/tests/webgpu/webgpu/api/operation/memory_sync/buffer/multiple_buffers.html [ Skip ]


### PR DESCRIPTION
#### 46da29f19ea617209bbd8cc51cc900e01ce9ed6b
<pre>
[GTK][WPE] Test gardening for `fast/text/` control characters spec

Unreviewed test gardening.

As detailed in recent 261493@main, per the spec, &quot;&quot;Control characters ...
other than tabs ... must be rendered as a visible glyph.&quot; This test
`fast/text/nbsp-no-space.html` previously tested a tab character, but
font provides visible space _or_ tab. Using a space to align w spec
<a href="https://www.w3.org/TR/css-text-3/#white-space-processing.">https://www.w3.org/TR/css-text-3/#white-space-processing.</a>

* LayoutTests/fast/text/nbsp-no-space.html: Use space character to
align with spec.
* LayoutTests/platform/glib/TestExpectations: Remove expected failures
as test will now pass in GTK/WPE now that it meets spec.
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/46da29f19ea617209bbd8cc51cc900e01ce9ed6b

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/5319 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/5455 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/5643 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/6855 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/5362 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/5678 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/5437 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/5957 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/5418 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/5490 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/4766 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/6881 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/2972 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/4769 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/11785 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/4836 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/4847 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/6473 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/5274 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/4332 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/4741 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/4766 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/8837 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/5101 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->