### PR TITLE
document.write of template producing multiple text nodes

### DIFF
--- a/LayoutTests/fast/parser/template-multiple-child-text-nodes-expected.txt
+++ b/LayoutTests/fast/parser/template-multiple-child-text-nodes-expected.txt
@@ -1,0 +1,11 @@
+This tests inserting multiple text tokens inside a template element. WebKit should create a single contiguous text node.
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+PASS templates[0].content.firstChild.data is "hello"
+PASS templates[1].content.childNodes[1].data is "world"
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/fast/parser/template-multiple-child-text-nodes.html
+++ b/LayoutTests/fast/parser/template-multiple-child-text-nodes.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<script src="../../resources/js-test.js"></script>
+<body>
+<script>
+
+for (character of "<template>hello</template>")
+    document.write(character);
+
+for (character of "<template><div></div>world<div></div></template>")
+    document.write(character);
+
+description('This tests inserting multiple text tokens inside a template element. WebKit should create a single contiguous text node.');
+
+const templates = Array.from(document.querySelectorAll('template'));
+shouldBeEqualToString('templates[0].content.firstChild.data', 'hello');
+shouldBeEqualToString('templates[1].content.childNodes[1].data', 'world');
+
+</script>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/html/syntax/parsing/html5lib_template_run_type=write_single-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/syntax/parsing/html5lib_template_run_type=write_single-expected.txt
@@ -1,13 +1,13 @@
 html5lib Parser Test
 
 
-FAIL html5lib_template.html 010950d55f4eccf16e9c4af1d263bb747294c646 assert_equals: expected "#document\n| <html>\n|   <head>\n|   <body>\n|     <template>\n|       content\n|         \"Hello\"" but got "#document\n| <html>\n|   <head>\n|   <body>\n|     <template>\n|       content\n|         \"H\"\n|         \"e\"\n|         \"l\"\n|         \"l\"\n|         \"o\""
-FAIL html5lib_template.html a838bd54410cef059a42eea9606356488e16535b assert_equals: expected "#document\n| <html>\n|   <head>\n|     <template>\n|       content\n|         \"Hello\"\n|   <body>" but got "#document\n| <html>\n|   <head>\n|     <template>\n|       content\n|         \"H\"\n|         \"e\"\n|         \"l\"\n|         \"l\"\n|         \"o\"\n|   <body>"
+PASS html5lib_template.html 010950d55f4eccf16e9c4af1d263bb747294c646
+PASS html5lib_template.html a838bd54410cef059a42eea9606356488e16535b
 PASS html5lib_template.html 27fb9111f6675a7e033b867480c0afddcda161a6
-FAIL html5lib_template.html aee883a65775489399a003b2371d58248a6aff6f assert_equals: expected "#document\n| <html>\n|   <head>\n|     <template>\n|       content\n|         \"Hello\"\n|   <body>" but got "#document\n| <html>\n|   <head>\n|     <template>\n|       content\n|         \"H\"\n|         \"e\"\n|         \"l\"\n|         \"l\"\n|         \"o\"\n|   <body>"
+PASS html5lib_template.html aee883a65775489399a003b2371d58248a6aff6f
 PASS html5lib_template.html 89b17b54ab343191bf74ef5434f4d2cfac40ea97
 PASS html5lib_template.html c4433556c7414cfd71f27b420f1ffc4348774f5e
-FAIL html5lib_template.html 3dcce7d97108b3e9ea7fa96f240ac62bf280e74b assert_equals: expected "#document\n| <html>\n|   <head>\n|   <body>\n|     <div>\n|       <template>\n|         content\n|           \"Hello\"" but got "#document\n| <html>\n|   <head>\n|   <body>\n|     <div>\n|       <template>\n|         content\n|           \"H\"\n|           \"e\"\n|           \"l\"\n|           \"l\"\n|           \"o\""
+PASS html5lib_template.html 3dcce7d97108b3e9ea7fa96f240ac62bf280e74b
 PASS html5lib_template.html a1f587f7ea85ccfe294bd45bfb501e850cb979e0
 PASS html5lib_template.html cd26a7832f13bdc135697321ca6c2fecdca6ef5d
 PASS html5lib_template.html e30571d90b0e56864499961eb7be955994cf72e2
@@ -70,7 +70,7 @@ PASS html5lib_template.html 9bd9687a65f258adc24450fc5cbd781fff6c038a
 PASS html5lib_template.html db1baeb846d718c773324746524fbd68f2e9436e
 PASS html5lib_template.html 4b0ce46c611dbcc016db272ef007f302bee0c897
 PASS html5lib_template.html 1a735e1c7f28f8701f3c7fd5e9404b8911916086
