### PR TITLE
Add test SPI to see the entire frame trees in all processes for site isolation

### DIFF
--- a/Source/WebKit/Shared/FrameInfoData.h
+++ b/Source/WebKit/Shared/FrameInfoData.h
@@ -31,8 +31,11 @@
 
 namespace WebKit {
 
+enum class FrameType : bool { Local, Remote };
+
 struct FrameInfoData {
     bool isMainFrame { false };
+    FrameType frameType { FrameType::Local };
     WebCore::ResourceRequest request;
     WebCore::SecurityOriginData securityOrigin;
     String frameName;

--- a/Source/WebKit/Shared/FrameInfoData.serialization.in
+++ b/Source/WebKit/Shared/FrameInfoData.serialization.in
@@ -22,8 +22,11 @@
 
 headers: "FrameInfoData.h" "WebCoreArgumentCoders.h"
 
+enum class WebKit::FrameType : bool
+
 struct WebKit::FrameInfoData {
     bool isMainFrame
+    WebKit::FrameType frameType
     WebCore::ResourceRequest request
     WebCore::SecurityOriginData securityOrigin
     String frameName

--- a/Source/WebKit/UIProcess/API/APIFrameInfo.h
+++ b/Source/WebKit/UIProcess/API/APIFrameInfo.h
@@ -50,6 +50,7 @@ public:
     virtual ~FrameInfo();
 
     bool isMainFrame() const { return m_data.isMainFrame; }
+    bool isLocalFrame() const { return m_data.frameType == WebKit::FrameType::Local; }
     const WebCore::ResourceRequest& request() const { return m_data.request; }
     WebCore::SecurityOriginData& securityOrigin() { return m_data.securityOrigin; }
     Ref<FrameHandle> handle() const;

--- a/Source/WebKit/UIProcess/API/APIFrameTreeNode.h
+++ b/Source/WebKit/UIProcess/API/APIFrameTreeNode.h
@@ -42,7 +42,9 @@ public:
     virtual ~FrameTreeNode();
 
     WebKit::WebPageProxy& page() { return m_page.get(); }
+    const WebKit::FrameInfoData& info() const { return m_data.info; }
     bool isMainFrame() const { return m_data.info.isMainFrame; }
+    bool isLocalFrame() const { return m_data.info.frameType == WebKit::FrameType::Local; }
     const WebCore::ResourceRequest& request() const { return m_data.info.request; }
     const WebCore::SecurityOriginData& securityOrigin() const { return m_data.info.securityOrigin; }
     const Vector<WebKit::FrameTreeNodeData>& childFrames() const { return m_data.children; }

--- a/Source/WebKit/UIProcess/API/Cocoa/WKFrameInfo.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKFrameInfo.mm
@@ -105,4 +105,9 @@
     return frame ? frame->processIdentifier() : 0;
 }
 
+- (BOOL)_isLocalFrame
+{
+    return _frameInfo->isLocalFrame();
+}
+
 @end

--- a/Source/WebKit/UIProcess/API/Cocoa/WKFrameInfoPrivate.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKFrameInfoPrivate.h
@@ -32,5 +32,6 @@
 @property (nonatomic, readonly, copy, nonnull) _WKFrameHandle *_handle WK_API_AVAILABLE(macos(10.12), ios(10.0));
 @property (nonatomic, readonly, copy, nullable) _WKFrameHandle *_parentFrameHandle WK_API_AVAILABLE(macos(11.0), ios(14.0));
 @property (nonatomic, readonly) pid_t _processIdentifier WK_API_AVAILABLE(macos(13.3), ios(16.4));
+@property (nonatomic, readonly) BOOL _isLocalFrame WK_API_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA));
 
 @end

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebView.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebView.mm
@@ -2159,6 +2159,16 @@ FOR_EACH_PRIVATE_WKCONTENTVIEW_ACTION(FORWARD_ACTION_TO_WKCONTENTVIEW)
     });
 }
 
+- (void)_frameTrees:(void (^)(NSSet<_WKFrameTreeNode *> *))completionHandler
+{
+    _page->getAllFrameTrees([completionHandler = makeBlockPtr(completionHandler), page = Ref { *_page.get() }] (Vector<WebKit::FrameTreeNodeData>&& vector) {
+        auto set = adoptNS([[NSMutableSet alloc] initWithCapacity:vector.size()]);
+        for (auto& data : vector)
+            [set addObject:wrapper(API::FrameTreeNode::create(WTFMove(data), page.get()))];
+        completionHandler(set.get());
+    });
+}
+
 - (BOOL)_isEditable
 {
     return _page && _page->isEditable();

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebViewPrivate.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebViewPrivate.h
@@ -196,6 +196,7 @@ for this property.
 @property (nonatomic, readonly) BOOL _wasPrivateRelayed WK_API_AVAILABLE(macos(13.1), ios(16.2));
 
 - (void)_frames:(void (^)(_WKFrameTreeNode *))completionHandler WK_API_AVAILABLE(macos(11.0), ios(14.0));
+- (void)_frameTrees:(void (^)(NSSet<_WKFrameTreeNode *> *))completionHandler WK_API_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA));
 
 // FIXME: Remove these once nobody is using them.
 @property (nonatomic, readonly) NSData *_sessionStateData;

