### PR TITLE
Adopt std::partial_ordering now that we require C++20

### DIFF
--- a/Source/WebCore/dom/BoundaryPoint.h
+++ b/Source/WebCore/dom/BoundaryPoint.h
@@ -42,14 +42,14 @@ bool operator==(const BoundaryPoint&, const BoundaryPoint&);
 
 WTF::TextStream& operator<<(WTF::TextStream&, const BoundaryPoint&);
 
-template<TreeType = Tree> PartialOrdering treeOrder(const BoundaryPoint&, const BoundaryPoint&);
+template<TreeType = Tree> std::partial_ordering treeOrder(const BoundaryPoint&, const BoundaryPoint&);
 
 WEBCORE_EXPORT std::optional<BoundaryPoint> makeBoundaryPointBeforeNode(Node&);
 WEBCORE_EXPORT std::optional<BoundaryPoint> makeBoundaryPointAfterNode(Node&);
 BoundaryPoint makeBoundaryPointBeforeNodeContents(Node&);
 BoundaryPoint makeBoundaryPointAfterNodeContents(Node&);
 
-WEBCORE_EXPORT PartialOrdering treeOrderForTesting(TreeType, const BoundaryPoint&, const BoundaryPoint&);
+WEBCORE_EXPORT std::partial_ordering treeOrderForTesting(TreeType, const BoundaryPoint&, const BoundaryPoint&);
 
 inline BoundaryPoint::BoundaryPoint(Ref<Node>&& container, unsigned offset)
     : container(WTFMove(container))

--- a/Source/WebCore/dom/Node.cpp
+++ b/Source/WebCore/dom/Node.cpp
@@ -2785,35 +2785,35 @@ static bool isSiblingSubsequent(const Node& siblingA, const Node& siblingB)
     return false;
 }
 
-template<TreeType treeType> PartialOrdering treeOrder(const Node& a, const Node& b)
+template<TreeType treeType> std::partial_ordering treeOrder(const Node& a, const Node& b)
 {
     if (&a == &b)
-        return PartialOrdering::equivalent;
+        return std::partial_ordering::equivalent;
     auto result = commonInclusiveAncestorAndChildren<treeType>(a, b);
     if (!result.commonAncestor)
-        return PartialOrdering::unordered;
+        return std::partial_ordering::unordered;
     if (!result.distinctAncestorA)
-        return PartialOrdering::less;
+        return std::partial_ordering::less;
     if (!result.distinctAncestorB)
-        return PartialOrdering::greater;
+        return std::partial_ordering::greater;
     bool isShadowRootA = result.distinctAncestorA->isShadowRoot();
     bool isShadowRootB = result.distinctAncestorB->isShadowRoot();
     if (isShadowRootA || isShadowRootB) {
         if (!isShadowRootB)
-            return PartialOrdering::less;
+            return std::partial_ordering::less;
         if (!isShadowRootA)
-            return PartialOrdering::greater;
+            return std::partial_ordering::greater;
         ASSERT_NOT_REACHED();
-        return PartialOrdering::unordered;
+        return std::partial_ordering::unordered;
     }
-    return isSiblingSubsequent(*result.distinctAncestorA, *result.distinctAncestorB) ? PartialOrdering::less : PartialOrdering::greater;
+    return isSiblingSubsequent(*result.distinctAncestorA, *result.distinctAncestorB) ? std::partial_ordering::less : std::partial_ordering::greater;
 }
 
-template PartialOrdering treeOrder<Tree>(const Node&, const Node&);
-template PartialOrdering treeOrder<ShadowIncludingTree>(const Node&, const Node&);
-template PartialOrdering treeOrder<ComposedTree>(const Node&, const Node&);
+template std::partial_ordering treeOrder<Tree>(const Node&, const Node&);
+template std::partial_ordering treeOrder<ShadowIncludingTree>(const Node&, const Node&);
+template std::partial_ordering treeOrder<ComposedTree>(const Node&, const Node&);
 
