### PR TITLE
Fix various -Werror build failures

### DIFF
--- a/Source/WebCore/platform/mediastream/gstreamer/GStreamerMediaStreamSource.cpp
+++ b/Source/WebCore/platform/mediastream/gstreamer/GStreamerMediaStreamSource.cpp
@@ -124,8 +124,13 @@ public:
         : m_parent(parent)
         , m_track(track)
         , m_padName(padName)
+#if USE(GSTREAMER_WEBRTC)
         , m_consumerIsVideoPlayer(consumerIsVideoPlayer)
+#endif
     {
+#if !USE(GSTREAMER_WEBRTC)
+        UNUSED_PARAM(consumerIsVideoPlayer);
+#endif
         static uint64_t audioCounter = 0;
         static uint64_t videoCounter = 0;
         String elementName;
@@ -536,7 +541,9 @@ private:
     Lock m_eosLock;
     bool m_eosPending WTF_GUARDED_BY_LOCK(m_eosLock) { false };
     std::optional<int> m_webrtcSourceClientId;
+#if USE(GSTREAMER_WEBRTC)
     bool m_consumerIsVideoPlayer { false };
+#endif
 };
 
 struct _WebKitMediaStreamSrcPrivate {

--- a/Tools/MiniBrowser/gtk/main.c
+++ b/Tools/MiniBrowser/gtk/main.c
@@ -384,8 +384,9 @@ static gboolean addSettingsGroupToContext(GOptionContext *context, WebKitSetting
             .arg_data = parseFeaturesOptionCallback,
             .arg_description = "FEATURE-LIST",
         },
-        { NULL }
+        { }
     };
+    memset(&featureEntries[1], 0, sizeof(GOptionEntry));
     g_option_group_add_entries(webSettingsGroup, featureEntries);
 
     /* Option context takes ownership of the group. */

--- a/Tools/TestWebKitAPI/Tests/WebCore/FloatSizeTests.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebCore/FloatSizeTests.cpp
@@ -190,9 +190,9 @@ TEST(FloatSize, TransposedSize)
 
 TEST(FloatSize, Casting)
 {
+#if USE(CG)
     WebCore::FloatSize test(1024.0f, 768.0f);
 
-#if USE(CG)
     CGSize cgSize = test;
 
     EXPECT_FLOAT_EQ(1024.0f, cgSize.width);


### PR DESCRIPTION
#### d76f2c41bc3b68f5c8500cc4201855ae17811e78
<pre>
Fix various -Werror build failures
<a href="https://bugs.webkit.org/show_bug.cgi?id=256466">https://bugs.webkit.org/show_bug.cgi?id=256466</a>

Unreviewed build fixes.

Fix unused variable warnings, plus placate Clang&apos;s overaggressive
-Wmissing-field-initializers in MiniBrowser.

* Source/WebCore/platform/mediastream/gstreamer/GStreamerMediaStreamSource.cpp:
* Tools/MiniBrowser/gtk/main.c:
(addSettingsGroupToContext):
* Tools/TestWebKitAPI/Tests/WebCore/FloatSizeTests.cpp:
(TestWebKitAPI::TEST):

Canonical link: <a href="https://commits.webkit.org/263801@main">https://commits.webkit.org/263801@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/007b8c02a45c4401ea5f3925322b57e1fd2fc995

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/5792 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/5958 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/6146 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/7352 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/6185 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/5793 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/6180 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/5925 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/7969 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/5898 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/15/builds/5946 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/5242 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/7407 "Built successfully") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/39/builds/3423 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/10/builds/5221 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/13181 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/5291 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/5299 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/7493 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/5744 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/4716 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/5187 "Built successfully") | | | 
| [❌ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/1368 "Failed to checkout and rebase branch from PR 13578") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/9306 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/665 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/5548 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->