### PR TITLE
Add support for `@font-face src tech()` and  `@supports font-tech()` (252153)

### DIFF
--- a/LayoutTests/TestExpectations
+++ b/LayoutTests/TestExpectations
@@ -1935,7 +1935,6 @@ imported/w3c/web-platform-tests/html/semantics/embedded-content/the-video-elemen
 
 imported/w3c/web-platform-tests/css/css-conditional/at-supports-namespace-001.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/css/css-conditional/at-supports-namespace-002.html [ ImageOnlyFailure ]
-webkit.org/b/252153 imported/w3c/web-platform-tests/css/css-conditional/at-supports-font-tech-001.html [ ImageOnlyFailure ]
 webkit.org/b/254682 imported/w3c/web-platform-tests/css/css-conditional/at-supports-047.html [ ImageOnlyFailure ]
 
 transitions/svg-text-shadow-transition.html [ Failure ]

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-conditional/js/CSS-supports-L5-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-conditional/js/CSS-supports-L5-expected.txt
@@ -3,7 +3,7 @@ PASS font-format() function accepts a known format
 PASS font-format() function doesn't accept an unknown format
 PASS font-format() function doesn't accept a format list
 PASS font-format() function doesn't accept a string.
-FAIL font-tech() function accepts a known technology assert_equals: expected true but got false
+PASS font-tech() function accepts a known technology
 PASS font-tech() function doesn't accept singular feature-* form for technology
 PASS font-tech() function doesn't accept an unknown technology
 PASS font-tech() function doesn't accept a technology list

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-fonts/parsing/font-face-src-tech-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-fonts/parsing/font-face-src-tech-expected.txt
@@ -1,18 +1,18 @@
 
 PASS Check that src: url("foo.ttf") is valid
 PASS Check that src: url("foo.ttf") tech() is invalid
-FAIL Check that src: url("foo.ttf") tech(features-opentype) is valid assert_equals: expected true but got false
-FAIL Check that src: url("foo.ttf") tech(features-aat) is valid assert_equals: expected true but got false
-FAIL Check that src: url("foo.ttf") tech(color-COLRv0) is valid assert_equals: expected true but got false
+PASS Check that src: url("foo.ttf") tech(features-opentype) is valid
+PASS Check that src: url("foo.ttf") tech(features-aat) is valid
+PASS Check that src: url("foo.ttf") tech(color-COLRv0) is valid
 FAIL Check that src: url("foo.ttf") tech(color-COLRv1) is valid assert_equals: expected true but got false
-FAIL Check that src: url("foo.ttf") tech(color-sbix) is valid assert_equals: expected true but got false
+PASS Check that src: url("foo.ttf") tech(color-sbix) is valid
 FAIL Check that src: url("foo.ttf") tech(color-CBDT) is valid assert_equals: expected true but got false
-FAIL Check that src: url("foo.ttf") tech(variations) is valid assert_equals: expected true but got false
-FAIL Check that src: url("foo.ttf") tech(palettes) is valid assert_equals: expected true but got false
+PASS Check that src: url("foo.ttf") tech(variations) is valid
+PASS Check that src: url("foo.ttf") tech(palettes) is valid
 PASS Check that src: url("foo.ttf") tech("features-opentype") is invalid
 PASS Check that src: url("foo.ttf") tech("color-COLRv0") is invalid
 PASS Check that src: url("foo.ttf") tech("variations") is invalid
-FAIL Check that src: url("foo.ttf") tech(features-opentype, color-COLRv0, variations, palettes) is valid assert_equals: expected true but got false
+PASS Check that src: url("foo.ttf") tech(features-opentype, color-COLRv0, variations, palettes) is valid
 PASS Check that src: url("foo.ttf") tech(features-opentype color-COLRv0 variations palettes) is invalid
 PASS Check that src: url("foo.ttf") tech(feature-opentype) is invalid
 PASS Check that src: url("foo.ttf") tech(feature-aat) is invalid
@@ -24,7 +24,7 @@ PASS Check that src: url("foo.ttf") tech(initial) is invalid
 PASS Check that src: url("foo.ttf") tech(none) is invalid
 PASS Check that src: url("foo.ttf") tech(normal) is invalid
 PASS Check that src: url("foo.ttf") tech(xyzzy) is invalid
