### PR TITLE
Web Inspector: REGRESSION(257744@main): Dark Mode simulation isn't maintained on page change, but remains selected in the UI

### DIFF
--- a/Source/WebCore/page/Page.cpp
+++ b/Source/WebCore/page/Page.cpp
@@ -1466,10 +1466,6 @@ void Page::didCommitLoad()
     m_isEditableRegionEnabled = false;
 #endif
 
-#if HAVE(OS_DARK_MODE_SUPPORT)
-    setUseDarkAppearanceOverride(std::nullopt);
-#endif
-
     resetSeenPlugins();
     resetSeenMediaEngines();
 

--- a/Source/WebInspectorUI/UserInterface/Controllers/CSSManager.js
+++ b/Source/WebInspectorUI/UserInterface/Controllers/CSSManager.js
@@ -648,6 +648,14 @@ WI.CSSManager = class CSSManager extends WI.Object
         this._styleSheetFrameURLMap.clear();
         this._modifiedStyles.clear();
 
+        // COMPATIBILITY (macOS X.0, iOS X.0): the `PrefersColorScheme` override used to be cleared on main frame navigation
+        // Since support can't be tested directly, check for the `reason` parameter of `Console.messagesCleared`.
+        // FIXME: Use explicit version checking once <https://webkit.org/b/148680> is fixed.
+        if (!InspectorBackend.hasEvent("Console.messagesCleared", "reason")) {
+            this._overriddenUserPreferences.delete(InspectorBackend.Enum.Page.UserPreferenceName.PrefersColorScheme);
+            this.dispatchEventToListeners(WI.CSSManager.Event.OverriddenUserPreferencesDidChange);
+        }
+
         this._nodeStylesMap = {};
     }
 

--- a/Source/WebInspectorUI/UserInterface/Views/DOMTreeContentView.js
+++ b/Source/WebInspectorUI/UserInterface/Views/DOMTreeContentView.js
@@ -56,8 +56,6 @@ WI.DOMTreeContentView = class DOMTreeContentView extends WI.ContentView
         // COMPATIBILITY (macOS 13.0, iOS 16.0): `Page.overrideUserPreference` did not exist yet.
         this._overrideUserPreferencesNavigationItem = new WI.ActivateButtonNavigationItem("toggle-user-preferences", WI.UIString("Override user preferences"), WI.UIString("User preferences overridden"), "Images/AppearanceOverride.svg", 16, 16);
         this._overrideUserPreferencesNavigationItem.addEventListener(WI.ButtonNavigationItem.Event.Clicked, this._handleOverrideUserPreferencesButtonClicked, this);
-        // COMPATIBILITY (macOS 13, iOS 16.0): `Page.setForcedAppearance()` was removed in favor of `Page.overrideUserPreference()`
-        this._overrideUserPreferencesNavigationItem.enabled = WI.cssManager.supportsOverrideUserPreference || WI.cssManager.supportsOverrideColorScheme;
         this._overrideUserPreferencesNavigationItem.visibilityPriority = WI.NavigationItem.VisibilityPriority.Low;
 
         this._compositingBordersButtonNavigationItem = new WI.ActivateButtonNavigationItem("layer-borders", WI.UIString("Show compositing borders"), WI.UIString("Hide compositing borders"), "Images/LayerBorders.svg", 13, 13);
@@ -88,7 +86,10 @@ WI.DOMTreeContentView = class DOMTreeContentView extends WI.ContentView
         WI.domManager.addEventListener(WI.DOMManager.Event.CharacterDataModified, this._domNodeChanged, this);
 
         WI.cssManager.addEventListener(WI.CSSManager.Event.DefaultUserPreferencesDidChange, this._defaultUserPreferencesDidChange, this);
+        this._defaultUserPreferencesDidChange();
+
         WI.cssManager.addEventListener(WI.CSSManager.Event.OverriddenUserPreferencesDidChange, this._overriddenUserPreferencesDidChange, this);
+        this._overriddenUserPreferencesDidChange();
 
         this._lastSelectedNodePathSetting = new WI.Setting("last-selected-node-path", null);
 


### PR DESCRIPTION
#### 1fb980be68f324dad7ad0d7770c4053354356399
<pre>
Web Inspector: REGRESSION(257744@main): Dark Mode simulation isn&apos;t maintained on page change, but remains selected in the UI
<a href="https://bugs.webkit.org/show_bug.cgi?id=254457">https://bugs.webkit.org/show_bug.cgi?id=254457</a>
&lt;rdar://problem/107506257&gt;

Reviewed by Patrick Angle.

Having to force dark (or light) mode with each refresh is pretty tedious, as it&apos;s probably pretty common that developers will refresh as they make changes to the backend source.

* Source/WebCore/page/Page.cpp:
(WebCore::Page::didCommitLoad):
Don&apos;t clear the forced appearance override on main frame navigation.

* Source/WebInspectorUI/UserInterface/Views/DOMTreeContentView.js:
(WI.DOMTreeContentView):
(WI.DOMTreeContentView.prototype._defaultUserPreferencesDidChange):
A new `WI.DOMTreeContentView` is created each time the main frame navigates, so make sure to initialize `activated` (and `enabled`) instead of waiting for `WI.CSSManager.Event.OverriddenUserPreferencesDidChange` (and `WI.CSSManager.Event.DefaultUserPreferencesDidChange`).

* Source/WebInspectorUI/UserInterface/Controllers/CSSManager.js:
(WI.CSSManager.prototype._mainResourceDidChange):
Add compatibility behavior for releases before this change.

Canonical link: <a href="https://commits.webkit.org/264172@main">https://commits.webkit.org/264172@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/10ab51b1dc71a7df2915ac9d9adfb2a45d8194ca

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/6916 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/7146 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/7329 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/8516 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/7162 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/6921 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/8401 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/7085 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/10069 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/7038 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/7705 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/6367 "Passed tests") | [❌ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/8618 "Failed to checkout and rebase branch from PR 13630") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/39/builds/5085 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/6275 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/2/builds/8618 "Failed to checkout and rebase branch from PR 13630") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/6770 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/6363 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/2/builds/8618 "Failed to checkout and rebase branch from PR 13630") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/6848 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/5616 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/6224 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/1644 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/10409 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/6606 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->