### PR TITLE
Web Inspector: objects can have multiple private fields with the same name

### DIFF
--- a/LayoutTests/inspector/runtime/getDisplayableProperties-expected.txt
+++ b/LayoutTests/inspector/runtime/getDisplayableProperties-expected.txt
@@ -132,23 +132,74 @@ Internal Properties:
     "boundThis"       =>  null (object null)  []
     "boundArgs"       =>  "Array" (object array)  []
 
--- Running test case: Runtime.getDisplayableProperties.Private.Instance
+-- Running test case: Runtime.getDisplayableProperties.Private.Instance.Parent
 Evaluating expression...
 Getting displayable properties...
 Properties:
+    "#instancePrivateProperty"        =>  "instancePrivatePropertyValue parent" (string)  [writable | enumerable | configurable | isOwn | isPrivate]
     "#parentInstancePrivateProperty"  =>  "parentInstancePrivatePropertyValue" (string)  [writable | enumerable | configurable | isOwn | isPrivate]
+    "instancePublicProperty"          =>  "instancePublicPropertyValue parent" (string)  [writable | enumerable | configurable | isOwn]
+    "parentInstancePublicProperty"    =>  "parentInstancePublicPropertyValue" (string)  [writable | enumerable | configurable | isOwn]
+    "__proto__"                       =>  "PrivateMembersTestClassParent" (object)  [writable | configurable | isOwn]
+
+-- Running test case: Runtime.getDisplayableProperties.Private.Instance.Child
+Evaluating expression...
+Getting displayable properties...
+Properties:
+    "#instancePrivateProperty"        =>  "instancePrivatePropertyValue parent" (string)  [writable | enumerable | configurable | isOwn | isPrivate]
+    "#parentInstancePrivateProperty"  =>  "parentInstancePrivatePropertyValue" (string)  [writable | enumerable | configurable | isOwn | isPrivate]
+    "#instancePrivateProperty"        =>  "instancePrivatePropertyValue child" (string)  [writable | enumerable | configurable | isOwn | isPrivate]
     "#childInstancePrivateProperty"   =>  "childInstancePrivatePropertyValue" (string)  [writable | enumerable | configurable | isOwn | isPrivate]
+    "instancePublicProperty"          =>  "instancePublicPropertyValue child" (string)  [writable | enumerable | configurable | isOwn]
     "parentInstancePublicProperty"    =>  "parentInstancePublicPropertyValue" (string)  [writable | enumerable | configurable | isOwn]
     "childInstancePublicProperty"     =>  "childInstancePublicPropertyValue" (string)  [writable | enumerable | configurable | isOwn]
     "__proto__"                       =>  "PrivateMembersTestClassChild" (object)  [writable | configurable | isOwn]
 
--- Running test case: Runtime.getDisplayableProperties.Private.Constructor
+-- Running test case: Runtime.getDisplayableProperties.Private.Constructor.Parent
 Evaluating expression...
 Getting displayable properties...
 Properties:
+    "#classPrivateProperty"          =>  "classPrivatePropertyValue parent" (string)  [writable | enumerable | configurable | isOwn | isPrivate]
+    "#parentClassPrivateProperty"    =>  "parentClassPrivatePropertyValue" (string)  [writable | enumerable | configurable | isOwn | isPrivate]
+    "length"                         =>  0 (number)  [configurable | isOwn]
+    "prototype"                      =>  "PrivateMembersTestClassParent" (object)  [isOwn]
+    "classPublicMethod"              =>  "classPublicMethod() { parent }" (function)  [writable | configurable | isOwn]
+    "classPublicGetter"              =>  get "get classPublicGetter() { parent }" (function)  [configurable | isOwn]
+    "classPublicGetter"              =>  set undefined (undefined)  [configurable | isOwn]
+    "classPublicSetter"              =>  get undefined (undefined)  [configurable | isOwn]
+    "classPublicSetter"              =>  set "set classPublicSetter(x) { parent }" (function)  [configurable | isOwn]
+    "classPublicGetterSetter"        =>  get "get classPublicGetterSetter() { parent }" (function)  [configurable | isOwn]
+    "classPublicGetterSetter"        =>  set "set classPublicGetterSetter(x) { parent }" (function)  [configurable | isOwn]
+    "parentClassPublicMethod"        =>  "parentClassPublicMethod() { }" (function)  [writable | configurable | isOwn]
+    "parentClassPublicGetter"        =>  get "get parentClassPublicGetter() { }" (function)  [configurable | isOwn]
+    "parentClassPublicGetter"        =>  set undefined (undefined)  [configurable | isOwn]
+    "parentClassPublicSetter"        =>  get undefined (undefined)  [configurable | isOwn]
+    "parentClassPublicSetter"        =>  set "set parentClassPublicSetter(x) { }" (function)  [configurable | isOwn]
+    "parentClassPublicGetterSetter"  =>  get "get parentClassPublicGetterSetter() { }" (function)  [configurable | isOwn]
+    "parentClassPublicGetterSetter"  =>  set "set parentClassPublicGetterSetter(x) { }" (function)  [configurable | isOwn]
+    "toString"                       =>  "toString() { return \"<redacted>\"; }" (function)  [writable | configurable | isOwn]
+    "classPublicProperty"            =>  "classPublicPropertyValue parent" (string)  [writable | enumerable | configurable | isOwn]
+    "parentClassPublicProperty"      =>  "parentClassPublicPropertyValue" (string)  [writable | enumerable | configurable | isOwn]
+    "name"                           =>  "PrivateMembersTestClassParent" (string)  [configurable | isOwn]
+    "arguments"                      =>  "TypeError: 'arguments', 'callee', and 'caller' cannot be accessed in this context." (object error)  [wasThrown]
+    "caller"                         =>  "TypeError: 'arguments', 'callee', and 'caller' cannot be accessed in this context." (object error)  [wasThrown]
+    "__proto__"                      =>  "function () {\n    [native code]\n}" (function)  [writable | configurable | isOwn]
+
+-- Running test case: Runtime.getDisplayableProperties.Private.Constructor.Child
+Evaluating expression...
+Getting displayable properties...
+Properties:
+    "#classPrivateProperty"         =>  "classPrivatePropertyValue child" (string)  [writable | enumerable | configurable | isOwn | isPrivate]
     "#childClassPrivateProperty"    =>  "childClassPrivatePropertyValue" (string)  [writable | enumerable | configurable | isOwn | isPrivate]
     "length"                        =>  0 (number)  [configurable | isOwn]
     "prototype"                     =>  "PrivateMembersTestClassChild" (object)  [isOwn]
