### PR TITLE
[GStreamer] USE_GSTREAMER_TRANSCODER and USE_GSTREAMER_WEBRTC should be public

### DIFF
--- a/Source/cmake/GStreamerDefinitions.cmake
+++ b/Source/cmake/GStreamerDefinitions.cmake
@@ -11,5 +11,5 @@ WEBKIT_OPTION_DEFINE(USE_GSTREAMER_FULL "Whether to enable support for static GS
 WEBKIT_OPTION_DEFINE(USE_GSTREAMER_NATIVE_VIDEO "Toggle native video support in GStreamer media player" PRIVATE OFF)
 WEBKIT_OPTION_DEFINE(USE_GSTREAMER_NATIVE_AUDIO "Toggle native audio support in GStreamer media player" PRIVATE OFF)
 WEBKIT_OPTION_DEFINE(USE_GSTREAMER_TEXT_SINK "Toggle text sink support in GStreamer media player" PRIVATE ON)
-WEBKIT_OPTION_DEFINE(USE_GSTREAMER_TRANSCODER "Whether to enable support for GStreamer MediaRecorder backend" PRIVATE ON)
-WEBKIT_OPTION_DEFINE(USE_GSTREAMER_WEBRTC "Whether to enable support for WebRTC" PRIVATE ON)
+WEBKIT_OPTION_DEFINE(USE_GSTREAMER_TRANSCODER "Whether to enable support for GStreamer MediaRecorder backend" PUBLIC ON)
+WEBKIT_OPTION_DEFINE(USE_GSTREAMER_WEBRTC "Whether to enable support for WebRTC" PUBLIC ON)


### PR DESCRIPTION
#### fd5659b3362fc4edde12a2482b828778a7b3323c
<pre>
[GStreamer] USE_GSTREAMER_TRANSCODER and USE_GSTREAMER_WEBRTC should be public
<a href="https://bugs.webkit.org/show_bug.cgi?id=256306">https://bugs.webkit.org/show_bug.cgi?id=256306</a>

Reviewed by Philippe Normand.

These build options are both ON by default, but increase the minimum
required GStreamer version from 1.18 to 1.20. They should be PUBLIC
rather than PRIVATE so that distros can build with 1.18 without relying
on secret build options.

* Source/cmake/GStreamerDefinitions.cmake:

Canonical link: <a href="https://commits.webkit.org/263691@main">https://commits.webkit.org/263691@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/722b215bb132990a2551e9501a366f270d24399a

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/5416 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/5555 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/5745 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/6958 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/5444 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/5784 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/5534 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/6354 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/5518 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/5584 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/4852 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/6987 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/3062 "Passed tests") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/12012 "Passed tests") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/4495 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/4928 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/4937 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/6634 "Passed tests") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/4998 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/5371 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/4409 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/5519 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/4831 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/1370 "Passed tests") | 
| [❌ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/1295 "") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/8932 "Built successfully") | | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/24/builds/5678 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/623 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/5194 "Built successfully") | | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/3/builds/1488 "Passed tests") | 
<!--EWS-Status-Bubble-End-->