### PR TITLE
REGRESSION (GPU Process): Data detector border doesn't appear when hovering over text in Mail

### DIFF
--- a/Source/WebKit/WebProcess/InjectedBundle/API/c/WKBundlePageOverlay.cpp
+++ b/Source/WebKit/WebProcess/InjectedBundle/API/c/WKBundlePageOverlay.cpp
@@ -38,6 +38,7 @@
 #include "WebPage.h"
 #include "WebPageOverlay.h"
 #include <WebCore/GraphicsContext.h>
+#include <WebCore/ImageBuffer.h>
 #include <WebCore/PageOverlay.h>
 #include <WebCore/PlatformMouseEvent.h>
 #include <WebCore/Range.h>
@@ -90,7 +91,15 @@ private:
         if (!m_client.drawRect)
             return;
 
-        m_client.drawRect(toAPI(&pageOverlay), graphicsContext.platformContext(), WebKit::toAPI(dirtyRect), m_client.base.clientInfo);
+        auto imageBuffer = graphicsContext.createAlignedImageBuffer(dirtyRect.size(), WebCore::DestinationColorSpace::SRGB(), WebCore::RenderingMethod::Local);
+        if (!imageBuffer)
+            return;
+
+        auto& imageBufferContext = imageBuffer->context();
+        imageBufferContext.translate(-dirtyRect.location());
+        m_client.drawRect(toAPI(&pageOverlay), imageBufferContext.platformContext(), WebKit::toAPI(dirtyRect), m_client.base.clientInfo);
+
+        graphicsContext.drawConsumingImageBuffer(WTFMove(imageBuffer), dirtyRect);
     }
     
     bool mouseEvent(WebKit::WebPageOverlay& pageOverlay, const WebCore::PlatformMouseEvent& event) override


### PR DESCRIPTION
#### a8ec36cfcdc70b595124542be1f6a89514db35aa
<pre>
REGRESSION (GPU Process): Data detector border doesn&apos;t appear when hovering over text in Mail
<a href="https://bugs.webkit.org/show_bug.cgi?id=256320">https://bugs.webkit.org/show_bug.cgi?id=256320</a>
rdar://108559329

Reviewed by Tim Horton.

DataDetectors UI in Mail is implemented using an injected bundle. Specifically,
the `PageOverlay` API is used to draw the content. Following the introduction of
the GPU Process on macOS, there is no longer a platform graphics context in the
Web Process. Consequently, WebKit hands DataDetectors.framework a `NULL`
`CGContextRef` to draw into, resulting in no content being drawn.

To fix, create a temporary image buffer in the Web Process, for clients of
the injected bundle `PageOverlay` API to draw into. The image buffer is then
drawn into the `GraphicsContext` using an existing drawing command.

* Source/WebKit/WebProcess/InjectedBundle/API/c/WKBundlePageOverlay.cpp:

To limit the size of the temporary image buffer, the size is restricted to the
size of the dirty rect. This also requires translating the image buffer&apos;s
context, as clients are drawing relative to (0, 0).

Canonical link: <a href="https://commits.webkit.org/263700@main">https://commits.webkit.org/263700@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/24c2ac0084524f54933b74f72a50e226f5772a88

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/5426 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/5565 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/5757 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/6968 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/5454 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/5794 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/5544 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/6361 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/5528 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/5592 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/4860 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/6997 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/3070 "Passed tests") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/12018 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/4936 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/4945 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/6653 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/5381 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/4418 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/4841 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/1307 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/8942 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/5204 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->