### PR TITLE
Unreviewed build fix on macOS

### DIFF
--- a/Source/WebCore/platform/ios/VideoFullscreenInterfaceAVKit.mm
+++ b/Source/WebCore/platform/ios/VideoFullscreenInterfaceAVKit.mm
@@ -461,7 +461,7 @@ ALLOW_NEW_API_WITHOUT_GUARDS_END
 
 - (void)enterFullScreenAnimated:(BOOL)animated completionHandler:(void (^)(BOOL success, NSError * __nullable error))completionHandler
 {
-    OBJC_ALWAYS_LOG(OBJC_LOGIDENTIFIER, animated);
+    OBJC_ALWAYS_LOG(OBJC_LOGIDENTIFIER, !!animated);
 #if PLATFORM(WATCHOS)
     auto fullscreenInterface = _fullscreenInterface.get();
     if (!fullscreenInterface) {
@@ -484,7 +484,7 @@ ALLOW_NEW_API_WITHOUT_GUARDS_END
 
 - (void)exitFullScreenAnimated:(BOOL)animated completionHandler:(void (^)(BOOL success, NSError * __nullable error))completionHandler
 {
-    OBJC_ALWAYS_LOG(OBJC_LOGIDENTIFIER, animated);
+    OBJC_ALWAYS_LOG(OBJC_LOGIDENTIFIER, !!animated);
 #if PLATFORM(WATCHOS)
     if (!_presentingViewController)
         return;
@@ -665,7 +665,7 @@ static const NSTimeInterval startPictureInPictureTimeInterval = 5.0;
 
 - (void)setShowsPlaybackControls:(BOOL)showsPlaybackControls
 {
-    OBJC_ALWAYS_LOG(OBJC_LOGIDENTIFIER, showsPlaybackControls);
+    OBJC_ALWAYS_LOG(OBJC_LOGIDENTIFIER, !!showsPlaybackControls);
 #if PLATFORM(WATCHOS)
     UNUSED_PARAM(showsPlaybackControls);
 #else
@@ -675,7 +675,7 @@ static const NSTimeInterval startPictureInPictureTimeInterval = 5.0;
 
 - (void)setAllowsPictureInPicturePlayback:(BOOL)allowsPictureInPicturePlayback
 {
-    OBJC_ALWAYS_LOG(OBJC_LOGIDENTIFIER, allowsPictureInPicturePlayback);
+    OBJC_ALWAYS_LOG(OBJC_LOGIDENTIFIER, !!allowsPictureInPicturePlayback);
 #if PLATFORM(WATCHOS)
     UNUSED_PARAM(allowsPictureInPicturePlayback);
 #else


### PR DESCRIPTION
#### 6537be3e9a0b73a0b05b521b104238713050f9f4
<pre>
Unreviewed build fix on macOS
<a href="https://bugs.webkit.org/show_bug.cgi?id=256476">https://bugs.webkit.org/show_bug.cgi?id=256476</a>
rdar://109042873

* Source/WebCore/platform/ios/VideoFullscreenInterfaceAVKit.mm:
(-[WebAVPlayerViewController enterFullScreenAnimated:completionHandler:]):

Canonical link: <a href="https://commits.webkit.org/263804@main">https://commits.webkit.org/263804@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/cab7c96637cd4f5cf190dc40ca9ca95ed385b4d0

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/5804 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/5970 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/6158 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/7364 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/32/builds/6197 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/5805 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/6192 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/5937 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/7984 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/5910 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/15/builds/5958 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/5256 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/7419 "Built successfully") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/39/builds/3435 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/10/builds/5233 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/13194 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/5303 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/5312 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/7516 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/5756 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/4728 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/30/builds/5198 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/4/builds/9318 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/667 "Built successfully and passed tests") | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/31/builds/5559 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->