### PR TITLE
[WebGPU] Texture address modes UVW mapped to RST instead of STR

### DIFF
--- a/Source/WebGPU/WebGPU/Sampler.mm
+++ b/Source/WebGPU/WebGPU/Sampler.mm
@@ -139,9 +139,9 @@ Ref<Sampler> Device::createSampler(const WGPUSamplerDescriptor& descriptor)
 
     MTLSamplerDescriptor *samplerDescriptor = [MTLSamplerDescriptor new];
 
-    samplerDescriptor.rAddressMode = addressMode(descriptor.addressModeU);
-    samplerDescriptor.sAddressMode = addressMode(descriptor.addressModeV);
-    samplerDescriptor.tAddressMode = addressMode(descriptor.addressModeW);
+    samplerDescriptor.sAddressMode = addressMode(descriptor.addressModeU);
+    samplerDescriptor.tAddressMode = addressMode(descriptor.addressModeV);
+    samplerDescriptor.rAddressMode = addressMode(descriptor.addressModeW);
     samplerDescriptor.magFilter = minMagFilter(descriptor.magFilter);
     samplerDescriptor.minFilter = minMagFilter(descriptor.minFilter);
     samplerDescriptor.mipFilter = mipFilter(descriptor.mipmapFilter);


### PR DESCRIPTION
#### e0068ddc6a2cc5bbe66d0043de8e436329887565
<pre>
[WebGPU] Texture address modes UVW mapped to RST instead of STR
<a href="https://bugs.webkit.org/show_bug.cgi?id=256467">https://bugs.webkit.org/show_bug.cgi?id=256467</a>
&lt;radar://109041637&gt;

Reviewed by Dan Glastonbury.

UV maps to ST. R maps to W.

Previously RST was mapping to UVW which is incorrect.

* Source/WebGPU/WebGPU/Sampler.mm:
(WebGPU::Device::createSampler):

Canonical link: <a href="https://commits.webkit.org/263837@main">https://commits.webkit.org/263837@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1e777e650996f1f80d6b933919c4aa3c4a957867

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/5794 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/5960 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/6148 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/7354 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/6187 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/6182 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/5927 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/7972 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/5900 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/5948 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/5244 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/7409 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/3425 "Passed tests") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/13185 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/5293 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/5311 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/7495 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/5746 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/4718 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/5189 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/9308 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/684 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/5550 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->