### PR TITLE
[WGSL] Make AST type nodes arena allocated

### DIFF
--- a/Source/WebGPU/WGSL/AST/ASTFunction.h
+++ b/Source/WebGPU/WGSL/AST/ASTFunction.h
@@ -41,13 +41,13 @@ class Function final : public Declaration {
 public:
     using List = UniqueRefVector<Function>;
 
-    Function(SourceSpan span, Identifier&& name, Parameter::List&& parameters, TypeName::Ptr&& returnType, CompoundStatement&& body, Attribute::List&& attributes, Attribute::List&& returnAttributes)
+    Function(SourceSpan span, Identifier&& name, Parameter::List&& parameters, TypeName::Ptr returnType, CompoundStatement&& body, Attribute::List&& attributes, Attribute::List&& returnAttributes)
         : Declaration(span)
         , m_name(WTFMove(name))
         , m_parameters(WTFMove(parameters))
         , m_attributes(WTFMove(attributes))
         , m_returnAttributes(WTFMove(returnAttributes))
-        , m_returnType(WTFMove(returnType))
+        , m_returnType(returnType)
         , m_body(WTFMove(body))
     { }
 
@@ -56,13 +56,13 @@ public:
     Parameter::List& parameters() { return m_parameters; }
     Attribute::List& attributes() { return m_attributes; }
     Attribute::List& returnAttributes() { return m_returnAttributes; }
-    TypeName* maybeReturnType() { return m_returnType.get(); }
+    TypeName* maybeReturnType() { return m_returnType; }
     CompoundStatement& body() { return m_body; }
     const Identifier& name() const { return m_name; }
     const Parameter::List& parameters() const { return m_parameters; }
     const Attribute::List& attributes() const { return m_attributes; }
     const Attribute::List& returnAttributes() const { return m_returnAttributes; }
-    const TypeName* maybeReturnType() const { return m_returnType.get(); }
+    const TypeName* maybeReturnType() const { return m_returnType; }
     const CompoundStatement& body() const { return m_body; }
 
 private:

--- a/Source/WebGPU/WGSL/AST/ASTVariable.h
+++ b/Source/WebGPU/WGSL/AST/ASTVariable.h
@@ -47,16 +47,16 @@ public:
     using Ref = UniqueRef<Variable>;
     using List = UniqueRefVector<Variable>;
 
-    Variable(SourceSpan span, VariableFlavor flavor, Identifier&& name, TypeName::Ptr&& type, Expression::Ptr&& initializer)
-        : Variable(span, flavor, WTFMove(name), { }, WTFMove(type), WTFMove(initializer), { })
+    Variable(SourceSpan span, VariableFlavor flavor, Identifier&& name, TypeName::Ptr type, Expression::Ptr&& initializer)
+        : Variable(span, flavor, WTFMove(name), { }, type, WTFMove(initializer), { })
     { }
 
-    Variable(SourceSpan span, VariableFlavor flavor, Identifier&& name, VariableQualifier::Ptr&& qualifier, TypeName::Ptr&& type, Expression::Ptr&& initializer, Attribute::List&& attributes)
+    Variable(SourceSpan span, VariableFlavor flavor, Identifier&& name, VariableQualifier::Ptr&& qualifier, TypeName::Ptr type, Expression::Ptr&& initializer, Attribute::List&& attributes)
         : Declaration(span)
         , m_name(WTFMove(name))
         , m_attributes(WTFMove(attributes))
         , m_qualifier(WTFMove(qualifier))
-        , m_type(WTFMove(type))
+        , m_type(type)
         , m_initializer(WTFMove(initializer))
         , m_flavor(flavor)
     {
@@ -68,7 +68,7 @@ public:
     Identifier& name() { return m_name; }
     Attribute::List& attributes() { return m_attributes; }
     VariableQualifier* maybeQualifier() { return m_qualifier.get(); }
-    TypeName* maybeTypeName() { return m_type.get(); }
+    TypeName* maybeTypeName() { return m_type; }
     Expression* maybeInitializer() { return m_initializer.get(); }
 
 private:

--- a/Source/WebGPU/WGSL/GlobalVariableRewriter.cpp
+++ b/Source/WebGPU/WGSL/GlobalVariableRewriter.cpp
@@ -311,7 +311,7 @@ void RewriteGlobalVariables::insertStructs(const UsedGlobals& usedGlobals)
 
             AST::TypeName::Ref memberType = *global->declaration->maybeTypeName();
             if (shouldBeReference)
-                memberType = adoptRef(*new AST::ReferenceTypeName(span, WTFMove(memberType)));
+                memberType = m_callGraph.ast().astBuilder().construct<AST::ReferenceTypeName>(span, WTFMove(memberType));
             structMembers.append(m_callGraph.ast().astBuilder().construct<AST::StructureMember>(
                 span,
                 AST::Identifier::make(global->declaration->name()),
@@ -338,12 +338,12 @@ void RewriteGlobalVariables::insertParameters(AST::Function& function, const Use
     auto span = function.span();
     for (auto& it : usedGlobals) {
         unsigned group = it.key;
-        auto type = adoptRef(*new AST::NamedTypeName(span, argumentBufferStructName(group)));
-        type->m_resolvedType = m_structTypes.get(group);
+        auto& type = m_callGraph.ast().astBuilder().construct<AST::NamedTypeName>(span, argumentBufferStructName(group));
+        type.m_resolvedType = m_structTypes.get(group);
         m_callGraph.ast().append(function.parameters(), adoptRef(*new AST::Parameter(
             span,
             argumentBufferParameterName(group),
-            WTFMove(type),
+            type,
             AST::Attribute::List {
                 m_callGraph.ast().astBuilder().construct<AST::GroupAttribute>(span, group)
             },


### PR DESCRIPTION
#### 844e05173dcb29fdbddc42c3e843d28962cba7a6
<pre>
[WGSL] Make AST type nodes arena allocated
<a href="https://bugs.webkit.org/show_bug.cgi?id=256265">https://bugs.webkit.org/show_bug.cgi?id=256265</a>
rdar://108849668

Reviewed by Dan Glastonbury.

Continue incrementally converting AST nodes to be arena allocated.

* Source/WebGPU/WGSL/AST/ASTFunction.h:
* Source/WebGPU/WGSL/AST/ASTTypeName.h:
(WGSL::AST::TypeName::resolvedType const):
(WGSL::AST::ArrayTypeName::maybeElementType const):
(WGSL::AST::ArrayTypeName::ArrayTypeName):
(WGSL::AST::NamedTypeName::name):
(WGSL::AST::ParameterizedTypeName::ParameterizedTypeName):
* Source/WebGPU/WGSL/AST/ASTVariable.h:
* Source/WebGPU/WGSL/EntryPointRewriter.cpp:
(WGSL::EntryPointRewriter::rewrite):
(WGSL::EntryPointRewriter::constructInputStruct):
(WGSL::EntryPointRewriter::materialize):
(WGSL::EntryPointRewriter::visit):
(WGSL::EntryPointRewriter::appendBuiltins):
* Source/WebGPU/WGSL/GlobalVariableRewriter.cpp:
(WGSL::RewriteGlobalVariables::insertStructs):
(WGSL::RewriteGlobalVariables::insertParameters):
* Source/WebGPU/WGSL/Parser.cpp:
(WGSL::Parser&lt;Lexer&gt;::parseTypeName):
(WGSL::Parser&lt;Lexer&gt;::parseTypeNameAfterIdentifier):
(WGSL::Parser&lt;Lexer&gt;::parseArrayType):
(WGSL::Parser&lt;Lexer&gt;::parseVariableWithAttributes):
(WGSL::Parser&lt;Lexer&gt;::parseFunction):

Canonical link: <a href="https://commits.webkit.org/263732@main">https://commits.webkit.org/263732@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/22900d8ef159322680c40d553cabca5c27904bcd

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/5320 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/5456 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/5644 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/6856 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/5363 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/5689 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/5438 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/5959 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/5419 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/5502 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/4767 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/6882 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/2982 "Passed tests") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/11850 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/4847 "Passed tests") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/4848 "3 failures") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/6466 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/5275 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/4333 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/4742 "Built successfully") | | | 
| [❌ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/1326 "Failed to push commit to Webkit repository") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/8838 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/5102 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->