### PR TITLE
Defer AX object cache update as an event loop task instead of a post layout task

### DIFF
--- a/LayoutTests/accessibility/mac/input-type-change-crash-expected.txt
+++ b/LayoutTests/accessibility/mac/input-type-change-crash-expected.txt
@@ -1,8 +1,8 @@
 This tests setting the value to a readonly or disabled text field which was previously editable
 
 AXTextStateChangeType=1 AXTextChangeValues=[{"AXTextChangeValue":"a","AXTextEditType":3}]
-AXTextStateChangeType=1 AXTextChangeValues=[{"AXTextChangeValue":"a","AXTextEditType":1},{"AXTextChangeValue":"hello","AXTextEditType":2}]
 AXTextStateChangeType=1 AXTextChangeValues=[{"AXTextChangeValue":"b","AXTextEditType":3}]
+AXTextStateChangeType=1 AXTextChangeValues=[{"AXTextChangeValue":"a","AXTextEditType":1},{"AXTextChangeValue":"hellob","AXTextEditType":2}]
 AXTextStateChangeType=1 AXTextChangeValues=[{"AXTextChangeValue":"hellob","AXTextEditType":1},{"AXTextChangeValue":"world","AXTextEditType":2}]
 AXTextStateChangeType=1 AXTextChangeValues=[{"AXTextChangeValue":"c","AXTextEditType":3}]
 AXTextStateChangeType=1 AXTextChangeValues=[{"AXTextChangeValue":"worldc","AXTextEditType":1},{"AXTextChangeValue":"WebKit","AXTextEditType":2}]

--- a/LayoutTests/accessibility/mac/tab-focus-post-notification.html
+++ b/LayoutTests/accessibility/mac/tab-focus-post-notification.html
@@ -34,16 +34,26 @@ if (window.testRunner && window.accessibilityController) {
             return;
         count++;
         if (count == 3) {
+          document.getElementById("content").remove();
           finishJSTest();
         }
     });
 
     // Tab 3 times we should be able to get same count of notificaitons
     shouldBeTrue("count == 0");
-    for (var i = 1; i <= 3; i++) 
-        eventSender.keyDown("\t");
 
-    document.getElementById("content").style.visibility = "hidden";
+    async function waitForRAF()
+    {
+        return new Promise(resolve => { requestAnimationFrame(() => setTimeout(resolve, 0)); });
+    }
+
+    (async function () {
+        await waitForRAF();
+        for (var i = 1; i <= 3; i++) {
+            eventSender.keyDown("\t");
+            await waitForRAF();
+        }
+    })();
 }
 </script>
 <script src="../../resources/js-test-post.js"></script>

--- a/LayoutTests/accessibility/mac/textbox-role-reports-notifications.html
+++ b/LayoutTests/accessibility/mac/textbox-role-reports-notifications.html
@@ -15,14 +15,16 @@
 
         var ariaTextBox = document.getElementById("ariaTextBox");
         ariaTextBox.focus();
+        internals.updateLayoutIgnorePendingStylesheetsAndRunPostLayoutTasks();
         textboxAxElement = accessibilityController.focusedElement;
         textboxAxElement.addNotificationListener(logNotification);
         pendingNotifications = 3;
         ariaTextBox.firstChild.deleteData(0, 5);
-        ariaTextBox.offsetWidth;
+        internals.updateLayoutIgnorePendingStylesheetsAndRunPostLayoutTasks();
         ariaTextBox.textContent = "changed textContent";
-        ariaTextBox.offsetWidth;
+        internals.updateLayoutIgnorePendingStylesheetsAndRunPostLayoutTasks();
         ariaTextBox.innerText = "changed innerText";
