### PR TITLE
[GPU Process][Filters] Top level SVGFilter should own its FilterResults

### DIFF
--- a/Source/WebCore/platform/graphics/GraphicsContext.cpp
+++ b/Source/WebCore/platform/graphics/GraphicsContext.cpp
@@ -359,12 +359,13 @@ void GraphicsContext::drawConsumingImageBuffer(RefPtr<ImageBuffer> image, const 
     ImageBuffer::drawConsuming(WTFMove(image), *this, destination, source, options);
 }
 
-void GraphicsContext::drawFilteredImageBuffer(ImageBuffer* sourceImage, const FloatRect& sourceImageRect, Filter& filter, FilterResults& results)
+void GraphicsContext::drawFilteredImageBuffer(ImageBuffer* sourceImage, const FloatRect& sourceImageRect, Filter& filter, const FilterResultsEnsurer& ensureFilterResults)
 {
-    auto result = filter.apply(sourceImage, sourceImageRect, results);
+    FilterResults results;
+    auto result = filter.apply(sourceImage, sourceImageRect, ensureFilterResults ? ensureFilterResults() : results);
     if (!result)
         return;
-    
+
     auto imageBuffer = result->imageBuffer();
     if (!imageBuffer)
         return;

--- a/Source/WebCore/platform/graphics/GraphicsContext.h
+++ b/Source/WebCore/platform/graphics/GraphicsContext.h
@@ -29,6 +29,7 @@
 #include "ControlPart.h"
 #include "DashArray.h"
 #include "DestinationColorSpace.h"
+#include "FilterResults.h"
 #include "FloatRect.h"
 #include "FontCascade.h"
 #include "GraphicsContextState.h"
@@ -48,7 +49,6 @@ namespace WebCore {
 class AffineTransform;
 class DecomposedGlyphs;
 class Filter;
-class FilterResults;
 class FloatRoundedRect;
 class Gradient;
 class GraphicsContextPlatformPrivate;
@@ -273,7 +273,7 @@ public:
     WEBCORE_EXPORT void drawConsumingImageBuffer(RefPtr<ImageBuffer>, const FloatRect& destination, const ImagePaintingOptions& = { });
     WEBCORE_EXPORT void drawConsumingImageBuffer(RefPtr<ImageBuffer>, const FloatRect& destination, const FloatRect& source, const ImagePaintingOptions& = { });
 
-    WEBCORE_EXPORT virtual void drawFilteredImageBuffer(ImageBuffer* sourceImage, const FloatRect& sourceImageRect, Filter&, FilterResults&);
+    WEBCORE_EXPORT virtual void drawFilteredImageBuffer(ImageBuffer* sourceImage, const FloatRect& sourceImageRect, Filter&, const FilterResultsEnsurer& = nullptr);
 
     virtual void drawPattern(NativeImage&, const FloatRect& destRect, const FloatRect& tileRect, const AffineTransform& patternTransform, const FloatPoint& phase, const FloatSize& spacing, const ImagePaintingOptions& = { }) = 0;
     WEBCORE_EXPORT virtual void drawPattern(ImageBuffer&, const FloatRect& destRect, const FloatRect& tileRect, const AffineTransform& patternTransform, const FloatPoint& phase, const FloatSize& spacing, const ImagePaintingOptions& = { });

--- a/Source/WebCore/platform/graphics/displaylists/DisplayListItems.cpp
+++ b/Source/WebCore/platform/graphics/displaylists/DisplayListItems.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2015-2022 Apple Inc. All rights reserved.
+ * Copyright (C) 2015-2023 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -160,9 +160,9 @@ DrawFilteredImageBuffer::DrawFilteredImageBuffer(std::optional<RenderingResource
 {
 }
 
-void DrawFilteredImageBuffer::apply(GraphicsContext& context, ImageBuffer* sourceImage, FilterResults& results)
+void DrawFilteredImageBuffer::apply(GraphicsContext& context, ImageBuffer* sourceImage, const FilterResultsEnsurer& ensureFilterResults)
 {
-    context.drawFilteredImageBuffer(sourceImage, m_sourceImageRect, m_filter, results);
+    context.drawFilteredImageBuffer(sourceImage, m_sourceImageRect, m_filter, ensureFilterResults);
 }
 
 DrawGlyphs::DrawGlyphs(RenderingResourceIdentifier fontIdentifier, PositionedGlyphs&& positionedGlyphs)

--- a/Source/WebCore/platform/graphics/displaylists/DisplayListItems.h
+++ b/Source/WebCore/platform/graphics/displaylists/DisplayListItems.h
@@ -492,7 +492,7 @@ public:
     std::optional<RenderingResourceIdentifier> sourceImageIdentifier() const { return m_sourceImageIdentifier; }
     FloatRect sourceImageRect() const { return m_sourceImageRect; }
 
-    WEBCORE_EXPORT void apply(GraphicsContext&, ImageBuffer* sourceImage, FilterResults&);
+    WEBCORE_EXPORT void apply(GraphicsContext&, ImageBuffer* sourceImage, const FilterResultsEnsurer& = nullptr);
 
 private:
     std::optional<RenderingResourceIdentifier> m_sourceImageIdentifier;

--- a/Source/WebCore/platform/graphics/displaylists/DisplayListRecorder.cpp
+++ b/Source/WebCore/platform/graphics/displaylists/DisplayListRecorder.cpp
@@ -151,25 +151,20 @@ void Recorder::setMiterLimit(float miterLimit)
     recordSetMiterLimit(miterLimit);
 }
 
-void Recorder::drawFilteredImageBuffer(ImageBuffer* sourceImage, const FloatRect& sourceImageRect, Filter& filter, FilterResults& results)
+void Recorder::drawFilteredImageBuffer(ImageBuffer* sourceImage, const FloatRect& sourceImageRect, Filter& filter, const FilterResultsEnsurer& ensureFilterResults)
 {
     appendStateChangeItemIfNecessary();
 
     for (auto& effect : filter.effectsOfType(FilterEffect::Type::FEImage)) {
         auto& feImage = downcast<FEImage>(effect.get());
         if (!recordResourceUse(feImage.sourceImage())) {
-            GraphicsContext::drawFilteredImageBuffer(sourceImage, sourceImageRect, filter, results);
+            GraphicsContext::drawFilteredImageBuffer(sourceImage, sourceImageRect, filter, ensureFilterResults);
             return;
         }
     }
 
-    if (!sourceImage) {
-        recordDrawFilteredImageBuffer(nullptr, sourceImageRect, filter);
-        return;
-    }
-
-    if (!recordResourceUse(*sourceImage)) {
-        GraphicsContext::drawFilteredImageBuffer(sourceImage, sourceImageRect, filter, results);
+    if (sourceImage && !recordResourceUse(*sourceImage)) {
+        GraphicsContext::drawFilteredImageBuffer(sourceImage, sourceImageRect, filter, ensureFilterResults);
         return;
     }
 

--- a/Source/WebCore/platform/graphics/displaylists/DisplayListRecorder.h
+++ b/Source/WebCore/platform/graphics/displaylists/DisplayListRecorder.h
@@ -230,7 +230,7 @@ private:
 
     WEBCORE_EXPORT void drawControlPart(ControlPart&, const FloatRoundedRect& borderRect, float deviceScaleFactor, const ControlStyle&) final;
 
-    WEBCORE_EXPORT void drawFilteredImageBuffer(ImageBuffer* sourceImage, const FloatRect& sourceImageRect, Filter&, FilterResults&) final;
+    WEBCORE_EXPORT void drawFilteredImageBuffer(ImageBuffer* sourceImage, const FloatRect& sourceImageRect, Filter&, const FilterResultsEnsurer& = nullptr) final;
 
     WEBCORE_EXPORT void drawGlyphs(const Font&, const GlyphBufferGlyph*, const GlyphBufferAdvance*, unsigned numGlyphs, const FloatPoint& anchorPoint, FontSmoothingMode) final;
     WEBCORE_EXPORT void drawDecomposedGlyphs(const Font&, const DecomposedGlyphs&) override;

--- a/Source/WebCore/platform/graphics/filters/FilterImageTargetSwitcher.cpp
+++ b/Source/WebCore/platform/graphics/filters/FilterImageTargetSwitcher.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022 Apple Inc.  All rights reserved.
+ * Copyright (C) 2022-2023 Apple Inc.  All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -27,16 +27,14 @@
 #include "FilterImageTargetSwitcher.h"
 
 #include "Filter.h"
-#include "FilterResults.h"
 #include "GraphicsContext.h"
 #include "ImageBuffer.h"
 
 namespace WebCore {
 
-FilterImageTargetSwitcher::FilterImageTargetSwitcher(GraphicsContext& destinationContext, Filter& filter, const FloatRect &sourceImageRect, const DestinationColorSpace& colorSpace, FilterResults* results)
+FilterImageTargetSwitcher::FilterImageTargetSwitcher(GraphicsContext& destinationContext, Filter& filter, const FloatRect &sourceImageRect, const DestinationColorSpace& colorSpace)
     : FilterTargetSwitcher(filter)
     , m_sourceImageRect(sourceImageRect)
-    , m_results(results)
 {
     if (sourceImageRect.isEmpty())
         return;
@@ -65,21 +63,20 @@ void FilterImageTargetSwitcher::beginClipAndDrawSourceImage(GraphicsContext& des
     }
 }
 
-void FilterImageTargetSwitcher::endClipAndDrawSourceImage(GraphicsContext& destinationContext)
+void FilterImageTargetSwitcher::endClipAndDrawSourceImage(GraphicsContext& destinationContext, const FilterResultsEnsurer& ensureFilterResults)
 {
     if (auto* context = drawingContext(destinationContext))
         context->restore();
 
-    endDrawSourceImage(destinationContext);
+    endDrawSourceImage(destinationContext, ensureFilterResults);
 }
 
-void FilterImageTargetSwitcher::endDrawSourceImage(GraphicsContext& destinationContext)
+void FilterImageTargetSwitcher::endDrawSourceImage(GraphicsContext& destinationContext, const FilterResultsEnsurer& ensureFilterResults)
 {
     if (!m_filter)
         return;
 
-    FilterResults results;
-    destinationContext.drawFilteredImageBuffer(m_sourceImage.get(), m_sourceImageRect, *m_filter, m_results ? *m_results : results);
+    destinationContext.drawFilteredImageBuffer(m_sourceImage.get(), m_sourceImageRect, *m_filter, ensureFilterResults);
 }
 
 } // namespace WebCore

--- a/Source/WebCore/platform/graphics/filters/FilterImageTargetSwitcher.h
+++ b/Source/WebCore/platform/graphics/filters/FilterImageTargetSwitcher.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022 Apple Inc.  All rights reserved.
+ * Copyright (C) 2022-2023 Apple Inc.  All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -34,19 +34,17 @@ class ImageBuffer;
 class FilterImageTargetSwitcher final : public FilterTargetSwitcher {
     WTF_MAKE_FAST_ALLOCATED;
 public:
-    FilterImageTargetSwitcher(GraphicsContext& destinationContext, Filter&, const FloatRect &sourceImageRect, const DestinationColorSpace&, FilterResults* = nullptr);
+    FilterImageTargetSwitcher(GraphicsContext& destinationContext, Filter&, const FloatRect &sourceImageRect, const DestinationColorSpace&);
 
 private:
     GraphicsContext* drawingContext(GraphicsContext& destinationContext) const override;
 
     void beginClipAndDrawSourceImage(GraphicsContext& destinationContext, const FloatRect& repaintRect) override;
-    void endClipAndDrawSourceImage(GraphicsContext& destinationContext) override;
-    void endDrawSourceImage(GraphicsContext& destinationContext) override;
+    void endClipAndDrawSourceImage(GraphicsContext& destinationContext, const FilterResultsEnsurer& = nullptr) override;
+    void endDrawSourceImage(GraphicsContext& destinationContext, const FilterResultsEnsurer& = nullptr) override;
 
     RefPtr<ImageBuffer> m_sourceImage;
     FloatRect m_sourceImageRect;
-
-    FilterResults* m_results { nullptr };
 };
 
 } // namespace WebCore

--- a/Source/WebCore/platform/graphics/filters/FilterResults.h
+++ b/Source/WebCore/platform/graphics/filters/FilterResults.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022 Apple Inc.  All rights reserved.
+ * Copyright (C) 2022-2023 Apple Inc.  All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -28,6 +28,7 @@
 #include "FilterEffect.h"
 #include "FilterImageVector.h"
 #include "ImageBufferAllocator.h"
+#include <wtf/FastMalloc.h>
 #include <wtf/HashMap.h>
 #include <wtf/HashSet.h>
 
@@ -37,6 +38,7 @@ class FilterEffect;
 class FilterImage;
 
 class FilterResults {
+    WTF_MAKE_FAST_ALLOCATED;
 public:
     WEBCORE_EXPORT FilterResults(std::unique_ptr<ImageBufferAllocator>&& = nullptr);
 
@@ -55,5 +57,8 @@ private:
 
     std::unique_ptr<ImageBufferAllocator> m_allocator;
 };
+
+using FilterResultsCreator = Function<std::unique_ptr<FilterResults>()>;
+using FilterResultsEnsurer = Function<FilterResults&()>;
 
 } // namespace WebCore

--- a/Source/WebCore/platform/graphics/filters/FilterStyleTargetSwitcher.cpp
+++ b/Source/WebCore/platform/graphics/filters/FilterStyleTargetSwitcher.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022 Apple Inc.  All rights reserved.
+ * Copyright (C) 2022-2023 Apple Inc.  All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -47,7 +47,7 @@ void FilterStyleTargetSwitcher::beginDrawSourceImage(GraphicsContext& destinatio
     }
 }
 
-void FilterStyleTargetSwitcher::endDrawSourceImage(GraphicsContext& destinationContext)
+void FilterStyleTargetSwitcher::endDrawSourceImage(GraphicsContext& destinationContext, const FilterResultsEnsurer&)
 {
     for ([[maybe_unused]] auto& filterStyle : makeReversedRange(m_filterStyles)) {
         destinationContext.endTransparencyLayer();

--- a/Source/WebCore/platform/graphics/filters/FilterStyleTargetSwitcher.h
+++ b/Source/WebCore/platform/graphics/filters/FilterStyleTargetSwitcher.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022 Apple Inc.  All rights reserved.
+ * Copyright (C) 2022-2023 Apple Inc.  All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -39,7 +39,7 @@ private:
     bool needsRedrawSourceImage() const override { return true; }
 
     void beginDrawSourceImage(GraphicsContext& destinationContext) override;
-    void endDrawSourceImage(GraphicsContext& destinationContext) override;
+    void endDrawSourceImage(GraphicsContext& destinationContext, const FilterResultsEnsurer& = nullptr) override;
 
     FilterStyleVector m_filterStyles;
 };

--- a/Source/WebCore/platform/graphics/filters/FilterTargetSwitcher.cpp
+++ b/Source/WebCore/platform/graphics/filters/FilterTargetSwitcher.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022 Apple Inc.  All rights reserved.
+ * Copyright (C) 2022-2023 Apple Inc.  All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -33,11 +33,11 @@
 
 namespace WebCore {
 
-std::unique_ptr<FilterTargetSwitcher> FilterTargetSwitcher::create(GraphicsContext& destinationContext, Filter& filter, const FloatRect &sourceImageRect, const DestinationColorSpace& colorSpace, FilterResults* results)
+std::unique_ptr<FilterTargetSwitcher> FilterTargetSwitcher::create(GraphicsContext& destinationContext, Filter& filter, const FloatRect &sourceImageRect, const DestinationColorSpace& colorSpace)
 {
     if (filter.filterRenderingModes().contains(FilterRenderingMode::GraphicsContext))
         return makeUnique<FilterStyleTargetSwitcher>(filter, sourceImageRect);
-    return makeUnique<FilterImageTargetSwitcher>(destinationContext, filter, sourceImageRect, colorSpace, results);
+    return makeUnique<FilterImageTargetSwitcher>(destinationContext, filter, sourceImageRect, colorSpace);
 }
 
 FilterTargetSwitcher::FilterTargetSwitcher(Filter& filter)

--- a/Source/WebCore/platform/graphics/filters/FilterTargetSwitcher.h
+++ b/Source/WebCore/platform/graphics/filters/FilterTargetSwitcher.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022 Apple Inc.  All rights reserved.
+ * Copyright (C) 2022-2023 Apple Inc.  All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -26,19 +26,19 @@
 #pragma once
 
 #include "DestinationColorSpace.h"
+#include "FilterResults.h"
 #include "FloatRect.h"
 
 namespace WebCore {
 
 class Filter;
-class FilterResults;
 class GraphicsContext;
 
 class FilterTargetSwitcher {
     WTF_MAKE_FAST_ALLOCATED;
 
 public:
-    static std::unique_ptr<FilterTargetSwitcher> create(GraphicsContext& destinationContext, Filter&, const FloatRect &sourceImageRect, const DestinationColorSpace&, FilterResults* = nullptr);
+    static std::unique_ptr<FilterTargetSwitcher> create(GraphicsContext& destinationContext, Filter&, const FloatRect &sourceImageRect, const DestinationColorSpace&);
 
     virtual ~FilterTargetSwitcher() = default;
 
@@ -47,10 +47,10 @@ public:
     virtual bool needsRedrawSourceImage() const { return false; }
 
     virtual void beginClipAndDrawSourceImage(GraphicsContext& destinationContext, const FloatRect&) { beginDrawSourceImage(destinationContext); }
-    virtual void endClipAndDrawSourceImage(GraphicsContext& destinationContext) { endDrawSourceImage(destinationContext); }
+    virtual void endClipAndDrawSourceImage(GraphicsContext& destinationContext, const FilterResultsEnsurer& ensureFilterResults = nullptr) { endDrawSourceImage(destinationContext, ensureFilterResults); }
 
     virtual void beginDrawSourceImage(GraphicsContext&) { }
-    virtual void endDrawSourceImage(GraphicsContext&) { }
+    virtual void endDrawSourceImage(GraphicsContext&, const FilterResultsEnsurer& = nullptr) { }
 
 protected:
     FilterTargetSwitcher(Filter&);

--- a/Source/WebCore/rendering/svg/RenderSVGResourceFilter.cpp
+++ b/Source/WebCore/rendering/svg/RenderSVGResourceFilter.cpp
@@ -145,7 +145,7 @@ bool RenderSVGResourceFilter::applyResource(RenderElement& renderer, const Rende
     auto colorSpace = DestinationColorSpace::SRGB();
 #endif
 
-    filterData->targetSwitcher = FilterTargetSwitcher::create(*context, *filterData->filter, filterData->sourceImageRect, colorSpace, &filterData->results);
+    filterData->targetSwitcher = FilterTargetSwitcher::create(*context, *filterData->filter, filterData->sourceImageRect, colorSpace);
     if (!filterData->targetSwitcher) {
         m_rendererFilterDataMap.remove(&renderer);
         return false;
@@ -211,7 +211,9 @@ void RenderSVGResourceFilter::postApplyResource(RenderElement& renderer, Graphic
 
     if (filterData.targetSwitcher) {
         filterData.state = FilterData::Built;
-        filterData.targetSwitcher->endDrawSourceImage(*context);
+        filterData.targetSwitcher->endDrawSourceImage(*context, [&filter = filterData.filter]() -> auto& {
+            return filter->ensureResults();
+        });
     }
 
     LOG_WITH_STREAM(Filters, stream << "RenderSVGResourceFilter " << this << " postApplyResource done\n");
@@ -234,7 +236,7 @@ void RenderSVGResourceFilter::markFilterForRepaint(FilterEffect& effect)
         // Repaint the image on the screen.
         markClientForInvalidation(*objectFilterDataPair.key, RepaintInvalidation);
 
-        filterData->results.clearEffectResult(effect);
+        filterData->filter->clearEffectResult(effect);
     }
 }
 

--- a/Source/WebCore/rendering/svg/RenderSVGResourceFilter.h
+++ b/Source/WebCore/rendering/svg/RenderSVGResourceFilter.h
@@ -45,7 +45,6 @@ public:
     FilterData() = default;
 
     RefPtr<SVGFilter> filter;
-    FilterResults results;
 
     std::unique_ptr<FilterTargetSwitcher> targetSwitcher;
     FloatRect sourceImageRect;

--- a/Source/WebCore/svg/graphics/filters/SVGFilter.cpp
+++ b/Source/WebCore/svg/graphics/filters/SVGFilter.cpp
@@ -230,6 +230,19 @@ FilterEffectVector SVGFilter::effectsOfType(FilterFunction::Type filterType) con
     return copyToVector(effects);
 }
 
+FilterResults& SVGFilter::ensureResults(const FilterResultsCreator& createFilterResults)
+{
+    if (!m_results)
+        m_results = createFilterResults();
+    return *m_results;
+}
+
+void SVGFilter::clearEffectResult(FilterEffect& effect)
+{
+    if (m_results)
+        m_results->clearEffectResult(effect);
+}
+
 RefPtr<FilterImage> SVGFilter::apply(const Filter&, FilterImage& sourceImage, FilterResults& results)
 {
     return apply(&sourceImage, results);

--- a/Source/WebCore/svg/graphics/filters/SVGFilter.h
+++ b/Source/WebCore/svg/graphics/filters/SVGFilter.h
@@ -22,6 +22,7 @@
 #pragma once
 
 #include "Filter.h"
+#include "FilterResults.h"
 #include "FloatRect.h"
 #include "SVGFilterExpression.h"
 #include "SVGUnitTypes.h"
@@ -49,6 +50,10 @@ public:
     
     FilterEffectVector effectsOfType(FilterFunction::Type) const final;
 
+    FilterResults* results() { return m_results.get(); }
+    WEBCORE_EXPORT FilterResults& ensureResults(const FilterResultsCreator& createFilterResults = [] { return makeUnique<FilterResults>(); });
+    void clearEffectResult(FilterEffect&);
+
     RefPtr<FilterImage> apply(FilterImage* sourceImage, FilterResults&) final;
     FilterStyleVector createFilterStyles(const FilterStyle& sourceStyle) const final;
 
@@ -75,6 +80,8 @@ private:
     SVGUnitTypes::SVGUnitType m_primitiveUnits;
 
     SVGFilterExpression m_expression;
+
+    std::unique_ptr<FilterResults> m_results;
 };
 
 } // namespace WebCore

--- a/Source/WebKit/GPUProcess/graphics/RemoteDisplayListRecorder.cpp
+++ b/Source/WebKit/GPUProcess/graphics/RemoteDisplayListRecorder.cpp
@@ -259,7 +259,9 @@ void RemoteDisplayListRecorder::drawFilteredImageBuffer(std::optional<RenderingR
     }
 
     FilterResults results(makeUnique<ImageBufferShareableAllocator>(m_renderingBackend->resourceOwner()));
-    handleItem(DisplayList::DrawFilteredImageBuffer(sourceImageIdentifier, sourceImageRect, WTFMove(filter)), sourceImage.get(), results);
+    handleItem(DisplayList::DrawFilteredImageBuffer(sourceImageIdentifier, sourceImageRect, WTFMove(filter)), sourceImage.get(), [&results]() -> auto& {
+        return results;
+    });
 }
 
 void RemoteDisplayListRecorder::drawGlyphs(DisplayList::DrawGlyphs&& item)


### PR DESCRIPTION
#### d8a093ac3195ffaba86032a56cb0e3c3f89f6e91
<pre>
[GPU Process][Filters] Top level SVGFilter should own its FilterResults
<a href="https://bugs.webkit.org/show_bug.cgi?id=256535">https://bugs.webkit.org/show_bug.cgi?id=256535</a>
rdar://109107572

Reviewed by NOBODY (OOPS!).

This will allow caching the FilterResults along with the SVGFilter in RemoteResourceCache.

GraphicsContext::drawFilteredImageBuffer() has to take FilterResultsEnsurer which
returns FilterResults&amp;. drawFilteredImageBuffer() will call it when FilterResults
is needed. SVGFilter::ensureResults() will return FilterResults&amp; and it takes
FilterResultsCreator. FilterResultsCreator returns a std::unique_ptr&lt;FilterResults&gt;
which SVGFilter will maintain.

* Source/WebCore/platform/graphics/GraphicsContext.cpp:
(WebCore::GraphicsContext::drawFilteredImageBuffer):
* Source/WebCore/platform/graphics/GraphicsContext.h:
* Source/WebCore/platform/graphics/displaylists/DisplayListItems.cpp:
(WebCore::DisplayList::DrawFilteredImageBuffer::apply):
* Source/WebCore/platform/graphics/displaylists/DisplayListItems.h:
* Source/WebCore/platform/graphics/displaylists/DisplayListRecorder.cpp:
(WebCore::DisplayList::Recorder::drawFilteredImageBuffer):
* Source/WebCore/platform/graphics/displaylists/DisplayListRecorder.h:
* Source/WebCore/platform/graphics/filters/FilterImageTargetSwitcher.cpp:
(WebCore::FilterImageTargetSwitcher::FilterImageTargetSwitcher):
(WebCore::FilterImageTargetSwitcher::endClipAndDrawSourceImage):
(WebCore::FilterImageTargetSwitcher::endDrawSourceImage):
* Source/WebCore/platform/graphics/filters/FilterImageTargetSwitcher.h:
* Source/WebCore/platform/graphics/filters/FilterResults.h:
* Source/WebCore/platform/graphics/filters/FilterStyleTargetSwitcher.cpp:
(WebCore::FilterStyleTargetSwitcher::endDrawSourceImage):
* Source/WebCore/platform/graphics/filters/FilterStyleTargetSwitcher.h:
* Source/WebCore/platform/graphics/filters/FilterTargetSwitcher.cpp:
(WebCore::FilterTargetSwitcher::create):
* Source/WebCore/platform/graphics/filters/FilterTargetSwitcher.h:
(WebCore::FilterTargetSwitcher::endClipAndDrawSourceImage):
(WebCore::FilterTargetSwitcher::endDrawSourceImage):
* Source/WebCore/rendering/svg/RenderSVGResourceFilter.cpp:
(WebCore::RenderSVGResourceFilter::applyResource):
(WebCore::RenderSVGResourceFilter::postApplyResource):
(WebCore::RenderSVGResourceFilter::markFilterForRepaint):
* Source/WebCore/rendering/svg/RenderSVGResourceFilter.h:
* Source/WebCore/svg/graphics/filters/SVGFilter.cpp:
(WebCore::SVGFilter::ensureResults):
(WebCore::SVGFilter::clearEffectResult):
* Source/WebCore/svg/graphics/filters/SVGFilter.h:
* Source/WebKit/GPUProcess/graphics/RemoteDisplayListRecorder.cpp:
(WebKit::RemoteDisplayListRecorder::drawFilteredImageBuffer):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d8a093ac3195ffaba86032a56cb0e3c3f89f6e91

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/5980 "1 style error") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/6157 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/6342 "Built successfully") | [❌ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/7535 "Failed to compile WebKit") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/6339 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/5979 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/6376 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/6116 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/5/builds/7535 "Failed to compile WebKit") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/6089 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/6126 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/5419 "Passed tests") | [❌ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/7595 "Failed to compile WebKit") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/3602 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/5397 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/2/builds/7595 "Failed to compile WebKit") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/5468 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/5476 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/2/builds/7595 "Failed to compile WebKit") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/5927 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/4865 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/5358 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/9486 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/5721 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->