### PR TITLE
[Mac Catalyst] Adjust autocorrection underline color based on caret color

### DIFF
--- a/Source/WebCore/rendering/RenderTheme.cpp
+++ b/Source/WebCore/rendering/RenderTheme.cpp
@@ -2037,8 +2037,9 @@ Color RenderTheme::platformDictationAlternativesMarkerColor(OptionSet<StyleColor
     return Color::green;
 }
 
-Color RenderTheme::autocorrectionReplacementMarkerColor(OptionSet<StyleColorOptions> options) const
+Color RenderTheme::autocorrectionReplacementMarkerColor(const RenderText& renderer) const
 {
+    auto options = renderer.styleColorOptions();
     auto& cache = colorCache(options);
     if (!cache.autocorrectionReplacementMarkerColor.isValid())
         cache.autocorrectionReplacementMarkerColor = platformAutocorrectionReplacementMarkerColor(options);
@@ -2063,8 +2064,10 @@ Color RenderTheme::platformGrammarMarkerColor(OptionSet<StyleColorOptions>) cons
     return Color::green;
 }
 
-Color RenderTheme::documentMarkerLineColor(DocumentMarkerLineStyleMode mode, OptionSet<StyleColorOptions> options) const
+Color RenderTheme::documentMarkerLineColor(const RenderText& renderer, DocumentMarkerLineStyleMode mode) const
 {
+    auto options = renderer.styleColorOptions();
+
     switch (mode) {
     case DocumentMarkerLineStyleMode::Spelling:
         return spellingMarkerColor(options);
@@ -2072,7 +2075,7 @@ Color RenderTheme::documentMarkerLineColor(DocumentMarkerLineStyleMode mode, Opt
     case DocumentMarkerLineStyleMode::TextCheckingDictationPhraseWithAlternatives:
         return dictationAlternativesMarkerColor(options);
     case DocumentMarkerLineStyleMode::AutocorrectionReplacement:
-        return autocorrectionReplacementMarkerColor(options);
+        return autocorrectionReplacementMarkerColor(renderer);
     case DocumentMarkerLineStyleMode::Grammar:
         return grammarMarkerColor(options);
     }

--- a/Source/WebCore/rendering/RenderTheme.h
+++ b/Source/WebCore/rendering/RenderTheme.h
@@ -186,7 +186,7 @@ public:
 
     Color datePlaceholderTextColor(const Color& textColor, const Color& backgroundColor) const;
 
-    Color documentMarkerLineColor(DocumentMarkerLineStyleMode, OptionSet<StyleColorOptions>) const;
+    Color documentMarkerLineColor(const RenderText&, DocumentMarkerLineStyleMode) const;
 
     WEBCORE_EXPORT Color focusRingColor(OptionSet<StyleColorOptions>) const;
     virtual Color platformFocusRingColor(OptionSet<StyleColorOptions>) const { return Color::black; }
@@ -445,13 +445,14 @@ protected:
 
     virtual ColorCache& colorCache(OptionSet<StyleColorOptions>) const;
 
+    virtual Color autocorrectionReplacementMarkerColor(const RenderText&) const;
+
 private:
     StyleAppearance autoAppearanceForElement(RenderStyle&, const Element*) const;
     StyleAppearance adjustAppearanceForElement(RenderStyle&, const Element*, StyleAppearance) const;
 
     Color spellingMarkerColor(OptionSet<StyleColorOptions>) const;
     Color dictationAlternativesMarkerColor(OptionSet<StyleColorOptions>) const;
-    Color autocorrectionReplacementMarkerColor(OptionSet<StyleColorOptions>) const;
     Color grammarMarkerColor(OptionSet<StyleColorOptions>) const;
 
     mutable HashMap<uint8_t, ColorCache, DefaultHash<uint8_t>, WTF::UnsignedWithZeroKeyHashTraits<uint8_t>> m_colorCacheMap;

--- a/Source/WebCore/rendering/RenderThemeCocoa.h
+++ b/Source/WebCore/rendering/RenderThemeCocoa.h
@@ -47,7 +47,6 @@ protected:
 
     Color platformSpellingMarkerColor(OptionSet<StyleColorOptions>) const override;
     Color platformDictationAlternativesMarkerColor(OptionSet<StyleColorOptions>) const override;
-    Color platformAutocorrectionReplacementMarkerColor(OptionSet<StyleColorOptions>) const override;
     Color platformGrammarMarkerColor(OptionSet<StyleColorOptions>) const override;
 
 private:

--- a/Source/WebCore/rendering/RenderThemeCocoa.mm
+++ b/Source/WebCore/rendering/RenderThemeCocoa.mm
@@ -269,12 +269,6 @@ Color RenderThemeCocoa::platformDictationAlternativesMarkerColor(OptionSet<Style
     return useDarkMode ? SRGBA<uint8_t> { 40, 145, 255, 217 } : SRGBA<uint8_t> { 0, 122, 255, 191 };
 }
 
-Color RenderThemeCocoa::platformAutocorrectionReplacementMarkerColor(OptionSet<StyleColorOptions> options) const
-{
-    auto useDarkMode = options.contains(StyleColorOptions::UseDarkAppearance);
-    return useDarkMode ? SRGBA<uint8_t> { 40, 145, 255, 217 } : SRGBA<uint8_t> { 0, 122, 255, 191 };
-}
-
 Color RenderThemeCocoa::platformGrammarMarkerColor(OptionSet<StyleColorOptions> options) const
 {
     auto useDarkMode = options.contains(StyleColorOptions::UseDarkAppearance);

--- a/Source/WebCore/rendering/RenderThemeIOS.h
+++ b/Source/WebCore/rendering/RenderThemeIOS.h
@@ -55,6 +55,7 @@ public:
     WEBCORE_EXPORT static void setCSSValueToSystemColorMap(CSSValueToSystemColorMap&&);
 
     WEBCORE_EXPORT static void setFocusRingColor(const Color&);
+    WEBCORE_EXPORT static void setInsertionPointColor(const Color&);
 
     WEBCORE_EXPORT static Color systemFocusRingColor();
 
@@ -157,6 +158,10 @@ private:
     bool supportsFocusRing(const RenderStyle&) const final;
 
     bool supportsBoxShadow(const RenderStyle&) const final;
+
+    static Color insertionPointColor();
+
+    Color autocorrectionReplacementMarkerColor(const RenderText&) const final;
 
     Color platformActiveSelectionBackgroundColor(OptionSet<StyleColorOptions>) const override;
     Color platformInactiveSelectionBackgroundColor(OptionSet<StyleColorOptions>) const override;

--- a/Source/WebCore/rendering/TextBoxPainter.cpp
+++ b/Source/WebCore/rendering/TextBoxPainter.cpp
@@ -847,7 +847,7 @@ void TextBoxPainter<TextBoxPath>::paintPlatformDocumentMarker(const MarkedText& 
         }
     }();
 
-    auto lineStyleColor = RenderTheme::singleton().documentMarkerLineColor(lineStyleMode, m_renderer.styleColorOptions());
+    auto lineStyleColor = RenderTheme::singleton().documentMarkerLineColor(m_renderer, lineStyleMode);
     if (auto* marker = markedText.marker)
         lineStyleColor = lineStyleColor.colorWithAlphaMultipliedBy(marker->opacity());
 

--- a/Source/WebKit/Shared/WebPageCreationParameters.cpp
+++ b/Source/WebKit/Shared/WebPageCreationParameters.cpp
@@ -110,6 +110,7 @@ void WebPageCreationParameters::encode(IPC::Encoder& encoder) const
     encoder << keyboardIsAttached;
     encoder << canShowWhileLocked;
     encoder << isCapturingScreen;
+    encoder << insertionPointColor;
 #endif
 #if PLATFORM(COCOA)
     encoder << smartInsertDeleteEnabled;
@@ -405,6 +406,8 @@ std::optional<WebPageCreationParameters> WebPageCreationParameters::decode(IPC::
     if (!decoder.decode(parameters.canShowWhileLocked))
         return std::nullopt;
     if (!decoder.decode(parameters.isCapturingScreen))
+        return std::nullopt;
+    if (!decoder.decode(parameters.insertionPointColor))
         return std::nullopt;
 #endif
 

--- a/Source/WebKit/Shared/WebPageCreationParameters.h
+++ b/Source/WebKit/Shared/WebPageCreationParameters.h
@@ -185,6 +185,7 @@ struct WebPageCreationParameters {
     bool keyboardIsAttached { false };
     bool canShowWhileLocked { false };
     bool isCapturingScreen { false };
+    WebCore::Color insertionPointColor;
 #endif
 #if PLATFORM(COCOA)
     bool smartInsertDeleteEnabled;

--- a/Source/WebKit/UIProcess/API/ios/WKWebViewIOS.h
+++ b/Source/WebKit/UIProcess/API/ios/WKWebViewIOS.h
@@ -168,6 +168,8 @@ enum class TapHandlingResult : uint8_t;
 - (void)_scrollView:(UIScrollView *)scrollView asynchronouslyHandleScrollEvent:(UIScrollEvent *)scrollEvent completion:(void (^)(BOOL handled))completion;
 #endif
 
+- (UIColor *)_insertionPointColor;
+
 @property (nonatomic, readonly) WKPasswordView *_passwordView;
 @property (nonatomic, readonly) WKWebViewContentProviderRegistry *_contentProviderRegistry;
 @property (nonatomic, readonly) WKSelectionGranularity _selectionGranularity;

--- a/Source/WebKit/UIProcess/API/ios/WKWebViewIOS.mm
+++ b/Source/WebKit/UIProcess/API/ios/WKWebViewIOS.mm
@@ -647,6 +647,11 @@ static WebCore::Color scrollViewBackgroundColor(WKWebView *webView, AllowPageBac
         [_scrollView _setIndicatorStyleInternal:UIScrollViewIndicatorStyleBlack];
 }
 
+- (UIColor *)_insertionPointColor
+{
+    return self._textInputTraits.insertionPointColor ?: UIColor.insertionPointColor;
+}
+
 - (void)_videoControlsManagerDidChange
 {
 #if ENABLE(FULLSCREEN_API)

--- a/Source/WebKit/UIProcess/PageClient.h
+++ b/Source/WebKit/UIProcess/PageClient.h
@@ -517,6 +517,8 @@ public:
 #endif
 
     virtual WebCore::Color contentViewBackgroundColor() = 0;
+    virtual WebCore::Color insertionPointColor() = 0;
+
     virtual String sceneID() = 0;
 
     virtual void beginTextRecognitionForFullscreenVideo(ShareableBitmap::Handle&&, AVPlayerViewController *) = 0;

--- a/Source/WebKit/UIProcess/WebPageProxy.cpp
+++ b/Source/WebKit/UIProcess/WebPageProxy.cpp
@@ -9183,6 +9183,7 @@ WebPageCreationParameters WebPageProxy::creationParameters(WebProcessProxy& proc
     parameters.deviceOrientation = m_deviceOrientation;
     parameters.keyboardIsAttached = isInHardwareKeyboardMode();
     parameters.canShowWhileLocked = m_configuration->canShowWhileLocked();
+    parameters.insertionPointColor = pageClient().insertionPointColor();
 #endif
 
 #if PLATFORM(COCOA)

--- a/Source/WebKit/UIProcess/WebPageProxy.h
+++ b/Source/WebKit/UIProcess/WebPageProxy.h
@@ -971,6 +971,9 @@ public:
     void requestDocumentEditingContext(DocumentEditingContextRequest, CompletionHandler<void(DocumentEditingContext)>&&);
     void generateSyntheticEditingCommand(SyntheticEditingCommandType);
     void showDataDetectorsUIForPositionInformation(const InteractionInformationAtPosition&);
+
+    void insertionPointColorDidChange();
+
 #if ENABLE(DRAG_SUPPORT)
     void didHandleDragStartRequest(bool started);
     void didHandleAdditionalDragItemsRequest(bool added);

--- a/Source/WebKit/UIProcess/ios/PageClientImplIOS.h
+++ b/Source/WebKit/UIProcess/ios/PageClientImplIOS.h
@@ -304,6 +304,8 @@ private:
 #endif
 
     WebCore::Color contentViewBackgroundColor() final;
+    WebCore::Color insertionPointColor() final;
+
     String sceneID() final;
 
     void beginTextRecognitionForFullscreenVideo(ShareableBitmap::Handle&&, AVPlayerViewController *) final;

--- a/Source/WebKit/UIProcess/ios/PageClientImplIOS.mm
+++ b/Source/WebKit/UIProcess/ios/PageClientImplIOS.mm
@@ -1078,6 +1078,11 @@ WebCore::Color PageClientImpl::contentViewBackgroundColor()
     return color;
 }
 
+Color PageClientImpl::insertionPointColor()
+{
+    return roundAndClampToSRGBALossy([m_webView _insertionPointColor].CGColor);
+}
+
 void PageClientImpl::requestScrollToRect(const FloatRect& targetRect, const FloatPoint& origin)
 {
     [m_contentView _scrollToRect:targetRect withOrigin:origin minimumScrollDistance:0];

--- a/Source/WebKit/UIProcess/ios/WKContentViewInteraction.mm
+++ b/Source/WebKit/UIProcess/ios/WKContentViewInteraction.mm
@@ -3937,6 +3937,8 @@ ALLOW_DEPRECATED_DECLARATIONS_END
     [self _updateInteractionTintColor:_traits.get()];
     if (shouldUpdateTextSelection)
         [_textInteractionAssistant activateSelection];
+
+    _page->insertionPointColorDidChange();
 }
 
 #if ENABLE(APP_HIGHLIGHTS)

--- a/Source/WebKit/UIProcess/ios/WebPageProxyIOS.mm
+++ b/Source/WebKit/UIProcess/ios/WebPageProxyIOS.mm
@@ -1619,6 +1619,11 @@ void WebPageProxy::showDataDetectorsUIForPositionInformation(const InteractionIn
     pageClient().showDataDetectorsUIForPositionInformation(positionInfo);
 }
 
+void WebPageProxy::insertionPointColorDidChange()
+{
+    send(Messages::WebPage::SetInsertionPointColor(pageClient().insertionPointColor()));
+}
+
 Color WebPageProxy::platformUnderPageBackgroundColor() const
 {
     if (auto contentViewBackgroundColor = pageClient().contentViewBackgroundColor(); contentViewBackgroundColor.isValid())

--- a/Source/WebKit/WebProcess/WebPage/Cocoa/WebPageCocoa.mm
+++ b/Source/WebKit/WebProcess/WebPage/Cocoa/WebPageCocoa.mm
@@ -101,6 +101,9 @@ void WebPage::platformInitialize(const WebPageCreationParameters& parameters)
     if (!WebProcess::singleton().isLockdownModeEnabled())
         CARenderServerGetServerPort(nullptr);
 #endif
+#if PLATFORM(IOS_FAMILY)
+    setInsertionPointColor(parameters.insertionPointColor);
+#endif
 }
 
 void WebPage::platformDidReceiveLoadParameters(const LoadParameters& parameters)

--- a/Source/WebKit/WebProcess/WebPage/WebPage.h
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.h
@@ -816,6 +816,8 @@ public:
     bool screenIsBeingCaptured() const { return m_screenIsBeingCaptured; }
     void setScreenIsBeingCaptured(bool);
 
+    void setInsertionPointColor(WebCore::Color);
+
     double minimumPageScaleFactor() const;
     double maximumPageScaleFactor() const;
     double maximumPageScaleFactorIgnoringAlwaysScalable() const;

--- a/Source/WebKit/WebProcess/WebPage/WebPage.messages.in
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.messages.in
@@ -62,6 +62,8 @@ messages -> WebPage LegacyReceiver {
     
     SetScreenIsBeingCaptured(bool captured)
 
+    SetInsertionPointColor(WebCore::Color color)
+
     AttemptSyntheticClick(WebCore::IntPoint point, OptionSet<WebKit::WebEventModifier> modifiers, WebKit::TransactionID lastLayerTreeTransactionId)
     PotentialTapAtPosition(WebKit::TapIdentifier requestID, WebCore::FloatPoint point, bool shouldRequestMagnificationInformation)
     CommitPotentialTap(OptionSet<WebKit::WebEventModifier> modifiers, WebKit::TransactionID lastLayerTreeTransactionId, WebCore::PointerID pointerId)

--- a/Source/WebKit/WebProcess/WebPage/ios/WebPageIOS.mm
+++ b/Source/WebKit/WebProcess/WebPage/ios/WebPageIOS.mm
@@ -5012,6 +5012,11 @@ void WebPage::setScreenIsBeingCaptured(bool captured)
     m_screenIsBeingCaptured = captured;
 }
 
+void WebPage::setInsertionPointColor(WebCore::Color color)
+{
+    RenderThemeIOS::setInsertionPointColor(color);
+}
+
 void WebPage::textInputContextsInRect(FloatRect searchRect, CompletionHandler<void(const Vector<ElementContext>&)>&& completionHandler)
 {
     auto contexts = m_page->editableElementsInRect(searchRect).map([&] (const auto& element) {


### PR DESCRIPTION
#### b199f7db6bc8daa14464c22f44e3d70845e791f7
<pre>
[Mac Catalyst] Adjust autocorrection underline color based on caret color
<a href="https://bugs.webkit.org/show_bug.cgi?id=256475">https://bugs.webkit.org/show_bug.cgi?id=256475</a>
rdar://108355409

Reviewed by Wenson Hsieh.

The autocorrection underline color should be a variant of the current caret
color. In order to facilitate this, the insertion point color is plumbed from
the UI Process into the Web Process.

* Source/WebCore/rendering/RenderTheme.cpp:
(WebCore::RenderTheme::autocorrectionReplacementMarkerColor const):
(WebCore::RenderTheme::documentMarkerLineColor const):
* Source/WebCore/rendering/RenderTheme.h:

Add a `RenderText` parameter to `documentMarkerLineColor`, since it is
necessary to determine the caret color.

* Source/WebCore/rendering/RenderThemeCocoa.h:
* Source/WebCore/rendering/RenderThemeCocoa.mm:
(WebCore::RenderThemeCocoa::platformAutocorrectionReplacementMarkerColor const): Deleted.

Remove override, as the color is too dynamic to be cached. `caret-color` can
differ per-element, so the autocorrection underline color can no longer be cached.

* Source/WebCore/rendering/RenderThemeIOS.h:

Add a static method to set the insertion point color to avoid unnecessary
initialization of the singleton.

* Source/WebCore/rendering/RenderThemeIOS.mm:
(WebCore::cachedInsertionPointColor):
(WebCore::RenderThemeIOS::insertionPointColor):
(WebCore::RenderThemeIOS::autocorrectionReplacementMarkerColor const):

Adjust the autocorrection underline color based on the current caret color. If
`caret-color` is `auto`, use the default color from the UI process. The
adjustment is performed using the HSL colorspace, matching UIKit.

(WebCore::RenderThemeIOS::setInsertionPointColor):
* Source/WebCore/rendering/TextBoxPainter.cpp:
(WebCore::TextBoxPainter&lt;TextBoxPath&gt;::paintPlatformDocumentMarker):
* Source/WebKit/Shared/WebPageCreationParameters.cpp:
(WebKit::WebPageCreationParameters::encode const):
(WebKit::WebPageCreationParameters::decode):
* Source/WebKit/Shared/WebPageCreationParameters.h:
* Source/WebKit/UIProcess/API/ios/WKWebViewIOS.h:
* Source/WebKit/UIProcess/API/ios/WKWebViewIOS.mm:
(-[WKWebView _insertionPointColor]):

Get the insertion point color from the text input traits if it exists. Otherwise,
use the default color specified in UIKit.

* Source/WebKit/UIProcess/PageClient.h:

Add a `PageClient` hook to get the insertion point color.

* Source/WebKit/UIProcess/WebPageProxy.cpp:
(WebKit::WebPageProxy::creationParameters):
* Source/WebKit/UIProcess/WebPageProxy.h:
* Source/WebKit/UIProcess/ios/PageClientImplIOS.h:
* Source/WebKit/UIProcess/ios/PageClientImplIOS.mm:
(WebKit::PageClientImpl::insertionPointColor):
* Source/WebKit/UIProcess/ios/WKContentViewInteraction.mm:
(-[WKContentView tintColorDidChange]):

Ensure the insertion point color is up-to-date, following changes to the view&apos;s
tint color.

* Source/WebKit/UIProcess/ios/WebPageProxyIOS.mm:
(WebKit::WebPageProxy::insertionPointColorDidChange):
* Source/WebKit/WebProcess/WebPage/Cocoa/WebPageCocoa.mm:
(WebKit::WebPage::platformInitialize):
* Source/WebKit/WebProcess/WebPage/WebPage.h:
* Source/WebKit/WebProcess/WebPage/WebPage.messages.in:
* Source/WebKit/WebProcess/WebPage/ios/WebPageIOS.mm:
(WebKit::WebPage::setInsertionPointColor):

Canonical link: <a href="https://commits.webkit.org/263879@main">https://commits.webkit.org/263879@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c346ce9507c4d13d43146cb3c82af29dd86caacf

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/5817 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/5985 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/6173 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/7377 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/6208 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/5818 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/6207 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/5952 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/8001 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/5923 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/5971 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/5270 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/7432 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/3448 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/5246 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/13208 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/5316 "Passed tests") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/5325 "5 failures") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/7538 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/5770 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/4739 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/5211 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/9332 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/701 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/5572 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->