### PR TITLE
Canvas dirty rect is cleared during snapshot or printing process

### DIFF
--- a/Source/WebCore/html/HTMLCanvasElement.cpp
+++ b/Source/WebCore/html/HTMLCanvasElement.cpp
@@ -52,7 +52,6 @@
 #include "ImageBuffer.h"
 #include "ImageData.h"
 #include "InMemoryDisplayList.h"
-#include "InspectorInstrumentation.h"
 #include "JSDOMConvertDictionary.h"
 #include "JSNodeCustomInlines.h"
 #include "LocalFrame.h"
@@ -647,9 +646,6 @@ bool HTMLCanvasElement::paintsIntoCanvasBuffer() const
 
 void HTMLCanvasElement::paint(GraphicsContext& context, const LayoutRect& r, CompositeOperator op)
 {
-    if (m_context)
-        m_context->clearAccumulatedDirtyRect();
-
     if (!context.paintingDisabled()) {
         bool shouldPaint = true;
 
@@ -668,9 +664,6 @@ void HTMLCanvasElement::paint(GraphicsContext& context, const LayoutRect& r, Com
             }
         }
     }
-
-    if (UNLIKELY(m_context && m_context->hasActiveInspectorCanvasCallTracer()))
-        InspectorInstrumentation::didFinishRecordingCanvasFrame(*m_context);
 }
 
 bool HTMLCanvasElement::isGPUBased() const

--- a/Source/WebCore/html/canvas/CanvasRenderingContext.cpp
+++ b/Source/WebCore/html/canvas/CanvasRenderingContext.cpp
@@ -36,6 +36,7 @@
 #include "HTMLVideoElement.h"
 #include "Image.h"
 #include "ImageBitmap.h"
+#include "InspectorInstrumentation.h"
 #include "OriginAccessPatterns.h"
 #include "PixelFormat.h"
 #include "SVGImageElement.h"
@@ -85,6 +86,12 @@ void CanvasRenderingContext::ref()
 void CanvasRenderingContext::deref()
 {
     m_canvas.derefCanvasBase();
+}
+
+void CanvasRenderingContext::prepareForDisplayWithPaint()
+{
+    if (UNLIKELY(hasActiveInspectorCanvasCallTracer()))
+        InspectorInstrumentation::didFinishRecordingCanvasFrame(*this);
 }
 
 RefPtr<GraphicsLayerContentsDisplayDelegate> CanvasRenderingContext::layerContentsDisplayDelegate()

--- a/Source/WebCore/html/canvas/CanvasRenderingContext.h
+++ b/Source/WebCore/html/canvas/CanvasRenderingContext.h
@@ -77,11 +77,9 @@ public:
     virtual bool isOffscreen2d() const { return false; }
     virtual bool isPaint() const { return false; }
 
-    virtual void clearAccumulatedDirtyRect() { }
-
     // Called before paintRenderingResultsToCanvas if paintRenderingResultsToCanvas is
     // used for compositing purposes.
-    virtual void prepareForDisplayWithPaint() { }
+    virtual void prepareForDisplayWithPaint();
     virtual void paintRenderingResultsToCanvas() { }
     virtual RefPtr<GraphicsLayerContentsDisplayDelegate> layerContentsDisplayDelegate();
     virtual void setContentsToLayer(GraphicsLayer&);

--- a/Source/WebCore/html/canvas/CanvasRenderingContext2DBase.cpp
+++ b/Source/WebCore/html/canvas/CanvasRenderingContext2DBase.cpp
@@ -2223,11 +2223,6 @@ void CanvasRenderingContext2DBase::didDraw(bool entireCanvas, RectProvider rectP
         didDraw(rectProvider());
 }
 
