### PR TITLE
[grid][masonry] Update masonry items' offsets using HashMap's set() instead of add().

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/masonry/tentative/item-placement/masonry-rows-with-grid-width-changed-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/masonry/tentative/item-placement/masonry-rows-with-grid-width-changed-expected.html
@@ -1,0 +1,29 @@
+<!DOCTYPE html>
+<html>
+<head>
+<link rel="author" title="Sammy Gill" href="mailto:sammy.gill@apple.com">
+<link rel="help" href="https://drafts.csswg.org/css-grid-3">
+<meta name="assert" content="When the width of the masonry grid changes, items are repositioned with correct offsets and are not overlapping">
+<link rel="stylesheet" type="text/css" href="/fonts/ahem.css">
+<style>
+grid {
+    display: grid;
+    width: 1%;
+    grid-template-rows: masonry;
+    grid-template-columns: auto;
+    grid-gap: 10px;
+    font-family: Ahem;
+    font-size: 40px;
+}
+item {
+    background-color: grey;
+}
+</style>
+</head>
+<body>
+  <grid>
+    <item>Hello, world!</item>
+    <item>2</item>
+  </grid>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/masonry/tentative/item-placement/masonry-rows-with-grid-width-changed-ref.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/masonry/tentative/item-placement/masonry-rows-with-grid-width-changed-ref.html
@@ -1,0 +1,29 @@
+<!DOCTYPE html>
+<html>
+<head>
+<link rel="author" title="Sammy Gill" href="mailto:sammy.gill@apple.com">
+<link rel="help" href="https://drafts.csswg.org/css-grid-3">
+<meta name="assert" content="When the width of the masonry grid changes, items are repositioned with correct offsets and are not overlapping">
+<link rel="stylesheet" type="text/css" href="/fonts/ahem.css">
+<style>
+grid {
+    display: grid;
+    width: 1%;
+    grid-template-rows: masonry;
+    grid-template-columns: auto;
+    grid-gap: 10px;
+    font-family: Ahem;
+    font-size: 40px;
+}
+item {
+    background-color: grey;
+}
+</style>
+</head>
+<body>
+  <grid>
+    <item>Hello, world!</item>
+    <item>2</item>
+  </grid>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/masonry/tentative/item-placement/masonry-rows-with-grid-width-changed.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/masonry/tentative/item-placement/masonry-rows-with-grid-width-changed.html
@@ -1,0 +1,35 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<link rel="author" title="Sammy Gill" href="mailto:sammy.gill@apple.com">
+<link rel="help" href="https://drafts.csswg.org/css-grid-3">
+<link rel="match" href="masonry-rows-with-grid-width-changed-ref.html">
+<meta name="assert" content="When the width of the masonry grid changes, items are repositioned with correct offsets and are not overlapping">
+<link rel="stylesheet" type="text/css" href="/fonts/ahem.css">
+<style>
+  grid {
+    display: grid;
+    grid-template-rows: masonry;
+    grid-template-columns: auto;
+    grid-gap: 10px;
+    font-family: Ahem;
+    font-size: 40px;
+  }
+  item {
+    background-color: grey;
+  }
+</style>
+</head>
+<body>
+  <grid>
+    <item>Hello, world!</item>
+    <item>2</item>
+  </grid>
+</body>
+<script>
+  // Make sure layout occurs and then mutate the style to retrigger it
+  document.body.offsetHeight;
+  document.querySelector("grid").style["width"] = "1%";
+</script>
+</html>

--- a/Source/WebCore/rendering/GridMasonryLayout.cpp
+++ b/Source/WebCore/rendering/GridMasonryLayout.cpp
@@ -226,7 +226,8 @@ void GridMasonryLayout::updateRunningPositions(const RenderBox& child, const Gri
 
 void GridMasonryLayout::updateItemOffset(const RenderBox& child, LayoutUnit offset)
 {
-    m_itemOffsets.add(&child, offset);
+    // We set() and not add() to update the value if the child is already inserted
+    m_itemOffsets.set(&child, offset);
 }
 
 GridSpan GridMasonryLayout::gridAxisPositionUsingPackAutoFlow(const RenderBox& item) const


### PR DESCRIPTION
#### 215644fbb8d3ce7fad0dc7732864cbf76928253a
<pre>
[grid][masonry] Update masonry items&apos; offsets using HashMap&apos;s set() instead of add().
<a href="https://bugs.webkit.org/show_bug.cgi?id=255023">https://bugs.webkit.org/show_bug.cgi?id=255023</a>
rdar://107666148

Reviewed by Brent Fulgham.

During Masonry layout we compute the offsets that each item should have
in the masonry axis and store them into a HashMap that we will reference
later to adjust the items to their final position in the grid. Currently,
we add() to the HashMap which is problematic if we need to relayout the
items when, for example, the size of the window changes. This will not
update the offsets for the items correctly and so instead we should use
set() to accomplish this.

* LayoutTests/imported/w3c/web-platform-tests/css/css-grid/masonry/tentative/item-placement/masonry-rows-with-grid-width-changed-expected.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-grid/masonry/tentative/item-placement/masonry-rows-with-grid-width-changed-ref.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-grid/masonry/tentative/item-placement/masonry-rows-with-grid-width-changed.html: Added.
* Source/WebCore/rendering/GridMasonryLayout.cpp:
(WebCore::GridMasonryLayout::updateItemOffset):

Canonical link: <a href="https://commits.webkit.org/263709@main">https://commits.webkit.org/263709@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/cf919ddd000615efae16f4aa67ebd50576da8894

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/5485 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/5631 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/5821 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/7030 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/5501 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/5484 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/5856 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/5605 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/6699 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/5586 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/5645 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/4909 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/7061 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/3122 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/4921 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/12068 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/4988 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/5001 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/6751 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/5439 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/4460 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/4895 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/4886 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [❌ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/1313 "Failed to push commit to Webkit repository") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/8999 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/5258 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->