### PR TITLE
Add value argument to URLSearchParams's has() and delete()

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/url/a-element-origin-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/url/a-element-origin-expected.txt
@@ -227,6 +227,7 @@ PASS Parsing origin: <#> against <test:test>
 PASS Parsing origin: <#x> against <mailto:x@x.com>
 PASS Parsing origin: <#x> against <data:,>
 PASS Parsing origin: <#x> against <about:blank>
+PASS Parsing origin: <#x:y> against <about:blank>
 PASS Parsing origin: <#> against <test:test?test>
 PASS Parsing origin: <https://@test@test@example:800/> against <http://doesnotmatter/>
 PASS Parsing origin: <https://@@@example> against <http://doesnotmatter/>

--- a/LayoutTests/imported/w3c/web-platform-tests/url/a-element-origin-xhtml-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/url/a-element-origin-xhtml-expected.txt
@@ -227,6 +227,7 @@ PASS Parsing origin: <#> against <test:test>
 PASS Parsing origin: <#x> against <mailto:x@x.com>
 PASS Parsing origin: <#x> against <data:,>
 PASS Parsing origin: <#x> against <about:blank>
+PASS Parsing origin: <#x:y> against <about:blank>
 PASS Parsing origin: <#> against <test:test?test>
 PASS Parsing origin: <https://@test@test@example:800/> against <http://doesnotmatter/>
 PASS Parsing origin: <https://@@@example> against <http://doesnotmatter/>

--- a/LayoutTests/imported/w3c/web-platform-tests/url/a-element-xhtml_exclude=(file_javascript_mailto)-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/url/a-element-xhtml_exclude=(file_javascript_mailto)-expected.txt
@@ -281,6 +281,7 @@ PASS Parsing: <http://foo:💩@example.com/bar> against <http://other.com/>
 PASS Parsing: <#> against <test:test>
 FAIL Parsing: <#x> against <data:,> assert_equals: href expected "data:,#x" but got "test:test#x"
 PASS Parsing: <#x> against <about:blank>
+PASS Parsing: <#x:y> against <about:blank>
 PASS Parsing: <#> against <test:test?test>
 PASS Parsing: <https://@test@test@example:800/> against <http://doesnotmatter/>
 PASS Parsing: <https://@@@example> against <http://doesnotmatter/>

--- a/LayoutTests/imported/w3c/web-platform-tests/url/a-element_exclude=(file_javascript_mailto)-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/url/a-element_exclude=(file_javascript_mailto)-expected.txt
@@ -281,6 +281,7 @@ PASS Parsing: <http://foo:💩@example.com/bar> against <http://other.com/>
 PASS Parsing: <#> against <test:test>
 FAIL Parsing: <#x> against <data:,> assert_equals: href expected "data:,#x" but got "test:test#x"
 PASS Parsing: <#x> against <about:blank>
+PASS Parsing: <#x:y> against <about:blank>
 PASS Parsing: <#> against <test:test?test>
 PASS Parsing: <https://@test@test@example:800/> against <http://doesnotmatter/>
 PASS Parsing: <https://@@@example> against <http://doesnotmatter/>

