### PR TITLE
StorageManager.persist() is not functional

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/storage/storagemanager-persist-persisted-match.https.any-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/storage/storagemanager-persist-persisted-match.https.any-expected.txt
@@ -1,0 +1,3 @@
+
+PASS navigator.storage.persist() resolves to a value that matches navigator.storage.persisted()
+

--- a/LayoutTests/imported/w3c/web-platform-tests/storage/storagemanager-persist-persisted-match.https.any.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/storage/storagemanager-persist-persisted-match.https.any.html
@@ -1,0 +1,1 @@
+<!-- This file is required for WebKit test infrastructure to run the templated test -->

--- a/LayoutTests/imported/w3c/web-platform-tests/storage/storagemanager-persist-persisted-match.https.any.js
+++ b/LayoutTests/imported/w3c/web-platform-tests/storage/storagemanager-persist-persisted-match.https.any.js
@@ -1,0 +1,9 @@
+// META: title=StorageManager: result of persist() matches result of persisted()
+
+promise_test(async t => {
+    var persistResult = await navigator.storage.persist();
+    assert_equals(typeof persistResult, 'boolean', persistResult + ' should be boolean');
+    var persistedResult = await navigator.storage.persisted();
+    assert_equals(typeof persistedResult, 'boolean', persistedResult + ' should be boolean');
+    assert_equals(persistResult, persistedResult);
+}, 'navigator.storage.persist() resolves to a value that matches navigator.storage.persisted()');

--- a/Source/WebKit/NetworkProcess/storage/NetworkStorageManager.h
+++ b/Source/WebKit/NetworkProcess/storage/NetworkStorageManager.h
@@ -138,7 +138,6 @@ private:
     HashSet<WebCore::ClientOrigin> getAllOrigins();
     Vector<WebsiteData::Entry> fetchDataFromDisk(OptionSet<WebsiteDataType>, ShouldComputeSize);
     HashSet<WebCore::ClientOrigin> deleteDataOnDisk(OptionSet<WebsiteDataType>, WallTime, const Function<bool(const WebCore::ClientOrigin&)>&);
-    bool evictDataByTopOrigin(const WebCore::SecurityOriginData&);
 #if PLATFORM(IOS_FAMILY)
     void includeOriginInBackupIfNecessary(OriginStorageManager&);
 #endif
@@ -228,8 +227,11 @@ private:
     WallTime lastModificationTimeForOrigin(const WebCore::ClientOrigin&, OriginStorageManager&) const;
     void updateLastModificationTimeForOrigin(const WebCore::ClientOrigin&);
     void schedulePerformEviction();
+    bool persistedInternal(const WebCore::ClientOrigin&);
+    String persistedFilePath(const WebCore::ClientOrigin&);
     struct AccessRecord {
         bool isActive { false };
+        std::optional<bool> isPersisted;
         uint64_t usage { 0 };
         WallTime lastAccessTime;
         Vector<WebCore::SecurityOriginData> clientOrigins;

--- a/Source/WebKit/NetworkProcess/storage/OriginStorageManager.cpp
+++ b/Source/WebKit/NetworkProcess/storage/OriginStorageManager.cpp
@@ -813,14 +813,6 @@ bool OriginStorageManager::isEmpty()
     return defaultBucket().isEmpty();
 }
 
-void OriginStorageManager::setPersisted(bool value)
-{
-    ASSERT(!RunLoop::isMain());
-
-    m_persisted = value;
-    defaultBucket().setMode(value ? StorageBucketMode::Persistent : StorageBucketMode::BestEffort);
-}
-
 WebCore::StorageEstimate OriginStorageManager::estimate()
 {
     ASSERT(!RunLoop::isMain());

--- a/Source/WebKit/NetworkProcess/storage/OriginStorageManager.h
+++ b/Source/WebKit/NetworkProcess/storage/OriginStorageManager.h
@@ -62,8 +62,6 @@ public:
     ~OriginStorageManager();
 
     void connectionClosed(IPC::Connection::UniqueID);
-    bool persisted() const { return m_persisted; }
-    void setPersisted(bool value);
     WebCore::StorageEstimate estimate();
     const String& path() const { return m_path; }
     OriginQuotaManager& quotaManager();
@@ -115,7 +113,6 @@ private:
     OriginQuotaManager::IncreaseQuotaFunction m_increaseQuotaFunction;
     OriginQuotaManager::NotifySpaceGrantedFunction m_notifySpaceGrantedFunction;
     RefPtr<OriginQuotaManager> m_quotaManager;
-    bool m_persisted { false };
     UnifiedOriginStorageLevel m_level;
     Markable<WallTime> m_originFileCreationTimestamp;
 #if PLATFORM(IOS_FAMILY)


### PR DESCRIPTION
#### 338e1ced429a53ada0a2e52569a2d031a3a63361
<pre>
StorageManager.persist() is not functional
<a href="https://bugs.webkit.org/show_bug.cgi?id=256483">https://bugs.webkit.org/show_bug.cgi?id=256483</a>
rdar://109057460

Reviewed by Youenn Fablet.

StorageManager.persist() currently sets an in-memory flag of OriginStorageManager unconditionally and the flag does not
do anything. Now that we have implemented eviction based on quota, this patch ensures the eviction will check persited
flag and skip deleting the origin if its flag is set. Also, this patch ensures persisted flag is stored to disk by
creating a persisted file.

* LayoutTests/imported/w3c/web-platform-tests/storage/storagemanager-persist-persisted-match.https.any-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/storage/storagemanager-persist-persisted-match.https.any.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/storage/storagemanager-persist-persisted-match.https.any.js: Added.
(promise_test.async t):
* Source/WebKit/NetworkProcess/storage/NetworkStorageManager.cpp:
(WebKit::NetworkStorageManager::persistedFilePath):
(WebKit::NetworkStorageManager::donePrepareForEviction):
(WebKit::NetworkStorageManager::performEviction):
(WebKit::NetworkStorageManager::persistedInternal):
(WebKit::NetworkStorageManager::persisted):
(WebKit::NetworkStorageManager::persist):
(WebKit::NetworkStorageManager::resetStoragePersistedState):
(WebKit::NetworkStorageManager::deleteDataOnDisk):
(WebKit::NetworkStorageManager::evictDataByTopOrigin): Deleted.
* Source/WebKit/NetworkProcess/storage/NetworkStorageManager.h:
* Source/WebKit/NetworkProcess/storage/OriginStorageManager.cpp:
(WebKit::OriginStorageManager::setPersisted): Deleted.
* Source/WebKit/NetworkProcess/storage/OriginStorageManager.h:
(WebKit::OriginStorageManager::persisted const): Deleted.

Canonical link: <a href="https://commits.webkit.org/263930@main">https://commits.webkit.org/263930@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a70d87048f4563e9b764ee53bb790a35392776d3

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/6128 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/6313 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/6496 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/7691 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/6474 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/6532 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/6266 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/9348 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/6238 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/6253 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/5540 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/7753 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/3728 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/5521 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/13425 "4 flakes 174 failures") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/5593 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/5599 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/7832 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/6073 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/4970 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/5493 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/5450 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/1456 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/9636 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/5861 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->