### PR TITLE
RemoteDisplayListRecorder sends trivial transforms to GPUP

### DIFF
--- a/Source/WebCore/platform/graphics/displaylists/DisplayListRecorder.cpp
+++ b/Source/WebCore/platform/graphics/displaylists/DisplayListRecorder.cpp
@@ -36,6 +36,7 @@
 #include "Logging.h"
 #include "MediaPlayer.h"
 #include "NotImplemented.h"
+#include <numbers>
 #include <wtf/MathExtras.h>
 #include <wtf/text/TextStream.h>
 
@@ -300,18 +301,24 @@ void Recorder::restore()
 
 void Recorder::translate(float x, float y)
 {
+    if (!x && !y)
+        return;
     currentState().translate(x, y);
     recordTranslate(x, y);
 }
 
 void Recorder::rotate(float angleInRadians)
 {
+    if (WTF::areEssentiallyEqual(0.f, fmodf(angleInRadians, std::numbers::pi_v<float> * 2.f)))
+        return;
     currentState().rotate(angleInRadians);
     recordRotate(angleInRadians);
 }
 
 void Recorder::scale(const FloatSize& size)
 {
+    if (areEssentiallyEqual(size, FloatSize { 1.f, 1.f }))
+        return;
     currentState().scale(size);
     recordScale(size);
 }

--- a/Tools/TestWebKitAPI/Tests/WebCore/DisplayListRecorderTests.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebCore/DisplayListRecorderTests.cpp
@@ -32,8 +32,8 @@
 #include <WebCore/GraphicsContext.h>
 #include <WebCore/ImageBuffer.h>
 #include <WebCore/InMemoryDisplayList.h>
+#include <numbers>
 #include <wtf/StdLibExtras.h>
-
 #if PLATFORM(COCOA)
 #include <WebCore/GraphicsContextCG.h>
 #endif
@@ -369,10 +369,81 @@ struct ChangeAntialiasBeforeClipToImageBuffer {
     }
 };
 
+struct TrivialTranslate {
+    void operator()(WebCore::GraphicsContext& c)
+    {
+        c.translate(1, 0);
+        c.translate(0, 0);
+        c.translate(0, 2);
+        c.drawRect({ 0, 0, 1, 1 });
+    }
+
+    static String description()
+    {
+        return R"DL(
+(translate
+  (x 1.00)
+  (y 0.00))
+(translate
+  (x 0.00)
+  (y 2.00))
+(draw-rect
+  (rect at (0,0) size 1x1)
+  (border-thickness 1.00)))DL"_s;
+    }
+};
+struct TrivialScale {
+    void operator()(WebCore::GraphicsContext& c)
+    {
+        c.scale({ 1.1f, 1.2f });
+        c.scale({ 1.f, 1.f });
+        c.scale({ .1f, .7f });
+        c.drawRect({ 0, 0, 1, 1 });
+    }
+
+    static String description()
+    {
+        return R"DL(
+(scale
+  (size width=1.10 height=1.20))
+(scale
+  (size width=0.10 height=0.70))
+(draw-rect
+  (rect at (0,0) size 1x1)
+  (border-thickness 1.00)))DL"_s;
+    }
+};
+struct TrivialRotate {
+    void operator()(WebCore::GraphicsContext& c)
+    {
+        c.rotate(1.f);
+        c.rotate(0.f);
+        c.rotate(2.f);
+        c.rotate(std::numbers::pi_v<float> * 2.f);
+        c.rotate(7.f * std::numbers::pi_v<float> * 2.f);
+        c.rotate(-2.f * std::numbers::pi_v<float> * 2.f);
+        c.drawRect({ 0, 0, 1, 1 });
+    }
+
+    static String description()
+    {
+        return R"DL(
+(rotate
+  (angle 1.00))
+(rotate
+  (angle 2.00))
+(rotate
+  (angle 43.98))
+(draw-rect
+  (rect at (0,0) size 1x1)
+  (border-thickness 1.00)))DL"_s;
+    }
+};
+
 using AllOperations = testing::Types<NoCommands, ChangeAntialias, ChangeAntialiasBeforeSave,
     ChangeAntialiasBeforeAndAfterSave, ChangeAntialiasInEmptySaveRestore, DrawSystemImage, ChangeAntialiasBeforeClipRect,
     ChangeAntialiasBeforeClipOutRect, ChangeAntialiasBeforeClipOutPath, ChangeAntialiasBeforeClipPath,
-    ChangeAntialiasBeforeClipToImageBuffer>;
+    ChangeAntialiasBeforeClipToImageBuffer, TrivialTranslate, TrivialScale, TrivialRotate>;
 
 }
 


### PR DESCRIPTION
#### 0d267f7455a4b8f173a0151f7e39a8e651691e3f
<pre>
RemoteDisplayListRecorder sends trivial transforms to GPUP
<a href="https://bugs.webkit.org/show_bug.cgi?id=256362">https://bugs.webkit.org/show_bug.cgi?id=256362</a>
rdar://108945948

Reviewed by Simon Fraser and Said Abou-Hallawa.

Avoid sending trivial translates, scales, rotates.
Avoids small amount of CPU work.

* Source/WebCore/platform/graphics/displaylists/DisplayListRecorder.cpp:
(WebCore::DisplayList::Recorder::translate):
(WebCore::DisplayList::Recorder::rotate):
(WebKit::RemoteLayerBackingStore::drawInContext):
* Tools/TestWebKitAPI/Tests/WebCore/DisplayListRecorderTests.cpp:

Canonical link: <a href="https://commits.webkit.org/263796@main">https://commits.webkit.org/263796@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9dc50aeb39d36e8c0d894a79e663ade4ae543cec

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/5781 "29 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/5946 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/6134 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/7340 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/6173 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/5781 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/6168 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/5913 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/7955 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/5886 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/5934 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/5225 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/7394 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/3411 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/5208 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/13116 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/5279 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/5285 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/7459 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/5732 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/4704 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/5175 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/1366 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/9294 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/5536 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->