--- a/LayoutTests/imported/w3c/web-platform-tests/url/resources/urltestdata.json
+++ b/LayoutTests/imported/w3c/web-platform-tests/url/resources/urltestdata.json
@@ -4067,6 +4067,21 @@
     "hash": "#x"
   },
   {
+    "input": "#x:y",
+    "base": "about:blank",
+    "href": "about:blank#x:y",
+    "origin": "null",
+    "protocol": "about:",
+    "username": "",
+    "password": "",
+    "host": "",
+    "hostname": "",
+    "port": "",
+    "pathname": "blank",
+    "search": "",
+    "hash": "#x:y"
+  },
+  {
     "input": "#",
     "base": "test:test?test",
     "href": "test:test?test#",

--- a/LayoutTests/imported/w3c/web-platform-tests/url/url-constructor.any.worker_exclude=(file_javascript_mailto)-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/url/url-constructor.any.worker_exclude=(file_javascript_mailto)-expected.txt
@@ -280,6 +280,7 @@ PASS Parsing: <http://foo:💩@example.com/bar> against <http://other.com/>
 PASS Parsing: <#> against <test:test>
 PASS Parsing: <#x> against <data:,>
 PASS Parsing: <#x> against <about:blank>
+PASS Parsing: <#x:y> against <about:blank>
 PASS Parsing: <#> against <test:test?test>
 PASS Parsing: <https://@test@test@example:800/> against <http://doesnotmatter/>
 PASS Parsing: <https://@@@example> against <http://doesnotmatter/>

--- a/LayoutTests/imported/w3c/web-platform-tests/url/url-constructor.any_exclude=(file_javascript_mailto)-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/url/url-constructor.any_exclude=(file_javascript_mailto)-expected.txt
@@ -280,6 +280,7 @@ PASS Parsing: <http://foo:💩@example.com/bar> against <http://other.com/>
 PASS Parsing: <#> against <test:test>
 PASS Parsing: <#x> against <data:,>
 PASS Parsing: <#x> against <about:blank>
+PASS Parsing: <#x:y> against <about:blank>
 PASS Parsing: <#> against <test:test?test>
 PASS Parsing: <https://@test@test@example:800/> against <http://doesnotmatter/>
 PASS Parsing: <https://@@@example> against <http://doesnotmatter/>

--- a/LayoutTests/imported/w3c/web-platform-tests/url/url-origin.any-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/url/url-origin.any-expected.txt
@@ -226,6 +226,7 @@ PASS Origin parsing: <#> against <test:test>
 PASS Origin parsing: <#x> against <mailto:x@x.com>
 PASS Origin parsing: <#x> against <data:,>
 PASS Origin parsing: <#x> against <about:blank>
+PASS Origin parsing: <#x:y> against <about:blank>
 PASS Origin parsing: <#> against <test:test?test>
 PASS Origin parsing: <https://@test@test@example:800/> against <http://doesnotmatter/>
 PASS Origin parsing: <https://@@@example> against <http://doesnotmatter/>

--- a/LayoutTests/imported/w3c/web-platform-tests/url/url-origin.any.worker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/url/url-origin.any.worker-expected.txt
@@ -226,6 +226,7 @@ PASS Origin parsing: <#> against <test:test>
 PASS Origin parsing: <#x> against <mailto:x@x.com>
 PASS Origin parsing: <#x> against <data:,>
 PASS Origin parsing: <#x> against <about:blank>
+PASS Origin parsing: <#x:y> against <about:blank>
 PASS Origin parsing: <#> against <test:test?test>
 PASS Origin parsing: <https://@test@test@example:800/> against <http://doesnotmatter/>
 PASS Origin parsing: <https://@@@example> against <http://doesnotmatter/>

--- a/LayoutTests/imported/w3c/web-platform-tests/url/urlsearchparams-delete.any-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/url/urlsearchparams-delete.any-expected.txt
@@ -5,4 +5,5 @@ PASS Deleting all params removes ? from URL
 PASS Removing non-existent param removes ? from URL
 PASS Changing the query of a URL with an opaque path can impact the path
 PASS Changing the query of a URL with an opaque path can impact the path if the URL has no fragment
+PASS Two-argument delete()
 

--- a/LayoutTests/imported/w3c/web-platform-tests/url/urlsearchparams-delete.any.js
+++ b/LayoutTests/imported/w3c/web-platform-tests/url/urlsearchparams-delete.any.js
@@ -61,3 +61,12 @@ test(() => {
   assert_equals(url.pathname, 'space    ');
   assert_equals(url.href, 'data:space    #test');
 }, 'Changing the query of a URL with an opaque path can impact the path if the URL has no fragment');
+
+test(() => {
+  const params = new URLSearchParams();
+  params.append('a', 'b');
+  params.append('a', 'c');
+  params.append('a', 'd');
+  params.delete('a', 'c');
+  assert_equals(params.toString(), 'a=b&a=d');
+}, "Two-argument delete()");

--- a/LayoutTests/imported/w3c/web-platform-tests/url/urlsearchparams-delete.any.worker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/url/urlsearchparams-delete.any.worker-expected.txt
@@ -5,4 +5,5 @@ PASS Deleting all params removes ? from URL
 PASS Removing non-existent param removes ? from URL
 PASS Changing the query of a URL with an opaque path can impact the path
 PASS Changing the query of a URL with an opaque path can impact the path if the URL has no fragment
+PASS Two-argument delete()
 

--- a/LayoutTests/imported/w3c/web-platform-tests/url/urlsearchparams-has.any-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/url/urlsearchparams-has.any-expected.txt
@@ -1,4 +1,5 @@
 
 PASS Has basics
 PASS has() following delete()
+PASS Two-argument has()
 

--- a/LayoutTests/imported/w3c/web-platform-tests/url/urlsearchparams-has.any.js
+++ b/LayoutTests/imported/w3c/web-platform-tests/url/urlsearchparams-has.any.js
@@ -22,3 +22,16 @@ test(function() {
     params.delete('first');
     assert_false(params.has('first'), 'Search params object has no name "first"');
 }, 'has() following delete()');
+
+test(() => {
+  const params = new URLSearchParams("a=b&a=d&c&e&");
+  assert_true(params.has('a', 'b'));
+  assert_false(params.has('a', 'c'));
+  assert_true(params.has('a', 'd'));
+  assert_true(params.has('e', ''));
+  params.append('first', null);
+  assert_false(params.has('first', ''));
+  assert_true(params.has('first', 'null'));
+  params.delete('a', 'b');
+  assert_true(params.has('a', 'd'));
+}, "Two-argument has()");

--- a/LayoutTests/imported/w3c/web-platform-tests/url/urlsearchparams-has.any.worker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/url/urlsearchparams-has.any.worker-expected.txt
@@ -1,4 +1,5 @@
 
 PASS Has basics
 PASS has() following delete()
+PASS Two-argument has()
 

--- a/Source/WebCore/html/URLSearchParams.cpp
+++ b/Source/WebCore/html/URLSearchParams.cpp
@@ -68,10 +68,10 @@ String URLSearchParams::get(const String& name) const
     return String();
 }
 
