### PR TITLE
Processes in the WebProcessCache should suspend more promptly

### DIFF
--- a/Source/WebKit/UIProcess/API/Cocoa/WKProcessPool.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKProcessPool.mm
@@ -397,6 +397,15 @@ static RetainPtr<WKProcessPool>& sharedProcessPool()
     return NO;
 }
 
+- (BOOL)_isWebProcessSuspended:(pid_t)pid
+{
+    for (auto& process : _processPool->processes()) {
+        if (process->processIdentifier() == pid)
+            return process->throttler().isSuspended();
+    }
+    return NO;
+}
+
 - (void)_makeNextWebProcessLaunchFailForTesting
 {
     _processPool->setShouldMakeNextWebProcessLaunchFailForTesting(true);

--- a/Source/WebKit/UIProcess/API/Cocoa/WKProcessPoolPrivate.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKProcessPoolPrivate.h
@@ -117,6 +117,7 @@
 - (pid_t)_gpuProcessIdentifier WK_API_AVAILABLE(macos(12.0), ios(15.0));
 - (BOOL)_hasAudibleMediaActivity WK_API_AVAILABLE(macos(13.0), ios(16.0));
 - (BOOL)_requestWebProcessTermination:(pid_t)pid WK_API_AVAILABLE(macos(12.0), ios(15.0));
+- (BOOL)_isWebProcessSuspended:(pid_t)pid;
 
 // Test only. Returns web processes running web pages (does not include web processes running service workers)
 - (size_t)_webPageContentProcessCount WK_API_AVAILABLE(macos(10.13.4), ios(11.3));

--- a/Source/WebKit/UIProcess/ProcessThrottler.h
+++ b/Source/WebKit/UIProcess/ProcessThrottler.h
@@ -135,6 +135,7 @@ public:
     void setShouldTakeNearSuspendedAssertion(bool);
     bool isSuspended() const { return m_processIdentifier && !m_assertion; }
     ProcessThrottleState currentState() const { return m_state; }
+    bool isHoldingNearSuspendedAssertion() const { return m_assertion && m_assertion->type() == ProcessAssertionType::NearSuspended; }
 
 private:
     friend class ProcessThrottlerActivity;
@@ -161,6 +162,7 @@ private:
 
     void clearPendingRequestToSuspend();
     void numberOfPagesAllowedToRunInTheBackgroundChanged();
+    void clearAssertion();
 
     ProcessThrottlerClient& m_process;
     ProcessID m_processIdentifier { 0 };

--- a/Source/WebKit/UIProcess/WebProcessProxy.h
+++ b/Source/WebKit/UIProcess/WebProcessProxy.h
@@ -755,6 +755,9 @@ private:
     std::unique_ptr<WebLockRegistryProxy> m_webLockRegistry;
     std::unique_ptr<WebPermissionControllerProxy> m_webPermissionController;
     bool m_isConnectedToHardwareConsole { true };
+#if PLATFORM(MAC)
+    bool m_platformSuspendDidReleaseNearSuspendedAssertion { false };
+#endif
     mutable String m_environmentIdentifier;
 };
 

--- a/Source/WebKit/UIProcess/mac/WebProcessProxyMac.mm
+++ b/Source/WebKit/UIProcess/mac/WebProcessProxyMac.mm
@@ -87,12 +87,16 @@ void WebProcessProxy::setDisplayLinkForDisplayWantsFullSpeedUpdates(WebCore::Pla
 
 void WebProcessProxy::platformSuspendProcess()
 {
-    // FIXME: Adopt RunningBoard on macOS to support process suspension.
+    m_platformSuspendDidReleaseNearSuspendedAssertion = throttler().isHoldingNearSuspendedAssertion();
+    throttler().setShouldTakeNearSuspendedAssertion(false);
 }
 
 void WebProcessProxy::platformResumeProcess()
 {
-    // FIXME: Adopt RunningBoard on macOS to support process suspension.
+    if (m_platformSuspendDidReleaseNearSuspendedAssertion) {
+        m_platformSuspendDidReleaseNearSuspendedAssertion = false;
+        throttler().setShouldTakeNearSuspendedAssertion(true);
+    }
 }
 
 } // namespace WebKit


### PR DESCRIPTION
#### 02d6615aea2e51b0f048e9500e9f24565231d36e
<pre>
Processes in the WebProcessCache should suspend more promptly
<a href="https://bugs.webkit.org/show_bug.cgi?id=256468">https://bugs.webkit.org/show_bug.cgi?id=256468</a>
rdar://108624630

Reviewed by Geoffrey Garen.

When processes entered the WebProcessCache, they would not suspend for ~8 minutes
due to the near-suspended assertion we take after releasing the last useful
process assertion.

To cause them to suspend more promptly, I am adding an implementation for
WebProcessProxy::platformSuspendProcess() &amp; platformResumeProcess() to drop
&amp; retake the near-suspended assertion. platformSuspendProcess() gets called
by the WebProcessCache 30 seconds after the process has entered the cache.

This patch effectively causes our WebProcesses to fully suspend 30 seconds after
entering the WebProcessCache, instead of 8 minutes. This tested as neutral on
PLT5 and Membuster.

* Source/WebKit/UIProcess/API/Cocoa/WKProcessPool.mm:
(-[WKProcessPool _requestWebProcessTermination:]):
(-[WKProcessPool _isWebProcessSuspended:]):
* Source/WebKit/UIProcess/API/Cocoa/WKProcessPoolPrivate.h:
* Source/WebKit/UIProcess/ProcessThrottler.cpp:
(WebKit::ProcessThrottler::setShouldTakeNearSuspendedAssertion):
* Source/WebKit/UIProcess/ProcessThrottler.h:
(WebKit::ProcessThrottler::isHoldingNearSuspendedAssertion const):
* Source/WebKit/UIProcess/WebProcessProxy.h:
* Source/WebKit/UIProcess/mac/WebProcessProxyMac.mm:
(WebKit::WebProcessProxy::platformSuspendProcess):
(WebKit::WebProcessProxy::platformResumeProcess):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/ProcessSwapOnNavigation.mm:

Canonical link: <a href="https://commits.webkit.org/263839@main">https://commits.webkit.org/263839@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/36ac37c83db883c383c7cc11722f19d7abf47ed3

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/5831 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/5999 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/6188 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/7391 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/6217 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/5832 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/6222 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/5966 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/8312 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/5937 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/5986 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/5284 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/7448 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/3463 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/5259 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/13224 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/5330 "Passed tests") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/5338 "5 failures") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/7559 "262 api tests failed or timed out") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/5784 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/4749 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/5225 "Built successfully") | | | 
| [  ~~🛠 🧪 merge~~](https://ews-build.webkit.org/#/builders/19/builds/1389 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/9346 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/5586 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->