### PR TITLE
InteractionRegions: configure guard layers differently than occlusions

### DIFF
--- a/LayoutTests/interaction-region/input-type-file-region-expected.txt
+++ b/LayoutTests/interaction-region/input-type-file-region-expected.txt
@@ -12,7 +12,7 @@
         (rect (0,0) width=800 height=600)
 
       (interaction regions [
-        (occlusion (1,-8) width=84 height=38)
+        (guard (1,-8) width=84 height=38)
         (borderRadius 0.00),
         (interaction (1,2) width=84 height=18)
         (borderRadius 9.00)])

--- a/LayoutTests/interaction-region/input-type-range-region-expected.txt
+++ b/LayoutTests/interaction-region/input-type-range-region-expected.txt
@@ -12,7 +12,7 @@
         (rect (0,0) width=800 height=600)
 
       (interaction regions [
-        (occlusion (48,-8) width=37 height=36)
+        (guard (48,-8) width=37 height=36)
         (borderRadius 0.00),
         (interaction (58,2) width=17 height=16)
         (borderRadius 8.00)])

--- a/LayoutTests/interaction-region/labels-expected.txt
+++ b/LayoutTests/interaction-region/labels-expected.txt
@@ -13,7 +13,7 @@ And checkboxes?
         (rect (0,0) width=800 height=600)
 
       (interaction regions [
-        (occlusion (272,13) width=37 height=36)
+        (guard (272,13) width=37 height=36)
         (borderRadius 0.00),
         (interaction (282,23) width=17 height=16)
         (borderRadius 5.00),

--- a/LayoutTests/interaction-region/layer-tree-expected.txt
+++ b/LayoutTests/interaction-region/layer-tree-expected.txt
@@ -66,12 +66,12 @@
                                   (layer anchorPoint [x: 0 y: 0])
                                   (sublayers
                                     (
-                                      (type interaction)
+                                      (type 0)
                                       (layer bounds [x: 0 y: 0 width: 59 height: 20])
                                       (layer position [x: 29.5 y: 29.5])
                                       (layer cornerRadius 9))
                                     (
-                                      (type interaction)
+                                      (type 0)
                                       (layer bounds [x: 0 y: 0 width: 284 height: 192])
                                       (layer position [x: 152 y: 152])
                                       (layer cornerRadius 8))
@@ -91,7 +91,7 @@
                                           (layer opacity 0)
                                           (sublayers
                                             (
-                                              (type interaction)
+                                              (type 0)
                                               (layer bounds [x: 0 y: 0 width: 76 height: 27])
                                               (layer position [x: 34 y: 34])
                                               (layer cornerRadius 8))))
@@ -101,11 +101,11 @@
                                           (layer opacity 0.8)
                                           (sublayers
                                             (
-                                              (type occlusion)
+                                              (type 1)
                                               (layer bounds [x: 0 y: 0 width: 800 height: 600])
                                               (layer position [x: 400 y: 400]))
                                             (
-                                              (type interaction)
+                                              (type 0)
                                               (layer bounds [x: 0 y: 0 width: 33 height: 27])
                                               (layer position [x: 12.5 y: 12.5])
                                               (layer cornerRadius 8))

--- a/LayoutTests/interaction-region/paused-video-regions-expected.txt
+++ b/LayoutTests/interaction-region/paused-video-regions-expected.txt
@@ -26,28 +26,26 @@
               (children 1
                 (GraphicsLayer
                   (position 176.00 144.00)
-                  (bounds 70.00 70.00)
-                  (transform [1.00 0.00 0.00 0.00] [0.00 1.00 0.00 0.00] [0.00 0.00 1.00 0.00] [-35.00 -35.00 0.00 1.00])
+                  (bounds 51.00 51.00)
+                  (transform [1.00 0.00 0.00 0.00] [0.00 1.00 0.00 0.00] [0.00 0.00 1.00 0.00] [-25.50 -25.50 0.00 1.00])
                   (event region
-                    (rect (18,0) width=34 height=5)
-                    (rect (5,5) width=60 height=13)
-                    (rect (0,18) width=70 height=34)
-                    (rect (5,52) width=60 height=13)
-                    (rect (18,65) width=34 height=5)
+                    (rect (8,0) width=35 height=8)
+                    (rect (0,8) width=51 height=35)
+                    (rect (8,43) width=35 height=8)
 
                   (interaction regions [
-                    (interaction (0,0) width=70 height=70)
-                    (borderRadius 35.00)])
+                    (interaction (0,0) width=51 height=51)
+                    (borderRadius 25.50)])
                   )
                   (children 1
                     (GraphicsLayer
-                      (position 3.00 0.00)
-                      (bounds 70.00 70.00)
+                      (position 10.00 10.00)
+                      (bounds 31.00 31.00)
                       (contentsOpaque 1)
-                      (transform [0.90 0.00 0.00 0.00] [0.00 0.90 0.00 0.00] [0.00 0.00 1.00 0.00] [0.00 0.00 0.00 1.00])
+                      (transform [0.90 0.00 0.00 0.00] [0.00 0.90 0.00 0.00] [0.00 0.00 1.00 0.00] [2.48 0.00 0.00 1.00])
                       (mask layer)
                         (GraphicsLayer
-                          (bounds 70.00 70.00)
+                          (bounds 31.00 31.00)
                           (drawsContent 1)
                         )
                     )

--- a/LayoutTests/interaction-region/tiny-regions-expected.txt
+++ b/LayoutTests/interaction-region/tiny-regions-expected.txt
@@ -11,7 +11,7 @@
         (rect (0,0) width=800 height=600)
 
       (interaction regions [
-        (occlusion (-10,0) width=30 height=30)
+        (guard (-10,0) width=30 height=30)
         (borderRadius 0.00),
         (interaction (0,10) width=10 height=10)
         (borderRadius 0.00),

--- a/LayoutTests/interaction-region/wrapped-inline-link-expected.txt
+++ b/LayoutTests/interaction-region/wrapped-inline-link-expected.txt
@@ -33,11 +33,11 @@ Line
         (borderRadius 0 8 0 0),
         (interaction (6,109) width=107 height=12)
         (borderRadius 0 0 8 0),
-        (occlusion (6,111) width=71 height=32)
+        (guard (6,111) width=71 height=32)
         (borderRadius 0.00),
         (interaction (6,121) width=71 height=12)
         (borderRadius 0 0 8 0),
-        (occlusion (6,123) width=38 height=32)
+        (guard (6,123) width=38 height=32)
         (borderRadius 0.00),
         (interaction (6,133) width=38 height=12)
         (borderRadius 0 0 8 8)])

--- a/Source/WebCore/page/InteractionRegion.cpp
+++ b/Source/WebCore/page/InteractionRegion.cpp
@@ -311,7 +311,10 @@ std::optional<InteractionRegion> interactionRegionForRenderedRegion(RenderObject
 
 TextStream& operator<<(TextStream& ts, const InteractionRegion& interactionRegion)
 {
-    ts.dumpProperty(interactionRegion.type == InteractionRegion::Type::Occlusion ? "occlusion" : "interaction", interactionRegion.rectInLayerCoordinates);
+    auto regionName = interactionRegion.type == InteractionRegion::Type::Interaction
+        ? "interaction"
+        : (interactionRegion.type == InteractionRegion::Type::Occlusion ? "occlusion" : "guard");
+    ts.dumpProperty(regionName, interactionRegion.rectInLayerCoordinates);
     auto radius = interactionRegion.borderRadius;
     if (interactionRegion.maskedCorners.isEmpty())
         ts.dumpProperty("borderRadius", radius);

--- a/Source/WebCore/page/InteractionRegion.h
+++ b/Source/WebCore/page/InteractionRegion.h
@@ -45,7 +45,7 @@ class Page;
 class RenderObject;
 
 struct InteractionRegion {
-    enum class Type : bool { Interaction, Occlusion };
+    enum class Type : uint8_t { Interaction, Occlusion, Guard };
     enum class CornerMask : uint8_t {
         MinXMinYCorner = 1 << 0,
         MaxXMinYCorner = 1 << 1,
@@ -75,4 +75,8 @@ WEBCORE_EXPORT std::optional<InteractionRegion> interactionRegionForRenderedRegi
 
 WTF::TextStream& operator<<(WTF::TextStream&, const InteractionRegion&);
 
+}
+namespace WTF {
+template<typename T> struct DefaultHash;
+template<> struct DefaultHash<WebCore::InteractionRegion::Type> : IntHash<WebCore::InteractionRegion::Type> { };
 }

--- a/Source/WebCore/rendering/EventRegion.cpp
+++ b/Source/WebCore/rendering/EventRegion.cpp
@@ -142,7 +142,7 @@ void EventRegionContext::uniteInteractionRegions(const Region& region, RenderObj
             auto occlusionRect = guardRectForRegionBounds(tempRegion.bounds());
             if (occlusionRect) {
                 m_interactionRegions.append({
-                    InteractionRegion::Type::Occlusion,
+                    InteractionRegion::Type::Guard,
                     interactionRegion->elementIdentifier,
                     occlusionRect.value()
                 });
@@ -164,7 +164,7 @@ void EventRegionContext::uniteInteractionRegions(const Region& region, RenderObj
         auto occlusionRect = guardRectForRegionBounds(interactionRegion->rectInLayerCoordinates);
         if (occlusionRect) {
             m_interactionRegions.append({
-                InteractionRegion::Type::Occlusion,
+                InteractionRegion::Type::Guard,
                 interactionRegion->elementIdentifier,
                 occlusionRect.value()
             });
@@ -217,7 +217,7 @@ bool EventRegionContext::shouldConsolidateInteractionRegion(IntRect bounds, Rend
 void EventRegionContext::shrinkWrapInteractionRegions()
 {
     for (auto& region : m_interactionRegions) {
-        if (region.type == InteractionRegion::Type::Occlusion)
+        if (region.type != InteractionRegion::Type::Interaction)
             continue;
 
         auto regionIterator = m_discoveredRegionsByElement.find(region.elementIdentifier);

--- a/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
+++ b/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
@@ -4812,7 +4812,11 @@ struct WebCore::GlobalWindowIdentifier {
     WebCore::WindowIdentifier windowIdentifier;
 };
 
-[Nested] enum class WebCore::InteractionRegion::Type : bool;
+[Nested] enum class WebCore::InteractionRegion::Type : uint8_t {
+    Interaction,
+    Occlusion,
+    Guard
+};
 [Nested, OptionSet] enum class WebCore::InteractionRegion::CornerMask : uint8_t {
     MinXMinYCorner
     MaxXMinYCorner

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebViewTesting.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebViewTesting.mm
@@ -94,11 +94,9 @@ static void dumpCALayer(TextStream& ts, CALayer *layer, bool traverse)
     };
 
 #if ENABLE(INTERACTION_REGIONS_IN_EVENT_REGION)
-    if ([layer valueForKey:@"WKInteractionRegionGroupName"]) {
-        ts.dumpProperty("type", "interaction");
-        traverse = false;
-    } else if ([layer valueForKey:@"WKInteractionRegionType"]) {
-        ts.dumpProperty("type", "occlusion");
+    NSNumber *interactionRegionLayerType = [layer valueForKey:@"WKInteractionRegionType"];
+    if (interactionRegionLayerType) {
+        ts.dumpProperty("type", interactionRegionLayerType);
         traverse = false;
     }
 #endif


### PR DESCRIPTION
#### ee57472bbda11ac4b56c3022f616b6d049c8716a
<pre>
InteractionRegions: configure guard layers differently than occlusions
<a href="https://bugs.webkit.org/show_bug.cgi?id=256343">https://bugs.webkit.org/show_bug.cgi?id=256343</a>
&lt;rdar://108847192&gt;

Reviewed by Tim Horton.

Make guards a proper InteractionRegion type, and configure the
corresponding layers differently.

* Source/WebCore/page/InteractionRegion.h:
Switch the InteractionRegion::Type to an `uint8_t` and add the Guard case.
Make the Type hash-able.
* Source/WebCore/page/InteractionRegion.cpp:
(WebCore::operator&lt;&lt;):
Update the dump format to support guards.
* Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in:
Make the Type serialize-able.
* Source/WebCore/rendering/EventRegion.cpp:
(WebCore::EventRegionContext::uniteInteractionRegions):
Generate guards with the proper Type.
(WebCore::EventRegionContext::shrinkWrapInteractionRegions):
Only shrink wrap Type::Interaction.

* Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeInteractionRegionLayers.mm:
(configureLayerAsGuard):
(WebKit::setInteractionRegion):
(WebKit::setInteractionRegionOcclusion):
(WebKit::setInteractionRegionGuard):
(WebKit::updateLayersForInteractionRegions):
(WebKit::isInteractionLayer): Deleted.
Refactor `updateLayersForInteractionRegions` to more gracefully handle
having 3 different InteractionRegion types.
Call the new `configureLayerAsGuard` for guard layers.

* Source/WebKit/UIProcess/API/Cocoa/WKWebViewTesting.mm:
(dumpCALayer):
Dump the raw `WKInteractionRegionType` for InteractionRegion layers.

* LayoutTests/interaction-region/input-type-file-region-expected.txt:
* LayoutTests/interaction-region/input-type-range-region-expected.txt:
* LayoutTests/interaction-region/labels-expected.txt:
* LayoutTests/interaction-region/layer-tree-expected.txt:
* LayoutTests/interaction-region/tiny-regions-expected.txt:
* LayoutTests/interaction-region/wrapped-inline-link-expected.txt:
Test updates covering the change.
* LayoutTests/interaction-region/paused-video-regions-expected.txt:
Test update.

Canonical link: <a href="https://commits.webkit.org/263730@main">https://commits.webkit.org/263730@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/70e1b9bca725af7f73b8dd0eee8bb951b37c76cc

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/5500 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/5646 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/5836 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/7045 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/5511 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/5498 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/5871 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/5620 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/6791 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/5601 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/5659 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/4922 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/7078 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/3136 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/4937 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/12077 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/5002 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/5017 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/6762 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/5452 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/4468 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/4909 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/1327 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/9012 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/5271 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->