### PR TITLE
RemoteRenderingBackend and GraphicsContextGL are opening the stream connection in inconsistent manner

### DIFF
--- a/Source/WebKit/GPUProcess/graphics/RemoteGraphicsContextGL.cpp
+++ b/Source/WebKit/GPUProcess/graphics/RemoteGraphicsContextGL.cpp
@@ -80,7 +80,7 @@ Ref<RemoteGraphicsContextGL> RemoteGraphicsContextGL::create(GPUConnectionToWebP
 RemoteGraphicsContextGL::RemoteGraphicsContextGL(GPUConnectionToWebProcess& gpuConnectionToWebProcess, GraphicsContextGLIdentifier graphicsContextGLIdentifier, RemoteRenderingBackend& renderingBackend, IPC::StreamServerConnection::Handle&& connectionHandle)
     : m_gpuConnectionToWebProcess(gpuConnectionToWebProcess)
     , m_workQueue(remoteGraphicsContextGLStreamWorkQueue())
-    , m_streamConnection(IPC::StreamServerConnection::create(WTFMove(connectionHandle), workQueue()))
+    , m_streamConnection(IPC::StreamServerConnection::create(WTFMove(connectionHandle)))
     , m_graphicsContextGLIdentifier(graphicsContextGLIdentifier)
     , m_renderingBackend(renderingBackend)
 #if ENABLE(VIDEO)
@@ -133,7 +133,7 @@ void RemoteGraphicsContextGL::workQueueInitialize(WebCore::GraphicsContextGLAttr
 {
     assertIsCurrent(workQueue());
     platformWorkQueueInitialize(WTFMove(attributes));
-    m_streamConnection->open();
+    m_streamConnection->open(workQueue());
     if (m_context) {
         m_context->setClient(this);
         String extensions = m_context->getString(GraphicsContextGL::EXTENSIONS);
@@ -150,12 +150,12 @@ void RemoteGraphicsContextGL::workQueueInitialize(WebCore::GraphicsContextGLAttr
 void RemoteGraphicsContextGL::workQueueUninitialize()
 {
     assertIsCurrent(workQueue());
-    m_streamConnection->invalidate();
     if (m_context) {
         m_context->setClient(nullptr);
         m_context = nullptr;
         m_streamConnection->stopReceivingMessages(Messages::RemoteGraphicsContextGL::messageReceiverName(), m_graphicsContextGLIdentifier.toUInt64());
     }
+    m_streamConnection->invalidate();
     m_streamConnection = nullptr;
     m_renderingResourcesRequest = { };
 }

--- a/Source/WebKit/Platform/IPC/StreamServerConnection.cpp
+++ b/Source/WebKit/Platform/IPC/StreamServerConnection.cpp
@@ -31,34 +31,17 @@
 #include <mutex>
 #include <wtf/NeverDestroyed.h>
 namespace IPC {
-namespace {
-// FIXME(http://webkit.org/b/238986): Workaround for not being able to deliver messages from the dedicated connection to the work queue the client uses.
-class DedicatedConnectionClient final : public Connection::Client {
-    WTF_MAKE_FAST_ALLOCATED;
-    WTF_MAKE_NONCOPYABLE(DedicatedConnectionClient);
-public:
-    DedicatedConnectionClient() = default;
-    // Connection::Client.
-    void didReceiveMessage(Connection& connection, Decoder& decoder) final { ASSERT_NOT_REACHED(); }
-    bool didReceiveSyncMessage(Connection& connection, Decoder& decoder, UniqueRef<Encoder>& replyEncoder) final { ASSERT_NOT_REACHED(); return false; }
-    void didClose(Connection&) final { } // Client is expected to listen to Connection::didClose() from the connection it sent to the dedicated connection to.
-    void didReceiveInvalidMessage(Connection&, MessageName) final { ASSERT_NOT_REACHED(); } // The sender is expected to be trusted, so all invalid messages are programming errors.
-private:
-};
 
-}
-
-Ref<StreamServerConnection> StreamServerConnection::create(Handle&& handle, StreamConnectionWorkQueue& workQueue)
+Ref<StreamServerConnection> StreamServerConnection::create(Handle&& handle)
 {
     auto connection = IPC::Connection::createClientConnection(IPC::Connection::Identifier { WTFMove(handle.outOfStreamConnection) });
     auto buffer = StreamServerConnectionBuffer::map(WTFMove(handle.buffer));
     RELEASE_ASSERT(buffer); // FIXME: make callers call this outside constructor.
-    return adoptRef(*new StreamServerConnection(WTFMove(connection), WTFMove(*buffer), workQueue));
+    return adoptRef(*new StreamServerConnection(WTFMove(connection), WTFMove(*buffer)));
 }
 
-StreamServerConnection::StreamServerConnection(Ref<Connection> connection, StreamServerConnectionBuffer&& stream, StreamConnectionWorkQueue& workQueue)
+StreamServerConnection::StreamServerConnection(Ref<Connection> connection, StreamServerConnectionBuffer&& stream)
     : m_connection(WTFMove(connection))
-    , m_workQueue(workQueue)
     , m_buffer(WTFMove(stream))
 {
 }
@@ -68,46 +51,43 @@ StreamServerConnection::~StreamServerConnection()
     ASSERT(!m_connection->isValid());
 }
 
-void StreamServerConnection::open()
+void StreamServerConnection::open(StreamConnectionWorkQueue& workQueue)
 {
-    ASSERT(!m_isOpen);
-    static LazyNeverDestroyed<DedicatedConnectionClient> s_dedicatedConnectionClient;
-    static std::once_flag s_onceFlag;
-    std::call_once(s_onceFlag, [] {
-        s_dedicatedConnectionClient.construct();
-    });
+    m_workQueue = &workQueue;
     // FIXME(http://webkit.org/b/238986): Workaround for not being able to deliver messages from the dedicated connection to the work queue the client uses.
     m_connection->addMessageReceiveQueue(*this, { });
-    m_connection->open(s_dedicatedConnectionClient.get());
-    m_isOpen = true;
+    m_connection->open(*this, *m_workQueue);
+    m_workQueue->addStreamConnection(*this);
 }
 
 void StreamServerConnection::invalidate()
 {
-    if (m_isOpen)
-        m_connection->removeMessageReceiveQueue({ });
+    if (!m_workQueue) {
+        m_connection->invalidate();
+        return;
+    }
+    m_workQueue->removeStreamConnection(*this);
     m_connection->invalidate();
+    m_connection->removeMessageReceiveQueue({ });
+    m_workQueue = nullptr;
+    Locker locker { m_outOfStreamMessagesLock };
+    m_outOfStreamMessages.clear();
 }
 
 void StreamServerConnection::startReceivingMessages(StreamMessageReceiver& receiver, ReceiverName receiverName, uint64_t destinationID)
 {
-    {
-        auto key = std::make_pair(static_cast<uint8_t>(receiverName), destinationID);
-        Locker locker { m_receiversLock };
-        ASSERT(!m_receivers.contains(key));
-        m_receivers.add(key, receiver);
-    }
-    m_workQueue.addStreamConnection(*this);
+    auto key = std::make_pair(static_cast<uint8_t>(receiverName), destinationID);
+    Locker locker { m_receiversLock };
+    auto result = m_receivers.add(key, receiver);
+    ASSERT_UNUSED(result, result.isNewEntry);
 }
 
 void StreamServerConnection::stopReceivingMessages(ReceiverName receiverName, uint64_t destinationID)
 {
-    m_workQueue.removeStreamConnection(*this);
-
     auto key = std::make_pair(static_cast<uint8_t>(receiverName), destinationID);
     Locker locker { m_receiversLock };
-    ASSERT(m_receivers.contains(key));
-    m_receivers.remove(key);
+    bool didRemove = m_receivers.remove(key);
+    ASSERT_UNUSED(didRemove, didRemove);
 }
 
 void StreamServerConnection::enqueueMessage(Connection&, std::unique_ptr<Decoder>&& message)
@@ -116,7 +96,31 @@ void StreamServerConnection::enqueueMessage(Connection&, std::unique_ptr<Decoder
         Locker locker { m_outOfStreamMessagesLock };
         m_outOfStreamMessages.append(WTFMove(message));
     }
-    m_workQueue.wakeUp();
+    ASSERT(m_workQueue);
+    m_workQueue->wakeUp();
+}
+
+void StreamServerConnection::didReceiveMessage(Connection&, Decoder&)
+{
+    // All messages go to message queue.
+    ASSERT_NOT_REACHED();
+}
+bool StreamServerConnection::didReceiveSyncMessage(Connection&, Decoder&, UniqueRef<Encoder>&)
+{
+    // All messages go to message queue.
+    ASSERT_NOT_REACHED();
+    return false;
+}
+
+void StreamServerConnection::didClose(Connection&)
+{
+    // Client is expected to listen to didClose from the main connection.
+}
+
+void StreamServerConnection::didReceiveInvalidMessage(Connection&, MessageName)
+{
+    // The sender is expected to be trusted, so all invalid messages are programming errors.
+    ASSERT_NOT_REACHED();
 }
 
 StreamServerConnection::DispatchResult StreamServerConnection::dispatchStreamMessages(size_t messageLimit)

--- a/Source/WebKit/Shared/IPCStreamTester.cpp
+++ b/Source/WebKit/Shared/IPCStreamTester.cpp
@@ -51,7 +51,7 @@ RefPtr<IPCStreamTester> IPCStreamTester::create(IPCStreamTesterIdentifier identi
 
 IPCStreamTester::IPCStreamTester(IPCStreamTesterIdentifier identifier, IPC::StreamServerConnection::Handle&& connectionHandle)
     : m_workQueue(IPC::StreamConnectionWorkQueue::create("IPCStreamTester work queue"))
-    , m_streamConnection(IPC::StreamServerConnection::create(WTFMove(connectionHandle), workQueue()))
+    , m_streamConnection(IPC::StreamServerConnection::create(WTFMove(connectionHandle)))
     , m_identifier(identifier)
 {
 }
@@ -60,17 +60,19 @@ IPCStreamTester::~IPCStreamTester() = default;
 
 void IPCStreamTester::initialize()
 {
-    m_streamConnection->startReceivingMessages(*this, Messages::IPCStreamTester::messageReceiverName(), m_identifier.toUInt64());
-    m_streamConnection->open();
     workQueue().dispatch([this] {
+        m_streamConnection->open(workQueue());
+        m_streamConnection->startReceivingMessages(*this, Messages::IPCStreamTester::messageReceiverName(), m_identifier.toUInt64());
         m_streamConnection->send(Messages::IPCStreamTesterProxy::WasCreated(workQueue().wakeUpSemaphore(), m_streamConnection->clientWaitSemaphore()), m_identifier);
     });
 }
 
 void IPCStreamTester::stopListeningForIPC(Ref<IPCStreamTester>&& refFromConnection)
 {
-    m_streamConnection->invalidate();
-    m_streamConnection->stopReceivingMessages(Messages::IPCStreamTester::messageReceiverName(), m_identifier.toUInt64());
+    workQueue().dispatch([this] {
+        m_streamConnection->stopReceivingMessages(Messages::IPCStreamTester::messageReceiverName(), m_identifier.toUInt64());
+        m_streamConnection->invalidate();
+    });
     workQueue().stopAndWaitForCompletion();
 }
 


### PR DESCRIPTION
#### 4f873b82003414b287d074b42e02d508cc6138e0
<pre>
RemoteRenderingBackend and GraphicsContextGL are opening the stream connection in inconsistent manner
<a href="https://bugs.webkit.org/show_bug.cgi?id=249769">https://bugs.webkit.org/show_bug.cgi?id=249769</a>
rdar://103635894

Reviewed by Fujii Hironori and Mike Wyrzykowski.

Align IPC::StreamServerConnection with IPC::Connection and adjust the
callers:
 - open(dispatcher) is currently called in the dispatcher of the connection
 - open(dispatcher) takes the dispatcher as the argument instead
   of passing it in the constructor
 - invalidate() is currently called in the dispatcher of the connection

Make StreamConnectionWorkQueue a SerialFunctionDispatcher. This way it
is the dispatcher that IPC::Connection is opened in.

Open the StreamServerConnection in the RemoteRenderingBackend and
RemoteGraphicsContextGL work queues. Currently other options are not
really thread-safe.

Start receiving the messages for a particular instances in the work
queue.

Stop receiving the messages for a particular instance in the work queue.

Invalidate the StreamServerConnection in the work queue. Currently other
options are not really thread-safe.

The messages stop being processed after all receivers are removed and
invalidate() has been called.

Move the registration of StreamServerConnection to a particular work
queue to be done during StreamServerConnection::open() time. Conversely
unregister during StreamServerConnection::invalidate(). Since each
connection is only registered once, store the StreamServerConnection
list as a vector instead of a counted set.

* Source/WebKit/GPUProcess/graphics/RemoteGraphicsContextGL.cpp:
(WebKit::RemoteGraphicsContextGL::RemoteGraphicsContextGL):
(WebKit::RemoteGraphicsContextGL::workQueueInitialize):
(WebKit::RemoteGraphicsContextGL::workQueueUninitialize):
* Source/WebKit/GPUProcess/graphics/RemoteGraphicsContextGL.h:
* Source/WebKit/GPUProcess/graphics/RemoteRenderingBackend.cpp:
(WebKit::RemoteRenderingBackend::RemoteRenderingBackend):
(WebKit::RemoteRenderingBackend::startListeningForIPC):
(WebKit::RemoteRenderingBackend::stopListeningForIPC):
(WebKit::RemoteRenderingBackend::workQueueInitialize):
(WebKit::RemoteRenderingBackend::workQueueUninitialize):
(WebKit::RemoteRenderingBackend::didCreateImageBufferBackend):
(WebKit::RemoteRenderingBackend::releaseResourceWithQualifiedIdentifier):
* Source/WebKit/GPUProcess/graphics/RemoteRenderingBackend.h:
(WebKit::RemoteRenderingBackend::workQueue const):
(WebKit::RemoteRenderingBackend::WTF_GUARDED_BY_LOCK): Deleted.
* Source/WebKit/GPUProcess/graphics/WebGPU/RemoteGPU.cpp:
(WebKit::RemoteGPU::RemoteGPU):
(WebKit::RemoteGPU::initialize):
(WebKit::RemoteGPU::stopListeningForIPC):
(WebKit::RemoteGPU::workQueueInitialize):
(WebKit::RemoteGPU::workQueueUninitialize):
* Source/WebKit/Platform/IPC/StreamConnectionWorkQueue.cpp:
(IPC::StreamConnectionWorkQueue::stopAndWaitForCompletion):
Avoid moving the thread away from the queue during stop.
Otherwise the tasks running before stop is done cannot
assert that the work queue is current.

* Source/WebKit/GPUProcess/graphics/RemoteGraphicsContextGL.cpp:
(WebKit::RemoteGraphicsContextGL::RemoteGraphicsContextGL):
(WebKit::RemoteGraphicsContextGL::workQueueInitialize):
(WebKit::RemoteGraphicsContextGL::workQueueUninitialize):
* Source/WebKit/GPUProcess/graphics/RemoteRenderingBackend.cpp:
(WebKit::RemoteRenderingBackend::RemoteRenderingBackend):
(WebKit::RemoteRenderingBackend::stopListeningForIPC):
(WebKit::RemoteRenderingBackend::workQueueInitialize):
(WebKit::RemoteRenderingBackend::workQueueUninitialize):
* Source/WebKit/GPUProcess/graphics/WebGPU/RemoteGPU.cpp:
(WebKit::RemoteGPU::RemoteGPU):
(WebKit::RemoteGPU::workQueueInitialize):
(WebKit::RemoteGPU::workQueueUninitialize):
* Source/WebKit/Platform/IPC/StreamConnectionWorkQueue.cpp:
(IPC::StreamConnectionWorkQueue::dispatch):
(IPC::StreamConnectionWorkQueue::addStreamConnection):
(IPC::StreamConnectionWorkQueue::removeStreamConnection):
(IPC::StreamConnectionWorkQueue::stopAndWaitForCompletion):
* Source/WebKit/Platform/IPC/StreamConnectionWorkQueue.h:
* Source/WebKit/Platform/IPC/StreamServerConnection.cpp:
(IPC::StreamServerConnection::create):
(IPC::StreamServerConnection::StreamServerConnection):
(IPC::StreamServerConnection::open):
(IPC::StreamServerConnection::invalidate):
(IPC::StreamServerConnection::startReceivingMessages):
(IPC::StreamServerConnection::stopReceivingMessages):
(IPC::StreamServerConnection::enqueueMessage):
(IPC::StreamServerConnection::didReceiveMessage):
(IPC::StreamServerConnection::didReceiveSyncMessage):
(IPC::StreamServerConnection::didClose):
(IPC::StreamServerConnection::didReceiveInvalidMessage):
(): Deleted.
* Source/WebKit/Platform/IPC/StreamServerConnection.h:
* Source/WebKit/Shared/IPCStreamTester.cpp:
(WebKit::IPCStreamTester::IPCStreamTester):
(WebKit::IPCStreamTester::initialize):
(WebKit::IPCStreamTester::stopListeningForIPC):
* Tools/TestWebKitAPI/Tests/IPC/StreamConnectionTests.cpp:
(TestWebKitAPI::TEST_F):
(TestWebKitAPI::TEST_P):

Canonical link: <a href="https://commits.webkit.org/264465@main">https://commits.webkit.org/264465@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1da3692616af5605642d9db41d04eda75840b279

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/7550 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/7818 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/8001 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/9190 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/7739 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/7561 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/9881 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/7742 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/10615 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/7681 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/8887 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/6970 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/9298 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/6195 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/6872 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/14573 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/7359 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/6993 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/10342 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/7486 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/6113 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/6827 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/1839 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/11035 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/7220 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->