-FAIL Check that src: url("foo.ttf") format(opentype) tech(features-opentype) is valid assert_equals: expected true but got false
+PASS Check that src: url("foo.ttf") format(opentype) tech(features-opentype) is valid
 PASS Check that src: url("foo.ttf") tech(features-opentype) format(opentype) is invalid
 PASS Check that src: url("foo.ttf") tech(incremental), url("bar.html") is valid
 PASS Check that src: url("foo.ttf") tech(incremental, color-SVG, features-graphite, features-aat), url("bar.html") is valid
@@ -34,6 +34,6 @@ PASS Check that src: url("foo.ttf") tech(features-graphite), url("bar.html") is 
 PASS Check that src: url("foo.ttf") dummy("opentype") tech(variations) is invalid
 PASS Check that src: url("foo.ttf") dummy("opentype") dummy(variations) is invalid
 PASS Check that src: url("foo.ttf") format(opentype) tech(features-opentype) dummy(something) is invalid
-FAIL Check that src: url("foo.ttf") format(dummy), url("foo.ttf") tech(variations) is valid assert_equals: expected true but got false
+PASS Check that src: url("foo.ttf") format(dummy), url("foo.ttf") tech(variations) is valid
 PASS Check that src: url("foo.ttf") tech(color), url("bar.html") is valid
 

--- a/LayoutTests/platform/gtk/TestExpectations
+++ b/LayoutTests/platform/gtk/TestExpectations
@@ -104,6 +104,8 @@ imported/w3c/web-platform-tests/service-workers/service-worker/fetch-audio-taint
 
 imported/w3c/web-platform-tests/css/css-masking/clip-path/clip-path-descendant-text-mutated-001.html [ Pass ]
 
+webkit.org/b/256310 imported/w3c/web-platform-tests/css/css-fonts/parsing/font-face-src-tech.html [ Skip ]
+
 #////////////////////////////////////////////////////////////////////////////////////////
 # End of PASSING tests. See below where to put expected failures.
 #////////////////////////////////////////////////////////////////////////////////////////

