### PR TITLE
[Windows] Drop support of older version of Windows.

### DIFF
--- a/Source/cmake/OptionsWin.cmake
+++ b/Source/cmake/OptionsWin.cmake
@@ -10,8 +10,12 @@ endif ()
 # Define minimum supported Windows version
 # https://msdn.microsoft.com/en-us/library/6sehtctf.aspx
 #
-# Currently set to Windows 7
-add_definitions(-D_WINDOWS -DWINVER=0x601 -D_WIN32_WINNT=0x601)
+# Windows 10 1809 "Redstone 5" NTDDI_WIN10_RS5 (0x0A000006)
+# https://learn.microsoft.com/en-us/windows/win32/winprog/using-the-windows-headers?redirectedfrom=MSDN#macros-for-conditional-declarations
+#
+# Supported versions of Windows client
+# https://learn.microsoft.com/en-us/windows/release-health/supported-versions-windows-client
+add_definitions(-D_WINDOWS -DNTDDI_VERSION=0x0A000006 -D_WIN32_WINNT=0x0A00)
 
 add_definitions(-DNOMINMAX)
 add_definitions(-DUNICODE -D_UNICODE)


### PR DESCRIPTION
#### d27a9b023902534f01844dd91c56de14ee95f493
<pre>
[Windows] Drop support of older version of Windows.
<a href="https://bugs.webkit.org/show_bug.cgi?id=256314">https://bugs.webkit.org/show_bug.cgi?id=256314</a>

Reviewed by Don Olmstead and Yusuke Suzuki.

Change the supported Windows version from Windows 7 to Windows 10 1809 &quot;Redstone 5&quot;.
Version 1809 is the oldest version which is still supported in Enterprise LTSB/LTSC
editions.

<a href="https://learn.microsoft.com/en-us/windows/release-health/supported-versions-windows-client">https://learn.microsoft.com/en-us/windows/release-health/supported-versions-windows-client</a>

* Source/cmake/OptionsWin.cmake:

Canonical link: <a href="https://commits.webkit.org/263812@main">https://commits.webkit.org/263812@main</a>
</pre>
