### PR TITLE
REGRESSION(261130@main): Canvas putImageData draws onto wrong canvas

### DIFF
--- a/LayoutTests/fast/canvas/canvas-put-image-data-after-draw-expected.html
+++ b/LayoutTests/fast/canvas/canvas-put-image-data-after-draw-expected.html
@@ -1,0 +1,11 @@
+<body style="margin:0">
+<canvas id="a"></canvas>
+<script>
+const imageData = new ImageData(300, 150);
+imageData.data.forEach((item, index) => {
+    imageData.data[index] = 128;
+});
+const ctxA = a.getContext('2d');
+ctxA.putImageData(imageData, 0, 0);
+</script>
+</body>

--- a/LayoutTests/fast/canvas/canvas-put-image-data-after-draw.html
+++ b/LayoutTests/fast/canvas/canvas-put-image-data-after-draw.html
@@ -1,0 +1,14 @@
+<body style="margin:0">
+<canvas id="a"></canvas>
+<canvas id="b"></canvas>
+<script>
+const imageData = new ImageData(300, 150);
+imageData.data.forEach((item, index) => {
+    imageData.data[index] = 128;
+});
+const ctxA = a.getContext('2d');
+const ctxB = b.getContext('2d');
+ctxB.drawImage(a, 0, 0);
+ctxA.putImageData(imageData, 0, 0); // This should not affect canvas b.
+</script>
+</body>

--- a/Source/WebKit/WebProcess/GPU/graphics/RemoteImageBufferProxy.cpp
+++ b/Source/WebKit/WebProcess/GPU/graphics/RemoteImageBufferProxy.cpp
@@ -266,11 +266,10 @@ GraphicsContext& RemoteImageBufferProxy::context() const
 void RemoteImageBufferProxy::putPixelBuffer(const PixelBuffer& pixelBuffer, const IntRect& srcRect, const IntPoint& destPoint, AlphaPremultiplication destFormat)
 {
     if (canMapBackingStore()) {
+        // Simulate a write so that pending reads migrate the data off of the mapped buffer.
+        context().fillRect({ });
         const_cast<RemoteImageBufferProxy&>(*this).flushDrawingContext();
         ImageBuffer::putPixelBuffer(pixelBuffer, srcRect, destPoint, destFormat);
-        // Simulate a write so that read caches are cleared.
-        // FIXME: This should not be done via the context draw, as that induces a flush.
-        context().fillRect({ });
         return;
     }
 


### PR DESCRIPTION
#### a658f97638bf521b0cbfb4df91ad5c79b89aebb6
<pre>
REGRESSION(261130@main): Canvas putImageData draws onto wrong canvas
<a href="https://bugs.webkit.org/show_bug.cgi?id=256151">https://bugs.webkit.org/show_bug.cgi?id=256151</a>
rdar://108741153

Reviewed by Said Abou-Hallawa.

Pending reads are of form CGImage that points to the IOSurface.
Thus the IOSurface cannot be modified without synchronizing with the
GPUP.
Fix by simulating a write and synchronizing with the GPUP. After
this completes, there are no readers to the IOSurface and the
operation may proceed.

* LayoutTests/fast/canvas/canvas-put-image-data-after-draw-expected.html: Added.
* LayoutTests/fast/canvas/canvas-put-image-data-after-draw.html: Added.
* Source/WebKit/WebProcess/GPU/graphics/RemoteImageBufferProxy.cpp:
(WebKit::RemoteImageBufferProxy::putPixelBuffer):

Canonical link: <a href="https://commits.webkit.org/263978@main">https://commits.webkit.org/263978@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/682de3c7eee4fba481daae47aaadce04b7ce256e

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/6240 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/6433 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/6612 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/7809 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/6571 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/6653 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/6383 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/9450 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/6351 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/6365 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/5649 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/7880 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/3838 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/5628 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/13528 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/5703 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/5708 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/7955 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/6188 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/5063 "Failed to checkout and rebase branch from PR 13689") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/5600 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/5557 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/1491 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/9748 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/5967 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->