### PR TITLE
The Document object is leaked on some pages using media (like YouTube.com)

### DIFF
--- a/LayoutTests/media/media-session/actionHandler-lifetime-expected.txt
+++ b/LayoutTests/media/media-session/actionHandler-lifetime-expected.txt
@@ -1,0 +1,13 @@
+Tests media session action handlers are not prematurely garbage collected. Test passes if it doesn't crash.
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+PASS () => areObjectsEqual(window.actionDetails, {action: "play"}) is true
+PASS () => areObjectsEqual(window.actionDetails, {action: "pause"}) is true
+PASS () => areObjectsEqual(window.actionDetails, {action: "play"}) is true
+PASS () => areObjectsEqual(window.actionDetails, {action: "pause"}) is true
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/media/media-session/actionHandler-lifetime.html
+++ b/LayoutTests/media/media-session/actionHandler-lifetime.html
@@ -1,0 +1,44 @@
+<!DOCTYPE html>
+<body>
+<script src="../../resources/js-test.js"></script>
+<script>
+description("Tests media session action handlers are not prematurely garbage collected. Test passes if it doesn't crash.");
+jsTestIsAsync = true;
+
+function runTest() {
+    internals.sendMediaSessionAction(navigator.mediaSession, {action: "play"});
+    shouldBeTrue(() => areObjectsEqual(window.actionDetails, {action: "play"}));
+
+    internals.sendMediaSessionAction(navigator.mediaSession, {action: "pause"});
+    shouldBeTrue(() => areObjectsEqual(window.actionDetails, {action: "pause"}));
+}
+
+function forceGCAndRunTest() {
+    gc();
+    requestAnimationFrame(() => {
+        runTest();
+        finishJSTest();
+    });
+}
+
+onload = () => {
+    if (!window.internals) {
+        testFailed("Test requires internals.");
+        finishJSTest();
+        return;
+    }
+
+    function callback(actionDetails) {
+        window.actionDetails = actionDetails;
+    };
+
+    let actions = ["play", "pause"];
+    for (action of actions)
+        navigator.mediaSession.setActionHandler(action, callback);
+
+    runTest();
+    requestAnimationFrame(() => forceGCAndRunTest());
+
+};
+</script>
+</body>

--- a/LayoutTests/media/media-session/actionHandler-no-document-leak-expected.txt
+++ b/LayoutTests/media/media-session/actionHandler-no-document-leak-expected.txt
@@ -1,0 +1,11 @@
+Tests that page installed actionHandlers do not leak documents.
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+PASS internals.isDocumentAlive(frameDocumentID) is true
+PASS The iframe document didn't leak.
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/media/media-session/actionHandler-no-document-leak.html
+++ b/LayoutTests/media/media-session/actionHandler-no-document-leak.html
@@ -1,0 +1,56 @@
+<!DOCTYPE html>
+<html>
+<head>
+</head>
+<body>
+<iframe id="iframe"></iframe>
+<script src="../../resources/js-test.js"></script>
+<script>
+description("Tests that page installed actionHandlers do not leak documents.");
+
+jsTestIsAsync = true;
+frameDocumentID = 0;
+checkCount = 0;
+
+function iframeLoaded(frameDocument) {
+    if (!window.internals) {
+        testFailed("Test requires internals.");
+        return;
+    }
+
+    frameDocumentID = internals.documentIdentifier(frameDocument);
+    shouldBeTrue("internals.isDocumentAlive(frameDocumentID)");
+
+    iframe.addEventListener("load", () => {
+        handle = setInterval(() => {
+            gc();
+            if (!internals.isDocumentAlive(frameDocumentID)) {
+                clearInterval(handle);
+                testPassed("The iframe document didn't leak.");
+                finishJSTest();
+            }
+            checkCount++;
+            if (checkCount > 500) {
+                clearInterval(handle);
+                testFailed("The iframe document leaked.");
+                finishJSTest();
+            }
+        }, 10);
+    });
+
+    iframe.src = "about:blank";
+}
+
+onload = () => {
+    iframe.src = "resources/media-session-action-handler-document-leak-frame.html";
+    document.body.appendChild(iframe);
+};
+
+onmessage = (message) => {
+    if (message.data === "frameLoaded")
+        iframeLoaded(iframe.contentWindow.document);
+};
+
+</script>
+</body>
+</html>

--- a/LayoutTests/media/media-session/resources/media-session-action-handler-document-leak-frame.html
+++ b/LayoutTests/media/media-session/resources/media-session-action-handler-document-leak-frame.html
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<html>
+<body>
+<script>
+onload = () => {
+    let actions = ["play", "pause", "seekbackward", "seekforward", "previoustrack", "nexttrack", "skipad", "stop", "seekto"];
+    for (action of actions) {
+        navigator.mediaSession.setActionHandler(action, actionDetails => {
+            window.actionDetails = actionDetails;
+        });
+    }
+
+    for (mediaAction of actions) {
+        internals.sendMediaSessionAction(navigator.mediaSession, {action: mediaAction});
+    }
+
+    parent.postMessage("frameLoaded");
+};
+</script>
+</body>
+</html>

