### PR TITLE
Make SharedMemoryHandle non-copyable

### DIFF
--- a/Source/WebKit/Platform/SharedMemory.cpp
+++ b/Source/WebKit/Platform/SharedMemory.cpp
@@ -33,6 +33,17 @@ namespace WebKit {
 
 using namespace WebCore;
 
+SharedMemoryHandle::SharedMemoryHandle(SharedMemoryHandle::Type&& handle, size_t size)
+    : m_handle(WTFMove(handle))
+    , m_size(size)
+{
+}
+
+bool SharedMemoryHandle::isNull() const
+{
+    return !m_handle;
+}
+
 RefPtr<SharedMemory> SharedMemory::copyBuffer(const FragmentedSharedBuffer& buffer)
 {
     if (buffer.isEmpty())

--- a/Source/WebKit/Platform/SharedMemory.h
+++ b/Source/WebKit/Platform/SharedMemory.h
@@ -60,6 +60,7 @@ namespace WebKit {
 enum class MemoryLedger { None, Default, Network, Media, Graphics, Neural };
 
 class SharedMemoryHandle {
+    WTF_MAKE_NONCOPYABLE(SharedMemoryHandle);
 public:
     using Type =
 #if USE(UNIX_DOMAIN_SOCKETS)
@@ -69,6 +70,12 @@ public:
 #elif OS(WINDOWS)
         Win32Handle;
 #endif
+
+    SharedMemoryHandle() = default;
+    SharedMemoryHandle(SharedMemoryHandle&&) = default;
+    SharedMemoryHandle(SharedMemoryHandle::Type&&, size_t);
+
+    SharedMemoryHandle& operator=(SharedMemoryHandle&&) = default;
 
     bool isNull() const;
 

--- a/Source/WebKit/Platform/cocoa/SharedMemoryCocoa.cpp
+++ b/Source/WebKit/Platform/cocoa/SharedMemoryCocoa.cpp
@@ -91,11 +91,6 @@ void SharedMemoryHandle::setOwnershipOfMemory(const WebCore::ProcessIdentity& pr
 #endif
 }
 
-bool SharedMemoryHandle::isNull() const
-{
-    return !m_handle;
-}
-
 static inline void* toPointer(mach_vm_address_t address)
 {
     return reinterpret_cast<void*>(static_cast<uintptr_t>(address));

--- a/Source/WebKit/Platform/unix/SharedMemoryUnix.cpp
+++ b/Source/WebKit/Platform/unix/SharedMemoryUnix.cpp
@@ -52,11 +52,6 @@
 
 namespace WebKit {
 
-bool SharedMemoryHandle::isNull() const
-{
-    return !m_handle;
-}
-
 UnixFileDescriptor SharedMemoryHandle::releaseHandle()
 {
     return WTFMove(m_handle);

--- a/Source/WebKit/Platform/win/SharedMemoryWin.cpp
+++ b/Source/WebKit/Platform/win/SharedMemoryWin.cpp
@@ -31,11 +31,6 @@
 
 namespace WebKit {
 
-bool SharedMemoryHandle::isNull() const
-{
-    return !m_handle;
-}
-
 RefPtr<SharedMemory> SharedMemory::allocate(size_t size)
 {
     Win32Handle handle { ::CreateFileMappingW(INVALID_HANDLE_VALUE, 0, PAGE_READWRITE, 0, size, 0) };

--- a/Source/WebKit/Shared/IPCStreamTester.cpp
+++ b/Source/WebKit/Shared/IPCStreamTester.cpp
@@ -26,15 +26,15 @@
 #include "config.h"
 #include "IPCStreamTester.h"
 
-#include <wtf/WTFProcess.h>
-
 #if ENABLE(IPC_TESTING_API)
+
 #include "Decoder.h"
 #include "IPCStreamTesterMessages.h"
 #include "IPCStreamTesterProxyMessages.h"
 #include "IPCUtilities.h"
 #include "StreamConnectionWorkQueue.h"
 #include "StreamServerConnection.h"
+#include <wtf/WTFProcess.h>
 
 #if USE(FOUNDATION)
 #include <CoreFoundation/CoreFoundation.h>
@@ -86,7 +86,7 @@ void IPCStreamTester::syncMessageReturningSharedMemory1(uint32_t byteCount, Comp
         uint8_t* data = static_cast<uint8_t*>(sharedMemory->data());
         for (size_t i = 0; i < sharedMemory->size(); ++i)
             data[i] = i;
-        return *handle;
+        return WTFMove(*handle);
     }();
     completionHandler(WTFMove(result));
 }

--- a/Source/WebKit/WebProcess/WebPage/IPCTestingAPI.cpp
+++ b/Source/WebKit/WebProcess/WebPage/IPCTestingAPI.cpp
@@ -1342,7 +1342,7 @@ JSValueRef JSIPCSemaphore::waitFor(JSContextRef context, JSObjectRef, JSObjectRe
 SharedMemory::Handle JSSharedMemory::createHandle(SharedMemory::Protection protection)
 {
     if (auto handle = m_sharedMemory->createHandle(protection))
-        return *handle;
+        return WTFMove(*handle);
     return { };
 }
 


### PR DESCRIPTION
#### 00afd6a353256ecc8010e64ac280ca4e1159825b
<pre>
Make SharedMemoryHandle non-copyable
<a href="https://bugs.webkit.org/show_bug.cgi?id=256539">https://bugs.webkit.org/show_bug.cgi?id=256539</a>

Reviewed by Kimmo Kinnunen.

Add `WTF_MAKE_NONCOPYABLE` to `SharedMemoryHandle`. Enumerate
constructors for the class.

Move common implementation of `SharedMemoryHandle` into common .cpp.

* Source/WebKit/Platform/SharedMemory.cpp:
(WebKit::SharedMemoryHandle::SharedMemoryHandle):
(WebKit::SharedMemoryHandle::isNull const):
* Source/WebKit/Platform/SharedMemory.h:
* Source/WebKit/Platform/cocoa/SharedMemoryCocoa.cpp:
(WebKit::SharedMemoryHandle::isNull const): Deleted.
* Source/WebKit/Platform/unix/SharedMemoryUnix.cpp:
(WebKit::SharedMemoryHandle::isNull const): Deleted.
* Source/WebKit/Platform/win/SharedMemoryWin.cpp:
(WebKit::SharedMemoryHandle::isNull const): Deleted.
* Source/WebKit/Shared/IPCStreamTester.cpp:
(WebKit::IPCStreamTester::syncMessageReturningSharedMemory1):
* Source/WebKit/WebProcess/WebPage/IPCTestingAPI.cpp:
(WebKit::IPCTestingAPI::JSSharedMemory::createHandle):

Canonical link: <a href="https://commits.webkit.org/263897@main">https://commits.webkit.org/263897@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/cbd8ee440a0beb863a9a14cd1c43af30ae3df8e8

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/6029 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/6207 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/6393 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/7585 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/6382 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/6425 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/6163 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/9269 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/6138 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/6166 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/5459 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/7645 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/3642 "Passed tests") | | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/13350 "1 flakes 1 missing results 188 failures") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/5508 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/5516 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/7735 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/5973 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/4894 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/5399 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/1434 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/9533 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/5765 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->