### PR TITLE
[macOS] Release memory in WebProcesses before fully suspending them

### DIFF
--- a/Source/WebKit/UIProcess/ProcessThrottler.cpp
+++ b/Source/WebKit/UIProcess/ProcessThrottler.cpp
@@ -183,7 +183,7 @@ void ProcessThrottler::setThrottleState(ProcessThrottleState newState)
 
     if (m_assertion->type() == ProcessAssertionType::NearSuspended) {
         if (!m_shouldTakeNearSuspendedAssertion)
-            m_assertion = nullptr;
+            m_process.prepareToDropLastAssertion([assertion = std::exchange(m_assertion, nullptr)] { });
         else
             m_dropNearSuspendedAssertionTimer.startOneShot(removeAllAssertionsTimeout);
     } else
@@ -254,7 +254,7 @@ void ProcessThrottler::dropNearSuspendedAssertionTimerFired()
     if (m_pageAllowedToRunInTheBackgroundCounter.value())
         PROCESSTHROTTLER_RELEASE_LOG("dropNearSuspendedAssertionTimerFired: Not releasing near-suspended assertion because a page is allowed to run in the background");
     else
-        m_assertion = nullptr;
+        m_process.prepareToDropLastAssertion([assertion = std::exchange(m_assertion, nullptr)] { });
 }
 
 void ProcessThrottler::processReadyToSuspend()
@@ -355,7 +355,7 @@ void ProcessThrottler::numberOfPagesAllowedToRunInTheBackgroundChanged()
 
     if (m_assertion && m_assertion->isValid() && m_assertion->type() == ProcessAssertionType::NearSuspended) {
         PROCESSTHROTTLER_RELEASE_LOG("numberOfPagesAllowedToRunInTheBackgroundChanged: Releasing near-suspended assertion");
-        m_assertion = nullptr;
+        m_process.prepareToDropLastAssertion([assertion = std::exchange(m_assertion, nullptr)] { });
     }
 }
 

--- a/Source/WebKit/UIProcess/ProcessThrottlerClient.h
+++ b/Source/WebKit/UIProcess/ProcessThrottlerClient.h
@@ -43,6 +43,7 @@ public:
     virtual void didChangeThrottleState(ProcessThrottleState) { };
     virtual ASCIILiteral clientName() const = 0;
     virtual String environmentIdentifier() const { return emptyString(); }
+    virtual void prepareToDropLastAssertion(CompletionHandler<void()>&& completionHandler) { completionHandler(); }
 };
 
 } // namespace WebKit

--- a/Source/WebKit/UIProcess/WebProcessProxy.h
+++ b/Source/WebKit/UIProcess/WebProcessProxy.h
@@ -362,6 +362,7 @@ public:
     void sendPrepareToSuspend(IsSuspensionImminent, double remainingRunTime, CompletionHandler<void()>&&) final;
     void sendProcessDidResume(ResumeReason) final;
     void didChangeThrottleState(ProcessThrottleState) final;
+    void prepareToDropLastAssertion(CompletionHandler<void()>&&) final;
     ASCIILiteral clientName() const final { return "WebProcess"_s; }
     String environmentIdentifier() const final;
 

--- a/Source/WebKit/WebProcess/WebProcess.cpp
+++ b/Source/WebKit/WebProcess/WebProcess.cpp
@@ -1547,6 +1547,16 @@ void WebProcess::pageActivityStateDidChange(PageIdentifier, OptionSet<WebCore::A
     }
 }
 
+void WebProcess::releaseMemory(CompletionHandler<void()>&& completionHandler)
+{
+    WEBPROCESS_RELEASE_LOG(ProcessSuspension, "releaseMemory: BEGIN");
+    MemoryPressureHandler::singleton().releaseMemory(Critical::Yes, Synchronous::Yes);
+    for (auto& page : m_pageMap.values())
+        page->releaseMemory(Critical::Yes);
+    WEBPROCESS_RELEASE_LOG(ProcessSuspension, "releaseMemory: END");
+    completionHandler();
+}
+
 void WebProcess::prepareToSuspend(bool isSuspensionImminent, MonotonicTime estimatedSuspendTime, CompletionHandler<void()>&& completionHandler)
 {
 #if !RELEASE_LOG_DISABLED

--- a/Source/WebKit/WebProcess/WebProcess.h
+++ b/Source/WebKit/WebProcess/WebProcess.h
@@ -298,6 +298,7 @@ public:
 
     void setHiddenPageDOMTimerThrottlingIncreaseLimit(int milliseconds);
 
+    void releaseMemory(CompletionHandler<void()>&&);
     void prepareToSuspend(bool isSuspensionImminent, MonotonicTime estimatedSuspendTime, CompletionHandler<void()>&&);
     void processDidResume();
 

--- a/Source/WebKit/WebProcess/WebProcess.messages.in
+++ b/Source/WebKit/WebProcess/WebProcess.messages.in
@@ -214,5 +214,7 @@ messages -> WebProcess LegacyReceiver NotRefCounted {
     OpenDirectoryCacheInvalidated(WebKit::SandboxExtension::Handle handle, WebKit::SandboxExtension::Handle machBootstrapHandle)
 #endif
 
+    ReleaseMemory() -> ()
+
     RemotePostMessage(struct WebCore::FrameIdentifier frameIdentifier, std::optional<WebCore::SecurityOriginData> target, struct WebCore::MessageWithMessagePorts message)
 }


### PR DESCRIPTION
#### 2f2fe47009094437126a5cf55d07b429fae71fff
<pre>
[macOS] Release memory in WebProcesses before fully suspending them
<a href="https://bugs.webkit.org/show_bug.cgi?id=256332">https://bugs.webkit.org/show_bug.cgi?id=256332</a>
rdar://108625394

Reviewed by Geoffrey Garen.

Before dropping the last assertion for a WebProcess on macOS, send
a ReleaseMemory IPC to it and slim down the process as much as possible
before suspension.

We don&apos;t do this for processes in the WebProcessCache for performance
reasons. These processes exit on memory pressure anyway.

* Source/WebKit/UIProcess/ProcessThrottler.cpp:
(WebKit::ProcessThrottler::setThrottleState):
(WebKit::ProcessThrottler::dropNearSuspendedAssertionTimerFired):
(WebKit::ProcessThrottler::numberOfPagesAllowedToRunInTheBackgroundChanged):
* Source/WebKit/UIProcess/ProcessThrottlerClient.h:
(WebKit::ProcessThrottlerClient::prepareToDropLastAssertion):
* Source/WebKit/UIProcess/WebProcessProxy.cpp:
(WebKit::WebProcessProxy::prepareToDropLastAssertion):
* Source/WebKit/UIProcess/WebProcessProxy.h:
* Source/WebKit/WebProcess/WebProcess.cpp:
(WebKit::WebProcess::releaseMemory):
* Source/WebKit/WebProcess/WebProcess.h:
* Source/WebKit/WebProcess/WebProcess.messages.in:

Canonical link: <a href="https://commits.webkit.org/263823@main">https://commits.webkit.org/263823@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/34c403e25c8d0b67563f9d7f15f3da1dc68be61b

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/5800 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/5966 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/6154 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/7360 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/6193 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/6188 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/5933 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/7977 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/5906 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/5954 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/5251 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/7415 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/3431 "Passed tests") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/13193 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/5299 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/5307 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/7511 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/5752 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/4724 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/5195 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/1380 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/9314 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/5556 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->