### PR TITLE
Provide a more useful exception message when a qualified name fails validation

### DIFF
--- a/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
+++ b/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
@@ -5782,16 +5782,16 @@ ShouldDisplayTextDescriptions:
     WebCore:
       default: false
 
-ShouldDropSuspendedAssertionAfterDelay:
+ShouldDropNearSuspendedAssertionAfterDelay:
   type: bool
   status: internal
-  humanReadableName: "Drop Suspended Assertion After Delay"
+  humanReadableName: "Drop Near-Suspended Assertion After Delay"
   humanReadableDescription: "Causes processes to fully suspend after a delay"
   defaultValue:
     WebKitLegacy:
       default: false
     WebKit:
-      default: WebKit::defaultShouldDropSuspendedAssertionAfterDelay()
+      default: WebKit::defaultShouldDropNearSuspendedAssertionAfterDelay()
     WebCore:
       default: false
 
@@ -5870,12 +5870,12 @@ ShouldSuppressTextInputFromEditingDuringProvisionalNavigation:
     WebCore:
       default: false
 
-ShouldTakeSuspendedAssertions:
+ShouldTakeNearSuspendedAssertions:
   type: bool
   status: internal
   category: dom
-  humanReadableName: "Take WebKit:Suspended assertions on background web content processes"
-  humanReadableDescription: "Take WebKit:Suspended assertions on background web content processes"
+  humanReadableName: "Take WebKit:NearSuspended assertions on background web content processes"
+  humanReadableDescription: "Take WebKit:NearSuspended assertions on background web content processes"
   exposed: [ WebKit ]
   defaultValue:
     WebKitLegacy:

--- a/Source/WebKit/Shared/WebPreferencesDefaultValues.cpp
+++ b/Source/WebKit/Shared/WebPreferencesDefaultValues.cpp
@@ -212,7 +212,7 @@ bool defaultRunningBoardThrottlingEnabled()
 #endif
 }
 
