### PR TITLE
[GPU Process][Filters] Top level SVGFilter should own its FilterResults

### DIFF
--- a/Source/WebCore/platform/graphics/filters/FilterResults.h
+++ b/Source/WebCore/platform/graphics/filters/FilterResults.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022 Apple Inc.  All rights reserved.
+ * Copyright (C) 2022-2023 Apple Inc.  All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -28,6 +28,7 @@
 #include "FilterEffect.h"
 #include "FilterImageVector.h"
 #include "ImageBufferAllocator.h"
+#include <wtf/FastMalloc.h>
 #include <wtf/HashMap.h>
 #include <wtf/HashSet.h>
 
@@ -37,6 +38,7 @@ class FilterEffect;
 class FilterImage;
 
 class FilterResults {
+    WTF_MAKE_FAST_ALLOCATED;
 public:
     WEBCORE_EXPORT FilterResults(std::unique_ptr<ImageBufferAllocator>&& = nullptr);
 
@@ -55,5 +57,7 @@ private:
 
     std::unique_ptr<ImageBufferAllocator> m_allocator;
 };
+
+using FilterResultsCreator = Function<std::unique_ptr<FilterResults>()>;
 
 } // namespace WebCore

--- a/Source/WebCore/rendering/svg/RenderSVGResourceFilter.cpp
+++ b/Source/WebCore/rendering/svg/RenderSVGResourceFilter.cpp
@@ -145,7 +145,11 @@ bool RenderSVGResourceFilter::applyResource(RenderElement& renderer, const Rende
     auto colorSpace = DestinationColorSpace::SRGB();
 #endif
 
-    filterData->targetSwitcher = FilterTargetSwitcher::create(*context, *filterData->filter, filterData->sourceImageRect, colorSpace, &filterData->results);
+    auto& results = filterData->filter->ensureResults([&]() {
+        return makeUnique<FilterResults>();
+    });
+
+    filterData->targetSwitcher = FilterTargetSwitcher::create(*context, *filterData->filter, filterData->sourceImageRect, colorSpace, &results);
     if (!filterData->targetSwitcher) {
         m_rendererFilterDataMap.remove(&renderer);
         return false;
@@ -234,7 +238,7 @@ void RenderSVGResourceFilter::markFilterForRepaint(FilterEffect& effect)
         // Repaint the image on the screen.
         markClientForInvalidation(*objectFilterDataPair.key, RepaintInvalidation);
 
-        filterData->results.clearEffectResult(effect);
+        filterData->filter->clearEffectResult(effect);
     }
 }
 

--- a/Source/WebCore/rendering/svg/RenderSVGResourceFilter.h
+++ b/Source/WebCore/rendering/svg/RenderSVGResourceFilter.h
@@ -45,7 +45,6 @@ public:
     FilterData() = default;
 
     RefPtr<SVGFilter> filter;
-    FilterResults results;
 
     std::unique_ptr<FilterTargetSwitcher> targetSwitcher;
     FloatRect sourceImageRect;

--- a/Source/WebCore/svg/graphics/filters/SVGFilter.cpp
+++ b/Source/WebCore/svg/graphics/filters/SVGFilter.cpp
@@ -244,6 +244,19 @@ FilterEffectVector SVGFilter::effectsOfType(FilterFunction::Type filterType) con
     return copyToVector(effects);
 }
 
+FilterResults& SVGFilter::ensureResults(const FilterResultsCreator& resultsCreator)
+{
+    if (!m_results)
+        m_results = resultsCreator();
+    return *m_results;
+}
+
+void SVGFilter::clearEffectResult(FilterEffect& effect)
+{
+    if (m_results)
+        m_results->clearEffectResult(effect);
+}
+
 RefPtr<FilterImage> SVGFilter::apply(const Filter&, FilterImage& sourceImage, FilterResults& results)
 {
     return apply(&sourceImage, results);

--- a/Source/WebCore/svg/graphics/filters/SVGFilter.h
+++ b/Source/WebCore/svg/graphics/filters/SVGFilter.h
@@ -22,6 +22,7 @@
 #pragma once
 
 #include "Filter.h"
+#include "FilterResults.h"
 #include "FloatRect.h"
 #include "SVGFilterExpression.h"
 #include "SVGUnitTypes.h"
@@ -49,6 +50,9 @@ public:
     const FilterEffectVector& effects() const { return m_effects; }
 
     FilterEffectVector effectsOfType(FilterFunction::Type) const final;
+
+    WEBCORE_EXPORT FilterResults& ensureResults(const FilterResultsCreator&);
+    void clearEffectResult(FilterEffect&);
 
     RefPtr<FilterImage> apply(FilterImage* sourceImage, FilterResults&) final;
     FilterStyleVector createFilterStyles(const FilterStyle& sourceStyle) const final;
@@ -78,6 +82,8 @@ private:
 
     SVGFilterExpression m_expression;
     FilterEffectVector m_effects;
+
+    std::unique_ptr<FilterResults> m_results;
 };
 
 } // namespace WebCore


### PR DESCRIPTION
#### b860110f0ae42268a9e9aac5975dd6881c866fc7
<pre>
[GPU Process][Filters] Top level SVGFilter should own its FilterResults
<a href="https://bugs.webkit.org/show_bug.cgi?id=256535">https://bugs.webkit.org/show_bug.cgi?id=256535</a>
rdar://109107572

Reviewed by Simon Fraser.

This allows caching the FilterResults along with the SVGFilter in RemoteResourceCache.

SVGFilter::ensureResults() returns FilterResults&amp; but it takes FilterResultsCreator.
FilterResultsCreator returns a std::unique_ptr&lt;FilterResults&gt; which SVGFilter
will maintain.

* Source/WebCore/platform/graphics/filters/FilterResults.h:
* Source/WebCore/rendering/svg/RenderSVGResourceFilter.cpp:
(WebCore::RenderSVGResourceFilter::applyResource):
(WebCore::RenderSVGResourceFilter::markFilterForRepaint):
* Source/WebCore/rendering/svg/RenderSVGResourceFilter.h:
* Source/WebCore/svg/graphics/filters/SVGFilter.cpp:
(WebCore::SVGFilter::ensureResults):
(WebCore::SVGFilter::clearEffectResult):
* Source/WebCore/svg/graphics/filters/SVGFilter.h:

Canonical link: <a href="https://commits.webkit.org/263996@main">https://commits.webkit.org/263996@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/631ef5b823851aadfb8334cf421a2bb43b786c04

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/6295 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/6491 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/6670 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/7869 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/6624 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/6298 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/6711 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/6440 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/9517 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/6407 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/6415 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/5701 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/7939 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/3887 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/5680 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/13568 "25 flakes 129 failures") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/5751 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/5763 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/8010 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/6245 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/5109 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/5657 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/1501 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/9811 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/6026 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->