### PR TITLE
CollectionType should be an enum class

### DIFF
--- a/Source/WebCore/bindings/js/JSHTMLCollectionCustom.cpp
+++ b/Source/WebCore/bindings/js/JSHTMLCollectionCustom.cpp
@@ -33,11 +33,11 @@ using namespace JSC;
 JSValue toJSNewlyCreated(JSGlobalObject*, JSDOMGlobalObject* globalObject, Ref<HTMLCollection>&& collection)
 {
     switch (collection->type()) {
-    case FormControls:
+    case CollectionType::FormControls:
         return createWrapper<HTMLFormControlsCollection>(globalObject, WTFMove(collection));
-    case SelectOptions:
+    case CollectionType::SelectOptions:
         return createWrapper<HTMLOptionsCollection>(globalObject, WTFMove(collection));
-    case DocAll:
+    case CollectionType::DocAll:
         return createWrapper<HTMLAllCollection>(globalObject, WTFMove(collection));
     default:
         break;

--- a/Source/WebCore/dom/AllDescendantsCollection.h
+++ b/Source/WebCore/dom/AllDescendantsCollection.h
@@ -29,12 +29,12 @@
 
 namespace WebCore {
 
-class AllDescendantsCollection : public CachedHTMLCollection<AllDescendantsCollection, CollectionTypeTraits<AllDescendants>::traversalType> {
+class AllDescendantsCollection : public CachedHTMLCollection<AllDescendantsCollection, CollectionTypeTraits<CollectionType::AllDescendants>::traversalType> {
     WTF_MAKE_ISO_ALLOCATED(AllDescendantsCollection);
 public:
     static Ref<AllDescendantsCollection> create(ContainerNode& rootNode, CollectionType type)
     {
-        ASSERT_UNUSED(type, type == AllDescendants);
+        ASSERT_UNUSED(type, type == CollectionType::AllDescendants);
         return adoptRef(*new AllDescendantsCollection(rootNode, type));
     }
 

--- a/Source/WebCore/dom/ClassCollection.cpp
+++ b/Source/WebCore/dom/ClassCollection.cpp
@@ -40,7 +40,7 @@ WTF_MAKE_ISO_ALLOCATED_IMPL(ClassCollection);
 
 Ref<ClassCollection> ClassCollection::create(ContainerNode& rootNode, CollectionType type, const AtomString& classNames)
 {
-    ASSERT(type == ByClass);
+    ASSERT(type == CollectionType::ByClass);
     return adoptRef(*new ClassCollection(rootNode, type, classNames));
 }
 

--- a/Source/WebCore/dom/ClassCollection.h
+++ b/Source/WebCore/dom/ClassCollection.h
@@ -35,7 +35,7 @@
 
 namespace WebCore {
 
-class ClassCollection final : public CachedHTMLCollection<ClassCollection, CollectionTypeTraits<ByClass>::traversalType> {
+class ClassCollection final : public CachedHTMLCollection<ClassCollection, CollectionTypeTraits<CollectionType::ByClass>::traversalType> {
     WTF_MAKE_ISO_ALLOCATED(ClassCollection);
 public:
     static Ref<ClassCollection> create(ContainerNode&, CollectionType, const AtomString& classNames);
@@ -69,4 +69,4 @@ inline bool ClassCollection::elementMatches(Element& element) const
 
 } // namespace WebCore
 
-SPECIALIZE_TYPE_TRAITS_HTMLCOLLECTION(ClassCollection, ByClass)
+SPECIALIZE_TYPE_TRAITS_HTMLCOLLECTION(ClassCollection, CollectionType::ByClass)

--- a/Source/WebCore/dom/ContainerNode.cpp
+++ b/Source/WebCore/dom/ContainerNode.cpp
@@ -981,11 +981,11 @@ Ref<HTMLCollection> ContainerNode::getElementsByTagName(const AtomString& qualif
     ASSERT(!qualifiedName.isNull());
 
     if (qualifiedName == starAtom())
-        return ensureRareData().ensureNodeLists().addCachedCollection<AllDescendantsCollection>(*this, AllDescendants);
+        return ensureRareData().ensureNodeLists().addCachedCollection<AllDescendantsCollection>(*this, CollectionType::AllDescendants);
 
     if (document().isHTMLDocument())
-        return ensureRareData().ensureNodeLists().addCachedCollection<HTMLTagCollection>(*this, ByHTMLTag, qualifiedName);
-    return ensureRareData().ensureNodeLists().addCachedCollection<TagCollection>(*this, ByTag, qualifiedName);
+        return ensureRareData().ensureNodeLists().addCachedCollection<HTMLTagCollection>(*this, CollectionType::ByHTMLTag, qualifiedName);
+    return ensureRareData().ensureNodeLists().addCachedCollection<TagCollection>(*this, CollectionType::ByTag, qualifiedName);
 }
 
 Ref<HTMLCollection> ContainerNode::getElementsByTagNameNS(const AtomString& namespaceURI, const AtomString& localName)
@@ -1001,7 +1001,7 @@ Ref<NodeList> ContainerNode::getElementsByName(const AtomString& elementName)
 
 Ref<HTMLCollection> ContainerNode::getElementsByClassName(const AtomString& classNames)
 {
-    return ensureRareData().ensureNodeLists().addCachedCollection<ClassCollection>(*this, ByClass, classNames);
+    return ensureRareData().ensureNodeLists().addCachedCollection<ClassCollection>(*this, CollectionType::ByClass, classNames);
 }
 
 Ref<RadioNodeList> ContainerNode::radioNodeList(const AtomString& name)
@@ -1012,7 +1012,7 @@ Ref<RadioNodeList> ContainerNode::radioNodeList(const AtomString& name)
 
 Ref<HTMLCollection> ContainerNode::children()
 {
-    return ensureRareData().ensureNodeLists().addCachedCollection<GenericCachedHTMLCollection<CollectionTypeTraits<NodeChildren>::traversalType>>(*this, NodeChildren);
+    return ensureRareData().ensureNodeLists().addCachedCollection<GenericCachedHTMLCollection<CollectionTypeTraits<CollectionType::NodeChildren>::traversalType>>(*this, CollectionType::NodeChildren);
 }
 
 Element* ContainerNode::firstElementChild() const

--- a/Source/WebCore/dom/Document.cpp
+++ b/Source/WebCore/dom/Document.cpp
@@ -6387,63 +6387,63 @@ Ref<HTMLCollection> Document::ensureCachedCollection()
 
 Ref<HTMLCollection> Document::images()
 {
-    return ensureCachedCollection<DocImages>();
+    return ensureCachedCollection<CollectionType::DocImages>();
 }
 
 Ref<HTMLCollection> Document::applets()
 {
-    return ensureRareData().ensureNodeLists().addCachedCollection<EmptyHTMLCollection>(*this, DocEmpty);
+    return ensureRareData().ensureNodeLists().addCachedCollection<EmptyHTMLCollection>(*this, CollectionType::DocEmpty);
 }
 
 Ref<HTMLCollection> Document::embeds()
 {
-    return ensureCachedCollection<DocEmbeds>();
+    return ensureCachedCollection<CollectionType::DocEmbeds>();
 }
 
 Ref<HTMLCollection> Document::plugins()
 {
     // This is an alias for embeds() required for the JS DOM bindings.
-    return ensureCachedCollection<DocEmbeds>();
+    return ensureCachedCollection<CollectionType::DocEmbeds>();
 }
 
 Ref<HTMLCollection> Document::scripts()
 {
-    return ensureCachedCollection<DocScripts>();
+    return ensureCachedCollection<CollectionType::DocScripts>();
 }
 
 Ref<HTMLCollection> Document::links()
 {
-    return ensureCachedCollection<DocLinks>();
+    return ensureCachedCollection<CollectionType::DocLinks>();
 }
 
 Ref<HTMLCollection> Document::forms()
 {
-    return ensureCachedCollection<DocForms>();
+    return ensureCachedCollection<CollectionType::DocForms>();
 }
 
 Ref<HTMLCollection> Document::anchors()
 {
-    return ensureCachedCollection<DocAnchors>();
+    return ensureCachedCollection<CollectionType::DocAnchors>();
 }
 
 Ref<HTMLCollection> Document::all()
 {
-    return ensureRareData().ensureNodeLists().addCachedCollection<HTMLAllCollection>(*this, DocAll);
+    return ensureRareData().ensureNodeLists().addCachedCollection<HTMLAllCollection>(*this, CollectionType::DocAll);
 }
 
 Ref<HTMLCollection> Document::allFilteredByName(const AtomString& name)
 {
-    return ensureRareData().ensureNodeLists().addCachedCollection<HTMLAllNamedSubCollection>(*this, DocumentAllNamedItems, name);
+    return ensureRareData().ensureNodeLists().addCachedCollection<HTMLAllNamedSubCollection>(*this, CollectionType::DocumentAllNamedItems, name);
 }
 
 Ref<HTMLCollection> Document::windowNamedItems(const AtomString& name)
 {
-    return ensureRareData().ensureNodeLists().addCachedCollection<WindowNameCollection>(*this, WindowNamedItems, name);
+    return ensureRareData().ensureNodeLists().addCachedCollection<WindowNameCollection>(*this, CollectionType::WindowNamedItems, name);
 }
 
 Ref<HTMLCollection> Document::documentNamedItems(const AtomString& name)
 {
-    return ensureRareData().ensureNodeLists().addCachedCollection<DocumentNameCollection>(*this, DocumentNamedItems, name);
+    return ensureRareData().ensureNodeLists().addCachedCollection<DocumentNameCollection>(*this, CollectionType::DocumentNamedItems, name);
 }
 
 void Document::finishedParsing()

--- a/Source/WebCore/dom/Document.h
+++ b/Source/WebCore/dom/Document.h
@@ -262,7 +262,7 @@ struct SystemPreviewInfo;
 
 template<typename> class ExceptionOr;
 
-enum CollectionType;
+enum class CollectionType : uint8_t;
 enum CSSPropertyID : uint16_t;
 
 enum class CompositeOperator : uint8_t;

--- a/Source/WebCore/dom/NodeRareData.h
+++ b/Source/WebCore/dom/NodeRareData.h
@@ -101,7 +101,7 @@ public:
     };
 
     using NodeListCacheMap = HashMap<std::pair<unsigned char, AtomString>, LiveNodeList*, NodeListCacheMapEntryHash>;
-    using CollectionCacheMap = HashMap<std::pair<unsigned char, AtomString>, HTMLCollection*, NodeListCacheMapEntryHash>;
+    using CollectionCacheMap = HashMap<std::pair<std::underlying_type_t<CollectionType>, AtomString>, HTMLCollection*, NodeListCacheMapEntryHash>;
     using TagCollectionNSCache = HashMap<QualifiedName, TagCollectionNS*>;
 
     template<typename T, typename ContainerType>
@@ -188,9 +188,9 @@ public:
     inline void adoptDocument(Document& oldDocument, Document& newDocument);
 
 private:
-    std::pair<unsigned char, AtomString> namedCollectionKey(CollectionType type, const AtomString& name)
+    std::pair<std::underlying_type_t<CollectionType>, AtomString> namedCollectionKey(CollectionType type, const AtomString& name)
     {
-        return std::pair<unsigned char, AtomString>(type, name);
+        return std::pair<std::underlying_type_t<CollectionType>, AtomString>(static_cast<std::underlying_type_t<CollectionType>>(type), name);
     }
 
     template<typename NodeListType>

--- a/Source/WebCore/dom/TagCollection.cpp
+++ b/Source/WebCore/dom/TagCollection.cpp
@@ -35,7 +35,7 @@ WTF_MAKE_ISO_ALLOCATED_IMPL(TagCollectionNS);
 WTF_MAKE_ISO_ALLOCATED_IMPL(HTMLTagCollection);
 
 TagCollectionNS::TagCollectionNS(ContainerNode& rootNode, const AtomString& namespaceURI, const AtomString& localName)
-    : CachedHTMLCollection(rootNode, ByTag)
+    : CachedHTMLCollection(rootNode, CollectionType::ByTag)
     , m_namespaceURI(namespaceURI)
     , m_localName(localName)
 {
@@ -48,7 +48,7 @@ TagCollectionNS::~TagCollectionNS()
 }
 
 TagCollection::TagCollection(ContainerNode& rootNode, const AtomString& qualifiedName)
-    : CachedHTMLCollection(rootNode, ByTag)
+    : CachedHTMLCollection(rootNode, CollectionType::ByTag)
     , m_qualifiedName(qualifiedName)
 {
     ASSERT(qualifiedName != starAtom());
@@ -60,7 +60,7 @@ TagCollection::~TagCollection()
 }
 
 HTMLTagCollection::HTMLTagCollection(ContainerNode& rootNode, const AtomString& qualifiedName)
-    : CachedHTMLCollection(rootNode, ByHTMLTag)
+    : CachedHTMLCollection(rootNode, CollectionType::ByHTMLTag)
     , m_qualifiedName(qualifiedName)
     , m_loweredQualifiedName(qualifiedName.convertToASCIILowercase())
 {

--- a/Source/WebCore/dom/TagCollection.h
+++ b/Source/WebCore/dom/TagCollection.h
@@ -30,12 +30,12 @@
 namespace WebCore {
 
 // HTMLCollection that limits to a particular tag.
-class TagCollection final : public CachedHTMLCollection<TagCollection, CollectionTypeTraits<ByTag>::traversalType> {
+class TagCollection final : public CachedHTMLCollection<TagCollection, CollectionTypeTraits<CollectionType::ByTag>::traversalType> {
     WTF_MAKE_ISO_ALLOCATED(TagCollection);
 public:
     static Ref<TagCollection> create(ContainerNode& rootNode, CollectionType type, const AtomString& qualifiedName)
     {
-        ASSERT_UNUSED(type, type == ByTag);
+        ASSERT_UNUSED(type, type == CollectionType::ByTag);
         return adoptRef(*new TagCollection(rootNode, qualifiedName));
     }
 
@@ -48,7 +48,7 @@ private:
     AtomString m_qualifiedName;
 };
 
-class TagCollectionNS final : public CachedHTMLCollection<TagCollectionNS, CollectionTypeTraits<ByTag>::traversalType> {
+class TagCollectionNS final : public CachedHTMLCollection<TagCollectionNS, CollectionTypeTraits<CollectionType::ByTag>::traversalType> {
     WTF_MAKE_ISO_ALLOCATED(TagCollectionNS);
 public:
     static Ref<TagCollectionNS> create(ContainerNode& rootNode, const AtomString& namespaceURI, const AtomString& localName)
@@ -66,12 +66,12 @@ private:
     AtomString m_localName;
 };
 
-class HTMLTagCollection final : public CachedHTMLCollection<HTMLTagCollection, CollectionTypeTraits<ByHTMLTag>::traversalType> {
+class HTMLTagCollection final : public CachedHTMLCollection<HTMLTagCollection, CollectionTypeTraits<CollectionType::ByHTMLTag>::traversalType> {
     WTF_MAKE_ISO_ALLOCATED(HTMLTagCollection);
 public:
     static Ref<HTMLTagCollection> create(ContainerNode& rootNode, CollectionType type, const AtomString& qualifiedName)
     {
-        ASSERT_UNUSED(type, type == ByHTMLTag);
+        ASSERT_UNUSED(type, type == CollectionType::ByHTMLTag);
         return adoptRef(*new HTMLTagCollection(rootNode, qualifiedName));
     }
 

--- a/Source/WebCore/html/CachedHTMLCollectionInlines.h
+++ b/Source/WebCore/html/CachedHTMLCollectionInlines.h
@@ -119,7 +119,7 @@ Element* CachedHTMLCollection<HTMLCollectionClass, traversalType>::namedItem(con
                 if ((candidate = treeScope.getElementByName(name))) {
                     if (!is<HTMLElement>(*candidate))
                         candidate = nullptr;
-                    else if (type() == DocAll && !nameShouldBeVisibleInDocumentAll(*candidate))
+                    else if (type() == CollectionType::DocAll && !nameShouldBeVisibleInDocumentAll(*candidate))
                         candidate = nullptr;
                 }
             }

--- a/Source/WebCore/html/CollectionType.h
+++ b/Source/WebCore/html/CollectionType.h
@@ -24,7 +24,7 @@
 
 namespace WebCore {
 
-enum CollectionType {
+enum class CollectionType : uint8_t {
     // Unnamed HTMLCollection types cached in the document.
     DocImages,    // all <img> elements in the document
     DocEmbeds,    // all <embed> elements
@@ -66,32 +66,32 @@ struct CollectionTypeTraits {
 };
 
 template<>
-struct CollectionTypeTraits<NodeChildren> {
+struct CollectionTypeTraits<CollectionType::NodeChildren> {
     static const CollectionTraversalType traversalType = CollectionTraversalType::ChildrenOnly;
 };
 
 template<>
-struct CollectionTypeTraits<TRCells> {
+struct CollectionTypeTraits<CollectionType::TRCells> {
     static const CollectionTraversalType traversalType = CollectionTraversalType::ChildrenOnly;
 };
 
 template<>
-struct CollectionTypeTraits<TSectionRows> {
+struct CollectionTypeTraits<CollectionType::TSectionRows> {
     static const CollectionTraversalType traversalType = CollectionTraversalType::ChildrenOnly;
 };
 
 template<>
-struct CollectionTypeTraits<TableTBodies> {
+struct CollectionTypeTraits<CollectionType::TableTBodies> {
     static const CollectionTraversalType traversalType = CollectionTraversalType::ChildrenOnly;
 };
 
 template<>
-struct CollectionTypeTraits<TableRows> {
+struct CollectionTypeTraits<CollectionType::TableRows> {
     static const CollectionTraversalType traversalType = CollectionTraversalType::CustomForwardOnly;
 };
 
 template<>
-struct CollectionTypeTraits<FormControls> {
+struct CollectionTypeTraits<CollectionType::FormControls> {
     static const CollectionTraversalType traversalType = CollectionTraversalType::CustomForwardOnly;
 };
 

--- a/Source/WebCore/html/GenericCachedHTMLCollection.cpp
+++ b/Source/WebCore/html/GenericCachedHTMLCollection.cpp
@@ -54,46 +54,46 @@ template <CollectionTraversalType traversalType>
 bool GenericCachedHTMLCollection<traversalType>::elementMatches(Element& element) const
 {
     switch (this->type()) {
-    case NodeChildren:
+    case CollectionType::NodeChildren:
         return true;
-    case DocImages:
+    case CollectionType::DocImages:
         return element.hasTagName(imgTag);
-    case DocScripts:
+    case CollectionType::DocScripts:
         return element.hasTagName(scriptTag);
-    case DocForms:
+    case CollectionType::DocForms:
         return element.hasTagName(formTag);
-    case TableTBodies:
+    case CollectionType::TableTBodies:
         return element.hasTagName(tbodyTag);
-    case TRCells:
+    case CollectionType::TRCells:
         return element.hasTagName(tdTag) || element.hasTagName(thTag);
-    case TSectionRows:
+    case CollectionType::TSectionRows:
         return element.hasTagName(trTag);
-    case SelectedOptions:
+    case CollectionType::SelectedOptions:
         return is<HTMLOptionElement>(element) && downcast<HTMLOptionElement>(element).selected();
-    case DataListOptions:
+    case CollectionType::DataListOptions:
         return is<HTMLOptionElement>(element);
-    case MapAreas:
+    case CollectionType::MapAreas:
         return element.hasTagName(areaTag);
-    case DocEmbeds:
+    case CollectionType::DocEmbeds:
         return element.hasTagName(embedTag);
-    case DocLinks:
+    case CollectionType::DocLinks:
         return (element.hasTagName(aTag) || element.hasTagName(areaTag)) && element.hasAttributeWithoutSynchronization(hrefAttr);
-    case DocAnchors:
+    case CollectionType::DocAnchors:
         return element.hasTagName(aTag) && element.hasAttributeWithoutSynchronization(nameAttr);
-    case FieldSetElements:
+    case CollectionType::FieldSetElements:
         return element.isFormListedElement();
-    case ByClass:
-    case ByTag:
-    case ByHTMLTag:
-    case AllDescendants:
-    case DocAll:
-    case DocEmpty:
-    case DocumentAllNamedItems:
-    case DocumentNamedItems:
-    case FormControls:
-    case SelectOptions:
-    case TableRows:
-    case WindowNamedItems:
+    case CollectionType::ByClass:
+    case CollectionType::ByTag:
+    case CollectionType::ByHTMLTag:
+    case CollectionType::AllDescendants:
+    case CollectionType::DocAll:
+    case CollectionType::DocEmpty:
+    case CollectionType::DocumentAllNamedItems:
+    case CollectionType::DocumentNamedItems:
+    case CollectionType::FormControls:
+    case CollectionType::SelectOptions:
+    case CollectionType::TableRows:
+    case CollectionType::WindowNamedItems:
         break;
     }
     // Remaining collection types have their own CachedHTMLCollection subclasses and are not using GenericCachedHTMLCollection.

--- a/Source/WebCore/html/HTMLAllCollection.cpp
+++ b/Source/WebCore/html/HTMLAllCollection.cpp
@@ -76,7 +76,7 @@ HTMLAllNamedSubCollection::HTMLAllNamedSubCollection(Document& document, Collect
     : CachedHTMLCollection(document, type)
     , m_name(name)
 {
-    ASSERT(type == DocumentAllNamedItems);
+    ASSERT(type == CollectionType::DocumentAllNamedItems);
 }
 
 HTMLAllNamedSubCollection::~HTMLAllNamedSubCollection()

--- a/Source/WebCore/html/HTMLAllCollection.h
+++ b/Source/WebCore/html/HTMLAllCollection.h
@@ -60,5 +60,5 @@ private:
 
 } // namespace WebCore
 
-SPECIALIZE_TYPE_TRAITS_HTMLCOLLECTION(HTMLAllCollection, DocAll)
-SPECIALIZE_TYPE_TRAITS_HTMLCOLLECTION(HTMLAllNamedSubCollection, DocumentAllNamedItems)
+SPECIALIZE_TYPE_TRAITS_HTMLCOLLECTION(HTMLAllCollection, CollectionType::DocAll)
+SPECIALIZE_TYPE_TRAITS_HTMLCOLLECTION(HTMLAllNamedSubCollection, CollectionType::DocumentAllNamedItems)

--- a/Source/WebCore/html/HTMLCollection.cpp
+++ b/Source/WebCore/html/HTMLCollection.cpp
@@ -37,33 +37,33 @@ WTF_MAKE_ISO_ALLOCATED_IMPL(HTMLCollection);
 inline auto HTMLCollection::rootTypeFromCollectionType(CollectionType type) -> RootType
 {
     switch (type) {
-    case DocImages:
-    case DocEmpty:
-    case DocEmbeds:
-    case DocForms:
-    case DocLinks:
-    case DocAnchors:
-    case DocScripts:
-    case DocAll:
-    case WindowNamedItems:
-    case DocumentNamedItems:
-    case DocumentAllNamedItems:
-    case FormControls:
+    case CollectionType::DocImages:
+    case CollectionType::DocEmpty:
+    case CollectionType::DocEmbeds:
+    case CollectionType::DocForms:
+    case CollectionType::DocLinks:
+    case CollectionType::DocAnchors:
+    case CollectionType::DocScripts:
+    case CollectionType::DocAll:
+    case CollectionType::WindowNamedItems:
+    case CollectionType::DocumentNamedItems:
+    case CollectionType::DocumentAllNamedItems:
+    case CollectionType::FormControls:
         return HTMLCollection::IsRootedAtTreeScope;
-    case AllDescendants:
-    case ByClass:
-    case ByTag:
-    case ByHTMLTag:
-    case FieldSetElements:
-    case NodeChildren:
-    case TableTBodies:
-    case TSectionRows:
-    case TableRows:
-    case TRCells:
-    case SelectOptions:
-    case SelectedOptions:
-    case DataListOptions:
-    case MapAreas:
+    case CollectionType::AllDescendants:
+    case CollectionType::ByClass:
+    case CollectionType::ByTag:
+    case CollectionType::ByHTMLTag:
+    case CollectionType::FieldSetElements:
+    case CollectionType::NodeChildren:
+    case CollectionType::TableTBodies:
+    case CollectionType::TSectionRows:
+    case CollectionType::TableRows:
+    case CollectionType::TRCells:
+    case CollectionType::SelectOptions:
+    case CollectionType::SelectedOptions:
+    case CollectionType::DataListOptions:
+    case CollectionType::MapAreas:
         return HTMLCollection::IsRootedAtNode;
     }
     ASSERT_NOT_REACHED();
@@ -73,39 +73,39 @@ inline auto HTMLCollection::rootTypeFromCollectionType(CollectionType type) -> R
 static NodeListInvalidationType invalidationTypeExcludingIdAndNameAttributes(CollectionType type)
 {
     switch (type) {
-    case ByTag:
-    case ByHTMLTag:
-    case AllDescendants:
-    case DocImages:
-    case DocEmbeds:
-    case DocForms:
-    case DocScripts:
-    case DocAll:
-    case NodeChildren:
-    case TableTBodies:
-    case TSectionRows:
-    case TableRows:
-    case TRCells:
-    case SelectOptions:
-    case MapAreas:
-    case DocEmpty:
+    case CollectionType::ByTag:
+    case CollectionType::ByHTMLTag:
+    case CollectionType::AllDescendants:
+    case CollectionType::DocImages:
+    case CollectionType::DocEmbeds:
+    case CollectionType::DocForms:
+    case CollectionType::DocScripts:
+    case CollectionType::DocAll:
+    case CollectionType::NodeChildren:
+    case CollectionType::TableTBodies:
+    case CollectionType::TSectionRows:
+    case CollectionType::TableRows:
+    case CollectionType::TRCells:
+    case CollectionType::SelectOptions:
+    case CollectionType::MapAreas:
+    case CollectionType::DocEmpty:
         return DoNotInvalidateOnAttributeChanges;
-    case SelectedOptions:
-    case DataListOptions:
+    case CollectionType::SelectedOptions:
+    case CollectionType::DataListOptions:
         // FIXME: We can do better some day.
         return InvalidateOnAnyAttrChange;
-    case ByClass:
+    case CollectionType::ByClass:
         return InvalidateOnClassAttrChange;
-    case DocAnchors:
+    case CollectionType::DocAnchors:
         return InvalidateOnNameAttrChange;
-    case DocLinks:
+    case CollectionType::DocLinks:
         return InvalidateOnHRefAttrChange;
-    case WindowNamedItems:
-    case DocumentNamedItems:
-    case DocumentAllNamedItems:
+    case CollectionType::WindowNamedItems:
+    case CollectionType::DocumentNamedItems:
+    case CollectionType::DocumentAllNamedItems:
         return InvalidateOnIdNameAttrChange;
-    case FieldSetElements:
-    case FormControls:
+    case CollectionType::FieldSetElements:
+    case CollectionType::FormControls:
         return InvalidateForFormControls;
     }
     ASSERT_NOT_REACHED();
@@ -113,7 +113,7 @@ static NodeListInvalidationType invalidationTypeExcludingIdAndNameAttributes(Col
 }
 
 HTMLCollection::HTMLCollection(ContainerNode& ownerNode, CollectionType type)
-    : m_collectionType(type)
+    : m_collectionType(static_cast<unsigned>(type))
     , m_invalidationType(invalidationTypeExcludingIdAndNameAttributes(type))
     , m_rootType(rootTypeFromCollectionType(type))
     , m_ownerNode(ownerNode)
@@ -131,12 +131,12 @@ HTMLCollection::~HTMLCollection()
     // HTMLNameCollection & ClassCollection remove cache by themselves.
     // FIXME: We need a cleaner way to handle this.
     switch (type()) {
-    case ByClass:
-    case ByTag:
-    case ByHTMLTag:
-    case WindowNamedItems:
-    case DocumentNamedItems:
-    case DocumentAllNamedItems:
+    case CollectionType::ByClass:
+    case CollectionType::ByTag:
+    case CollectionType::ByHTMLTag:
+    case CollectionType::WindowNamedItems:
+    case CollectionType::DocumentNamedItems:
+    case CollectionType::DocumentAllNamedItems:
         break;
     default:
         ownerNode().nodeLists()->removeCachedCollection(this);
@@ -216,7 +216,7 @@ void HTMLCollection::updateNamedElementCache() const
         if (!is<HTMLElement>(element))
             continue;
         const AtomString& name = element.getNameAttribute();
-        if (!name.isEmpty() && id != name && (type() != DocAll || nameShouldBeVisibleInDocumentAll(downcast<HTMLElement>(element))))
+        if (!name.isEmpty() && id != name && (type() != CollectionType::DocAll || nameShouldBeVisibleInDocumentAll(downcast<HTMLElement>(element))))
             cache->appendToNameCache(name, element);
     }
 

--- a/Source/WebCore/html/HTMLDataListElement.cpp
+++ b/Source/WebCore/html/HTMLDataListElement.cpp
@@ -72,7 +72,7 @@ void HTMLDataListElement::didMoveToNewDocument(Document& oldDocument, Document& 
 
 Ref<HTMLCollection> HTMLDataListElement::options()
 {
-    return ensureRareData().ensureNodeLists().addCachedCollection<GenericCachedHTMLCollection<CollectionTypeTraits<DataListOptions>::traversalType>>(*this, DataListOptions);
+    return ensureRareData().ensureNodeLists().addCachedCollection<GenericCachedHTMLCollection<CollectionTypeTraits<CollectionType::DataListOptions>::traversalType>>(*this, CollectionType::DataListOptions);
 }
 
 void HTMLDataListElement::optionElementChildrenChanged()

--- a/Source/WebCore/html/HTMLFieldSetElement.cpp
+++ b/Source/WebCore/html/HTMLFieldSetElement.cpp
@@ -177,7 +177,7 @@ HTMLLegendElement* HTMLFieldSetElement::legend() const
 
 Ref<HTMLCollection> HTMLFieldSetElement::elements()
 {
-    return ensureRareData().ensureNodeLists().addCachedCollection<GenericCachedHTMLCollection<CollectionTypeTraits<FieldSetElements>::traversalType>>(*this, FieldSetElements);
+    return ensureRareData().ensureNodeLists().addCachedCollection<GenericCachedHTMLCollection<CollectionTypeTraits<CollectionType::FieldSetElements>::traversalType>>(*this, CollectionType::FieldSetElements);
 }
 
 void HTMLFieldSetElement::addInvalidDescendant(const HTMLElement& invalidFormControlElement)

--- a/Source/WebCore/html/HTMLFormControlsCollection.cpp
+++ b/Source/WebCore/html/HTMLFormControlsCollection.cpp
@@ -41,7 +41,7 @@ using namespace HTMLNames;
 WTF_MAKE_ISO_ALLOCATED_IMPL(HTMLFormControlsCollection);
 
 HTMLFormControlsCollection::HTMLFormControlsCollection(ContainerNode& ownerNode)
-    : CachedHTMLCollection(ownerNode, FormControls)
+    : CachedHTMLCollection(ownerNode, CollectionType::FormControls)
     , m_cachedElement(nullptr)
     , m_cachedElementOffsetInArray(0)
 {

--- a/Source/WebCore/html/HTMLFormControlsCollection.h
+++ b/Source/WebCore/html/HTMLFormControlsCollection.h
@@ -34,7 +34,7 @@ class HTMLImageElement;
 // This class is just a big hack to find form elements even in malformed HTML elements.
 // The famous <table><tr><form><td> problem.
 
-class HTMLFormControlsCollection final : public CachedHTMLCollection<HTMLFormControlsCollection, CollectionTypeTraits<FormControls>::traversalType> {
+class HTMLFormControlsCollection final : public CachedHTMLCollection<HTMLFormControlsCollection, CollectionTypeTraits<CollectionType::FormControls>::traversalType> {
     WTF_MAKE_ISO_ALLOCATED(HTMLFormControlsCollection);
 public:
     static Ref<HTMLFormControlsCollection> create(ContainerNode&, CollectionType);
@@ -60,4 +60,4 @@ private:
 
 } // namespace WebCore
 
-SPECIALIZE_TYPE_TRAITS_HTMLCOLLECTION(HTMLFormControlsCollection, FormControls)
+SPECIALIZE_TYPE_TRAITS_HTMLCOLLECTION(HTMLFormControlsCollection, CollectionType::FormControls)

--- a/Source/WebCore/html/HTMLFormElement.cpp
+++ b/Source/WebCore/html/HTMLFormElement.cpp
@@ -700,7 +700,7 @@ void HTMLFormElement::unregisterImgElement(HTMLImageElement& element)
 
 Ref<HTMLFormControlsCollection> HTMLFormElement::elements()
 {
-    return ensureRareData().ensureNodeLists().addCachedCollection<HTMLFormControlsCollection>(*this, FormControls);
+    return ensureRareData().ensureNodeLists().addCachedCollection<HTMLFormControlsCollection>(*this, CollectionType::FormControls);
 }
 
 Ref<HTMLCollection> HTMLFormElement::elementsForNativeBindings()

--- a/Source/WebCore/html/HTMLMapElement.cpp
+++ b/Source/WebCore/html/HTMLMapElement.cpp
@@ -111,7 +111,7 @@ void HTMLMapElement::attributeChanged(const QualifiedName& name, const AtomStrin
 
 Ref<HTMLCollection> HTMLMapElement::areas()
 {
-    return ensureRareData().ensureNodeLists().addCachedCollection<GenericCachedHTMLCollection<CollectionTypeTraits<MapAreas>::traversalType>>(*this, MapAreas);
+    return ensureRareData().ensureNodeLists().addCachedCollection<GenericCachedHTMLCollection<CollectionTypeTraits<CollectionType::MapAreas>::traversalType>>(*this, CollectionType::MapAreas);
 }
 
 Node::InsertedIntoAncestorResult HTMLMapElement::insertedIntoAncestor(InsertionType insertionType, ContainerNode& parentOfInsertedTree)

--- a/Source/WebCore/html/HTMLNameCollection.h
+++ b/Source/WebCore/html/HTMLNameCollection.h
@@ -71,7 +71,7 @@ private:
     WindowNameCollection(Document& document, CollectionType type, const AtomString& name)
         : HTMLNameCollection<WindowNameCollection, CollectionTraversalType::Descendants>(document, type, name)
     {
-        ASSERT(type == WindowNamedItems);
+        ASSERT(type == CollectionType::WindowNamedItems);
     }
 };
 
@@ -95,11 +95,11 @@ private:
     DocumentNameCollection(Document& document, CollectionType type, const AtomString& name)
         : HTMLNameCollection<DocumentNameCollection, CollectionTraversalType::Descendants>(document, type, name)
     {
-        ASSERT(type == DocumentNamedItems);
+        ASSERT(type == CollectionType::DocumentNamedItems);
     }
 };
 
 } // namespace WebCore
 
-SPECIALIZE_TYPE_TRAITS_HTMLCOLLECTION(WindowNameCollection, WindowNamedItems)
-SPECIALIZE_TYPE_TRAITS_HTMLCOLLECTION(DocumentNameCollection, DocumentNamedItems)
+SPECIALIZE_TYPE_TRAITS_HTMLCOLLECTION(WindowNameCollection, CollectionType::WindowNamedItems)
+SPECIALIZE_TYPE_TRAITS_HTMLCOLLECTION(DocumentNameCollection, CollectionType::DocumentNamedItems)

--- a/Source/WebCore/html/HTMLNameCollectionInlines.h
+++ b/Source/WebCore/html/HTMLNameCollectionInlines.h
@@ -34,7 +34,7 @@ namespace WebCore {
 template <typename HTMLCollectionClass, CollectionTraversalType traversalType>
 HTMLNameCollection<HTMLCollectionClass, traversalType>::~HTMLNameCollection()
 {
-    ASSERT(this->type() == WindowNamedItems || this->type() == DocumentNamedItems);
+    ASSERT(this->type() == CollectionType::WindowNamedItems || this->type() == CollectionType::DocumentNamedItems);
 
     document().nodeLists()->removeCachedCollection(this, m_name);
 }

--- a/Source/WebCore/html/HTMLOptionsCollection.cpp
+++ b/Source/WebCore/html/HTMLOptionsCollection.cpp
@@ -30,7 +30,7 @@ namespace WebCore {
 WTF_MAKE_ISO_ALLOCATED_IMPL(HTMLOptionsCollection);
 
 HTMLOptionsCollection::HTMLOptionsCollection(HTMLSelectElement& select)
-    : CachedHTMLCollection(select, SelectOptions)
+    : CachedHTMLCollection(select, CollectionType::SelectOptions)
 {
 }
 

--- a/Source/WebCore/html/HTMLOptionsCollection.h
+++ b/Source/WebCore/html/HTMLOptionsCollection.h
@@ -29,10 +29,10 @@
 
 namespace WebCore {
 
-class HTMLOptionsCollection final : public CachedHTMLCollection<HTMLOptionsCollection, CollectionTypeTraits<SelectOptions>::traversalType> {
+class HTMLOptionsCollection final : public CachedHTMLCollection<HTMLOptionsCollection, CollectionTypeTraits<CollectionType::SelectOptions>::traversalType> {
     WTF_MAKE_ISO_ALLOCATED_EXPORT(HTMLOptionsCollection, WEBCORE_EXPORT);
 public:
-    using Base = CachedHTMLCollection<HTMLOptionsCollection, CollectionTypeTraits<SelectOptions>::traversalType>;
+    using Base = CachedHTMLCollection<HTMLOptionsCollection, CollectionTypeTraits<CollectionType::SelectOptions>::traversalType>;
 
     static Ref<HTMLOptionsCollection> create(HTMLSelectElement&, CollectionType);
 
@@ -64,4 +64,4 @@ private:
 
 } // namespace WebCore
 
-SPECIALIZE_TYPE_TRAITS_HTMLCOLLECTION(HTMLOptionsCollection, SelectOptions)
+SPECIALIZE_TYPE_TRAITS_HTMLCOLLECTION(HTMLOptionsCollection, CollectionType::SelectOptions)

--- a/Source/WebCore/html/HTMLSelectElement.cpp
+++ b/Source/WebCore/html/HTMLSelectElement.cpp
@@ -368,12 +368,12 @@ bool HTMLSelectElement::childShouldCreateRenderer(const Node& child) const
 
 Ref<HTMLCollection> HTMLSelectElement::selectedOptions()
 {
-    return ensureRareData().ensureNodeLists().addCachedCollection<GenericCachedHTMLCollection<CollectionTypeTraits<SelectedOptions>::traversalType>>(*this, SelectedOptions);
+    return ensureRareData().ensureNodeLists().addCachedCollection<GenericCachedHTMLCollection<CollectionTypeTraits<CollectionType::SelectedOptions>::traversalType>>(*this, CollectionType::SelectedOptions);
 }
 
 Ref<HTMLOptionsCollection> HTMLSelectElement::options()
 {
-    return ensureRareData().ensureNodeLists().addCachedCollection<HTMLOptionsCollection>(*this, SelectOptions);
+    return ensureRareData().ensureNodeLists().addCachedCollection<HTMLOptionsCollection>(*this, CollectionType::SelectOptions);
 }
 
 void HTMLSelectElement::updateListItemSelectedStates(AllowStyleInvalidation allowStyleInvalidation)
@@ -786,7 +786,7 @@ const Vector<WeakPtr<HTMLElement, WeakPtrImplWithEventTargetData>>& HTMLSelectEl
 
 void HTMLSelectElement::invalidateSelectedItems()
 {
-    if (HTMLCollection* collection = cachedHTMLCollection(SelectedOptions))
+    if (HTMLCollection* collection = cachedHTMLCollection(CollectionType::SelectedOptions))
         collection->invalidateCache();
 }
 
@@ -798,7 +798,7 @@ void HTMLSelectElement::setRecalcListItems()
     setOptionsChangedOnRenderer();
     invalidateStyleForSubtree();
     if (!isConnected()) {
-        if (HTMLCollection* collection = cachedHTMLCollection(SelectOptions))
+        if (HTMLCollection* collection = cachedHTMLCollection(CollectionType::SelectOptions))
             collection->invalidateCache();
     }
     if (!isConnected())

--- a/Source/WebCore/html/HTMLTableElement.cpp
+++ b/Source/WebCore/html/HTMLTableElement.cpp
@@ -588,12 +588,12 @@ bool HTMLTableElement::isURLAttribute(const Attribute& attribute) const
 
 Ref<HTMLCollection> HTMLTableElement::rows()
 {
-    return ensureRareData().ensureNodeLists().addCachedCollection<HTMLTableRowsCollection>(*this, TableRows);
+    return ensureRareData().ensureNodeLists().addCachedCollection<HTMLTableRowsCollection>(*this, CollectionType::TableRows);
 }
 
 Ref<HTMLCollection> HTMLTableElement::tBodies()
 {
-    return ensureRareData().ensureNodeLists().addCachedCollection<GenericCachedHTMLCollection<CollectionTypeTraits<TableTBodies>::traversalType>>(*this, TableTBodies);
+    return ensureRareData().ensureNodeLists().addCachedCollection<GenericCachedHTMLCollection<CollectionTypeTraits<CollectionType::TableTBodies>::traversalType>>(*this, CollectionType::TableTBodies);
 }
 
 const AtomString& HTMLTableElement::rules() const

--- a/Source/WebCore/html/HTMLTableRowElement.cpp
+++ b/Source/WebCore/html/HTMLTableRowElement.cpp
@@ -146,7 +146,7 @@ ExceptionOr<void> HTMLTableRowElement::deleteCell(int index)
 
 Ref<HTMLCollection> HTMLTableRowElement::cells()
 {
-    return ensureRareData().ensureNodeLists().addCachedCollection<GenericCachedHTMLCollection<CollectionTypeTraits<TRCells>::traversalType>>(*this, TRCells);
+    return ensureRareData().ensureNodeLists().addCachedCollection<GenericCachedHTMLCollection<CollectionTypeTraits<CollectionType::TRCells>::traversalType>>(*this, CollectionType::TRCells);
 }
 
 }

--- a/Source/WebCore/html/HTMLTableRowsCollection.cpp
+++ b/Source/WebCore/html/HTMLTableRowsCollection.cpp
@@ -154,13 +154,13 @@ HTMLTableRowElement* HTMLTableRowsCollection::lastRow(HTMLTableElement& table)
 }
 
 HTMLTableRowsCollection::HTMLTableRowsCollection(HTMLTableElement& table)
-    : CachedHTMLCollection(table, TableRows)
+    : CachedHTMLCollection(table, CollectionType::TableRows)
 {
 }
 
 Ref<HTMLTableRowsCollection> HTMLTableRowsCollection::create(HTMLTableElement& table, CollectionType type)
 {
-    ASSERT_UNUSED(type, type == TableRows);
+    ASSERT_UNUSED(type, type == CollectionType::TableRows);
     return adoptRef(*new HTMLTableRowsCollection(table));
 }
 

--- a/Source/WebCore/html/HTMLTableRowsCollection.h
+++ b/Source/WebCore/html/HTMLTableRowsCollection.h
@@ -35,7 +35,7 @@ namespace WebCore {
 
 class HTMLTableRowElement;
 
-class HTMLTableRowsCollection final : public CachedHTMLCollection<HTMLTableRowsCollection, CollectionTypeTraits<TableRows>::traversalType> {
+class HTMLTableRowsCollection final : public CachedHTMLCollection<HTMLTableRowsCollection, CollectionTypeTraits<CollectionType::TableRows>::traversalType> {
     WTF_MAKE_ISO_ALLOCATED(HTMLTableRowsCollection);
 public:
     static Ref<HTMLTableRowsCollection> create(HTMLTableElement&, CollectionType);
@@ -55,4 +55,4 @@ private:
 
 } // namespace WebCore
 
-SPECIALIZE_TYPE_TRAITS_HTMLCOLLECTION(HTMLTableRowsCollection, TableRows)
+SPECIALIZE_TYPE_TRAITS_HTMLCOLLECTION(HTMLTableRowsCollection, CollectionType::TableRows)

--- a/Source/WebCore/html/HTMLTableSectionElement.cpp
+++ b/Source/WebCore/html/HTMLTableSectionElement.cpp
@@ -100,7 +100,7 @@ int HTMLTableSectionElement::numRows() const
 
 Ref<HTMLCollection> HTMLTableSectionElement::rows()
 {
-    return ensureRareData().ensureNodeLists().addCachedCollection<GenericCachedHTMLCollection<CollectionTypeTraits<TSectionRows>::traversalType>>(*this, TSectionRows);
+    return ensureRareData().ensureNodeLists().addCachedCollection<GenericCachedHTMLCollection<CollectionTypeTraits<CollectionType::TSectionRows>::traversalType>>(*this, CollectionType::TSectionRows);
 }
 
 }

--- a/Source/WebKitLegacy/mac/DOM/DOMHTML.mm
+++ b/Source/WebKitLegacy/mac/DOM/DOMHTML.mm
@@ -295,7 +295,7 @@ static WebAutocapitalizeType webAutocapitalizeType(WebCore::AutocapitalizeType t
 
 Class kitClass(WebCore::HTMLCollection* collection)
 {
-    if (collection->type() == WebCore::SelectOptions)
+    if (collection->type() == WebCore::CollectionType::SelectOptions)
         return [DOMHTMLOptionsCollection class];
     return [DOMHTMLCollection class];
 }


### PR DESCRIPTION
#### 8efe93387102c06cb10d329f5bf6d01abccdb5b0
<pre>
CollectionType should be an enum class
<a href="https://bugs.webkit.org/show_bug.cgi?id=256504">https://bugs.webkit.org/show_bug.cgi?id=256504</a>

Reviewed by Chris Dumez.

* Source/WebCore/bindings/js/JSHTMLCollectionCustom.cpp:
(WebCore::toJSNewlyCreated):
* Source/WebCore/dom/AllDescendantsCollection.h:
(WebCore::AllDescendantsCollection::create):
* Source/WebCore/dom/ClassCollection.cpp:
(WebCore::ClassCollection::create):
* Source/WebCore/dom/ClassCollection.h:
* Source/WebCore/dom/ContainerNode.cpp:
(WebCore::ContainerNode::getElementsByTagName):
(WebCore::ContainerNode::getElementsByClassName):
(WebCore::ContainerNode::children):
* Source/WebCore/dom/Document.cpp:
(WebCore::Document::images):
(WebCore::Document::applets):
(WebCore::Document::embeds):
(WebCore::Document::plugins):
(WebCore::Document::scripts):
(WebCore::Document::links):
(WebCore::Document::forms):
(WebCore::Document::anchors):
(WebCore::Document::all):
(WebCore::Document::allFilteredByName):
(WebCore::Document::windowNamedItems):
(WebCore::Document::documentNamedItems):
* Source/WebCore/dom/Document.h:
* Source/WebCore/dom/NodeRareData.h:
(WebCore::NodeListsNodeData::namedCollectionKey):
* Source/WebCore/dom/TagCollection.cpp:
(WebCore::TagCollectionNS::TagCollectionNS):
(WebCore::TagCollection::TagCollection):
(WebCore::HTMLTagCollection::HTMLTagCollection):
* Source/WebCore/dom/TagCollection.h:
* Source/WebCore/html/CachedHTMLCollectionInlines.h:
(WebCore::traversalType&gt;::namedItem const):
* Source/WebCore/html/CollectionType.h:
(): Deleted.
* Source/WebCore/html/GenericCachedHTMLCollection.cpp:
(WebCore::GenericCachedHTMLCollection&lt;traversalType&gt;::elementMatches const):
* Source/WebCore/html/HTMLAllCollection.cpp:
(WebCore::HTMLAllNamedSubCollection::HTMLAllNamedSubCollection):
* Source/WebCore/html/HTMLAllCollection.h:
* Source/WebCore/html/HTMLCollection.cpp:
(WebCore::HTMLCollection::rootTypeFromCollectionType):
(WebCore::invalidationTypeExcludingIdAndNameAttributes):
(WebCore::HTMLCollection::HTMLCollection):
(WebCore::HTMLCollection::~HTMLCollection):
(WebCore::HTMLCollection::updateNamedElementCache const):
* Source/WebCore/html/HTMLDataListElement.cpp:
(WebCore::HTMLDataListElement::options):
* Source/WebCore/html/HTMLFieldSetElement.cpp:
(WebCore::HTMLFieldSetElement::elements):
* Source/WebCore/html/HTMLFormControlsCollection.cpp:
(WebCore::HTMLFormControlsCollection::HTMLFormControlsCollection):
* Source/WebCore/html/HTMLFormControlsCollection.h:
* Source/WebCore/html/HTMLFormElement.cpp:
(WebCore::HTMLFormElement::elements):
* Source/WebCore/html/HTMLMapElement.cpp:
(WebCore::HTMLMapElement::areas):
* Source/WebCore/html/HTMLNameCollection.h:
* Source/WebCore/html/HTMLNameCollectionInlines.h:
(WebCore::traversalType&gt;::~HTMLNameCollection):
* Source/WebCore/html/HTMLOptionsCollection.cpp:
(WebCore::HTMLOptionsCollection::HTMLOptionsCollection):
* Source/WebCore/html/HTMLOptionsCollection.h:
* Source/WebCore/html/HTMLSelectElement.cpp:
(WebCore::HTMLSelectElement::selectedOptions):
(WebCore::HTMLSelectElement::options):
(WebCore::HTMLSelectElement::invalidateSelectedItems):
(WebCore::HTMLSelectElement::setRecalcListItems):
* Source/WebCore/html/HTMLTableElement.cpp:
(WebCore::HTMLTableElement::rows):
(WebCore::HTMLTableElement::tBodies):
* Source/WebCore/html/HTMLTableRowElement.cpp:
(WebCore::HTMLTableRowElement::cells):
* Source/WebCore/html/HTMLTableRowsCollection.cpp:
(WebCore::HTMLTableRowsCollection::HTMLTableRowsCollection):
(WebCore::HTMLTableRowsCollection::create):
* Source/WebCore/html/HTMLTableRowsCollection.h:
* Source/WebCore/html/HTMLTableSectionElement.cpp:
(WebCore::HTMLTableSectionElement::rows):
* Source/WebKitLegacy/mac/DOM/DOMHTML.mm:
(kitClass):

Canonical link: <a href="https://commits.webkit.org/263894@main">https://commits.webkit.org/263894@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/18b765cc46a7220bf00aeb5d329910d9abd2940d

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/5903 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/6076 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/6263 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/7455 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/6266 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/5900 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/6295 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/6037 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/8678 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/6011 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/6049 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/5346 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/7513 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/3526 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/5322 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/13261 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/5391 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/5400 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/7610 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/5849 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/4794 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/5282 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/9406 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/705 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/5643 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->