### PR TITLE
Update implementation of contain flag for motion path <ray>

### DIFF
--- a/LayoutTests/TestExpectations
+++ b/LayoutTests/TestExpectations
@@ -5271,13 +5271,6 @@ webkit.org/b/233340 imported/w3c/web-platform-tests/css/motion/offset-anchor-tra
 # CSS motion path ray test failing due to getting wrong size from containing block.
 webkit.org/b/233344 imported/w3c/web-platform-tests/css/motion/offset-path-ray-007.html [ ImageOnlyFailure ]
 
-# CSS motion path needs to implement new spec for contain: https://bugs.webkit.org/show_bug.cgi?id=256225.
-webkit.org/b/256225 imported/w3c/web-platform-tests/css/motion/offset-path-ray-contain-001.html [ ImageOnlyFailure ]
-webkit.org/b/256225 imported/w3c/web-platform-tests/css/motion/offset-path-ray-contain-002.html [ ImageOnlyFailure ]
-webkit.org/b/256225 imported/w3c/web-platform-tests/css/motion/offset-path-ray-contain-003.html [ ImageOnlyFailure ]
-webkit.org/b/256225 imported/w3c/web-platform-tests/css/motion/offset-path-ray-contain-004.html [ ImageOnlyFailure ]
-webkit.org/b/256225 imported/w3c/web-platform-tests/css/motion/offset-path-ray-contain-005.html [ ImageOnlyFailure ]
-
 # IPC test failing in Debug mode due to assert.
 [ Debug ] ipc/send-invalid-message.html [ Skip ]
 # mac-only IPC test

--- a/LayoutTests/imported/w3c/web-platform-tests/css/motion/offset-path-ray-contain-004.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/motion/offset-path-ray-contain-004.html
@@ -5,6 +5,7 @@
     <link rel="help" href="https://drafts.fxtf.org/motion-1/#offset-path-property">
     <link rel="match" href="offset-path-ray-contain-004-ref.html">
     <meta name="assert" content="This tests that the element should be contained in ray() path circle.">
+    <meta name="fuzzy" content="maxDifference=0-20; totalPixels=0-10"/>
     <style>
       #container {
         width: 300px;

--- a/Source/WebCore/platform/animation/AcceleratedEffectValues.cpp
+++ b/Source/WebCore/platform/animation/AcceleratedEffectValues.cpp
@@ -165,7 +165,7 @@ AcceleratedEffectValues::AcceleratedEffectValues(const RenderStyle& style, const
         if (!offsetAnchor.x().isAuto())
             anchor = floatPointForLengthPoint(offsetAnchor, borderBoxRect.size()) + borderBoxRect.location();
 
-        auto path = offsetPath->getPath(borderBoxRect, anchor, offsetRotate);
+        auto path = offsetPath->getPath(borderBoxRect);
         offsetDistance = { path ? path->length() : 0.0f, LengthType:: Fixed };
     }
 

--- a/Source/WebCore/rendering/PathOperation.h
+++ b/Source/WebCore/rendering/PathOperation.h
@@ -62,7 +62,7 @@ public:
 
     OperationType type() const { return m_type; }
     bool isSameType(const PathOperation& o) const { return o.type() == m_type; }
-    virtual const std::optional<Path> getPath(const FloatRect& reference = { }, FloatPoint anchor = { }, OffsetRotation rotation = { }) const = 0;
+    virtual const std::optional<Path> getPath(const FloatRect& reference = { }) const = 0;
 protected:
     explicit PathOperation(OperationType type)
         : m_type(type)
@@ -79,7 +79,7 @@ public:
     const String& url() const { return m_url; }
     const AtomString& fragment() const { return m_fragment; }
     const SVGElement* element() const;
-    const std::optional<Path> getPath(const FloatRect&, FloatPoint, OffsetRotation) const final { return m_path; }
+    const std::optional<Path> getPath(const FloatRect&) const final { return m_path; }
     const std::optional<Path> path() const { return m_path; }
 private:
     bool operator==(const PathOperation& other) const override
@@ -134,7 +134,7 @@ public:
 
     void setReferenceBox(CSSBoxType referenceBox) { m_referenceBox = referenceBox; }
     CSSBoxType referenceBox() const { return m_referenceBox; }
-    const std::optional<Path> getPath(const FloatRect& reference, FloatPoint, OffsetRotation) const final { return pathForReferenceRect(reference); }
+    const std::optional<Path> getPath(const FloatRect& reference) const final { return pathForReferenceRect(reference); }
 
 private:
     bool operator==(const PathOperation& other) const override