-void CanvasRenderingContext2DBase::clearAccumulatedDirtyRect()
-{
-    m_dirtyRect = { };
-}
-
 bool CanvasRenderingContext2DBase::isEntireBackingStoreDirty() const
 {
     return m_dirtyRect == backingStoreBounds();
@@ -2237,6 +2232,12 @@ const Vector<CanvasRenderingContext2DBase::State, 1>& CanvasRenderingContext2DBa
 {
     realizeSaves();
     return m_stateStack;
+}
+
+void CanvasRenderingContext2DBase::prepareForDisplayWithPaint()
+{
+    CanvasRenderingContext::prepareForDisplayWithPaint();
+    m_dirtyRect = { }; // Note: might have been already cleared in prepare phase.
 }
 
 void CanvasRenderingContext2DBase::paintRenderingResultsToCanvas()
@@ -2267,6 +2268,7 @@ GraphicsContext* CanvasRenderingContext2DBase::drawingContext() const
 
 void CanvasRenderingContext2DBase::prepareForDisplay()
 {
+    m_dirtyRect = { };
     if (auto buffer = canvasBase().buffer())
         buffer->flushDrawingContextAsync();
 }

--- a/Source/WebCore/html/canvas/CanvasRenderingContext2DBase.h
+++ b/Source/WebCore/html/canvas/CanvasRenderingContext2DBase.h
@@ -342,11 +342,11 @@ private:
     template<typename RectProvider> void didDraw(bool entireCanvas, RectProvider);
 
     bool is2dBase() const final { return true; }
+    void prepareForDisplayWithPaint() override;
     void paintRenderingResultsToCanvas() override;
     bool needsPreparationForDisplay() const final;
     void prepareForDisplay() final;
 
-    void clearAccumulatedDirtyRect() final;
     bool isEntireBackingStoreDirty() const;
     FloatRect backingStoreBounds() const { return FloatRect { { }, FloatSize { canvasBase().size() } }; }
 

--- a/Source/WebCore/html/canvas/WebGLRenderingContextBase.cpp
+++ b/Source/WebCore/html/canvas/WebGLRenderingContextBase.cpp
@@ -1072,6 +1072,7 @@ void WebGLRenderingContextBase::restoreStateAfterClear()
 
 void WebGLRenderingContextBase::prepareForDisplayWithPaint()
 {
+    CanvasRenderingContext::prepareForDisplayWithPaint();
     m_isDisplayingWithPaint = true;
 }
 


### PR DESCRIPTION
#### 31d7ca34b84a2a0608db9fa1fd28931883ea8b46
<pre>
Canvas dirty rect is cleared during snapshot or printing process
<a href="https://bugs.webkit.org/show_bug.cgi?id=256463">https://bugs.webkit.org/show_bug.cgi?id=256463</a>
rdar://problem/109036641

Reviewed by NOBODY (OOPS!).

RenderHTMLCanvas::paintReplaced / HTMLCanvasElement::paint is called
whenever render tree is traversed, including when contentful paint
is being detected and asynchronous image loading is being cancelled.

The Context2D dirty rect should be only cleared once the draw has
been committed to compositor, either by painting to backing store
or by compositing.

This is work towards removing HTMLCanvasElement::paint and invoking all
needed canvas context paint code from RenderHTMLCanvas::paintReplaced.

* Source/WebCore/html/HTMLCanvasElement.cpp:
* Source/WebCore/html/canvas/CanvasRenderingContext.cpp:
(WebCore::CanvasRenderingContext::prepareForDisplayWithPaint):
* Source/WebCore/html/canvas/CanvasRenderingContext2DBase.cpp:
(WebCore::CanvasRenderingContext2DBase::prepareForDisplayWithPaint):
* Source/WebCore/html/canvas/CanvasRenderingContext2DBase.h:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/31d7ca34b84a2a0608db9fa1fd28931883ea8b46

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/5788 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/5953 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/6141 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/7347 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/6180 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/5788 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/6175 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/5920 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/7963 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/5893 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/5941 "2 new passes 4 flakes 1 failures") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/5235 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/7401 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/3418 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/5216 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/13174 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/5286 "Passed tests") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/5294 "5 failures") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/7473 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/5739 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/4711 "1 failures") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/5182 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/9301 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/5543 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->