### PR TITLE
[Catalyst] Occasional invalid IPC: `WebPageProxy_HandleSmartMagnificationInformationForPotentialTap`

### DIFF
--- a/Source/WebCore/dom/Node.cpp
+++ b/Source/WebCore/dom/Node.cpp
@@ -853,7 +853,7 @@ RenderBoxModelObject* Node::renderBoxModelObject() const
 }
     
 LayoutRect Node::renderRect(bool* isReplaced)
-{    
+{
     RenderObject* hitRenderer = this->renderer();
     if (!hitRenderer && is<HTMLAreaElement>(*this)) {
         auto& area = downcast<HTMLAreaElement>(*this);
@@ -869,6 +869,7 @@ LayoutRect Node::renderRect(bool* isReplaced)
         }
         renderer = renderer->parent();
     }
+    *isReplaced = false;
     return LayoutRect();    
 }
 


### PR DESCRIPTION
#### f68717fc7602f406e9fb0993e81b9d344c016513
<pre>
[Catalyst] Occasional invalid IPC: `WebPageProxy_HandleSmartMagnificationInformationForPotentialTap`
<a href="https://bugs.webkit.org/show_bug.cgi?id=256433">https://bugs.webkit.org/show_bug.cgi?id=256433</a>
rdar://108517664

Reviewed by Tim Horton.

In Mac Catalyst, we sometimes end up trying to decode an invalid IPC message in the UI process for
`WebPageProxy::HandleSmartMagnificationInformationForPotentialTap`, due to the boolean value for
`fitEntireRect` being a value that isn&apos;t 0 or 1. This can happen in the case where the user clicks
on the body or document element, since we always pass the (uninitialized) boolean flag as an
outparam here:

```
void ViewGestureGeometryCollector::computeZoomInformationForNode(…, bool&amp; isReplaced, …)
{
    renderRect = node.renderRect(&amp;isReplaced);
…
```

...but `Node::renderRect` only sets the outparam in the case where we find a block-level renderer
that is neither the body element&apos;s nor the document element&apos;s renderer:

```
LayoutRect Node::renderRect(bool* isReplaced)
{
…
    while (renderer &amp;&amp; !renderer-&gt;isBody() &amp;&amp; !renderer-&gt;isDocumentElementRenderer()) {
        if (renderer-&gt;isRenderBlock() || renderer-&gt;isInlineBlockOrInlineTable() || renderer-&gt;isReplacedOrInlineBlock()) {
            // FIXME: Is this really what callers want for the &quot;isReplaced&quot; flag?
            *isReplaced = renderer-&gt;isReplacedOrInlineBlock();
            return renderer-&gt;absoluteBoundingBoxRect();
        }
        renderer = renderer-&gt;parent();
    }
    return LayoutRect();
}
```

To fix this, we simply ensure that the outparam is initialized to `false` in the case where we never
found a suitable render block in the first place.

* Source/WebCore/dom/Node.cpp:
(WebCore::Node::renderRect):

Canonical link: <a href="https://commits.webkit.org/263782@main">https://commits.webkit.org/263782@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/7e3fc6d0556d5d6b562254b8b74bdaae349b39cf

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/5747 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/5910 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/6099 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/7304 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/6139 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/5747 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/6132 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/5878 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/7911 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/5852 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/5898 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/5181 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/7358 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/3375 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/5174 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/12947 "1 flakes 152 failures") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/5243 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/5251 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/7325 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/5696 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/4668 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/5142 "Built successfully") | | | 
| [  ~~🛠 🧪 merge~~](https://ews-build.webkit.org/#/builders/19/builds/1353 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/9258 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/5502 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->