### PR TITLE
[popover] Prevent hidePopover from causing a recursive loop

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/popovers/popover-light-dismiss-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/popovers/popover-light-dismiss-expected.txt
@@ -1,4 +1,4 @@
-Popover 1 Popover 1 Popover1 anchor (no action) Outside all popovers  Next control after popover1  Popover 3 - button 3 Popover 6  Popover8 anchor (no action)  Open convoluted popover Popover 1
+Popover 1 Popover 1 Popover1 anchor (no action) Outside all popovers  Next control after popover1  Popover 3 - button 3 Popover 6  Popover8 anchor (no action)  Open convoluted popover  Example 2
 
 PASS Clicking outside a popover will dismiss the popover
 PASS Canceling pointer events should not keep clicks from light dismissing popovers
@@ -24,4 +24,6 @@ PASS Moving focus back to the anchor element should not dismiss the popover
 PASS Ensure circular/convoluted ancestral relationships are functional
 PASS Ensure circular/convoluted ancestral relationships are functional, with a direct showPopover()
 PASS Hide the target popover during "hide all popovers until"
+PASS Show a sibling popover during "hide all popovers until"
+PASS Show an unrelated popover during "hide popover"
 

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/popovers/popover-light-dismiss.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/popovers/popover-light-dismiss.html
@@ -13,7 +13,7 @@
 
 <button id=b1t popovertarget='p1'>Popover 1</button>
 <button id=b1s popovertarget='p1' popovertargetaction=show>Popover 1</button>
-<button id=p1anchor tabindex="0">Popover1 anchor (no action)</button>
+<button id=p1anchor  tabindex="0">Popover1 anchor (no action)</button>
 <span id=outside>Outside all popovers</span>
 <div popover id=p1 anchor=p1anchor>
   <span id=inside1>Inside popover 1</span>
@@ -265,12 +265,12 @@
   },'Dragging from an open popover outside an open popover should leave the popover open');
 </script>
 
-<button id=b3 popovertarget=p3>Popover 3 - button 3
+<button id=b3 popovertarget=p3 tabindex="0">Popover 3 - button 3
   <div popover id=p4>Inside popover 4</div>
 </button>
 <div popover id=p3>Inside popover 3</div>
 <div popover id=p5>Inside popover 5
-  <button popovertarget=p3>Popover 3 - button 4 - unused</button>
+  <button popovertarget=p3 tabindex="0">Popover 3 - button 4 - unused</button>
 </div>
 <style>
   #p3 {top:100px;}
@@ -380,7 +380,7 @@
     await sendTab();
     assert_equals(document.activeElement,popover8Anchor,'Focus should move to the anchor element');
     assert_true(popover8.matches(':popover-open'),'popover should stay open');
-    popover8.hidePopover();
+    popover8.hidePopover(); // Cleanup
   },'Moving focus back to the anchor element should not dismiss the popover');
 </script>
 
@@ -534,5 +534,53 @@ promise_test(async () => {
   assert_true(p13.matches(':popover-open'),'p13 should still be open');
   assert_false(p14.matches(':popover-open'));
   assert_false(p15.matches(':popover-open'));
+  p13.hidePopover(); // Cleanup
 },'Hide the target popover during "hide all popovers until"');
+</script>
+
+<div id=p16 popover>Popover 16
+    <div id=p17 popover>Popover 17</div>
+    <div id=p18 popover>Popover 18</div>
+</div>
+
+<script>
+promise_test(async () => {
+  p16.showPopover();
+  p18.showPopover();
+  let events = [];
+  const logEvents = (e) => {events.push(`${e.newState==='open' ? 'show' : 'hide'} ${e.target.id}`)};
+  p16.addEventListener('beforetoggle', logEvents);
+  p17.addEventListener('beforetoggle', logEvents);
+  p18.addEventListener('beforetoggle', (e) => {
+    logEvents(e);
+    p17.showPopover();
+  });
+  p16.hidePopover();
+  assert_array_equals(events,['hide p18','show p17','hide p16'],'There should not be a hide event for p17');
+  assert_false(p16.matches(':popover-open'));
+  assert_false(p17.matches(':popover-open'));
+  assert_false(p18.matches(':popover-open'));
+},'Show a sibling popover during "hide all popovers until"');
+</script>
+
+<div id=p19 popover>Popover 19</div>
+<div id=p20 popover>Popover 20</div>
+<button id=example2 tabindex="0">Example 2</button>
+
+<script>
+promise_test(async () => {
+  p19.showPopover();
+  let events = [];
+  const logEvents = (e) => {events.push(`${e.newState==='open' ? 'show' : 'hide'} ${e.target.id}`)};
+  p19.addEventListener('beforetoggle', (e) => {
+    logEvents(e);
+    p20.showPopover();
+  });
+  p20.addEventListener('beforetoggle', logEvents);
+  p19.hidePopover();
+  assert_array_equals(events,['hide p19','show p20'],'There should not be a second hide event for 19');
+  assert_false(p19.matches(':popover-open'));
+  assert_true(p20.matches(':popover-open'));
+  p20.hidePopover(); // Cleanup
+},'Show an unrelated popover during "hide popover"');
 </script>