--- a/Source/WebKit/UIProcess/API/Cocoa/_WKFrameTreeNode.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKFrameTreeNode.h
@@ -31,6 +31,9 @@ WK_CLASS_AVAILABLE(macos(11.0), ios(14.0))
 + (instancetype)new NS_UNAVAILABLE;
 - (instancetype)init NS_UNAVAILABLE;
 
+// FIXME: Move Safari to use _WKFrameTreeNode.info and make _WKFrameTreeNode no longer inherit from WKFrameInfo
+// so we don't have to implement all the selectors of WKFrameInfo twice.
+@property (nonatomic, readonly, copy) WKFrameInfo *info WK_API_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA));
 @property (nonatomic, readonly) NSArray<_WKFrameTreeNode *> *childFrames;
 
 @end

--- a/Source/WebKit/UIProcess/API/Cocoa/_WKFrameTreeNode.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKFrameTreeNode.mm
@@ -44,6 +44,11 @@
     [super dealloc];
 }
 
+- (WKFrameInfo *)info
+{
+    return wrapper(API::FrameInfo::create(WebKit::FrameInfoData(_node->info()), &_node->page()));
+}
+
 - (BOOL)isMainFrame
 {
     return _node->isMainFrame();
@@ -92,6 +97,11 @@
 {
     auto* frame = WebKit::WebFrameProxy::webFrame(_node->handle()->frameID());
     return frame ? frame->processIdentifier() : 0;
+}
+
+- (BOOL)_isLocalFrame
+{
+    return _node->isLocalFrame();
 }
 
 - (API::Object&)_apiObject

--- a/Source/WebKit/UIProcess/Cocoa/UIDelegate.mm
+++ b/Source/WebKit/UIProcess/Cocoa/UIDelegate.mm
@@ -1201,7 +1201,7 @@ void UIDelegate::UIClient::promptForDisplayCapturePermission(WebPageProxy& page,
     std::optional<WebCore::FrameIdentifier> mainFrameID;
     if (auto* mainFrame = frame.page() ? frame.page()->mainFrame() : nullptr)
         mainFrameID = mainFrame->frameID();
-    FrameInfoData frameInfo { frame.isMainFrame(), { }, userMediaOrigin.securityOrigin(), { }, frame.frameID(), mainFrameID };
+    FrameInfoData frameInfo { frame.isMainFrame(), FrameType::Local, { }, userMediaOrigin.securityOrigin(), { }, frame.frameID(), mainFrameID };
     RetainPtr<WKFrameInfo> frameInfoWrapper = wrapper(API::FrameInfo::create(WTFMove(frameInfo), frame.page()));
 
     BOOL requestSystemAudio = !!request.requiresDisplayCaptureWithAudio();
@@ -1267,7 +1267,7 @@ void UIDelegate::UIClient::decidePolicyForUserMediaPermissionRequest(WebPageProx
         std::optional<WebCore::FrameIdentifier> mainFrameID;
         if (auto* mainFrame = frame.page() ? frame.page()->mainFrame() : nullptr)
             mainFrameID = mainFrame->frameID();
-        FrameInfoData frameInfo { frame.isMainFrame(), { }, userMediaOrigin.securityOrigin(), { }, frame.frameID(), mainFrameID };
+        FrameInfoData frameInfo { frame.isMainFrame(), FrameType::Local, { }, userMediaOrigin.securityOrigin(), { }, frame.frameID(), mainFrameID };
         RetainPtr<WKFrameInfo> frameInfoWrapper = wrapper(API::FrameInfo::create(WTFMove(frameInfo), frame.page()));
 
         WKMediaCaptureType type = WKMediaCaptureTypeCamera;

--- a/Source/WebKit/UIProcess/ProvisionalPageProxy.cpp
+++ b/Source/WebKit/UIProcess/ProvisionalPageProxy.cpp
@@ -155,6 +155,7 @@ void ProvisionalPageProxy::cancel()
     error.setType(WebCore::ResourceError::Type::Cancellation);
     FrameInfoData frameInfo {
         true, // isMainFrame
+        FrameType::Local,
         m_request,
         SecurityOriginData::fromURLWithoutStrictOpaqueness(m_request.url()),
         { },

--- a/Source/WebKit/UIProcess/WebPageProxy.h
+++ b/Source/WebKit/UIProcess/WebPageProxy.h
@@ -579,6 +579,7 @@ public:
     void sendMessageToInspectorFrontend(const String& targetId, const String& message);
 
     void getAllFrames(CompletionHandler<void(FrameTreeNodeData&&)>&&);
+    void getAllFrameTrees(CompletionHandler<void(Vector<FrameTreeNodeData>&&)>&&);
     std::optional<FrameTreeCreationParameters> frameTreeCreationParameters() const;
 
 #if ENABLE(REMOTE_INSPECTOR)

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebFrameLoaderClient.cpp
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebFrameLoaderClient.cpp
@@ -1043,6 +1043,7 @@ void WebFrameLoaderClient::dispatchDecidePolicyForNavigationAction(const Navigat
 
     FrameInfoData originatingFrameInfoData {
         navigationAction.initiatedByMainFrame() == InitiatedByMainFrame::Yes,
+        FrameType::Local,
         ResourceRequest { requester.url },
         requester.securityOrigin->data(),
         { },

--- a/Source/WebKit/WebProcess/WebPage/WebFrame.h
+++ b/Source/WebKit/WebProcess/WebPage/WebFrame.h
@@ -72,6 +72,7 @@ class InjectedBundleScriptWorld;
 class WebImage;
 class WebPage;
 struct FrameInfoData;
+struct FrameTreeNodeData;
 struct WebsitePoliciesData;
 
 class WebFrame : public API::ObjectImpl<API::Object::Type::BundleFrame>, public CanMakeWeakPtr<WebFrame> {
@@ -97,6 +98,7 @@ public:
     void transitionToLocal(WebCore::LayerHostingContextIdentifier);
 
     FrameInfoData info() const;
+    FrameTreeNodeData frameTreeData() const;
     void getFrameInfo(CompletionHandler<void(FrameInfoData&&)>&&);
 
     WebCore::FrameIdentifier frameID() const;

--- a/Source/WebKit/WebProcess/WebPage/WebPage.cpp
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.cpp
@@ -1045,6 +1045,11 @@ void WebPage::getFrameInfo(WebCore::FrameIdentifier frameID, CompletionHandler<v
     frame->getFrameInfo(WTFMove(completionHandler));
 }
 
+void WebPage::getFrameTree(CompletionHandler<void(FrameTreeNodeData&&)>&& completionHandler)
+{
+    completionHandler(m_mainFrame->frameTreeData());
+}
+
 void WebPage::continueWillSubmitForm(WebCore::FrameIdentifier frameID, WebKit::FormSubmitListenerIdentifier formListenerID)
 {
     auto* frame = WebProcess::singleton().webFrame(frameID);

--- a/Source/WebKit/WebProcess/WebPage/WebPage.h
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.h
@@ -601,6 +601,7 @@ public:
     void createRemoteSubframe(WebCore::FrameIdentifier parentID, WebCore::FrameIdentifier newChildID, WebCore::ProcessIdentifier remoteProcessIdentifier);
 
     void getFrameInfo(WebCore::FrameIdentifier, CompletionHandler<void(FrameInfoData&&)>&&);
+    void getFrameTree(CompletionHandler<void(FrameTreeNodeData&&)>&&);
     void continueWillSubmitForm(WebCore::FrameIdentifier, WebKit::FormSubmitListenerIdentifier);
     void didCommitLoadInAnotherProcess(WebCore::FrameIdentifier, WebCore::LayerHostingContextIdentifier, WebCore::ProcessIdentifier remoteProcessIdentifier);
     void didFinishLoadInAnotherProcess(WebCore::FrameIdentifier);

--- a/Source/WebKit/WebProcess/WebPage/WebPage.messages.in
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.messages.in
@@ -196,6 +196,7 @@ GenerateSyntheticEditingCommand(enum:uint8_t WebKit::SyntheticEditingCommandType
     CreateRemoteSubframe(WebCore::FrameIdentifier parentID, WebCore::FrameIdentifier newChildID, WebCore::ProcessIdentifier remoteProcessIdentifier)
 
     GetFrameInfo(WebCore::FrameIdentifier frameID) -> (struct WebKit::FrameInfoData data)
+    GetFrameTree() -> (struct WebKit::FrameTreeNodeData data)
     ContinueWillSubmitForm(WebCore::FrameIdentifier frameID, WebKit::FormSubmitListenerIdentifier listenerID)
     DidCommitLoadInAnotherProcess(WebCore::FrameIdentifier frameID, WebCore::LayerHostingContextIdentifier layerHostingContextIdentifier, WebCore::ProcessIdentifier remoteProcessIdentifier)
     DidFinishLoadInAnotherProcess(WebCore::FrameIdentifier frameID)


### PR DESCRIPTION
#### 538b503285b8484286ba03b3a0e7c96279f7f7a8
<pre>
Add test SPI to see the entire frame trees in all processes for site isolation
<a href="https://bugs.webkit.org/show_bug.cgi?id=256574">https://bugs.webkit.org/show_bug.cgi?id=256574</a>
rdar://109134755

Reviewed by J Pascoe and Youenn Fablet.

WKWebView._frames gets info about the frame tree from whatever process each frame is in.
In order to add tests that verifies the whole frame tree state in multiple process during
operations like frame destruction, we need to get the whole frame tree state from each
process and inspect all of it.  This introduces such SPI and uses it for tests.

* Source/WebKit/Shared/FrameInfoData.h:
* Source/WebKit/Shared/FrameInfoData.serialization.in:
* Source/WebKit/UIProcess/API/APIFrameInfo.h:
* Source/WebKit/UIProcess/API/APIFrameTreeNode.h:
* Source/WebKit/UIProcess/API/Cocoa/WKFrameInfo.mm:
(-[WKFrameInfo _isLocalFrame]):
* Source/WebKit/UIProcess/API/Cocoa/WKFrameInfoPrivate.h:
* Source/WebKit/UIProcess/API/Cocoa/WKWebView.mm:
(-[WKWebView _frames:]):
(-[WKWebView _frameTrees:]):
* Source/WebKit/UIProcess/API/Cocoa/WKWebViewPrivate.h:
* Source/WebKit/UIProcess/API/Cocoa/_WKFrameTreeNode.h:
* Source/WebKit/UIProcess/API/Cocoa/_WKFrameTreeNode.mm:
(-[_WKFrameTreeNode info]):
(-[_WKFrameTreeNode _isLocalFrame]):
* Source/WebKit/UIProcess/Cocoa/UIDelegate.mm:
(WebKit::UIDelegate::UIClient::promptForDisplayCapturePermission):
(WebKit::UIDelegate::UIClient::decidePolicyForUserMediaPermissionRequest):
* Source/WebKit/UIProcess/ProvisionalPageProxy.cpp:
(WebKit::ProvisionalPageProxy::cancel):
* Source/WebKit/UIProcess/WebPageProxy.cpp:
(WebKit::WebPageProxy::getAllFrameTrees):
* Source/WebKit/UIProcess/WebPageProxy.h:
* Source/WebKit/WebProcess/WebCoreSupport/WebFrameLoaderClient.cpp:
(WebKit::WebFrameLoaderClient::dispatchDecidePolicyForNavigationAction):
* Source/WebKit/WebProcess/WebPage/WebFrame.cpp:
(WebKit::WebFrame::info const):
(WebKit::WebFrame::frameTreeData const):
* Source/WebKit/WebProcess/WebPage/WebFrame.h:
* Source/WebKit/WebProcess/WebPage/WebPage.cpp:
(WebKit::WebPage::getFrameTree):
* Source/WebKit/WebProcess/WebPage/WebPage.h:
* Source/WebKit/WebProcess/WebPage/WebPage.messages.in:
* Tools/TestWebKitAPI/Tests/WebKitCocoa/SiteIsolation.mm:
(TestWebKitAPI::nullTerminatedIndentation):
(TestWebKitAPI::debugPrint):
(TestWebKitAPI::frameTreesMatch):
(TestWebKitAPI::checkFrameTreesInProcesses):
(TestWebKitAPI::TEST):

Canonical link: <a href="https://commits.webkit.org/263912@main">https://commits.webkit.org/263912@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/6c383b3fb50aac3bccd1de2cbcd699762a74bee7

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/6115 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/6300 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/6483 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/7678 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/32/builds/6463 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/6115 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/6518 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/6253 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/9338 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/6225 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/6241 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/5532 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/7740 "Built successfully") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/39/builds/3717 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/10/builds/5513 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/13419 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/5582 "Passed tests") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/5591 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/7823 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/6061 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/4961 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/30/builds/5482 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| [  ~~🛠 🧪 merge~~](https://ews-build.webkit.org/#/builders/19/builds/1444 "The change is no longer eligible for processing.") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/9622 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/711 "Built successfully and passed tests") | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/31/builds/5850 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->