### PR TITLE
Dynamically extend GPU Process to Apple Camera Client IOKit Classes when appropriate

### DIFF
--- a/Source/WebKit/GPUProcess/mac/com.apple.WebKit.GPUProcess.sb.in
+++ b/Source/WebKit/GPUProcess/mac/com.apple.WebKit.GPUProcess.sb.in
@@ -701,8 +701,20 @@
     (iokit-user-client-class "IOAudioEngineUserClient")
     ;; Following is needed due to <rdar://problem/10427451> && <rdar://problem/10808817>
     (iokit-user-client-class "AudioAUUC")
-    ;; Following is needed due to <rdar://problem/108282689>
-    (iokit-user-client-class "H11ANEInDirectPathClient"))
+)
+
+#if HAVE(APPLE_CAMERA_USER_CLIENT)
+;; Following is needed due to <rdar://problem/108282689>
+(allow IOKIT_OPEN_USER_CLIENT
+    (require-all
+        (extension "com.apple.webkit.extension.iokit")
+        (iokit-user-client-class "H11ANEInDirectPathClient")))
+
+(allow iokit-open-service
+    (require-all
+        (extension "com.apple.webkit.extension.iokit")
+        (iokit-user-client-class "H11ANEIn")))
+#endif // HAVE(APPLE_CAMERA_USER_CLIENT)
 
 (deny IOKIT_OPEN_USER_CLIENT
     (iokit-user-client-class "AppleMultitouchDeviceUserClient")

--- a/Source/WebKit/UIProcess/GPU/GPUProcessProxy.cpp
+++ b/Source/WebKit/UIProcess/GPU/GPUProcessProxy.cpp
@@ -225,6 +225,8 @@ void GPUProcessProxy::setOrientationForMediaCapture(WebCore::IntDegrees orientat
 
 #if HAVE(APPLE_CAMERA_USER_CLIENT)
 static const ASCIILiteral appleCameraUserClientPath { "com.apple.aneuserd"_s };
+static const ASCIILiteral appleCameraUserClientIOKitClientClass { "H11ANEInDirectPathClient"_s };
+static const ASCIILiteral appleCameraUserClientIOKitServiceClass { "H11ANEIn"_s };
 #endif
 
 static inline bool addCameraSandboxExtensions(Vector<SandboxExtension::Handle>& extensions)
@@ -258,6 +260,21 @@ static inline bool addCameraSandboxExtensions(Vector<SandboxExtension::Handle>& 
                 return false;
             }
             extensions.append(WTFMove(*appleCameraUserClientExtensionHandle));
+
+            auto appleCameraUserClientIOKitClientClassExtensionHandle = SandboxExtension::createHandleForIOKitClassExtension(appleCameraUserClientIOKitClientClass, std::nullopt);
+            if (!appleCameraUserClientIOKitClientClassExtensionHandle) {
+                RELEASE_LOG_ERROR(WebRTC, "Unable to create %s sandbox extension", appleCameraUserClientIOKitClientClass.characters8());
+                return false;
+            }
+            extensions.append(WTFMove(*appleCameraUserClientIOKitClientClassExtensionHandle));
+
+            auto appleCameraUserClientIOKitServiceClassExtensionHandle = SandboxExtension::createHandleForIOKitClassExtension(appleCameraUserClientIOKitServiceClass, std::nullopt);
+            if (!appleCameraUserClientIOKitServiceClassExtensionHandle) {
+                RELEASE_LOG_ERROR(WebRTC, "Unable to create %s sandbox extension", appleCameraUserClientIOKitServiceClass.characters8());
+                return false;
+            }
+            extensions.append(WTFMove(*appleCameraUserClientIOKitServiceClassExtensionHandle));
+
 #endif
         }
 #endif // HAVE(AUDIT_TOKEN)

--- a/Source/WebKit/UIProcess/UserMediaProcessManager.cpp
+++ b/Source/WebKit/UIProcess/UserMediaProcessManager.cpp
@@ -40,6 +40,8 @@ static const ASCIILiteral videoExtensionPath { "com.apple.webkit.camera"_s };
 static const ASCIILiteral appleCameraServicePath { "com.apple.applecamerad"_s };
 static const ASCIILiteral additionalAppleCameraServicePath { "com.apple.appleh13camerad"_s };
 static const ASCIILiteral appleCameraUserClientPath { "com.apple.aneuserd"_s };
+static const ASCIILiteral appleCameraUserClientIOKitClientClass { "H11ANEInDirectPathClient"_s };
+static const ASCIILiteral appleCameraUserClientIOKitServiceClass { "H11ANEIn"_s };
 #endif
 
 UserMediaProcessManager& UserMediaProcessManager::singleton()
@@ -96,7 +98,7 @@ bool UserMediaProcessManager::willCreateMediaStream(UserMediaPermissionRequestMa
         extensionCount++;
 #endif
 #if HAVE(APPLE_CAMERA_USER_CLIENT)
-        extensionCount++;
+        extensionCount += 3;
 #endif
     }
 
@@ -140,6 +142,16 @@ bool UserMediaProcessManager::willCreateMediaStream(UserMediaPermissionRequestMa
                 if (auto handle = SandboxExtension::createHandleForMachLookup(appleCameraUserClientPath, auditToken)) {
                     handles[--extensionCount] = WTFMove(*handle);
                     ids.uncheckedAppend(appleCameraUserClientPath);
+                }
+
+                if (auto handle = SandboxExtension::createHandleForIOKitClassExtension(appleCameraUserClientIOKitClientClass, auditToken)) {
+                    handles[--extensionCount] = WTFMove(*handle);
+                    ids.uncheckedAppend(appleCameraUserClientIOKitClientClass);
+                }
+
+                if (auto handle = SandboxExtension::createHandleForIOKitClassExtension(appleCameraUserClientIOKitServiceClass, auditToken)) {
+                    handles[--extensionCount] = WTFMove(*handle);
+                    ids.uncheckedAppend(appleCameraUserClientIOKitServiceClass);
                 }
 #endif
             }


### PR DESCRIPTION
#### 419d742e96e5d321c25a5b814b63be6d3507d980
<pre>
Dynamically extend GPU Process to Apple Camera Client IOKit Classes when appropriate
<a href="https://bugs.webkit.org/show_bug.cgi?id=256562">https://bugs.webkit.org/show_bug.cgi?id=256562</a>
&lt;rdar://109117566&gt;

Reviewed by Youenn Fablet, Eric Carlson and Per Arne Vollan.

Continue the work from Bug 256013 by dynamically extending the IOKit classes used
when the camera is enabled during WebRTC.

* Source/WebKit/GPUProcess/mac/com.apple.WebKit.GPUProcess.sb.in:
* Source/WebKit/UIProcess/GPU/GPUProcessProxy.cpp:
(WebKit::addCameraSandboxExtensions):
* Source/WebKit/UIProcess/UserMediaProcessManager.cpp:
(WebKit::UserMediaProcessManager::willCreateMediaStream):

Canonical link: <a href="https://commits.webkit.org/263903@main">https://commits.webkit.org/263903@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c21e458c47dd498822a7d4638fdd74d991b07a0f

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/6022 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/6199 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/6385 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/7578 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/6376 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/6418 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/6155 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/9195 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/6131 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/6157 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/5455 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/7638 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/3633 "Passed tests") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/13347 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/5499 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/5512 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/7732 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/5966 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/4888 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/5393 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/1437 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/9526 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/5758 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->