### PR TITLE
[JSC] JSON.parse should use simple recursion until it hits soft-recursion threshold

### DIFF
--- a/JSTests/stress/JSON-parse-should-cache-array-lengths-complex.js
+++ b/JSTests/stress/JSON-parse-should-cache-array-lengths-complex.js
@@ -1,0 +1,101 @@
+//@ requireOptions("--useRecursiveJSONParse=0")
+// This test should not hang, and should call the reviver function the expected number of times.
+
+function shouldBe(actualExpr, expectedExpr) {
+    function toString(x) {
+        return "" + x;
+    }
+
+    let actual = eval(actualExpr);
+    let expected = eval(expectedExpr);
+    if (typeof actual != typeof expected)
+        throw Error("expected type " + typeof expected + " actual type " + typeof actual);
+    if (toString(actual) != toString(expected))
+        throw Error("expected: " + expected + " actual: " + actual);
+}
+
+let result;
+let visited;
+
+function test(parseString, clearLength) {
+    visited = [];
+    var result = JSON.parse(parseString, function (key, value) {
+        visited.push('{' + key + ':' + value + '}');
+        if (clearLength)
+            this.length = 0;
+        return; // returning undefined deletes the value.
+    });
+    return result;
+}
+
+result = test('[10]', false);
+shouldBe("result", "undefined");
+shouldBe("visited", "['{0:10}','{:}']");
+shouldBe("visited.length", "2");
+
+result = test('[10]', true);
+shouldBe("result", "undefined");
+shouldBe("visited", "['{0:10}','{:}']");
+shouldBe("visited.length", "2");
+
+result = test('[ [ 10, 11 ], 12, [13, 14, 15], 16, 17]', false);
+shouldBe("result", "undefined");
+shouldBe("visited", "['{0:10}','{1:11}','{0:,}','{1:12}','{0:13}','{1:14}','{2:15}','{2:,,}','{3:16}','{4:17}','{:,,,,}']");
+shouldBe("visited.length", "11");
+
+result = test('[ [ 10, 11 ], 12, [13, 14, 15], 16, 17]', true);
+shouldBe("result", "undefined");
+shouldBe("visited", "['{0:10}','{1:undefined}','{0:}','{1:undefined}','{2:undefined}','{3:undefined}','{4:undefined}','{:}']");
+shouldBe("visited.length", "8");
+
+result = test('[ { "a": [ 10, 11 ], "b": 12 } , [ 13, { "c": 14 }, 15], 16, 17]', false);
+shouldBe("result", "undefined");
+shouldBe("visited", "['{0:10}','{1:11}','{a:,}','{b:12}','{0:[object Object]}','{0:13}','{c:14}','{1:[object Object]}','{2:15}','{1:,,}','{2:16}','{3:17}','{:,,,}']");
+shouldBe("visited.length", "13");
+
+result = test('[ { "a": [ 10, 11 ], "b": 12 } , [ 13, { "c": 14 }, 15], 16, 17]', true);
+shouldBe("result", "undefined");
+shouldBe("visited", "['{0:10}','{1:undefined}','{a:}','{b:12}','{0:[object Object]}','{1:undefined}','{2:undefined}','{3:undefined}','{:}']");
+shouldBe("visited.length", "9");
+
+
+function test2(parseString, clearLength) {
+    visited = [];
+    var result = JSON.parse(parseString, function (key, value) {
+        visited.push('{' + key + ':' + value + '}');
+        if (clearLength)
+            this.length = 0;
+        return (typeof value === "number") ? value * 2 : value;
+    });
+    return result;
+}
+
+result = test2('[10]', false);
+shouldBe("result", "[20]");
+shouldBe("visited", "['{0:10}','{:20}']");
+shouldBe("visited.length", "2");
+
+result = test2('[10]', true);
+shouldBe("result", "[20]");
+shouldBe("visited", "['{0:10}','{:20}']");
+shouldBe("visited.length", "2");
+
+result = test2('[ [ 10, 11 ], 12, [13, 14, 15], 16, 17]', false);
+shouldBe("result", "[20,22,24,26,28,30,32,34]");
+shouldBe("visited", "['{0:10}','{1:11}','{0:20,22}','{1:12}','{0:13}','{1:14}','{2:15}','{2:26,28,30}','{3:16}','{4:17}','{:20,22,24,26,28,30,32,34}']");
+shouldBe("visited.length", "11");
+
+result = test2('[ [ 10, 11 ], 12, [13, 14, 15], 16, 17]', true);
+shouldBe("result", "[]");
+shouldBe("visited", "['{0:10}','{1:undefined}','{0:}','{1:undefined}','{2:undefined}','{3:undefined}','{4:undefined}','{:}']");
+shouldBe("visited.length", "8");
+
+result = test2('[ { "a": [ 10, 11 ], "b": 12 } , [ 13, { "c": 14 }, 15], 16, 17]', false);
+shouldBe("result", "['[object Object]',26,'[object Object]',30,32,34]");
+shouldBe("visited", "['{0:10}','{1:11}','{a:20,22}','{b:12}','{0:[object Object]}','{0:13}','{c:14}','{1:[object Object]}','{2:15}','{1:26,[object Object],30}','{2:16}','{3:17}','{:[object Object],26,[object Object],30,32,34}']");
+shouldBe("visited.length", "13");
+
+result = test2('[ { "a": [ 10, 11 ], "b": 12 } , [ 13, { "c": 14 }, 15], 16, 17]', true);
+shouldBe("result", "[]");
+shouldBe("visited", "['{0:10}','{1:undefined}','{a:}','{b:12}','{0:[object Object]}','{1:undefined}','{2:undefined}','{3:undefined}','{:}']");
+shouldBe("visited.length", "9");

--- a/JSTests/stress/json-parse-256-complex.js
+++ b/JSTests/stress/json-parse-256-complex.js
@@ -1,0 +1,21 @@
+//@ requireOptions("--useRecursiveJSONParse=0")
+
+for (var j = 0; j < 3; ++j) {
+    var text = `[`;
+    for (var k = 0; k < 2; ++k) {
+        for (var i = 0; i < 256; ++i)
+            text += `"\\u00${i.toString(16).padStart(2, '0')}test",`;
+    }
+    text += `0 ]`;
+    JSON.parse(text);
+}
+
+for (var j = 0; j < 3; ++j) {
+    var text = `[`;
+    for (var k = 0; k < 2; ++k) {
+        for (var i = 0; i < 256; ++i)
+            text += `"\\u00${i.toString(16).padStart(2, '0')}test",`;
+    }
+    text += `"ココア" ]`;
+    JSON.parse(text);
+}