-PartialOrdering treeOrderForTesting(TreeType type, const Node& a, const Node& b)
+std::partial_ordering treeOrderForTesting(TreeType type, const Node& a, const Node& b)
 {
     switch (type) {
     case Tree:
@@ -2824,7 +2824,7 @@ PartialOrdering treeOrderForTesting(TreeType type, const Node& a, const Node& b)
         return treeOrder<ComposedTree>(a, b);
     }
     ASSERT_NOT_REACHED();
-    return PartialOrdering::unordered;
+    return std::partial_ordering::unordered;
 }
 
 TextStream& operator<<(TextStream& ts, const Node& node)

--- a/Source/WebCore/dom/Position.cpp
+++ b/Source/WebCore/dom/Position.cpp
@@ -1616,22 +1616,22 @@ std::optional<BoundaryPoint> makeBoundaryPoint(const Position& position)
     return BoundaryPoint { container.releaseNonNull(), static_cast<unsigned>(position.computeOffsetInContainerNode()) };
 }
 
-template<TreeType treeType> PartialOrdering treeOrder(const Position& a, const Position& b)
+template<TreeType treeType> std::partial_ordering treeOrder(const Position& a, const Position& b)
 {
     if (a.isNull() || b.isNull())
-        return a.isNull() && b.isNull() ? PartialOrdering::equivalent : PartialOrdering::unordered;
+        return a.isNull() && b.isNull() ? std::partial_ordering::equivalent : std::partial_ordering::unordered;
 
     auto aContainer = a.containerNode();
     auto bContainer = b.containerNode();
 
     if (!aContainer || !bContainer) {
         if (!commonInclusiveAncestor<treeType>(*a.anchorNode(), *b.anchorNode()))
-            return PartialOrdering::unordered;
+            return std::partial_ordering::unordered;
         if (!aContainer && !bContainer && a.anchorType() == b.anchorType())
-            return PartialOrdering::equivalent;
+            return std::partial_ordering::equivalent;
         if (bContainer)
-            return a.anchorType() == Position::PositionIsBeforeAnchor ? PartialOrdering::less : PartialOrdering::greater;
-        return b.anchorType() == Position::PositionIsBeforeAnchor ? PartialOrdering::greater : PartialOrdering::less;
+            return a.anchorType() == Position::PositionIsBeforeAnchor ? std::partial_ordering::less : std::partial_ordering::greater;
+        return b.anchorType() == Position::PositionIsBeforeAnchor ? std::partial_ordering::greater : std::partial_ordering::less;
     }
 
     // FIXME: Avoid computing node offset for cases where we don't need to.
@@ -1639,13 +1639,13 @@ template<TreeType treeType> PartialOrdering treeOrder(const Position& a, const P
     return treeOrder<treeType>(*makeBoundaryPoint(a), *makeBoundaryPoint(b));
 }
 
-PartialOrdering documentOrder(const Position& a, const Position& b)
+std::partial_ordering documentOrder(const Position& a, const Position& b)
 {
     return treeOrder<ComposedTree>(a, b);
 }
 
-template PartialOrdering treeOrder<ComposedTree>(const Position&, const Position&);
-template PartialOrdering treeOrder<ShadowIncludingTree>(const Position&, const Position&);
+template std::partial_ordering treeOrder<ComposedTree>(const Position&, const Position&);
+template std::partial_ordering treeOrder<ShadowIncludingTree>(const Position&, const Position&);
 
 } // namespace WebCore
 

--- a/Source/WebCore/dom/Position.h
+++ b/Source/WebCore/dom/Position.h
@@ -219,8 +219,8 @@ private:
 
 bool operator==(const Position&, const Position&);
 
-template<TreeType treeType> PartialOrdering treeOrder(const Position&, const Position&);
-WEBCORE_EXPORT PartialOrdering documentOrder(const Position&, const Position&);
+template<TreeType treeType> std::partial_ordering treeOrder(const Position&, const Position&);
+WEBCORE_EXPORT std::partial_ordering documentOrder(const Position&, const Position&);
 bool operator<(const Position&, const Position&);
 bool operator>(const Position&, const Position&);
 bool operator>=(const Position&, const Position&);

