### PR TITLE
Remove RealtimeMediaSource::m_aspectRatio

### DIFF
--- a/LayoutTests/fast/mediastream/MediaStreamTrack-getSettings-expected.txt
+++ b/LayoutTests/fast/mediastream/MediaStreamTrack-getSettings-expected.txt
@@ -4,6 +4,7 @@ On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE
 
 
 video track settings:
+  settings.aspectRatio = 1.333
   settings.deviceId = <UUID>
   settings.facingMode = user
   settings.frameRate = 30
@@ -18,6 +19,7 @@ audio track settings:
 
 According to the spec: "[every setting] MUST be a member of the set defined for that property by getCapabilities()"
 
+PASS "aspectRatio" in track.getCapabilities() is true
 PASS "deviceId" in track.getCapabilities() is true
 PASS "facingMode" in track.getCapabilities() is true
 PASS "frameRate" in track.getCapabilities() is true

--- a/LayoutTests/imported/w3c/web-platform-tests/mediacapture-streams/MediaStreamTrack-getSettings.https-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/mediacapture-streams/MediaStreamTrack-getSettings.https-expected.txt
@@ -17,7 +17,7 @@ PASS deviceId is reported by getSettings() for getUserMedia() video tracks
 FAIL groupId is reported by getSettings() for getUserMedia() video tracks assert_equals: groupId should exist and it should be a string. expected "string" but got "undefined"
 PASS width is reported by getSettings() for getUserMedia() video tracks
 PASS height is reported by getSettings() for getUserMedia() video tracks
-FAIL aspectRatio is reported by getSettings() for getUserMedia() video tracks assert_equals: aspectRatio should exist and it should be a number. expected "number" but got "undefined"
+PASS aspectRatio is reported by getSettings() for getUserMedia() video tracks
 PASS frameRate is reported by getSettings() for getUserMedia() video tracks
 PASS facingMode is reported by getSettings() for getUserMedia() video tracks
 FAIL resizeMode is reported by getSettings() for getUserMedia() video tracks assert_equals: resizeMode should exist and it should be a string. expected "string" but got "undefined"

--- a/Source/WebCore/Modules/mediastream/MediaStreamTrack.cpp
+++ b/Source/WebCore/Modules/mediastream/MediaStreamTrack.cpp
@@ -258,8 +258,8 @@ MediaStreamTrack::TrackSettings MediaStreamTrack::getSettings() const
         result.width = settings.width();
     if (settings.supportsHeight())
         result.height = settings.height();
-    if (settings.supportsAspectRatio() && settings.aspectRatio()) // FIXME: Why the check for zero here?
-        result.aspectRatio = settings.aspectRatio();
+    if (settings.supportsAspectRatio() && result.height && result.width)
+        result.aspectRatio = *result.width / static_cast<double>(*result.height);
     if (settings.supportsFrameRate())
         result.frameRate = settings.frameRate();
     if (settings.supportsFacingMode())
@@ -280,8 +280,6 @@ MediaStreamTrack::TrackSettings MediaStreamTrack::getSettings() const
         result.displaySurface = RealtimeMediaSourceSettings::displaySurface(settings.displaySurface());
     if (settings.supportsZoom())
         result.zoom = settings.zoom();
-
-    // FIXME: shouldn't this include logicalSurface?
 
     return result;
 }

--- a/Source/WebCore/Modules/mediastream/MediaStreamTrack.h
+++ b/Source/WebCore/Modules/mediastream/MediaStreamTrack.h
@@ -115,7 +115,6 @@ public:
         std::optional<int> sampleSize;
         std::optional<bool> echoCancellation;
         String displaySurface;
-        std::optional<bool> logicalSurface;
         String deviceId;
         String groupId;
         std::optional<double> zoom;

--- a/Source/WebCore/platform/mediastream/RealtimeMediaSource.h
+++ b/Source/WebCore/platform/mediastream/RealtimeMediaSource.h
@@ -173,9 +173,6 @@ public:
     double frameRate() const { return m_frameRate; }
     void setFrameRate(double);
 
-    double aspectRatio() const { return m_aspectRatio; }
-    void setAspectRatio(double);
-
     double zoom() const { return m_zoom; }
     void setZoom(double);
 
@@ -338,7 +335,6 @@ private:
     // Set on sample generation thread.
     IntSize m_intrinsicSize;
     double m_frameRate { 30 };
-    double m_aspectRatio { 0 };
     double m_zoom { 1 };
     double m_volume { 1 };
     double m_sampleRate { 0 };

