### PR TITLE
Regression(262252@main) Flaky crash under ~CanMakeCheckedPtrBase() for ScriptExecutionContext

### DIFF
--- a/Source/WebCore/bindings/js/ScriptModuleLoader.h
+++ b/Source/WebCore/bindings/js/ScriptModuleLoader.h
@@ -54,12 +54,12 @@ class ScriptModuleLoader final : private ModuleScriptLoaderClient {
 public:
     enum class OwnerType : uint8_t { Document, WorkerOrWorklet };
     enum class ModuleType : uint8_t { Invalid, JavaScript, WebAssembly, JSON };
-    explicit ScriptModuleLoader(ScriptExecutionContext&, OwnerType);
+    explicit ScriptModuleLoader(ScriptExecutionContext*, OwnerType);
     ~ScriptModuleLoader();
 
     UniqueRef<ScriptModuleLoader> shadowRealmLoader(JSC::JSGlobalObject* realmGlobal) const;
 
-    ScriptExecutionContext& context() { return m_context.get(); }
+    ScriptExecutionContext* context() { return m_context.get(); }
 
     JSC::Identifier resolve(JSC::JSGlobalObject*, JSC::JSModuleLoader*, JSC::JSValue moduleName, JSC::JSValue importerModuleKey, JSC::JSValue scriptFetcher);
     JSC::JSInternalPromise* fetch(JSC::JSGlobalObject*, JSC::JSModuleLoader*, JSC::JSValue moduleKey, JSC::JSValue parameters, JSC::JSValue scriptFetcher);
@@ -73,7 +73,7 @@ private:
     URL moduleURL(JSC::JSGlobalObject&, JSC::JSValue);
     URL responseURLFromRequestURL(JSC::JSGlobalObject&, JSC::JSValue);
 
-    CheckedRef<ScriptExecutionContext> m_context;
+    WeakPtr<ScriptExecutionContext> m_context;
     MemoryCompactRobinHoodHashMap<String, URL> m_requestURLToResponseURLMap;
     HashSet<Ref<ModuleScriptLoader>> m_loaders;
     OwnerType m_ownerType;

--- a/Source/WebCore/dom/Document.cpp
+++ b/Source/WebCore/dom/Document.cpp
@@ -601,7 +601,7 @@ Document::Document(LocalFrame* frame, const Settings& settings, const URL& url, 
     , m_documentCreationTime(MonotonicTime::now())
 #endif
     , m_scriptRunner(makeUnique<ScriptRunner>(*this))
-    , m_moduleLoader(makeUnique<ScriptModuleLoader>(*this, ScriptModuleLoader::OwnerType::Document))
+    , m_moduleLoader(makeUnique<ScriptModuleLoader>(this, ScriptModuleLoader::OwnerType::Document))
 #if ENABLE(XSLT)
     , m_applyPendingXSLTransformsTimer(*this, &Document::applyPendingXSLTransformsTimerFired)
 #endif

--- a/Source/WebCore/workers/WorkerOrWorkletGlobalScope.cpp
+++ b/Source/WebCore/workers/WorkerOrWorkletGlobalScope.cpp
@@ -43,7 +43,7 @@ WTF_MAKE_ISO_ALLOCATED_IMPL(WorkerOrWorkletGlobalScope);
 WorkerOrWorkletGlobalScope::WorkerOrWorkletGlobalScope(WorkerThreadType type, PAL::SessionID sessionID, Ref<JSC::VM>&& vm, ReferrerPolicy referrerPolicy, WorkerOrWorkletThread* thread, std::optional<uint64_t> noiseInjectionHashSalt, ScriptExecutionContextIdentifier contextIdentifier)
     : ScriptExecutionContext(contextIdentifier)
     , m_script(makeUnique<WorkerOrWorkletScriptController>(type, WTFMove(vm), this))
-    , m_moduleLoader(makeUnique<ScriptModuleLoader>(*this, ScriptModuleLoader::OwnerType::WorkerOrWorklet))
+    , m_moduleLoader(makeUnique<ScriptModuleLoader>(this, ScriptModuleLoader::OwnerType::WorkerOrWorklet))
     , m_thread(thread)
     , m_inspectorController(makeUnique<WorkerInspectorController>(*this))
     , m_sessionID(sessionID)


### PR DESCRIPTION
#### 1116cdd2710a182d19d7b473b5ffe7aca5791df7
<pre>
Regression(262252@main) Flaky crash under ~CanMakeCheckedPtrBase() for ScriptExecutionContext
<a href="https://bugs.webkit.org/show_bug.cgi?id=256290">https://bugs.webkit.org/show_bug.cgi?id=256290</a>

Reviewed by Ryosuke Niwa and Alex Christensen.

ScriptModuleLoader has a CheckedRef to its ScriptExecutionContext. In general, a
ScriptModuleLoader cannot outlive its ScriptExecutionContext. This is the case
for the ScriptModuleLoader owned by Document and WorkerOrWorkletGlobalScope.
Document and WorkerOrWorkletGlobalScope are scriptExecutionContexts and own a
ScriptModuleLoader, so the ownership is clear in this case.

However, ShadowRealmGlobalScope::moduleLoader() calls
ScriptModuleLoader::shadowRealmLoader() which constructs a new ScriptModuleLoader
using another ScriptModuleLoader&apos;s scriptExecutionContext. ShadowRealmGlobalScope
is not a ScriptExecutionContext and the lifetime of the ShadowRealmGlobalScope
seems to be tied to its JS wrapper.

To address the issue, I am now using a WeakPtr&lt;&gt; instead of a CheckedRef. I am
also adding null checks.

* Source/WebCore/bindings/js/ScriptModuleLoader.cpp:
(WebCore::ScriptModuleLoader::ScriptModuleLoader):
(WebCore::ScriptModuleLoader::shadowRealmLoader const):
(WebCore::ScriptModuleLoader::resolve):
(WebCore::ScriptModuleLoader::fetch):
(WebCore::ScriptModuleLoader::moduleURL):
(WebCore::ScriptModuleLoader::responseURLFromRequestURL):
(WebCore::ScriptModuleLoader::evaluate):
(WebCore::ScriptModuleLoader::importModule):
(WebCore::ScriptModuleLoader::notifyFinished):
* Source/WebCore/bindings/js/ScriptModuleLoader.h:
* Source/WebCore/dom/Document.cpp:
* Source/WebCore/workers/WorkerOrWorkletGlobalScope.cpp:
(WebCore::WorkerOrWorkletGlobalScope::WorkerOrWorkletGlobalScope):

Canonical link: <a href="https://commits.webkit.org/263662@main">https://commits.webkit.org/263662@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/49483f9a09ba99f85072aff085f022a222e43314

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/5379 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/5517 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/5706 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/6918 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/5412 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/5378 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/5744 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/5496 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/6267 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/5479 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/5548 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/4815 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/6947 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/3027 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/4822 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/11977 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/4893 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/4900 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/6527 "run-api-tests-without-change (failure)") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/5333 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/4377 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/4794 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/1287 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/8893 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/5155 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->