--- a/LayoutTests/platform/glib/imported/w3c/web-platform-tests/html/semantics/popovers/popover-light-dismiss-expected.txt
+++ b/LayoutTests/platform/glib/imported/w3c/web-platform-tests/html/semantics/popovers/popover-light-dismiss-expected.txt
@@ -1,4 +1,4 @@
-Popover 1 Popover 1 Popover1 anchor (no action) Outside all popovers  Next control after popover1 Popover 3 - button 3   Popover 6  Popover8 anchor (no action)  Open convoluted popover Popover 1
+Popover 1 Popover 1 Popover1 anchor (no action) Outside all popovers  Next control after popover1 Popover 3 - button 3   Popover 6  Popover8 anchor (no action)  Open convoluted popover Example 2
 
 PASS Clicking outside a popover will dismiss the popover
 PASS Canceling pointer events should not keep clicks from light dismissing popovers
@@ -24,4 +24,6 @@ PASS Moving focus back to the anchor element should not dismiss the popover
 PASS Ensure circular/convoluted ancestral relationships are functional
 PASS Ensure circular/convoluted ancestral relationships are functional, with a direct showPopover()
 PASS Hide the target popover during "hide all popovers until"
+PASS Show a sibling popover during "hide all popovers until"
+PASS Show an unrelated popover during "hide popover"
 

--- a/LayoutTests/platform/ios/imported/w3c/web-platform-tests/html/semantics/popovers/popover-light-dismiss-expected.txt
+++ b/LayoutTests/platform/ios/imported/w3c/web-platform-tests/html/semantics/popovers/popover-light-dismiss-expected.txt
@@ -1,4 +1,4 @@
-Popover 1 Popover 1 Popover1 anchor (no action) Outside all popovers  Next control after popover1  Popover 3 - button 3 Popover 6  Popover8 anchor (no action)  Open convoluted popover Popover 1
+Popover 1 Popover 1 Popover1 anchor (no action) Outside all popovers  Next control after popover1  Popover 3 - button 3 Popover 6  Popover8 anchor (no action)  Open convoluted popover  Example 2
 
 FAIL Clicking outside a popover will dismiss the popover assert_false: expected false got true
 FAIL Canceling pointer events should not keep clicks from light dismissing popovers assert_false: expected false got true
@@ -24,4 +24,6 @@ FAIL Moving focus back to the anchor element should not dismiss the popover asse
 PASS Ensure circular/convoluted ancestral relationships are functional
 PASS Ensure circular/convoluted ancestral relationships are functional, with a direct showPopover()
 PASS Hide the target popover during "hide all popovers until"
+PASS Show a sibling popover during "hide all popovers until"
+PASS Show an unrelated popover during "hide popover"
 

--- a/Source/WebCore/dom/PopoverData.h
+++ b/Source/WebCore/dom/PopoverData.h
@@ -62,12 +62,33 @@ public:
     HTMLFormControlElement* invoker() const { return m_invoker.get(); }
     void setInvoker(const HTMLFormControlElement* element) { m_invoker = element; }
 
+    class ScopedStartShowingOrHiding {
+    public:
+    explicit ScopedStartShowingOrHiding(Element& popover)
+        : m_popover(popover)
+        , m_wasSet(popover.popoverData()->m_isHidingOrShowingPopover)
+    {
+        m_popover->popoverData()->m_isHidingOrShowingPopover = true;
+    }
+    ~ScopedStartShowingOrHiding()
+    {
+        if (!m_wasSet && m_popover->popoverData())
+            m_popover->popoverData()->m_isHidingOrShowingPopover = false;
+    }
+    bool wasShowingOrHiding() const { return m_wasSet; }
+
+    private:
+        const Ref<Element> m_popover;
+        bool m_wasSet;
+    };
+
 private:
     PopoverState m_popoverState;
     PopoverVisibilityState m_visibilityState;
     std::optional<PopoverToggleEventData> m_queuedToggleEventData;
     WeakPtr<Element, WeakPtrImplWithEventTargetData> m_previouslyFocusedElement;
     WeakPtr<HTMLFormControlElement, WeakPtrImplWithEventTargetData> m_invoker;
+    bool m_isHidingOrShowingPopover = false;
 };
 
 }

