### PR TITLE
Fix list of supported font-formats at parse time (256313)

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-fonts/parsing/font-face-src-format-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-fonts/parsing/font-face-src-format-expected.txt
@@ -11,7 +11,7 @@ PASS Check that src: url("foo.ttf") format("truetype") is valid
 PASS Check that src: url("foo.ttf") format("woff") is valid
 PASS Check that src: url("foo.ttf") format("woff2") is valid
 PASS Check that src: url("foo.ttf") format("opentype", "truetype") is invalid
-PASS Check that src: url("foo.ttf") format(collection) is valid
+FAIL Check that src: url("foo.ttf") format(collection) is valid assert_equals: expected true but got false
 PASS Check that src: url("foo.ttf") format(opentype) is valid
 PASS Check that src: url("foo.ttf") format(truetype) is valid
 PASS Check that src: url("foo.ttf") format(woff) is valid

--- a/Source/WebCore/css/CSSFontFaceSrcValue.cpp
+++ b/Source/WebCore/css/CSSFontFaceSrcValue.cpp
@@ -100,7 +100,7 @@ std::unique_ptr<FontLoadRequest> CSSFontFaceSrcResourceValue::fontLoadRequest(Sc
         isFormatSVG = false;
     } else {
         isFormatSVG = equalLettersIgnoringASCIICase(m_format, "svg"_s);
-        if (!isFormatSVG && !FontCustomPlatformData::supportsFormat(m_format))
+        if (!FontCustomPlatformData::supportsFormat(m_format))
             return nullptr;
     }
 

--- a/Source/WebCore/css/parser/CSSPropertyParserHelpers.cpp
+++ b/Source/WebCore/css/parser/CSSPropertyParserHelpers.cpp
@@ -8193,19 +8193,6 @@ RefPtr<CSSValue> consumeFontFaceFontFamily(CSSParserTokenRange& range)
     return CSSValueList::createCommaSeparated(name.releaseNonNull());
 }
 
