### PR TITLE
iOS: Duplicate WebGL content after switching away from Safari and coming back

### DIFF
--- a/Source/WebCore/page/LocalFrameView.cpp
+++ b/Source/WebCore/page/LocalFrameView.cpp
@@ -4742,14 +4742,8 @@ void LocalFrameView::willPaintContents(GraphicsContext& context, const IntRect&,
     paintingState.paintBehavior = m_paintBehavior;
     
     if (auto* parentView = parentFrameView()) {
-        if (parentView->paintBehavior() & PaintBehavior::FlattenCompositingLayers)
-            m_paintBehavior.add(PaintBehavior::FlattenCompositingLayers);
-        
-        if (parentView->paintBehavior() & PaintBehavior::Snapshotting)
-            m_paintBehavior.add(PaintBehavior::Snapshotting);
-        
-        if (parentView->paintBehavior() & PaintBehavior::TileFirstPaint)
-            m_paintBehavior.add(PaintBehavior::TileFirstPaint);
+        constexpr OptionSet<PaintBehavior> flagsToCopy { PaintBehavior::FlattenCompositingLayers, PaintBehavior::Snapshotting, PaintBehavior::DefaultAsynchronousImageDecode, PaintBehavior::ForceSynchronousImageDecode };
+        m_paintBehavior.add(parentView->paintBehavior() & flagsToCopy);
     }
 
     if (document->printing()) {

--- a/Source/WebCore/platform/graphics/GraphicsLayerClient.h
+++ b/Source/WebCore/platform/graphics/GraphicsLayerClient.h
@@ -70,9 +70,10 @@ enum class PlatformLayerTreeAsTextFlags : uint8_t {
     IncludeModels = 1 << 2,
 };
 
+// See WebCore::PaintBehavior.
 enum class GraphicsLayerPaintBehavior : uint8_t {
-    Snapshotting              = 1 << 0,
-    FirstTilePaint            = 1 << 1,
+    DefaultAsynchronousImageDecode = 1 << 0,
+    ForceSynchronousImageDecode = 1 << 1,
 };
     
 class GraphicsLayerClient {

--- a/Source/WebCore/platform/graphics/ca/TileGrid.cpp
+++ b/Source/WebCore/platform/graphics/ca/TileGrid.cpp
@@ -697,8 +697,10 @@ void TileGrid::platformCALayerPaintContents(PlatformCALayer* platformCALayer, Gr
         WebThreadLock();
 #endif
 
-    if (!platformCALayerRepaintCount(platformCALayer))
-        layerPaintBehavior.add(GraphicsLayerPaintBehavior::FirstTilePaint);
+    if (!layerPaintBehavior.contains(GraphicsLayerPaintBehavior::ForceSynchronousImageDecode)) {
+        if (!platformCALayerRepaintCount(platformCALayer))
+            layerPaintBehavior.add(GraphicsLayerPaintBehavior::DefaultAsynchronousImageDecode);
+    }
 
     {
         GraphicsContextStateSaver stateSaver(context);

--- a/Source/WebCore/platform/graphics/ca/cocoa/PlatformCALayerCocoa.mm
+++ b/Source/WebCore/platform/graphics/ca/cocoa/PlatformCALayerCocoa.mm
@@ -1193,8 +1193,10 @@ void PlatformCALayer::drawLayerContents(GraphicsContext& graphicsContext, WebCor
     if (!layerContents)
         return;
 
-    if (!layerContents->platformCALayerRepaintCount(platformCALayer))
-        layerPaintBehavior.add(GraphicsLayerPaintBehavior::FirstTilePaint);
+    if (!layerPaintBehavior.contains(GraphicsLayerPaintBehavior::ForceSynchronousImageDecode)) {
+        if (!layerContents->platformCALayerRepaintCount(platformCALayer))
+            layerPaintBehavior.add(GraphicsLayerPaintBehavior::DefaultAsynchronousImageDecode);
+    }
 
     {
         GraphicsContextStateSaver saver(graphicsContext);

--- a/Source/WebCore/platform/graphics/mac/WebLayer.mm
+++ b/Source/WebCore/platform/graphics/mac/WebLayer.mm
@@ -55,7 +55,7 @@
         WebCore::PlatformCALayer::RepaintRectList rectsToPaint = WebCore::PlatformCALayer::collectRectsToPaint(graphicsContext, layer.get());
         OptionSet<WebCore::GraphicsLayerPaintBehavior> paintBehavior;
         if (self.isRenderingInContext)
-            paintBehavior.add(WebCore::GraphicsLayerPaintBehavior::Snapshotting);
+            paintBehavior.add(WebCore::GraphicsLayerPaintBehavior::ForceSynchronousImageDecode);
         WebCore::PlatformCALayer::drawLayerContents(graphicsContext, layer.get(), rectsToPaint, paintBehavior);
     }
 }
@@ -142,7 +142,7 @@
         WebCore::FloatRect clipBounds = CGContextGetClipBoundingBox(context);
         OptionSet<WebCore::GraphicsLayerPaintBehavior> paintBehavior;
         if (self.isRenderingInContext)
-            paintBehavior.add(WebCore::GraphicsLayerPaintBehavior::Snapshotting);
+            paintBehavior.add(WebCore::GraphicsLayerPaintBehavior::ForceSynchronousImageDecode);
         layer->owner()->platformCALayerPaintContents(layer.get(), graphicsContext, clipBounds, paintBehavior);
     }
 }

--- a/Source/WebCore/rendering/PaintPhase.h
+++ b/Source/WebCore/rendering/PaintPhase.h
@@ -54,7 +54,7 @@ enum class PaintPhase : uint16_t {
     Accessibility            = 1 << 13,
 };
 
-enum class PaintBehavior : uint16_t {
+enum class PaintBehavior : uint32_t {
     Normal                              = 0,
     SelectionOnly                       = 1 << 0,
     SkipSelectionHighlight              = 1 << 1,
@@ -66,12 +66,13 @@ enum class PaintBehavior : uint16_t {
     SelectionAndBackgroundsOnly         = 1 << 7,
     ExcludeSelection                    = 1 << 8,
     FlattenCompositingLayers            = 1 << 9, // Paint doesn't stop at compositing layer boundaries.
-    Snapshotting                        = 1 << 10,
-    TileFirstPaint                      = 1 << 11,
+    ForceSynchronousImageDecode         = 1 << 10, // Paint should always complete image decoding of painted images.
+    DefaultAsynchronousImageDecode      = 1 << 11, // Paint should always start asynchronous image decode of painted images, unless otherwise specified.
     CompositedOverflowScrollContent     = 1 << 12,
     AnnotateLinks                       = 1 << 13, // Collect all renderers with links to annotate their URLs (e.g. PDFs)
     EventRegionIncludeForeground        = 1 << 14, // FIXME: Event region painting should use paint phases.
     EventRegionIncludeBackground        = 1 << 15,
+    Snapshotting                        = 1 << 16, // Paint is updating external backing store and visits all content, including composited content and always completes image decoding of painted images. FIXME: Will be removed.
 };
 
 } // namespace WebCore

--- a/Source/WebCore/rendering/RenderBoxModelObject.cpp
+++ b/Source/WebCore/rendering/RenderBoxModelObject.cpp
@@ -315,6 +315,8 @@ DecodingMode RenderBoxModelObject::decodingModeForImageDraw(const Image& image, 
 #endif
     if (paintInfo.paintBehavior.contains(PaintBehavior::Snapshotting))
         return DecodingMode::Synchronous;
+    if (paintInfo.paintBehavior.contains(PaintBehavior::ForceSynchronousImageDecode))
+        return DecodingMode::Synchronous;
     if (is<HTMLImageElement>(element())) {
         auto decodingMode = downcast<HTMLImageElement>(*element()).decodingMode();
         if (decodingMode == DecodingMode::Asynchronous)
@@ -330,7 +332,7 @@ DecodingMode RenderBoxModelObject::decodingModeForImageDraw(const Image& image, 
         return DecodingMode::Synchronous;
     if (!bitmapImage.canUseAsyncDecodingForLargeImages())
         return DecodingMode::Synchronous;
-    if (paintInfo.paintBehavior.contains(PaintBehavior::TileFirstPaint))
+    if (paintInfo.paintBehavior.contains(PaintBehavior::DefaultAsynchronousImageDecode))
         return DecodingMode::Asynchronous;
     // FIXME: isVisibleInViewport() is not cheap. Find a way to make this condition faster.
     if (!isVisibleInViewport())

--- a/Source/WebCore/rendering/RenderLayer.cpp
+++ b/Source/WebCore/rendering/RenderLayer.cpp
@@ -3260,9 +3260,9 @@ void RenderLayer::paintLayerContents(GraphicsContext& context, const LayerPainti
         else if (localPaintFlags.contains(PaintLayerFlag::PaintingRootBackgroundOnly))
             paintBehavior.add(PaintBehavior::RootBackgroundOnly);
 
-        // FIXME: This seems wrong. We should retain the TileFirstPaint flag for all RenderLayers painted into the root tile cache.
-        if ((paintingInfo.paintBehavior & PaintBehavior::TileFirstPaint) && isRenderViewLayer())
-            paintBehavior.add(PaintBehavior::TileFirstPaint);
+        // FIXME: This seems wrong. We should retain the DefaultAsynchronousImageDecode flag for all RenderLayers painted into the root tile cache.
+        if ((paintingInfo.paintBehavior & PaintBehavior::DefaultAsynchronousImageDecode) && isRenderViewLayer())
+            paintBehavior.add(PaintBehavior::DefaultAsynchronousImageDecode);
 
         if (isPaintingOverflowContents)
             paintBehavior.add(PaintBehavior::CompositedOverflowScrollContent);
@@ -3717,17 +3717,8 @@ void RenderLayer::paintForegroundForFragments(const LayerFragments& layerFragmen
         localPaintBehavior = paintBehavior;
 
     // FIXME: It's unclear if this flag copying is necessary.
-    if (localPaintingInfo.paintBehavior & PaintBehavior::ExcludeSelection)
-        localPaintBehavior.add(PaintBehavior::ExcludeSelection);
-    
-    if (localPaintingInfo.paintBehavior & PaintBehavior::Snapshotting)
-        localPaintBehavior.add(PaintBehavior::Snapshotting);
-    
-    if (localPaintingInfo.paintBehavior & PaintBehavior::TileFirstPaint)
-        localPaintBehavior.add(PaintBehavior::TileFirstPaint);
-
-    if (localPaintingInfo.paintBehavior & PaintBehavior::CompositedOverflowScrollContent)
-        localPaintBehavior.add(PaintBehavior::CompositedOverflowScrollContent);
+    constexpr OptionSet<PaintBehavior> flagsToCopy { PaintBehavior::ExcludeSelection, PaintBehavior::Snapshotting, PaintBehavior::DefaultAsynchronousImageDecode, PaintBehavior::CompositedOverflowScrollContent, PaintBehavior::ForceSynchronousImageDecode };
+    localPaintBehavior.add(localPaintingInfo.paintBehavior & flagsToCopy);
 
     GraphicsContextStateSaver stateSaver(context, false);
     RegionContextStateSaver regionContextStateSaver(localPaintingInfo.regionContext);
@@ -5799,12 +5790,13 @@ TextStream& operator<<(TextStream& ts, PaintBehavior behavior)
     case PaintBehavior::SelectionAndBackgroundsOnly: ts << "SelectionAndBackgroundsOnly"; break;
     case PaintBehavior::ExcludeSelection: ts << "ExcludeSelection"; break;
     case PaintBehavior::FlattenCompositingLayers: ts << "FlattenCompositingLayers"; break;
-    case PaintBehavior::Snapshotting: ts << "Snapshotting"; break;
-    case PaintBehavior::TileFirstPaint: ts << "TileFirstPaint"; break;
+    case PaintBehavior::ForceSynchronousImageDecode: ts << "ForceSynchronousImageDecode"; break;
+    case PaintBehavior::DefaultAsynchronousImageDecode: ts << "DefaultAsynchronousImageDecode"; break;
     case PaintBehavior::CompositedOverflowScrollContent: ts << "CompositedOverflowScrollContent"; break;
     case PaintBehavior::AnnotateLinks: ts << "AnnotateLinks"; break;
     case PaintBehavior::EventRegionIncludeForeground: ts << "EventRegionIncludeForeground"; break;
     case PaintBehavior::EventRegionIncludeBackground: ts << "EventRegionIncludeBackground"; break;
+    case PaintBehavior::Snapshotting: ts << "Snapshotting"; break;
     }
 
     return ts;

--- a/Source/WebCore/rendering/RenderLayerBacking.cpp
+++ b/Source/WebCore/rendering/RenderLayerBacking.cpp
@@ -3710,8 +3710,10 @@ void RenderLayerBacking::paintContents(const GraphicsLayer* graphicsLayer, Graph
     adjustedClipRect.move(m_subpixelOffsetFromRenderer);
     IntRect dirtyRect = enclosingIntRect(adjustedClipRect);
 
-    if (!graphicsLayer->repaintCount())
-        layerPaintBehavior.add(GraphicsLayerPaintBehavior::FirstTilePaint);
+    if (!layerPaintBehavior.contains(GraphicsLayerPaintBehavior::ForceSynchronousImageDecode)) {
+        if (!graphicsLayer->repaintCount())
+            layerPaintBehavior.add(GraphicsLayerPaintBehavior::DefaultAsynchronousImageDecode);
+    }
 
     if (graphicsLayer == m_graphicsLayer.get()
         || graphicsLayer == m_foregroundLayer.get()
@@ -3724,11 +3726,10 @@ void RenderLayerBacking::paintContents(const GraphicsLayer* graphicsLayer, Graph
 
         // We have to use the same root as for hit testing, because both methods can compute and cache clipRects.
         OptionSet<PaintBehavior> behavior = PaintBehavior::Normal;
-        if (layerPaintBehavior.contains(GraphicsLayerPaintBehavior::Snapshotting))
-            behavior.add(PaintBehavior::Snapshotting);
-        
-        if (layerPaintBehavior.contains(GraphicsLayerPaintBehavior::FirstTilePaint))
-            behavior.add(PaintBehavior::TileFirstPaint);
+        if (layerPaintBehavior.contains(GraphicsLayerPaintBehavior::ForceSynchronousImageDecode))
+            behavior.add(PaintBehavior::ForceSynchronousImageDecode);
+        else if (layerPaintBehavior.contains(GraphicsLayerPaintBehavior::DefaultAsynchronousImageDecode))
+            behavior.add(PaintBehavior::DefaultAsynchronousImageDecode);
 
         paintIntoLayer(graphicsLayer, context, dirtyRect, behavior);
 

--- a/Source/WebCore/rendering/RenderWidget.cpp
+++ b/Source/WebCore/rendering/RenderWidget.cpp
@@ -249,10 +249,10 @@ void RenderWidget::paintContents(PaintInfo& paintInfo, const LayoutPoint& paintO
     LayoutRect paintRect = paintInfo.rect;
 
     OptionSet<PaintBehavior> oldBehavior = PaintBehavior::Normal;
-    if (is<LocalFrameView>(*m_widget) && (paintInfo.paintBehavior & PaintBehavior::TileFirstPaint)) {
+    if (is<LocalFrameView>(*m_widget) && (paintInfo.paintBehavior & PaintBehavior::DefaultAsynchronousImageDecode)) {
         LocalFrameView& frameView = downcast<LocalFrameView>(*m_widget);
         oldBehavior = frameView.paintBehavior();
-        frameView.setPaintBehavior(oldBehavior | PaintBehavior::TileFirstPaint);
+        frameView.setPaintBehavior(oldBehavior | PaintBehavior::DefaultAsynchronousImageDecode);
     }
 
     IntPoint widgetLocation = m_widget->frameRect().location();
@@ -286,7 +286,7 @@ void RenderWidget::paintContents(PaintInfo& paintInfo, const LayoutPoint& paintO
             ASSERT(!paintInfo.overlapTestRequests->contains(this) || (paintInfo.overlapTestRequests->get(this) == m_widget->frameRect()));
             paintInfo.overlapTestRequests->set(this, m_widget->frameRect());
         }
-        if (paintInfo.paintBehavior & PaintBehavior::TileFirstPaint)
+        if (paintInfo.paintBehavior & PaintBehavior::DefaultAsynchronousImageDecode)
             frameView.setPaintBehavior(oldBehavior);
     }
 }

--- a/Source/WebKit/Shared/RemoteLayerTree/RemoteLayerBackingStore.mm
+++ b/Source/WebKit/Shared/RemoteLayerTree/RemoteLayerBackingStore.mm
@@ -580,10 +580,9 @@ void RemoteLayerBackingStore::drawInContext(GraphicsContext& context, WTF::Funct
         context.fillRect(layerBounds, SRGBA<uint8_t> { 255, 47, 146 });
 #endif
 
-    // FIXME: Clarify that GraphicsLayerPaintBehavior::Snapshotting is just about image decoding.
-    OptionSet<GraphicsLayerPaintBehavior> paintBehavior;
+    OptionSet<WebCore::GraphicsLayerPaintBehavior> paintBehavior;
     if (m_layer->context() && m_layer->context()->nextRenderingUpdateRequiresSynchronousImageDecoding())
-        paintBehavior.add(WebCore::GraphicsLayerPaintBehavior::Snapshotting);
+        paintBehavior.add(GraphicsLayerPaintBehavior::ForceSynchronousImageDecode);
     
     // FIXME: This should be moved to PlatformCALayerRemote for better layering.
     switch (m_layer->layerType()) {

--- a/Source/WebKitLegacy/mac/WebView/WebFrame.mm
+++ b/Source/WebKitLegacy/mac/WebView/WebFrame.mm
@@ -645,14 +645,8 @@ ALLOW_DEPRECATED_DECLARATIONS_END
     if (auto* parentFrame = dynamicDowncast<WebCore::LocalFrame>(_private->coreFrame->tree().parent())) {
         // For subframes, we need to inherit the paint behavior from our parent
         if (auto* parentView = parentFrame ? parentFrame->view() : nullptr) {
-            if (parentView->paintBehavior().contains(WebCore::PaintBehavior::FlattenCompositingLayers))
-                paintBehavior.add(WebCore::PaintBehavior::FlattenCompositingLayers);
-            
-            if (parentView->paintBehavior().contains(WebCore::PaintBehavior::Snapshotting))
-                paintBehavior.add(WebCore::PaintBehavior::Snapshotting);
-            
-            if (parentView->paintBehavior().contains(WebCore::PaintBehavior::TileFirstPaint))
-                paintBehavior.add(WebCore::PaintBehavior::TileFirstPaint);
+            constexpr OptionSet<WebCore::PaintBehavior> flagsToCopy { WebCore::PaintBehavior::FlattenCompositingLayers, WebCore::PaintBehavior::Snapshotting, WebCore::PaintBehavior::DefaultAsynchronousImageDecode, WebCore::PaintBehavior::ForceSynchronousImageDecode };
+            paintBehavior.add(parentView->paintBehavior() & flagsToCopy);
         }
     } else
         paintBehavior.add([self _paintBehaviorForDestinationContext:ctx]);


### PR DESCRIPTION
#### 05fc19839037c4e09946ed54a19b4a1ea5820d9b
<pre>
iOS: Duplicate WebGL content after switching away from Safari and coming back
<a href="https://bugs.webkit.org/show_bug.cgi?id=256039">https://bugs.webkit.org/show_bug.cgi?id=256039</a>
rdar://87609216

Reviewed by Simon Fraser.

Minimizing to Dock (macOS) or going to home screen (iOS) would suspend
the page and discard decoded images. After coming back to the view,
the view compositing context would be marked as
nextRenderingUpdateRequiresSynchronousImageDecoding. This is done
in order to obtain full image of the loaded page with images.

This &quot;paint images with synchronous image decode&quot; would be implemented
with GraphicsLayerPaintBehavior::Snapshot. This would trigger
WebCore::PaintBehavior::Snapshotting. However, in painting,
Snapshotting would serve two purposes:
  1) Draw composited content for snapshot-like behavior
  2) Force the synchronous image decode.

This would mean that WebGL or Video would be painted to the background
layer, since the element would think the paint would be in snapshot-like
state whenever the intention is to force the synchronous image decoding.

Snapshot-like behavior is following:
 - The whole render tree is painted from root down, visiting all content
   in all render layers, including those typically painted to compositing
   layers
 - The paint is intended for external use, so it is &quot;one shot only&quot;.
   This means the content, including the images, must be painted.
 - The paint should not modify the paint state related to the real
   compositing paint state.

Instead:
Remove GraphicsLayerPaintBehavior::Snapshot, GraphicsLayers are never
drawn in snapshot-like manner. GraphicsLayers are painted per graphics
layer, even in renderInContext case. Use
GraphicsLayerPaintBehavior::ForceSynchronousImageDecode to signify that
the image content has to end up painted by the paint

Rename GraphicsLayerPaintBehaviorFirstTilePaint to
GraphicsLayerPaintBehavior::DefaultAsynchronousImageDecode.
&quot;FirstTilePaint&quot; is not a &quot;paint behavior&quot;. This was used to signify
&quot;paint fast since this is first paint, do not decode images even if
they are in the viewport unless they&apos;re marked as sync decode&quot;.

Add corresponding WebCore::PaintBehavior flags, with corresponding
rationale. WebCore::PaintBehavior::Snapshotting is preserved for now.
This also should be removed, as it is not &quot;paint behavior&quot;, it is &quot;paint
reason&quot;. In future patches it should possibly be defined in terms of
real paint behaviors, namely FlattenCompositingLayers,
ForceSynchronousImageDecode.

* Source/WebCore/display/compositing/DisplayLayerController.cpp:
(WebCore::Display::LayerController::RootLayerClient::paintContents):
* Source/WebCore/display/compositing/DisplayLayerController.h:
* Source/WebCore/page/LocalFrameView.cpp:
(WebCore::LocalFrameView::willPaintContents):
* Source/WebCore/page/PageOverlayController.cpp:
(WebCore::PageOverlayController::paintContents):
* Source/WebCore/page/PageOverlayController.h:
* Source/WebCore/page/linux/ResourceUsageOverlayLinux.cpp:
* Source/WebCore/platform/graphics/GraphicsLayer.cpp:
(WebCore::GraphicsLayer::paintGraphicsLayerContents):
* Source/WebCore/platform/graphics/GraphicsLayer.h:
(WebCore::GraphicsLayer::paintGraphicsLayerContents):
* Source/WebCore/platform/graphics/GraphicsLayerClient.h:
(WebCore::GraphicsLayerClient::paintContents):
(): Deleted.
* Source/WebCore/platform/graphics/ca/GraphicsLayerCA.cpp:
(WebCore::GraphicsLayerCA::platformCALayerPaintContents):
* Source/WebCore/platform/graphics/ca/GraphicsLayerCA.h:
* Source/WebCore/platform/graphics/ca/PlatformCALayer.h:
* Source/WebCore/platform/graphics/ca/PlatformCALayerClient.h:
* Source/WebCore/platform/graphics/ca/TileCoverageMap.cpp:
(WebCore::TileCoverageMap::platformCALayerPaintContents):
* Source/WebCore/platform/graphics/ca/TileCoverageMap.h:
* Source/WebCore/platform/graphics/ca/TileGrid.cpp:
(WebCore::TileGrid::platformCALayerPaintContents):
* Source/WebCore/platform/graphics/ca/TileGrid.h:
* Source/WebCore/platform/graphics/ca/cocoa/PlatformCALayerCocoa.mm:
(WebCore::PlatformCALayer::drawLayerContents):
* Source/WebCore/platform/graphics/mac/WebLayer.mm:
(-[WebLayer drawInContext:]):
(-[WebSimpleLayer drawInContext:]):
* Source/WebCore/platform/mac/DataDetectorHighlight.h:
* Source/WebCore/platform/mac/DataDetectorHighlight.mm:
(WebCore::DataDetectorHighlight::paintContents):
* Source/WebCore/rendering/PaintPhase.h:
* Source/WebCore/rendering/RenderBoxModelObject.cpp:
(WebCore::RenderBoxModelObject::decodingModeForImageDraw const):
* Source/WebCore/rendering/RenderLayer.cpp:
(WebCore::RenderLayer::paintLayerContents):
(WebCore::RenderLayer::paintForegroundForFragments):
(WebCore::RenderLayer::calculateClipRects const):
* Source/WebCore/rendering/RenderLayerBacking.cpp:
(WebCore::RenderLayerBacking::paintContents):
* Source/WebCore/rendering/RenderLayerBacking.h:
* Source/WebCore/rendering/RenderLayerCompositor.cpp:
(WebCore::RenderLayerCompositor::paintContents):
* Source/WebCore/rendering/RenderLayerCompositor.h:
* Source/WebCore/rendering/RenderWidget.cpp:
(WebCore::RenderWidget::paintContents):
* Source/WebKit/Shared/RemoteLayerTree/RemoteLayerBackingStore.mm:
(WebKit::RemoteLayerBackingStore::drawInContext):
* Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/LayerTreeHostTextureMapper.cpp:
(WebKit::LayerTreeHost::paintContents):
* Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/LayerTreeHostTextureMapper.h:
* Source/WebKitLegacy/mac/WebView/WebFrame.mm:
(-[WebFrame _drawRect:contentsOnly:]):

Canonical link: <a href="https://commits.webkit.org/263803@main">https://commits.webkit.org/263803@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4508b4bbca2288cddd1cf194f6820c4344849b43

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/5786 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/5951 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/6139 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/7345 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/6178 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/5786 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/6173 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/5918 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/7960 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/5891 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/5939 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/5232 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/7399 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/3416 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/5214 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/13169 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/5284 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/5291 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/7469 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/5737 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/4709 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/5180 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/1369 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/9299 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/5541 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->