### PR TITLE
[GPU Process][Filters] Make RemoteResourceCache be capable of caching Filter

### DIFF
--- a/Source/WebCore/platform/graphics/RenderingResource.h
+++ b/Source/WebCore/platform/graphics/RenderingResource.h
@@ -53,6 +53,7 @@ public:
     virtual bool isNativeImage() const { return false; }
     virtual bool isGradient() const { return false; }
     virtual bool isDecomposedGlyphs() const { return false; }
+    virtual bool isFilter() const { return false; }
 
     bool hasValidRenderingResourceIdentifier() const
     {

--- a/Source/WebCore/platform/graphics/displaylists/DisplayList.h
+++ b/Source/WebCore/platform/graphics/displaylists/DisplayList.h
@@ -29,6 +29,7 @@
 #include "DisplayListItemBuffer.h"
 #include "DisplayListItemType.h"
 #include "DisplayListResourceHeap.h"
+#include "Filter.h"
 #include "FloatRect.h"
 #include "Font.h"
 #include "GraphicsContext.h"
@@ -118,6 +119,11 @@ private:
     void cacheGradient(Gradient& gradient)
     {
         m_resourceHeap.add(gradient.renderingResourceIdentifier(), Ref { gradient });
+    }
+
+    void cacheFilter(Filter& filter)
+    {
+        m_resourceHeap.add(filter.renderingResourceIdentifier(), Ref { filter });
     }
 
     static bool shouldDumpForFlags(OptionSet<AsTextFlag>, ItemHandle);

--- a/Source/WebCore/platform/graphics/displaylists/DisplayListRecorder.h
+++ b/Source/WebCore/platform/graphics/displaylists/DisplayListRecorder.h
@@ -152,6 +152,7 @@ protected:
     virtual bool recordResourceUse(Font&) = 0;
     virtual bool recordResourceUse(DecomposedGlyphs&) = 0;
     virtual bool recordResourceUse(Gradient&) = 0;
+    virtual bool recordResourceUse(Filter&) = 0;
 
     struct ContextState {
         GraphicsContextState state;

--- a/Source/WebCore/platform/graphics/displaylists/DisplayListRecorderImpl.cpp
+++ b/Source/WebCore/platform/graphics/displaylists/DisplayListRecorderImpl.cpp
@@ -444,5 +444,11 @@ bool RecorderImpl::recordResourceUse(Gradient& gradient)
     return true;
 }
 
+bool RecorderImpl::recordResourceUse(Filter& filter)
+{
+    m_displayList.cacheFilter(filter);
+    return true;
+}
+
 } // namespace DisplayList
 } // namespace WebCore

--- a/Source/WebCore/platform/graphics/displaylists/DisplayListRecorderImpl.h
+++ b/Source/WebCore/platform/graphics/displaylists/DisplayListRecorderImpl.h
@@ -125,6 +125,7 @@ private:
     bool recordResourceUse(Font&) final;
     bool recordResourceUse(DecomposedGlyphs&) final;
     bool recordResourceUse(Gradient&) final;
+    bool recordResourceUse(Filter&) final;
 
     template<typename T, class... Args>
     void append(Args&&... args)

--- a/Source/WebCore/platform/graphics/displaylists/DisplayListResourceHeap.h
+++ b/Source/WebCore/platform/graphics/displaylists/DisplayListResourceHeap.h
@@ -26,6 +26,7 @@
 #pragma once
 
 #include "DecomposedGlyphs.h"
+#include "Filter.h"
 #include "Font.h"
 #include "Gradient.h"
 #include "ImageBuffer.h"
@@ -47,6 +48,7 @@ public:
     virtual std::optional<SourceImage> getSourceImage(RenderingResourceIdentifier) const = 0;
     virtual DecomposedGlyphs* getDecomposedGlyphs(RenderingResourceIdentifier) const = 0;
     virtual Gradient* getGradient(RenderingResourceIdentifier) const = 0;
+    virtual Filter* getFilter(RenderingResourceIdentifier) const = 0;
     virtual Font* getFont(RenderingResourceIdentifier) const = 0;
 };
 