--- a/LayoutTests/platform/wpe/TestExpectations
+++ b/LayoutTests/platform/wpe/TestExpectations
@@ -769,6 +769,8 @@ webkit.org/b/217369 fast/canvas/fill-text-with-font-features.html [ ImageOnlyFai
 
 webkit.org/b/217370 fast/events/setDragImage-element-non-nullable.html [ Failure ]
 
+webkit.org/b/256310 imported/w3c/web-platform-tests/css/css-fonts/parsing/font-face-src-tech.html [ Skip ]
+
 # WebXR
 webkit.org/b/225483 [ Release ] imported/w3c/web-platform-tests/webxr/events_input_source_recreation.https.html [ Pass ]
 webkit.org/b/225483 [ Release ] imported/w3c/web-platform-tests/webxr/events_input_sources_change.https.html [ Pass ]

--- a/Source/WebCore/css/CSSFontFaceSrcValue.h
+++ b/Source/WebCore/css/CSSFontFaceSrcValue.h
@@ -29,6 +29,7 @@
 #include "CSSValue.h"
 #include "CachedResourceHandle.h"
 #include "ResourceLoaderOptions.h"
+#include <wtf/Vector.h>
 
 namespace WebCore {
 
@@ -59,9 +60,56 @@ private:
     WeakPtr<SVGFontFaceElement, WeakPtrImplWithEventTargetData> m_element;
 };
 
+enum class FontTechnology : uint8_t {
+    ColorColrv0,
+    ColorColrv1,
+    ColorCbdt,
+    ColorSbix,
+    ColorSvg,
+    FeaturesAat,
+    FeaturesGraphite,
+    FeaturesOpentype,
+    Incremental,
+    Palettes,
+    Variations,
+    // Reserved for invalid conversion result.
+    Invalid
+};
+
+inline ASCIILiteral cssTextFromFontTech(FontTechnology tech)
+{
+    switch (tech) {
+    case FontTechnology::ColorColrv0:
+        return "color-colrv0"_s;
+    case FontTechnology::ColorColrv1:
+        return "color-colrv1"_s;
+    case FontTechnology::ColorCbdt:
+        return "color-cbdt"_s;
+    case FontTechnology::ColorSbix:
+        return "color-sbix"_s;
+    case FontTechnology::ColorSvg:
+        return "color-svg"_s;
+    case FontTechnology::FeaturesAat:
+        return "features-aat"_s;
+    case FontTechnology::FeaturesGraphite:
+        return "features-graphite"_s;
+    case FontTechnology::FeaturesOpentype:
+        return "features-opentype"_s;
+    case FontTechnology::Incremental:
+        return "incremental"_s;
+    case FontTechnology::Palettes:
+        return "palettes"_s;
+    case FontTechnology::Variations:
+        return "variations"_s;
+    default:
+        return ""_s;
+    }
+}
+
 class CSSFontFaceSrcResourceValue final : public CSSValue {
 public:
-    static Ref<CSSFontFaceSrcResourceValue> create(ResolvedURL, String format, LoadedFromOpaqueSource = LoadedFromOpaqueSource::No);
+
+    static Ref<CSSFontFaceSrcResourceValue> create(ResolvedURL, String format, Vector<FontTechnology>&& technologies, LoadedFromOpaqueSource = LoadedFromOpaqueSource::No);
 
     bool isEmpty() const { return m_location.specifiedURLString.isEmpty(); }
     std::unique_ptr<FontLoadRequest> fontLoadRequest(ScriptExecutionContext&, bool isInitiatingElementInUserAgentShadowTree);
@@ -71,10 +119,11 @@ public:
     bool equals(const CSSFontFaceSrcResourceValue&) const;
 
 private:
-    explicit CSSFontFaceSrcResourceValue(ResolvedURL&&, String&& format, LoadedFromOpaqueSource);
+    explicit CSSFontFaceSrcResourceValue(ResolvedURL&&, String&& format, Vector<FontTechnology>&& technologies, LoadedFromOpaqueSource);
 
     ResolvedURL m_location;
     String m_format;
+    Vector<FontTechnology> m_technologies;
     LoadedFromOpaqueSource m_loadedFromOpaqueSource { LoadedFromOpaqueSource::No };
     CachedResourceHandle<CachedFont> m_cachedFont;
 };

--- a/Source/WebCore/css/CSSPrimitiveValueMappings.h
+++ b/Source/WebCore/css/CSSPrimitiveValueMappings.h
@@ -30,6 +30,7 @@
 #pragma once
 
 #include "CSSCalcValue.h"
+#include "CSSFontFaceSrcValue.h"
 #include "CSSPrimitiveValue.h"
 #include "CSSToLengthConversionData.h"
 #include "CSSValueKeywords.h"
@@ -2408,6 +2409,37 @@ template<> constexpr FontOpticalSizing fromCSSValueID(CSSValueID valueID)
     }
     ASSERT_NOT_REACHED_UNDER_CONSTEXPR_CONTEXT();
     return FontOpticalSizing::Enabled;
+}
+
+template<> constexpr FontTechnology fromCSSValueID(CSSValueID valueID)
+{
+    switch (valueID) {
+    case CSSValueColorColrv0:
+        return FontTechnology::ColorColrv0;
+    case CSSValueColorColrv1:
+        return FontTechnology::ColorColrv1;
+    case CSSValueColorCbdt:
+        return FontTechnology::ColorCbdt;
+    case CSSValueColorSbix:
+        return FontTechnology::ColorSbix;
+    case CSSValueColorSvg:
+        return FontTechnology::ColorSvg;
+    case CSSValueFeaturesAat:
+        return FontTechnology::FeaturesAat;
+    case CSSValueFeaturesGraphite:
+        return FontTechnology::FeaturesGraphite;
+    case CSSValueFeaturesOpentype:
+        return FontTechnology::FeaturesOpentype;
+    case CSSValueIncremental:
+        return FontTechnology::Incremental;
+    case CSSValuePalettes:
+        return FontTechnology::Palettes;
+    case CSSValueVariations:
+        return FontTechnology::Variations;
+    default:
+        break;
+    }
+    return FontTechnology::Invalid;
 }
 
 #define TYPE FontSynthesisLonghandValue

--- a/Source/WebCore/css/CSSValueKeywords.in
+++ b/Source/WebCore/css/CSSValueKeywords.in
@@ -1316,6 +1316,19 @@ svg
 truetype
 woff
 woff2
+// @font-face src tech()
+tech
+color-cbdt
+color-colrv0
+color-colrv1
+color-sbix
+color-svg
+features-aat
+features-graphite
+features-opentype
+incremental
+palettes
+variations
 
 // (-webkit-)filter
 // invert
