### PR TITLE
[GStreamer][WebCodecs] Video decoder flush should not clear caps and sticky events

### DIFF
--- a/LayoutTests/platform/glib/TestExpectations
+++ b/LayoutTests/platform/glib/TestExpectations
@@ -1131,17 +1131,9 @@ media/media-hevc-video-as-img.html [ ImageOnlyFailure ]
 
 imported/w3c/web-platform-tests/webcodecs/videoFrame-createImageBitmap.any.worker.html [ Pass ]
 
-# Expected to pass when updating to GStreamer 1.22, but still failing. Investigation pending.
+# Likely bugs related with dav1ddec.
 imported/w3c/web-platform-tests/webcodecs/videoDecoder-codec-specific.https.any.html?av1 [ Failure ]
-imported/w3c/web-platform-tests/webcodecs/videoDecoder-codec-specific.https.any.html?h264_annexb [ Failure ]
-imported/w3c/web-platform-tests/webcodecs/videoDecoder-codec-specific.https.any.html?h264_avc [ Failure ]
-imported/w3c/web-platform-tests/webcodecs/videoDecoder-codec-specific.https.any.html?vp8 [ Failure ]
-imported/w3c/web-platform-tests/webcodecs/videoDecoder-codec-specific.https.any.html?vp9 [ Failure ]
 imported/w3c/web-platform-tests/webcodecs/videoDecoder-codec-specific.https.any.worker.html?av1 [ Failure ]
-imported/w3c/web-platform-tests/webcodecs/videoDecoder-codec-specific.https.any.worker.html?h264_annexb [ Failure ]
-imported/w3c/web-platform-tests/webcodecs/videoDecoder-codec-specific.https.any.worker.html?h264_avc [ Failure ]
-imported/w3c/web-platform-tests/webcodecs/videoDecoder-codec-specific.https.any.worker.html?vp8 [ Failure ]
-imported/w3c/web-platform-tests/webcodecs/videoDecoder-codec-specific.https.any.worker.html?vp9 [ Failure ]
 
 #////////////////////////////////////////////////////////////////////////////////////////
 # End of GStreamer-related bugs

--- a/Source/WebCore/platform/graphics/gstreamer/VideoDecoderGStreamer.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/VideoDecoderGStreamer.cpp
@@ -227,7 +227,7 @@ void GStreamerInternalVideoDecoder::flush(Function<void()>&& callback)
         return;
     }
 
-    m_harness->flush();
+    m_harness->flushBuffers();
     m_postTaskCallback(WTFMove(callback));
 }
 

--- a/Source/WebCore/platform/gstreamer/GStreamerElementHarness.cpp
+++ b/Source/WebCore/platform/gstreamer/GStreamerElementHarness.cpp
@@ -385,9 +385,20 @@ void GStreamerElementHarness::flush()
 {
     GST_DEBUG_OBJECT(element(), "Flushing");
 
+    if (!flushBuffers())
+        return;
+
+    m_inputCaps.clear();
+    m_stickyEventsSent.store(false);
+    GST_DEBUG_OBJECT(element(), "Flushing done, input caps and sticky events cleared");
+}
+
+bool GStreamerElementHarness::flushBuffers()
+{
+    GST_DEBUG_OBJECT(element(), "Flushing buffers");
     if (element()->current_state <= GST_STATE_PAUSED) {
         GST_DEBUG_OBJECT(element(), "No need to flush in paused state");
-        return;
+        return false;
     }
 
     processOutputBuffers();
@@ -403,9 +414,8 @@ void GStreamerElementHarness::flush()
         }
     }
 
-    m_inputCaps.clear();
-    m_stickyEventsSent.store(false);
-    GST_DEBUG_OBJECT(element(), "Flushing done");
+    GST_DEBUG_OBJECT(element(), "Buffers flushed");
+    return true;
 }
 
 #ifndef GST_DISABLE_GST_DEBUG

--- a/Source/WebCore/platform/gstreamer/GStreamerElementHarness.h
+++ b/Source/WebCore/platform/gstreamer/GStreamerElementHarness.h
@@ -100,6 +100,7 @@ public:
 
     void processOutputBuffers();
     void flush();
+    bool flushBuffers();
 
     void dumpGraph(const char* filenamePrefix);
 


### PR DESCRIPTION
#### fff29015f30320e2451013f6bbb3563caedc2f82
<pre>
[GStreamer][WebCodecs] Video decoder flush should not clear caps and sticky events
<a href="https://bugs.webkit.org/show_bug.cgi?id=256376">https://bugs.webkit.org/show_bug.cgi?id=256376</a>

Reviewed by Xabier Rodriguez-Calvar.

The element harness now has API to flush only buffers, eg force processing of the currently queued
output buffers, without clearing input caps and sticky events. The decoder uses that API, there&apos;s no
need to explicitly re-push new caps or sticky events because the input format is not expected to
change across flushes.

* LayoutTests/platform/glib/TestExpectations:
* Source/WebCore/platform/graphics/gstreamer/VideoDecoderGStreamer.cpp:
(WebCore::GStreamerInternalVideoDecoder::flush):
* Source/WebCore/platform/gstreamer/GStreamerElementHarness.cpp:
(WebCore::GStreamerElementHarness::flush):
(WebCore::GStreamerElementHarness::flushBuffers):
* Source/WebCore/platform/gstreamer/GStreamerElementHarness.h:

Canonical link: <a href="https://commits.webkit.org/263792@main">https://commits.webkit.org/263792@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5bcf2651a8b0892d003ea7f20b39a5dd75c4dd89

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/5583 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/5736 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/5924 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/7135 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/5582 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/5583 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/5961 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/5709 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/7274 "2 flakes 104 failures") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/5686 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/5747 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/5002 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/7173 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/3225 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/5021 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/12139 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/5091 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/5100 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/6902 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/5538 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/4530 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/4991 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/1359 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/9096 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/5352 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->