### PR TITLE
[Tools][CISupport] start-local-buildbot-server fails to start or detect the http config ports

### DIFF
--- a/Tools/CISupport/start-local-buildbot-server
+++ b/Tools/CISupport/start-local-buildbot-server
@@ -128,20 +128,34 @@ class BuildbotTestRunner(object):
         self._server_http_port, self._server_pb_port = self._get_config_tcp_ports()
 
     def _get_config_tcp_ports(self):
-        pb_port = 17000
-        http_port = 8010
-        try:
-            with open(os.path.join(self._configdir, self._server_config_file_name)) as f:
-                for line in f:
-                    if '=' in line:
-                        if 'protocols' in line and 'pb' in line and 'port' in line:
-                            pb = eval(line.split('=', 1)[1])
-                            pb_port = int((pb['pb']['port']))
-                        if 'www' in line and 'port' in line:
-                            http = eval(line.split('=', 1)[1])
-                            http_port = int((http['port']))
-        except:
-            print("Unable to detect http and pb ports from config. Using defaults")
+
+        def get_numeric_from_port_line(line):
+            port_string = str(line)
+            if 'tcp:' in port_string:
+                port_string = port_string.split('tcp:', 1)[1]
+                if ':' in port_string:
+                    port_string = port_string.split(':', 1)[0]
+            if port_string.isnumeric():
+                return int((port_string))
+            return None
+
+        pb_port = None
+        http_port = None
+        with open(os.path.join(self._configdir, self._server_config_file_name)) as f:
+            for line in f:
+                if '=' in line:
+                    if 'protocols' in line and 'pb' in line and 'port' in line:
+                        pb = eval(line.split('=', 1)[1])
+                        pb_port = get_numeric_from_port_line(pb['pb']['port'])
+                    if 'www' in line and 'port' in line:
+                        http = eval(line.split('=', 1)[1])
+                        http_port = get_numeric_from_port_line(http['port'])
+        if pb_port is None:
+            print("Unable to detect pb port from config. Using default")
+            pb_port = 17000
+        if http_port is None:
+            print("Unable to detect http port from config. Using default")
+            http_port = 8010
         return http_port, pb_port
 
     def start(self, basetempdir=None, no_clean=False, number_workers=1, use_system_version=False):
@@ -263,9 +277,11 @@ class BuildbotTestRunner(object):
                        'buildbot-waterfall-view=={}'.format(buildbot_version),
                        'buildbot-worker=={}'.format(buildbot_version),
                        'buildbot-www=={}'.format(buildbot_version),
-                       'twisted==21.2.0',
+                       'lz4==1.1.0',
+                       'mock==4',
+                       'rapidfuzz==2.11.1',
                        'requests==2.21.0',
-                       'lz4==1.1.0']
+                       'twisted==21.2.0']
             pip_process = subprocess.Popen(pip_cmd, cwd=self._base_workdir_temp,
                                            stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
             stdout, stderr = pip_process.communicate()


### PR DESCRIPTION
#### 7b95348e510900f30d6c53184bc29e3dd38a0fc7
<pre>
[Tools][CISupport] start-local-buildbot-server fails to start or detect the http config ports
<a href="https://bugs.webkit.org/show_bug.cgi?id=256277">https://bugs.webkit.org/show_bug.cgi?id=256277</a>

Reviewed by Jonathan Bedard.

Install new required python modules for the EWS config on the virtual env,
and improve the function to detect the http/pb ports so it handles properly
the case when the port value is a string like &apos;tcp:8710:interface=127.0.0.1&apos;

* Tools/CISupport/start-local-buildbot-server:

Canonical link: <a href="https://commits.webkit.org/263676@main">https://commits.webkit.org/263676@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c953789991893447a9e9f81c7debb3c16b5f4860

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/5353 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/5490 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/5678 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/6890 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/5392 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/5353 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/5717 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/5471 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/6081 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/5452 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/5526 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/4796 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/6917 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/3005 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/4801 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/11956 "2 flakes 178 failures") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/4871 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/4880 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/6497 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/5308 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/4361 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/4772 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/8869 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/613 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/5133 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->