### PR TITLE
[WPE] Add new post-commit bots for performance tests with RPis

### DIFF
--- a/Tools/CISupport/build-webkit-org/config.json
+++ b/Tools/CISupport/build-webkit-org/config.json
@@ -124,7 +124,25 @@
                   { "name": "wpe-linux-bot-13", "platform": "wpe" },
                   { "name": "wpe-linux-bot-14", "platform": "wpe" },
                   { "name": "wpe-linux-bot-15", "platform": "wpe" },
-                  { "name": "wpe-linux-bot-16", "platform": "wpe" }
+                  { "name": "wpe-linux-bot-16", "platform": "wpe" },
+                  { "name": "wpe-linux-bot-17", "platform": "wpe" },
+                  { "name": "wpe-linux-bot-18", "platform": "wpe" },
+                  { "name": "wpe-linux-bot-19", "platform": "wpe" },
+                  { "name": "wpe-linux-bot-20", "platform": "wpe" },
+                  { "name": "wpe-linux-bot-21", "platform": "wpe" },
+                  { "name": "wpe-linux-bot-22", "platform": "wpe" },
+                  { "name": "wpe-linux-bot-23", "platform": "wpe" },
+                  { "name": "wpe-linux-bot-24", "platform": "wpe" },
+                  { "name": "wpe-linux-bot-25", "platform": "wpe" },
+                  { "name": "wpe-linux-bot-26", "platform": "wpe" },
+                  { "name": "wpe-linux-bot-27", "platform": "wpe" },
+                  { "name": "wpe-linux-bot-28", "platform": "wpe" },
+                  { "name": "wpe-linux-bot-29", "platform": "wpe" },
+                  { "name": "wpe-linux-bot-30", "platform": "wpe" },
+                  { "name": "wpe-linux-bot-31", "platform": "wpe" },
+                  { "name": "wpe-linux-bot-32", "platform": "wpe" },
+                  { "name": "wpe-linux-bot-33", "platform": "wpe" },
+                  { "name": "wpe-linux-bot-34", "platform": "wpe" }
                 ],
 
   "builders":   [
@@ -405,19 +423,19 @@
                     "workernames": ["gtk-linux-bot-9"]
                   },
                   {
-                    "name": "GTK-Linux-64-bit-Release-Debian-Stable-Build", "factory": "BuildFactory",
+                    "name": "GTK-Linux-64-bit-Release-Debian-Stable-Build", "factory": "NoInstallDependenciesBuildFactory",
                     "platform": "gtk", "configuration": "release", "architectures": ["x86_64"],
                     "additionalArguments": ["--no-experimental-features"],
                     "workernames": ["gtk-linux-bot-10"]
                   },
                   {
-                    "name": "GTK-Linux-64-bit-Release-Ubuntu-2004-Build", "factory": "BuildFactory",
+                    "name": "GTK-Linux-64-bit-Release-Ubuntu-2004-Build", "factory": "NoInstallDependenciesBuildFactory",
                     "platform": "gtk", "configuration": "release", "architectures": ["x86_64"],
                     "additionalArguments": ["--no-experimental-features"],
                     "workernames": ["gtk-linux-bot-11"]
                   },
                   {
-                    "name": "GTK-Linux-64-bit-Release-Ubuntu-LTS-Build", "factory": "BuildFactory",
+                    "name": "GTK-Linux-64-bit-Release-Ubuntu-LTS-Build", "factory": "NoInstallDependenciesBuildFactory",
                     "platform": "gtk", "configuration": "release", "architectures": ["x86_64"],
                     "additionalArguments": ["--no-experimental-features"],
                     "workernames": ["gtk-linux-bot-21"]
@@ -556,13 +574,13 @@
                     "workernames": ["wpe-linux-bot-9"]
                   },
                   {
-                    "name": "WPE-Linux-64-bit-Release-Ubuntu-2004-Build", "factory": "BuildFactory",
+                    "name": "WPE-Linux-64-bit-Release-Ubuntu-2004-Build", "factory": "NoInstallDependenciesBuildFactory",
                     "platform": "wpe", "configuration": "release", "architectures": ["x86_64"],
                     "additionalArguments": ["--no-experimental-features"],
                     "workernames": ["wpe-linux-bot-10"]
                   },
                   {
-                    "name": "WPE-Linux-64-bit-Release-Ubuntu-LTS-Build", "factory": "BuildFactory",
+                    "name": "WPE-Linux-64-bit-Release-Ubuntu-LTS-Build", "factory": "NoInstallDependenciesBuildFactory",
                     "platform": "wpe", "configuration": "release", "architectures": ["x86_64"],
                     "additionalArguments": ["--no-experimental-features"],
                     "workernames": ["wpe-linux-bot-11"]
@@ -583,17 +601,41 @@
                     "workernames": ["wpe-linux-bot-14"]
                   },
                   {
-                    "name": "WPE-Linux-ARM64-bit-Release-Debian-Stable-Build", "factory": "BuildFactory",
+                    "name": "WPE-Linux-ARM64-bit-Release-Debian-Stable-Build", "factory": "NoInstallDependenciesBuildFactory",
                     "platform": "wpe", "configuration": "release", "architectures": ["arm64"],
                     "additionalArguments": ["--no-experimental-features"],
                     "workernames": ["wpe-linux-bot-15"]
                   },
                   {
-                    "name": "WPE-Linux-ARM32-bit-Release-Debian-Stable-Build", "factory": "BuildFactory",
+                    "name": "WPE-Linux-ARM32-bit-Release-Debian-Stable-Build", "factory": "NoInstallDependenciesBuildFactory",
                     "platform": "wpe", "configuration": "release", "architectures": ["armv7"],
                     "additionalArguments": ["--no-experimental-features"],
                     "workernames": ["wpe-linux-bot-16"]
-                  }
+                  },
+                  {
+                    "name": "WPE-Linux-RPi4-32bits-Mesa-Release-Perf-Build", "factory": "CrossTargetBuildFactory",
+                    "platform": "wpe", "configuration": "release", "architectures": ["armv7"],
+                    "additionalArguments": ["--cross-target=rpi4-32bits-mesa"],
+                    "triggers": ["wpe-linux-rpi4-32-mesa-release-perf-tests"],
+                    "workernames": ["wpe-linux-bot-17"]
+                  },
+                  {
+                    "name": "WPE-Linux-RPi4-64bits-Mesa-Release-Perf-Build", "factory": "CrossTargetBuildFactory",
+                    "platform": "wpe", "configuration": "release", "architectures": ["arm64"],
+                    "additionalArguments": ["--cross-target=rpi4-64bits-mesa"],
+                    "triggers": ["wpe-linux-rpi4-64-mesa-release-perf-tests"],
+                    "workernames": ["wpe-linux-bot-18"]
+                  },
+                  {
+                    "name": "WPE-Linux-RPi4-32bits-Mesa-Release-Perf-Tests", "factory": "CrossTargetDownloadAndPerfTestFactory",
+                    "platform": "wpe", "configuration": "release", "architectures": ["armv7"],
+                    "workernames": ["wpe-linux-bot-19", "wpe-linux-bot-20", "wpe-linux-bot-21", "wpe-linux-bot-22", "wpe-linux-bot-23", "wpe-linux-bot-24", "wpe-linux-bot-25", "wpe-linux-bot-26"]
+                  },
+                  {
+                    "name": "WPE-Linux-RPi4-64bits-Mesa-Release-Perf-Tests", "factory": "CrossTargetDownloadAndPerfTestFactory",
+                    "platform": "wpe", "configuration": "release", "architectures": ["arm64"],
+                    "workernames": ["wpe-linux-bot-27", "wpe-linux-bot-28", "wpe-linux-bot-29", "wpe-linux-bot-30", "wpe-linux-bot-31", "wpe-linux-bot-32", "wpe-linux-bot-33", "wpe-linux-bot-34"]
+                   }
                 ],
 
   "schedulers": [ { "type": "AnyBranchScheduler", "name": "main", "change_filter": "main_filter", "treeStableTimer": 45.0,
@@ -605,6 +647,8 @@
                                      "GTK-Linux-64-bit-Release-GTK4-Tests",
                                      "WPE-Linux-64-bit-Release-Ubuntu-2004-Build",
                                      "WPE-Linux-64-bit-Release-Ubuntu-LTS-Build",
+                                     "WPE-Linux-RPi4-32bits-Mesa-Release-Perf-Build",
+                                     "WPE-Linux-RPi4-64bits-Mesa-Release-Perf-Build",
                                      "JSCOnly-Linux-AArch64-Release",
                                      "JSCOnly-Linux-ARMv7-Thumb2-Release",
                                      "JSCOnly-Linux-MIPS32el-Release", "PlayStation-Release-Build", "PlayStation-Debug-Build",
@@ -787,6 +831,12 @@
                   },
                   { "type": "Triggerable", "name": "wpe-linux-64-debug-tests-webdriver",
                     "builderNames": ["WPE-Linux-64-bit-Debug-WebDriver-Tests"]
+                  },
+                  { "type": "Triggerable", "name": "wpe-linux-rpi4-32-mesa-release-perf-tests",
+                    "builderNames": ["WPE-Linux-RPi4-32bits-Mesa-Release-Perf-Tests"]
+                  },
+                  { "type": "Triggerable", "name": "wpe-linux-rpi4-64-mesa-release-perf-tests",
+                    "builderNames": ["WPE-Linux-RPi4-64bits-Mesa-Release-Perf-Tests"]
                   },
                   { "type": "Nightly", "name": "NightlyScheduler", "change_filter": "main_filter",
                     "branch": "main", "hour": 22, "minute": 0,

--- a/Tools/CISupport/build-webkit-org/factories_unittest.py
+++ b/Tools/CISupport/build-webkit-org/factories_unittest.py
@@ -1587,6 +1587,66 @@ class TestExpectedBuildSteps(unittest.TestCase):
             'delete-stale-build-files',
             'compile-webkit'
         ],
+        'WPE-Linux-RPi4-32bits-Mesa-Release-Perf-Build': [
+            'configure-build',
+            'configuration',
+            'clean-and-update-working-directory',
+            'checkout-specific-revision',
+            'show-identifier',
+            'kill-old-processes',
+            'delete-WebKitBuild-directory',
+            'delete-stale-build-files',
+            'compile-webkit',
+            'check-if-deployed-cross-target-image-is-updated',
+            'archive-built-product',
+            'upload-built-product',
+            'transfer-to-s3',
+            'trigger'
+        ],
+        'WPE-Linux-RPi4-64bits-Mesa-Release-Perf-Build': [
+            'configure-build',
+            'configuration',
+            'clean-and-update-working-directory',
+            'checkout-specific-revision',
+            'show-identifier',
+            'kill-old-processes',
+            'delete-WebKitBuild-directory',
+            'delete-stale-build-files',
+            'compile-webkit',
+            'check-if-deployed-cross-target-image-is-updated',
+            'archive-built-product',
+            'upload-built-product',
+            'transfer-to-s3',
+            'trigger'
+        ],
+        'WPE-Linux-RPi4-32bits-Mesa-Release-Perf-Tests': [
+            'configure-build',
+            'configuration',
+            'clean-and-update-working-directory',
+            'checkout-specific-revision',
+            'show-identifier',
+            'kill-old-processes',
+            'delete-WebKitBuild-directory',
+            'delete-stale-build-files',
+            'check-if-running-cross-target-image-is-updated',
+            'download-built-product',
+            'extract-built-product',
+            'benchmark-test'
+        ],
+        'WPE-Linux-RPi4-64bits-Mesa-Release-Perf-Tests': [
+            'configure-build',
+            'configuration',
+            'clean-and-update-working-directory',
+            'checkout-specific-revision',
+            'show-identifier',
+            'kill-old-processes',
+            'delete-WebKitBuild-directory',
+            'delete-stale-build-files',
+            'check-if-running-cross-target-image-is-updated',
+            'download-built-product',
+            'extract-built-product',
+            'benchmark-test'
+        ],
     }
 
     def setUp(self):

