### PR TITLE
REGRESSION(r228279): [GTK] Many aria tests are now flaky

### DIFF
--- a/LayoutTests/accessibility/gtk/aria-busy-changed-notification-expected.txt
+++ b/LayoutTests/accessibility/gtk/aria-busy-changed-notification-expected.txt
@@ -3,8 +3,13 @@ This tests that changing the aria-busy value results in a state-changed notifica
 On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
 
 
+PASS axElement.boolAttributeValue('AXElementBusy') is false
 Setting aria-busy to true on listbox.
 Setting aria-busy to false on listbox.
+AXElementBusyChanged: AXTitle:  AXRole: AXWebArea
+AXElementBusyChanged: AXTitle:  AXRole: AXListBox
+AXElementBusyChanged: AXTitle:  AXRole: AXListBox
+PASS axElement.boolAttributeValue('AXElementBusy') is false
 PASS successfullyParsed is true
 
 TEST COMPLETE

--- a/LayoutTests/accessibility/gtk/aria-busy-changed-notification.html
+++ b/LayoutTests/accessibility/gtk/aria-busy-changed-notification.html
@@ -1,5 +1,6 @@
 <html>
 <head>
+<script src="../../resources/accessibility-helper.js"></script>
 <script src="../../resources/js-test-pre.js"></script>
 </head>
 <body>
