### PR TITLE
Fix bug in preload scanner with nested templates

### DIFF
--- a/LayoutTests/fast/preloader/image-in-nested-template-expected.txt
+++ b/LayoutTests/fast/preloader/image-in-nested-template-expected.txt
@@ -1,0 +1,1 @@
+This test requires DumpRenderTree to see the log of what resources are loaded.

--- a/LayoutTests/fast/preloader/image-in-nested-template.html
+++ b/LayoutTests/fast/preloader/image-in-nested-template.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<body>
+    <script>
+    if (window.testRunner) {
+        testRunner.dumpAsText();
+        testRunner.dumpResourceResponseMIMETypes();
+    }
+    </script>
+    This test requires DumpRenderTree to see the log of what resources are loaded.
+    <template>
+        <template></template>
+        <script src=resources/non-existant.js></script>
+        <script>document.write("<plaintext>");</script>
+        <img src=resources/image1.png>
+    </template>
+</body>

--- a/Source/WebCore/html/parser/HTMLPreloadScanner.cpp
+++ b/Source/WebCore/html/parser/HTMLPreloadScanner.cpp
@@ -1,7 +1,7 @@
 /*
- * Copyright (C) 2008, 2014 Apple Inc. All Rights Reserved.
+ * Copyright (C) 2008-2023 Apple Inc. All Rights Reserved.
  * Copyright (C) 2009 Torch Mobile, Inc. http://www.torchmobile.com/
- * Copyright (C) 2010 Google Inc. All Rights Reserved.
+ * Copyright (C) 2010-2021 Google Inc. All Rights Reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -451,13 +451,13 @@ void TokenPreloadScanner::scan(const HTMLToken& token, Vector<std::unique_ptr<Pr
     }
 
     case HTMLToken::Type::StartTag: {
-        if (m_templateCount)
-            return;
         TagId tagId = tagIdFor(token.name());
         if (tagId == TagId::Template) {
             ++m_templateCount;
             return;
         }
+        if (m_templateCount)
+            return;
         if (tagId == TagId::Style) {
             m_inStyle = true;
             return;


### PR DESCRIPTION
#### 0434048daa53e9e16f072e710fe8c555eb310813
<pre>
Fix bug in preload scanner with nested templates

<a href="https://bugs.webkit.org/show_bug.cgi?id=256456">https://bugs.webkit.org/show_bug.cgi?id=256456</a>

Reviewed by Ryosuke Niwa.

This patch aligns WebKit with Gecko / Firefox and Blink / Chromium.

Merge: <a href="https://chromium.googlesource.com/chromium/src/+/168fe3ddcae333c7f2073e32b6f9a9f2b343be98">https://chromium.googlesource.com/chromium/src/+/168fe3ddcae333c7f2073e32b6f9a9f2b343be98</a>

Prior to this patch, the preload scanner would incorrectly count
nested templates, which would cause it to load some resources
that it shouldn&apos;t. This patch fixes that bug, and adds tests.

* Source/WebCore/html/parser/HTMLPreloadScanner.cpp:
(TokenPreloadScanner::scan): As above
* LayoutTests/fast/preloader/image-in-nested-template.html: Add Test Case
* LayoutTests/fast/preloader/image-in-nested-template-expected.txt: Add Test Case Expectation

Canonical link: <a href="https://commits.webkit.org/263850@main">https://commits.webkit.org/263850@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e6d8d23800b863cb88e02902a370ce69491adeec

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/5857 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/6028 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/6215 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/7411 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/6232 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/5857 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/6247 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/5990 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/8264 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/5964 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/6005 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/5300 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/7508 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/3482 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/5275 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/13255 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/5349 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/5354 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/7599 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/5806 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/4764 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/5243 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/5205 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/1397 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/9365 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/5604 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->