### PR TITLE
Use more accurate information for presentingApplicationBundleIdentifier

### DIFF
--- a/Source/WebKit/UIProcess/Cocoa/WebProcessPoolCocoa.mm
+++ b/Source/WebKit/UIProcess/Cocoa/WebProcessPoolCocoa.mm
@@ -409,6 +409,10 @@ ALLOW_DEPRECATED_DECLARATIONS_END
         else
             parameters.presentingApplicationBundleIdentifier = bundleProxy.bundleIdentifier;
     }
+#if PLATFORM(MAC)
+    else
+        parameters.presentingApplicationBundleIdentifier = [NSRunningApplication currentApplication].bundleIdentifier;
+#endif
 
 #if PLATFORM(COCOA) && ENABLE(REMOTE_INSPECTOR)
     if (WebProcessProxy::shouldEnableRemoteInspector()) {


### PR DESCRIPTION
#### 391aa4f2b4d206e9bbf8477c7d51a46947e4a531
<pre>
Use more accurate information for presentingApplicationBundleIdentifier
<a href="https://bugs.webkit.org/show_bug.cgi?id=256547">https://bugs.webkit.org/show_bug.cgi?id=256547</a>
rdar://106709153

Reviewed by Chris Dumez.

On macOS, when the main executable of an app bundle is a shebang shell script
that points to another app, trying to obtain the canonical bundle identity via
-[NSBundle mainBundle] provides an incorrect value. This can result in incorrect
attribution for apps in MediaRemote, which drives the Now Playing module in
Control Center.

As a part of bug 243481, to ensure we pass the correct information to MediaRemote
on iOS, we have already introduced a mechanism to provide a presenting application
bundle identifier as the override identity. Clients can pass an override audit
token to set this value.

On macOS, if an override audit token isn&apos;t already provided by the client, use
NSRunningApplication to determine the presenting application bundle identifier.

See radar for more detail.

* Source/WebKit/UIProcess/Cocoa/WebProcessPoolCocoa.mm:
(WebKit::WebProcessPool::platformInitializeWebProcess):
Use NSRunningApplication to determine the presenting application bundle identifier.

Canonical link: <a href="https://commits.webkit.org/264091@main">https://commits.webkit.org/264091@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/bf38d3815ae13c600fdb5efcdec063b7a0575b2e

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/6332 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/6528 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/6709 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/7907 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/6649 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/6748 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/6478 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/9545 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/6444 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/6443 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/5727 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/7978 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/3915 "Passed tests") | | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/13589 "6 flakes 1 missing results 158 failures") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/5779 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/5790 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/8039 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/6278 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/5132 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/5687 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/1574 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/9844 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/6058 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->