--- a/Source/WebCore/platform/mediastream/RealtimeMediaSourceSettings.cpp
+++ b/Source/WebCore/platform/mediastream/RealtimeMediaSourceSettings.cpp
@@ -86,9 +86,6 @@ String RealtimeMediaSourceSettings::convertFlagsToString(const OptionSet<Realtim
         case RealtimeMediaSourceSettings::Height:
             builder.append("Height");
             break;
-        case RealtimeMediaSourceSettings::AspectRatio:
-            builder.append("AspectRatio");
-            break;
         case RealtimeMediaSourceSettings::FrameRate:
             builder.append("FrameRate");
             break;
@@ -140,8 +137,6 @@ OptionSet<RealtimeMediaSourceSettings::Flag> RealtimeMediaSourceSettings::differ
         difference.add(RealtimeMediaSourceSettings::Width);
     if (height() != that.height())
         difference.add(RealtimeMediaSourceSettings::Height);
-    if (aspectRatio() != that.aspectRatio())
-        difference.add(RealtimeMediaSourceSettings::AspectRatio);
     if (frameRate() != that.frameRate())
         difference.add(RealtimeMediaSourceSettings::FrameRate);
     if (facingMode() != that.facingMode())

--- a/Source/WebCore/platform/mediastream/RealtimeMediaSourceSettings.h
+++ b/Source/WebCore/platform/mediastream/RealtimeMediaSourceSettings.h
@@ -60,30 +60,28 @@ public:
     enum Flag {
         Width = 1 << 0,
         Height = 1 << 1,
-        AspectRatio = 1 << 2,
-        FrameRate = 1 << 3,
-        FacingMode = 1 << 4,
-        Volume = 1 << 5,
-        SampleRate = 1 << 6,
-        SampleSize = 1 << 7,
-        EchoCancellation = 1 << 8,
-        DeviceId = 1 << 9,
-        GroupId = 1 << 10,
-        Label = 1 << 11,
-        DisplaySurface = 1 << 12,
-        LogicalSurface = 1 << 13,
-        Zoom = 1 << 14,
+        FrameRate = 1 << 2,
+        FacingMode = 1 << 3,
+        Volume = 1 << 4,
+        SampleRate = 1 << 5,
+        SampleSize = 1 << 6,
+        EchoCancellation = 1 << 7,
+        DeviceId = 1 << 8,
+        GroupId = 1 << 9,
+        Label = 1 << 10,
+        DisplaySurface = 1 << 11,
+        LogicalSurface = 1 << 12,
+        Zoom = 1 << 13,
     };
 
-    static constexpr OptionSet<Flag> allFlags() { return { Width, Height, AspectRatio, FrameRate, FacingMode, Volume, SampleRate, SampleSize, EchoCancellation, DeviceId, GroupId, Label, DisplaySurface, LogicalSurface, Zoom }; }
+    static constexpr OptionSet<Flag> allFlags() { return { Width, Height, FrameRate, FacingMode, Volume, SampleRate, SampleSize, EchoCancellation, DeviceId, GroupId, Label, DisplaySurface, LogicalSurface, Zoom }; }
 
     WEBCORE_EXPORT OptionSet<RealtimeMediaSourceSettings::Flag> difference(const RealtimeMediaSourceSettings&) const;
 
     RealtimeMediaSourceSettings() = default;
-    RealtimeMediaSourceSettings(uint32_t width, uint32_t height, float aspectRatio, float frameRate, VideoFacingMode facingMode, double volume, uint32_t sampleRate, uint32_t sampleSize, bool echoCancellation, AtomString&& deviceId, AtomString&& groupId, AtomString&& label, DisplaySurfaceType displaySurface, bool logicalSurface, double zoom, RealtimeMediaSourceSupportedConstraints&& supportedConstraints)
+    RealtimeMediaSourceSettings(uint32_t width, uint32_t height, float frameRate, VideoFacingMode facingMode, double volume, uint32_t sampleRate, uint32_t sampleSize, bool echoCancellation, AtomString&& deviceId, AtomString&& groupId, AtomString&& label, DisplaySurfaceType displaySurface, bool logicalSurface, double zoom, RealtimeMediaSourceSupportedConstraints&& supportedConstraints)
         : m_width(width)
         , m_height(height)
-        , m_aspectRatio(aspectRatio)
         , m_frameRate(frameRate)
         , m_facingMode(facingMode)
         , m_volume(volume)
@@ -109,8 +107,6 @@ public:
     void setHeight(uint32_t height) { m_height = height; }
 
     bool supportsAspectRatio() const { return m_supportedConstraints.supportsAspectRatio(); }
-    float aspectRatio() const { return m_aspectRatio; }
-    void setAspectRatio(float aspectRatio) { m_aspectRatio = aspectRatio; }
 
     bool supportsFrameRate() const { return m_supportedConstraints.supportsFrameRate(); }
     float frameRate() const { return m_frameRate; }
@@ -167,7 +163,6 @@ public:
 private:
     uint32_t m_width { 0 };
     uint32_t m_height { 0 };
-    float m_aspectRatio { 0 };
     float m_frameRate { 0 };
     VideoFacingMode m_facingMode { VideoFacingMode::Unknown };
     double m_volume { 0 };

--- a/Source/WebCore/platform/mediastream/gstreamer/GStreamerVideoCaptureSource.cpp
+++ b/Source/WebCore/platform/mediastream/gstreamer/GStreamerVideoCaptureSource.cpp
@@ -247,7 +247,6 @@ const RealtimeMediaSourceSettings& GStreamerVideoCaptureSource::settings()
     m_currentSettings->setWidth(size().width());
     m_currentSettings->setHeight(size().height());
     m_currentSettings->setFrameRate(frameRate());
-    m_currentSettings->setAspectRatio(aspectRatio());
     m_currentSettings->setFacingMode(facingMode());
     return m_currentSettings.value();
 }

