### PR TITLE
Web Inspector: Regression (258503@main) Font feature property values shown in Font panel are always Normal

### DIFF
--- a/Source/WebInspectorUI/UserInterface/Views/FontDetailsPanel.js
+++ b/Source/WebInspectorUI/UserInterface/Views/FontDetailsPanel.js
@@ -303,7 +303,7 @@ WI.FontDetailsPanel = class FontDetailsPanel extends WI.StyleDetailsPanel
 
     _formatSimpleFeatureValues(property, features, noMatchesResult)
     {
-        let valueParts = property.value.match(WI.Font.SettingPattern);
+        let valueParts = property.value.match(WI.FontStyles.SettingPattern);
         let results = [];
         // Only one result should be pushed per group.
         let resultGroups = new Set;
@@ -322,7 +322,7 @@ WI.FontDetailsPanel = class FontDetailsPanel extends WI.StyleDetailsPanel
 
     _formatLigatureValue(property)
     {
-        let valueParts = property.value.match(WI.Font.SettingPattern);
+        let valueParts = property.value.match(WI.FontStyles.SettingPattern);
 
         let results = [];
 


### PR DESCRIPTION
#### 38b868bbbaa50a85247eab0ae0ea58723a803641
<pre>
Web Inspector: Regression (258503@main) Font feature property values shown in Font panel are always Normal
<a href="https://bugs.webkit.org/show_bug.cgi?id=256364">https://bugs.webkit.org/show_bug.cgi?id=256364</a>

Reviewed by Patrick Angle.

When relocating code from the `Font` model to the `FontStyles` model
in <a href="https://github.com/WebKit/WebKit/pull/8157">https://github.com/WebKit/WebKit/pull/8157</a>, we forgot to update
the path to the font styles regular expression pattern,
`WI.Font.SettingPattern` -&gt; `WI.FontStyles.SettingPattern`,
used to match the parts of `font-variant-*` CSS property values.

In absence of a match, the fallback UI string was used,
which is `Normal` for most font feature property values.

* Source/WebInspectorUI/UserInterface/Views/FontDetailsPanel.js:
(WI.FontDetailsPanel.prototype._formatSimpleFeatureValues):
(WI.FontDetailsPanel.prototype._formatLigatureValue):

Canonical link: <a href="https://commits.webkit.org/263814@main">https://commits.webkit.org/263814@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a57a83f75de527bd7fa72193d0da84cb1f0637fd

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/5563 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/5714 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/5902 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/7113 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/5566 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/5939 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/5688 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/7126 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/5666 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/5723 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/4981 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/7150 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/3201 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/5001 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/12122 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/5067 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/5080 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/6867 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/5518 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/4512 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/4971 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/1377 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/9076 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/5333 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->