### PR TITLE
[WebGPU] Rename the setting from just "WebGPU" to "WebGPUEnabled"

### DIFF
--- a/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
+++ b/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
@@ -7222,7 +7222,7 @@ WebGLUsingMetal:
       "HAVE(WEBGL_COMPATIBLE_METAL)": true
       default: false
 
-WebGPU:
+WebGPUEnabled:
   type: bool
   status: unstable
   humanReadableName: "WebGPU"

--- a/Source/WebCore/Modules/WebGPU/GPU.idl
+++ b/Source/WebCore/Modules/WebGPU/GPU.idl
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021 Apple Inc. All rights reserved.
+ * Copyright (C) 2021-2023 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -26,7 +26,7 @@
 // https://gpuweb.github.io/gpuweb/#gpu
 
 [
-    EnabledBySetting=WebGPU,
+    EnabledBySetting=WebGPUEnabled,
     Exposed=(Window), /* https://bugs.webkit.org/show_bug.cgi?id=232542: DedicatedWorker */
     SecureContext
 ]

--- a/Source/WebCore/Modules/WebGPU/GPUAdapter.idl
+++ b/Source/WebCore/Modules/WebGPU/GPUAdapter.idl
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021 Apple Inc. All rights reserved.
+ * Copyright (C) 2021-2023 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -26,7 +26,7 @@
 // https://gpuweb.github.io/gpuweb/#gpuadapter
 
 [
-    EnabledBySetting=WebGPU,
+    EnabledBySetting=WebGPUEnabled,
     Exposed=(Window), /* https://bugs.webkit.org/show_bug.cgi?id=232542: DedicatedWorker */
     SecureContext
 ]

--- a/Source/WebCore/Modules/WebGPU/GPUAdapterInfo.idl
+++ b/Source/WebCore/Modules/WebGPU/GPUAdapterInfo.idl
@@ -26,7 +26,7 @@
 // https://gpuweb.github.io/gpuweb/#gpuadapterinfo
 
 [
-    EnabledBySetting=WebGPU,
+    EnabledBySetting=WebGPUEnabled,
     Exposed=(Window), /* https://bugs.webkit.org/show_bug.cgi?id=232542: DedicatedWorker */
     SecureContext
 ]