--- a/Source/WebCore/dom/Range.cpp
+++ b/Source/WebCore/dom/Range.cpp
@@ -180,7 +180,7 @@ ExceptionOr<short> Range::comparePoint(Node& container, unsigned offset) const
     auto ordering = treeOrder({ container, offset }, makeSimpleRange(*this));
     if (is_lt(ordering))
         return -1;
-    if (is_eq(ordering))
+    if (WebCore::is_eq(ordering))
         return 0;
     if (is_gt(ordering))
         return 1;
@@ -248,7 +248,7 @@ ExceptionOr<short> Range::compareBoundaryPoints(unsigned short how, const Range&
     auto ordering = treeOrder(makeBoundaryPoint(*thisPoint), makeBoundaryPoint(*otherPoint));
     if (is_lt(ordering))
         return -1;
-    if (is_eq(ordering))
+    if (WebCore::is_eq(ordering))
         return 0;
     if (is_gt(ordering))
         return 1;

--- a/Source/WebCore/dom/SimpleRange.cpp
+++ b/Source/WebCore/dom/SimpleRange.cpp
@@ -174,26 +174,26 @@ bool containsForTesting(TreeType type, const SimpleRange& range, const BoundaryP
     return false;
 }
 
-template<TreeType treeType> PartialOrdering treeOrder(const SimpleRange& range, const BoundaryPoint& point)
+template<TreeType treeType> std::partial_ordering treeOrder(const SimpleRange& range, const BoundaryPoint& point)
 {
     if (auto order = treeOrder<treeType>(range.start, point); !is_lt(order))
         return order;
     if (auto order = treeOrder<treeType>(range.end, point); !is_gt(order))
         return order;
-    return PartialOrdering::equivalent;
+    return std::partial_ordering::equivalent;
 }
 
-template<TreeType treeType> PartialOrdering treeOrder(const BoundaryPoint& point, const SimpleRange& range)
+template<TreeType treeType> std::partial_ordering treeOrder(const BoundaryPoint& point, const SimpleRange& range)
 {
     if (auto order = treeOrder<treeType>(point, range.start); !is_gt(order))
         return order;
     if (auto order = treeOrder<treeType>(point, range.end); !is_lt(order))
         return order;
-    return PartialOrdering::equivalent;
+    return std::strong_ordering::equivalent;
 }
 
-template PartialOrdering treeOrder<Tree>(const SimpleRange&, const BoundaryPoint&);
-template PartialOrdering treeOrder<Tree>(const BoundaryPoint&, const SimpleRange&);
+template std::partial_ordering treeOrder<Tree>(const SimpleRange&, const BoundaryPoint&);
+template std::partial_ordering treeOrder<Tree>(const BoundaryPoint&, const SimpleRange&);
 
 template<TreeType treeType> bool contains(const SimpleRange& outerRange, const SimpleRange& innerRange)
 {

--- a/Source/WebCore/dom/SimpleRange.h
+++ b/Source/WebCore/dom/SimpleRange.h
@@ -83,8 +83,8 @@ WEBCORE_EXPORT bool intersectsForTesting(TreeType, const SimpleRange&, const Sim
 WEBCORE_EXPORT bool intersectsForTesting(TreeType, const SimpleRange&, const Node&);
 
 // Returns equivalent if point is in range.
-template<TreeType = Tree> PartialOrdering treeOrder(const SimpleRange&, const BoundaryPoint&);
-template<TreeType = Tree> PartialOrdering treeOrder(const BoundaryPoint&, const SimpleRange&);
+template<TreeType = Tree> std::partial_ordering treeOrder(const SimpleRange&, const BoundaryPoint&);
+template<TreeType = Tree> std::partial_ordering treeOrder(const BoundaryPoint&, const SimpleRange&);
 
 struct OffsetRange {
     unsigned start { 0 };

--- a/Source/WebCore/editing/ApplyStyleCommand.cpp
+++ b/Source/WebCore/editing/ApplyStyleCommand.cpp
@@ -363,7 +363,7 @@ void ApplyStyleCommand::applyRelativeFontStyleChange(EditingStyle* style)
     // is performed in the following loops below.
     if (beyondEnd) {
         auto treeOrderPos = treeOrder(*startNode, *beyondEnd);
-        if (is_gt(treeOrderPos) || is_eq(treeOrderPos))
+        if (is_gteq(treeOrderPos))
             return;
     }
     

--- a/Source/WebCore/editing/VisiblePosition.cpp
+++ b/Source/WebCore/editing/VisiblePosition.cpp
@@ -801,7 +801,7 @@ VisiblePositionRange makeVisiblePositionRange(const std::optional<SimpleRange>& 
     return { makeContainerOffsetPosition(range->start), makeContainerOffsetPosition(range->end) };
 }
 
-PartialOrdering documentOrder(const VisiblePosition& a, const VisiblePosition& b)
+std::partial_ordering documentOrder(const VisiblePosition& a, const VisiblePosition& b)
 {
     // FIXME: Should two positions with different affinity be considered equivalent or not?
     return treeOrder<ComposedTree>(a.deepEquivalent(), b.deepEquivalent());

--- a/Source/WebCore/editing/VisiblePosition.h
+++ b/Source/WebCore/editing/VisiblePosition.h
@@ -107,7 +107,7 @@ private:
 
 bool operator==(const VisiblePosition&, const VisiblePosition&);
 
-WEBCORE_EXPORT PartialOrdering documentOrder(const VisiblePosition&, const VisiblePosition&);
+WEBCORE_EXPORT std::partial_ordering documentOrder(const VisiblePosition&, const VisiblePosition&);
 bool operator<(const VisiblePosition&, const VisiblePosition&);
 bool operator>(const VisiblePosition&, const VisiblePosition&);
 bool operator<=(const VisiblePosition&, const VisiblePosition&);

--- a/Source/WebCore/testing/Internals.cpp
+++ b/Source/WebCore/testing/Internals.cpp
@@ -6926,13 +6926,13 @@ ExceptionOr<void> Internals::setMockMediaSessionCoordinatorCommandsShouldFail(bo
 }
 #endif // ENABLE(MEDIA_SESSION)
 
-constexpr ASCIILiteral string(PartialOrdering ordering)
+constexpr ASCIILiteral string(std::partial_ordering ordering)
 {
     if (is_lt(ordering))
         return "less"_s;
     if (is_gt(ordering))
         return "greater"_s;
-    if (is_eq(ordering))
+    if (WebCore::is_eq(ordering))
         return "equivalent"_s;
     return "unordered"_s;
 }

--- a/Tools/TestWebKitAPI/Tests/WebCore/DocumentOrder.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebCore/DocumentOrder.cpp
@@ -64,23 +64,23 @@ static Ref<Document> createDocument()
     return document;
 }
 
-static constexpr const char* string(PartialOrdering ordering)
+static constexpr const char* string(std::partial_ordering ordering)
 {
     if (is_lt(ordering))
         return "less";
     if (is_gt(ordering))
         return "greater";
-    if (is_eq(ordering))
+    if (WebCore::is_eq(ordering))
         return "equivalent";
     return "unordered";
 }
 
-static PartialOrdering operator-(PartialOrdering ordering)
+static std::partial_ordering operator-(std::partial_ordering ordering)
 {
     if (is_lt(ordering))
-        return PartialOrdering::greater;
+        return std::partial_ordering::greater;
     if (is_gt(ordering))
-        return PartialOrdering::less;
+        return std::partial_ordering::less;
     return ordering;
 }
 
@@ -140,7 +140,7 @@ static String join(const Vector<String>& vector, ASCIILiteral separator)
     return builder.toString();
 }
 
-static CString allPositionTypeFailures(const Position& a, Node* nodeB, unsigned offsetB, PartialOrdering expectedResult)
+static CString allPositionTypeFailures(const Position& a, Node* nodeB, unsigned offsetB, std::partial_ordering expectedResult)
 {
     Vector<String> failures;
     for (auto& b : allPositionTypes(nodeB, offsetB)) {
@@ -154,7 +154,7 @@ static CString allPositionTypeFailures(const Position& a, Node* nodeB, unsigned 
     return join(failures, ", "_s).utf8();
 }
 
-static CString allPositionTypeFailures(Node* nodeA, unsigned offsetA, Node* nodeB, unsigned offsetB, PartialOrdering expectedResult)
+static CString allPositionTypeFailures(Node* nodeA, unsigned offsetA, Node* nodeB, unsigned offsetB, std::partial_ordering expectedResult)
 {
     Vector<String> failures;
     for (auto& a : allPositionTypes(nodeA, offsetA)) {
@@ -170,25 +170,25 @@ static CString allPositionTypeFailures(Node* nodeA, unsigned offsetA, Node* node
     return join(failures, " | "_s).utf8();
 }
 
-static CString allPositionTypeFailures(Node& nodeA, unsigned offsetA, Node& nodeB, unsigned offsetB, PartialOrdering expectedResult)
+static CString allPositionTypeFailures(Node& nodeA, unsigned offsetA, Node& nodeB, unsigned offsetB, std::partial_ordering expectedResult)
 {
     return allPositionTypeFailures(&nodeA, offsetA, &nodeB, offsetB, expectedResult);
 }
 
-static CString allPositionTypeFailures(Node* nodeA, unsigned offsetA, Node& nodeB, unsigned offsetB, PartialOrdering expectedResult)
+static CString allPositionTypeFailures(Node* nodeA, unsigned offsetA, Node& nodeB, unsigned offsetB, std::partial_ordering expectedResult)
 {
     return allPositionTypeFailures(nodeA, offsetA, &nodeB, offsetB, expectedResult);
 }
 
-static CString allPositionTypeFailures(const Position& a, Node& nodeB, unsigned offsetB, PartialOrdering expectedResult)
+static CString allPositionTypeFailures(const Position& a, Node& nodeB, unsigned offsetB, std::partial_ordering expectedResult)
 {
     return allPositionTypeFailures(a, &nodeB, offsetB, expectedResult);
 }
 
 #define TEST_ALL_POSITION_TYPES(nodeA, offsetA, nodeB, offsetB, expectedResult) \
-    EXPECT_STREQ(allPositionTypeFailures(nodeA, offsetA, nodeB, offsetB, PartialOrdering::expectedResult).data(), "")
+    EXPECT_STREQ(allPositionTypeFailures(nodeA, offsetA, nodeB, offsetB, std::partial_ordering::expectedResult).data(), "")
 #define TEST_ALL_POSITION_TYPES_B(positionA, nodeB, offsetB, expectedResult) \
-    EXPECT_STREQ(allPositionTypeFailures(positionA, nodeB, offsetB, PartialOrdering::expectedResult).data(), "")
+    EXPECT_STREQ(allPositionTypeFailures(positionA, nodeB, offsetB, std::partial_ordering::expectedResult).data(), "")
 
 static Position makePositionBefore(Node& node)
 {


### PR DESCRIPTION
#### 081bc346f6bfd314ec53525c8b9afd1a52ff3bae
<pre>
Adopt std::partial_ordering now that we require C++20
<a href="https://bugs.webkit.org/show_bug.cgi?id=256406">https://bugs.webkit.org/show_bug.cgi?id=256406</a>

Reviewed by Darin Adler.

* Source/WebCore/Modules/highlight/Highlight.cpp:
(WebCore::repaintRange):
* Source/WebCore/accessibility/AXObjectCache.cpp:
(WebCore::characterOffsetsInOrder):
* Source/WebCore/accessibility/AccessibilityObject.cpp:
(WebCore::AccessibilityObject::misspellingRange const):
(WebCore::AccessibilityObject::rangeOfStringClosestToRangeInDirection const):
* Source/WebCore/animation/WebAnimationUtilities.cpp:
(WebCore::compareDeclarativeAnimationOwningElementPositionsInDocumentTreeOrder):
* Source/WebCore/dom/BoundaryPoint.cpp:
(WebCore::order):
(WebCore::treeOrder):
(WebCore::treeOrderForTesting):
* Source/WebCore/dom/BoundaryPoint.h:
* Source/WebCore/dom/FragmentDirectiveRangeFinder.cpp:
(WebCore::FragmentDirectiveRangeFinder::rangeOfStringInRange):
* Source/WebCore/dom/Node.cpp:
(WebCore::treeOrder):
(WebCore::treeOrderForTesting):
* Source/WebCore/dom/Node.h:
(WebCore::PartialOrdering::PartialOrdering): Deleted.
(WebCore::is_eq): Deleted.
(WebCore::is_lt): Deleted.
(WebCore::is_gt): Deleted.
(WebCore::is_neq): Deleted.
(WebCore::is_lteq): Deleted.
(WebCore::is_gteq): Deleted.
* Source/WebCore/dom/Position.cpp:
(WebCore::treeOrder):
(WebCore::documentOrder):
* Source/WebCore/dom/Position.h:
(WebCore::operator&lt;):
(WebCore::operator&gt;):
(WebCore::operator&gt;=):
(WebCore::operator&lt;=):
* Source/WebCore/dom/RadioButtonGroups.cpp:
(WebCore::RadioButtonGroup::members const):
* Source/WebCore/dom/Range.cpp:
(WebCore::Range::setStart):
(WebCore::Range::setEnd):
(WebCore::Range::comparePoint const):
(WebCore::Range::compareNode const):
(WebCore::Range::compareBoundaryPoints const):
* Source/WebCore/dom/SimpleRange.cpp:
(WebCore::contains):
(WebCore::treeOrder):
(WebCore::intersects):
(WebCore::compareByComposedTreeOrder):
* Source/WebCore/dom/SimpleRange.h:
* Source/WebCore/editing/ApplyStyleCommand.cpp:
(WebCore::ApplyStyleCommand::updateStartEnd):
(WebCore::ApplyStyleCommand::applyRelativeFontStyleChange):
(WebCore::ApplyStyleCommand::removeInlineStyle):
* Source/WebCore/editing/Editor.cpp:
(WebCore::Editor::simplifyMarkup):
* Source/WebCore/editing/TextIterator.cpp:
(WebCore::characterCount):
* Source/WebCore/editing/VisiblePosition.cpp:
(WebCore::documentOrder):
* Source/WebCore/editing/VisiblePosition.h:
(WebCore::operator&lt;):
(WebCore::operator&gt;):
(WebCore::operator&lt;=):
(WebCore::operator&gt;=):
* Source/WebCore/editing/VisibleSelection.cpp:
(WebCore::VisibleSelection::setBaseAndExtentToDeepEquivalents):
(WebCore::VisibleSelection::setWithoutValidation):
* Source/WebCore/page/Page.cpp:
(WebCore::Page::findTextMatches):
(WebCore::replaceRanges):
* Source/WebCore/testing/Internals.cpp:
(WebCore::string):
* Tools/TestWebKitAPI/Tests/WebCore/DocumentOrder.cpp:
(TestWebKitAPI::string):
(TestWebKitAPI::operator-):
(TestWebKitAPI::allPositionTypeFailures):

Canonical link: <a href="https://commits.webkit.org/263767@main">https://commits.webkit.org/263767@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/7ea74af40c35b5c282b37ddab0de7f6e95a28a11

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/5700 "2 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/5858 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/6048 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/7252 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/32/builds/6097 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/5702 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/6080 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/5829 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/7851 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/5806 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/5851 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/5116 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/7303 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/3328 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/5130 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/12879 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/5196 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/5207 "Passed tests") | [⏳ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/API-Tests-GTK-EWS "Waiting to run tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/5648 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/4624 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/5096 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/1342 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/9210 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/5456 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->