### PR TITLE
[JSC] Accept Int32 as a replacement of String.replace

### DIFF
--- a/Source/JavaScriptCore/dfg/DFGAbstractInterpreterInlines.h
+++ b/Source/JavaScriptCore/dfg/DFGAbstractInterpreterInlines.h
@@ -2768,7 +2768,7 @@ bool AbstractInterpreter<AbstractStateType>::executeEffects(unsigned clobberLimi
         break;
 
     case StringReplaceString:
-        if (node->child3().useKind() != StringUse) {
+        if (node->child3().useKind() != StringUse && node->child3().useKind() != Int32Use) {
             // child3 could be non String (e.g. function). In this case, any side effect can happen.
             clobberWorld();
         }

--- a/Source/JavaScriptCore/dfg/DFGClobberize.h
+++ b/Source/JavaScriptCore/dfg/DFGClobberize.h
@@ -1914,7 +1914,7 @@ void clobberize(Graph& graph, Node* node, const ReadFunctor& read, const WriteFu
         return;
 
     case StringReplaceString:
-        if (node->child3().useKind() == StringUse)
+        if (node->child3().useKind() == StringUse || node->child3().useKind() == Int32Use)
             return;
         clobberTop();
         return;

--- a/Source/JavaScriptCore/dfg/DFGFixupPhase.cpp
+++ b/Source/JavaScriptCore/dfg/DFGFixupPhase.cpp
@@ -1545,6 +1545,8 @@ private:
                 fixEdge<StringUse>(node->child2());
                 if (node->child3()->shouldSpeculateString())
                     fixEdge<StringUse>(node->child3());
+                else if (node->child3()->shouldSpeculateInt32())
+                    fixEdge<Int32Use>(node->child3());
                 break;
             }
 
@@ -1578,6 +1580,8 @@ private:
             fixEdge<StringUse>(node->child2());
             if (node->child3()->shouldSpeculateString())
                 fixEdge<StringUse>(node->child3());
+            else if (node->child3()->shouldSpeculateInt32())
+                fixEdge<Int32Use>(node->child3());
             break;
         }
             

--- a/Source/JavaScriptCore/dfg/DFGOperations.cpp
+++ b/Source/JavaScriptCore/dfg/DFGOperations.cpp
@@ -2668,6 +2668,38 @@ JSC_DEFINE_JIT_OPERATION(operationStringReplaceStringEmptyStringWithTable8, JSSt
     return jsString(vm, WTFMove(result));
 }
 
+JSC_DEFINE_JIT_OPERATION(operationStringReplaceStringStringInt32, JSString*, (JSGlobalObject* globalObject, JSString* stringCell, JSString* searchCell, int32_t replacement))
+{
+    VM& vm = globalObject->vm();
+    CallFrame* callFrame = DECLARE_CALL_FRAME(vm);
+    JITOperationPrologueCallFrameTracer tracer(vm, callFrame);
+    auto scope = DECLARE_THROW_SCOPE(vm);
+
+    String string = stringCell->value(globalObject);
+    RETURN_IF_EXCEPTION(scope, nullptr);
+
+    String search = searchCell->value(globalObject);
+    RETURN_IF_EXCEPTION(scope, nullptr);
+
+    RELEASE_AND_RETURN(scope, (stringReplaceStringString<StringReplaceSubstitutions::No, StringReplaceUseTable::No, BoyerMooreHorspoolTable<uint8_t>>(globalObject, stringCell, WTFMove(string), WTFMove(search), replacement, nullptr)));
+}
+
+JSC_DEFINE_JIT_OPERATION(operationStringReplaceStringStringInt32WithTable8, JSString*, (JSGlobalObject* globalObject, JSString* stringCell, JSString* searchCell, int32_t replacement, const BoyerMooreHorspoolTable<uint8_t>* table))
+{
+    VM& vm = globalObject->vm();
+    CallFrame* callFrame = DECLARE_CALL_FRAME(vm);
+    JITOperationPrologueCallFrameTracer tracer(vm, callFrame);
+    auto scope = DECLARE_THROW_SCOPE(vm);
+
+    String string = stringCell->value(globalObject);
+    RETURN_IF_EXCEPTION(scope, nullptr);
+
+    String search = searchCell->value(globalObject);
+    RETURN_IF_EXCEPTION(scope, nullptr);
+
+    RELEASE_AND_RETURN(scope, (stringReplaceStringString<StringReplaceSubstitutions::No, StringReplaceUseTable::Yes>(globalObject, stringCell, WTFMove(string), WTFMove(search), replacement, table)));
+}
+
 JSC_DEFINE_JIT_OPERATION(operationStringReplaceStringGeneric, JSString*, (JSGlobalObject* globalObject, JSString* stringCell, JSString* searchCell, EncodedJSValue encodedReplaceValue))
 {
     VM& vm = globalObject->vm();

--- a/Source/JavaScriptCore/dfg/DFGOperations.h
+++ b/Source/JavaScriptCore/dfg/DFGOperations.h
@@ -268,6 +268,8 @@ JSC_DECLARE_JIT_OPERATION(operationStringReplaceStringStringWithTable8, JSString
 JSC_DECLARE_JIT_OPERATION(operationStringReplaceStringStringWithoutSubstitutionWithTable8, JSString*, (JSGlobalObject*, JSString*, JSString*, JSString*, const BoyerMooreHorspoolTable<uint8_t>*));
 JSC_DECLARE_JIT_OPERATION(operationStringReplaceStringEmptyStringWithTable8, JSString*, (JSGlobalObject*, JSString*, JSString*, const BoyerMooreHorspoolTable<uint8_t>*));
 JSC_DECLARE_JIT_OPERATION(operationStringReplaceStringGeneric, JSString*, (JSGlobalObject*, JSString*, JSString*, EncodedJSValue));
+JSC_DECLARE_JIT_OPERATION(operationStringReplaceStringStringInt32, JSString*, (JSGlobalObject*, JSString*, JSString*, int32_t));
+JSC_DECLARE_JIT_OPERATION(operationStringReplaceStringStringInt32WithTable8, JSString*, (JSGlobalObject*, JSString*, JSString*, int32_t, const BoyerMooreHorspoolTable<uint8_t>*));
 JSC_DECLARE_JIT_OPERATION(operationStringSubstring, JSString*, (JSGlobalObject*, JSString*, int32_t));
 JSC_DECLARE_JIT_OPERATION(operationStringSubstringWithEnd, JSString*, (JSGlobalObject*, JSString*, int32_t, int32_t));
 JSC_DECLARE_JIT_OPERATION(operationToLowerCase, JSString*, (JSGlobalObject*, JSString*, uint32_t));

--- a/Source/JavaScriptCore/dfg/DFGSafeToExecute.h
+++ b/Source/JavaScriptCore/dfg/DFGSafeToExecute.h
@@ -715,7 +715,7 @@ bool safeToExecute(AbstractStateType& state, Graph& graph, Node* node, bool igno
         return false;
 
     case StringReplaceString:
-        return node->child3().useKind() == StringUse;
+        return node->child3().useKind() == StringUse || node->child3().useKind() == Int32Use;
 
     case Inc:
     case Dec:

--- a/Source/JavaScriptCore/dfg/DFGSpeculativeJIT.cpp
+++ b/Source/JavaScriptCore/dfg/DFGSpeculativeJIT.cpp
@@ -13854,6 +13854,32 @@ void SpeculativeJIT::compileStringReplaceString(Node* node)
         return;
     }
 
+    if (node->child3().useKind() == Int32Use) {
+        const BoyerMooreHorspoolTable<uint8_t>* tablePointer = nullptr;
+        String searchString = node->child2()->tryGetString(m_graph);
+        if (!!searchString)
+            tablePointer = m_graph.tryAddStringSearchTable8(searchString);
+
+        SpeculateCellOperand string(this, node->child1());
+        SpeculateCellOperand search(this, node->child2());
+        SpeculateInt32Operand replace(this, node->child3());
+        GPRReg stringGPR = string.gpr();
+        GPRReg searchGPR = search.gpr();
+        GPRReg replaceGPR = replace.gpr();
+        speculateString(node->child1(), stringGPR);
+        speculateString(node->child2(), searchGPR);
+
+        flushRegisters();
+        GPRFlushedCallResult result(this);
+        if (tablePointer)
+            callOperation(operationStringReplaceStringStringInt32WithTable8, result.gpr(), LinkableConstant::globalObject(*this, node), stringGPR, searchGPR, replaceGPR, TrustedImmPtr(tablePointer));
+        else
+            callOperation(operationStringReplaceStringStringInt32, result.gpr(), LinkableConstant::globalObject(*this, node), stringGPR, searchGPR, replaceGPR);
+        exceptionCheck();
+        cellResult(result.gpr(), node);
+        return;
+    }
+
     // Otherwise, maybe function. Let's call slow path.
     SpeculateCellOperand string(this, node->child1());
     SpeculateCellOperand search(this, node->child2());

--- a/Source/JavaScriptCore/ftl/FTLLowerDFGToB3.cpp
+++ b/Source/JavaScriptCore/ftl/FTLLowerDFGToB3.cpp
@@ -15778,6 +15778,22 @@ IGNORE_CLANG_WARNINGS_END
             return;
         }
 
+        if (m_node->child3().useKind() == Int32Use) {
+            const BoyerMooreHorspoolTable<uint8_t>* tablePointer = nullptr;
+            String searchString = m_node->child2()->tryGetString(m_graph);
+            if (!!searchString)
+                tablePointer = m_graph.tryAddStringSearchTable8(searchString);
+
+            LValue string = lowString(m_node->child1());
+            LValue search = lowString(m_node->child2());
+            LValue replace = lowInt32(m_node->child3());
+            if (tablePointer)
+                setJSValue(vmCall(pointerType(), operationStringReplaceStringStringInt32WithTable8, weakPointer(globalObject), string, search, replace, m_out.constIntPtr(tablePointer)));
+            else
+                setJSValue(vmCall(pointerType(), operationStringReplaceStringStringInt32, weakPointer(globalObject), string, search, replace));
+            return;
+        }
+
         setJSValue(vmCall(pointerType(), operationStringReplaceStringGeneric, weakPointer(globalObject), lowString(m_node->child1()), lowString(m_node->child2()), lowJSValue(m_node->child3())));
     }
 

--- a/Source/JavaScriptCore/runtime/StringPrototypeInlines.h
+++ b/Source/JavaScriptCore/runtime/StringPrototypeInlines.h
@@ -189,8 +189,8 @@ ALWAYS_INLINE JSString* jsSpliceSubstringsWithSeparators(JSGlobalObject* globalO
 
 enum class StringReplaceSubstitutions : bool { No, Yes };
 enum class StringReplaceUseTable : bool { No, Yes };
-template<StringReplaceSubstitutions substitutions, StringReplaceUseTable useTable, typename TableType>
-ALWAYS_INLINE JSString* stringReplaceStringString(JSGlobalObject* globalObject, JSString* stringCell, String string, String search, String replacement, const TableType* table)
+template<StringReplaceSubstitutions substitutions, StringReplaceUseTable useTable, typename TableType, typename ReplacementType>
+ALWAYS_INLINE JSString* stringReplaceStringString(JSGlobalObject* globalObject, JSString* stringCell, String string, String search, ReplacementType replacement, const TableType* table)
 {
     VM& vm = globalObject->vm();
     auto scope = DECLARE_THROW_SCOPE(vm);


### PR DESCRIPTION
#### 30d44f091a10332fc7fed9607a0cfb51cd41498b
<pre>
[JSC] Accept Int32 as a replacement of String.replace
<a href="https://bugs.webkit.org/show_bug.cgi?id=256416">https://bugs.webkit.org/show_bug.cgi?id=256416</a>
rdar://108985250

Reviewed by NOBODY (OOPS!).

WIP

* Source/JavaScriptCore/dfg/DFGAbstractInterpreterInlines.h:
(JSC::DFG::AbstractInterpreter&lt;AbstractStateType&gt;::executeEffects):
* Source/JavaScriptCore/dfg/DFGClobberize.h:
(JSC::DFG::clobberize):
* Source/JavaScriptCore/dfg/DFGFixupPhase.cpp:
(JSC::DFG::FixupPhase::fixupNode):
* Source/JavaScriptCore/dfg/DFGOperations.cpp:
(JSC::DFG::JSC_DEFINE_JIT_OPERATION):
* Source/JavaScriptCore/dfg/DFGOperations.h:
* Source/JavaScriptCore/dfg/DFGSafeToExecute.h:
(JSC::DFG::safeToExecute):
* Source/JavaScriptCore/dfg/DFGSpeculativeJIT.cpp:
* Source/JavaScriptCore/ftl/FTLLowerDFGToB3.cpp:
(JSC::FTL::DFG::LowerDFGToB3::compileCompareStrictEq):
* Source/JavaScriptCore/runtime/StringPrototypeInlines.h:
(JSC::stringReplaceStringString):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/30d44f091a10332fc7fed9607a0cfb51cd41498b

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/5688 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/5845 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/6035 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/7240 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/6096 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/6067 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/5817 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/7836 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/5794 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/5838 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/5099 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/7290 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/3315 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/5119 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/12866 "Passed tests") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/4729 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/5183 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/5196 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/7056 "Passed tests") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/5271 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/5636 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/4613 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/5800 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/5084 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/1418 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/9198 "Built successfully") | | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/24/builds/5963 "Built successfully") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/5444 "Built successfully") | | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/3/builds/1538 "Passed tests") | 
<!--EWS-Status-Bubble-End-->