### PR TITLE
overflow="visible" has no effect on the dimension of a `use` element unless its dimensions are specified

### DIFF
--- a/LayoutTests/platform/glib/imported/w3c/web-platform-tests/svg/struct/reftests/use-symbol-dimensions-override-001-expected.txt
+++ b/LayoutTests/platform/glib/imported/w3c/web-platform-tests/svg/struct/reftests/use-symbol-dimensions-override-001-expected.txt
@@ -6,16 +6,16 @@ layer at (0,0) size 800x600
       RenderSVGHiddenContainer {symbol} at (0,0) size 0x0
         RenderSVGRect {rect} at (0,0) size 0x0 [fill={[type=SOLID] [color=#008000]}] [x=0.00] [y=0.00] [width=0.00] [height=0.00]
     RenderSVGRect {rect} at (0,0) size 100x100 [fill={[type=SOLID] [color=#FF0000]}] [x=0.00] [y=0.00] [width=100.00] [height=100.00]
-    RenderSVGViewportContainer {svg} at (0,0) size 91x91
-      RenderSVGContainer {use} at (90,90) size 1x1 [transform={m=((1.00,0.00)(0.00,1.00)) t=(90.00,90.00)}]
-        RenderSVGViewportContainer {svg} at (90,90) size 1x1
-          RenderSVGRect {rect} at (90,90) size 1x1 [fill={[type=SOLID] [color=#008000]}] [x=0.00] [y=0.00] [width=1.00] [height=1.00]
-      RenderSVGContainer {use} at (0,90) size 90x1 [transform={m=((1.00,0.00)(0.00,1.00)) t=(0.00,90.00)}]
-        RenderSVGViewportContainer {svg} at (0,90) size 90x1
-          RenderSVGRect {rect} at (0,90) size 90x1 [fill={[type=SOLID] [color=#008000]}] [x=0.00] [y=0.00] [width=90.00] [height=1.00]
-      RenderSVGContainer {use} at (90,0) size 1x90 [transform={m=((1.00,0.00)(0.00,1.00)) t=(90.00,0.00)}]
-        RenderSVGViewportContainer {svg} at (90,0) size 1x90
-          RenderSVGRect {rect} at (90,0) size 1x90 [fill={[type=SOLID] [color=#008000]}] [x=0.00] [y=0.00] [width=1.00] [height=90.00]
+    RenderSVGViewportContainer {svg} at (0,0) size 100x100
+      RenderSVGContainer {use} at (90,90) size 10x10 [transform={m=((1.00,0.00)(0.00,1.00)) t=(90.00,90.00)}]
+        RenderSVGViewportContainer {svg} at (90,90) size 10x10
+          RenderSVGRect {rect} at (90,90) size 10x10 [fill={[type=SOLID] [color=#008000]}] [x=0.00] [y=0.00] [width=10.00] [height=10.00]
+      RenderSVGContainer {use} at (0,90) size 90x10 [transform={m=((1.00,0.00)(0.00,1.00)) t=(0.00,90.00)}]
+        RenderSVGViewportContainer {svg} at (0,90) size 90x10
+          RenderSVGRect {rect} at (0,90) size 90x10 [fill={[type=SOLID] [color=#008000]}] [x=0.00] [y=0.00] [width=90.00] [height=10.00]
+      RenderSVGContainer {use} at (90,0) size 10x90 [transform={m=((1.00,0.00)(0.00,1.00)) t=(90.00,0.00)}]
+        RenderSVGViewportContainer {svg} at (90,0) size 10x90
+          RenderSVGRect {rect} at (90,0) size 10x90 [fill={[type=SOLID] [color=#008000]}] [x=0.00] [y=0.00] [width=10.00] [height=90.00]
       RenderSVGContainer {use} at (0,0) size 90x90
         RenderSVGViewportContainer {svg} at (0,0) size 90x90
           RenderSVGRect {rect} at (0,0) size 90x90 [fill={[type=SOLID] [color=#008000]}] [x=0.00] [y=0.00] [width=90.00] [height=90.00]

--- a/LayoutTests/platform/ios-simulator/imported/w3c/web-platform-tests/svg/struct/reftests/use-symbol-dimensions-override-001-expected.txt
+++ b/LayoutTests/platform/ios-simulator/imported/w3c/web-platform-tests/svg/struct/reftests/use-symbol-dimensions-override-001-expected.txt
@@ -6,16 +6,16 @@ layer at (0,0) size 800x600
       RenderSVGHiddenContainer {symbol} at (0,0) size 0x0
         RenderSVGRect {rect} at (0,0) size 0x0 [fill={[type=SOLID] [color=#008000]}] [x=0.00] [y=0.00] [width=0.00] [height=0.00]
     RenderSVGRect {rect} at (0,0) size 100x100 [fill={[type=SOLID] [color=#FF0000]}] [x=0.00] [y=0.00] [width=100.00] [height=100.00]
-    RenderSVGViewportContainer {svg} at (0,0) size 91x91
-      RenderSVGContainer {use} at (90,90) size 1x1 [transform={m=((1.00,0.00)(0.00,1.00)) t=(90.00,90.00)}]
-        RenderSVGViewportContainer {svg} at (90,90) size 1x1
-          RenderSVGRect {rect} at (90,90) size 1x1 [fill={[type=SOLID] [color=#008000]}] [x=0.00] [y=0.00] [width=1.00] [height=1.00]
-      RenderSVGContainer {use} at (0,90) size 90x1 [transform={m=((1.00,0.00)(0.00,1.00)) t=(0.00,90.00)}]
-        RenderSVGViewportContainer {svg} at (0,90) size 90x1
-          RenderSVGRect {rect} at (0,90) size 90x1 [fill={[type=SOLID] [color=#008000]}] [x=0.00] [y=0.00] [width=90.00] [height=1.00]
-      RenderSVGContainer {use} at (90,0) size 1x90 [transform={m=((1.00,0.00)(0.00,1.00)) t=(90.00,0.00)}]
-        RenderSVGViewportContainer {svg} at (90,0) size 1x90
-          RenderSVGRect {rect} at (90,0) size 1x90 [fill={[type=SOLID] [color=#008000]}] [x=0.00] [y=0.00] [width=1.00] [height=90.00]
+    RenderSVGViewportContainer {svg} at (0,0) size 100x100
+      RenderSVGContainer {use} at (90,90) size 10x10 [transform={m=((1.00,0.00)(0.00,1.00)) t=(90.00,90.00)}]
+        RenderSVGViewportContainer {svg} at (90,90) size 10x10
+          RenderSVGRect {rect} at (90,90) size 10x10 [fill={[type=SOLID] [color=#008000]}] [x=0.00] [y=0.00] [width=10.00] [height=10.00]
+      RenderSVGContainer {use} at (0,90) size 90x10 [transform={m=((1.00,0.00)(0.00,1.00)) t=(0.00,90.00)}]
+        RenderSVGViewportContainer {svg} at (0,90) size 90x10
+          RenderSVGRect {rect} at (0,90) size 90x10 [fill={[type=SOLID] [color=#008000]}] [x=0.00] [y=0.00] [width=90.00] [height=10.00]
+      RenderSVGContainer {use} at (90,0) size 10x90 [transform={m=((1.00,0.00)(0.00,1.00)) t=(90.00,0.00)}]
+        RenderSVGViewportContainer {svg} at (90,0) size 10x90
+          RenderSVGRect {rect} at (90,0) size 10x90 [fill={[type=SOLID] [color=#008000]}] [x=0.00] [y=0.00] [width=10.00] [height=90.00]
       RenderSVGContainer {use} at (0,0) size 90x90
         RenderSVGViewportContainer {svg} at (0,0) size 90x90
           RenderSVGRect {rect} at (0,0) size 90x90 [fill={[type=SOLID] [color=#008000]}] [x=0.00] [y=0.00] [width=90.00] [height=90.00]

--- a/LayoutTests/platform/mac/imported/w3c/web-platform-tests/svg/struct/reftests/use-symbol-dimensions-override-001-expected.txt
+++ b/LayoutTests/platform/mac/imported/w3c/web-platform-tests/svg/struct/reftests/use-symbol-dimensions-override-001-expected.txt
@@ -6,16 +6,16 @@ layer at (0,0) size 800x600
       RenderSVGHiddenContainer {symbol} at (0,0) size 0x0
         RenderSVGRect {rect} at (0,0) size 0x0 [fill={[type=SOLID] [color=#008000]}] [x=0.00] [y=0.00] [width=0.00] [height=0.00]
     RenderSVGRect {rect} at (0,0) size 100x100 [fill={[type=SOLID] [color=#FF0000]}] [x=0.00] [y=0.00] [width=100.00] [height=100.00]
-    RenderSVGViewportContainer {svg} at (0,0) size 91x91
-      RenderSVGContainer {use} at (90,90) size 1x1 [transform={m=((1.00,0.00)(0.00,1.00)) t=(90.00,90.00)}]
-        RenderSVGViewportContainer {svg} at (90,90) size 1x1
-          RenderSVGRect {rect} at (90,90) size 1x1 [fill={[type=SOLID] [color=#008000]}] [x=0.00] [y=0.00] [width=1.00] [height=1.00]
-      RenderSVGContainer {use} at (0,90) size 90x1 [transform={m=((1.00,0.00)(0.00,1.00)) t=(0.00,90.00)}]
-        RenderSVGViewportContainer {svg} at (0,90) size 90x1
-          RenderSVGRect {rect} at (0,90) size 90x1 [fill={[type=SOLID] [color=#008000]}] [x=0.00] [y=0.00] [width=90.00] [height=1.00]
-      RenderSVGContainer {use} at (90,0) size 1x90 [transform={m=((1.00,0.00)(0.00,1.00)) t=(90.00,0.00)}]
-        RenderSVGViewportContainer {svg} at (90,0) size 1x90
-          RenderSVGRect {rect} at (90,0) size 1x90 [fill={[type=SOLID] [color=#008000]}] [x=0.00] [y=0.00] [width=1.00] [height=90.00]
+    RenderSVGViewportContainer {svg} at (0,0) size 100x100
+      RenderSVGContainer {use} at (90,90) size 10x10 [transform={m=((1.00,0.00)(0.00,1.00)) t=(90.00,90.00)}]
+        RenderSVGViewportContainer {svg} at (90,90) size 10x10
+          RenderSVGRect {rect} at (90,90) size 10x10 [fill={[type=SOLID] [color=#008000]}] [x=0.00] [y=0.00] [width=10.00] [height=10.00]
+      RenderSVGContainer {use} at (0,90) size 90x10 [transform={m=((1.00,0.00)(0.00,1.00)) t=(0.00,90.00)}]
+        RenderSVGViewportContainer {svg} at (0,90) size 90x10
+          RenderSVGRect {rect} at (0,90) size 90x10 [fill={[type=SOLID] [color=#008000]}] [x=0.00] [y=0.00] [width=90.00] [height=10.00]
+      RenderSVGContainer {use} at (90,0) size 10x90 [transform={m=((1.00,0.00)(0.00,1.00)) t=(90.00,0.00)}]
+        RenderSVGViewportContainer {svg} at (90,0) size 10x90
+          RenderSVGRect {rect} at (90,0) size 10x90 [fill={[type=SOLID] [color=#008000]}] [x=0.00] [y=0.00] [width=10.00] [height=90.00]
       RenderSVGContainer {use} at (0,0) size 90x90
         RenderSVGViewportContainer {svg} at (0,0) size 90x90
           RenderSVGRect {rect} at (0,0) size 90x90 [fill={[type=SOLID] [color=#008000]}] [x=0.00] [y=0.00] [width=90.00] [height=90.00]

--- a/LayoutTests/svg/custom/relative-sized-shadow-tree-content-with-symbol.xhtml
+++ b/LayoutTests/svg/custom/relative-sized-shadow-tree-content-with-symbol.xhtml
@@ -6,7 +6,7 @@
     <div id="contentBox" style="width: 100px; height: 400px; border: 1px solid red;">
         <svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="100%" height="100%">
             <defs>
-                <symbol id="targetSymbol" viewBox="0 0 200 200" width="50%" height="50%">
+                <symbol id="targetSymbol" viewBox="0 0 200 200">
                     <rect x="50%" y="50%" width="50%" height="50%" fill="green"/>
                     <rect width="100" height="100" fill="green"/>
                 </symbol>


### PR DESCRIPTION
#### fd0a41d19f81d423ff6070fb537cce16bb86f576
<pre>
overflow=&quot;visible&quot; has no effect on the dimension of a `use` element unless its dimensions are specified

<a href="https://bugs.webkit.org/show_bug.cgi?id=200445">https://bugs.webkit.org/show_bug.cgi?id=200445</a>
rdar://problem/98577733

Reviewed by Simon Fraser.

This patch aligns WebKit with Gecko / Firefox, Blink / Chromium and SVG2 Spec.

Merge - <a href="https://chromium.googlesource.com/chromium/src.git/+/2e863303d9035d517bfd13de1a5b3388576e4443">https://chromium.googlesource.com/chromium/src.git/+/2e863303d9035d517bfd13de1a5b3388576e4443</a>

Per [1], &apos;width&apos; and/or &apos;height&apos; on a `use` override the corresponding
values on a referenced `svg` or `symbol`. If no &apos;width&apos; or &apos;height&apos; is
specified on the `use`, the values set on the referenced elements are
retained.
Previously we would always set &apos;width&apos; / &apos;height&apos; on a referenced
`symbol` to &apos;100%&apos; if the `use` did not have any overriding values.
Change this to follow the specification and copy the values from the
shadow element as needed - much like what was previously done for
referenced `svg` elements.

[1] <a href="https://svgwg.org/svg2-draft/struct.html#UseLayout">https://svgwg.org/svg2-draft/struct.html#UseLayout</a>

* Source/WebCore/svg/SVGUseElement.cpp:
(SVGUseElement::transferSizeAttributesToTargetClone): Align as per Spec
* LayoutTests/svg/custom/relative-sized-shadow-tree-content-with-symbol.xhtml: Rebaselined
* LayoutTests/platform/glib/imported/w3c/web-platform-tests/svg/struct/reftests/use-symbol-dimensions-override-001-expected.txt: Rebaselined
* LayoutTests/platform/ios-simulator/imported/w3c/web-platform-tests/svg/struct/reftests/use-symbol-dimensions-override-001-expected.txt: Rebaselined
* LayoutTests/platform/mac/imported/w3c/web-platform-tests/svg/struct/reftests/use-symbol-dimensions-override-001-expected.txt: Rebaselined

Canonical link: <a href="https://commits.webkit.org/263977@main">https://commits.webkit.org/263977@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/323b19218aad6d5c76dab4b8f7a72073a04d8c86

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/6155 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/6342 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/6525 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/7717 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/6494 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/6155 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/6562 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/6294 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/9370 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/6265 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/6283 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/5571 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/7782 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/3757 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/5551 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/13446 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/5622 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/5630 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/7858 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/6099 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/4989 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/5517 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/1490 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/9660 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/5884 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->