### PR TITLE
ResizeObserver: Fix node depth computation for shadow nodes

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/resize-observer/calculate-depth-for-node-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/resize-observer/calculate-depth-for-node-expected.txt
@@ -1,6 +1,3 @@
-CONSOLE MESSAGE: ResizeObserver loop completed with undelivered notifications.
 
-Harness Error (FAIL), message = ResizeObserver loop completed with undelivered notifications.
-
-FAIL "Calculate depth for node" algorithm with Shadow DOM assert_false: expected false got true
+PASS "Calculate depth for node" algorithm with Shadow DOM
 

--- a/Source/WebCore/page/ResizeObservation.cpp
+++ b/Source/WebCore/page/ResizeObservation.cpp
@@ -138,11 +138,12 @@ std::optional<ResizeObservation::BoxSizes> ResizeObservation::elementSizeChanged
     return { };
 }
 
+// https://drafts.csswg.org/resize-observer/#calculate-depth-for-node
 size_t ResizeObservation::targetElementDepth() const
 {
     unsigned depth = 0;
     for (Element* ownerElement = m_target.get(); ownerElement; ownerElement = ownerElement->document().ownerElement()) {
-        for (Element* parent = ownerElement; parent; parent = parent->parentElement())
+        for (Element* parent = ownerElement; parent; parent = parent->parentElementInComposedTree())
             ++depth;
     }
 


### PR DESCRIPTION
#### 495d920632fd2468c94b1ef75e102282d594d64b
<pre>
ResizeObserver: Fix node depth computation for shadow nodes
<a href="https://bugs.webkit.org/show_bug.cgi?id=256553">https://bugs.webkit.org/show_bug.cgi?id=256553</a>

Reviewed by Chris Dumez.

Merge <a href="https://chromium.googlesource.com/chromium/src/+/2b6f3f4bfda3b1326b15a956d06a6e3c5f0bb362">https://chromium.googlesource.com/chromium/src/+/2b6f3f4bfda3b1326b15a956d06a6e3c5f0bb362</a>

* LayoutTests/imported/w3c/web-platform-tests/resize-observer/calculate-depth-for-node-expected.txt:
* Source/WebCore/page/ResizeObservation.cpp:
(WebCore::ResizeObservation::targetElementDepth const):

Canonical link: <a href="https://commits.webkit.org/263920@main">https://commits.webkit.org/263920@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/69fefd9a74f8e5ce2004b46d80c6aa7405fc418c

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/6070 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/6252 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/6436 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/7630 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/6417 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/6069 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/6470 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/6206 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/9295 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/6179 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/6198 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/5487 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/7692 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/3673 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/5468 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/13383 "3 flakes 149 failures") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/5539 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/5546 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/7783 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/6015 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/4922 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/5438 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/9575 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/718 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/5805 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->