### PR TITLE
REGRESSION(261354@main): [macOS] TestWebKitAPI.WebKit.MediaBufferingPolicy  is a constant failure

### DIFF
--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/MediaBufferingPolicy.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/MediaBufferingPolicy.mm
@@ -47,8 +47,7 @@ static void waitUntilBufferingPolicyIsEqualTo(WKWebView* webView, const char* ex
     EXPECT_WK_STREQ(expected, observed);
 }
 
-// FIXME Re-enable when https://bugs.webkit.org/show_bug.cgi?id=253658 is fixed
-TEST(WebKit, DISABLED_MediaBufferingPolicy)
+TEST(WebKit, MediaBufferingPolicy)
 {
     auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
     auto context = adoptWK(TestWebKitAPI::Util::createContextForInjectedBundleTest("InternalsInjectedBundleTest"));
@@ -70,8 +69,8 @@ TEST(WebKit, DISABLED_MediaBufferingPolicy)
     // Suspending the process also forces a memory warning, which should purge whatever possible ASAP.
     [webView _processWillSuspendImminentlyForTesting];
 #if PLATFORM(MAC)
-    // Suspending the page on macOS shouldn't cause resource purging
-    waitUntilBufferingPolicyIsEqualTo(webView.get(), "Default");
+    // On macOS, we don't run the memory pressure logic on suspension.
+    waitUntilBufferingPolicyIsEqualTo(webView.get(), "LimitReadAhead");
 #else
     waitUntilBufferingPolicyIsEqualTo(webView.get(), "PurgeResources");
 #endif

--- a/Tools/TestWebKitAPI/Tests/WebKitLegacy/ios/video-with-audio.html
+++ b/Tools/TestWebKitAPI/Tests/WebKitLegacy/ios/video-with-audio.html
@@ -65,7 +65,7 @@
 </head>
 <body onload="go()">
     <video src="video-with-audio.mp4" webkit-playsinline></video>
-    <audio src="video-with-audio.mp4" webkit-playsinline></video>
+    <audio src="video-with-audio.mp4" webkit-playsinline></audio>
     <canvas id="myCanvas" width="200" height="200"></canvas>
 </body>
 </html>


### PR DESCRIPTION
#### 74b006a7fec7e2b21313fc6877e9200f7001d01e
<pre>
REGRESSION(261354@main): [macOS] TestWebKitAPI.WebKit.MediaBufferingPolicy  is a constant failure
<a href="https://bugs.webkit.org/show_bug.cgi?id=253658">https://bugs.webkit.org/show_bug.cgi?id=253658</a>
rdar://106508946

Reviewed by Geoffrey Garen.

Update expectation on macOS. The test sends a prepareToSuspend() and expects
the memory pressure handler logic to get called. However, we don&apos;t call it
on macOS for performance reasons.

* Tools/TestWebKitAPI/Tests/WebKitCocoa/MediaBufferingPolicy.mm:
(TEST):
* Tools/TestWebKitAPI/Tests/WebKitLegacy/ios/video-with-audio.html:

Canonical link: <a href="https://commits.webkit.org/263873@main">https://commits.webkit.org/263873@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d8dce045bc86941c319f5375f01e5107b3c8aba3

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/5947 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/6122 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/6308 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/7500 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/6306 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/5944 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/6341 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/6081 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/8740 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/6055 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/6093 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/5388 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/7560 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/3570 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/5364 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/13295 "13 flakes 156 failures") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/5435 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/5443 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/7665 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/5893 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/4834 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/5325 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/1415 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/9451 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/5686 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->