### PR TITLE
[JSC] LICM fuzzer should always try to hoist check nodes

### DIFF
--- a/JSTests/stress/licm-fuzzer-check-node.js
+++ b/JSTests/stress/licm-fuzzer-check-node.js
@@ -1,0 +1,23 @@
+//@ runDefault("--jitPolicyScale=0", "--useLICMFuzzing=1")
+function foo() {
+    let s = Symbol();
+    for (let i = 0; i < 2; i++) {
+        let z0 = [];
+        let z1 = [];
+        '' + s + '';
+        let z2 = [];
+        let z3 = [];
+        let z4 = [];
+        let z5 = [];
+        let z6 = [];
+        let z7 = [];
+        let z8 = [];
+        let z9 = [];
+        let z10 = [];
+        let z11 = [];
+    }
+};
+
+for (let i = 0; i < 10000; i++) {
+    try { foo(); } catch { }
+}

--- a/Source/JavaScriptCore/dfg/DFGLICMPhase.cpp
+++ b/Source/JavaScriptCore/dfg/DFGLICMPhase.cpp
@@ -219,7 +219,7 @@ public:
                 for (unsigned stackIndex = loopStack.size(); stackIndex--;) {
                     if (UNLIKELY(Options::useLICMFuzzing())) {
                         bool shouldAttemptHoist = random.returnTrueWithProbability(Options::allowHoistingLICMProbability());
-                        if (!shouldAttemptHoist)
+                        if (!shouldAttemptHoist && !nodeRef->isCheckNode())
                             continue;
                     }
 

--- a/Source/JavaScriptCore/dfg/DFGNode.h
+++ b/Source/JavaScriptCore/dfg/DFGNode.h
@@ -561,6 +561,37 @@ public:
         }
     }
 
+    bool isCheckNode()
+    {
+        switch (op()) {
+        case Check:
+        case CheckVarargs:
+        case CheckTierUpInLoop:
+        case CheckTierUpAndOSREnter:
+        case CheckTierUpAtReturn:
+        case CheckPrivateBrand:
+        case CheckStructure:
+        case CheckStructureOrEmpty:
+        case CheckArray:
+        case CheckArrayOrEmpty:
+        case CheckDetached:
+        case CheckIsConstant:
+        case CheckNotEmpty:
+        case CheckBadValue:
+        case CheckInBounds:
+        case CheckInBoundsInt52:
+        case CheckIdent:
+        case CheckTypeInfoFlags:
+        case CheckJSCast:
+        case CheckNotJSCast:
+        case CheckStructureImmediate:
+        case CheckTraps:
+            return true;
+        default:
+            return false;
+        }
+    }
+
     FrozenValue* constant()
     {
         ASSERT(hasConstant());


### PR DESCRIPTION
#### d38e9253394d559bee6fd15031f489eced98cd37
<pre>
[JSC] LICM fuzzer should always try to hoist check nodes
<a href="https://bugs.webkit.org/show_bug.cgi?id=256223">https://bugs.webkit.org/show_bug.cgi?id=256223</a>
rdar://108693746

Reviewed by Yusuke Suzuki.

The LICM fuzzer is introduced in <a href="https://trac.webkit.org/changeset/264133/webkit">https://trac.webkit.org/changeset/264133/webkit</a>,
which is intend for checking unsafe hoisting. However, we might get crash when
some nodes got hoisted but not for its corresponding check nodes. This is because
when the useLICMFuzzing=1 the fuzzer will try to hoist randomly picked nodes.
To fix the issue, the fuzzer should always try to hoist check nodes.

* Source/JavaScriptCore/dfg/DFGLICMPhase.cpp:
(JSC::DFG::LICMPhase::run):
* Source/JavaScriptCore/dfg/DFGNode.h:
(JSC::DFG::Node::isCheckNode):

Canonical link: <a href="https://commits.webkit.org/263648@main">https://commits.webkit.org/263648@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/898f6f4f7847ed454545ca04c274c0bd0d705298

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/5330 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/5467 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/5655 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/6867 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/5372 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/5694 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/5448 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/5996 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/5429 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/5505 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/4775 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/6893 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/2985 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/4780 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/11864 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/4420 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/4850 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/4859 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/6474 "Passed tests") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/4916 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/5285 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/4341 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/5431 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/4750 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/1358 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/1274 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/8847 "Built successfully") | | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/24/builds/5587 "Built successfully") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/5111 "Built successfully") | | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/3/builds/1476 "Passed tests") | 
<!--EWS-Status-Bubble-End-->