### PR TITLE
[macOS] Allow WebKitAdditions to modify MiniBrowser entitlements

### DIFF
--- a/Tools/MiniBrowser/Configurations/MiniBrowser.xcconfig
+++ b/Tools/MiniBrowser/Configurations/MiniBrowser.xcconfig
@@ -22,7 +22,6 @@
 // OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE. 
 
 PRODUCT_NAME = MiniBrowser
-CODE_SIGN_ENTITLEMENTS = MiniBrowser.entitlements;
 PRODUCT_BUNDLE_IDENTIFIER = org.webkit.$(PRODUCT_NAME:rfc1034identifier)
 GCC_PREFIX_HEADER = mac/MiniBrowser_Prefix.pch
 INFOPLIST_FILE = mac/Info.plist
@@ -31,3 +30,9 @@ EXCLUDED_SOURCE_FILE_NAMES[sdk=macosx*] = $(EXCLUDED_SOURCE_FILE_NAMES_$(WK_PLAT
 EXCLUDED_SOURCE_FILE_NAMES_maccatalyst = *
 OTHER_LDFLAGS[sdk=macosx*] = $(inherited) -framework Cocoa -framework UniformTypeIdentifiers -framework WebKit
 STRIP_STYLE = debugging;
+
+WK_PROCESSED_XCENT_FILE = $(TEMP_FILE_DIR)/$(FULL_PRODUCT_NAME).entitlements;
+
+// The use of CODE_SIGN_ENTITLEMENTS leads to a circular build dependency.
+CODE_SIGN_INJECT_BASE_ENTITLEMENTS[sdk=macosx*] = NO;
+OTHER_CODE_SIGN_FLAGS[sdk=macosx*] = --entitlements $(WK_PROCESSED_XCENT_FILE);

--- a/Tools/MiniBrowser/MiniBrowser.xcodeproj/project.pbxproj
+++ b/Tools/MiniBrowser/MiniBrowser.xcodeproj/project.pbxproj
@@ -62,6 +62,7 @@
 		2DC37341198B62D300EC33E9 /* SettingsController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = SettingsController.h; path = mac/SettingsController.h; sourceTree = "<group>"; };
 		2DC37342198B62D300EC33E9 /* SettingsController.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = SettingsController.m; path = mac/SettingsController.m; sourceTree = "<group>"; };
 		37BAF90620218053000EA879 /* MiniBrowser.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = MiniBrowser.entitlements; sourceTree = "<group>"; };
+		3A4EE1382A09DAD800D16301 /* process-minibrowser-entitlements.sh */ = {isa = PBXFileReference; lastKnownFileType = text.script.sh; path = "process-minibrowser-entitlements.sh"; sourceTree = "<group>"; };
 		51E244F811EFCE07008228D1 /* MBToolbarItem.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MBToolbarItem.h; sourceTree = "<group>"; };
 		51E244F911EFCE07008228D1 /* MBToolbarItem.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = MBToolbarItem.m; sourceTree = "<group>"; };
 		5C9332AE24C1349C0036DECE /* SecurityInterface.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = SecurityInterface.framework; path = System/Library/Frameworks/SecurityInterface.framework; sourceTree = SDKROOT; };
@@ -142,6 +143,7 @@
 				256AC3F00F4B6AF500CF3369 /* MiniBrowser_Prefix.pch */,
 				080E96DDFE201D6D7F000001 /* MiniBrowser */,
 				29B97317FDCFA39411CA2CEA /* Resources */,
+				3A4EE1362A09DAD800D16301 /* Scripts */,
 				BCA8CBDA11E5787800812FB7 /* Configurations */,
 				29B97323FDCFA39411CA2CEA /* Frameworks */,
 				19C28FACFE9D520D11CA2CBB /* Products */,
@@ -171,6 +173,14 @@
 			name = Frameworks;
 			sourceTree = "<group>";
 		};
+		3A4EE1362A09DAD800D16301 /* Scripts */ = {
+			isa = PBXGroup;
+			children = (
+				3A4EE1382A09DAD800D16301 /* process-minibrowser-entitlements.sh */,
+			);
+			path = Scripts;
+			sourceTree = "<group>";
+		};
 		BCA8CBDA11E5787800812FB7 /* Configurations */ = {
 			isa = PBXGroup;
 			children = (
@@ -189,6 +199,7 @@
 			buildConfigurationList = C01FCF4A08A954540054247B /* Build configuration list for PBXNativeTarget "MiniBrowser" */;
 			buildPhases = (
 				8D1107290486CEB800E47090 /* Resources */,
+				3A4EE1342A09DA5F00D16301 /* Process MiniBrowser entitlements */,
 				8D11072C0486CEB800E47090 /* Sources */,
 				8D11072E0486CEB800E47090 /* Frameworks */,
 			);
@@ -249,6 +260,29 @@
 			runOnlyForDeploymentPostprocessing = 0;
 		};
 /* End PBXResourcesBuildPhase section */
+
+/* Begin PBXShellScriptBuildPhase section */
+		3A4EE1342A09DA5F00D16301 /* Process MiniBrowser entitlements */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+			);
+			inputPaths = (
+				"$(SRCROOT)/MiniBrowser.entitlements",
+			);
+			name = "Process MiniBrowser entitlements";
+			outputFileListPaths = (
+			);
+			outputPaths = (
+				"$(WK_PROCESSED_XCENT_FILE)",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "Scripts/process-minibrowser-entitlements.sh\n";
+		};
+/* End PBXShellScriptBuildPhase section */
 
 /* Begin PBXSourcesBuildPhase section */
 		8D11072C0486CEB800E47090 /* Sources */ = {

--- a/Tools/MiniBrowser/Scripts/process-minibrowser-entitlements.sh
+++ b/Tools/MiniBrowser/Scripts/process-minibrowser-entitlements.sh
@@ -1,0 +1,46 @@
+#!/bin/bash
+set -e
+
+function plistbuddy()
+{
+    /usr/libexec/PlistBuddy -c "$*" "${WK_PROCESSED_XCENT_FILE}"
+}
+
+# ========================================
+# Mac entitlements
+# ========================================
+
+function mac_process_minibrowser_entitlements()
+{
+    # Start with the template entitlements from MiniBrowser.entitlements
+    plistbuddy Merge "${SCRIPT_INPUT_FILE_0}"
+}
+
+rm -f "${WK_PROCESSED_XCENT_FILE}"
+plistbuddy Clear dict
+
+if [[ "${WK_PLATFORM_NAME}" == macosx ]]
+then
+    if [[ "${PRODUCT_NAME}" == MiniBrowser ]]; then mac_process_minibrowser_entitlements
+    else echo "Unsupported/unknown product: ${PRODUCT_NAME}"
+    fi
+else
+    echo "Unsupported/unknown platform: ${WK_PLATFORM_NAME}"
+fi
+
+function process_additional_entitlements()
+{
+    local ENTITLEMENTS_SCRIPT=$1
+    shift
+    for PREFIX in "${@}"; do
+        if [[ -f "${PREFIX}/${ENTITLEMENTS_SCRIPT}" ]]; then
+            source "${PREFIX}/${ENTITLEMENTS_SCRIPT}"
+            break
+        fi
+    done
+}
+
+ADDITIONAL_ENTITLEMENTS_SCRIPT=usr/local/include/WebKitAdditions/Scripts/process-additional-entitlements.sh
+process_additional_entitlements "${ADDITIONAL_ENTITLEMENTS_SCRIPT}" "${BUILT_PRODUCTS_DIR}" "${SDKROOT}"
+
+exit 0


### PR DESCRIPTION
#### 65be517acc45895cd231fe078b2950324b59ab70
<pre>
[macOS] Allow WebKitAdditions to modify MiniBrowser entitlements
<a href="https://bugs.webkit.org/show_bug.cgi?id=256505">https://bugs.webkit.org/show_bug.cgi?id=256505</a>
rdar://109074823

Reviewed by NOBODY (OOPS!).

This change adds the infrastructure to allow WebKitAdditions to modify
MiniBrowser.entitlements.

Based upon WebKit/Scripts/process-entitlements.sh,
process-minibrowser-entitlement.sh is a new build step that copies
MiniBrowser/MiniBrowser.entitlement to a build temporary location before running
process-additional-entitlement.sh, which can adjust entitlements as needed.

* Tools/MiniBrowser/Configurations/MiniBrowser.xcconfig:
* Tools/MiniBrowser/MiniBrowser.xcodeproj/project.pbxproj:
* Tools/MiniBrowser/Scripts/process-minibrowser-entitlements.sh: Added.
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/65be517acc45895cd231fe078b2950324b59ab70

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/5896 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/6068 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/6255 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/7447 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/6261 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/5893 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/6287 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/6029 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/8582 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/6004 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/6041 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/5339 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/7519 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/3518 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/5315 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/13263 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/5383 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/5393 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/7614 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/5842 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/4788 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/5275 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/9399 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/5636 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->