@@ -70,6 +72,11 @@ public:
     void add(RenderingResourceIdentifier renderingResourceIdentifier, Ref<Gradient>&& gradient)
     {
         add<RenderingResource>(renderingResourceIdentifier, WTFMove(gradient));
+    }
+
+    void add(RenderingResourceIdentifier renderingResourceIdentifier, Ref<Filter>&& filter)
+    {
+        add<RenderingResource>(renderingResourceIdentifier, WTFMove(filter));
     }
 
     void add(RenderingResourceIdentifier renderingResourceIdentifier, Ref<Font>&& font)
@@ -112,6 +119,12 @@ public:
     {
         auto* renderingResource = get<RenderingResource>(renderingResourceIdentifier);
         return dynamicDowncast<Gradient>(renderingResource);
+    }
+
+    Filter* getFilter(RenderingResourceIdentifier renderingResourceIdentifier) const final
+    {
+        auto* renderingResource = get<RenderingResource>(renderingResourceIdentifier);
+        return dynamicDowncast<Filter>(renderingResource);
     }
 
     Font* getFont(RenderingResourceIdentifier renderingResourceIdentifier) const final

--- a/Source/WebCore/platform/graphics/filters/Filter.h
+++ b/Source/WebCore/platform/graphics/filters/Filter.h
@@ -84,5 +84,5 @@ private:
 } // namespace WebCore
 
 SPECIALIZE_TYPE_TRAITS_BEGIN(WebCore::Filter)
-    static bool isType(const WebCore::FilterFunction& function) { return function.isFilter(); }
+    static bool isType(const WebCore::RenderingResource& renderingResource) { return renderingResource.isFilter(); }
 SPECIALIZE_TYPE_TRAITS_END()

--- a/Source/WebCore/platform/graphics/filters/FilterFunction.h
+++ b/Source/WebCore/platform/graphics/filters/FilterFunction.h
@@ -87,7 +87,7 @@ public:
 
     bool isCSSFilter() const { return m_filterType == Type::CSSFilter; }
     bool isSVGFilter() const { return m_filterType == Type::SVGFilter; }
-    bool isFilter() const { return m_filterType == Type::CSSFilter || m_filterType == Type::SVGFilter; }
+    bool isFilter() const override { return m_filterType == Type::CSSFilter || m_filterType == Type::SVGFilter; }
     bool isFilterEffect() const { return m_filterType >= Type::FEFirst && m_filterType <= Type::FELast; }
 
     static AtomString filterName(Type);

--- a/Source/WebKit/GPUProcess/graphics/QualifiedResourceHeap.h
+++ b/Source/WebKit/GPUProcess/graphics/QualifiedResourceHeap.h
@@ -29,6 +29,7 @@
 
 #include "QualifiedRenderingResourceIdentifier.h"
 #include <WebCore/DecomposedGlyphs.h>
+#include <WebCore/Filter.h>
 #include <WebCore/Font.h>
 #include <WebCore/FontCustomPlatformData.h>
 #include <WebCore/Gradient.h>
@@ -65,6 +66,11 @@ public:
     void add(QualifiedRenderingResourceIdentifier renderingResourceIdentifier, Ref<WebCore::Gradient>&& gradient)
     {
         add<WebCore::RenderingResource>(renderingResourceIdentifier, WTFMove(gradient), m_renderingResourceCount);
+    }
+
+    void add(QualifiedRenderingResourceIdentifier renderingResourceIdentifier, Ref<WebCore::Filter>&& filter)
+    {
+        add<WebCore::RenderingResource>(renderingResourceIdentifier, WTFMove(filter), m_renderingResourceCount);
     }
 
     void add(QualifiedRenderingResourceIdentifier renderingResourceIdentifier, Ref<WebCore::Font>&& font)
@@ -117,6 +123,12 @@ public:
     {
         auto* renderingResource = get<WebCore::RenderingResource>(renderingResourceIdentifier);
         return dynamicDowncast<WebCore::Gradient>(renderingResource);
+    }
+
+    WebCore::Filter* getFilter(QualifiedRenderingResourceIdentifier renderingResourceIdentifier) const
+    {
+        auto* renderingResource = get<WebCore::RenderingResource>(renderingResourceIdentifier);
+        return dynamicDowncast<WebCore::Filter>(renderingResource);
     }
 
     WebCore::FontCustomPlatformData* getFontCustomPlatformData(QualifiedRenderingResourceIdentifier renderingResourceIdentifier) const

