### PR TITLE
Update remote RTCDataChannel readyState initialisation

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/webrtc/RTCPeerConnection-ondatachannel-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/webrtc/RTCPeerConnection-ondatachannel-expected.txt
@@ -1,10 +1,10 @@
 
-FAIL Data channel event should fire when new data channel is announced to the remote peer assert_equals: Expect channel ready state to be open expected "open" but got "connecting"
-FAIL Should be able to send data in a datachannel event handler The object is in an invalid state.
+PASS Data channel event should fire when new data channel is announced to the remote peer
+PASS Should be able to send data in a datachannel event handler
 PASS Open event should not be raised when closing the channel in the datachannel event
 PASS Open event should be raised when closing the channel in the datachannel event after enqueuing a task
-FAIL Open event should not be raised when sending and immediately closing the channel in the datachannel event The object is in an invalid state.
-FAIL In-band negotiated channel created on remote peer should match the same configuration as local peer assert_equals: expected (object) null but got (number) 65535
-FAIL In-band negotiated channel created on remote peer should match the same (default) configuration as local peer assert_equals: expected (object) null but got (number) 65535
+PASS Open event should not be raised when sending and immediately closing the channel in the datachannel event
+PASS In-band negotiated channel created on remote peer should match the same configuration as local peer
+PASS In-band negotiated channel created on remote peer should match the same (default) configuration as local peer
 PASS Negotiated channel should not fire datachannel event on remote peer
 

--- a/LayoutTests/imported/w3c/web-platform-tests/webrtc/protocol/handover-datachannel-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/webrtc/protocol/handover-datachannel-expected.txt
@@ -1,3 +1,3 @@
 
-FAIL Handover with datachannel reinitiated from new callee completes promise_test: Unhandled rejection with value: object "InvalidStateError: The object is in an invalid state."
+PASS Handover with datachannel reinitiated from new callee completes
 

--- a/Source/WebCore/Modules/mediastream/PeerConnectionBackend.cpp
+++ b/Source/WebCore/Modules/mediastream/PeerConnectionBackend.cpp
@@ -568,8 +568,9 @@ void PeerConnectionBackend::newDataChannel(UniqueRef<RTCDataChannelHandler>&& ch
         if (connection->isClosed())
             return;
 
-        auto channel = RTCDataChannel::create(*connection->document(), channelHandler.moveToUniquePtr(), WTFMove(label), WTFMove(channelInit));
-        connection->dispatchEvent(RTCDataChannelEvent::create(eventNames().datachannelEvent, Event::CanBubble::No, Event::IsCancelable::No, WTFMove(channel)));
+        auto channel = RTCDataChannel::create(*connection->document(), channelHandler.moveToUniquePtr(), WTFMove(label), WTFMove(channelInit), RTCDataChannelState::Open);
+        connection->dispatchEvent(RTCDataChannelEvent::create(eventNames().datachannelEvent, Event::CanBubble::No, Event::IsCancelable::No, Ref { channel }));
+        channel->fireOpenEventIfNeeded();
     });
 }
 

--- a/Source/WebCore/Modules/mediastream/RTCDataChannel.cpp
+++ b/Source/WebCore/Modules/mediastream/RTCDataChannel.cpp
@@ -59,10 +59,10 @@ static const AtomString& arraybufferKeyword()
     return arraybuffer;
 }
 
