### PR TITLE
[Cocoa] Video doesn't resize on YouTube.com in theater mode

### DIFF
--- a/Source/WebCore/platform/cocoa/VideoFullscreenModel.h
+++ b/Source/WebCore/platform/cocoa/VideoFullscreenModel.h
@@ -76,6 +76,11 @@ public:
     virtual UIViewController *presentingViewController() { return nullptr; }
     virtual RetainPtr<UIViewController> createVideoFullscreenViewController(AVPlayerViewController *) { return nullptr; }
 #endif
+
+#if !RELEASE_LOG_DISABLED
+    virtual const void* logIdentifier() const { return nullptr; }
+    virtual const Logger* loggerPtr() const { return nullptr; }
+#endif
 };
 
 class VideoFullscreenModelClient {

--- a/Source/WebCore/platform/cocoa/VideoFullscreenModelVideoElement.h
+++ b/Source/WebCore/platform/cocoa/VideoFullscreenModelVideoElement.h
@@ -79,8 +79,8 @@ public:
     WEBCORE_EXPORT void requestRouteSharingPolicyAndContextUID(CompletionHandler<void(RouteSharingPolicy, String)>&&) override;
 
 #if !RELEASE_LOG_DISABLED
-    const Logger* loggerPtr() const;
-    WEBCORE_EXPORT const void* logIdentifier();
+    const Logger* loggerPtr() const override;
+    WEBCORE_EXPORT const void* logIdentifier() const override;
     const char* logClassName() const { return "VideoFullscreenModelVideoElement"; }
     WTFLogChannel& logChannel() const;
 #endif

--- a/Source/WebCore/platform/cocoa/VideoFullscreenModelVideoElement.mm
+++ b/Source/WebCore/platform/cocoa/VideoFullscreenModelVideoElement.mm
@@ -333,7 +333,7 @@ const Logger* VideoFullscreenModelVideoElement::loggerPtr() const
     return m_videoElement ? &m_videoElement->logger() : nullptr;
 }
 
-const void* VideoFullscreenModelVideoElement::logIdentifier()
+const void* VideoFullscreenModelVideoElement::logIdentifier() const
 {
     return m_videoElement ? m_videoElement->logIdentifier() : nullptr;
 }

--- a/Source/WebCore/platform/cocoa/WebAVPlayerLayer.h
+++ b/Source/WebCore/platform/cocoa/WebAVPlayerLayer.h
@@ -37,20 +37,12 @@ OBJC_CLASS NSString;
 
 namespace WebCore {
 class VideoFullscreenModel;
-class VideoFullscreenInterfaceAVKit;
-class VideoFullscreenInterfaceMac;
 }
-
-#if PLATFORM(IOS_FAMILY)
-typedef WebCore::VideoFullscreenInterfaceAVKit PlatformVideoFullscreenInterface;
-#else
-typedef WebCore::VideoFullscreenInterfaceMac PlatformVideoFullscreenInterface;
-#endif
 
 WEBCORE_EXPORT @interface WebAVPlayerLayer : CALayer
 @property (nonatomic, retain, nullable) NSString *videoGravity;
 @property (nonatomic, getter=isReadyForDisplay) BOOL readyForDisplay;
-@property (nonatomic, assign, nullable) PlatformVideoFullscreenInterface* fullscreenInterface;
+@property (nonatomic, assign, nullable) WebCore::VideoFullscreenModel* fullscreenModel;
 @property (nonatomic, retain, nonnull) AVPlayerController *playerController;
 @property (nonatomic, retain, nonnull) CALayer *videoSublayer;
 @property (nonatomic, copy, nullable) NSDictionary *pixelBufferAttributes;

--- a/Source/WebCore/platform/cocoa/WebAVPlayerLayerView.mm
+++ b/Source/WebCore/platform/cocoa/WebAVPlayerLayerView.mm
@@ -100,7 +100,7 @@ static void WebAVPlayerLayerView_startRoutingVideoToPictureInPicturePlayerLayerV
     auto *playerLayer = (WebAVPlayerLayer *)[playerLayerView playerLayer];
     auto *pipPlayerLayer = (WebAVPlayerLayer *)[pipView layer];
     [playerLayer setVideoGravity:AVLayerVideoGravityResizeAspectFill];
-    [pipPlayerLayer setFullscreenInterface:playerLayer.fullscreenInterface];
+    [pipPlayerLayer setFullscreenModel:playerLayer.fullscreenModel];
     [pipPlayerLayer setVideoSublayer:playerLayer.videoSublayer];
     [pipPlayerLayer setVideoDimensions:playerLayer.videoDimensions];
     [pipPlayerLayer setVideoGravity:playerLayer.videoGravity];

