### PR TITLE
REGRESSION(263286@main): [ Debug ] ASSERTION FAILED: !m_scrollDimensionsDirty

### DIFF
--- a/LayoutTests/fast/layers/scroll-dimentions-dirty-assertion-expected.txt
+++ b/LayoutTests/fast/layers/scroll-dimentions-dirty-assertion-expected.txt
@@ -1,0 +1,1 @@
+This test should not assert Hello world

--- a/LayoutTests/fast/layers/scroll-dimentions-dirty-assertion.html
+++ b/LayoutTests/fast/layers/scroll-dimentions-dirty-assertion.html
@@ -1,0 +1,35 @@
+<!DOCTYPE html>
+<html>
+<head>
+	<style>
+		span {
+			display: inline-block;
+			width: 28px;
+			height: 40px;
+			margin: 0;
+			word-break: break-all;
+			font-size: 32px;
+		}
+		a {
+			display: block;
+			width: 100px;
+			height: 100px;
+			overflow: hidden;
+		}
+	</style>
+	<script>
+		if (window.testRunner)
+			testRunner.dumpAsText();
+
+		window.addEventListener('load', () => {
+			document.body.offsetWidth;
+			const target = document.getElementById('target');
+			target.textContent = "This test should not assert";
+			target.style.overflowX = 'hidden';
+		}, false);
+	</script>
+</head>
+<body>
+	<a><span id="target">A</span> Hello world</a>
+</body>
+</html>

--- a/Source/WebCore/rendering/RenderLayer.cpp
+++ b/Source/WebCore/rendering/RenderLayer.cpp
@@ -2766,6 +2766,12 @@ bool RenderLayer::hasCompositedScrollableOverflow() const
     return false;
 }
 
+void RenderLayer::computeHasCompositedScrollableOverflow(LayoutUpToDate layoutUpToDate)
+{
+    if (m_scrollableArea)
+        m_scrollableArea->computeHasCompositedScrollableOverflow(layoutUpToDate);
+}
+
 bool RenderLayer::hasOverlayScrollbars() const
 {
     if (m_scrollableArea)
@@ -5408,7 +5414,7 @@ void RenderLayer::styleChanged(StyleDifference diff, const RenderStyle* oldStyle
         // Visibility and scrollability are input to canUseCompositedScrolling().
         if (m_scrollableArea) {
             if (visibilityChanged || oldStyle->isOverflowVisible() != renderer().style().isOverflowVisible())
-                m_scrollableArea->computeHasCompositedScrollableOverflow();
+                m_scrollableArea->computeHasCompositedScrollableOverflow(LayoutUpToDate::No);
         }
     }
 

--- a/Source/WebCore/rendering/RenderLayer.h
+++ b/Source/WebCore/rendering/RenderLayer.h
@@ -89,6 +89,7 @@ class TransformationMatrix;
 enum BorderRadiusClippingRule { IncludeSelfForBorderRadius, DoNotIncludeSelfForBorderRadius };
 enum IncludeSelfOrNot { IncludeSelf, ExcludeSelf };
 enum CrossFrameBoundaries : bool { No, Yes };
+enum class LayoutUpToDate : bool { No, Yes };
 
 enum RepaintStatus {
     NeedsNormalRepaint,
@@ -465,6 +466,7 @@ public:
     bool canUseCompositedScrolling() const;
     // Returns true when there is actually scrollable overflow (requires layout to be up-to-date).
     bool hasCompositedScrollableOverflow() const;
+    void computeHasCompositedScrollableOverflow(LayoutUpToDate);
 
     bool hasOverlayScrollbars() const;
 

--- a/Source/WebCore/rendering/RenderLayerCompositor.cpp
+++ b/Source/WebCore/rendering/RenderLayerCompositor.cpp
@@ -3446,6 +3446,7 @@ bool RenderLayerCompositor::requiresCompositingForOverflowScrolling(const Render
         return layer.isComposited();
     }
 
+    const_cast<RenderLayer&>(layer).computeHasCompositedScrollableOverflow(LayoutUpToDate::Yes);
     return layer.hasCompositedScrollableOverflow();
 }
 

--- a/Source/WebCore/rendering/RenderLayerCompositor.h
+++ b/Source/WebCore/rendering/RenderLayerCompositor.h
@@ -198,8 +198,6 @@ public:
     // Update event regions, which only needs to happen once per rendering update.
     void updateEventRegions();
 
-    enum class LayoutUpToDate : bool { No, Yes };
-
     struct RequiresCompositingData {
         LayoutUpToDate layoutUpToDate { LayoutUpToDate::Yes };
         RenderLayer::ViewportConstrainedNotCompositedReason nonCompositedForPositionReason { RenderLayer::NoNotCompositedReason };

--- a/Source/WebCore/rendering/RenderLayerScrollableArea.cpp
+++ b/Source/WebCore/rendering/RenderLayerScrollableArea.cpp
@@ -1085,7 +1085,7 @@ void RenderLayerScrollableArea::computeScrollDimensions()
     m_scrollHeight = roundToInt(overflowBottom() - overflowTop());
 
     computeScrollOrigin();
-    computeHasCompositedScrollableOverflow();
+    computeHasCompositedScrollableOverflow(LayoutUpToDate::Yes);
 }
 
 void RenderLayerScrollableArea::computeScrollOrigin()
@@ -1105,9 +1105,21 @@ void RenderLayerScrollableArea::computeScrollOrigin()
         m_hBar->offsetDidChange();
 }
 
