### PR TITLE
[JSC] Optimize Proxy get with various keys without handlers

### DIFF
--- a/JSTests/microbenchmarks/proxy-get-by-val-hit.js
+++ b/JSTests/microbenchmarks/proxy-get-by-val-hit.js
@@ -1,0 +1,9 @@
+(function() {
+    var proxy = new Proxy({}, {});
+    var keys = [ "a", "b", "c", "d", "e", "f", "g", "h", "i", "j", "k", "l", "m", "n", "o", "p" ];
+    for (let key of keys)
+        proxy[key] = 42;
+
+    for (var i = 0; i < 1e7; ++i)
+        proxy[keys[i & 15]];
+})();

--- a/JSTests/microbenchmarks/proxy-get-by-val-miss.js
+++ b/JSTests/microbenchmarks/proxy-get-by-val-miss.js
@@ -1,0 +1,7 @@
+(function() {
+    var proxy = new Proxy({}, {});
+    var keys = [ "a", "b", "c", "d", "e", "f", "g", "h", "i", "j", "k", "l", "m", "n", "o", "p" ];
+
+    for (var i = 0; i < 1e7; ++i)
+        proxy[keys[i & 15]];
+})();

--- a/JSTests/microbenchmarks/proxy-get-megamorphic.js
+++ b/JSTests/microbenchmarks/proxy-get-megamorphic.js
@@ -1,0 +1,18 @@
+var proxy = new Proxy({}, {});
+
+var keys = [];
+
+for (var i = 0; i < 0x100; ++i) {
+    keys.push('key' + i);
+    keys[i][0];
+}
+
+function test(proxy, key) {
+    return proxy[key];
+}
+noInline(test);
+
+for (var i = 0; i < 1e6; ++i) {
+    var key = keys[i & (0x100 - 1)];
+    test(proxy, key);
+}

--- a/Source/JavaScriptCore/builtins/ProxyHelpers.js
+++ b/Source/JavaScriptCore/builtins/ProxyHelpers.js
@@ -77,6 +77,33 @@ function performProxyObjectGet(propertyName, receiver)
 }
 
 @linkTimeConstant