-bool identMatchesSupportedFontFormat(CSSValueID id)
-{
-    return identMatches<
-        CSSValueCollection,
-        CSSValueEmbeddedOpentype,
-        CSSValueOpentype,
-        CSSValueSvg,
-        CSSValueTruetype,
-        CSSValueWoff,
-        CSSValueWoff2
-    >(id);
-}
-
 
 Vector<FontTechnology> consumeFontTech(CSSParserTokenRange& range, bool singleValue)
 {
@@ -8222,6 +8209,22 @@ Vector<FontTechnology> consumeFontTech(CSSParserTokenRange& range, bool singleVa
     if (!args.atEnd())
         return { };
     return technologies;
+}
+
+String consumeFontFormat(CSSParserTokenRange& range, bool rejectStringValues)
+{
+    // https://drafts.csswg.org/css-fonts/#descdef-font-face-src
+    // FIXME: We allow any identifier here and convert to strings; specification calls for certain keywords and legacy compatibility strings.
+    auto args = CSSPropertyParserHelpers::consumeFunction(range);
+    auto& arg = args.consumeIncludingWhitespace();
+    if (!args.atEnd())
+        return nullString();
+    if (arg.type() != IdentToken && (rejectStringValues || arg.type() != StringToken))
+        return nullString();
+    auto format = arg.value().toString();
+    if (arg.type() == IdentToken && !FontCustomPlatformData::supportsFormat(format))
+        return nullString();
+    return format;
 }
 
 // MARK: @font-palette-values

--- a/Source/WebCore/css/parser/CSSPropertyParserHelpers.h
+++ b/Source/WebCore/css/parser/CSSPropertyParserHelpers.h
@@ -321,7 +321,7 @@ RefPtr<CSSValue> consumeDeclarationValue(CSSParserTokenRange&, const CSSParserCo
 
 RefPtr<CSSValue> consumeFontFaceFontFamily(CSSParserTokenRange&);
 Vector<FontTechnology> consumeFontTech(CSSParserTokenRange&, bool singleValue = false);
-bool identMatchesSupportedFontFormat(CSSValueID);
+String consumeFontFormat(CSSParserTokenRange&, bool rejectStringValues = false);
 
 // @font-palette-values descriptor consumers:
 

--- a/Source/WebCore/css/parser/CSSPropertyParserWorkerSafe.cpp
+++ b/Source/WebCore/css/parser/CSSPropertyParserWorkerSafe.cpp
@@ -44,6 +44,7 @@
 #include "CSSTokenizer.h"
 #include "CSSUnicodeRangeValue.h"
 #include "Document.h"
+#include "FontCustomPlatformData.h"
 #include "ParsingUtilities.h"
 #include "ScriptExecutionContext.h"
 #include "StyleSheetContents.h"
@@ -235,18 +236,9 @@ static RefPtr<CSSFontFaceSrcResourceValue> consumeFontFaceSrcURI(CSSParserTokenR
     String format;
     Vector<FontTechnology> supportedTechnologies;
     if (range.peek().functionId() == CSSValueFormat) {
-        // https://drafts.csswg.org/css-fonts/#descdef-font-face-src
-        // FIXME: We allow any identifier here and convert to strings; specification calls for certain keywords and legacy compatibility strings.
-        auto args = CSSPropertyParserHelpers::consumeFunction(range);
-        auto& arg = args.consumeIncludingWhitespace();
-        if (!args.atEnd())
+        format = CSSPropertyParserHelpers::consumeFontFormat(range);
+        if (format.isNull())
             return nullptr;
-        if (arg.type() == IdentToken) {
-            if (!CSSPropertyParserHelpers::identMatchesSupportedFontFormat(arg.id()))
-                return nullptr;
-        } else if (arg.type() != StringToken)
-            return nullptr;
-        format = arg.value().toString();
     }
     if (range.peek().functionId() == CSSValueTech) {
         supportedTechnologies = CSSPropertyParserHelpers::consumeFontTech(range);

--- a/Source/WebCore/css/parser/CSSSupportsParser.cpp
+++ b/Source/WebCore/css/parser/CSSSupportsParser.cpp
@@ -169,15 +169,8 @@ CSSSupportsParser::SupportsResult CSSSupportsParser::consumeSupportsSelectorFunc
 CSSSupportsParser::SupportsResult CSSSupportsParser::consumeSupportsFontFormatFunction(CSSParserTokenRange& range)
 {
     ASSERT(range.peek().type() == FunctionToken && range.peek().functionId() == CSSValueFontFormat);
-
-    auto block = range.consumeBlock();
-    block.consumeWhitespace();
-
-    auto isSupported = CSSPropertyParserHelpers::consumeIdent(block, CSSPropertyParserHelpers::identMatchesSupportedFontFormat) ? Supported : Unsupported;
-    if (!block.atEnd())
-        return Unsupported;
-
-    return isSupported;
+    auto format = CSSPropertyParserHelpers::consumeFontFormat(range, true);
+    return format.isNull() ? Unsupported : Supported;
 }
 
 // <supports-font-tech-fn>

--- a/Source/WebCore/platform/graphics/coretext/FontCustomPlatformDataCoreText.cpp
+++ b/Source/WebCore/platform/graphics/coretext/FontCustomPlatformDataCoreText.cpp
@@ -99,7 +99,8 @@ bool FontCustomPlatformData::supportsFormat(const String& format)
         || equalLettersIgnoringASCIICase(format, "woff-variations"_s)
         || equalLettersIgnoringASCIICase(format, "truetype-variations"_s)
         || equalLettersIgnoringASCIICase(format, "opentype-variations"_s)
-        || equalLettersIgnoringASCIICase(format, "woff"_s);
+        || equalLettersIgnoringASCIICase(format, "woff"_s)
+        || equalLettersIgnoringASCIICase(format, "svg"_s);
 }
 
 bool FontCustomPlatformData::supportsTechnology(const FontTechnology& tech)

--- a/Source/WebCore/platform/graphics/freetype/FontCustomPlatformDataFreeType.cpp
+++ b/Source/WebCore/platform/graphics/freetype/FontCustomPlatformDataFreeType.cpp
@@ -161,7 +161,8 @@ bool FontCustomPlatformData::supportsFormat(const String& format)
         || equalLettersIgnoringASCIICase(format, "truetype-variations"_s)
         || equalLettersIgnoringASCIICase(format, "opentype-variations"_s)
 #endif
-        || equalLettersIgnoringASCIICase(format, "woff"_s);
+        || equalLettersIgnoringASCIICase(format, "woff"_s)
+        || equalLettersIgnoringASCIICase(format, "svg"_s);
 }
 
 bool FontCustomPlatformData::supportsTechnology(const FontTechnology&)

--- a/Source/WebCore/platform/graphics/win/FontCustomPlatformDataWin.cpp
+++ b/Source/WebCore/platform/graphics/win/FontCustomPlatformDataWin.cpp
@@ -105,7 +105,8 @@ bool FontCustomPlatformData::supportsFormat(const String& format)
 #if USE(WOFF2)
         || equalLettersIgnoringASCIICase(format, "woff2"_s)
 #endif
-        || equalLettersIgnoringASCIICase(format, "woff"_s);
+        || equalLettersIgnoringASCIICase(format, "woff"_s)
+        || equalLettersIgnoringASCIICase(format, "svg"_s);
 }
 
 bool FontCustomPlatformData::supportsTechnology(const FontTechnology&)


### PR DESCRIPTION
#### 0a0261e666d93c3ad1f0e942ebba0e419d2be2bd
<pre>
Fix list of supported font-formats at parse time (256313)
<a href="https://bugs.webkit.org/show_bug.cgi?id=256313">https://bugs.webkit.org/show_bug.cgi?id=256313</a>
rdar://108897052

Reviewed by Myles C. Maxfield.

We are now rejecting unsupported formats at parsing time.
We are also moving the code fragment that parses the font-format to
its own function, so it can be used by both @font-face src and @supports
parsers.

* LayoutTests/imported/w3c/web-platform-tests/css/css-fonts/parsing/font-face-src-format-expected.txt:
* Source/WebCore/css/CSSFontFaceSrcValue.cpp:
(WebCore::CSSFontFaceSrcResourceValue::fontLoadRequest):
* Source/WebCore/css/parser/CSSPropertyParserHelpers.cpp:
(WebCore::CSSPropertyParserHelpers::consumeFontFormat):
(WebCore::CSSPropertyParserHelpers::identMatchesSupportedFontFormat): Deleted.
* Source/WebCore/css/parser/CSSPropertyParserHelpers.h:
* Source/WebCore/css/parser/CSSPropertyParserWorkerSafe.cpp:
(WebCore::CSSPropertyParserHelpersWorkerSafe::consumeFontFaceSrcURI):
* Source/WebCore/css/parser/CSSSupportsParser.cpp:
(WebCore::CSSSupportsParser::consumeSupportsFontFormatFunction):
* Source/WebCore/platform/graphics/coretext/FontCustomPlatformDataCoreText.cpp:
(WebCore::FontCustomPlatformData::supportsFormat):
* Source/WebCore/platform/graphics/freetype/FontCustomPlatformDataFreeType.cpp:
(WebCore::FontCustomPlatformData::supportsFormat):
* Source/WebCore/platform/graphics/win/FontCustomPlatformDataWin.cpp:
(WebCore::FontCustomPlatformData::supportsFormat):

Canonical link: <a href="https://commits.webkit.org/263914@main">https://commits.webkit.org/263914@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2651178fd30c7969bbc19a2981e46f68ca58d32d

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/6079 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/6262 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/6445 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/7640 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/6427 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/6079 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/6480 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/6216 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/9306 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/6189 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/6210 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/5500 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/7702 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/3685 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/5481 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/13389 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/5551 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/5559 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/7790 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/6025 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/4928 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/5447 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/1441 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/9586 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/5815 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->