### PR TITLE
[WGSL] Make function parameter nodes arena allocated

### DIFF
--- a/Source/WebGPU/WGSL/AST/ASTParameter.h
+++ b/Source/WebGPU/WGSL/AST/ASTParameter.h
@@ -26,10 +26,11 @@
 #pragma once
 
 #include "ASTAttribute.h"
+#include "ASTBuilder.h"
 #include "ASTIdentifier.h"
 #include "ASTTypeName.h"
 #include <wtf/RefCounted.h>
-#include <wtf/RefVector.h>
+#include <wtf/ReferenceWrapperVector.h>
 
 namespace WGSL::AST {
 
@@ -39,18 +40,10 @@ enum class ParameterRole : uint8_t {
     BindGroup,
 };
 
-class Parameter final : public Node, public RefCounted<Parameter> {
-    WTF_MAKE_FAST_ALLOCATED;
+class Parameter final : public Node {
+    WGSL_AST_BUILDER_NODE(Parameter);
 public:
-    using List = RefVector<Parameter>;
-
-    Parameter(SourceSpan span, Identifier&& name, TypeName::Ref&& typeName, Attribute::List&& attributes, ParameterRole role)
-        : Node(span)
-        , m_role(role)
-        , m_name(WTFMove(name))
-        , m_typeName(WTFMove(typeName))
-        , m_attributes(WTFMove(attributes))
-    { }
+    using List = ReferenceWrapperVector<Parameter>;
 
     NodeKind kind() const override;
     Identifier& name() { return m_name; }
@@ -59,6 +52,14 @@ public:
     ParameterRole role() { return m_role; }
 
 private:
+    Parameter(SourceSpan span, Identifier&& name, TypeName::Ref&& typeName, Attribute::List&& attributes, ParameterRole role)
+        : Node(span)
+        , m_role(role)
+        , m_name(WTFMove(name))
+        , m_typeName(WTFMove(typeName))
+        , m_attributes(WTFMove(attributes))
+    { }
+
     ParameterRole m_role;
     Identifier m_name;
     TypeName::Ref m_typeName;

--- a/Source/WebGPU/WGSL/EntryPointRewriter.cpp
+++ b/Source/WebGPU/WGSL/EntryPointRewriter.cpp
@@ -113,14 +113,14 @@ void EntryPointRewriter::rewrite()
     // add parameter to builtins: ${structName} : ${structType}
     auto& type = m_shaderModule.astBuilder().construct<AST::NamedTypeName>(SourceSpan::empty(), AST::Identifier::make(m_structTypeName));
     type.m_resolvedType = m_structType;
-    auto parameter = adoptRef(*new AST::Parameter(
+    auto& parameter = m_shaderModule.astBuilder().construct<AST::Parameter>(
         SourceSpan::empty(),
         AST::Identifier::make(m_structParameterName),
         type,
         AST::Attribute::List { },
         AST::ParameterRole::StageIn
-    ));
-    m_shaderModule.append(m_function.parameters(), WTFMove(parameter));
+    );
+    m_shaderModule.append(m_function.parameters(), parameter);
 
     while (m_materializations.size())
         m_shaderModule.insert(m_function.body().statements(), 0, m_materializations.takeLast());
@@ -134,9 +134,9 @@ Reflection::EntryPointInformation EntryPointRewriter::takeEntryPointInformation(
 void EntryPointRewriter::collectParameters()
 {
     while (m_function.parameters().size()) {
-        auto parameter = m_shaderModule.takeLast(m_function.parameters());
+        AST::Parameter& parameter = m_shaderModule.takeLast(m_function.parameters());
         Vector<String> path;
-        visit(path, MemberOrParameter { parameter->name(), parameter->typeName(), parameter->attributes() });
+        visit(path, MemberOrParameter { parameter.name(), parameter.typeName(), parameter.attributes() });
     }
 }
 
@@ -287,13 +287,13 @@ void EntryPointRewriter::visit(Vector<String>& path, MemberOrParameter&& data)
 void EntryPointRewriter::appendBuiltins()
 {
     for (auto& data : m_builtins) {
-        m_shaderModule.append(m_function.parameters(), adoptRef(*new AST::Parameter(
+        m_shaderModule.append(m_function.parameters(), m_shaderModule.astBuilder().construct<AST::Parameter>(
             SourceSpan::empty(),
             AST::Identifier::make(data.name),
             data.type,
             WTFMove(data.attributes),
             AST::ParameterRole::UserDefined
-        )));
+        ));
     }
 }
 

--- a/Source/WebGPU/WGSL/GlobalVariableRewriter.cpp
+++ b/Source/WebGPU/WGSL/GlobalVariableRewriter.cpp
@@ -340,7 +340,7 @@ void RewriteGlobalVariables::insertParameters(AST::Function& function, const Use
         unsigned group = it.key;
         auto& type = m_callGraph.ast().astBuilder().construct<AST::NamedTypeName>(span, argumentBufferStructName(group));
         type.m_resolvedType = m_structTypes.get(group);
-        m_callGraph.ast().append(function.parameters(), adoptRef(*new AST::Parameter(
+        m_callGraph.ast().append(function.parameters(), m_callGraph.ast().astBuilder().construct<AST::Parameter>(
             span,
             argumentBufferParameterName(group),
             type,
@@ -348,7 +348,7 @@ void RewriteGlobalVariables::insertParameters(AST::Function& function, const Use
                 m_callGraph.ast().astBuilder().construct<AST::GroupAttribute>(span, group)
             },
             AST::ParameterRole::BindGroup
-        )));
+        ));
     }
 }
 

--- a/Source/WebGPU/WGSL/Parser.cpp
+++ b/Source/WebGPU/WGSL/Parser.cpp
@@ -824,7 +824,7 @@ Result<AST::Function> Parser<Lexer>::parseFunction(AST::Attribute::List&& attrib
 }
 
 template<typename Lexer>
-Result<Ref<AST::Parameter>> Parser<Lexer>::parseParameter()
+Result<std::reference_wrapper<AST::Parameter>> Parser<Lexer>::parseParameter()
 {
     START_PARSE();
 
@@ -833,7 +833,7 @@ Result<Ref<AST::Parameter>> Parser<Lexer>::parseParameter()
     CONSUME_TYPE(Colon);
     PARSE(type, TypeName);
 
-    RETURN_NODE_REF(Parameter, WTFMove(name), WTFMove(type), WTFMove(attributes), AST::ParameterRole::UserDefined);
+    RETURN_ARENA_NODE(Parameter, WTFMove(name), WTFMove(type), WTFMove(attributes), AST::ParameterRole::UserDefined);
 }
 
 template<typename Lexer>

--- a/Source/WebGPU/WGSL/ParserPrivate.h
+++ b/Source/WebGPU/WGSL/ParserPrivate.h
@@ -71,7 +71,7 @@ public:
     Result<AST::StorageClass> parseStorageClass();
     Result<AST::AccessMode> parseAccessMode();
     Result<AST::Function> parseFunction(AST::Attribute::List&&);
-    Result<Ref<AST::Parameter>> parseParameter();
+    Result<std::reference_wrapper<AST::Parameter>> parseParameter();
     Result<AST::Statement::Ref> parseStatement();
     Result<AST::CompoundStatement> parseCompoundStatement();
     Result<AST::IfStatement> parseIfStatement();

--- a/Source/WebGPU/WGSL/WGSLShaderModule.h
+++ b/Source/WebGPU/WGSL/WGSLShaderModule.h
@@ -103,10 +103,10 @@ public:
         return last;
     }
 
-    template<typename T, size_t size>
-    void append(const Vector<T, size>& constVector, T&& value)
+    template<typename T, typename U, size_t size>
+    void append(const Vector<U, size>& constVector, T&& value)
     {
-        auto& vector = const_cast<Vector<T, size>&>(constVector);
+        auto& vector = const_cast<Vector<U, size>&>(constVector);
         vector.append(std::forward<T>(value));
         m_replacements.append([&vector]() {
             vector.takeLast();


### PR DESCRIPTION
#### 5353ac427dc75694705483542f32c48f237e04a7
<pre>
[WGSL] Make function parameter nodes arena allocated
<a href="https://bugs.webkit.org/show_bug.cgi?id=256464">https://bugs.webkit.org/show_bug.cgi?id=256464</a>
rdar://109039819

Reviewed by Mike Wyrzykowski.

Continue incrementally converting AST nodes to be arena allocated.

* Source/WebGPU/WGSL/AST/ASTParameter.h:
* Source/WebGPU/WGSL/EntryPointRewriter.cpp:
(WGSL::EntryPointRewriter::rewrite):
(WGSL::EntryPointRewriter::collectParameters):
(WGSL::EntryPointRewriter::appendBuiltins):
* Source/WebGPU/WGSL/GlobalVariableRewriter.cpp:
(WGSL::RewriteGlobalVariables::insertParameters):
* Source/WebGPU/WGSL/Parser.cpp:
(WGSL::Parser&lt;Lexer&gt;::parseParameter):
* Source/WebGPU/WGSL/ParserPrivate.h:
* Source/WebGPU/WGSL/WGSLShaderModule.h:
(WGSL::ShaderModule::append):

Canonical link: <a href="https://commits.webkit.org/263867@main">https://commits.webkit.org/263867@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1af88cea69386a2ad499e51237331264398556e3

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/5917 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/6090 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/6277 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/7468 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/6276 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/6309 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/6051 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/8696 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/6025 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/6061 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/5358 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/7528 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/3538 "Passed tests") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/13270 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/5403 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/5412 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/7626 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/5861 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/4806 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/5295 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/1409 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/9419 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/5655 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->