### PR TITLE
Provide a more useful exception message when a qualified name fails validation

### DIFF
--- a/LayoutTests/fast/dom/dataset-expected.txt
+++ b/LayoutTests/fast/dom/dataset-expected.txt
@@ -33,7 +33,7 @@ PASS testSet('à', 'data-à') is true
 PASS testSet('foo豈', 'data-foo豈') is true
 
 PASS testSet('-foo', 'dummy') threw exception SyntaxError: The string did not match the expected pattern..
-PASS testSet('foo ', 'dummy') threw exception InvalidCharacterError: The string contains invalid characters..
+PASS testSet('foo ', 'dummy') threw exception InvalidCharacterError: Invalid qualified name: 'data-foo '.
 
 PASS testDelete('data-foo', 'foo') is true
 PASS testDelete('data-foo-bar', 'fooBar') is true

--- a/LayoutTests/fast/dom/dataset-xhtml-expected.txt
+++ b/LayoutTests/fast/dom/dataset-xhtml-expected.txt
@@ -24,7 +24,7 @@ PASS testSet('à', 'data-à') is true
 PASS testSet('foo豈', 'data-foo豈') is true
 
 PASS testSet('-foo', 'dummy') threw exception SyntaxError: The string did not match the expected pattern..
-PASS testSet('foo ', 'dummy') threw exception InvalidCharacterError: The string contains invalid characters..
+PASS testSet('foo ', 'dummy') threw exception InvalidCharacterError: Invalid qualified name: 'data-foo '.
 
 PASS testDelete('data-foo', 'foo') is true
 PASS testDelete('data-foo-bar', 'fooBar') is true

--- a/LayoutTests/fast/dom/qualified-name-validation-expected.txt
+++ b/LayoutTests/fast/dom/qualified-name-validation-expected.txt
@@ -1,0 +1,18 @@
+Tests failing cases for qualified name validation.
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+PASS document.createElement('@foo') threw exception InvalidCharacterError: The string contains invalid characters..
+PASS document.createElementNS('ns', '@foo') threw exception InvalidCharacterError: Invalid qualified name start in '@foo'.
+PASS document.createElementNS('ns', 'f@ast') threw exception InvalidCharacterError: Invalid qualified name part in 'f@ast'.
+PASS document.createAttribute('@foo') threw exception InvalidCharacterError: Invalid qualified name: '@foo'.
+PASS document.createAttributeNS('ns', '@foo') threw exception InvalidCharacterError: Invalid qualified name start in '@foo'.
+PASS document.createAttributeNS('ns', 'f@ast') threw exception InvalidCharacterError: Invalid qualified name part in 'f@ast'.
+PASS document.body.setAttribute('@foo', 'test') threw exception InvalidCharacterError: Invalid qualified name: '@foo'.
+PASS document.body.setAttributeNS('ns', '@foo', 'test') threw exception InvalidCharacterError: Invalid qualified name start in '@foo'.
+PASS document.body.setAttributeNS('ns', 'f@st', 'test') threw exception InvalidCharacterError: Invalid qualified name part in 'f@st'.
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/fast/dom/qualified-name-validation.html
+++ b/LayoutTests/fast/dom/qualified-name-validation.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<html>
+<body>
+<script src="../../resources/js-test.js"></script>
+<script>
+description("Tests failing cases for qualified name validation.");
+
+shouldThrowErrorName("document.createElement('@foo')", "InvalidCharacterError");
+shouldThrowErrorName("document.createElementNS('ns', '@foo')", "InvalidCharacterError");
+shouldThrowErrorName("document.createElementNS('ns', 'f@ast')", "InvalidCharacterError");
+shouldThrowErrorName("document.createAttribute('@foo')", "InvalidCharacterError");
+shouldThrowErrorName("document.createAttributeNS('ns', '@foo')", "InvalidCharacterError");
+shouldThrowErrorName("document.createAttributeNS('ns', 'f@ast')", "InvalidCharacterError");
+shouldThrowErrorName("document.body.setAttribute('@foo', 'test')", "InvalidCharacterError");
+shouldThrowErrorName("document.body.setAttributeNS('ns', '@foo', 'test')", "InvalidCharacterError");
+shouldThrowErrorName("document.body.setAttributeNS('ns', 'f@st', 'test')", "InvalidCharacterError");
+</script>
+</body>
+</html>

--- a/Source/WebCore/dom/Document.cpp
+++ b/Source/WebCore/dom/Document.cpp
@@ -1097,7 +1097,7 @@ ExceptionOr<Ref<Element>> Document::createElementForBindings(const AtomString& n
         return createHTMLElementWithNameValidation(*this, name);
 
     if (!isValidName(name))
-        return Exception { InvalidCharacterError };
+        return Exception { InvalidCharacterError, makeString("Invalid qualified name: '", name, "'") };
 
     return createElement(QualifiedName(nullAtom(), name, nullAtom()), false);
 }
