### PR TITLE
[GPU Process] Cache all RenderingResources as one type

### DIFF
--- a/Source/WebCore/platform/graphics/DecomposedGlyphs.h
+++ b/Source/WebCore/platform/graphics/DecomposedGlyphs.h
@@ -41,7 +41,13 @@ public:
 private:
     DecomposedGlyphs(PositionedGlyphs&&, RenderingResourceIdentifier);
 
+    bool isDecomposedGlyphs() const final { return true; }
+
     PositionedGlyphs m_positionedGlyphs;
 };
 
 } // namespace WebCore
+
+SPECIALIZE_TYPE_TRAITS_BEGIN(WebCore::DecomposedGlyphs)
+    static bool isType(const WebCore::RenderingResource& renderingResource) { return renderingResource.isDecomposedGlyphs(); }
+SPECIALIZE_TYPE_TRAITS_END()

--- a/Source/WebCore/platform/graphics/Gradient.h
+++ b/Source/WebCore/platform/graphics/Gradient.h
@@ -108,6 +108,8 @@ public:
 private:
     Gradient(Data&&, ColorInterpolationMethod, GradientSpreadMethod, GradientColorStops&&, std::optional<RenderingResourceIdentifier>);
 
+    bool isGradient() const final { return true; }
+
     void stopsChanged();
 
     Data m_data;
@@ -124,3 +126,7 @@ private:
 WEBCORE_EXPORT WTF::TextStream& operator<<(WTF::TextStream&, const Gradient&);
 
 } // namespace WebCore
+
+SPECIALIZE_TYPE_TRAITS_BEGIN(WebCore::Gradient)
+    static bool isType(const WebCore::RenderingResource& renderingResource) { return renderingResource.isGradient(); }
+SPECIALIZE_TYPE_TRAITS_END()

--- a/Source/WebCore/platform/graphics/NativeImage.h
+++ b/Source/WebCore/platform/graphics/NativeImage.h
@@ -66,6 +66,8 @@ private:
     NativeImage(PlatformImagePtr&&, RenderingResourceIdentifier, Ref<PixelBuffer>&&);
 #endif
 
+    bool isNativeImage() const final { return true; }
+
     PlatformImagePtr m_platformImage;
 #if USE(CAIRO)
     RefPtr<PixelBuffer> m_pixelBuffer;
@@ -73,3 +75,7 @@ private:
 };
 
 } // namespace WebCore
+
+SPECIALIZE_TYPE_TRAITS_BEGIN(WebCore::NativeImage)
+    static bool isType(const WebCore::RenderingResource& renderingResource) { return renderingResource.isNativeImage(); }
+SPECIALIZE_TYPE_TRAITS_END()

--- a/Source/WebCore/platform/graphics/RenderingResource.h
+++ b/Source/WebCore/platform/graphics/RenderingResource.h
@@ -50,6 +50,10 @@ public:
             observer->releaseRenderingResource(renderingResourceIdentifier());
     }
 
