### PR TITLE
[css-counter-styles] Simplify assertions in CSSCounterStyle.cpp

### DIFF
--- a/Source/WebCore/css/CSSCounterStyle.cpp
+++ b/Source/WebCore/css/CSSCounterStyle.cpp
@@ -38,19 +38,14 @@ namespace WebCore {
 String CSSCounterStyle::counterForSystemCyclic(int value) const
 {
     auto amountOfSymbols = symbols().size();
-    if (amountOfSymbols < 1) {
-        ASSERT_NOT_REACHED();
-        return { };
-    }
+    ASSERT(amountOfSymbols > 0);
 
     // For avoiding subtracting -1 from INT_MAX we will sum-up amountOfSymbols in case the value is not positive.
     // This works because x % y = (x + y) % y
     unsigned symbolIndex = static_cast<unsigned>(value > 0 ? value : value + amountOfSymbols);
     symbolIndex = (symbolIndex - 1) % amountOfSymbols;
-    if (static_cast<unsigned>(symbolIndex) >= amountOfSymbols) {
-        ASSERT_NOT_REACHED();
-        return  { };
-    }
+    ASSERT(static_cast<unsigned>(symbolIndex) < amountOfSymbols);
+
     return symbols().at(static_cast<unsigned>(symbolIndex)).text;
 }
 
@@ -69,10 +64,8 @@ String CSSCounterStyle::counterForSystemFixed(int value) const
 String CSSCounterStyle::counterForSystemSymbolic(unsigned value) const
 {
     auto amountOfSymbols = symbols().size();
-    if (!amountOfSymbols) {
-        ASSERT_NOT_REACHED();
-        return { };
-    }
+    ASSERT(amountOfSymbols > 0);
+
     if (value < 1)
         return { };
 
@@ -89,10 +82,8 @@ String CSSCounterStyle::counterForSystemSymbolic(unsigned value) const
 String CSSCounterStyle::counterForSystemAlphabetic(unsigned value) const
 {
     auto amountOfSymbols = symbols().size();
-    if (amountOfSymbols < 2) {
-        ASSERT_NOT_REACHED();
-        return { };
-    }
+    ASSERT(amountOfSymbols >= 2);
+
     if (value < 1)
         return { };
 
@@ -112,10 +103,8 @@ String CSSCounterStyle::counterForSystemAlphabetic(unsigned value) const
 String CSSCounterStyle::counterForSystemNumeric(unsigned value) const
 {
     auto amountOfSymbols = symbols().size();
-    if (amountOfSymbols < 2) {
-        ASSERT_NOT_REACHED();
-        return { };
-    }
+    ASSERT(amountOfSymbols >= 2);
+
     if (!value)
         return symbols().at(0).text;
 


### PR DESCRIPTION
#### 9e7dac2e339c6e802307770798061c244be29c4b
<pre>
[css-counter-styles] Simplify assertions in CSSCounterStyle.cpp
<a href="https://bugs.webkit.org/show_bug.cgi?id=256497">https://bugs.webkit.org/show_bug.cgi?id=256497</a>
rdar://109065413

Reviewed by Myles C. Maxfield.

* Source/WebCore/css/CSSCounterStyle.cpp:
(WebCore::CSSCounterStyle::counterForSystemCyclic const):
(WebCore::CSSCounterStyle::counterForSystemSymbolic const):
(WebCore::CSSCounterStyle::counterForSystemAlphabetic const):
(WebCore::CSSCounterStyle::counterForSystemNumeric const):

Canonical link: <a href="https://commits.webkit.org/263840@main">https://commits.webkit.org/263840@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5e2c9617f2624661e73c919f24942487dbde8064

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/5860 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/6031 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/6218 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/7414 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/32/builds/6235 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/5860 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/6250 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/5993 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/8340 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/5967 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/6008 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/5306 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/7473 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/3485 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/5281 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/13233 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/5352 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/5360 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/7570 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/5809 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/4766 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/5246 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/1391 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/9368 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/5607 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->