### PR TITLE
[GPU Process][Filters] Make FilterFunction a RenderingResource

### DIFF
--- a/Source/WebCore/platform/graphics/RenderingResource.h
+++ b/Source/WebCore/platform/graphics/RenderingResource.h
@@ -61,6 +61,11 @@ public:
         return *m_renderingResourceIdentifier;
     }
 
+    std::optional<RenderingResourceIdentifier> renderingResourceIdentifierIfExists() const
+    {
+        return m_renderingResourceIdentifier;
+    }
+
     void addObserver(Observer& observer)
     {
         ASSERT(hasValidRenderingResourceIdentifier());

--- a/Source/WebCore/platform/graphics/filters/Filter.cpp
+++ b/Source/WebCore/platform/graphics/filters/Filter.cpp
@@ -34,8 +34,13 @@
 
 namespace WebCore {
 
-Filter::Filter(Filter::Type filterType, const FloatSize& filterScale, const FloatRect& filterRegion)
-    : FilterFunction(filterType)
+Filter::Filter(Filter::Type filterType, std::optional<RenderingResourceIdentifier> renderingResourceIdentifier)
+    : FilterFunction(filterType, renderingResourceIdentifier)
+{
+}
+
+Filter::Filter(Filter::Type filterType, const FloatSize& filterScale, const FloatRect& filterRegion, std::optional<RenderingResourceIdentifier> renderingResourceIdentifier)
+    : FilterFunction(filterType, renderingResourceIdentifier)
     , m_filterScale(filterScale)
     , m_filterRegion(filterRegion)
 {

--- a/Source/WebCore/platform/graphics/filters/Filter.h
+++ b/Source/WebCore/platform/graphics/filters/Filter.h
@@ -69,8 +69,8 @@ public:
     WEBCORE_EXPORT FilterStyleVector createFilterStyles(const FloatRect& sourceImageRect) const;
 
 protected:
-    using FilterFunction::FilterFunction;
-    Filter(Filter::Type, const FloatSize& filterScale, const FloatRect& filterRegion = { });
+    Filter(Filter::Type, std::optional<RenderingResourceIdentifier> = std::nullopt);
+    Filter(Filter::Type, const FloatSize& filterScale, const FloatRect& filterRegion = { }, std::optional<RenderingResourceIdentifier> = std::nullopt);
 
     virtual RefPtr<FilterImage> apply(FilterImage* sourceImage, FilterResults&) = 0;
     virtual FilterStyleVector createFilterStyles(const FilterStyle& sourceStyle) const = 0;

--- a/Source/WebCore/platform/graphics/filters/FilterFunction.cpp
+++ b/Source/WebCore/platform/graphics/filters/FilterFunction.cpp
@@ -32,8 +32,9 @@
 
 namespace WebCore {
 
-FilterFunction::FilterFunction(Type filterType)
-    : m_filterType(filterType)
+FilterFunction::FilterFunction(Type filterType, std::optional<RenderingResourceIdentifier> renderingResourceIdentifier)
+    : RenderingResource(renderingResourceIdentifier)
+    , m_filterType(filterType)
 {
 }
 

--- a/Source/WebCore/platform/graphics/filters/FilterFunction.h
+++ b/Source/WebCore/platform/graphics/filters/FilterFunction.h
@@ -32,7 +32,7 @@
 #include "FilterStyle.h"
 #include "FloatRect.h"
 #include "LengthBox.h"
-#include <wtf/RefCounted.h>
+#include "RenderingResource.h"
 #include <wtf/text/AtomString.h>
 
 namespace WTF {
@@ -49,7 +49,7 @@ enum class FilterRepresentation : uint8_t {
     Debugging
 };
 
-class FilterFunction : public RefCounted<FilterFunction> {
+class FilterFunction : public RenderingResource {
 public:
     enum class Type : uint8_t {
         CSSFilter,
@@ -80,7 +80,7 @@ public:
         FELast = SourceGraphic
     };
 
-    FilterFunction(Type);
+    FilterFunction(Type, std::optional<RenderingResourceIdentifier> = std::nullopt);
     virtual ~FilterFunction() = default;
 
     Type filterType() const { return m_filterType; }

--- a/Source/WebCore/svg/graphics/filters/SVGFilter.cpp
+++ b/Source/WebCore/svg/graphics/filters/SVGFilter.cpp
@@ -36,9 +36,9 @@ namespace WebCore {
 static constexpr unsigned maxTotalNumberFilterEffects = 100;
 static constexpr unsigned maxCountChildNodes = 200;
 
-RefPtr<SVGFilter> SVGFilter::create(SVGFilterElement& filterElement, OptionSet<FilterRenderingMode> preferredFilterRenderingModes, const FloatSize& filterScale, const FloatRect& filterRegion, const FloatRect& targetBoundingBox, const GraphicsContext& destinationContext)
+RefPtr<SVGFilter> SVGFilter::create(SVGFilterElement& filterElement, OptionSet<FilterRenderingMode> preferredFilterRenderingModes, const FloatSize& filterScale, const FloatRect& filterRegion, const FloatRect& targetBoundingBox, const GraphicsContext& destinationContext, std::optional<RenderingResourceIdentifier> renderingResourceIdentifier)
 {
-    auto filter = adoptRef(*new SVGFilter(filterScale, filterRegion, targetBoundingBox, filterElement.primitiveUnits()));
+    auto filter = adoptRef(*new SVGFilter(filterScale, filterRegion, targetBoundingBox, filterElement.primitiveUnits(), renderingResourceIdentifier));
 
     auto expression = buildExpression(filterElement, filter, destinationContext);
     if (!expression)
@@ -51,20 +51,20 @@ RefPtr<SVGFilter> SVGFilter::create(SVGFilterElement& filterElement, OptionSet<F
     return filter;
 }
 
-RefPtr<SVGFilter> SVGFilter::create(const FloatRect& targetBoundingBox, SVGUnitTypes::SVGUnitType primitiveUnits, SVGFilterExpression&& expression)
+RefPtr<SVGFilter> SVGFilter::create(const FloatRect& targetBoundingBox, SVGUnitTypes::SVGUnitType primitiveUnits, SVGFilterExpression&& expression, std::optional<RenderingResourceIdentifier> renderingResourceIdentifier)
 {
-    return adoptRef(*new SVGFilter(targetBoundingBox, primitiveUnits, WTFMove(expression)));
+    return adoptRef(*new SVGFilter(targetBoundingBox, primitiveUnits, WTFMove(expression), renderingResourceIdentifier));
 }
 
-SVGFilter::SVGFilter(const FloatSize& filterScale, const FloatRect& filterRegion, const FloatRect& targetBoundingBox, SVGUnitTypes::SVGUnitType primitiveUnits)
-    : Filter(Filter::Type::SVGFilter, filterScale, filterRegion)
+SVGFilter::SVGFilter(const FloatSize& filterScale, const FloatRect& filterRegion, const FloatRect& targetBoundingBox, SVGUnitTypes::SVGUnitType primitiveUnits, std::optional<RenderingResourceIdentifier> renderingResourceIdentifier)
+    : Filter(Filter::Type::SVGFilter, filterScale, filterRegion, renderingResourceIdentifier)
     , m_targetBoundingBox(targetBoundingBox)
     , m_primitiveUnits(primitiveUnits)
 {
 }
 
-SVGFilter::SVGFilter(const FloatRect& targetBoundingBox, SVGUnitTypes::SVGUnitType primitiveUnits, SVGFilterExpression&& expression)
-    : Filter(Filter::Type::SVGFilter)
+SVGFilter::SVGFilter(const FloatRect& targetBoundingBox, SVGUnitTypes::SVGUnitType primitiveUnits, SVGFilterExpression&& expression, std::optional<RenderingResourceIdentifier> renderingResourceIdentifier)
+    : Filter(Filter::Type::SVGFilter, renderingResourceIdentifier)
     , m_targetBoundingBox(targetBoundingBox)
     , m_primitiveUnits(primitiveUnits)
     , m_expression(WTFMove(expression))

--- a/Source/WebCore/svg/graphics/filters/SVGFilter.h
+++ b/Source/WebCore/svg/graphics/filters/SVGFilter.h
@@ -36,8 +36,8 @@ class SVGFilterElement;
 
 class SVGFilter final : public Filter {
 public:
-    static RefPtr<SVGFilter> create(SVGFilterElement&, OptionSet<FilterRenderingMode> preferredFilterRenderingModes, const FloatSize& filterScale, const FloatRect& filterRegion, const FloatRect& targetBoundingBox, const GraphicsContext& destinationContext);
-    WEBCORE_EXPORT static RefPtr<SVGFilter> create(const FloatRect& targetBoundingBox, SVGUnitTypes::SVGUnitType primitiveUnits, SVGFilterExpression&&);
+    static RefPtr<SVGFilter> create(SVGFilterElement&, OptionSet<FilterRenderingMode> preferredFilterRenderingModes, const FloatSize& filterScale, const FloatRect& filterRegion, const FloatRect& targetBoundingBox, const GraphicsContext& destinationContext, std::optional<RenderingResourceIdentifier> = std::nullopt);
+    WEBCORE_EXPORT static RefPtr<SVGFilter> create(const FloatRect& targetBoundingBox, SVGUnitTypes::SVGUnitType primitiveUnits, SVGFilterExpression&&, std::optional<RenderingResourceIdentifier>);
 
     static bool isIdentity(SVGFilterElement&);
     static IntOutsets calculateOutsets(SVGFilterElement&, const FloatRect& targetBoundingBox);
@@ -57,8 +57,8 @@ public:
     WTF::TextStream& externalRepresentation(WTF::TextStream&, FilterRepresentation) const final;
 
 private:
-    SVGFilter(const FloatSize& filterScale, const FloatRect& filterRegion, const FloatRect& targetBoundingBox, SVGUnitTypes::SVGUnitType primitiveUnits);
-    SVGFilter(const FloatRect& targetBoundingBox, SVGUnitTypes::SVGUnitType primitiveUnits, SVGFilterExpression&&);
+    SVGFilter(const FloatSize& filterScale, const FloatRect& filterRegion, const FloatRect& targetBoundingBox, SVGUnitTypes::SVGUnitType primitiveUnits, std::optional<RenderingResourceIdentifier>);
+    SVGFilter(const FloatRect& targetBoundingBox, SVGUnitTypes::SVGUnitType primitiveUnits, SVGFilterExpression&&, std::optional<RenderingResourceIdentifier>);
 
     static std::optional<SVGFilterExpression> buildExpression(SVGFilterElement&, const SVGFilter&, const GraphicsContext& destinationContext);
     void setExpression(SVGFilterExpression&& expression) { m_expression = WTFMove(expression); }


### PR DESCRIPTION
#### 9a8998b85a0acaa34a0c0756c3e77cfe645512c6
<pre>
[GPU Process][Filters] Make FilterFunction a RenderingResource
<a href="https://bugs.webkit.org/show_bug.cgi?id=256318">https://bugs.webkit.org/show_bug.cgi?id=256318</a>
rdar://108900138

Reviewed by Simon Fraser.

This will allow caching the SVGFilter in GPU Process and will allow referencing
it in DisplayList items by its RenderingResourceIdentifier.

To do that, FilterFunction has to be a RenderingResource. This will overcome a
layering violation because we should not reference SVGFilter in platform sources.
Also this will overcome a ref-counting problem since FilterFunction and
RenderingResource are both RefCounted classes.

* Source/WebCore/platform/graphics/RenderingResource.h:
(WebCore::RenderingResource::renderingResourceIdentifierIfExists const):
* Source/WebCore/platform/graphics/filters/Filter.cpp:
(WebCore::Filter::Filter):
* Source/WebCore/platform/graphics/filters/Filter.h:
(WebCore::Filter::Filter):
* Source/WebCore/platform/graphics/filters/FilterFunction.cpp:
(WebCore::FilterFunction::FilterFunction):
* Source/WebCore/platform/graphics/filters/FilterFunction.h:
* Source/WebCore/svg/graphics/filters/SVGFilter.cpp:
(WebCore::SVGFilter::create):
(WebCore::SVGFilter::SVGFilter):
* Source/WebCore/svg/graphics/filters/SVGFilter.h:
* Source/WebKit/Shared/WebCoreArgumentCoders.cpp:
(IPC::ArgumentCoder&lt;SVGFilter&gt;::encode):
(IPC::ArgumentCoder&lt;SVGFilter&gt;::decode):

Canonical link: <a href="https://commits.webkit.org/263820@main">https://commits.webkit.org/263820@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/bdb832d9667ddeccb3772f17db4e3114f18fe0c1

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/5569 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/5721 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/5909 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/7120 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/5572 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/5569 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/5946 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/5694 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/7217 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/5672 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/5731 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/4989 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/7174 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/3209 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/5008 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/12142 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/5075 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/5087 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/6904 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/5524 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/4518 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/4977 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/1379 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/9082 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/5339 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->