### PR TITLE
[GPU Process] [Filters 22/23] Cache the SVGFilter applying results in RemoteResourceCache

### DIFF
--- a/Source/WebCore/Headers.cmake
+++ b/Source/WebCore/Headers.cmake
@@ -2240,7 +2240,7 @@ set(WebCore_PRIVATE_FRAMEWORK_HEADERS
 
     svg/graphics/filters/SVGFilter.h
     svg/graphics/filters/SVGFilterExpression.h
-    svg/graphics/filters/SVGFilterExpressionReference.h
+    svg/graphics/filters/SVGFilterTransaction.h
 
     svg/properties/SVGList.h
     svg/properties/SVGPrimitiveList.h

--- a/Source/WebCore/platform/graphics/DecomposedGlyphs.h
+++ b/Source/WebCore/platform/graphics/DecomposedGlyphs.h
@@ -27,10 +27,11 @@
 
 #include "PositionedGlyphs.h"
 #include "RenderingResource.h"
+#include <wtf/ThreadSafeRefCounted.h>
 
 namespace WebCore {
 
-class DecomposedGlyphs final : public RenderingResource {
+class DecomposedGlyphs final : public ThreadSafeRefCounted<DecomposedGlyphs>, public RenderingResource {
     WTF_MAKE_FAST_ALLOCATED;
 public:
     static WEBCORE_EXPORT Ref<DecomposedGlyphs> create(const GlyphBufferGlyph*, const GlyphBufferAdvance*, unsigned count, const FloatPoint& localAnchor, FontSmoothingMode, RenderingResourceIdentifier = RenderingResourceIdentifier::generate());

--- a/Source/WebCore/platform/graphics/Gradient.h
+++ b/Source/WebCore/platform/graphics/Gradient.h
@@ -34,6 +34,7 @@
 #include "GraphicsTypes.h"
 #include "RenderingResource.h"
 #include <variant>
+#include <wtf/ThreadSafeRefCounted.h>
 #include <wtf/Vector.h>
 
 #if USE(CG)
@@ -58,7 +59,7 @@ class AffineTransform;
 class FloatRect;
 class GraphicsContext;
 
-class Gradient : public RenderingResource {
+class Gradient : public ThreadSafeRefCounted<Gradient>, public RenderingResource {
 public:
     struct LinearData {
         FloatPoint point0;

--- a/Source/WebCore/platform/graphics/ImageBufferAllocator.h
+++ b/Source/WebCore/platform/graphics/ImageBufferAllocator.h
@@ -27,6 +27,7 @@
 
 #include "PixelBufferFormat.h"
 #include "RenderingMode.h"
+#include <wtf/FastMalloc.h>
 #include <wtf/RefPtr.h>
 
 namespace WebCore {

--- a/Source/WebCore/platform/graphics/NativeImage.h
+++ b/Source/WebCore/platform/graphics/NativeImage.h
@@ -32,6 +32,7 @@
 #include "IntSize.h"
 #include "PlatformImage.h"
 #include "RenderingResource.h"
+#include <wtf/ThreadSafeRefCounted.h>
 
 #if USE(CAIRO)
 #include "PixelBuffer.h"
@@ -41,7 +42,7 @@ namespace WebCore {
 
 class GraphicsContext;
 
-class NativeImage final : public RenderingResource {
+class NativeImage final : public ThreadSafeRefCounted<NativeImage>, public RenderingResource {
     WTF_MAKE_FAST_ALLOCATED;
 public:
     static WEBCORE_EXPORT RefPtr<NativeImage> create(PlatformImagePtr&&, RenderingResourceIdentifier = RenderingResourceIdentifier::generate());

--- a/Source/WebCore/platform/graphics/RenderingResource.h
+++ b/Source/WebCore/platform/graphics/RenderingResource.h
@@ -27,12 +27,11 @@
 
 #include "RenderingResourceIdentifier.h"
 #include <wtf/HashSet.h>
-#include <wtf/ThreadSafeWeakPtr.h>
+#include <wtf/WeakPtr.h>
 
 namespace WebCore {
 
-class RenderingResource
-    : public ThreadSafeRefCountedAndCanMakeThreadSafeWeakPtr<RenderingResource> {
+class RenderingResource : public CanMakeWeakPtr<RenderingResource> {
 public:
     class Observer {
     public:
@@ -59,6 +58,11 @@ public:
     {
         ASSERT(m_renderingResourceIdentifier);
         return *m_renderingResourceIdentifier;
+    }
+
+    std::optional<RenderingResourceIdentifier> renderingResourceIdentifierIfExists() const
+    {
+        return m_renderingResourceIdentifier;
     }
 
     void addObserver(Observer& observer)

--- a/Source/WebCore/platform/graphics/displaylists/DisplayList.h
+++ b/Source/WebCore/platform/graphics/displaylists/DisplayList.h
@@ -120,6 +120,11 @@ private:
         m_resourceHeap.add(gradient.renderingResourceIdentifier(), Ref { gradient });
     }
 
+    void cacheSVGFilter(SVGFilter& svgFilter)
+    {
+        m_resourceHeap.add(svgFilter.renderingResourceIdentifier(), Ref { svgFilter });
+    }
+
     static bool shouldDumpForFlags(OptionSet<AsTextFlag>, ItemHandle);
 
     LocalResourceHeap m_resourceHeap;

--- a/Source/WebCore/platform/graphics/displaylists/DisplayListRecorder.cpp
+++ b/Source/WebCore/platform/graphics/displaylists/DisplayListRecorder.cpp
@@ -163,12 +163,7 @@ void Recorder::drawFilteredImageBuffer(ImageBuffer* sourceImage, const FloatRect
         }
     }
 
-    if (!sourceImage) {
-        recordDrawFilteredImageBuffer(nullptr, sourceImageRect, filter);
-        return;
-    }
-
-    if (!recordResourceUse(*sourceImage)) {
+    if (sourceImage && !recordResourceUse(*sourceImage)) {
         GraphicsContext::drawFilteredImageBuffer(sourceImage, sourceImageRect, filter, results);
         return;
     }

--- a/Source/WebCore/platform/graphics/displaylists/DisplayListRecorder.h
+++ b/Source/WebCore/platform/graphics/displaylists/DisplayListRecorder.h
@@ -152,6 +152,7 @@ protected:
     virtual bool recordResourceUse(Font&) = 0;
     virtual bool recordResourceUse(DecomposedGlyphs&) = 0;
     virtual bool recordResourceUse(Gradient&) = 0;
+    virtual bool recordResourceUse(SVGFilter&) = 0;
 
     struct ContextState {
         GraphicsContextState state;

--- a/Source/WebCore/platform/graphics/displaylists/DisplayListRecorderImpl.cpp
+++ b/Source/WebCore/platform/graphics/displaylists/DisplayListRecorderImpl.cpp
@@ -444,5 +444,11 @@ bool RecorderImpl::recordResourceUse(Gradient& gradient)
     return true;
 }
 
+bool RecorderImpl::recordResourceUse(SVGFilter& svgFilter)
+{
+    m_displayList.cacheSVGFilter(svgFilter);
+    return true;
+}
+
 } // namespace DisplayList
 } // namespace WebCore

--- a/Source/WebCore/platform/graphics/displaylists/DisplayListRecorderImpl.h
+++ b/Source/WebCore/platform/graphics/displaylists/DisplayListRecorderImpl.h
@@ -125,6 +125,7 @@ private:
     bool recordResourceUse(Font&) final;
     bool recordResourceUse(DecomposedGlyphs&) final;
     bool recordResourceUse(Gradient&) final;
+    bool recordResourceUse(SVGFilter&) final;
 
     template<typename T, class... Args>
     void append(Args&&... args)

--- a/Source/WebCore/platform/graphics/displaylists/DisplayListResourceHeap.h
+++ b/Source/WebCore/platform/graphics/displaylists/DisplayListResourceHeap.h
@@ -31,6 +31,7 @@
 #include "ImageBuffer.h"
 #include "NativeImage.h"
 #include "RenderingResourceIdentifier.h"
+#include "SVGFilter.h"
 #include "SourceImage.h"
 #include <wtf/HashMap.h>
 #include <wtf/RefCounted.h>
@@ -48,6 +49,7 @@ public:
     virtual Font* getFont(RenderingResourceIdentifier) const = 0;
     virtual DecomposedGlyphs* getDecomposedGlyphs(RenderingResourceIdentifier) const = 0;
     virtual Gradient* getGradient(RenderingResourceIdentifier) const = 0;
+    virtual SVGFilter* getSVGFilter(RenderingResourceIdentifier) const = 0;
 };
 
 class LocalResourceHeap : public ResourceHeap {
@@ -75,6 +77,11 @@ public:
     void add(RenderingResourceIdentifier renderingResourceIdentifier, Ref<Gradient>&& gradient)
     {
         m_resources.add(renderingResourceIdentifier, WTFMove(gradient));
+    }
+
+    void add(RenderingResourceIdentifier renderingResourceIdentifier, Ref<SVGFilter>&& svgFilter)
+    {
+        m_resources.add(renderingResourceIdentifier, WTFMove(svgFilter));
     }
 
     ImageBuffer* getImageBuffer(RenderingResourceIdentifier renderingResourceIdentifier) const final
@@ -116,6 +123,11 @@ public:
         return get<Gradient>(renderingResourceIdentifier);
     }
 
+    SVGFilter* getSVGFilter(RenderingResourceIdentifier renderingResourceIdentifier) const final
+    {
+        return get<SVGFilter>(renderingResourceIdentifier);
+    }
+
     void clear()
     {
         m_resources.clear();
@@ -138,7 +150,8 @@ private:
         Ref<NativeImage>,
         Ref<Font>,
         Ref<DecomposedGlyphs>,
-        Ref<Gradient>
+        Ref<Gradient>,
+        Ref<SVGFilter>
     >;
 
     HashMap<RenderingResourceIdentifier, Resource> m_resources;

--- a/Source/WebCore/platform/graphics/filters/FilterFunction.h
+++ b/Source/WebCore/platform/graphics/filters/FilterFunction.h
@@ -33,6 +33,7 @@
 #include "FloatRect.h"
 #include "LengthBox.h"
 #include <wtf/RefCounted.h>
+#include <wtf/ThreadSafeRefCounted.h>
 #include <wtf/text/AtomString.h>
 
 namespace WTF {
@@ -49,7 +50,7 @@ enum class FilterRepresentation : uint8_t {
     Debugging
 };
 
-class FilterFunction : public RefCounted<FilterFunction> {
+class FilterFunction : public ThreadSafeRefCounted<FilterFunction> {
 public:
     enum class Type : uint8_t {
         CSSFilter,

--- a/Source/WebCore/platform/graphics/filters/FilterResults.h
+++ b/Source/WebCore/platform/graphics/filters/FilterResults.h
@@ -28,6 +28,7 @@
 #include "FilterEffect.h"
 #include "FilterImageVector.h"
 #include "ImageBufferAllocator.h"
+#include <wtf/FastMalloc.h>
 #include <wtf/HashMap.h>
 #include <wtf/HashSet.h>
 
@@ -37,6 +38,7 @@ class FilterEffect;
 class FilterImage;
 
 class FilterResults {
+    WTF_MAKE_FAST_ALLOCATED;
 public:
     WEBCORE_EXPORT FilterResults(std::unique_ptr<ImageBufferAllocator>&& = nullptr);
 

--- a/Source/WebCore/rendering/svg/RenderSVGResourceFilter.h
+++ b/Source/WebCore/rendering/svg/RenderSVGResourceFilter.h
@@ -45,7 +45,6 @@ public:
     FilterData() = default;
 
     RefPtr<SVGFilter> filter;
-    FilterResults results;
 
     std::unique_ptr<FilterTargetSwitcher> targetSwitcher;
     FloatRect sourceImageRect;

--- a/Source/WebCore/svg/graphics/filters/SVGFilterExpression.h
+++ b/Source/WebCore/svg/graphics/filters/SVGFilterExpression.h
@@ -30,10 +30,8 @@
 
 namespace WebCore {
 
-class FilterEffect;
-
 struct SVGFilterExpressionTerm {
-    Ref<FilterEffect> effect;
+    unsigned index;
     std::optional<FilterEffectGeometry> geometry;
     unsigned level;
 };

--- a/Source/WebCore/svg/graphics/filters/SVGFilterGraph.h
+++ b/Source/WebCore/svg/graphics/filters/SVGFilterGraph.h
@@ -47,6 +47,7 @@ public:
         m_sourceNodes.add(SourceGraphic::effectName(), WTFMove(sourceGraphic));
         m_sourceNodes.add(SourceAlpha::effectName(), WTFMove(sourceAlpha));
 
+        setNodeInputs(*this->sourceGraphic(), NodeVector { });
         setNodeInputs(*this->sourceAlpha(), NodeVector { *this->sourceGraphic() });
     }
 
@@ -115,8 +116,15 @@ public:
         return m_nodeInputs.get(node);
     }
 
+    NodeVector nodes() const
+    {
+        return WTF::map(m_nodeInputs, [] (auto& pair) -> Ref<NodeType> {
+            return pair.key;
+        });
+    }
+
     NodeType* lastNode() const { return m_lastNode.get(); }
-    
+
     template<typename Callback>
     bool visit(Callback callback)
     {

--- a/Source/WebCore/svg/graphics/filters/SVGFilterTransaction.h
+++ b/Source/WebCore/svg/graphics/filters/SVGFilterTransaction.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022 Apple Inc.  All rights reserved.
+ * Copyright (C) 2023 Apple Inc.  All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -25,18 +25,17 @@
 
 #pragma once
 
-#include "FilterEffectGeometry.h"
 #include <wtf/Vector.h>
 
 namespace WebCore {
 
-struct SVGFilterExpressionNode {
+class FilterEffect;
+
+struct SVGFilterTransactionItem {
     unsigned index;
-    std::optional<FilterEffectGeometry> geometry;
-    unsigned level;
+    Ref<FilterEffect> effect;
 };
 
-using SVGFilterExpressionReference = Vector<SVGFilterExpressionNode>;
-
+using SVGFilterTransaction = Vector<SVGFilterTransactionItem>;
 
 } // namespace WebCore

--- a/Source/WebKit/GPUProcess/graphics/QualifiedResourceHeap.h
+++ b/Source/WebKit/GPUProcess/graphics/QualifiedResourceHeap.h
@@ -35,6 +35,7 @@
 #include <WebCore/ImageBuffer.h>
 #include <WebCore/NativeImage.h>
 #include <WebCore/ProcessIdentifier.h>
+#include <WebCore/SVGFilter.h>
 #include <WebCore/SourceImage.h>
 #include <wtf/HashMap.h>
 
@@ -70,6 +71,11 @@ public:
     void add(QualifiedRenderingResourceIdentifier renderingResourceIdentifier, Ref<WebCore::Gradient>&& gradient)
     {
         add(renderingResourceIdentifier, WTFMove(gradient), m_gradientCount);
+    }
+
+    void add(QualifiedRenderingResourceIdentifier renderingResourceIdentifier, Ref<WebCore::SVGFilter>&& svgFilter)
+    {
+        add(renderingResourceIdentifier, WTFMove(svgFilter), m_svgFilterCount);
     }
 
     void add(QualifiedRenderingResourceIdentifier renderingResourceIdentifier, Ref<WebCore::FontCustomPlatformData>&& customPlatformData)
@@ -116,6 +122,11 @@ public:
         return get<WebCore::Gradient>(renderingResourceIdentifier);
     }
 
+    WebCore::SVGFilter* getSVGFilter(QualifiedRenderingResourceIdentifier renderingResourceIdentifier) const
+    {
+        return get<WebCore::SVGFilter>(renderingResourceIdentifier);
+    }
+
     WebCore::FontCustomPlatformData* getFontCustomPlatformData(QualifiedRenderingResourceIdentifier renderingResourceIdentifier) const
     {
         return get<WebCore::FontCustomPlatformData>(renderingResourceIdentifier);
@@ -146,6 +157,11 @@ public:
         return remove<WebCore::Gradient>(renderingResourceIdentifier, m_gradientCount);
     }
 
+    bool removeSVGFilter(QualifiedRenderingResourceIdentifier renderingResourceIdentifier)
+    {
+        return remove<WebCore::SVGFilter>(renderingResourceIdentifier, m_svgFilterCount);
+    }
+
     bool removeFontCustomPlatformData(QualifiedRenderingResourceIdentifier renderingResourceIdentifier)
     {
         return remove<WebCore::FontCustomPlatformData>(renderingResourceIdentifier, m_customPlatformDataCount);
@@ -155,7 +171,7 @@ public:
     {
         checkInvariants();
 
-        if (!m_nativeImageCount && !m_fontCount && !m_decomposedGlyphsCount && !m_gradientCount)
+        if (!m_nativeImageCount && !m_fontCount && !m_decomposedGlyphsCount && !m_gradientCount && !m_svgFilterCount)
             return;
 
         m_resources.removeIf([] (const auto& resource) {
@@ -163,6 +179,7 @@ public:
                 || std::holds_alternative<Ref<WebCore::Font>>(resource.value)
                 || std::holds_alternative<Ref<WebCore::DecomposedGlyphs>>(resource.value)
                 || std::holds_alternative<Ref<WebCore::Gradient>>(resource.value)
+                || std::holds_alternative<Ref<WebCore::SVGFilter>>(resource.value)
                 || std::holds_alternative<Ref<WebCore::FontCustomPlatformData>>(resource.value);
         });
 
@@ -170,6 +187,7 @@ public:
         m_fontCount = 0;
         m_decomposedGlyphsCount = 0;
         m_gradientCount = 0;
+        m_svgFilterCount = 0;
         m_customPlatformDataCount = 0;
 
         checkInvariants();
@@ -248,6 +266,7 @@ private:
         unsigned customPlatformDataCount = 0;
         unsigned decomposedGlyphsCount = 0;
         unsigned gradientCount = 0;
+        unsigned svgFilterCount = 0;
         for (const auto& pair : m_resources) {
             WTF::switchOn(pair.value, [&] (std::monostate) {
                 ASSERT_NOT_REACHED();
@@ -263,6 +282,8 @@ private:
                 ++decomposedGlyphsCount;
             }, [&] (const Ref<WebCore::Gradient>&) {
                 ++gradientCount;
+            }, [&] (const Ref<WebCore::SVGFilter>&) {
+                ++svgFilterCount;
             });
         }
         ASSERT(imageBufferCount == m_imageBufferCount);
@@ -271,7 +292,8 @@ private:
         ASSERT(customPlatformDataCount == m_customPlatformDataCount);
         ASSERT(decomposedGlyphsCount == m_decomposedGlyphsCount);
         ASSERT(gradientCount == m_gradientCount);
-        ASSERT(m_resources.size() == m_imageBufferCount + m_nativeImageCount + m_fontCount + m_decomposedGlyphsCount + m_customPlatformDataCount + m_gradientCount);
+        ASSERT(svgFilterCount == m_svgFilterCount);
+        ASSERT(m_resources.size() == m_imageBufferCount + m_nativeImageCount + m_fontCount + m_decomposedGlyphsCount + m_customPlatformDataCount + m_gradientCount + m_svgFilterCount);
 #endif
     }
 
@@ -282,6 +304,7 @@ private:
         Ref<WebCore::Font>,
         Ref<WebCore::DecomposedGlyphs>,
         Ref<WebCore::Gradient>,
+        Ref<WebCore::SVGFilter>,
         Ref<WebCore::FontCustomPlatformData>
     >;
     HashMap<QualifiedRenderingResourceIdentifier, Resource> m_resources;
@@ -291,6 +314,7 @@ private:
     unsigned m_fontCount { 0 };
     unsigned m_decomposedGlyphsCount { 0 };
     unsigned m_gradientCount { 0 };
+    unsigned m_svgFilterCount { 0 };
     unsigned m_customPlatformDataCount { 0 };
 };
 

--- a/Source/WebKit/GPUProcess/graphics/RemoteDisplayListRecorder.h
+++ b/Source/WebKit/GPUProcess/graphics/RemoteDisplayListRecorder.h
@@ -82,6 +82,7 @@ public:
     void drawGlyphs(WebCore::DisplayList::DrawGlyphs&&);
     void drawDecomposedGlyphs(WebCore::RenderingResourceIdentifier fontIdentifier, WebCore::RenderingResourceIdentifier decomposedGlyphsIdentifier);
     void drawFilteredImageBuffer(std::optional<WebCore::RenderingResourceIdentifier> sourceImageIdentifier, const WebCore::FloatRect& sourceImageRect, Ref<WebCore::Filter>);
+    void drawSVGFilteredImageBuffer(std::optional<WebCore::RenderingResourceIdentifier> sourceImageIdentifier, const WebCore::FloatRect& sourceImageRect, WebCore::RenderingResourceIdentifier filterIdentifier, WebCore::SVGFilterTransaction);
     void drawImageBuffer(WebCore::RenderingResourceIdentifier imageBufferIdentifier, const WebCore::FloatRect& destinationRect, const WebCore::FloatRect& srcRect, const WebCore::ImagePaintingOptions&);
     void drawNativeImage(WebCore::RenderingResourceIdentifier imageIdentifier, const WebCore::FloatSize& imageSize, const WebCore::FloatRect& destRect, const WebCore::FloatRect& srcRect, const WebCore::ImagePaintingOptions&);
     void drawSystemImage(Ref<WebCore::SystemImage>, const WebCore::FloatRect&);
@@ -139,6 +140,7 @@ private:
 
     void setStateWithQualifiedIdentifiers(WebCore::DisplayList::SetState&&, QualifiedRenderingResourceIdentifier strokePatternImageIdentifier, QualifiedRenderingResourceIdentifier fillPatternImageIdentifier);
     void clipToImageBufferWithQualifiedIdentifier(QualifiedRenderingResourceIdentifier, const WebCore::FloatRect& destinationRect);
+    void drawFilteredImageBufferInternal(std::optional<WebCore::RenderingResourceIdentifier> sourceImageIdentifier, const WebCore::FloatRect& sourceImageRect, WebCore::Filter&, WebCore::FilterResults&);
     void drawGlyphsWithQualifiedIdentifier(WebCore::DisplayList::DrawGlyphs&&, QualifiedRenderingResourceIdentifier fontIdentifier);
     void drawDecomposedGlyphsWithQualifiedIdentifiers(QualifiedRenderingResourceIdentifier fontIdentifier, QualifiedRenderingResourceIdentifier decomposedGlyphsIdentifier);
     void drawImageBufferWithQualifiedIdentifier(QualifiedRenderingResourceIdentifier imageBufferIdentifier, const WebCore::FloatRect& destinationRect, const WebCore::FloatRect& srcRect, const WebCore::ImagePaintingOptions&);

--- a/Source/WebKit/GPUProcess/graphics/RemoteDisplayListRecorder.messages.in
+++ b/Source/WebKit/GPUProcess/graphics/RemoteDisplayListRecorder.messages.in
@@ -48,6 +48,7 @@ messages -> RemoteDisplayListRecorder NotRefCounted Stream {
     DrawGlyphs(WebCore::DisplayList::DrawGlyphs item)
     DrawDecomposedGlyphs(WebCore::RenderingResourceIdentifier fontIdentifier, WebCore::RenderingResourceIdentifier decomposedGlyphsIdentifier)
     DrawFilteredImageBuffer(std::optional<WebCore::RenderingResourceIdentifier> sourceImageIdentifier, WebCore::FloatRect sourceImageRect, Ref<WebCore::Filter> filter)
+    DrawSVGFilteredImageBuffer(std::optional<WebCore::RenderingResourceIdentifier> sourceImageIdentifier, WebCore::FloatRect sourceImageRect, WebCore::RenderingResourceIdentifier filterIdentifier, WebCore::SVGFilterTransaction transaction)
     DrawImageBuffer(WebCore::RenderingResourceIdentifier imageBufferIdentifier, WebCore::FloatRect destinationRect, WebCore::FloatRect srcRect, struct WebCore::ImagePaintingOptions options)
     DrawNativeImage(WebCore::RenderingResourceIdentifier imageIdentifier, WebCore::FloatSize imageSize, WebCore::FloatRect destRect, WebCore::FloatRect srcRect, struct WebCore::ImagePaintingOptions options)
     DrawSystemImage(Ref<WebCore::SystemImage> systemImage, WebCore::FloatRect destinationRect)

--- a/Source/WebKit/GPUProcess/graphics/RemoteRenderingBackend.cpp
+++ b/Source/WebKit/GPUProcess/graphics/RemoteRenderingBackend.cpp
@@ -425,6 +425,17 @@ void RemoteRenderingBackend::cacheGradientWithQualifiedIdentifier(Ref<Gradient>&
     m_remoteResourceCache.cacheGradient(WTFMove(gradient), gradientResourceIdentifier);
 }
 
+void RemoteRenderingBackend::cacheSVGFilter(Ref<SVGFilter>&& svgFilter, RenderingResourceIdentifier renderingResourceIdentifier)
+{
+    cacheSVGFilterWithQualifiedIdentifier(WTFMove(svgFilter), { renderingResourceIdentifier, m_gpuConnectionToWebProcess->webProcessIdentifier() });
+}
+
+void RemoteRenderingBackend::cacheSVGFilterWithQualifiedIdentifier(Ref<SVGFilter>&& svgFilter, QualifiedRenderingResourceIdentifier svgFilterResourceIdentifier)
+{
+    ASSERT(!RunLoop::isMain());
+    m_remoteResourceCache.cacheSVGFilter(WTFMove(svgFilter), svgFilterResourceIdentifier);
+}
+
 void RemoteRenderingBackend::releaseAllResources()
 {
     ASSERT(!RunLoop::isMain());

--- a/Source/WebKit/GPUProcess/graphics/RemoteRenderingBackend.h
+++ b/Source/WebKit/GPUProcess/graphics/RemoteRenderingBackend.h
@@ -138,6 +138,7 @@ private:
     void cacheNativeImage(ShareableBitmap::Handle&&, WebCore::RenderingResourceIdentifier);
     void cacheDecomposedGlyphs(Ref<WebCore::DecomposedGlyphs>&&);
     void cacheGradient(Ref<WebCore::Gradient>&&, WebCore::RenderingResourceIdentifier);
+    void cacheSVGFilter(Ref<WebCore::SVGFilter>&&, WebCore::RenderingResourceIdentifier);
     void cacheFont(const WebCore::Font::Attributes&, WebCore::FontPlatformData::Attributes, std::optional<WebCore::RenderingResourceIdentifier>);
     void cacheFontCustomPlatformData(Ref<WebCore::FontCustomPlatformData>&&);
     void releaseAllResources();
@@ -155,6 +156,7 @@ private:
     void cacheNativeImageWithQualifiedIdentifier(ShareableBitmap::Handle&&, QualifiedRenderingResourceIdentifier);
     void cacheDecomposedGlyphsWithQualifiedIdentifier(Ref<WebCore::DecomposedGlyphs>&&, QualifiedRenderingResourceIdentifier);
     void cacheGradientWithQualifiedIdentifier(Ref<WebCore::Gradient>&&, QualifiedRenderingResourceIdentifier);
+    void cacheSVGFilterWithQualifiedIdentifier(Ref<WebCore::SVGFilter>&&, QualifiedRenderingResourceIdentifier);
     void releaseRenderingResourceWithQualifiedIdentifier(QualifiedRenderingResourceIdentifier);
     void cacheFontWithQualifiedIdentifier(Ref<WebCore::Font>&&, QualifiedRenderingResourceIdentifier);
     void cacheFontCustomPlatformDataWithQualifiedIdentifier(Ref<WebCore::FontCustomPlatformData>&&, QualifiedRenderingResourceIdentifier);

--- a/Source/WebKit/GPUProcess/graphics/RemoteRenderingBackend.messages.in
+++ b/Source/WebKit/GPUProcess/graphics/RemoteRenderingBackend.messages.in
@@ -35,6 +35,7 @@ messages -> RemoteRenderingBackend NotRefCounted Stream {
     CacheFontCustomPlatformData(Ref<WebCore::FontCustomPlatformData> customPlatformData) NotStreamEncodable
     CacheDecomposedGlyphs(Ref<WebCore::DecomposedGlyphs> decomposedGlyphs) NotStreamEncodable
     CacheGradient(Ref<WebCore::Gradient> gradient, WebCore::RenderingResourceIdentifier renderingResourceIdentifier) NotStreamEncodable
+    CacheSVGFilter(Ref<WebCore::SVGFilter> svgFilter, WebCore::RenderingResourceIdentifier renderingResourceIdentifier) NotStreamEncodable
     ReleaseAllResources()
     ReleaseAllImageResources()
     ReleaseRenderingResource(WebCore::RenderingResourceIdentifier renderingResourceIdentifier)

--- a/Source/WebKit/GPUProcess/graphics/RemoteResourceCache.cpp
+++ b/Source/WebKit/GPUProcess/graphics/RemoteResourceCache.cpp
@@ -75,6 +75,11 @@ void RemoteResourceCache::cacheGradient(Ref<Gradient>&& gradient, QualifiedRende
     m_resourceHeap.add(renderingResourceIdentifier, WTFMove(gradient));
 }
 
+void RemoteResourceCache::cacheSVGFilter(Ref<SVGFilter>&& svgFilter, QualifiedRenderingResourceIdentifier renderingResourceIdentifier)
+{
+    m_resourceHeap.add(renderingResourceIdentifier, WTFMove(svgFilter));
+}
+
 NativeImage* RemoteResourceCache::cachedNativeImage(QualifiedRenderingResourceIdentifier renderingResourceIdentifier) const
 {
     return m_resourceHeap.getNativeImage(renderingResourceIdentifier);
@@ -117,6 +122,11 @@ Gradient* RemoteResourceCache::cachedGradient(QualifiedRenderingResourceIdentifi
     return m_resourceHeap.getGradient(renderingResourceIdentifier);
 }
 
+SVGFilter* RemoteResourceCache::cachedSVGFilter(QualifiedRenderingResourceIdentifier renderingResourceIdentifier) const
+{
+    return m_resourceHeap.getSVGFilter(renderingResourceIdentifier);
+}
+
 void RemoteResourceCache::releaseAllResources()
 {
     m_resourceHeap.releaseAllResources();
@@ -134,6 +144,7 @@ bool RemoteResourceCache::releaseRenderingResource(QualifiedRenderingResourceIde
         || m_resourceHeap.removeFont(renderingResourceIdentifier)
         || m_resourceHeap.removeDecomposedGlyphs(renderingResourceIdentifier)
         || m_resourceHeap.removeGradient(renderingResourceIdentifier)
+        || m_resourceHeap.removeSVGFilter(renderingResourceIdentifier)
         || m_resourceHeap.removeFontCustomPlatformData(renderingResourceIdentifier))
         return true;
 

--- a/Source/WebKit/GPUProcess/graphics/RemoteResourceCache.h
+++ b/Source/WebKit/GPUProcess/graphics/RemoteResourceCache.h
@@ -45,6 +45,7 @@ public:
     void cacheFont(Ref<WebCore::Font>&&, QualifiedRenderingResourceIdentifier);
     void cacheDecomposedGlyphs(Ref<WebCore::DecomposedGlyphs>&&, QualifiedRenderingResourceIdentifier);
     void cacheGradient(Ref<WebCore::Gradient>&&, QualifiedRenderingResourceIdentifier);
+    void cacheSVGFilter(Ref<WebCore::SVGFilter>&&, QualifiedRenderingResourceIdentifier);
     void cacheFontCustomPlatformData(Ref<WebCore::FontCustomPlatformData>&&, QualifiedRenderingResourceIdentifier);
 
     RemoteImageBuffer* cachedImageBuffer(QualifiedRenderingResourceIdentifier) const;
@@ -53,6 +54,7 @@ public:
     WebCore::Font* cachedFont(QualifiedRenderingResourceIdentifier) const;
     WebCore::DecomposedGlyphs* cachedDecomposedGlyphs(QualifiedRenderingResourceIdentifier) const;
     WebCore::Gradient* cachedGradient(QualifiedRenderingResourceIdentifier) const;
+    WebCore::SVGFilter* cachedSVGFilter(QualifiedRenderingResourceIdentifier) const;
     WebCore::FontCustomPlatformData* cachedFontCustomPlatformData(QualifiedRenderingResourceIdentifier) const;
 
     std::optional<WebCore::SourceImage> cachedSourceImage(QualifiedRenderingResourceIdentifier) const;

--- a/Source/WebKit/Scripts/webkit/messages.py
+++ b/Source/WebKit/Scripts/webkit/messages.py
@@ -350,6 +350,7 @@ def types_that_cannot_be_forward_declared():
         'WebCore::PolicyCheckIdentifier',
         'WebCore::RenderingMode',
         'WebCore::RenderingPurpose',
+        'WebCore::SVGFilterTransaction',
         'WebCore::ScriptExecutionContextIdentifier',
         'WebCore::ServiceWorkerOrClientData',
         'WebCore::ServiceWorkerOrClientIdentifier',

--- a/Source/WebKit/Shared/WebCoreArgumentCoders.h
+++ b/Source/WebKit/Shared/WebCoreArgumentCoders.h
@@ -448,7 +448,10 @@ template<> struct ArgumentCoder<WebCore::SVGFilter> {
 
 template<> struct ArgumentCoder<WebCore::Filter> {
     template<typename Encoder>
+    static void encodeFilterProperties(Encoder&, const WebCore::Filter&);
+    template<typename Encoder>
     static void encode(Encoder&, const WebCore::Filter&);
+    static WARN_UNUSED_RETURN bool decodeFilterProperties(Decoder&, WebCore::Filter&);
     static std::optional<Ref<WebCore::Filter>> decode(Decoder&);
 };
 

--- a/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
+++ b/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
@@ -4425,11 +4425,17 @@ struct WebCore::RTCDataChannelIdentifier {
 
 #endif // ENABLE(WEB_RTC)
 
-header: <WebCore/SVGFilterExpressionReference.h>
-[CustomHeader, AdditionalEncoder=StreamConnectionEncoder] struct WebCore::SVGFilterExpressionNode {
+header: <WebCore/SVGFilterExpression.h>
+[CustomHeader, AdditionalEncoder=StreamConnectionEncoder] struct WebCore::SVGFilterExpressionTerm {
     unsigned index;
     std::optional<WebCore::FilterEffectGeometry> geometry;
     unsigned level;
+};
+
+header: <WebCore/SVGFilterTransaction.h>
+[CustomHeader, AdditionalEncoder=StreamConnectionEncoder] struct WebCore::SVGFilterTransactionItem {
+    unsigned index;
+    Ref<WebCore::FilterEffect> effect;
 };
 
 [AdditionalEncoder=StreamConnectionEncoder] class WebCore::SVGPreserveAspectRatioValue {

--- a/Source/WebKit/WebProcess/GPU/graphics/RemoteDisplayListRecorderProxy.h
+++ b/Source/WebKit/WebProcess/GPU/graphics/RemoteDisplayListRecorderProxy.h
@@ -141,6 +141,7 @@ private:
     bool recordResourceUse(WebCore::Font&) final;
     bool recordResourceUse(WebCore::DecomposedGlyphs&) final;
     bool recordResourceUse(WebCore::Gradient&) final;
+    bool recordResourceUse(WebCore::SVGFilter&) final;
 
     RefPtr<WebCore::ImageBuffer> createImageBuffer(const WebCore::FloatSize&, float resolutionScale, const WebCore::DestinationColorSpace&, std::optional<WebCore::RenderingMode>, std::optional<WebCore::RenderingMethod>) const final;
     RefPtr<WebCore::ImageBuffer> createAlignedImageBuffer(const WebCore::FloatSize&, const WebCore::DestinationColorSpace&, std::optional<WebCore::RenderingMethod>) const final;

--- a/Source/WebKit/WebProcess/GPU/graphics/RemoteRenderingBackendProxy.cpp
+++ b/Source/WebKit/WebProcess/GPU/graphics/RemoteRenderingBackendProxy.cpp
@@ -275,6 +275,12 @@ void RemoteRenderingBackendProxy::cacheGradient(Ref<Gradient>&& gradient)
     send(Messages::RemoteRenderingBackend::CacheGradient(WTFMove(gradient), renderingResourceIdentifier));
 }
 
+void RemoteRenderingBackendProxy::cacheSVGFilter(Ref<SVGFilter>&& svgFilter)
+{
+    auto renderingResourceIdentifier = svgFilter->renderingResourceIdentifier();
+    send(Messages::RemoteRenderingBackend::CacheSVGFilter(WTFMove(svgFilter), renderingResourceIdentifier));
+}
+
 void RemoteRenderingBackendProxy::releaseAllRemoteResources()
 {
     if (!m_streamConnection)

--- a/Source/WebKit/WebProcess/GPU/graphics/RemoteRenderingBackendProxy.h
+++ b/Source/WebKit/WebProcess/GPU/graphics/RemoteRenderingBackendProxy.h
@@ -100,6 +100,7 @@ public:
     void cacheFontCustomPlatformData(Ref<const WebCore::FontCustomPlatformData>&&);
     void cacheDecomposedGlyphs(Ref<WebCore::DecomposedGlyphs>&&);
     void cacheGradient(Ref<WebCore::Gradient>&&);
+    void cacheSVGFilter(Ref<WebCore::SVGFilter>&&);
     void releaseAllRemoteResources();
     void releaseAllImageResources();
     void releaseRenderingResource(WebCore::RenderingResourceIdentifier);

--- a/Source/WebKit/WebProcess/GPU/graphics/RemoteResourceCacheProxy.h
+++ b/Source/WebKit/WebProcess/GPU/graphics/RemoteResourceCacheProxy.h
@@ -31,7 +31,7 @@
 #include <WebCore/DecomposedGlyphs.h>
 #include <WebCore/Gradient.h>
 #include <WebCore/NativeImage.h>
-#include <WebCore/RenderingResource.h>
+#include <WebCore/SVGFilter.h>
 #include <wtf/HashMap.h>
 
 namespace WebCore {
@@ -61,6 +61,7 @@ public:
     void recordImageBufferUse(WebCore::ImageBuffer&);
     void recordDecomposedGlyphsUse(WebCore::DecomposedGlyphs&);
     void recordGradientUse(WebCore::Gradient&);
+    void recordSVGFilterUse(WebCore::SVGFilter&);
     void recordFontCustomPlatformDataUse(const WebCore::FontCustomPlatformData&);
 
     void didPaintLayers();
@@ -75,15 +76,17 @@ public:
 
 private:
     using ImageBufferHashMap = HashMap<WebCore::RenderingResourceIdentifier, WeakPtr<RemoteImageBufferProxy>>;
-    using NativeImageHashMap = HashMap<WebCore::RenderingResourceIdentifier, ThreadSafeWeakPtr<WebCore::NativeImage>>;
+    using NativeImageHashMap = HashMap<WebCore::RenderingResourceIdentifier, WeakPtr<WebCore::NativeImage>>;
     using FontHashMap = HashMap<WebCore::RenderingResourceIdentifier, uint64_t>;
-    using DecomposedGlyphsHashMap = HashMap<WebCore::RenderingResourceIdentifier, ThreadSafeWeakPtr<WebCore::DecomposedGlyphs>>;
-    using GradientHashMap = HashMap<WebCore::RenderingResourceIdentifier, ThreadSafeWeakPtr<WebCore::Gradient>>;
+    using DecomposedGlyphsHashMap = HashMap<WebCore::RenderingResourceIdentifier, WeakPtr<WebCore::DecomposedGlyphs>>;
+    using GradientHashMap = HashMap<WebCore::RenderingResourceIdentifier, WeakPtr<WebCore::Gradient>>;
+    using SVGFilterHashMap = HashMap<WebCore::RenderingResourceIdentifier, WeakPtr<WebCore::SVGFilter>>;
 
     void releaseRenderingResource(WebCore::RenderingResourceIdentifier) override;
     void clearNativeImageMap();
     void clearDecomposedGlyphsMap();
     void clearGradientMap();
+    void clearSVGFilterMap();
 
     void finalizeRenderingUpdateForFonts();
     void prepareForNextRenderingUpdate();
@@ -96,6 +99,7 @@ private:
     FontHashMap m_fonts;
     DecomposedGlyphsHashMap m_decomposedGlyphs;
     GradientHashMap m_gradients;
+    SVGFilterHashMap m_svgFilters;
     FontHashMap m_fontCustomPlatformDatas;
 
     unsigned m_numberOfFontsUsedInCurrentRenderingUpdate { 0 };


### PR DESCRIPTION
#### a59ad65c2a57a7b02ab9a1f2e96417c223c9dbea
<pre>
[GPU Process] [Filters 22/23] Cache the SVGFilter applying results in RemoteResourceCache
<a href="https://bugs.webkit.org/show_bug.cgi?id=232845">https://bugs.webkit.org/show_bug.cgi?id=232845</a>
rdar://85426641

Reviewed by NOBODY (OOPS!).

This allows caching the results of applying an SVGFilter to a source ImageBuffer
in GPU Process. We should be able to use the result if the Filter was not changed.
We should be also able to clear some of the result FilterImages if a FilterEffect
was changed.

* Source/WebCore/Headers.cmake:
* Source/WebCore/WebCore.xcodeproj/project.pbxproj:
* Source/WebCore/platform/graphics/DecomposedGlyphs.h:
* Source/WebCore/platform/graphics/Gradient.h:
* Source/WebCore/platform/graphics/ImageBufferAllocator.h:
* Source/WebCore/platform/graphics/NativeImage.h:
* Source/WebCore/platform/graphics/RenderingResource.h:
(WebCore::RenderingResource::renderingResourceIdentifierIfExists const):
* Source/WebCore/platform/graphics/displaylists/DisplayList.h:
(WebCore::DisplayList::DisplayList::cacheSVGFilter):
* Source/WebCore/platform/graphics/displaylists/DisplayListRecorder.cpp:
(WebCore::DisplayList::Recorder::drawFilteredImageBuffer):
* Source/WebCore/platform/graphics/displaylists/DisplayListRecorder.h:
* Source/WebCore/platform/graphics/displaylists/DisplayListRecorderImpl.cpp:
(WebCore::DisplayList::RecorderImpl::recordResourceUse):
* Source/WebCore/platform/graphics/displaylists/DisplayListRecorderImpl.h:
* Source/WebCore/platform/graphics/displaylists/DisplayListResourceHeap.h:
(WebCore::DisplayList::LocalResourceHeap::add):
* Source/WebCore/platform/graphics/filters/FilterFunction.h:
* Source/WebCore/platform/graphics/filters/FilterResults.h:
* Source/WebCore/rendering/svg/RenderSVGResourceFilter.cpp:
(WebCore::RenderSVGResourceFilter::applyResource):
(WebCore::RenderSVGResourceFilter::markFilterForRepaint):
* Source/WebCore/rendering/svg/RenderSVGResourceFilter.h:
* Source/WebCore/svg/graphics/filters/SVGFilter.cpp:
(WebCore::SVGFilter::create):
(WebCore::SVGFilter::SVGFilter):
(WebCore::SVGFilter::buildExpression):
(WebCore::SVGFilter::supportedFilterRenderingModes const):
(WebCore::SVGFilter::effectsOfType const):
(WebCore::SVGFilter::ensureResults):
(WebCore::SVGFilter::addToTransaction):
(WebCore::SVGFilter::buildTransaction):
(WebCore::SVGFilter::applyTransaction):
(WebCore::SVGFilter::apply):
(WebCore::SVGFilter::createFilterStyles const):
(WebCore::SVGFilter::externalRepresentation const):
* Source/WebCore/svg/graphics/filters/SVGFilter.h:
* Source/WebCore/svg/graphics/filters/SVGFilterExpression.h:
* Source/WebCore/svg/graphics/filters/SVGFilterGraph.h:
(WebCore::SVGFilterGraph::SVGFilterGraph):
(WebCore::SVGFilterGraph::nodes const):
* Source/WebCore/svg/graphics/filters/SVGFilterTransaction.h: Renamed from Source/WebCore/svg/graphics/filters/SVGFilterExpressionReference.h.
* Source/WebKit/GPUProcess/graphics/QualifiedResourceHeap.h:
(WebKit::QualifiedResourceHeap::add):
(WebKit::QualifiedResourceHeap::getSVGFilter const):
(WebKit::QualifiedResourceHeap::removeSVGFilter):
(WebKit::QualifiedResourceHeap::releaseAllResources):
(WebKit::QualifiedResourceHeap::checkInvariants const):
* Source/WebKit/GPUProcess/graphics/RemoteDisplayListRecorder.cpp:
(WebKit::RemoteDisplayListRecorder::drawFilteredImageBufferInternal):
(WebKit::RemoteDisplayListRecorder::drawFilteredImageBuffer):
(WebKit::RemoteDisplayListRecorder::drawSVGFilteredImageBuffer):
* Source/WebKit/GPUProcess/graphics/RemoteDisplayListRecorder.h:
* Source/WebKit/GPUProcess/graphics/RemoteDisplayListRecorder.messages.in:
* Source/WebKit/GPUProcess/graphics/RemoteRenderingBackend.cpp:
(WebKit::RemoteRenderingBackend::cacheSVGFilter):
(WebKit::RemoteRenderingBackend::cacheSVGFilterWithQualifiedIdentifier):
* Source/WebKit/GPUProcess/graphics/RemoteRenderingBackend.h:
* Source/WebKit/GPUProcess/graphics/RemoteRenderingBackend.messages.in:
* Source/WebKit/GPUProcess/graphics/RemoteResourceCache.cpp:
(WebKit::RemoteResourceCache::cacheSVGFilter):
(WebKit::RemoteResourceCache::cachedSVGFilter const):
(WebKit::RemoteResourceCache::releaseRenderingResource):
* Source/WebKit/GPUProcess/graphics/RemoteResourceCache.h:
* Source/WebKit/Scripts/webkit/messages.py:
(types_that_cannot_be_forward_declared):
* Source/WebKit/Shared/WebCoreArgumentCoders.cpp:
(IPC::ArgumentCoder&lt;CSSFilter&gt;::encode):
(IPC::ArgumentCoder&lt;CSSFilter&gt;::decode):
(IPC::ArgumentCoder&lt;SVGFilter&gt;::encode):
(IPC::ArgumentCoder&lt;SVGFilter&gt;::decode):
(IPC::ArgumentCoder&lt;Filter&gt;::encodeFilterProperties):
(IPC::ArgumentCoder&lt;Filter&gt;::decodeFilterProperties):
(IPC::ArgumentCoder&lt;Filter&gt;::encode):
(IPC::ArgumentCoder&lt;Filter&gt;::decode):
* Source/WebKit/Shared/WebCoreArgumentCoders.h:
* Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in:
* Source/WebKit/WebProcess/GPU/graphics/RemoteDisplayListRecorderProxy.cpp:
(WebKit::RemoteDisplayListRecorderProxy::recordDrawFilteredImageBuffer):
(WebKit::RemoteDisplayListRecorderProxy::recordResourceUse):
* Source/WebKit/WebProcess/GPU/graphics/RemoteDisplayListRecorderProxy.h:
* Source/WebKit/WebProcess/GPU/graphics/RemoteRenderingBackendProxy.cpp:
(WebKit::RemoteRenderingBackendProxy::cacheSVGFilter):
* Source/WebKit/WebProcess/GPU/graphics/RemoteRenderingBackendProxy.h:
* Source/WebKit/WebProcess/GPU/graphics/RemoteResourceCacheProxy.cpp:
(WebKit::RemoteResourceCacheProxy::~RemoteResourceCacheProxy):
(WebKit::RemoteResourceCacheProxy::clear):
(WebKit::RemoteResourceCacheProxy::recordSVGFilterUse):
(WebKit::RemoteResourceCacheProxy::releaseRenderingResource):
(WebKit::RemoteResourceCacheProxy::clearGradientMap):
(WebKit::RemoteResourceCacheProxy::clearSVGFilterMap):
(WebKit::RemoteResourceCacheProxy::remoteResourceCacheWasDestroyed):
(WebKit::RemoteResourceCacheProxy::releaseMemory):
* Source/WebKit/WebProcess/GPU/graphics/RemoteResourceCacheProxy.h:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a59ad65c2a57a7b02ab9a1f2e96417c223c9dbea

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/5385 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/5524 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/5713 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/6925 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/5416 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/5384 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/5751 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/5503 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/6288 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/5485 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/5553 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/4821 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/6954 "Built successfully") | 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/5493 "Passed tests") | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/3032 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/4828 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/11982 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/4898 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/4906 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/6549 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/5339 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/4382 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/4800 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/8900 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/5161 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->