--- a/Tools/CISupport/build-webkit-org/steps.py
+++ b/Tools/CISupport/build-webkit-org/steps.py
@@ -49,6 +49,36 @@ WithProperties = properties.WithProperties
 Interpolate = properties.Interpolate
 
 
+class CustomFlagsMixin(object):
+
+    def appendCrossTargetFlags(self, additionalArguments):
+        if additionalArguments:
+            for additionalArgument in additionalArguments:
+                if additionalArgument.startswith('--cross-target='):
+                    self.command.append(additionalArgument)
+                    return
+
+    def appendCustomBuildFlags(self, platform, fullPlatform):
+        if platform not in ('gtk', 'wincairo', 'ios', 'jsc-only', 'wpe', 'playstation', 'tvos', 'watchos',):
+            return
+        if 'simulator' in fullPlatform:
+            platform = platform + '-simulator'
+        elif platform in ['ios', 'tvos', 'watchos']:
+            platform = platform + '-device'
+        self.setCommand(self.command + ['--' + platform])
+
+    def appendCustomTestingFlags(self, platform, device_model):
+        if platform not in ('gtk', 'wincairo', 'ios', 'jsc-only', 'wpe'):
+            return
+        if device_model == 'iphone':
+            device_model = 'iphone-simulator'
+        elif device_model == 'ipad':
+            device_model = 'ipad-simulator'
+        else:
+            device_model = platform
+        self.setCommand(self.command + ['--' + device_model])
+
+
 class ParseByLineLogObserver(logobserver.LineConsumerLogObserver):
     """A pretty wrapper for LineConsumerLogObserver to avoid
        repeatedly setting up generator processors."""