--- a/Source/WebCore/Modules/mediasession/MediaSession.h
+++ b/Source/WebCore/Modules/mediasession/MediaSession.h
@@ -67,6 +67,8 @@ public:
 
     void callActionHandler(const MediaSessionActionDetails&, DOMPromiseDeferred<void>&&);
 
+    template <typename Visitor> void visitActionHandlers(Visitor&) const;
+
     ExceptionOr<void> setPositionState(std::optional<MediaPositionState>&&);
     std::optional<MediaPositionState> positionState() const { return m_positionState; }
 
@@ -88,7 +90,8 @@ public:
     ExceptionOr<void> setPlaylist(ScriptExecutionContext&, Vector<RefPtr<MediaMetadata>>&&);
 #endif
 
-    bool hasActiveActionHandlers() const { return !m_actionHandlers.isEmpty(); }
+    bool hasActiveActionHandlers() const;
+
     enum class TriggerGestureIndicator {
         No,
         Yes,
@@ -135,6 +138,7 @@ private:
     const char* activeDOMObjectName() const final { return "MediaSession"; }
     void suspend(ReasonForSuspension) final;
     void stop() final;
+    bool virtualHasPendingActivity() const final;
 
     WeakPtr<Navigator> m_navigator;
     RefPtr<MediaMetadata> m_metadata;
@@ -142,7 +146,7 @@ private:
     std::optional<MediaPositionState> m_positionState;
     std::optional<double> m_lastReportedPosition;
     MonotonicTime m_timeAtLastPositionUpdate;
-    HashMap<MediaSessionAction, RefPtr<MediaSessionActionHandler>, IntHash<MediaSessionAction>, WTF::StrongEnumHashTraits<MediaSessionAction>> m_actionHandlers;
+    HashMap<MediaSessionAction, RefPtr<MediaSessionActionHandler>, IntHash<MediaSessionAction>, WTF::StrongEnumHashTraits<MediaSessionAction>> m_actionHandlers WTF_GUARDED_BY_LOCK(m_actionHandlersLock);
     RefPtr<const Logger> m_logger;
     const void* m_logIdentifier;
 
@@ -156,10 +160,27 @@ private:
 #if ENABLE(MEDIA_SESSION_PLAYLIST)
     Vector<Ref<MediaMetadata>> m_playlist;
 #endif
+    mutable Lock m_actionHandlersLock;
 };
 
 String convertEnumerationToString(MediaSessionPlaybackState);
 String convertEnumerationToString(MediaSessionAction);
+
+inline bool MediaSession::hasActiveActionHandlers() const
+{
+    Locker lock { m_actionHandlersLock };
+    return !m_actionHandlers.isEmpty();
+}
+
+template <typename Visitor>
+void MediaSession::visitActionHandlers(Visitor& visitor) const
+{
+    Locker lock { m_actionHandlersLock };
+    for (auto& actionHandler : m_actionHandlers) {
+        if (actionHandler.value)
+            actionHandler.value->visitJSFunction(visitor);
+    }
+}
 
 }
 

--- a/Source/WebCore/Modules/mediasession/MediaSession.idl
+++ b/Source/WebCore/Modules/mediasession/MediaSession.idl
@@ -28,6 +28,7 @@
     Conditional=MEDIA_SESSION,
     Exposed=Window,
     ExportMacro=WEBCORE_EXPORT,
+    JSCustomMarkFunction
 ] interface MediaSession
 {
     attribute MediaMetadata? metadata;

--- a/Source/WebCore/Modules/mediasession/MediaSessionActionHandler.h
+++ b/Source/WebCore/Modules/mediasession/MediaSessionActionHandler.h
@@ -40,6 +40,9 @@ public:
     using ActiveDOMCallback::ActiveDOMCallback;
 
     virtual CallbackResult<void> handleEvent(const MediaSessionActionDetails&) = 0;
+
+private:
+    virtual bool hasCallback() const = 0;
 };
 
 } // namespace WebCore

--- a/Source/WebCore/Modules/mediasession/MediaSessionActionHandler.idl
+++ b/Source/WebCore/Modules/mediasession/MediaSessionActionHandler.idl
@@ -23,4 +23,7 @@
  * THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-[ Conditional=MEDIA_SESSION ] callback MediaSessionActionHandler = undefined (MediaSessionActionDetails details);
+[
+    Conditional=MEDIA_SESSION,
+    IsWeakCallback
+] callback MediaSessionActionHandler = undefined (MediaSessionActionDetails details);

