### PR TITLE
git-webkit prints "error: invalid key:" during prepare-commit-msg

### DIFF
--- a/Tools/Scripts/hooks/prepare-commit-msg
+++ b/Tools/Scripts/hooks/prepare-commit-msg
@@ -36,13 +36,15 @@ for name, variable in dict(
     try:
         value = subprocess.check_output(
             ['git', 'config', '--get-all', 'branch.{}.{}'.format(BRANCH, name)],
+            stderr=subprocess.PIPE,
             **ENCODING_KWARGS
         ).strip()
-        if not value:
-            continue
-        os.environ[variable] = value
-    except subprocess.CalledProcessError:
-        continue
+        if value:
+            os.environ[variable] = value
+    except subprocess.CalledProcessError as error:
+        # `1` means that key did not exist, which is valid.
+        if error.returncode != 1:
+            sys.stderr.write(error.stderr)
 
 
 def get_bugs_string():


### PR DESCRIPTION
#### b614d2729f547c08146a1ee78ef81c1818c7aec4
<pre>
git-webkit prints &quot;error: invalid key:&quot; during prepare-commit-msg
<a href="https://bugs.webkit.org/show_bug.cgi?id=256534">https://bugs.webkit.org/show_bug.cgi?id=256534</a>
rdar://109107387

Reviewed by Jonathan Bedard.

git-config(1) exits &quot;1&quot; when a key is missing, which is an expected
case for the hook. AFAICT, there&apos;s not a good way to silence the error,
so capture stderr when making the call and only print it out if
git-config fails with a *different* exit code.

* Tools/Scripts/hooks/prepare-commit-msg:

Canonical link: <a href="https://commits.webkit.org/263965@main">https://commits.webkit.org/263965@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/273da5da3d7d8939dbdcae73c7b4e8c43a35ff04

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/5962 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/6137 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/6323 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/7515 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/6321 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/5959 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/6356 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/6096 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/8825 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/6070 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/6106 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/5402 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/7575 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/3583 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/5378 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/13311 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/5449 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/5457 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/7692 "run-api-tests-without-change (failure)") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/5908 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/4848 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/5340 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/9466 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/736 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/5701 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->