### PR TITLE
EditorCommandSource and EditorParagraphSeparator should be enum classes

### DIFF
--- a/Source/WebCore/dom/Document.cpp
+++ b/Source/WebCore/dom/Document.cpp
@@ -6130,7 +6130,7 @@ static Editor::Command command(Document* document, const String& commandName, bo
         return Editor::Command();
 
     return frame->editor().command(commandName,
-        userInterface ? CommandFromDOMWithUserInterface : CommandFromDOM);
+        userInterface ? EditorCommandSource::DOMWithUserInterface : EditorCommandSource::DOM);
 }
 
 ExceptionOr<bool> Document::execCommand(const String& commandName, bool userInterface, const String& value)

--- a/Source/WebCore/dom/TextEvent.h
+++ b/Source/WebCore/dom/TextEvent.h
@@ -34,7 +34,7 @@ namespace WebCore {
 
     class DocumentFragment;
 
-    enum class MailBlockquoteHandling;
+    enum class MailBlockquoteHandling : bool;
 
     class TextEvent final : public UIEvent {
         WTF_MAKE_ISO_ALLOCATED(TextEvent);

--- a/Source/WebCore/editing/Editing.cpp
+++ b/Source/WebCore/editing/Editing.cpp
@@ -784,9 +784,9 @@ bool isEmptyTableCell(const Node* node)
 Ref<HTMLElement> createDefaultParagraphElement(Document& document)
 {
     switch (document.editor().defaultParagraphSeparator()) {
-    case EditorParagraphSeparatorIsDiv:
+    case EditorParagraphSeparator::div:
         return HTMLDivElement::create(document);
-    case EditorParagraphSeparatorIsP:
+    case EditorParagraphSeparator::p:
         break;
     }
     return HTMLParagraphElement::create(document);

--- a/Source/WebCore/editing/Editor.cpp
+++ b/Source/WebCore/editing/Editor.cpp
@@ -1315,7 +1315,7 @@ void Editor::clear()
     m_customCompositionUnderlines.clear();
     m_customCompositionHighlights.clear();
     m_shouldStyleWithCSS = false;
-    m_defaultParagraphSeparator = EditorParagraphSeparatorIsDiv;
+    m_defaultParagraphSeparator = EditorParagraphSeparator::div;
     m_mark = { };
     m_oldSelectionForEditorUIUpdate = { };
     m_editorUIUpdateTimer.stop();

--- a/Source/WebCore/editing/Editor.h
+++ b/Source/WebCore/editing/Editor.h
@@ -99,10 +99,10 @@ struct PromisedAttachmentInfo;
 struct SerializedAttachmentData;
 #endif
 
-enum EditorCommandSource { CommandFromMenuOrKeyBinding, CommandFromDOM, CommandFromDOMWithUserInterface };
-enum EditorParagraphSeparator { EditorParagraphSeparatorIsDiv, EditorParagraphSeparatorIsP };
+enum class EditorCommandSource : uint8_t { MenuOrKeyBinding, DOM, DOMWithUserInterface };
+enum class EditorParagraphSeparator : bool { div, p };
 
-enum class MailBlockquoteHandling {
+enum class MailBlockquoteHandling : bool {
     RespectBlockquote,
     IgnoreBlockquote,
 };
@@ -319,7 +319,7 @@ public:
         RefPtr<Document> m_document;
         RefPtr<LocalFrame> m_frame;
     };
-    WEBCORE_EXPORT Command command(const String& commandName); // Command source is CommandFromMenuOrKeyBinding.
+    WEBCORE_EXPORT Command command(const String& commandName); // Command source is EditorCommandSource::MenuOrKeyBinding.
     Command command(const String& commandName, EditorCommandSource);
     WEBCORE_EXPORT static bool commandIsSupportedFromMenuOrKeyBinding(const String& commandName); // Works without a frame.
 
@@ -666,7 +666,7 @@ private:
     const std::unique_ptr<PAL::KillRing> m_killRing;
     const std::unique_ptr<SpellChecker> m_spellChecker;
     const std::unique_ptr<AlternativeTextController> m_alternativeTextController;
-    EditorParagraphSeparator m_defaultParagraphSeparator { EditorParagraphSeparatorIsDiv };
+    EditorParagraphSeparator m_defaultParagraphSeparator { EditorParagraphSeparator::div };
     bool m_overwriteModeEnabled { false };
 
 #if ENABLE(ATTACHMENT_ELEMENT)


### PR DESCRIPTION
#### 0fd2f46306b7c97422a6668742c5b94dae9ea872
<pre>
EditorCommandSource and EditorParagraphSeparator should be enum classes
<a href="https://bugs.webkit.org/show_bug.cgi?id=256446">https://bugs.webkit.org/show_bug.cgi?id=256446</a>

Reviewed by Wenson Hsieh.

Made them enum classes.

* Source/WebCore/dom/Document.cpp:
(WebCore::command):
* Source/WebCore/dom/TextEvent.h:
* Source/WebCore/editing/Editing.cpp:
(WebCore::createDefaultParagraphElement):
* Source/WebCore/editing/Editor.cpp:
(WebCore::Editor::clear):
* Source/WebCore/editing/Editor.h:
* Source/WebCore/editing/EditorCommand.cpp:
(WebCore::applyCommandToFrame):
(WebCore::executeApplyParagraphStyle):
(WebCore::executeCopy):
(WebCore::executeCopyFont):
(WebCore::executeCut):
(WebCore::executeDefaultParagraphSeparator):
(WebCore::executeDelete):
(WebCore::executeForwardDelete):
(WebCore::executeInsertLineBreak):
(WebCore::executePaste):
(WebCore::executePasteFont):
(WebCore::executePasteGlobalSelection):
(WebCore::executePasteAndMatchStyle):
(WebCore::executePasteAsPlainText):
(WebCore::executePasteAsQuotation):
(WebCore::enabledCopy):
(WebCore::enabledCut):
(WebCore::enabledDelete):
(WebCore::enabledPaste):
(WebCore::valueDefaultParagraphSeparator):
(WebCore::allowExecutionWhenDisabledCopyCut):
(WebCore::Editor::command):
(WebCore::Editor::Command::isSupported const):

Canonical link: <a href="https://commits.webkit.org/263805@main">https://commits.webkit.org/263805@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/27f8fa69c1649b5ace823fad97ce69503d9d9bbe

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/5766 "2 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/5929 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/6118 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/7323 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/6158 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/5766 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/6151 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/5897 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/7932 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/5871 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/5917 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/5207 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/7377 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/3394 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/5193 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/12966 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/5262 "Passed tests") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/5270 "4 failures") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/7407 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/5715 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/4688 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/5160 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/9277 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/668 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/5521 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->