### PR TITLE
[iOS] Cleanup MediaPlayerSPI.h

### DIFF
--- a/Source/WebCore/PAL/pal/spi/ios/MediaPlayerSPI.h
+++ b/Source/WebCore/PAL/pal/spi/ios/MediaPlayerSPI.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2014, 2015 Apple Inc. All rights reserved.
+ * Copyright (C) 2014-2023 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -36,13 +36,7 @@
 
 #if !PLATFORM(WATCHOS) && !PLATFORM(APPLETV)
 #import <MediaPlayer/MPMediaControlsConfiguration.h>
-#endif
-
-#if !PLATFORM(WATCHOS) && !PLATFORM(APPLETV)
 #import <MediaPlayer/MPMediaControlsViewController.h>
-#else
-#import <MediaPlayer/MPAVRoutingSheet.h>
-#import <MediaPlayer/MPAudioVideoRoutingPopoverController.h>
 #endif
 
 #else
@@ -65,45 +59,12 @@ typedef NSInteger MPRouteDiscoveryMode;
 @end
 
 #if !PLATFORM(WATCHOS) && !PLATFORM(APPLETV)
-
 @interface MPMediaControlsViewController : UIViewController
 @property (nonatomic, copy, nullable) void (^didDismissHandler)(void);
 @end
 
 @interface MPMediaControlsConfiguration : NSObject <NSSecureCoding, NSCopying>
 @end
-
-#else
-
-enum {
-    MPAVItemTypeUnknown = 0,
-    MPAVItemTypeAudio = 1,
-    MPAVItemTypeVideo = 2,
-};
-typedef NSUInteger MPAVItemType;
-
-ALLOW_DEPRECATED_DECLARATIONS_BEGIN
-@interface MPAudioVideoRoutingPopoverController : UIPopoverController
-@end
-ALLOW_DEPRECATED_DECLARATIONS_END
-
-@interface MPAudioVideoRoutingPopoverController ()
-- (id)initWithType:(MPAVItemType)avItemType;
-@end
-
-ALLOW_DEPRECATED_DECLARATIONS_BEGIN
-@interface MPAVRoutingSheet : UIView
-@end
-ALLOW_DEPRECATED_DECLARATIONS_END
-
-@interface MPAVRoutingSheet ()
-@property (nonatomic, assign, setter=setAVItemType:) MPAVItemType avItemType;
-@property (nonatomic, assign) BOOL mirroringOnly;
-- (id)initWithAVItemType:(MPAVItemType)avItemType;
-- (void)showInView:(UIView *)view withCompletionHandler:(void (^)(void))completionHandler;
-- (void)dismiss;
-@end
-
 #endif
 
 NS_ASSUME_NONNULL_END


### PR DESCRIPTION
#### 9b1654017ffa7dc9bc85d5f5ca80120c3758b9b3
<pre>
[iOS] Cleanup MediaPlayerSPI.h
<a href="https://bugs.webkit.org/show_bug.cgi?id=256308">https://bugs.webkit.org/show_bug.cgi?id=256308</a>
rdar://108894032

Reviewed by Jer Noble.

* Source/WebCore/PAL/pal/spi/ios/MediaPlayerSPI.h: Remove unused declarations.

Canonical link: <a href="https://commits.webkit.org/263703@main">https://commits.webkit.org/263703@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/eb3fb7e3be4fb2c037f990287ca4ef66680ccbdf

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/5417 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/5556 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/5746 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/6959 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/5445 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/5417 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/5785 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/5535 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/6356 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/5519 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/5585 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/4853 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/6988 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/3063 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/4858 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/12013 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/4929 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/4938 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/6636 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/5372 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/4410 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/4832 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/1310 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/8933 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/5195 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->