### PR TITLE
Implement ArgumentCoder for SharedMemoryHandle

### DIFF
--- a/Source/WebKit/Platform/unix/SharedMemoryUnix.cpp
+++ b/Source/WebKit/Platform/unix/SharedMemoryUnix.cpp
@@ -26,10 +26,10 @@
  */
 
 #include "config.h"
-#if USE(UNIX_DOMAIN_SOCKETS)
 #include "SharedMemory.h"
 
-#include "WebCoreArgumentCoders.h"
+#if USE(UNIX_DOMAIN_SOCKETS)
+
 #include <errno.h>
 #include <fcntl.h>
 #include <stdlib.h>
@@ -52,38 +52,17 @@
 
 namespace WebKit {
 
-void SharedMemory::Handle::clear()
+void SharedMemoryHandle::clear()
 {
     *this = { };
 }
 
-bool SharedMemory::Handle::isNull() const
+bool SharedMemoryHandle::isNull() const
 {
     return !m_handle;
 }
 
-void SharedMemory::Handle::encode(IPC::Encoder& encoder) const
-{
-    encoder << m_size << WTFMove(m_handle);
-}
-
-bool SharedMemory::Handle::decode(IPC::Decoder& decoder, SharedMemory::Handle& handle)
-{
-    ASSERT_ARG(handle, handle.isNull());
-    size_t size;
-    if (!decoder.decode(size))
-        return false;
-
-    auto fd = decoder.decode<UnixFileDescriptor>();
-    if (UNLIKELY(!decoder.isValid()))
-        return false;
-
-    handle.m_size = size;
-    handle.m_handle = WTFMove(*fd);
-    return true;
-}
-
-UnixFileDescriptor SharedMemory::Handle::releaseHandle()
+UnixFileDescriptor SharedMemoryHandle::releaseHandle()
 {
     return WTFMove(m_handle);
 }

--- a/Source/WebKit/Platform/win/SharedMemoryWin.cpp
+++ b/Source/WebKit/Platform/win/SharedMemoryWin.cpp
@@ -27,45 +27,16 @@
 #include "config.h"
 #include "SharedMemory.h"
 
-#include "ArgumentCoders.h"
 #include <wtf/RefPtr.h>
 
 namespace WebKit {
 
-bool SharedMemory::Handle::isNull() const
+bool SharedMemoryHandle::isNull() const
 {
     return !m_handle;
 }
 
-void SharedMemory::Handle::encode(IPC::Encoder& encoder) const
-{
-    encoder << static_cast<uint64_t>(m_size);
-    // Hand off ownership of our HANDLE to the receiving process. It will close it for us.
-    // FIXME: If the receiving process crashes before it receives the memory, the memory will be
-    // leaked. See <http://webkit.org/b/47502>.
-    encoder << WTFMove(m_handle);
-}
-
-bool SharedMemory::Handle::decode(IPC::Decoder& decoder, SharedMemory::Handle& handle)
-{
-    ASSERT_ARG(handle, !handle.m_handle);
-    ASSERT_ARG(handle, !handle.m_size);
-
-    uint64_t dataLength;
-    if (!decoder.decode(dataLength))
-        return false;
-    
-    auto processSpecificHandle = decoder.decode<Win32Handle>();
-    if (!processSpecificHandle)
-        return false;
-
-    handle.m_handle = WTFMove(*processSpecificHandle);
-    handle.m_size = dataLength;
-    return true;
-}
-
-
-void SharedMemory::Handle::clear()
+void SharedMemoryHandle::clear()
 {
     m_handle = { };
 }

--- a/Source/WebKit/Shared/ShareableBitmap.serialization.in
+++ b/Source/WebKit/Shared/ShareableBitmap.serialization.in
@@ -34,7 +34,7 @@ header: "ShareableBitmap.h"
 }
 
 [CustomHeader] class WebKit::ShareableBitmapHandle {
-    WebKit::SharedMemory::Handle m_handle;
+    WebKit::SharedMemoryHandle m_handle;
     [Validator='!m_configuration->sizeInBytes().hasOverflowed() && m_handle->size() >= m_configuration->sizeInBytes()'] WebKit::ShareableBitmapConfiguration m_configuration;
 }
 

--- a/Source/WebKit/Shared/WebHitTestResultData.serialization.in
+++ b/Source/WebKit/Shared/WebHitTestResultData.serialization.in
@@ -47,7 +47,7 @@ struct WebKit::WebHitTestResultData {
     String lookupText;
     String toolTipText;
     String imageText;
-    std::optional<WebKit::SharedMemory::Handle> getImageSharedMemoryHandle();
+    std::optional<WebKit::SharedMemoryHandle> getImageSharedMemoryHandle();
     RefPtr<WebKit::ShareableBitmap> imageBitmap;
     String sourceImageMIMEType;
     


### PR DESCRIPTION
#### 4efa5e604a3679ed00add70c7451c7dfb50b0a59
<pre>
Implement ArgumentCoder for SharedMemoryHandle
<a href="https://bugs.webkit.org/show_bug.cgi?id=256402">https://bugs.webkit.org/show_bug.cgi?id=256402</a>

Reviewed by Darin Adler.

Move serialization of `SharedMemoryHandle` to use an `ArgumentCoder`.
This patch prepares `SharedMemoryHandle` for being generated through
a `serialization.in` file. The generator cannot currently handle move
semantics so it was not able to be used yet.

* Source/WebKit/Platform/SharedMemory.cpp:
* Source/WebKit/Platform/SharedMemory.h:
* Source/WebKit/Platform/cocoa/SharedMemoryCocoa.cpp:
* Source/WebKit/Platform/unix/SharedMemoryUnix.cpp:
* Source/WebKit/Platform/win/SharedMemoryWin.cpp:
* Source/WebKit/Shared/ShareableBitmap.serialization.in:
* Source/WebKit/Shared/WebHitTestResultData.serialization.in:

Canonical link: <a href="https://commits.webkit.org/263781@main">https://commits.webkit.org/263781@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/cf8d951c2bac06210b051cfb247ca8b006083f7a

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/5738 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/5901 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/6090 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/7295 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/6130 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/6123 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/5869 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/7901 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/5843 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/5889 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/5168 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/7351 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/3366 "Passed tests") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/12939 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/5234 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/5242 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/7298 "run-api-tests-without-change (failure)") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/5687 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/4659 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/5133 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/1351 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/9249 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/5493 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->