### PR TITLE
Hide the file icon when the progress or placeholder is visible.

### DIFF
--- a/LayoutTests/platform/ios-wk2/fast/attachment/cocoa/wide-attachment-rendering-expected.txt
+++ b/LayoutTests/platform/ios-wk2/fast/attachment/cocoa/wide-attachment-rendering-expected.txt
@@ -53,33 +53,30 @@ layer at (0,0) size 800x768
                     RenderBlock (anonymous) at (0,9) size 40x22
                       RenderBlock {DIV} at (9,0) size 22x22
       RenderBlock {DIV} at (0,470) size 784x94
-        RenderText {#text} at (0,68) size 97x19
-          text run at (0,68) width 97: "Zero progress: "
+        RenderText {#text} at (0,60) size 97x19
+          text run at (0,60) width 97: "Zero progress: "
         RenderBlock {ATTACHMENT} at (96,0) size 341x94 [color=#007AFF]
           RenderGrid {DIV} at (1,1) size 338x92 [bgcolor=#74748014]
             RenderGrid {DIV} at (0,0) size 76x92
-              RenderAttachment {ATTACHMENT} at (10,10) size 56x72
               RenderBlock {DIV} at (10,18) size 56x56
             RenderGrid {DIV} at (76,0) size 262x92
               RenderGrid {DIV} at (6,37) size 230x18
       RenderBlock {DIV} at (0,564) size 784x94
-        RenderText {#text} at (0,68) size 96x19
-          text run at (0,68) width 96: "75% progress: "
+        RenderText {#text} at (0,60) size 96x19
+          text run at (0,60) width 96: "75% progress: "
         RenderBlock {ATTACHMENT} at (95,0) size 341x94 [color=#007AFF]
           RenderGrid {DIV} at (1,1) size 338x92 [bgcolor=#74748014]
             RenderGrid {DIV} at (0,0) size 76x92
-              RenderAttachment {ATTACHMENT} at (10,10) size 56x72
               RenderBlock {DIV} at (10,18) size 56x56 [color=#3C3C4399]
                 RenderBlock {DIV} at (0,0) size 56x56 [border: (4px solid #3C3C4399)]
             RenderGrid {DIV} at (76,0) size 262x92
               RenderGrid {DIV} at (6,37) size 230x18
       RenderBlock {DIV} at (0,658) size 784x94
-        RenderText {#text} at (0,68) size 104x19
-          text run at (0,68) width 104: "100% progress: "
+        RenderText {#text} at (0,60) size 104x19
+          text run at (0,60) width 104: "100% progress: "
         RenderBlock {ATTACHMENT} at (103,0) size 341x94 [color=#007AFF]
           RenderGrid {DIV} at (1,1) size 338x92 [bgcolor=#74748014]
             RenderGrid {DIV} at (0,0) size 76x92
-              RenderAttachment {ATTACHMENT} at (10,10) size 56x72
               RenderBlock {DIV} at (10,18) size 56x56 [color=#3C3C4399]
                 RenderBlock {DIV} at (0,0) size 56x56 [border: (4px solid #3C3C4399)]
             RenderGrid {DIV} at (76,0) size 262x92

--- a/LayoutTests/platform/mac-wk2/fast/attachment/cocoa/wide-attachment-rendering-expected.txt
+++ b/LayoutTests/platform/mac-wk2/fast/attachment/cocoa/wide-attachment-rendering-expected.txt
@@ -53,33 +53,30 @@ layer at (0,0) size 785x672
                     RenderBlock (anonymous) at (1,3) size 26x22
                       RenderBlock {DIV} at (2,0) size 22x22
       RenderBlock {DIV} at (0,410) size 769x82
-        RenderText {#text} at (0,53) size 97x18
-          text run at (0,53) width 97: "Zero progress: "
+        RenderText {#text} at (0,47) size 97x18
+          text run at (0,47) width 97: "Zero progress: "
         RenderBlock {ATTACHMENT} at (96,0) size 269x82
           RenderGrid {DIV} at (1,1) size 266x80 [bgcolor=#0000000D]
             RenderGrid {DIV} at (0,0) size 68x80
-              RenderAttachment {ATTACHMENT} at (8,14) size 52x52
               RenderBlock {DIV} at (14,20) size 40x40
             RenderGrid {DIV} at (68,0) size 198x80
               RenderGrid {DIV} at (4,32) size 170x16
       RenderBlock {DIV} at (0,492) size 769x82
-        RenderText {#text} at (0,53) size 96x18
-          text run at (0,53) width 96: "75% progress: "
+        RenderText {#text} at (0,47) size 96x18
+          text run at (0,47) width 96: "75% progress: "
         RenderBlock {ATTACHMENT} at (95,0) size 269x82
           RenderGrid {DIV} at (1,1) size 266x80 [bgcolor=#0000000D]
             RenderGrid {DIV} at (0,0) size 68x80
-              RenderAttachment {ATTACHMENT} at (8,14) size 52x52
               RenderBlock {DIV} at (14,20) size 40x40 [color=#0000007F]
                 RenderBlock {DIV} at (0,0) size 40x40 [border: (4px solid #0000007F)]
             RenderGrid {DIV} at (68,0) size 198x80
               RenderGrid {DIV} at (4,32) size 170x16
       RenderBlock {DIV} at (0,574) size 769x82
-        RenderText {#text} at (0,53) size 104x18
-          text run at (0,53) width 104: "100% progress: "
+        RenderText {#text} at (0,47) size 104x18
+          text run at (0,47) width 104: "100% progress: "
         RenderBlock {ATTACHMENT} at (103,0) size 269x82
           RenderGrid {DIV} at (1,1) size 266x80 [bgcolor=#0000000D]
             RenderGrid {DIV} at (0,0) size 68x80
-              RenderAttachment {ATTACHMENT} at (8,14) size 52x52
               RenderBlock {DIV} at (14,20) size 40x40 [color=#0000007F]
                 RenderBlock {DIV} at (0,0) size 40x40 [border: (4px solid #0000007F)]
             RenderGrid {DIV} at (68,0) size 198x80

--- a/Source/WebCore/html/HTMLAttachmentElement.cpp
+++ b/Source/WebCore/html/HTMLAttachmentElement.cpp
@@ -305,6 +305,7 @@ void HTMLAttachmentElement::updateProgress(const AtomString& progress)
     bool validProgress = false;
     float value = progress.toFloat(&validProgress);
     if (validProgress && std::isfinite(value)) {
+        m_innerLegacyAttachment->setInlineStyleProperty(CSSPropertyDisplay, CSSValueNone);
         if (!value) {
             m_placeholderElement->removeInlineStyleProperty(CSSPropertyDisplay);
             m_progressElement->setInlineStyleProperty(CSSPropertyDisplay, CSSValueNone);
@@ -317,6 +318,7 @@ void HTMLAttachmentElement::updateProgress(const AtomString& progress)
         return;
     }
 
+    m_innerLegacyAttachment->removeInlineStyleProperty(CSSPropertyDisplay);
     m_placeholderElement->setInlineStyleProperty(CSSPropertyDisplay, CSSValueNone);
     m_progressElement->setInlineStyleProperty(CSSPropertyDisplay, CSSValueNone);
     m_progressElement->removeInlineStyleCustomProperty(attachmentProgressCSSProperty());


### PR DESCRIPTION
#### 7c123c5201f1cdc9d552fae30bbf412c5d45d3f6
<pre>
Hide the file icon when the progress or placeholder is visible.
<a href="https://bugs.webkit.org/show_bug.cgi?id=256294">https://bugs.webkit.org/show_bug.cgi?id=256294</a>
rdar://108566278

Reviewed by Wenson Hsieh.

The progress or placeholder would otherwise overlap the file icon, which looks messy and confusing.

* LayoutTests/platform/ios-wk2/fast/attachment/cocoa/wide-attachment-rendering-expected.txt:
* Source/WebCore/html/HTMLAttachmentElement.cpp:
(WebCore::HTMLAttachmentElement::updateProgress):

Canonical link: <a href="https://commits.webkit.org/263713@main">https://commits.webkit.org/263713@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a88e1ab95425baa20ff628ab1be6bd3a061f44f1

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/5517 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/5664 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/5853 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/7063 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/5526 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/5515 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/5889 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/5638 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/6924 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/5618 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/5677 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/4935 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/7097 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/3154 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/4951 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/12090 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/5020 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/5031 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/6776 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/5469 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/4481 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/4924 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/1317 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/9028 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/5286 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->