--- a/Source/WebCore/Modules/WebGPU/GPUAddressMode.idl
+++ b/Source/WebCore/Modules/WebGPU/GPUAddressMode.idl
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021 Apple Inc. All rights reserved.
+ * Copyright (C) 2021-2023 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -26,7 +26,7 @@
 // https://gpuweb.github.io/gpuweb/#enumdef-gpuaddressmode
 
 [
-    EnabledBySetting=WebGPU
+    EnabledBySetting=WebGPUEnabled
 ]
 enum GPUAddressMode {
     "clamp-to-edge",

--- a/Source/WebCore/Modules/WebGPU/GPUAutoLayoutMode.idl
+++ b/Source/WebCore/Modules/WebGPU/GPUAutoLayoutMode.idl
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022 Apple Inc. All rights reserved.
+ * Copyright (C) 2022-2023 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -26,7 +26,7 @@
 // https://gpuweb.github.io/gpuweb/#enumdef-gpuautolayoutmode
 
 [
-    EnabledBySetting=WebGPU
+    EnabledBySetting=WebGPUEnabled
 ]
 enum GPUAutoLayoutMode {
     "auto"

--- a/Source/WebCore/Modules/WebGPU/GPUBindGroup.idl
+++ b/Source/WebCore/Modules/WebGPU/GPUBindGroup.idl
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021 Apple Inc. All rights reserved.
+ * Copyright (C) 2021-2023 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -26,7 +26,7 @@
 // https://gpuweb.github.io/gpuweb/#gpubindgroup
 
 [
-    EnabledBySetting=WebGPU,
+    EnabledBySetting=WebGPUEnabled,
     Exposed=(Window), /* https://bugs.webkit.org/show_bug.cgi?id=232542: DedicatedWorker */
     SecureContext
 ]

--- a/Source/WebCore/Modules/WebGPU/GPUBindGroupDescriptor.idl
+++ b/Source/WebCore/Modules/WebGPU/GPUBindGroupDescriptor.idl
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021 Apple Inc. All rights reserved.
+ * Copyright (C) 2021-2023 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -26,7 +26,7 @@
 // https://gpuweb.github.io/gpuweb/#dictdef-gpubindgroupdescriptor
 
 [
-    EnabledBySetting=WebGPU
+    EnabledBySetting=WebGPUEnabled
 ]
 dictionary GPUBindGroupDescriptor : GPUObjectDescriptorBase {
     required GPUBindGroupLayout layout;

--- a/Source/WebCore/Modules/WebGPU/GPUBindGroupEntry.idl
+++ b/Source/WebCore/Modules/WebGPU/GPUBindGroupEntry.idl
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021 Apple Inc. All rights reserved.
+ * Copyright (C) 2021-2023 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -31,7 +31,7 @@ typedef [EnforceRange] unsigned long GPUIndex32;
 typedef (GPUSampler or GPUTextureView or GPUBufferBinding or GPUExternalTexture) GPUBindingResource;
 
 [
-    EnabledBySetting=WebGPU
+    EnabledBySetting=WebGPUEnabled
 ]
 dictionary GPUBindGroupEntry {
     required GPUIndex32 binding;

--- a/Source/WebCore/Modules/WebGPU/GPUBindGroupLayout.idl
+++ b/Source/WebCore/Modules/WebGPU/GPUBindGroupLayout.idl
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021 Apple Inc. All rights reserved.
+ * Copyright (C) 2021-2023 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -26,7 +26,7 @@
 // https://gpuweb.github.io/gpuweb/#gpubindgrouplayout
 
 [
-    EnabledBySetting=WebGPU,
+    EnabledBySetting=WebGPUEnabled,
     Exposed=(Window), /* https://bugs.webkit.org/show_bug.cgi?id=232542: DedicatedWorker */
     SecureContext
 ]

--- a/Source/WebCore/Modules/WebGPU/GPUBindGroupLayoutDescriptor.idl
+++ b/Source/WebCore/Modules/WebGPU/GPUBindGroupLayoutDescriptor.idl
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021 Apple Inc. All rights reserved.
+ * Copyright (C) 2021-2023 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -26,7 +26,7 @@
 // https://gpuweb.github.io/gpuweb/#dictdef-gpubindgrouplayoutdescriptor
 
 [
-    EnabledBySetting=WebGPU
+    EnabledBySetting=WebGPUEnabled
 ]
 dictionary GPUBindGroupLayoutDescriptor : GPUObjectDescriptorBase {
     required sequence<GPUBindGroupLayoutEntry> entries;

--- a/Source/WebCore/Modules/WebGPU/GPUBindGroupLayoutEntry.idl
+++ b/Source/WebCore/Modules/WebGPU/GPUBindGroupLayoutEntry.idl
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021 Apple Inc. All rights reserved.
+ * Copyright (C) 2021-2023 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -30,7 +30,7 @@ typedef [EnforceRange] unsigned long GPUIndex32;
 typedef [EnforceRange] unsigned long GPUShaderStageFlags;
 
 [
-    EnabledBySetting=WebGPU
+    EnabledBySetting=WebGPUEnabled
 ]
 dictionary GPUBindGroupLayoutEntry {
     required GPUIndex32 binding;

--- a/Source/WebCore/Modules/WebGPU/GPUBlendComponent.idl
+++ b/Source/WebCore/Modules/WebGPU/GPUBlendComponent.idl
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021 Apple Inc. All rights reserved.
+ * Copyright (C) 2021-2023 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -26,7 +26,7 @@
 // https://gpuweb.github.io/gpuweb/#dictdef-gpublendcomponent
 
 [
-    EnabledBySetting=WebGPU
+    EnabledBySetting=WebGPUEnabled
 ]
 dictionary GPUBlendComponent {
     GPUBlendOperation operation = "add";

--- a/Source/WebCore/Modules/WebGPU/GPUBlendFactor.idl
+++ b/Source/WebCore/Modules/WebGPU/GPUBlendFactor.idl
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021 Apple Inc. All rights reserved.
+ * Copyright (C) 2021-2023 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -26,7 +26,7 @@
 // https://gpuweb.github.io/gpuweb/#enumdef-gpublendfactor
 
 [
-    EnabledBySetting=WebGPU
+    EnabledBySetting=WebGPUEnabled
 ]
 enum GPUBlendFactor {
     "zero",

--- a/Source/WebCore/Modules/WebGPU/GPUBlendOperation.idl
+++ b/Source/WebCore/Modules/WebGPU/GPUBlendOperation.idl
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021 Apple Inc. All rights reserved.
+ * Copyright (C) 2021-2023 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -26,7 +26,7 @@
 // https://gpuweb.github.io/gpuweb/#enumdef-gpublendoperation
 
 [
-    EnabledBySetting=WebGPU
+    EnabledBySetting=WebGPUEnabled
 ]
 enum GPUBlendOperation {
     "add",

--- a/Source/WebCore/Modules/WebGPU/GPUBlendState.idl
+++ b/Source/WebCore/Modules/WebGPU/GPUBlendState.idl
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021 Apple Inc. All rights reserved.
+ * Copyright (C) 2021-2023 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -26,7 +26,7 @@
 // https://gpuweb.github.io/gpuweb/#dictdef-gpublendstate
 
 [
-    EnabledBySetting=WebGPU
+    EnabledBySetting=WebGPUEnabled
 ]
 dictionary GPUBlendState {
     required GPUBlendComponent color;

--- a/Source/WebCore/Modules/WebGPU/GPUBuffer.idl
+++ b/Source/WebCore/Modules/WebGPU/GPUBuffer.idl
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021 Apple Inc. All rights reserved.
+ * Copyright (C) 2021-2023 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -31,7 +31,7 @@ typedef [EnforceRange] unsigned long long GPUSize64;
 typedef [EnforceRange] unsigned long GPUBufferUsageFlags;
 
 [
-    EnabledBySetting=WebGPU,
+    EnabledBySetting=WebGPUEnabled,
     Exposed=(Window), /* https://bugs.webkit.org/show_bug.cgi?id=232542: DedicatedWorker */
     SecureContext
 ]

--- a/Source/WebCore/Modules/WebGPU/GPUBufferBinding.idl
+++ b/Source/WebCore/Modules/WebGPU/GPUBufferBinding.idl
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021 Apple Inc. All rights reserved.
+ * Copyright (C) 2021-2023 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -29,7 +29,7 @@
 typedef [EnforceRange] unsigned long long GPUSize64;
 
 [
-    EnabledBySetting=WebGPU
+    EnabledBySetting=WebGPUEnabled
 ]
 dictionary GPUBufferBinding {
     required GPUBuffer buffer;

--- a/Source/WebCore/Modules/WebGPU/GPUBufferBindingLayout.idl
+++ b/Source/WebCore/Modules/WebGPU/GPUBufferBindingLayout.idl
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021 Apple Inc. All rights reserved.
+ * Copyright (C) 2021-2023 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -29,7 +29,7 @@
 typedef [EnforceRange] unsigned long long GPUSize64;
 
 [
-    EnabledBySetting=WebGPU
+    EnabledBySetting=WebGPUEnabled
 ]
 dictionary GPUBufferBindingLayout {
     GPUBufferBindingType type = "uniform";

--- a/Source/WebCore/Modules/WebGPU/GPUBufferBindingType.idl
+++ b/Source/WebCore/Modules/WebGPU/GPUBufferBindingType.idl
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021 Apple Inc. All rights reserved.
+ * Copyright (C) 2021-2023 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -26,7 +26,7 @@
 // https://gpuweb.github.io/gpuweb/#enumdef-gpubufferbindingtype
 
 [
-    EnabledBySetting=WebGPU
+    EnabledBySetting=WebGPUEnabled
 ]
 enum GPUBufferBindingType {
     "uniform",

--- a/Source/WebCore/Modules/WebGPU/GPUBufferDescriptor.idl
+++ b/Source/WebCore/Modules/WebGPU/GPUBufferDescriptor.idl
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021 Apple Inc. All rights reserved.
+ * Copyright (C) 2021-2023 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -30,7 +30,7 @@ typedef [EnforceRange] unsigned long long GPUSize64;
 typedef [EnforceRange] unsigned long GPUBufferUsageFlags;
 
 [
-    EnabledBySetting=WebGPU
+    EnabledBySetting=WebGPUEnabled
 ]
 dictionary GPUBufferDescriptor : GPUObjectDescriptorBase {
     required GPUSize64 size;

--- a/Source/WebCore/Modules/WebGPU/GPUBufferMapState.idl
+++ b/Source/WebCore/Modules/WebGPU/GPUBufferMapState.idl
@@ -26,7 +26,7 @@
 // https://gpuweb.github.io/gpuweb/#enumdef-gpubuffermapstate
 
 [
-    EnabledBySetting=WebGPU
+    EnabledBySetting=WebGPUEnabled
 ]
 enum GPUBufferMapState {
     "unmapped",

--- a/Source/WebCore/Modules/WebGPU/GPUBufferUsage.idl
+++ b/Source/WebCore/Modules/WebGPU/GPUBufferUsage.idl
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021 Apple Inc. All rights reserved.
+ * Copyright (C) 2021-2023 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -27,7 +27,7 @@
 
 typedef [EnforceRange] unsigned long GPUBufferUsageFlags;
 [
-    EnabledBySetting=WebGPU,
+    EnabledBySetting=WebGPUEnabled,
     Exposed=(Window), /* https://bugs.webkit.org/show_bug.cgi?id=232542: DedicatedWorker */
     SecureContext
 ]

--- a/Source/WebCore/Modules/WebGPU/GPUCanvasCompositingAlphaMode.idl
+++ b/Source/WebCore/Modules/WebGPU/GPUCanvasCompositingAlphaMode.idl
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021 Apple Inc. All rights reserved.
+ * Copyright (C) 2021-2023 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -26,7 +26,7 @@
 // https://gpuweb.github.io/gpuweb/#enumdef-gpucanvascompositingalphamode
 
 [
-    EnabledBySetting=WebGPU
+    EnabledBySetting=WebGPUEnabled
 ]
 enum GPUCanvasCompositingAlphaMode {
     "opaque",

--- a/Source/WebCore/Modules/WebGPU/GPUCanvasConfiguration.idl
+++ b/Source/WebCore/Modules/WebGPU/GPUCanvasConfiguration.idl
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2022 Apple Inc. All rights reserved.
+ * Copyright (C) 2021-2023 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -29,7 +29,7 @@
 typedef [EnforceRange] unsigned long GPUTextureUsageFlags;
 
 [
-    EnabledBySetting=WebGPU
+    EnabledBySetting=WebGPUEnabled
 ]
 dictionary GPUCanvasConfiguration {
     required GPUDevice device;

--- a/Source/WebCore/Modules/WebGPU/GPUColorDict.idl
+++ b/Source/WebCore/Modules/WebGPU/GPUColorDict.idl
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021 Apple Inc. All rights reserved.
+ * Copyright (C) 2021-2023 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -26,7 +26,7 @@
 // https://gpuweb.github.io/gpuweb/#typedefdef-gpucolor
 
 [
-    EnabledBySetting=WebGPU
+    EnabledBySetting=WebGPUEnabled
 ]
 dictionary GPUColorDict {
     required double r;

--- a/Source/WebCore/Modules/WebGPU/GPUColorTargetState.idl
+++ b/Source/WebCore/Modules/WebGPU/GPUColorTargetState.idl
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021 Apple Inc. All rights reserved.
+ * Copyright (C) 2021-2023 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -29,7 +29,7 @@ typedef [EnforceRange] unsigned long GPUColorWriteFlags;
 // https://gpuweb.github.io/gpuweb/#dictdef-gpucolortargetstate
 
 [
-    EnabledBySetting=WebGPU
+    EnabledBySetting=WebGPUEnabled
 ]
 dictionary GPUColorTargetState {
     required GPUTextureFormat format;

--- a/Source/WebCore/Modules/WebGPU/GPUColorWrite.idl
+++ b/Source/WebCore/Modules/WebGPU/GPUColorWrite.idl
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021 Apple Inc. All rights reserved.
+ * Copyright (C) 2021-2023 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -27,7 +27,7 @@
 
 typedef [EnforceRange] unsigned long GPUColorWriteFlags;
 [
-    EnabledBySetting=WebGPU,
+    EnabledBySetting=WebGPUEnabled,
     Exposed=(Window), /* https://bugs.webkit.org/show_bug.cgi?id=232542: DedicatedWorker */
     SecureContext
 ]

--- a/Source/WebCore/Modules/WebGPU/GPUCommandBuffer.idl
+++ b/Source/WebCore/Modules/WebGPU/GPUCommandBuffer.idl
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021 Apple Inc. All rights reserved.
+ * Copyright (C) 2021-2023 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -26,7 +26,7 @@
 // https://gpuweb.github.io/gpuweb/#gpucommandbuffer
 
 [
-    EnabledBySetting=WebGPU,
+    EnabledBySetting=WebGPUEnabled,
     Exposed=(Window), /* https://bugs.webkit.org/show_bug.cgi?id=232542: DedicatedWorker */
     SecureContext
 ]

--- a/Source/WebCore/Modules/WebGPU/GPUCommandBufferDescriptor.idl
+++ b/Source/WebCore/Modules/WebGPU/GPUCommandBufferDescriptor.idl
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021 Apple Inc. All rights reserved.
+ * Copyright (C) 2021-2023 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -26,7 +26,7 @@
 // https://gpuweb.github.io/gpuweb/#dictdef-gpucommandbufferdescriptor
 
 [
-    EnabledBySetting=WebGPU
+    EnabledBySetting=WebGPUEnabled
 ]
 dictionary GPUCommandBufferDescriptor : GPUObjectDescriptorBase {
 };

--- a/Source/WebCore/Modules/WebGPU/GPUCommandEncoder.idl
+++ b/Source/WebCore/Modules/WebGPU/GPUCommandEncoder.idl
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2022 Apple Inc. All rights reserved.
+ * Copyright (C) 2021-2023 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -32,7 +32,7 @@ typedef [EnforceRange] unsigned long GPUIntegerCoordinate;
 typedef (sequence<GPUIntegerCoordinate> or GPUExtent3DDict) GPUExtent3D;
 
 [
-    EnabledBySetting=WebGPU,
+    EnabledBySetting=WebGPUEnabled,
     Exposed=(Window), /* https://bugs.webkit.org/show_bug.cgi?id=232542: DedicatedWorker */
     SecureContext
 ]

--- a/Source/WebCore/Modules/WebGPU/GPUCommandEncoderDescriptor.idl
+++ b/Source/WebCore/Modules/WebGPU/GPUCommandEncoderDescriptor.idl
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021 Apple Inc. All rights reserved.
+ * Copyright (C) 2021-2023 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -26,7 +26,7 @@
 // https://gpuweb.github.io/gpuweb/#dictdef-gpucommandencoderdescriptor
 
 [
-    EnabledBySetting=WebGPU
+    EnabledBySetting=WebGPUEnabled
 ]
 dictionary GPUCommandEncoderDescriptor : GPUObjectDescriptorBase {
 };

--- a/Source/WebCore/Modules/WebGPU/GPUCommandsMixin.idl
+++ b/Source/WebCore/Modules/WebGPU/GPUCommandsMixin.idl
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022 Apple Inc. All rights reserved.
+ * Copyright (C) 2022-2023 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -26,7 +26,7 @@
 // https://gpuweb.github.io/gpuweb/#gpucommandsmixin
 
 [
-    EnabledBySetting=WebGPU
+    EnabledBySetting=WebGPUEnabled
 ]
 interface mixin GPUCommandsMixin {
 };

--- a/Source/WebCore/Modules/WebGPU/GPUCompareFunction.idl
+++ b/Source/WebCore/Modules/WebGPU/GPUCompareFunction.idl
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021 Apple Inc. All rights reserved.
+ * Copyright (C) 2021-2023 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -26,7 +26,7 @@
 // https://gpuweb.github.io/gpuweb/#enumdef-gpucomparefunction
 
 [
-    EnabledBySetting=WebGPU
+    EnabledBySetting=WebGPUEnabled
 ]
 enum GPUCompareFunction {
     "never",

--- a/Source/WebCore/Modules/WebGPU/GPUCompilationInfo.idl
+++ b/Source/WebCore/Modules/WebGPU/GPUCompilationInfo.idl
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021 Apple Inc. All rights reserved.
+ * Copyright (C) 2021-2023 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -26,7 +26,7 @@
 // https://gpuweb.github.io/gpuweb/#gpucompilationinfo
 
 [
-    EnabledBySetting=WebGPU,
+    EnabledBySetting=WebGPUEnabled,
     Exposed=(Window), /* https://bugs.webkit.org/show_bug.cgi?id=232542: DedicatedWorker */
     Serializable,
     SecureContext

--- a/Source/WebCore/Modules/WebGPU/GPUCompilationMessage.idl
+++ b/Source/WebCore/Modules/WebGPU/GPUCompilationMessage.idl
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021 Apple Inc. All rights reserved.
+ * Copyright (C) 2021-2023 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -26,7 +26,7 @@
 // https://gpuweb.github.io/gpuweb/#gpucompilationmessage
 
 [
-    EnabledBySetting=WebGPU,
+    EnabledBySetting=WebGPUEnabled,
     Exposed=(Window), /* https://bugs.webkit.org/show_bug.cgi?id=232542: DedicatedWorker */
     Serializable,
     SecureContext

--- a/Source/WebCore/Modules/WebGPU/GPUCompilationMessageType.idl
+++ b/Source/WebCore/Modules/WebGPU/GPUCompilationMessageType.idl
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021 Apple Inc. All rights reserved.
+ * Copyright (C) 2021-2023 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -26,7 +26,7 @@
 // https://gpuweb.github.io/gpuweb/#enumdef-gpucompilationmessagetype
 
 [
-    EnabledBySetting=WebGPU
+    EnabledBySetting=WebGPUEnabled
 ]
 enum GPUCompilationMessageType {
     "error",

--- a/Source/WebCore/Modules/WebGPU/GPUComputePassDescriptor.idl
+++ b/Source/WebCore/Modules/WebGPU/GPUComputePassDescriptor.idl
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021 Apple Inc. All rights reserved.
+ * Copyright (C) 2021-2023 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -29,7 +29,7 @@
 typedef sequence<GPUComputePassTimestampWrite> GPUComputePassTimestampWrites;
 
 [
-    EnabledBySetting=WebGPU
+    EnabledBySetting=WebGPUEnabled
 ]
 dictionary GPUComputePassDescriptor : GPUObjectDescriptorBase {
     GPUComputePassTimestampWrites timestampWrites = [];

--- a/Source/WebCore/Modules/WebGPU/GPUComputePassEncoder.idl
+++ b/Source/WebCore/Modules/WebGPU/GPUComputePassEncoder.idl
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2022 Apple Inc. All rights reserved.
+ * Copyright (C) 2021-2023 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -30,7 +30,7 @@ typedef [EnforceRange] unsigned long GPUSize32;
 typedef [EnforceRange] unsigned long long GPUSize64;
 
 [
-    EnabledBySetting=WebGPU,
+    EnabledBySetting=WebGPUEnabled,
     Exposed=(Window), /* https://bugs.webkit.org/show_bug.cgi?id=232542: DedicatedWorker */
     SecureContext
 ]

--- a/Source/WebCore/Modules/WebGPU/GPUComputePassTimestampLocation.idl
+++ b/Source/WebCore/Modules/WebGPU/GPUComputePassTimestampLocation.idl
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021 Apple Inc. All rights reserved.
+ * Copyright (C) 2021-2023 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -26,7 +26,7 @@
 // https://gpuweb.github.io/gpuweb/#enumdef-gpucomputepasstimestamplocation
 
 [
-    EnabledBySetting=WebGPU
+    EnabledBySetting=WebGPUEnabled
 ]
 enum GPUComputePassTimestampLocation {
     "beginning",

--- a/Source/WebCore/Modules/WebGPU/GPUComputePassTimestampWrite.idl
+++ b/Source/WebCore/Modules/WebGPU/GPUComputePassTimestampWrite.idl
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021 Apple Inc. All rights reserved.
+ * Copyright (C) 2021-2023 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -29,7 +29,7 @@
 typedef [EnforceRange] unsigned long GPUSize32;
 
 [
-    EnabledBySetting=WebGPU
+    EnabledBySetting=WebGPUEnabled
 ]
 dictionary GPUComputePassTimestampWrite {
     required GPUQuerySet querySet;

--- a/Source/WebCore/Modules/WebGPU/GPUComputePipeline.idl
+++ b/Source/WebCore/Modules/WebGPU/GPUComputePipeline.idl
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021 Apple Inc. All rights reserved.
+ * Copyright (C) 2021-2023 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -26,7 +26,7 @@
 // https://gpuweb.github.io/gpuweb/#gpucomputepipeline
 
 [
-    EnabledBySetting=WebGPU,
+    EnabledBySetting=WebGPUEnabled,
     Exposed=(Window), /* https://bugs.webkit.org/show_bug.cgi?id=232542: DedicatedWorker */
     SecureContext
 ]

--- a/Source/WebCore/Modules/WebGPU/GPUComputePipelineDescriptor.idl
+++ b/Source/WebCore/Modules/WebGPU/GPUComputePipelineDescriptor.idl
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021 Apple Inc. All rights reserved.
+ * Copyright (C) 2021-2023 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -26,7 +26,7 @@
 // https://gpuweb.github.io/gpuweb/#dictdef-gpucomputepipelinedescriptor
 
 [
-    EnabledBySetting=WebGPU
+    EnabledBySetting=WebGPUEnabled
 ]
 dictionary GPUComputePipelineDescriptor : GPUPipelineDescriptorBase {
     required GPUProgrammableStage compute;

--- a/Source/WebCore/Modules/WebGPU/GPUCullMode.idl
+++ b/Source/WebCore/Modules/WebGPU/GPUCullMode.idl
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021 Apple Inc. All rights reserved.
+ * Copyright (C) 2021-2023 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -26,7 +26,7 @@
 // https://gpuweb.github.io/gpuweb/#enumdef-gpucullmode
 
 [
-    EnabledBySetting=WebGPU
+    EnabledBySetting=WebGPUEnabled
 ]
 enum GPUCullMode {
     "none",

--- a/Source/WebCore/Modules/WebGPU/GPUDebugCommandsMixin.idl
+++ b/Source/WebCore/Modules/WebGPU/GPUDebugCommandsMixin.idl
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022 Apple Inc. All rights reserved.
+ * Copyright (C) 2022-2023 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -26,7 +26,7 @@
 // https://gpuweb.github.io/gpuweb/#gpudebugcommandsmixin
 
 [
-    EnabledBySetting=WebGPU
+    EnabledBySetting=WebGPUEnabled
 ]
 interface mixin GPUDebugCommandsMixin {
     undefined pushDebugGroup(USVString groupLabel);

--- a/Source/WebCore/Modules/WebGPU/GPUDepthStencilState.idl
+++ b/Source/WebCore/Modules/WebGPU/GPUDepthStencilState.idl
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021 Apple Inc. All rights reserved.
+ * Copyright (C) 2021-2023 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -30,7 +30,7 @@ typedef [EnforceRange] unsigned long GPUStencilValue;
 typedef [EnforceRange] long GPUDepthBias;
 
 [
-    EnabledBySetting=WebGPU
+    EnabledBySetting=WebGPUEnabled
 ]
 dictionary GPUDepthStencilState {
     required GPUTextureFormat format;

--- a/Source/WebCore/Modules/WebGPU/GPUDevice.idl
+++ b/Source/WebCore/Modules/WebGPU/GPUDevice.idl
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021 Apple Inc. All rights reserved.
+ * Copyright (C) 2021-2023 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -26,7 +26,7 @@
 // https://gpuweb.github.io/gpuweb/#gpudevice
 
 [
-    EnabledBySetting=WebGPU,
+    EnabledBySetting=WebGPUEnabled,
     ActiveDOMObject,
     Exposed=(Window), /* https://bugs.webkit.org/show_bug.cgi?id=232542: DedicatedWorker */
     SecureContext

--- a/Source/WebCore/Modules/WebGPU/GPUDeviceDescriptor.idl
+++ b/Source/WebCore/Modules/WebGPU/GPUDeviceDescriptor.idl
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021 Apple Inc. All rights reserved.
+ * Copyright (C) 2021-2023 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -28,7 +28,7 @@
 typedef [EnforceRange] unsigned long long GPUSize64;
 
 [
-    EnabledBySetting=WebGPU
+    EnabledBySetting=WebGPUEnabled
 ]
 dictionary GPUDeviceDescriptor : GPUObjectDescriptorBase {
     sequence<GPUFeatureName> requiredFeatures = [];

--- a/Source/WebCore/Modules/WebGPU/GPUDeviceLostInfo.idl
+++ b/Source/WebCore/Modules/WebGPU/GPUDeviceLostInfo.idl
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021 Apple Inc. All rights reserved.
+ * Copyright (C) 2021-2023 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -26,7 +26,7 @@
 // https://gpuweb.github.io/gpuweb/#gpudevicelostinfo
 
 [
-    EnabledBySetting=WebGPU,
+    EnabledBySetting=WebGPUEnabled,
     Exposed=(Window), /* https://bugs.webkit.org/show_bug.cgi?id=232542: DedicatedWorker */
     SecureContext
 ]

--- a/Source/WebCore/Modules/WebGPU/GPUDeviceLostReason.idl
+++ b/Source/WebCore/Modules/WebGPU/GPUDeviceLostReason.idl
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021 Apple Inc. All rights reserved.
+ * Copyright (C) 2021-2023 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -26,7 +26,7 @@
 // https://gpuweb.github.io/gpuweb/#enumdef-gpudevicelostreason
 
 [
-    EnabledBySetting=WebGPU
+    EnabledBySetting=WebGPUEnabled
 ]
 enum GPUDeviceLostReason {
     "unknown",

--- a/Source/WebCore/Modules/WebGPU/GPUErrorFilter.idl
+++ b/Source/WebCore/Modules/WebGPU/GPUErrorFilter.idl
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021 Apple Inc. All rights reserved.
+ * Copyright (C) 2021-2023 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -26,7 +26,7 @@
 // https://gpuweb.github.io/gpuweb/#enumdef-gpuerrorfilter
 
 [
-    EnabledBySetting=WebGPU
+    EnabledBySetting=WebGPUEnabled
 ]
 enum GPUErrorFilter {
     "out-of-memory",

--- a/Source/WebCore/Modules/WebGPU/GPUExtent3DDict.idl
+++ b/Source/WebCore/Modules/WebGPU/GPUExtent3DDict.idl
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021 Apple Inc. All rights reserved.
+ * Copyright (C) 2021-2023 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -29,7 +29,7 @@
 typedef [EnforceRange] unsigned long GPUIntegerCoordinate;
 
 [
-    EnabledBySetting=WebGPU
+    EnabledBySetting=WebGPUEnabled
 ]
 dictionary GPUExtent3DDict {
     required GPUIntegerCoordinate width;

--- a/Source/WebCore/Modules/WebGPU/GPUExternalTexture.idl
+++ b/Source/WebCore/Modules/WebGPU/GPUExternalTexture.idl
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021 Apple Inc. All rights reserved.
+ * Copyright (C) 2021-2023 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -26,7 +26,7 @@
 // https://gpuweb.github.io/gpuweb/#gpuexternaltexture
 
 [
-    EnabledBySetting=WebGPU,
+    EnabledBySetting=WebGPUEnabled,
     Exposed=(Window), /* https://bugs.webkit.org/show_bug.cgi?id=232542: DedicatedWorker */
     SecureContext
 ]

--- a/Source/WebCore/Modules/WebGPU/GPUExternalTextureBindingLayout.idl
+++ b/Source/WebCore/Modules/WebGPU/GPUExternalTextureBindingLayout.idl
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021 Apple Inc. All rights reserved.
+ * Copyright (C) 2021-2023 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -28,7 +28,7 @@
 // https://gpuweb.github.io/gpuweb/#dictdef-gpuexternaltexturebindinglayout
 
 [
-    EnabledBySetting=WebGPU
+    EnabledBySetting=WebGPUEnabled
 ]
 dictionary GPUExternalTextureBindingLayout {
 };

--- a/Source/WebCore/Modules/WebGPU/GPUExternalTextureDescriptor.idl
+++ b/Source/WebCore/Modules/WebGPU/GPUExternalTextureDescriptor.idl
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021 Apple Inc. All rights reserved.
+ * Copyright (C) 2021-2023 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -26,7 +26,7 @@
 // https://gpuweb.github.io/gpuweb/#dictdef-gpuexternaltexturedescriptor
 
 [
-    EnabledBySetting=WebGPU
+    EnabledBySetting=WebGPUEnabled
 ]
 dictionary GPUExternalTextureDescriptor : GPUObjectDescriptorBase {
 #if defined(ENABLE_VIDEO) && ENABLE_VIDEO

--- a/Source/WebCore/Modules/WebGPU/GPUFeatureName.idl
+++ b/Source/WebCore/Modules/WebGPU/GPUFeatureName.idl
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2022 Apple Inc. All rights reserved.
+ * Copyright (C) 2021-2023 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -26,7 +26,7 @@
 // https://gpuweb.github.io/gpuweb/#enumdef-gpufeaturename
 
 [
-    EnabledBySetting=WebGPU
+    EnabledBySetting=WebGPUEnabled
 ]
 enum GPUFeatureName {
     "depth-clip-control",

--- a/Source/WebCore/Modules/WebGPU/GPUFilterMode.idl
+++ b/Source/WebCore/Modules/WebGPU/GPUFilterMode.idl
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021 Apple Inc. All rights reserved.
+ * Copyright (C) 2021-2023 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -26,7 +26,7 @@
 // https://gpuweb.github.io/gpuweb/#enumdef-gpufiltermode
 
 [
-    EnabledBySetting=WebGPU
+    EnabledBySetting=WebGPUEnabled
 ]
 enum GPUFilterMode {
     "nearest",

--- a/Source/WebCore/Modules/WebGPU/GPUFragmentState.idl
+++ b/Source/WebCore/Modules/WebGPU/GPUFragmentState.idl
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2022 Apple Inc. All rights reserved.
+ * Copyright (C) 2021-2023 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -26,7 +26,7 @@
 // https://gpuweb.github.io/gpuweb/#dictdef-gpufragmentstate
 
 [
-    EnabledBySetting=WebGPU
+    EnabledBySetting=WebGPUEnabled
 ]
 dictionary GPUFragmentState : GPUProgrammableStage {
     required sequence<GPUColorTargetState?> targets;

--- a/Source/WebCore/Modules/WebGPU/GPUFrontFace.idl
+++ b/Source/WebCore/Modules/WebGPU/GPUFrontFace.idl
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021 Apple Inc. All rights reserved.
+ * Copyright (C) 2021-2023 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -26,7 +26,7 @@
 // https://gpuweb.github.io/gpuweb/#enumdef-gpufrontface
 
 [
-    EnabledBySetting=WebGPU
+    EnabledBySetting=WebGPUEnabled
 ]
 enum GPUFrontFace {
     "ccw",

--- a/Source/WebCore/Modules/WebGPU/GPUImageCopyBuffer.idl
+++ b/Source/WebCore/Modules/WebGPU/GPUImageCopyBuffer.idl
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021 Apple Inc. All rights reserved.
+ * Copyright (C) 2021-2023 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -26,7 +26,7 @@
 // https://gpuweb.github.io/gpuweb/#dictdef-gpuimagecopybuffer
 
 [
-    EnabledBySetting=WebGPU
+    EnabledBySetting=WebGPUEnabled
 ]
 dictionary GPUImageCopyBuffer : GPUImageDataLayout {
     required GPUBuffer buffer;

--- a/Source/WebCore/Modules/WebGPU/GPUImageCopyExternalImage.idl
+++ b/Source/WebCore/Modules/WebGPU/GPUImageCopyExternalImage.idl
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2022 Apple Inc. All rights reserved.
+ * Copyright (C) 2021-2023 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -30,7 +30,7 @@ typedef [EnforceRange] unsigned long GPUIntegerCoordinate;
 typedef (sequence<GPUIntegerCoordinate> or GPUOrigin2DDict) GPUOrigin2D;
 
 [
-    EnabledBySetting=WebGPU
+    EnabledBySetting=WebGPUEnabled
 ]
 dictionary GPUImageCopyExternalImage {
     required (ImageBitmap or HTMLCanvasElement

--- a/Source/WebCore/Modules/WebGPU/GPUImageCopyTexture.idl
+++ b/Source/WebCore/Modules/WebGPU/GPUImageCopyTexture.idl
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021 Apple Inc. All rights reserved.
+ * Copyright (C) 2021-2023 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -30,7 +30,7 @@ typedef [EnforceRange] unsigned long GPUIntegerCoordinate;
 typedef (sequence<GPUIntegerCoordinate> or GPUOrigin3DDict) GPUOrigin3D;
 
 [
-    EnabledBySetting=WebGPU
+    EnabledBySetting=WebGPUEnabled
 ]
 dictionary GPUImageCopyTexture {
     required GPUTexture texture;

--- a/Source/WebCore/Modules/WebGPU/GPUImageCopyTextureTagged.idl
+++ b/Source/WebCore/Modules/WebGPU/GPUImageCopyTextureTagged.idl
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021 Apple Inc. All rights reserved.
+ * Copyright (C) 2021-2023 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -26,7 +26,7 @@
 // https://gpuweb.github.io/gpuweb/#dictdef-gpuimagecopytexturetagged
 
 [
-    EnabledBySetting=WebGPU
+    EnabledBySetting=WebGPUEnabled
 ]
 dictionary GPUImageCopyTextureTagged : GPUImageCopyTexture {
     GPUPredefinedColorSpace colorSpace = "srgb";

--- a/Source/WebCore/Modules/WebGPU/GPUImageDataLayout.idl
+++ b/Source/WebCore/Modules/WebGPU/GPUImageDataLayout.idl
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021 Apple Inc. All rights reserved.
+ * Copyright (C) 2021-2023 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -30,7 +30,7 @@ typedef [EnforceRange] unsigned long GPUSize32;
 typedef [EnforceRange] unsigned long long GPUSize64;
 
 [
-    EnabledBySetting=WebGPU
+    EnabledBySetting=WebGPUEnabled
 ]
 dictionary GPUImageDataLayout {
     GPUSize64 offset = 0;

--- a/Source/WebCore/Modules/WebGPU/GPUIndexFormat.idl
+++ b/Source/WebCore/Modules/WebGPU/GPUIndexFormat.idl
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021 Apple Inc. All rights reserved.
+ * Copyright (C) 2021-2023 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -26,7 +26,7 @@
 // https://gpuweb.github.io/gpuweb/#enumdef-gpuindexformat
 
 [
-    EnabledBySetting=WebGPU
+    EnabledBySetting=WebGPUEnabled
 ]
 enum GPUIndexFormat {
     "uint16",

--- a/Source/WebCore/Modules/WebGPU/GPUInternalError.idl
+++ b/Source/WebCore/Modules/WebGPU/GPUInternalError.idl
@@ -24,7 +24,7 @@
  */
 
 [
-    EnabledBySetting=WebGPU,
+    EnabledBySetting=WebGPUEnabled,
     Exposed=(Window), /* https://bugs.webkit.org/show_bug.cgi?id=232542: DedicatedWorker */
     SecureContext
 ]

--- a/Source/WebCore/Modules/WebGPU/GPULoadOp.idl
+++ b/Source/WebCore/Modules/WebGPU/GPULoadOp.idl
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2022 Apple Inc. All rights reserved.
+ * Copyright (C) 2021-2023 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -26,7 +26,7 @@
 // https://gpuweb.github.io/gpuweb/#enumdef-gpuloadop
 
 [
-    EnabledBySetting=WebGPU
+    EnabledBySetting=WebGPUEnabled
 ]
 enum GPULoadOp {
     "load",

--- a/Source/WebCore/Modules/WebGPU/GPUMapMode.idl
+++ b/Source/WebCore/Modules/WebGPU/GPUMapMode.idl
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021 Apple Inc. All rights reserved.
+ * Copyright (C) 2021-2023 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -27,7 +27,7 @@
 
 typedef [EnforceRange] unsigned long GPUMapModeFlags;
 [
-    EnabledBySetting=WebGPU,
+    EnabledBySetting=WebGPUEnabled,
     Exposed=(Window), /* https://bugs.webkit.org/show_bug.cgi?id=232542: DedicatedWorker */
     SecureContext
 ]

--- a/Source/WebCore/Modules/WebGPU/GPUMipmapFilterMode.idl
+++ b/Source/WebCore/Modules/WebGPU/GPUMipmapFilterMode.idl
@@ -26,7 +26,7 @@
 // https://gpuweb.github.io/gpuweb/#enumdef-gpufiltermode
 
 [
-    EnabledBySetting=WebGPU
+    EnabledBySetting=WebGPUEnabled
 ]
 enum GPUMipmapFilterMode {
     "nearest",

--- a/Source/WebCore/Modules/WebGPU/GPUMultisampleState.idl
+++ b/Source/WebCore/Modules/WebGPU/GPUMultisampleState.idl
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021 Apple Inc. All rights reserved.
+ * Copyright (C) 2021-2023 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -30,7 +30,7 @@ typedef [EnforceRange] unsigned long GPUSize32;
 typedef [EnforceRange] unsigned long GPUSampleMask;
 
 [
-    EnabledBySetting=WebGPU
+    EnabledBySetting=WebGPUEnabled
 ]
 dictionary GPUMultisampleState {
     GPUSize32 count = 1;

--- a/Source/WebCore/Modules/WebGPU/GPUObjectBase.idl
+++ b/Source/WebCore/Modules/WebGPU/GPUObjectBase.idl
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2022 Apple Inc. All rights reserved.
+ * Copyright (C) 2021-2023 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -26,7 +26,7 @@
 // https://gpuweb.github.io/gpuweb/#gpuobjectbase
 
 [
-    EnabledBySetting=WebGPU
+    EnabledBySetting=WebGPUEnabled
 ]
 interface mixin GPUObjectBase {
     attribute USVString? label; // FIXME: https://bugs.webkit.org/show_bug.cgi?id=236723 This is supposed to be (USVString or undefined) but our bindings generator can't handle that.

--- a/Source/WebCore/Modules/WebGPU/GPUObjectDescriptorBase.idl
+++ b/Source/WebCore/Modules/WebGPU/GPUObjectDescriptorBase.idl
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021 Apple Inc. All rights reserved.
+ * Copyright (C) 2021-2023 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -26,7 +26,7 @@
 // https://gpuweb.github.io/gpuweb/#dictdef-gpuobjectdescriptorbase
 
 [
-    EnabledBySetting=WebGPU
+    EnabledBySetting=WebGPUEnabled
 ]
 dictionary GPUObjectDescriptorBase {
     USVString label;

--- a/Source/WebCore/Modules/WebGPU/GPUOrigin2DDict.idl
+++ b/Source/WebCore/Modules/WebGPU/GPUOrigin2DDict.idl
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021 Apple Inc. All rights reserved.
+ * Copyright (C) 2021-2023 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -29,7 +29,7 @@
 typedef [EnforceRange] unsigned long GPUIntegerCoordinate;
 
 [
-    EnabledBySetting=WebGPU
+    EnabledBySetting=WebGPUEnabled
 ]
 dictionary GPUOrigin2DDict {
     GPUIntegerCoordinate x = 0;

--- a/Source/WebCore/Modules/WebGPU/GPUOrigin3DDict.idl
+++ b/Source/WebCore/Modules/WebGPU/GPUOrigin3DDict.idl
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021 Apple Inc. All rights reserved.
+ * Copyright (C) 2021-2023 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -29,7 +29,7 @@
 typedef [EnforceRange] unsigned long GPUIntegerCoordinate;
 
 [
-    EnabledBySetting=WebGPU
+    EnabledBySetting=WebGPUEnabled
 ]
 dictionary GPUOrigin3DDict {
     GPUIntegerCoordinate x = 0;

--- a/Source/WebCore/Modules/WebGPU/GPUOutOfMemoryError.idl
+++ b/Source/WebCore/Modules/WebGPU/GPUOutOfMemoryError.idl
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021 Apple Inc. All rights reserved.
+ * Copyright (C) 2021-2023 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -26,7 +26,7 @@
 // https://gpuweb.github.io/gpuweb/#gpuoutofmemoryerror
 
 [
-    EnabledBySetting=WebGPU,
+    EnabledBySetting=WebGPUEnabled,
     Exposed=(Window), /* https://bugs.webkit.org/show_bug.cgi?id=232542: DedicatedWorker */
     SecureContext
 ]

--- a/Source/WebCore/Modules/WebGPU/GPUPipelineBase.idl
+++ b/Source/WebCore/Modules/WebGPU/GPUPipelineBase.idl
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021 Apple Inc. All rights reserved.
+ * Copyright (C) 2021-2023 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -24,7 +24,7 @@
  */
 
 [
-    EnabledBySetting=WebGPU
+    EnabledBySetting=WebGPUEnabled
 ]
 interface mixin GPUPipelineBase {
     GPUBindGroupLayout getBindGroupLayout(unsigned long index);

--- a/Source/WebCore/Modules/WebGPU/GPUPipelineDescriptorBase.idl
+++ b/Source/WebCore/Modules/WebGPU/GPUPipelineDescriptorBase.idl
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021 Apple Inc. All rights reserved.
+ * Copyright (C) 2021-2023 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -26,7 +26,7 @@
 // https://gpuweb.github.io/gpuweb/#dictdef-gpupipelinedescriptorbase
 
 [
-    EnabledBySetting=WebGPU
+    EnabledBySetting=WebGPUEnabled
 ]
 dictionary GPUPipelineDescriptorBase : GPUObjectDescriptorBase {
     (GPUPipelineLayout or GPUAutoLayoutMode) layout;

--- a/Source/WebCore/Modules/WebGPU/GPUPipelineError.idl
+++ b/Source/WebCore/Modules/WebGPU/GPUPipelineError.idl
@@ -29,7 +29,7 @@
     Exposed=(Window),
     SecureContext,
     Serializable,
-    EnabledBySetting=WebGPU
+    EnabledBySetting=WebGPUEnabled
 ]
 interface GPUPipelineError : DOMException {
     constructor(DOMString message, GPUPipelineErrorInit options);

--- a/Source/WebCore/Modules/WebGPU/GPUPipelineErrorInit.idl
+++ b/Source/WebCore/Modules/WebGPU/GPUPipelineErrorInit.idl
@@ -26,7 +26,7 @@
 // https://gpuweb.github.io/gpuweb/#gpupipelineerror
 
 [
-    EnabledBySetting=WebGPU
+    EnabledBySetting=WebGPUEnabled
 ]
 dictionary GPUPipelineErrorInit {
     required GPUPipelineErrorReason reason;

--- a/Source/WebCore/Modules/WebGPU/GPUPipelineErrorReason.idl
+++ b/Source/WebCore/Modules/WebGPU/GPUPipelineErrorReason.idl
@@ -26,7 +26,7 @@
 // https://gpuweb.github.io/gpuweb/#gpupipelineerrorreason
 
 [
-    EnabledBySetting=WebGPU
+    EnabledBySetting=WebGPUEnabled
 ]
 enum GPUPipelineErrorReason {
     "validation",

--- a/Source/WebCore/Modules/WebGPU/GPUPipelineLayout.idl
+++ b/Source/WebCore/Modules/WebGPU/GPUPipelineLayout.idl
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021 Apple Inc. All rights reserved.
+ * Copyright (C) 2021-2023 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -26,7 +26,7 @@
 // https://gpuweb.github.io/gpuweb/#gpupipelinelayout
 
 [
-    EnabledBySetting=WebGPU,
+    EnabledBySetting=WebGPUEnabled,
     Exposed=(Window), /* https://bugs.webkit.org/show_bug.cgi?id=232542: DedicatedWorker */
     SecureContext
 ]

--- a/Source/WebCore/Modules/WebGPU/GPUPipelineLayoutDescriptor.idl
+++ b/Source/WebCore/Modules/WebGPU/GPUPipelineLayoutDescriptor.idl
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021 Apple Inc. All rights reserved.
+ * Copyright (C) 2021-2023 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -26,7 +26,7 @@
 // https://gpuweb.github.io/gpuweb/#dictdef-gpupipelinelayoutdescriptor
 
 [
-    EnabledBySetting=WebGPU
+    EnabledBySetting=WebGPUEnabled
 ]
 dictionary GPUPipelineLayoutDescriptor : GPUObjectDescriptorBase {
     required sequence<GPUBindGroupLayout> bindGroupLayouts;

--- a/Source/WebCore/Modules/WebGPU/GPUPowerPreference.idl
+++ b/Source/WebCore/Modules/WebGPU/GPUPowerPreference.idl
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021 Apple Inc. All rights reserved.
+ * Copyright (C) 2021-2023 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -26,7 +26,7 @@
 // https://gpuweb.github.io/gpuweb/#enumdef-gpupowerpreference
 
 [
-    EnabledBySetting=WebGPU
+    EnabledBySetting=WebGPUEnabled
 ]
 enum GPUPowerPreference {
     "low-power",

--- a/Source/WebCore/Modules/WebGPU/GPUPredefinedColorSpace.idl
+++ b/Source/WebCore/Modules/WebGPU/GPUPredefinedColorSpace.idl
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021 Apple Inc. All rights reserved.
+ * Copyright (C) 2021-2023 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -26,7 +26,7 @@
 // https://gpuweb.github.io/gpuweb/#enumdef-gpupredefinedcolorspace
 
 [
-    EnabledBySetting=WebGPU
+    EnabledBySetting=WebGPUEnabled
 ]
 enum GPUPredefinedColorSpace {
     "srgb"

--- a/Source/WebCore/Modules/WebGPU/GPUPrimitiveState.idl
+++ b/Source/WebCore/Modules/WebGPU/GPUPrimitiveState.idl
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021 Apple Inc. All rights reserved.
+ * Copyright (C) 2021-2023 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -26,7 +26,7 @@
 // https://gpuweb.github.io/gpuweb/#dictdef-gpuprimitivestate
 
 [
-    EnabledBySetting=WebGPU
+    EnabledBySetting=WebGPUEnabled
 ]
 dictionary GPUPrimitiveState {
     GPUPrimitiveTopology topology = "triangle-list";

--- a/Source/WebCore/Modules/WebGPU/GPUPrimitiveTopology.idl
+++ b/Source/WebCore/Modules/WebGPU/GPUPrimitiveTopology.idl
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021 Apple Inc. All rights reserved.
+ * Copyright (C) 2021-2023 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -26,7 +26,7 @@
 // https://gpuweb.github.io/gpuweb/#enumdef-gpuprimitivetopology
 
 [
-    EnabledBySetting=WebGPU
+    EnabledBySetting=WebGPUEnabled
 ]
 enum GPUPrimitiveTopology {
     "point-list",

--- a/Source/WebCore/Modules/WebGPU/GPUProgrammablePassEncoder.idl
+++ b/Source/WebCore/Modules/WebGPU/GPUProgrammablePassEncoder.idl
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2022 Apple Inc. All rights reserved.
+ * Copyright (C) 2021-2023 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -32,7 +32,7 @@ typedef [EnforceRange] unsigned long GPUIndex32;
 typedef [EnforceRange] unsigned long GPUBufferDynamicOffset;
 
 [
-    EnabledBySetting=WebGPU
+    EnabledBySetting=WebGPUEnabled
 ]
 interface mixin GPUProgrammablePassEncoder {
     undefined setBindGroup(GPUIndex32 index, GPUBindGroup bindGroup,

--- a/Source/WebCore/Modules/WebGPU/GPUProgrammableStage.idl
+++ b/Source/WebCore/Modules/WebGPU/GPUProgrammableStage.idl
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021 Apple Inc. All rights reserved.
+ * Copyright (C) 2021-2023 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -26,7 +26,7 @@
 // https://gpuweb.github.io/gpuweb/#dictdef-gpuprogrammablestage
 
 [
-    EnabledBySetting=WebGPU
+    EnabledBySetting=WebGPUEnabled
 ]
 dictionary GPUProgrammableStage {
     required GPUShaderModule module;

--- a/Source/WebCore/Modules/WebGPU/GPUQuerySet.idl
+++ b/Source/WebCore/Modules/WebGPU/GPUQuerySet.idl
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021 Apple Inc. All rights reserved.
+ * Copyright (C) 2021-2023 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -26,7 +26,7 @@
 // https://gpuweb.github.io/gpuweb/#gpuqueryset
 
 [
-    EnabledBySetting=WebGPU,
+    EnabledBySetting=WebGPUEnabled,
     Exposed=(Window), /* https://bugs.webkit.org/show_bug.cgi?id=232542: DedicatedWorker */
     SecureContext
 ]

--- a/Source/WebCore/Modules/WebGPU/GPUQuerySetDescriptor.idl
+++ b/Source/WebCore/Modules/WebGPU/GPUQuerySetDescriptor.idl
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2022 Apple Inc. All rights reserved.
+ * Copyright (C) 2021-2023 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -29,7 +29,7 @@
 typedef [EnforceRange] unsigned long GPUSize32;
 
 [
-    EnabledBySetting=WebGPU
+    EnabledBySetting=WebGPUEnabled
 ]
 dictionary GPUQuerySetDescriptor : GPUObjectDescriptorBase {
     required GPUQueryType type;

--- a/Source/WebCore/Modules/WebGPU/GPUQueryType.idl
+++ b/Source/WebCore/Modules/WebGPU/GPUQueryType.idl
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2022 Apple Inc. All rights reserved.
+ * Copyright (C) 2021-2023 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -26,7 +26,7 @@
 // https://gpuweb.github.io/gpuweb/#enumdef-gpuquerytype
 
 [
-    EnabledBySetting=WebGPU
+    EnabledBySetting=WebGPUEnabled
 ]
 enum GPUQueryType {
     "occlusion",

--- a/Source/WebCore/Modules/WebGPU/GPUQueue.idl
+++ b/Source/WebCore/Modules/WebGPU/GPUQueue.idl
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021 Apple Inc. All rights reserved.
+ * Copyright (C) 2021-2023 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -32,7 +32,7 @@ typedef [EnforceRange] unsigned long GPUIntegerCoordinate;
 typedef (sequence<GPUIntegerCoordinate> or GPUExtent3DDict) GPUExtent3D;
 
 [
-    EnabledBySetting=WebGPU,
+    EnabledBySetting=WebGPUEnabled,
     Exposed=(Window), /* https://bugs.webkit.org/show_bug.cgi?id=232542: DedicatedWorker */
     SecureContext
 ]

--- a/Source/WebCore/Modules/WebGPU/GPURenderBundle.idl
+++ b/Source/WebCore/Modules/WebGPU/GPURenderBundle.idl
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021 Apple Inc. All rights reserved.
+ * Copyright (C) 2021-2023 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -26,7 +26,7 @@
 // https://gpuweb.github.io/gpuweb/#gpurenderbundle
 
 [
-    EnabledBySetting=WebGPU,
+    EnabledBySetting=WebGPUEnabled,
     Exposed=(Window), /* https://bugs.webkit.org/show_bug.cgi?id=232542: DedicatedWorker */
     SecureContext
 ]

--- a/Source/WebCore/Modules/WebGPU/GPURenderBundleDescriptor.idl
+++ b/Source/WebCore/Modules/WebGPU/GPURenderBundleDescriptor.idl
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021 Apple Inc. All rights reserved.
+ * Copyright (C) 2021-2023 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -26,7 +26,7 @@
 // https://gpuweb.github.io/gpuweb/#dictdef-gpurenderbundledescriptor
 
 [
-    EnabledBySetting=WebGPU
+    EnabledBySetting=WebGPUEnabled
 ]
 dictionary GPURenderBundleDescriptor : GPUObjectDescriptorBase {
 };

--- a/Source/WebCore/Modules/WebGPU/GPURenderBundleEncoder.idl
+++ b/Source/WebCore/Modules/WebGPU/GPURenderBundleEncoder.idl
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2022 Apple Inc. All rights reserved.
+ * Copyright (C) 2021-2023 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -26,7 +26,7 @@
 // https://gpuweb.github.io/gpuweb/#gpurenderbundleencoder
 
 [
-    EnabledBySetting=WebGPU,
+    EnabledBySetting=WebGPUEnabled,
     Exposed=(Window), /* https://bugs.webkit.org/show_bug.cgi?id=232542: DedicatedWorker */
     SecureContext
 ]

--- a/Source/WebCore/Modules/WebGPU/GPURenderBundleEncoderDescriptor.idl
+++ b/Source/WebCore/Modules/WebGPU/GPURenderBundleEncoderDescriptor.idl
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021 Apple Inc. All rights reserved.
+ * Copyright (C) 2021-2023 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -26,7 +26,7 @@
 // https://gpuweb.github.io/gpuweb/#dictdef-gpurenderbundleencoderdescriptor
 
 [
-    EnabledBySetting=WebGPU
+    EnabledBySetting=WebGPUEnabled
 ]
 dictionary GPURenderBundleEncoderDescriptor : GPURenderPassLayout {
     boolean depthReadOnly = false;

--- a/Source/WebCore/Modules/WebGPU/GPURenderEncoderBase.idl
+++ b/Source/WebCore/Modules/WebGPU/GPURenderEncoderBase.idl
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021 Apple Inc. All rights reserved.
+ * Copyright (C) 2021-2023 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -30,7 +30,7 @@ typedef [EnforceRange] unsigned long GPUIndex32;
 typedef [EnforceRange] long GPUSignedOffset32;
 
 [
-    EnabledBySetting=WebGPU
+    EnabledBySetting=WebGPUEnabled
 ]
 interface mixin GPURenderEncoderBase {
     undefined setPipeline(GPURenderPipeline pipeline);

--- a/Source/WebCore/Modules/WebGPU/GPURenderPassColorAttachment.idl
+++ b/Source/WebCore/Modules/WebGPU/GPURenderPassColorAttachment.idl
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2022 Apple Inc. All rights reserved.
+ * Copyright (C) 2021-2023 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -29,7 +29,7 @@
 typedef (sequence<double> or GPUColorDict) GPUColor;
 
 [
-    EnabledBySetting=WebGPU
+    EnabledBySetting=WebGPUEnabled
 ]
 dictionary GPURenderPassColorAttachment {
     required GPUTextureView view;

--- a/Source/WebCore/Modules/WebGPU/GPURenderPassDepthStencilAttachment.idl
+++ b/Source/WebCore/Modules/WebGPU/GPURenderPassDepthStencilAttachment.idl
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2022 Apple Inc. All rights reserved.
+ * Copyright (C) 2021-2023 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -29,7 +29,7 @@
 typedef [EnforceRange] unsigned long GPUStencilValue;
 
 [
-    EnabledBySetting=WebGPU
+    EnabledBySetting=WebGPUEnabled
 ]
 dictionary GPURenderPassDepthStencilAttachment {
     required GPUTextureView view;

--- a/Source/WebCore/Modules/WebGPU/GPURenderPassDescriptor.idl
+++ b/Source/WebCore/Modules/WebGPU/GPURenderPassDescriptor.idl
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2022 Apple Inc. All rights reserved.
+ * Copyright (C) 2021-2023 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -29,7 +29,7 @@
 typedef sequence<GPURenderPassTimestampWrite> GPURenderPassTimestampWrites;
 
 [
-    EnabledBySetting=WebGPU
+    EnabledBySetting=WebGPUEnabled
 ]
 dictionary GPURenderPassDescriptor : GPUObjectDescriptorBase {
     required sequence<GPURenderPassColorAttachment?> colorAttachments;

--- a/Source/WebCore/Modules/WebGPU/GPURenderPassEncoder.idl
+++ b/Source/WebCore/Modules/WebGPU/GPURenderPassEncoder.idl
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2022 Apple Inc. All rights reserved.
+ * Copyright (C) 2021-2023 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -32,7 +32,7 @@ typedef [EnforceRange] unsigned long GPUStencilValue;
 typedef (sequence<double> or GPUColorDict) GPUColor;
 
 [
-    EnabledBySetting=WebGPU,
+    EnabledBySetting=WebGPUEnabled,
     Exposed=(Window), /* https://bugs.webkit.org/show_bug.cgi?id=232542: DedicatedWorker */
     SecureContext
 ]

--- a/Source/WebCore/Modules/WebGPU/GPURenderPassLayout.idl
+++ b/Source/WebCore/Modules/WebGPU/GPURenderPassLayout.idl
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2022 Apple Inc. All rights reserved.
+ * Copyright (C) 2021-2023 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -29,7 +29,7 @@
 typedef [EnforceRange] unsigned long GPUSize32;
 
 [
-    EnabledBySetting=WebGPU
+    EnabledBySetting=WebGPUEnabled
 ]
 dictionary GPURenderPassLayout : GPUObjectDescriptorBase {
     required sequence<GPUTextureFormat?> colorFormats;

--- a/Source/WebCore/Modules/WebGPU/GPURenderPassTimestampLocation.idl
+++ b/Source/WebCore/Modules/WebGPU/GPURenderPassTimestampLocation.idl
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021 Apple Inc. All rights reserved.
+ * Copyright (C) 2021-2023 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -26,7 +26,7 @@
 // https://gpuweb.github.io/gpuweb/#enumdef-gpurenderpasstimestamplocation
 
 [
-    EnabledBySetting=WebGPU
+    EnabledBySetting=WebGPUEnabled
 ]
 enum GPURenderPassTimestampLocation {
     "beginning",

--- a/Source/WebCore/Modules/WebGPU/GPURenderPassTimestampWrite.idl
+++ b/Source/WebCore/Modules/WebGPU/GPURenderPassTimestampWrite.idl
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021 Apple Inc. All rights reserved.
+ * Copyright (C) 2021-2023 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -29,7 +29,7 @@
 typedef [EnforceRange] unsigned long GPUSize32;
 
 [
-    EnabledBySetting=WebGPU
+    EnabledBySetting=WebGPUEnabled
 ]
 dictionary GPURenderPassTimestampWrite {
     required GPUQuerySet querySet;

--- a/Source/WebCore/Modules/WebGPU/GPURenderPipeline.idl
+++ b/Source/WebCore/Modules/WebGPU/GPURenderPipeline.idl
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021 Apple Inc. All rights reserved.
+ * Copyright (C) 2021-2023 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -26,7 +26,7 @@
 // https://gpuweb.github.io/gpuweb/#gpurenderpipeline
 
 [
-    EnabledBySetting=WebGPU,
+    EnabledBySetting=WebGPUEnabled,
     Exposed=(Window), /* https://bugs.webkit.org/show_bug.cgi?id=232542: DedicatedWorker */
     SecureContext
 ]

--- a/Source/WebCore/Modules/WebGPU/GPURenderPipelineDescriptor.idl
+++ b/Source/WebCore/Modules/WebGPU/GPURenderPipelineDescriptor.idl
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021 Apple Inc. All rights reserved.
+ * Copyright (C) 2021-2023 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -26,7 +26,7 @@
 // https://gpuweb.github.io/gpuweb/#dictdef-gpurenderpipelinedescriptor
 
 [
-    EnabledBySetting=WebGPU
+    EnabledBySetting=WebGPUEnabled
 ]
 dictionary GPURenderPipelineDescriptor : GPUPipelineDescriptorBase {
     required GPUVertexState vertex;

--- a/Source/WebCore/Modules/WebGPU/GPURequestAdapterOptions.idl
+++ b/Source/WebCore/Modules/WebGPU/GPURequestAdapterOptions.idl
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021 Apple Inc. All rights reserved.
+ * Copyright (C) 2021-2023 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -26,7 +26,7 @@
 // https://gpuweb.github.io/gpuweb/#dictdef-gpurequestadapteroptions
 
 [
-    EnabledBySetting=WebGPU
+    EnabledBySetting=WebGPUEnabled
 ]
 dictionary GPURequestAdapterOptions {
     GPUPowerPreference powerPreference;

--- a/Source/WebCore/Modules/WebGPU/GPUSampler.idl
+++ b/Source/WebCore/Modules/WebGPU/GPUSampler.idl
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021 Apple Inc. All rights reserved.
+ * Copyright (C) 2021-2023 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -26,7 +26,7 @@
 // https://gpuweb.github.io/gpuweb/#gpusampler
 
 [
-    EnabledBySetting=WebGPU,
+    EnabledBySetting=WebGPUEnabled,
     Exposed=(Window), /* https://bugs.webkit.org/show_bug.cgi?id=232542: DedicatedWorker */
     SecureContext
 ]

--- a/Source/WebCore/Modules/WebGPU/GPUSamplerBindingLayout.idl
+++ b/Source/WebCore/Modules/WebGPU/GPUSamplerBindingLayout.idl
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021 Apple Inc. All rights reserved.
+ * Copyright (C) 2021-2023 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -26,7 +26,7 @@
 // https://gpuweb.github.io/gpuweb/#dictdef-gpusamplerbindinglayout
 
 [
-    EnabledBySetting=WebGPU
+    EnabledBySetting=WebGPUEnabled
 ]
 dictionary GPUSamplerBindingLayout {
     GPUSamplerBindingType type = "filtering";

--- a/Source/WebCore/Modules/WebGPU/GPUSamplerBindingType.idl
+++ b/Source/WebCore/Modules/WebGPU/GPUSamplerBindingType.idl
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021 Apple Inc. All rights reserved.
+ * Copyright (C) 2021-2023 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -26,7 +26,7 @@
 // https://gpuweb.github.io/gpuweb/#enumdef-gpusamplerbindingtype
 
 [
-    EnabledBySetting=WebGPU
+    EnabledBySetting=WebGPUEnabled
 ]
 enum GPUSamplerBindingType {
     "filtering",

--- a/Source/WebCore/Modules/WebGPU/GPUSamplerDescriptor.idl
+++ b/Source/WebCore/Modules/WebGPU/GPUSamplerDescriptor.idl
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021 Apple Inc. All rights reserved.
+ * Copyright (C) 2021-2023 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -26,7 +26,7 @@
 // https://gpuweb.github.io/gpuweb/#dictdef-gpusamplerdescriptor
 
 [
-    EnabledBySetting=WebGPU
+    EnabledBySetting=WebGPUEnabled
 ]
 dictionary GPUSamplerDescriptor : GPUObjectDescriptorBase {
     GPUAddressMode addressModeU = "clamp-to-edge";

--- a/Source/WebCore/Modules/WebGPU/GPUShaderModule.idl
+++ b/Source/WebCore/Modules/WebGPU/GPUShaderModule.idl
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021 Apple Inc. All rights reserved.
+ * Copyright (C) 2021-2023 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -26,7 +26,7 @@
 // https://gpuweb.github.io/gpuweb/#gpushadermodule
 
 [
-    EnabledBySetting=WebGPU,
+    EnabledBySetting=WebGPUEnabled,
     Exposed=(Window), /* https://bugs.webkit.org/show_bug.cgi?id=232542: DedicatedWorker */
     SecureContext
 ]

--- a/Source/WebCore/Modules/WebGPU/GPUShaderModuleCompilationHint.idl
+++ b/Source/WebCore/Modules/WebGPU/GPUShaderModuleCompilationHint.idl
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022 Apple Inc. All rights reserved.
+ * Copyright (C) 2022-2023 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -26,7 +26,7 @@
 // https://gpuweb.github.io/gpuweb/#dictdef-gpushadermodulecompilationhint
 
 [
-    EnabledBySetting=WebGPU
+    EnabledBySetting=WebGPUEnabled
 ]
 dictionary GPUShaderModuleCompilationHint {
     required (GPUPipelineLayout or GPUAutoLayoutMode) layout;

--- a/Source/WebCore/Modules/WebGPU/GPUShaderModuleDescriptor.idl
+++ b/Source/WebCore/Modules/WebGPU/GPUShaderModuleDescriptor.idl
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2022 Apple Inc. All rights reserved.
+ * Copyright (C) 2021-2023 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -26,7 +26,7 @@
 // https://gpuweb.github.io/gpuweb/#dictdef-gpushadermoduledescriptor
 
 [
-    EnabledBySetting=WebGPU
+    EnabledBySetting=WebGPUEnabled
 ]
 dictionary GPUShaderModuleDescriptor : GPUObjectDescriptorBase {
     required USVString code;

--- a/Source/WebCore/Modules/WebGPU/GPUShaderStage.idl
+++ b/Source/WebCore/Modules/WebGPU/GPUShaderStage.idl
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021 Apple Inc. All rights reserved.
+ * Copyright (C) 2021-2023 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -27,7 +27,7 @@
 
 typedef [EnforceRange] unsigned long GPUShaderStageFlags;
 [
-    EnabledBySetting=WebGPU,
+    EnabledBySetting=WebGPUEnabled,
     Exposed=(Window), /* https://bugs.webkit.org/show_bug.cgi?id=232542: DedicatedWorker */
     SecureContext
 ]

--- a/Source/WebCore/Modules/WebGPU/GPUStencilFaceState.idl
+++ b/Source/WebCore/Modules/WebGPU/GPUStencilFaceState.idl
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021 Apple Inc. All rights reserved.
+ * Copyright (C) 2021-2023 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -26,7 +26,7 @@
 // https://gpuweb.github.io/gpuweb/#dictdef-gpustencilfacestate
 
 [
-    EnabledBySetting=WebGPU
+    EnabledBySetting=WebGPUEnabled
 ]
 dictionary GPUStencilFaceState {
     GPUCompareFunction compare = "always";

--- a/Source/WebCore/Modules/WebGPU/GPUStencilOperation.idl
+++ b/Source/WebCore/Modules/WebGPU/GPUStencilOperation.idl
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021 Apple Inc. All rights reserved.
+ * Copyright (C) 2021-2023 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -26,7 +26,7 @@
 // https://gpuweb.github.io/gpuweb/#enumdef-gpustenciloperation
 
 [
-    EnabledBySetting=WebGPU
+    EnabledBySetting=WebGPUEnabled
 ]
 enum GPUStencilOperation {
     "keep",

--- a/Source/WebCore/Modules/WebGPU/GPUStorageTextureAccess.idl
+++ b/Source/WebCore/Modules/WebGPU/GPUStorageTextureAccess.idl
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021 Apple Inc. All rights reserved.
+ * Copyright (C) 2021-2023 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -26,7 +26,7 @@
 // https://gpuweb.github.io/gpuweb/#enumdef-gpustoragetextureaccess
 
 [
-    EnabledBySetting=WebGPU
+    EnabledBySetting=WebGPUEnabled
 ]
 enum GPUStorageTextureAccess {
     "write-only"

--- a/Source/WebCore/Modules/WebGPU/GPUStorageTextureBindingLayout.idl
+++ b/Source/WebCore/Modules/WebGPU/GPUStorageTextureBindingLayout.idl
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021 Apple Inc. All rights reserved.
+ * Copyright (C) 2021-2023 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -26,7 +26,7 @@
 // https://gpuweb.github.io/gpuweb/#dictdef-gpustoragetexturebindinglayout
 
 [
-    EnabledBySetting=WebGPU
+    EnabledBySetting=WebGPUEnabled
 ]
 dictionary GPUStorageTextureBindingLayout {
     GPUStorageTextureAccess access = "write-only";

--- a/Source/WebCore/Modules/WebGPU/GPUStoreOp.idl
+++ b/Source/WebCore/Modules/WebGPU/GPUStoreOp.idl
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021 Apple Inc. All rights reserved.
+ * Copyright (C) 2021-2023 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -26,7 +26,7 @@
 // https://gpuweb.github.io/gpuweb/#enumdef-gpustoreop
 
 [
-    EnabledBySetting=WebGPU
+    EnabledBySetting=WebGPUEnabled
 ]
 enum GPUStoreOp {
     "store",

--- a/Source/WebCore/Modules/WebGPU/GPUSupportedFeatures.idl
+++ b/Source/WebCore/Modules/WebGPU/GPUSupportedFeatures.idl
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021 Apple Inc. All rights reserved.
+ * Copyright (C) 2021-2023 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -26,7 +26,7 @@
 // https://gpuweb.github.io/gpuweb/#gpusupportedfeatures
 
 [
-    EnabledBySetting=WebGPU,
+    EnabledBySetting=WebGPUEnabled,
     Exposed=(Window), /* https://bugs.webkit.org/show_bug.cgi?id=232542: DedicatedWorker */
     SecureContext
 ]

--- a/Source/WebCore/Modules/WebGPU/GPUSupportedLimits.idl
+++ b/Source/WebCore/Modules/WebGPU/GPUSupportedLimits.idl
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021 Apple Inc. All rights reserved.
+ * Copyright (C) 2021-2023 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -26,7 +26,7 @@
 // https://gpuweb.github.io/gpuweb/#gpusupportedlimits
 
 [
-    EnabledBySetting=WebGPU,
+    EnabledBySetting=WebGPUEnabled,
     Exposed=(Window), /* https://bugs.webkit.org/show_bug.cgi?id=232542: DedicatedWorker */
     SecureContext
 ]

--- a/Source/WebCore/Modules/WebGPU/GPUTexture.idl
+++ b/Source/WebCore/Modules/WebGPU/GPUTexture.idl
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021 Apple Inc. All rights reserved.
+ * Copyright (C) 2021-2023 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -26,7 +26,7 @@
 // https://gpuweb.github.io/gpuweb/#gputexture
 
 [
-    EnabledBySetting=WebGPU,
+    EnabledBySetting=WebGPUEnabled,
     Exposed=(Window), /* https://bugs.webkit.org/show_bug.cgi?id=232542: DedicatedWorker */
     SecureContext
 ]

--- a/Source/WebCore/Modules/WebGPU/GPUTextureAspect.idl
+++ b/Source/WebCore/Modules/WebGPU/GPUTextureAspect.idl
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021 Apple Inc. All rights reserved.
+ * Copyright (C) 2021-2023 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -26,7 +26,7 @@
 // https://gpuweb.github.io/gpuweb/#enumdef-gputextureaspect
 
 [
-    EnabledBySetting=WebGPU
+    EnabledBySetting=WebGPUEnabled
 ]
 enum GPUTextureAspect {
     "all",

--- a/Source/WebCore/Modules/WebGPU/GPUTextureBindingLayout.idl
+++ b/Source/WebCore/Modules/WebGPU/GPUTextureBindingLayout.idl
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021 Apple Inc. All rights reserved.
+ * Copyright (C) 2021-2023 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -26,7 +26,7 @@
 // https://gpuweb.github.io/gpuweb/#dictdef-gputexturebindinglayout
 
 [
-    EnabledBySetting=WebGPU
+    EnabledBySetting=WebGPUEnabled
 ]
 dictionary GPUTextureBindingLayout {
     GPUTextureSampleType sampleType = "float";

--- a/Source/WebCore/Modules/WebGPU/GPUTextureDescriptor.idl
+++ b/Source/WebCore/Modules/WebGPU/GPUTextureDescriptor.idl
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2022 Apple Inc. All rights reserved.
+ * Copyright (C) 2021-2023 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -32,7 +32,7 @@ typedef (sequence<GPUIntegerCoordinate> or GPUExtent3DDict) GPUExtent3D;
 typedef [EnforceRange] unsigned long GPUTextureUsageFlags;
 
 [
-    EnabledBySetting=WebGPU
+    EnabledBySetting=WebGPUEnabled
 ]
 dictionary GPUTextureDescriptor : GPUObjectDescriptorBase {
     required GPUExtent3D size;

--- a/Source/WebCore/Modules/WebGPU/GPUTextureDimension.idl
+++ b/Source/WebCore/Modules/WebGPU/GPUTextureDimension.idl
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021 Apple Inc. All rights reserved.
+ * Copyright (C) 2021-2023 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -26,7 +26,7 @@
 // https://gpuweb.github.io/gpuweb/#enumdef-gputexturedimension
 
 [
-    EnabledBySetting=WebGPU
+    EnabledBySetting=WebGPUEnabled
 ]
 enum GPUTextureDimension {
     "1d",

--- a/Source/WebCore/Modules/WebGPU/GPUTextureFormat.idl
+++ b/Source/WebCore/Modules/WebGPU/GPUTextureFormat.idl
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2022 Apple Inc. All rights reserved.
+ * Copyright (C) 2021-2023 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -26,7 +26,7 @@
 // https://gpuweb.github.io/gpuweb/#enumdef-gputextureformat
 
 [
-    EnabledBySetting=WebGPU
+    EnabledBySetting=WebGPUEnabled
 ]
 enum GPUTextureFormat {
     // 8-bit formats

--- a/Source/WebCore/Modules/WebGPU/GPUTextureSampleType.idl
+++ b/Source/WebCore/Modules/WebGPU/GPUTextureSampleType.idl
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021 Apple Inc. All rights reserved.
+ * Copyright (C) 2021-2023 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -26,7 +26,7 @@
 // https://gpuweb.github.io/gpuweb/#enumdef-gputexturesampletype
 
 [
-    EnabledBySetting=WebGPU
+    EnabledBySetting=WebGPUEnabled
 ]
 enum GPUTextureSampleType {
     "float",

--- a/Source/WebCore/Modules/WebGPU/GPUTextureUsage.idl
+++ b/Source/WebCore/Modules/WebGPU/GPUTextureUsage.idl
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021 Apple Inc. All rights reserved.
+ * Copyright (C) 2021-2023 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -27,7 +27,7 @@
 
 typedef [EnforceRange] unsigned long GPUTextureUsageFlags;
 [
-    EnabledBySetting=WebGPU,
+    EnabledBySetting=WebGPUEnabled,
     Exposed=(Window), /* https://bugs.webkit.org/show_bug.cgi?id=232542: DedicatedWorker */
     SecureContext
 ]

--- a/Source/WebCore/Modules/WebGPU/GPUTextureView.idl
+++ b/Source/WebCore/Modules/WebGPU/GPUTextureView.idl
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021 Apple Inc. All rights reserved.
+ * Copyright (C) 2021-2023 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -26,7 +26,7 @@
 // https://gpuweb.github.io/gpuweb/#gputextureview
 
 [
-    EnabledBySetting=WebGPU,
+    EnabledBySetting=WebGPUEnabled,
     Exposed=(Window), /* https://bugs.webkit.org/show_bug.cgi?id=232542: DedicatedWorker */
     SecureContext
 ]

--- a/Source/WebCore/Modules/WebGPU/GPUTextureViewDescriptor.idl
+++ b/Source/WebCore/Modules/WebGPU/GPUTextureViewDescriptor.idl
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021 Apple Inc. All rights reserved.
+ * Copyright (C) 2021-2023 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -29,7 +29,7 @@
 typedef [EnforceRange] unsigned long GPUIntegerCoordinate;
 
 [
-    EnabledBySetting=WebGPU
+    EnabledBySetting=WebGPUEnabled
 ]
 dictionary GPUTextureViewDescriptor : GPUObjectDescriptorBase {
     GPUTextureFormat format;

--- a/Source/WebCore/Modules/WebGPU/GPUTextureViewDimension.idl
+++ b/Source/WebCore/Modules/WebGPU/GPUTextureViewDimension.idl
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021 Apple Inc. All rights reserved.
+ * Copyright (C) 2021-2023 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -26,7 +26,7 @@
 // https://gpuweb.github.io/gpuweb/#enumdef-gputextureviewdimension
 
 [
-    EnabledBySetting=WebGPU
+    EnabledBySetting=WebGPUEnabled
 ]
 enum GPUTextureViewDimension {
     "1d",

--- a/Source/WebCore/Modules/WebGPU/GPUUncapturedErrorEvent.idl
+++ b/Source/WebCore/Modules/WebGPU/GPUUncapturedErrorEvent.idl
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2022 Apple Inc. All rights reserved.
+ * Copyright (C) 2021-2023 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -30,7 +30,7 @@
 typedef (GPUOutOfMemoryError or GPUValidationError or GPUInternalError) GPUError;
 
 [
-    EnabledBySetting=WebGPU,
+    EnabledBySetting=WebGPUEnabled,
     Exposed=(Window), /* https://bugs.webkit.org/show_bug.cgi?id=232542: DedicatedWorker */
     SecureContext
 ]

--- a/Source/WebCore/Modules/WebGPU/GPUUncapturedErrorEventInit.idl
+++ b/Source/WebCore/Modules/WebGPU/GPUUncapturedErrorEventInit.idl
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021 Apple Inc. All rights reserved.
+ * Copyright (C) 2021-2023 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -30,7 +30,7 @@
 typedef (GPUOutOfMemoryError or GPUValidationError or GPUInternalError) GPUError;
 
 [
-    EnabledBySetting=WebGPU
+    EnabledBySetting=WebGPUEnabled
 ]
 dictionary GPUUncapturedErrorEventInit : EventInit {
     required GPUError error;

--- a/Source/WebCore/Modules/WebGPU/GPUValidationError.idl
+++ b/Source/WebCore/Modules/WebGPU/GPUValidationError.idl
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021 Apple Inc. All rights reserved.
+ * Copyright (C) 2021-2023 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -24,7 +24,7 @@
  */
 
 [
-    EnabledBySetting=WebGPU,
+    EnabledBySetting=WebGPUEnabled,
     Exposed=(Window), /* https://bugs.webkit.org/show_bug.cgi?id=232542: DedicatedWorker */
     SecureContext
 ]

--- a/Source/WebCore/Modules/WebGPU/GPUVertexAttribute.idl
+++ b/Source/WebCore/Modules/WebGPU/GPUVertexAttribute.idl
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021 Apple Inc. All rights reserved.
+ * Copyright (C) 2021-2023 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -30,7 +30,7 @@ typedef [EnforceRange] unsigned long GPUIndex32;
 typedef [EnforceRange] unsigned long long GPUSize64;
 
 [
-    EnabledBySetting=WebGPU
+    EnabledBySetting=WebGPUEnabled
 ]
 dictionary GPUVertexAttribute {
     required GPUVertexFormat format;

--- a/Source/WebCore/Modules/WebGPU/GPUVertexBufferLayout.idl
+++ b/Source/WebCore/Modules/WebGPU/GPUVertexBufferLayout.idl
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021 Apple Inc. All rights reserved.
+ * Copyright (C) 2021-2023 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -29,7 +29,7 @@
 typedef [EnforceRange] unsigned long long GPUSize64;
 
 [
-    EnabledBySetting=WebGPU
+    EnabledBySetting=WebGPUEnabled
 ]
 dictionary GPUVertexBufferLayout {
     required GPUSize64 arrayStride;

--- a/Source/WebCore/Modules/WebGPU/GPUVertexFormat.idl
+++ b/Source/WebCore/Modules/WebGPU/GPUVertexFormat.idl
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021 Apple Inc. All rights reserved.
+ * Copyright (C) 2021-2023 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -26,7 +26,7 @@
 // https://gpuweb.github.io/gpuweb/#enumdef-gpuvertexformat
 
 [
-    EnabledBySetting=WebGPU
+    EnabledBySetting=WebGPUEnabled
 ]
 enum GPUVertexFormat {
     "uint8x2",

--- a/Source/WebCore/Modules/WebGPU/GPUVertexState.idl
+++ b/Source/WebCore/Modules/WebGPU/GPUVertexState.idl
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021 Apple Inc. All rights reserved.
+ * Copyright (C) 2021-2023 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -26,7 +26,7 @@
 // https://gpuweb.github.io/gpuweb/#dictdef-gpuvertexstate
 
 [
-    EnabledBySetting=WebGPU
+    EnabledBySetting=WebGPUEnabled
 ]
 dictionary GPUVertexState : GPUProgrammableStage {
     sequence<GPUVertexBufferLayout?> buffers = [];

--- a/Source/WebCore/Modules/WebGPU/GPUVertexStepMode.idl
+++ b/Source/WebCore/Modules/WebGPU/GPUVertexStepMode.idl
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021 Apple Inc. All rights reserved.
+ * Copyright (C) 2021-2023 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -26,7 +26,7 @@
 // https://gpuweb.github.io/gpuweb/#enumdef-gpuvertexstepmode
 
 [
-    EnabledBySetting=WebGPU
+    EnabledBySetting=WebGPUEnabled
 ]
 enum GPUVertexStepMode {
     "vertex",

--- a/Source/WebCore/Modules/WebGPU/NavigatorGPU.idl
+++ b/Source/WebCore/Modules/WebGPU/NavigatorGPU.idl
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021 Apple Inc. All rights reserved.
+ * Copyright (C) 2021-2023 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -26,7 +26,7 @@
 // https://gpuweb.github.io/gpuweb/#navigatorgpu
 
 [
-    EnabledBySetting=WebGPU,
+    EnabledBySetting=WebGPUEnabled,
 ]
 interface mixin NavigatorGPU {
     [SameObject, SecureContext] readonly attribute GPU gpu;

--- a/Source/WebCore/html/HTMLCanvasElement.cpp
+++ b/Source/WebCore/html/HTMLCanvasElement.cpp
@@ -517,7 +517,7 @@ GPUCanvasContext* HTMLCanvasElement::createContextWebGPU(const String& type, GPU
     ASSERT_UNUSED(type, HTMLCanvasElement::isWebGPUType(type));
     ASSERT(!m_context);
 
-    if (!document().settings().webGPU() || !gpu)
+    if (!document().settings().webGPUEnabled() || !gpu)
         return nullptr;
 
     m_context = GPUCanvasContext::create(*this, *gpu);
@@ -538,7 +538,7 @@ GPUCanvasContext* HTMLCanvasElement::getContextWebGPU(const String& type, GPU* g
 {
     ASSERT_UNUSED(type, HTMLCanvasElement::isWebGPUType(type));
 
-    if (!document().settings().webGPU())
+    if (!document().settings().webGPUEnabled())
         return nullptr;
 
     if (m_context && !m_context->isWebGPU())

--- a/Source/WebCore/html/canvas/GPUCanvasContext.idl
+++ b/Source/WebCore/html/canvas/GPUCanvasContext.idl
@@ -27,7 +27,7 @@
 
 [
     ActiveDOMObject,
-    EnabledBySetting=WebGPU,
+    EnabledBySetting=WebGPUEnabled,
     Exposed=(Window), /* https://bugs.webkit.org/show_bug.cgi?id=232542: DedicatedWorker */
     SecureContext,
     SkipVTableValidation,

--- a/Source/WebCore/page/Navigator.cpp
+++ b/Source/WebCore/page/Navigator.cpp
@@ -366,7 +366,7 @@ GPU* Navigator::gpu()
         auto* frame = this->frame();
         if (!frame)
             return nullptr;
-        if (!frame->settings().webGPU())
+        if (!frame->settings().webGPUEnabled())
             return nullptr;
         auto* page = frame->page();
         if (!page)

--- a/Source/WebCore/rendering/RenderLayerBacking.cpp
+++ b/Source/WebCore/rendering/RenderLayerBacking.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2009, 2010, 2011 Apple Inc. All rights reserved.
+ * Copyright (C) 2009-2023 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -586,7 +586,7 @@ bool RenderLayerBacking::shouldSetContentsDisplayDelegate() const
 #if ENABLE(WEBGL) || ENABLE(OFFSCREEN_CANVAS)
     return true;
 #else
-    return renderer().settings().webGPU();
+    return renderer().settings().webGPUEnabled();
 #endif
 }
 

--- a/Tools/TestRunnerShared/TestFeatures.cpp
+++ b/Tools/TestRunnerShared/TestFeatures.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020 Apple Inc. All rights reserved.
+ * Copyright (C) 2020-2023 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -139,7 +139,7 @@ TestFeatures hardcodedFeaturesBasedOnPathForTest(const TestCommand& command)
         features.doubleTestRunnerFeatures.insert({ "viewHeight", viewWidthAndHeight->second });
     }
     if (shouldEnableWebGPU(command.pathOrURL))
-        features.boolWebPreferenceFeatures.insert({ "WebGPU", true });
+        features.boolWebPreferenceFeatures.insert({ "WebGPUEnabled", true });
 
     return features;
 }


### PR DESCRIPTION
#### 529569b680163e9d37ed746acdf2f74d5035120f
<pre>
[WebGPU] Rename the setting from just &quot;WebGPU&quot; to &quot;WebGPUEnabled&quot;
<a href="https://bugs.webkit.org/show_bug.cgi?id=256575">https://bugs.webkit.org/show_bug.cgi?id=256575</a>
rdar://109134933

Reviewed by Simon Fraser and Mike Wyrzykowski.

This is so we can say settings().webGPUEnabled() instead of settings().webGPU(),
which is a bit more ergonomic.

* Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml:
* Source/WebCore/Modules/WebGPU/GPU.idl:
* Source/WebCore/Modules/WebGPU/GPUAdapter.idl:
* Source/WebCore/Modules/WebGPU/GPUAdapterInfo.idl:
* Source/WebCore/Modules/WebGPU/GPUAddressMode.idl:
* Source/WebCore/Modules/WebGPU/GPUAutoLayoutMode.idl:
* Source/WebCore/Modules/WebGPU/GPUBindGroup.idl:
* Source/WebCore/Modules/WebGPU/GPUBindGroupDescriptor.idl:
* Source/WebCore/Modules/WebGPU/GPUBindGroupEntry.idl:
* Source/WebCore/Modules/WebGPU/GPUBindGroupLayout.idl:
* Source/WebCore/Modules/WebGPU/GPUBindGroupLayoutDescriptor.idl:
* Source/WebCore/Modules/WebGPU/GPUBindGroupLayoutEntry.idl:
* Source/WebCore/Modules/WebGPU/GPUBlendComponent.idl:
* Source/WebCore/Modules/WebGPU/GPUBlendFactor.idl:
* Source/WebCore/Modules/WebGPU/GPUBlendOperation.idl:
* Source/WebCore/Modules/WebGPU/GPUBlendState.idl:
* Source/WebCore/Modules/WebGPU/GPUBuffer.idl:
* Source/WebCore/Modules/WebGPU/GPUBufferBinding.idl:
* Source/WebCore/Modules/WebGPU/GPUBufferBindingLayout.idl:
* Source/WebCore/Modules/WebGPU/GPUBufferBindingType.idl:
* Source/WebCore/Modules/WebGPU/GPUBufferDescriptor.idl:
* Source/WebCore/Modules/WebGPU/GPUBufferMapState.idl:
* Source/WebCore/Modules/WebGPU/GPUBufferUsage.idl:
* Source/WebCore/Modules/WebGPU/GPUCanvasCompositingAlphaMode.idl:
* Source/WebCore/Modules/WebGPU/GPUCanvasConfiguration.idl:
* Source/WebCore/Modules/WebGPU/GPUColorDict.idl:
* Source/WebCore/Modules/WebGPU/GPUColorTargetState.idl:
* Source/WebCore/Modules/WebGPU/GPUColorWrite.idl:
* Source/WebCore/Modules/WebGPU/GPUCommandBuffer.idl:
* Source/WebCore/Modules/WebGPU/GPUCommandBufferDescriptor.idl:
* Source/WebCore/Modules/WebGPU/GPUCommandEncoder.idl:
* Source/WebCore/Modules/WebGPU/GPUCommandEncoderDescriptor.idl:
* Source/WebCore/Modules/WebGPU/GPUCommandsMixin.idl:
* Source/WebCore/Modules/WebGPU/GPUCompareFunction.idl:
* Source/WebCore/Modules/WebGPU/GPUCompilationInfo.idl:
* Source/WebCore/Modules/WebGPU/GPUCompilationMessage.idl:
* Source/WebCore/Modules/WebGPU/GPUCompilationMessageType.idl:
* Source/WebCore/Modules/WebGPU/GPUComputePassDescriptor.idl:
* Source/WebCore/Modules/WebGPU/GPUComputePassEncoder.idl:
* Source/WebCore/Modules/WebGPU/GPUComputePassTimestampLocation.idl:
* Source/WebCore/Modules/WebGPU/GPUComputePassTimestampWrite.idl:
* Source/WebCore/Modules/WebGPU/GPUComputePipeline.idl:
* Source/WebCore/Modules/WebGPU/GPUComputePipelineDescriptor.idl:
* Source/WebCore/Modules/WebGPU/GPUCullMode.idl:
* Source/WebCore/Modules/WebGPU/GPUDebugCommandsMixin.idl:
* Source/WebCore/Modules/WebGPU/GPUDepthStencilState.idl:
* Source/WebCore/Modules/WebGPU/GPUDevice.idl:
* Source/WebCore/Modules/WebGPU/GPUDeviceDescriptor.idl:
* Source/WebCore/Modules/WebGPU/GPUDeviceLostInfo.idl:
* Source/WebCore/Modules/WebGPU/GPUDeviceLostReason.idl:
* Source/WebCore/Modules/WebGPU/GPUErrorFilter.idl:
* Source/WebCore/Modules/WebGPU/GPUExtent3DDict.idl:
* Source/WebCore/Modules/WebGPU/GPUExternalTexture.idl:
* Source/WebCore/Modules/WebGPU/GPUExternalTextureBindingLayout.idl:
* Source/WebCore/Modules/WebGPU/GPUExternalTextureDescriptor.idl:
* Source/WebCore/Modules/WebGPU/GPUFeatureName.idl:
* Source/WebCore/Modules/WebGPU/GPUFilterMode.idl:
* Source/WebCore/Modules/WebGPU/GPUFragmentState.idl:
* Source/WebCore/Modules/WebGPU/GPUFrontFace.idl:
* Source/WebCore/Modules/WebGPU/GPUImageCopyBuffer.idl:
* Source/WebCore/Modules/WebGPU/GPUImageCopyExternalImage.idl:
* Source/WebCore/Modules/WebGPU/GPUImageCopyTexture.idl:
* Source/WebCore/Modules/WebGPU/GPUImageCopyTextureTagged.idl:
* Source/WebCore/Modules/WebGPU/GPUImageDataLayout.idl:
* Source/WebCore/Modules/WebGPU/GPUIndexFormat.idl:
* Source/WebCore/Modules/WebGPU/GPUInternalError.idl:
* Source/WebCore/Modules/WebGPU/GPULoadOp.idl:
* Source/WebCore/Modules/WebGPU/GPUMapMode.idl:
* Source/WebCore/Modules/WebGPU/GPUMipmapFilterMode.idl:
* Source/WebCore/Modules/WebGPU/GPUMultisampleState.idl:
* Source/WebCore/Modules/WebGPU/GPUObjectBase.idl:
* Source/WebCore/Modules/WebGPU/GPUObjectDescriptorBase.idl:
* Source/WebCore/Modules/WebGPU/GPUOrigin2DDict.idl:
* Source/WebCore/Modules/WebGPU/GPUOrigin3DDict.idl:
* Source/WebCore/Modules/WebGPU/GPUOutOfMemoryError.idl:
* Source/WebCore/Modules/WebGPU/GPUPipelineBase.idl:
* Source/WebCore/Modules/WebGPU/GPUPipelineDescriptorBase.idl:
* Source/WebCore/Modules/WebGPU/GPUPipelineError.idl:
* Source/WebCore/Modules/WebGPU/GPUPipelineErrorInit.idl:
* Source/WebCore/Modules/WebGPU/GPUPipelineErrorReason.idl:
* Source/WebCore/Modules/WebGPU/GPUPipelineLayout.idl:
* Source/WebCore/Modules/WebGPU/GPUPipelineLayoutDescriptor.idl:
* Source/WebCore/Modules/WebGPU/GPUPowerPreference.idl:
* Source/WebCore/Modules/WebGPU/GPUPredefinedColorSpace.idl:
* Source/WebCore/Modules/WebGPU/GPUPrimitiveState.idl:
* Source/WebCore/Modules/WebGPU/GPUPrimitiveTopology.idl:
* Source/WebCore/Modules/WebGPU/GPUProgrammablePassEncoder.idl:
* Source/WebCore/Modules/WebGPU/GPUProgrammableStage.idl:
* Source/WebCore/Modules/WebGPU/GPUQuerySet.idl:
* Source/WebCore/Modules/WebGPU/GPUQuerySetDescriptor.idl:
* Source/WebCore/Modules/WebGPU/GPUQueryType.idl:
* Source/WebCore/Modules/WebGPU/GPUQueue.idl:
* Source/WebCore/Modules/WebGPU/GPURenderBundle.idl:
* Source/WebCore/Modules/WebGPU/GPURenderBundleDescriptor.idl:
* Source/WebCore/Modules/WebGPU/GPURenderBundleEncoder.idl:
* Source/WebCore/Modules/WebGPU/GPURenderBundleEncoderDescriptor.idl:
* Source/WebCore/Modules/WebGPU/GPURenderEncoderBase.idl:
* Source/WebCore/Modules/WebGPU/GPURenderPassColorAttachment.idl:
* Source/WebCore/Modules/WebGPU/GPURenderPassDepthStencilAttachment.idl:
* Source/WebCore/Modules/WebGPU/GPURenderPassDescriptor.idl:
* Source/WebCore/Modules/WebGPU/GPURenderPassEncoder.idl:
* Source/WebCore/Modules/WebGPU/GPURenderPassLayout.idl:
* Source/WebCore/Modules/WebGPU/GPURenderPassTimestampLocation.idl:
* Source/WebCore/Modules/WebGPU/GPURenderPassTimestampWrite.idl:
* Source/WebCore/Modules/WebGPU/GPURenderPipeline.idl:
* Source/WebCore/Modules/WebGPU/GPURenderPipelineDescriptor.idl:
* Source/WebCore/Modules/WebGPU/GPURequestAdapterOptions.idl:
* Source/WebCore/Modules/WebGPU/GPUSampler.idl:
* Source/WebCore/Modules/WebGPU/GPUSamplerBindingLayout.idl:
* Source/WebCore/Modules/WebGPU/GPUSamplerBindingType.idl:
* Source/WebCore/Modules/WebGPU/GPUSamplerDescriptor.idl:
* Source/WebCore/Modules/WebGPU/GPUShaderModule.idl:
* Source/WebCore/Modules/WebGPU/GPUShaderModuleCompilationHint.idl:
* Source/WebCore/Modules/WebGPU/GPUShaderModuleDescriptor.idl:
* Source/WebCore/Modules/WebGPU/GPUShaderStage.idl:
* Source/WebCore/Modules/WebGPU/GPUStencilFaceState.idl:
* Source/WebCore/Modules/WebGPU/GPUStencilOperation.idl:
* Source/WebCore/Modules/WebGPU/GPUStorageTextureAccess.idl:
* Source/WebCore/Modules/WebGPU/GPUStorageTextureBindingLayout.idl:
* Source/WebCore/Modules/WebGPU/GPUStoreOp.idl:
* Source/WebCore/Modules/WebGPU/GPUSupportedFeatures.idl:
* Source/WebCore/Modules/WebGPU/GPUSupportedLimits.idl:
* Source/WebCore/Modules/WebGPU/GPUTexture.idl:
* Source/WebCore/Modules/WebGPU/GPUTextureAspect.idl:
* Source/WebCore/Modules/WebGPU/GPUTextureBindingLayout.idl:
* Source/WebCore/Modules/WebGPU/GPUTextureDescriptor.idl:
* Source/WebCore/Modules/WebGPU/GPUTextureDimension.idl:
* Source/WebCore/Modules/WebGPU/GPUTextureFormat.idl:
* Source/WebCore/Modules/WebGPU/GPUTextureSampleType.idl:
* Source/WebCore/Modules/WebGPU/GPUTextureUsage.idl:
* Source/WebCore/Modules/WebGPU/GPUTextureView.idl:
* Source/WebCore/Modules/WebGPU/GPUTextureViewDescriptor.idl:
* Source/WebCore/Modules/WebGPU/GPUTextureViewDimension.idl:
* Source/WebCore/Modules/WebGPU/GPUUncapturedErrorEvent.idl:
* Source/WebCore/Modules/WebGPU/GPUUncapturedErrorEventInit.idl:
* Source/WebCore/Modules/WebGPU/GPUValidationError.idl:
* Source/WebCore/Modules/WebGPU/GPUVertexAttribute.idl:
* Source/WebCore/Modules/WebGPU/GPUVertexBufferLayout.idl:
* Source/WebCore/Modules/WebGPU/GPUVertexFormat.idl:
* Source/WebCore/Modules/WebGPU/GPUVertexState.idl:
* Source/WebCore/Modules/WebGPU/GPUVertexStepMode.idl:
* Source/WebCore/Modules/WebGPU/NavigatorGPU.idl:
* Source/WebCore/html/HTMLCanvasElement.cpp:
(WebCore::HTMLCanvasElement::createContextWebGPU):
(WebCore::HTMLCanvasElement::getContextWebGPU):
* Source/WebCore/html/canvas/GPUCanvasContext.idl:
* Source/WebCore/page/Navigator.cpp:
(WebCore::Navigator::gpu):
* Source/WebCore/rendering/RenderLayerBacking.cpp:
(WebCore::RenderLayerBacking::shouldSetContentsDisplayDelegate const):

Canonical link: <a href="https://commits.webkit.org/264033@main">https://commits.webkit.org/264033@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0e17518984ae0ea83f16e00101ce8ac0af15b59d

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/6465 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/6673 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/6854 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/8044 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/6760 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/6461 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/6994 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/6624 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/9653 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/6578 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/6637 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/5859 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/8123 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/4102 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/5839 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/13689 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/5443 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/6023 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/5918 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/8246 "Passed tests") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/6056 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/6401 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/5235 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/6599 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/5807 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/1537 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/1530 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/9966 "Built successfully") | | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/24/builds/6781 "Built successfully") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/6178 "Built successfully") | | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/3/builds/1666 "Passed tests") | 
<!--EWS-Status-Bubble-End-->