### PR TITLE
REGRESSION (260364@main-260393@main): [ iOS , Ventura ] 2x  TestWebKitAPI.GPUProcess tests are near constant failures

### DIFF
--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/GPUProcess.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/GPUProcess.mm
@@ -78,7 +78,7 @@ TEST(GPUProcess, RelaunchOnCrash)
 
     // evaluateJavaScript gives us the user gesture we need to reliably start audio playback on all platforms.
     __block bool done = false;
-    [webView evaluateJavaScript:@"startPlaying()" completionHandler:^(id result, NSError *error) {
+    [webView callAsyncJavaScript:@"return startPlaying()" arguments:nil inFrame:nil inContentWorld:WKContentWorld.pageWorld completionHandler:^(id result, NSError *error) {
         EXPECT_TRUE(!error);
         done = true;
     }];
@@ -129,7 +129,7 @@ TEST(GPUProcess, WebProcessTerminationAfterTooManyGPUProcessCrashes)
 
     // evaluateJavaScript gives us the user gesture we need to reliably start audio playback on all platforms.
     __block bool done = false;
-    [webView evaluateJavaScript:@"startPlaying()" completionHandler:^(id result, NSError *error) {
+    [webView callAsyncJavaScript:@"return startPlaying()" arguments:nil inFrame:nil inContentWorld:WKContentWorld.pageWorld completionHandler:^(id result, NSError *error) {
         EXPECT_TRUE(!error);
         done = true;
     }];
@@ -200,7 +200,7 @@ TEST(GPUProcess, WebProcessTerminationAfterTooManyGPUProcessCrashes)
     // Manually start audio playback again.
     // evaluateJavaScript gives us the user gesture we need to reliably start audio playback on all platforms.
     done = false;
-    [webView evaluateJavaScript:@"startPlaying()" completionHandler:^(id result, NSError *error) {
+    [webView callAsyncJavaScript:@"return startPlaying()" arguments:nil inFrame:nil inContentWorld:WKContentWorld.pageWorld completionHandler:^(id result, NSError *error) {
         EXPECT_TRUE(!error);
         done = true;
     }];
@@ -799,7 +799,7 @@ TEST(GPUProcess, ExitsUnderMemoryPressureWebAudioCase)
 
         // evaluateJavaScript gives us the user gesture we need to reliably start audio playback on all platforms.
         __block bool done = false;
-        [webView evaluateJavaScript:@"startPlaying()" completionHandler:^(id result, NSError *error) {
+        [webView callAsyncJavaScript:@"return startPlaying()" arguments:nil inFrame:nil inContentWorld:WKContentWorld.pageWorld completionHandler:^(id result, NSError *error) {
             EXPECT_TRUE(!error);
             done = true;
         }];
@@ -823,7 +823,7 @@ TEST(GPUProcess, ExitsUnderMemoryPressureWebAudioNonRenderingAudioContext)
 
     // evaluateJavaScript gives us the user gesture we need to reliably start audio playback on all platforms.
     __block bool done = false;
-    [webView evaluateJavaScript:@"startPlaying()" completionHandler:^(id result, NSError *error) {
+    [webView callAsyncJavaScript:@"return startPlaying()" arguments:nil inFrame:nil inContentWorld:WKContentWorld.pageWorld completionHandler:^(id result, NSError *error) {
         EXPECT_TRUE(!error);
         done = true;
     }];

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/audio-context-playing.html
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/audio-context-playing.html
@@ -4,15 +4,37 @@
 <script>
 var context;
 var oscillator;
+var scriptProcessor;
+var isFirst = true;
+
 function startPlaying()
 {
     if (context)
         context.close();
 
-    context = new AudioContext();
-    oscillator = new OscillatorNode(context);
-    oscillator.connect(context.destination);
-    oscillator.start();
+    isFirst = true;
+    return new Promise(function(resolve, reject) {
+        context = new AudioContext();
+        oscillator = new OscillatorNode(context);
+        scriptProcessor = context.createScriptProcessor();
+        oscillator.connect(scriptProcessor);
+        scriptProcessor.connect(context.destination);
+        scriptProcessor.onaudioprocess = (event) => {
+            if (isFirst) {
+                resolve();
+                isFirst = false;
+            }
+            let inputBuffer = event.inputBuffer;
+            let outputBuffer = event.outputBuffer;
+            for (let channel = 0; channel < outputBuffer.numberOfChannels; channel++) {
+                let inputData = inputBuffer.getChannelData(channel);
+                let outputData = outputBuffer.getChannelData(channel);
+                for (let sample = 0; sample < inputBuffer.length; sample++)
+                  outputData[sample] = inputData[sample];
+            }
+        };
+        oscillator.start();
+    });
 }
 
 function generateAudioInMediaStreamTrack()


### PR DESCRIPTION
#### 8bc686eae52a71bcb222c488081db29d5787dd83
<pre>
REGRESSION (260364@main-260393@main): [ iOS , Ventura ] 2x  TestWebKitAPI.GPUProcess tests are near constant failures
<a href="https://bugs.webkit.org/show_bug.cgi?id=255250">https://bugs.webkit.org/show_bug.cgi?id=255250</a>
rdar://107852513

Reviewed by Brent Fulgham.

Make sure that audio has started rendering before we proceed with the test
and send a memory pressure signal. If we don&apos;t the signal may get sent too
early, causing the GPUProcess to exit because it is not yet rendering
audio.

* Tools/TestWebKitAPI/Tests/WebKitCocoa/GPUProcess.mm:
(TestWebKitAPI::TEST):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/audio-context-playing.html:

Canonical link: <a href="https://commits.webkit.org/263728@main">https://commits.webkit.org/263728@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2c8f274ec2b4ff5c1ae863090ea92e5e612eb21a

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/5568 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/5719 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/5907 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/7118 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/5571 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/5568 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/5944 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/5693 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/7133 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/5671 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/5728 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/4986 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/7155 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/3206 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/5005 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/12126 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/5072 "Passed tests") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/5084 "3 failures") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/6877 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/5523 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/4517 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/4976 "Built successfully") | | | 
| [  ~~🛠 🧪 merge~~](https://ews-build.webkit.org/#/builders/19/builds/1324 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/9081 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/5338 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->