+function performProxyObjectGetByVal(propertyName, receiver)
+{
+    "use strict";
+
+    var target = @getProxyInternalField(this, @proxyFieldTarget);
+    var handler = @getProxyInternalField(this, @proxyFieldHandler);
+    var propertyName = @toPropertyKey(propertyName);
+
+    if (handler === null)
+        @throwTypeError("Proxy has already been revoked. No more operations are allowed to be performed on it");
+
+    var trap = handler.get;
+    if (@isUndefinedOrNull(trap))
+        return @getByValWithThis(target, receiver, propertyName);
+
+    if (!@isCallable(trap))
+        @throwTypeError("'get' property of a Proxy's handler should be callable");
+
+    var trapResult = trap.@call(handler, target, propertyName, receiver);
+
+    if (@mustValidateResultOfProxyGetAndSetTraps(target))
+        @handleProxyGetTrapResult(trapResult, target, propertyName);
+
+    return trapResult;
+}
+
+@linkTimeConstant
 function performProxyObjectSetSloppy(propertyName, receiver, value)
 {
     "use strict";

--- a/Source/JavaScriptCore/bytecode/AccessCase.cpp
+++ b/Source/JavaScriptCore/bytecode/AccessCase.cpp
@@ -88,6 +88,7 @@ Ref<AccessCase> AccessCase::create(VM& vm, JSCell* owner, AccessType type, Cache
     case ProxyObjectStore:
     case Replace:
     case InstanceOfGeneric:
+    case IndexedProxyObjectLoad:
     case IndexedMegamorphicLoad:
     case IndexedInt32Load:
     case IndexedDoubleLoad:
@@ -350,6 +351,7 @@ bool AccessCase::guardedByStructureCheckSkippingConstantIdentifierCheck() const
     case InstanceOfHit:
     case InstanceOfMiss:
     case InstanceOfGeneric:
+    case IndexedProxyObjectLoad:
     case IndexedMegamorphicLoad:
     case IndexedInt32Load:
     case IndexedDoubleLoad:
@@ -460,6 +462,7 @@ bool AccessCase::requiresIdentifierNameMatch() const
     case InstanceOfHit:
     case InstanceOfMiss:
     case InstanceOfGeneric:
+    case IndexedProxyObjectLoad:
     case IndexedMegamorphicLoad:
     case IndexedInt32Load:
     case IndexedDoubleLoad:
@@ -548,6 +551,7 @@ bool AccessCase::requiresInt32PropertyCheck() const
     case InstanceOfGeneric:
     case CheckPrivateBrand:
     case SetPrivateBrand:
+    case IndexedProxyObjectLoad:
     case IndexedMegamorphicLoad:
         return false;
     case IndexedInt32Load:
@@ -636,6 +640,7 @@ bool AccessCase::needsScratchFPR() const
     case InstanceOfHit:
     case InstanceOfMiss:
     case InstanceOfGeneric:
+    case IndexedProxyObjectLoad:
     case IndexedMegamorphicLoad:
     case IndexedInt32Load:
     case IndexedContiguousLoad:
@@ -735,7 +740,8 @@ void AccessCase::forEachDependentCell(VM&, const Functor& functor) const
     }
     case ProxyObjectHas:
     case ProxyObjectLoad:
-    case ProxyObjectStore: {
+    case ProxyObjectStore:
+    case IndexedProxyObjectLoad: {
         auto& accessor = this->as<ProxyObjectAccessCase>();
         if (accessor.callLinkInfo())
             accessor.callLinkInfo()->forEachDependentCell(functor);
@@ -835,6 +841,7 @@ bool AccessCase::doesCalls(VM& vm, Vector<JSCell*>* cellsToMarkIfDoesCalls) cons
     case ProxyObjectHas:
     case ProxyObjectLoad:
     case ProxyObjectStore:
+    case IndexedProxyObjectLoad:
         doesCalls = true;
         break;
     case IntrinsicGetter: {
@@ -1026,6 +1033,7 @@ bool AccessCase::canReplace(const AccessCase& other) const
     case ProxyObjectHas:
     case ProxyObjectLoad:
     case ProxyObjectStore:
+    case IndexedProxyObjectLoad:
         return other.type() == type();
 
     case ModuleNamespaceLoad: {
@@ -1277,6 +1285,7 @@ inline void AccessCase::runWithDowncast(const Func& func)
     case ProxyObjectHas:
     case ProxyObjectLoad:
     case ProxyObjectStore:
+    case IndexedProxyObjectLoad:
         func(static_cast<ProxyObjectAccessCase*>(this));
         break;
     }
@@ -1390,8 +1399,9 @@ bool AccessCase::canBeShared(const AccessCase& lhs, const AccessCase& rhs)
     case Setter:
     case ProxyObjectHas:
     case ProxyObjectLoad:
-    case ProxyObjectStore: {
-        // Getter / Setter / ProxyObjectHas / ProxyObjectLoad / ProxyObjectStore relies on CodeBlock, which makes sharing impossible.
+    case ProxyObjectStore:
+    case IndexedProxyObjectLoad: {
+        // Getter / Setter / ProxyObjectHas / ProxyObjectLoad / ProxyObjectStore / IndexedProxyObjectLoad rely on CodeBlock, which makes sharing impossible.
         return false;
     }
 

--- a/Source/JavaScriptCore/bytecode/AccessCase.h
+++ b/Source/JavaScriptCore/bytecode/AccessCase.h
@@ -123,6 +123,7 @@ DECLARE_ALLOCATOR_WITH_HEAP_IDENTIFIER(AccessCase);
     macro(InstanceOfGeneric) \
     macro(CheckPrivateBrand) \
     macro(SetPrivateBrand) \
+    macro(IndexedProxyObjectLoad) \
     macro(IndexedMegamorphicLoad) \
     macro(IndexedInt32Load) \
     macro(IndexedDoubleLoad) \

--- a/Source/JavaScriptCore/bytecode/GetByStatus.cpp
+++ b/Source/JavaScriptCore/bytecode/GetByStatus.cpp
@@ -85,6 +85,8 @@ GetByStatus GetByStatus::computeFromLLInt(CodeBlock* profiledBlock, BytecodeInde
         break;
 
     case op_get_by_val:
+    case op_get_by_val_with_this:
+    case op_get_by_id_with_this:
         return GetByStatus(NoInformation, false);
 
     case op_enumerator_get_by_val:

--- a/Source/JavaScriptCore/bytecode/InlineCacheCompiler.cpp
+++ b/Source/JavaScriptCore/bytecode/InlineCacheCompiler.cpp
@@ -520,7 +520,8 @@ void InlineCacheCompiler::generateWithGuard(AccessCase& accessCase, CCallHelpers
 
     case AccessCase::ProxyObjectHas:
     case AccessCase::ProxyObjectLoad:
-    case AccessCase::ProxyObjectStore: {
+    case AccessCase::ProxyObjectStore:
+    case AccessCase::IndexedProxyObjectLoad: {
         ASSERT(!accessCase.viaGlobalProxy());
         emitProxyObjectAccess(accessCase.as<ProxyObjectAccessCase>(), fallThrough);
         return;
@@ -2097,6 +2098,7 @@ void InlineCacheCompiler::generateImpl(AccessCase& accessCase)
     case AccessCase::ProxyObjectStore:
     case AccessCase::InstanceOfGeneric:
     case AccessCase::LoadMegamorphic:
+    case AccessCase::IndexedProxyObjectLoad:
     case AccessCase::IndexedMegamorphicLoad:
     case AccessCase::IndexedInt32Load:
     case AccessCase::IndexedDoubleLoad:
@@ -2333,6 +2335,10 @@ void InlineCacheCompiler::emitProxyObjectAccess(ProxyObjectAccessCase& accessCas
         numberOfParameters = 3;
         proxyInternalMethod = globalObject->performProxyObjectGetFunction();
         break;
+    case AccessCase::IndexedProxyObjectLoad:
+        numberOfParameters = 3;
+        proxyInternalMethod = globalObject->performProxyObjectGetByValFunction();
+        break;
     case AccessCase::ProxyObjectStore:
         numberOfParameters = 4;
         proxyInternalMethod = ecmaMode.isStrict() ? globalObject->performProxyObjectSetStrictFunction() : globalObject->performProxyObjectSetSloppyFunction();
@@ -2358,14 +2364,15 @@ void InlineCacheCompiler::emitProxyObjectAccess(ProxyObjectAccessCase& accessCas
     jit.storeCell(baseGPR, calleeFrame.withOffset(virtualRegisterForArgumentIncludingThis(0).offset() * sizeof(Register)));
 
     if (!stubInfo.hasConstantIdentifier) {
-        RELEASE_ASSERT(accessCase.identifier());
-        GPRReg propertyGPR = stubInfo.propertyGPR();
-        jit.storeCell(propertyGPR, calleeFrame.withOffset(virtualRegisterForArgumentIncludingThis(1).offset() * sizeof(Register)));
+        if (accessCase.m_type != AccessCase::IndexedProxyObjectLoad)
+            RELEASE_ASSERT(accessCase.identifier());
+        jit.storeValue(stubInfo.propertyRegs(), calleeFrame.withOffset(virtualRegisterForArgumentIncludingThis(1).offset() * sizeof(Register)));
     } else
         jit.storeTrustedValue(accessCase.identifier().cell(), calleeFrame.withOffset(virtualRegisterForArgumentIncludingThis(1).offset() * sizeof(Register)));
 
     switch (accessCase.m_type) {
     case AccessCase::ProxyObjectLoad:
+    case AccessCase::IndexedProxyObjectLoad:
         jit.storeCell(thisGPR, calleeFrame.withOffset(virtualRegisterForArgumentIncludingThis(2).offset() * sizeof(Register)));
         break;
     case AccessCase::ProxyObjectStore:
@@ -2682,7 +2689,8 @@ AccessGenerationResult InlineCacheCompiler::regenerate(const GCSafeConcurrentJSL
             generatedMegamorphicCode = true;
             break;
         }
-        case AccessType::GetById: {
+        case AccessType::GetById:
+        case AccessType::GetByIdWithThis: {
             auto identifier = cases.last()->m_identifier;
             bool allAreSimpleLoadOrMiss = true;
             for (auto& accessCase : cases) {
@@ -2710,7 +2718,8 @@ AccessGenerationResult InlineCacheCompiler::regenerate(const GCSafeConcurrentJSL
             }
             break;
         }
-        case AccessType::GetByVal: {
+        case AccessType::GetByVal:
+        case AccessType::GetByValWithThis: {
             bool allAreSimpleLoadOrMiss = true;
             for (auto& accessCase : cases) {
                 if (accessCase->type() != AccessCase::Load && accessCase->type() != AccessCase::Miss)
@@ -2766,7 +2775,8 @@ AccessGenerationResult InlineCacheCompiler::regenerate(const GCSafeConcurrentJSL
         case AccessCase::Setter:
         case AccessCase::ProxyObjectLoad:
         case AccessCase::ProxyObjectStore:
-            // Getter / Setter / ProxyObjectLoad / ProxyObjectStore relies on stack-pointer adjustment, which is tied to the linked CodeBlock, which makes this code unshareable.
+        case AccessCase::IndexedProxyObjectLoad:
+            // Getter / Setter / ProxyObjectLoad / ProxyObjectStore / IndexedProxyObjectLoad rely on stack-pointer adjustment, which is tied to the linked CodeBlock, which makes this code unshareable.
             canBeShared = false;
             doesJSCalls = true;
             break;

--- a/Source/JavaScriptCore/bytecode/Repatch.cpp
+++ b/Source/JavaScriptCore/bytecode/Repatch.cpp
@@ -399,11 +399,24 @@ static InlineCacheAction tryCacheGetBy(JSGlobalObject* globalObject, CodeBlock* 
                 newCase = ModuleNamespaceAccessCase::create(vm, codeBlock, propertyName, jsCast<JSModuleNamespaceObject*>(baseCell), moduleNamespaceSlot->environment, ScopeOffset(moduleNamespaceSlot->scopeOffset));
         }
 
-        if ((kind == GetByKind::ById || kind == GetByKind::ByVal || kind == GetByKind::ByIdWithThis || kind == GetByKind::ByValWithThis) && !propertyName.isPrivateName() && baseCell->inherits<ProxyObject>()) {
-            propertyName.ensureIsCell(vm);
-            newCase = ProxyObjectAccessCase::create(vm, codeBlock, AccessCase::ProxyObjectLoad, propertyName);
+        if (!propertyName.isPrivateName() && baseCell->inherits<ProxyObject>()) {
+            switch (kind) {
+            case GetByKind::ById:
+            case GetByKind::ByIdWithThis: {
+                propertyName.ensureIsCell(vm);
+                newCase = ProxyObjectAccessCase::create(vm, codeBlock, AccessCase::ProxyObjectLoad, propertyName);
+                break;
+            }
+            case GetByKind::ByVal:
+            case GetByKind::ByValWithThis: {
+                newCase = ProxyObjectAccessCase::create(vm, codeBlock, AccessCase::IndexedProxyObjectLoad, nullptr);
+                break;
+            }
+            default:
+                break;
+            }
         }
-        
+
         if (!newCase) {
             if (!slot.isCacheable() && !slot.isUnset())
                 return GiveUpOnCache;
@@ -608,10 +621,23 @@ void repatchGetBy(JSGlobalObject* globalObject, CodeBlock* codeBlock, JSValue ba
 
     switch (tryCacheGetBy(globalObject, codeBlock, baseValue, propertyName, slot, stubInfo, kind)) {
     case PromoteToMegamorphic: {
-        if (kind == GetByKind::ById)
+        switch (kind) {
+        case GetByKind::ById:
             repatchSlowPathCall(codeBlock, stubInfo, operationGetByIdMegamorphic);
-        else
+            break;
+        case GetByKind::ByIdWithThis:
+            repatchSlowPathCall(codeBlock, stubInfo, operationGetByIdWithThisMegamorphic);
+            break;
+        case GetByKind::ByVal:
             repatchSlowPathCall(codeBlock, stubInfo, operationGetByValMegamorphic);
+            break;
+        case GetByKind::ByValWithThis:
+            repatchSlowPathCall(codeBlock, stubInfo, operationGetByValWithThisMegamorphic);
+            break;
+        default:
+            RELEASE_ASSERT_NOT_REACHED();
+            break;
+        }
         break;
     }
     case GiveUpOnCache:

--- a/Source/JavaScriptCore/dfg/DFGAbstractInterpreterInlines.h
+++ b/Source/JavaScriptCore/dfg/DFGAbstractInterpreterInlines.h
@@ -3689,7 +3689,9 @@ bool AbstractInterpreter<AbstractStateType>::executeEffects(unsigned clobberLimi
 
     case GetPrivateName:
     case GetByValWithThis:
+    case GetByValWithThisMegamorphic:
     case GetByIdWithThis:
+    case GetByIdWithThisMegamorphic:
         clobberWorld();
         makeHeapTopForNode(node);
         break;

--- a/Source/JavaScriptCore/dfg/DFGByteCodeParser.cpp
+++ b/Source/JavaScriptCore/dfg/DFGByteCodeParser.cpp
@@ -6859,7 +6859,9 @@ void ByteCodeParser::parseBlock(unsigned limit)
             Node* base = get(bytecode.m_base);
             Node* thisValue = get(bytecode.m_thisValue);
             Node* property = get(bytecode.m_property);
-            Node* getByValWithThis = addToGraph(GetByValWithThis, OpInfo(), OpInfo(prediction), base, thisValue, property);
+
+            GetByStatus getByStatus = GetByStatus::computeFor(m_inlineStackTop->m_profiledBlock, m_inlineStackTop->m_baselineMap, m_icContextStack, currentCodeOrigin());
+            Node* getByValWithThis = addToGraph(getByStatus.isMegamorphic() ? GetByValWithThisMegamorphic : GetByValWithThis, OpInfo(), OpInfo(prediction), base, thisValue, property);
             set(bytecode.m_dst, getByValWithThis);
 
             NEXT_OPCODE(op_get_by_val_with_this);
@@ -7093,7 +7095,9 @@ void ByteCodeParser::parseBlock(unsigned limit)
             unsigned identifierNumber = m_inlineStackTop->m_identifierRemap[bytecode.m_property];
             UniquedStringImpl* uid = m_graph.identifiers()[identifierNumber];
 
-            set(bytecode.m_dst, addToGraph(GetByIdWithThis, OpInfo(CacheableIdentifier::createFromIdentifierOwnedByCodeBlock(m_inlineStackTop->m_profiledBlock, uid)), OpInfo(prediction), base, thisValue));
+            GetByStatus getByStatus = GetByStatus::computeFor(m_inlineStackTop->m_profiledBlock, m_inlineStackTop->m_baselineMap, m_icContextStack, currentCodeOrigin());
+
+            set(bytecode.m_dst, addToGraph(getByStatus.isMegamorphic() ? GetByIdWithThisMegamorphic : GetByIdWithThis, OpInfo(CacheableIdentifier::createFromIdentifierOwnedByCodeBlock(m_inlineStackTop->m_profiledBlock, uid)), OpInfo(prediction), base, thisValue));
 
             NEXT_OPCODE(op_get_by_id_with_this);
         }

--- a/Source/JavaScriptCore/dfg/DFGClobberize.h
+++ b/Source/JavaScriptCore/dfg/DFGClobberize.h
@@ -705,9 +705,11 @@ void clobberize(Graph& graph, Node* node, const ReadFunctor& read, const WriteFu
     case GetByIdFlush:
     case GetByIdMegamorphic:
     case GetByIdWithThis:
+    case GetByIdWithThisMegamorphic:
     case GetByIdDirect:
     case GetByIdDirectFlush:
     case GetByValWithThis:
+    case GetByValWithThisMegamorphic:
     case PutById:
     case PutByIdWithThis:
     case PutByValWithThis:

--- a/Source/JavaScriptCore/dfg/DFGDoesGC.cpp
+++ b/Source/JavaScriptCore/dfg/DFGDoesGC.cpp
@@ -300,7 +300,9 @@ bool doesGC(Graph& graph, Node* node)
     case GetByIdFlush:
     case GetByIdMegamorphic:
     case GetByIdWithThis:
+    case GetByIdWithThisMegamorphic:
     case GetByValWithThis:
+    case GetByValWithThisMegamorphic:
     case GetDynamicVar:
     case GetMapBucket:
     case HasIndexedProperty:

--- a/Source/JavaScriptCore/dfg/DFGFixupPhase.cpp
+++ b/Source/JavaScriptCore/dfg/DFGFixupPhase.cpp
@@ -1200,9 +1200,12 @@ private:
             break;
         }
 
-        case GetByValWithThis: {
+        case GetByValWithThis:
             break;
-        }
+
+        case GetByValWithThisMegamorphic:
+            fixEdge<CellUse>(node->child1());
+            break;
 
         case EnumeratorPutByVal: {
             fixEdge<CellUse>(m_graph.varArgChild(node, 0));
@@ -1975,6 +1978,10 @@ private:
             }
             break;
         }
+
+        case GetByIdWithThisMegamorphic:
+            fixEdge<CellUse>(node->child1());
+            break;
 
         case PutById:
         case PutByIdFlush:

--- a/Source/JavaScriptCore/dfg/DFGNode.h
+++ b/Source/JavaScriptCore/dfg/DFGNode.h
@@ -1138,6 +1138,7 @@ public:
         case GetByIdFlush:
         case GetByIdMegamorphic:
         case GetByIdWithThis:
+        case GetByIdWithThisMegamorphic:
         case GetByIdDirect:
         case GetByIdDirectFlush:
         case GetPrivateNameById:
@@ -1888,6 +1889,7 @@ public:
         case GetByIdFlush:
         case GetByIdMegamorphic:
         case GetByIdWithThis:
+        case GetByIdWithThisMegamorphic:
         case GetByIdDirect:
         case GetByIdDirectFlush:
         case GetPrototypeOf:
@@ -1896,6 +1898,7 @@ public:
         case GetByVal:
         case GetByValMegamorphic:
         case GetByValWithThis:
+        case GetByValWithThisMegamorphic:
         case GetPrivateName:
         case GetPrivateNameById:
         case Call:

--- a/Source/JavaScriptCore/dfg/DFGNodeType.h
+++ b/Source/JavaScriptCore/dfg/DFGNodeType.h
@@ -204,6 +204,7 @@ namespace JSC { namespace DFG {
     macro(GetByVal, NodeResultJS | NodeMustGenerate | NodeHasVarArgs) \
     macro(GetByValMegamorphic, NodeResultJS | NodeMustGenerate | NodeHasVarArgs) \
     macro(GetByValWithThis, NodeResultJS | NodeMustGenerate) \
+    macro(GetByValWithThisMegamorphic, NodeResultJS | NodeMustGenerate) \
     macro(GetMyArgumentByVal, NodeResultJS | NodeMustGenerate) \
     macro(GetMyArgumentByValOutOfBounds, NodeResultJS | NodeMustGenerate) \
     macro(VarargsLength, NodeMustGenerate | NodeResultInt32) \
@@ -220,6 +221,7 @@ namespace JSC { namespace DFG {
     macro(GetById, NodeResultJS | NodeMustGenerate) \
     macro(GetByIdFlush, NodeResultJS | NodeMustGenerate) \
     macro(GetByIdWithThis, NodeResultJS | NodeMustGenerate) \
+    macro(GetByIdWithThisMegamorphic, NodeResultJS | NodeMustGenerate) \
     macro(GetByIdDirect, NodeResultJS | NodeMustGenerate) \
     macro(GetByIdDirectFlush, NodeResultJS | NodeMustGenerate) \
     macro(GetByIdMegamorphic, NodeResultJS | NodeMustGenerate) \

--- a/Source/JavaScriptCore/dfg/DFGPredictionPropagationPhase.cpp
+++ b/Source/JavaScriptCore/dfg/DFGPredictionPropagationPhase.cpp
@@ -931,10 +931,12 @@ private:
         case GetByIdFlush:
         case GetByIdMegamorphic:
         case GetByIdWithThis:
+        case GetByIdWithThisMegamorphic:
         case GetByIdDirect:
         case GetByIdDirectFlush:
         case TryGetById:
         case GetByValWithThis:
+        case GetByValWithThisMegamorphic:
         case GetByOffset:
         case GetPrivateName:
         case GetPrivateNameById:

--- a/Source/JavaScriptCore/dfg/DFGSafeToExecute.h
+++ b/Source/JavaScriptCore/dfg/DFGSafeToExecute.h
@@ -535,7 +535,9 @@ bool safeToExecute(AbstractStateType& state, Graph& graph, Node* node, bool igno
     case GetById:
     case GetByIdMegamorphic:
     case GetByIdWithThis:
+    case GetByIdWithThisMegamorphic:
     case GetByValWithThis:
+    case GetByValWithThisMegamorphic:
     case GetByIdFlush:
     case GetByIdDirect:
     case GetByIdDirectFlush:

--- a/Source/JavaScriptCore/dfg/DFGSpeculativeJIT.h
+++ b/Source/JavaScriptCore/dfg/DFGSpeculativeJIT.h
@@ -714,6 +714,7 @@ public:
     void compileGetById(Node*, AccessType);
     void compileGetByIdFlush(Node*, AccessType);
     void compileGetByIdMegamorphic(Node*);
+    void compileGetByIdWithThisMegamorphic(Node*);
     void compileInById(Node*);
     void compileInByVal(Node*);
     void compileHasPrivate(Node*, AccessType);
@@ -1475,6 +1476,7 @@ public:
     void compilePutByValForCellWithString(Node*);
     void compilePutByValForCellWithSymbol(Node*);
     void compileGetByValWithThis(Node*);
+    void compileGetByValWithThisMegamorphic(Node*);
     void compilePutPrivateName(Node*);
     void compilePutPrivateNameById(Node*);
     void compileCheckPrivateBrand(Node*);

--- a/Source/JavaScriptCore/dfg/DFGSpeculativeJIT32_64.cpp
+++ b/Source/JavaScriptCore/dfg/DFGSpeculativeJIT32_64.cpp
@@ -4276,7 +4276,9 @@ void SpeculativeJIT::compile(Node* node)
     case NewBoundFunction:
     case EnumeratorPutByVal:
     case GetByIdMegamorphic:
+    case GetByIdWithThisMegamorphic:
     case GetByValMegamorphic:
+    case GetByValWithThisMegamorphic:
         DFG_CRASH(m_graph, node, "unexpected node in DFG backend");
         break;
     }

--- a/Source/JavaScriptCore/ftl/FTLCapabilities.cpp
+++ b/Source/JavaScriptCore/ftl/FTLCapabilities.cpp
@@ -244,6 +244,7 @@ inline CapabilityLevel canCompile(Node* node)
     case GetByIdFlush:
     case GetByIdMegamorphic:
     case GetByIdWithThis:
+    case GetByIdWithThisMegamorphic:
     case GetByIdDirect:
     case GetByIdDirectFlush:
     case ToThis:
@@ -413,6 +414,7 @@ inline CapabilityLevel canCompile(Node* node)
     case GetByVal:
     case GetByValMegamorphic:
     case GetByValWithThis:
+    case GetByValWithThisMegamorphic:
     case PutByVal:
     case PutByValAlias:
     case PutByValDirect:

--- a/Source/JavaScriptCore/jit/JITOperations.h
+++ b/Source/JavaScriptCore/jit/JITOperations.h
@@ -176,6 +176,7 @@ JSC_DECLARE_JIT_OPERATION(operationGetByIdOptimize, EncodedJSValue, (JSGlobalObj
 JSC_DECLARE_JIT_OPERATION(operationGetByIdWithThis, EncodedJSValue, (JSGlobalObject*, StructureStubInfo*, EncodedJSValue, EncodedJSValue, uintptr_t));
 JSC_DECLARE_JIT_OPERATION(operationGetByIdWithThisGeneric, EncodedJSValue, (JSGlobalObject*, EncodedJSValue, EncodedJSValue, uintptr_t));
 JSC_DECLARE_JIT_OPERATION(operationGetByIdWithThisOptimize, EncodedJSValue, (JSGlobalObject*, StructureStubInfo*, EncodedJSValue, EncodedJSValue, uintptr_t));
+JSC_DECLARE_JIT_OPERATION(operationGetByIdWithThisMegamorphic, EncodedJSValue, (JSGlobalObject*, StructureStubInfo*, EncodedJSValue, EncodedJSValue, uintptr_t));
 JSC_DECLARE_JIT_OPERATION(operationGetByIdDirect, EncodedJSValue, (JSGlobalObject*, StructureStubInfo*, EncodedJSValue, uintptr_t));
 JSC_DECLARE_JIT_OPERATION(operationGetByIdDirectGeneric, EncodedJSValue, (JSGlobalObject*, EncodedJSValue, uintptr_t));
 JSC_DECLARE_JIT_OPERATION(operationGetByIdDirectOptimize, EncodedJSValue, (JSGlobalObject*, StructureStubInfo*, EncodedJSValue, uintptr_t));
@@ -278,6 +279,7 @@ JSC_DECLARE_JIT_OPERATION(operationGetByValMegamorphic, EncodedJSValue, (JSGloba
 JSC_DECLARE_JIT_OPERATION(operationGetByVal, EncodedJSValue, (JSGlobalObject*, EncodedJSValue encodedBase, EncodedJSValue encodedProperty));
 JSC_DECLARE_JIT_OPERATION(operationGetByValWithThisOptimize, EncodedJSValue, (JSGlobalObject*, StructureStubInfo*, ArrayProfile*, EncodedJSValue encodedBase, EncodedJSValue encodedSubscript, EncodedJSValue encodedThis));
 JSC_DECLARE_JIT_OPERATION(operationGetByValWithThisGeneric, EncodedJSValue, (JSGlobalObject*, StructureStubInfo*, ArrayProfile*, EncodedJSValue encodedBase, EncodedJSValue encodedSubscript, EncodedJSValue encodedThis));
+JSC_DECLARE_JIT_OPERATION(operationGetByValWithThisMegamorphic, EncodedJSValue, (JSGlobalObject*, StructureStubInfo*, ArrayProfile*, EncodedJSValue encodedBase, EncodedJSValue encodedSubscript, EncodedJSValue encodedThis));
 JSC_DECLARE_JIT_OPERATION(operationGetByValWithThis, EncodedJSValue, (JSGlobalObject*, EncodedJSValue encodedBase, EncodedJSValue encodedProperty, EncodedJSValue encodedThis));
 
 JSC_DECLARE_JIT_OPERATION(operationDeleteByIdOptimize, size_t, (JSGlobalObject*, StructureStubInfo*, EncodedJSValue base, uintptr_t, ECMAMode));

--- a/Source/JavaScriptCore/runtime/JSGlobalObject.h
+++ b/Source/JavaScriptCore/runtime/JSGlobalObject.h
@@ -669,6 +669,8 @@ public:
     JSFunction* performProxyObjectHasFunction() const;
     JSFunction* performProxyObjectGetFunction() const;
     JSFunction* performProxyObjectGetFunctionConcurrently() const;
+    JSFunction* performProxyObjectGetByValFunction() const;
+    JSFunction* performProxyObjectGetByValFunctionConcurrently() const;
     JSFunction* performProxyObjectSetSloppyFunction() const;
     JSFunction* performProxyObjectSetSloppyFunctionConcurrently() const;
     JSFunction* performProxyObjectSetStrictFunction() const;

--- a/Source/JavaScriptCore/runtime/JSGlobalObjectInlines.h
+++ b/Source/JavaScriptCore/runtime/JSGlobalObjectInlines.h
@@ -219,6 +219,8 @@ inline JSFunction* JSGlobalObject::stringProtoSubstringFunction() const { return
 inline JSFunction* JSGlobalObject::performProxyObjectHasFunction() const { return jsCast<JSFunction*>(linkTimeConstant(LinkTimeConstant::performProxyObjectHas)); }
 inline JSFunction* JSGlobalObject::performProxyObjectGetFunction() const { return jsCast<JSFunction*>(linkTimeConstant(LinkTimeConstant::performProxyObjectGet)); }
 inline JSFunction* JSGlobalObject::performProxyObjectGetFunctionConcurrently() const { return linkTimeConstantConcurrently<JSFunction*>(LinkTimeConstant::performProxyObjectGet); }
+inline JSFunction* JSGlobalObject::performProxyObjectGetByValFunction() const { return jsCast<JSFunction*>(linkTimeConstant(LinkTimeConstant::performProxyObjectGetByVal)); }
+inline JSFunction* JSGlobalObject::performProxyObjectGetByValFunctionConcurrently() const { return linkTimeConstantConcurrently<JSFunction*>(LinkTimeConstant::performProxyObjectGetByVal); }
 inline JSFunction* JSGlobalObject::performProxyObjectSetSloppyFunction() const { return jsCast<JSFunction*>(linkTimeConstant(LinkTimeConstant::performProxyObjectSetSloppy)); }
 inline JSFunction* JSGlobalObject::performProxyObjectSetSloppyFunctionConcurrently() const { return linkTimeConstantConcurrently<JSFunction*>(LinkTimeConstant::performProxyObjectSetSloppy); }
 inline JSFunction* JSGlobalObject::performProxyObjectSetStrictFunction() const { return jsCast<JSFunction*>(linkTimeConstant(LinkTimeConstant::performProxyObjectSetStrict)); }


### PR DESCRIPTION
#### 871d04ba21fbb2ae92396f13d51f367fdba23508
<pre>
[JSC] Optimize Proxy get with various keys without handlers
<a href="https://bugs.webkit.org/show_bug.cgi?id=256340">https://bugs.webkit.org/show_bug.cgi?id=256340</a>
rdar://108920491

Reviewed by Michael Saboff.

This patch optimizes the use case, which is the following,

    var proxy = new Proxy({}, { .. not get handler });
    proxy[varousKeys];

1. First, we introduce IndexedProxyObjectLoad IC to handle GetByVal with ProxyObject case.
   We just extend existing ProxyObjectLoad with non-constant subscript. And to enforce property-keys,
   we need to call @toPropertyKey, and that&apos;s why we introduce a performProxyObjectGetByVal separately
   from performProxyObjectGet.
2. Inside performProxyObjectGetByVal, we would like to handle GetByValWithThis efficiently. And one of
   the key improvement we can have is introducing megamorphic IC for that. Because megamorphic IC only
   handles non-getter cases, it perfectly works well with GetByValWithThis since megamorphic IC fast
   path does not care about |this| value.
3. We introduce GetByValWithThisMegamorphic and GetByIdWithThisMegamorphic DFG / FTL nodes to handle
   these megamorphic cases efficiently in DFG and FTL.

                                         ToT                     Patched

    proxy-get-by-val-hit          334.7270+-1.2121     ^     62.1673+-0.2790        ^ definitely 5.3843x faster
    proxy-get-megamorphic          33.8379+-0.1459     ^      9.9726+-0.0896        ^ definitely 3.3931x faster
    proxy-get-by-val-miss         390.1010+-1.5733     ^     57.8217+-0.2928        ^ definitely 6.7466x faster

* Source/JavaScriptCore/bytecode/InlineCacheCompiler.cpp:
(JSC::InlineCacheCompiler::regenerate):
* Source/JavaScriptCore/bytecode/Repatch.cpp:
(JSC::repatchGetBy):
* Source/JavaScriptCore/jit/JITOperations.cpp:
(JSC::JSC_DEFINE_JIT_OPERATION):
* Source/JavaScriptCore/jit/JITOperations.h:

Canonical link: <a href="https://commits.webkit.org/263892@main">https://commits.webkit.org/263892@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/29e680aae66a43e953d7b6ea2296d134f11f7f26

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/5892 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/6064 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/6251 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/7443 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/6257 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/6283 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/6025 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/8558 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/6000 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/6036 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/5334 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/7501 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/3513 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/5310 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/13252 "Passed tests") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/4922 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/5378 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/5388 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/7595 "Passed tests") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/5476 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/5838 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/4787 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/6009 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/5271 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/1460 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/1428 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/9395 "Built successfully") | | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/24/builds/6178 "Built successfully") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/5632 "Built successfully") | | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/3/builds/1581 "Passed tests") | 
<!--EWS-Status-Bubble-End-->