### PR TITLE
Expose aspectRatio and frameRate in RTCPeerConnection remote MediaStreamTrack settings

### DIFF
--- a/LayoutTests/webrtc/video.html
+++ b/LayoutTests/webrtc/video.html
@@ -79,6 +79,19 @@ promise_test(async (test) => {
     await video.play();
 
     testImage();
+
+    let settings = stream.getVideoTracks()[0].getSettings();
+    assert_equals(settings.width, 640, "remote track settings width");
+    assert_equals(settings.height, 480, "remote track settings height");
+    assert_equals(settings.aspectRatio, 640 / 480, "remote track settings aspectRatio");
+
+    let counter = 0;
+    while (++counter < 100 && settings.frameRate < 5) {
+        await new Promise(resolve => setTimeout(resolve, 50));
+        settings = stream.getVideoTracks()[0].getSettings();
+    }
+    assert_greater_than(settings.frameRate, 5 ,"remote track settings height");
+
 }, "Basic video exchange");
 
 function getCircleImageData()

--- a/Source/WebCore/platform/mediastream/RealtimeIncomingVideoSource.cpp
+++ b/Source/WebCore/platform/mediastream/RealtimeIncomingVideoSource.cpp
@@ -37,19 +37,37 @@
 
 namespace WebCore {
 
+static RealtimeMediaSourceSupportedConstraints supportedRealtimeIncomingVideoSourceSettingConstraints()
+{
+    RealtimeMediaSourceSupportedConstraints constraints;
+    constraints.setSupportsWidth(true);
+    constraints.setSupportsHeight(true);
+    constraints.setSupportsFrameRate(true);
+    constraints.setSupportsAspectRatio(true);
+    return constraints;
+}
+
 RealtimeIncomingVideoSource::RealtimeIncomingVideoSource(rtc::scoped_refptr<webrtc::VideoTrackInterface>&& videoTrack, String&& videoTrackId)
     : RealtimeMediaSource(CaptureDevice { WTFMove(videoTrackId), CaptureDevice::DeviceType::Camera, "remote video"_s })
     , m_videoTrack(WTFMove(videoTrack))
 {
     ASSERT(m_videoTrack);
 
-    RealtimeMediaSourceSupportedConstraints constraints;
-    constraints.setSupportsWidth(true);
-    constraints.setSupportsHeight(true);
     m_currentSettings = RealtimeMediaSourceSettings { };
-    m_currentSettings->setSupportedConstraints(WTFMove(constraints));
+    m_currentSettings->setSupportedConstraints(supportedRealtimeIncomingVideoSourceSettingConstraints());
 
     m_videoTrack->RegisterObserver(this);
+
+    m_frameRateMonitor = makeUnique<FrameRateMonitor>([this](auto info) {
+#if !RELEASE_LOG_DISABLED
+        if (!m_enableFrameRatedMonitoringLogging)
+            return;
+
+        auto frameTime = info.frameTime.secondsSinceEpoch().value();
+        auto lastFrameTime = info.lastFrameTime.secondsSinceEpoch().value();
+        ALWAYS_LOG_IF(loggerPtr(), LOGIDENTIFIER, "frame at ", frameTime, " previous frame was at ", lastFrameTime, ", observed frame rate is ", info.observedFrameRate, ", delay since last frame is ", (frameTime - lastFrameTime) * 1000, " ms, frame count is ", info.frameCount);
+#endif
+    });
 }
 
 RealtimeIncomingVideoSource::~RealtimeIncomingVideoSource()
@@ -61,15 +79,8 @@ RealtimeIncomingVideoSource::~RealtimeIncomingVideoSource()
 void RealtimeIncomingVideoSource::enableFrameRatedMonitoring()
 {
 #if !RELEASE_LOG_DISABLED
-    if (m_frameRateMonitor)
-        return;
-    m_frameRateMonitor = makeUnique<FrameRateMonitor>([this](auto info) {
-        auto frameTime = info.frameTime.secondsSinceEpoch().value();
-        auto lastFrameTime = info.lastFrameTime.secondsSinceEpoch().value();
-        ALWAYS_LOG_IF(loggerPtr(), LOGIDENTIFIER, "frame at ", frameTime, " previous frame was at ", lastFrameTime, ", observed frame rate is ", info.observedFrameRate, ", delay since last frame is ", (frameTime - lastFrameTime) * 1000, " ms, frame count is ", info.frameCount);
-    });
+    m_enableFrameRatedMonitoringLogging = true;
 #endif
-
 }
 
 void RealtimeIncomingVideoSource::startProducingData()
@@ -97,18 +108,17 @@ const RealtimeMediaSourceCapabilities& RealtimeIncomingVideoSource::capabilities
 
 const RealtimeMediaSourceSettings& RealtimeIncomingVideoSource::settings()
 {
-    if (m_currentSettings)
+    auto observedFrameRate = m_frameRateMonitor->observedFrameRate();
+    if (m_currentSettings && fabs(m_currentSettings->frameRate() - observedFrameRate) <= 0.1)
         return m_currentSettings.value();
 
-    RealtimeMediaSourceSupportedConstraints constraints;
-    constraints.setSupportsWidth(true);
-    constraints.setSupportsHeight(true);
-
     RealtimeMediaSourceSettings settings;
+    settings.setSupportedConstraints(supportedRealtimeIncomingVideoSourceSettingConstraints());
+
     auto& size = this->size();
     settings.setWidth(size.width());
     settings.setHeight(size.height());
-    settings.setSupportedConstraints(constraints);
+    settings.setFrameRate(observedFrameRate);
 
     m_currentSettings = WTFMove(settings);
     return m_currentSettings.value();
@@ -139,10 +149,8 @@ VideoFrameTimeMetadata RealtimeIncomingVideoSource::metadataFromVideoFrame(const
 
 void RealtimeIncomingVideoSource::notifyNewFrame()
 {
-#if !RELEASE_LOG_DISABLED
     if (m_frameRateMonitor)
         m_frameRateMonitor->update();
-#endif
 }
 
 } // namespace WebCore

--- a/Source/WebCore/platform/mediastream/RealtimeIncomingVideoSource.h
+++ b/Source/WebCore/platform/mediastream/RealtimeIncomingVideoSource.h
@@ -89,8 +89,9 @@ private:
     std::optional<RealtimeMediaSourceSettings> m_currentSettings;
     rtc::scoped_refptr<webrtc::VideoTrackInterface> m_videoTrack;
 
-#if !RELEASE_LOG_DISABLED
     std::unique_ptr<FrameRateMonitor> m_frameRateMonitor;
+#if !RELEASE_LOG_DISABLED
+    bool m_enableFrameRatedMonitoringLogging { false };
     mutable RefPtr<const Logger> m_logger;
     const void* m_logIdentifier;
 #endif


### PR DESCRIPTION
#### 362b1ce629571cea0c9692e473a90dde22258aa1
<pre>
Expose aspectRatio and frameRate in RTCPeerConnection remote MediaStreamTrack settings
<a href="https://bugs.webkit.org/show_bug.cgi?id=256361">https://bugs.webkit.org/show_bug.cgi?id=256361</a>
rdar://problem/108944252

Reviewed by Eric Carlson.

As per spec, we should expose aspectRatio and frameRate settings.
Implement this, using width/height to compute aspectRatio and use observed frameRate, as per spec.

* LayoutTests/webrtc/video.html:
* Source/WebCore/platform/mediastream/RealtimeIncomingVideoSource.cpp:
(WebCore::supportedRealtimeIncomingVideoSourceSettingConstraints):
(WebCore::m_videoTrack):
(WebCore::RealtimeIncomingVideoSource::enableFrameRatedMonitoring):
(WebCore::RealtimeIncomingVideoSource::settings):
(WebCore::RealtimeIncomingVideoSource::notifyNewFrame):
* Source/WebCore/platform/mediastream/RealtimeIncomingVideoSource.h:

Canonical link: <a href="https://commits.webkit.org/263849@main">https://commits.webkit.org/263849@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a1219f3e44856ad15580d57226a9b3e13d2af151

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/5774 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/5937 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/6126 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/7331 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/6166 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/5774 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/6159 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/5905 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/7940 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/5879 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/5926 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/5218 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/7385 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/3403 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/5202 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/12976 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/5271 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/5279 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/7436 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/5723 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/4699 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/5168 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/5132 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/1396 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/9285 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/5529 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->