### PR TITLE
If a page changes its title while in the background, allow the page to run in the background

### DIFF
--- a/Source/WebKit/UIProcess/ProcessThrottler.cpp
+++ b/Source/WebKit/UIProcess/ProcessThrottler.cpp
@@ -54,6 +54,7 @@ ProcessThrottler::ProcessThrottler(ProcessThrottlerClient& process, bool shouldT
     : m_process(process)
     , m_prepareToSuspendTimeoutTimer(RunLoop::main(), this, &ProcessThrottler::prepareToSuspendTimeoutTimerFired)
     , m_dropNearSuspendedAssertionTimer(RunLoop::main(), this, &ProcessThrottler::dropNearSuspendedAssertionTimerFired)
+    , m_pageAllowedToRunInTheBackgroundCounter([this](RefCounterEvent) { numberOfPagesAllowedToRunInTheBackgroundChanged(); })
     , m_shouldTakeUIBackgroundAssertion(shouldTakeUIBackgroundAssertion)
 {
 }
@@ -250,7 +251,10 @@ void ProcessThrottler::dropNearSuspendedAssertionTimerFired()
 {
     PROCESSTHROTTLER_RELEASE_LOG("dropNearSuspendedAssertionTimerFired: Removing near-suspended process assertion");
     RELEASE_ASSERT(m_assertion && m_assertion->type() == ProcessAssertionType::NearSuspended);
-    m_assertion = nullptr;
+    if (m_pageAllowedToRunInTheBackgroundCounter.value())
+        PROCESSTHROTTLER_RELEASE_LOG("dropNearSuspendedAssertionTimerFired: Not releasing near-suspended assertion because a page is allowed to run in the background");
+    else
+        m_assertion = nullptr;
 }
 
 void ProcessThrottler::processReadyToSuspend()
@@ -336,11 +340,23 @@ void ProcessThrottler::setShouldTakeNearSuspendedAssertion(bool shouldTakeNearSu
     m_shouldTakeNearSuspendedAssertion = shouldTakeNearSuspendedAssertion;
 }
 
-void ProcessThrottler::delaySuspension()
+PageAllowedToRunInTheBackgroundCounter::Token ProcessThrottler::pageAllowedToRunInTheBackgroundToken()
 {
-    PROCESSTHROTTLER_RELEASE_LOG("delaySuspension");
+    return m_pageAllowedToRunInTheBackgroundCounter.count();
+}
+
+void ProcessThrottler::numberOfPagesAllowedToRunInTheBackgroundChanged()
+{
+    if (m_pageAllowedToRunInTheBackgroundCounter.value())
+        return;
+
     if (m_dropNearSuspendedAssertionTimer.isActive())
-        m_dropNearSuspendedAssertionTimer.startOneShot(removeAllAssertionsTimeout);
+        return;
+
+    if (m_assertion && m_assertion->isValid() && m_assertion->type() == ProcessAssertionType::NearSuspended) {
+        PROCESSTHROTTLER_RELEASE_LOG("numberOfPagesAllowedToRunInTheBackgroundChanged: Releasing near-suspended assertion");
+        m_assertion = nullptr;
+    }
 }
 
 ProcessThrottlerTimedActivity::ProcessThrottlerTimedActivity(Seconds timeout, ProcessThrottler::ActivityVariant&& activity)

--- a/Source/WebKit/UIProcess/ProcessThrottler.h
+++ b/Source/WebKit/UIProcess/ProcessThrottler.h
@@ -50,6 +50,9 @@ enum ProcessSuppressionDisabledCounterType { };
 using ProcessSuppressionDisabledCounter = RefCounter<ProcessSuppressionDisabledCounterType>;
 using ProcessSuppressionDisabledToken = ProcessSuppressionDisabledCounter::Token;
 
+enum PageAllowedToRunInTheBackgroundCounterType { };
+using PageAllowedToRunInTheBackgroundCounter = RefCounter<PageAllowedToRunInTheBackgroundCounterType>;
+
 enum class IsSuspensionImminent : bool { No, Yes };
 enum class ProcessThrottleState : uint8_t { Suspended, Background, Foreground };
 enum class ProcessThrottlerActivityType : bool { Background, Foreground };
@@ -117,6 +120,11 @@ public:
     static bool isValidBackgroundActivity(const ActivityVariant&);
     static bool isValidForegroundActivity(const ActivityVariant&);
 
+    // If any page holds one of these tokens, we will never release the "suspended" assertion which
+    // means that the page will not be suspended when in the background, except if the application
+    // also gets backgrounded.
+    PageAllowedToRunInTheBackgroundCounter::Token pageAllowedToRunInTheBackgroundToken();
+
     using TimedActivity = ProcessThrottlerTimedActivity;
 
     void didConnectToProcess(ProcessID);
@@ -125,7 +133,6 @@ public:
     void setAllowsActivities(bool);
     void setShouldDropNearSuspendedAssertionAfterDelay(bool shouldDropAfterDelay) { m_shouldDropNearSuspendedAssertionAfterDelay = shouldDropAfterDelay; }
     void setShouldTakeNearSuspendedAssertion(bool);
-    void delaySuspension();
     bool isSuspended() const { return m_processIdentifier && !m_assertion; }
     ProcessThrottleState currentState() const { return m_state; }
 
@@ -153,6 +160,7 @@ private:
     void assertionWasInvalidated();
 
     void clearPendingRequestToSuspend();
+    void numberOfPagesAllowedToRunInTheBackgroundChanged();
 
     ProcessThrottlerClient& m_process;
     ProcessID m_processIdentifier { 0 };
@@ -163,6 +171,7 @@ private:
     HashSet<Activity*> m_backgroundActivities;
     std::optional<uint64_t> m_pendingRequestToSuspendID;
     ProcessThrottleState m_state { ProcessThrottleState::Suspended };
+    PageAllowedToRunInTheBackgroundCounter m_pageAllowedToRunInTheBackgroundCounter;
     bool m_shouldDropNearSuspendedAssertionAfterDelay { false };
     bool m_shouldTakeUIBackgroundAssertion { false };
     bool m_shouldTakeNearSuspendedAssertion { true };

--- a/Source/WebKit/UIProcess/WebPageProxy.cpp
+++ b/Source/WebKit/UIProcess/WebPageProxy.cpp
@@ -487,33 +487,11 @@ void WebPageProxy::ProcessActivityState::takeCapturingActivity()
     m_isCapturingActivity = m_page.process().throttler().foregroundActivity("View is capturing media"_s).moveToUniquePtr();
 }
 
