### PR TITLE
Correct typo in Document::createProcessingInstruction exception

### DIFF
--- a/LayoutTests/fast/dom/qualified-name-validation-expected.txt
+++ b/LayoutTests/fast/dom/qualified-name-validation-expected.txt
@@ -12,6 +12,7 @@ PASS document.createAttributeNS('ns', 'f@ast') threw exception InvalidCharacterE
 PASS document.body.setAttribute('@foo', 'test') threw exception InvalidCharacterError: Invalid qualified name: '@foo'.
 PASS document.body.setAttributeNS('ns', '@foo', 'test') threw exception InvalidCharacterError: Invalid qualified name start in '@foo'.
 PASS document.body.setAttributeNS('ns', 'f@st', 'test') threw exception InvalidCharacterError: Invalid qualified name part in 'f@st'.
+PASS document.createProcessingInstruction('@foo', 'test') threw exception InvalidCharacterError: Invalid qualified name: '@foo'.
 PASS successfullyParsed is true
 
 TEST COMPLETE

--- a/LayoutTests/fast/dom/qualified-name-validation.html
+++ b/LayoutTests/fast/dom/qualified-name-validation.html
@@ -14,6 +14,7 @@ shouldThrowErrorName("document.createAttributeNS('ns', 'f@ast')", "InvalidCharac
 shouldThrowErrorName("document.body.setAttribute('@foo', 'test')", "InvalidCharacterError");
 shouldThrowErrorName("document.body.setAttributeNS('ns', '@foo', 'test')", "InvalidCharacterError");
 shouldThrowErrorName("document.body.setAttributeNS('ns', 'f@st', 'test')", "InvalidCharacterError");
+shouldThrowErrorName("document.createProcessingInstruction('@foo', 'test')", "InvalidCharacterError");
 </script>
 </body>
 </html>

--- a/Source/WebCore/dom/Document.cpp
+++ b/Source/WebCore/dom/Document.cpp
@@ -1131,7 +1131,7 @@ ExceptionOr<Ref<CDATASection>> Document::createCDATASection(String&& data)
 ExceptionOr<Ref<ProcessingInstruction>> Document::createProcessingInstruction(String&& target, String&& data)
 {
     if (!isValidName(target))
-        return Exception { InvalidCharacterError, makeString("Invalid qualified name: ", target, "'") };
+        return Exception { InvalidCharacterError, makeString("Invalid qualified name: '", target, "'") };
 
     if (data.contains("?>"_s))
         return Exception { InvalidCharacterError };


### PR DESCRIPTION
#### be86bca8e67be2ed9a1f7c3e75996c9b94a7fc50
<pre>
Correct typo in Document::createProcessingInstruction exception
<a href="https://bugs.webkit.org/show_bug.cgi?id=256426">https://bugs.webkit.org/show_bug.cgi?id=256426</a>
rdar://109000003

Reviewed by Chris Dumez.

Correct minor oversight of dcf5f162b4888136d70d4eb5e74c6c3edd211590.

* LayoutTests/fast/dom/qualified-name-validation-expected.txt:
* LayoutTests/fast/dom/qualified-name-validation.html:
* Source/WebCore/dom/Document.cpp:
(WebCore::Document::createProcessingInstruction):

Canonical link: <a href="https://commits.webkit.org/263772@main">https://commits.webkit.org/263772@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/47f588a1976e4176f87564eab330bcd153417b6e

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/5726 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/5887 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/6078 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/7281 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/6119 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/5726 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/6109 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/5857 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/7880 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/5831 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/5876 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/5150 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/7334 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/3353 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/5155 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/12913 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/5221 "Passed tests") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/5232 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/7216 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/5673 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/4648 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/5121 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/5085 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/1345 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/9235 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/5481 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->