### PR TITLE
Add a new motionmark test to simulate drawing Spreadsheet on canvas

### DIFF
--- a/PerformanceTests/MotionMark/resources/debug-runner/tests.js
+++ b/PerformanceTests/MotionMark/resources/debug-runner/tests.js
@@ -427,6 +427,10 @@ Suites.push(new Suite("Basic canvas path suite",
             name: "Canvas ellipses"
         },
         {
+            url: "simple/simple-canvas-paths.html?pathType=sheetCells",
+            name: "Canvas simulate sheet cells"
+        },
+        {
             url: "simple/simple-canvas-paths.html?pathType=lineFill",
             name: "Canvas line path, fill"
         },

--- a/PerformanceTests/MotionMark/resources/debug-runner/tests.js
+++ b/PerformanceTests/MotionMark/resources/debug-runner/tests.js
@@ -427,8 +427,8 @@ Suites.push(new Suite("Basic canvas path suite",
             name: "Canvas ellipses"
         },
         {
-            url: "simple/simple-canvas-paths.html?pathType=sheetCells",
-            name: "Canvas simulate sheet cells"
+            url: "simple/simple-canvas-paths.html?pathType=spreadSheets",
+            name: "Canvas Spreadsheets"
         },
         {
             url: "simple/simple-canvas-paths.html?pathType=lineFill",

--- a/PerformanceTests/MotionMark/tests/simple/resources/simple-canvas-paths.js
+++ b/PerformanceTests/MotionMark/tests/simple/resources/simple-canvas-paths.js
@@ -269,6 +269,42 @@ CanvasEllipseFill = Utilities.createClass(
     }
 });
 
+CanvasSheetCells = Utilities.createClass(
+    function(stage) {
+        this._start = Stage.randomPosition(stage.size)
+        this._color = Stage.randomColor()
+        this._cell_width = Stage.randomInt(90, 150)
+        this._cell_height = Stage.randomInt(20, 30)
+        this._font = Stage.randomInt(10, 40) + 'px Arial';
+        this._border_style_index = Stage.randomInt(0, 3);
+        this._color = Stage.randomColor();
+    }, {
+
+    draw: function(context) {
+        context.save();
+        rectPath = new Path2D();
+        rectPath.rect(this._start.x, this._start.y, this._cell_width, this._cell_height);
+        context.clip(rectPath);
+        context.beginPath();
+        if (this._border_style_index === 0) {
+            context.setLineDash([5, 5]);
+        } else if (this._border_style_index === 1) {
+            context.globalAlpha = 0.5;
+        } else {
+            context.strokeStyle = "#000000";
+        }
+        context.rect(this._start.x, this._start.y, this._cell_width, this._cell_height);
+        context.stroke();
+        context.globalAlpha = 0.5;
+        context.fillStyle = this._color;
+        context.fillRect(this._start.x, this._start.y, this._cell_width, this._cell_height);
+        context.globalAlpha = 1;
+        context.font = this._font;
+        context.fillText("hello world", this._start.x, this._start.y + this._cell_height);
+        context.restore();
+    }
+});
+
 CanvasStroke = Utilities.createClass(
     function (stage) {
         this._object = new (Stage.randomElementInArray(this.objectTypes))(stage);
@@ -459,6 +495,9 @@ CanvasPathBenchmark = Utilities.createSubclass(Benchmark,
             break;
         case "ellipseFill":
             stage = new SimpleCanvasStage(CanvasEllipseFill);
+            break;
+        case "sheetCells":
+            stage = new SimpleCanvasStage(CanvasSheetCells);
             break;
         case "strokes":
             stage = new SimpleCanvasStage(CanvasStroke);

--- a/PerformanceTests/MotionMark/tests/simple/resources/simple-canvas-paths.js
+++ b/PerformanceTests/MotionMark/tests/simple/resources/simple-canvas-paths.js
@@ -269,23 +269,39 @@ CanvasEllipseFill = Utilities.createClass(
     }
 });
 
-CanvasSheetCells = Utilities.createClass(
+CanvasSpreadSheets = Utilities.createClass(
     function(stage) {
+        // Some good dark color for writing text in spreadsheet.
+        var dark_colors = ['#000000', '#404040', '#00008B', '#442D16', '#7E0000'];
+        // Some good light color for filling cells in spreadsheet.
+        var light_colors = ['#ADFF2F', '#ADD8E6', '#FFC0CB', '#E3C8C8', '#EBEEAF'];
+        // Possible text alignment in spreadsheet.
+        var align = ['left', 'right', 'center', 'start' , 'end']
+        this._text_color = dark_colors[Stage.randomInt(0, 5)];
+        this._fill_color = light_colors[Stage.randomInt(0, 5)];
+        this._text_align = align[Stage.randomInt(0, 5)];
         this._start = Stage.randomPosition(stage.size)
-        this._color = Stage.randomColor()
-        this._cell_width = Stage.randomInt(90, 150)
-        this._cell_height = Stage.randomInt(20, 30)
+        this._color = Stage.randomColor();
+        this._cell_width = Stage.randomInt(90, 150);
+        this._cell_height = Stage.randomInt(20, 30);
         this._font = Stage.randomInt(10, 40) + 'px Arial';
         this._border_style_index = Stage.randomInt(0, 3);
         this._color = Stage.randomColor();
     }, {
-
     draw: function(context) {
         context.save();
         rectPath = new Path2D();
         rectPath.rect(this._start.x, this._start.y, this._cell_width, this._cell_height);
         context.clip(rectPath);
         context.beginPath();
+        context.globalAlpha = 0.5;
+        context.fillStyle = this._fill_color;
+        context.fill(rectPath);
+        context.globalAlpha = 1;
+        context.font = this._font;
+        context.fillStyle = this._text_color;
+        context.textAlign = this._text_align;
+        context.fillText("hello world", (this._start.x + this._start.x + this._cell_width)/2, this._start.y + this._cell_height);
         if (this._border_style_index === 0) {
             context.setLineDash([5, 5]);
         } else if (this._border_style_index === 1) {
@@ -293,14 +309,7 @@ CanvasSheetCells = Utilities.createClass(
         } else {
             context.strokeStyle = "#000000";
         }
-        context.rect(this._start.x, this._start.y, this._cell_width, this._cell_height);
-        context.stroke();
-        context.globalAlpha = 0.5;
-        context.fillStyle = this._color;
-        context.fillRect(this._start.x, this._start.y, this._cell_width, this._cell_height);
-        context.globalAlpha = 1;
-        context.font = this._font;
-        context.fillText("hello world", this._start.x, this._start.y + this._cell_height);
+        context.stroke(rectPath);
         context.restore();
     }
 });
@@ -496,8 +505,8 @@ CanvasPathBenchmark = Utilities.createSubclass(Benchmark,
         case "ellipseFill":
             stage = new SimpleCanvasStage(CanvasEllipseFill);
             break;
-        case "sheetCells":
-            stage = new SimpleCanvasStage(CanvasSheetCells);
+        case "spreadSheets":
+            stage = new SimpleCanvasStage(CanvasSpreadSheets);
             break;
         case "strokes":
             stage = new SimpleCanvasStage(CanvasStroke);


### PR DESCRIPTION
<pre>

Add a new motionmark test to simulate drawing Spreadsheet on canvas
<a href="https://bugs.webkit.org/show_bug.cgi?id=256561">https://bugs.webkit.org/show_bug.cgi?id=256561</a>

Reviewed by NOBODY (OOPS!).

Spreadsheet is often powered by Canvas. It would be an interesting idea to add a test simulates spreadsheet behaviors:
- draw a cell
- draw some border
- fill the cell with a background color
- fill some text to the cell

Note that this test is inspired by <a href="https://source.chromium.org/chromium/chromium/src/+/main:tools/perf/page_sets/simple_canvas/sheets_render.html">draw operations emitted by Google Sheets</a>

* path/changed.ext:
In file PerformanceTests/MotionMark/tests/simple/resources/simple-canvas-paths.js, added class CanvasSheetCells.
In file PerformanceTests/MotionMark/resources/debug-runner/tests.js, added a new case
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b6b24d36d61013f0bc3e42080d2262c7da004c39

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/6649 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/6865 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/7047 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/8240 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/6930 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/8012 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/6813 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/9824 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/6767 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/7347 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/6083 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/8327 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/4806 "Passed tests") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/13846 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/6589 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/6092 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/8779 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/6583 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/5393 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/5979 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/10151 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/6352 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->