--- a/Source/WebKit/GPUProcess/graphics/RemoteRenderingBackend.cpp
+++ b/Source/WebKit/GPUProcess/graphics/RemoteRenderingBackend.cpp
@@ -420,6 +420,17 @@ void RemoteRenderingBackend::cacheGradientWithQualifiedIdentifier(Ref<Gradient>&
     m_remoteResourceCache.cacheGradient(WTFMove(gradient), gradientResourceIdentifier);
 }
 
+void RemoteRenderingBackend::cacheFilter(Ref<Filter>&& filter, RenderingResourceIdentifier renderingResourceIdentifier)
+{
+    cacheFilterWithQualifiedIdentifier(WTFMove(filter), { renderingResourceIdentifier, m_gpuConnectionToWebProcess->webProcessIdentifier() });
+}
+
+void RemoteRenderingBackend::cacheFilterWithQualifiedIdentifier(Ref<Filter>&& filter, QualifiedRenderingResourceIdentifier filterResourceIdentifier)
+{
+    ASSERT(!RunLoop::isMain());
+    m_remoteResourceCache.cacheFilter(WTFMove(filter), filterResourceIdentifier);
+}
+
 void RemoteRenderingBackend::releaseAllResources()
 {
     ASSERT(!RunLoop::isMain());

--- a/Source/WebKit/GPUProcess/graphics/RemoteRenderingBackend.h
+++ b/Source/WebKit/GPUProcess/graphics/RemoteRenderingBackend.h
@@ -137,6 +137,7 @@ private:
     void cacheNativeImage(ShareableBitmap::Handle&&, WebCore::RenderingResourceIdentifier);
     void cacheDecomposedGlyphs(Ref<WebCore::DecomposedGlyphs>&&);
     void cacheGradient(Ref<WebCore::Gradient>&&, WebCore::RenderingResourceIdentifier);
+    void cacheFilter(Ref<WebCore::Filter>&&, WebCore::RenderingResourceIdentifier);
     void cacheFont(const WebCore::Font::Attributes&, WebCore::FontPlatformData::Attributes, std::optional<WebCore::RenderingResourceIdentifier>);
     void cacheFontCustomPlatformData(Ref<WebCore::FontCustomPlatformData>&&);
     void releaseAllResources();
@@ -154,6 +155,7 @@ private:
     void cacheNativeImageWithQualifiedIdentifier(ShareableBitmap::Handle&&, QualifiedRenderingResourceIdentifier);
     void cacheDecomposedGlyphsWithQualifiedIdentifier(Ref<WebCore::DecomposedGlyphs>&&, QualifiedRenderingResourceIdentifier);
     void cacheGradientWithQualifiedIdentifier(Ref<WebCore::Gradient>&&, QualifiedRenderingResourceIdentifier);
+    void cacheFilterWithQualifiedIdentifier(Ref<WebCore::Filter>&&, QualifiedRenderingResourceIdentifier);
     void releaseRenderingResourceWithQualifiedIdentifier(QualifiedRenderingResourceIdentifier);
     void cacheFontWithQualifiedIdentifier(Ref<WebCore::Font>&&, QualifiedRenderingResourceIdentifier);
     void cacheFontCustomPlatformDataWithQualifiedIdentifier(Ref<WebCore::FontCustomPlatformData>&&, QualifiedRenderingResourceIdentifier);

--- a/Source/WebKit/GPUProcess/graphics/RemoteRenderingBackend.messages.in
+++ b/Source/WebKit/GPUProcess/graphics/RemoteRenderingBackend.messages.in
@@ -35,6 +35,7 @@ messages -> RemoteRenderingBackend NotRefCounted Stream {
     CacheFontCustomPlatformData(Ref<WebCore::FontCustomPlatformData> customPlatformData) NotStreamEncodable
     CacheDecomposedGlyphs(Ref<WebCore::DecomposedGlyphs> decomposedGlyphs) NotStreamEncodable
     CacheGradient(Ref<WebCore::Gradient> gradient, WebCore::RenderingResourceIdentifier renderingResourceIdentifier) NotStreamEncodable
+    CacheFilter(Ref<WebCore::Filter> filter, WebCore::RenderingResourceIdentifier renderingResourceIdentifier) NotStreamEncodable
     ReleaseAllResources()
     ReleaseAllImageResources()
     ReleaseRenderingResource(WebCore::RenderingResourceIdentifier renderingResourceIdentifier)

--- a/Source/WebKit/GPUProcess/graphics/RemoteResourceCache.cpp
+++ b/Source/WebKit/GPUProcess/graphics/RemoteResourceCache.cpp
@@ -75,6 +75,11 @@ void RemoteResourceCache::cacheGradient(Ref<Gradient>&& gradient, QualifiedRende
     m_resourceHeap.add(renderingResourceIdentifier, WTFMove(gradient));
 }
 
+void RemoteResourceCache::cacheFilter(Ref<Filter>&& filter, QualifiedRenderingResourceIdentifier renderingResourceIdentifier)
+{
+    m_resourceHeap.add(renderingResourceIdentifier, WTFMove(filter));
+}
+
 NativeImage* RemoteResourceCache::cachedNativeImage(QualifiedRenderingResourceIdentifier renderingResourceIdentifier) const
 {
     return m_resourceHeap.getNativeImage(renderingResourceIdentifier);
@@ -115,6 +120,11 @@ DecomposedGlyphs* RemoteResourceCache::cachedDecomposedGlyphs(QualifiedRendering
 Gradient* RemoteResourceCache::cachedGradient(QualifiedRenderingResourceIdentifier renderingResourceIdentifier) const
 {
     return m_resourceHeap.getGradient(renderingResourceIdentifier);
+}
+
+Filter* RemoteResourceCache::cachedFilter(QualifiedRenderingResourceIdentifier renderingResourceIdentifier) const
+{
+    return m_resourceHeap.getFilter(renderingResourceIdentifier);
 }
 
 void RemoteResourceCache::releaseAllResources()

--- a/Source/WebKit/GPUProcess/graphics/RemoteResourceCache.h
+++ b/Source/WebKit/GPUProcess/graphics/RemoteResourceCache.h
@@ -45,6 +45,7 @@ public:
     void cacheFont(Ref<WebCore::Font>&&, QualifiedRenderingResourceIdentifier);
     void cacheDecomposedGlyphs(Ref<WebCore::DecomposedGlyphs>&&, QualifiedRenderingResourceIdentifier);
     void cacheGradient(Ref<WebCore::Gradient>&&, QualifiedRenderingResourceIdentifier);
+    void cacheFilter(Ref<WebCore::Filter>&&, QualifiedRenderingResourceIdentifier);
     void cacheFontCustomPlatformData(Ref<WebCore::FontCustomPlatformData>&&, QualifiedRenderingResourceIdentifier);
 
     RemoteImageBuffer* cachedImageBuffer(QualifiedRenderingResourceIdentifier) const;
@@ -53,6 +54,7 @@ public:
     WebCore::Font* cachedFont(QualifiedRenderingResourceIdentifier) const;
     WebCore::DecomposedGlyphs* cachedDecomposedGlyphs(QualifiedRenderingResourceIdentifier) const;
     WebCore::Gradient* cachedGradient(QualifiedRenderingResourceIdentifier) const;
+    WebCore::Filter* cachedFilter(QualifiedRenderingResourceIdentifier) const;
     WebCore::FontCustomPlatformData* cachedFontCustomPlatformData(QualifiedRenderingResourceIdentifier) const;
 
     std::optional<WebCore::SourceImage> cachedSourceImage(QualifiedRenderingResourceIdentifier) const;

--- a/Source/WebKit/WebProcess/GPU/graphics/RemoteDisplayListRecorderProxy.cpp
+++ b/Source/WebKit/WebProcess/GPU/graphics/RemoteDisplayListRecorderProxy.cpp
@@ -515,6 +515,17 @@ bool RemoteDisplayListRecorderProxy::recordResourceUse(Gradient& gradient)
     return true;
 }
 
+bool RemoteDisplayListRecorderProxy::recordResourceUse(Filter& filter)
+{
+    if (UNLIKELY(!m_renderingBackend)) {
+        ASSERT_NOT_REACHED();
+        return false;
+    }
+
+    m_renderingBackend->remoteResourceCacheProxy().recordFilterUse(filter);
+    return true;
+}
+
 void RemoteDisplayListRecorderProxy::flushContext(const IPC::Semaphore& semaphore)
 {
     send(Messages::RemoteDisplayListRecorder::FlushContext(semaphore));

--- a/Source/WebKit/WebProcess/GPU/graphics/RemoteDisplayListRecorderProxy.h
+++ b/Source/WebKit/WebProcess/GPU/graphics/RemoteDisplayListRecorderProxy.h
@@ -144,6 +144,7 @@ private:
     bool recordResourceUse(WebCore::Font&) final;
     bool recordResourceUse(WebCore::DecomposedGlyphs&) final;
     bool recordResourceUse(WebCore::Gradient&) final;
+    bool recordResourceUse(WebCore::Filter&) final;
 
     RefPtr<WebCore::ImageBuffer> createImageBuffer(const WebCore::FloatSize&, float resolutionScale, const WebCore::DestinationColorSpace&, std::optional<WebCore::RenderingMode>, std::optional<WebCore::RenderingMethod>) const final;
     RefPtr<WebCore::ImageBuffer> createAlignedImageBuffer(const WebCore::FloatSize&, const WebCore::DestinationColorSpace&, std::optional<WebCore::RenderingMethod>) const final;

--- a/Source/WebKit/WebProcess/GPU/graphics/RemoteRenderingBackendProxy.cpp
+++ b/Source/WebKit/WebProcess/GPU/graphics/RemoteRenderingBackendProxy.cpp
@@ -268,6 +268,12 @@ void RemoteRenderingBackendProxy::cacheGradient(Ref<Gradient>&& gradient)
     send(Messages::RemoteRenderingBackend::CacheGradient(WTFMove(gradient), renderingResourceIdentifier));
 }
 
+void RemoteRenderingBackendProxy::cacheFilter(Ref<Filter>&& filter)
+{
+    auto renderingResourceIdentifier = filter->renderingResourceIdentifier();
+    send(Messages::RemoteRenderingBackend::CacheFilter(WTFMove(filter), renderingResourceIdentifier));
+}
+
 void RemoteRenderingBackendProxy::releaseAllRemoteResources()
 {
     if (!m_streamConnection)

--- a/Source/WebKit/WebProcess/GPU/graphics/RemoteRenderingBackendProxy.h
+++ b/Source/WebKit/WebProcess/GPU/graphics/RemoteRenderingBackendProxy.h
@@ -102,6 +102,7 @@ public:
     void cacheFontCustomPlatformData(Ref<const WebCore::FontCustomPlatformData>&&);
     void cacheDecomposedGlyphs(Ref<WebCore::DecomposedGlyphs>&&);
     void cacheGradient(Ref<WebCore::Gradient>&&);
+    void cacheFilter(Ref<WebCore::Filter>&&);
     void releaseAllRemoteResources();
     void releaseAllImageResources();
     void releaseRenderingResource(WebCore::RenderingResourceIdentifier);

--- a/Source/WebKit/WebProcess/GPU/graphics/RemoteResourceCacheProxy.cpp
+++ b/Source/WebKit/WebProcess/GPU/graphics/RemoteResourceCacheProxy.cpp
@@ -149,6 +149,14 @@ void RemoteResourceCacheProxy::recordGradientUse(Gradient& gradient)
     }
 }
 
+void RemoteResourceCacheProxy::recordFilterUse(Filter& filter)
+{
+    if (m_renderingResources.add(filter.renderingResourceIdentifier(), filter).isNewEntry) {
+        filter.addObserver(*this);
+        m_remoteRenderingBackendProxy.cacheFilter(filter);
+    }
+}
+
 void RemoteResourceCacheProxy::recordNativeImageUse(NativeImage& image)
 {
     WebProcess::singleton().deferNonVisibleProcessEarlyMemoryCleanupTimer();

--- a/Source/WebKit/WebProcess/GPU/graphics/RemoteResourceCacheProxy.h
+++ b/Source/WebKit/WebProcess/GPU/graphics/RemoteResourceCacheProxy.h
@@ -33,6 +33,7 @@
 
 namespace WebCore {
 class DecomposedGlyphs;
+class Filter;
 class Font;
 class Gradient;
 class ImageBuffer;
@@ -62,6 +63,7 @@ public:
     void recordImageBufferUse(WebCore::ImageBuffer&);
     void recordDecomposedGlyphsUse(WebCore::DecomposedGlyphs&);
     void recordGradientUse(WebCore::Gradient&);
+    void recordFilterUse(WebCore::Filter&);
     void recordFontCustomPlatformDataUse(const WebCore::FontCustomPlatformData&);
 
     void didPaintLayers();


### PR DESCRIPTION
#### e4cb3bdcaddcf79ba58dab47b0245b781c7db975
<pre>
[GPU Process][Filters] Make RemoteResourceCache be capable of caching Filter
<a href="https://bugs.webkit.org/show_bug.cgi?id=256324">https://bugs.webkit.org/show_bug.cgi?id=256324</a>
rdar://109069946

Reviewed by Simon Fraser.

This will allow sending the SVGFilter once to the GPU Process and referencing it
later by its RenderingResourceIdentifier in the StreamConnection message.

* Source/WebCore/platform/graphics/RenderingResource.h:
(WebCore::RenderingResource::isFilter const):
* Source/WebCore/platform/graphics/displaylists/DisplayList.h:
(WebCore::DisplayList::DisplayList::cacheFilter):
* Source/WebCore/platform/graphics/displaylists/DisplayListRecorder.h:
* Source/WebCore/platform/graphics/displaylists/DisplayListRecorderImpl.cpp:
(WebCore::DisplayList::RecorderImpl::recordResourceUse):
* Source/WebCore/platform/graphics/displaylists/DisplayListRecorderImpl.h:
* Source/WebCore/platform/graphics/displaylists/DisplayListResourceHeap.h:
(WebCore::DisplayList::LocalResourceHeap::add):
* Source/WebCore/platform/graphics/filters/Filter.h:
(isType):
* Source/WebCore/platform/graphics/filters/FilterFunction.h:
(WebCore::FilterFunction::isFilter const): Deleted.
* Source/WebKit/GPUProcess/graphics/QualifiedResourceHeap.h:
(WebKit::QualifiedResourceHeap::add):
(WebKit::QualifiedResourceHeap::getFilter const):
* Source/WebKit/GPUProcess/graphics/RemoteRenderingBackend.cpp:
(WebKit::RemoteRenderingBackend::cacheFilter):
(WebKit::RemoteRenderingBackend::cacheFilterWithQualifiedIdentifier):
* Source/WebKit/GPUProcess/graphics/RemoteRenderingBackend.h:
* Source/WebKit/GPUProcess/graphics/RemoteRenderingBackend.messages.in:
* Source/WebKit/GPUProcess/graphics/RemoteResourceCache.cpp:
(WebKit::RemoteResourceCache::cacheFilter):
(WebKit::RemoteResourceCache::cachedFilter const):
* Source/WebKit/GPUProcess/graphics/RemoteResourceCache.h:
* Source/WebKit/WebProcess/GPU/graphics/RemoteDisplayListRecorderProxy.cpp:
(WebKit::RemoteDisplayListRecorderProxy::recordResourceUse):
* Source/WebKit/WebProcess/GPU/graphics/RemoteDisplayListRecorderProxy.h:
* Source/WebKit/WebProcess/GPU/graphics/RemoteRenderingBackendProxy.cpp:
(WebKit::RemoteRenderingBackendProxy::cacheFilter):
* Source/WebKit/WebProcess/GPU/graphics/RemoteRenderingBackendProxy.h:
* Source/WebKit/WebProcess/GPU/graphics/RemoteResourceCacheProxy.cpp:
(WebKit::RemoteResourceCacheProxy::recordFilterUse):
* Source/WebKit/WebProcess/GPU/graphics/RemoteResourceCacheProxy.h:

Canonical link: <a href="https://commits.webkit.org/264001@main">https://commits.webkit.org/264001@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/df0085d45b05aaa182f4d27455e9f1406f71c540

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/6372 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/6572 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/6755 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/7942 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/6673 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/6366 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/6802 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/6522 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/9568 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/6484 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/6485 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/5758 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/8019 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/3952 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/5746 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/13611 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/5830 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/5825 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/8079 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/6309 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/5152 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/5714 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/1503 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/9873 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/6084 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->