### PR TITLE
MediaSession should keep its action handlers alive

### DIFF
--- a/Source/WebCore/Modules/mediasession/MediaSession.cpp
+++ b/Source/WebCore/Modules/mediasession/MediaSession.cpp
@@ -239,15 +239,22 @@ void MediaSession::setActionHandler(MediaSessionAction action, RefPtr<MediaSessi
 {
     if (handler) {
         ALWAYS_LOG(LOGIDENTIFIER, "adding ", action);
-        m_actionHandlers.set(action, handler);
+        {
+            Locker lock { m_actionHandlersLock };
+            m_actionHandlers.set(action, handler);
+        }
         auto platformCommand = platformCommandForMediaSessionAction(action);
         if (platformCommand != PlatformMediaSession::NoCommand)
             PlatformMediaSessionManager::sharedManager().addSupportedCommand(platformCommand);
     } else {
-        if (m_actionHandlers.contains(action)) {
-            ALWAYS_LOG(LOGIDENTIFIER, "removing ", action);
-            m_actionHandlers.remove(action);
+        bool containedAction;
+        {
+            Locker lock { m_actionHandlersLock };
+            containedAction = m_actionHandlers.remove(action);
         }
+
+        if (containedAction)
+            ALWAYS_LOG(LOGIDENTIFIER, "removing ", action);
         PlatformMediaSessionManager::sharedManager().removeSupportedCommand(platformCommandForMediaSessionAction(action));
     }
 
@@ -268,7 +275,12 @@ void MediaSession::callActionHandler(const MediaSessionActionDetails& actionDeta
 
 bool MediaSession::callActionHandler(const MediaSessionActionDetails& actionDetails, TriggerGestureIndicator triggerGestureIndicator)
 {
-    if (auto handler = m_actionHandlers.get(actionDetails.action)) {
+    RefPtr<MediaSessionActionHandler> handler;
+    {
+        Locker lock { m_actionHandlersLock };
+        handler = m_actionHandlers.get(actionDetails.action);
+    }
+    if (handler) {
         std::optional<UserGestureIndicator> maybeGestureIndicator;
         if (triggerGestureIndicator == TriggerGestureIndicator::Yes)
             maybeGestureIndicator.emplace(ProcessingUserGesture, document());

--- a/Source/WebCore/Modules/mediasession/MediaSession.h
+++ b/Source/WebCore/Modules/mediasession/MediaSession.h
@@ -67,6 +67,8 @@ public:
 
     void callActionHandler(const MediaSessionActionDetails&, DOMPromiseDeferred<void>&&);
 
+    template <typename Visitor> void visitActionHandlers(Visitor&) const;
+
     ExceptionOr<void> setPositionState(std::optional<MediaPositionState>&&);
     std::optional<MediaPositionState> positionState() const { return m_positionState; }
 
@@ -88,7 +90,8 @@ public:
     ExceptionOr<void> setPlaylist(ScriptExecutionContext&, Vector<RefPtr<MediaMetadata>>&&);
 #endif
 
-    bool hasActiveActionHandlers() const { return !m_actionHandlers.isEmpty(); }
+    bool hasActiveActionHandlers() const;
+
     enum class TriggerGestureIndicator {
         No,
         Yes,
@@ -142,7 +145,7 @@ private:
     std::optional<MediaPositionState> m_positionState;
     std::optional<double> m_lastReportedPosition;
     MonotonicTime m_timeAtLastPositionUpdate;
-    HashMap<MediaSessionAction, RefPtr<MediaSessionActionHandler>, IntHash<MediaSessionAction>, WTF::StrongEnumHashTraits<MediaSessionAction>> m_actionHandlers;
+    HashMap<MediaSessionAction, RefPtr<MediaSessionActionHandler>, IntHash<MediaSessionAction>, WTF::StrongEnumHashTraits<MediaSessionAction>> m_actionHandlers WTF_GUARDED_BY_LOCK(m_actionHandlersLock);
     RefPtr<const Logger> m_logger;
     const void* m_logIdentifier;
 
@@ -156,10 +159,27 @@ private:
 #if ENABLE(MEDIA_SESSION_PLAYLIST)
     Vector<Ref<MediaMetadata>> m_playlist;
 #endif
+    mutable Lock m_actionHandlersLock;
 };
 
 String convertEnumerationToString(MediaSessionPlaybackState);
 String convertEnumerationToString(MediaSessionAction);
+
+inline bool MediaSession::hasActiveActionHandlers() const
+{
+    Locker lock { m_actionHandlersLock };
+    return !m_actionHandlers.isEmpty();
+}
+
+template <typename Visitor>
+void MediaSession::visitActionHandlers(Visitor& visitor) const
+{
+    Locker lock { m_actionHandlersLock };
+    for (auto& actionHandler : m_actionHandlers) {
+        if (actionHandler.value)
+            actionHandler.value->visitJSFunction(visitor);
+    }
+}
 
 }
 

--- a/Source/WebCore/Modules/mediasession/MediaSession.idl
+++ b/Source/WebCore/Modules/mediasession/MediaSession.idl
@@ -28,6 +28,7 @@
     Conditional=MEDIA_SESSION,
     Exposed=Window,
     ExportMacro=WEBCORE_EXPORT,
+    JSCustomMarkFunction
 ] interface MediaSession
 {
     attribute MediaMetadata? metadata;

--- a/Source/WebCore/Sources.txt
+++ b/Source/WebCore/Sources.txt
@@ -608,6 +608,7 @@ bindings/js/JSKeyframeEffectCustom.cpp
 bindings/js/JSLazyEventListener.cpp
 bindings/js/JSLocalDOMWindowCustom.cpp
 bindings/js/JSLocationCustom.cpp
+bindings/js/JSMediaSessionCustom.cpp
 bindings/js/JSMediaStreamTrackCustom.cpp
 bindings/js/JSMessageChannelCustom.cpp
 bindings/js/JSMessageEventCustom.cpp

--- a/Source/WebCore/bindings/js/JSMediaSessionCustom.cpp
+++ b/Source/WebCore/bindings/js/JSMediaSessionCustom.cpp
@@ -1,0 +1,45 @@
+/*
+ * Copyright (C) 2023 Apple, Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#if ENABLE(MEDIA_SESSION)
+
+#include "config.h"
+#include "JSMediaSession.h"
+
+#include <JavaScriptCore/JSCInlines.h>
+
+namespace WebCore {
+
+template <typename Visitor>
+void JSMediaSession::visitAdditionalChildren(Visitor& visitor)
+{
+    wrapped().visitActionHandlers(visitor);
+}
+
+DEFINE_VISIT_ADDITIONAL_CHILDREN(JSMediaSession);
+
+}
+
+#endif


### PR DESCRIPTION
#### 0743137c2f4f602963fc409ebc56ecd6690d204d
<pre>
MediaSession should keep its action handlers alive
<a href="https://bugs.webkit.org/show_bug.cgi?id=256334">https://bugs.webkit.org/show_bug.cgi?id=256334</a>
rdar://108913983

Reviewed by Chris Dumez.

The MediaSessionActionHandler callback is now a weak reference and so
when the MediaSession is visited it needs to mark any action handlers
that have been added to it.

* Source/WebCore/Modules/mediasession/MediaSession.cpp:
(WebCore::MediaSession::setActionHandler):
(WebCore::MediaSession::callActionHandler):
* Source/WebCore/Modules/mediasession/MediaSession.h:
(WebCore::MediaSession::hasActiveActionHandlers const):
(WebCore::MediaSession::visitActionHandlers const):
* Source/WebCore/Modules/mediasession/MediaSession.idl:
* Source/WebCore/Sources.txt:
* Source/WebCore/WebCore.xcodeproj/project.pbxproj:
* Source/WebCore/bindings/js/JSMediaSessionCustom.cpp: Added.
(WebCore::JSMediaSession::visitAdditionalChildren):

Canonical link: <a href="https://commits.webkit.org/263715@main">https://commits.webkit.org/263715@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c811ccbb0d2fc7a5c568491fcde4584135de3bea

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/5522 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/5669 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/5858 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/7068 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/5531 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/5520 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/5894 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/5643 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/6971 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/5623 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/5683 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/4940 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/7103 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/3160 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/4957 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/12096 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/5026 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/5037 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/6783 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/5474 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/4485 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/4929 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/1319 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/9033 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/5291 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->