### PR TITLE
form.elements should not contain image elements

### DIFF
--- a/LayoutTests/fast/dom/htmlformcontrolscollection-no-img-expected.txt
+++ b/LayoutTests/fast/dom/htmlformcontrolscollection-no-img-expected.txt
@@ -1,0 +1,4 @@
+
+
+PASS HTMLFormControlsCollection should not handle IMG elements.
+

--- a/LayoutTests/fast/dom/htmlformcontrolscollection-no-img.html
+++ b/LayoutTests/fast/dom/htmlformcontrolscollection-no-img.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<body>
+<script src="../../resources/testharness.js"></script>
+<script src="../../resources/testharnessreport.js"></script>
+<form>
+<img name="imageName">
+<img id="imageId">
+</form>
+<script>
+test(function() {
+    var collection = document.querySelector('form').elements;
+    assert_equals(collection['imageName'], undefined, 'name getter for name=');
+    assert_equals(collection['imageId'], undefined, 'name getter for id=');
+    assert_equals(collection.namedItem('imageName'), null);
+    assert_equals(collection.namedItem('imageId'), null);
+    for (var i = 0; i < collection.length; ++i)
+        assert_not_equals(collection[i].tagName, 'IMG');
+}, 'HTMLFormControlsCollection should not handle IMG elements.');
+</script>
+</body>

--- a/LayoutTests/fast/forms/form-image-access-by-name-expected.txt
+++ b/LayoutTests/fast/forms/form-image-access-by-name-expected.txt
@@ -1,9 +1,7 @@
 
 PASS form.imageElement.id is '1'
 PASS form.imageElement.id is '2'
-PASS form.imageElement.name = 'foo'; form.foo.id is '2'
-PASS form.imageElement is form.foo
-PASS !!form.imageElement is false
+PASS form.imageElement is undefined.
 PASS document.imageElement is undefined.
 PASS !!document.newImage is true
 PASS !!form.newImage is true

--- a/LayoutTests/fast/forms/form-image-access-by-name.html
+++ b/LayoutTests/fast/forms/form-image-access-by-name.html
@@ -1,7 +1,7 @@
 <!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML//EN">
 <html>
 <head>
-<script src="../../resources/js-test-pre.js"></script>
+<script src="../../resources/js-test.js"></script>
 </head>
 <body>
 <p id="description"></p>
@@ -26,13 +26,11 @@ shouldBe("form.imageElement.id", "'1'");
 
 span.innerHTML = "<img id='2' name='imageElement'>";
 shouldBe("form.imageElement.id", "'2'");
-shouldBe("form.imageElement.name = 'foo'; form.foo.id", "'2'");
-shouldBe("form.imageElement", "form.foo");
 
 span.innerHTML = "<img id='2' name='newImage'>";
-shouldBeFalse("!!form.imageElement");
 
-// This quirk has no bearing on document. access
+// imageElement has been removed from the DOM.
+shouldBeUndefined("form.imageElement");
 shouldBeUndefined("document.imageElement");
 
 // Of coruse, the new image should be accessible both ways.
@@ -44,6 +42,5 @@ span.innerHTML = "<img id='3' name='thirdImage'>";
 span.innerHTML = "<img id='4' name='fourthImage'>";
 shouldBeUndefined("form.thirdImage");
 </script>
-<script src="../../resources/js-test-post.js"></script>
 </body>
 </html>

--- a/Source/WebCore/html/HTMLFormControlsCollection.cpp
+++ b/Source/WebCore/html/HTMLFormControlsCollection.cpp
@@ -1,7 +1,7 @@
 /*
  * Copyright (C) 1999 Lars Knoll (knoll@kde.org)
  *           (C) 1999 Antti Koivisto (koivisto@kde.org)
- * Copyright (C) 2003, 2004, 2005, 2006, 2007, 2010, 2011, 2012 Apple Inc. All rights reserved.
+ * Copyright (C) 2003-2023 Apple Inc. All rights reserved.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Library General Public
@@ -26,7 +26,6 @@
 #include "CachedHTMLCollectionInlines.h"
 #include "FormListedElement.h"
 #include "HTMLFormElement.h"
-#include "HTMLImageElement.h"
 #include "HTMLNames.h"
 #include "ScriptDisallowedScope.h"
 #include <wtf/IsoMallocInlines.h>
@@ -137,18 +136,6 @@ void HTMLFormControlsCollection::updateNamedElementCache() const
                 foundInputElements.add(name);
             }
         }
-    }
-
-    for (auto& elementPtr : ownerNode().imageElements()) {
-        if (!elementPtr)
-            continue;
-        HTMLImageElement& element = *elementPtr;
-        const AtomString& id = element.getIdAttribute();
-        if (!id.isEmpty() && !foundInputElements.contains(id))
-            cache->appendToIdCache(id, element);
-        const AtomString& name = element.getNameAttribute();
-        if (!name.isEmpty() && id != name && !foundInputElements.contains(name))
-            cache->appendToNameCache(name, element);
     }
 
     setNamedItemCache(WTFMove(cache));


### PR DESCRIPTION
<pre>
form.elements should not contain image elements
<a href="https://bugs.webkit.org/show_bug.cgi?id=87834">https://bugs.webkit.org/show_bug.cgi?id=87834</a>

Reviewed by NOBODY (OOPS!).

This patch aligns WebKit with Web-Spec [1], Blink / Chromium and Gecko / Firefox.

Image elements should not appear in the form.elements as image element is not
mentioned in listed elements of specs.

[1] <a href="http://www.whatwg.org/specs/web-apps/current-work/multipage/forms.html#category-listed">http://www.whatwg.org/specs/web-apps/current-work/multipage/forms.html#category-listed</a>

Cherry-pick test: <a href="https://chromium.googlesource.com/chromium/src.git/+/5ab9146e05f7e315976e7066b29738dbd6d56f9e">https://chromium.googlesource.com/chromium/src.git/+/5ab9146e05f7e315976e7066b29738dbd6d56f9e</a>

* Source/WebCore/html/HTMLFormControlsCollection.cpp:
(HTMLFormControlsCollection::updateNamedElementCache): Remove 'imageElements' stuff
* LayoutTests/fast/dom/htmlformcontrolscollection-no-img.html: Add Test Case
* LayoutTests/fast/dom/htmlformcontrolscollection-no-img-expected.txt: Add Test Case Expectation
* LayoutTests/fast/forms/form-image-access-by-name-expected.txt: Rebaselined
* LayoutTests/fast/forms/form-image-access-by-name.html: Rebaselined
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0a8ca6d4e29291d264ca10dbda416db5c0afc7e2

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/5974 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/6150 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/6335 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/7528 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/6332 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/5972 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/6369 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/6109 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/8956 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/6082 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/6119 "2 new passes 4 flakes 4 failures") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/5417 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/7588 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/3595 "Passed tests") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/5394 "6 failures") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/13319 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/5461 "Passed tests") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/5473 "5 failures") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/7700 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/5920 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/4859 "1 failures") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/5352 "Built successfully") | [❌ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/5324 "Exiting early after 10 failures. 65 tests run. 1 failures") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/9479 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/5714 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->