### PR TITLE
Don't get transitions of zoom

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-transitions/properties-value-003-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-transitions/properties-value-003-expected.txt
@@ -89,10 +89,6 @@ PASS transform transform(rotate) / values
 PASS transform transform(rotate) / events
 PASS transform-origin horizontal(keyword) / values
 FAIL transform-origin horizontal(keyword) / events assert_equals: Expected TransitionEnd events triggered on .transition expected "transform-origin:2s" but got "transform-origin-x:2s"
-PASS zoom number(integer) / values
-FAIL zoom number(integer) / events assert_equals: Expected TransitionEnd events triggered on .transition expected "zoom:2s" but got "font-size:2s zoom:2s"
-PASS zoom number(decimal) / values
-FAIL zoom number(decimal) / events assert_equals: Expected TransitionEnd events triggered on .transition expected "zoom:2s" but got "font-size:2s zoom:2s"
 FAIL display display(static to absolute) / values assert_not_equals: must not be target value after start got disallowed value "block"
 FAIL display display(static to absolute) / events assert_equals: Expected TransitionEnd events triggered on .transition expected "display:2s" but got ""
 FAIL display display(block to inline-block) / values assert_not_equals: must not be target value after start got disallowed value "inline-block"

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-transitions/support/properties.js
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-transitions/support/properties.js
@@ -260,7 +260,6 @@ var unspecified_properties = {
     'column-width': ['length'],
     'transform': ['transform'],
     'transform-origin': ['horizontal'],
-    'zoom': ['number'],
     'display': ['display'],
     'position': ['position']
 };

--- a/Source/WebCore/animation/CSSPropertyAnimation.cpp
+++ b/Source/WebCore/animation/CSSPropertyAnimation.cpp
@@ -3473,7 +3473,6 @@ CSSPropertyAnimationWrapperMap::CSSPropertyAnimationWrapperMap()
         new LengthVariantPropertyWrapper<LengthSize>(CSSPropertyBorderBottomLeftRadius, &RenderStyle::borderBottomLeftRadius, &RenderStyle::setBorderBottomLeftRadius),
         new LengthVariantPropertyWrapper<LengthSize>(CSSPropertyBorderBottomRightRadius, &RenderStyle::borderBottomRightRadius, &RenderStyle::setBorderBottomRightRadius),
         new PropertyWrapper<Visibility>(CSSPropertyVisibility, &RenderStyle::visibility, &RenderStyle::setVisibility),
-        new FloatPropertyWrapper(CSSPropertyZoom, &RenderStyle::zoom, &RenderStyle::setZoomWithoutReturnValue, FloatPropertyWrapper::ValueRange::Positive),
 
         new ClipWrapper,
 
@@ -3984,6 +3983,7 @@ CSSPropertyAnimationWrapperMap::CSSPropertyAnimationWrapperMap()
         case CSSPropertyWebkitUserDrag:
         case CSSPropertyWebkitUserModify:
         case CSSPropertyWebkitUserSelect:
+        case CSSPropertyZoom:
             continue;
         default:
             if (CSSProperty::isDescriptorOnly(property))


### PR DESCRIPTION
#### be05571ab5fe4f51bd9f1ab85a0a2017b821a3c4
<pre>
Don&apos;t get transitions of zoom
<a href="https://bugs.webkit.org/show_bug.cgi?id=145136">https://bugs.webkit.org/show_bug.cgi?id=145136</a>

Reviewed by Antti Koivisto.

Let&apos;s remove animation support for &quot;zoom&quot; altogether. This matches Chrome&apos;s behavior and Firefox does
not implement this non-standard property at all.

* LayoutTests/imported/w3c/web-platform-tests/css/css-transitions/properties-value-003-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-transitions/support/properties.js:
* Source/WebCore/animation/CSSPropertyAnimation.cpp:
(WebCore::CSSPropertyAnimationWrapperMap::CSSPropertyAnimationWrapperMap):

Canonical link: <a href="https://commits.webkit.org/263908@main">https://commits.webkit.org/263908@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0d99461413f39867b6dc4695468f0f767cc8e6be

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/6065 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/6247 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/6431 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/7625 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/6414 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/6064 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/6465 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/6201 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/9296 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/6174 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/6199 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/5489 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/7687 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/3674 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/5470 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/13385 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/5540 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/5548 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/7785 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/6010 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/4918 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/5433 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/9569 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/709 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/5800 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->