--- a/JSTests/stress/json-parse-array-prototype-is-array-assert-complex.js
+++ b/JSTests/stress/json-parse-array-prototype-is-array-assert-complex.js
@@ -1,0 +1,30 @@
+//@ requireOptions("--useRecursiveJSONParse=0")
+
+function assert(b) {
+    if (!b)
+        throw new Error;
+}
+
+assert(JSON.stringify(JSON.parse('[1337,42]', function (x, y) {
+    if (this instanceof Array) {
+        Object.defineProperty(this, '1', {value: Array.prototype});
+        return y;
+    }
+    return this;
+})) === '{"":[1337,[]]}');
+
+assert(JSON.stringify(JSON.parse('[0, 1]', function(x, y) {
+    this[1] = Array.prototype;
+    return y;
+})) === '[0,[]]');
+
+assert(JSON.stringify(JSON.parse('{"x":22, "y":44}', function(a, b) {
+    this.y = Array.prototype;
+    return b;
+})) === '{"x":22,"y":[]}');
+
+Array.prototype[0] = 42;
+assert(JSON.stringify(JSON.parse('{"x":22, "y":44}', function(a, b) {
+    this.y = Array.prototype;
+    return b;
+})) === '{"x":22,"y":[42]}');

--- a/JSTests/stress/json-parse-big-object-complex.js
+++ b/JSTests/stress/json-parse-big-object-complex.js
@@ -1,0 +1,16 @@
+//@ requireOptions("--useRecursiveJSONParse=0")
+
+var obj = {
+    "foo1": { "foo2": { "foo3":  { "foo4":  { "foo5":  { "foo6":  { "foo7": [
+        { "bar1":  "a".repeat(670)},
+        { "bar2":  "a".repeat(15771)},
+    ]
+    }}}}}}};
+
+function doTest(x) {
+    for (let i=1; i<10000; i++) {
+        var s = JSON.stringify(x);
+    }
+}
+
+doTest(obj);

--- a/JSTests/stress/json-parse-empty-objects-complex.js
+++ b/JSTests/stress/json-parse-empty-objects-complex.js
@@ -1,0 +1,12 @@
+//@ requireOptions("--useRecursiveJSONParse=0")
+
+function shouldBe(actual, expected) {
+    if (actual !== expected)
+        throw new Error('bad value: ' + actual);
+}
+
+var string = '[{},{},{},{}]';
+shouldBe(JSON.stringify(JSON.parse(string)), `[{},{},{},{}]`);
+
+var string = '[[],[],[],[]]';
+shouldBe(JSON.stringify(JSON.parse(string)), `[[],[],[],[]]`);

--- a/JSTests/stress/json-parse-empty-objects.js
+++ b/JSTests/stress/json-parse-empty-objects.js
@@ -1,0 +1,10 @@
+function shouldBe(actual, expected) {
+    if (actual !== expected)
+        throw new Error('bad value: ' + actual);
+}
+
+var string = '[{},{},{},{}]';
+shouldBe(JSON.stringify(JSON.parse(string)), `[{},{},{},{}]`);
+
+var string = '[[],[],[],[]]';
+shouldBe(JSON.stringify(JSON.parse(string)), `[[],[],[],[]]`);

--- a/JSTests/stress/json-parse-on-frozen-object-complex.js
+++ b/JSTests/stress/json-parse-on-frozen-object-complex.js
@@ -1,0 +1,76 @@
+//@ runFTLNoCJIT
+//@ requireOptions("--useRecursiveJSONParse=0")
+
+function shouldEqual(testId, actual, expected) {
+    if (actual != expected) {
+        throw testId + ": ERROR: expect " + expected + ", actual " + actual;
+    }
+}
+
+function frozenArrayReviver(k, v) {
+    if (k === "a") {
+        this.b = Object.freeze(["unmodifiable"]);
+        return v;
+    }
+    if (k === "0")
+        return "modified";
+    return v;
+}
+
+function frozenArrayLikeObjectReviver(k, v) {
+    if (k === "a") {
+        var obj = {};
+        obj[0] = 'unmodifiable';
+        obj.length = 1; 
+        this.b = Object.freeze(obj);
+        return v;
+    }
+    if (k === "0")
+        return "modified";
+    return v;
+}
+
+function frozenArrayReviverWithDelete(k, v) {
+    if (k === "a") {
+        this.b = Object.freeze(["unmodifiable"]);
+        return v;
+    }
+    if (k === "0")
+        return undefined;
+    return v;
+}
+
+function frozenArrayLikeObjectReviverWithDelete(k, v) {
+    if (k === "a") {
+        var obj = {};
+        obj[0] = 'unmodifiable';
+        obj.length = 1; 
+        this.b = Object.freeze(obj);
+        return v;
+    }
+    if (k === "0")
+        return undefined;
+    return v;
+}
+
+function runTest(testId, reviver, expectedValue, expectedException) {
+    let numIterations = 10000;
+    for (var i = 0; i < numIterations; i++) {
+        var exception = undefined;
+
+        var obj;
+        try {
+            obj = JSON.parse('{ "a": 0, "b": 0 }', reviver);
+        } catch (e) {
+            exception = "" + e;
+            exception = exception.substr(0, 10); // Search for "TypeError:".
+        }
+        shouldEqual(testId, exception, expectedException);
+        shouldEqual(testId, obj.b[0], expectedValue);
+    }
+}
+
+runTest(10000, frozenArrayReviver,                     "unmodifiable", undefined);
+runTest(10001, frozenArrayLikeObjectReviver,           "unmodifiable", undefined);
+runTest(10002, frozenArrayReviverWithDelete,           "unmodifiable", undefined);
+runTest(10003, frozenArrayLikeObjectReviverWithDelete, "unmodifiable", undefined);

--- a/JSTests/stress/json-parse-reviver-array-proxy-complex.js
+++ b/JSTests/stress/json-parse-reviver-array-proxy-complex.js
@@ -1,0 +1,30 @@
+//@ requireOptions("--useRecursiveJSONParse=0")
+
+function shouldBe(actual, expected) {
+    if (actual !== expected)
+        throw new Error('bad value: ' + actual);
+}
+
+const json = '{"a": 1, "b": 2}';
+
+for (let i = 1; i < 10000; i++) {
+    let keys = [];
+    let proxy = new Proxy([2, 3], {
+        get: function(target, key) {
+            keys.push(key);
+            return target[key];
+        },
+        ownKeys: function() {
+            throw new Error('[[OwnPropertyKeys]] should not be called');
+        },
+    });
+
+    let result = JSON.parse(json, function(key, value) {
+        if (key === 'a')
+            this.b = proxy;
+        return value;
+    });
+
+    shouldBe(keys.toString(), 'length,0,1');
+    shouldBe(JSON.stringify(result), '{"a":1,"b":[2,3]}');
+}

--- a/JSTests/stress/json-parse-reviver-revoked-proxy-complex.js
+++ b/JSTests/stress/json-parse-reviver-revoked-proxy-complex.js
@@ -1,0 +1,50 @@
+//@ requireOptions("--useRecursiveJSONParse=0")
+
+function shouldBe(actual, expected) {
+    if (actual !== expected)
+        throw new Error('bad value: ' + actual);
+}
+
+function revivedObjProxy(key, value) {
+    if (key === 'a') {
+        let {proxy, revoke} = Proxy.revocable({}, {});
+        revoke();
+        this.b = proxy;
+    }
+
+    return value;
+}
+
+function revivedArrProxy(key, value) {
+    if (key === '0') {
+        let {proxy, revoke} = Proxy.revocable([], {});
+        revoke();
+        this[1] = proxy;
+    }
+
+    return value;
+}
+
+const objJSON = '{"a": 1, "b": 2}';
+const arrJSON = '[3, 4]';
+const isArrayError = 'TypeError: Array.isArray cannot be called on a Proxy that has been revoked';
+
+for (let i = 1; i < 10000; i++) {
+    let error;
+    try {
+        JSON.parse(objJSON, revivedObjProxy);
+    } catch (e) {
+        error = e;
+    }
+    shouldBe(error.toString(), isArrayError);
+}
+
+for (let i = 1; i < 10000; i++) {
+    let error;
+    try {
+        JSON.parse(arrJSON, revivedArrProxy);
+    } catch (e) {
+        error = e;
+    }
+    shouldBe(error.toString(), isArrayError);
+}

