### PR TITLE
IPC::StreamServerConnection is leaking IPC::Connection object for RemoteGraphicsContextGL

### DIFF
--- a/Source/WebKit/Platform/IPC/Connection.cpp
+++ b/Source/WebKit/Platform/IPC/Connection.cpp
@@ -467,7 +467,6 @@ void Connection::invalidate()
     m_isValid = false;
     if (!m_client)
         return;
-    assertIsCurrent(dispatcher());
     m_client = nullptr;
     [this] {
         Locker locker { m_incomingMessagesLock };

--- a/Source/WebKit/Platform/IPC/StreamServerConnection.cpp
+++ b/Source/WebKit/Platform/IPC/StreamServerConnection.cpp
@@ -78,7 +78,7 @@ void StreamServerConnection::open()
     });
     // FIXME(http://webkit.org/b/238986): Workaround for not being able to deliver messages from the dedicated connection to the work queue the client uses.
     m_connection->addMessageReceiveQueue(*this, { });
-    m_connection->open(s_dedicatedConnectionClient.get());
+    m_connection->open(s_dedicatedConnectionClient.get(), RunLoop::main());
     m_isOpen = true;
 }
 


### PR DESCRIPTION
#### 61ce5ef1d812a0a8f5779cc7e649f6d8b2c75ad8
<pre>
IPC::StreamServerConnection is leaking IPC::Connection object for RemoteGraphicsContextGL
<a href="https://bugs.webkit.org/show_bug.cgi?id=256200">https://bugs.webkit.org/show_bug.cgi?id=256200</a>

Reviewed by NOBODY (OOPS!).

IPC::Connection::open takes an optional dispatcher of type
SerialFunctionDispatcher. It uses RunLoop::current() by default if not
specified. IPC::StreamServerConnection opened a IPC::Connection with
using the default RunLoop::current() as the dispatcher even though the
RemoteGraphicsContextGL work queue thread isn&apos;t a RunLoop thread.
Connection::dispatchToClient didn&apos;t work as expected in the thread
because the RunLoop never executed dispatched jobs. As the result,
IPC::Connection objects in jobs were leaked.

Use RunLoop::main() as the dispatcher instead of the default
RunLoop::current().

* Source/WebKit/Platform/IPC/Connection.cpp:
(IPC::Connection::invalidate): Removed an assertion ensuring the
thread is dispatcher&apos;s thread.
* Source/WebKit/Platform/IPC/StreamServerConnection.cpp:
(IPC::StreamServerConnection::open):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/61ce5ef1d812a0a8f5779cc7e649f6d8b2c75ad8

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/5763 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/5926 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/6115 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/7320 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/6155 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/6148 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/5894 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/8101 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/5868 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/5914 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/5203 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/7374 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/3391 "Passed tests") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/12963 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/5259 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/5267 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/7391 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/5712 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/4684 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/5157 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/9274 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/5518 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->