### PR TITLE
[JSC] JSC::JIT should be fully created and destroyed in the compiler thread

### DIFF
--- a/Source/JavaScriptCore/jit/BaselineJITPlan.h
+++ b/Source/JavaScriptCore/jit/BaselineJITPlan.h
@@ -33,6 +33,8 @@
 
 namespace JSC {
 
+class BaselineJITCode;
+
 class BaselineJITPlan final : public JITPlan {
     using Base = JITPlan;
 
@@ -44,7 +46,9 @@ public:
     CompilationResult finalize() override;
 
 private:
-    JIT m_jit;
+    BytecodeIndex m_loopOSREntryBytecodeIndex;
+    std::unique_ptr<LinkBuffer> m_linkBuffer;
+    RefPtr<BaselineJITCode> m_jitCode;
 };
 
 } // namespace JSC

--- a/Source/JavaScriptCore/jit/JIT.cpp
+++ b/Source/JavaScriptCore/jit/JIT.cpp
@@ -731,7 +731,7 @@ void JIT::emitConsistencyCheck()
 }
 #endif
 
-void JIT::compileAndLinkWithoutFinalizing(JITCompilationEffort effort)
+std::tuple<std::unique_ptr<LinkBuffer>, RefPtr<BaselineJITCode>> JIT::compileAndLinkWithoutFinalizing(JITCompilationEffort effort)
 {
     DFG::CapabilityLevel level = m_profiledCodeBlock->capabilityLevel();
     switch (level) {
@@ -883,16 +883,15 @@ void JIT::compileAndLinkWithoutFinalizing(JITCompilationEffort effort)
         m_disassembler->setEndOfCode(label());
     m_pcToCodeOriginMapBuilder.appendItem(label(), PCToCodeOriginMapBuilder::defaultCodeOrigin());
 
-    m_linkBuffer = makeUnique<LinkBuffer>(*this, m_unlinkedCodeBlock, LinkBuffer::Profile::BaselineJIT, effort);
-    link();
+    auto linkBuffer = makeUnique<LinkBuffer>(*this, m_unlinkedCodeBlock, LinkBuffer::Profile::BaselineJIT, effort);
+    auto jitCode = link(*linkBuffer);
+    return std::tuple { WTFMove(linkBuffer), WTFMove(jitCode) };
 }
 
-void JIT::link()
+RefPtr<BaselineJITCode> JIT::link(LinkBuffer& patchBuffer)
 {
-    LinkBuffer& patchBuffer = *m_linkBuffer;
-    
     if (patchBuffer.didFailToAllocate())
-        return;
+        return nullptr;
 
     // Translate vPC offsets into addresses in JIT generated code, for switch tables.
     for (auto& record : m_switches) {
@@ -997,8 +996,9 @@ void JIT::link()
         m_vm->m_perBytecodeProfiler->addCompilation(m_profiledCodeBlock, *m_compilation);
     }
 
+    std::unique_ptr<PCToCodeOriginMap> pcToCodeOriginMap;
     if (m_pcToCodeOriginMapBuilder.didBuildMapping())
-        m_pcToCodeOriginMap = makeUnique<PCToCodeOriginMap>(WTFMove(m_pcToCodeOriginMapBuilder), patchBuffer);
+        pcToCodeOriginMap = makeUnique<PCToCodeOriginMap>(WTFMove(m_pcToCodeOriginMapBuilder), patchBuffer);
     
     // FIXME: Make a version of CodeBlockWithJITType that knows about UnlinkedCodeBlock.
     CodeRef<JSEntryPtrTag> result = FINALIZE_CODE(
@@ -1006,65 +1006,57 @@ void JIT::link()
         "Baseline JIT code for %s", toCString(CodeBlockWithJITType(m_profiledCodeBlock, JITType::BaselineJIT)).data());
     
     CodePtr<JSEntryPtrTag> withArityCheck = patchBuffer.locationOf<JSEntryPtrTag>(m_arityCheck);
-    m_jitCode = adoptRef(*new BaselineJITCode(result, withArityCheck));
+    auto jitCode = adoptRef(*new BaselineJITCode(result, withArityCheck));
 
-    m_jitCode->m_unlinkedCalls = FixedVector<BaselineUnlinkedCallLinkInfo>(m_unlinkedCalls.size());
-    if (m_jitCode->m_unlinkedCalls.size())
-        std::move(m_unlinkedCalls.begin(), m_unlinkedCalls.end(), m_jitCode->m_unlinkedCalls.begin());
-    m_jitCode->m_unlinkedStubInfos = FixedVector<BaselineUnlinkedStructureStubInfo>(m_unlinkedStubInfos.size());
-    if (m_jitCode->m_unlinkedStubInfos.size())
-        std::move(m_unlinkedStubInfos.begin(), m_unlinkedStubInfos.end(), m_jitCode->m_unlinkedStubInfos.begin());
-    m_jitCode->m_switchJumpTables = WTFMove(m_switchJumpTables);
-    m_jitCode->m_stringSwitchJumpTables = WTFMove(m_stringSwitchJumpTables);
-    m_jitCode->m_jitCodeMap = jitCodeMapBuilder.finalize();
-    m_jitCode->adoptMathICs(m_mathICs);
-    m_jitCode->m_constantPool = WTFMove(m_constantPool);
-    m_jitCode->m_isShareable = m_isShareable;
+    jitCode->m_unlinkedCalls = FixedVector<BaselineUnlinkedCallLinkInfo>(m_unlinkedCalls.size());
+    if (jitCode->m_unlinkedCalls.size())
+        std::move(m_unlinkedCalls.begin(), m_unlinkedCalls.end(), jitCode->m_unlinkedCalls.begin());
+    jitCode->m_unlinkedStubInfos = FixedVector<BaselineUnlinkedStructureStubInfo>(m_unlinkedStubInfos.size());
+    if (jitCode->m_unlinkedStubInfos.size())
+        std::move(m_unlinkedStubInfos.begin(), m_unlinkedStubInfos.end(), jitCode->m_unlinkedStubInfos.begin());
+    jitCode->m_switchJumpTables = WTFMove(m_switchJumpTables);
+    jitCode->m_stringSwitchJumpTables = WTFMove(m_stringSwitchJumpTables);
+    jitCode->m_jitCodeMap = jitCodeMapBuilder.finalize();
+    jitCode->adoptMathICs(m_mathICs);
+    jitCode->m_constantPool = WTFMove(m_constantPool);
+    jitCode->m_isShareable = m_isShareable;
+    jitCode->m_pcToCodeOriginMap = WTFMove(pcToCodeOriginMap);
 
     if (JITInternal::verbose)
         dataLogF("JIT generated code for %p at [%p, %p).\n", m_unlinkedCodeBlock, result.executableMemory()->start().untaggedPtr(), result.executableMemory()->end().untaggedPtr());
+    return jitCode;
 }
 
-CompilationResult JIT::finalizeOnMainThread(CodeBlock* codeBlock)
+CompilationResult JIT::finalizeOnMainThread(CodeBlock* codeBlock, LinkBuffer& linkBuffer, RefPtr<BaselineJITCode> jitCode)
 {
     RELEASE_ASSERT(!isCompilationThread());
 
-    if (!m_jitCode)
+    if (!jitCode)
         return CompilationFailed;
 
-    m_linkBuffer->runMainThreadFinalizationTasks();
+    linkBuffer.runMainThreadFinalizationTasks();
 
-    if (m_pcToCodeOriginMap)
-        m_jitCode->m_pcToCodeOriginMap = WTFMove(m_pcToCodeOriginMap);
+    codeBlock->vm().machineCodeBytesPerBytecodeWordForBaselineJIT->add(
+        static_cast<double>(jitCode->size()) /
+        static_cast<double>(codeBlock->unlinkedCodeBlock()->instructionsSize()));
 
-    m_vm->machineCodeBytesPerBytecodeWordForBaselineJIT->add(
-        static_cast<double>(m_jitCode->size()) /
-        static_cast<double>(m_unlinkedCodeBlock->instructionsSize()));
-
-    codeBlock->setupWithUnlinkedBaselineCode(m_jitCode.releaseNonNull());
+    codeBlock->setupWithUnlinkedBaselineCode(jitCode.releaseNonNull());
 
     return CompilationSuccessful;
 }
 
-size_t JIT::codeSize() const
-{
-    if (!m_linkBuffer)
-        return 0;
-    return m_linkBuffer->size();
-}
-
 CompilationResult JIT::privateCompile(CodeBlock* codeBlock, JITCompilationEffort effort)
 {
-    doMainThreadPreparationBeforeCompile();
-    compileAndLinkWithoutFinalizing(effort);
-    return finalizeOnMainThread(codeBlock);
+    doMainThreadPreparationBeforeCompile(vm());
+    auto [ linkBuffer, jitCode ] = compileAndLinkWithoutFinalizing(effort);
+    return JIT::finalizeOnMainThread(codeBlock, *linkBuffer, WTFMove(jitCode));
 }
 
-void JIT::doMainThreadPreparationBeforeCompile()
+void JIT::doMainThreadPreparationBeforeCompile(VM& vm)
 {
     // This ensures that we have the most up to date type information when performing typecheck optimizations for op_profile_type.
-    if (m_vm->typeProfiler())
-        m_vm->typeProfilerLog()->processLogEntries(*m_vm, "Preparing for JIT compilation."_s);
+    if (vm.typeProfiler())
+        vm.typeProfilerLog()->processLogEntries(vm, "Preparing for JIT compilation."_s);
 }
 
 unsigned JIT::frameRegisterCountFor(UnlinkedCodeBlock* codeBlock)

--- a/Source/JavaScriptCore/jit/JIT.h
+++ b/Source/JavaScriptCore/jit/JIT.h
@@ -165,11 +165,10 @@ namespace JSC {
 
         VM& vm() { return *JSInterfaceJIT::vm(); }
 
-        void compileAndLinkWithoutFinalizing(JITCompilationEffort);
-        CompilationResult finalizeOnMainThread(CodeBlock*);
-        size_t codeSize() const;
+        std::tuple<std::unique_ptr<LinkBuffer>, RefPtr<BaselineJITCode>> compileAndLinkWithoutFinalizing(JITCompilationEffort);
+        static CompilationResult finalizeOnMainThread(CodeBlock*, LinkBuffer&, RefPtr<BaselineJITCode>);
 
-        void doMainThreadPreparationBeforeCompile();
+        static void doMainThreadPreparationBeforeCompile(VM&);
         
         static CompilationResult compile(VM& vm, CodeBlock* codeBlock, JITCompilationEffort effort)
         {
@@ -192,7 +191,7 @@ namespace JSC {
         void privateCompileMainPass();
         void privateCompileLinkPass();
         void privateCompileSlowCases();
-        void link();
+        RefPtr<BaselineJITCode> link(LinkBuffer&);
         CompilationResult privateCompile(CodeBlock*, JITCompilationEffort);
 
         // Add a call out from JIT code, without an exception check.
@@ -955,13 +954,11 @@ namespace JSC {
         unsigned m_bytecodeCountHavingSlowCase { 0 };
         
         Label m_arityCheck;
-        std::unique_ptr<LinkBuffer> m_linkBuffer;
 
         std::unique_ptr<JITDisassembler> m_disassembler;
         RefPtr<Profiler::Compilation> m_compilation;
 
         PCToCodeOriginMapBuilder m_pcToCodeOriginMapBuilder;
-        std::unique_ptr<PCToCodeOriginMap> m_pcToCodeOriginMap;
 
         HashMap<const JSInstruction*, void*> m_instructionToMathIC;
         HashMap<const JSInstruction*, UniqueRef<MathICGenerationState>> m_instructionToMathICGenerationState;
@@ -974,7 +971,6 @@ namespace JSC {
         UnlinkedCodeBlock* const m_unlinkedCodeBlock { nullptr };
 
         MathICHolder m_mathICs;
-        RefPtr<BaselineJITCode> m_jitCode;
 
         Vector<JITConstantPool::Value> m_constantPool;
         SegmentedVector<BaselineUnlinkedCallLinkInfo> m_unlinkedCalls;


### PR DESCRIPTION
#### 81f52509684ddc620c4c121aa8a3d226953687f6
<pre>
[JSC] JSC::JIT should be fully created and destroyed in the compiler thread
<a href="https://bugs.webkit.org/show_bug.cgi?id=256394">https://bugs.webkit.org/show_bug.cgi?id=256394</a>
rdar://108965411

Reviewed by Justin Michaud.

This patch avoids creating and destroying JSC::JIT in the main thread. This is involving a lot of costly things,
like AssemblerBuffer instantiation, destruction of many data structures related to JIT etc.
This is the same to DFG / FTL: compiler should be instantiated in the compiler thread. From the compiler thread,
we get BaselineJITCode and LinkBuffer, and run the remaining main-thread task in BaselineJITPlan::finalize.

* Source/JavaScriptCore/jit/BaselineJITPlan.cpp:
(JSC::BaselineJITPlan::BaselineJITPlan):
(JSC::BaselineJITPlan::compileInThreadImpl):
(JSC::BaselineJITPlan::codeSize const):
(JSC::BaselineJITPlan::finalize):
* Source/JavaScriptCore/jit/BaselineJITPlan.h:
* Source/JavaScriptCore/jit/JIT.cpp:
(JSC::JIT::compileAndLinkWithoutFinalizing):
(JSC::JIT::link):
(JSC::JIT::finalizeOnMainThread):
(JSC::JIT::privateCompile):
(JSC::JIT::doMainThreadPreparationBeforeCompile):
(JSC::JIT::codeSize const): Deleted.
* Source/JavaScriptCore/jit/JIT.h:

Canonical link: <a href="https://commits.webkit.org/263878@main">https://commits.webkit.org/263878@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/72d6525b7d5312caa536fe7c129f024ba511e1bf

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/5991 "Failed to checkout and rebase branch from PR 13516") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/6168 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/6353 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/7546 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/32/builds/6350 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/6387 "Built successfully") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/16/builds/6127 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/9002 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/6100 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/15/builds/6133 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/5426 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/7606 "Built successfully") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/39/builds/3609 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/10/builds/5404 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/13328 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [  ~~🛠 🧪 jsc~~](https://ews-build.webkit.org/#/builders/20/builds/5021 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/5475 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/5483 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/7710 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [  ~~🛠 🧪 jsc-arm64~~](https://ews-build.webkit.org/#/builders/12/builds/5577 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/5938 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/16/builds/6127 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 jsc-armv7~~](https://ews-build.webkit.org/#/builders/35/builds/6110 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/30/builds/5369 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [  ~~🧪 jsc-armv7-tests~~](https://ews-build.webkit.org/#/builders/35/builds/6110 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/9497 "Built successfully") | | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/24/builds/6279 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/700 "Built successfully and passed tests") | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/31/builds/5732 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [  ~~🧪 jsc-mips-tests~~](https://ews-build.webkit.org/#/builders/3/builds/1597 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
<!--EWS-Status-Bubble-End-->