### PR TITLE
[UI-side compositing ]Scrolling carousel on shopping.google.com triggers history swipe

### DIFF
--- a/LayoutTests/swipe/swipe-back-with-active-wheel-listener-and-scroller-expected.txt
+++ b/LayoutTests/swipe/swipe-back-with-active-wheel-listener-and-scroller-expected.txt
@@ -1,0 +1,4 @@
+This test should not start a swipe, and instead scroll the horizontal overflow.
+startSlowSwipeGesture
+completeSwipeGesture
+

--- a/LayoutTests/swipe/swipe-back-with-active-wheel-listener-and-scroller.html
+++ b/LayoutTests/swipe/swipe-back-with-active-wheel-listener-and-scroller.html
@@ -1,0 +1,99 @@
+<!-- webkit-test-runner [ UsesBackForwardCache=true ] -->
+<head>
+<style>
+    body, html {
+        height: 100%;
+    }
+    #swipeTarget {
+        position: absolute;
+        inset: 100px;
+        border: 1px solid black;
+        padding: 20px;
+    }
+    #scroller {
+        overflow-x: scroll;
+        width: 500px;
+        height: 300px;
+        border: 1px solid blue;
+    }
+    .contents {
+        width: 500%;
+    }
+</style>
+<script src="../resources/ui-helper.js"></script>
+<script src="resources/swipe-test.js"></script>
+<script>
+    var logElement;
+    function didBeginSwipeCallback()
+    {
+        log("didBeginSwipe");
+
+        completeSwipeGesture();
+    }
+
+    function willEndSwipeCallback()
+    {
+        log("willEndSwipe");
+
+        shouldBe(false, isFirstPage(), "The swipe should not yet have navigated away from the second page.");
+    }
+
+    function didEndSwipeCallback()
+    {
+        log("didEndSwipe");
+
+        testComplete(logElement);
+    }
+
+    function isFirstPage()
+    {
+        return window.location.href.indexOf("second") == -1;
+    }
+
+    window.onload = async function () {
+        logElement = document.getElementById('console');
+        logElement.innerHTML = isFirstPage() ? "first" : "second";
+
+        if (isFirstPage()) {
+            setTimeout(function () { 
+                window.location.href = window.location.href + "?second";
+            }, 0);
+
+            if (!window.eventSender || !window.testRunner)
+                return;
+
+            initializeSwipeTest();
+        
+            testRunner.installDidBeginSwipeCallback(didBeginSwipeCallback);
+            testRunner.installWillEndSwipeCallback(willEndSwipeCallback);
+            testRunner.installDidEndSwipeCallback(didEndSwipeCallback);
+
+            testRunner.dumpAsText();
+            testRunner.waitUntilDone();
+
+            return;
+        }
+        
+        const scroller = document.getElementById('scroller');
+        scroller.scrollLeft = 500;
+
+        const swipeTarget = document.getElementById('swipeTarget');
+        swipeTarget.addEventListener('wheel', () => { }, { passive: false });
+
+        await startSlowSwipeGesture();
+        await completeSwipeGesture();
+
+        testComplete(logElement);
+    };
+</script>
+</head>
+<body>
+    <div id="swipeTarget">
+        <div id="scroller">
+            <div class="contents">
+                This test should not start a swipe, and instead scroll the horizontal overflow.
+            </div>
+        </div>
+    </div>
+    <div id="console">This test must be run in WebKitTestRunner.</div>
+</body>

--- a/LayoutTests/swipe/swipe-back-with-passive-wheel-listener-and-scroller-expected.txt
+++ b/LayoutTests/swipe/swipe-back-with-passive-wheel-listener-and-scroller-expected.txt
@@ -1,0 +1,4 @@
+This test should not start a swipe, and instead scroll the horizontal overflow.
+startSlowSwipeGesture
+completeSwipeGesture
+

