### PR TITLE
Sync 'SVGClipPathElement' with IDL Spec and add 'transform' as well

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-masking/idlharness-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-masking/idlharness-expected.txt
@@ -9,18 +9,14 @@ PASS Element includes ParentNode: member names are unique
 PASS Element includes NonDocumentTypeChildNode: member names are unique
 PASS Element includes ChildNode: member names are unique
 PASS Element includes Slottable: member names are unique
-FAIL SVGClipPathElement interface: existence and properties of interface object assert_equals: prototype of SVGClipPathElement is not SVGElement expected function "function SVGElement() {
-    [native code]
-}" but got function "function SVGGraphicsElement() {
-    [native code]
-}"
+PASS SVGClipPathElement interface: existence and properties of interface object
 PASS SVGClipPathElement interface object length
 PASS SVGClipPathElement interface object name
-FAIL SVGClipPathElement interface: existence and properties of interface prototype object assert_equals: prototype of SVGClipPathElement.prototype is not SVGElement.prototype expected object "[object SVGElement]" but got object "[object SVGGraphicsElement]"
+PASS SVGClipPathElement interface: existence and properties of interface prototype object
 PASS SVGClipPathElement interface: existence and properties of interface prototype object's "constructor" property
 PASS SVGClipPathElement interface: existence and properties of interface prototype object's @@unscopables property
 PASS SVGClipPathElement interface: attribute clipPathUnits
-FAIL SVGClipPathElement interface: attribute transform assert_own_property: expected property "transform" missing
+PASS SVGClipPathElement interface: attribute transform
 PASS SVGClipPathElement must be primary interface of [object SVGClipPathElement]
 PASS Stringification of [object SVGClipPathElement]
 PASS SVGClipPathElement interface: [object SVGClipPathElement] must inherit property "clipPathUnits" with the proper type

--- a/LayoutTests/svg/dom/svg2-inheritance-expected.txt
+++ b/LayoutTests/svg/dom/svg2-inheritance-expected.txt
@@ -25,7 +25,7 @@ PASS SVGAnimatedTransformList inherits Object
 PASS SVGAnimationElement inherits SVGElement
 FAIL SVGCSSRule is not defined
 PASS SVGCircleElement inherits SVGGeometryElement
-FAIL SVGClipPathElement should inherit SVGDefinitionElement but got SVGGraphicsElement instead
+FAIL SVGClipPathElement should inherit SVGDefinitionElement but got SVGElement instead
 FAIL SVGColorProfileElement is not defined
 FAIL SVGColorProfileRule is not defined
 PASS SVGDefsElement inherits SVGGraphicsElement

--- a/Source/WebCore/svg/SVGClipPathElement.idl
+++ b/Source/WebCore/svg/SVGClipPathElement.idl
@@ -24,8 +24,11 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE. 
  */
 
+// https://drafts.fxtf.org/css-masking/#InterfaceSVGClipPathElement
+
 [
     Exposed=Window
-] interface SVGClipPathElement : SVGGraphicsElement {
+] interface SVGClipPathElement : SVGElement {
     readonly attribute SVGAnimatedEnumeration clipPathUnits;
+    readonly attribute SVGAnimatedTransformList transform;
 };


### PR DESCRIPTION
#### 81881e6b668f137e4dd22f54edacc02df0f90c31
<pre>
Sync &apos;SVGClipPathElement&apos; with IDL Spec and add &apos;transform&apos; as well

<a href="https://bugs.webkit.org/show_bug.cgi?id=256316">https://bugs.webkit.org/show_bug.cgi?id=256316</a>

Reviewed by Simon Fraser.

This patch aligns WebKit with web-spec [1]:

[1] <a href="https://drafts.fxtf.org/css-masking/#InterfaceSVGClipPathElement">https://drafts.fxtf.org/css-masking/#InterfaceSVGClipPathElement</a>

This is also part of Interop 2023.

* Source/WebCore/svg/SVGClipPathElement.idl: As above
* LayoutTests/imported/w3c/web-platform-tests/css/css-masking/idlharness-expected.txt: Rebaselined
* LayoutTests/svg/dom/svg2-inheritance-expected.txt: Rebaselined

Canonical link: <a href="https://commits.webkit.org/263808@main">https://commits.webkit.org/263808@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ea761083a3ac4db3f1204925c9b944776120e359

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/5729 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/5890 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/6081 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/7284 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/6122 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/5729 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/6112 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/5860 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/7883 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/5834 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/5878 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/5153 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/7337 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/3355 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/5157 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/12917 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/5223 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/5234 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/7224 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/5676 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/4651 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/5124 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/1371 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/9238 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/5484 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->