### PR TITLE
Shuffle clobbers indirect call target in BBQ JIT

### DIFF
--- a/JSTests/wasm/stress/call-indirect-argument-depends-on-load.js
+++ b/JSTests/wasm/stress/call-indirect-argument-depends-on-load.js
@@ -1,0 +1,37 @@
+import { instantiate } from "../wabt-wrapper.js";
+import * as assert from "../assert.js";
+
+let wat = `
+(module
+    (type $takes_i32_i32 (func (param i32 i32) (result i32)))
+    (table 1 funcref)
+    (memory $mem 10 100)
+
+    (func $foo (param i32 i32) (result i32)
+        local.get 0
+    )
+
+    (elem (i32.const 0) $foo)
+
+    (func (export "test") (result i32) (local i32)
+        i32.const 0
+        i32.const 42
+        i32.store
+
+        i32.const 0
+        i32.load
+        local.get 0
+        i32.const 0
+        call_indirect (type $takes_i32_i32)
+    )
+)
+`;
+
+async function test() {
+    const instance = await instantiate(wat, {}, {});
+    const { test } = instance.exports;
+    for (let i = 0; i < 10000; i ++)
+        assert.eq(test(), 42);
+}
+
+assert.asyncTest(test());


### PR DESCRIPTION
#### c0664686f49dda83274d0dcc85c2ff4419db81c5
<pre>
Shuffle clobbers indirect call target in BBQ JIT
<a href="https://bugs.webkit.org/show_bug.cgi?id=256331">https://bugs.webkit.org/show_bug.cgi?id=256331</a>
rdar://108908936

Reviewed by Justin Michaud.

Fixes a bug where passing arguments in an indirect call in WebAssembly
BBQ JIT could clobber the target address, stored in the wasmScratchGPR.
Instead of assuming we can use the normal scratch register, parameter
passing now takes scratch registers as parameters. Since we have lots
of spare scratch registers that no longer hold live values in indirect
calls, we just reuse one as the scratch for parameter passing.

* JSTests/wasm/stress/call-indirect-argument-depends-on-load.js: Added.
(async test):
* Source/JavaScriptCore/wasm/WasmBBQJIT.cpp:
(JSC::Wasm::BBQJIT::saveValuesAcrossCallAndPassArguments):
(JSC::Wasm::BBQJIT::emitCCall):
(JSC::Wasm::BBQJIT::addCall):
(JSC::Wasm::BBQJIT::emitIndirectCall):

Canonical link: <a href="https://commits.webkit.org/263697@main">https://commits.webkit.org/263697@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/3aa0442fac07a6244391b0a088f1754e40ae10c9

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/5451 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/5593 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/5786 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/6995 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/5476 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/5821 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/5570 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/6451 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/5553 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/5613 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/4887 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/7025 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/3091 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/4894 "Passed tests") | [⏳ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/GTK-WK2-Tests-EWS "Waiting to run tests") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/4528 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/4957 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/4974 "Passed tests") | [⏳ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/API-Tests-GTK-EWS "Waiting to run tests") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/5033 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/5405 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/4436 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/5553 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/4865 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/1377 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/1308 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/8967 "Built successfully") | | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/24/builds/5714 "Built successfully") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/5228 "Built successfully") | | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/3/builds/1495 "Passed tests") | 
<!--EWS-Status-Bubble-End-->