--- a/LayoutTests/swipe/swipe-back-with-passive-wheel-listener-and-scroller.html
+++ b/LayoutTests/swipe/swipe-back-with-passive-wheel-listener-and-scroller.html
@@ -1,0 +1,99 @@
+<!-- webkit-test-runner [ UsesBackForwardCache=true ] -->
+<head>
+<style>
+    body, html {
+        height: 100%;
+    }
+    #swipeTarget {
+        position: absolute;
+        inset: 100px;
+        border: 1px solid black;
+        padding: 20px;
+    }
+    #scroller {
+        overflow-x: scroll;
+        width: 500px;
+        height: 300px;
+        border: 1px solid blue;
+    }
+    .contents {
+        width: 500%;
+    }
+</style>
+<script src="../resources/ui-helper.js"></script>
+<script src="resources/swipe-test.js"></script>
+<script>
+    var logElement;
+    function didBeginSwipeCallback()
+    {
+        log("didBeginSwipe");
+
+        completeSwipeGesture();
+    }
+
+    function willEndSwipeCallback()
+    {
+        log("willEndSwipe");
+
+        shouldBe(false, isFirstPage(), "The swipe should not yet have navigated away from the second page.");
+    }
+
+    function didEndSwipeCallback()
+    {
+        log("didEndSwipe");
+
+        testComplete(logElement);
+    }
+
+    function isFirstPage()
+    {
+        return window.location.href.indexOf("second") == -1;
+    }
+
+    window.onload = async function () {
+        logElement = document.getElementById('console');
+        logElement.innerHTML = isFirstPage() ? "first" : "second";
+
+        if (isFirstPage()) {
+            setTimeout(function () { 
+                window.location.href = window.location.href + "?second";
+            }, 0);
+
+            if (!window.eventSender || !window.testRunner)
+                return;
+
+            initializeSwipeTest();
+        
+            testRunner.installDidBeginSwipeCallback(didBeginSwipeCallback);
+            testRunner.installWillEndSwipeCallback(willEndSwipeCallback);
+            testRunner.installDidEndSwipeCallback(didEndSwipeCallback);
+
+            testRunner.dumpAsText();
+            testRunner.waitUntilDone();
+
+            return;
+        }
+        
+        const scroller = document.getElementById('scroller');
+        scroller.scrollLeft = 500;
+
+        const swipeTarget = document.getElementById('swipeTarget');
+        swipeTarget.addEventListener('wheel', () => { }, { passive: true });
+
+        await startSlowSwipeGesture();
+        await completeSwipeGesture();
+
+        testComplete(logElement);
+    };
+</script>
+</head>
+<body>
+    <div id="swipeTarget">
+        <div id="scroller">
+            <div class="contents">
+                This test should not start a swipe, and instead scroll the horizontal overflow.
+            </div>
+        </div>
+    </div>
+    <div id="console">This test must be run in WebKitTestRunner.</div>
+</body>

--- a/Source/WebKit/UIProcess/RemoteLayerTree/RemoteScrollingTree.h
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/RemoteScrollingTree.h
@@ -28,6 +28,7 @@
 #if ENABLE(UI_SIDE_COMPOSITING)
 
 #include <WebCore/ScrollingConstraints.h>
+#include <WebCore/ScrollingCoordinatorTypes.h>
 #include <WebCore/ScrollingTree.h>
 #include <WebCore/WheelEventTestMonitor.h>
 #include <wtf/WeakPtr.h>
@@ -53,7 +54,7 @@ public:
 
     virtual void willSendEventForDefaultHandling(const WebCore::PlatformWheelEvent&) { }
     virtual void waitForEventDefaultHandlingCompletion(const WebCore::PlatformWheelEvent&) { }
-    virtual void wheelEventDefaultHandlingCompleted(const WebCore::PlatformWheelEvent&, WebCore::ScrollingNodeID, std::optional<WebCore::WheelScrollGestureState>) { }
+    virtual WebCore::WheelEventHandlingResult handleWheelEventAfterDefaultHandling(const WebCore::PlatformWheelEvent&, WebCore::ScrollingNodeID, std::optional<WebCore::WheelScrollGestureState>) { return WebCore::WheelEventHandlingResult::unhandled(); }
 
     RemoteScrollingCoordinatorProxy* scrollingCoordinatorProxy() const;
 