--- a/JSTests/stress/json-parse-syntax-complex.js
+++ b/JSTests/stress/json-parse-syntax-complex.js
@@ -1,0 +1,28 @@
+//@ requireOptions("--useRecursiveJSONParse=0")
+
+function shouldThrow(func, errorMessage) {
+    var errorThrown = false;
+    var error = null;
+    try {
+        func();
+    } catch (e) {
+        errorThrown = true;
+        error = e;
+    }
+    if (!errorThrown)
+        throw new Error('not thrown');
+    if (String(error) !== errorMessage)
+        throw new Error(`bad error: ${String(error)}`);
+}
+
+function shouldBe(actual, expected) {
+    if (actual !== expected)
+        throw new Error('bad value: ' + actual);
+}
+
+shouldThrow(() => JSON.parse(`{"object": 42`), `SyntaxError: JSON Parse error: Expected '}'`);
+shouldBe(JSON.stringify(JSON.parse(`{}`)), `{}`);
+shouldBe(JSON.stringify(JSON.parse(`{"object": {}}`)), `{"object":{}}`);
+shouldThrow(() => JSON.parse(`{"object": 42, "test":{}`), `SyntaxError: JSON Parse error: Expected '}'`);
+shouldBe(JSON.stringify(JSON.parse(`{"hello":42, "object": {}}`)), `{"hello":42,"object":{}}`);
+shouldBe(JSON.stringify(JSON.parse(`{"hello":42, "object": 42, "test": 43}`)), `{"hello":42,"object":42,"test":43}`);

--- a/JSTests/stress/json-parse-very-nested-complex.js
+++ b/JSTests/stress/json-parse-very-nested-complex.js
@@ -1,0 +1,3 @@
+//@ requireOptions("--useRecursiveJSONParse=0")
+var string = '['.repeat(1000000) + ']'.repeat(1000000);
+JSON.parse(string);

--- a/JSTests/stress/json-parse-very-nested.js
+++ b/JSTests/stress/json-parse-very-nested.js
@@ -1,0 +1,2 @@
+var string = '['.repeat(1000000) + ']'.repeat(1000000);
+JSON.parse(string);

--- a/LayoutTests/js/JSON-parse-reviver-complex-expected.txt
+++ b/LayoutTests/js/JSON-parse-reviver-complex-expected.txt
@@ -1,0 +1,121 @@
+Test behaviour of JSON reviver function.
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+
+Ensure the holder for our array is indeed an array
+PASS Array.isArray(currentHolder) is true
+PASS currentHolder.length is 5
+
+Ensure that the holder already has all the properties present at the start of filtering
+PASS currentHolder[0] is "a value"
+PASS currentHolder[1] is "another value"
+PASS currentHolder[2] is "and another value"
+PASS currentHolder[3] is "to delete"
+PASS currentHolder[4] is "extra value"
+
+Ensure the holder for our array is indeed an array
+PASS Array.isArray(currentHolder) is true
+PASS currentHolder.length is 5
+
+Ensure that we always get the same holder
+PASS currentHolder is lastHolder
+
+Ensure that returning undefined has removed the property 0 from the holder during filtering.
+PASS currentHolder.hasOwnProperty(0) is false
+
+Ensure the holder for our array is indeed an array
+PASS Array.isArray(currentHolder) is true
+PASS currentHolder.length is 5
+
+Ensure that we always get the same holder
+PASS currentHolder is lastHolder
+
+Ensure that changing the value of a property is reflected while filtering.
+PASS currentHolder[2] is "a replaced value"
+
+Ensure that the changed value is reflected in the arguments passed to the reviver
+PASS value is currentHolder[2]
+
+Ensure the holder for our array is indeed an array
+PASS Array.isArray(currentHolder) is true
+PASS currentHolder.length is 5
+
+Ensure that we always get the same holder
+PASS currentHolder is lastHolder
+
+Ensure that we visited a value that we have deleted, and that deletion is reflected while filtering.
+PASS currentHolder.hasOwnProperty(3) is false
+
+Ensure that when visiting a deleted property value is undefined
+PASS value is undefined.
+
+Ensure the holder for our array is indeed an array
+PASS Array.isArray(currentHolder) is true
+PASS currentHolder.length is 4
+
+Ensure that we always get the same holder
+PASS currentHolder is lastHolder
+PASS Ensured that property was visited despite Array length being reduced.
+PASS value is undefined.
+
+Ensure that we created the root holder as specified in ES5
+PASS '' in lastHolder is true
+PASS result is lastHolder['']
+
+Ensure that a deleted value is revived if the reviver function returns a value
+PASS result.hasOwnProperty(3) is true
+PASS casesVisited is [0,1,2,3,4,5]
+
+Test behaviour of revivor used in conjunction with an object
+PASS currentHolder != globalObject is true
+
+Ensure that the holder already has all the properties present at the start of filtering
+PASS currentHolder['a property'] is "a value"
+PASS currentHolder['another property'] is "another value"
+PASS currentHolder['and another property'] is "and another value"
+PASS currentHolder['to delete'] is "will be deleted"
+PASS currentHolder != globalObject is true
+
+Ensure that we get the same holder object for each property
+PASS currentHolder is lastHolder
+
+Ensure that returning undefined has correctly removed the property 'a property' from the holder object
+PASS currentHolder.hasOwnProperty('a property') is false
+PASS currentHolder != globalObject is true
+
+Ensure that we get the same holder object for each property
+PASS currentHolder is lastHolder
+Ensure that changing the value of a property is reflected while filtering.
+PASS currentHolder['and another property'] is "a replaced value"
+
+Ensure that the changed value is reflected in the arguments passed to the reviver
+PASS value is "a replaced value"
+PASS currentHolder != globalObject is true
+
+Ensure that we get the same holder object for each property
+PASS currentHolder is lastHolder
+
+Ensure that we visited a value that we have deleted, and that deletion is reflected while filtering.
+PASS currentHolder.hasOwnProperty('to delete') is false
+
+Ensure that when visiting a deleted property value is undefined
+PASS value is undefined.
+
+Ensure that we created the root holder as specified in ES5
+PASS lastHolder.hasOwnProperty('') is true
+PASS result.hasOwnProperty('a property') is false
+PASS result.hasOwnProperty('to delete') is true
+PASS result is lastHolder['']
+PASS casesVisited is ['a property', 'another property', 'and another property', 'to delete']
+
+Test behaviour of revivor that introduces a cycle
+PASS JSON.parse("[0,1]", reviveAddsCycle) threw exception RangeError: Maximum call stack size exceeded..
+
+Test behaviour of revivor that introduces a new array classed object (the result of a regex)
+PASS JSON.stringify(JSON.parse("[0,1]", reviveIntroducesNewArrayLikeObject)) is '[0,["a","a"]]'
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/js/JSON-parse-reviver-complex.html
+++ b/LayoutTests/js/JSON-parse-reviver-complex.html
@@ -1,4 +1,4 @@
-<!DOCTYPE HTML><!-- webkit-test-runner [ jscOptions=--useRecursiveJSONParse=true ] -->
+<!DOCTYPE HTML><!-- webkit-test-runner [ jscOptions=--useRecursiveJSONParse=false ] -->
 <html>
 <head>
 <script src="../resources/js-test-pre.js"></script>

