### PR TITLE
imported/w3c/web-platform-tests/html/interaction/focus/the-autofocus-attribute/document-with-fragment-valid.html is a flaky text failure.

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/html/interaction/focus/the-autofocus-attribute/document-with-fragment-valid-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/interaction/focus/the-autofocus-attribute/document-with-fragment-valid-expected.txt
@@ -1,5 +1,5 @@
 
-
-FAIL Autofocus elements in iframed documents with URL fragments should be skipped. assert_not_equals: got disallowed value Element node <input autofocus=""></input>
-FAIL Autofocus elements in top-level browsing context's documents with URL fragments should be skipped. assert_not_equals: got disallowed value Element node <input autofocus=""></input>
+PASS Autofocus elements in iframed documents with URL fragments should be skipped. (id matches)
+PASS Autofocus elements in iframed documents with URL fragments should be skipped.(a element)
+PASS Autofocus elements in top-level browsing context's documents with URL fragments should be skipped.
 

--- a/LayoutTests/imported/w3c/web-platform-tests/html/interaction/focus/the-autofocus-attribute/document-with-fragment-valid.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/interaction/focus/the-autofocus-attribute/document-with-fragment-valid.html
@@ -21,7 +21,23 @@ promise_test(async () => {
   doc.body.appendChild(input);
   await waitUntilStableAutofocusState();
   assert_not_equals(doc.activeElement, input);
-}, 'Autofocus elements in iframed documents with URL fragments should be skipped.');
+  iframe.remove();
+}, 'Autofocus elements in iframed documents with URL fragments should be skipped. (id matches)');
+
+promise_test(async () => {
+  let iframe = await waitForIframeLoad("resources/frame-with-a.html");
+  iframe.contentWindow.location.hash = 'anchor1';
+  await waitForEvent(iframe.contentWindow, 'hashchange');
+  const doc = iframe.contentDocument;
+  assert_true(!!doc.querySelector(':target'));
+
+  let input = doc.createElement('input');
+  input.autofocus = true;
+  doc.body.appendChild(input);
+  await waitUntilStableAutofocusState();
+  assert_not_equals(doc.activeElement, input);
+  iframe.remove();
+}, 'Autofocus elements in iframed documents with URL fragments should be skipped.(a element)');
 
 promise_test(async () => {
   let w = window.open('resources/frame-with-anchor.html');

--- a/LayoutTests/imported/w3c/web-platform-tests/html/interaction/focus/the-autofocus-attribute/resources/frame-with-a.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/interaction/focus/the-autofocus-attribute/resources/frame-with-a.html
@@ -1,0 +1,4 @@
+<!DOCTYPE html>
+<body>
+<a name="anchor1"></a>
+</body>

--- a/LayoutTests/imported/w3c/web-platform-tests/html/interaction/focus/the-autofocus-attribute/resources/utils.js
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/interaction/focus/the-autofocus-attribute/resources/utils.js
@@ -39,3 +39,13 @@ async function waitUntilStableAutofocusState(w) {
   // Awaiting one animation frame is an easy way to determine autofocus state.
   await waitForAnimationFrame(targetWindow);
 }
+
+async function waitForIframeLoad(src, w = window) {
+  const iframe = w.document.createElement("iframe");
+  let loadPromise = new Promise(resolve => {
+    iframe.addEventListener("load", () => resolve(iframe));
+  });
+  iframe.src = src;
+  w.document.body.appendChild(iframe);
+  return loadPromise;
+}

--- a/LayoutTests/platform/ios-wk2/TestExpectations
+++ b/LayoutTests/platform/ios-wk2/TestExpectations
@@ -2009,8 +2009,6 @@ webkit.org/b/247632 imported/w3c/web-platform-tests/fetch/metadata/generated/win
 
 webkit.org/b/227998 imported/w3c/web-platform-tests/html/semantics/embedded-content/the-embed-element/embed-network-error.sub.html [ Pass Failure ]
 
-webkit.org/b/227762 imported/w3c/web-platform-tests/html/interaction/focus/the-autofocus-attribute/document-with-fragment-valid.html [ Pass Failure ]
-
 webkit.org/b/231959 imported/w3c/web-platform-tests/html/canvas/element/manual/wide-gamut-canvas/canvas-display-p3-drawImage-ImageBitmap-video.html [ Failure ]
 webkit.org/b/231959 imported/w3c/web-platform-tests/html/canvas/element/manual/wide-gamut-canvas/canvas-display-p3-drawImage-video.html [ Failure ]
 

--- a/LayoutTests/platform/mac-wk1/TestExpectations
+++ b/LayoutTests/platform/mac-wk1/TestExpectations
@@ -2222,8 +2222,6 @@ webkit.org/b/244499 [ Debug ]  imported/w3c/web-platform-tests/workers/modules/d
 
 webkit.org/b/228260 [ BigSur Debug ] imported/w3c/web-platform-tests/IndexedDB/idb_binary_key_conversion.htm [ Pass Timeout ]
 
-webkit.org/b/227762 imported/w3c/web-platform-tests/html/interaction/focus/the-autofocus-attribute/document-with-fragment-valid.html [ Pass Failure ]
-
 webkit.org/b/232276 imported/w3c/web-platform-tests/html/interaction/focus/the-autofocus-attribute/spin-by-blocking-style-sheet.html [ Pass Failure ]
 
 imported/w3c/web-platform-tests/mathml/presentation-markup/operators/operator-dictionary-arabic-002.html [ ImageOnlyFailure ]

--- a/LayoutTests/platform/wpe/imported/w3c/web-platform-tests/html/interaction/focus/the-autofocus-attribute/document-with-fragment-valid-expected.txt
+++ b/LayoutTests/platform/wpe/imported/w3c/web-platform-tests/html/interaction/focus/the-autofocus-attribute/document-with-fragment-valid-expected.txt
@@ -1,5 +1,0 @@
-
-
-FAIL Autofocus elements in iframed documents with URL fragments should be skipped. assert_not_equals: got disallowed value Element node <input autofocus=""></input>
-PASS Autofocus elements in top-level browsing context's documents with URL fragments should be skipped.
-


### PR DESCRIPTION
#### 7b474c357fab882048bfa1b9f2fdbcd839183ff6
<pre>
imported/w3c/web-platform-tests/html/interaction/focus/the-autofocus-attribute/document-with-fragment-valid.html is a flaky text failure.
<a href="https://bugs.webkit.org/show_bug.cgi?id=254642">https://bugs.webkit.org/show_bug.cgi?id=254642</a>
rdar://107348996

Reviewed by Aditya Keerthi.

Get our &quot;flush autofocus candidates&quot; logic closer to the HTML specification:
- <a href="https://html.spec.whatwg.org/multipage/interaction.html#flush-autofocus-candidates">https://html.spec.whatwg.org/multipage/interaction.html#flush-autofocus-candidates</a>

In particular, it adds the required checks for the document&apos;s target element.

* LayoutTests/imported/w3c/web-platform-tests/html/interaction/focus/the-autofocus-attribute/document-with-fragment-valid-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/html/interaction/focus/the-autofocus-attribute/document-with-fragment-valid.html:
* LayoutTests/imported/w3c/web-platform-tests/html/interaction/focus/the-autofocus-attribute/resources/frame-with-a.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/html/interaction/focus/the-autofocus-attribute/resources/utils.js:
(async waitForIframeLoad):
Resync from upstream WPT.

* Source/WebCore/dom/Document.cpp:
(WebCore::Document::flushAutofocusCandidates):

Canonical link: <a href="https://commits.webkit.org/263893@main">https://commits.webkit.org/263893@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/00a8ecf1fe06e634ebf0e1a2f2d4f70874a4d4a7

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/6042 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/6221 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/6407 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/7599 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/6391 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/6041 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/6439 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/6177 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/9275 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/6151 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/6174 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/5467 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/7660 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/3650 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/5449 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/13359 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/5516 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/5527 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/7749 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/5986 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/4901 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/5411 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/5378 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/1430 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/9546 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/5777 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->