### PR TITLE
Validation message should be repositioned in a update-the-rendering step

### DIFF
--- a/Source/WebCore/dom/Document.cpp
+++ b/Source/WebCore/dom/Document.cpp
@@ -267,6 +267,7 @@
 #include "TypedElementDescendantIteratorInlines.h"
 #include "UndoManager.h"
 #include "UserGestureIndicator.h"
+#include "ValidationMessage.h"
 #include "ValidationMessageClient.h"
 #include "ViolationReportType.h"
 #include "VisibilityChangeClient.h"
@@ -4587,6 +4588,18 @@ void Document::invalidateScrollbars()
 {
     if (RefPtr frameView = view())
         frameView->invalidateScrollbarsForAllScrollableAreas();
+}
+
+void Document::scheduleToAdjustValidationMessagePosition(ValidationMessage& validationMessage)
+{
+    m_validationMessagesToPosition.add(validationMessage);
+    scheduleRenderingUpdate(RenderingUpdateStep::UpdateValidationMessagePositions);
+}
+
+void Document::adjustValidationMessagePositions()
+{
+    for (auto& message : std::exchange(m_validationMessagesToPosition, { }))
+        message.adjustBubblePosition();
 }
 
 void Document::addAudioProducer(MediaProducer& audioProducer)

--- a/Source/WebCore/dom/Document.h
+++ b/Source/WebCore/dom/Document.h
@@ -223,6 +223,7 @@ class TextResourceDecoder;
 class TransformSource;
 class TreeWalker;
 class UndoManager;
+class ValidationMessage;
 class VisibilityChangeClient;
 class VisitedLinkState;
 class WakeLockManager;
@@ -1489,6 +1490,9 @@ public:
 
     void invalidateScrollbars();
 
+    void scheduleToAdjustValidationMessagePosition(ValidationMessage&);
+    void adjustValidationMessagePositions();
+
     WEBCORE_EXPORT void addAudioProducer(MediaProducer&);
     WEBCORE_EXPORT void removeAudioProducer(MediaProducer&);
     void setActiveSpeechRecognition(SpeechRecognition*);
@@ -2233,6 +2237,8 @@ private:
 
     struct PendingScrollEventTargetList;
     std::unique_ptr<PendingScrollEventTargetList> m_pendingScrollEventTargetList;
+
+    WeakHashSet<ValidationMessage> m_validationMessagesToPosition;
 
     MediaProducerMediaStateFlags m_mediaState;
 

--- a/Source/WebCore/html/ValidationMessage.cpp
+++ b/Source/WebCore/html/ValidationMessage.cpp
@@ -230,14 +230,7 @@ void ValidationMessage::buildBubbleTree()
     setMessageDOMAndStartTimer();
 
     // FIXME: Use transition to show the bubble.
-
-    if (!document.view())
-        return;
-    document.view()->queuePostLayoutCallback([weakThis = WeakPtr { *this }] {
-        if (!weakThis)
-            return;
-        weakThis->adjustBubblePosition();
-    });
+    document.scheduleToAdjustValidationMessagePosition(*this);
 }
 
 void ValidationMessage::requestToHideMessage()

--- a/Source/WebCore/html/ValidationMessage.h
+++ b/Source/WebCore/html/ValidationMessage.h
@@ -56,12 +56,12 @@ public:
     void requestToHideMessage();
     bool isVisible() const;
     bool shadowTreeContains(const Node&) const;
+    void adjustBubblePosition();
 
 private:
     ValidationMessageClient* validationMessageClient() const;
     void setMessage(const String&);
     void setMessageDOMAndStartTimer();
-    void adjustBubblePosition();
     void buildBubbleTree();
     void deleteBubbleTree();
 

--- a/Source/WebCore/page/Page.cpp
+++ b/Source/WebCore/page/Page.cpp
@@ -1810,6 +1810,10 @@ void Page::updateRendering()
         }
     });
 
+    runProcessingStep(RenderingUpdateStep::UpdateValidationMessagePositions, [] (Document& document) {
+        document.adjustValidationMessagePositions();
+    });
+
     for (auto& document : initialDocuments) {
         if (document && document->domWindow())
             document->domWindow()->unfreezeNowTimestamp();
@@ -4119,6 +4123,7 @@ WTF::TextStream& operator<<(WTF::TextStream& ts, RenderingUpdateStep step)
     case RenderingUpdateStep::PrepareCanvasesForDisplay: ts << "PrepareCanvasesForDisplay"; break;
     case RenderingUpdateStep::CaretAnimation: ts << "CaretAnimation"; break;
     case RenderingUpdateStep::FocusFixup: ts << "FocusFixup"; break;
+    case RenderingUpdateStep::UpdateValidationMessagePositions: ts << "UpdateValidationMessagePositions"; break;
     }
     return ts;
 }

--- a/Source/WebCore/page/Page.h
+++ b/Source/WebCore/page/Page.h
@@ -237,6 +237,7 @@ enum class RenderingUpdateStep : uint32_t {
     PrepareCanvasesForDisplay       = 1 << 16,
     CaretAnimation                  = 1 << 17,
     FocusFixup                      = 1 << 18,
+    UpdateValidationMessagePositions= 1 << 19,
 };
 
 enum class LookalikeCharacterSanitizationTrigger : uint8_t {


### PR DESCRIPTION
#### 987db2a04859e9c6a68d0bc4e7ac89c99fb80402
<pre>
Validation message should be repositioned in a update-the-rendering step
<a href="https://bugs.webkit.org/show_bug.cgi?id=256291">https://bugs.webkit.org/show_bug.cgi?id=256291</a>

Reviewed by Tim Nguyen.

Update the positions of validation messages as a rendering update step instead of a post layout task.

* Source/WebCore/dom/Document.cpp:
(WebCore::Document::scheduleToAdjustValidationMessagePosition):
(WebCore::Document::adjustValidationMessagePositions):
* Source/WebCore/dom/Document.h:
* Source/WebCore/html/ValidationMessage.cpp:
(WebCore::ValidationMessage::buildBubbleTree):
* Source/WebCore/html/ValidationMessage.h:
* Source/WebCore/page/Page.cpp:
(WebCore::Page::updateRendering):
(WebCore::operator&lt;&lt;):
* Source/WebCore/page/Page.h:

Canonical link: <a href="https://commits.webkit.org/263663@main">https://commits.webkit.org/263663@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d3441246675f63e39f28534ba1b3aee1f1cb73fc

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/5384 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/5523 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/5712 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/6924 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/5415 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/5383 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/5750 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/5502 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/6282 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/5484 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/5552 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/4820 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/6953 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/3031 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/4827 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/11981 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/4897 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/4905 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/6541 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/5338 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/4381 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/4799 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/8899 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/607 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/5160 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->