### PR TITLE
[PlayStation] Start RemoteInspectorServer

### DIFF
--- a/Source/JavaScriptCore/API/JSRemoteInspectorServer.cpp
+++ b/Source/JavaScriptCore/API/JSRemoteInspectorServer.cpp
@@ -28,13 +28,17 @@
 
 #if ENABLE(REMOTE_INSPECTOR)
 #include "RemoteInspectorServer.h"
+#endif
 
 uint16_t JSRemoteInspectorServerStart(const char* address, uint16_t port)
 {
+#if ENABLE(REMOTE_INSPECTOR)
     auto& server = Inspector::RemoteInspectorServer::singleton();
     if (!server.start(address, port))
         return 0;
 
     return server.getPort().value_or(0);
-}
+#else
+    return 0;
 #endif // ENABLE(REMOTE_INSPECTOR)
+}

--- a/Tools/MiniBrowser/playstation/main.cpp
+++ b/Tools/MiniBrowser/playstation/main.cpp
@@ -27,6 +27,7 @@
 #include "cmakeconfig.h"
 #endif
 #include "MainWindow.h"
+#include <JavaScriptCore/JSRemoteInspectorServer.h>
 #include <WebKit/WKRunLoop.h>
 #include <dlfcn.h>
 #include <toolkitten/Application.h>
@@ -50,13 +51,12 @@ __attribute__((constructor(110)))
 static void initialize()
 {
     loadLibraryOrExit("PosixWebKit");
-    setenv_np("WebInspectorServerPort", "868", 1);
 
     loadLibraryOrExit(ICU_LOAD_AT);
     loadLibraryOrExit(PNG_LOAD_AT);
 #if defined(JPEG_LOAD_AT)
     loadLibraryOrExit(JPEG_LOAD_AT);
-#endif 
+#endif
 #if defined(WebP_LOAD_AT)
     loadLibraryOrExit(WebP_LOAD_AT);
 #endif
@@ -80,6 +80,8 @@ static void initialize()
 #if defined (USE_WPE_BACKEND_PLAYSTATION) && USE_WPE_BACKEND_PLAYSTATION
     wpe_playstation_process_provider_register_backend();
 #endif
+
+    JSRemoteInspectorServerStart(nullptr, 868);
 }
 
 class ApplicationClient : public Application::Client {


### PR DESCRIPTION
#### 650c693e1678cb6f0fd0a31353f959ab204473eb
<pre>
[PlayStation] Start RemoteInspectorServer
<a href="https://bugs.webkit.org/show_bug.cgi?id=256576">https://bugs.webkit.org/show_bug.cgi?id=256576</a>

Reviewed by Devin Rousso and Fujii Hironori.

The MiniBrowser starts RemoteInspectorServer.
Also, fixed build error when ENABLE_REMOTE_INSPECTOR is OFF.

* Source/JavaScriptCore/API/JSRemoteInspectorServer.cpp:
(JSRemoteInspectorServerStart):
* Tools/MiniBrowser/playstation/main.cpp:
(initialize):

Canonical link: <a href="https://commits.webkit.org/264404@main">https://commits.webkit.org/264404@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d23d35a506a5120909ace6ec646b653415210c4a

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/7398 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/7656 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/7831 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/9027 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/7603 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/7408 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/9513 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/7581 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/10488 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/7527 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/8588 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/6845 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/9136 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/5902 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/6729 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/14455 "Passed tests") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/6293 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/7200 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/6841 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/10097 "Passed tests") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/6981 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/7332 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/5995 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/7543 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/6683 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/1740 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/1783 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/10890 "Built successfully") | | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/24/builds/7748 "Built successfully") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/7068 "Built successfully") | | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/3/builds/1880 "Passed tests") | 
<!--EWS-Status-Bubble-End-->