### PR TITLE
[GStreamer][WebRTC] Outgoing video with odd dimensions refused by encoder

### DIFF
--- a/Source/WebCore/platform/graphics/gstreamer/VideoFrameGStreamer.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/VideoFrameGStreamer.cpp
@@ -501,7 +501,7 @@ uint32_t VideoFrameGStreamer::pixelFormat() const
     return m_cachedVideoFormat;
 }
 
-RefPtr<VideoFrameGStreamer> VideoFrameGStreamer::resizeTo(const IntSize& destinationSize)
+GRefPtr<GstSample> VideoFrameGStreamer::resizedSample(const IntSize& destinationSize)
 {
     auto* caps = gst_sample_get_caps(m_sample.get());
 
@@ -536,8 +536,13 @@ RefPtr<VideoFrameGStreamer> VideoFrameGStreamer::resizeTo(const IntSize& destina
 
     auto presentationTime = this->presentationTime();
     setBufferFields(outputBuffer.get(), presentationTime, frameRate);
-    auto sample = adoptGRef(gst_sample_new(outputBuffer.get(), outputCaps.get(), nullptr, nullptr));
-    return VideoFrameGStreamer::create(WTFMove(sample), destinationSize, presentationTime, rotation(), isMirrored());
+    return adoptGRef(gst_sample_new(outputBuffer.get(), outputCaps.get(), nullptr, nullptr));
+}
+
+RefPtr<VideoFrameGStreamer> VideoFrameGStreamer::resizeTo(const IntSize& destinationSize)
+{
+    auto presentationTime = this->presentationTime();
+    return VideoFrameGStreamer::create(resizedSample(destinationSize), destinationSize, presentationTime, rotation(), isMirrored());
 }
 
 RefPtr<ImageGStreamer> VideoFrameGStreamer::convertToImage()

--- a/Source/WebCore/platform/graphics/gstreamer/VideoFrameGStreamer.h
+++ b/Source/WebCore/platform/graphics/gstreamer/VideoFrameGStreamer.h
@@ -50,6 +50,8 @@ public:
 
     RefPtr<VideoFrameGStreamer> resizeTo(const IntSize&);
 
+    GRefPtr<GstSample> resizedSample(const IntSize&);
+
     GstSample* sample() const { return m_sample.get(); }
 
     RefPtr<ImageGStreamer> convertToImage();

--- a/Source/WebCore/platform/mediastream/gstreamer/GStreamerMediaStreamSource.h
+++ b/Source/WebCore/platform/mediastream/gstreamer/GStreamerMediaStreamSource.h
@@ -52,7 +52,7 @@ struct _WebKitMediaStreamSrcClass {
 
 GstElement* webkitMediaStreamSrcNew();
 void webkitMediaStreamSrcSetStream(WebKitMediaStreamSrc*, WebCore::MediaStreamPrivate*, bool isVideoPlayer);
-void webkitMediaStreamSrcAddTrack(WebKitMediaStreamSrc*, WebCore::MediaStreamTrackPrivate*, bool onlyTrack);
+void webkitMediaStreamSrcAddTrack(WebKitMediaStreamSrc*, WebCore::MediaStreamTrackPrivate*, bool onlyTrack, bool consumerIsVideoPlayer = false);
 void webkitMediaStreamSrcConfigureAudioTracks(WebKitMediaStreamSrc*, float volume, bool isMuted, bool isPlaying);
 void webkitMediaStreamSrcSignalEndOfStream(WebKitMediaStreamSrc*);
 


### PR DESCRIPTION
#### 03ed22e40854af5ac798de592c22f7e7c22706ab
<pre>
[GStreamer][WebRTC] Outgoing video with odd dimensions refused by encoder
<a href="https://bugs.webkit.org/show_bug.cgi?id=256368">https://bugs.webkit.org/show_bug.cgi?id=256368</a>

Reviewed by Xabier Rodriguez-Calvar.

Video encoders require a multiple of two frame size. At least x264enc does anyway. This can&apos;t easily
be applied in our encoder wrapper, so we do it in the MediaStream source instead.

* Source/WebCore/platform/graphics/gstreamer/VideoFrameGStreamer.cpp:
(WebCore::VideoFrameGStreamer::resizedSample):
(WebCore::VideoFrameGStreamer::resizeTo):
* Source/WebCore/platform/graphics/gstreamer/VideoFrameGStreamer.h:
* Source/WebCore/platform/mediastream/gstreamer/GStreamerMediaStreamSource.cpp:

Canonical link: <a href="https://commits.webkit.org/263797@main">https://commits.webkit.org/263797@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/767ebe0456dc5472f3c13dd70f85d760377219dd

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/5585 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/5738 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/5926 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/7137 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/5584 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/5585 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/5963 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/5711 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/7291 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/5688 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/5748 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/5006 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/7176 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/3226 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/5025 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/12141 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/5092 "Passed tests") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/5104 "3 failures") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/6900 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/5540 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/4533 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/4993 "Built successfully") | | | 
| [❌ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/1360 "Failed to push commit to Webkit repository") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/9098 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/5354 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->