@@ -271,45 +301,31 @@ class InstallWinCairoDependencies(shell.ShellCommandNewStyle):
     haltOnFailure = True
 
 
-class InstallGtkDependencies(shell.ShellCommandNewStyle):
+class InstallGtkDependencies(shell.ShellCommandNewStyle, CustomFlagsMixin):
     name = "jhbuild"
     description = ["updating gtk dependencies"]
     descriptionDone = ["updated gtk dependencies"]
     command = ["perl", "Tools/Scripts/update-webkitgtk-libs", WithProperties("--%(configuration)s")]
     haltOnFailure = True
 
+    def run(self):
+        self.appendCrossTargetFlags(self.getProperty('additionalArguments'))
+        return super().run()
 
-class InstallWpeDependencies(shell.ShellCommandNewStyle):
+
+class InstallWpeDependencies(shell.ShellCommandNewStyle, CustomFlagsMixin):
     name = "jhbuild"
     description = ["updating wpe dependencies"]
     descriptionDone = ["updated wpe dependencies"]
     command = ["perl", "Tools/Scripts/update-webkitwpe-libs", WithProperties("--%(configuration)s")]
     haltOnFailure = True
 
-
-def appendCustomBuildFlags(step, platform, fullPlatform):
-    if platform not in ('gtk', 'wincairo', 'ios', 'jsc-only', 'wpe', 'playstation', 'tvos', 'watchos',):
-        return
-    if 'simulator' in fullPlatform:
-        platform = platform + '-simulator'
-    elif platform in ['ios', 'tvos', 'watchos']:
-        platform = platform + '-device'
-    step.setCommand(step.command + ['--' + platform])
+    def run(self):
+        self.appendCrossTargetFlags(self.getProperty('additionalArguments'))
+        return super().run()
 
 
-def appendCustomTestingFlags(step, platform, device_model):
-    if platform not in ('gtk', 'wincairo', 'ios', 'jsc-only', 'wpe'):
-        return
-    if device_model == 'iphone':
-        device_model = 'iphone-simulator'
-    elif device_model == 'ipad':
-        device_model = 'ipad-simulator'
-    else:
-        device_model = platform
-    step.setCommand(step.command + ['--' + device_model])
-
-
-class CompileWebKit(shell.Compile):
+class CompileWebKit(shell.Compile, CustomFlagsMixin):
     command = ["perl", "Tools/Scripts/build-webkit", "--no-fatal-warnings", WithProperties("--%(configuration)s")]
     env = {'MFLAGS': ''}
     name = "compile-webkit"
