### PR TITLE
A `frameset` tag inside `template` should be simply ignored

### DIFF
--- a/LayoutTests/fast/parser/disable-frameset-ok-flag-inside-template-expected.txt
+++ b/LayoutTests/fast/parser/disable-frameset-ok-flag-inside-template-expected.txt
@@ -1,0 +1,3 @@
+
+PASS A frameset tag inside template should be simply ignored.
+

--- a/LayoutTests/fast/parser/disable-frameset-ok-flag-inside-template.html
+++ b/LayoutTests/fast/parser/disable-frameset-ok-flag-inside-template.html
@@ -1,0 +1,15 @@
+<!doctype html>
+<link rel=help href="https://html.spec.whatwg.org/multipage/syntax.html#parsing-main-inhead">
+<script src="../../resources/testharness.js"></script>
+<script src="../../resources/testharnessreport.js"></script>
+<body>
+<script>
+var test = async_test("A frameset tag inside template should be simply ignored.");
+var iframe = document.createElement("iframe");
+iframe.onload = function() {
+  document.body.removeChild(iframe);
+  test.done();
+};
+iframe.src = './resources/frameset-inside-template.html';
+document.body.appendChild(iframe);
+</script>

--- a/LayoutTests/fast/parser/resources/frameset-inside-template.html
+++ b/LayoutTests/fast/parser/resources/frameset-inside-template.html
@@ -1,0 +1,3 @@
+<ins>
+    <template>
+    <frameset></frameset>

--- a/Source/WebCore/html/parser/HTMLTreeBuilder.cpp
+++ b/Source/WebCore/html/parser/HTMLTreeBuilder.cpp
@@ -1,6 +1,6 @@
 /*
- * Copyright (C) 2010 Google, Inc. All Rights Reserved.
- * Copyright (C) 2011-2017 Apple Inc. All rights reserved.
+ * Copyright (C) 2010-2016 Google, Inc. All Rights Reserved.
+ * Copyright (C) 2011-2023 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -964,6 +964,7 @@ void HTMLTreeBuilder::processTemplateStartTag(AtomHTMLToken&& token)
 {
     m_tree.activeFormattingElements().appendMarker();
     m_tree.insertHTMLTemplateElement(WTFMove(token));
+    m_framesetOk = false;
     m_templateInsertionModes.append(InsertionMode::TemplateContents);
     m_insertionMode = InsertionMode::TemplateContents;
 }


### PR DESCRIPTION
#### dc45153ce2d1ba0b2f778a5da7c835d99556feb6
<pre>
A `frameset` tag inside `template` should be simply ignored

<a href="https://bugs.webkit.org/show_bug.cgi?id=256455">https://bugs.webkit.org/show_bug.cgi?id=256455</a>

Reviewed by Ryosuke Niwa.

This patch aligns WebKit with Web-Spec [1] and Blink / Chromium.

Merge: <a href="https://chromium.googlesource.com/chromium/src/+/93198017327e240584facc073ae5853a1cc78a6c">https://chromium.googlesource.com/chromium/src/+/93198017327e240584facc073ae5853a1cc78a6c</a>

As stated in the spec [1], `template` tag start token should set framesetOk
flag to false when in in-body/in-head insertion mode.

[1] <a href="https://html.spec.whatwg.org/multipage/parsing.html#parsing-main-inbody">https://html.spec.whatwg.org/multipage/parsing.html#parsing-main-inbody</a>

* Source/WebCore/html/parser/HTMLTreeBuilder.cpp:
(HTMLTreeBuilder::processTemplateStartTag): As above
* LayoutTests/fast/parser/resources/frameset-inside-template.html: Add Test Case Resource
* LayoutTests/fast/parser/disable-frameset-ok-flag-inside-template.html: Add Test Case
* LayoutTests/fast/parser/disable-frameset-ok-flag-inside-template-expected.txt: Add Test Case Expectation

Canonical link: <a href="https://commits.webkit.org/263851@main">https://commits.webkit.org/263851@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/237d07ff13abdbc236d86b5052e0b89d51eca619

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/5822 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/5990 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/6179 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/7382 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/6211 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/5823 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/6213 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/5957 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/8119 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/5928 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/5978 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/5276 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/7437 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/3455 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/5252 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/13216 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/5322 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/5331 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/7550 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/5775 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/4743 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/5216 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/5182 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/1394 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/9337 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/5577 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->