-bool URLSearchParams::has(const String& name) const
+bool URLSearchParams::has(const String& name, const String& value) const
 {
     for (const auto& pair : m_pairs) {
-        if (pair.key == name)
+        if (pair.key == name && (value.isNull() || pair.value == value))
             return true;
     }
     return false;
@@ -126,10 +126,10 @@ Vector<String> URLSearchParams::getAll(const String& name) const
     return values;
 }
 
-void URLSearchParams::remove(const String& name)
+void URLSearchParams::remove(const String& name, const String& value)
 {
     m_pairs.removeAllMatching([&] (const auto& pair) {
-        return pair.key == name;
+        return pair.key == name && (value.isNull() || pair.value == value);
     });
     updateURL();
 }

--- a/Source/WebCore/html/URLSearchParams.h
+++ b/Source/WebCore/html/URLSearchParams.h
@@ -47,10 +47,10 @@ public:
     size_t size() const { return m_pairs.size(); }
 
     void append(const String& name, const String& value);
-    void remove(const String& name);
+    void remove(const String& name, const String& value = { });
     String get(const String& name) const;
     Vector<String> getAll(const String& name) const;
-    bool has(const String& name) const;
+    bool has(const String& name, const String& value = { }) const;
     void set(const String& name, const String& value);
     String toString() const;
     void updateFromAssociatedURL();

--- a/Source/WebCore/html/URLSearchParams.idl
+++ b/Source/WebCore/html/URLSearchParams.idl
@@ -31,10 +31,10 @@
     readonly attribute unsigned long size;
 
     undefined append(USVString name, USVString value);
-    [ImplementedAs=remove] undefined delete(USVString name);
+    [ImplementedAs=remove] undefined delete(USVString name, optional USVString value);
     USVString? get(USVString name);
     sequence<USVString> getAll(USVString name);
-    boolean has(USVString name);
+    boolean has(USVString name, optional USVString value);
     undefined set(USVString name, USVString value);
 
     undefined sort();


### PR DESCRIPTION
#### 93a5678f2d4f370aa8f957928f96fbb501e9e168
<pre>
Add value argument to URLSearchParams&apos;s has() and delete()
<a href="https://bugs.webkit.org/show_bug.cgi?id=256369">https://bugs.webkit.org/show_bug.cgi?id=256369</a>
rdar://108949109

Reviewed by Chris Dumez.

Aligns WebKit with a recent URLSearchParams change.

Also syncs WPT url/ and new tests are upstreamed via <a href="https://github.com/web-platform-tests/wpt/pull/39865.">https://github.com/web-platform-tests/wpt/pull/39865.</a>

* LayoutTests/imported/w3c/web-platform-tests/url/a-element-origin-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/url/a-element-origin-xhtml-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/url/a-element-xhtml_exclude=(file_javascript_mailto)-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/url/a-element_exclude=(file_javascript_mailto)-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/url/resources/urltestdata.json:
* LayoutTests/imported/w3c/web-platform-tests/url/url-constructor.any.worker_exclude=(file_javascript_mailto)-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/url/url-constructor.any_exclude=(file_javascript_mailto)-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/url/url-origin.any-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/url/url-origin.any.worker-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/url/urlsearchparams-delete.any-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/url/urlsearchparams-delete.any.js:
(test):
* LayoutTests/imported/w3c/web-platform-tests/url/urlsearchparams-delete.any.worker-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/url/urlsearchparams-has.any-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/url/urlsearchparams-has.any.js:
(test):
* LayoutTests/imported/w3c/web-platform-tests/url/urlsearchparams-has.any.worker-expected.txt:
* Source/WebCore/html/URLSearchParams.cpp:
(WebCore::URLSearchParams::has const):
(WebCore::URLSearchParams::remove):
* Source/WebCore/html/URLSearchParams.h:
(WebCore::URLSearchParams::remove):
(WebCore::URLSearchParams::has const):
* Source/WebCore/html/URLSearchParams.idl:

Canonical link: <a href="https://commits.webkit.org/263726@main">https://commits.webkit.org/263726@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4eef375a8c9f5005d29be0db81c10641e823cfb4

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/5582 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/5735 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/5923 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/7134 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/5581 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/5582 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/5960 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/5708 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/7271 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/5685 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/5746 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/5001 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/7172 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/3224 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/5020 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/12145 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/5090 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/5099 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/6908 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/5537 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/4532 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/4990 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/1322 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/9095 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/5351 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->