### PR TITLE
Regression(262025@main) WebProcesses on macOS 13.0 are still marked as managed by RunningBoard

### DIFF
--- a/Source/WebKit/Scripts/update-info-plist-for-runningboard.sh
+++ b/Source/WebKit/Scripts/update-info-plist-for-runningboard.sh
@@ -1,4 +1,4 @@
-if [[ "${USE_INTERNAL_SDK}" == "YES"  &&  "${WK_PLATFORM_NAME}" == macosx ]] && (( "${TARGET_MAC_OS_X_VERSION_MAJOR}" >= 130000 ))
+if [[ "${USE_INTERNAL_SDK}" == "YES"  &&  "${WK_PLATFORM_NAME}" == macosx ]] && (( "${TARGET_MAC_OS_X_VERSION_MAJOR}" >= 130300 ))
 then
     /usr/libexec/PlistBuddy -c "Add :LSDoNotSetTaskPolicyAutomatically bool YES" "${SCRIPT_INPUT_FILE_0}"
     /usr/libexec/PlistBuddy -c "Add :XPCService:_AdditionalProperties:RunningBoard:Managed bool YES" "${SCRIPT_INPUT_FILE_0}"


### PR DESCRIPTION
#### 99c9a20cadf67aca618c1457d19d544d306a849f
<pre>
Regression(262025@main) WebProcesses on macOS 13.0 are still marked as managed by RunningBoard
<a href="https://bugs.webkit.org/show_bug.cgi?id=256489">https://bugs.webkit.org/show_bug.cgi?id=256489</a>
rdar://108417115

Reviewed by Geoffrey Garen and Ben Nham.

WebProcesses on macOS 13.0 are still marked as managed by RunningBoard even
though 262025@main made it so that we only use RunningBoard assertions on macOS
13.3+.

USE(RUNNINGBOARD) requires `__MAC_OS_X_VERSION_MIN_REQUIRED &gt;= 130300` after
262025@main but update-info-plist-for-runningboard.sh was still checking for
130000. This meant RunningBoard was managing process priority on macOS 13.0+
even though we are only taking RunningBoard assertion on macOS 13.3+. This
was causing our processes to have low priority.

* Source/WebKit/Scripts/update-info-plist-for-runningboard.sh:

Canonical link: <a href="https://commits.webkit.org/263830@main">https://commits.webkit.org/263830@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5baef03d60eea75a96981d7bf77d3a372fba456f

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/5839 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/6012 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/6199 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/7395 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/32/builds/6220 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/6228 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/5972 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/8215 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/5945 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/15/builds/5996 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/5288 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/7452 "Built successfully") | 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/5945 "Passed tests") | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/39/builds/3473 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/13222 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/5340 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/5342 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/7556 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/5790 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/4753 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/30/builds/5229 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| [  ~~🛠 🧪 merge~~](https://ews-build.webkit.org/#/builders/19/builds/1384 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/9350 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/677 "Built successfully and passed tests") | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/31/builds/5590 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->