--- a/Source/WebCore/Sources.txt
+++ b/Source/WebCore/Sources.txt
@@ -609,6 +609,7 @@ bindings/js/JSKeyframeEffectCustom.cpp
 bindings/js/JSLazyEventListener.cpp
 bindings/js/JSLocalDOMWindowCustom.cpp
 bindings/js/JSLocationCustom.cpp
+bindings/js/JSMediaSessionCustom.cpp
 bindings/js/JSMediaStreamTrackCustom.cpp
 bindings/js/JSMessageChannelCustom.cpp
 bindings/js/JSMessageEventCustom.cpp

--- a/Source/WebCore/bindings/js/JSMediaSessionCustom.cpp
+++ b/Source/WebCore/bindings/js/JSMediaSessionCustom.cpp
@@ -1,0 +1,45 @@
+/*
+ * Copyright (C) 2023 Apple, Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#if ENABLE(MEDIA_SESSION)
+
+#include "config.h"
+#include "JSMediaSession.h"
+
+#include <JavaScriptCore/JSCInlines.h>
+
+namespace WebCore {
+
+template <typename Visitor>
+void JSMediaSession::visitAdditionalChildren(Visitor& visitor)
+{
+    wrapped().visitActionHandlers(visitor);
+}
+
+DEFINE_VISIT_ADDITIONAL_CHILDREN(JSMediaSession);
+
+}
+
+#endif


### PR DESCRIPTION
#### e938617efad650e9578a649cdba3085c97393e4b
<pre>
The Document object is leaked on some pages using media (like YouTube.com)
<a href="https://bugs.webkit.org/show_bug.cgi?id=251835">https://bugs.webkit.org/show_bug.cgi?id=251835</a>
rdar://105112595

Reviewed by Chris Dumez.

Re-land of 263660@main (and 263715@main) fixing crashes due to
prematurely garbage collected MediaSessionActionHandler JS wrappers.

By default a callback holds a Strong&lt;&gt; reference to the JS Function
object. This has the effect of making the callback a GC root. Another
option is to annotate the callback with the IsWeakCallback extended
attribute which will hold the callback object as a Weak reference and
keep it alive via the visitJSFunction mechanism instead of making it a
root.

In the case of MediaSessionActionHandler the strong reference will
prevent an HTMLDocument from being garbage collected even after
navigating away and clearing the caches (after a low memory warning, for
example). This change adds the IsWeakCallback attribute and the
necessary virtual function to the MediaSessionActionHandler base class
and makes changes to allow the MediaSession to mark any action handlers
that have been added to it.

LayoutTests:

    Add a test to check that action handlers installed by the page are
    not leaked. Use an iframe to install and exercise the action
    handlers before the iframe is navigated away and a garbage
    collection is triggered (repeatedly). If after 500 attempts at GC
    the document containing the action handlers still exists we consider
    the document leaked.

    Also add a test to check that action handlers survive garbage
    collection and can be called when appropriate.

* LayoutTests/media/media-session/actionHandler-lifetime-expected.txt: Added.
* LayoutTests/media/media-session/actionHandler-lifetime.html: Added.
* LayoutTests/media/media-session/actionHandler-no-document-leak-expected.txt: Added.
* LayoutTests/media/media-session/actionHandler-no-document-leak.html: Added.
* LayoutTests/media/media-session/resources/media-session-action-handler-document-leak-frame.html: Added.

* Source/WebCore/Modules/mediasession/MediaSession.cpp:
(WebCore::MediaSession::virtualHasPendingActivity const):
(WebCore::MediaSession::setActionHandler):
(WebCore::MediaSession::callActionHandler):
* Source/WebCore/Modules/mediasession/MediaSession.h:
(WebCore::MediaSession::hasActiveActionHandlers const):
(WebCore::MediaSession::visitActionHandlers const):
* Source/WebCore/Modules/mediasession/MediaSession.idl:
* Source/WebCore/Modules/mediasession/MediaSessionActionHandler.h:
* Source/WebCore/Modules/mediasession/MediaSessionActionHandler.idl:
* Source/WebCore/Sources.txt:
* Source/WebCore/WebCore.xcodeproj/project.pbxproj:
* Source/WebCore/bindings/js/JSMediaSessionCustom.cpp: Added.
(WebCore::JSMediaSession::visitAdditionalChildren):

Canonical link: <a href="https://commits.webkit.org/263868@main">https://commits.webkit.org/263868@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d99c378196fdb112eb5413fab677de0b6d35fec4

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/5940 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/6115 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/6301 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/7493 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/6299 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/5937 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/6334 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/6074 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/8727 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/6048 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/6086 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/5382 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/7553 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/3563 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/5358 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/13289 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/5428 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/5437 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/7659 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/5886 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/4828 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/5318 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/5288 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/1410 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/9444 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/5679 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->