### PR TITLE
canvas freezed when drawing new VideoFrame(video) to canvas

### DIFF
--- a/LayoutTests/http/wpt/webcodecs/canvas-drawVideoFrame-expected.html
+++ b/LayoutTests/http/wpt/webcodecs/canvas-drawVideoFrame-expected.html
@@ -1,0 +1,31 @@
+<!DOCTYPE html>
+<html>
+<header>
+</header>
+<body>
+<canvas id=canvas width=100px hwight=100px></canvas>
+<script>
+function createVideoFrame(value) {
+  const init = {
+    format: 'I420',
+    timestamp: 1234,
+    codedWidth: 4,
+    codedHeight: 4,
+    timestamp: 100,
+    duration: 33
+  };
+  const data = new Uint8Array([
+    value, value, value, value, value, value, value, value,  // y
+    value, value, value, value, value, value, value, value,  // y
+    value, value, value, value,                   // u
+    value, value, value, value                    // v
+  ]);
+  return new VideoFrame(data, init);
+}
+
+const frame2 = createVideoFrame(0);
+canvas.getContext('2d').drawImage(frame2, 0, 0);
+frame2.close();
+</script>
+</body>
+</html>

--- a/LayoutTests/http/wpt/webcodecs/canvas-drawVideoFrame.html
+++ b/LayoutTests/http/wpt/webcodecs/canvas-drawVideoFrame.html
@@ -1,0 +1,46 @@
+<!DOCTYPE html>
+<html>
+<head>
+<link rel=match href="canvas-drawVideoFrame-expected.html">
+</head>
+<body>
+<canvas id=canvas width=100px hwight=100px></canvas>
+<script>
+function createVideoFrame(value) {
+  const init = {
+    format: 'I420',
+    timestamp: 1234,
+    codedWidth: 4,
+    codedHeight: 4,
+    timestamp: 100,
+    duration: 33
+  };
+  const data = new Uint8Array([
+    value, value, value, value, value, value, value, value,  // y
+    value, value, value, value, value, value, value, value,  // y
+    value, value, value, value,                   // u
+    value, value, value, value                    // v
+  ]);
+  return new VideoFrame(data, init);
+}
+
+if (window.testRunner)
+    testRunner.waitUntilDone();
+
+window.onload = async () => {
+    const frame1 = createVideoFrame(255);
+    canvas.getContext('2d').drawImage(frame1, 0, 0);
+    frame1.close();
+
+    await new Promise(resolve => setTimeout(resolve, 0));
+
+    const frame2 = createVideoFrame(0);
+    canvas.getContext('2d').drawImage(frame2, 0, 0);
+    frame2.close();
+
+    if (window.testRunner)
+        testRunner.notifyDone();
+}
+</script>
+</body>
+</html>

--- a/Source/WebCore/html/canvas/CanvasRenderingContext2DBase.cpp
+++ b/Source/WebCore/html/canvas/CanvasRenderingContext2DBase.cpp
@@ -1589,7 +1589,12 @@ ExceptionOr<void> CanvasRenderingContext2DBase::drawImage(WebCodecsVideoFrame& f
     if (!internalFrame)
         return { };
 
+    // FIXME: Add support for srcRect
     context->paintVideoFrame(*internalFrame, dstRect, frame.shoudlDiscardAlpha());
+
+    auto normalizedDstRect = normalizeRect(dstRect);
+    bool repaintEntireCanvas = rectContainsCanvas(normalizedDstRect);
+    didDraw(repaintEntireCanvas, normalizedDstRect);
 
     return { };
 }


### PR DESCRIPTION
#### 0a48a1c5428e9ca3783332415b7d4b674348c994
<pre>
canvas freezed when drawing new VideoFrame(video) to canvas
<a href="https://bugs.webkit.org/show_bug.cgi?id=256509">https://bugs.webkit.org/show_bug.cgi?id=256509</a>
rdar://109100283

Reviewed by Eric Carlson.

We need to invalidate the canvas after drawing the VideoFrame.
Covered by added ref test.

* LayoutTests/http/wpt/webcodecs/canvas-drawVideoFrame-expected.html: Added.
* LayoutTests/http/wpt/webcodecs/canvas-drawVideoFrame.html: Added.
* Source/WebCore/html/canvas/CanvasRenderingContext2DBase.cpp:
(WebCore::CanvasRenderingContext2DBase::drawImage):

Canonical link: <a href="https://commits.webkit.org/263959@main">https://commits.webkit.org/263959@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d67f06648375a51f6ba7e3a1434ecd4e9a3a60e4

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/6198 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/6388 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/6569 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/7763 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/6532 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/6198 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/6608 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/6339 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/9412 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/6308 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/6324 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/5610 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/7831 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/3798 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/5589 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/13482 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/5663 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/5669 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/7916 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/6144 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/5024 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/5560 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/5518 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/1476 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/9705 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/5927 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->