### PR TITLE
`input.validity` reports `valid: true` for partially completed dates/times

### DIFF
--- a/LayoutTests/fast/forms/date/date-validity-badinput-expected.txt
+++ b/LayoutTests/fast/forms/date/date-validity-badinput-expected.txt
@@ -1,0 +1,3 @@
+
+PASS A date input field with a bad user input should make validity.badInput true and have :invalid style.
+

--- a/LayoutTests/fast/forms/date/date-validity-badinput.html
+++ b/LayoutTests/fast/forms/date/date-validity-badinput.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<html>
+<meta charset="utf-8">
+<script src="../../../resources/testharness.js"></script>
+<script src="../../../resources/testharnessreport.js"></script>
+<script src="../resources/datetime-validity-badinput.js"></script>
+<style>
+:invalid {
+    background-color: #ff0000;
+}
+</style>
+<body>
+<div id="log"></div>
+<script>
+testBadInput('date');
+</script>
+</body>
+</html>

--- a/LayoutTests/fast/forms/datetimelocal/datetimelocal-validity-badinput-expected.txt
+++ b/LayoutTests/fast/forms/datetimelocal/datetimelocal-validity-badinput-expected.txt
@@ -1,0 +1,3 @@
+
+PASS A datetime-local input field with a bad user input should make validity.badInput true and have :invalid style.
+

--- a/LayoutTests/fast/forms/datetimelocal/datetimelocal-validity-badinput.html
+++ b/LayoutTests/fast/forms/datetimelocal/datetimelocal-validity-badinput.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<html>
+<meta charset="utf-8">
+<script src="../../../resources/testharness.js"></script>
+<script src="../../../resources/testharnessreport.js"></script>
+<script src="../resources/datetime-validity-badinput.js"></script>
+<style>
+:invalid {
+    background-color: #ff0000;
+}
+</style>
+<body>
+<div id="log"></div>
+<script>
+testBadInput('datetime-local');
+</script>
+</body>
+</html>

--- a/LayoutTests/fast/forms/resources/datetime-validity-badinput.js
+++ b/LayoutTests/fast/forms/resources/datetime-validity-badinput.js
@@ -1,0 +1,46 @@
+function testBadInput(type) {
+    test(() => {
+        if (!window.eventSender) {
+            assert_false(true, 'eventSender is required for this test');
+            return;
+        }
+
+        function backgroundColor(el) {
+            return getComputedStyle(el, null).getPropertyValue('background-color');
+        }
+
+        const invalidStyleColor = 'rgb(255, 0, 0)';
+
+        const input = document.createElement('input');
+        input.type = type;
+        document.body.appendChild(input);
+
+        input.focus();
+
+        // Initial state. The element has no value.
+        assert_not_equals(backgroundColor(input), invalidStyleColor, 'Input has no value. It should not have invalid style.');
+        assert_false(input.validity.badInput, 'Input has no value. badInput should be false.');
+
+        // Set a value to the first sub-field. The element becomes badInput.
+        eventSender.keyDown('upArrow');
+        assert_equals(backgroundColor(input), invalidStyleColor, 'Input is partially filled, it is invalid.');
+        assert_true(input.validity.badInput, 'Input is partially filled. badInput should be true.');
+
+        if (type == 'date' || type== 'datetime' || type == 'datetime-local') {
+            // Set an invalid date, 2012-02-31.
+            if (type == 'date')
+                input.value = '2012-02-01';
+            else if (type == 'datetime')
+                input.value = '2012-02-01T03:04Z';
+            else
+                input.value = '2012-02-01T03:04';
+            assert_not_equals(backgroundColor(input), invalidStyleColor, 'Input has valid date, it is valid.');
+            assert_false(input.validity.badInput, 'Input has valid date. badInput should be false.');
+            eventSender.keyDown('rightArrow'); // -> 02/[01]/2012 ...
+            eventSender.keyDown('downArrow'); //  -> 02/[31]/2012 ...
+            assert_equals(input.value, '', 'Input was changed to invalid date, value is empty.');
+            assert_true(input.validity.badInput, 'Input was changed to invalid date. badInput should be true');
+            assert_equals(backgroundColor(input), invalidStyleColor, 'Input was changed to invalid date.');
+        }
+    }, 'A ' + type + ' input field with a bad user input should make validity.badInput true and have :invalid style.');
+}

--- a/LayoutTests/fast/forms/time/time-validity-badinput-expected.txt
+++ b/LayoutTests/fast/forms/time/time-validity-badinput-expected.txt
@@ -1,0 +1,3 @@
+
+PASS A time input field with a bad user input should make validity.badInput true and have :invalid style.
+

--- a/LayoutTests/fast/forms/time/time-validity-badinput.html
+++ b/LayoutTests/fast/forms/time/time-validity-badinput.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<html>
+<meta charset="utf-8">
+<script src="../../../resources/testharness.js"></script>
+<script src="../../../resources/testharnessreport.js"></script>
+<script src="../resources/datetime-validity-badinput.js"></script>
+<style>
+:invalid {
+    background-color: #ff0000;
+}
+</style>
+<body>
+<div id="log"></div>
+<script>
+testBadInput('time');
+</script>
+</body>
+</html>

--- a/LayoutTests/platform/ios-wk2/TestExpectations
+++ b/LayoutTests/platform/ios-wk2/TestExpectations
@@ -2399,3 +2399,8 @@ http/wpt/loading/early-hints [ Pass ]
 webkit.org/b/253533 imported/w3c/web-platform-tests/fetch/api/basic/status.h2.any.html [ Pass ]
 webkit.org/b/253533 imported/w3c/web-platform-tests/fetch/api/basic/status.h2.any.worker.html [ Pass ]
 webkit.org/b/253533 imported/w3c/web-platform-tests/xhr/status.h2.window.html [ Pass ]