-#if PLATFORM(MAC)
-// On macOS, we opt pages out of process suspension if they used the Notification API to avoid breaking
-// some use cases.
-// In particular, we opt out if either:
-// - The page showed a notification
-// - The page called navigator.permissions.query({ name: "notifications" }) and it returned true.
-// - The page accessed Notification.permission and it returned "granted".
-// - The page requested permission via Notification.requestPermission() and it was granted.
-// This gets reset whenever a new main frame load commits inside the page.
-void WebPageProxy::ProcessActivityState::takeLikelyToUseNotificationsActivity()
-{
-    if (!m_likelyToUseNotificationsActivity)
-        m_likelyToUseNotificationsActivity = m_page.process().throttler().backgroundActivity("View is likely to use notifications"_s).moveToUniquePtr();
-}
-
-void WebPageProxy::ProcessActivityState::dropLikelyToUseNotificationsActivity()
-{
-    m_likelyToUseNotificationsActivity = nullptr;
-}
-#endif
-
 void WebPageProxy::ProcessActivityState::reset()
 {
     m_isVisibleActivity = nullptr;
 #if PLATFORM(MAC)
     *m_wasRecentlyVisibleActivity = nullptr;
-    m_likelyToUseNotificationsActivity = nullptr;
 #endif
     m_isAudibleActivity = nullptr;
     m_isCapturingActivity = nullptr;
@@ -5590,9 +5568,7 @@ void WebPageProxy::didCommitLoadForFrame(FrameIdentifier frameID, FrameInfoData&
         if (is<RemoteLayerTreeDrawingAreaProxy>(*m_drawingArea))
             internals().firstLayerTreeTransactionIdAfterDidCommitLoad = downcast<RemoteLayerTreeDrawingAreaProxy>(*drawingArea()).nextLayerTreeTransactionID();
 #endif
-#if PLATFORM(MAC)
-        m_processActivityState.dropLikelyToUseNotificationsActivity();
-#endif
+        internals().pageAllowedToRunInTheBackgroundToken = nullptr;
     }
 
     auto transaction = internals().pageLoadState.transaction();
@@ -5806,8 +5782,10 @@ void WebPageProxy::didFailLoadForFrame(FrameIdentifier frameID, FrameInfoData&& 
 
     bool isMainFrame = frame->isMainFrame();
 
-    if (isMainFrame)
+    if (isMainFrame) {
         internals().pageLoadState.didFailLoad(transaction);
+        internals().pageAllowedToRunInTheBackgroundToken = nullptr;
+    }
 
     if (m_controlledByAutomation) {
         if (auto* automationSession = process().processPool().automationSession())
@@ -5960,7 +5938,13 @@ void WebPageProxy::didReceiveTitleForFrame(FrameIdentifier frameID, const String
 
     if (frame->isMainFrame()) {
         internals().pageLoadState.setTitle(transaction, title);
-        process().throttler().delaySuspension();
+        if (!isViewVisible() && !frame->title().isNull() && frame->title() != title) {
+            WEBPAGEPROXY_RELEASE_LOG(ViewState, "didReceiveTitleForFrame: This page changes its title in the background and is allowed to run in the background");
+            // This page updates its title in the background and is thus able to communicate with
+            // the user while in the background. Allow it to run in the background.
+            if (!internals().pageAllowedToRunInTheBackgroundToken)
+                internals().pageAllowedToRunInTheBackgroundToken = process().throttler().pageAllowedToRunInTheBackgroundToken();
+        }
     }
 
     frame->didChangeTitle(title);
@@ -8952,6 +8936,7 @@ void WebPageProxy::resetStateAfterProcessExited(ProcessTerminationReason termina
 
     internals().pageIsUserObservableCount = nullptr;
     internals().visiblePageToken = nullptr;
+    internals().pageAllowedToRunInTheBackgroundToken = nullptr;
 
     m_hasRunningProcess = false;
     m_areActiveDOMObjectsAndAnimationsSuspended = false;
@@ -9789,17 +9774,17 @@ void WebPageProxy::requestNotificationPermission(const String& originString, Com
 
 void WebPageProxy::pageWillLikelyUseNotifications()
 {
-#if PLATFORM(MAC)
-    m_processActivityState.takeLikelyToUseNotificationsActivity();
-#endif
+    WEBPAGEPROXY_RELEASE_LOG(ViewState, "pageWillLikelyUseNotifications: This page is likely to use notifications and is allowed to run in the background");
+    if (!internals().pageAllowedToRunInTheBackgroundToken)
+        internals().pageAllowedToRunInTheBackgroundToken = process().throttler().pageAllowedToRunInTheBackgroundToken();
 }
 
 void WebPageProxy::showNotification(IPC::Connection& connection, const WebCore::NotificationData& notificationData, RefPtr<WebCore::NotificationResources>&& notificationResources)
 {
     m_process->processPool().supplement<WebNotificationManagerProxy>()->show(this, connection, notificationData, WTFMove(notificationResources));
-#if PLATFORM(MAC)
-    m_processActivityState.takeLikelyToUseNotificationsActivity();
-#endif
+    WEBPAGEPROXY_RELEASE_LOG(ViewState, "showNotification: This page shows notifications and is allowed to run in the background");
+    if (!internals().pageAllowedToRunInTheBackgroundToken)
+        internals().pageAllowedToRunInTheBackgroundToken = process().throttler().pageAllowedToRunInTheBackgroundToken();
 }
 
 void WebPageProxy::cancelNotification(const UUID& notificationID)

--- a/Source/WebKit/UIProcess/WebPageProxy.h
+++ b/Source/WebKit/UIProcess/WebPageProxy.h
@@ -2816,18 +2816,12 @@ private:
         bool hasValidOpeningAppLinkActivity() const;
 #endif
 
-#if PLATFORM(MAC)
-        void takeLikelyToUseNotificationsActivity();
-        void dropLikelyToUseNotificationsActivity();
-#endif
-
     private:
         WebPageProxy& m_page;
 
         std::unique_ptr<ProcessThrottlerActivity> m_isVisibleActivity;
 #if PLATFORM(MAC)
         UniqueRef<ProcessThrottlerTimedActivity> m_wasRecentlyVisibleActivity;
-        std::unique_ptr<ProcessThrottlerActivity> m_likelyToUseNotificationsActivity;
 #endif
         std::unique_ptr<ProcessThrottlerActivity> m_isAudibleActivity;
         std::unique_ptr<ProcessThrottlerActivity> m_isCapturingActivity;

--- a/Source/WebKit/UIProcess/WebPageProxyInternals.h
+++ b/Source/WebKit/UIProcess/WebPageProxyInternals.h
@@ -212,6 +212,7 @@ struct WebPageProxy::Internals final : WebPopupMenuProxy::Client
     WebCore::IntRect visibleScrollerThumbRect;
     WebCore::PageIdentifier webPageID;
     WindowKind windowKind { WindowKind::Unparented };
+    PageAllowedToRunInTheBackgroundCounter::Token pageAllowedToRunInTheBackgroundToken;
 
     HashMap<WebCore::RegistrableDomain, UniqueRef<SubframePageProxy>> domainToSubframePageProxyMap;
     HashMap<WebCore::FrameIdentifier, WebCore::RegistrableDomain> frameIdentifierToDomainMap;


### PR DESCRIPTION
#### 15b769bec7729ee3cccd1885c6e58f730aa8bf79
<pre>
If a page changes its title while in the background, allow the page to run in the background
<a href="https://bugs.webkit.org/show_bug.cgi?id=256259">https://bugs.webkit.org/show_bug.cgi?id=256259</a>
rdar://103388697

Reviewed by Ben Nham.

If a page changes its title while in the background, allow the page to run in the
background, as long as the app is foreground. Previously, the page changing its
title would buy its an extra 8 minutes of background running time. We are now
more permissive and allow the page to run indefinitely in the background when we
detect this (as long as the application is foreground).

* Source/WebKit/UIProcess/ProcessThrottler.cpp:
(WebKit::ProcessThrottler::ProcessThrottler):
(WebKit::ProcessThrottler::dropSuspendedAssertionTimerFired):
(WebKit::ProcessThrottler::pageAllowedToRunInTheBackgroundToken):
(WebKit::ProcessThrottler::numberOfPagesAllowedToRunInTheBackgroundChanged):
(WebKit::ProcessThrottler::delaySuspension): Deleted.
* Source/WebKit/UIProcess/ProcessThrottler.h:
* Source/WebKit/UIProcess/WebPageProxy.cpp:
(WebKit::WebPageProxy::ProcessActivityState::reset):
(WebKit::WebPageProxy::didCommitLoadForFrame):
(WebKit::WebPageProxy::didFailLoadForFrame):
(WebKit::WebPageProxy::didReceiveTitleForFrame):
(WebKit::WebPageProxy::resetStateAfterProcessExited):
(WebKit::WebPageProxy::pageWillLikelyUseNotifications):
(WebKit::WebPageProxy::showNotification):
(WebKit::WebPageProxy::ProcessActivityState::takeLikelyToUseNotificationsActivity): Deleted.
(WebKit::WebPageProxy::ProcessActivityState::dropLikelyToUseNotificationsActivity): Deleted.
* Source/WebKit/UIProcess/WebPageProxy.h:
* Source/WebKit/UIProcess/WebPageProxyInternals.h:

Canonical link: <a href="https://commits.webkit.org/263769@main">https://commits.webkit.org/263769@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f68877a076ad55f078b9814c9a24a19c443afc20

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/5711 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/5872 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/6062 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/7266 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/32/builds/6106 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/6094 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/5842 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/7866 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/5816 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/5863 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/5132 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/7319 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/3340 "Passed tests") | | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/12894 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/5208 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/5219 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/7156 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/5658 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/4635 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/5106 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/1343 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/9220 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/5466 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->