### PR TITLE
LocalFrameView::performPostLayoutTasks should not synchronously scroll to or focus an element

### DIFF
--- a/Source/WebCore/page/LocalFrameView.h
+++ b/Source/WebCore/page/LocalFrameView.h
@@ -867,6 +867,8 @@ private:
     void updateWidgetPositionsTimerFired();
 
     bool scrollToFragmentInternal(StringView);
+    void scheduleScrollToAnchorAndTextFragment();
+    void scrollToAnchorAndTextFragmentNowIfNeeded();
     void scrollToAnchor();
     void scrollToTextFragmentRange();
     void scrollPositionChanged(const ScrollPosition& oldPosition, const ScrollPosition& newPosition);
@@ -1054,6 +1056,7 @@ private:
     // True if autosize has been run since m_shouldAutoSize was set.
     bool m_didRunAutosize { false };
     bool m_inUpdateEmbeddedObjects { false };
+    bool m_scheduledToScrollToAnchor { false };
 };
 
 inline void LocalFrameView::incrementVisuallyNonEmptyPixelCount(const IntSize& size)


### PR DESCRIPTION
#### 99b736b108034efd1b8c06c1807e670f9998330e
<pre>
LocalFrameView::performPostLayoutTasks should not synchronously scroll to or focus an element
<a href="https://bugs.webkit.org/show_bug.cgi?id=256300">https://bugs.webkit.org/show_bug.cgi?id=256300</a>

Reviewed by Alan Baradlay.

Schedule a task to scroll to a fragment or text fragment in LocalFrameView::performPostLayoutTasks
instead of synchronously triggering a scroll.

* Source/WebCore/page/LocalFrameView.cpp:
(WebCore::LocalFrameView::maintainScrollPositionAtAnchor):
(WebCore::LocalFrameView::scheduleScrollToAnchorAndTextFragment): Added.
(WebCore::LocalFrameView::scrollToAnchorAndTextFragmentNowIfNeeded): Added.
* Source/WebCore/page/LocalFrameView.h:

Canonical link: <a href="https://commits.webkit.org/263699@main">https://commits.webkit.org/263699@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/851c992006ab6cc4f8f1b48653e0909a5cfa6d92

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/5457 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/5600 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/5793 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/7002 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/5480 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/5457 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/5828 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/5576 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/6497 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/5559 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/5618 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/4890 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/7032 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/3096 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/4897 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/12045 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/4962 "Passed tests") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/4977 "3 failures") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/6703 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/5412 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/4441 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/4871 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/8974 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/627 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/5234 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->