+    virtual bool isNativeImage() const { return false; }
+    virtual bool isGradient() const { return false; }
+    virtual bool isDecomposedGlyphs() const { return false; }
+
     bool hasValidRenderingResourceIdentifier() const
     {
         return m_renderingResourceIdentifier.has_value();

--- a/Source/WebKit/GPUProcess/graphics/RemoteResourceCache.cpp
+++ b/Source/WebKit/GPUProcess/graphics/RemoteResourceCache.cpp
@@ -130,10 +130,8 @@ void RemoteResourceCache::releaseAllImageResources()
 bool RemoteResourceCache::releaseRenderingResource(QualifiedRenderingResourceIdentifier renderingResourceIdentifier)
 {
     if (m_resourceHeap.removeImageBuffer(renderingResourceIdentifier)
-        || m_resourceHeap.removeNativeImage(renderingResourceIdentifier)
+        || m_resourceHeap.removeRenderingResource(renderingResourceIdentifier)
         || m_resourceHeap.removeFont(renderingResourceIdentifier)
-        || m_resourceHeap.removeDecomposedGlyphs(renderingResourceIdentifier)
-        || m_resourceHeap.removeGradient(renderingResourceIdentifier)
         || m_resourceHeap.removeFontCustomPlatformData(renderingResourceIdentifier))
         return true;
 

--- a/Source/WebKit/WebProcess/GPU/graphics/RemoteResourceCacheProxy.cpp
+++ b/Source/WebKit/WebProcess/GPU/graphics/RemoteResourceCacheProxy.cpp
@@ -44,19 +44,22 @@ RemoteResourceCacheProxy::RemoteResourceCacheProxy(RemoteRenderingBackendProxy& 
 
 RemoteResourceCacheProxy::~RemoteResourceCacheProxy()
 {
-    clearNativeImageMap();
     clearImageBufferBackends();
-    clearDecomposedGlyphsMap();
-    clearGradientMap();
+    clearRenderingResourceMap();
 }
 
 void RemoteResourceCacheProxy::clear()
 {
-    clearNativeImageMap();
     clearImageBufferBackends();
     m_imageBuffers.clear();
-    clearDecomposedGlyphsMap();
-    clearGradientMap();
+    clearRenderingResourceMap();
+}
+
+unsigned RemoteResourceCacheProxy::imagesCount() const
+{
+    return std::count_if(m_renderingResources.begin(), m_renderingResources.end(), [](const auto& keyValuePair) {
+        return is<NativeImage>(keyValuePair.value.get());
+    });
 }
 
 void RemoteResourceCacheProxy::cacheImageBuffer(RemoteImageBufferProxy& imageBuffer)
@@ -84,6 +87,12 @@ void RemoteResourceCacheProxy::forgetImageBuffer(RenderingResourceIdentifier ide
 
     auto success = m_imageBuffers.remove(iterator);
     ASSERT_UNUSED(success, success);
+}
+
+NativeImage* RemoteResourceCacheProxy::cachedNativeImage(RenderingResourceIdentifier identifier) const
+{
+    auto renderingResource = m_renderingResources.get(identifier);
+    return dynamicDowncast<NativeImage>(renderingResource.get().get());
 }
 
 void RemoteResourceCacheProxy::recordImageBufferUse(WebCore::ImageBuffer& imageBuffer)
@@ -124,12 +133,27 @@ inline static std::optional<ShareableBitmap::Handle> createShareableBitmapFromNa
     return handle;
 }
 
+void RemoteResourceCacheProxy::recordDecomposedGlyphsUse(DecomposedGlyphs& decomposedGlyphs)
+{
+    if (m_renderingResources.add(decomposedGlyphs.renderingResourceIdentifier(), decomposedGlyphs).isNewEntry) {
+        decomposedGlyphs.addObserver(*this);
+        m_remoteRenderingBackendProxy.cacheDecomposedGlyphs(decomposedGlyphs);
+    }
+}
+
+void RemoteResourceCacheProxy::recordGradientUse(Gradient& gradient)
+{
+    if (m_renderingResources.add(gradient.renderingResourceIdentifier(), gradient).isNewEntry) {
+        gradient.addObserver(*this);
+        m_remoteRenderingBackendProxy.cacheGradient(gradient);
+    }
+}
+
 void RemoteResourceCacheProxy::recordNativeImageUse(NativeImage& image)
 {
     WebProcess::singleton().deferNonVisibleProcessEarlyMemoryCleanupTimer();
 
-    auto iterator = m_nativeImages.find(image.renderingResourceIdentifier());
-    if (iterator != m_nativeImages.end())
+    if (cachedNativeImage(image.renderingResourceIdentifier()))
         return;
 
     auto handle = createShareableBitmapFromNativeImage(image);
@@ -143,7 +167,7 @@ void RemoteResourceCacheProxy::recordNativeImageUse(NativeImage& image)
         return;
     }
 
-    m_nativeImages.add(image.renderingResourceIdentifier(), image);
+    m_renderingResources.add(image.renderingResourceIdentifier(), image);
 
     // Set itself as an observer to NativeImage, so releaseNativeImage()
     // gets called when NativeImage is being deleleted.
@@ -191,36 +215,30 @@ void RemoteResourceCacheProxy::recordFontCustomPlatformDataUse(const FontCustomP
     }
 }
 
-void RemoteResourceCacheProxy::recordDecomposedGlyphsUse(DecomposedGlyphs& decomposedGlyphs)
-{
-    if (m_decomposedGlyphs.add(decomposedGlyphs.renderingResourceIdentifier(), decomposedGlyphs).isNewEntry) {
-        decomposedGlyphs.addObserver(*this);
-        m_remoteRenderingBackendProxy.cacheDecomposedGlyphs(decomposedGlyphs);
-    }
-}
-
-void RemoteResourceCacheProxy::recordGradientUse(Gradient& gradient)
-{
-    if (m_gradients.add(gradient.renderingResourceIdentifier(), gradient).isNewEntry) {
-        gradient.addObserver(*this);
-        m_remoteRenderingBackendProxy.cacheGradient(gradient);
-    }
-}
-
 void RemoteResourceCacheProxy::releaseRenderingResource(RenderingResourceIdentifier renderingResourceIdentifier)
 {
-    bool removed = m_nativeImages.remove(renderingResourceIdentifier)
-        || m_decomposedGlyphs.remove(renderingResourceIdentifier)
-        || m_gradients.remove(renderingResourceIdentifier);
+    bool removed = m_renderingResources.remove(renderingResourceIdentifier);
     RELEASE_ASSERT(removed);
     m_remoteRenderingBackendProxy.releaseRenderingResource(renderingResourceIdentifier);
 }
 
+void RemoteResourceCacheProxy::clearRenderingResourceMap()
+{
+    for (auto& renderingResource : m_renderingResources.values())
+        renderingResource.get()->removeObserver(*this);
+    m_renderingResources.clear();
+}
+
 void RemoteResourceCacheProxy::clearNativeImageMap()
 {
-    for (auto& nativeImage : m_nativeImages.values())
-        nativeImage.get()->removeObserver(*this);
-    m_nativeImages.clear();
+    m_renderingResources.removeIf([&] (auto& keyValuePair) {
+        if (!is<NativeImage>(keyValuePair.value.get()))
+            return false;
+
+        auto& nativeImage = downcast<NativeImage>(*keyValuePair.value.get());
+        nativeImage.removeObserver(*this);
+        return true;
+    });
 }
 
 void RemoteResourceCacheProxy::prepareForNextRenderingUpdate()
@@ -250,20 +268,6 @@ void RemoteResourceCacheProxy::clearImageBufferBackends()
             continue;
         imageBuffer->clearBackend();
     }