+        internals.updateLayoutIgnorePendingStylesheetsAndRunPostLayoutTasks();
     }
 
     function logNotification(notification) {

--- a/LayoutTests/accessibility/nested-textareas-value-changed-notifications-expected.txt
+++ b/LayoutTests/accessibility/nested-textareas-value-changed-notifications-expected.txt
@@ -8,12 +8,12 @@ AXValue:
 AXValue: aabc
 xyz
 def
-3 AXValueChanged for element outer_editable with AXRole: AXTextArea
+3 AXValueChanged for element  with AXRole: AXWebArea
+AXValue:
+4 AXValueChanged for element outer_editable with AXRole: AXTextArea
 AXValue: aabc
 xyz
 def
-4 AXValueChanged for element  with AXRole: AXWebArea
-AXValue:
 5 AXValueChanged for element  with AXRole: AXWebArea
 AXValue:
 6 AXValueChanged for element outer_editable with AXRole: AXTextArea

--- a/Source/WebCore/dom/Document.h
+++ b/Source/WebCore/dom/Document.h
@@ -1223,6 +1223,9 @@ public:
 
     WEBCORE_EXPORT String displayStringModifiedByEncoding(const String&) const;
 
+    void scheduleDeferredAXObjectCacheUpdate();
+    WEBCORE_EXPORT void flushDeferredAXObjectCacheUpdate();
+
     void updateAccessibilityObjectRegions();
     void updateEventRegions();
 
@@ -2397,6 +2400,8 @@ private:
     bool m_didDispatchViewportPropertiesChanged { false };
 #endif
     bool m_isDirAttributeDirty { false };
+
+    bool m_scheduledDeferredAXObjectCacheUpdate { false };
 
     static bool hasEverCreatedAnAXObjectCache;
 

--- a/Source/WebCore/page/LocalFrameView.cpp
+++ b/Source/WebCore/page/LocalFrameView.cpp
@@ -3857,8 +3857,7 @@ void LocalFrameView::performPostLayoutTasks()
 
     resnapAfterLayout();
 
-    if (AXObjectCache* cache = m_frame->document()->existingAXObjectCache())
-        cache->performDeferredCacheUpdate();
+    m_frame->document()->scheduleDeferredAXObjectCacheUpdate();
 }
 
 IntSize LocalFrameView::sizeForResizeEvent() const

--- a/Source/WebCore/testing/Internals.cpp
+++ b/Source/WebCore/testing/Internals.cpp
@@ -3977,6 +3977,8 @@ ExceptionOr<void> Internals::updateLayoutIgnorePendingStylesheetsAndRunPostLayou
         return Exception { TypeError };
 
     document->updateLayoutIgnorePendingStylesheets(Document::RunPostLayoutTasks::Synchronously);
+    document->flushDeferredAXObjectCacheUpdate();
+
     return { };
 }
 


### PR DESCRIPTION
#### e8027f0de5396f635ddfaf6b7ad8b38e05bc8fdd
<pre>
Defer AX object cache update as an event loop task instead of a post layout task
<a href="https://bugs.webkit.org/show_bug.cgi?id=256403">https://bugs.webkit.org/show_bug.cgi?id=256403</a>

Reviewed by Antti Koivisto.

Defer accessibility object cache updates until an event loop task instead of running
them as a post layout task since they can trigger synchronous author script execution.

* LayoutTests/accessibility/mac/input-type-change-crash-expected.txt: Rebaselined.

* LayoutTests/accessibility/mac/tab-focus-post-notification.html: Wait for rAF between
each tabbing so that AX objects have a chance to update themselves.

* LayoutTests/accessibility/mac/textbox-role-reports-notifications.html: Manually call
updateLayoutIgnorePendingStylesheetsAndRunPostLayoutTasks to flush AX cache updates.

* LayoutTests/accessibility/nested-textareas-value-changed-notifications-expected.txt:
Rebaselined.

* Source/WebCore/dom/Document.cpp:
(WebCore::Document::scheduleDeferredAXObjectCacheUpdate):
(WebCore::Document::flushDeferredAXObjectCacheUpdate):

* Source/WebCore/dom/Document.h:

* Source/WebCore/page/LocalFrameView.cpp:
(WebCore::LocalFrameView::performPostLayoutTasks):

* Source/WebCore/testing/Internals.cpp:
(WebCore::Internals::updateLayoutIgnorePendingStylesheetsAndRunPostLayoutTasks):
Manually flush the pending AX object cache updates.

Canonical link: <a href="https://commits.webkit.org/263832@main">https://commits.webkit.org/263832@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d84d80360d0d0a31b0a77dbdcd4be27c87ee5245

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/5818 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/5986 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/6174 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/7378 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/6209 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/5819 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/6208 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/5953 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/8097 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/5924 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/5973 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/5273 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/7433 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/3450 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/5249 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/13213 "8 flakes 149 failures") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/5318 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/5328 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/7545 "run-api-tests-without-change (failure)") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/5771 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/4740 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/5212 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/5179 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/9333 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/680 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/5573 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->