--- a/LayoutTests/js/dom/JSON-parse-complex-expected.txt
+++ b/LayoutTests/js/dom/JSON-parse-complex-expected.txt
@@ -1,0 +1,613 @@
+function (jsonObject){
+        return jsonObject.parse();
+    }
+PASS tests[i](nativeJSON) threw exception SyntaxError: JSON Parse error: Unexpected identifier "undefined".
+function (jsonObject){
+        return jsonObject.parse('');
+    }
+PASS tests[i](nativeJSON) threw exception SyntaxError: JSON Parse error: Unexpected EOF.
+function (jsonObject){
+        return jsonObject.parse('1');
+    }
+PASS JSON.stringify(tests[i](nativeJSON)) is JSON.stringify(tests[i](JSON))
+function (jsonObject){
+        return jsonObject.parse('-1');
+    }
+PASS JSON.stringify(tests[i](nativeJSON)) is JSON.stringify(tests[i](JSON))
+function (jsonObject){
+        return jsonObject.parse('Infinity');
+    }
+PASS tests[i](nativeJSON) threw exception SyntaxError: JSON Parse error: Unexpected identifier "Infinity".
+function (jsonObject){
+        return jsonObject.parse('NaN');
+    }
+PASS tests[i](nativeJSON) threw exception SyntaxError: JSON Parse error: Unexpected identifier "NaN".
+function (jsonObject){
+        return jsonObject.parse('null');
+    }
+PASS JSON.stringify(tests[i](nativeJSON)) is JSON.stringify(tests[i](JSON))
+function (jsonObject){
+        return jsonObject.parse('undefined');
+    }
+PASS tests[i](nativeJSON) threw exception SyntaxError: JSON Parse error: Unexpected identifier "undefined".
+function (jsonObject){
+        return jsonObject.parse('{}');
+    }
+PASS JSON.stringify(tests[i](nativeJSON)) is JSON.stringify(tests[i](JSON))
+function (jsonObject){
+        return jsonObject.parse('({})');
+    }
+PASS tests[i](nativeJSON) threw exception SyntaxError: JSON Parse error: Unexpected token '('.
+function (jsonObject){
+        return jsonObject.parse('{a}');
+    }
+PASS tests[i](nativeJSON) threw exception SyntaxError: JSON Parse error: Expected '}'.
+function (jsonObject){
+        return jsonObject.parse('{a:}');
+    }
+PASS tests[i](nativeJSON) threw exception SyntaxError: JSON Parse error: Expected '}'.
+function (jsonObject){
+        return jsonObject.parse('{a:5}');
+    }
+PASS tests[i](nativeJSON) threw exception SyntaxError: JSON Parse error: Expected '}'.
+function (jsonObject){
+        return jsonObject.parse('{a:5,}');
+    }
+PASS tests[i](nativeJSON) threw exception SyntaxError: JSON Parse error: Expected '}'.
+function (jsonObject){
+        return jsonObject.parse('{"a"}');
+    }
+PASS tests[i](nativeJSON) threw exception SyntaxError: JSON Parse error: Expected ':' before value in object property definition.
+function (jsonObject){
+        return jsonObject.parse('{"a":}');
+    }
+PASS tests[i](nativeJSON) threw exception SyntaxError: JSON Parse error: Unexpected token '}'.
+function (jsonObject){
+        return jsonObject.parse('{"a":5}');
+    }
+PASS JSON.stringify(tests[i](nativeJSON)) is JSON.stringify(tests[i](JSON))
+function (jsonObject){
+        return jsonObject.parse('{"__proto__":5}');
+    }
+json2.js uses eval and will differ when parsing JSON with __proto__.
+PASS JSON.stringify(tests[i](nativeJSON)) is not JSON.stringify(tests[i](JSON))
+PASS JSON.stringify(tests[i](nativeJSON)) is tests[i].jsonParseExpected
+PASS JSON.stringify(tests[i](JSON)) is tests[i].evalExpected
+function (jsonObject){
+        return jsonObject.parse('{"a":5,}');
+    }
+PASS tests[i](nativeJSON) threw exception SyntaxError: JSON Parse error: Property name must be a string literal.
+json2.js did not throw for a test we expect to throw.
+function (jsonObject){
+        return jsonObject.parse('{"a":5,,}');
+    }
+PASS tests[i](nativeJSON) threw exception SyntaxError: JSON Parse error: Property name must be a string literal.
+function (jsonObject){
+        return jsonObject.parse('{"a":5,"a",}');
+    }
+PASS tests[i](nativeJSON) threw exception SyntaxError: JSON Parse error: Expected ':' before value in object property definition.
+function (jsonObject){
+        return jsonObject.parse('{"a":(5,"a"),}');
+    }
+PASS tests[i](nativeJSON) threw exception SyntaxError: JSON Parse error: Unexpected token '('.
+function (jsonObject){
+        return jsonObject.parse('[]');
+    }
+PASS JSON.stringify(tests[i](nativeJSON)) is JSON.stringify(tests[i](JSON))
+function (jsonObject){
+        return jsonObject.parse('[1]');
+    }
+PASS JSON.stringify(tests[i](nativeJSON)) is JSON.stringify(tests[i](JSON))
+function (jsonObject){
+        return jsonObject.parse('[1,]');
+    }
+PASS tests[i](nativeJSON) threw exception SyntaxError: JSON Parse error: Unexpected comma at the end of array expression.
+json2.js did not throw for a test we expect to throw.
+function (jsonObject){
+        return jsonObject.parse('[1,2]');
+    }
+PASS JSON.stringify(tests[i](nativeJSON)) is JSON.stringify(tests[i](JSON))
+function (jsonObject){
+        return jsonObject.parse('[1,2,,]');
+    }
+PASS tests[i](nativeJSON) threw exception SyntaxError: JSON Parse error: Unexpected token ','.
+json2.js did not throw for a test we expect to throw.
+function (jsonObject){
+        return jsonObject.parse('[1,2,,4]');
+    }
+PASS tests[i](nativeJSON) threw exception SyntaxError: JSON Parse error: Unexpected token ','.
+json2.js did not throw for a test we expect to throw.
+function (jsonObject){
+        return jsonObject.parse('""');
+    }
+PASS JSON.stringify(tests[i](nativeJSON)) is JSON.stringify(tests[i](JSON))
+function (jsonObject){
+        return jsonObject.parse('"\'"');
+    }
+PASS JSON.stringify(tests[i](nativeJSON)) is JSON.stringify(tests[i](JSON))
+function (jsonObject){
+        return jsonObject.parse('"a\"');
+    }
+PASS JSON.stringify(tests[i](nativeJSON)) is JSON.stringify(tests[i](JSON))
+function (jsonObject){
+        return jsonObject.parse('"a\\"');
+    }
+PASS tests[i](nativeJSON) threw exception SyntaxError: JSON Parse error: Unterminated string.
+function (jsonObject){
+        return jsonObject.parse('"a\\z"');
+    }
+PASS tests[i](nativeJSON) threw exception SyntaxError: JSON Parse error: Invalid escape character z.
+function (jsonObject){
+        return jsonObject.parse('"a\\\z"');
+    }
+PASS tests[i](nativeJSON) threw exception SyntaxError: JSON Parse error: Invalid escape character z.
+function (jsonObject){
+        return jsonObject.parse('"a\\\\z"');
+    }
+PASS JSON.stringify(tests[i](nativeJSON)) is JSON.stringify(tests[i](JSON))
+function (jsonObject){
+        return jsonObject.parse('"a\tz"');
+    }
+PASS tests[i](nativeJSON) threw exception SyntaxError: JSON Parse error: Unterminated string.
+json2.js did not throw for a test we expect to throw.
+function (jsonObject){
+        return jsonObject.parse('"a\\tz"');
+    }
+PASS JSON.stringify(tests[i](nativeJSON)) is JSON.stringify(tests[i](JSON))
+function (jsonObject){
+        return jsonObject.parse('"a\nz"');
+    }
+PASS tests[i](nativeJSON) threw exception SyntaxError: JSON Parse error: Unterminated string.
+function (jsonObject){
+        return jsonObject.parse('"a\\nz"');
+    }
+PASS JSON.stringify(tests[i](nativeJSON)) is JSON.stringify(tests[i](JSON))
+function (jsonObject){
+        return jsonObject.parse('"a\rz"');
+    }
+PASS tests[i](nativeJSON) threw exception SyntaxError: JSON Parse error: Unterminated string.
+function (jsonObject){
+        return jsonObject.parse('"a\\rz"');
+    }
+PASS JSON.stringify(tests[i](nativeJSON)) is JSON.stringify(tests[i](JSON))
+function (jsonObject){
+        return jsonObject.parse('"a\/z"');
+    }
+PASS JSON.stringify(tests[i](nativeJSON)) is JSON.stringify(tests[i](JSON))
+function (jsonObject){
+        return jsonObject.parse('"a\\/z"');
+    }
+PASS JSON.stringify(tests[i](nativeJSON)) is JSON.stringify(tests[i](JSON))
+function (jsonObject){
+        return jsonObject.parse('"a\bz"');
+    }
+PASS tests[i](nativeJSON) threw exception SyntaxError: JSON Parse error: Unterminated string.
+json2.js did not throw for a test we expect to throw.
+function (jsonObject){
+        return jsonObject.parse('"a\\bz"');
+    }
+PASS JSON.stringify(tests[i](nativeJSON)) is JSON.stringify(tests[i](JSON))
+function (jsonObject){
+        return jsonObject.parse('"a\rz"');
+    }
+PASS tests[i](nativeJSON) threw exception SyntaxError: JSON Parse error: Unterminated string.
+function (jsonObject){
+        return jsonObject.parse('"a\\rz"');
+    }
+PASS JSON.stringify(tests[i](nativeJSON)) is JSON.stringify(tests[i](JSON))
+function (jsonObject){
+        return jsonObject.parse('"a\\uz"     ');
+    }
+PASS tests[i](nativeJSON) threw exception SyntaxError: JSON Parse error: "\uz"  " is not a valid unicode escape.
+function (jsonObject){
+        return jsonObject.parse('"a\\u0z"    ');
+    }
+PASS tests[i](nativeJSON) threw exception SyntaxError: JSON Parse error: "\u0z" " is not a valid unicode escape.
+function (jsonObject){
+        return jsonObject.parse('"a\\u00z"   ');
+    }
+PASS tests[i](nativeJSON) threw exception SyntaxError: JSON Parse error: "\u00z"" is not a valid unicode escape.
+function (jsonObject){
+        return jsonObject.parse('"a\\u000z"  ');
+    }
+PASS tests[i](nativeJSON) threw exception SyntaxError: JSON Parse error: "\u000z" is not a valid unicode escape.
+function (jsonObject){
+        return jsonObject.parse('"a\\u0000z" ');
+    }
+PASS JSON.stringify(tests[i](nativeJSON)) is JSON.stringify(tests[i](JSON))
+function (jsonObject){
+        return jsonObject.parse('"a\\u000Az" ');
+    }
+PASS JSON.stringify(tests[i](nativeJSON)) is JSON.stringify(tests[i](JSON))
+function (jsonObject){
+        return jsonObject.parse('"a\\u000az" ');
+    }
+PASS JSON.stringify(tests[i](nativeJSON)) is JSON.stringify(tests[i](JSON))
+function (jsonObject){
+        return jsonObject.parse('"a\\u000Gz" ');
+    }
+PASS tests[i](nativeJSON) threw exception SyntaxError: JSON Parse error: "\u000G" is not a valid unicode escape.
+function (jsonObject){
+        return jsonObject.parse('"a\\u000gz" ');
+    }
+PASS tests[i](nativeJSON) threw exception SyntaxError: JSON Parse error: "\u000g" is not a valid unicode escape.
+function (jsonObject){
+        return jsonObject.parse('"a\\u00A0z" ');
+    }
+PASS JSON.stringify(tests[i](nativeJSON)) is JSON.stringify(tests[i](JSON))
+function (jsonObject){
+        return jsonObject.parse('"a\\u00a0z" ');
+    }
+PASS JSON.stringify(tests[i](nativeJSON)) is JSON.stringify(tests[i](JSON))
+function (jsonObject){
+        return jsonObject.parse('"a\\u00G0z" ');
+    }
+PASS tests[i](nativeJSON) threw exception SyntaxError: JSON Parse error: "\u00G0" is not a valid unicode escape.
+function (jsonObject){
+        return jsonObject.parse('"a\\u00g0z" ');
+    }
+PASS tests[i](nativeJSON) threw exception SyntaxError: JSON Parse error: "\u00g0" is not a valid unicode escape.
+function (jsonObject){
+        return jsonObject.parse('"a\\u0A00z" ');
+    }
+PASS JSON.stringify(tests[i](nativeJSON)) is JSON.stringify(tests[i](JSON))
+function (jsonObject){
+        return jsonObject.parse('"a\\u0a00z" ');
+    }
+PASS JSON.stringify(tests[i](nativeJSON)) is JSON.stringify(tests[i](JSON))
+function (jsonObject){
+        return jsonObject.parse('"a\\u0G00z" ');
+    }
+PASS tests[i](nativeJSON) threw exception SyntaxError: JSON Parse error: "\u0G00" is not a valid unicode escape.
+function (jsonObject){
+        return jsonObject.parse('"a\\u0g00z" ');
+    }
+PASS tests[i](nativeJSON) threw exception SyntaxError: JSON Parse error: "\u0g00" is not a valid unicode escape.
+function (jsonObject){
+        return jsonObject.parse('"a\\uA000z" ');
+    }
+PASS JSON.stringify(tests[i](nativeJSON)) is JSON.stringify(tests[i](JSON))
+function (jsonObject){
+        return jsonObject.parse('"a\\ua000z" ');
+    }
+PASS JSON.stringify(tests[i](nativeJSON)) is JSON.stringify(tests[i](JSON))
+function (jsonObject){
+        return jsonObject.parse('"a\\uG000z" ');
+    }
+PASS tests[i](nativeJSON) threw exception SyntaxError: JSON Parse error: "\uG000" is not a valid unicode escape.
+function (jsonObject){
+        return jsonObject.parse('"a\\ug000z" ');
+    }
+PASS tests[i](nativeJSON) threw exception SyntaxError: JSON Parse error: "\ug000" is not a valid unicode escape.
+function (jsonObject){
+        return jsonObject.parse('00');
+    }
+PASS tests[i](nativeJSON) threw exception SyntaxError: JSON Parse error: Unable to parse JSON string.
+json2.js did not throw for a test we expect to throw.
+function (jsonObject){
+        return jsonObject.parse('01');
+    }
+PASS tests[i](nativeJSON) threw exception SyntaxError: JSON Parse error: Unable to parse JSON string.
+json2.js did not throw for a test we expect to throw.
+function (jsonObject){
+        return jsonObject.parse('0.a');
+    }
+PASS tests[i](nativeJSON) threw exception SyntaxError: JSON Parse error: Invalid digits after decimal point.
+function (jsonObject){
+        return jsonObject.parse('0x0');
+    }
+PASS tests[i](nativeJSON) threw exception SyntaxError: JSON Parse error: Unable to parse JSON string.
+function (jsonObject){
+        return jsonObject.parse('2e1.3');
+    }
+PASS tests[i](nativeJSON) threw exception SyntaxError: JSON Parse error: Unable to parse JSON string.
+function (jsonObject){
+        return jsonObject.parse('2e-+10');
+    }
+PASS tests[i](nativeJSON) threw exception SyntaxError: JSON Parse error: Exponent symbols should be followed by an optional '+' or '-' and then by at least one number.
+function (jsonObject){
+        return jsonObject.parse('2e+-10');
+    }
+PASS tests[i](nativeJSON) threw exception SyntaxError: JSON Parse error: Exponent symbols should be followed by an optional '+' or '-' and then by at least one number.
+function (jsonObject){
+        return jsonObject.parse('2e3e4');
+    }
+PASS tests[i](nativeJSON) threw exception SyntaxError: JSON Parse error: Unable to parse JSON string.
+function (jsonObject){
+        return jsonObject.parse('-01.0');
+    }
+PASS tests[i](nativeJSON) threw exception SyntaxError: JSON Parse error: Unable to parse JSON string.
+function (jsonObject){
+        return jsonObject.parse('-01');
+    }
+PASS tests[i](nativeJSON) threw exception SyntaxError: JSON Parse error: Unable to parse JSON string.
+json2.js did not throw for a test we expect to throw.
+function (jsonObject){
+        return jsonObject.parse('-01.a');
+    }
+PASS tests[i](nativeJSON) threw exception SyntaxError: JSON Parse error: Invalid digits after decimal point.
+function (jsonObject){
+        return jsonObject.parse('1.e1');
+    }
+PASS tests[i](nativeJSON) threw exception SyntaxError: JSON Parse error: Invalid digits after decimal point.
+json2.js did not throw for a test we expect to throw.
+function (jsonObject){
+        return jsonObject.parse('{/* block comments are not allowed */}');
+    }
+PASS tests[i](nativeJSON) threw exception SyntaxError: JSON Parse error: Unrecognized token '/'.
+function (jsonObject){
+        return jsonObject.parse('{// line comments are not allowed \n}');
+    }
+PASS tests[i](nativeJSON) threw exception SyntaxError: JSON Parse error: Unrecognized token '/'.
+function (jsonObject){
+        return jsonObject.parse('true');
+    }
+PASS JSON.stringify(tests[i](nativeJSON)) is JSON.stringify(tests[i](JSON))
+function (jsonObject){
+        return jsonObject.parse('false');
+    }
+PASS JSON.stringify(tests[i](nativeJSON)) is JSON.stringify(tests[i](JSON))
+function (jsonObject){
+        return jsonObject.parse('\\')
+    }
+PASS tests[i](nativeJSON) threw exception SyntaxError: JSON Parse error: Unrecognized token '\'.
+function (jsonObject){
+        return jsonObject.parse(JSON.stringify(simpleObject));
+    }
+PASS JSON.stringify(tests[i](nativeJSON)) is tests[i].expected
+function (jsonObject){
+        return jsonObject.parse(JSON.stringify(complexObject));
+    }
+PASS JSON.stringify(tests[i](nativeJSON)) is JSON.stringify(tests[i](JSON))
+function (jsonObject){
+        return jsonObject.parse(JSON.stringify(complexObject));
+    }
+PASS JSON.stringify(tests[i](nativeJSON)) is tests[i].expected
+function (jsonObject){
+        return jsonObject.parse(JSON.stringify(simpleObject,null,100));
+    }
+PASS JSON.stringify(tests[i](nativeJSON)) is tests[i].expected
+function (jsonObject){
+        return jsonObject.parse(JSON.stringify(complexObject,null,100));
+    }
+PASS JSON.stringify(tests[i](nativeJSON)) is JSON.stringify(tests[i](JSON))
+function (jsonObject){
+        return jsonObject.parse(JSON.stringify(complexObject,null,100));
+    }
+PASS JSON.stringify(tests[i](nativeJSON)) is tests[i].expected
+function (jsonObject){
+        return jsonObject.parse(JSON.stringify(simpleObject,null," "));
+    }
+PASS JSON.stringify(tests[i](nativeJSON)) is tests[i].expected
+function (jsonObject){
+        return jsonObject.parse(JSON.stringify(complexObject,null," "));
+    }
+PASS JSON.stringify(tests[i](nativeJSON)) is JSON.stringify(tests[i](JSON))
+function (jsonObject){
+        return jsonObject.parse(JSON.stringify(complexObject,null," "));
+    }
+PASS JSON.stringify(tests[i](nativeJSON)) is tests[i].expected
+function (jsonObject){
+        return jsonObject.parse(JSON.stringify(simpleObject,null,"\t"));
+    }
+PASS JSON.stringify(tests[i](nativeJSON)) is tests[i].expected
+function (jsonObject){
+        return jsonObject.parse(JSON.stringify(complexObject,null,"\t"));
+    }
+PASS JSON.stringify(tests[i](nativeJSON)) is JSON.stringify(tests[i](JSON))
+function (jsonObject){
+        return jsonObject.parse(JSON.stringify(complexObject,null,"\t"));
+    }
+PASS JSON.stringify(tests[i](nativeJSON)) is tests[i].expected
+function (jsonObject){
+        return jsonObject.parse(JSON.stringify(simpleObject,null,"\n"));
+    }
+PASS JSON.stringify(tests[i](nativeJSON)) is tests[i].expected
+function (jsonObject){
+        return jsonObject.parse(JSON.stringify(complexObject,null,"\n"));
+    }
+PASS JSON.stringify(tests[i](nativeJSON)) is tests[i].expected
+function (jsonObject){
+        return jsonObject.parse("true", log);
+    }
+PASS JSON.stringify(tests[i](nativeJSON)) is JSON.stringify(tests[i](JSON))
+function (jsonObject){
+        return jsonObject.parse("false", log);
+    }
+PASS JSON.stringify(tests[i](nativeJSON)) is JSON.stringify(tests[i](JSON))
+function (jsonObject){
+        return jsonObject.parse("null", log);
+    }
+PASS JSON.stringify(tests[i](nativeJSON)) is JSON.stringify(tests[i](JSON))
+function (jsonObject){
+        return jsonObject.parse("1", log);
+    }
+PASS JSON.stringify(tests[i](nativeJSON)) is JSON.stringify(tests[i](JSON))
+function (jsonObject){
+        return jsonObject.parse("1.5", log);
+    }
+PASS JSON.stringify(tests[i](nativeJSON)) is JSON.stringify(tests[i](JSON))
+function (jsonObject){
+        return jsonObject.parse('"a string"', log);
+    }
+PASS JSON.stringify(tests[i](nativeJSON)) is JSON.stringify(tests[i](JSON))
+function (jsonObject){
+        return jsonObject.parse(JSON.stringify(simpleArray), log);
+    }
+PASS JSON.stringify(tests[i](nativeJSON)) is JSON.stringify(tests[i](JSON))
+function (jsonObject){
+        return jsonObject.parse(JSON.stringify(complexArray), log);
+    }
+PASS JSON.stringify(tests[i](nativeJSON)) is JSON.stringify(tests[i](JSON))
+function (jsonObject){
+        return jsonObject.parse(JSON.stringify(simpleObject), log);
+    }
+PASS JSON.stringify(tests[i](nativeJSON)) is JSON.stringify(tests[i](JSON))
+function (jsonObject){
+        return jsonObject.parse(JSON.stringify(complexObject), log);
+    }
+PASS JSON.stringify(tests[i](nativeJSON)) is JSON.stringify(tests[i](JSON))
+function (jsonObject){
+        return jsonObject.parse('{"__proto__":{"a":5}}', log);
+    }
+json2.js uses eval and will differ when parsing JSON with __proto__.
+PASS JSON.stringify(tests[i](nativeJSON)) is not JSON.stringify(tests[i](JSON))
+PASS JSON.stringify(tests[i](nativeJSON)) is tests[i].jsonParseExpected
+PASS JSON.stringify(tests[i](JSON)) is tests[i].evalExpected
+function (jsonObject){
+        logOrderString = "";
+        return jsonObject.parse("true", logOrder);
+    }
+PASS JSON.stringify(tests[i](nativeJSON)) is JSON.stringify(tests[i](JSON))
+function (jsonObject){
+        logOrderString = "";
+        return jsonObject.parse("false", logOrder);
+    }
+PASS JSON.stringify(tests[i](nativeJSON)) is JSON.stringify(tests[i](JSON))
+function (jsonObject){
+        logOrderString = "";
+        return jsonObject.parse("null", logOrder);
+    }
+PASS JSON.stringify(tests[i](nativeJSON)) is JSON.stringify(tests[i](JSON))
+function (jsonObject){
+        logOrderString = "";
+        return jsonObject.parse("1", logOrder);
+    }
+PASS JSON.stringify(tests[i](nativeJSON)) is JSON.stringify(tests[i](JSON))
+function (jsonObject){
+        logOrderString = "";
+        return jsonObject.parse("1.5", logOrder);
+    }
+PASS JSON.stringify(tests[i](nativeJSON)) is JSON.stringify(tests[i](JSON))
+function (jsonObject){
+        logOrderString = "";
+        return jsonObject.parse('"a string"', logOrder);
+    }
+PASS JSON.stringify(tests[i](nativeJSON)) is JSON.stringify(tests[i](JSON))
+function (jsonObject){
+        logOrderString = "";
+        return jsonObject.parse(JSON.stringify(simpleArray), logOrder);
+    }
+PASS JSON.stringify(tests[i](nativeJSON)) is JSON.stringify(tests[i](JSON))
+function (jsonObject){
+        logOrderString = "";
+        return jsonObject.parse(JSON.stringify(complexArray), logOrder);
+    }
+PASS JSON.stringify(tests[i](nativeJSON)) is JSON.stringify(tests[i](JSON))
+function (jsonObject){
+        logOrderString = "";
+        return jsonObject.parse(JSON.stringify(simpleObject), logOrder);
+    }
+PASS JSON.stringify(tests[i](nativeJSON)) is JSON.stringify(tests[i](JSON))
+function (jsonObject){
+        logOrderString = "";
+        return jsonObject.parse(JSON.stringify(complexObject), logOrder);
+    }
+PASS JSON.stringify(tests[i](nativeJSON)) is JSON.stringify(tests[i](JSON))
+function (jsonObject){
+        logOrderString = "";
+        jsonObject.parse("true", logOrder);
+        return logOrderString;
+    }
+PASS JSON.stringify(tests[i](nativeJSON)) is JSON.stringify(tests[i](JSON))
+function (jsonObject){
+        logOrderString = "";
+        jsonObject.parse("false", logOrder);
+        return logOrderString;
+    }
+PASS JSON.stringify(tests[i](nativeJSON)) is JSON.stringify(tests[i](JSON))
+function (jsonObject){
+        logOrderString = "";
+        jsonObject.parse("null", logOrder);
+        return logOrderString;
+    }
+PASS JSON.stringify(tests[i](nativeJSON)) is JSON.stringify(tests[i](JSON))
+function (jsonObject){
+        logOrderString = "";
+        jsonObject.parse("1", logOrder);
+        return logOrderString;
+    }
+PASS JSON.stringify(tests[i](nativeJSON)) is JSON.stringify(tests[i](JSON))
+function (jsonObject){
+        logOrderString = "";
+        jsonObject.parse("1.5", logOrder);
+        return logOrderString;
+    }
+PASS JSON.stringify(tests[i](nativeJSON)) is JSON.stringify(tests[i](JSON))
+function (jsonObject){
+        logOrderString = "";
+        jsonObject.parse('"a string"', logOrder);
+        return logOrderString;
+    }
+PASS JSON.stringify(tests[i](nativeJSON)) is JSON.stringify(tests[i](JSON))
+function (jsonObject){
+        logOrderString = "";
+        jsonObject.parse(JSON.stringify(simpleArray), logOrder);
+        return logOrderString;
+    }
+PASS JSON.stringify(tests[i](nativeJSON)) is JSON.stringify(tests[i](JSON))
+function (jsonObject){
+        logOrderString = "";
+        jsonObject.parse(JSON.stringify(complexArray), logOrder);
+        return logOrderString;
+    }
+PASS JSON.stringify(tests[i](nativeJSON)) is JSON.stringify(tests[i](JSON))
+function (jsonObject){
+        logOrderString = "";
+        jsonObject.parse(JSON.stringify(simpleObject), logOrder);
+        return logOrderString;
+    }
+PASS JSON.stringify(tests[i](nativeJSON)) is JSON.stringify(tests[i](JSON))
+function (jsonObject){
+        logOrderString = "";
+        jsonObject.parse(JSON.stringify(complexObject), logOrder);
+        return logOrderString;
+    }
+PASS JSON.stringify(tests[i](nativeJSON)) is JSON.stringify(tests[i](JSON))
+function (jsonObject){
+        callCount = 0;
+        logOrderString = "";
+        return jsonObject.parse(JSON.stringify(complexArray), throwAfterFifthCall);
+    }
+PASS tests[i](nativeJSON) threw exception from reviver.
+function (jsonObject){
+        callCount = 0;
+        logOrderString = "";
+        return jsonObject.parse(JSON.stringify(simpleObject), throwAfterFifthCall);
+    }
+PASS JSON.stringify(tests[i](nativeJSON)) is JSON.stringify(tests[i](JSON))
+function (jsonObject){
+        callCount = 0;
+        logOrderString = "";
+        return jsonObject.parse(JSON.stringify(complexObject), throwAfterFifthCall);
+    }
+PASS tests[i](nativeJSON) threw exception from reviver.
+function (jsonObject){
+        callCount = 0;
+        logOrderString = "";
+        try { jsonObject.parse(JSON.stringify(complexArray), throwAfterFifthCall); } catch (e) {}
+        return logOrderString;
+    }
+PASS JSON.stringify(tests[i](nativeJSON)) is JSON.stringify(tests[i](JSON))
+function (jsonObject){
+        callCount = 0;
+        logOrderString = "";
+        try { jsonObject.parse(JSON.stringify(simpleObject), throwAfterFifthCall); } catch (e) {}
+        return logOrderString;
+    }
+PASS JSON.stringify(tests[i](nativeJSON)) is JSON.stringify(tests[i](JSON))
+function (jsonObject){
+        callCount = 0;
+        logOrderString = "";
+        try { jsonObject.parse(JSON.stringify(complexObject), throwAfterFifthCall); } catch (e) {}
+        return logOrderString;
+    }
+PASS JSON.stringify(tests[i](nativeJSON)) is JSON.stringify(tests[i](JSON))
+function (jsonObject){
+        return jsonObject.parse(JSON.stringify(unicode));
+    }
+PASS tests[i](nativeJSON) is tests[i].unstringifiedExpected
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/js/dom/JSON-parse-complex.html
+++ b/LayoutTests/js/dom/JSON-parse-complex.html
@@ -1,4 +1,4 @@
-<!DOCTYPE HTML><!-- webkit-test-runner [ jscOptions=--useRecursiveJSONParse=true ] -->
+<!DOCTYPE HTML><!-- webkit-test-runner [ jscOptions=--useRecursiveJSONParse=false ] -->
 <html>
 <head>
 <script src="../../resources/js-test-pre.js"></script>