--- a/Source/WebKit/UIProcess/RemoteLayerTree/mac/RemoteLayerTreeEventDispatcher.cpp
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/mac/RemoteLayerTreeEventDispatcher.cpp
@@ -269,23 +269,26 @@ WheelEventHandlingResult RemoteLayerTreeEventDispatcher::internalHandleWheelEven
     scrollingTree->willProcessWheelEvent();
 
     auto filteredEvent = filteredWheelEvent(wheelEvent);
-    auto result = scrollingTree->handleWheelEvent(filteredEvent, processingSteps);
-
-    return result;
+    return scrollingTree->handleWheelEvent(filteredEvent, processingSteps);
 }
 
 void RemoteLayerTreeEventDispatcher::wheelEventHandlingCompleted(const PlatformWheelEvent& wheelEvent, ScrollingNodeID scrollingNodeID, std::optional<WheelScrollGestureState> gestureState)
 {
     ASSERT(isMainRunLoop());
 
-    LOG_WITH_STREAM(Scrolling, stream << "RemoteLayerTreeEventDispatcher::wheelEventHandlingCompleted " << wheelEvent << " - sending event to scrolling thread, node " << 0 << " gestureState " << gestureState);
+    LOG_WITH_STREAM(WheelEvents, stream << "RemoteLayerTreeEventDispatcher::wheelEventHandlingCompleted " << wheelEvent << " - sending event to scrolling thread, node " << 0 << " gestureState " << gestureState);
 
     ScrollingThread::dispatch([protectedThis = Ref { *this }, wheelEvent, scrollingNodeID, gestureState] {
         auto scrollingTree = protectedThis->scrollingTree();
         if (!scrollingTree)
             return;
 
-        scrollingTree->wheelEventDefaultHandlingCompleted(wheelEvent, scrollingNodeID, gestureState);
+        auto result = scrollingTree->handleWheelEventAfterDefaultHandling(wheelEvent, scrollingNodeID, gestureState);
+        RunLoop::main().dispatch([protectedThis, result]() {
+            if (auto* scrollingCoordinator = protectedThis->scrollingCoordinator())
+                scrollingCoordinator->webPageProxy().wheelEventHandlingCompleted(result.wasHandled);
+        });
+
     });
 }
 

--- a/Source/WebKit/UIProcess/RemoteLayerTree/mac/RemoteLayerTreeEventDispatcher.h
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/mac/RemoteLayerTreeEventDispatcher.h
@@ -91,6 +91,8 @@ private:
 
     WebCore::PlatformWheelEvent filteredWheelEvent(const WebCore::PlatformWheelEvent&);
 
+    RemoteScrollingCoordinatorProxyMac* scrollingCoordinator() const { return m_scrollingCoordinator.get(); }
+
     void wheelEventHysteresisUpdated(PAL::HysteresisState);
 
     void willHandleWheelEvent(const WebWheelEvent&);

--- a/Source/WebKit/UIProcess/RemoteLayerTree/mac/RemoteScrollingTreeMac.h
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/mac/RemoteScrollingTreeMac.h
@@ -69,7 +69,7 @@ private:
     // "Default handling" here refers to sending the event to the web process for synchronous scrolling, and DOM event handling.
     void willSendEventForDefaultHandling(const WebCore::PlatformWheelEvent&) override;
     void waitForEventDefaultHandlingCompletion(const WebCore::PlatformWheelEvent&) override;
-    void wheelEventDefaultHandlingCompleted(const WebCore::PlatformWheelEvent&, WebCore::ScrollingNodeID, std::optional<WebCore::WheelScrollGestureState>) override;
+    WheelEventHandlingResult handleWheelEventAfterDefaultHandling(const WebCore::PlatformWheelEvent&, WebCore::ScrollingNodeID, std::optional<WebCore::WheelScrollGestureState>) override;
 
     void deferWheelEventTestCompletionForReason(WebCore::ScrollingNodeID, WebCore::WheelEventTestMonitor::DeferReason) override;
     void removeWheelEventTestCompletionDeferralForReason(WebCore::ScrollingNodeID, WebCore::WheelEventTestMonitor::DeferReason) override;