@@ -349,7 +365,7 @@ class CompileWebKit(shell.Compile):
             prefix = os.path.join("/app", "webkit", "WebKitBuild", self.getProperty("configuration").title(), "install")
             self.setCommand(self.command + [f'--prefix={prefix}'])
 
-        appendCustomBuildFlags(self, platform, self.getProperty('fullPlatform'))
+        self.appendCustomBuildFlags(platform, self.getProperty('fullPlatform'))
 
         return shell.Compile.start(self)
 
@@ -405,13 +421,18 @@ class InstallBuiltProduct(shell.ShellCommandNewStyle):
                WithProperties("--platform=%(fullPlatform)s"), WithProperties("--%(configuration)s")]
 
 
-class ArchiveBuiltProduct(shell.ShellCommandNewStyle):
+class ArchiveBuiltProduct(shell.ShellCommandNewStyle, CustomFlagsMixin):
     command = ["python3", "Tools/CISupport/built-product-archive",
-               WithProperties("--platform=%(fullPlatform)s"), WithProperties("--%(configuration)s"), "archive"]
+               WithProperties("--platform=%(fullPlatform)s"), WithProperties("--%(configuration)s")]
     name = "archive-built-product"
     description = ["archiving built product"]
     descriptionDone = ["archived built product"]
     haltOnFailure = True
