### PR TITLE
CSS Masonry Ensure Grid Size Updates on Resize

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/masonry/tentative/track-sizing/masonry-track-sizing-check-grid-height-on-resize-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/masonry/tentative/track-sizing/masonry-track-sizing-check-grid-height-on-resize-expected.html
@@ -1,0 +1,38 @@
+<!DOCTYPE html>
+<html>
+
+<head>
+<meta charset="utf-8">
+<link rel="author" title="Brandon Stewart" href="mailto:brandonstewart@apple.com">
+<link rel="help" href="https://drafts.csswg.org/css-grid-3">
+<meta name="assert" content="When the height of an element in the grid changes, ensure the grid is properly resized">
+</head>
+
+<style>
+  grid {
+    display: grid;
+    grid-template-rows: masonry;
+    grid-template-columns: auto;
+    grid-gap: 10px;
+    border: 10px;
+    border-style: solid;
+  }
+  item1 {
+    background-color: grey;
+    height: 125px;
+    width: 250px;
+  }
+  item2 {
+    background-color: grey;
+    height: 250px;
+    width: 250px;
+  }
+</style>
+</head>
+<body>
+  <grid>
+    <item1>1</item1>
+    <item2>2</item2>
+  </grid>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/masonry/tentative/track-sizing/masonry-track-sizing-check-grid-height-on-resize-ref.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/masonry/tentative/track-sizing/masonry-track-sizing-check-grid-height-on-resize-ref.html
@@ -1,0 +1,38 @@
+<!DOCTYPE html>
+<html>
+
+<head>
+<meta charset="utf-8">
+<link rel="author" title="Brandon Stewart" href="mailto:brandonstewart@apple.com">
+<link rel="help" href="https://drafts.csswg.org/css-grid-3">
+<meta name="assert" content="When the height of an element in the grid changes, ensure the grid is properly resized">
+</head>
+
+<style>
+  grid {
+    display: grid;
+    grid-template-rows: masonry;
+    grid-template-columns: auto;
+    grid-gap: 10px;
+    border: 10px;
+    border-style: solid;
+  }
+  item1 {
+    background-color: grey;
+    height: 125px;
+    width: 250px;
+  }
+  item2 {
+    background-color: grey;
+    height: 250px;
+    width: 250px;
+  }
+</style>
+</head>
+<body>
+  <grid>
+    <item1>1</item1>
+    <item2>2</item2>
+  </grid>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/masonry/tentative/track-sizing/masonry-track-sizing-check-grid-height-on-resize.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/masonry/tentative/track-sizing/masonry-track-sizing-check-grid-height-on-resize.html
@@ -1,0 +1,39 @@
+<!DOCTYPE html>
+<html>
+
+<head>
+<meta charset="utf-8">
+<link rel="author" title="Brandon Stewart" href="mailto:brandonstewart@apple.com">
+<link rel="help" href="https://drafts.csswg.org/css-grid-3">
+<link rel="match" href="masonry-track-sizing-check-grid-height-on-resize-ref.html">
+<meta name="assert" content="When the height of an element in the grid changes, ensure the grid is properly resized">
+</head>
+
+<style>
+  grid {
+    display: grid;
+    grid-template-rows: masonry;
+    grid-template-columns: auto;
+    grid-gap: 10px;
+    border: 10px;
+    border-style: solid;
+  }
+  item {
+    background-color: grey;
+    height: 250px;
+    width: 250px;
+  }
+</style>
+</head>
+<body>
+  <grid>
+    <item>1</item>
+    <item>2</item>
+  </grid>
+</body>
+<script>
+    /* Force a relayout */
+    document.body.offsetHeight;
+    document.querySelector("item").style["height"] = "125px";
+</script>
+</html>

--- a/Source/WebCore/rendering/GridMasonryLayout.cpp
+++ b/Source/WebCore/rendering/GridMasonryLayout.cpp
@@ -34,9 +34,11 @@ namespace WebCore {
 
 void GridMasonryLayout::performMasonryPlacement(unsigned gridAxisTracks, GridTrackSizingDirection masonryAxisDirection)
 {
+    // Reset the global variables as they may contain state from previous runs of Masonry.
     m_masonryAxisDirection = masonryAxisDirection;
     m_masonryAxisGridGap = m_renderGrid.gridGap(m_masonryAxisDirection);
     m_gridAxisTracksCount = gridAxisTracks;
+    m_gridContentSize = 0;
 
     allocateCapacityForMasonryVectors();
     collectMasonryItems();


### PR DESCRIPTION
#### bc2ea4d4cf826d62361b7744522954a7b4be96b0
<pre>
CSS Masonry Ensure Grid Size Updates on Resize
<a href="https://bugs.webkit.org/show_bug.cgi?id=256337">https://bugs.webkit.org/show_bug.cgi?id=256337</a>

Reviewed by Brent Fulgham.

During a resize of an element, the grid was not properly updating. The total grid size was remaining the same size while
the content was properly resized. This was caused by not clearing the m_gridContentSize at the start of the masonry algorithm.

* LayoutTests/imported/w3c/web-platform-tests/css/css-grid/masonry/tentative/track-sizing/masonry-track-sizing-check-grid-height-on-resize-expected.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-grid/masonry/tentative/track-sizing/masonry-track-sizing-check-grid-height-on-resize-ref.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-grid/masonry/tentative/track-sizing/masonry-track-sizing-check-grid-height-on-resize.html: Added.
* Source/WebCore/rendering/GridMasonryLayout.cpp:
(WebCore::GridMasonryLayout::performMasonryPlacement):

Canonical link: <a href="https://commits.webkit.org/263712@main">https://commits.webkit.org/263712@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/329b54bde989098d52ff4152a6793f9e5e6a5eab

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/5534 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/5683 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/5872 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/7082 "Built successfully") | [❌ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/5538 "Failed to checkout and rebase branch from PR 13464") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/5533 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/5908 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/5657 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/7045 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/5635 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/5695 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/4948 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/7117 "Built successfully") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/39/builds/3173 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/4970 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/12100 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/5039 "Passed tests") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/5050 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/6793 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/5488 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/4490 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/4941 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/4913 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/1316 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/9046 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/5303 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->