### PR TITLE
[JSC] Optimize JSON.stringify integer serialization

### DIFF
--- a/JSTests/stress/json-stringify-integer.js
+++ b/JSTests/stress/json-stringify-integer.js
@@ -1,0 +1,10 @@
+function shouldBe(actual, expected) {
+    if (actual !== expected)
+        throw new Error('bad value: ' + actual);
+}
+
+shouldBe(JSON.stringify(-1), `-1`);
+shouldBe(JSON.stringify(-2147483648), `-2147483648`); // INT32_MIN
+shouldBe(JSON.stringify(2147483647), `2147483647`); // INT32_MAX
+shouldBe(JSON.stringify(0), `0`);
+shouldBe(JSON.stringify(1), `1`);


### PR DESCRIPTION
#### 3fa658700239c8e7cbe8fa20793a6314274560cd
<pre>
[JSC] Optimize JSON.stringify integer serialization
<a href="https://bugs.webkit.org/show_bug.cgi?id=256409">https://bugs.webkit.org/show_bug.cgi?id=256409</a>
rdar://108978640

Reviewed by Darin Adler.

Let&apos;s use std::to_chars. The current implementation is extremely optimized, and faster than our custom implementation.
Right now, we are not switching to std::to_chars for everything since there is an impedance mismatch in our API and this function,
but we can just use it for FastStringifier. We also optimized forEachProperty code to just use `auto` of parameter, which
continues using CompactPropertyTableEntry for CompactPRopertyTable (majority of objects).

                                               ToT                     Patched

    vanilla-todomvc-json-stringify       52.0172+-0.3011     ^     46.4912+-0.2382        ^ definitely 1.1189x faster

* JSTests/stress/json-stringify-integer.js: Added.
(shouldBe):
* Source/JavaScriptCore/runtime/JSONObject.cpp:
(JSC::Stringifier::Holder::appendNextProperty):
(JSC::FastStringifier::append):

Canonical link: <a href="https://commits.webkit.org/263765@main">https://commits.webkit.org/263765@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/52edc0167ddde47fdc7f1859bdc5ce3babbc6b01

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/5706 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/5866 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/6056 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/7260 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/32/builds/6102 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/6088 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/5836 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/7858 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/5811 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/5857 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/5125 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/7313 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/3334 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/5137 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/12889 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/4748 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/5202 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/5214 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/7146 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/5291 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/5654 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/4629 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/5818 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/5101 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/1421 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/9215 "Built successfully") | | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/24/builds/5983 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/654 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/5461 "Built successfully") | | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/3/builds/1541 "Passed tests") | 
<!--EWS-Status-Bubble-End-->