--- a/Source/WebKit/UIProcess/RemoteLayerTree/mac/RemoteScrollingTreeMac.mm
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/mac/RemoteScrollingTreeMac.mm
@@ -294,9 +294,9 @@ void RemoteScrollingTreeMac::waitForEventDefaultHandlingCompletion(const Platfor
     LOG_WITH_STREAM(Scrolling, stream << "RemoteScrollingTreeMac::waitForEventDefaultHandlingCompletion took " << (MonotonicTime::now() - startTime).milliseconds() << "ms - timed out " << !receivedEvent << " gesture state is " << gestureState());
 }
 
-void RemoteScrollingTreeMac::wheelEventDefaultHandlingCompleted(const PlatformWheelEvent& wheelEvent, ScrollingNodeID targetNodeID, std::optional<WheelScrollGestureState> gestureState)
+WheelEventHandlingResult RemoteScrollingTreeMac::handleWheelEventAfterDefaultHandling(const PlatformWheelEvent& wheelEvent, ScrollingNodeID targetNodeID, std::optional<WheelScrollGestureState> gestureState)
 {
-    LOG_WITH_STREAM(Scrolling, stream << "RemoteScrollingTreeMac::wheelEventDefaultHandlingCompleted - targetNodeID " << targetNodeID << " gestureState " << gestureState);
+    LOG_WITH_STREAM(Scrolling, stream << "RemoteScrollingTreeMac::handleWheelEventAfterDefaultHandling - targetNodeID " << targetNodeID << " gestureState " << gestureState);
 
     ASSERT(ScrollingThread::isCurrentThread());
     
@@ -318,7 +318,7 @@ void RemoteScrollingTreeMac::wheelEventDefaultHandlingCompleted(const PlatformWh
 
     SetForScope disallowLatchingScope(m_allowLatching, allowLatching);
     RefPtr<ScrollingTreeNode> targetNode = nodeForID(targetNodeID);
-    handleWheelEventWithNode(wheelEvent, processingSteps, targetNode.get(), EventTargeting::NodeOnly);
+    return handleWheelEventWithNode(wheelEvent, processingSteps, targetNode.get(), EventTargeting::NodeOnly);
 }
 
 void RemoteScrollingTreeMac::deferWheelEventTestCompletionForReason(ScrollingNodeID nodeID, WheelEventTestMonitor::DeferReason reason)

--- a/Source/WebKit/UIProcess/WebPageProxy.h
+++ b/Source/WebKit/UIProcess/WebPageProxy.h
@@ -184,6 +184,7 @@ enum class TextGranularity : uint8_t;
 enum class TrackingType : uint8_t;
 enum class UserInterfaceLayoutDirection : bool;
 enum class WheelEventProcessingSteps : uint8_t;
+enum class WheelScrollGestureState : uint8_t;
 enum class WillContinueLoading : bool;
 enum class WillInternallyHandleFailure : bool;
 enum class WritingDirection : uint8_t;
@@ -1101,6 +1102,7 @@ public:
     bool isProcessingWheelEvents() const;
     void handleNativeWheelEvent(const NativeWebWheelEvent&);
     void continueWheelEventHandling(const WebWheelEvent&, const WebCore::WheelEventHandlingResult&, std::optional<bool> willStartSwipe);
+    void wheelEventHandlingCompleted(bool wasHandled);
 
     bool isProcessingKeyboardEvents() const;
     bool handleKeyboardEvent(const NativeWebKeyboardEvent&);
@@ -2630,9 +2632,8 @@ private:
     void setRenderTreeSize(uint64_t treeSize) { m_renderTreeSize = treeSize; }
 
     void handleWheelEvent(const WebWheelEvent&);
-    void sendWheelEvent(const WebWheelEvent&, OptionSet<WebCore::WheelEventProcessingSteps>, WebCore::RectEdges<bool> rubberBandableEdges, std::optional<bool> willStartSwipe);
-
-    void wheelEventHandlingCompleted(bool wasHandled);
+    void sendWheelEvent(const WebWheelEvent&, OptionSet<WebCore::WheelEventProcessingSteps>, WebCore::RectEdges<bool> rubberBandableEdges, std::optional<bool> willStartSwipe, bool wasHandledForScrolling);
+    void handleWheelEventReply(const WebWheelEvent&, WebCore::ScrollingNodeID, std::optional<WebCore::WheelScrollGestureState>, bool wasHandledForScrolling, bool wasHandledByWebProcess);
 
     void cacheWheelEventScrollingAccelerationCurve(const NativeWebWheelEvent&);
     void sendWheelEventScrollingAccelerationCurveIfNecessary(const WebWheelEvent&);

--- a/Source/WebKit/UIProcess/mac/WebViewImpl.mm
+++ b/Source/WebKit/UIProcess/mac/WebViewImpl.mm
@@ -4579,7 +4579,7 @@ void WebViewImpl::scrollWheel(NSEvent *event)
     if (m_allowsBackForwardNavigationGestures && ensureGestureController().handleScrollWheelEvent(event))
         return;
 
-    NativeWebWheelEvent webEvent = NativeWebWheelEvent(event, m_view.getAutoreleased());
+    auto webEvent = NativeWebWheelEvent(event, m_view.getAutoreleased());
     m_page->handleNativeWheelEvent(webEvent);
 }
 