+
+    def run(self):
+        self.appendCrossTargetFlags(self.getProperty('additionalArguments'))
+        self.command.append("archive")
+        return super().run()
 
 
 class ArchiveMinifiedBuiltProduct(ArchiveBuiltProduct):
@@ -567,7 +588,7 @@ class DownloadBuiltProductFromMaster(transfer.FileDownload):
         return super(DownloadBuiltProductFromMaster, self).getResultSummary()
 
 
-class RunJavaScriptCoreTests(TestWithFailureCount):
+class RunJavaScriptCoreTests(TestWithFailureCount, CustomFlagsMixin):
     name = "jscore-test"
     description = ["jscore-tests running"]
     descriptionDone = ["jscore-tests"]
@@ -616,7 +637,7 @@ class RunJavaScriptCoreTests(TestWithFailureCount):
         elif platform == 'wincairo':
             self.setCommand(self.command + ['--test-writer=ruby'])
 
-        appendCustomBuildFlags(self, platform, self.getProperty('fullPlatform'))
+        self.appendCustomBuildFlags(platform, self.getProperty('fullPlatform'))
         return shell.Test.start(self)
 
     def countFailures(self, cmd):
@@ -638,7 +659,7 @@ class RunJavaScriptCoreTests(TestWithFailureCount):
         return count
 
 
-class RunTest262Tests(TestWithFailureCount):
+class RunTest262Tests(TestWithFailureCount, CustomFlagsMixin):
     name = "test262-test"
     description = ["test262-tests running"]
     descriptionDone = ["test262-tests"]
@@ -650,7 +671,7 @@ class RunTest262Tests(TestWithFailureCount):
         self.log_observer = ParseByLineLogObserver(self.parseOutputLine)
         self.addLogObserver('stdio', self.log_observer)
         self.failedTestCount = 0
-        appendCustomBuildFlags(self, self.getProperty('platform'), self.getProperty('fullPlatform'))
+        self.appendCustomBuildFlags(self.getProperty('platform'), self.getProperty('fullPlatform'))
         return shell.Test.start(self)
 
     def parseOutputLine(self, line):
@@ -662,7 +683,7 @@ class RunTest262Tests(TestWithFailureCount):
         return self.failedTestCount
 
 
-class RunWebKitTests(shell.Test):
+class RunWebKitTests(shell.Test, CustomFlagsMixin):
     name = "layout-test"
     description = ["layout-tests running"]
     descriptionDone = ["layout-tests"]
@@ -702,7 +723,7 @@ class RunWebKitTests(shell.Test):
         self.testFailures = {}
 
         platform = self.getProperty('platform')
-        appendCustomTestingFlags(self, platform, self.getProperty('device_model'))
+        self.appendCustomTestingFlags(platform, self.getProperty('device_model'))
         additionalArguments = self.getProperty('additionalArguments')
 
         self.setCommand(self.command + ["--results-directory", self.resultDirectory])
@@ -784,7 +805,7 @@ class RunDashboardTests(RunWebKitTests):
         return RunWebKitTests.start(self)
 
 
-class RunAPITests(TestWithFailureCount):
+class RunAPITests(TestWithFailureCount, CustomFlagsMixin):
     name = "run-api-tests"
     VALID_ADDITIONAL_ARGUMENTS_LIST = ["--remote-layer-tree", "--use-gpu-process"]
     description = ["api tests running"]
