### PR TITLE
Merge LocalFrameView::layoutOrVisualViewportChanged into LocalFrameView::updateLayoutViewport

### DIFF
--- a/Source/WebCore/page/LocalFrameView.h
+++ b/Source/WebCore/page/LocalFrameView.h
@@ -328,8 +328,6 @@ public:
     // offsets from rubber-banding, and it takes zooming into account. 
     LayoutRect viewportConstrainedVisibleContentRect() const;
 
-    WEBCORE_EXPORT void layoutOrVisualViewportChanged();
-
     LayoutRect rectForFixedPositionLayout() const;
 
     void viewportContentsChanged();


### PR DESCRIPTION
#### 7b1c4eadadd08c3fe14d5b69c0bd89ce2c976938
<pre>
Merge LocalFrameView::layoutOrVisualViewportChanged into LocalFrameView::updateLayoutViewport
<a href="https://bugs.webkit.org/show_bug.cgi?id=256355">https://bugs.webkit.org/show_bug.cgi?id=256355</a>

Reviewed by NOBODY (OOPS!).

Merged LocalFrameView::layoutOrVisualViewportChanged into LocalFrameView::updateLayoutViewport.

* Source/WebCore/page/LocalFrameView.cpp:
(WebCore::LocalFrameView::updateLayoutViewport):
(WebCore::LocalFrameView::layoutOrVisualViewportChanged): Deleted.
* Source/WebCore/page/LocalFrameView.h:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/7b1c4eadadd08c3fe14d5b69c0bd89ce2c976938

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/5544 "Passed style check") | [❌ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/5693 "Failed to compile WebKit") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/5882 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/7092 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/5547 "Built successfully") 
| [  ~~🧪 bindings~~](https://ews-build.webkit.org/#/builders/9/builds/5543 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/5918 "Failed to compile WebKit") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/5667 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/7104 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [  ~~🧪 webkitperl~~](https://ews-build.webkit.org/#/builders/11/builds/5645 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/23/builds/5918 "Failed to compile WebKit") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/4958 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/7128 "Built successfully") | 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/23/builds/5918 "Failed to compile WebKit") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/10/builds/4980 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/12107 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [❌ 🧪 api-ios](https://ews-build.webkit.org/#/builders/23/builds/5918 "Failed to compile WebKit") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/5060 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/6811 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [❌ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/5498 "Failed to compile WebKit") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/4497 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [❌ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/4951 "Failed to compile WebKit") | | | 
| | [❌ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/9056 "Failed to compile WebKit") | | | 
| | [❌ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/5313 "Failed to compile WebKit") | | | 
<!--EWS-Status-Bubble-End-->