@@ -1131,7 +1131,7 @@ ExceptionOr<Ref<CDATASection>> Document::createCDATASection(String&& data)
 ExceptionOr<Ref<ProcessingInstruction>> Document::createProcessingInstruction(String&& target, String&& data)
 {
     if (!isValidName(target))
-        return Exception { InvalidCharacterError };
+        return Exception { InvalidCharacterError, makeString("Invalid qualified name: ", target, "'") };
 
     if (data.contains("?>"_s))
         return Exception { InvalidCharacterError };
@@ -5770,17 +5770,17 @@ ExceptionOr<std::pair<AtomString, AtomString>> Document::parseQualifiedName(cons
         U16_NEXT(qualifiedName, i, length, c);
         if (c == ':') {
             if (sawColon)
-                return Exception { InvalidCharacterError };
+                return Exception { InvalidCharacterError, makeString("Unexpected colon in qualified name '", qualifiedName, "'") };
             nameStart = true;
             sawColon = true;
             colonPosition = i - 1;
         } else if (nameStart) {
             if (!isValidNameStart(c))
-                return Exception { InvalidCharacterError };
+                return Exception { InvalidCharacterError, makeString("Invalid qualified name start in '", qualifiedName, "'") };
             nameStart = false;
         } else {
             if (!isValidNamePart(c))
-                return Exception { InvalidCharacterError };
+                return Exception { InvalidCharacterError, makeString("Invalid qualified name part in '", qualifiedName, "'") };
         }
     }
 
@@ -5788,7 +5788,7 @@ ExceptionOr<std::pair<AtomString, AtomString>> Document::parseQualifiedName(cons
         return std::pair<AtomString, AtomString> { { }, { qualifiedName } };
 
     if (!colonPosition || length - colonPosition <= 1)
-        return Exception { InvalidCharacterError };
+        return Exception { InvalidCharacterError, makeString("Namespace in qualified name '", qualifiedName, "' is too short") };
 
     return std::pair<AtomString, AtomString> { StringView { qualifiedName }.left(colonPosition).toAtomString(), StringView { qualifiedName }.substring(colonPosition + 1).toAtomString() };
 }
@@ -6308,7 +6308,7 @@ Document& Document::topDocument() const
 ExceptionOr<Ref<Attr>> Document::createAttribute(const AtomString& localName)
 {
     if (!isValidName(localName))
-        return Exception { InvalidCharacterError };
+        return Exception { InvalidCharacterError, makeString("Invalid qualified name: '", localName, "'") };
     return Attr::create(*this, QualifiedName { nullAtom(), isHTMLDocument() ? localName.convertToASCIILowercase() : localName, nullAtom() }, emptyAtom());
 }
 

--- a/Source/WebCore/dom/Element.cpp
+++ b/Source/WebCore/dom/Element.cpp
@@ -1921,7 +1921,7 @@ const AtomString& Element::getAttributeNS(const AtomString& namespaceURI, const 
 ExceptionOr<bool> Element::toggleAttribute(const AtomString& qualifiedName, std::optional<bool> force)
 {
     if (!Document::isValidName(qualifiedName))
-        return Exception { InvalidCharacterError };
+        return Exception { InvalidCharacterError, makeString("Invalid qualified name: '", qualifiedName, "'") };
 
     synchronizeAttribute(qualifiedName);
 
@@ -1945,7 +1945,7 @@ ExceptionOr<bool> Element::toggleAttribute(const AtomString& qualifiedName, std:
 ExceptionOr<void> Element::setAttribute(const AtomString& qualifiedName, const AtomString& value)
 {
     if (!Document::isValidName(qualifiedName))
-        return Exception { InvalidCharacterError };
+        return Exception { InvalidCharacterError, makeString("Invalid qualified name: '", qualifiedName, "'") };
 
     synchronizeAttribute(qualifiedName);
     auto caseAdjustedQualifiedName = shouldIgnoreAttributeCase(*this) ? qualifiedName.convertToASCIILowercase() : qualifiedName;


### PR DESCRIPTION
#### dcf5f162b4888136d70d4eb5e74c6c3edd211590
<pre>
Provide a more useful exception message when a qualified name fails validation
<a href="https://bugs.webkit.org/show_bug.cgi?id=256385">https://bugs.webkit.org/show_bug.cgi?id=256385</a>

Reviewed by Ryosuke Niwa.

* LayoutTests/fast/dom/dataset-expected.txt:
* LayoutTests/fast/dom/dataset-xhtml-expected.txt:
* LayoutTests/fast/dom/qualified-name-validation-expected.txt: Added.
* LayoutTests/fast/dom/qualified-name-validation.html: Added.
* Source/WebCore/dom/Document.cpp:
(WebCore::Document::createElementForBindings):
(WebCore::Document::createProcessingInstruction):
(WebCore::Document::parseQualifiedName):
(WebCore::Document::createAttribute):
* Source/WebCore/dom/Element.cpp:
(WebCore::Element::toggleAttribute):
(WebCore::Element::setAttribute):

Canonical link: <a href="https://commits.webkit.org/263745@main">https://commits.webkit.org/263745@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/725baabf99499e288ac06612634c23e9dd58869b

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/5643 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/5796 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/5986 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/7194 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/5628 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/5642 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/6019 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/5768 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/7659 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/5747 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/5800 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/5051 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/7236 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/3276 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/5074 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/12212 "6 flakes 168 failures") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/5145 "Passed tests") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/5151 "4 failures") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/6974 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/5591 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/4575 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/5039 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/5005 "Passed tests") | | 
| [  ~~🛠 🧪 merge~~](https://ews-build.webkit.org/#/builders/19/builds/1336 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/9150 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/5400 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->