@@ -816,7 +837,7 @@ class RunAPITests(TestWithFailureCount):
         self.log_observer = ParseByLineLogObserver(self.parseOutputLine)
         self.addLogObserver('stdio', self.log_observer)
         self.failedTestCount = 0
-        appendCustomTestingFlags(self, self.getProperty('platform'), self.getProperty('device_model'))
+        self.appendCustomTestingFlags(self.getProperty('platform'), self.getProperty('device_model'))
         additionalArguments = self.getProperty("additionalArguments")
         for additionalArgument in additionalArguments or []:
             if additionalArgument in self.VALID_ADDITIONAL_ARGUMENTS_LIST:
@@ -1091,7 +1112,7 @@ class RunWPEAPITests(RunGLibAPITests):
     command = ["python3", "Tools/Scripts/run-wpe-tests", WithProperties("--%(configuration)s")]
 
 
-class RunWebDriverTests(shell.Test):
+class RunWebDriverTests(shell.Test, CustomFlagsMixin):
     name = "webdriver-test"
     description = ["webdriver-tests running"]
     descriptionDone = ["webdriver-tests"]
@@ -1104,7 +1125,7 @@ class RunWebDriverTests(shell.Test):
         if additionalArguments:
             self.setCommand(self.command + additionalArguments)
 
-        appendCustomBuildFlags(self, self.getProperty('platform'), self.getProperty('fullPlatform'))
+        self.appendCustomBuildFlags(self.getProperty('platform'), self.getProperty('fullPlatform'))
         return shell.Test.start(self)
 
     def commandComplete(self, cmd):
@@ -1449,3 +1470,68 @@ class ShowIdentifier(shell.ShellCommandNewStyle):
 
     def hideStepIf(self, results, step):
         return results == SUCCESS
+
+
+class CheckIfNeededUpdateDeployedCrossTargetImage(shell.ShellCommandNewStyle, CustomFlagsMixin):
+    command = ["python3", "Tools/Scripts/cross-toolchain-helper", "--check-if-image-is-updated", "deployed"]
+    name = "check-if-deployed-cross-target-image-is-updated"
+    description = ["checking if deployed cross target image is updated"]
+    descriptionDone = ["deployed cross target image is updated"]
+    haltOnFailure = False
+    flunkOnFailure = False
+    warnOnFailure = False
+
+    @defer.inlineCallbacks
+    def run(self):
+        self.appendCrossTargetFlags(self.getProperty('additionalArguments'))
+        rc = yield super().run()
+        if rc != SUCCESS:
+            self.build.addStepsAfterCurrentStep([BuildAndDeployCrossTargetImage()])
+        defer.returnValue(rc)
+
+
+class CheckIfNeededUpdateRunningCrossTargetImage(shell.ShellCommandNewStyle):
+    command = ["python3", "Tools/Scripts/cross-toolchain-helper", "--check-if-image-is-updated", "running"]
+    name = "check-if-running-cross-target-image-is-updated"
+    description = ["checking if running cross target image is updated"]
+    descriptionDone = ["running cross target image is updated"]
+    haltOnFailure = False
+    flunkOnFailure = False
+    warnOnFailure = False
+
+    @defer.inlineCallbacks
+    def run(self):
+        rc = yield super().run()
+        if rc != SUCCESS:
+            self.build.addStepsAfterCurrentStep([RebootWithUpdatedCrossTargetImage()])
+        defer.returnValue(rc)
+
+
+class BuildAndDeployCrossTargetImage(shell.ShellCommandNewStyle, CustomFlagsMixin):
+    command = ["python3", "Tools/Scripts/cross-toolchain-helper", "--build-image",
+               "--deploy-image-with-script", "../../cross-toolchain-helper-deploy.sh"]
+    name = "build-and-deploy-cross-target-image"
+    description = ["building and deploying cross target image"]
+    descriptionDone = ["cross target image built and deployed"]
+    haltOnFailure = True
+
+    def run(self):
+        self.appendCrossTargetFlags(self.getProperty('additionalArguments'))
+        return super().run()
+
+
+class RebootWithUpdatedCrossTargetImage(shell.ShellCommandNewStyle):
+    # Either use env var SUDO_ASKPASS or configure /etc/sudoers for passwordless reboot
+    command = ["sudo", "-A", "reboot"]
+    name = "reboot-with-updated-cross-target-image"
+    description = ["rebooting with updated cross target image"]
+    descriptionDone = ["rebooted with updated cross target image"]
+    haltOnFailure = True
+
+    # This step can never succeed.. either it timeouts (bot has rebooted) or it fails.
+    # Ideally buildbot should have built-in reboot support so it waits for the bot to
+    # do a reboot, but it doesn't. See: https://github.com/buildbot/buildbot/issues/4578
+    @defer.inlineCallbacks
+    def run(self):
+        rc = yield super().run()
+        defer.returnValue(FAILURE)