+
+# Date-time inputs on iOS work differently.
+fast/forms/date/date-validity-badinput.html [ Skip ]
+fast/forms/datetimelocal/datetimelocal-validity-badinput.html [ Skip ]
+fast/forms/time/time-validity-badinput.html [ Skip ]

--- a/Source/WebCore/html/BaseDateAndTimeInputType.cpp
+++ b/Source/WebCore/html/BaseDateAndTimeInputType.cpp
@@ -168,6 +168,12 @@ bool BaseDateAndTimeInputType::typeMismatch() const
     return typeMismatchFor(element()->value());
 }
 
+bool BaseDateAndTimeInputType::hasBadInput() const
+{
+    ASSERT(element());
+    return element()->value().isEmpty() && m_dateTimeEditElement && m_dateTimeEditElement->editableFieldsHaveValues();
+}
+
 Decimal BaseDateAndTimeInputType::defaultValueForStepUp() const
 {
     double ms = WallTime::now().secondsSinceEpoch().milliseconds();

--- a/Source/WebCore/html/BaseDateAndTimeInputType.h
+++ b/Source/WebCore/html/BaseDateAndTimeInputType.h
@@ -52,6 +52,7 @@ public:
     bool typeMismatchFor(const String&) const final;
     bool valueMissing(const String&) const final;
     bool typeMismatch() const final;
+    bool hasBadInput() const final;
 
 protected:
     enum class DateTimeFormatValidationResults : uint8_t {

--- a/Source/WebCore/html/shadow/DateTimeEditElement.cpp
+++ b/Source/WebCore/html/shadow/DateTimeEditElement.cpp
@@ -404,6 +404,15 @@ DateTimeFieldsState DateTimeEditElement::valueAsDateTimeFieldsState() const
     return dateTimeFieldsState;
 }
 
+bool DateTimeEditElement::editableFieldsHaveValues() const
+{
+    for (auto& field : m_fields) {
+        if (field->hasValue())
+            return true;
+    }
+    return false;
+}
+
 } // namespace WebCore
 
 #endif // ENABLE(DATE_AND_TIME_INPUT_TYPES)

--- a/Source/WebCore/html/shadow/DateTimeEditElement.h
+++ b/Source/WebCore/html/shadow/DateTimeEditElement.h
@@ -73,6 +73,7 @@ public:
     void setEmptyValue(const LayoutParameters&);
     void setValueAsDate(const LayoutParameters&, const DateComponents&);
     String value() const;
+    bool editableFieldsHaveValues() const;
 
 private:
     // Datetime can be represented by at most 8 fields:


### PR DESCRIPTION
#### ec9036933491f8f64f0f2c1c75736a2e125da1b9
<pre>
`input.validity` reports `valid: true` for partially completed dates/times
<a href="https://bugs.webkit.org/show_bug.cgi?id=248401">https://bugs.webkit.org/show_bug.cgi?id=248401</a>
rdar://102984901

Reviewed by Aditya Keerthi.

Porting over parts of: <a href="https://github.com/chromium/chromium/commit/f890442a85ed9791096348138eb305cd97b385b7">https://github.com/chromium/chromium/commit/f890442a85ed9791096348138eb305cd97b385b7</a>

We should report badInput: true (and hence valid: false), when the input[type=date/time/datetime-local] are partially filled.

* LayoutTests/fast/forms/date/date-validity-badinput-expected.txt: Added.
* LayoutTests/fast/forms/date/date-validity-badinput.html: Added.
* LayoutTests/fast/forms/datetimelocal/datetimelocal-validity-badinput-expected.txt: Added.
* LayoutTests/fast/forms/datetimelocal/datetimelocal-validity-badinput.html: Added.
* LayoutTests/fast/forms/resources/datetime-validity-badinput.js: Added.
(testBadInput.test):
(testBadInput):
* LayoutTests/fast/forms/time/time-validity-badinput-expected.txt: Added.
* LayoutTests/fast/forms/time/time-validity-badinput.html: Added.
* LayoutTests/platform/ios-wk2/TestExpectations:
* Source/WebCore/html/BaseDateAndTimeInputType.cpp:
(WebCore::BaseDateAndTimeInputType::hasBadInput const):
* Source/WebCore/html/BaseDateAndTimeInputType.h:
* Source/WebCore/html/shadow/DateTimeEditElement.cpp:
(WebCore::DateTimeEditElement::editableFieldsHaveValues const):
* Source/WebCore/html/shadow/DateTimeEditElement.h:

Canonical link: <a href="https://commits.webkit.org/263748@main">https://commits.webkit.org/263748@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/da356c9b11f09f0eef4b05bd383aeefc1df8fba1

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/5674 "Failed to checkout and rebase branch from PR 13523") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/5830 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/6020 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/7226 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/32/builds/5677 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [  ~~🧪 bindings~~](https://ews-build.webkit.org/#/builders/9/builds/5675 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/6052 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/5802 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/7826 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [❌ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/5780 "Failed to checkout and rebase branch from PR 13523") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/15/builds/5826 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/5083 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/7275 "Built successfully") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/39/builds/3303 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/10/builds/5107 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/12805 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/5171 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/5184 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/7024 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/5623 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/4600 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/30/builds/5070 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/5037 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/9184 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/649 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/5431 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->