@@ -1632,8 +1645,10 @@ words
 // @supports
 // https://drafts.csswg.org/css-conditional-4/#typedef-supports-selector-fn
 // https://drafts.csswg.org/css-conditional-5/#typedef-supports-font-format-fn
+// https://drafts.csswg.org/css-conditional-5/#typedef-supports-font-tech-fn
 selector
 font-format
+font-tech
 
 // math-style
 // normal

--- a/Source/WebCore/css/parser/CSSPropertyParserHelpers.cpp
+++ b/Source/WebCore/css/parser/CSSPropertyParserHelpers.cpp
@@ -46,6 +46,7 @@
 #include "CSSCursorImageValue.h"
 #include "CSSCustomPropertyValue.h"
 #include "CSSFilterImageValue.h"
+#include "CSSFontFaceSrcValue.h"
 #include "CSSFontPaletteValuesOverrideColorsValue.h"
 #include "CSSFontVariantAlternatesValue.h"
 #include "CSSFontVariantLigaturesParser.h"
@@ -84,6 +85,7 @@
 #include "ColorInterpolation.h"
 #include "ColorLuminance.h"
 #include "ColorNormalization.h"
+#include "FontCustomPlatformData.h"
 #include "FontFace.h"
 #include "Logging.h"
 #include "RenderStyleConstants.h"
@@ -8211,6 +8213,24 @@ bool identMatchesSupportedFontFormat(CSSValueID id)
         CSSValueWoff,
         CSSValueWoff2
     >(id);
+}
+
+
+Vector<FontTechnology> consumeFontTech(CSSParserTokenRange& range, bool singleValue)
+{
+    Vector<FontTechnology> technologies;
+    auto args = consumeFunction(range);
+    do {
+        auto& arg = args.consumeIncludingWhitespace();
+        if (arg.type() != IdentToken)
+            return { };
+        auto technology = fromCSSValueID<FontTechnology>(arg.id());
+        if (technology != FontTechnology::Invalid && FontCustomPlatformData::supportsTechnology(technology))
+            technologies.append(technology);
+    } while (consumeCommaIncludingWhitespace(args) && !singleValue);
+    if (!args.atEnd())
+        return { };
+    return technologies;
 }
 
 // MARK: @font-palette-values

--- a/Source/WebCore/css/parser/CSSPropertyParserHelpers.h
+++ b/Source/WebCore/css/parser/CSSPropertyParserHelpers.h
@@ -52,6 +52,7 @@ enum class FamilyNamesIndex;
 }
 
 enum class BoxOrient : bool;
+enum class FontTechnology : uint8_t;
 
 // When these functions are successful, they will consume all the relevant
 // tokens from the range and also consume any whitespace which follows. When