--- a/Source/WebCore/html/HTMLElement.cpp
+++ b/Source/WebCore/html/HTMLElement.cpp
@@ -1362,6 +1362,9 @@ ExceptionOr<void> HTMLElement::showPopover(const HTMLFormControlElement* invoker
 
     ASSERT(!isInTopLayer());
 
+    PopoverData::ScopedStartShowingOrHiding showOrHidingPopoverScope(*this);
+    auto fireEvents = showOrHidingPopoverScope.wasShowingOrHiding() ? FireEvents::No : FireEvents::Yes;
+
     Ref document = this->document();
     auto event = ToggleEvent::create(eventNames().beforetoggleEvent, { EventInit { }, "closed"_s, "open"_s }, Event::IsCancelable::Yes);
     dispatchEvent(event);
@@ -1376,10 +1379,12 @@ ExceptionOr<void> HTMLElement::showPopover(const HTMLFormControlElement* invoker
 
     ASSERT(popoverData());
 
+    bool shouldRestoreFocus = false;
+
     if (popoverState() == PopoverState::Auto) {
         auto originalState = popoverState();
         RefPtr ancestor = topmostPopoverAncestor(*this);
-        document->hideAllPopoversUntil(ancestor.get(), FocusPreviousElement::No, FireEvents::Yes);
+        document->hideAllPopoversUntil(ancestor.get(), FocusPreviousElement::No, fireEvents);
 
         if (popoverState() != originalState)
             return Exception { InvalidStateError, "The value of the popover attribute was changed while hiding the popover."_s };
@@ -1389,9 +1394,10 @@ ExceptionOr<void> HTMLElement::showPopover(const HTMLFormControlElement* invoker
             return check.releaseException();
         if (!check.returnValue())
             return { };
+
+        shouldRestoreFocus = !document->topmostAutoPopover();
     }
 
-    bool shouldRestoreFocus = !document->topmostAutoPopover();
     RefPtr previouslyFocusedElement = document->focusedElement();
 
     addToTopLayer();
@@ -1403,8 +1409,10 @@ ExceptionOr<void> HTMLElement::showPopover(const HTMLFormControlElement* invoker
 
     runPopoverFocusingSteps(*this);
 
-    if (shouldRestoreFocus && popoverState() == PopoverState::Auto)
+    if (shouldRestoreFocus) {
+        ASSERT(popoverState() == PopoverState::Auto);
         popoverData()->setPreviouslyFocusedElement(previouslyFocusedElement.get());
+    }
 
     queuePopoverToggleEventTask(PopoverVisibilityState::Hidden, PopoverVisibilityState::Showing);
 
@@ -1419,8 +1427,11 @@ ExceptionOr<void> HTMLElement::hidePopoverInternal(FocusPreviousElement focusPre
     if (!check.returnValue())
         return { };
 
-
     ASSERT(popoverData());
+
+    PopoverData::ScopedStartShowingOrHiding showOrHidingPopoverScope(*this);
+    if (showOrHidingPopoverScope.wasShowingOrHiding())
+        fireEvents = FireEvents::No;
 
     if (popoverState() == PopoverState::Auto) {
         document().hideAllPopoversUntil(this, focusPreviousElement, fireEvents);


### PR DESCRIPTION
#### 0bd9e48790d43285feb2f971e6b5ae12dc290fc8
<pre>
[popover] Prevent hidePopover from causing a recursive loop
<a href="https://bugs.webkit.org/show_bug.cgi?id=256379">https://bugs.webkit.org/show_bug.cgi?id=256379</a>

Reviewed by Tim Nguyen.

Fix hideAllPopoversUntil for the case where hiding an auto popover changes the auto popover
list (through beforetoggle) so the same auto popover is on top, causing a loop. To fix this, when
this is detected, continue the loop without firing events.

See:
<a href="https://github.com/whatwg/html/pull/9198">https://github.com/whatwg/html/pull/9198</a>

* LayoutTests/imported/w3c/web-platform-tests/html/semantics/popovers/popover-light-dismiss-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/popovers/popover-light-dismiss.html:
* LayoutTests/platform/glib/imported/w3c/web-platform-tests/html/semantics/popovers/popover-light-dismiss-expected.txt:
* LayoutTests/platform/ios/imported/w3c/web-platform-tests/html/semantics/popovers/popover-light-dismiss-expected.txt:
* Source/WebCore/dom/Document.cpp:
(WebCore::Document::topmostAutoPopover const):
(WebCore::Document::hideAllPopoversUntil):
* Source/WebCore/dom/PopoverData.h:
(WebCore::PopoverData::ScopedStartShowingOrHiding::ScopedStartShowingOrHiding):
(WebCore::PopoverData::ScopedStartShowingOrHiding::~ScopedStartShowingOrHiding):
(WebCore::PopoverData::ScopedStartShowingOrHiding::wasShowingOrHiding const):
* Source/WebCore/html/HTMLElement.cpp:
(WebCore::HTMLElement::showPopover):
(WebCore::HTMLElement::hidePopoverInternal):

Canonical link: <a href="https://commits.webkit.org/264623@main">https://commits.webkit.org/264623@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/fe61382e6d6d7063b3ab2b2ce3e09d6a062e905f

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/8089 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/8376 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/8590 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/9744 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/8185 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/8094 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/10362 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/8287 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/11044 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/8233 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/9315 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/7369 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/9865 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/6616 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/7407 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/14975 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/7739 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/7533 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/10882 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/7999 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/6509 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/7309 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/7320 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/1965 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/11518 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/7741 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->