### PR TITLE
ShouldDropNearSuspendedAssertionAfterDelay setting has no effect

### DIFF
--- a/Source/WebKit/UIProcess/ProcessThrottler.h
+++ b/Source/WebKit/UIProcess/ProcessThrottler.h
@@ -131,7 +131,7 @@ public:
     void didDisconnectFromProcess();
     bool shouldBeRunnable() const { return m_foregroundActivities.size() || m_backgroundActivities.size(); }
     void setAllowsActivities(bool);
-    void setShouldDropNearSuspendedAssertionAfterDelay(bool shouldDropAfterDelay) { m_shouldDropNearSuspendedAssertionAfterDelay = shouldDropAfterDelay; }
+    void setShouldDropNearSuspendedAssertionAfterDelay(bool);
     void setShouldTakeNearSuspendedAssertion(bool);
     bool isSuspended() const { return m_processIdentifier && !m_assertion; }
     ProcessThrottleState currentState() const { return m_state; }


### PR DESCRIPTION
#### 9be1d82ea16f9b778ae5d800448aa468ad562fd8
<pre>
ShouldDropNearSuspendedAssertionAfterDelay setting has no effect
<a href="https://bugs.webkit.org/show_bug.cgi?id=256541">https://bugs.webkit.org/show_bug.cgi?id=256541</a>

Reviewed by Geoffrey Garen.

The &quot;ShouldDropNearSuspendedAssertionAfterDelay&quot; setting has no effect. This
setting is connected to a linked-on-after flag and was meant to only enable
full process suspension once apps get rebuilt against the latest SDK. Because
of this bug, every app is currently opted into full process suspension even if
they don&apos;t rebuild with the latest SDK.

* Source/WebKit/UIProcess/ProcessThrottler.cpp:
(WebKit::ProcessThrottler::setThrottleState):
(WebKit::ProcessThrottler::dropNearSuspendedAssertionTimerFired):
(WebKit::ProcessThrottler::setShouldDropNearSuspendedAssertionAfterDelay):
* Source/WebKit/UIProcess/ProcessThrottler.h:
(WebKit::ProcessThrottler::setShouldDropNearSuspendedAssertionAfterDelay): Deleted.

Canonical link: <a href="https://commits.webkit.org/263882@main">https://commits.webkit.org/263882@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c162d89f5cf4354dbd2db7c908e06985edb2d189

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/5968 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/6143 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/6329 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/7521 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/6326 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/6362 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/6102 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/8833 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/6076 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/6112 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/5413 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/7581 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/3589 "Passed tests") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/13312 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/5455 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/5468 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/7689 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/5914 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/4853 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/5346 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/1421 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/9472 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/5707 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->