### PR TITLE
REGRESSION(263796@main): C++20 is not needed in order to have a pi constant

### DIFF
--- a/Source/WebCore/platform/graphics/displaylists/DisplayListRecorder.cpp
+++ b/Source/WebCore/platform/graphics/displaylists/DisplayListRecorder.cpp
@@ -36,7 +36,6 @@
 #include "Logging.h"
 #include "MediaPlayer.h"
 #include "NotImplemented.h"
-#include <numbers>
 #include <wtf/MathExtras.h>
 #include <wtf/text/TextStream.h>
 
@@ -309,7 +308,7 @@ void Recorder::translate(float x, float y)
 
 void Recorder::rotate(float angleInRadians)
 {
-    if (WTF::areEssentiallyEqual(0.f, fmodf(angleInRadians, std::numbers::pi_v<float> * 2.f)))
+    if (WTF::areEssentiallyEqual(0.f, fmodf(angleInRadians, piFloat * 2.f)))
         return;
     currentState().rotate(angleInRadians);
     recordRotate(angleInRadians);

--- a/Tools/TestWebKitAPI/Tests/WebCore/DisplayListRecorderTests.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebCore/DisplayListRecorderTests.cpp
@@ -32,8 +32,7 @@
 #include <WebCore/GraphicsContext.h>
 #include <WebCore/ImageBuffer.h>
 #include <WebCore/InMemoryDisplayList.h>
-#include <numbers>
-#include <wtf/StdLibExtras.h>
+#include <wtf/MathExtras.h>
 #if PLATFORM(COCOA)
 #include <WebCore/GraphicsContextCG.h>
 #endif
@@ -419,9 +418,9 @@ struct TrivialRotate {
         c.rotate(1.f);
         c.rotate(0.f);
         c.rotate(2.f);
-        c.rotate(std::numbers::pi_v<float> * 2.f);
-        c.rotate(7.f * std::numbers::pi_v<float> * 2.f);
-        c.rotate(-2.f * std::numbers::pi_v<float> * 2.f);
+        c.rotate(piFloat * 2.f);
+        c.rotate(7.f * piFloat * 2.f);
+        c.rotate(-2.f * piFloat * 2.f);
         c.drawRect({ 0, 0, 1, 1 });
     }
 


### PR DESCRIPTION
#### 3dd065753ef71af08141959e6508c473514cf3cb
<pre>
REGRESSION(263796@main): C++20 is not needed in order to have a pi constant
<a href="https://bugs.webkit.org/show_bug.cgi?id=256512">https://bugs.webkit.org/show_bug.cgi?id=256512</a>

Unreviewed PlayStation build fix.

* Source/WebCore/platform/graphics/displaylists/DisplayListRecorder.cpp:
(WebCore::DisplayList::Recorder::rotate):
* Tools/TestWebKitAPI/Tests/WebCore/DisplayListRecorderTests.cpp:
We already have `piFloat` at home.

Canonical link: <a href="https://commits.webkit.org/263856@main">https://commits.webkit.org/263856@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ef62886c09d587c604d57409f7743c02658d9d37

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/5913 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/6086 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/6273 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/7464 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/32/builds/6272 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/5910 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/6305 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/6047 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/8687 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/6021 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/6058 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/5354 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/7524 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/3535 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/5330 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/13267 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/5400 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/5408 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/7622 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/5857 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/4804 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/5291 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/1399 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/9415 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/5651 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->