--- a/Source/WebKit/WebProcess/WebPage/WebPage.h
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.h
@@ -1172,7 +1172,7 @@ public:
     void startWaitingForContextMenuToShow() { m_waitingForContextMenuToShow = true; }
 #endif
 
-    void handleWheelEvent(const WebWheelEvent&, const OptionSet<WebCore::WheelEventProcessingSteps>&, std::optional<bool> willStartSwipe, CompletionHandler<void(WebCore::ScrollingNodeID, std::optional<WebCore::WheelScrollGestureState>)>&&);
+    void handleWheelEvent(const WebWheelEvent&, const OptionSet<WebCore::WheelEventProcessingSteps>&, std::optional<bool> willStartSwipe, CompletionHandler<void(WebCore::ScrollingNodeID, std::optional<WebCore::WheelScrollGestureState>, bool handled)>&&);
     bool wheelEvent(const WebWheelEvent&, OptionSet<WebCore::WheelEventProcessingSteps>, EventDispatcher::WheelEventOrigin);
 
     void wheelEventHandlersChanged(bool);

--- a/Source/WebKit/WebProcess/WebPage/WebPage.messages.in
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.messages.in
@@ -688,7 +688,7 @@ GenerateSyntheticEditingCommand(enum:uint8_t WebKit::SyntheticEditingCommandType
     SetAppHighlightsVisibility(enum:bool WebCore::HighlightVisibility highlightVisibility)
 #endif
 
-    HandleWheelEvent(WebKit::WebWheelEvent event, OptionSet<WebCore::WheelEventProcessingSteps> processingSteps, std::optional<bool> willStartSwipe) -> (uint64_t scrollingNodeID, std::optional<WebCore::WheelScrollGestureState> gestureState)
+    HandleWheelEvent(WebKit::WebWheelEvent event, OptionSet<WebCore::WheelEventProcessingSteps> processingSteps, std::optional<bool> willStartSwipe) -> (uint64_t scrollingNodeID, std::optional<WebCore::WheelScrollGestureState> gestureState, bool handled)
 #if PLATFORM(IOS_FAMILY)
     DispatchWheelEventWithoutScrolling(WebKit::WebWheelEvent event) -> (bool handled)
 #endif


### PR DESCRIPTION
#### 86f6cfcadb5dc2b02991c05da87b2e1d8b4bcf98
<pre>
[UI-side compositing ]Scrolling carousel on shopping.google.com triggers history swipe
<a href="https://bugs.webkit.org/show_bug.cgi?id=256508">https://bugs.webkit.org/show_bug.cgi?id=256508</a>
rdar://108418750

Reviewed by Tim Horton.

shopping.google.com has horizontal scrolling carousels with passive wheel event listeners, but with
UI-side compositing enabled, we&apos;d fail to detect that we&apos;d handled scrolls for these, which allowed
history swipes to start.

The basic issue is that with passive listeners, the scrolling coordinator gets first crack at the
event in `WebPageProxy::handleWheelEvent()`, and may handle it, but the event still goes to the web
process for JS dispatch. But when we get back to `WebPageProxy::handleWheelEventReply()`, `handled`
is false because it only represents the WebProcess part of handling. Fix that by tracking whether
the scrolling tree handled the event first in wasHandledForScrolling, which is passed to
`WebPageProxy::sendWheelEvent()` and thence to the reply function.

In addition, we need to know if the post-WebProcess scrolling coordinator handling, in
`WebPageProxy::handleWheelEventReply()`, handled the event. To do that we have
`RemoteScrollingTreeMac::handleWheelEventAfterDefaultHandling()` return a handled value, which is
bounced back to `WebPageProxy::wheelEventHandlingCompleted()` on the main thread.

Since we now pass `handled` to the `WebPage::handleWheelEvent()` completion handler, it makes sense
to address the FIXME and remove the separate `WebPageProxy::DidReceiveEvent` reply here. This means
that only the non-UI-side compositing WebPageProxy::didReceiveEvent() will run for wheel events, so
add an assertion there.

* LayoutTests/swipe/swipe-back-with-active-wheel-listener-and-scroller-expected.txt: Added.
* LayoutTests/swipe/swipe-back-with-active-wheel-listener-and-scroller.html: Added.
* LayoutTests/swipe/swipe-back-with-passive-wheel-listener-and-scroller-expected.txt: Added.
* LayoutTests/swipe/swipe-back-with-passive-wheel-listener-and-scroller.html: Added.
* Source/WebKit/UIProcess/RemoteLayerTree/RemoteScrollingTree.h:
(WebKit::RemoteScrollingTree::handleWheelEventAfterDefaultHandling):
(WebKit::RemoteScrollingTree::wheelEventDefaultHandlingCompleted): Deleted.
* Source/WebKit/UIProcess/RemoteLayerTree/mac/RemoteLayerTreeEventDispatcher.cpp:
(WebKit::RemoteLayerTreeEventDispatcher::internalHandleWheelEvent):
(WebKit::RemoteLayerTreeEventDispatcher::wheelEventHandlingCompleted):
* Source/WebKit/UIProcess/RemoteLayerTree/mac/RemoteLayerTreeEventDispatcher.h:
(WebKit::RemoteLayerTreeEventDispatcher::scrollingCoordinator const):
* Source/WebKit/UIProcess/RemoteLayerTree/mac/RemoteScrollingTreeMac.h:
* Source/WebKit/UIProcess/RemoteLayerTree/mac/RemoteScrollingTreeMac.mm:
(WebKit::RemoteScrollingTreeMac::handleWheelEventAfterDefaultHandling):
(WebKit::RemoteScrollingTreeMac::wheelEventDefaultHandlingCompleted): Deleted.
* Source/WebKit/UIProcess/WebPageProxy.cpp:
(WebKit::WebPageProxy::continueWheelEventHandling):
(WebKit::WebPageProxy::sendWheelEvent):
(WebKit::WebPageProxy::handleWheelEventReply):
(WebKit::WebPageProxy::didReceiveEvent):
* Source/WebKit/UIProcess/WebPageProxy.h:
* Source/WebKit/UIProcess/mac/WebViewImpl.mm:
(WebKit::WebViewImpl::scrollWheel):
* Source/WebKit/WebProcess/WebPage/WebPage.cpp:
(WebKit::WebPage::handleWheelEvent):
* Source/WebKit/WebProcess/WebPage/WebPage.h:
* Source/WebKit/WebProcess/WebPage/WebPage.messages.in:

Canonical link: <a href="https://commits.webkit.org/263995@main">https://commits.webkit.org/263995@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/62e4c8e0dd754b2778a58d3b6ee36c2f0232766d

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/5897 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/6069 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/6256 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/7448 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/6262 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/6288 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/6030 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/8578 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/6005 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/6042 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/5338 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/7506 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/3519 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/5314 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/13259 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/5384 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/5392 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/7606 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/5843 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/4789 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/5276 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/5244 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/1499 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/9400 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/5637 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->