### PR TITLE
Web Inspector: Truncated localStorage editing gives an illusion of a proper edit and truncated string is saved

### DIFF
--- a/LayoutTests/inspector/unit-tests/html-utilities-expected.txt
+++ b/LayoutTests/inspector/unit-tests/html-utilities-expected.txt
@@ -1,0 +1,8 @@
+
+== Running test suite: HTMLUtilities
+-- Running test case: HTMLCollection.prototype.indexOf
+PASS: Should find the right index for the first child.
+PASS: Should find the right index for the second child.
+PASS: Should find the right index for the third child.
+PASS: Should not find an index for something not in the collection.
+

--- a/LayoutTests/inspector/unit-tests/html-utilities.html
+++ b/LayoutTests/inspector/unit-tests/html-utilities.html
@@ -1,0 +1,31 @@
+<!doctype html>
+<html>
+<head>
+<script src="../../http/tests/inspector/resources/inspector-test.js"></script>
+<script>
+function test()
+{
+    let suite = InspectorTest.createSyncSuite("HTMLUtilities");
+
+    suite.addTestCase({
+        name: "HTMLCollection.prototype.indexOf",
+        test() {
+            let parent = document.createElement("div");
+            let child1 = parent.appendChild(document.createElement("div"));
+            let child2 = parent.appendChild(document.createElement("div"));
+            let child3 = parent.appendChild(document.createElement("div"));
+
+            InspectorTest.expectEqual(parent.getElementsByTagName("div").indexOf(child1), 0, "Should find the right index for the first child.");
+            InspectorTest.expectEqual(parent.getElementsByTagName("div").indexOf(child2), 1, "Should find the right index for the second child.");
+            InspectorTest.expectEqual(parent.getElementsByTagName("div").indexOf(child3), 2, "Should find the right index for the third child.");
+            InspectorTest.expectEqual(parent.getElementsByTagName("div").indexOf(null), -1, "Should not find an index for something not in the collection.");
+        },
+    });
+
+    suite.runTestCasesAndFinish();
+}
+</script>
+</head>
+<body onLoad="runTest()">
+</body>
+</html>

--- a/Source/WebInspectorUI/UserInterface/Base/Utilities.js
+++ b/Source/WebInspectorUI/UserInterface/Base/Utilities.js
@@ -580,6 +580,19 @@ Object.defineProperty(DocumentFragment.prototype, "createChild",
     });
 })();
 
+Object.defineProperty(HTMLCollection.prototype, "indexOf",
+{
+    value(element)
+    {
+        let length = this.length;
+        for (let i = 0; i < length; ++i) {
+            if (this[i] === element)
+                return i;
+        }
+        return -1;
+    }
+});
+
 Object.defineProperty(Event.prototype, "stop",
 {
     value()

--- a/Source/WebInspectorUI/UserInterface/Views/LocalResourceOverridePopover.js
+++ b/Source/WebInspectorUI/UserInterface/Views/LocalResourceOverridePopover.js
@@ -328,7 +328,7 @@ WI.LocalResourceOverridePopover = class LocalResourceOverridePopover extends WI.
         statusTextEditorElement.className = "editor status-text";
         this._statusTextCodeMirror = this._createEditor(statusTextEditorElement, {value: valueData.statusText || "", placeholder: placeholderData.statusText});
 
-        let editCallback = () => {};
+        let afterEditCallback = () => {}; // We must provide a callback in order to enable builtin editing support.
         let deleteCallback = (node) => {
             if (node === contentTypeDataGridNode)
                 return;
@@ -352,7 +352,7 @@ WI.LocalResourceOverridePopover = class LocalResourceOverridePopover extends WI.
             },
         };
 
-        this._headersDataGrid = new WI.DataGrid(columns, {editCallback, deleteCallback});
+        this._headersDataGrid = new WI.DataGrid(columns, {afterEditCallback, deleteCallback});
         this._headersDataGrid.inline = true;
         this._headersDataGrid.variableHeightRows = true;
         this._headersDataGrid.copyTextDelimiter = ": ";


### PR DESCRIPTION
#### 3db01ec96898f9a730ba4ad44a10ca533b4bd1b2
<pre>
Web Inspector: Truncated localStorage editing gives an illusion of a proper edit and truncated string is saved
<a href="https://bugs.webkit.org/show_bug.cgi?id=203013">https://bugs.webkit.org/show_bug.cgi?id=203013</a>

Reviewed by Patrick Angle.

This makes it impossible to edit large `localStorage`/`sessionStorage` values as the `WI.DataGridNode` only shows the first 200 characters.

* Source/WebInspectorUI/UserInterface/Views/DataGrid.js:
(WI.DataGrid.prototype.startEditingNode):
(WI.DataGrid.prototype._startEditingNodeAtColumnIndex):
(WI.DataGrid.prototype._startEditing):
(WI.DataGrid.prototype._editingCommitted):
(WI.DataGrid.prototype._keyDown):
(WI.DataGrid.prototype._contextMenuInDataTable):
Add support for a `beforeEditCallback` that allows the caller to do work on the `WI.DataGridNode` (and its `element`) before editing starts.

* Source/WebInspectorUI/UserInterface/Views/DOMStorageContentView.js:
(WI.DOMStorageContentView):
(WI.DOMStorageContentView.prototype.itemAdded):
(WI.DOMStorageContentView.prototype.itemUpdated):
(WI.DOMStorageContentView.prototype._populate):
(WI.DOMStorageContentView.prototype._beforeEditCallback): Added.
(WI.DOMStorageContentView.prototype._afterEditCallback): Renamed from `_editingCallback`.
(WI.DOMStorageContentView.prototype._dataGridCopy):
(WI.DOMStorageContentView.prototype._editingCallback.cleanup): Deleted.
(WI.DOMStorageContentView.prototype._editingCallback): Deleted.
Leverage the new `beforeEditCallback` to replace the contents of the `element` with the actual value before editing starts.
Drive-by: Rename `value` to `displayValue` since it&apos;s not the actual value of `localStorage`/`sessionStorage`.

* Source/WebInspectorUI/UserInterface/Views/LocalResourceOverridePopover.js:
(WI.LocalResourceOverridePopover.prototype.show):
Renamed `editCallback` to `afterEditCallback`.

* Source/WebInspectorUI/UserInterface/Base/Utilities.js:
(HTMLCollection.prototype.indexOf): Added.
Add a utility function to allow `HTMLCollection` to behave similar to `Array.prototype.indexOf`, allowing for the same code to work with both.

* LayoutTests/inspector/unit-tests/html-utilities.html: Added.
* LayoutTests/inspector/unit-tests/html-utilities-expected.txt: Added.

Canonical link: <a href="https://commits.webkit.org/264166@main">https://commits.webkit.org/264166@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/7330ab1251f5fdb175c593b92f31041af0739654

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/6908 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/7138 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/7321 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/8507 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/32/builds/7154 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/8392 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/7077 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/10054 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/7030 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/15/builds/7699 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/6361 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/8607 "Built successfully") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/39/builds/5080 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/6270 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/14068 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/6765 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/6358 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/9174 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/6840 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/5606 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/6216 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/6184 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/1638 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/10401 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/6594 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->