### PR TITLE
Support navigating cross-site iframe to mainFrame domain

### DIFF
--- a/Source/WebCore/page/Page.cpp
+++ b/Source/WebCore/page/Page.cpp
@@ -4362,6 +4362,12 @@ void Page::didFinishScrolling()
 #endif
 }
 
+void Page::addRootFrame(LocalFrame& frame)
+{
+    ASSERT(frame.isRootFrame());
+    m_rootFrames.add(frame);
+}
+
 void Page::reloadExecutionContextsForOrigin(const ClientOrigin& origin, std::optional<FrameIdentifier> triggeringFrame) const
 {
     auto* localMainFrame = dynamicDowncast<LocalFrame>(m_mainFrame.get());

--- a/Source/WebCore/page/Page.h
+++ b/Source/WebCore/page/Page.h
@@ -1041,7 +1041,7 @@ public:
     void didFinishScrolling();
 
     const WeakHashSet<LocalFrame>& rootFrames() const { return m_rootFrames; }
-    void addRootFrame(LocalFrame& frame) { m_rootFrames.add(frame); }
+    WEBCORE_EXPORT void addRootFrame(LocalFrame&);
 
 private:
     struct Navigation {

--- a/Source/WebKit/UIProcess/SubframePageProxy.cpp
+++ b/Source/WebKit/UIProcess/SubframePageProxy.cpp
@@ -104,6 +104,7 @@ void SubframePageProxy::decidePolicyForResponse(WebCore::FrameIdentifier frameID
 
 void SubframePageProxy::didCommitLoadForFrame(WebCore::FrameIdentifier frameID, FrameInfoData&& frameInfo, WebCore::ResourceRequest&& request, uint64_t navigationID, const String& mimeType, bool frameHasCustomContentProvider, WebCore::FrameLoadType frameLoadType, const WebCore::CertificateInfo& certificateInfo, bool usedLegacyTLS, bool privateRelayed, bool containsPluginDocument, WebCore::HasInsecureContent hasInsecureContent, WebCore::MouseEventPolicy mouseEventPolicy, const UserData& userData)
 {
+    m_process->didCommitProvisionalLoad();
     RefPtr frame = WebFrameProxy::webFrame(frameID);
     if (frame)
         frame->commitProvisionalFrame(frameID, WTFMove(frameInfo), WTFMove(request), navigationID, mimeType, frameHasCustomContentProvider, frameLoadType, certificateInfo, usedLegacyTLS, privateRelayed, containsPluginDocument, hasInsecureContent, mouseEventPolicy, userData); // Will delete |this|.

--- a/Source/WebKit/UIProcess/WebFrameProxy.h
+++ b/Source/WebKit/UIProcess/WebFrameProxy.h
@@ -162,6 +162,7 @@ public:
 
     WebFrameProxy* parentFrame() { return m_parentFrame.get(); }
     WebProcessProxy& process() { return m_process.get(); }
+    ProvisionalFrameProxy* provisionalFrame() { return m_provisionalFrame.get(); }
 
 private:
     WebFrameProxy(WebPageProxy&, WebProcessProxy&, WebCore::FrameIdentifier);

--- a/Source/WebKit/UIProcess/WebPageProxy.h
+++ b/Source/WebKit/UIProcess/WebPageProxy.h
@@ -1351,7 +1351,7 @@ public:
     class PolicyDecisionSender;
     enum class WillContinueLoadInNewProcess : bool { No, Yes };
     void receivedPolicyDecision(WebCore::PolicyAction, API::Navigation*, RefPtr<API::WebsitePolicies>&&, std::variant<Ref<API::NavigationResponse>, Ref<API::NavigationAction>>&&, Ref<PolicyDecisionSender>&&, WillContinueLoadInNewProcess, std::optional<SandboxExtensionHandle>);
-    void receivedNavigationPolicyDecision(WebCore::PolicyAction, API::Navigation*, Ref<API::NavigationAction>&&, ProcessSwapRequestedByClient, WebFrameProxy&, const FrameInfoData&, Ref<PolicyDecisionSender>&&);
+    void receivedNavigationPolicyDecision(WebProcessProxy&, WebCore::PolicyAction, API::Navigation*, Ref<API::NavigationAction>&&, ProcessSwapRequestedByClient, WebFrameProxy&, const FrameInfoData&, Ref<PolicyDecisionSender>&&);
 
     void backForwardRemovedItem(const WebCore::BackForwardItemIdentifier&);
 

--- a/Source/WebKit/WebProcess/WebPage/WebFrame.cpp
+++ b/Source/WebKit/WebProcess/WebPage/WebFrame.cpp
@@ -407,7 +407,8 @@ void WebFrame::transitionToLocal(WebCore::LayerHostingContextIdentifier layerHos
     localFrame->init();
 
     setLayerHostingContextIdentifier(layerHostingContextIdentifier);
-    corePage->addRootFrame(localFrame.get());
+    if (localFrame->isRootFrame())
+        corePage->addRootFrame(localFrame.get());
 
     if (auto* webPage = page(); webPage && m_coreFrame->isRootFrame()) {
         if (auto* drawingArea = webPage->drawingArea())

--- a/Source/WebKit/WebProcess/WebPage/WebPage.cpp
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.cpp
@@ -5716,8 +5716,6 @@ void WebPage::SandboxExtensionTracker::willPerformLoadDragDestinationAction(RefP
 
 void WebPage::SandboxExtensionTracker::beginLoad(WebFrame* frame, SandboxExtension::Handle&& handle)
 {
-    ASSERT_UNUSED(frame, frame->isRootFrame());
-
     setPendingProvisionalSandboxExtension(SandboxExtension::create(WTFMove(handle)));
 }
 

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/SiteIsolation.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/SiteIsolation.mm
@@ -411,7 +411,7 @@ TEST(SiteIsolation, NavigatingCrossOriginIframeToSameOrigin)
         pid_t childFramePid = childFrame._processIdentifier;
         EXPECT_NE(mainFramePid, 0);
         EXPECT_NE(childFramePid, 0);
-        EXPECT_NE(mainFramePid, childFramePid); // FIXME: These should be equal.
+        EXPECT_EQ(mainFramePid, childFramePid);
         EXPECT_WK_STREQ(mainFrame.securityOrigin.host, "example.com");
         EXPECT_WK_STREQ(childFrame.securityOrigin.host, "example.com");
         done = true;
@@ -612,7 +612,7 @@ TEST(SiteIsolation, ChildNavigatingToMainFrameDomain)
     [navigationDelegate allowAnyTLSCertificate];
 
     auto configuration = server.httpsProxyConfiguration();
-    // FIXME: Enable site isolation once the new frame can be loaded in the same process as mainFrame
+    enableSiteIsolation(configuration);
 
     auto webView = adoptNS([[WKWebView alloc] initWithFrame:CGRectZero configuration:configuration]);
     webView.get().navigationDelegate = navigationDelegate.get();


### PR DESCRIPTION
#### 4ca041a13dfafa4a2fbe427511dd2705969b1be8
<pre>
Support navigating cross-site iframe to mainFrame domain
<a href="https://bugs.webkit.org/show_bug.cgi?id=256339">https://bugs.webkit.org/show_bug.cgi?id=256339</a>

Reviewed by Alex Christensen.

This change adds support so that an iframe can navigate back to the
mainFrame domain, and so that the load happens in the mainFrame process.

* Source/WebCore/page/Page.cpp:
(WebCore::Page::addRootFrame):
* Source/WebCore/page/Page.h:
(WebCore::Page::addRootFrame): Deleted.
* Source/WebKit/UIProcess/SubframePageProxy.cpp:
(WebKit::SubframePageProxy::didCommitLoadForFrame):
* Source/WebKit/UIProcess/WebFrameProxy.h:
(WebKit::WebFrameProxy::provisionalFrame):
* Source/WebKit/UIProcess/WebPageProxy.cpp:
(WebKit::WebPageProxy::receivedNavigationPolicyDecision):
(WebKit::WebPageProxy::didCommitLoadForFrame):
(WebKit::WebPageProxy::decidePolicyForNavigationAction):
(WebKit::WebPageProxy::decidePolicyForResponse):
* Source/WebKit/UIProcess/WebPageProxy.h:
* Source/WebKit/UIProcess/WebProcessPool.cpp:
(WebKit::WebProcessPool::processForNavigation):
* Source/WebKit/WebProcess/WebPage/WebFrame.cpp:
(WebKit::WebFrame::transitionToLocal):
* Source/WebKit/WebProcess/WebPage/WebPage.cpp:
(WebKit::WebPage::SandboxExtensionTracker::beginLoad):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/SiteIsolation.mm:
(TestWebKitAPI::TEST):

Canonical link: <a href="https://commits.webkit.org/263747@main">https://commits.webkit.org/263747@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/6011356407a861c6a3065277e48a39ed0ba28e95

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/5645 "1 style error") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/5798 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/5988 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/7196 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/5630 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/5644 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/6021 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/5770 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/7737 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/5749 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/5797 "2 new passes 10 flakes 1 failures") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/5056 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/7238 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/3274 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/5082 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/12294 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/5143 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/5158 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/6986 "run-api-tests-without-change (failure)") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/5593 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/4573 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/5041 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/9152 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/648 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/5402 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->