--- a/Source/WebCore/platform/mock/MockRealtimeVideoSource.cpp
+++ b/Source/WebCore/platform/mock/MockRealtimeVideoSource.cpp
@@ -198,14 +198,13 @@ const RealtimeMediaSourceSettings& MockRealtimeVideoSource::settings()
     }
     settings.setWidth(size.width());
     settings.setHeight(size.height());
-    if (aspectRatio())
-        settings.setAspectRatio(aspectRatio());
 
     RealtimeMediaSourceSupportedConstraints supportedConstraints;
     supportedConstraints.setSupportsFrameRate(true);
     supportedConstraints.setSupportsWidth(true);
     supportedConstraints.setSupportsHeight(true);
-    supportedConstraints.setSupportsAspectRatio(true);
+    if (mockCamera())
+        supportedConstraints.setSupportsAspectRatio(true);
     supportedConstraints.setSupportsDeviceId(true);
     if (mockCamera()) {
         if (facingMode() != VideoFacingMode::Unknown)

--- a/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
+++ b/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
@@ -4265,7 +4265,6 @@ enum class WebCore::DisplaySurfaceType : uint8_t {
 class WebCore::RealtimeMediaSourceSettings {
     uint32_t width();
     uint32_t height();
-    float aspectRatio();
     float frameRate();
     WebCore::VideoFacingMode facingMode();
     double volume();


### PR DESCRIPTION
#### 1ad7df2c94c9ce9eac05ceb81acffedac33b5504
<pre>
Remove RealtimeMediaSource::m_aspectRatio
<a href="https://bugs.webkit.org/show_bug.cgi?id=256360">https://bugs.webkit.org/show_bug.cgi?id=256360</a>
rdar://problem/108944135

Reviewed by Philippe Normand.

m_aspectRatio is no longer really needed as we resolve the aspect ratio to generate complete width/height constraints.
We remove this constraint for simplification and we expose it for camera sources as per spec by computing it from width/height at MediaStreamTrack level.

* LayoutTests/fast/mediastream/MediaStreamTrack-getSettings-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/mediacapture-streams/MediaStreamTrack-getSettings.https-expected.txt:
* Source/WebCore/Modules/mediastream/MediaStreamTrack.cpp:
(WebCore::MediaStreamTrack::getSettings const):
* Source/WebCore/Modules/mediastream/MediaStreamTrack.h:
* Source/WebCore/platform/mediastream/RealtimeMediaSource.cpp:
(WebCore::RealtimeMediaSource::applyConstraint):
(WebCore::RealtimeMediaSource::extractVideoFrameSizeConstraints):
(WebCore::RealtimeMediaSource::applyConstraints):
(WebCore::RealtimeMediaSource::size const):
(WebCore::RealtimeMediaSource::setAspectRatio): Deleted.
* Source/WebCore/platform/mediastream/RealtimeMediaSource.h:
* Source/WebCore/platform/mediastream/RealtimeMediaSourceSettings.cpp:
(WebCore::RealtimeMediaSourceSettings::convertFlagsToString):
(WebCore::RealtimeMediaSourceSettings::difference const):
* Source/WebCore/platform/mediastream/RealtimeMediaSourceSettings.h:
(WebCore::RealtimeMediaSourceSettings::allFlags):
(WebCore::RealtimeMediaSourceSettings::RealtimeMediaSourceSettings):
(WebCore::RealtimeMediaSourceSettings::supportsAspectRatio const):
(WebCore::RealtimeMediaSourceSettings::aspectRatio const): Deleted.
(WebCore::RealtimeMediaSourceSettings::setAspectRatio): Deleted.
* Source/WebCore/platform/mediastream/gstreamer/GStreamerVideoCaptureSource.cpp:
(WebCore::GStreamerVideoCaptureSource::settings):
* Source/WebCore/platform/mock/MockRealtimeVideoSource.cpp:
(WebCore::MockRealtimeVideoSource::settings):
* Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in:

Canonical link: <a href="https://commits.webkit.org/263778@main">https://commits.webkit.org/263778@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ce0e168edfac8e80092d883c2fcec228d466f8e9

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/5695 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/5852 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/6042 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/7247 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/6093 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/5697 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/6074 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/5824 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/7846 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/5801 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/5845 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/5111 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/7304 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/3322 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/5126 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/12880 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/5190 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/5203 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/7112 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/5643 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/4619 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/5091 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/1350 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/9205 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/5451 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->