### PR TITLE
GraphicsLayerPaintBehavior options do not name paint behavior

### DIFF
--- a/Source/WebCore/page/LocalFrameView.cpp
+++ b/Source/WebCore/page/LocalFrameView.cpp
@@ -4742,14 +4742,13 @@ void LocalFrameView::willPaintContents(GraphicsContext& context, const IntRect&,
     paintingState.paintBehavior = m_paintBehavior;
     
     if (auto* parentView = parentFrameView()) {
-        if (parentView->paintBehavior() & PaintBehavior::FlattenCompositingLayers)
-            m_paintBehavior.add(PaintBehavior::FlattenCompositingLayers);
-        
-        if (parentView->paintBehavior() & PaintBehavior::Snapshotting)
-            m_paintBehavior.add(PaintBehavior::Snapshotting);
-        
-        if (parentView->paintBehavior() & PaintBehavior::TileFirstPaint)
-            m_paintBehavior.add(PaintBehavior::TileFirstPaint);
+        constexpr OptionSet<PaintBehavior> flagsToCopy {
+            PaintBehavior::FlattenCompositingLayers,
+            PaintBehavior::Snapshotting,
+            PaintBehavior::ForceSynchronousImageDecoding,
+            PaintBehavior::DefaultAsynchronousImageDecoding
+        };
+        m_paintBehavior.add(parentView->paintBehavior() & flagsToCopy);
     }
 
     if (document->printing()) {

--- a/Source/WebCore/platform/graphics/GraphicsLayerClient.h
+++ b/Source/WebCore/platform/graphics/GraphicsLayerClient.h
@@ -71,8 +71,8 @@ enum class PlatformLayerTreeAsTextFlags : uint8_t {
 };
 
 enum class GraphicsLayerPaintBehavior : uint8_t {
-    Snapshotting              = 1 << 0,
-    FirstTilePaint            = 1 << 1,
+    ForceSynchronousImageDecoding = 1 << 0,
+    DefaultAsynchronousImageDecoding = 1 << 1,
 };
     
 class GraphicsLayerClient {

--- a/Source/WebCore/platform/graphics/ca/TileGrid.cpp
+++ b/Source/WebCore/platform/graphics/ca/TileGrid.cpp
@@ -697,8 +697,10 @@ void TileGrid::platformCALayerPaintContents(PlatformCALayer* platformCALayer, Gr
         WebThreadLock();
 #endif
 
-    if (!platformCALayerRepaintCount(platformCALayer))
-        layerPaintBehavior.add(GraphicsLayerPaintBehavior::FirstTilePaint);
+    if (!layerPaintBehavior.contains(GraphicsLayerPaintBehavior::ForceSynchronousImageDecoding)) {
+        if (!platformCALayerRepaintCount(platformCALayer))
+            layerPaintBehavior.add(GraphicsLayerPaintBehavior::DefaultAsynchronousImageDecoding);
+    }
 
     {
         GraphicsContextStateSaver stateSaver(context);

--- a/Source/WebCore/platform/graphics/ca/cocoa/PlatformCALayerCocoa.mm
+++ b/Source/WebCore/platform/graphics/ca/cocoa/PlatformCALayerCocoa.mm
@@ -1193,8 +1193,10 @@ void PlatformCALayer::drawLayerContents(GraphicsContext& graphicsContext, WebCor
     if (!layerContents)
         return;
 
-    if (!layerContents->platformCALayerRepaintCount(platformCALayer))
-        layerPaintBehavior.add(GraphicsLayerPaintBehavior::FirstTilePaint);
+    if (!layerPaintBehavior.contains(GraphicsLayerPaintBehavior::ForceSynchronousImageDecoding)) {
+        if (!layerContents->platformCALayerRepaintCount(platformCALayer))
+            layerPaintBehavior.add(GraphicsLayerPaintBehavior::DefaultAsynchronousImageDecoding);
+    }
 
     {
         GraphicsContextStateSaver saver(graphicsContext);

--- a/Source/WebCore/platform/graphics/mac/WebLayer.mm
+++ b/Source/WebCore/platform/graphics/mac/WebLayer.mm
@@ -55,7 +55,7 @@
         WebCore::PlatformCALayer::RepaintRectList rectsToPaint = WebCore::PlatformCALayer::collectRectsToPaint(graphicsContext, layer.get());
         OptionSet<WebCore::GraphicsLayerPaintBehavior> paintBehavior;
         if (self.isRenderingInContext)
-            paintBehavior.add(WebCore::GraphicsLayerPaintBehavior::Snapshotting);
+            paintBehavior.add(WebCore::GraphicsLayerPaintBehavior::ForceSynchronousImageDecoding);
         WebCore::PlatformCALayer::drawLayerContents(graphicsContext, layer.get(), rectsToPaint, paintBehavior);
     }
 }
@@ -142,7 +142,7 @@
         WebCore::FloatRect clipBounds = CGContextGetClipBoundingBox(context);
         OptionSet<WebCore::GraphicsLayerPaintBehavior> paintBehavior;
         if (self.isRenderingInContext)
-            paintBehavior.add(WebCore::GraphicsLayerPaintBehavior::Snapshotting);
+            paintBehavior.add(WebCore::GraphicsLayerPaintBehavior::ForceSynchronousImageDecoding);
         layer->owner()->platformCALayerPaintContents(layer.get(), graphicsContext, clipBounds, paintBehavior);
     }
 }

--- a/Source/WebCore/rendering/PaintPhase.h
+++ b/Source/WebCore/rendering/PaintPhase.h
@@ -54,7 +54,7 @@ enum class PaintPhase : uint16_t {
     Accessibility            = 1 << 13,
 };
 
-enum class PaintBehavior : uint16_t {
+enum class PaintBehavior : uint32_t {
     Normal                              = 0,
     SelectionOnly                       = 1 << 0,
     SkipSelectionHighlight              = 1 << 1,
@@ -66,12 +66,13 @@ enum class PaintBehavior : uint16_t {
     SelectionAndBackgroundsOnly         = 1 << 7,
     ExcludeSelection                    = 1 << 8,
     FlattenCompositingLayers            = 1 << 9, // Paint doesn't stop at compositing layer boundaries.
-    Snapshotting                        = 1 << 10,
-    TileFirstPaint                      = 1 << 11,
+    ForceSynchronousImageDecoding       = 1 << 10, // Paint always paints images completely.
+    DefaultAsynchronousImageDecoding    = 1 << 11, // Paint skips images if they are not decoded and no other rule applies to decoding.
     CompositedOverflowScrollContent     = 1 << 12,
     AnnotateLinks                       = 1 << 13, // Collect all renderers with links to annotate their URLs (e.g. PDFs)
     EventRegionIncludeForeground        = 1 << 14, // FIXME: Event region painting should use paint phases.
     EventRegionIncludeBackground        = 1 << 15,
+    Snapshotting                        = 1 << 16, // Paint is a snapshot-like paint to external context. FIXME: Should be removed.
 };
 
 } // namespace WebCore

--- a/Source/WebCore/rendering/RenderBoxModelObject.cpp
+++ b/Source/WebCore/rendering/RenderBoxModelObject.cpp
@@ -315,6 +315,8 @@ DecodingMode RenderBoxModelObject::decodingModeForImageDraw(const Image& image, 
 #endif
     if (paintInfo.paintBehavior.contains(PaintBehavior::Snapshotting))
         return DecodingMode::Synchronous;
+    if (paintInfo.paintBehavior.contains(PaintBehavior::ForceSynchronousImageDecoding))
+        return DecodingMode::Synchronous;
     if (is<HTMLImageElement>(element())) {
         auto decodingMode = downcast<HTMLImageElement>(*element()).decodingMode();
         if (decodingMode == DecodingMode::Asynchronous)
@@ -330,7 +332,7 @@ DecodingMode RenderBoxModelObject::decodingModeForImageDraw(const Image& image, 
         return DecodingMode::Synchronous;
     if (!bitmapImage.canUseAsyncDecodingForLargeImages())
         return DecodingMode::Synchronous;
-    if (paintInfo.paintBehavior.contains(PaintBehavior::TileFirstPaint))
+    if (paintInfo.paintBehavior.contains(PaintBehavior::DefaultAsynchronousImageDecoding))
         return DecodingMode::Asynchronous;
     // FIXME: isVisibleInViewport() is not cheap. Find a way to make this condition faster.
     if (!isVisibleInViewport())

--- a/Source/WebCore/rendering/RenderWidget.cpp
+++ b/Source/WebCore/rendering/RenderWidget.cpp
@@ -249,10 +249,10 @@ void RenderWidget::paintContents(PaintInfo& paintInfo, const LayoutPoint& paintO
     LayoutRect paintRect = paintInfo.rect;
 
     OptionSet<PaintBehavior> oldBehavior = PaintBehavior::Normal;
-    if (is<LocalFrameView>(*m_widget) && (paintInfo.paintBehavior & PaintBehavior::TileFirstPaint)) {
+    if (is<LocalFrameView>(*m_widget) && (paintInfo.paintBehavior & PaintBehavior::DefaultAsynchronousImageDecoding)) {
         LocalFrameView& frameView = downcast<LocalFrameView>(*m_widget);
         oldBehavior = frameView.paintBehavior();
-        frameView.setPaintBehavior(oldBehavior | PaintBehavior::TileFirstPaint);
+        frameView.setPaintBehavior(oldBehavior | PaintBehavior::DefaultAsynchronousImageDecoding);
     }
 
     IntPoint widgetLocation = m_widget->frameRect().location();
@@ -286,7 +286,7 @@ void RenderWidget::paintContents(PaintInfo& paintInfo, const LayoutPoint& paintO
             ASSERT(!paintInfo.overlapTestRequests->contains(this) || (paintInfo.overlapTestRequests->get(this) == m_widget->frameRect()));
             paintInfo.overlapTestRequests->set(this, m_widget->frameRect());
         }
-        if (paintInfo.paintBehavior & PaintBehavior::TileFirstPaint)
+        if (paintInfo.paintBehavior & PaintBehavior::DefaultAsynchronousImageDecoding)
             frameView.setPaintBehavior(oldBehavior);
     }
 }

--- a/Source/WebKit/Shared/RemoteLayerTree/RemoteLayerBackingStore.mm
+++ b/Source/WebKit/Shared/RemoteLayerTree/RemoteLayerBackingStore.mm
@@ -580,10 +580,9 @@ void RemoteLayerBackingStore::drawInContext(GraphicsContext& context, WTF::Funct
         context.fillRect(layerBounds, SRGBA<uint8_t> { 255, 47, 146 });
 #endif
 
-    // FIXME: Clarify that GraphicsLayerPaintBehavior::Snapshotting is just about image decoding.
     OptionSet<GraphicsLayerPaintBehavior> paintBehavior;
     if (m_layer->context() && m_layer->context()->nextRenderingUpdateRequiresSynchronousImageDecoding())
-        paintBehavior.add(WebCore::GraphicsLayerPaintBehavior::Snapshotting);
+        paintBehavior.add(WebCore::GraphicsLayerPaintBehavior::ForceSynchronousImageDecoding);
     
     // FIXME: This should be moved to PlatformCALayerRemote for better layering.
     switch (m_layer->layerType()) {

--- a/Source/WebKitLegacy/mac/WebView/WebFrame.mm
+++ b/Source/WebKitLegacy/mac/WebView/WebFrame.mm
@@ -645,14 +645,13 @@ ALLOW_DEPRECATED_DECLARATIONS_END
     if (auto* parentFrame = dynamicDowncast<WebCore::LocalFrame>(_private->coreFrame->tree().parent())) {
         // For subframes, we need to inherit the paint behavior from our parent
         if (auto* parentView = parentFrame ? parentFrame->view() : nullptr) {
-            if (parentView->paintBehavior().contains(WebCore::PaintBehavior::FlattenCompositingLayers))
-                paintBehavior.add(WebCore::PaintBehavior::FlattenCompositingLayers);
-            
-            if (parentView->paintBehavior().contains(WebCore::PaintBehavior::Snapshotting))
-                paintBehavior.add(WebCore::PaintBehavior::Snapshotting);
-            
-            if (parentView->paintBehavior().contains(WebCore::PaintBehavior::TileFirstPaint))
-                paintBehavior.add(WebCore::PaintBehavior::TileFirstPaint);
+            constexpr OptionSet<WebCore::PaintBehavior> flagsToCopy {
+                WebCore::PaintBehavior::FlattenCompositingLayers,
+                WebCore::PaintBehavior::Snapshotting,
+                WebCore::PaintBehavior::ForceSynchronousImageDecoding,
+                WebCore::PaintBehavior::DefaultAsynchronousImageDecoding
+            };
+            paintBehavior.add(parentView->paintBehavior() & flagsToCopy);
         }
     } else
         paintBehavior.add([self _paintBehaviorForDestinationContext:ctx]);


### PR DESCRIPTION
#### 177570c8393c64d414164ae77d2e33fceb1f6e86
<pre>
GraphicsLayerPaintBehavior options do not name paint behavior
<a href="https://bugs.webkit.org/show_bug.cgi?id=256459">https://bugs.webkit.org/show_bug.cgi?id=256459</a>
rdar://109035129

Reviewed by NOBODY (OOPS!).

Rename GraphicsLayerPaintBehavior::Snapshotting to
GraphicsLayerPaintBehavior::ForceSynchronousImageDecode. &quot;Snapshotting&quot;
is not a real &quot;paint behavior&quot;. This was used to signify that
the image content has to end up painted by the paint.

Rename GraphicsLayerPaintBehavior::FirstTilePaint to
GraphicsLayerPaintBehavior::DefaultAsynchronousImageDecode.
&quot;FirstTilePaint&quot; is not a &quot;paint behavior&quot;. This was used to signify
&quot;paint fast since this is first paint, do not decode images even if
they are in the viewport unless they&apos;re marked as sync decode&quot;.

Add corresponding WebCore::PaintBehavior flags, with corresponding
rationale. WebCore::PaintBehavior::Snapshotting is preserved for now.
This also should be removed, as it is not &quot;paint behavior&quot;, it is &quot;paint
reason&quot;. In future patches it should possibly be defined in terms of
real paint behaviors, namely FlattenCompositingLayers,
ForceSynchronousImageDecode.

No behavior change, highlights the bug where ForceSynchronousImageDecode
causes PaintBehavior::Snapshotting which in turn causes WebGL rendering
error. This error will be fixed in subsequent patches.

* Source/WebCore/page/LocalFrameView.cpp:
(WebCore::LocalFrameView::willPaintContents):
* Source/WebCore/platform/graphics/GraphicsLayerClient.h:
* Source/WebCore/platform/graphics/ca/TileGrid.cpp:
(WebCore::TileGrid::platformCALayerPaintContents):
* Source/WebCore/platform/graphics/ca/cocoa/PlatformCALayerCocoa.mm:
(WebCore::PlatformCALayer::drawLayerContents):
* Source/WebCore/platform/graphics/mac/WebLayer.mm:
(-[WebLayer drawInContext:]):
(-[WebSimpleLayer drawInContext:]):
* Source/WebCore/rendering/PaintPhase.h:
* Source/WebCore/rendering/RenderBoxModelObject.cpp:
(WebCore::RenderBoxModelObject::decodingModeForImageDraw const):
* Source/WebCore/rendering/RenderLayer.cpp:
(WebCore::RenderLayer::paintLayerContents):
(WebCore::RenderLayer::paintForegroundForFragments):
(WebCore::RenderLayer::calculateClipRects const):
* Source/WebCore/rendering/RenderLayerBacking.cpp:
(WebCore::RenderLayerBacking::paintContents):
* Source/WebCore/rendering/RenderWidget.cpp:
(WebCore::RenderWidget::paintContents):
* Source/WebKit/Shared/RemoteLayerTree/RemoteLayerBackingStore.mm:
(WebKit::RemoteLayerBackingStore::drawInContext):
* Source/WebKitLegacy/mac/WebView/WebFrame.mm:
(-[WebFrame _drawRect:contentsOnly:]):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/177570c8393c64d414164ae77d2e33fceb1f6e86

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/5784 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/5949 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/6137 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/7343 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/6176 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/5784 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/6171 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/5916 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/7961 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/5889 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/5937 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/5230 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/7397 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/3414 "Passed tests") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/10/builds/5212 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/13170 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/5282 "Passed tests") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/5289 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/7466 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/5735 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/4708 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/5178 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/9297 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/5539 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->