### PR TITLE
REGRESSION (262853@main): Text selection sometimes disappears after interacting with selection handles

### DIFF
--- a/LayoutTests/editing/selection/ios/no-click-event-when-adjusting-selection-handles-expected.txt
+++ b/LayoutTests/editing/selection/ios/no-click-event-when-adjusting-selection-handles-expected.txt
@@ -1,0 +1,10 @@
+This test verifies that interacting with selection handles doesn't trigger a synthetic click. To manually run the test, select a word in the paragraph above and then adjust either selection handle by a single letter. The selection should not disappear.
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+PASS firstSelectionRect.width > 0 is true
+PASS firstSelectionRect.height > 0 is true
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/editing/selection/ios/no-click-event-when-adjusting-selection-handles.html
+++ b/LayoutTests/editing/selection/ios/no-click-event-when-adjusting-selection-handles.html
@@ -1,0 +1,58 @@
+<!DOCTYPE html> <!-- webkit-test-runner [ useFlexibleViewport=true ] -->
+<html>
+<head>
+<script src="../../../resources/ui-helper.js"></script>
+<script src="../../../resources/js-test.js"></script>
+<meta name=viewport content="width=device-width, initial-scale=1">
+<meta charset="utf-8">
+<style>
+body, html {
+    width: 100%;
+    height: 100%;
+    margin: 0;
+}
+
+p {
+    font-size: 24px;
+}
+
+#target {
+    border: 2px solid tomato;
+    padding: 1px;
+}
+</style>
+<script>
+jsTestIsAsync = true;
+
+addEventListener("load", async () => {
+    description("This test verifies that interacting with selection handles doesn't trigger a synthetic click. To manually run the test, select a word in the paragraph above and then adjust either selection handle by a single letter. The selection should not disappear.");
+    document.body.addEventListener("click", () => testFailed("Handled unexpected click event"));
+
+    await UIHelper.longPressElement(document.getElementById("target"));
+    await UIHelper.waitForSelectionToAppear();
+
+    const rect = await UIHelper.getSelectionEndGrabberViewRect();
+    const midpoint = { x: rect.left + rect.width / 2, y: rect.top + rect.height / 2 };
+
+    await UIHelper.sendEventStream(new UIHelper.EventStreamBuilder()
+        .begin(midpoint.x, midpoint.y)
+        .move(midpoint.x - 20, midpoint.y, 0.1)
+        .end()
+        .takeResult());
+
+    await UIHelper.ensurePresentationUpdate();
+    firstSelectionRect = (await UIHelper.getUISelectionViewRects())[0];
+    shouldBeTrue("firstSelectionRect.width > 0");
+    shouldBeTrue("firstSelectionRect.height > 0");
+
+    document.querySelector("p.text").remove();
+    finishJSTest();
+});
+</script>
+</head>
+<body>
+<p class="text">Here’s to the crazy ones. The misfits. The rebels. The <span id="target">troublemakers</span>. The round pegs in the square holes. The ones who see things differently.</p>
+<pre id="description"></pre>
+<pre id="console"></pre>
+</body>
+</html>


### PR DESCRIPTION
#### 0f118a09c40eacfb6d7ca0e8370486b10b3c6cce
<pre>
REGRESSION (262853@main): Text selection sometimes disappears after interacting with selection handles
<a href="https://bugs.webkit.org/show_bug.cgi?id=256542">https://bugs.webkit.org/show_bug.cgi?id=256542</a>
rdar://108200433

Reviewed by Aditya Keerthi.

This is more fallout from the changes in 262853@main, which made pan gestures recognize alongside
the synthetic tap gesture; after that commit, the pan gesture for adjusting selection handles —
`UITextRangeAdjustmentGestureRecognizer` — no longer prevents the synthetic tap gesture from firing
when adjusting selection handles by panning over very short distances (i.e., under the 45pt maximum
allowable movement threshold for recognizing tap gestures).

When performing a pan gesture in this manner on a selection handle over any element with a click
event listener, this causes the selection to collapse as the synthetic click is sent to the page and
sets the selection to a caret at the tap location.

The original intent behind the changes in 262853@main was to allow tap gestures to recognize
alongside scroll view pan gestures only, so this is merely a result of that logic being overly
aggressive. Instead of allowing simultaneous recognition with all pan gestures, we fix this by
limiting it to system scroll view pan gestures only.

Test: editing/selection/ios/no-click-event-when-adjusting-selection-handles.html

* LayoutTests/editing/selection/ios/no-click-event-when-adjusting-selection-handles-expected.txt: Added.
* LayoutTests/editing/selection/ios/no-click-event-when-adjusting-selection-handles.html: Added.
* Source/WebKit/UIProcess/ios/WKContentViewInteraction.mm:
(isBuiltInScrollViewPanGestureRecognizer):
(isBuiltInScrollViewGestureRecognizer):

Pull functionality to check whether or not a given gesture recognizer is a built-in scroll view pan
gesture out into a separate helper method; also, optimize this code slightly by caching the result
of the dynamic `NSString` -&gt; `Class` lookup in static variables.

(-[WKContentView gestureRecognizer:shouldRecognizeSimultaneouslyWithGestureRecognizer:]):

Replace the &quot;is pan gesture&quot; check with a more targeted &quot;is built-in scroll view pan gesture&quot; check.
See above for more details.

Canonical link: <a href="https://commits.webkit.org/263880@main">https://commits.webkit.org/263880@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f38342016d959294e519f6212324a87af271f0ae

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/5976 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/6153 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/6338 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/7531 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/6335 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/6372 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/6112 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/8906 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/6085 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/6120 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/5416 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/7591 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/3596 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/5392 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/13320 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/5462 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/5471 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/7701 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/5923 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/4861 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/5354 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/5322 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/1420 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/9482 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/5717 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->