--- a/Source/JavaScriptCore/runtime/OptionsList.h
+++ b/Source/JavaScriptCore/runtime/OptionsList.h
@@ -553,6 +553,7 @@ bool canUseWebAssemblyFastMemory();
     v(Bool, dumpWasmOpcodeStatistics, false, Normal, nullptr) \
     v(Bool, dumpCompilerConstructionSite, false, Normal, nullptr) \
     v(Bool, dumpWasmWarnings, false, Normal, nullptr) \
+    v(Bool, useRecursiveJSONParse, true, Normal, nullptr) \
     \
     /* Feature Flags */\
     \

--- a/Tools/Scripts/webkitpy/layout_tests/run_webkit_tests.py
+++ b/Tools/Scripts/webkitpy/layout_tests/run_webkit_tests.py
@@ -89,6 +89,8 @@ def main(argv, stdout, stderr):
         options.additional_env_var.append('__XPC_JSC_maxPerThreadStackUsage=' + str(stackSizeInBytes))
         options.additional_env_var.append('JSC_useSharedArrayBuffer=1')
         options.additional_env_var.append('__XPC_JSC_useSharedArrayBuffer=1')
+        options.additional_env_var.append('JSC_useRecursiveJSONParse=0')
+        options.additional_env_var.append('__XPC_JSC_useRecursiveJSONParse=0')
         run_details = run(port, options, args, stderr)
         if run_details.exit_code != -1 and run_details.skipped_all_tests:
             return run_details.exit_code