-Ref<RTCDataChannel> RTCDataChannel::create(ScriptExecutionContext& context, std::unique_ptr<RTCDataChannelHandler>&& handler, String&& label, RTCDataChannelInit&& options)
+Ref<RTCDataChannel> RTCDataChannel::create(ScriptExecutionContext& context, std::unique_ptr<RTCDataChannelHandler>&& handler, String&& label, RTCDataChannelInit&& options, RTCDataChannelState state)
 {
     ASSERT(handler);
-    auto channel = adoptRef(*new RTCDataChannel(context, WTFMove(handler), WTFMove(label), WTFMove(options)));
+    auto channel = adoptRef(*new RTCDataChannel(context, WTFMove(handler), WTFMove(label), WTFMove(options), state));
     channel->suspendIfNeeded();
     queueTaskKeepingObjectAlive(channel.get(), TaskSource::Networking, [channel = channel.ptr()] {
         if (!channel->m_isDetachable)
@@ -93,11 +93,12 @@ NetworkSendQueue RTCDataChannel::createMessageQueue(ScriptExecutionContext& cont
     } };
 }
 
-RTCDataChannel::RTCDataChannel(ScriptExecutionContext& context, std::unique_ptr<RTCDataChannelHandler>&& handler, String&& label, RTCDataChannelInit&& options)
+RTCDataChannel::RTCDataChannel(ScriptExecutionContext& context, std::unique_ptr<RTCDataChannelHandler>&& handler, String&& label, RTCDataChannelInit&& options, RTCDataChannelState readyState)
     : ActiveDOMObject(&context)
     , m_handler(WTFMove(handler))
     , m_identifier(RTCDataChannelIdentifier { Process::identifier(), RTCDataChannelLocalIdentifier::generate() })
     , m_contextIdentifier(context.isDocument() ? ScriptExecutionContextIdentifier { } : context.identifier())
+    , m_readyState(readyState)
     , m_label(WTFMove(label))
     , m_options(WTFMove(options))
     , m_messageQueue(createMessageQueue(context, *this))
@@ -332,9 +333,14 @@ std::unique_ptr<RTCDataChannelHandler> RTCDataChannel::handlerFromIdentifier(RTC
 
 static Ref<RTCDataChannel> createClosedChannel(ScriptExecutionContext& context, String&& label, RTCDataChannelInit&& options)
 {
-    auto channel = RTCDataChannel::create(context, nullptr, WTFMove(label), WTFMove(options));
-    channel->close();
+    auto channel = RTCDataChannel::create(context, nullptr, WTFMove(label), WTFMove(options), RTCDataChannelState::Closed);
     return channel;
+}
+
+void RTCDataChannel::fireOpenEventIfNeeded()
+{
+    if (readyState() != RTCDataChannelState::Closing && readyState() != RTCDataChannelState::Closed)
+        dispatchEvent(Event::create(eventNames().openEvent, Event::CanBubble::No, Event::IsCancelable::No));
 }
 
 Ref<RTCDataChannel> RTCDataChannel::create(ScriptExecutionContext& context, RTCDataChannelIdentifier identifier, String&& label, RTCDataChannelInit&& options, RTCDataChannelState state)
@@ -352,11 +358,16 @@ Ref<RTCDataChannel> RTCDataChannel::create(ScriptExecutionContext& context, RTCD
     if (!handler)
         return createClosedChannel(context, WTFMove(label), WTFMove(options));
 
-    auto channel = RTCDataChannel::create(context, WTFMove(handler), WTFMove(label), WTFMove(options));
-    channel->m_readyState = state;
+    auto channel = RTCDataChannel::create(context, WTFMove(handler), WTFMove(label), WTFMove(options), state);
 
     if (remoteHandlerPtr)
         remoteHandlerPtr->setLocalIdentifier(channel->identifier());
+
+    if (state == RTCDataChannelState::Open) {
+        channel->queueTaskKeepingObjectAlive(channel.get(), TaskSource::Networking, [channel = channel.ptr()] {
+            channel->fireOpenEventIfNeeded();
+        });
+    }
 
     return channel;
 }

--- a/Source/WebCore/Modules/mediastream/RTCDataChannel.h
+++ b/Source/WebCore/Modules/mediastream/RTCDataChannel.h
@@ -53,7 +53,7 @@ class RTCPeerConnectionHandler;
 class RTCDataChannel final : public RefCounted<RTCDataChannel>, public ActiveDOMObject, public RTCDataChannelHandlerClient, public EventTarget {
     WTF_MAKE_ISO_ALLOCATED(RTCDataChannel);
 public:
-    static Ref<RTCDataChannel> create(ScriptExecutionContext&, std::unique_ptr<RTCDataChannelHandler>&&, String&&, RTCDataChannelInit&&);
+    static Ref<RTCDataChannel> create(ScriptExecutionContext&, std::unique_ptr<RTCDataChannelHandler>&&, String&&, RTCDataChannelInit&&, RTCDataChannelState);
     static Ref<RTCDataChannel> create(ScriptExecutionContext&, RTCDataChannelIdentifier, String&&, RTCDataChannelInit&&, RTCDataChannelState);
 
     bool ordered() const { return *m_options.ordered; }
@@ -89,9 +89,10 @@ public:
     using RefCounted<RTCDataChannel>::deref;
 
     WEBCORE_EXPORT static std::unique_ptr<RTCDataChannelHandler> handlerFromIdentifier(RTCDataChannelLocalIdentifier);
+    void fireOpenEventIfNeeded();
 
 private:
-    RTCDataChannel(ScriptExecutionContext&, std::unique_ptr<RTCDataChannelHandler>&&, String&&, RTCDataChannelInit&&);
+    RTCDataChannel(ScriptExecutionContext&, std::unique_ptr<RTCDataChannelHandler>&&, String&&, RTCDataChannelInit&&, RTCDataChannelState);
 
     static NetworkSendQueue createMessageQueue(ScriptExecutionContext&, RTCDataChannel&);
 

--- a/Source/WebCore/Modules/mediastream/RTCPeerConnection.cpp
+++ b/Source/WebCore/Modules/mediastream/RTCPeerConnection.cpp
@@ -564,7 +564,7 @@ ExceptionOr<Ref<RTCDataChannel>> RTCPeerConnection::createDataChannel(String&& l
     if (!channelHandler)
         return Exception { OperationError };
 
-    return RTCDataChannel::create(*document(), WTFMove(channelHandler), WTFMove(label), WTFMove(options));
+    return RTCDataChannel::create(*document(), WTFMove(channelHandler), WTFMove(label), WTFMove(options), RTCDataChannelState::Connecting);
 }
 
 bool RTCPeerConnection::doClose()

--- a/Source/WebCore/Modules/mediastream/libwebrtc/LibWebRTCDataChannelHandler.cpp
+++ b/Source/WebCore/Modules/mediastream/libwebrtc/LibWebRTCDataChannelHandler.cpp
@@ -73,8 +73,10 @@ RTCDataChannelInit LibWebRTCDataChannelHandler::dataChannelInit() const
 
     RTCDataChannelInit init;
     init.ordered = m_channel->ordered();
-    init.maxPacketLifeTime = m_channel->maxRetransmitTime();
-    init.maxRetransmits = m_channel->maxRetransmits();
+    if (auto maxPacketLifeTime = m_channel->maxPacketLifeTime())
+        init.maxPacketLifeTime = *maxPacketLifeTime;
+    if (auto maxRetransmitsOpt = m_channel->maxRetransmitsOpt())
+        init.maxRetransmits = *maxRetransmitsOpt;
     init.protocol = fromStdString(protocol);
     init.negotiated = m_channel->negotiated();
     init.id = m_channel->id();


### PR DESCRIPTION
#### 927935ae05e79398c2377e2903f2c636290d4e4b
<pre>
Update remote RTCDataChannel readyState initialisation
<a href="https://bugs.webkit.org/show_bug.cgi?id=256365">https://bugs.webkit.org/show_bug.cgi?id=256365</a>
rdar://problem/108946592

Reviewed by Eric Carlson.

readyState should be set to open just before firing the datachannel event, while still scheduling the open event.

Side fix to use the mreo recent libwebrtc API for better conformance of maxPacketLifeTime and maxRetransmitsOpt.
This makes the whole LayoutTests/imported/w3c/web-platform-tests/webrtc/RTCPeerConnection-ondatachannel.html file to pass.

* LayoutTests/imported/w3c/web-platform-tests/webrtc/RTCPeerConnection-ondatachannel-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/webrtc/protocol/handover-datachannel-expected.txt:
* Source/WebCore/Modules/mediastream/PeerConnectionBackend.cpp:
(WebCore::PeerConnectionBackend::newDataChannel):
* Source/WebCore/Modules/mediastream/RTCDataChannel.cpp:
(WebCore::RTCDataChannel::create):
(WebCore::RTCDataChannel::RTCDataChannel):
* Source/WebCore/Modules/mediastream/RTCDataChannel.h:
* Source/WebCore/Modules/mediastream/libwebrtc/LibWebRTCDataChannelHandler.cpp:
(WebCore::LibWebRTCDataChannelHandler::dataChannelInit const):

Canonical link: <a href="https://commits.webkit.org/263775@main">https://commits.webkit.org/263775@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0193ecb7d57f73c33f6229a10ba963ef217c2cb2

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/5698 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/5855 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/6045 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/7250 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/6094 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/5700 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/6077 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/5827 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/7847 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/5804 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/5848 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/5115 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/7300 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/3325 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/5129 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/12876 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/5193 "Passed tests") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/5206 "4 failures") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/7107 "run-api-tests-without-change (failure)") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/5646 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/4623 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/5094 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/1348 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/9208 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/5454 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->