### PR TITLE
SubframeDisconnectPolicy should be an enum classs

### DIFF
--- a/Source/WebCore/dom/ContainerNode.cpp
+++ b/Source/WebCore/dom/ContainerNode.cpp
@@ -125,7 +125,7 @@ ALWAYS_INLINE auto ContainerNode::removeAllChildrenWithScriptAssertion(ChildChan
         }
     }
 
-    disconnectSubframesIfNeeded(*this, DescendantsOnly);
+    disconnectSubframesIfNeeded(*this, SubframeDisconnectPolicy::DescendantsOnly);
 
     ContainerNode::ChildChange childChange { ChildChange::Type::AllChildrenRemoved, nullptr, nullptr, nullptr, source, ContainerNode::ChildChange::AffectsElements::Unknown };
 
@@ -201,10 +201,10 @@ ALWAYS_INLINE bool ContainerNode::removeNodeWithScriptAssertion(Node& childToRem
 
     if (source == ChildChange::Source::Parser) {
         // FIXME: Merge these two code paths. It's a bug in the parser not to update connectedSubframeCount in time.
-        disconnectSubframesIfNeeded(*this, DescendantsOnly);
+        disconnectSubframesIfNeeded(*this, SubframeDisconnectPolicy::DescendantsOnly);
     } else {
         if (auto containerChild = dynamicDowncast<ContainerNode>(childToRemove))
-            disconnectSubframesIfNeeded(*containerChild, RootAndDescendants);
+            disconnectSubframesIfNeeded(*containerChild, SubframeDisconnectPolicy::RootAndDescendants);
     }
 
     if (childToRemove.parentNode() != this)
@@ -655,7 +655,7 @@ ExceptionOr<void> ContainerNode::replaceChild(Node& newChild, Node& oldChild)
 
 void ContainerNode::disconnectDescendantFrames()
 {
-    disconnectSubframesIfNeeded(*this, RootAndDescendants);
+    disconnectSubframesIfNeeded(*this, SubframeDisconnectPolicy::RootAndDescendants);
 }
 
 ExceptionOr<void> ContainerNode::removeChild(Node& oldChild)

--- a/Source/WebCore/dom/ContainerNodeAlgorithms.cpp
+++ b/Source/WebCore/dom/ContainerNodeAlgorithms.cpp
@@ -260,7 +260,7 @@ void disconnectSubframes(ContainerNode& root, SubframeDisconnectPolicy policy)
 
     Vector<Ref<HTMLFrameOwnerElement>> frameOwners;
 
-    if (policy == RootAndDescendants) {
+    if (policy == SubframeDisconnectPolicy::RootAndDescendants) {
         if (is<HTMLFrameOwnerElement>(root))
             frameOwners.append(downcast<HTMLFrameOwnerElement>(root));
     }

--- a/Source/WebCore/dom/ContainerNodeAlgorithms.h
+++ b/Source/WebCore/dom/ContainerNodeAlgorithms.h
@@ -63,14 +63,14 @@ public:
 
 void notifyChildNodeInserted(ContainerNode& parentOfInsertedTree, Node&, NodeVector& postInsertionNotificationTargets);
 
-enum class RemovedSubtreeObservability {
+enum class RemovedSubtreeObservability : bool {
     NotObservable,
     MaybeObservableByRefPtr,
 };
 RemovedSubtreeObservability notifyChildNodeRemoved(ContainerNode& oldParentOfRemovedTree, Node&);
 void removeDetachedChildrenInContainer(ContainerNode&);
 
-enum SubframeDisconnectPolicy {
+enum class SubframeDisconnectPolicy : bool {
     RootAndDescendants,
     DescendantsOnly
 };


### PR DESCRIPTION
#### 7e98f47ac4907300f25abc9b6f76d37be735e273
<pre>
SubframeDisconnectPolicy should be an enum classs
<a href="https://bugs.webkit.org/show_bug.cgi?id=256579">https://bugs.webkit.org/show_bug.cgi?id=256579</a>

Reviewed by Chris Dumez.

* Source/WebCore/dom/ContainerNode.cpp:
(WebCore::ContainerNode::removeAllChildrenWithScriptAssertion):
(WebCore::ContainerNode::removeNodeWithScriptAssertion):
(WebCore::ContainerNode::disconnectDescendantFrames):
* Source/WebCore/dom/ContainerNodeAlgorithms.cpp:
(WebCore::disconnectSubframes):
* Source/WebCore/dom/ContainerNodeAlgorithms.h:

Canonical link: <a href="https://commits.webkit.org/263923@main">https://commits.webkit.org/263923@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/92da1e0a0c38a24f150f0f395e6e5e8b925d4c60

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/6064 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/6246 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/6430 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/7624 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/6413 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/6063 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/6464 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/6200 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/9289 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/6173 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/6200 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/5488 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/7686 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/3675 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/5469 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/13380 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/5541 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/5547 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/7778 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/6009 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/4919 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/5432 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/9568 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/719 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/5799 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->