-FAIL html5lib_template.html 0686eedec06b2db1dc283fac92c1ef1a33114c71 assert_equals: expected "#document\n| <html>\n|   <head>\n|   <body>\n|     <template>\n|       content\n|         <template>\n|           content\n|             <b>\n|               <template>\n|                 content\n|         \"text\"" but got "#document\n| <html>\n|   <head>\n|   <body>\n|     <template>\n|       content\n|         <template>\n|           content\n|             <b>\n|               <template>\n|                 content\n|         \"t\"\n|         \"e\"\n|         \"x\"\n|         \"t\""
+PASS html5lib_template.html 0686eedec06b2db1dc283fac92c1ef1a33114c71
 PASS html5lib_template.html d4dfb87ce626f12923056a6cd77448eaf4660ac2
 PASS html5lib_template.html 1f295920f2937b2c8023b3761c43a0d4d9e5353c
 PASS html5lib_template.html 3b91fa08fad923d387d924cff37fbf6b4c3a5712
@@ -102,220 +102,10 @@ PASS html5lib_template.html b79387a54c3b136db0f28ed96555ff683b3947fe
 PASS html5lib_template.html c477a29a4deb32d072a415fa809a84a4f2beee0c
 PASS html5lib_template.html 26e4480c08e1f5f7b6ac8b8c1832ab0312e3b7c5
 PASS html5lib_template.html 24b3b50fdd0bf8d5cf2ebaa6bf502d7bcfde1da4
-FAIL html5lib_template.html d3704c68528357189eb5826ab66eea071d6137a5 assert_equals: expected "#document\n| <html>\n|   <head>\n|   <body>\n|     <table>\n|       <tbody>\n|         <tr>\n|           <td>\n|             <select>\n|               <template>\n|                 content\n|                   \"Foo\"\n|       <caption>\n|         \"A\"" but got "#document\n| <html>\n|   <head>\n|   <body>\n|     <table>\n|       <tbody>\n|         <tr>\n|           <td>\n|             <select>\n|               <template>\n|                 content\n|                   \"F\"\n|                   \"o\"\n|                   \"o\"\n|       <caption>\n|         \"A\""
+PASS html5lib_template.html d3704c68528357189eb5826ab66eea071d6137a5
 PASS html5lib_template.html d958f7d44faf772d1fb60f1a8f186f837ca735d9
 PASS html5lib_template.html 3fc4d97fa68fc2658356bdbd4e051c867de8de53
-FAIL html5lib_template.html 94820107bbf3fab3f82de1f717e8413aead7d3a6 assert_equals: expected "#document\n| <html>\n|   <head>\n|     <template>\n|       content\n|         \"Foo\"\n|   <body>" but got "#document\n| <html>\n|   <head>\n|     <template>\n|       content\n|         \"F\"\n|         \"o\"\n|         \"o\"\n|   <body>"
+PASS html5lib_template.html 94820107bbf3fab3f82de1f717e8413aead7d3a6
 PASS html5lib_template.html 657c00ebdda37ae060cc69633ed98482ccc29e18
 PASS html5lib_template.html 649fc955a4b60ab2a5b881d94c9493eb4a545002