@@ -319,6 +320,7 @@ RefPtr<CSSValue> consumeDeclarationValue(CSSParserTokenRange&, const CSSParserCo
 // @font-face descriptor consumers:
 
 RefPtr<CSSValue> consumeFontFaceFontFamily(CSSParserTokenRange&);
+Vector<FontTechnology> consumeFontTech(CSSParserTokenRange&, bool singleValue = false);
 bool identMatchesSupportedFontFormat(CSSValueID);
 
 // @font-palette-values descriptor consumers:

--- a/Source/WebCore/css/parser/CSSPropertyParserWorkerSafe.cpp
+++ b/Source/WebCore/css/parser/CSSPropertyParserWorkerSafe.cpp
@@ -233,6 +233,7 @@ static RefPtr<CSSFontFaceSrcResourceValue> consumeFontFaceSrcURI(CSSParserTokenR
         return nullptr;
 
     String format;
+    Vector<FontTechnology> supportedTechnologies;
     if (range.peek().functionId() == CSSValueFormat) {
         // https://drafts.csswg.org/css-fonts/#descdef-font-face-src
         // FIXME: We allow any identifier here and convert to strings; specification calls for certain keywords and legacy compatibility strings.
@@ -247,10 +248,15 @@ static RefPtr<CSSFontFaceSrcResourceValue> consumeFontFaceSrcURI(CSSParserTokenR
             return nullptr;
         format = arg.value().toString();
     }
+    if (range.peek().functionId() == CSSValueTech) {
+        supportedTechnologies = CSSPropertyParserHelpers::consumeFontTech(range);
+        if (supportedTechnologies.isEmpty())
+            return nullptr;
+    }
     if (!range.atEnd())
         return nullptr;
 
-    return CSSFontFaceSrcResourceValue::create(WTFMove(location), WTFMove(format), context.isContentOpaque ? LoadedFromOpaqueSource::Yes : LoadedFromOpaqueSource::No);
+    return CSSFontFaceSrcResourceValue::create(WTFMove(location), WTFMove(format), WTFMove(supportedTechnologies), context.isContentOpaque ? LoadedFromOpaqueSource::Yes : LoadedFromOpaqueSource::No);
 }
 
 static RefPtr<CSSValue> consumeFontFaceSrcLocal(CSSParserTokenRange& range)

--- a/Source/WebCore/css/parser/CSSSupportsParser.cpp
+++ b/Source/WebCore/css/parser/CSSSupportsParser.cpp
@@ -124,7 +124,7 @@ CSSSupportsParser::SupportsResult CSSSupportsParser::consumeNegation(CSSParserTo
     return result ? Unsupported : Supported;
 }
 
-// <function-token> <any-value>? | <supports-selector-fn> | <supports-font-format-fn>
+// <function-token> <any-value>? | <supports-selector-fn> | <supports-font-format-fn> | <supports-font-tech-fn>
 CSSSupportsParser::SupportsResult CSSSupportsParser::consumeSupportsFunction(CSSParserTokenRange& range)
 {
     if (range.peek().type() != FunctionToken)
@@ -135,6 +135,8 @@ CSSSupportsParser::SupportsResult CSSSupportsParser::consumeSupportsFunction(CSS
         return consumeSupportsSelectorFunction(range);
     case CSSValueFontFormat:
         return consumeSupportsFontFormatFunction(range);
+    case CSSValueFontTech:
+        return consumeSupportsFontTechFunction(range);
     default: // Unknown functions should parse as unsupported.
         range.consumeComponentValue();
         return Unsupported;
@@ -176,6 +178,14 @@ CSSSupportsParser::SupportsResult CSSSupportsParser::consumeSupportsFontFormatFu
         return Unsupported;
 
     return isSupported;
+}
+
+// <supports-font-tech-fn>
+CSSSupportsParser::SupportsResult CSSSupportsParser::consumeSupportsFontTechFunction(CSSParserTokenRange& range)
+{
+    ASSERT(range.peek().type() == FunctionToken && range.peek().functionId() == CSSValueFontTech);
+    auto supportedTechnologies = CSSPropertyParserHelpers::consumeFontTech(range, true);
+    return supportedTechnologies.isEmpty() ? Unsupported : Supported;
 }
 
 // <supports-in-parens> = ( <supports-condition> ) | <supports-feature> | <general-enclosed>

--- a/Source/WebCore/css/parser/CSSSupportsParser.h
+++ b/Source/WebCore/css/parser/CSSSupportsParser.h
@@ -68,6 +68,8 @@ private:
 
     // https://drafts.csswg.org/css-conditional-5/#typedef-supports-font-format-fn
     SupportsResult consumeSupportsFontFormatFunction(CSSParserTokenRange&);
+    // https://drafts.csswg.org/css-conditional-5/#typedef-supports-font-tech-fn
+    SupportsResult consumeSupportsFontTechFunction(CSSParserTokenRange&);
 
     SupportsResult consumeConditionInParenthesis(CSSParserTokenRange&, CSSParserTokenType);
 

--- a/Source/WebCore/platform/graphics/FontCustomPlatformData.h
+++ b/Source/WebCore/platform/graphics/FontCustomPlatformData.h
@@ -49,6 +49,7 @@ namespace WebCore {
 class SharedBuffer;
 class FontDescription;
 class FontCreationContext;
+enum class FontTechnology : uint8_t;
 
 template <typename T> class FontTaggedSettings;
 typedef FontTaggedSettings<int> FontFeatureSettings;
@@ -74,6 +75,7 @@ public:
     FontPlatformData fontPlatformData(const FontDescription&, bool bold, bool italic, const FontCreationContext&);
 
     static bool supportsFormat(const String&);
+    static bool supportsTechnology(const FontTechnology&);
 
 #if PLATFORM(WIN)
     String name;

--- a/Source/WebCore/platform/graphics/coretext/FontCustomPlatformDataCoreText.cpp
+++ b/Source/WebCore/platform/graphics/coretext/FontCustomPlatformDataCoreText.cpp
@@ -21,6 +21,7 @@
 #include "config.h"
 #include "FontCustomPlatformData.h"
 
+#include "CSSFontFaceSrcValue.h"
 #include "Font.h"
 #include "FontCache.h"
 #include "FontCacheCoreText.h"
@@ -99,6 +100,22 @@ bool FontCustomPlatformData::supportsFormat(const String& format)
         || equalLettersIgnoringASCIICase(format, "truetype-variations"_s)
         || equalLettersIgnoringASCIICase(format, "opentype-variations"_s)
         || equalLettersIgnoringASCIICase(format, "woff"_s);
+}
+
+bool FontCustomPlatformData::supportsTechnology(const FontTechnology& tech)
+{
+    switch (tech) {
+    case FontTechnology::ColorColrv0:
+    case FontTechnology::ColorSbix:
+    case FontTechnology::ColorSvg:
+    case FontTechnology::FeaturesAat:
+    case FontTechnology::FeaturesOpentype:
+    case FontTechnology::Palettes:
+    case FontTechnology::Variations:
+        return true;
+    default:
+        return false;
+    }
 }
 
 }

--- a/Source/WebCore/platform/graphics/freetype/FontCustomPlatformDataFreeType.cpp
+++ b/Source/WebCore/platform/graphics/freetype/FontCustomPlatformDataFreeType.cpp
@@ -22,6 +22,7 @@
 #include "config.h"
 #include "FontCustomPlatformData.h"
 
+#include "CSSFontFaceSrcValue.h"
 #include "CairoUtilities.h"
 #include "Font.h"
 #include "FontCacheFreeType.h"
@@ -161,6 +162,12 @@ bool FontCustomPlatformData::supportsFormat(const String& format)
         || equalLettersIgnoringASCIICase(format, "opentype-variations"_s)
 #endif
         || equalLettersIgnoringASCIICase(format, "woff"_s);
+}
+
+bool FontCustomPlatformData::supportsTechnology(const FontTechnology&)
+{
+    // FIXME: define supported technologies for this platform (webkit.org/b/256310).
+    return true;
 }
 
 }