### PR DESCRIPTION
#### e7e596ed660c38a7dbd1940cdd1ccf8aa34b08de
<pre>
[WPE] Add new post-commit bots for performance tests with RPis
<a href="https://bugs.webkit.org/show_bug.cgi?id=256283">https://bugs.webkit.org/show_bug.cgi?id=256283</a>

Reviewed by Jonathan Bedard.

This adds new bots for running performance tests on WPE with RPi4 boards.
The configuration is the following:

1) Build-only bots (x86_64 machines that cross-build)
 - WPE-Linux-RPi4-32bits-Mesa-Release-Perf-Build
   (builds with --cross-target=rpi4-32bits-mesa)
 - WPE-Linux-RPi4-64bits-Mesa-Release-Perf-Build
   (builds with --cross-target=rpi4-64bits-mesa)

2) Test-only bots (RPi4 boards that run the tests)
 - WPE-Linux-RPi4-32bits-Mesa-Release-Perf-Tests
 - WPE-Linux-RPi4-64bits-Mesa-Release-Perf-Tests

There will be 8 workers (RPi4 boards) connected per
tester (so a total of 16 RPi4 boards).

The bots use the standard BuildOnly and DownloadAndPerfTest factories
with a few extra steps for handling the cross-target setup.

And for handling everything related with the cross builds and the generation
and deployment of target images it uses the cross-toolchain-helper script
and related functionality that was introduced at 259479@main

The append*Flags() functions at steps.py are moved into a common MixIn class

* Tools/CISupport/build-webkit-org/config.json:
* Tools/CISupport/build-webkit-org/factories.py:
(Factory):
(Factory.__init__):
(BuildFactory.__init__):
(NoInstallDependenciesBuildFactory):
(CrossTargetBuildFactory):
(DownloadAndPerfTestFactory.__init__):
(CrossTargetDownloadAndPerfTestFactory):
* Tools/CISupport/build-webkit-org/factories_unittest.py:
(TestExpectedBuildSteps):
* Tools/CISupport/build-webkit-org/steps.py:
(appendCrossTargetFlags):
(appendCustomBuildFlags):
(appendCustomTestingFlags):
(InstallWpeDependencies.start):
(ArchiveBuiltProduct):
(ArchiveBuiltProduct.start):
(ShowIdentifier.hideStepIf):
(CheckIfNeededUpdateDeployedCrossTargetImage):
(CheckIfNeededUpdateDeployedCrossTargetImage.start):
(CheckIfNeededUpdateDeployedCrossTargetImage.evaluateCommand):
(CheckIfNeededUpdateRunningCrossTargetImage):
(CheckIfNeededUpdateRunningCrossTargetImage.evaluateCommand):
(BuildAndDeployCrossTargetImage):
(BuildAndDeployCrossTargetImage.start):
(RebootWithUpdatedCrossTargetImage):
* Tools/CISupport/build-webkit-org/steps_unittest.py:

Canonical link: <a href="https://commits.webkit.org/264798@main">https://commits.webkit.org/264798@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/881c26e62caa7b101b90ed5efb352de07643e1b9

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/8548 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/8838 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/9052 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/10204 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/8575 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/8557 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/10827 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/8803 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/11442 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/8694 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/9725 "3 failures") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/7684 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/10359 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/7025 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/7815 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/15357 "2 flakes 116 failures") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/8144 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/7963 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/11311 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/8443 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/6898 "Passed tests") | | 
| [✅ 🧪 services](https://ews-build.webkit.org/#/builders/28/builds/8499 "Passed tests") | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/7720 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/11929 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/1021 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/8185 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->