### PR TITLE
Input[type=date] with invalid date should return empty string for value IDL attribute instead of the default value

### DIFF
--- a/LayoutTests/fast/forms/date/date-editable-components/date-editable-components-keyboard-events-expected.txt
+++ b/LayoutTests/fast/forms/date/date-editable-components/date-editable-components-keyboard-events-expected.txt
@@ -79,6 +79,9 @@ PASS input.value is "2020-01-01"
 PASS input.value is "2020-01-02"
 PASS changeEventsFired is 2
 PASS inputEventsFired is 2
+
+EmptyString Test
+PASS input.value is ""
 PASS successfullyParsed is true
 
 TEST COMPLETE

--- a/LayoutTests/fast/forms/date/date-editable-components/date-editable-components-keyboard-events.html
+++ b/LayoutTests/fast/forms/date/date-editable-components/date-editable-components-keyboard-events.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html>
 <head>
-<script src="../../../../resources/js-test-pre.js"></script>
+<script src="../../../../resources/js-test.js"></script>
 <script src="../../../../resources/ui-helper.js"></script>
 </head>
 <body>
@@ -221,11 +221,16 @@ addEventListener("load", async () => {
     shouldBe("changeEventsFired", "2");
     shouldBe("inputEventsFired", "2");
 
+    input.setAttribute('value', '2012-02-01');
+    beginTest("EmptyString Test", "2012-02-01");
+    UIHelper.keyDown("\t"); // -> 02/[01]/2012
+    UIHelper.keyDown("downArrow"); // -> 02/[31]/2012
+    shouldBeEqualToString('input.value', ''); // 2012-02-31 is not a valid date.
+    input.removeAttribute('value');
+
     finishJSTest();
 });
 
 </script>
-
-<script src="../../../../resources/js-test-post.js"></script>
 </body>
 </html>

--- a/Source/WebCore/html/BaseDateAndTimeInputType.cpp
+++ b/Source/WebCore/html/BaseDateAndTimeInputType.cpp
@@ -1,6 +1,6 @@
 /*
- * Copyright (C) 2010 Google Inc. All rights reserved.
- * Copyright (C) 2016-2018 Apple Inc. All rights reserved.
+ * Copyright (C) 2010-2013 Google Inc. All rights reserved.
+ * Copyright (C) 2016-2023 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are
@@ -236,7 +236,7 @@ String BaseDateAndTimeInputType::visibleValue() const
 
 String BaseDateAndTimeInputType::sanitizeValue(const String& proposedValue) const
 {
-    return typeMismatchFor(proposedValue) ? String() : proposedValue;
+    return typeMismatchFor(proposedValue) ? emptyString() : proposedValue;
 }
 
 bool BaseDateAndTimeInputType::supportsReadOnly() const


### PR DESCRIPTION
#### 6a08e90633f7219e33c16a58f294c5a5a7f32d4a
<pre>
Input[type=date] with invalid date should return empty string for value IDL attribute instead of the default value

<a href="https://bugs.webkit.org/show_bug.cgi?id=120038">https://bugs.webkit.org/show_bug.cgi?id=120038</a>

Reviewed by Ryosuke Niwa.

This patch aligns WebKit with Chromium / Blink and Firefox / Gecko.

Merge - <a href="https://chromium.googlesource.com/chromium/blink/+/cb52052e3522824fa9ffc73cb34667492d47d976">https://chromium.googlesource.com/chromium/blink/+/cb52052e3522824fa9ffc73cb34667492d47d976</a>

BaseDateAndTimeInputType::sanitizeValue should return an empty string if the
input string is invalid.

* Source/WebCore/html/BaseDateAndTimeInputType.cpp
(BaseDateAndTimeInputType::sanitizeValue): Return &apos;emptyString&apos;
* LayoutTests/fast/forms/date/date-editable-components/date-editable-components-keyboard-events.html: Add &apos;emptyString&apos; test
* LayoutTests/fast/forms/date/date-editable-components/date-editable-components-keyboard-events-expected.txt: Update Expectations for new sub-test

Canonical link: <a href="https://commits.webkit.org/263784@main">https://commits.webkit.org/263784@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4eb3cd9b58fb1fa3c5ed006a8f8948968949bf5b

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/5728 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/5889 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/6080 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/7283 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/6121 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/5728 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/6111 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/5859 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/7882 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/5833 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/5877 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/5152 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/7336 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/3354 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/5156 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/12914 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/5222 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/5233 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/7217 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/5675 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/4649 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/5123 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/5086 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/1355 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/9237 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/5483 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->