-bool defaultShouldDropSuspendedAssertionAfterDelay()
+bool defaultShouldDropNearSuspendedAssertionAfterDelay()
 {
 #if PLATFORM(COCOA)
     static bool newSDK = linkedOnOrAfterSDKWithBehavior(SDKAlignedBehavior::FullySuspendsBackgroundContent);

--- a/Source/WebKit/Shared/WebPreferencesDefaultValues.h
+++ b/Source/WebKit/Shared/WebPreferencesDefaultValues.h
@@ -95,7 +95,7 @@ bool defaultGamepadVibrationActuatorEnabled();
 #endif
 
 bool defaultRunningBoardThrottlingEnabled();
-bool defaultShouldDropSuspendedAssertionAfterDelay();
+bool defaultShouldDropNearSuspendedAssertionAfterDelay();
 bool defaultShowModalDialogEnabled();
 bool defaultLiveRangeSelectionEnabled();
 

--- a/Source/WebKit/UIProcess/API/Cocoa/WKPreferences.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKPreferences.mm
@@ -1666,15 +1666,15 @@ static WebCore::EditableLinkBehavior toEditableLinkBehavior(_WKEditableLinkBehav
 {
     switch (policy) {
     case WKInactiveSchedulingPolicySuspend:
-        _preferences->setShouldTakeSuspendedAssertions(false);
+        _preferences->setShouldTakeNearSuspendedAssertions(false);
         _preferences->setBackgroundWebContentRunningBoardThrottlingEnabled(true);
         break;
     case WKInactiveSchedulingPolicyThrottle:
-        _preferences->setShouldTakeSuspendedAssertions(true);
+        _preferences->setShouldTakeNearSuspendedAssertions(true);
         _preferences->setBackgroundWebContentRunningBoardThrottlingEnabled(true);
         break;
     case WKInactiveSchedulingPolicyNone:
-        _preferences->setShouldTakeSuspendedAssertions(true);
+        _preferences->setShouldTakeNearSuspendedAssertions(true);
         _preferences->setBackgroundWebContentRunningBoardThrottlingEnabled(false);
         break;
     default:
@@ -1684,7 +1684,7 @@ static WebCore::EditableLinkBehavior toEditableLinkBehavior(_WKEditableLinkBehav
 
 - (WKInactiveSchedulingPolicy)inactiveSchedulingPolicy
 {
-    return _preferences->backgroundWebContentRunningBoardThrottlingEnabled() ? (_preferences->shouldTakeSuspendedAssertions() ? WKInactiveSchedulingPolicyThrottle : WKInactiveSchedulingPolicySuspend) : WKInactiveSchedulingPolicyNone;
+    return _preferences->backgroundWebContentRunningBoardThrottlingEnabled() ? (_preferences->shouldTakeNearSuspendedAssertions() ? WKInactiveSchedulingPolicyThrottle : WKInactiveSchedulingPolicySuspend) : WKInactiveSchedulingPolicyNone;
 }
 
 - (void)_setVerifyWindowOpenUserGestureFromUIProcess:(BOOL)enabled

--- a/Source/WebKit/UIProcess/Cocoa/ProcessAssertionCocoa.mm
+++ b/Source/WebKit/UIProcess/Cocoa/ProcessAssertionCocoa.mm
@@ -318,8 +318,8 @@ namespace WebKit {
 static NSString *runningBoardNameForAssertionType(ProcessAssertionType assertionType)
 {
     switch (assertionType) {
-    case ProcessAssertionType::Suspended:
-        return @"Suspended";
+    case ProcessAssertionType::NearSuspended:
+        return @"Suspended"; // FIXME: This name is confusing since it doesn't cause suspension.
     case ProcessAssertionType::Background:
 #if PLATFORM(MAC)
         // The background assertions time out after 30 seconds on iOS but not macOS.
@@ -343,7 +343,7 @@ static NSString *runningBoardNameForAssertionType(ProcessAssertionType assertion
 static NSString *runningBoardDomainForAssertionType(ProcessAssertionType assertionType)
 {
     switch (assertionType) {
-    case ProcessAssertionType::Suspended:
+    case ProcessAssertionType::NearSuspended:
     case ProcessAssertionType::Background:
     case ProcessAssertionType::UnboundedNetworking:
     case ProcessAssertionType::Foreground:
@@ -489,7 +489,7 @@ ProcessAndUIAssertion::~ProcessAndUIAssertion()
 #if PLATFORM(IOS_FAMILY)
 void ProcessAndUIAssertion::updateRunInBackgroundCount()
 {
-    bool shouldHoldBackgroundTask = isValid() && type() != ProcessAssertionType::Suspended;
+    bool shouldHoldBackgroundTask = isValid() && type() != ProcessAssertionType::NearSuspended;
     if (m_isHoldingBackgroundTask == shouldHoldBackgroundTask)
         return;
 

--- a/Source/WebKit/UIProcess/ProcessAssertion.cpp
+++ b/Source/WebKit/UIProcess/ProcessAssertion.cpp
@@ -34,8 +34,8 @@ namespace WebKit {
 ASCIILiteral processAssertionTypeDescription(ProcessAssertionType type)
 {
     switch (type) {
-    case ProcessAssertionType::Suspended:
-        return "suspended"_s;
+    case ProcessAssertionType::NearSuspended:
+        return "near-suspended"_s;
     case ProcessAssertionType::Background:
         return "background"_s;
     case ProcessAssertionType::UnboundedNetworking:

--- a/Source/WebKit/UIProcess/ProcessAssertion.h
+++ b/Source/WebKit/UIProcess/ProcessAssertion.h
@@ -45,7 +45,7 @@ OBJC_CLASS WKRBSAssertionDelegate;
 namespace WebKit {
 
 enum class ProcessAssertionType {
-    Suspended,
+    NearSuspended,
     Background,
     UnboundedNetworking,
     Foreground,

--- a/Source/WebKit/UIProcess/ProcessThrottler.h
+++ b/Source/WebKit/UIProcess/ProcessThrottler.h
@@ -123,8 +123,8 @@ public:
     void didDisconnectFromProcess();
     bool shouldBeRunnable() const { return m_foregroundActivities.size() || m_backgroundActivities.size(); }
     void setAllowsActivities(bool);
-    void setShouldDropSuspendedAssertionAfterDelay(bool shouldDropAfterDelay) { m_shouldDropSuspendedAssertionAfterDelay = shouldDropAfterDelay; }
-    void setShouldTakeSuspendedAssertion(bool);
+    void setShouldDropNearSuspendedAssertionAfterDelay(bool shouldDropAfterDelay) { m_shouldDropNearSuspendedAssertionAfterDelay = shouldDropAfterDelay; }
+    void setShouldTakeNearSuspendedAssertion(bool);
     void delaySuspension();
     bool isSuspended() const { return m_processIdentifier && !m_assertion; }
     ProcessThrottleState currentState() const { return m_state; }
@@ -139,7 +139,7 @@ private:
     void setAssertionType(ProcessAssertionType);
     void setThrottleState(ProcessThrottleState);
     void prepareToSuspendTimeoutTimerFired();
-    void dropSuspendedAssertionTimerFired();
+    void dropNearSuspendedAssertionTimerFired();
     void sendPrepareToSuspendIPC(IsSuspensionImminent);
     void processReadyToSuspend();
 
@@ -158,14 +158,14 @@ private:
     ProcessID m_processIdentifier { 0 };
     RefPtr<ProcessAssertion> m_assertion;
     RunLoop::Timer m_prepareToSuspendTimeoutTimer;
-    RunLoop::Timer m_dropSuspendedAssertionTimer;
+    RunLoop::Timer m_dropNearSuspendedAssertionTimer;
     HashSet<Activity*> m_foregroundActivities;
     HashSet<Activity*> m_backgroundActivities;
     std::optional<uint64_t> m_pendingRequestToSuspendID;
     ProcessThrottleState m_state { ProcessThrottleState::Suspended };
-    bool m_shouldDropSuspendedAssertionAfterDelay { false };
+    bool m_shouldDropNearSuspendedAssertionAfterDelay { false };
     bool m_shouldTakeUIBackgroundAssertion { false };
-    bool m_shouldTakeSuspendedAssertion { true };
+    bool m_shouldTakeNearSuspendedAssertion { true };
     bool m_allowsActivities { true };
 };
 

--- a/Source/WebKit/UIProcess/WebProcessProxy.cpp
+++ b/Source/WebKit/UIProcess/WebProcessProxy.cpp
@@ -698,22 +698,22 @@ Ref<WebPageProxy> WebProcessProxy::createWebPage(PageClient& pageClient, Ref<API
     return webPage;
 }
 
-bool WebProcessProxy::shouldTakeSuspendedAssertion() const
+bool WebProcessProxy::shouldTakeNearSuspendedAssertion() const
 {
 #if USE(RUNNINGBOARD)
     for (auto& page : m_pageMap.values()) {
         bool processSuppressionEnabled = page->preferences().pageVisibilityBasedProcessSuppressionEnabled();
-        bool suspendedAssertionsEnabled = page->preferences().shouldTakeSuspendedAssertions();
-        if (suspendedAssertionsEnabled || !processSuppressionEnabled)
+        bool nearSuspendedAssertionsEnabled = page->preferences().shouldTakeNearSuspendedAssertions();
+        if (nearSuspendedAssertionsEnabled || !processSuppressionEnabled)
             return true;
     }
 #endif
     return false;
 }
 
-bool WebProcessProxy::shouldDropSuspendedAssertionAfterDelay() const
+bool WebProcessProxy::shouldDropNearSuspendedAssertionAfterDelay() const
 {
-    return WTF::anyOf(m_pageMap.values(), [](auto& page) { return page->preferences().shouldDropSuspendedAssertionAfterDelay(); });
+    return WTF::anyOf(m_pageMap.values(), [](auto& page) { return page->preferences().shouldDropNearSuspendedAssertionAfterDelay(); });
 }
 
 void WebProcessProxy::addExistingWebPage(WebPageProxy& webPage, BeginsUsingDataStore beginsUsingDataStore)
@@ -740,8 +740,8 @@ void WebProcessProxy::addExistingWebPage(WebPageProxy& webPage, BeginsUsingDataS
     m_pageMap.set(webPage.identifier(), WeakPtr { webPage });
     globalPageMap().set(webPage.identifier(), WeakPtr { webPage });
 
-    m_throttler.setShouldTakeSuspendedAssertion(shouldTakeSuspendedAssertion());
-    m_throttler.setShouldDropSuspendedAssertionAfterDelay(shouldDropSuspendedAssertionAfterDelay());
+    m_throttler.setShouldTakeNearSuspendedAssertion(shouldTakeNearSuspendedAssertion());
+    m_throttler.setShouldDropNearSuspendedAssertionAfterDelay(shouldDropNearSuspendedAssertionAfterDelay());
 
     updateRegistrationWithDataStore();
     updateBackgroundResponsivenessTimer();
@@ -1241,8 +1241,8 @@ void WebProcessProxy::didFinishLaunching(ProcessLauncher* launcher, IPC::Connect
 #endif // PLATFORM(MAC)
 #endif // USE(RUNNINGBOARD)
 
-    m_throttler.setShouldTakeSuspendedAssertion(shouldTakeSuspendedAssertion());
-    m_throttler.setShouldDropSuspendedAssertionAfterDelay(shouldDropSuspendedAssertionAfterDelay());
+    m_throttler.setShouldTakeNearSuspendedAssertion(shouldTakeNearSuspendedAssertion());
+    m_throttler.setShouldDropNearSuspendedAssertionAfterDelay(shouldDropNearSuspendedAssertionAfterDelay());
 
 #if PLATFORM(COCOA)
     unblockAccessibilityServerIfNeeded();

--- a/Source/WebKit/UIProcess/WebProcessProxy.h
+++ b/Source/WebKit/UIProcess/WebProcessProxy.h
@@ -600,8 +600,8 @@ private:
     bool messageSourceIsValidWebContentProcess();
 #endif
 
-    bool shouldTakeSuspendedAssertion() const;
-    bool shouldDropSuspendedAssertionAfterDelay() const;
+    bool shouldTakeNearSuspendedAssertion() const;
+    bool shouldDropNearSuspendedAssertionAfterDelay() const;
 
     enum class IsWeak : bool { No, Yes };
     template<typename T> class WeakOrStrongPtr {


### PR DESCRIPTION
#### 725baabf99499e288ac06612634c23e9dd58869b
<pre>
Provide a more useful exception message when a qualified name fails validation
<a href="https://bugs.webkit.org/show_bug.cgi?id=256385">https://bugs.webkit.org/show_bug.cgi?id=256385</a>

Reviewed by NOBODY (OOPS!).

* LayoutTests/fast/dom/dataset-expected.txt:
* LayoutTests/fast/dom/dataset-xhtml-expected.txt:
* LayoutTests/fast/dom/qualified-name-validation-expected.txt: Added.
* LayoutTests/fast/dom/qualified-name-validation.html: Added.
* Source/WebCore/dom/Document.cpp:
(WebCore::Document::createElementForBindings):
(WebCore::Document::createProcessingInstruction):
(WebCore::Document::parseQualifiedName):
(WebCore::Document::createAttribute):
* Source/WebCore/dom/Element.cpp:
(WebCore::Element::toggleAttribute):
(WebCore::Element::setAttribute):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e1aecbf721c07a09a84e51660a85aea2c127c2a2

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/5630 "1 style error") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/5784 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/5972 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/7182 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/32/builds/5621 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/6009 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/5757 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/7575 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/5733 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/5788 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/5046 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/7223 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/3265 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/5067 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/12178 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/4685 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/5134 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/5144 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/6970 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/5214 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/5582 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/4566 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/5740 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/5032 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/1405 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/9141 "Built successfully") | | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/24/builds/5901 "Built successfully") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/5393 "Built successfully") | | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/3/builds/1524 "Passed tests") | 
<!--EWS-Status-Bubble-End-->