### PR TITLE
REGRESSION(259811@main-259818@main): [ iOS Debug ] 4X TestWebKitAPI.AppPrivacyReport (API-Tests) are failing

### DIFF
--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/AppPrivacyReport.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/AppPrivacyReport.mm
@@ -777,14 +777,12 @@ static void restoreFromSessionStateTest(IsAppInitiated isAppInitiated)
     TestWebKitAPI::Util::run(&isDone);
 }
 
-// FIXME: Re-enable this test once webkit.org/b/254289 has been resolved.
-TEST(AppPrivacyReport, DISABLED_RestoreFromSessionStateIsAppInitiated)
+TEST(AppPrivacyReport, RestoreFromSessionStateIsAppInitiated)
 {
     restoreFromSessionStateTest(IsAppInitiated::Yes);
 }
 
-// FIXME: Re-enable this test once webkit.org/b/254289 has been resolved.
-TEST(AppPrivacyReport, DISABLED_RestoreFromSessionStateIsNonAppInitiated)
+TEST(AppPrivacyReport, RestoreFromSessionStateIsNonAppInitiated)
 {
     restoreFromSessionStateTest(IsAppInitiated::No);
 }
@@ -824,14 +822,12 @@ static void restoreFromInteractionStateTest(IsAppInitiated isAppInitiated)
     TestWebKitAPI::Util::run(&isDone);
 }
 
-// FIXME: Re-enable this test once webkit.org/b/254289 has been resolved.
-TEST(AppPrivacyReport, DISABLED_RestoreFromInteractionStateIsAppInitiated)
+TEST(AppPrivacyReport, RestoreFromInteractionStateIsAppInitiated)
 {
     restoreFromInteractionStateTest(IsAppInitiated::Yes);
 }
 
-// FIXME: Re-enable this test once webkit.org/b/254289 has been resolved.
-TEST(AppPrivacyReport, DISABLED_RestoreFromInteractionStateIsNonAppInitiated)
+TEST(AppPrivacyReport, RestoreFromInteractionStateIsNonAppInitiated)
 {
     restoreFromInteractionStateTest(IsAppInitiated::No);
 }


### PR DESCRIPTION
#### e017118eac7150f5027126d7240fbf40e003e52c
<pre>
REGRESSION(259811@main-259818@main): [ iOS Debug ] 4X TestWebKitAPI.AppPrivacyReport (API-Tests) are failing
<a href="https://bugs.webkit.org/show_bug.cgi?id=254289">https://bugs.webkit.org/show_bug.cgi?id=254289</a>
rdar://107077600

Reviewed by NOBODY (OOPS!).

Unskip the tests to see what bots think.

* Tools/TestWebKitAPI/Tests/WebKitCocoa/AppPrivacyReport.mm:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e017118eac7150f5027126d7240fbf40e003e52c

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/5837 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/6005 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/6194 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/7394 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/6219 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/5837 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/12335 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/5971 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/8389 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/5943 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/11023 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/5290 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/7451 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/8328 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/5265 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/13221 "Passed tests") | 
| | [❌ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/9429 "3 api tests failed or timed out") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/5344 "6 failures") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/7555 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/5788 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/4751 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/5228 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/9349 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/5589 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->