--- a/Source/WebCore/platform/graphics/win/FontCustomPlatformDataWin.cpp
+++ b/Source/WebCore/platform/graphics/win/FontCustomPlatformDataWin.cpp
@@ -21,6 +21,7 @@
 #include "config.h"
 #include "FontCustomPlatformData.h"
 
+#include "CSSFontFaceSrcValue.h"
 #include "FontCreationContext.h"
 #include "FontDescription.h"
 #include "FontMemoryResource.h"
@@ -105,6 +106,12 @@ bool FontCustomPlatformData::supportsFormat(const String& format)
         || equalLettersIgnoringASCIICase(format, "woff2"_s)
 #endif
         || equalLettersIgnoringASCIICase(format, "woff"_s);
+}
+
+bool FontCustomPlatformData::supportsTechnology(const FontTechnology&)
+{
+    // FIXME: define supported technologies for this platform (webkit.org/b/256310).
+    return true;
 }
 
 }

--- a/Source/WebCore/svg/SVGFontFaceUriElement.cpp
+++ b/Source/WebCore/svg/SVGFontFaceUriElement.cpp
@@ -63,7 +63,7 @@ Ref<CSSFontFaceSrcResourceValue> SVGFontFaceUriElement::createSrcValue() const
     if (!location.specifiedURLString.isNull())
         location.resolvedURL = document().completeURL(location.specifiedURLString);
     auto& format = attributeWithoutSynchronization(formatAttr);
-    return CSSFontFaceSrcResourceValue::create(WTFMove(location), format.isEmpty() ? "svg"_s : format.string(), LoadedFromOpaqueSource::No);
+    return CSSFontFaceSrcResourceValue::create(WTFMove(location), format.isEmpty() ? "svg"_s : format.string(), { FontTechnology::ColorSvg }, LoadedFromOpaqueSource::No);
 }
 
 void SVGFontFaceUriElement::attributeChanged(const QualifiedName& name, const AtomString& oldValue, const AtomString& newValue, AttributeModificationReason attributeModificationReason)