+    "classPublicMethod"             =>  "classPublicMethod() { child }" (function)  [writable | configurable | isOwn]
+    "classPublicGetter"             =>  get "get classPublicGetter() { child }" (function)  [configurable | isOwn]
+    "classPublicGetter"             =>  set undefined (undefined)  [configurable | isOwn]
+    "classPublicSetter"             =>  get undefined (undefined)  [configurable | isOwn]
+    "classPublicSetter"             =>  set "set classPublicSetter(x) { child }" (function)  [configurable | isOwn]
+    "classPublicGetterSetter"       =>  get "get classPublicGetterSetter() { child }" (function)  [configurable | isOwn]
+    "classPublicGetterSetter"       =>  set "set classPublicGetterSetter(x) { child }" (function)  [configurable | isOwn]
     "childClassPublicMethod"        =>  "childClassPublicMethod() { }" (function)  [writable | configurable | isOwn]
     "childClassPublicGetter"        =>  get "get childClassPublicGetter() { }" (function)  [configurable | isOwn]
     "childClassPublicGetter"        =>  set undefined (undefined)  [configurable | isOwn]
@@ -157,17 +208,46 @@ Properties:
     "childClassPublicGetterSetter"  =>  get "get childClassPublicGetterSetter() { }" (function)  [configurable | isOwn]
     "childClassPublicGetterSetter"  =>  set "set childClassPublicGetterSetter(x) { }" (function)  [configurable | isOwn]
     "toString"                      =>  "toString() { return \"<redacted>\"; }" (function)  [writable | configurable | isOwn]
+    "classPublicProperty"           =>  "classPublicPropertyValue child" (string)  [writable | enumerable | configurable | isOwn]
     "childClassPublicProperty"      =>  "childClassPublicPropertyValue" (string)  [writable | enumerable | configurable | isOwn]
     "name"                          =>  "PrivateMembersTestClassChild" (string)  [configurable | isOwn]
     "arguments"                     =>  "TypeError: 'arguments', 'callee', and 'caller' cannot be accessed in this context." (object error)  [wasThrown]
     "caller"                        =>  "TypeError: 'arguments', 'callee', and 'caller' cannot be accessed in this context." (object error)  [wasThrown]
     "__proto__"                     =>  "<redacted>" (function class)  [writable | configurable | isOwn]
 
--- Running test case: Runtime.getDisplayableProperties.Private.Prototype
+-- Running test case: Runtime.getDisplayableProperties.Private.Prototype.Parent
+Evaluating expression...
+Getting displayable properties...
+Properties:
+    "constructor"                       =>  "<redacted>" (function class)  [writable | configurable | isOwn]
+    "instancePublicMethod"              =>  "instancePublicMethod() { parent }" (function)  [writable | configurable | isOwn]
+    "instancePublicGetter"              =>  get "get instancePublicGetter() { parent }" (function)  [configurable | isOwn]
+    "instancePublicGetter"              =>  set undefined (undefined)  [configurable | isOwn]
+    "instancePublicSetter"              =>  get undefined (undefined)  [configurable | isOwn]
+    "instancePublicSetter"              =>  set "set instancePublicSetter(x) { parent }" (function)  [configurable | isOwn]
+    "instancePublicGetterSetter"        =>  get "get instancePublicGetterSetter() { parent }" (function)  [configurable | isOwn]
+    "instancePublicGetterSetter"        =>  set "set instancePublicGetterSetter(x) { parent }" (function)  [configurable | isOwn]
+    "parentInstancePublicMethod"        =>  "parentInstancePublicMethod() { }" (function)  [writable | configurable | isOwn]
+    "parentInstancePublicGetter"        =>  get "get parentInstancePublicGetter() { }" (function)  [configurable | isOwn]
+    "parentInstancePublicGetter"        =>  set undefined (undefined)  [configurable | isOwn]
+    "parentInstancePublicSetter"        =>  get undefined (undefined)  [configurable | isOwn]
+    "parentInstancePublicSetter"        =>  set "set parentInstancePublicSetter(x) { }" (function)  [configurable | isOwn]
+    "parentInstancePublicGetterSetter"  =>  get "get parentInstancePublicGetterSetter() { }" (function)  [configurable | isOwn]
+    "parentInstancePublicGetterSetter"  =>  set "set parentInstancePublicGetterSetter(x) { }" (function)  [configurable | isOwn]
+    "__proto__"                         =>  "Object" (object)  [writable | configurable | isOwn]
+
+-- Running test case: Runtime.getDisplayableProperties.Private.Prototype.Child
 Evaluating expression...
 Getting displayable properties...
 Properties:
     "constructor"                      =>  "<redacted>" (function class)  [writable | configurable | isOwn]
