### PR TITLE
[GTK] Hook up the prefers-reduced-motion media query

### DIFF
--- a/Source/WebCore/platform/adwaita/ThemeAdwaita.h
+++ b/Source/WebCore/platform/adwaita/ThemeAdwaita.h
@@ -37,6 +37,8 @@ class Path;
 
 class ThemeAdwaita : public Theme {
 public:
+    ThemeAdwaita();
+
     enum class PaintRounded : bool { No, Yes };
 
     static void paintFocus(GraphicsContext&, const FloatRect&, int offset, const Color&, PaintRounded = PaintRounded::No);
@@ -46,6 +48,8 @@ public:
     static void paintArrow(GraphicsContext&, const FloatRect&, ArrowDirection, bool);
 
     virtual void platformColorsDidChange() { };
+
+    bool userPrefersReducedMotion() const final;
 
     void setAccentColor(const Color&);
     Color accentColor();
@@ -62,7 +66,13 @@ private:
 
     static Color focusColor(const Color&);
 
+#if PLATFORM(GTK)
+    void refreshGtkSettings();
+#endif
+
     Color m_accentColor { SRGBA<uint8_t> { 52, 132, 228 } };
+
+    bool m_prefersReducedMotion { false };
 };
 
 } // namespace WebCore

--- a/Source/WebKit/Shared/gtk/GtkSettingsState.h
+++ b/Source/WebKit/Shared/gtk/GtkSettingsState.h
@@ -51,6 +51,7 @@ struct GtkSettingsState {
     std::optional<int> cursorBlinkTime;
     std::optional<bool> primaryButtonWarpsSlider;
     std::optional<bool> overlayScrolling;
+    std::optional<bool> enableAnimations;
 };
 
 } // namespace WebKit

--- a/Source/WebKit/UIProcess/gtk/GtkSettingsManager.cpp
+++ b/Source/WebKit/UIProcess/gtk/GtkSettingsManager.cpp
@@ -125,6 +125,13 @@ bool GtkSettingsManager::overlayScrolling() const
     return overlayScrollingSetting ? true : false;
 }
 
+bool GtkSettingsManager::enableAnimations() const
+{
+    gboolean enableAnimationsSetting;
+    g_object_get(m_settings, "gtk-enable-animations", &enableAnimationsSetting, nullptr);
+    return enableAnimationsSetting ? true : false;
+}
+
 void GtkSettingsManager::settingsDidChange()
 {
     GtkSettingsState state;
@@ -173,6 +180,10 @@ void GtkSettingsManager::settingsDidChange()
     if (m_settingsState.overlayScrolling != overlayScrolling)
         m_settingsState.overlayScrolling = state.overlayScrolling = overlayScrolling;
 
+    auto enableAnimations = this->enableAnimations();
+    if (m_settingsState.enableAnimations != enableAnimations)
+        m_settingsState.enableAnimations = state.enableAnimations = enableAnimations;
+
     for (auto& processPool : WebProcessPool::allProcessPools())
         processPool->sendToAllProcesses(Messages::GtkSettingsManagerProxy::SettingsDidChange(state));
 }
@@ -195,6 +206,7 @@ GtkSettingsManager::GtkSettingsManager()
     m_settingsState.cursorBlinkTime = cursorBlinkTime();
     m_settingsState.primaryButtonWarpsSlider = primaryButtonWarpsSlider();
     m_settingsState.overlayScrolling = overlayScrolling();
+    m_settingsState.enableAnimations = enableAnimations();
 
     g_signal_connect_swapped(m_settings, "notify::gtk-theme-name", G_CALLBACK(settingsChangedCallback), this);
     g_signal_connect_swapped(m_settings, "notify::gtk-font-name", G_CALLBACK(settingsChangedCallback), this);
@@ -207,6 +219,7 @@ GtkSettingsManager::GtkSettingsManager()
     g_signal_connect_swapped(m_settings, "notify::gtk-cursor-blink-time", G_CALLBACK(settingsChangedCallback), this);
     g_signal_connect_swapped(m_settings, "notify::gtk-primary-button-warps-slider", G_CALLBACK(settingsChangedCallback), this);
     g_signal_connect_swapped(m_settings, "notify::gtk-overlay-scrolling", G_CALLBACK(settingsChangedCallback), this);
+    g_signal_connect_swapped(m_settings, "notify::gtk-enable-animations", G_CALLBACK(settingsChangedCallback), this);
 }
 
 } // namespace WebKit

--- a/Source/WebKit/UIProcess/gtk/GtkSettingsManager.h
+++ b/Source/WebKit/UIProcess/gtk/GtkSettingsManager.h
@@ -54,6 +54,7 @@ private:
     int cursorBlinkTime() const;
     bool primaryButtonWarpsSlider() const;
     bool overlayScrolling() const;
+    bool enableAnimations() const;
 
     GtkSettings* m_settings;
     GtkSettingsState m_settingsState;

--- a/Source/WebKit/WebProcess/gtk/GtkSettingsManagerProxy.cpp
+++ b/Source/WebKit/WebProcess/gtk/GtkSettingsManagerProxy.cpp
@@ -107,6 +107,9 @@ void GtkSettingsManagerProxy::applySettings(GtkSettingsState&& state)
 
     if (state.overlayScrolling)
         g_object_set(m_settings, "gtk-overlay-scrolling", *state.overlayScrolling, nullptr);
+
+    if (state.enableAnimations)
+        g_object_set(m_settings, "gtk-enable-animations", *state.enableAnimations, nullptr);
 }
 
 void GtkSettingsManagerProxy::applyHintingSettings()


### PR DESCRIPTION
#### 4fbff322603faa574954f3edb2ad44cc4bc66bd6
<pre>
[GTK] Hook up the prefers-reduced-motion media query
<a href="https://bugs.webkit.org/show_bug.cgi?id=255097">https://bugs.webkit.org/show_bug.cgi?id=255097</a>

Reviewed by Michael Catanzaro.

This connects the prefers-reduced-motion media query to the
gtk-enable-animations GtkSetting.

* Source/WebCore/platform/adwaita/ThemeAdwaita.cpp:
(WebCore::ThemeAdwaita::ThemeAdwaita):
(WebCore::ThemeAdwaita::refreshGtkSettings):
(WebCore::ThemeAdwaita::userPrefersReducedMotion const):
* Source/WebCore/platform/adwaita/ThemeAdwaita.h:
* Source/WebKit/Shared/gtk/GtkSettingsState.h:
* Source/WebKit/UIProcess/gtk/GtkSettingsManager.cpp:
(WebKit::GtkSettingsManager::enableAnimations const):
(WebKit::GtkSettingsManager::settingsDidChange):
(WebKit::GtkSettingsManager::GtkSettingsManager):
* Source/WebKit/UIProcess/gtk/GtkSettingsManager.h:
* Source/WebKit/WebProcess/gtk/GtkSettingsManagerProxy.cpp:
(WebKit::GtkSettingsManagerProxy::applySettings):

Canonical link: <a href="https://commits.webkit.org/263777@main">https://commits.webkit.org/263777@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4e9b78935c0ff7932bea4b10e18a4e5a7c621f2c

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/5736 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/5898 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/6088 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/7292 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/6128 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/5736 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/6120 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/5867 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/7899 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/5841 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/5887 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/5164 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/7345 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/3364 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/5162 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/12927 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/5232 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/5239 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/7281 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/5684 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/4658 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/5131 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/1349 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/9246 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/5491 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->