### PR TITLE
[JSC] Skip ProxyObject's trap result validation in the common case (C++ code)

### DIFF
--- a/JSTests/microbenchmarks/proxy-defineproperty.js
+++ b/JSTests/microbenchmarks/proxy-defineproperty.js
@@ -1,0 +1,11 @@
+(function() {
+    var desc = { value: 1 };
+    var proxy = new Proxy({}, {
+        defineProperty(target, propertyName, desc) {
+            return true;
+        }
+    });
+
+    for (var i = 0; i < 1e6; ++i)
+        Object.defineProperty(proxy, "test", desc);
+})();

--- a/JSTests/microbenchmarks/proxy-delete.js
+++ b/JSTests/microbenchmarks/proxy-delete.js
@@ -1,0 +1,12 @@
+(function() {
+    "use strict";
+
+    var proxy = new Proxy({}, {
+        deleteProperty(target, propertyName) {
+            return true;
+        }
+    });
+
+    for (var i = 0; i < 1e6; ++i)
+        delete proxy.foo;
+})();

--- a/JSTests/microbenchmarks/proxy-gopd.js
+++ b/JSTests/microbenchmarks/proxy-gopd.js
@@ -1,0 +1,9 @@
+(function() {
+    var proxy = new Proxy({}, {
+        getOwnPropertyDescriptor(target, propertyName) {}
+    });
+
+    var desc;
+    for (var i = 0; i < 1e6; ++i)
+        desc = Object.getOwnPropertyDescriptor(proxy, "test");
+})();


### PR DESCRIPTION
#### 05c634fc9b5a2fe04c30aaa1dcd06e1639fee341
<pre>
[JSC] Skip ProxyObject&apos;s trap result validation in the common case (C++ code)
<a href="https://bugs.webkit.org/show_bug.cgi?id=256213">https://bugs.webkit.org/show_bug.cgi?id=256213</a>
&lt;rdar://problem/108795682&gt;

Reviewed by Yusuke Suzuki.

This change leverages Structure flags introduced in <a href="https://webkit.org/b/255661">https://webkit.org/b/255661</a> to be used in C++
ProxyObject code, slightly speeding up (6-13%) the following traps in the common case of [[ProxyTarget]]
being an ordinary extensible object without non-configurable properties:
  * &quot;has&quot;, &quot;get&quot;, &quot;set&quot; before the IC kicks in (if any),
  * &quot;defineProperty&quot;,
  * &quot;deleteProperty&quot; returning `true`,
  * &quot;getOwnPropertyDescriptor&quot; returning `undefined`.

In a follow-up, most likely we can do a little better with &quot;getOwnPropertyDescriptor&quot; trap by
leveraging known descriptor structures since toPropertyDescriptor() is the bottleneck of this trap.

                                     ToT                      patch

proxy-defineproperty          105.9173+-0.2895     ^    100.1405+-0.3956        ^ definitely 1.0577x faster
proxy-delete                   71.9609+-0.5476     ^     67.1882+-0.4754        ^ definitely 1.0710x faster
proxy-get                     560.3030+-2.0679     ^    503.2683+-1.7229        ^ definitely 1.1133x faster
proxy-gopd                     85.5031+-0.3219     ^     80.2407+-0.3543        ^ definitely 1.0656x faster
proxy-has-miss                 53.7071+-0.2929     ^     48.3547+-0.2941        ^ definitely 1.1107x faster
proxy-set                      53.9783+-0.3207     ^     47.6111+-0.1005        ^ definitely 1.1337x faster

* JSTests/microbenchmarks/proxy-defineproperty.js: Added.
* JSTests/microbenchmarks/proxy-delete.js: Added.
* JSTests/microbenchmarks/proxy-gopd.js: Added.
* Source/JavaScriptCore/runtime/ProxyObject.cpp:
(JSC::performProxyGet):
(JSC::ProxyObject::performInternalMethodGetOwnProperty):
(JSC::ProxyObject::performHasProperty):
(JSC::ProxyObject::performPut):
(JSC::ProxyObject::performDelete):
(JSC::ProxyObject::performDefineOwnProperty):

Canonical link: <a href="https://commits.webkit.org/263653@main">https://commits.webkit.org/263653@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5636dc850b5b72dc884716bca234ba1717c276e5

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/5321 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/5457 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/5645 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/6857 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/5364 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/5690 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/5439 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/5961 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/5420 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/5507 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/4770 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/6883 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/2987 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/4773 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/11803 "Passed tests") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/4412 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/4852 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/4851 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/6467 "Passed tests") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/4907 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/5276 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/4337 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/5422 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/4743 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/1354 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/8839 "Built successfully") | | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/24/builds/5578 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/602 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/5103 "Built successfully") | | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/3/builds/1472 "Passed tests") | 
<!--EWS-Status-Bubble-End-->