--- a/Source/WebCore/platform/ios/VideoFullscreenInterfaceAVKit.mm
+++ b/Source/WebCore/platform/ios/VideoFullscreenInterfaceAVKit.mm
@@ -1321,8 +1321,7 @@ void VideoFullscreenInterfaceAVKit::doSetup()
 
     WebAVPlayerLayer *playerLayer = (WebAVPlayerLayer *)[m_playerLayerView playerLayer];
 
-    playerLayer.fullscreenInterface = this;
-    [playerLayer setVideoDimensions:[playerController() contentDimensions]];
+    playerLayer.fullscreenModel = m_videoFullscreenModel;
 
     if (!m_playerViewController)
         m_playerViewController = adoptNS([[WebAVPlayerViewController alloc] initWithFullscreenInterface:this]);

--- a/Source/WebCore/platform/mac/VideoFullscreenInterfaceMac.mm
+++ b/Source/WebCore/platform/mac/VideoFullscreenInterfaceMac.mm
@@ -201,8 +201,9 @@ enum class PIPState {
     [_pipViewController setUserCanResize:YES];
     [_pipViewController setPlaying:_playing];
     [self setVideoDimensions:NSEqualSizes(_videoDimensions, NSZeroSize) ? frame.size : _videoDimensions];
-    if (_videoFullscreenInterfaceMac && _videoFullscreenInterfaceMac->videoFullscreenModel())
-        _videoFullscreenInterfaceMac->videoFullscreenModel()->setVideoLayerGravity(MediaPlayerEnums::VideoGravity::ResizeAspectFill);
+    auto* model = _videoFullscreenInterfaceMac ? _videoFullscreenInterfaceMac->videoFullscreenModel() : nullptr;
+    if (model)
+        model->setVideoLayerGravity(MediaPlayerEnums::VideoGravity::ResizeAspectFill);
 
     _videoViewContainer = adoptNS([[WebVideoViewContainer alloc] initWithFrame:frame]);
     [_videoViewContainer setVideoViewContainerDelegate:self];
@@ -213,7 +214,7 @@ enum class PIPState {
     _playerLayer = adoptNS([[WebAVPlayerLayer alloc] init]);
     [[_videoViewContainer layer] addSublayer:_playerLayer.get()];
     [_playerLayer setFrame:[_videoViewContainer layer].bounds];
-    [_playerLayer setFullscreenInterface:_videoFullscreenInterfaceMac];
+    [_playerLayer setFullscreenModel:model];
     [_playerLayer setVideoSublayer:videoView.layer];
     [_playerLayer setVideoDimensions:_videoDimensions];
     [_playerLayer setAutoresizingMask:(kCALayerWidthSizable | kCALayerHeightSizable)];

--- a/Source/WebKit/UIProcess/Cocoa/VideoFullscreenManagerProxy.h
+++ b/Source/WebKit/UIProcess/Cocoa/VideoFullscreenManagerProxy.h
@@ -97,6 +97,8 @@ private:
     friend class VideoFullscreenManagerProxy;
     VideoFullscreenModelContext(VideoFullscreenManagerProxy&, PlaybackSessionModelContext&, PlaybackSessionContextIdentifier);
 
+    void setVideoDimensions(const WebCore::FloatSize&);
+
     // VideoFullscreenModel
     void addClient(WebCore::VideoFullscreenModelClient&) override;
     void removeClient(WebCore::VideoFullscreenModelClient&) override;
@@ -131,8 +133,8 @@ private:
     void fullscreenMayReturnToInline() final;
 
 #if !RELEASE_LOG_DISABLED
-    const void* logIdentifier() const;
-    const Logger* loggerPtr() const;
+    const void* logIdentifier() const override;
+    const Logger* loggerPtr() const override;
 
     const char* logClassName() const { return "VideoFullscreenModelContext"; };
     WTFLogChannel& logChannel() const;


### PR DESCRIPTION
#### 95f95436a7cdf8752aaa4e411c35ca32cd921c0e
<pre>
[Cocoa] Video doesn&apos;t resize on YouTube.com in theater mode
<a href="https://bugs.webkit.org/show_bug.cgi?id=256473">https://bugs.webkit.org/show_bug.cgi?id=256473</a>
rdar://105929105

Reviewed by Simon Fraser.

A rare timing issue will sometimes cause WebAVPlayerLayer to get &quot;stuck&quot; thinking it has an empty
videoDimensions. This seems to occur when layerCreationProperies are initialized in the WebContent
process before the video element has a valid nativeSize, but the video element&apos;s &quot;resize&quot; event
is fired before the layer is created in the UI process.

One cause of this symptom is that not all the relevant objects are notified when the videoDimensions
change in the UI process. The VideoFullscreenModelContext object has a videoDimensions() method whose
instance variable is never modified. And notifying the relevent objects becomes a job of the
VideoFullscreenManagerProxy itself, and that coverage was spotty.

Instead, fully implement VideoFullscreenModelContext::setVideoDimensions() and use the pre-existing
VideoFullscreenModelClient callbacks to notify both the VideoFullscreenInterface{Mac,AVKit} and the
WebAVPlayerLayer when the underlying video dimensions change.

WebAVPlayerLayer will therefore need a VideoFullscreenModelClient proxy object to use as the client
for the model, and since the only thing it uses a VideoFullscreenInteraface object for is to get its
associated model, it should just keep a weak reference to the model itself. Adding the model to the
WebAVPlayerLayer will cause its videoDimensions property to update. And when the videoDimensions
change, it can mark itself as needing layout.

Drive-by fix: In WebAVPlayerLayer, the -layoutSublayers method would bail out early if its own
affineTransform property was identity. This was incorrect, it should have checked it&apos;s videoSublayer&apos;s
affineTransform property, as that&apos;s what is actually changed later in the method. Also, don&apos;t
disable animations in the -layoutSublayers method, as this will cause animated property changes
to break (such as PiP animations on iOS).

* Source/WebCore/platform/cocoa/VideoFullscreenModel.h:
(WebCore::VideoFullscreenModel::logIdentifier const):
(WebCore::VideoFullscreenModel::loggerPtr const):
* Source/WebCore/platform/cocoa/VideoFullscreenModelVideoElement.h:
* Source/WebCore/platform/cocoa/VideoFullscreenModelVideoElement.mm:
(WebCore::VideoFullscreenModelVideoElement::logIdentifier const):
(WebCore::VideoFullscreenModelVideoElement::logIdentifier): Deleted.
* Source/WebCore/platform/cocoa/WebAVPlayerLayer.h:
* Source/WebCore/platform/cocoa/WebAVPlayerLayer.mm:
(WebCore::WebAVPlayerLayerFullscreenModelClient::WebAVPlayerLayerFullscreenModelClient):
(WebCore::WebAVPlayerLayerFullscreenModelClient::videoDimensionsChanged):
(-[WebAVPlayerLayer init]):
(-[WebAVPlayerLayer fullscreenModel]):
(-[WebAVPlayerLayer setFullscreenModel:]):
(-[WebAVPlayerLayer videoDimensions]):
(-[WebAVPlayerLayer setVideoDimensions:]):
(-[WebAVPlayerLayer layoutSublayers]):
(-[WebAVPlayerLayer resolveBounds]):
(-[WebAVPlayerLayer setVideoGravity:]):
(-[WebAVPlayerLayer logIdentifier]):
(-[WebAVPlayerLayer loggerPtr]):
(-[WebAVPlayerLayer fullscreenInterface]): Deleted.
(-[WebAVPlayerLayer setFullscreenInterface:]): Deleted.
* Source/WebCore/platform/cocoa/WebAVPlayerLayerView.mm:
(WebCore::WebAVPlayerLayerView_startRoutingVideoToPictureInPicturePlayerLayerView):
* Source/WebCore/platform/ios/VideoFullscreenInterfaceAVKit.mm:
(VideoFullscreenInterfaceAVKit::doSetup):
* Source/WebCore/platform/mac/VideoFullscreenInterfaceMac.mm:
(-[WebVideoFullscreenInterfaceMacObjC setUpPIPForVideoView:withFrame:inWindow:]):
(WebCore::boolString): Deleted.
* Source/WebKit/UIProcess/Cocoa/VideoFullscreenManagerProxy.h:
* Source/WebKit/UIProcess/Cocoa/VideoFullscreenManagerProxy.mm:
(WebKit::VideoFullscreenModelContext::setVideoDimensions):
(WebKit::VideoFullscreenManagerProxy::createLayerWithID):
(WebKit::VideoFullscreenManagerProxy::createViewWithID):
(WebKit::VideoFullscreenManagerProxy::setVideoDimensions):

Canonical link: <a href="https://commits.webkit.org/263836@main">https://commits.webkit.org/263836@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a601d280e08c7e8178b445e0a4be9e39d79c87b4

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/5823 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/5991 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/6180 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/7383 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/6212 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/5824 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/6214 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/5958 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/8109 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/5929 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/5979 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/5278 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/7439 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/3456 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/5253 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/13214 "Passed tests") | 
| | [❌ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/5323 "1 api test failed or timed out") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/5332 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/7561 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/5776 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/4744 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/5217 "Built successfully") | | | 
| [❌ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/1386 "Failed to push commit to Webkit repository") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/9338 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/5578 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->