### PR TITLE
RetainPtr<>::leakRef() should have NS/CF_RETURNS_RETAINED attributes

### DIFF
--- a/Source/WTF/wtf/RetainPtr.h
+++ b/Source/WTF/wtf/RetainPtr.h
@@ -1,5 +1,5 @@
 /*
- *  Copyright (C) 2005-2021 Apple Inc. All rights reserved.
+ *  Copyright (C) 2005-2023 Apple Inc. All rights reserved.
  *
  *  This library is free software; you can redistribute it and/or
  *  modify it under the terms of the GNU Library General Public
@@ -99,7 +99,27 @@ public:
     ~RetainPtr();
 
     void clear();
-    PtrType leakRef() WARN_UNUSED_RETURN;
+
+#ifdef __OBJC__
+    template<typename U = T>
+    std::enable_if_t<std::is_convertible_v<U, id>, PtrType> leakRef() NS_RETURNS_RETAINED WARN_UNUSED_RETURN {
+        static_assert(std::is_same_v<T, U>, "explicit specialization not allowed");
+        return fromStorageType(std::exchange(m_ptr, nullptr));
+    }
+#else
+    template<typename U = T>
+    std::enable_if_t<std::is_same_v<U, id>, PtrType> leakRef() CF_RETURNS_RETAINED WARN_UNUSED_RETURN {
+        static_assert(std::is_same_v<T, U>, "explicit specialization not allowed");
+        return fromStorageType(std::exchange(m_ptr, nullptr));
+    }
+#endif
+
+    template<typename U = T>
+    std::enable_if_t<!std::is_convertible_v<U, id>, PtrType> leakRef() CF_RETURNS_RETAINED WARN_UNUSED_RETURN {
+        static_assert(std::is_same_v<T, U>, "explicit specialization not allowed");
+        return fromStorageType(std::exchange(m_ptr, nullptr));
+    }
+
 #if HAVE(CFAUTORELEASE)
     PtrType autorelease();
 #endif
@@ -199,11 +219,6 @@ template<typename T> inline void RetainPtr<T>::clear()
 {
     if (auto ptr = std::exchange(m_ptr, nullptr))
         CFRelease(ptr);
-}
-
-template<typename T> inline auto RetainPtr<T>::leakRef() -> PtrType
-{
-    return fromStorageType(std::exchange(m_ptr, nullptr));
 }
 
 #if HAVE(CFAUTORELEASE)


### PR DESCRIPTION
#### 611c1a1ceeaf4a530810d3d60c7460ff89bf1767
<pre>
RetainPtr&lt;&gt;::leakRef() should have NS/CF_RETURNS_RETAINED attributes
<a href="https://bugs.webkit.org/show_bug.cgi?id=256311">https://bugs.webkit.org/show_bug.cgi?id=256311</a>
&lt;rdar://108895655&gt;

Reviewed by Alex Christensen and Darin Adler.

Use template specialization with SFINAE to add the
CF_RETAINS_RETAINED attribute for CFType objects and the
NS_RETURNS_RETAINED attribute for Cocoa objects.

This allows the clang static analyzer to reason about the
leakRef() method.

* Source/WTF/wtf/RetainPtr.h:
(WTF::RetainPtr&lt;T&gt;::leakRef):
- Use a technique to allow for template specialization without
  using the class template type.
- Note that this specialization must also cover the case of
  using `id` in C++ code.

Canonical link: <a href="https://commits.webkit.org/263742@main">https://commits.webkit.org/263742@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a3fa3cb7ac49b2e2bb527860ce4dd4d1d2839278

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/5649 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/5802 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/5992 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/7200 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/32/builds/5634 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/6025 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/5774 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/7724 "1 flakes 104 failures") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/5753 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/5803 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/5061 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/7243 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/3280 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/5088 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/12375 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [  ~~🛠 🧪 jsc~~](https://ews-build.webkit.org/#/builders/20/builds/4698 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/5149 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/5164 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/6992 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/5232 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/5597 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/4579 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/5759 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/5045 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/1410 "Passed tests") | 
| [  ~~🛠 🧪 merge~~](https://ews-build.webkit.org/#/builders/19/builds/1334 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/9156 "Built successfully") | | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/24/builds/5921 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/645 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/5406 "Built successfully") | | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/3/builds/1530 "Passed tests") | 
<!--EWS-Status-Bubble-End-->