-}
-
-void RemoteResourceCacheProxy::clearDecomposedGlyphsMap()
-{
-    for (auto& decomposedGlyphs : m_decomposedGlyphs.values())
-        decomposedGlyphs.get()->removeObserver(*this);
-    m_decomposedGlyphs.clear();
-}
-
-void RemoteResourceCacheProxy::clearGradientMap()
-{
-    for (auto& gradients : m_gradients.values())
-        gradients.get()->removeObserver(*this);
-    m_gradients.clear();
 }
 
 void RemoteResourceCacheProxy::finalizeRenderingUpdateForFonts()
@@ -314,27 +318,25 @@ void RemoteResourceCacheProxy::didPaintLayers()
 
 void RemoteResourceCacheProxy::remoteResourceCacheWasDestroyed()
 {
-    clearNativeImageMap();
-    clearFontMap();
-    clearFontCustomPlatformDataMap();
     clearImageBufferBackends();
-    clearDecomposedGlyphsMap();
-    clearGradientMap();
 
     for (auto& imageBuffer : m_imageBuffers.values()) {
         if (!imageBuffer)
             continue;
         m_remoteRenderingBackendProxy.createRemoteImageBuffer(*imageBuffer);
     }
+
+    clearRenderingResourceMap();
+    clearFontMap();
+    clearFontCustomPlatformDataMap();
 }
 
 void RemoteResourceCacheProxy::releaseMemory()
 {
-    clearNativeImageMap();
+    clearRenderingResourceMap();
     clearFontMap();
     clearFontCustomPlatformDataMap();
-    clearDecomposedGlyphsMap();
-    clearGradientMap();
+
     m_remoteRenderingBackendProxy.releaseAllRemoteResources();
 }
 

