### PR TITLE
LocalFrameView::performPostLayoutTasks should not synchronously scroll to or focus an element (2)

### DIFF
--- a/LayoutTests/fast/dynamic/anchor-lock.html
+++ b/LayoutTests/fast/dynamic/anchor-lock.html
@@ -16,6 +16,14 @@
 <p><img src="resources/largeblank.png"></p>
 <p><img src="resources/largeblank.png"></p>
 <script type="text/javascript">
+
+if (window.testRunner) {
+    testRunner.waitUntilDone();
+    window.addEventListener('scroll', () => {
+        testRunner.notifyDone();
+    });
+}
+
 document.write(location.href="#anchor1");
 </script>
 </body>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-scroll-anchoring/fragment-scrolling-anchors.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-scroll-anchoring/fragment-scrolling-anchors.html
@@ -37,7 +37,7 @@
 </div>
 
 <script>
-  test(function(t) {
+  promise_test(async function(t) {
     // Note that this test passes even without scroll anchoring because of
     // fragment anchoring.
     window.location.hash = 'fragment';
@@ -48,7 +48,13 @@
     var ch = document.getElementById('changer');
     ch.style.height = 100;
 
+    await (new Promise((resolve) => window.addEventListener('scroll', resolve)));
+
     // Height of first + height changer + fragment margin-top.
     assert_equals(window.scrollY, 1110);
+
+    first.remove();
+    changer.remove();
+    anchor.remove();
   }, 'Verify scroll anchoring interaction with fragment scrolls');
 </script>

--- a/Source/WebCore/loader/FrameLoader.cpp
+++ b/Source/WebCore/loader/FrameLoader.cpp
@@ -1265,9 +1265,6 @@ void FrameLoader::completed()
         if (auto* localParent = dynamicDowncast<LocalFrame>(parent))
             localParent->loader().checkCompleted();
     }
-
-    if (m_frame.view())
-        m_frame.view()->maintainScrollPositionAtAnchor(nullptr);
 }
 
 void FrameLoader::started()

--- a/Source/WebCore/page/LocalFrameView.cpp
+++ b/Source/WebCore/page/LocalFrameView.cpp
@@ -3845,12 +3845,10 @@ void LocalFrameView::performPostLayoutTasks()
             renderView->compositor().frameViewDidLayout();
     }
 
-    scrollToAnchor();
-    
-    scrollToTextFragmentRange();
+    scheduleScrollToAnchorAndTextFragment();
 
     scheduleResizeEventIfNeeded();
-    
+
     updateLayoutViewport();
     viewportContentsChanged();
 


### PR DESCRIPTION
#### be4701c3c0d1491a72cf568157a5e8e7d16e2639
<pre>
LocalFrameView::performPostLayoutTasks should not synchronously scroll to or focus an element (2)
<a href="https://bugs.webkit.org/show_bug.cgi?id=256353">https://bugs.webkit.org/show_bug.cgi?id=256353</a>

Reviewed by Simon Fraser.

Somehow 263699@main didn&apos;t contain the most crucial code change to make performPostLayoutTasks not
trigger synchronous scroll or focus so do that for real this time.

This PR also fixes tests that had assumed synchronous scroll anchoring.

* LayoutTests/fast/dynamic/anchor-lock.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-scroll-anchoring/fragment-scrolling-anchors.html:

* Source/WebCore/loader/FrameLoader.cpp:
(WebCore::FrameLoader::completed): Don&apos;t clear the scroll anchoring at the end for no reason.

* Source/WebCore/page/LocalFrameView.cpp:
(WebCore::LocalFrameView::performPostLayoutTasks):

Canonical link: <a href="https://commits.webkit.org/263724@main">https://commits.webkit.org/263724@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2f88c034caaac14cc00d42205ae5754b31399fdd

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/5555 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/5706 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/5894 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/7105 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/5558 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/5555 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/5931 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/5680 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/7117 "1 flakes 106 failures") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/5658 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/5717 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/4969 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/7142 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/3195 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/4992 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/12113 "2 flakes 131 failures") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/5061 "Passed tests") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/5072 "3 failures") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/6833 "run-api-tests-without-change (failure)") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/5510 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/4504 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/4963 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/4928 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/9068 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/637 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/5325 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->