### PR TITLE
Use move semantics for UpdateInfo

### DIFF
--- a/Source/WebKit/UIProcess/BackingStore.cpp
+++ b/Source/WebKit/UIProcess/BackingStore.cpp
@@ -44,7 +44,7 @@ BackingStore::~BackingStore()
 {
 }
 
-void BackingStore::incorporateUpdate(const UpdateInfo& updateInfo)
+void BackingStore::incorporateUpdate(UpdateInfo&& updateInfo)
 {
     ASSERT(m_size == updateInfo.viewSize);
     
@@ -58,7 +58,7 @@ void BackingStore::incorporateUpdate(const UpdateInfo& updateInfo)
     ASSERT(bitmap->size() == updateSize);
 #endif
     
-    incorporateUpdate(bitmap.get(), updateInfo);
+    incorporateUpdate(bitmap.get(), WTFMove(updateInfo));
 }
 
 } // namespace WebKit

--- a/Source/WebKit/UIProcess/BackingStore.h
+++ b/Source/WebKit/UIProcess/BackingStore.h
@@ -54,10 +54,10 @@ public:
 #endif
 
     void paint(PlatformGraphicsContext, const WebCore::IntRect&);
-    void incorporateUpdate(const UpdateInfo&);
+    void incorporateUpdate(UpdateInfo&&);
 
 private:
-    void incorporateUpdate(ShareableBitmap*, const UpdateInfo&);
+    void incorporateUpdate(ShareableBitmap*, UpdateInfo&&);
     void scroll(const WebCore::IntRect& scrollRect, const WebCore::IntSize& scrollOffset);
 
 #if USE(CAIRO)

--- a/Source/WebKit/UIProcess/CoordinatedGraphics/DrawingAreaProxyCoordinatedGraphics.h
+++ b/Source/WebKit/UIProcess/CoordinatedGraphics/DrawingAreaProxyCoordinatedGraphics.h
@@ -63,16 +63,16 @@ private:
 #endif
 
     // IPC message handlers
-    void update(uint64_t backingStoreStateID, const UpdateInfo&) override;
+    void update(uint64_t backingStoreStateID, UpdateInfo&&) override;
     void enterAcceleratedCompositingMode(uint64_t backingStoreStateID, const LayerTreeContext&) override;
-    void exitAcceleratedCompositingMode(uint64_t backingStoreStateID, const UpdateInfo&) override;
+    void exitAcceleratedCompositingMode(uint64_t backingStoreStateID, UpdateInfo&&) override;
     void updateAcceleratedCompositingMode(uint64_t backingStoreStateID, const LayerTreeContext&) override;
     void targetRefreshRateDidChange(unsigned) override;
 
     bool shouldSendWheelEventsToEventDispatcher() const override { return true; }
 
 #if !PLATFORM(WPE)
-    void incorporateUpdate(const UpdateInfo&);
+    void incorporateUpdate(UpdateInfo&&);
 #endif
 
     bool alwaysUseCompositing() const;

--- a/Source/WebKit/UIProcess/DrawingAreaProxy.h
+++ b/Source/WebKit/UIProcess/DrawingAreaProxy.h
@@ -159,8 +159,8 @@ private:
 #endif // PLATFORM(MAC)
 
 #if USE(COORDINATED_GRAPHICS) || USE(TEXTURE_MAPPER)
-    virtual void update(uint64_t /* backingStoreStateID */, const UpdateInfo&) { }
-    virtual void exitAcceleratedCompositingMode(uint64_t /* backingStoreStateID */, const UpdateInfo&) { }
+    virtual void update(uint64_t /* backingStoreStateID */, UpdateInfo&&) { }
+    virtual void exitAcceleratedCompositingMode(uint64_t /* backingStoreStateID */, UpdateInfo&&) { }
 #endif
 };
 

--- a/Source/WebKit/UIProcess/cairo/BackingStoreCairo.cpp
+++ b/Source/WebKit/UIProcess/cairo/BackingStoreCairo.cpp
@@ -73,7 +73,7 @@ void BackingStore::paint(cairo_t* context, const IntRect& rect)
     cairo_restore(context);
 }
 
-void BackingStore::incorporateUpdate(ShareableBitmap* bitmap, const UpdateInfo& updateInfo)
+void BackingStore::incorporateUpdate(ShareableBitmap* bitmap, UpdateInfo&& updateInfo)
 {
     if (!m_backend)
         m_backend = createBackend();

--- a/Source/WebKit/UIProcess/wc/DrawingAreaProxyWC.h
+++ b/Source/WebKit/UIProcess/wc/DrawingAreaProxyWC.h
@@ -51,10 +51,10 @@ private:
     bool shouldSendWheelEventsToEventDispatcher() const final { return true; }
 
     // message handers
-    void update(uint64_t, const UpdateInfo&) override;
+    void update(uint64_t, UpdateInfo&&) override;
     void enterAcceleratedCompositingMode(uint64_t, const LayerTreeContext&) override;
 
-    void incorporateUpdate(const UpdateInfo&);
+    void incorporateUpdate(UpdateInfo&&);
     void discardBackingStore();
 
     uint64_t m_currentBackingStoreStateID { 0 };


### PR DESCRIPTION
#### 970189b6617f75784fdc0b692b301740b36e148a
<pre>
Use move semantics for UpdateInfo
<a href="https://bugs.webkit.org/show_bug.cgi?id=256273">https://bugs.webkit.org/show_bug.cgi?id=256273</a>

Reviewed by Carlos Garcia Campos and Kimmo Kinnunen.

Use move semantics so ShareableBitmap::Handle can use them to denote
ownership.

* Source/WebKit/UIProcess/BackingStore.cpp:
* Source/WebKit/UIProcess/BackingStore.h:
* Source/WebKit/UIProcess/CoordinatedGraphics/DrawingAreaProxyCoordinatedGraphics.cpp:
* Source/WebKit/UIProcess/CoordinatedGraphics/DrawingAreaProxyCoordinatedGraphics.h:
* Source/WebKit/UIProcess/DrawingAreaProxy.h:
* Source/WebKit/UIProcess/cairo/BackingStoreCairo.cpp:
* Source/WebKit/UIProcess/wc/DrawingAreaProxyWC.cpp:
* Source/WebKit/UIProcess/wc/DrawingAreaProxyWC.h:

Canonical link: <a href="https://commits.webkit.org/263674@main">https://commits.webkit.org/263674@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/79a97087fbaa494ea78610d6df751ae2067dbec6

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/5349 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/5486 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/5674 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/6886 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/5389 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/5713 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/5467 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/6080 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/5448 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/5524 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/4793 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/6912 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/3003 "Passed tests") | | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/11955 "181 failures") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/4869 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/4877 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/6495 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/5304 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/4358 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/4768 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/1294 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/8865 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/5129 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->