@@ -195,7 +195,7 @@ public:
         m_path.addRoundedRect(boundingRect);
     }
     
-    const std::optional<Path> getPath(const FloatRect&, FloatPoint, OffsetRotation) const final { return m_path; }
+    const std::optional<Path> getPath(const FloatRect&) const final { return m_path; }
     const Path& path() const { return m_path; }
     CSSBoxType referenceBox() const { return m_referenceBox; }
 
@@ -253,7 +253,7 @@ public:
     WEBCORE_EXPORT RefPtr<PathOperation> blend(const PathOperation*, const BlendingContext&) const final;
 
     double lengthForPath() const;
-    double lengthForContainPath(const FloatRect& elementRect, double computedPathLength, const FloatPoint& anchor, const OffsetRotation rotation) const;
+    double lengthForContainPath(const FloatRect& elementRect, double computedPathLength) const;
     
     void setContainingBlockReferenceRect(const FloatRect& boundingRect)
     {
@@ -263,7 +263,7 @@ public:
     {
         m_position = position;
     }
-    const std::optional<Path> getPath(const FloatRect& referenceRect = { }, FloatPoint anchor = { }, OffsetRotation rotation = { }) const final;
+    const std::optional<Path> getPath(const FloatRect& referenceRect = { }) const final;
 
     const FloatRect& containingBlockBoundingRect() const { return m_containingBlockBoundingRect; }
     const FloatPoint& position() const { return m_position; }

--- a/Source/WebCore/rendering/style/RenderStyle.cpp
+++ b/Source/WebCore/rendering/style/RenderStyle.cpp
@@ -1689,7 +1689,7 @@ void RenderStyle::applyMotionPathTransform(TransformationMatrix& transform, cons
         anchor = floatPointForLengthPoint(offsetAnchor(), boundingBox.size()) + boundingBox.location();
     
     // Shift element to the point on path specified by offset-path and offset-distance.
-    auto path = offsetPath()->getPath(boundingBox, anchor, offsetRotate());
+    auto path = offsetPath()->getPath(boundingBox);
     if (!path)
         return;
     auto traversalState = getTraversalStateAtDistance(*path, offsetDistance());


### PR DESCRIPTION
#### 7e206701112298ed0df6f7a8e3a393e9e8531530
<pre>
Update implementation of contain flag for motion path &lt;ray&gt;
<a href="https://bugs.webkit.org/show_bug.cgi?id=256225">https://bugs.webkit.org/show_bug.cgi?id=256225</a>
rdar://108861663

Reviewed by Tim Nguyen.

After w3c/fxtf-drafts@bd9fb9b, we need to update our contain
implementation to follow this new behavior. This involves replacing the old implementation
in RayPathOperation::lengthForContainPath to the new behavior, which just bases the length
we shorten the computed path length on half the width or height of the element that we are
animating. Since we no longer need the anchor point or the angle of the ray, remove this
from RayPathOperation::lengthForContainPath&apos;s function parameters (as well as all other
PathOperations).

* LayoutTests/TestExpectations:
* LayoutTests/imported/w3c/web-platform-tests/css/motion/offset-path-ray-contain-004.html:
* Source/WebCore/platform/animation/AcceleratedEffectValues.cpp:
(WebCore::AcceleratedEffectValues::AcceleratedEffectValues):
* Source/WebCore/rendering/PathOperation.cpp:
(WebCore::RayPathOperation::lengthForContainPath const):
(WebCore::RayPathOperation::getPath const):
* Source/WebCore/rendering/PathOperation.h:
(WebCore::PathOperation::getPath):
* Source/WebCore/rendering/style/RenderStyle.cpp:
(WebCore::RenderStyle::applyMotionPathTransform const):

Canonical link: <a href="https://commits.webkit.org/265106@main">https://commits.webkit.org/265106@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f354e141c00f5de778c7587efbe08797d20d6dfb

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/9824 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/10072 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/10317 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/11476 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/9552 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/9833 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/12056 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/10022 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/12482 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/9978 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/10785 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/8330 "Passed tests") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/2/builds/11886 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/8092 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/8910 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/2/builds/11886 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/9190 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/9059 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/2/builds/11886 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/9559 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/7784 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/8725 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/8807 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/2357 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/12951 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/9335 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->