+    "instancePublicMethod"             =>  "instancePublicMethod() { child }" (function)  [writable | configurable | isOwn]
+    "instancePublicGetter"             =>  get "get instancePublicGetter() { child }" (function)  [configurable | isOwn]
+    "instancePublicGetter"             =>  set undefined (undefined)  [configurable | isOwn]
+    "instancePublicSetter"             =>  get undefined (undefined)  [configurable | isOwn]
+    "instancePublicSetter"             =>  set "set instancePublicSetter(x) { child }" (function)  [configurable | isOwn]
+    "instancePublicGetterSetter"       =>  get "get instancePublicGetterSetter() { child }" (function)  [configurable | isOwn]
+    "instancePublicGetterSetter"       =>  set "set instancePublicGetterSetter(x) { child }" (function)  [configurable | isOwn]
     "childInstancePublicMethod"        =>  "childInstancePublicMethod() { }" (function)  [writable | configurable | isOwn]
     "childInstancePublicGetter"        =>  get "get childInstancePublicGetter() { }" (function)  [configurable | isOwn]
     "childInstancePublicGetter"        =>  set undefined (undefined)  [configurable | isOwn]

--- a/LayoutTests/inspector/runtime/getDisplayableProperties.html
+++ b/LayoutTests/inspector/runtime/getDisplayableProperties.html
@@ -110,21 +110,33 @@ function test()
     });
 
     addTestCase({
-        name: "Runtime.getDisplayableProperties.Private.Instance",
+        name: "Runtime.getDisplayableProperties.Private.Instance.Parent",
+        expression: `new PrivateMembersTestClassParent`,
+    });
+
+    addTestCase({
+        name: "Runtime.getDisplayableProperties.Private.Instance.Child",
         expression: `new PrivateMembersTestClassChild`,
-        ownProperties: true,
     });
 
     addTestCase({
-        name: "Runtime.getDisplayableProperties.Private.Constructor",
+        name: "Runtime.getDisplayableProperties.Private.Constructor.Parent",
+        expression: `PrivateMembersTestClassParent`,
+    });
+
+    addTestCase({
+        name: "Runtime.getDisplayableProperties.Private.Constructor.Child",
         expression: `PrivateMembersTestClassChild`,
-        ownProperties: true,
     });
 
     addTestCase({
-        name: "Runtime.getDisplayableProperties.Private.Prototype",
+        name: "Runtime.getDisplayableProperties.Private.Prototype.Parent",
+        expression: `PrivateMembersTestClassParent.prototype`,
+    });
+
+    addTestCase({
+        name: "Runtime.getDisplayableProperties.Private.Prototype.Child",
         expression: `PrivateMembersTestClassChild.prototype`,
-        ownProperties: true,
     });
 
     addTestCase({

--- a/LayoutTests/inspector/runtime/getProperties-expected.txt
+++ b/LayoutTests/inspector/runtime/getProperties-expected.txt
@@ -114,23 +114,72 @@ Internal Properties:
     "boundThis"       =>  null (object null)  []
     "boundArgs"       =>  "Array" (object array)  []
 
--- Running test case: Runtime.getProperties.Private.Instance
+-- Running test case: Runtime.getProperties.Private.Instance.Parent
 Evaluating expression...
 Getting own properties...
 Properties:
+    "#instancePrivateProperty"        =>  "instancePrivatePropertyValue parent" (string)  [writable | enumerable | configurable | isOwn | isPrivate]
     "#parentInstancePrivateProperty"  =>  "parentInstancePrivatePropertyValue" (string)  [writable | enumerable | configurable | isOwn | isPrivate]
+    "instancePublicProperty"          =>  "instancePublicPropertyValue parent" (string)  [writable | enumerable | configurable | isOwn]
+    "parentInstancePublicProperty"    =>  "parentInstancePublicPropertyValue" (string)  [writable | enumerable | configurable | isOwn]
+    "__proto__"                       =>  "PrivateMembersTestClassParent" (object)  [writable | configurable | isOwn]
+
+-- Running test case: Runtime.getProperties.Private.Instance.Child
+Evaluating expression...
+Getting own properties...
+Properties:
+    "#instancePrivateProperty"        =>  "instancePrivatePropertyValue parent" (string)  [writable | enumerable | configurable | isOwn | isPrivate]
+    "#parentInstancePrivateProperty"  =>  "parentInstancePrivatePropertyValue" (string)  [writable | enumerable | configurable | isOwn | isPrivate]
+    "#instancePrivateProperty"        =>  "instancePrivatePropertyValue child" (string)  [writable | enumerable | configurable | isOwn | isPrivate]
     "#childInstancePrivateProperty"   =>  "childInstancePrivatePropertyValue" (string)  [writable | enumerable | configurable | isOwn | isPrivate]
+    "instancePublicProperty"          =>  "instancePublicPropertyValue child" (string)  [writable | enumerable | configurable | isOwn]
     "parentInstancePublicProperty"    =>  "parentInstancePublicPropertyValue" (string)  [writable | enumerable | configurable | isOwn]
     "childInstancePublicProperty"     =>  "childInstancePublicPropertyValue" (string)  [writable | enumerable | configurable | isOwn]
     "__proto__"                       =>  "PrivateMembersTestClassChild" (object)  [writable | configurable | isOwn]
 
--- Running test case: Runtime.getProperties.Private.Constructor
+-- Running test case: Runtime.getProperties.Private.Constructor.Parent
 Evaluating expression...
 Getting own properties...
 Properties:
+    "#classPrivateProperty"          =>  "classPrivatePropertyValue parent" (string)  [writable | enumerable | configurable | isOwn | isPrivate]
+    "#parentClassPrivateProperty"    =>  "parentClassPrivatePropertyValue" (string)  [writable | enumerable | configurable | isOwn | isPrivate]
+    "length"                         =>  0 (number)  [configurable | isOwn]
+    "prototype"                      =>  "PrivateMembersTestClassParent" (object)  [isOwn]
+    "classPublicMethod"              =>  "classPublicMethod() { parent }" (function)  [writable | configurable | isOwn]
+    "classPublicGetter"              =>  get "get classPublicGetter() { parent }" (function)  [configurable | isOwn]
+    "classPublicGetter"              =>  set undefined (undefined)  [configurable | isOwn]
+    "classPublicSetter"              =>  get undefined (undefined)  [configurable | isOwn]
+    "classPublicSetter"              =>  set "set classPublicSetter(x) { parent }" (function)  [configurable | isOwn]
+    "classPublicGetterSetter"        =>  get "get classPublicGetterSetter() { parent }" (function)  [configurable | isOwn]
+    "classPublicGetterSetter"        =>  set "set classPublicGetterSetter(x) { parent }" (function)  [configurable | isOwn]
+    "parentClassPublicMethod"        =>  "parentClassPublicMethod() { }" (function)  [writable | configurable | isOwn]
+    "parentClassPublicGetter"        =>  get "get parentClassPublicGetter() { }" (function)  [configurable | isOwn]
+    "parentClassPublicGetter"        =>  set undefined (undefined)  [configurable | isOwn]
+    "parentClassPublicSetter"        =>  get undefined (undefined)  [configurable | isOwn]
+    "parentClassPublicSetter"        =>  set "set parentClassPublicSetter(x) { }" (function)  [configurable | isOwn]
+    "parentClassPublicGetterSetter"  =>  get "get parentClassPublicGetterSetter() { }" (function)  [configurable | isOwn]
+    "parentClassPublicGetterSetter"  =>  set "set parentClassPublicGetterSetter(x) { }" (function)  [configurable | isOwn]
+    "toString"                       =>  "toString() { return \"<redacted>\"; }" (function)  [writable | configurable | isOwn]
+    "classPublicProperty"            =>  "classPublicPropertyValue parent" (string)  [writable | enumerable | configurable | isOwn]
+    "parentClassPublicProperty"      =>  "parentClassPublicPropertyValue" (string)  [writable | enumerable | configurable | isOwn]
+    "name"                           =>  "PrivateMembersTestClassParent" (string)  [configurable | isOwn]
+    "__proto__"                      =>  "function () {\n    [native code]\n}" (function)  [writable | configurable | isOwn]
+
+-- Running test case: Runtime.getProperties.Private.Constructor.Child
+Evaluating expression...
+Getting own properties...
+Properties:
+    "#classPrivateProperty"         =>  "classPrivatePropertyValue child" (string)  [writable | enumerable | configurable | isOwn | isPrivate]
     "#childClassPrivateProperty"    =>  "childClassPrivatePropertyValue" (string)  [writable | enumerable | configurable | isOwn | isPrivate]
     "length"                        =>  0 (number)  [configurable | isOwn]
     "prototype"                     =>  "PrivateMembersTestClassChild" (object)  [isOwn]
+    "classPublicMethod"             =>  "classPublicMethod() { child }" (function)  [writable | configurable | isOwn]
+    "classPublicGetter"             =>  get "get classPublicGetter() { child }" (function)  [configurable | isOwn]
+    "classPublicGetter"             =>  set undefined (undefined)  [configurable | isOwn]
+    "classPublicSetter"             =>  get undefined (undefined)  [configurable | isOwn]
+    "classPublicSetter"             =>  set "set classPublicSetter(x) { child }" (function)  [configurable | isOwn]
+    "classPublicGetterSetter"       =>  get "get classPublicGetterSetter() { child }" (function)  [configurable | isOwn]
+    "classPublicGetterSetter"       =>  set "set classPublicGetterSetter(x) { child }" (function)  [configurable | isOwn]
     "childClassPublicMethod"        =>  "childClassPublicMethod() { }" (function)  [writable | configurable | isOwn]
     "childClassPublicGetter"        =>  get "get childClassPublicGetter() { }" (function)  [configurable | isOwn]
     "childClassPublicGetter"        =>  set undefined (undefined)  [configurable | isOwn]
@@ -139,15 +188,44 @@ Properties:
     "childClassPublicGetterSetter"  =>  get "get childClassPublicGetterSetter() { }" (function)  [configurable | isOwn]
     "childClassPublicGetterSetter"  =>  set "set childClassPublicGetterSetter(x) { }" (function)  [configurable | isOwn]
     "toString"                      =>  "toString() { return \"<redacted>\"; }" (function)  [writable | configurable | isOwn]
+    "classPublicProperty"           =>  "classPublicPropertyValue child" (string)  [writable | enumerable | configurable | isOwn]
     "childClassPublicProperty"      =>  "childClassPublicPropertyValue" (string)  [writable | enumerable | configurable | isOwn]
     "name"                          =>  "PrivateMembersTestClassChild" (string)  [configurable | isOwn]
     "__proto__"                     =>  "<redacted>" (function class)  [writable | configurable | isOwn]
 
--- Running test case: Runtime.getProperties.Private.Prototype
+-- Running test case: Runtime.getProperties.Private.Prototype.Parent
+Evaluating expression...
+Getting own properties...
+Properties:
+    "constructor"                       =>  "<redacted>" (function class)  [writable | configurable | isOwn]
+    "instancePublicMethod"              =>  "instancePublicMethod() { parent }" (function)  [writable | configurable | isOwn]
+    "instancePublicGetter"              =>  get "get instancePublicGetter() { parent }" (function)  [configurable | isOwn]
+    "instancePublicGetter"              =>  set undefined (undefined)  [configurable | isOwn]
+    "instancePublicSetter"              =>  get undefined (undefined)  [configurable | isOwn]
+    "instancePublicSetter"              =>  set "set instancePublicSetter(x) { parent }" (function)  [configurable | isOwn]
+    "instancePublicGetterSetter"        =>  get "get instancePublicGetterSetter() { parent }" (function)  [configurable | isOwn]
+    "instancePublicGetterSetter"        =>  set "set instancePublicGetterSetter(x) { parent }" (function)  [configurable | isOwn]
+    "parentInstancePublicMethod"        =>  "parentInstancePublicMethod() { }" (function)  [writable | configurable | isOwn]
+    "parentInstancePublicGetter"        =>  get "get parentInstancePublicGetter() { }" (function)  [configurable | isOwn]
+    "parentInstancePublicGetter"        =>  set undefined (undefined)  [configurable | isOwn]
+    "parentInstancePublicSetter"        =>  get undefined (undefined)  [configurable | isOwn]
+    "parentInstancePublicSetter"        =>  set "set parentInstancePublicSetter(x) { }" (function)  [configurable | isOwn]
+    "parentInstancePublicGetterSetter"  =>  get "get parentInstancePublicGetterSetter() { }" (function)  [configurable | isOwn]
+    "parentInstancePublicGetterSetter"  =>  set "set parentInstancePublicGetterSetter(x) { }" (function)  [configurable | isOwn]
+    "__proto__"                         =>  "Object" (object)  [writable | configurable | isOwn]
+
+-- Running test case: Runtime.getProperties.Private.Prototype.Child
 Evaluating expression...
 Getting own properties...
 Properties:
     "constructor"                      =>  "<redacted>" (function class)  [writable | configurable | isOwn]
+    "instancePublicMethod"             =>  "instancePublicMethod() { child }" (function)  [writable | configurable | isOwn]
+    "instancePublicGetter"             =>  get "get instancePublicGetter() { child }" (function)  [configurable | isOwn]
+    "instancePublicGetter"             =>  set undefined (undefined)  [configurable | isOwn]
+    "instancePublicSetter"             =>  get undefined (undefined)  [configurable | isOwn]
+    "instancePublicSetter"             =>  set "set instancePublicSetter(x) { child }" (function)  [configurable | isOwn]
+    "instancePublicGetterSetter"       =>  get "get instancePublicGetterSetter() { child }" (function)  [configurable | isOwn]
+    "instancePublicGetterSetter"       =>  set "set instancePublicGetterSetter(x) { child }" (function)  [configurable | isOwn]
     "childInstancePublicMethod"        =>  "childInstancePublicMethod() { }" (function)  [writable | configurable | isOwn]
     "childInstancePublicGetter"        =>  get "get childInstancePublicGetter() { }" (function)  [configurable | isOwn]
     "childInstancePublicGetter"        =>  set undefined (undefined)  [configurable | isOwn]

--- a/LayoutTests/inspector/runtime/getProperties.html
+++ b/LayoutTests/inspector/runtime/getProperties.html
@@ -125,20 +125,38 @@ function test()
     });
 
     addTestCase({
-        name: "Runtime.getProperties.Private.Instance",
-        expression: `new PrivateMembersTestClassChild`.replaceAll(/\s+/g, ' '),
+        name: "Runtime.getProperties.Private.Instance.Parent",
+        expression: `new PrivateMembersTestClassParent`,
         ownProperties: true,
     });
 
     addTestCase({
-        name: "Runtime.getProperties.Private.Constructor",
-        expression: `PrivateMembersTestClassChild`.replaceAll(/\s+/g, ' '),
+        name: "Runtime.getProperties.Private.Instance.Child",
+        expression: `new PrivateMembersTestClassChild`,
         ownProperties: true,
     });
 
     addTestCase({
-        name: "Runtime.getProperties.Private.Prototype",
-        expression: `PrivateMembersTestClassChild.prototype`.replaceAll(/\s+/g, ' '),
+        name: "Runtime.getProperties.Private.Constructor.Parent",
+        expression: `PrivateMembersTestClassParent`,
+        ownProperties: true,
+    });
+
+    addTestCase({
+        name: "Runtime.getProperties.Private.Constructor.Child",
+        expression: `PrivateMembersTestClassChild`,
+        ownProperties: true,
+    });
+
+    addTestCase({
+        name: "Runtime.getProperties.Private.Prototype.Parent",
+        expression: `PrivateMembersTestClassParent.prototype`,
+        ownProperties: true,
+    });
+
+    addTestCase({
+        name: "Runtime.getProperties.Private.Prototype.Child",
+        expression: `PrivateMembersTestClassChild.prototype`,
         ownProperties: true,
     });
 

