### PR TITLE
Put post-processed pixel buffer at correct location

### DIFF
--- a/Source/WebCore/html/CanvasBase.cpp
+++ b/Source/WebCore/html/CanvasBase.cpp
@@ -386,13 +386,14 @@ void CanvasBase::postProcessDirtyCanvasBuffer() const
         return;
 
     auto imageRect = enclosingIntRect(m_postProcessDirtyRect);
+    imageRect.intersect({ { }, size() });
     PixelBufferFormat format { AlphaPremultiplication::Unpremultiplied, PixelFormat::RGBA8, imageBuffer->colorSpace() };
     auto pixelBuffer = imageBuffer->getPixelBuffer(format, imageRect);
     if (!is<ByteArrayPixelBuffer>(pixelBuffer))
         return;
 
     if (postProcessPixelBufferResults(*pixelBuffer, { })) {
-        imageBuffer->putPixelBuffer(*pixelBuffer, imageRect, { 0, 0 });
+        imageBuffer->putPixelBuffer(*pixelBuffer, imageRect, imageRect.location());
         m_postProcessDirtyRect = { };
     }
 }


### PR DESCRIPTION
#### f0109a1cfaae333c56ef9f5c93b3bc75b0fb9b3e
<pre>
Put post-processed pixel buffer at correct location
<a href="https://bugs.webkit.org/show_bug.cgi?id=256563">https://bugs.webkit.org/show_bug.cgi?id=256563</a>
rdar://109124810

Reviewed by Kimmo Kinnunen.

The call to ImageBuffer::putPixelBuffer may put the buffer at the wrong
location in the backend buffer if m_postProcessDirtyRect has a location at a
negative offset. This can happen, for example, if fillText draws outside the
bounds of the canvas. Therefore in this change we clip the dirty rect to
the bounds of the canvas, and we use the rect&apos;s location as the offset value.

* Source/WebCore/html/CanvasBase.cpp:
(WebCore::CanvasBase::postProcessDirtyCanvasBuffer const):

Canonical link: <a href="https://commits.webkit.org/263939@main">https://commits.webkit.org/263939@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/cc445c0421b66b57d8118c84ca0553a3ce3e0ba6

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/6021 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/6198 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/6384 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/7577 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/6375 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/6020 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/6417 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/6154 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/9217 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/6130 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/6158 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/5453 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/7637 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/3634 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/5431 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/13346 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/5500 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/5510 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/7731 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/5965 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/4902 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/5392 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/1465 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/9525 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/5757 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->