### PR TITLE
Media Controls not fading on click/tap when up.

### DIFF
--- a/Source/WebCore/Modules/modern-media-controls/controls/media-controls.css
+++ b/Source/WebCore/Modules/modern-media-controls/controls/media-controls.css
@@ -126,6 +126,10 @@
     mix-blend-mode: plus-lighter;
 }
 
+.backdrop {
+    pointer-events: none;
+}
+
 .stats-container {
     display: flex;
     justify-content: center;

--- a/Source/WebCore/Modules/modern-media-controls/controls/media-controls.js
+++ b/Source/WebCore/Modules/modern-media-controls/controls/media-controls.js
@@ -172,7 +172,7 @@ class MediaControls extends LayoutNode
         this.element.classList.add("fade-in");
     }
 
-    isPointInControls(point, includeContainer)
+    isPointInControls(point)
     {
         let ancestor = this.element.parentNode;
         while (ancestor && !(ancestor instanceof ShadowRoot))
@@ -183,9 +183,6 @@ class MediaControls extends LayoutNode
             return false;
 
         const tappedElement = shadowRoot.elementFromPoint(point.x, point.y);
-
-        if (includeContainer && this.element === tappedElement)
-            return true;
 
         return this.children.some(child => child.element.contains(tappedElement));
     }


### PR DESCRIPTION
#### 4c392f892c13fe6745da4cc09d02431b431b9de1
<pre>
Media Controls not fading on click/tap when up.
<a href="https://bugs.webkit.org/show_bug.cgi?id=256565">https://bugs.webkit.org/show_bug.cgi?id=256565</a>
rdar://109126598

Reviewed by Aditya Keerthi.

The code to check if a tap/click is in/on a media element was returing
true because of the &quot;backdrop&quot; element, which should not count as a
media control, even though it is part of the shadowdom. We should not
have pointer-events active on this element.
Also, I removed the code about also checking the container, as it was not
being used anywhere.

* Source/WebCore/Modules/modern-media-controls/controls/media-controls.js:
(MediaControls.prototype.isPointInControls):

Canonical link: <a href="https://commits.webkit.org/263987@main">https://commits.webkit.org/263987@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/802fce932203dbc03b910efa11ca11ff66e213aa

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/6052 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/6234 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/6418 "Built successfully") | [❌ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/7612 "Failed to compile WebKit") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/6401 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/6051 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/6452 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/6188 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/9280 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/6161 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/6184 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/5478 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/7673 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/3660 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/5459 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/13368 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/5526 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/5537 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/7763 "run-api-tests-without-change (failure)") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/5997 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/4908 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/5420 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/1494 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/9556 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/5787 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->