### PR TITLE
Web Inspector: Step Over behaves like resume when stepping over a function with a falsey conditional breakpoint

### DIFF
--- a/LayoutTests/inspector/debugger/stepping/stepOver-breakpoint-expected.txt
+++ b/LayoutTests/inspector/debugger/stepping/stepOver-breakpoint-expected.txt
@@ -1,0 +1,45 @@
+Checking pause locations when stepping with "stepOver".
+
+
+== Running test suite: Debugger.stepOver
+-- Running test case: Debugger.stepOver.Breakpoint.Condition.Falsy
+PAUSED (debugger-statement)
+PAUSE AT testInnerFunction:9:5
+      5    <script>
+      6
+      7    function testInnerFunction() {
+ ->   8        |debugger;
+      9        function alpha() {
+     10            debugger;
+     11        }
+
+PAUSE AT testInnerFunction:13:5
+      9        function alpha() {
+     10            debugger;
+     11        }
+ ->  12        |alpha();
+     13        function beta() {
+     14            let x = 42;
+     15        }
+
+PASS: Should evaluate condition.
+PAUSE AT testInnerFunction:17:5
+     13        function beta() {
+     14            let x = 42;
+     15        }
+ ->  16        |beta();
+     17    }
+     18
+     19    function test()
+
+PAUSE AT testInnerFunction:18:2
+     14            let x = 42;
+     15        }
+     16        beta();
+ ->  17    }|
+     18
+     19    function test()
+     20    {
+
+RESUMED
+

--- a/LayoutTests/inspector/debugger/stepping/stepOver-breakpoint.html
+++ b/LayoutTests/inspector/debugger/stepping/stepOver-breakpoint.html
@@ -1,0 +1,71 @@
+<!DOCTYPE html>
+<html>
+<head>
+<script src="../../../http/tests/inspector/resources/inspector-test.js"></script>
+<script src="../resources/log-pause-location.js"></script>
+<script>
+
+function testInnerFunction() {
+    debugger;
+    function alpha() {
+        debugger;
+    }
+    alpha();
+    function beta() {
+        let x = 42;
+    }
+    beta();
+}
+
+function test()
+{
+    let suite = InspectorTest.createAsyncSuite("Debugger.stepOver");
+
+    let handleCallFramesDidChange = null;
+
+    // Always step-over when call frames change.
+    WI.debuggerManager.addEventListener(WI.DebuggerManager.Event.CallFramesDidChange, (event) => {
+        if (!WI.debuggerManager.activeCallFrame)
+            return;
+        logPauseLocation();
+        handleCallFramesDidChange?.();
+        WI.debuggerManager.stepOver();
+    });
+
+    WI.debuggerManager.addEventListener(WI.DebuggerManager.Event.Paused, (event) => {
+        InspectorTest.log(`PAUSED (${WI.debuggerManager.dataForTarget(WI.debuggerManager.activeCallFrame.target).pauseReason})`);
+    });
+
+    suite.addTestCase({
+        name: "Debugger.stepOver.Breakpoint.Condition.Falsy",
+        description: "Stepping should continue after hitting a breakpoint that does not pause.",
+        async test() {
+            WI.debuggerManager.debuggerStatementsBreakpoint.disabled = false;
+
+            handleCallFramesDidChange = function() {
+                WI.debuggerManager.debuggerStatementsBreakpoint.condition = "TestPage.addResult(`PASS: Should evaluate condition.`)";
+            };
+
+            await Promise.all([
+                InspectorTest.evaluateInPage(`setTimeout(testInnerFunction)`),
+                WI.debuggerManager.awaitEvent(WI.DebuggerManager.Event.Resumed),
+            ]);
+
+            InspectorTest.log("RESUMED");
+
+            handleCallFramesDidChange = null;
+
+            WI.debuggerManager.debuggerStatementsBreakpoint.condition = "";
+        },
+    });
+
+    loadMainPageContent().then(() => {
+        suite.runTestCasesAndFinish();
+    });
+}
+</script>
+</head>
+<body onload="runTest()">
+<p>Checking pause locations when stepping with "stepOver".</p>
+</body>
+</html>

--- a/Source/JavaScriptCore/debugger/Debugger.h
+++ b/Source/JavaScriptCore/debugger/Debugger.h
@@ -294,7 +294,8 @@ private:
     void updateCallFrame(JSC::JSGlobalObject*, JSC::CallFrame*, CallFrameUpdateAction);
     void updateCallFrameInternal(JSC::CallFrame*);
     void pauseIfNeeded(JSC::JSGlobalObject*);
-    void clearNextPauseState();
+    void resetImmediatePauseState();
+    void resetEventualPauseState();
 
     enum SteppingMode {
         SteppingModeDisabled,


### PR DESCRIPTION
#### 5b1242114ff523ce7b13e97ddb0881af98a887d6
<pre>
Web Inspector: Step Over behaves like resume when stepping over a function with a falsey conditional breakpoint
<a href="https://bugs.webkit.org/show_bug.cgi?id=247088">https://bugs.webkit.org/show_bug.cgi?id=247088</a>
&lt;rdar://problem/101604843&gt;

Reviewed by Patrick Angle.

Breakpoints should only take precedence over stepping actions if they are actually triggering a pause.

If the breakpoint doesn&apos;t pause (e.g. a falsy `condition`, below the `ignoreCount`, etc.) then the `Debugger` should still behave as if it&apos;s stepping.

* Source/JavaScriptCore/debugger/Debugger.h:
* Source/JavaScriptCore/debugger/Debugger.cpp:
(JSC::Debugger::continueProgram):
(JSC::Debugger::pauseIfNeeded):
(JSC::Debugger::didExecuteProgram):
(JSC::Debugger::resetImmediatePauseState): Added.
(JSC::Debugger::resetEventualPauseState): Added.
(JSC::Debugger::clearNextPauseState): Deleted.
Split the resetting of pause state variables into two &quot;variants&quot;:
- immediate pause state variables (e.g. &quot;Pause script execution&quot;, after blackboxed scripts, special breakpoints, etc.)
- eventual pause state variables (e.g. Step over&quot;, Step out&quot;, &quot;Step next&quot;, etc.)
Only clear eventual pause state variables if we&apos;re at the desired call frame, or if we&apos;re actually pausing at a breakpoint (because the pause reason is now the breakpoint, not the stepping action).

* LayoutTests/inspector/debugger/stepping/stepOver-breakpoint.html: Added.
* LayoutTests/inspector/debugger/stepping/stepOver-breakpoint-expected.txt: Added.

Canonical link: <a href="https://commits.webkit.org/264160@main">https://commits.webkit.org/264160@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/3994c24720c00241ecb8650d949184e2af14266a

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/5755 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/5918 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/6107 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/7312 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/6147 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/6140 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/5886 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/7922 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/5860 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/5907 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/5190 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/7366 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/3384 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/5182 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/12955 "Passed tests") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/4795 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/5252 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/5259 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/7393 "Passed tests") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/5341 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/5704 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/4685 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/5867 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/5149 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/5112 "Passed tests") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/1438 "Passed tests") | 
| [❌ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/1632 "Failed to push commit to Webkit repository") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/9266 "Built successfully") | | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/24/builds/6032 "Built successfully") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/5510 "Built successfully") | | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/3/builds/1558 "Passed tests") | 
<!--EWS-Status-Bubble-End-->