### PR TITLE
Command-+ zoom on a frameset page fails to resize the frames, only resizes their content

### DIFF
--- a/LayoutTests/fast/frames/frame-set-zoom-expected.html
+++ b/LayoutTests/fast/frames/frame-set-zoom-expected.html
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<html>
+    <head>
+        <title>Tests that framesets scale according to full page zoom</title>
+    </head>
+    <frameset rows="120,*">
+        <frame id="top_frame" src="data:text/html,<!DOCTYPE html><html><body></body></html>">
+        <frame id="bottom_frame" src="data:text/html,<!DOCTYPE html><html><body></body></html>">
+    </frameset>
+</html>

--- a/LayoutTests/fast/frames/frame-set-zoom.html
+++ b/LayoutTests/fast/frames/frame-set-zoom.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<html>
+    <head>
+        <title>Tests that framesets scale according to full page zoom</title>
+        <script>
+            window.onload = function() {
+                if (window.eventSender)
+                    eventSender.zoomPageIn();
+            };
+        </script>
+    </head>
+    <frameset rows="100,*">
+        <frame id="top_frame" src="data:text/html,<!DOCTYPE html><html><body></body></html>">
+        <frame id="bottom_frame" src="data:text/html,<!DOCTYPE html><html><body></body></html>">
+    </frameset>
+</html>

--- a/Source/WebCore/rendering/RenderFrameSet.cpp
+++ b/Source/WebCore/rendering/RenderFrameSet.cpp
@@ -2,7 +2,7 @@
  * Copyright (C) 1999 Lars Knoll (knoll@kde.org)
  *           (C) 2000 Simon Hausmann <hausmann@kde.org>
  *           (C) 2000 Stefan Schimanski (1Stein@gmx.de)
- * Copyright (C) 2004, 2005, 2006, 2013 Apple Inc.
+ * Copyright (C) 2004-2023 Apple Inc. All rights reserved.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Library General Public
@@ -187,7 +187,9 @@ void RenderFrameSet::layOutAxis(GridAxis& axis, const Length* grid, int availabl
         // Count the total length of all of the fixed columns/rows -> totalFixed
         // Count the number of columns/rows which are fixed -> countFixed
         if (grid[i].isFixed()) {
-            gridLayout[i] = std::max(grid[i].intValue(), 0);
+            float zoomFactor = style().effectiveZoom();
+            int fixedLen = lroundf(grid[i].value() * zoomFactor);
+            gridLayout[i] = std::max(fixedLen, 0);
             totalFixed += gridLayout[i];
             countFixed++;
         }


### PR DESCRIPTION
<pre>
Command-+ zoom on a frameset page fails to resize the frames, only resizes their content
<a href="https://bugs.webkit.org/show_bug.cgi?id=64883">https://bugs.webkit.org/show_bug.cgi?id=64883</a>

Reviewed by NOBODY (OOPS!).

This patch aligns WebKit with Blink / Chromium and Gecko / Firefox.

The original patch was authored by Uday Kiran.

This patch changes our frameset code to take the page zoom factor into account while computing
the width and/or height of frames with pixel size values. This allows pages
using frames to layout correctly even after user page zoom.

Cherry-Pick Tests: <a href="https://chromium.googlesource.com/chromium/src.git/+/9c7ef525d830b014626d787f3060512c2d3251a2">https://chromium.googlesource.com/chromium/src.git/+/9c7ef525d830b014626d787f3060512c2d3251a2</a>

* Source/WebCore/rendering/RenderFrameSet.cpp:
(RenderFrameSet::layOutAxis): As above
* LayoutTests/fast/frames/frame-set-zoom.html: Add Test Case
* LayoutTests/fast/frames/frame-set-zoom-expected.html: Add Test Case Expectation
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/345bf3b946f850e4565d7f473bfcfb1ce1abf00a

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/5954 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/6129 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/6315 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/7507 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/6313 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/5951 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/6348 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/6088 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/8745 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/6062 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/6099 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/5395 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/7567 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/3576 "Passed tests") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/10/builds/5371 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/13298 "7 flakes 1 missing results 173 failures") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/5441 "Passed tests") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/5450 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/7678 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/5900 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/4841 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/5332 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/5301 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/9458 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/5693 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->