### PR DESCRIPTION
#### 3a9af61361977e1f775f847136d0cf239182c526
<pre>
[JSC] JSON.parse should use simple recursion until it hits soft-recursion threshold
<a href="https://bugs.webkit.org/show_bug.cgi?id=256349">https://bugs.webkit.org/show_bug.cgi?id=256349</a>
rdar://108930906

Reviewed by Alexey Shvayka and Alexey Proskuryakov.

Let&apos;s do super simple JSON.parse until it hits soft-recursion threshold. Our existing code
handles JSON.parse without recursion, this is great, but it is very complicated. And most of
JSON can be parsed with recursion with the current stack capacity. Let&apos;s start with super
simple recursion path, and check soft stack limit carefully. And if we hit, then stop the
recursion and fallback to our generic code. Good thing is that JSON&apos;s leaf object creation
is isolated, so we can start this generic code at any time. We can repeatedly enter and exit
this.

                                                         ToT                     Patched

    vanilla-es2015-babel-webpack-todomvc-json-parse
                                                   63.0883+-0.1159     ^     58.6921+-0.1383        ^ definitely 1.0749x faster
    flight-todomvc-json-parse                      28.3211+-0.0977     ^     25.8927+-0.1618        ^ definitely 1.0938x faster
    vanilla-es2015-todomvc-json-parse              63.1916+-0.2224     ^     58.8631+-0.2339        ^ definitely 1.0735x faster
    vanilla-todomvc-json-parse                     46.7609+-0.1348     ^     43.9075+-0.1779        ^ definitely 1.0650x faster