--- a/Source/WebKit/WebProcess/GPU/graphics/RemoteResourceCacheProxy.h
+++ b/Source/WebKit/WebProcess/GPU/graphics/RemoteResourceCacheProxy.h
@@ -28,16 +28,15 @@
 #if ENABLE(GPU_PROCESS)
 
 #include "RenderingUpdateID.h"
-#include <WebCore/DecomposedGlyphs.h>
-#include <WebCore/Gradient.h>
-#include <WebCore/NativeImage.h>
 #include <WebCore/RenderingResource.h>
 #include <wtf/HashMap.h>
 
 namespace WebCore {
+class DecomposedGlyphs;
 class Font;
 class Gradient;
 class ImageBuffer;
+class NativeImage;
 struct FontCustomPlatformData;
 }
 
@@ -56,6 +55,8 @@ public:
     void releaseImageBuffer(RemoteImageBufferProxy&);
     void forgetImageBuffer(WebCore::RenderingResourceIdentifier);
 
+    WebCore::NativeImage* cachedNativeImage(WebCore::RenderingResourceIdentifier) const;
+
     void recordNativeImageUse(WebCore::NativeImage&);
     void recordFontUse(WebCore::Font&);
     void recordImageBufferUse(WebCore::ImageBuffer&);
@@ -69,21 +70,18 @@ public:
     void releaseMemory();
     void releaseAllImageResources();
     
-    unsigned imagesCount() const { return m_nativeImages.size(); }
+    unsigned imagesCount() const;
 
     void clear();
 
 private:
     using ImageBufferHashMap = HashMap<WebCore::RenderingResourceIdentifier, WeakPtr<RemoteImageBufferProxy>>;
-    using NativeImageHashMap = HashMap<WebCore::RenderingResourceIdentifier, ThreadSafeWeakPtr<WebCore::NativeImage>>;
+    using RenderingResourceHashMap = HashMap<WebCore::RenderingResourceIdentifier, ThreadSafeWeakPtr<WebCore::RenderingResource>>;
     using FontHashMap = HashMap<WebCore::RenderingResourceIdentifier, uint64_t>;
-    using DecomposedGlyphsHashMap = HashMap<WebCore::RenderingResourceIdentifier, ThreadSafeWeakPtr<WebCore::DecomposedGlyphs>>;
-    using GradientHashMap = HashMap<WebCore::RenderingResourceIdentifier, ThreadSafeWeakPtr<WebCore::Gradient>>;
 
     void releaseRenderingResource(WebCore::RenderingResourceIdentifier) override;
+    void clearRenderingResourceMap();
     void clearNativeImageMap();
-    void clearDecomposedGlyphsMap();
-    void clearGradientMap();
 
     void finalizeRenderingUpdateForFonts();
     void prepareForNextRenderingUpdate();
@@ -92,15 +90,12 @@ private:
     void clearImageBufferBackends();
 
     ImageBufferHashMap m_imageBuffers;
-    NativeImageHashMap m_nativeImages;
+    RenderingResourceHashMap m_renderingResources;
     FontHashMap m_fonts;
-    DecomposedGlyphsHashMap m_decomposedGlyphs;
-    GradientHashMap m_gradients;
     FontHashMap m_fontCustomPlatformDatas;
 
     unsigned m_numberOfFontsUsedInCurrentRenderingUpdate { 0 };
     unsigned m_numberOfFontCustomPlatformDatasUsedInCurrentRenderingUpdate { 0 };
-
 
     RemoteRenderingBackendProxy& m_remoteRenderingBackendProxy;
     uint64_t m_renderingUpdateID;


### PR DESCRIPTION
#### d67761f1060aca4aef599fb47020365003a5544d
<pre>
[GPU Process] Cache all RenderingResources as one type
<a href="https://bugs.webkit.org/show_bug.cgi?id=256408">https://bugs.webkit.org/show_bug.cgi?id=256408</a>
&lt;rdar://problem/108977457&gt;

