### PR TITLE
Make threadGlobalData inlined

### DIFF
--- a/Source/WTF/wtf/Threading.h
+++ b/Source/WTF/wtf/Threading.h
@@ -279,6 +279,14 @@ public:
     struct NewThreadContext;
     static void entryPoint(NewThreadContext*);
     ThreadLikeAssertion threadLikeAssertion() const { return createThreadLikeAssertion(m_uid); }
+
+    // Returns nullptr if thread-specific storage was not initialized.
+#if OS(WINDOWS)
+    WTF_EXPORT_PRIVATE static Thread* currentMayBeNull();
+#else
+    static Thread* currentMayBeNull();
+#endif
+
 protected:
     Thread() = default;
 
@@ -345,13 +353,6 @@ protected:
     // Creates and puts an instance of Thread into thread-specific storage.
     static Thread& initializeTLS(Ref<Thread>&&);
     WTF_EXPORT_PRIVATE static Thread& initializeCurrentTLS();
-
-    // Returns nullptr if thread-specific storage was not initialized.
-#if OS(WINDOWS)
-    WTF_EXPORT_PRIVATE static Thread* currentMayBeNull();
-#else
-    static Thread* currentMayBeNull();
-#endif
 
     static Lock s_allThreadsLock;
 
@@ -424,7 +425,7 @@ inline Thread& Thread::current()
     if (UNLIKELY(Thread::s_key == InvalidThreadSpecificKey))
         WTF::initialize();
 #endif
-    if (auto* thread = currentMayBeNull())
+    if (auto* thread = currentMayBeNull(); LIKELY(thread))
         return *thread;
     return initializeCurrentTLS();
 }

--- a/Source/WebCore/platform/ThreadGlobalData.cpp
+++ b/Source/WebCore/platform/ThreadGlobalData.cpp
@@ -71,11 +71,11 @@ void ThreadGlobalData::setWebCoreThreadData()
     ASSERT(&threadGlobalData() == sharedMainThreadStaticData);
 }
 
-ThreadGlobalData& threadGlobalData()
+ThreadGlobalData& threadGlobalDataSlow()
 {
     auto& thread = Thread::current();
     auto* clientData = thread.m_clientData.get();
-    if (LIKELY(clientData))
+    if (UNLIKELY(clientData))
         return *static_cast<ThreadGlobalData*>(clientData);
 
     auto data = adoptRef(*new ThreadGlobalData);
@@ -91,11 +91,11 @@ ThreadGlobalData& threadGlobalData()
 
 #else
 
-ThreadGlobalData& threadGlobalData()
+ThreadGlobalData& threadGlobalDataSlow()
 {
     auto& thread = Thread::current();
     auto* clientData = thread.m_clientData.get();
-    if (LIKELY(clientData))
+    if (UNLIKELY(clientData))
         return *static_cast<ThreadGlobalData*>(clientData);
 
     auto data = adoptRef(*new ThreadGlobalData);


### PR DESCRIPTION
#### 77a93a825be95c43038288b174a73d817d5b5f66
<pre>
Make threadGlobalData inlined
<a href="https://bugs.webkit.org/show_bug.cgi?id=256425">https://bugs.webkit.org/show_bug.cgi?id=256425</a>
rdar://108999187

Reviewed by Justin Michaud.

WebCore::threadGlobalData is not inlined, which is silly.
Let&apos;s just define it inlined function. And put LIKELY / UNLIKELY appropriately
to make our fastest path super fast.

    mrs     x26, TPIDRRO_EL0
    ldr     x8, [x26, #0x2e0]
    cbz     x8, 0x11e284
    ldr     x21, [x8, #0x68]
    cbnz    x21, 0x11e28c
    bl      WebCore::threadGlobalDataSlow()

* Source/WebCore/platform/ThreadGlobalData.cpp:
(WebCore::threadGlobalDataSlow):
(WebCore::threadGlobalData): Deleted.
* Source/WebCore/platform/ThreadGlobalData.h:
(WebCore::threadGlobalData):

Canonical link: <a href="https://commits.webkit.org/263872@main">https://commits.webkit.org/263872@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b13ec176bd310fd7e67b5701bf729e2bf27d47f5

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/5893 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/6065 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/6252 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/7444 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/6258 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/5890 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/6284 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/6026 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/8588 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/6001 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/6037 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/5335 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/7502 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/3514 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/5311 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/13258 "1 flakes 193 failures") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/4923 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/5379 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/5389 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/7612 "262 api tests failed or timed out") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/5477 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/5839 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/4786 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/6010 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/5272 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/1461 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/9396 "Built successfully") | | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/24/builds/6179 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/698 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/5633 "Built successfully") | | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/3/builds/1582 "Passed tests") | 
<!--EWS-Status-Bubble-End-->