-010950d55f4eccf16e9c4af1d263bb747294c646
-
-Input
-
-<body><template>Hello</template>
-Expected
-
-#document
-| <html>
-|   <head>
-|   <body>
-|     <template>
-|       content
-|         "Hello"
-Actual
-
-#document
-| <html>
-|   <head>
-|   <body>
-|     <template>
-|       content
-|         "H"
-|         "e"
-|         "l"
-|         "l"
-|         "o"
-a838bd54410cef059a42eea9606356488e16535b
-
-Input
-
-<template>Hello</template>
-Expected
-
-#document
-| <html>
-|   <head>
-|     <template>
-|       content
-|         "Hello"
-|   <body>
-Actual
-
-#document
-| <html>
-|   <head>
-|     <template>
-|       content
-|         "H"
-|         "e"
-|         "l"
-|         "l"
-|         "o"
-|   <body>
-aee883a65775489399a003b2371d58248a6aff6f
-
-Input
-
-<html><template>Hello</template>
-Expected
-
-#document
-| <html>
-|   <head>
-|     <template>
-|       content
-|         "Hello"
-|   <body>
-Actual
-
-#document
-| <html>
-|   <head>
-|     <template>
-|       content
-|         "H"
-|         "e"
-|         "l"
-|         "l"
-|         "o"
-|   <body>
-3dcce7d97108b3e9ea7fa96f240ac62bf280e74b
-
-Input
-
-<div><template></div>Hello
-Expected
-
-#document
-| <html>
-|   <head>
-|   <body>
-|     <div>
-|       <template>
-|         content
-|           "Hello"
-Actual
-
-#document
-| <html>
-|   <head>
-|   <body>
-|     <div>
-|       <template>
-|         content
-|           "H"
-|           "e"
-|           "l"
-|           "l"
-|           "o"
-0686eedec06b2db1dc283fac92c1ef1a33114c71
-
-Input
-
-<body><template><template><b><template></template></template>text</template>
-Expected
-
-#document
-| <html>
-|   <head>
-|   <body>
-|     <template>
-|       content
-|         <template>
-|           content
-|             <b>
-|               <template>
-|                 content
-|         "text"
-Actual
-
-#document
-| <html>
-|   <head>
-|   <body>
-|     <template>
-|       content
-|         <template>
-|           content
-|             <b>
-|               <template>
-|                 content
-|         "t"
-|         "e"
-|         "x"
-|         "t"
-d3704c68528357189eb5826ab66eea071d6137a5
-
-Input
-
-<body><table><tr><td><select><template>Foo</template><caption>A</table>
-Expected
-
-#document
-| <html>
-|   <head>
-|   <body>
-|     <table>
-|       <tbody>
-|         <tr>
-|           <td>
-|             <select>
-|               <template>
-|                 content
-|                   "Foo"
-|       <caption>
-|         "A"
-Actual
-
-#document
-| <html>
-|   <head>
-|   <body>
-|     <table>
-|       <tbody>
-|         <tr>
-|           <td>
-|             <select>
-|               <template>
-|                 content
-|                   "F"
-|                   "o"
-|                   "o"
-|       <caption>
-|         "A"
-94820107bbf3fab3f82de1f717e8413aead7d3a6
-
-Input
-
-<head></head><template>Foo</template>
-Expected
-
-#document
-| <html>
-|   <head>
-|     <template>
-|       content
-|         "Foo"
-|   <body>
-Actual
-
-#document
-| <html>
-|   <head>
-|     <template>
-|       content
-|         "F"
-|         "o"
-|         "o"
-|   <body>
 

--- a/Source/WebCore/html/parser/HTMLConstructionSite.cpp
+++ b/Source/WebCore/html/parser/HTMLConstructionSite.cpp
@@ -669,7 +669,16 @@ void HTMLConstructionSite::insertTextNode(const String& characters)
     // FIXME: Splitting text nodes into smaller chunks contradicts HTML5 spec, but is currently necessary
     // for performance, see <https://bugs.webkit.org/show_bug.cgi?id=55898>.
 
-    RefPtr<Node> previousChild = task.nextChild ? task.nextChild->previousSibling() : task.parent->lastChild();
+    RefPtr<Node> previousChild;
+    if (task.nextChild)
+        previousChild = task.nextChild->previousSibling();
+    else {
+        if (auto templateParent = dynamicDowncast<HTMLTemplateElement>(task.parent.get()); UNLIKELY(templateParent)) {
+            auto parentNode = templateParent->contentIfAvailable();
+            previousChild = parentNode ? parentNode->lastChild() : nullptr;
+        } else
+            previousChild = task.parent->lastChild();
+    }
     if (auto* previousTextChild = dynamicDowncast<Text>(previousChild.get()); previousTextChild && previousTextChild->length() < lengthLimit) {
         // FIXME: We're only supposed to append to this text node if it was the last text node inserted by the parser.
         unsigned proposedBreakIndex = std::min(characters.length(), lengthLimit - previousTextChild->length());


### PR DESCRIPTION
#### 830fc599637395e1d3260565dc1d8e84ad53f6ce
<pre>
document.write of template producing multiple text nodes
<a href="https://bugs.webkit.org/show_bug.cgi?id=254334">https://bugs.webkit.org/show_bug.cgi?id=254334</a>

Reviewed by Chris Dumez.

The bug was caused by HTMLConstructionSite::insertTextNode not considering the case where
the parent node is a template element in which case its text node is in its content fragment.

* LayoutTests/imported/w3c/web-platform-tests/html/syntax/parsing/html5lib_template_run_type=write_single-expected.txt:
* LayoutTests/fast/parser/template-multiple-child-text-nodes-expected.txt: Added.
* LayoutTests/fast/parser/template-multiple-child-text-nodes.html: Added.
* Source/WebCore/html/parser/HTMLConstructionSite.cpp:
(WebCore::HTMLConstructionSite::insertTextNode):

Canonical link: <a href="https://commits.webkit.org/263841@main">https://commits.webkit.org/263841@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/fa8f293c048fbdc0601381015f02a938072901f7

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/5833 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/6001 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/6190 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/7392 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/6218 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/5833 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/6224 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/5967 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/8131 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/5939 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/5989 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/5286 "Passed tests") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/2/builds/7485 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/3466 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/5261 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/13220 "layout-tests (failure)") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/5333 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/5340 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/7554 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/5785 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/4750 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/5226 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/5191 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/9347 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/687 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/5587 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->