### PR TITLE
[browserperfdash-benchmark] Support supplying browser arguments on linux

### DIFF
--- a/Tools/Scripts/webkitpy/benchmark_runner/browser_driver/linux_browser_driver.py
+++ b/Tools/Scripts/webkitpy/benchmark_runner/browser_driver/linux_browser_driver.py
@@ -54,7 +54,7 @@ class LinuxBrowserDriver(BrowserDriver):
 
     def prepare_env(self, config):
         self._browser_process = None
-        self._browser_arguments = None
+        self._default_browser_arguments = None
         self._temp_profiledir = tempfile.mkdtemp()
         self._test_environ = dict(os.environ)
         self._test_environ['HOME'] = self._temp_profiledir
@@ -100,9 +100,11 @@ class LinuxBrowserDriver(BrowserDriver):
                             browser_retcode=self._browser_process.returncode))
 
     def launch_url(self, url, options, browser_build_path, browser_path):
-        if not self._browser_arguments:
-            self._browser_arguments = [url]
-        exec_args = [self.process_name] + self._browser_arguments
+        if not self._default_browser_arguments:
+            self._default_browser_arguments = [url]
+        if not self.browser_args:
+            self.browser_args = []
+        exec_args = [self.process_name] + self.browser_args + self._default_browser_arguments
         _log.info('Executing: {browser_cmdline}'.format(browser_cmdline=' '.join(exec_args)))
         self._browser_process = subprocess.Popen(
             exec_args, env=self._test_environ,

--- a/Tools/Scripts/webkitpy/benchmark_runner/browser_driver/linux_chrome_driver.py
+++ b/Tools/Scripts/webkitpy/benchmark_runner/browser_driver/linux_chrome_driver.py
@@ -31,10 +31,10 @@ from webkitpy.benchmark_runner.browser_driver.linux_browser_driver import LinuxB
 
 class LinuxChromeDriver(LinuxBrowserDriver):
     browser_name = 'chrome'
-    process_search_list = ['chromium', 'chromium-browser', 'chrome']
+    process_search_list = ['chromium', 'chromium-browser', 'chrome', 'google-chrome']
 
     def launch_url(self, url, options, browser_build_path, browser_path):
-        self._browser_arguments = ['--temp-profile', '--start-maximized',
+        self._default_browser_arguments = ['--temp-profile', '--start-maximized',
                                    '--homepage', url]
         super(LinuxChromeDriver, self).launch_url(url, options, browser_build_path, browser_path)
 

--- a/Tools/Scripts/webkitpy/benchmark_runner/browser_driver/linux_cog_driver.py
+++ b/Tools/Scripts/webkitpy/benchmark_runner/browser_driver/linux_cog_driver.py
@@ -34,10 +34,10 @@ class CogBrowserDriver(LinuxBrowserDriver):
     # If you want to execute Cog with a specific platform plugin (drm, wayland, etc)
     # Then set the environment variables COG_PLATFORM_NAME and COG_PLATFORM_PARAMS
     def launch_url(self, url, options, browser_build_path, browser_path):
-        self._browser_arguments = []
+        self._default_browser_arguments = []
         if self.process_name.endswith('run-minibrowser'):
-            self._browser_arguments.append('--wpe')
-        self._browser_arguments.append(url)
+            self._default_browser_arguments.append('--wpe')
+        self._default_browser_arguments.append(url)
         super(CogBrowserDriver, self).launch_url(url, options, browser_build_path, browser_path)
 
     def launch_driver(self, url, options, browser_build_path):

--- a/Tools/Scripts/webkitpy/benchmark_runner/browser_driver/linux_epiphany_driver.py
+++ b/Tools/Scripts/webkitpy/benchmark_runner/browser_driver/linux_epiphany_driver.py
@@ -32,7 +32,7 @@ class EpiphanyBrowserDriver(LinuxBrowserDriver):
     process_search_list = ['epiphany', 'epiphany-browser']
 
     def launch_url(self, url, options, browser_build_path, browser_path):
-        self._browser_arguments = ['--new-window', '-p',
+        self._default_browser_arguments = ['--new-window', '-p',
                                    '--profile={profile}'.format(profile=self._temp_profiledir),
                                    url]
         super(EpiphanyBrowserDriver, self).launch_url(url, options, browser_build_path, browser_path)

--- a/Tools/Scripts/webkitpy/benchmark_runner/browser_driver/linux_firefox_driver.py
+++ b/Tools/Scripts/webkitpy/benchmark_runner/browser_driver/linux_firefox_driver.py
@@ -34,7 +34,7 @@ class LinuxFirefoxDriver(LinuxBrowserDriver):
     process_search_list = ['firefox', 'firefox-bin']
 
     def launch_url(self, url, options, browser_build_path, browser_path):
-        self._browser_arguments = ['-new-instance', '-profile', self._temp_profiledir,
+        self._default_browser_arguments = ['-new-instance', '-profile', self._temp_profiledir,
                                    '-width', str(self._screen_size().width),
                                    '-height', str(self._screen_size().height),
                                    url]

--- a/Tools/Scripts/webkitpy/benchmark_runner/browser_driver/linux_minibrowsergtk_driver.py
+++ b/Tools/Scripts/webkitpy/benchmark_runner/browser_driver/linux_minibrowsergtk_driver.py
@@ -32,11 +32,11 @@ class GTKMiniBrowserDriver(LinuxBrowserDriver):
     process_search_list = ['Tools/Scripts/run-minibrowser', 'MiniBrowser']
 
     def launch_url(self, url, options, browser_build_path, browser_path):
-        self._browser_arguments = []
+        self._default_browser_arguments = []
         if self.process_name.endswith('run-minibrowser'):
-            self._browser_arguments.append('--gtk')
-        self._browser_arguments.append('--full-screen')
-        self._browser_arguments.append(url)
+            self._default_browser_arguments.append('--gtk')
+        self._default_browser_arguments.append('--full-screen')
+        self._default_browser_arguments.append(url)
         super(GTKMiniBrowserDriver, self).launch_url(url, options, browser_build_path, browser_path)
 
     def launch_driver(self, url, options, browser_build_path):

--- a/Tools/Scripts/webkitpy/benchmark_runner/browser_driver/linux_minibrowserwpe_driver.py
+++ b/Tools/Scripts/webkitpy/benchmark_runner/browser_driver/linux_minibrowserwpe_driver.py
@@ -32,10 +32,10 @@ class WPEMiniBrowserDriver(LinuxBrowserDriver):
     process_search_list = ['Tools/Scripts/run-minibrowser', 'MiniBrowser']
 
     def launch_url(self, url, options, browser_build_path, browser_path):
-        self._browser_arguments = []
+        self._default_browser_arguments = []
         if self.process_name.endswith('run-minibrowser'):
-            self._browser_arguments.append('--wpe')
-        self._browser_arguments.append(url)
+            self._default_browser_arguments.append('--wpe')
+        self._default_browser_arguments.append(url)
         super(WPEMiniBrowserDriver, self).launch_url(url, options, browser_build_path, browser_path)
 
     def launch_driver(self, url, options, browser_build_path):

--- a/Tools/Scripts/webkitpy/benchmark_runner/run_benchmark.py
+++ b/Tools/Scripts/webkitpy/benchmark_runner/run_benchmark.py
@@ -60,11 +60,12 @@ def config_argument_parser():
     parser.add_argument('--show-iteration-values', dest='show_iteration_values', action='store_true', help="Show the measured value for each iteration in addition to averages.")
     parser.add_argument('--generate-pgo-profiles', dest="generate_pgo_profiles", action='store_true', help="Collect LLVM profiles for PGO, and copy them to the diagnostics directory.")
     parser.add_argument('--profile', action='store_true', help="Collect profiling traces, and copy them to the diagnostic directory.")
-    parser.add_argument('browser_args', nargs='*', help='Additional arguments to pass to the browser process')
 
     group = parser.add_mutually_exclusive_group()
     group.add_argument('--browser-path', help='Specify the path to a non-default copy of the target browser as a path to the .app.')
     group.add_argument('--build-directory', dest='build_dir', help='Path to the browser executable (e.g. WebKitBuild/Release/).')
+
+    parser.add_argument('browser_args', nargs='*', help='Additional arguments to pass to the browser process. These are positional arguments and must follow all other arguments. If the pass through arguments begin with a dash, use `--` before the argument list begins.')
 
     return parser
 

--- a/Tools/Scripts/webkitpy/browserperfdash/browserperfdash_runner.py
+++ b/Tools/Scripts/webkitpy/browserperfdash/browserperfdash_runner.py
@@ -59,6 +59,8 @@ def parse_args():
     mutual_group.add_argument('--plan', dest='plan', help='Benchmark plan to run. e.g. speedometer, jetstream')
     mutual_group.add_argument('--plans-from-config', action='store_true', help='Run the list of plans specified in the config file.')
     mutual_group.add_argument('--allplans', action='store_true', help='Run all available benchmark plans sequentially')
+
+    parser.add_argument('browser_args', nargs='*', help='Additional arguments to pass to the browser process. These are positional arguments and must follow all other arguments. If the pass through arguments begin with a dash, use `--` before the argument list begins.')
     args = parser.parse_args()
     return args
 
@@ -243,7 +245,16 @@ class BrowserPerfDashRunner(object):
                 # Run test and save test info
                 with tempfile.NamedTemporaryFile() as temp_result_file:
                     benchmark_runner_class = benchmark_runner_subclasses[self._args.driver]
-                    runner = benchmark_runner_class(plan, self._args.localCopy, self._args.countOverride, self._args.timeoutOverride, self._args.buildDir, temp_result_file.name, self._args.platform, self._args.browser, None)
+                    runner = benchmark_runner_class(plan,
+                                                    self._args.localCopy,
+                                                    self._args.countOverride,
+                                                    self._args.timeoutOverride,
+                                                    self._args.buildDir,
+                                                    temp_result_file.name,
+                                                    self._args.platform,
+                                                    self._args.browser,
+                                                    None,
+                                                    browser_args=self._args.browser_args)
                     runner.execute()
                     _log.info('Finished benchmark plan: {plan_name}'.format(plan_name=plan))
                     # Fill test info for upload


### PR DESCRIPTION
#### 51cfd93f9ff47129799f25676bcca75e48f57416
<pre>
[browserperfdash-benchmark] Support supplying browser arguments on linux
<a href="https://bugs.webkit.org/show_bug.cgi?id=256555">https://bugs.webkit.org/show_bug.cgi?id=256555</a>

Reviewed by Carlos Alberto Lopez Perez and Elliott Williams.

Add support for &quot;--browser-args&quot; on linux. This change involved changing
the browser arg arguments from a positional args to non-positional args.

Canonical link: <a href="https://commits.webkit.org/264122@main">https://commits.webkit.org/264122@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9b9d8ff2195c010bb54f68c6a99a2d2e2d9040f2

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/6790 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/7009 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/7193 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/8380 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/7043 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/6789 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/8182 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/6952 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/9939 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/6908 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/7507 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/6231 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/8475 "Built successfully") | 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/6895 "Passed tests") | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/39/builds/4934 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/6149 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/13956 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/6667 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/6230 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/9013 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/6719 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/5506 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/6103 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/1602 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/10281 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/6480 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->