### PR TITLE
[JSC] Cache lookups of ProxyObject's traps

### DIFF
--- a/JSTests/stress/object-prototype-is-immutable-prototype-object.js
+++ b/JSTests/stress/object-prototype-is-immutable-prototype-object.js
@@ -1,0 +1,27 @@
+function shouldBe(actual, expected) {
+    if (actual !== expected)
+        throw new Error(`Bad value: ${actual}!`);
+}
+
+function shouldThrow(func, errorMessage) {
+    let errorThrown = false;
+    let error = null;
+    try {
+        func();
+    } catch (error) {
+        errorThrown = true;
+        if (String(error) !== errorMessage)
+            throw new Error(`Bad error: ${error}`);
+    }
+    if (!errorThrown)
+        throw new Error("Didn't throw!");
+}
+
+const immutablePrototypeError = `TypeError: Cannot set prototype of immutable prototype object`;
+
+// ProxyObject's handler traps caching depends on this
+shouldThrow(() => { Object.prototype.__proto__ = { foo: 1 }; }, immutablePrototypeError);
+shouldThrow(() => { Object.setPrototypeOf(Object.prototype, { bar: 2 }); }, immutablePrototypeError);
+
+shouldBe(Reflect.setPrototypeOf(Object.prototype, {}), false);
+shouldBe(Object.getPrototypeOf(Object.prototype), null);

--- a/Source/JavaScriptCore/runtime/JSObject.cpp
+++ b/Source/JavaScriptCore/runtime/JSObject.cpp
@@ -4067,7 +4067,7 @@ JSValue JSObject::getMethod(JSGlobalObject* globalObject, CallData& callData, co
         return jsUndefined();
     }
 
-    callData = JSC::getCallData(method);
+    callData = JSC::getCallData(method.asCell());
     if (callData.type == CallData::Type::None) {
         throwVMTypeError(globalObject, scope, errorMessage);
         return jsUndefined();

--- a/Source/JavaScriptCore/runtime/ProxyObject.h
+++ b/Source/JavaScriptCore/runtime/ProxyObject.h
@@ -48,6 +48,14 @@ public:
         } };
     }
 
+    enum class HandlerTrap : uint8_t {
+        Has = 0,
+        Get,
+        Set,
+    };
+
+    static constexpr unsigned numberOfCachedHandlerTrapsOffsets = 3;
+
     template<typename CellType, SubspaceAccess mode>
     static GCClient::IsoSubspace* subspaceFor(VM& vm)
     {
@@ -93,10 +101,14 @@ public:
     const WriteBarrier<Unknown>& internalField(Field field) const { return Base::internalField(static_cast<uint32_t>(field)); }
     WriteBarrier<Unknown>& internalField(Field field) { return Base::internalField(static_cast<uint32_t>(field)); }
 
+    JSObject* getHandlerTrap(JSGlobalObject*, JSObject*, CallData&, const Identifier&, HandlerTrap);
+
 private:
     JS_EXPORT_PRIVATE ProxyObject(VM&, Structure*);
     JS_EXPORT_PRIVATE void finishCreation(VM&, JSGlobalObject*, JSValue target, JSValue handler);
     JS_EXPORT_PRIVATE static Structure* structureForTarget(JSGlobalObject*, JSValue target);
+
+    void clearHandlerTrapsOffsetsCache();
 
     static bool getOwnPropertySlot(JSObject*, JSGlobalObject*, PropertyName, PropertySlot&);
     static bool getOwnPropertySlotByIndex(JSObject*, JSGlobalObject*, unsigned propertyName, PropertySlot&);
@@ -129,6 +141,9 @@ private:
 
     bool m_isCallable : 1 { false };
     bool m_isConstructible : 1 { false };
+    PropertyOffset m_handlerTrapsOffsetsCache[numberOfCachedHandlerTrapsOffsets];
+    WriteBarrierStructureID m_handlerStructureID;
+    WriteBarrierStructureID m_handlerPrototypeStructureID;
 };
 
 } // namespace JSC


### PR DESCRIPTION
#### e1e2cbbf2d6f36f82c6b7094312c230f6d152a2a
<pre>
[JSC] Cache lookups of ProxyObject&apos;s traps
<a href="https://bugs.webkit.org/show_bug.cgi?id=256554">https://bugs.webkit.org/show_bug.cgi?id=256554</a>
&lt;rdar://problem/109119378&gt;

Reviewed by Yusuke Suzuki.

This patch introduces a caching of handler&apos;s traps by storing an array of property offsets, handler&apos;s
structure ID, and handler&apos;s prototype structure ID. We optimize for common case of ProxyObject&apos;s handler
being a plain JSFinalObject inheriting from Object.prototype, which [[Prototype]] is always `null`.

For now, only 3 of the most popular traps are cached: &quot;has&quot;, &quot;get&quot;, and &quot;set&quot;.
Also, removes extra isCell() check from getMethod() to micro-optimize lookup of other traps.

This change progresses microbenchmarks with missing handlers by 60-70% when IC is off,
and speeds up Speedometer2/Flight-TodoMVC by 2%.

                                   ToT                      patch

proxy-has-miss-handler      310.7297+-1.4310     ^    182.3500+-0.2509        ^ definitely 1.7040x faster
proxy-set-miss-handler     1305.7705+-2.9307     ^   1179.7164+-4.0497        ^ definitely 1.1069x faster
proxy-get-miss-handler      310.6261+-0.1537     ^    190.5240+-0.3619        ^ definitely 1.6304x faster

&lt;geometric&gt;                 501.3743+-1.0979     ^    344.7815+-0.4166        ^ definitely 1.4542x faster

* Source/JavaScriptCore/runtime/JSObject.cpp:
(JSC::JSObject::getMethod):
* Source/JavaScriptCore/runtime/ProxyObject.cpp:
(JSC::ProxyObject::ProxyObject):
(JSC::ProxyObject::getHandlerTrap):
(JSC::ProxyObject::clearHandlerTrapsOffsetsCache):
(JSC::performProxyGet):
(JSC::ProxyObject::performHasProperty):
(JSC::ProxyObject::performPut):
(JSC::ProxyObject::visitChildrenImpl):
* Source/JavaScriptCore/runtime/ProxyObject.h:

Canonical link: <a href="https://commits.webkit.org/263944@main">https://commits.webkit.org/263944@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/117834751c64c21c67cfcc3d38e87aa624803b4e

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/6153 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/6340 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/6522 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/7715 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/6492 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/6560 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/6292 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/9372 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/6263 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/6280 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/5572 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/7780 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/3754 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/5552 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/13450 "Passed tests") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/5169 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/5619 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/5631 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/7863 "Passed tests") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/5747 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/6097 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/4991 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/6274 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/5515 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/1494 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/1468 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/9658 "Built successfully") | | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/24/builds/6449 "Built successfully") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/5882 "Built successfully") | | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/3/builds/1620 "Passed tests") | 
<!--EWS-Status-Bubble-End-->