--- a/LayoutTests/inspector/runtime/resources/property-descriptor-utilities.js
+++ b/LayoutTests/inspector/runtime/resources/property-descriptor-utilities.js
@@ -1,4 +1,28 @@
 class PrivateMembersTestClassParent {
+    instancePublicProperty = 'instancePublicPropertyValue parent';
+    #instancePrivateProperty = 'instancePrivatePropertyValue parent';
+    instancePublicMethod() { parent }
+    #instancePrivateMethod() { parent }
+    get instancePublicGetter() { parent }
+    set instancePublicSetter(x) { parent }
+    get instancePublicGetterSetter() { parent }
+    set instancePublicGetterSetter(x) { parent }
+    get #instancePrivateGetter() { parent }
+    set #instancePrivateSetter(x) { parent }
+    get #instancePrivateGetterSetter() { parent }
+    set #instancePrivateGetterSetter(x) { parent }
+    static classPublicProperty = 'classPublicPropertyValue parent';
+    static #classPrivateProperty = 'classPrivatePropertyValue parent';
+    static classPublicMethod() { parent }
+    static #classPrivateMethod() { parent }
+    static get classPublicGetter() { parent }
+    static set classPublicSetter(x) { parent }
+    static get classPublicGetterSetter() { parent }
+    static set classPublicGetterSetter(x) { parent }
+    static get #classPrivateGetter() { parent }
+    static set #classPrivateSetter(x) { parent }
+    static get #classPrivateGetterSetter() { parent }
+    static set #classPrivateGetterSetter(x) { parent }
     parentInstancePublicProperty = 'parentInstancePublicPropertyValue';
     #parentInstancePrivateProperty = 'parentInstancePrivatePropertyValue';
     parentInstancePublicMethod() { }
@@ -27,6 +51,30 @@ class PrivateMembersTestClassParent {
 }
 
 class PrivateMembersTestClassChild extends PrivateMembersTestClassParent {
+    instancePublicProperty = 'instancePublicPropertyValue child';
+    #instancePrivateProperty = 'instancePrivatePropertyValue child';
+    instancePublicMethod() { child }
+    #instancePrivateMethod() { child }
+    get instancePublicGetter() { child }
+    set instancePublicSetter(x) { child }
+    get instancePublicGetterSetter() { child }
+    set instancePublicGetterSetter(x) { child }
+    get #instancePrivateGetter() { child }
+    set #instancePrivateSetter(x) { child }
+    get #instancePrivateGetterSetter() { child }
+    set #instancePrivateGetterSetter(x) { child }
+    static classPublicProperty = 'classPublicPropertyValue child';
+    static #classPrivateProperty = 'classPrivatePropertyValue child';
+    static classPublicMethod() { child }
+    static #classPrivateMethod() { child }
+    static get classPublicGetter() { child }
+    static set classPublicSetter(x) { child }
+    static get classPublicGetterSetter() { child }
+    static set classPublicGetterSetter(x) { child }
+    static get #classPrivateGetter() { child }
+    static set #classPrivateSetter(x) { child }
+    static get #classPrivateGetterSetter() { child }
+    static set #classPrivateGetterSetter(x) { child }
     childInstancePublicProperty = 'childInstancePublicPropertyValue';
     #childInstancePrivateProperty = 'childInstancePrivatePropertyValue';
     childInstancePublicMethod() { }

--- a/Source/JavaScriptCore/inspector/JSInjectedScriptHost.cpp
+++ b/Source/JavaScriptCore/inspector/JSInjectedScriptHost.cpp
@@ -292,7 +292,7 @@ static JSObject* constructInternalProperty(JSGlobalObject* globalObject, const S
     return result;
 }
 
-JSValue JSInjectedScriptHost::getOwnPrivatePropertyDescriptors(JSGlobalObject* globalObject, CallFrame* callFrame)
+JSValue JSInjectedScriptHost::getOwnPrivatePropertySymbols(JSGlobalObject* globalObject, CallFrame* callFrame)
 {
     if (callFrame->argumentCount() < 1)
         return jsUndefined();
@@ -301,13 +301,14 @@ JSValue JSInjectedScriptHost::getOwnPrivatePropertyDescriptors(JSGlobalObject* g
     auto scope = DECLARE_THROW_SCOPE(vm);
     JSValue value = callFrame->uncheckedArgument(0);
 
-    JSObject* result = constructEmptyObject(globalObject);
+    JSArray* result = constructEmptyArray(globalObject, nullptr);
     RETURN_IF_EXCEPTION(scope, JSValue());
 
     JSObject* object = jsDynamicCast<JSObject*>(value);
     if (!object)
         return result;
 
+    unsigned index = 0;
     PropertyNameArray propertyNames(vm, PropertyNameMode::StringsAndSymbols, PrivateSymbolMode::Include);
     JSObject::getOwnPropertyNames(object, globalObject, propertyNames, DontEnumPropertiesMode::Include);
     for (const auto& propertyName : propertyNames) {
@@ -318,7 +319,7 @@ JSValue JSInjectedScriptHost::getOwnPrivatePropertyDescriptors(JSGlobalObject* g
         if (!propertyName.string().startsWith('#'))
             continue;
 
-        result->putDirect(vm, Identifier::fromString(vm, String(propertyName.impl()->isolatedCopy())), objectConstructorGetOwnPropertyDescriptor(globalObject, object, propertyName));
+        result->putDirectIndex(globalObject, index++, Symbol::create(vm, *static_cast<SymbolImpl*>(propertyName.impl())));
     }
 
     return result;

--- a/Source/JavaScriptCore/inspector/JSInjectedScriptHost.h
+++ b/Source/JavaScriptCore/inspector/JSInjectedScriptHost.h
@@ -73,7 +73,7 @@ public:
     JSC::JSValue isPromiseRejectedWithNativeGetterTypeError(JSC::JSGlobalObject*, JSC::CallFrame*);
     JSC::JSValue subtype(JSC::JSGlobalObject*, JSC::CallFrame*);
     JSC::JSValue functionDetails(JSC::JSGlobalObject*, JSC::CallFrame*);
-    JSC::JSValue getOwnPrivatePropertyDescriptors(JSC::JSGlobalObject*, JSC::CallFrame*);
+    JSC::JSValue getOwnPrivatePropertySymbols(JSC::JSGlobalObject*, JSC::CallFrame*);
     JSC::JSValue getInternalProperties(JSC::JSGlobalObject*, JSC::CallFrame*);
     JSC::JSValue proxyTargetValue(JSC::CallFrame*);
     JSC::JSValue weakRefTargetValue(JSC::JSGlobalObject*, JSC::CallFrame*);

--- a/Source/JavaScriptCore/inspector/JSInjectedScriptHostPrototype.cpp
+++ b/Source/JavaScriptCore/inspector/JSInjectedScriptHostPrototype.cpp
@@ -35,7 +35,7 @@ using namespace JSC;
 
 static JSC_DECLARE_HOST_FUNCTION(jsInjectedScriptHostPrototypeFunctionSubtype);
 static JSC_DECLARE_HOST_FUNCTION(jsInjectedScriptHostPrototypeFunctionFunctionDetails);
-static JSC_DECLARE_HOST_FUNCTION(jsInjectedScriptHostPrototypeFunctionGetOwnPrivatePropertyDescriptors);
+static JSC_DECLARE_HOST_FUNCTION(jsInjectedScriptHostPrototypeFunctionGetOwnPrivatePropertySymbols);
 static JSC_DECLARE_HOST_FUNCTION(jsInjectedScriptHostPrototypeFunctionGetInternalProperties);
 static JSC_DECLARE_HOST_FUNCTION(jsInjectedScriptHostPrototypeFunctionInternalConstructorName);
 static JSC_DECLARE_HOST_FUNCTION(jsInjectedScriptHostPrototypeFunctionIsHTMLAllCollection);
@@ -63,7 +63,7 @@ void JSInjectedScriptHostPrototype::finishCreation(VM& vm, JSGlobalObject* globa
     
     JSC_NATIVE_FUNCTION_WITHOUT_TRANSITION("subtype"_s, jsInjectedScriptHostPrototypeFunctionSubtype, static_cast<unsigned>(PropertyAttribute::DontEnum), 1, ImplementationVisibility::Private);
     JSC_NATIVE_FUNCTION_WITHOUT_TRANSITION("functionDetails"_s, jsInjectedScriptHostPrototypeFunctionFunctionDetails, static_cast<unsigned>(PropertyAttribute::DontEnum), 1, ImplementationVisibility::Private);
-    JSC_NATIVE_FUNCTION_WITHOUT_TRANSITION("getOwnPrivatePropertyDescriptors"_s, jsInjectedScriptHostPrototypeFunctionGetOwnPrivatePropertyDescriptors, static_cast<unsigned>(PropertyAttribute::DontEnum), 1, ImplementationVisibility::Private);
+    JSC_NATIVE_FUNCTION_WITHOUT_TRANSITION("getOwnPrivatePropertySymbols"_s, jsInjectedScriptHostPrototypeFunctionGetOwnPrivatePropertySymbols, static_cast<unsigned>(PropertyAttribute::DontEnum), 1, ImplementationVisibility::Private);
     JSC_NATIVE_FUNCTION_WITHOUT_TRANSITION("getInternalProperties"_s, jsInjectedScriptHostPrototypeFunctionGetInternalProperties, static_cast<unsigned>(PropertyAttribute::DontEnum), 1, ImplementationVisibility::Private);
     JSC_NATIVE_FUNCTION_WITHOUT_TRANSITION("internalConstructorName"_s, jsInjectedScriptHostPrototypeFunctionInternalConstructorName, static_cast<unsigned>(PropertyAttribute::DontEnum), 1, ImplementationVisibility::Private);
     JSC_NATIVE_FUNCTION_WITHOUT_TRANSITION("isHTMLAllCollection"_s, jsInjectedScriptHostPrototypeFunctionIsHTMLAllCollection, static_cast<unsigned>(PropertyAttribute::DontEnum), 1, ImplementationVisibility::Private);
@@ -305,7 +305,7 @@ JSC_DEFINE_HOST_FUNCTION(jsInjectedScriptHostPrototypeFunctionFunctionDetails, (
     return JSValue::encode(castedThis->functionDetails(globalObject, callFrame));
 }
 
-JSC_DEFINE_HOST_FUNCTION(jsInjectedScriptHostPrototypeFunctionGetOwnPrivatePropertyDescriptors, (JSGlobalObject* globalObject, CallFrame* callFrame))
+JSC_DEFINE_HOST_FUNCTION(jsInjectedScriptHostPrototypeFunctionGetOwnPrivatePropertySymbols, (JSGlobalObject* globalObject, CallFrame* callFrame))
 {
     VM& vm = globalObject->vm();
     auto scope = DECLARE_THROW_SCOPE(vm);
@@ -315,7 +315,7 @@ JSC_DEFINE_HOST_FUNCTION(jsInjectedScriptHostPrototypeFunctionGetOwnPrivatePrope
     if (!castedThis)
         return throwVMTypeError(globalObject, scope);
 
-    return JSValue::encode(castedThis->getOwnPrivatePropertyDescriptors(globalObject, callFrame));
+    return JSValue::encode(castedThis->getOwnPrivatePropertySymbols(globalObject, callFrame));
 }
 
 JSC_DEFINE_HOST_FUNCTION(jsInjectedScriptHostPrototypeFunctionGetInternalProperties, (JSGlobalObject* globalObject, CallFrame* callFrame))


### PR DESCRIPTION
#### eba01be516e6823677fedb7e3676d3e2cef5914e
<pre>
Web Inspector: objects can have multiple private fields with the same name
<a href="https://bugs.webkit.org/show_bug.cgi?id=256319">https://bugs.webkit.org/show_bug.cgi?id=256319</a>

Reviewed by Patrick Angle.

We should show all private fields for an object, not just the most recently defined one for each name.

Developers will be able to identify the value for `this.#foo` by looking for the last `#foo` in the list, as private fields must be declared as part of the `class` definition, meaning they will be created in that order.

* Source/JavaScriptCore/inspector/JSInjectedScriptHost.h:
* Source/JavaScriptCore/inspector/JSInjectedScriptHost.cpp:
(Inspector::JSInjectedScriptHost::getOwnPrivatePropertySymbols): Added.
(Inspector::JSInjectedScriptHost::getOwnPrivatePropertyDescriptors): Deleted.
* Source/JavaScriptCore/inspector/JSInjectedScriptHostPrototype.cpp:
(Inspector::JSInjectedScriptHostPrototype::finishCreation):
(Inspector::jsInjectedScriptHostPrototypeFunctionGetOwnPrivatePropertySymbols): Added.
(Inspector::jsInjectedScriptHostPrototypeFunctionGetOwnPrivatePropertyDescriptors): Deleted.
Instead of returning an object keyed by the stringified private symbol, mimic `Object.getOwnPropertySymbols` to just return the list of all private field symbols.
We can then use the existing code that calls `Object.getOwnPropertyDescriptor` (instead of doing that manually in C++).

* Source/JavaScriptCore/inspector/InjectedScriptSource.js:
(InjectedScript.prototype._forEachPropertyDescriptor.processProperty):
(InjectedScript.prototype._forEachPropertyDescriptor):
Since we&apos;re now using `Symbol`, differentiate private fields from regular (public) `Symbol` properties.

* LayoutTests/inspector/runtime/resources/property-descriptor-utilities.js:
* LayoutTests/inspector/runtime/getDisplayableProperties.html:
* LayoutTests/inspector/runtime/getDisplayableProperties-expected.txt:
* LayoutTests/inspector/runtime/getProperties.html:
* LayoutTests/inspector/runtime/getProperties-expected.txt:

Canonical link: <a href="https://commits.webkit.org/267483@main">https://commits.webkit.org/267483@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c27d580f920821b024f0e3f81b9f3b6d3f5f243e

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/14755 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/15060 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/15412 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/16502 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/13906 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/17581 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/15160 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/16550 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/14935 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/15433 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/12529 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/17235 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/12717 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/13312 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/20302 "Passed tests") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/12633 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/13791 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/13479 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/16716 "Passed tests") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/14024 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/14021 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/11860 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/14955 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/13314 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/13168 "Passed tests") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/3825 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/4001 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/17651 "Built successfully") | | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/24/builds/15185 "Built successfully") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/13865 "Built successfully") | | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/3/builds/3635 "Passed tests") | 
<!--EWS-Status-Bubble-End-->