* Source/JavaScriptCore/runtime/LiteralParser.cpp:
(JSC::LiteralParser&lt;CharType&gt;::tryJSONPParse):
(JSC::LiteralParser&lt;CharType&gt;::Lexer::next):
(JSC::LiteralParser&lt;CharType&gt;::parseRecursivelyEntry):
(JSC::LiteralParser&lt;CharType&gt;::parseRecursively):
(JSC::LiteralParser&lt;CharType&gt;::parse):
* Source/JavaScriptCore/runtime/LiteralParser.h:
(JSC::LiteralParser::tryLiteralParse):

Canonical link: <a href="https://commits.webkit.org/263744@main">https://commits.webkit.org/263744@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/965e60c717c0bc3645d7e0b0f1293dad52339bc0

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/5647 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/5800 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/5990 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/7198 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/5632 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/5646 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/6023 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/5772 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/7759 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/5751 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/5802 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/5058 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/7240 "Built successfully") | 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/5753 "Passed tests") | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/3278 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/5084 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/12278 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/4696 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/5147 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/5160 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/6988 "Passed tests") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/5230 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/5595 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/4577 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/5757 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/5043 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/5014 "Passed tests") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/1409 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/9154 "Built successfully") | | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/24/builds/5919 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/646 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/5404 "Built successfully") | | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/3/builds/1528 "Passed tests") | 
<!--EWS-Status-Bubble-End-->