@@ -11,11 +12,16 @@ window.jsTestIsAsync = true;
 description("This tests that changing the aria-busy value results in a state-changed notification.");
 
 if (window.testRunner && window.accessibilityController) {
+    var notificationCount = 0;
     accessibilityController.addNotificationListener(function(element, notification) {
         if (notification != "AXElementBusyChanged")
             return;
         debug(notification + ": " + element.title + " " + element.role);
+        ++notificationCount;
     });
+
+    var axElement = accessibilityController.accessibleElementById("listbox");
+    shouldBe("axElement.boolAttributeValue('AXElementBusy')", "false");
 
     var element = document.getElementById("listbox");
     element.focus();
@@ -26,7 +32,12 @@ if (window.testRunner && window.accessibilityController) {
     debug("Setting aria-busy to false on listbox.");
     element.setAttribute("aria-busy", "false");
 
-    window.setTimeout(function() {
+    window.setTimeout(async function() {
+        await waitFor(() => {
+            return notificationCount == 3;
+        });
+
+        shouldBe("axElement.boolAttributeValue('AXElementBusy')", "false");
         accessibilityController.removeNotificationListener();
         finishJSTest();
     }, 0);

--- a/LayoutTests/accessibility/gtk/aria-current-changed-notification-expected.txt
+++ b/LayoutTests/accessibility/gtk/aria-current-changed-notification-expected.txt
@@ -3,8 +3,16 @@ This tests that changing the aria-current value results in a state-changed notif
 On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
 
 
+PASS item1.currentStateValue is 'false'
+PASS item2.currentStateValue is 'page'
+PASS item3.currentStateValue is 'false'
 Setting aria-current to false on item2.
 Setting aria-current to page on item3.
+ActiveStateChanged: AXTitle:  AXRole: AXListItem
+ActiveStateChanged: AXTitle:  AXRole: AXListItem
+PASS item1.currentStateValue is 'false'
+PASS item2.currentStateValue is 'false'
+PASS item3.currentStateValue is 'page'
 PASS successfullyParsed is true
 
 TEST COMPLETE

--- a/LayoutTests/accessibility/gtk/aria-current-changed-notification.html
+++ b/LayoutTests/accessibility/gtk/aria-current-changed-notification.html
@@ -1,5 +1,6 @@
 <html>
 <head>
+<script src="../../resources/accessibility-helper.js"></script>
 <script src="../../resources/js-test-pre.js"></script>
 </head>
 <body>
@@ -16,13 +17,22 @@ window.jsTestIsAsync = true;
 description("This tests that changing the aria-current value results in a state-changed notification.");
 
 if (window.testRunner && window.accessibilityController) {
+    var notificationCount = 0;
     accessibilityController.addNotificationListener(function(element, notification) {
         if (notification != "ActiveStateChanged")
             return;
         debug(notification + ": " + element.title + " " + element.role);
+        ++notificationCount;
     });
 
     document.getElementById("content").focus();
+
+    var item1 = accessibilityController.accessibleElementById("item1");
+    shouldBe("item1.currentStateValue", "'false'");
+    var item2 = accessibilityController.accessibleElementById("item2");
+    shouldBe("item2.currentStateValue", "'page'");
+    var item3 = accessibilityController.accessibleElementById("item3");
+    shouldBe("item3.currentStateValue", "'false'");
 
     debug("Setting aria-current to false on item2.");
     document.getElementById("item2").setAttribute("aria-current", "false");
@@ -32,7 +42,15 @@ if (window.testRunner && window.accessibilityController) {
 
     document.getElementById("content").style.visibility = "hidden";
 
-    window.setTimeout(function() {
+    window.setTimeout(async function() {
+        await waitFor(() => {
+            return notificationCount == 2;
+        });
+
+        shouldBe("item1.currentStateValue", "'false'");
+        shouldBe("item2.currentStateValue", "'false'");
+        shouldBe("item3.currentStateValue", "'page'");
+
         accessibilityController.removeNotificationListener();
         finishJSTest();
     }, 0);

--- a/LayoutTests/accessibility/gtk/aria-disabled-changed-notification-expected.txt
+++ b/LayoutTests/accessibility/gtk/aria-disabled-changed-notification-expected.txt
@@ -3,8 +3,16 @@ This tests that changing the aria-disabled value results in a state-changed noti
 On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
 
 
+PASS axTextbox1.isEnabled is true
+PASS axTextbox2.isEnabled is false
 Setting aria-disabled to true on textbox1.
 Setting aria-disabled to false on textbox2.
+AXDisabledStateChanged true on textbox1
+AXSensitiveStateChanged false on textbox1
+AXDisabledStateChanged false on textbox2
+AXSensitiveStateChanged true on textbox2
+PASS axTextbox1.isEnabled is false
+PASS axTextbox2.isEnabled is true
 PASS successfullyParsed is true
 
 TEST COMPLETE

--- a/LayoutTests/accessibility/gtk/aria-disabled-changed-notification.html
+++ b/LayoutTests/accessibility/gtk/aria-disabled-changed-notification.html
@@ -1,5 +1,6 @@
 <html>
 <head>
+<script src="../../resources/accessibility-helper.js"></script>
 <script src="../../resources/js-test-pre.js"></script>
 </head>
 <body>
@@ -12,16 +13,25 @@ window.jsTestIsAsync = true;
 description("This tests that changing the aria-disabled value results in a state-changed notification.");
 
 if (window.testRunner && window.accessibilityController) {
+    var notificationCount = 0;
     accessibilityController.addNotificationListener(function(element, notification, state) {
         if (notification == "AXDisabledStateChanged") {
             // The platform notification is for STATE_ENABLED.
-            debug(notification + " " + (state != "1") + " on " + element.stringAttributeValue("html-id"));
+            debug(notification + " " + (state != "1") + " on " + element.domIdentifier);
+            ++notificationCount;
             return;
         }
 
-        if (notification == "AXSensitiveStateChanged")
-            debug(notification + " " + (state == "1") + " on " + element.stringAttributeValue("html-id"));
+        if (notification == "AXSensitiveStateChanged") {
+            debug(notification + " " + (state == "1") + " on " + element.domIdentifier);
+            ++notificationCount;
+        }
     });
+
+    var axTextbox1 = accessibilityController.accessibleElementById("textbox1");
+    shouldBe("axTextbox1.isEnabled", "true");
+    var axTextbox2 = accessibilityController.accessibleElementById("textbox2");
+    shouldBe("axTextbox2.isEnabled", "false");
 
     var element = document.getElementById("textbox1");
     element.focus();
@@ -33,7 +43,13 @@ if (window.testRunner && window.accessibilityController) {
     debug("Setting aria-disabled to false on textbox2.");
     element.setAttribute("aria-disabled", "false");
 
-    window.setTimeout(function() {
+    window.setTimeout(async function() {
+        await waitFor(() => {
+            return notificationCount == 4;
+        });
+
+        shouldBe("axTextbox1.isEnabled", "false");
+        shouldBe("axTextbox2.isEnabled", "true");
         accessibilityController.removeNotificationListener();
         finishJSTest();
     }, 0);

--- a/LayoutTests/accessibility/gtk/aria-expanded-changed-notification-expected.txt
+++ b/LayoutTests/accessibility/gtk/aria-expanded-changed-notification-expected.txt
@@ -3,10 +3,18 @@ This tests that changing the aria-expanded value results in a state-changed noti
 On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
 
 
+PASS combobox1.isExpanded is false
+PASS combobox2.isExpanded is true
+PASS menu1.isExpanded is false
+PASS menu2.isExpanded is true
 Setting aria-expanded to true on combobox1.
 Setting aria-expanded to false on combobox2.
 Setting aria-expanded to true on menu1.
 Setting aria-expanded to false on menu2.
+AXExpandedChanged true on combobox1
+AXExpandedChanged false on combobox2
+AXExpandedChanged true on menu1
+AXExpandedChanged false on menu2
 PASS successfullyParsed is true
 
 TEST COMPLETE

--- a/LayoutTests/accessibility/gtk/aria-expanded-changed-notification.html
+++ b/LayoutTests/accessibility/gtk/aria-expanded-changed-notification.html
@@ -1,12 +1,13 @@
 <html>
 <head>
+<script src="../../resources/accessibility-helper.js"></script>
 <script src="../../resources/js-test-pre.js"></script>
 </head>
 <body>
 <div id="combobox1" role="combobox" aria-expanded="false" tabindex="0"></div>
 <div id="combobox2" role="combobox" aria-expanded="true" tabindex="0"></div>
-<div id="menu1" role="menu" aria-expanded="false" tabindex="0"></div>
-<div id="menu2" role="menu" aria-expanded="true" tabindex="0"></div>
+<div id="menu1" role="menuitem" aria-expanded="false" tabindex="0"></div>
+<div id="menu2" role="menuitem" aria-expanded="true" tabindex="0"></div>
 <p id="description"></p>
 <div id="console"></div>
 <script>
@@ -14,11 +15,22 @@ window.jsTestIsAsync = true;
 description("This tests that changing the aria-expanded value results in a state-changed notification.");
 
 if (window.testRunner && window.accessibilityController) {
+    var notificationCount = 0;
     accessibilityController.addNotificationListener(function(element, notification, state) {
         if (notification != "AXExpandedChanged")
             return;
-        debug(notification + " " + (state == "1") + " on " + element.stringAttributeValue("html-id"));
+        debug(notification + " " + (state == "1") + " on " + element.domIdentifier);
+        ++notificationCount;
     });
+
+    var combobox1 = accessibilityController.accessibleElementById("combobox1");
+    shouldBe("combobox1.isExpanded", "false");
+    var combobox2 = accessibilityController.accessibleElementById("combobox2");
+    shouldBe("combobox2.isExpanded", "true");
+    var menu1 = accessibilityController.accessibleElementById("menu1");
+    shouldBe("menu1.isExpanded", "false");
+    var menu2 = accessibilityController.accessibleElementById("menu2");
+    shouldBe("menu2.isExpanded", "true");
 
     var element = document.getElementById("combobox1");
     element.focus();
@@ -40,7 +52,11 @@ if (window.testRunner && window.accessibilityController) {
     debug("Setting aria-expanded to false on menu2.");
     element.setAttribute("aria-expanded", "false");
 
-    window.setTimeout(function() {
+    window.setTimeout(async function() {
+        await waitFor(() => {
+            return notificationCount == 4;
+        });
+
         accessibilityController.removeNotificationListener();
         finishJSTest();
     }, 0);

--- a/LayoutTests/accessibility/gtk/aria-pressed-changed-notification-expected.txt
+++ b/LayoutTests/accessibility/gtk/aria-pressed-changed-notification-expected.txt
@@ -5,6 +5,8 @@ On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE
 
 Setting aria-pressed to true on button1.
 Setting aria-pressed to false on button2.
+AXPressedStateChanged true on button1
+AXPressedStateChanged false on button2
 PASS successfullyParsed is true
 
 TEST COMPLETE

--- a/LayoutTests/accessibility/gtk/aria-pressed-changed-notification.html
+++ b/LayoutTests/accessibility/gtk/aria-pressed-changed-notification.html
@@ -1,5 +1,6 @@
 <html>
 <head>
+<script src="../../resources/accessibility-helper.js"></script>
 <script src="../../resources/js-test-pre.js"></script>
 </head>
 <body>
@@ -12,11 +13,16 @@ window.jsTestIsAsync = true;
 description("This tests that changing the aria-pressed value results in a state-changed notification.");
 
 if (window.testRunner && window.accessibilityController) {
+    var notificationCount = 0;
     accessibilityController.addNotificationListener(function(element, notification, state) {
         if (notification != "AXPressedStateChanged")
             return;
-        debug(notification + " " + (state == "1") + " on " + element.stringAttributeValue("html-id"));
+        debug(notification + " " + (state == "1") + " on " + element.domIdentifier);
+        ++notificationCount;
     });
+
+    var button1 = accessibilityController.accessibleElementById("button1");
+    var button2 = accessibilityController.accessibleElementById("button2");
 
     var element = document.getElementById("button1");
     element.focus();
@@ -28,7 +34,11 @@ if (window.testRunner && window.accessibilityController) {
     debug("Setting aria-pressed to false on button2.");
     element.setAttribute("aria-pressed", "false");
 
-    window.setTimeout(function() {
+    window.setTimeout(async function() {
+        await waitFor(() => {
+            return notificationCount == 2;
+        });
+
         accessibilityController.removeNotificationListener();
         finishJSTest();
     }, 0);

--- a/LayoutTests/accessibility/gtk/aria-readonly-changed-notification-expected.txt
+++ b/LayoutTests/accessibility/gtk/aria-readonly-changed-notification-expected.txt
@@ -3,8 +3,14 @@ This tests that changing the aria-readonly value results in a state-changed noti
 On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
 
 
+PASS textbox1.isAttributeSettable('AXValue') is true
+PASS textbox2.isAttributeSettable('AXValue') is false
 Setting aria-readonly to true on textbox1.
 Setting aria-readonly to false on textbox2.
+AXReadOnlyStatusChanged true on textbox1
+AXReadOnlyStatusChanged false on textbox2
+PASS textbox1.isAttributeSettable('AXValue') is false
+PASS textbox2.isAttributeSettable('AXValue') is true
 PASS successfullyParsed is true
 
 TEST COMPLETE

--- a/LayoutTests/accessibility/gtk/aria-readonly-changed-notification.html
+++ b/LayoutTests/accessibility/gtk/aria-readonly-changed-notification.html
@@ -1,5 +1,6 @@
 <html>
 <head>
+<script src="../../resources/accessibility-helper.js"></script>
 <script src="../../resources/js-test-pre.js"></script>
 </head>
 <body>
@@ -12,11 +13,18 @@ window.jsTestIsAsync = true;
 description("This tests that changing the aria-readonly value results in a state-changed notification.");
 
 if (window.testRunner && window.accessibilityController) {
+    var notificationCount = 0;
     accessibilityController.addNotificationListener(function(element, notification, state) {
         if (notification != "AXReadOnlyStatusChanged")
             return;
-        debug(notification + " " + (state == "1") + " on " + element.stringAttributeValue("html-id"));
+        debug(notification + " " + (state == "1") + " on " + element.domIdentifier);
+        ++notificationCount;
     });
+
+    var textbox1 = accessibilityController.accessibleElementById("textbox1");
+    shouldBe("textbox1.isAttributeSettable('AXValue')", "true");
+    var textbox2 = accessibilityController.accessibleElementById("textbox2");
+    shouldBe("textbox2.isAttributeSettable('AXValue')", "false");
 
     var element = document.getElementById("textbox1");
     element.focus();
@@ -28,7 +36,13 @@ if (window.testRunner && window.accessibilityController) {
     debug("Setting aria-readonly to false on textbox2.");
     element.setAttribute("aria-readonly", "false");
 
-    window.setTimeout(function() {
+    window.setTimeout(async function() {
+        await waitFor(() => {
+            return notificationCount == 2;
+        });
+
+        shouldBe("textbox1.isAttributeSettable('AXValue')", "false");
+        shouldBe("textbox2.isAttributeSettable('AXValue')", "true");
         accessibilityController.removeNotificationListener();
         finishJSTest();
     }, 0);

--- a/LayoutTests/accessibility/gtk/aria-required-changed-notification-expected.txt
+++ b/LayoutTests/accessibility/gtk/aria-required-changed-notification-expected.txt
@@ -3,8 +3,14 @@ This tests that changing the aria-required value results in a state-changed noti
 On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
 
 
+PASS textbox1.isRequired is false
+PASS textbox2.isRequired is true
 Setting aria-required to true on textbox1.
 Setting aria-required to false on textbox2.
+AXRequiredStatusChanged true on textbox1
+AXRequiredStatusChanged false on textbox2
+PASS textbox1.isRequired is true
+PASS textbox2.isRequired is false
 PASS successfullyParsed is true
 
 TEST COMPLETE

--- a/LayoutTests/accessibility/gtk/aria-required-changed-notification.html
+++ b/LayoutTests/accessibility/gtk/aria-required-changed-notification.html
@@ -1,5 +1,6 @@
 <html>
 <head>
+<script src="../../resources/accessibility-helper.js"></script>
 <script src="../../resources/js-test-pre.js"></script>
 </head>
 <body>
@@ -12,11 +13,18 @@ window.jsTestIsAsync = true;
 description("This tests that changing the aria-required value results in a state-changed notification.");
 
 if (window.testRunner && window.accessibilityController) {
+    var notificationCount = 0;
     accessibilityController.addNotificationListener(function(element, notification, state) {
         if (notification != "AXRequiredStatusChanged")
             return;
-        debug(notification + " " + (state == "1") + " on " + element.stringAttributeValue("html-id"));
+        debug(notification + " " + (state == "1") + " on " + element.domIdentifier);
+        ++notificationCount;
     });
+
+    var textbox1 = accessibilityController.accessibleElementById("textbox1");
+    shouldBe("textbox1.isRequired", "false");
+    var textbox2 = accessibilityController.accessibleElementById("textbox2");
+    shouldBe("textbox2.isRequired", "true");
 
     var element = document.getElementById("textbox1");
     element.focus();
@@ -28,7 +36,13 @@ if (window.testRunner && window.accessibilityController) {
     debug("Setting aria-required to false on textbox2.");
     element.setAttribute("aria-required", "false");
 
-    window.setTimeout(function() {
+    window.setTimeout(async function() {
+        await waitFor(() => {
+            return notificationCount == 2;
+        });
+
+        shouldBe("textbox1.isRequired", "true");
+        shouldBe("textbox2.isRequired", "false");
         accessibilityController.removeNotificationListener();
         finishJSTest();
     }, 0);

--- a/LayoutTests/platform/gtk/TestExpectations
+++ b/LayoutTests/platform/gtk/TestExpectations
@@ -1111,8 +1111,6 @@ webkit.org/b/170337 fast/repaint/obscured-background-no-repaint.html [ Failure ]
 
 webkit.org/b/172283 inspector/worker/debugger-multiple-targets-pause.html [ Timeout Pass Failure ]
 
-webkit.org/b/182761 accessibility/gtk/aria-busy-changed-notification.html [ Pass Failure ]
-
 webkit.org/b/186136 compositing/animation/layer-for-filling-animation.html [ Failure ]
 
 webkit.org/b/186667 compositing/repaint/iframes/composited-iframe-with-fixed-background-doc-repaint.html [ Failure Pass ]

--- a/Source/WebCore/accessibility/atspi/AXObjectCacheAtspi.cpp
+++ b/Source/WebCore/accessibility/atspi/AXObjectCacheAtspi.cpp
@@ -130,7 +130,7 @@ void AXObjectCache::postPlatformNotification(AXCoreObject* coreObject, AXNotific
         wrapper->stateChanged("pressed", coreObject->isPressed());
         break;
     case AXReadOnlyStatusChanged:
-        wrapper->stateChanged("read-only", coreObject->canSetValueAttribute());
+        wrapper->stateChanged("read-only", !coreObject->canSetValueAttribute());
         break;
     case AXRequiredStatusChanged:
         wrapper->stateChanged("required", coreObject->isRequired());


### PR DESCRIPTION
#### 4f4e045dca43c110e25b5098a7071685248cc50a
<pre>
REGRESSION(r228279): [GTK] Many aria tests are now flaky
<a href="https://bugs.webkit.org/show_bug.cgi?id=182761">https://bugs.webkit.org/show_bug.cgi?id=182761</a>

Reviewed by Adrian Perez de Castro.

Wait for notification changes ansynchronously instead of assuming they will
happen in the next run loop iteration.

* LayoutTests/accessibility/gtk/aria-busy-changed-notification-expected.txt:
* LayoutTests/accessibility/gtk/aria-busy-changed-notification.html:
* LayoutTests/accessibility/gtk/aria-current-changed-notification-expected.txt:
* LayoutTests/accessibility/gtk/aria-current-changed-notification.html:
* LayoutTests/accessibility/gtk/aria-disabled-changed-notification-expected.txt:
* LayoutTests/accessibility/gtk/aria-disabled-changed-notification.html:
* LayoutTests/accessibility/gtk/aria-expanded-changed-notification-expected.txt:
* LayoutTests/accessibility/gtk/aria-expanded-changed-notification.html:
* LayoutTests/accessibility/gtk/aria-pressed-changed-notification-expected.txt:
* LayoutTests/accessibility/gtk/aria-pressed-changed-notification.html:
* LayoutTests/accessibility/gtk/aria-readonly-changed-notification-expected.txt:
* LayoutTests/accessibility/gtk/aria-readonly-changed-notification.html:
* LayoutTests/accessibility/gtk/aria-required-changed-notification-expected.txt:
* LayoutTests/accessibility/gtk/aria-required-changed-notification.html:
* LayoutTests/platform/gtk/TestExpectations:
* Source/WebCore/accessibility/atspi/AXObjectCacheAtspi.cpp:
(WebCore::AXObjectCache::postPlatformNotification):

Canonical link: <a href="https://commits.webkit.org/263855@main">https://commits.webkit.org/263855@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/580e12d488ef8a0d3115d83b089744bc90bb4e97

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/5780 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/5944 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/6133 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/7338 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/6172 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/5780 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/6166 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/5912 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/7953 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/5885 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/5932 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/5226 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/7392 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/3409 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/5209 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/13097 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/5277 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/5286 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/7463 "run-api-tests-without-change (failure)") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/5730 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/4703 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/5174 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/5139 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/9292 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/694 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/5535 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->