-void RenderLayerScrollableArea::computeHasCompositedScrollableOverflow()
+void RenderLayerScrollableArea::computeHasCompositedScrollableOverflow(LayoutUpToDate layoutUpToDate)
 {
-    bool hasCompositedScrollableOverflow = canUseCompositedScrolling() && (hasScrollableHorizontalOverflow() || hasScrollableVerticalOverflow());
+    bool hasCompositedScrollableOverflow = m_hasCompositedScrollableOverflow;
+
+    switch (layoutUpToDate) {
+    case LayoutUpToDate::No:
+        // If layout is not up to date, the only thing we can reliably know is that style prevents overflow scrolling.
+        if (!canUseCompositedScrolling())
+            hasCompositedScrollableOverflow = false;
+        break;
+    case LayoutUpToDate::Yes:
+        hasCompositedScrollableOverflow = canUseCompositedScrolling() && (hasScrollableHorizontalOverflow() || hasScrollableVerticalOverflow());
+        break;
+    }
+
     if (hasCompositedScrollableOverflow == m_hasCompositedScrollableOverflow)
         return;
 
@@ -1286,7 +1298,6 @@ void RenderLayerScrollableArea::updateScrollbarSteps()
         m_vBar->setSteps(Scrollbar::pixelsPerLineStep(height), Scrollbar::pageStep(height));
     }
 }
-
 
 // This is called from layout code (before updateLayerPositions).
 void RenderLayerScrollableArea::updateScrollInfoAfterLayout()

--- a/Source/WebCore/rendering/RenderLayerScrollableArea.h
+++ b/Source/WebCore/rendering/RenderLayerScrollableArea.h
@@ -236,7 +236,7 @@ public:
 
     bool scrollingMayRevealBackground() const;
 
-    void computeHasCompositedScrollableOverflow();
+    void computeHasCompositedScrollableOverflow(LayoutUpToDate);
 
     // NOTE: This should only be called by the overridden setScrollOffset from ScrollableArea.
     void scrollTo(const ScrollPosition&);


### PR DESCRIPTION
#### 3a9fba1a0f45a422ca23ce9f157a576e938925ed
<pre>
REGRESSION(263286@main): [ Debug ] ASSERTION FAILED: !m_scrollDimensionsDirty
<a href="https://bugs.webkit.org/show_bug.cgi?id=256177">https://bugs.webkit.org/show_bug.cgi?id=256177</a>
rdar://108753838

Reviewed by Alan Baradlay.

263286@main made us call computeHasCompositedScrollableOverflow() in more cases; doing this from
`RenderLayer::styleChanged()` was already wrong, because layout is not up-to-date then, so asking
questions about overflow geometry is not valid.

Fix by passing LayoutUpToDate; if No, the only thing we can do is to consult the style to see
if it prevents overflow scrolling.

In order to not regress 225752@main, we need to eagerly recompute layer.hasCompositedScrollableOverflow()
in RenderLayerCompositor::requiresCompositingForOverflowScrolling().

* LayoutTests/fast/layers/scroll-dimentions-dirty-assertion.html: Added.
* LayoutTests/fast/layers/scroll-dimentions-dirty-assertion-expected.txt: Added.
* Source/WebCore/rendering/RenderLayer.cpp:
(WebCore::RenderLayer::calculateClipRects const):
* Source/WebCore/rendering/RenderLayer.h:
* Source/WebCore/rendering/RenderLayerCompositor.h:
* Source/WebCore/rendering/RenderLayerScrollableArea.cpp:
(WebCore::RenderLayerScrollableArea::computeScrollDimensions):
(WebCore::RenderLayerScrollableArea::computeHasCompositedScrollableOverflow):
* Source/WebCore/rendering/RenderLayerScrollableArea.h:

Canonical link: <a href="https://commits.webkit.org/263722@main">https://commits.webkit.org/263722@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/52eb74641ab486d03816239bf45d018b59fd6586

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/5513 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/5660 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/5849 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/7059 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/5522 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/5511 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/5885 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/5634 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/6885 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/5614 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/5673 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/4931 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/7122 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/3150 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/4947 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/12102 "31 flakes 138 failures") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/5016 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/5027 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/6798 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/5465 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/4477 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/4920 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/4901 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/1321 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/9024 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/5282 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->