### PR TITLE
Map align='abscenter' to vertical-align: middle

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/html/rendering/replaced-elements/attributes-for-embedded-content-and-images/align-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/rendering/replaced-elements/attributes-for-embedded-content-and-images/align-expected.txt
@@ -19,7 +19,7 @@ PASS align=texttop on replaced elements
 PASS align=texttop on non-replaced elements
 PASS align=absmiddle on replaced elements
 PASS align=absmiddle on non-replaced elements
-FAIL align=abscenter on replaced elements assert_equals: align=abscenter should map to vertical-align: middle expected "middle" but got "baseline"
+PASS align=abscenter on replaced elements
 PASS align=abscenter on non-replaced elements
 PASS align=absbottom on replaced elements
 PASS align=absbottom on non-replaced elements

--- a/LayoutTests/imported/w3c/web-platform-tests/html/rendering/replaced-elements/attributes-for-embedded-content-and-images/embedded-and-images-presentational-hints-ascii-case-insensitive-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/rendering/replaced-elements/attributes-for-embedded-content-and-images/embedded-and-images-presentational-hints-ascii-case-insensitive-expected.txt
@@ -1,6 +1,6 @@
 
 
 PASS keyword absbottom
-FAIL keyword abscenter assert_equals: lowercase valid expected "middle" but got "baseline"
+PASS keyword abscenter
 PASS keyword absmiddle
 

--- a/Source/WebCore/html/HTMLElement.cpp
+++ b/Source/WebCore/html/HTMLElement.cpp
@@ -1,7 +1,8 @@
 /*
  * Copyright (C) 1999 Lars Knoll (knoll@kde.org)
  *           (C) 1999 Antti Koivisto (koivisto@kde.org)
- * Copyright (C) 2004-2021 Apple Inc. All rights reserved.
+ * Copyright (C) 2004-2023 Apple Inc. All rights reserved.
+ * Copyright (C) 2021 Google Inc. All rights reserved.
  * Copyright (C) 2009 Torch Mobile Inc. All rights reserved. (http://www.torchmobile.com/)
  * Copyright (C) 2011 Motorola Mobility. All rights reserved.
  *
@@ -626,7 +627,7 @@ void HTMLElement::applyAlignmentAttributeToStyle(const AtomString& alignment, Mu
     CSSValueID floatValue = CSSValueInvalid;
     CSSValueID verticalAlignValue = CSSValueInvalid;
 
-    if (equalLettersIgnoringASCIICase(alignment, "absmiddle"_s))
+    if (equalLettersIgnoringASCIICase(alignment, "absmiddle"_s) || equalLettersIgnoringASCIICase(alignment, "abscenter"_s))
         verticalAlignValue = CSSValueMiddle;
     else if (equalLettersIgnoringASCIICase(alignment, "absbottom"_s))
         verticalAlignValue = CSSValueBottom;


### PR DESCRIPTION
#### de1ad6893e6e2dd353c5b44ca03c900e1e68a67b
<pre>
Map align=&apos;abscenter&apos; to vertical-align: middle

<a href="https://bugs.webkit.org/show_bug.cgi?id=256500">https://bugs.webkit.org/show_bug.cgi?id=256500</a>

Reviewed by Ryosuke Niwa.

This patch aligns WebKit with Web-Spec [1], Blink / Chromium and Gecko / Firefox.

Web-Spec: <a href="https://html.spec.whatwg.org/multipage/rendering.html#attributes-for-embedded-content-and-images">https://html.spec.whatwg.org/multipage/rendering.html#attributes-for-embedded-content-and-images</a>

This patch map &apos;abscenter&apos; to vertical-align: middle.

Merge: <a href="https://chromium.googlesource.com/chromium/src/+/468b59212b185a87c92c45ccfec93589bf10b17c">https://chromium.googlesource.com/chromium/src/+/468b59212b185a87c92c45ccfec93589bf10b17c</a>

* Source/WebCore/html/HTMLElement.cpp:
(HTMLElement::applyAlignmentAttributeToStyle): As above
* LayoutTests/imported/w3c/web-platform-tests/html/rendering/embedded-and-images-presentational-hints-ascii-case-insensitive-expected.txt: Rebaselined
* LayoutTests/imported/w3c/web-platform-tests/html/rendering/replaced-elements/attributes-for-embedded-content-and-images/align-expected.txt: Rebaselined

Canonical link: <a href="https://commits.webkit.org/263852@main">https://commits.webkit.org/263852@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e7a7dc83dcb28329b3dd09cd125c3f17d915082a

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/5880 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/6052 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/6239 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/7431 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/6246 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/5877 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/6271 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/6013 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/8394 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/5988 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/6022 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/5325 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/7489 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/3499 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/5301 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/13240 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/5365 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/5379 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/7578 "run-api-tests-without-change (failure)") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/5826 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/4775 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/5259 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/1395 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/9383 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/5620 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->