### PR TITLE
[WGSL] Make expression nodes arena allocated

### DIFF
--- a/Source/WebGPU/WGSL/AST/ASTAbstractFloatLiteral.h
+++ b/Source/WebGPU/WGSL/AST/ASTAbstractFloatLiteral.h
@@ -33,17 +33,17 @@ namespace WGSL::AST {
 // floating point numbers.
 // https://gpuweb.github.io/gpuweb/wgsl/#abstractfloat
 class AbstractFloatLiteral final : public Expression {
-    WTF_MAKE_FAST_ALLOCATED;
+    WGSL_AST_BUILDER_NODE(AbstractFloatLiteral);
 public:
+    NodeKind kind() const final;
+    double value() const { return m_value; }
+
+private:
     AbstractFloatLiteral(SourceSpan span, double value)
         : Expression(span)
         , m_value(value)
     { }
 
-    NodeKind kind() const final;
-    double value() const { return m_value; }
-
-private:
     double m_value;
 };
 

--- a/Source/WebGPU/WGSL/AST/ASTAbstractIntegerLiteral.h
+++ b/Source/WebGPU/WGSL/AST/ASTAbstractIntegerLiteral.h
@@ -32,17 +32,17 @@ namespace WGSL::AST {
 // Literal ints without size prefix; these ints are signed 64-bit numbers.
 // https://gpuweb.github.io/gpuweb/wgsl/#abstractint
 class AbstractIntegerLiteral final : public Expression {
-    WTF_MAKE_FAST_ALLOCATED;
+    WGSL_AST_BUILDER_NODE(AbstractIntegerLiteral);
 public:
+    NodeKind kind() const final;
+    int64_t value() const { return m_value; }
+
+private:
     AbstractIntegerLiteral(SourceSpan span, int64_t value)
         : Expression(span)
         , m_value(value)
     { }
 
-    NodeKind kind() const final;
-    int64_t value() const { return m_value; }
-
-private:
     int64_t m_value;
 };
 

--- a/Source/WebGPU/WGSL/AST/ASTBinaryExpression.h
+++ b/Source/WebGPU/WGSL/AST/ASTBinaryExpression.h
@@ -72,11 +72,14 @@ constexpr ASCIILiteral toASCIILiteral(BinaryOperation op)
 void printInternal(PrintStream&, BinaryOperation);
 
 class BinaryExpression : public Expression {
-    WTF_MAKE_FAST_ALLOCATED;
+    WGSL_AST_BUILDER_NODE(BinaryExpression);
 public:
-    using Ref = UniqueRef<Expression>;
-    using List = UniqueRefVector<Expression>;
+    NodeKind kind() const override;
+    BinaryOperation operation() const { return m_operation; }
+    Expression& leftExpression() { return m_lhs.get(); }
+    Expression& rightExpression() { return m_rhs.get(); }
 
+private:
     BinaryExpression(SourceSpan span, Expression::Ref&& lhs, Expression::Ref&& rhs, BinaryOperation operation)
         : Expression(span)
         , m_lhs(WTFMove(lhs))
@@ -84,12 +87,6 @@ public:
         , m_operation(operation)
     { }
 
-    NodeKind kind() const override;
-    BinaryOperation operation() const { return m_operation; }
-    Expression& leftExpression() { return m_lhs.get(); }
-    Expression& rightExpression() { return m_rhs.get(); }
-
-private:
     Expression::Ref m_lhs;
     Expression::Ref m_rhs;
     BinaryOperation m_operation;

--- a/Source/WebGPU/WGSL/AST/ASTBitcastExpression.h
+++ b/Source/WebGPU/WGSL/AST/ASTBitcastExpression.h
@@ -31,18 +31,18 @@
 namespace WGSL::AST {
 
 class BitcastExpression final : public Expression {
-    WTF_MAKE_FAST_ALLOCATED;
+    WGSL_AST_BUILDER_NODE(BitcastExpression);
 public:
+    NodeKind kind() const final;
+    Expression& expression() { return m_expression.get(); }
+
+private:
     BitcastExpression(SourceSpan span, TypeName::Ref&& castToType, Expression::Ref&& expression)
         : Expression(span)
         , m_castToType(WTFMove(castToType))
         , m_expression(WTFMove(expression))
     { }
 
-    NodeKind kind() const final;
-    Expression& expression() { return m_expression.get(); }
-
-private:
     TypeName::Ref m_castToType;
     Expression::Ref m_expression;
 };

--- a/Source/WebGPU/WGSL/AST/ASTBoolLiteral.h
+++ b/Source/WebGPU/WGSL/AST/ASTBoolLiteral.h
@@ -30,17 +30,17 @@
 namespace WGSL::AST {
 
 class BoolLiteral final : public Expression {
-    WTF_MAKE_FAST_ALLOCATED;
+    WGSL_AST_BUILDER_NODE(BoolLiteral);
 public:
+    NodeKind kind() const override;
+    bool value() const { return m_value; }
+
+private:
     BoolLiteral(SourceSpan span, bool value)
         : Expression(span)
         , m_value(value)
     { }
 
-    NodeKind kind() const override;
-    bool value() const { return m_value; }
-
-private:
     bool m_value;
 };
 

--- a/Source/WebGPU/WGSL/AST/ASTBuilder.h
+++ b/Source/WebGPU/WGSL/AST/ASTBuilder.h
@@ -32,11 +32,20 @@
 #include <wtf/Vector.h>
 
 #define WGSL_AST_BUILDER_NODE(Node) \
-    WTF_MAKE_NONCOPYABLE(Node); \
-    WTF_MAKE_NONMOVABLE(Node); \
+protected: \
+    Node(const Node&) = default; \
+    Node(Node&&) = default; \
+    Node& operator=(const Node&) = default; \
+    Node& operator=(Node&&) = default; \
+private: \
     friend class Builder; \
+    friend ShaderModule;
 
-namespace WGSL::AST {
+namespace WGSL {
+
+class ShaderModule;
+
+namespace AST {
 
 DECLARE_ALLOCATOR_WITH_HEAP_IDENTIFIER(WGSLAST);
 
@@ -80,4 +89,5 @@ private:
     Vector<Node*> m_nodes;
 };
 
-} // namespace WGSL::AST
+} // namespace AST
+} // namespace WGSL

--- a/Source/WebGPU/WGSL/AST/ASTCallExpression.h
+++ b/Source/WebGPU/WGSL/AST/ASTCallExpression.h
@@ -35,19 +35,19 @@ namespace WGSL::AST {
 // but can also be a type, in which the whole call is a type conversion expression. The exact
 // kind of expression can only be resolved during semantic analysis.
 class CallExpression final : public Expression {
-    WTF_MAKE_FAST_ALLOCATED;
+    WGSL_AST_BUILDER_NODE(CallExpression);
 public:
+    NodeKind kind() const override;
+    TypeName& target() { return m_target.get(); }
+    Expression::List& arguments() { return m_arguments; }
+
+private:
     CallExpression(SourceSpan span, TypeName::Ref&& target, Expression::List&& arguments)
         : Expression(span)
         , m_target(WTFMove(target))
         , m_arguments(WTFMove(arguments))
     { }
 
-    NodeKind kind() const override;
-    TypeName& target() { return m_target.get(); }
-    Expression::List& arguments() { return m_arguments; }
-
-private:
     // If m_target is a NamedType, it could either be a:
     //   * Type that does not accept parameters (bool, i32, u32, ...)
     //   * Identifier that refers to a type alias.

--- a/Source/WebGPU/WGSL/AST/ASTExpression.h
+++ b/Source/WebGPU/WGSL/AST/ASTExpression.h
@@ -25,7 +25,9 @@
 
 #pragma once
 
+#include "ASTBuilder.h"
 #include "ASTNode.h"
+#include <wtf/ReferenceWrapperVector.h>
 
 namespace WGSL {
 class TypeChecker;
@@ -34,21 +36,22 @@ struct Type;
 namespace AST {
 
 class Expression : public Node {
-    WTF_MAKE_FAST_ALLOCATED;
+    WGSL_AST_BUILDER_NODE(Expression);
     friend TypeChecker;
 
 public:
-    using Ref = UniqueRef<Expression>;
-    using Ptr = std::unique_ptr<Expression>;
-    using List = UniqueRefVector<Expression>;
-
-    Expression(SourceSpan span)
-        : Node(span)
-    { }
+    using Ref = std::reference_wrapper<Expression>;
+    using Ptr = Expression*;
+    using List = ReferenceWrapperVector<Expression>;
 
     virtual ~Expression() { }
 
     const Type* inferredType() const { return m_inferredType; }
+
+protected:
+    Expression(SourceSpan span)
+        : Node(span)
+    { }
 
 private:
     const Type* m_inferredType;

--- a/Source/WebGPU/WGSL/AST/ASTFieldAccessExpression.h
+++ b/Source/WebGPU/WGSL/AST/ASTFieldAccessExpression.h
@@ -31,20 +31,20 @@
 namespace WGSL::AST {
 
 class FieldAccessExpression final : public Expression {
-    WTF_MAKE_FAST_ALLOCATED;
+    WGSL_AST_BUILDER_NODE(FieldAccessExpression);
 public:
-    FieldAccessExpression(SourceSpan span, UniqueRef<Expression>&& base, Identifier&& fieldName)
-        : Expression(span)
-        , m_base(WTFMove(base))
-        , m_fieldName(WTFMove(fieldName))
-    { }
-
     NodeKind kind() const override;
 
     Expression& base() { return m_base.get(); }
     Identifier& fieldName() { return m_fieldName; }
 
 private:
+    FieldAccessExpression(SourceSpan span, Expression::Ref&& base, Identifier&& fieldName)
+        : Expression(span)
+        , m_base(WTFMove(base))
+        , m_fieldName(WTFMove(fieldName))
+    { }
+
     Expression::Ref m_base;
     Identifier m_fieldName;
 };

--- a/Source/WebGPU/WGSL/AST/ASTFloat32Literal.h
+++ b/Source/WebGPU/WGSL/AST/ASTFloat32Literal.h
@@ -30,17 +30,17 @@
 namespace WGSL::AST {
 
 class Float32Literal final : public Expression {
-    WTF_MAKE_FAST_ALLOCATED;
+    WGSL_AST_BUILDER_NODE(Float32Literal);
 public:
+    NodeKind kind() const final;
+    float value() const { return m_value; }
+
+private:
     Float32Literal(SourceSpan span, float value)
         : Expression(span)
         , m_value(value)
     { }
 
-    NodeKind kind() const final;
-    float value() const { return m_value; }
-
-private:
     float m_value;
 };
 

--- a/Source/WebGPU/WGSL/AST/ASTForStatement.h
+++ b/Source/WebGPU/WGSL/AST/ASTForStatement.h
@@ -33,17 +33,17 @@ namespace WGSL::AST {
 class ForStatement final : public Statement {
     WTF_MAKE_FAST_ALLOCATED;
 public:
-    ForStatement(SourceSpan span, Statement::Ptr&& initializer, Expression::Ptr&& test, Statement::Ptr&& update, CompoundStatement&& body)
+    ForStatement(SourceSpan span, Statement::Ptr&& initializer, Expression::Ptr test, Statement::Ptr&& update, CompoundStatement&& body)
         : Statement(span)
         , m_initializer(WTFMove(initializer))
-        , m_test(WTFMove(test))
+        , m_test(test)
         , m_update(WTFMove(update))
         , m_body(WTFMove(body))
     { }
 
     NodeKind kind() const override;
     Statement* maybeInitializer() { return m_initializer.get(); }
-    Expression* maybeTest() { return m_test.get(); }
+    Expression* maybeTest() { return m_test; }
     Statement* maybeUpdate() { return m_update.get(); }
     CompoundStatement& body() { return m_body; }
 

--- a/Source/WebGPU/WGSL/AST/ASTIdentifierExpression.h
+++ b/Source/WebGPU/WGSL/AST/ASTIdentifierExpression.h
@@ -31,19 +31,19 @@
 namespace WGSL::AST {
 
 class IdentifierExpression final : public Expression {
-    WTF_MAKE_FAST_ALLOCATED;
+    WGSL_AST_BUILDER_NODE(IdentifierExpression);
 public:
-    IdentifierExpression(SourceSpan span, Identifier&& identifier)
-        : Expression(span)
-        , m_identifier(WTFMove(identifier))
-    { }
-
     NodeKind kind() const override;
 
     Identifier& identifier() { return m_identifier; }
     const Identifier& identifier() const { return m_identifier; }
 
 private:
+    IdentifierExpression(SourceSpan span, Identifier&& identifier)
+        : Expression(span)
+        , m_identifier(WTFMove(identifier))
+    { }
+
     Identifier m_identifier;
 };
 

--- a/Source/WebGPU/WGSL/AST/ASTIdentityExpression.h
+++ b/Source/WebGPU/WGSL/AST/ASTIdentityExpression.h
@@ -35,18 +35,18 @@ namespace WGSL::AST {
 // larger node than the one current in the tree. E.g. replacing an identifier
 // with a structure access.
 class IdentityExpression final : public Expression {
-    WTF_MAKE_FAST_ALLOCATED;
+    friend ShaderModule;
 public:
-    IdentityExpression(SourceSpan span, UniqueRef<Expression>&& expression)
-        : Expression(span)
-        , m_expression(WTFMove(expression))
-    { }
-
     NodeKind kind() const override;
     Expression& expression() { return m_expression.get(); }
 
 private:
-    UniqueRef<Expression> m_expression;
+    IdentityExpression(SourceSpan span, Expression::Ref&& expression)
+        : Expression(span)
+        , m_expression(WTFMove(expression))
+    { }
+
+    Expression::Ref m_expression;
 };
 
 } // namespace WGSL::AST

--- a/Source/WebGPU/WGSL/AST/ASTIndexAccessExpression.h
+++ b/Source/WebGPU/WGSL/AST/ASTIndexAccessExpression.h
@@ -30,21 +30,21 @@
 namespace WGSL::AST {
 
 class IndexAccessExpression final : public Expression {
-    WTF_MAKE_FAST_ALLOCATED;
+    WGSL_AST_BUILDER_NODE(IndexAccessExpression);
 public:
+    NodeKind kind() const override;
+    Expression& base() { return m_base.get(); }
+    Expression& index() { return m_index.get(); }
+
+private:
     IndexAccessExpression(SourceSpan span, Expression::Ref&& base, Expression::Ref&& index)
         : Expression(span)
         , m_base(WTFMove(base))
         , m_index(WTFMove(index))
     { }
 
-    NodeKind kind() const override;
-    Expression& base() { return m_base.get(); }
-    Expression& index() { return m_index.get(); }
-
-private:
-    UniqueRef<Expression> m_base;
-    UniqueRef<Expression> m_index;
+    Expression::Ref m_base;
+    Expression::Ref m_index;
 };
 
 } // namespace WGSL::AST

--- a/Source/WebGPU/WGSL/AST/ASTReturnStatement.h
+++ b/Source/WebGPU/WGSL/AST/ASTReturnStatement.h
@@ -33,13 +33,13 @@ namespace WGSL::AST {
 class ReturnStatement final : public Statement {
     WTF_MAKE_FAST_ALLOCATED;
 public:
-    ReturnStatement(SourceSpan span, Expression::Ptr&& expression)
+    ReturnStatement(SourceSpan span, Expression::Ptr expression)
         : Statement(span)
-        , m_expression(WTFMove(expression))
+        , m_expression(expression)
     { }
 
     NodeKind kind() const override;
-    Expression* maybeExpression() { return m_expression.get(); }
+    Expression* maybeExpression() { return m_expression; }
 
 private:
     Expression::Ptr m_expression;

--- a/Source/WebGPU/WGSL/AST/ASTSigned32Literal.h
+++ b/Source/WebGPU/WGSL/AST/ASTSigned32Literal.h
@@ -30,17 +30,17 @@
 namespace WGSL::AST {
 
 class Signed32Literal final : public Expression {
-    WTF_MAKE_FAST_ALLOCATED;
+    WGSL_AST_BUILDER_NODE(Signed32Literal);
 public:
+    NodeKind kind() const final;
+    int32_t value() const { return m_value; }
+
+private:
     Signed32Literal(SourceSpan span, int32_t value)
         : Expression(span)
         , m_value(value)
     { }
 
-    NodeKind kind() const final;
-    int32_t value() const { return m_value; }
-
-private:
     int32_t m_value;
 };
 

--- a/Source/WebGPU/WGSL/AST/ASTTypeName.h
+++ b/Source/WebGPU/WGSL/AST/ASTTypeName.h
@@ -65,13 +65,13 @@ public:
     NodeKind kind() const override;
 
     TypeName* maybeElementType() const { return m_elementType; }
-    Expression* maybeElementCount() const { return m_elementCount.get(); }
+    Expression* maybeElementCount() const { return m_elementCount; }
 
 private:
-    ArrayTypeName(SourceSpan span, TypeName::Ptr elementType, Expression::Ptr&& elementCount)
+    ArrayTypeName(SourceSpan span, TypeName::Ptr elementType, Expression::Ptr elementCount)
         : TypeName(span)
         , m_elementType(elementType)
-        , m_elementCount(WTFMove(elementCount))
+        , m_elementCount(elementCount)
     { }
 
     TypeName::Ptr m_elementType;

--- a/Source/WebGPU/WGSL/AST/ASTUnaryExpression.h
+++ b/Source/WebGPU/WGSL/AST/ASTUnaryExpression.h
@@ -59,20 +59,20 @@ WGSL_AST_UNARYOP_IMPL
 void printInternal(PrintStream&, UnaryOperation);
 
 class UnaryExpression final : public Expression {
-    WTF_MAKE_FAST_ALLOCATED;
+    WGSL_AST_BUILDER_NODE(UnaryExpression);
 public:
+    NodeKind kind() const final;
+    Expression& expression() { return m_expression.get(); }
+    UnaryOperation operation() const { return m_operation; }
+
+private:
     UnaryExpression(SourceSpan span, Expression::Ref&& expression, UnaryOperation operation)
         : Expression(span)
         , m_expression(WTFMove(expression))
         , m_operation(operation)
     { }
 
-    NodeKind kind() const final;
-    Expression& expression() { return m_expression.get(); }
-    UnaryOperation operation() const { return m_operation; }
-
-private:
-    UniqueRef<Expression> m_expression;
+    Expression::Ref m_expression;
     UnaryOperation m_operation;
 };
 

--- a/Source/WebGPU/WGSL/AST/ASTUnsigned32Literal.h
+++ b/Source/WebGPU/WGSL/AST/ASTUnsigned32Literal.h
@@ -30,17 +30,17 @@
 namespace WGSL::AST {
 
 class Unsigned32Literal final : public Expression {
-    WTF_MAKE_FAST_ALLOCATED;
+    WGSL_AST_BUILDER_NODE(Unsigned32Literal);
 public:
+    NodeKind kind() const final;
+    uint32_t value() const { return m_value; }
+
+private:
     Unsigned32Literal(SourceSpan span, uint32_t value)
         : Expression(span)
         , m_value(value)
     { }
 
-    NodeKind kind() const final;
-    uint32_t value() const { return m_value; }
-
-private:
     uint32_t m_value;
 };
 

--- a/Source/WebGPU/WGSL/AST/ASTVariable.h
+++ b/Source/WebGPU/WGSL/AST/ASTVariable.h
@@ -47,17 +47,17 @@ public:
     using Ref = UniqueRef<Variable>;
     using List = UniqueRefVector<Variable>;
 
-    Variable(SourceSpan span, VariableFlavor flavor, Identifier&& name, TypeName::Ptr type, Expression::Ptr&& initializer)
-        : Variable(span, flavor, WTFMove(name), { }, type, WTFMove(initializer), { })
+    Variable(SourceSpan span, VariableFlavor flavor, Identifier&& name, TypeName::Ptr type, Expression::Ptr initializer)
+        : Variable(span, flavor, WTFMove(name), { }, type, initializer, { })
     { }
 
-    Variable(SourceSpan span, VariableFlavor flavor, Identifier&& name, VariableQualifier::Ptr&& qualifier, TypeName::Ptr type, Expression::Ptr&& initializer, Attribute::List&& attributes)
+    Variable(SourceSpan span, VariableFlavor flavor, Identifier&& name, VariableQualifier::Ptr&& qualifier, TypeName::Ptr type, Expression::Ptr initializer, Attribute::List&& attributes)
         : Declaration(span)
         , m_name(WTFMove(name))
         , m_attributes(WTFMove(attributes))
         , m_qualifier(WTFMove(qualifier))
         , m_type(type)
-        , m_initializer(WTFMove(initializer))
+        , m_initializer(initializer)
         , m_flavor(flavor)
     {
         ASSERT(m_type || m_initializer);
@@ -69,7 +69,7 @@ public:
     Attribute::List& attributes() { return m_attributes; }
     VariableQualifier* maybeQualifier() { return m_qualifier.get(); }
     TypeName* maybeTypeName() { return m_type; }
-    Expression* maybeInitializer() { return m_initializer.get(); }
+    Expression* maybeInitializer() { return m_initializer; }
 
 private:
     Identifier m_name;

--- a/Source/WebGPU/WGSL/AST/ASTWorkgroupSizeAttribute.h
+++ b/Source/WebGPU/WGSL/AST/ASTWorkgroupSizeAttribute.h
@@ -34,15 +34,15 @@ class WorkgroupSizeAttribute final : public Attribute {
 public:
     NodeKind kind() const override;
     Expression& x() { return m_x.get(); }
-    Expression* maybeY() { return m_y.get(); }
-    Expression* maybeZ() { return m_z.get(); }
+    Expression* maybeY() { return m_y; }
+    Expression* maybeZ() { return m_z; }
 
 private:
-    WorkgroupSizeAttribute(SourceSpan span, Expression::Ref&& x, Expression::Ptr&& maybeY, Expression::Ptr&& maybeZ)
+    WorkgroupSizeAttribute(SourceSpan span, Expression::Ref&& x, Expression::Ptr maybeY, Expression::Ptr maybeZ)
         : Attribute(span)
         , m_x(WTFMove(x))
-        , m_y(WTFMove(maybeY))
-        , m_z(WTFMove(maybeZ))
+        , m_y(maybeY)
+        , m_z(maybeZ)
     { }
 
     Expression::Ref m_x;

--- a/Source/WebGPU/WGSL/GlobalVariableRewriter.cpp
+++ b/Source/WebGPU/WGSL/GlobalVariableRewriter.cpp
@@ -130,9 +130,9 @@ void RewriteGlobalVariables::visit(AST::IdentifierExpression& identifier)
     auto name = identifier.identifier();
     if (Global* global = read(name)) {
         if (auto resource = global->resource) {
-            auto base = makeUniqueRef<AST::IdentifierExpression>(identifier.span(), argumentBufferParameterName(resource->group));
-            auto structureAccess = makeUniqueRef<AST::FieldAccessExpression>(identifier.span(), WTFMove(base), WTFMove(name));
-            m_callGraph.ast().replace(&identifier, AST::IdentityExpression(identifier.span(), WTFMove(structureAccess)));
+            auto& base = m_callGraph.ast().astBuilder().construct<AST::IdentifierExpression>(identifier.span(), argumentBufferParameterName(resource->group));
+            auto& structureAccess = m_callGraph.ast().astBuilder().construct<AST::FieldAccessExpression>(identifier.span(), base, WTFMove(name));
+            m_callGraph.ast().replace(identifier, structureAccess);
         }
     }
 }

--- a/Source/WebGPU/WGSL/MangleNames.cpp
+++ b/Source/WebGPU/WGSL/MangleNames.cpp
@@ -164,7 +164,7 @@ void NameManglerVisitor::visit(AST::Variable& variable)
     for (auto& attribute : variable.attributes()) {
         if (is<AST::IdAttribute>(attribute)) {
             unsigned value;
-            auto expression = downcast<AST::IdAttribute>(attribute).value();
+            auto& expression = downcast<AST::IdAttribute>(attribute).value();
             if (is<AST::AbstractIntegerLiteral>(expression))
                 value = downcast<AST::AbstractIntegerLiteral>(expression).value();
             else if (is<AST::Signed32Literal>(expression))

--- a/Source/WebGPU/WGSL/TypeCheck.cpp
+++ b/Source/WebGPU/WGSL/TypeCheck.cpp
@@ -362,7 +362,7 @@ void TypeChecker::visit(AST::IndexAccessExpression& access)
 
 void TypeChecker::visit(AST::BinaryExpression& binary)
 {
-    chooseOverload("operator", binary.span(), toString(binary.operation()), Vector<AST::Expression*> { &binary.leftExpression(), &binary.rightExpression() }, { });
+    chooseOverload("operator", binary.span(), toString(binary.operation()), ReferenceWrapperVector<AST::Expression, 2> { binary.leftExpression(), binary.rightExpression() }, { });
 }
 
 void TypeChecker::visit(AST::IdentifierExpression& identifier)
@@ -463,7 +463,7 @@ void TypeChecker::visit(AST::CallExpression& call)
 
 void TypeChecker::visit(AST::UnaryExpression& unary)
 {
-    chooseOverload("operator", unary.span(), toString(unary.operation()), Vector<AST::Expression*> { &unary.expression() }, { });
+    chooseOverload("operator", unary.span(), toString(unary.operation()), ReferenceWrapperVector<AST::Expression, 1> { unary.expression() }, { });
 }
 
 // Literal Expressions
@@ -633,7 +633,7 @@ Type* TypeChecker::chooseOverload(const char* kind, const SourceSpan& span, cons
     Vector<Type*> valueArguments;
     valueArguments.reserveInitialCapacity(callArguments.size());
     for (unsigned i = 0; i < callArguments.size(); ++i) {
-        auto* type = infer(*callArguments.Vector::at(i));
+        auto* type = infer(callArguments[i]);
         if (isBottom(type)) {
             inferred(m_types.bottomType());
             return m_types.bottomType();
@@ -645,7 +645,7 @@ Type* TypeChecker::chooseOverload(const char* kind, const SourceSpan& span, cons
     if (overload.has_value()) {
         ASSERT(overload->parameters.size() == callArguments.size());
         for (unsigned i = 0; i < callArguments.size(); ++i)
-            callArguments.Vector::at(i)->m_inferredType = overload->parameters[i];
+            callArguments[i].m_inferredType = overload->parameters[i];
         inferred(overload->result);
         return overload->result;
     }

--- a/Tools/TestWebKitAPI/Tests/WGSL/ConstLiteralTests.cpp
+++ b/Tools/TestWebKitAPI/Tests/WGSL/ConstLiteralTests.cpp
@@ -29,13 +29,16 @@
 #include "ParserPrivate.h"
 #include "WGSLShaderModule.h"
 
-static Expected<UniqueRef<WGSL::AST::Expression>, WGSL::Error> parseLCharPrimaryExpression(const String& input)
+static Expected<std::pair<WGSL::ShaderModule, WGSL::AST::Expression::Ref>, WGSL::Error> parseLCharPrimaryExpression(const String& input)
 {
     WGSL::ShaderModule shaderModule(input, { });
     WGSL::Lexer<LChar> lexer(input);
     WGSL::Parser parser(shaderModule, lexer);
 
-    return parser.parsePrimaryExpression();
+    auto expression = parser.parsePrimaryExpression();
+    if (!expression)
+        return makeUnexpected(expression.error());
+    return { std::make_pair(WTFMove(shaderModule), *expression) };
 }
 
 template<class NumberType>
@@ -59,10 +62,10 @@ TEST(WGSLConstLiteralTests, BoolLiteral)
         auto parseResult = parseLCharPrimaryExpression(testCase.input);
         EXPECT_TRUE(parseResult);
 
-        auto expr = WTFMove(*parseResult);
+        AST::Expression& expr = parseResult->second;
         EXPECT_TRUE(is<AST::BoolLiteral>(expr));
 
-        const auto& intLiteral = downcast<AST::BoolLiteral>(expr.get());
+        const auto& intLiteral = downcast<AST::BoolLiteral>(expr);
         EXPECT_EQ(intLiteral.value(), testCase.expectedValue);
         auto inputLength = testCase.input.length();
         EXPECT_EQ(intLiteral.span(), SourceSpan(1, inputLength, inputLength, 0));
@@ -83,10 +86,10 @@ TEST(WGSLConstLiteralTests, AbstractIntegerLiteralDecimal)
         auto parseResult = parseLCharPrimaryExpression(testCase.input);
         EXPECT_TRUE(parseResult);
 
-        auto expr = WTFMove(*parseResult);
+        AST::Expression& expr = parseResult->second;
         EXPECT_TRUE(is<AST::AbstractIntegerLiteral>(expr));
 
-        const auto& intLiteral = downcast<AST::AbstractIntegerLiteral>(expr.get());
+        const auto& intLiteral = downcast<AST::AbstractIntegerLiteral>(expr);
         EXPECT_EQ(intLiteral.value(), testCase.expectedValue);
         auto inputLength = testCase.input.length();
         EXPECT_EQ(intLiteral.span(), SourceSpan(1, inputLength, inputLength, 0));
@@ -107,10 +110,10 @@ TEST(WGSLConstLiteralTests, AbstractIntegerLiteralHex)
         auto parseResult = parseLCharPrimaryExpression(testCase.input);
         EXPECT_TRUE(parseResult);
 
-        auto expr = WTFMove(*parseResult);
+        AST::Expression& expr = parseResult->second;
         EXPECT_TRUE(is<AST::AbstractIntegerLiteral>(expr));
 
-        const auto& intLiteral = downcast<AST::AbstractIntegerLiteral>(expr.get());
+        const auto& intLiteral = downcast<AST::AbstractIntegerLiteral>(expr);
         EXPECT_EQ(intLiteral.value(), testCase.expectedValue);
         auto inputLength = testCase.input.length();
         EXPECT_EQ(intLiteral.span(), WGSL::SourceSpan(1, inputLength, inputLength, 0));
@@ -136,10 +139,10 @@ TEST(WGSLConstLiteralTests, AbstractFloatLiteralDec)
         auto parseResult = parseLCharPrimaryExpression(testCase.input);
         EXPECT_TRUE(parseResult);
 
-        auto expr = WTFMove(*parseResult);
+        AST::Expression& expr = parseResult->second;
         EXPECT_TRUE(is<AST::AbstractFloatLiteral>(expr));
 
-        const auto& floatLiteral = downcast<AST::AbstractFloatLiteral>(expr.get());
+        const auto& floatLiteral = downcast<AST::AbstractFloatLiteral>(expr);
         EXPECT_EQ(floatLiteral.value(), testCase.expectedValue);
         auto inputLength = testCase.input.length();
         EXPECT_EQ(floatLiteral.span(), SourceSpan(1, inputLength, inputLength, 0));

--- a/Tools/TestWebKitAPI/Tests/WGSL/ParserTests.cpp
+++ b/Tools/TestWebKitAPI/Tests/WGSL/ParserTests.cpp
@@ -670,9 +670,27 @@ TEST(WGSLParserTests, UnaryExpression)
 
 static void testUnaryExpressionX(ASCIILiteral program, WGSL::AST::UnaryOperation op)
 {
-    EXPECT_EXPRESSION(expression, program);
-    EXPECT_TRUE(is<WGSL::AST::UnaryExpression>(expression.get()));
-    auto& unaryExpression = downcast<WGSL::AST::UnaryExpression>(expression.get());
+    auto source = makeString(
+        "fn f() {\n"_s,
+        "_ = "_s, program, ";"_s,
+        "}\n"_s
+    );
+    auto shader = parse(source);
+
+    EXPECT_SHADER(shader);
+    EXPECT_TRUE(shader.has_value());
+    EXPECT_TRUE(shader->directives().isEmpty());
+    EXPECT_TRUE(shader->structures().isEmpty());
+    EXPECT_TRUE(shader->variables().isEmpty());
+    EXPECT_EQ(shader->functions().size(), 1u);
+    auto& function = shader->functions()[0];
+
+    EXPECT_EQ(function.body().statements().size(), 1u);
+    EXPECT_TRUE(is<WGSL::AST::PhonyAssignmentStatement>(function.body().statements()[0]));
+    auto& statement = downcast<WGSL::AST::PhonyAssignmentStatement>(function.body().statements()[0]);
+
+    EXPECT_TRUE(is<WGSL::AST::UnaryExpression>(statement.rhs()));
+    auto& unaryExpression = downcast<WGSL::AST::UnaryExpression>(statement.rhs());
 
     EXPECT_EQ(unaryExpression.operation(), op);
     EXPECT_TRUE(is<WGSL::AST::IdentifierExpression>(unaryExpression.expression()));
@@ -693,9 +711,26 @@ static void testBinaryExpressionXY(ASCIILiteral program, WGSL::AST::BinaryOperat
 {
     EXPECT_EQ(ids.size(), 2u);
 
-    EXPECT_EXPRESSION(expression, program);
-    EXPECT_TRUE(is<WGSL::AST::BinaryExpression>(expression.get()));
-    auto& binaryExpression = downcast<WGSL::AST::BinaryExpression>(expression.get());
+    auto source = makeString(
+        "fn f() {\n"_s,
+        "_ = "_s, program, ";"_s,
+        "}\n"_s
+    );
+    auto shader = parse(source);
+
+    EXPECT_SHADER(shader);
+    EXPECT_TRUE(shader.has_value());
+    EXPECT_TRUE(shader->directives().isEmpty());
+    EXPECT_TRUE(shader->structures().isEmpty());
+    EXPECT_TRUE(shader->variables().isEmpty());
+    EXPECT_EQ(shader->functions().size(), 1u);
+    auto& function = shader->functions()[0];
+
+    EXPECT_EQ(function.body().statements().size(), 1u);
+    EXPECT_TRUE(is<WGSL::AST::PhonyAssignmentStatement>(function.body().statements()[0]));
+    auto& statement = downcast<WGSL::AST::PhonyAssignmentStatement>(function.body().statements()[0]);
+    EXPECT_TRUE(is<WGSL::AST::BinaryExpression>(statement.rhs()));
+    auto& binaryExpression = downcast<WGSL::AST::BinaryExpression>(statement.rhs());
 
     EXPECT_EQ(binaryExpression.operation(), op);
     EXPECT_TRUE(is<WGSL::AST::IdentifierExpression>(binaryExpression.leftExpression()));
@@ -711,9 +746,27 @@ static void testBinaryExpressionXYZ(ASCIILiteral program, const Vector<WGSL::AST
     EXPECT_EQ(ops.size(), 2u);
     EXPECT_EQ(ids.size(), 3u);
 
-    EXPECT_EXPRESSION(expression, program);
-    EXPECT_TRUE(is<WGSL::AST::BinaryExpression>(expression.get()));
-    auto& binaryExpression = downcast<WGSL::AST::BinaryExpression>(expression.get());
+    auto source = makeString(
+        "fn f() {\n"_s,
+        "_ = "_s, program, ";"_s,
+        "}\n"_s
+    );
+    auto shader = parse(source);
+
+    EXPECT_SHADER(shader);
+    EXPECT_TRUE(shader.has_value());
+    EXPECT_TRUE(shader->directives().isEmpty());
+    EXPECT_TRUE(shader->structures().isEmpty());
+    EXPECT_TRUE(shader->variables().isEmpty());
+    EXPECT_EQ(shader->functions().size(), 1u);
+    auto& function = shader->functions()[0];
+
+    EXPECT_EQ(function.body().statements().size(), 1u);
+    EXPECT_TRUE(is<WGSL::AST::PhonyAssignmentStatement>(function.body().statements()[0]));
+    auto& statement = downcast<WGSL::AST::PhonyAssignmentStatement>(function.body().statements()[0]);
+
+    EXPECT_TRUE(is<WGSL::AST::BinaryExpression>(statement.rhs()));
+    auto& binaryExpression = downcast<WGSL::AST::BinaryExpression>(statement.rhs());
 
     auto& complex = is<WGSL::AST::BinaryExpression>(binaryExpression.leftExpression()) ?
         binaryExpression.leftExpression() : binaryExpression.rightExpression();

--- a/Tools/TestWebKitAPI/Tests/WGSL/TestWGSLAPI.h
+++ b/Tools/TestWebKitAPI/Tests/WGSL/TestWGSLAPI.h
@@ -33,14 +33,6 @@
         } \
     } while (false)
 
-#define EXPECT_EXPRESSION(name, source) \
-    auto name##Expected = WGSL::parseExpression(source); \
-    if (!name##Expected) { \
-        ::TestWGSLAPI::logCompilationError(name##Expected.error()); \
-        return; \
-    } \
-    auto& name = *name##Expected;
-
 namespace WGSL {
 class CompilationMessage;
 }


### PR DESCRIPTION
#### e3b4aba1b3abf42f1f959b26b3c52df95132cd2d
<pre>
[WGSL] Make expression nodes arena allocated
<a href="https://bugs.webkit.org/show_bug.cgi?id=256530">https://bugs.webkit.org/show_bug.cgi?id=256530</a>
rdar://109104698

Reviewed by Dan Glastonbury.

Continue converting nodes to be arena allocated.

* Source/WebGPU/WGSL/AST/ASTAbstractFloatLiteral.h:
* Source/WebGPU/WGSL/AST/ASTAbstractIntegerLiteral.h:
* Source/WebGPU/WGSL/AST/ASTBinaryExpression.h:
(WGSL::AST::BinaryExpression::operation const):
(WGSL::AST::BinaryExpression::leftExpression):
(WGSL::AST::BinaryExpression::rightExpression):
* Source/WebGPU/WGSL/AST/ASTBitcastExpression.h:
* Source/WebGPU/WGSL/AST/ASTBoolLiteral.h:
* Source/WebGPU/WGSL/AST/ASTBuilder.h:
* Source/WebGPU/WGSL/AST/ASTCallExpression.h:
* Source/WebGPU/WGSL/AST/ASTExpression.h:
(WGSL::AST::Expression::Expression):
* Source/WebGPU/WGSL/AST/ASTFieldAccessExpression.h:
* Source/WebGPU/WGSL/AST/ASTFloat32Literal.h:
* Source/WebGPU/WGSL/AST/ASTForStatement.h:
* Source/WebGPU/WGSL/AST/ASTIdentifierExpression.h:
* Source/WebGPU/WGSL/AST/ASTIdentityExpression.h:
* Source/WebGPU/WGSL/AST/ASTIndexAccessExpression.h:
* Source/WebGPU/WGSL/AST/ASTReturnStatement.h:
* Source/WebGPU/WGSL/AST/ASTSigned32Literal.h:
* Source/WebGPU/WGSL/AST/ASTTypeName.h:
(WGSL::AST::ArrayTypeName::maybeElementCount const):
(WGSL::AST::ArrayTypeName::ArrayTypeName):
* Source/WebGPU/WGSL/AST/ASTUnaryExpression.h:
* Source/WebGPU/WGSL/AST/ASTUnsigned32Literal.h:
* Source/WebGPU/WGSL/AST/ASTVariable.h:
* Source/WebGPU/WGSL/AST/ASTWorkgroupSizeAttribute.h:
* Source/WebGPU/WGSL/EntryPointRewriter.cpp:
(WGSL::EntryPointRewriter::materialize):
* Source/WebGPU/WGSL/GlobalVariableRewriter.cpp:
(WGSL::RewriteGlobalVariables::visit):
* Source/WebGPU/WGSL/MangleNames.cpp:
(WGSL::NameManglerVisitor::visit):
* Source/WebGPU/WGSL/Parser.cpp:
(WGSL::Parser&lt;Lexer&gt;::parseAttribute):
(WGSL::Parser&lt;Lexer&gt;::parseArrayType):
(WGSL::Parser&lt;Lexer&gt;::parseVariableWithAttributes):
(WGSL::Parser&lt;Lexer&gt;::parseForStatement):
(WGSL::Parser&lt;Lexer&gt;::parseReturnStatement):
(WGSL::Parser&lt;Lexer&gt;::parseShortCircuitExpression):
(WGSL::Parser&lt;Lexer&gt;::parseRelationalExpressionPostUnary):
(WGSL::Parser&lt;Lexer&gt;::parseShiftExpressionPostUnary):
(WGSL::Parser&lt;Lexer&gt;::parseAdditiveExpressionPostUnary):
(WGSL::Parser&lt;Lexer&gt;::parseBitwiseExpressionPostUnary):
(WGSL::Parser&lt;Lexer&gt;::parseMultiplicativeExpressionPostUnary):
(WGSL::Parser&lt;Lexer&gt;::parseUnaryExpression):
(WGSL::Parser&lt;Lexer&gt;::parsePostfixExpression):
(WGSL::Parser&lt;Lexer&gt;::parsePrimaryExpression):
(WGSL::Parser&lt;Lexer&gt;::parseCoreLHSExpression):
* Source/WebGPU/WGSL/TypeCheck.cpp:
(WGSL::TypeChecker::visit):
(WGSL::TypeChecker::chooseOverload):
* Source/WebGPU/WGSL/WGSLShaderModule.h:
(WGSL::ShaderModule::replace):

Canonical link: <a href="https://commits.webkit.org/263895@main">https://commits.webkit.org/263895@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/36a4df0c583bffdd6f9917061ff9090d363a2867

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/5993 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/6170 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/6355 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/7548 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/6352 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/5992 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/6389 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/6129 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/9034 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/6102 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/6135 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/5428 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/7608 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/3611 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/5406 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/13329 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/5477 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/5485 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/7711 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/5940 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/4869 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/5371 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/1433 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/9499 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/5734 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->