### PR TITLE
editing/selection/ios/hide-selection-in-hidden-contenteditable.html fails with a text diff

### DIFF
--- a/Tools/WebKitTestRunner/ios/UIScriptControllerIOS.mm
+++ b/Tools/WebKitTestRunner/ios/UIScriptControllerIOS.mm
@@ -63,6 +63,19 @@ SOFT_LINK_CLASS(UIKit, UIPhysicalKeyboardEvent)
 
 namespace WTR {
 
+#if HAVE(UI_TEXT_SELECTION_DISPLAY_INTERACTION)
+
+static bool isHiddenOrHasHiddenAncestor(UIView *view)
+{
+    for (auto currentAncestor = view; currentAncestor; currentAncestor = currentAncestor.superview) {
+        if (currentAncestor.hidden)
+            return true;
+    }
+    return false;
+}
+
+#endif // HAVE(UI_TEXT_SELECTION_DISPLAY_INTERACTION)
+
 static BOOL returnYes()
 {
     return YES;
@@ -840,10 +853,7 @@ JSObjectRef UIScriptControllerIOS::selectionStartGrabberViewRect() const
 
 #if HAVE(UI_TEXT_SELECTION_DISPLAY_INTERACTION)
     if (!handleView) {
-        // FIXME: We should be able to use -handleViews here, but this seems returns an empty array,
-        // even when selection handles are present. Use -handleViews once rdar://108607881 is fixed.
-        auto view = findAllViewsInHierarchyOfType(contentView, NSClassFromString(@"_UITextSelectionLollipopView")).firstObject;
-        if (!view.hidden)
+        if (auto view = textSelectionDisplayInteraction().handleViews.firstObject; !isHiddenOrHasHiddenAncestor(view))
             handleView = view;
     }
 #endif
@@ -861,10 +871,7 @@ JSObjectRef UIScriptControllerIOS::selectionEndGrabberViewRect() const
 
 #if HAVE(UI_TEXT_SELECTION_DISPLAY_INTERACTION)
     if (!handleView) {
-        // FIXME: We should be able to use -handleViews here, but this seems returns an empty array,
-        // even when selection handles are present. Use -handleViews once rdar://108607881 is fixed.
-        auto view = findAllViewsInHierarchyOfType(contentView, NSClassFromString(@"_UITextSelectionLollipopView")).lastObject;
-        if (!view.hidden)
+        if (auto view = textSelectionDisplayInteraction().handleViews.lastObject; !isHiddenOrHasHiddenAncestor(view))
             handleView = view;
     }
 #endif
@@ -882,7 +889,7 @@ JSObjectRef UIScriptControllerIOS::selectionCaretViewRect() const
 
 #if HAVE(UI_TEXT_SELECTION_DISPLAY_INTERACTION)
     if (!caretView) {
-        if (auto view = textSelectionDisplayInteraction().cursorView; !view.hidden)
+        if (auto view = textSelectionDisplayInteraction().cursorView; !isHiddenOrHasHiddenAncestor(view))
             caretView = view;
     }
 #endif
@@ -901,7 +908,7 @@ JSObjectRef UIScriptControllerIOS::selectionRangeViewRects() const
 
 #if HAVE(UI_TEXT_SELECTION_DISPLAY_INTERACTION)
     if (!textRectInfoArray) {
-        if (auto view = textSelectionDisplayInteraction().highlightView; !view.hidden) {
+        if (auto view = textSelectionDisplayInteraction().highlightView; !isHiddenOrHasHiddenAncestor(view)) {
             textRectInfoArray = view.selectionRects;
             rangeView = view;
         }
@@ -1324,7 +1331,7 @@ JSRetainPtr<JSStringRef> UIScriptControllerIOS::selectionCaretBackgroundColor() 
     UIColor *backgroundColor = [contentView valueForKeyPath:@"textInteractionAssistant.selectionView.caretView.backgroundColor"];
 #if HAVE(UI_TEXT_SELECTION_DISPLAY_INTERACTION)
     if (!backgroundColor) {
-        if (auto view = textSelectionDisplayInteraction().cursorView; !view.hidden)
+        if (auto view = textSelectionDisplayInteraction().cursorView; !isHiddenOrHasHiddenAncestor(view))
             backgroundColor = view.tintColor;
     }
 #endif


### PR DESCRIPTION
#### 91f212cfd96fd4495bce653e047f8102d0132513
<pre>
editing/selection/ios/hide-selection-in-hidden-contenteditable.html fails with a text diff
<a href="https://bugs.webkit.org/show_bug.cgi?id=256564">https://bugs.webkit.org/show_bug.cgi?id=256564</a>
rdar://107724393

Reviewed by Aditya Keerthi.

This test fails when `HAVE(UI_TEXT_SELECTION_DISPLAY_INTERACTION)` is defined; this is because, in
the case where a text selection has been previously shown in the same web view (i.e. using the same
text selection display interaction), the `UIView`s representing the selection handles will be non-
hidden and also have a non-zero frame. However, they&apos;ll still be visually hidden, because their
parent `UIView` that contains both selection lollipop views will be marked `hidden`.

When run after another test that selects text (and therefore assigns a non-zero frame to the
selection handles), `hide-selection-in-hidden-contenteditable.html` fails when trying to verify that
selection handles are hidden.

To fix this, adjust our test runner logic for getting the current selection handle rects (and other
selection UI too) by walking the view hierarchy in search for _any_ hidden ancestor, instead of only
checking whether the view itself is hidden.

* Tools/WebKitTestRunner/ios/UIScriptControllerIOS.mm:
(WTR::isHiddenOrHasHiddenAncestor):
(WTR::UIScriptControllerIOS::selectionStartGrabberViewRect const):
(WTR::UIScriptControllerIOS::selectionEndGrabberViewRect const):

Also address a couple of FIXMEs, now that the fix for the blocking radar — rdar://108607881 — is
deployed on the relevant iOS test runners.

(WTR::UIScriptControllerIOS::selectionCaretViewRect const):
(WTR::UIScriptControllerIOS::selectionRangeViewRects const):
(WTR::UIScriptControllerIOS::selectionCaretBackgroundColor const):

Canonical link: <a href="https://commits.webkit.org/263891@main">https://commits.webkit.org/263891@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/59aec81dfc24d05ca86d09abc0ed76a81b9bc0e9

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/6034 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/6212 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/6398 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/7590 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/6386 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/6033 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/6430 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/6168 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/9272 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/6143 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/6169 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/5463 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/7650 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/3645 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/5443 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/13355 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/5511 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/5522 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/7742 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/5978 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/4897 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/5403 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/1427 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/9538 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/5769 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->