### PR TITLE
[CMake] Changing files listed in gi-docgen's TOML configuration does not rebuild documentation

### DIFF
--- a/Source/cmake/FindGIDocgen.cmake
+++ b/Source/cmake/FindGIDocgen.cmake
@@ -200,7 +200,18 @@ function(GI_DOCGEN namespace toml)
         COMMENT "Generating documentation: ${namespace}"
         WORKING_DIRECTORY "${CMAKE_SOURCE_DIR}"
         DEPENDS ${docdeps}
+        DEPFILE ${contentdir}.dep
         VERBATIM
+        COMMAND "${GIDocgen_EXE}" gen-deps
+            ${common_flags}
+            --content-dir "${contentdir}"
+            --content-dir "${toml_dir}"
+            --config "${toml_path}"
+            "${gir_path}"
+            "${contentdir}.depfiles"
+        COMMAND "${Python_EXECUTABLE}" -c
+            "import sys; print(sys.argv[1], ':', ' '.join((l[:-1] for l in sys.stdin.readlines())))"
+            "${outdir}/index.html" < "${contentdir}.depfiles" > "${contentdir}.dep"
         COMMAND "${GIDocgen_EXE}" generate
             ${common_flags}
             --no-namespace-dir


### PR DESCRIPTION
#### 9e4a1ee88a137f0dcf667cc0d0ca2d36771c7e79
<pre>
[CMake] Changing files listed in gi-docgen&apos;s TOML configuration does not rebuild documentation
<a href="https://bugs.webkit.org/show_bug.cgi?id=256518">https://bugs.webkit.org/show_bug.cgi?id=256518</a>

Reviewed by Carlos Garcia Campos.

Use &quot;gi-docgen gen-deps&quot; to extract the list of files on which
documentation generation depends and transform tyhe output into a
Make fragment that can be passed as DEPFILE. This makes the build
system aware of the need for documentation rebuilds when e.g. the
Markdown files or images referenced as extra content files in the
TOML configuration file change. Unfortunately, there is a small bug
in gi-docgen and at the moment it does not list the URL mapping file
as a dependency in its output, so changes to such files will not
cause rebuilds until the gi-docgen bug is fixed.

* Source/cmake/FindGIDocgen.cmake: Arrange generating a DEPFILE for
  documentation targets.

Canonical link: <a href="https://commits.webkit.org/263862@main">https://commits.webkit.org/263862@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/941a74ef0753121531b5c0f0243c8e8ec6b5f8f6

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/5931 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/6106 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/6292 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/7484 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/6290 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/6325 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/6065 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/8711 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/6039 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/6080 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/5374 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/7544 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/3557 "Passed tests") | | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/13281 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/4959 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/5422 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/5429 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/7644 "Passed tests") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/5516 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/5877 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/4820 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/6048 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/5309 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/1469 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/9435 "Built successfully") | | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/24/builds/6218 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/696 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/5670 "Built successfully") | | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/3/builds/1592 "Passed tests") | 
<!--EWS-Status-Bubble-End-->