### PR TITLE
Remove SharedMemoryHandle::clear

### DIFF
--- a/Source/WebKit/Platform/SharedMemory.h
+++ b/Source/WebKit/Platform/SharedMemory.h
@@ -78,8 +78,6 @@ public:
     void takeOwnershipOfMemory(MemoryLedger) const;
     void setOwnershipOfMemory(const WebCore::ProcessIdentity&, MemoryLedger) const;
 
-    void clear();
-
 #if USE(UNIX_DOMAIN_SOCKETS)
     UnixFileDescriptor releaseHandle();
 #endif

--- a/Source/WebKit/Platform/cocoa/SharedMemoryCocoa.cpp
+++ b/Source/WebKit/Platform/cocoa/SharedMemoryCocoa.cpp
@@ -96,11 +96,6 @@ bool SharedMemoryHandle::isNull() const
     return !m_handle;
 }
 
-void SharedMemoryHandle::clear()
-{
-    *this = { };
-}
-
 static inline void* toPointer(mach_vm_address_t address)
 {
     return reinterpret_cast<void*>(static_cast<uintptr_t>(address));

--- a/Source/WebKit/Platform/unix/SharedMemoryUnix.cpp
+++ b/Source/WebKit/Platform/unix/SharedMemoryUnix.cpp
@@ -52,11 +52,6 @@
 
 namespace WebKit {
 
-void SharedMemoryHandle::clear()
-{
-    *this = { };
-}
-
 bool SharedMemoryHandle::isNull() const
 {
     return !m_handle;

--- a/Source/WebKit/Platform/win/SharedMemoryWin.cpp
+++ b/Source/WebKit/Platform/win/SharedMemoryWin.cpp
@@ -36,11 +36,6 @@ bool SharedMemoryHandle::isNull() const
     return !m_handle;
 }
 
-void SharedMemoryHandle::clear()
-{
-    m_handle = { };
-}
-
 RefPtr<SharedMemory> SharedMemory::allocate(size_t size)
 {
     Win32Handle handle { ::CreateFileMappingW(INVALID_HANDLE_VALUE, 0, PAGE_READWRITE, 0, size, 0) };

--- a/Source/WebKit/Shared/ShareableBitmap.h
+++ b/Source/WebKit/Shared/ShareableBitmap.h
@@ -108,7 +108,6 @@ public:
     // Take ownership of the memory for process memory accounting purposes.
     void takeOwnershipOfMemory(MemoryLedger) const;
 
-    void clear();
 private:
     friend struct IPC::ArgumentCoder<ShareableBitmapHandle, void>;
     friend class ShareableBitmap;

--- a/Source/WebKit/Shared/ShareableBitmapHandle.cpp
+++ b/Source/WebKit/Shared/ShareableBitmapHandle.cpp
@@ -49,10 +49,4 @@ void ShareableBitmapHandle::takeOwnershipOfMemory(MemoryLedger ledger) const
     m_handle.takeOwnershipOfMemory(ledger);
 }
 
-void ShareableBitmapHandle::clear()
-{
-    m_handle.clear();
-    m_configuration = { };
-}
-
 } // namespace WebKit


### PR DESCRIPTION
#### 62bea872d1f186dcb512d2296f2e5cce1f499f94
<pre>
Remove SharedMemoryHandle::clear
<a href="https://bugs.webkit.org/show_bug.cgi?id=256556">https://bugs.webkit.org/show_bug.cgi?id=256556</a>

Reviewed by Chris Dumez.

Removes `SharedMemoryHandle::clear` and `ShareableBitmapHandle::clear`
which was using referencing it.

* Source/WebKit/Platform/SharedMemory.h:
* Source/WebKit/Platform/cocoa/SharedMemoryCocoa.cpp:
(WebKit::SharedMemoryHandle::clear): Deleted.
* Source/WebKit/Platform/unix/SharedMemoryUnix.cpp:
(WebKit::SharedMemoryHandle::clear): Deleted.
* Source/WebKit/Platform/win/SharedMemoryWin.cpp:
(WebKit::SharedMemoryHandle::clear): Deleted.
* Source/WebKit/Shared/ShareableBitmap.h:
* Source/WebKit/Shared/ShareableBitmapHandle.cpp:
(WebKit::ShareableBitmapHandle::clear): Deleted.

Canonical link: <a href="https://commits.webkit.org/263885@main">https://commits.webkit.org/263885@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/85f1cdb45094b12b13336b5175a8e37a66c54883

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/6000 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/6177 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/6362 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/7555 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/6359 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/6396 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/6136 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/9047 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/6109 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/6138 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/5433 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/7615 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/3614 "Passed tests") | | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/13333 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/5480 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/5490 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/7715 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/5947 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/4872 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/5378 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/1423 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/9506 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/5741 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->