Reviewed by Simon Fraser.

This makes adding a new RenderingResource less pervasive. RenderingResources are
mainly cached to control their lifetime between WebProcess and GPUProcess. Their
concrete types are rarely used especially in WebProcess. So replace the pointers
to NativeImage, DecomposedGlyphs and Gradient to just a pointer to RenderingResource.
Add traits to these classes so RenderingResource can be casted to any of them.

* Source/WebCore/platform/graphics/DecomposedGlyphs.h:
(isType):
* Source/WebCore/platform/graphics/Gradient.h:
(isType):
* Source/WebCore/platform/graphics/NativeImage.h:
(isType):
* Source/WebCore/platform/graphics/RenderingResource.h:
(WebCore::RenderingResource::isNativeImage const):
(WebCore::RenderingResource::isGradient const):
(WebCore::RenderingResource::isDecomposedGlyphs const):
* Source/WebCore/platform/graphics/displaylists/DisplayListResourceHeap.h:
(WebCore::DisplayList::LocalResourceHeap::add):
* Source/WebKit/GPUProcess/graphics/QualifiedResourceHeap.h:
(WebKit::QualifiedResourceHeap::add):
(WebKit::QualifiedResourceHeap::getNativeImage const):
(WebKit::QualifiedResourceHeap::getDecomposedGlyphs const):
(WebKit::QualifiedResourceHeap::getGradient const):
(WebKit::QualifiedResourceHeap::removeRenderingResource):
(WebKit::QualifiedResourceHeap::releaseAllResources):
(WebKit::QualifiedResourceHeap::releaseAllImageResources):
(WebKit::QualifiedResourceHeap::checkInvariants const):
(WebKit::QualifiedResourceHeap::removeNativeImage): Deleted.
(WebKit::QualifiedResourceHeap::removeDecomposedGlyphs): Deleted.
(WebKit::QualifiedResourceHeap::removeGradient): Deleted.
* Source/WebKit/GPUProcess/graphics/RemoteResourceCache.cpp:
(WebKit::RemoteResourceCache::releaseRenderingResource):
* Source/WebKit/WebProcess/GPU/graphics/RemoteResourceCacheProxy.cpp:
(WebKit::RemoteResourceCacheProxy::~RemoteResourceCacheProxy):
(WebKit::RemoteResourceCacheProxy::clear):
(WebKit::RemoteResourceCacheProxy::imagesCount const):
(WebKit::RemoteResourceCacheProxy::cachedNativeImage const):
(WebKit::RemoteResourceCacheProxy::recordDecomposedGlyphsUse):
(WebKit::RemoteResourceCacheProxy::recordGradientUse):
(WebKit::RemoteResourceCacheProxy::recordNativeImageUse):
(WebKit::RemoteResourceCacheProxy::releaseRenderingResource):
(WebKit::RemoteResourceCacheProxy::clearRenderingResourceMap):
(WebKit::RemoteResourceCacheProxy::clearNativeImageMap):
(WebKit::RemoteResourceCacheProxy::remoteResourceCacheWasDestroyed):
(WebKit::RemoteResourceCacheProxy::releaseMemory):
(WebKit::RemoteResourceCacheProxy::clearDecomposedGlyphsMap): Deleted.
(WebKit::RemoteResourceCacheProxy::clearGradientMap): Deleted.
* Source/WebKit/WebProcess/GPU/graphics/RemoteResourceCacheProxy.h:
(WebKit::RemoteResourceCacheProxy::imagesCount const): Deleted.

Canonical link: <a href="https://commits.webkit.org/263824@main">https://commits.webkit.org/263824@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/01443d6f2f3da2e830f4f57c4cc076a12e61f221

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/5663 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/5818 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/6008 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/7214 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/5684 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/5663 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/6040 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/5790 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/7773 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/5768 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/5814 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/5073 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/7261 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/3291 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/5098 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/12548 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/5159 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/5175 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/7006 "262 api tests failed or timed out") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/5611 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/4589 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/5059 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/1381 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/9172 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/5419 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->