### PR DESCRIPTION
#### ccfcd8af6c04a080d6350d17f33959d0a1ced378
<pre>
Add support for `@font-face src tech()` and  `@supports font-tech()` (252153)
<a href="https://bugs.webkit.org/show_bug.cgi?id=252153">https://bugs.webkit.org/show_bug.cgi?id=252153</a>
rdar://105665900

Reviewed by Myles C. Maxfield.

Implementing @font-face src tech() [1] and @supports font-tech() [2]
according to:

[1] <a href="https://www.w3.org/TR/css-fonts-4/#font-face-src-parsing">https://www.w3.org/TR/css-fonts-4/#font-face-src-parsing</a>
[2] <a href="https://drafts.csswg.org/css-conditional-5/#typedef-supports-font-tech-fn">https://drafts.csswg.org/css-conditional-5/#typedef-supports-font-tech-fn</a>

* LayoutTests/TestExpectations:
- We should pass this test now.
* LayoutTests/imported/w3c/web-platform-tests/css/css-fonts/parsing/font-face-src-tech-expected.txt:
- We pass all the subtests now, except for 2, since we don&apos;t support these
two font techonologies and techonologies are validated during parsing.

 * LayoutTests/platform/gtk/TestExpectations:
 * LayoutTests/platform/wpe/TestExpectations:
 - Skipping test for these platforms until webkit.org/b/256310 gets resolved.
 * LayoutTests/TestExpectations:
 * LayoutTests/imported/w3c/web-platform-tests/css/css-conditional/js/CSS-supports-L5-expected.txt:
 * LayoutTests/imported/w3c/web-platform-tests/css/css-fonts/parsing/font-face-src-tech-expected.txt:
 * Source/WebCore/css/CSSFontFaceSrcValue.cpp:
 (WebCore::CSSFontFaceSrcResourceValue::CSSFontFaceSrcResourceValue):
 (WebCore::CSSFontFaceSrcResourceValue::create):
 (WebCore::CSSFontFaceSrcResourceValue::customCSSText const):
 (WebCore::CSSFontFaceSrcResourceValue::equals const):
 * Source/WebCore/css/CSSFontFaceSrcValue.h:
 (WebCore::cssTextFromFontTech):
 * Source/WebCore/css/CSSPrimitiveValueMappings.h:
 (WebCore::fromCSSValueID):
 * Source/WebCore/css/CSSValueKeywords.in:
 * Source/WebCore/css/parser/CSSPropertyParserHelpers.cpp:
 (WebCore::CSSPropertyParserHelpers::consumeFontTech):
 * Source/WebCore/css/parser/CSSPropertyParserHelpers.h:
 * Source/WebCore/css/parser/CSSPropertyParserWorkerSafe.cpp:
 (WebCore::CSSPropertyParserHelpersWorkerSafe::consumeFontFaceSrcURI):
 * Source/WebCore/css/parser/CSSSupportsParser.cpp:
 (WebCore::CSSSupportsParser::consumeSupportsFunction):
 (WebCore::CSSSupportsParser::consumeSupportsFontTechFunction):
 * Source/WebCore/css/parser/CSSSupportsParser.h:
 * Source/WebCore/platform/graphics/FontCustomPlatformData.h:
 * Source/WebCore/platform/graphics/freetype/FontCustomPlatformDataFreeType.cpp:
 (WebCore::FontCustomPlatformData::supportsTech):
 * Source/WebCore/platform/graphics/mac/FontCustomPlatformDataMac.cpp:
 (WebCore::FontCustomPlatformData::supportsTech):
 * Source/WebCore/platform/graphics/win/FontCustomPlatformDataWin.cpp:
 (WebCore::FontCustomPlatformData::supportsTech):
 * Source/WebCore/svg/SVGFontFaceUriElement.cpp:
 (WebCore::SVGFontFaceUriElement::createSrcValue const):

Canonical link: <a href="https://commits.webkit.org/263725@main">https://commits.webkit.org/263725@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d419867a1083e71dcc2e37434396153d3d97d3b1

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/5551 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/5702 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/5890 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/7101 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/5555 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/5551 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/5927 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/5676 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/7118 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/5654 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/5715 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/4967 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/7137 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/3193 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/4990 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/12117 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/5059 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/5070 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/6836 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/5506 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/4502 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/4959 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/1325 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/9064 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/5321 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->