### PR TITLE
Web Inspector: REGRESSION(?): Console: find results count has no left padding

### DIFF
--- a/Source/WebInspectorUI/UserInterface/Views/FindBanner.css
+++ b/Source/WebInspectorUI/UserInterface/Views/FindBanner.css
@@ -43,8 +43,7 @@
 
     z-index: var(--z-index-header);
 
-    --find-banner-outer-child-margin: 8px;
-    --find-banner-input-margin-start: 6px;
+    --find-banner-inline-space: 6px;
 }
 
 .find-banner.showing {
@@ -67,14 +66,6 @@
     transition-timing-function: ease-out;
 }
 
-.find-banner > :first-child {
-    margin-inline-start: var(--find-banner-outer-child-margin) !important;
-}
-
-.find-banner > :last-child {
-    margin-inline-end: var(--find-banner-outer-child-margin) !important;
-}
-
 .find-banner > input[type="search"] {
     width: 30vw;
     min-width: 143px;
@@ -82,7 +73,7 @@
     height: 19px;
     margin-top: 1px;
     margin-bottom: 1px;
-    margin-inline: var(--find-banner-input-margin-start) -1px;
+    margin-inline: 0 -1px;
     vertical-align: top;
     background-color: white;
     border: 1px solid var(--border-color);
@@ -110,7 +101,7 @@ body[dir=rtl] .find-banner > input[type="search"] {
 .find-banner > button {
     margin: 1px 4px;
 
-    padding-inline: 6px;
+    padding-inline: var(--find-banner-inline-space);
 
     appearance: none;
 
@@ -208,7 +199,7 @@ body[dir=rtl] .find-banner > button.segmented.next-result:active:not(:disabled) 
 
 .find-banner > button.segmented {
     min-width: 22px;
-    padding: 3px 6px 2px;
+    padding: 3px var(--find-banner-inline-space) 2px;
 }
 
 .find-banner > button.segmented > .glyph {
@@ -217,57 +208,11 @@ body[dir=rtl] .find-banner > button.segmented.next-result:active:not(:disabled) 
 }
 
 .find-banner > label {
-    margin: 0 6px;
     line-height: 21px;
 }
 
-.find-banner.console-find-banner {
-    position: relative;
-    top: auto;
-    border: 0;
-}
-
-body .find-banner.console-find-banner {
-    flex-wrap: nowrap;
-}
-
-.find-banner.console-find-banner > input[type="search"] {
-    padding-top: 0;
-    outline: none;
-    border: 1px solid var(--border-color);
-
-    --console-find-banner-search-box-border-radius-start: 3px;
-    --console-find-banner-search-box-border-radius-end: 0;
-}
-
-body[dir=ltr] .find-banner.console-find-banner > input[type="search"] {
-    border-top-left-radius: var(--console-find-banner-search-box-border-radius-start);
-    border-bottom-left-radius: var(--console-find-banner-search-box-border-radius-start);
-    border-top-right-radius: var(--console-find-banner-search-box-border-radius-end);
-    border-bottom-right-radius: var(--console-find-banner-search-box-border-radius-end);
-}
-
-body[dir=rtl] .find-banner.console-find-banner > input[type="search"] {
-    border-top-left-radius: var(--console-find-banner-search-box-border-radius-end);
-    border-bottom-left-radius: var(--console-find-banner-search-box-border-radius-end);
-    border-top-right-radius: var(--console-find-banner-search-box-border-radius-start);
-    border-bottom-right-radius: var(--console-find-banner-search-box-border-radius-start);
-}
-
-.find-banner.console-find-banner > :is(input[type="search"], button) {
-    background-color: inherit;
-    height: 22px;
-}
-
-.find-banner.console-find-banner > input[type="search"]::-webkit-textfield-decoration-container {
-    margin-inline-start: 4px;
-}
-
-.find-banner.console-find-banner > input[type="search"]:focus,
-.find-banner.console-find-banner > input[type="search"]:focus ~ button,
-.find-banner.console-find-banner > input[type="search"]:not(:placeholder-shown),
-.find-banner.console-find-banner > input[type="search"]:not(:placeholder-shown) ~ button {
-    background-color: var(--background-color);
+.find-banner > label:not(:empty) {
+    margin-inline-end: var(--find-banner-inline-space);
 }
 
 @media (prefers-color-scheme: dark) {

--- a/Source/WebInspectorUI/UserInterface/Views/FindBanner.js
+++ b/Source/WebInspectorUI/UserInterface/Views/FindBanner.js
@@ -25,7 +25,7 @@
 
 WI.FindBanner = class FindBanner extends WI.NavigationItem
 {
-    constructor(delegate, className, alwaysShowing = false)
+    constructor(delegate, {alwaysShowing, className} = {})
     {
         super();
 

--- a/Source/WebInspectorUI/UserInterface/Views/LogContentView.css
+++ b/Source/WebInspectorUI/UserInterface/Views/LogContentView.css
@@ -23,11 +23,6 @@
  * THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-.console-find-banner {
-    --find-banner-outer-child-margin: 0;
-    --find-banner-input-margin-start: 0;
-}
-
 .message-channel-scope-bar.default-item-selected:not(:hover) {
     --scope-bar-text-color-override: var(--text-color);
     --scope-bar-background-color-override: transparent;
@@ -59,6 +54,39 @@
 
 .console-other-filters-button.active:active > .glyph {
     color: var(--glyph-color-active-pressed);
+}
+
+.navigation-bar > .item.find-banner.console {
+    flex-wrap: nowrap;
+    position: relative;
+    top: auto;
+    border: none;
+}
+
+:not(.console-drawer) > .navigation-bar > .item.find-banner.console {
+    margin-inline-start: var(--find-banner-inline-space);
+}
+
+.navigation-bar > .item.find-banner.console > input[type="search"] {
+    padding-top: 0;
+    border: 1px solid var(--border-color);
+    outline: none;
+}
+
+.navigation-bar > .item.find-banner.console > :is(input[type="search"], button) {
+    background-color: inherit;
+    height: 22px;
+}
+
+.navigation-bar > .item.find-banner.console > input[type="search"]::-webkit-textfield-decoration-container {
+    margin-inline-start: 4px;
+}
+
+.navigation-bar > .item.find-banner.console > input[type="search"]:focus,
+.navigation-bar > .item.find-banner.console > input[type="search"]:focus ~ button,
+.navigation-bar > .item.find-banner.console > input[type="search"]:not(:placeholder-shown),
+.navigation-bar > .item.find-banner.console > input[type="search"]:not(:placeholder-shown) ~ button {
+    background-color: var(--background-color);
 }
 
 .navigation-bar > .item.console-snippets > img {

--- a/Source/WebInspectorUI/UserInterface/Views/LogContentView.js
+++ b/Source/WebInspectorUI/UserInterface/Views/LogContentView.js
@@ -60,8 +60,7 @@ WI.LogContentView = class LogContentView extends WI.ContentView
         this._logViewController = new WI.JavaScriptLogViewController(this.messagesElement, this.messagesElement, this.prompt, this, "console-prompt-history");
         this._lastMessageView = null;
 
-        const fixed = true;
-        this._findBanner = new WI.FindBanner(this, "console-find-banner", fixed);
+        this._findBanner = new WI.FindBanner(this, {alwaysShowing: true, className: "console"});
         this._findBanner.visibilityPriority = WI.NavigationItem.VisibilityPriority.Low;
         this._findBanner.targetElement = this.element;
 


### PR DESCRIPTION
#### 347111d578a4171bc5ef8b5917ba41c4c22acc59
<pre>
Web Inspector: REGRESSION(?): Console: find results count has no left padding
<a href="https://bugs.webkit.org/show_bug.cgi?id=256531">https://bugs.webkit.org/show_bug.cgi?id=256531</a>

Reviewed by Patrick Angle.

* Source/WebInspectorUI/UserInterface/Views/FindBanner.css:
(.find-banner):
(.find-banner &gt; input[type=&quot;search&quot;]):
(.find-banner &gt; button):
(.find-banner &gt; button.segmented):
(.find-banner &gt; label):
(.find-banner &gt; label:not(:empty)): Added.
(.find-banner &gt; :first-child): Deleted.
(.find-banner &gt; :last-child): Deleted.
(.find-banner.console-find-banner): Deleted.
(body .find-banner.console-find-banner): Deleted.
(.find-banner.console-find-banner &gt; input[type=&quot;search&quot;]): Deleted.
(body[dir=ltr] .find-banner.console-find-banner &gt; input[type=&quot;search&quot;]): Deleted.
(body[dir=rtl] .find-banner.console-find-banner &gt; input[type=&quot;search&quot;]): Deleted.
(.find-banner.console-find-banner &gt; :is(input[type=&quot;search&quot;], button)): Deleted.
(.find-banner.console-find-banner &gt; input[type=&quot;search&quot;]::-webkit-textfield-decoration-container): Deleted.
(.find-banner.console-find-banner &gt; input[type=&quot;search&quot;]:focus, .find-banner.console-find-banner &gt; input[type=&quot;search&quot;]:focus ~ button, .find-banner.console-find-banner &gt; input[type=&quot;search&quot;]:not(:placeholder-shown), .find-banner.console-find-banner &gt; input[type=&quot;search&quot;]:not(:placeholder-shown) ~ button): Deleted.
* Source/WebInspectorUI/UserInterface/Views/LogContentView.css:
(.navigation-bar &gt; .item.find-banner.console): Added.
(:not(.console-drawer) &gt; .navigation-bar &gt; .item.find-banner.console): Added.
(.navigation-bar &gt; .item.find-banner.console &gt; input[type=&quot;search&quot;]): Added.
(.navigation-bar &gt; .item.find-banner.console &gt; :is(input[type=&quot;search&quot;], button)): Added.
(.navigation-bar &gt; .item.find-banner.console &gt; input[type=&quot;search&quot;]::-webkit-textfield-decoration-container): Added.
(.navigation-bar &gt; .item.find-banner.console &gt; input[type=&quot;search&quot;]:focus, .navigation-bar &gt; .item.find-banner.console &gt; input[type=&quot;search&quot;]:focus ~ button, .navigation-bar &gt; .item.find-banner.console &gt; input[type=&quot;search&quot;]:not(:placeholder-shown), .navigation-bar &gt; .item.find-banner.console &gt; input[type=&quot;search&quot;]:not(:placeholder-shown) ~ button ): Added.
(.console-find-banner): Deleted.
Avoid using `:first-child`/`:last-child` (and `!important`) as they have very little control over what kinds of situations they apply (e.g. we don&apos;t want to add padding to `label:empty`).
Don&apos;t add any outside `margin` as that&apos;s handled by the containing `WI.NavigationBar` (or adjacent `WI.NavigationItem`) unless we know for sure that it&apos;s the first/last `WI.NavigationItem` in the `WI.NavigationBar`.
Drive-by: Move styles to a more relevant location.

* Source/WebInspectorUI/UserInterface/Views/FindBanner.js:
(WI.FindBanner):
* Source/WebInspectorUI/UserInterface/Views/LogContentView.js:
(WI.LogContentView):

Drive-by: Rework optional parameters into `{...} = {}` to match existing pattern elsewhere.
Canonical link: <a href="https://commits.webkit.org/264167@main">https://commits.webkit.org/264167@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f0610917b1ff947603a05e1007a5bd19ed9a5b5a

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/6915 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/7145 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/7328 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/8515 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/32/builds/7161 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/8400 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/7084 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/10065 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/7037 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/15/builds/7704 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/6369 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/8615 "Failed to checkout and rebase branch from PR 13645") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/39/builds/5084 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/6277 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/2/builds/8615 "Failed to checkout and rebase branch from PR 13645") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/6769 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/6365 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/2/builds/8615 "Failed to checkout and rebase branch from PR 13645") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/6847 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/5614 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/6223 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/1643 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/10408 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/6601 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->