### PR TITLE
[JSC] validateAIState should ignore EnumeratorNextUpdateIndexAndMode when asking for AbstractValue

### DIFF
--- a/JSTests/stress/dfg-tuple-validate-ai-state.js
+++ b/JSTests/stress/dfg-tuple-validate-ai-state.js
@@ -1,0 +1,3 @@
+//@ runDefault("--validateAbstractInterpreterState=1")
+for (let i = 0; i < 100000; i++)
+    for (let x in 'a');

--- a/Source/JavaScriptCore/dfg/DFGAbstractInterpreter.h
+++ b/Source/JavaScriptCore/dfg/DFGAbstractInterpreter.h
@@ -124,6 +124,11 @@ public:
         makeHeapTopForNode(edge.node());
     }
     
+    bool hasClearedAbstractState(NodeFlowProjection node)
+    {
+        return m_state.hasClearedAbstractState(node);
+    }
+
     bool needsTypeCheck(Node* node, SpeculatedType typesPassedThrough)
     {
         return !forNode(node).isType(typesPassedThrough);

--- a/Source/JavaScriptCore/dfg/DFGInPlaceAbstractState.h
+++ b/Source/JavaScriptCore/dfg/DFGInPlaceAbstractState.h
@@ -47,6 +47,11 @@ public:
     
     void createValueForNode(NodeFlowProjection) { }
     
+    ALWAYS_INLINE bool hasClearedAbstractState(NodeFlowProjection node)
+    {
+        return !m_abstractValues.at(node);
+    }
+
     ALWAYS_INLINE AbstractValue& fastForward(AbstractValue& value)
     {
         value.fastForwardTo(m_effectEpoch);

--- a/Source/JavaScriptCore/ftl/FTLLowerDFGToB3.cpp
+++ b/Source/JavaScriptCore/ftl/FTLLowerDFGToB3.cpp
@@ -615,6 +615,10 @@ private:
                 continue;
             if (node->op() == CheckInBoundsInt52)
                 continue;
+            if (node->op() == EnumeratorNextUpdateIndexAndMode) {
+                ASSERT(m_interpreter.hasClearedAbstractState(node));
+                continue;
+            }
 
             AbstractValue value = m_interpreter.forNode(node);
             {


### PR DESCRIPTION
#### 40c95aef90c7c931fde333441c7481763a3c7129
<pre>
[JSC] validateAIState should ignore EnumeratorNextUpdateIndexAndMode when asking for AbstractValue
<a href="https://bugs.webkit.org/show_bug.cgi?id=256263">https://bugs.webkit.org/show_bug.cgi?id=256263</a>
rdar://108693426

Reviewed by Yusuke Suzuki.

According to <a href="https://github.com/WebKit/WebKit/commit/39dd6c8334a66035cb396c8593a28dfca2b50f5e">https://github.com/WebKit/WebKit/commit/39dd6c8334a66035cb396c8593a28dfca2b50f5e</a>
&quot;DFG tuples don&apos;t have a type themselves, they represent a collection of
elements.&quot; Function validateAIState should stop asking for AbstractValue from
EnumeratorNextUpdateIndexAndMode node.

* JSTests/stress/dfg-tuple-validate-ai-state.js: Added.
* Source/JavaScriptCore/dfg/DFGAbstractInterpreter.h:
(JSC::DFG::AbstractInterpreter::hasClearedAbstractState):
* Source/JavaScriptCore/dfg/DFGInPlaceAbstractState.h:
(JSC::DFG::InPlaceAbstractState::hasClearedAbstractState):
* Source/JavaScriptCore/ftl/FTLLowerDFGToB3.cpp:
(JSC::FTL::DFG::LowerDFGToB3::validateAIState):

Canonical link: <a href="https://commits.webkit.org/263650@main">https://commits.webkit.org/263650@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d0432b430e2798323f9f47ec860bb97224267f62

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/5325 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/5461 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/5649 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/6861 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/5367 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/5685 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/5443 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/5974 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/5424 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/5495 "Passed tests") | [⏳ 🧪 api-mac](https://ews-build.webkit.org/#/builders/API-Tests-macOS-EWS "Waiting to run tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/6887 "Built successfully") | 
| | [⏳ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/iOS-16-Simulator-WPT-WK2-Tests-EWS "Waiting to run tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/4775 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/11916 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/4416 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/4841 "Passed tests") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/4854 "3 failures") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/6471 "Passed tests") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/4911 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/5280 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/4338 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/5426 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/4746 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/1356 "Passed tests") | 
| [  ~~🛠 🧪 merge~~](https://ews-build.webkit.org/#/builders/19/builds/1278 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/8842 "Built successfully") | | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/24/builds/5582 "Built successfully") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/5106 "Built successfully") | | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/3/builds/1474 "Passed tests") | 
<!--EWS-Status-Bubble-End-->