### PR TITLE
REGRESSION (159729@main): Recover sort-export-file from the mists of time

### DIFF
--- a/Tools/Scripts/sort-export-file
+++ b/Tools/Scripts/sort-export-file
@@ -1,0 +1,266 @@
+#!/usr/bin/perl -w
+
+# Copyright (C) 2014 Apple Inc. All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#
+# 1.  Redistributions of source code must retain the above copyright
+#     notice, this list of conditions and the following disclaimer. 
+# 2.  Redistributions in binary form must reproduce the above copyright
+#     notice, this list of conditions and the following disclaimer in the
+#     documentation and/or other materials provided with the distribution. 
+# 3.  Neither the name of Apple Inc. ("Apple") nor the names of
+#     its contributors may be used to endorse or promote products derived
+#     from this software without specific prior written permission. 
+#
+# THIS SOFTWARE IS PROVIDED BY APPLE AND ITS CONTRIBUTORS "AS IS" AND ANY
+# EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+# WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL APPLE OR ITS CONTRIBUTORS BE LIABLE FOR ANY
+# DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+# (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+# LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+# ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+# THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+use strict;
+
+use Cwd;
+use File::Basename;
+use FindBin;
+use Getopt::Long;
+
+my $shouldPrintWarnings = 1;
+my $shouldShowHelp;
+my $shouldBeVerbose;
+my $shouldBeDryRun;
+
+my $getOptionsResult = GetOptions(
+    'h|help' => \$shouldShowHelp,
+    'v|verbose' => \$shouldBeVerbose,
+    'w|warnings!' => \$shouldPrintWarnings,
+    'dry-run' => \$shouldBeDryRun,
+);
+
+if (!$getOptionsResult || $shouldShowHelp) {
+    print STDERR <<END;
+Usage: @{[ basename($0) ]} [options] [path/to/file.exp.in ...]
+  -h|--help           show this help message
+  -v|--verbose        include verbose output about progress
+  -w|--[no-]warnings  show or suppress warnings (default: show warnings)
+  --dry-run           do not change any files
+
+  Exit status:
+       0      if OK
+       1      if parse error
+       2      if file(s) should be sorted (only with --dry-run)
+       3      if parse error and file(s) should be sorted (only with --dry-run)
+END
+    exit 1;
+}
+
+if (!scalar @ARGV) {
+    my $prefix = "$FindBin::RealBin/Source/";
+    $prefix =~ s|/Tools\/Scripts/|/| or die "ERROR: Script not in Tools/Scripts\n";
+    my $currentDirectory = cwd();
+    $prefix =~ s|^\Q$currentDirectory\E/||;
+    @ARGV = (
+        $prefix . "WebCore/WebCore.exp.in",
+        $prefix . "WebKit/mac/WebKit.exp",
+        $prefix . "WebKit/mac/WebKit.mac.exp",
+    );
+}
+
+my @conditionalStack = ();
+my %symbols = ();
+
+sub pushConditional($);
+sub negateTopConditional();
+sub popTopConditional();
+sub addSymbol($);
+sub serializeAll();
+
+my $sawError = 0;
+my $exitStatus = 0;
+
+sub sawError($)
+{
+    my $error = shift;
+
+    warn "ERROR: $error";
+    $sawError = 1;
+    $exitStatus |= 1;
+}
+
+for my $exportFile (@ARGV) {
+    if ($exportFile !~ /\.exp(\.in)?$/) {
+        print STDERR "WARNING: Not an export file: $exportFile\n" if $shouldPrintWarnings;
+        next;
+    }
+
+    print STDERR "Sorting $exportFile\n";
+
+    $sawError = 0;
+    my $before = "";
+
+    @conditionalStack = ();
+    %symbols = ();
+
+    open IN, "<", $exportFile or die "Could not open $exportFile: $!";
+    while (my $line = <IN>) {
+        $before .= $line;
+        next if $line =~ /^\s*$/;
+        if ($line =~ /^\#if (.+)$/) {
+            pushConditional($1);
+            next;
+        }
+        if ($line =~ /^\#else$/) {
+            negateTopConditional() or sawError("#else without matching #if");
+            next;
+        }
+        if ($line =~ /^\#endif$/) {
+            popTopConditional() or sawError("#endif without matching #if");
+            next;
+        }
+        if ($line =~ /^(\.?[A-Za-z0-9_\?]+)$/) {
+            addSymbol($1);
+            next;
+        }
+        if ($line =~ /^  \"(\.?[A-Za-z0-9_\?]+)\", referenced from:$/) { # For easy paste from build errors
+            addSymbol($1);
+            next;
+        }
+        if ($line =~ /^      .+ in .+\.o$/) { # For easy paste from build errors
+            next;
+        }
+        chomp $line;
+        sawError("Could not parse: \"$line\"");
+    }
+    close IN;
+
+    next if $sawError;
+
+    my $after = serializeAll();
+
+    if ($before eq $after) {
+        print STDERR "Leaving $exportFile alone since it is already sorted\n" if $shouldBeVerbose;
+    } elsif (!$shouldBeDryRun) {
+        print STDERR "Writing sorted $exportFile\n" if $shouldBeVerbose;
+        open OUT, ">", $exportFile or die "Could not overwrite $exportFile: $!";
+        print OUT $after;
+        close OUT;
+    } else {
+        print STDERR "$exportFile should be sorted \n" if $shouldBeVerbose;
+        $exitStatus |= 2;
+    }
+}
+
+exit $exitStatus;
+
+sub makeExpressionCanonical($)
+{
+    my $expression = shift;
+
+    # PLATFORM(MAC) and PLATFORM(IOS) are mutually exclusive.
+    $expression =~ s/!PLATFORM\(IOS\)/PLATFORM(MAC)/g;
+    $expression =~ s/!PLATFORM\(MAC\)/PLATFORM(IOS)/g;
+
+    return $expression;
+}
+
+sub negateExpression($)
+{
+    my $expression = shift;
+
+    return makeExpressionCanonical(substr $expression, 1) if $expression =~ /^\!/;
+    return makeExpressionCanonical("!" . $expression) unless $expression =~ /\s/;
+    return makeExpressionCanonical("!(" . $expression . ")");
+}
+
+sub pushConditional($)
+{
+    my $expression = shift;
+
+    push @conditionalStack, makeExpressionCanonical($expression);
+}
+
+sub negateTopConditional()
+{
+    return 0 if !scalar @conditionalStack;
+    push @conditionalStack, negateExpression(pop @conditionalStack);
+    return 1;
+}
+
+sub popTopConditional()
+{
+    return 0 if !scalar @conditionalStack;
+    pop @conditionalStack;
+    return 1;
+}
+
+sub addSymbol($)
+{
+    my $symbol = shift;
+
+    $symbols{serializeConditionalStack()}{$symbol} = 1;
+}
+
+sub serializeConditionalStack()
+{
+    return join ' && ', @conditionalStack;
+}
+
+sub compareExpressions
+{
+    my $mungedA = $a;
+    my $mungedB = $b;
+
+    # NSGEOMETRY_TYPES_SAME_AS_CGGEOMETRY_TYPES
+    $mungedA =~ s/\bNSGEOMETRY_TYPES_SAME_AS_CGGEOMETRY_TYPES\b/000/g;
+    $mungedB =~ s/\bNSGEOMETRY_TYPES_SAME_AS_CGGEOMETRY_TYPES\b/000/g;
+
+    # NDEBUG
+    $mungedA =~ s/\bNDEBUG\b/001/g;
+    $mungedB =~ s/\bNDEBUG\b/001/g;
+
+    # ASSERT_DISABLED and LOG_DISABLED
+    $mungedA =~ s/(\w+)_DISABLED/002$1/g;
+    $mungedB =~ s/(\w+)_DISABLED/002$1/g;
+
+    # PLATFORM(MAC)
+    $mungedA =~ s/\bPLATFORM\(MAC/010/g;
+    $mungedB =~ s/\bPLATFORM\(MAC/010/g;
+
+    # PLATFORM(IOS)
+    $mungedA =~ s/\bPLATFORM\(IOS/011/g;
+    $mungedB =~ s/\bPLATFORM\(IOS/011/g;
+
+    # USE(X) sorts under X, not USE
+    $mungedA =~ s/\b(\w+)\((.+?)\)/$2:$1/g;
+    $mungedB =~ s/\b(\w+)\((.+?)\)/$2:$1/g;
+
+    # Negated version of a condition sorts just after that condition.
+    $mungedA =~ s/\!\((.+)\)/$1~/g;
+    $mungedA =~ s/\!(.+)/$1~/g;
+    $mungedB =~ s/\!\((.+)\)/$1~/g;
+    $mungedB =~ s/\!(.+)/$1~/g;
+
+    return $mungedA cmp $mungedB;
+}
+
+sub serializeAll()
+{
+    my $result = "";
+    foreach my $expression (sort compareExpressions keys %symbols) {
+        $result .= "\n" if $result ne "";
+        $result .= "#if $expression\n" if $expression ne "";
+        foreach my $symbol (sort keys %{$symbols{$expression}}) {
+            $result .= "$symbol\n";
+        }
+        $result .= "#endif\n" if $expression ne "";
+    }
+    return $result;
+}


### PR DESCRIPTION
#### 7be4438ed6ff5c33eed56d6152180216ee2a8271
<pre>
REGRESSION (159729@main): Recover sort-export-file from the mists of time
<a href="https://bugs.webkit.org/show_bug.cgi?id=256544">https://bugs.webkit.org/show_bug.cgi?id=256544</a>
&lt;rdar://109116226&gt;

Unreviewed revert of a tool script.

WebKitLegacy and libwebrtc still use export files.

* Tools/Scripts/sort-export-file: Add.

Canonical link: <a href="https://commits.webkit.org/263875@main">https://commits.webkit.org/263875@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/22d27679c2186fc42b2e6a33ac20633980c3b624

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/5982 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/6159 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/6344 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/7537 "Built successfully") | [❌ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/6341 "Failed to checkout and rebase branch from PR 13654") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/5981 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/6378 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/6118 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/8933 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/6091 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/15/builds/6128 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/5422 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/7597 "Built successfully") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/39/builds/3604 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/10/builds/5400 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/13323 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/5470 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/5479 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/7705 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/5929 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/4862 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/5360 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/9488 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/699 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/5723 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->