### PR TITLE
[JSC] Refine Object.create modeling in DFG after mayBePrototype bit is mored to Structure

### DIFF
--- a/JSTests/stress/object-create-will-do-transition.js
+++ b/JSTests/stress/object-create-will-do-transition.js
@@ -1,0 +1,21 @@
+var p = 0;
+var q=[]
+function __f_0(a,b,__v_6,__v_8) {p=p+1;
+if(p > 5000) {
+    q.push(a);
+    q.push(b);
+    q.push(__v_6);
+    q.push(__v_8);
+    return ;
+  }
+  var a = {};
+  var b = {};
+  __v_6 = Object.create(a);
+  a.method1 = 1;
+  b.method1 = 1;
+  __v_8 = Object.create(a);
+  __f_0(a,b,__v_6,__v_8);
+}
+
+optimizeNextInvocation(__f_0);
+__f_0();

--- a/Source/JavaScriptCore/dfg/DFGAbstractInterpreterInlines.h
+++ b/Source/JavaScriptCore/dfg/DFGAbstractInterpreterInlines.h
@@ -3297,14 +3297,12 @@ bool AbstractInterpreter<AbstractStateType>::executeEffects(unsigned clobberLimi
 
             if (structure) {
                 m_state.setShouldTryConstantFolding(true);
-                if (node->child1().useKind() == UntypedUse)
-                    didFoldClobberWorld();
+                didFoldClobberWorld();
                 setForNode(node, structure);
                 break;
             }
         }
-        if (node->child1().useKind() == UntypedUse)
-            clobberWorld();
+        clobberWorld();
         setTypeForNode(node, SpecFinalObject);
         break;
     }

--- a/Source/JavaScriptCore/dfg/DFGClobberize.h
+++ b/Source/JavaScriptCore/dfg/DFGClobberize.h
@@ -1824,6 +1824,7 @@ void clobberize(Graph& graph, Node* node, const ReadFunctor& read, const WriteFu
         case ObjectUse:
             read(HeapObjectCount);
             write(HeapObjectCount);
+            write(JSCell_structureID); // prototype object can be transitioned.
             return;
         case UntypedUse:
             clobberTop();


### PR DESCRIPTION
#### d60bafb0be1bf24b79a858f9208e5047c58f0d06
<pre>
[JSC] Refine Object.create modeling in DFG after mayBePrototype bit is mored to Structure
<a href="https://bugs.webkit.org/show_bug.cgi?id=256551">https://bugs.webkit.org/show_bug.cgi?id=256551</a>
rdar://109045428

Reviewed by Justin Michaud.

To adopt megamorphic IC, we moved mayBePrototype to Structure. As a result, DFG ObjectCreate should
claim that it can clobber JSCell_structureID since prototype object can be transitioned. This fixes it appropriately.

* JSTests/stress/object-create-will-do-transition.js: Added.
(q):
* Source/JavaScriptCore/dfg/DFGAbstractInterpreterInlines.h:
(JSC::DFG::AbstractInterpreter&lt;AbstractStateType&gt;::executeEffects):
* Source/JavaScriptCore/dfg/DFGClobberize.h:
(JSC::DFG::clobberize):

Canonical link: <a href="https://commits.webkit.org/263889@main">https://commits.webkit.org/263889@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a18a221809cb98cb2ab989c0296a5923d07c73e7

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/5989 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/6166 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/6351 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/7544 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/6348 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/6385 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/6125 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/8997 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/6098 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/6132 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/5429 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/7604 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/3608 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/5407 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/13326 "Passed tests") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/5019 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/5474 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/5486 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/7716 "Passed tests") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/5575 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/5936 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/4867 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/6108 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/5367 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/1473 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/1426 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/9495 "Built successfully") | | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/24/builds/6277 "Built successfully") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/5730 "Built successfully") | | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/3/builds/1596 "Passed tests") | 
<!--EWS-Status-Bubble-End-->