### PR TITLE
Managed Media Source should only be available if airplay source alternative is present

### DIFF
--- a/LayoutTests/media/media-source/media-managedmse-airplay-expected.txt
+++ b/LayoutTests/media/media-source/media-managedmse-airplay-expected.txt
@@ -1,0 +1,19 @@
+
+RUN(source = new ManagedMediaSource())
+RUN(video.src = URL.createObjectURL(source))
+RUN(video.disableRemotePlayback = true)
+RUN(sourceOpenAllowed = true)
+EVENT(sourceopen)
+EVENT(sourceopen)
+RUN(sourceOpenAllowed = false)
+RUN(video.disableRemotePlayback = false)
+RUN(source = new ManagedMediaSource())
+RUN(video.src = URL.createObjectURL(source))
+RUN(sourceElement = document.createElement("source"))
+RUN(sourceElement.src = "http://foo.com/playlist.m3u8")
+RUN(sourceElement.type = "application/vnd.apple.mpegurl")
+RUN(video.appendChild(sourceElement))
+RUN(sourceOpenAllowed = true)
+EVENT(sourceopen)
+END OF TEST
+

--- a/LayoutTests/media/media-source/media-managedmse-airplay.html
+++ b/LayoutTests/media/media-source/media-managedmse-airplay.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html> <!-- webkit-test-runner [ ManagedMediaSourceEnabled=true MediaSourceEnabled=true ] -->
 <html>
 <head>
-    <title>managedmediasource-streaming</title>
+    <title>managedmediasource-airplay</title>
     <script src="../../media/media-source/media-source-loader.js"></script>
     <script src="../../media/video-test.js"></script>
     <script src="../../media/utilities.js"></script>
@@ -9,7 +9,8 @@
     var loader;
     var source;
     var sourceBuffer;
-    var ended = false;
+    var sourceElement;
+    var sourceOpenAllowed = false;
 
     function loaderPromise(loader) {
         return new Promise((resolve, reject) => {
@@ -32,35 +33,39 @@
 
             waitFor(video, 'error').then(failTest);
 
-            video.disableRemotePlayback = true;
-            source = new ManagedMediaSource();
+            run('source = new ManagedMediaSource()');
             run('video.src = URL.createObjectURL(source)');
 
-            await Promise.all([ waitFor(source, 'sourceopen'), waitFor(source, 'startstreaming')]);
-
-            run('sourceBuffer = source.addSourceBuffer(loader.type())');
-
-            run('sourceBuffer.appendBuffer(loader.initSegment())');
-            await waitFor(sourceBuffer, 'update');
-            run('source.duration = 0.1');
-            await waitFor(video, 'durationchange');
-
-            // The endstreaming event shouldn't be fired even if we have appended data past the element's duration
-            // unless the mediasource is ended.
-            waitFor(source, 'endstreaming').then(() => {
-                if (!ended)
-                    failTest();
-                else
-                    endTest();
+            waitFor(source, 'sourceopen').then(() => {
+                if (!sourceOpenAllowed)
+                    failTest()
             });
 
-            do {
-                sourceBuffer.appendBuffer(loader.mediaSegment(0));
-                await once(sourceBuffer, 'update');
-                sourceBuffer.timestampOffset = sourceBuffer.buffered.end(sourceBuffer.buffered.length - 1);
-            } while (source.duration <= 5);
-            run('ended = true');
-            run('source.endOfStream()');
+            await sleepFor(100);
+            run('video.disableRemotePlayback = true');
+            run('sourceOpenAllowed = true');
+
+            await waitFor(source, 'sourceopen');
+            run('sourceOpenAllowed = false');
+
+            run('video.disableRemotePlayback = false');
+
+            run('source = new ManagedMediaSource()');
+            waitFor(source, 'sourceopen').then(() => {
+                if (!sourceOpenAllowed)
+                    failTest()
+                endTest();
+            });
+
+            run('video.src = URL.createObjectURL(source)');
+            await sleepFor(100);
+
+            run('sourceElement = document.createElement("source")');
+            run('sourceElement.src = "http://foo.com/playlist.m3u8"');
+            run('sourceElement.type = "application/vnd.apple.mpegurl"');
+            run('video.appendChild(sourceElement)');
+            run('sourceOpenAllowed = true');
+
         } catch (e) {
             failTest(`Caught exception: "${e}"`);
         }

--- a/LayoutTests/media/media-source/media-managedmse-bufferedchange.html
+++ b/LayoutTests/media/media-source/media-managedmse-bufferedchange.html
@@ -28,6 +28,7 @@
                     break;
             }
 
+            video.disableRemotePlayback = true;
             source = new ManagedMediaSource();
             run('video.src = URL.createObjectURL(source)');
             await waitFor(source, 'sourceopen');

--- a/LayoutTests/media/media-source/media-managedmse-memorypressure-inactive.html
+++ b/LayoutTests/media/media-source/media-managedmse-memorypressure-inactive.html
@@ -41,6 +41,7 @@
                     break;
             }
 
+            video.disableRemotePlayback = true;
             source = new ManagedMediaSource();
             run('video.src = URL.createObjectURL(source)');
             await waitFor(source, 'sourceopen');

--- a/LayoutTests/media/media-source/media-managedmse-memorypressure.html
+++ b/LayoutTests/media/media-source/media-managedmse-memorypressure.html
@@ -41,6 +41,7 @@
                     break;
             }
 
+            video.disableRemotePlayback = true;
             source = new ManagedMediaSource();
             run('video.src = URL.createObjectURL(source)');
             await waitFor(source, 'sourceopen');

--- a/LayoutTests/media/media-source/media-managedmse-streaming.html
+++ b/LayoutTests/media/media-source/media-managedmse-streaming.html
@@ -31,6 +31,7 @@
 
             waitFor(video, 'error').then(failTest);
 
+            video.disableRemotePlayback = true;
             source = new ManagedMediaSource();
             run('video.src = URL.createObjectURL(source)');
 

--- a/LayoutTests/media/media-source/media-managedmse.html
+++ b/LayoutTests/media/media-source/media-managedmse.html
@@ -28,6 +28,7 @@
                     break;
             }
 
+            video.disableRemotePlayback = true;
             source = new ManagedMediaSource();
             run('video.src = URL.createObjectURL(source)');
             await waitFor(source, 'sourceopen');

--- a/LayoutTests/platform/glib/TestExpectations
+++ b/LayoutTests/platform/glib/TestExpectations
@@ -1032,6 +1032,8 @@ webkit.org/b/238201 media/media-source/media-mp4-hevc-bframes.html [ Failure ]
 # WebProcess's MemoryPressureHandler are disabled, test is nonfunctional
 media/media-source/media-managedmse-memorypressure.html [ Timeout ]
 media/media-source/media-managedmse-memorypressure-inactive.html [ Timeout ]
+# No AirPlay on glib platforms.
+media/media-source/media-managedmse-airplay.html [ Skip ]
 
 webkit.org/b/211995 fast/images/animated-image-mp4.html [ Failure Timeout ]
 

--- a/LayoutTests/platform/ios/TestExpectations
+++ b/LayoutTests/platform/ios/TestExpectations
@@ -249,6 +249,7 @@ media/video-size-intrinsic-scale.html [ WontFix ]
 media/video-element-fullscreen-not-in-dom-accelerated-iphone.html [ Pass ]
 
 # MediaSource is not currently supported on iOS.
+media/media-source/media-managedmse-airplay.html [ Pass ]
 media/media-source
 http/tests/media/media-source [ Skip ]
 imported/w3c/web-platform-tests/media-source/ [ Skip ]

--- a/LayoutTests/platform/ipad/TestExpectations
+++ b/LayoutTests/platform/ipad/TestExpectations
@@ -93,6 +93,7 @@ webkit.org/b/231635 [ Release ] editing/selection/ios/scroll-to-reveal-selection
 media/picture-in-picture [ Pass ]
 media/remove-video-element-in-pip-from-document.html [ Pass ]
 
+media/media-source/media-managedmse-airplay.html [ Fail ] # This test must fail on all platform but iPhone.
 http/tests/media/media-source/mediasource-rvfc.html [ Pass ]
 
 webkit.org/b/228622 [ Debug ] accessibility/ios-simulator/scroll-in-overflow-div.html [ Crash ]

--- a/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
+++ b/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
@@ -3926,6 +3926,21 @@ ManagedMediaSourceLowThreshold:
     WebCore:
       default: 10
 
+ManagedMediaSourceNeedsAirPlay:
+  type: bool
+  status: stable
+  category: media
+  humanReadableName: "Managed Media Source Requires AirPlay source"
+  humanReadableDescription: "Managed Media Source Requires AirPlay source"
+  condition: ENABLE(MANAGED_MEDIA_SOURCE) && ENABLE(MEDIA_SOURCE) && ENABLE(WIRELESS_PLAYBACK_TARGET)
+  defaultValue:
+    WebKitLegacy:
+      default: false
+    WebKit:
+      default: WebKit::defaultManagedMediaSourceNeedsAirPlay()
+    WebCore:
+      default: false
+
 MarkedTextInputEnabled:
   type: bool
   status: embedder

--- a/Source/WebCore/Modules/mediasource/ManagedMediaSource.cpp
+++ b/Source/WebCore/Modules/mediasource/ManagedMediaSource.cpp
@@ -167,5 +167,17 @@ void ManagedMediaSource::streamingTimerFired()
     notifyElementUpdateMediaState();
 }
 
+bool ManagedMediaSource::isOpen() const
+{
+#if !ENABLE(WIRELESS_PLAYBACK_TARGET)
+    return MediaSource::isOpen();
+#else
+    return MediaSource::isOpen()
+        && (!mediaElement()->document().settings().managedMediaSourceNeedsAirPlay()
+            || mediaElement()->isWirelessPlaybackTargetDisabled()
+            || mediaElement()->hasWirelessPlaybackTargetAlternative());
+#endif
+}
+
 }
 #endif

--- a/Source/WebCore/Modules/mediasource/ManagedMediaSource.h
+++ b/Source/WebCore/Modules/mediasource/ManagedMediaSource.h
@@ -52,6 +52,7 @@ public:
 private:
     explicit ManagedMediaSource(ScriptExecutionContext&);
     void monitorSourceBuffers() final;
+    bool isOpen() const final;
     bool isBuffered(const PlatformTimeRanges&) const;
     void setStreaming(bool);
     void streamingTimerFired();

--- a/Source/WebCore/Modules/mediasource/MediaSource.h
+++ b/Source/WebCore/Modules/mediasource/MediaSource.h
@@ -72,7 +72,8 @@ public:
     void addedToRegistry();
     void removedFromRegistry();
     void openIfInEndedState();
-    bool isOpen() const;
+    void openIfDeferredOpen();
+    virtual bool isOpen() const;
     bool isClosed() const;
     bool isEnded() const;
     void sourceBufferDidChangeActiveState(SourceBuffer&, bool);
@@ -96,7 +97,7 @@ public:
     MediaTime currentTime() const;
 
     enum class ReadyState { Closed, Open, Ended };
-    ReadyState readyState() const { return m_readyState; }
+    ReadyState readyState() const;
     ExceptionOr<void> endOfStream(std::optional<EndOfStreamError>);
 
     HTMLMediaElement* mediaElement() const { return m_mediaElement.get(); }
@@ -179,6 +180,7 @@ private:
     MediaTime m_duration;
     MediaTime m_pendingSeekTime;
     ReadyState m_readyState { ReadyState::Closed };
+    bool m_openDeferred { false };
 #if !RELEASE_LOG_DISABLED
     Ref<const Logger> m_logger;
     const void* m_logIdentifier { nullptr };

--- a/Source/WebCore/Modules/remoteplayback/RemotePlayback.cpp
+++ b/Source/WebCore/Modules/remoteplayback/RemotePlayback.cpp
@@ -94,9 +94,7 @@ void RemotePlayback::watchAvailability(Ref<RemotePlaybackAvailabilityCallback>&&
 
         // 3. If the disableRemotePlayback attribute is present for the media element, reject the promise with
         //    InvalidStateError and abort all the remaining steps.
-        if (!m_mediaElement
-            || m_mediaElement->hasAttributeWithoutSynchronization(HTMLNames::webkitwirelessvideoplaybackdisabledAttr)
-            || m_mediaElement->hasAttributeWithoutSynchronization(HTMLNames::disableremoteplaybackAttr)) {
+        if (!m_mediaElement || m_mediaElement->isWirelessPlaybackTargetDisabled()) {
             ERROR_LOG(identifier, "promise rejected, remote playback disabled");
             promise->reject(InvalidStateError);
             return;
@@ -156,9 +154,7 @@ void RemotePlayback::cancelWatchAvailability(std::optional<int32_t> id, Ref<Defe
             return;
         // 3. If the disableRemotePlayback attribute is present for the media element, reject promise with
         //    InvalidStateError and abort all the remaining steps.
-        if (!m_mediaElement
-            || m_mediaElement->hasAttributeWithoutSynchronization(HTMLNames::webkitwirelessvideoplaybackdisabledAttr)
-            || m_mediaElement->hasAttributeWithoutSynchronization(HTMLNames::disableremoteplaybackAttr)) {
+        if (!m_mediaElement || m_mediaElement->isWirelessPlaybackTargetDisabled()) {
             ERROR_LOG(identifier, "promise rejected, remote playback disabled");
             promise->reject(InvalidStateError);
             return;
@@ -207,9 +203,7 @@ void RemotePlayback::prompt(Ref<DeferredPromise>&& promise)
 
         // 3. If the disableRemotePlayback attribute is present for the media element, reject the promise with
         //    InvalidStateError and abort all the remaining steps.
-        if (!m_mediaElement
-            || m_mediaElement->hasAttributeWithoutSynchronization(HTMLNames::webkitwirelessvideoplaybackdisabledAttr)
-            || m_mediaElement->hasAttributeWithoutSynchronization(HTMLNames::disableremoteplaybackAttr)) {
+        if (!m_mediaElement || m_mediaElement->isWirelessPlaybackTargetDisabled()) {
             ERROR_LOG(identifier, "promise rejected, remote playback disabled");
             promise->reject(InvalidStateError);
             return;

--- a/Source/WebCore/html/HTMLMediaElement.h
+++ b/Source/WebCore/html/HTMLMediaElement.h
@@ -450,7 +450,10 @@ public:
     void setWirelessPlaybackTarget(Ref<MediaPlaybackTarget>&&) override;
     void setShouldPlayToPlaybackTarget(bool) override;
     void playbackTargetPickerWasDismissed() override;
+    bool hasWirelessPlaybackTargetAlternative() const;
+    bool isWirelessPlaybackTargetDisabled() const;
 #endif
+
     bool isPlayingToWirelessPlaybackTarget() const override { return m_isPlayingToWirelessTarget; };
     void setIsPlayingToWirelessTarget(bool);
     bool webkitCurrentPlaybackTargetIsWireless() const;
@@ -507,7 +510,7 @@ public:
 #endif
 
     using HTMLMediaElementEnums::InvalidURLAction;
-    bool isSafeToLoadURL(const URL&, InvalidURLAction);
+    bool isSafeToLoadURL(const URL&, InvalidURLAction, bool shouldLog = true) const;
 
     const String& mediaGroup() const;
     void setMediaGroup(const String&);

--- a/Source/WebCore/html/HTMLVideoElement.cpp
+++ b/Source/WebCore/html/HTMLVideoElement.cpp
@@ -151,12 +151,8 @@ void HTMLVideoElement::attributeChanged(const QualifiedName& name, const AtomStr
         HTMLMediaElement::attributeChanged(name, oldValue, newValue, attributeModificationReason);
 
 #if PLATFORM(IOS_FAMILY) && ENABLE(WIRELESS_PLAYBACK_TARGET)
-        if (name == webkitairplayAttr) {
-            bool disabled = false;
-            if (equalLettersIgnoringASCIICase(attributeWithoutSynchronization(HTMLNames::webkitairplayAttr), "deny"_s))
-                disabled = true;
-            mediaSession().setWirelessVideoPlaybackDisabled(disabled);
-        }
+        if (name == webkitairplayAttr)
+            mediaSession().setWirelessVideoPlaybackDisabled(isWirelessPlaybackTargetDisabled());
 #endif
     }
 }

--- a/Source/WebKit/Shared/WebPreferencesDefaultValues.cpp
+++ b/Source/WebKit/Shared/WebPreferencesDefaultValues.cpp
@@ -32,6 +32,9 @@
 #if PLATFORM(COCOA)
 #include <wtf/NumberOfCores.h>
 #include <wtf/cocoa/RuntimeApplicationChecksCocoa.h>
+#if PLATFORM(IOS_FAMILY)
+#include "UserInterfaceIdiom.h"
+#endif
 #endif
 
 #if ENABLE(MEDIA_SESSION_COORDINATOR)
@@ -181,6 +184,17 @@ bool defaultManagedMediaSourceEnabled()
     // Enable everywhere that MediaSource is enabled
     return defaultMediaSourceEnabled();
 #elif PLATFORM(MAC)
+    return true;
+#else
+    return false;
+#endif
+}
+#endif
+
+#if ENABLE(MANAGED_MEDIA_SOURCE) && ENABLE(MEDIA_SOURCE) && ENABLE(WIRELESS_PLAYBACK_TARGET)
+bool defaultManagedMediaSourceNeedsAirPlay()
+{
+#if PLATFORM(IOS_FAMILY) || PLATFORM(MAC)
     return true;
 #else
     return false;

--- a/Source/WebKit/Shared/WebPreferencesDefaultValues.h
+++ b/Source/WebKit/Shared/WebPreferencesDefaultValues.h
@@ -78,6 +78,9 @@ bool defaultMediaSourceEnabled();
 
 #if ENABLE(MANAGED_MEDIA_SOURCE) && ENABLE(MEDIA_SOURCE)
 bool defaultManagedMediaSourceEnabled();
+#if ENABLE(WIRELESS_PLAYBACK_TARGET)
+bool defaultManagedMediaSourceNeedsAirPlay();
+#endif
 #endif
 
 #if ENABLE(MEDIA_SESSION_COORDINATOR)

--- a/Tools/TestWebKitAPI/Tests/WebKit/file-with-managedmse.html
+++ b/Tools/TestWebKitAPI/Tests/WebKit/file-with-managedmse.html
@@ -22,6 +22,7 @@
       function loadVideo()
       {
           video = document.getElementById('test-video');
+          video.disableRemotePlayback = true;
           request = new XMLHttpRequest();
           request.responseType = 'arraybuffer';
           request.open('GET', isMP4Supported() ? 'test-mse.mp4' : isWebMVP9Supported() ? 'test-mse.webm' : 'test-mse-audio.webm', true);


### PR DESCRIPTION
#### 0a9b7c59e3fa9131c40823fa108c5c9818269b08
<pre>
Managed Media Source should only be available if airplay source alternative is present
<a href="https://bugs.webkit.org/show_bug.cgi?id=256570">https://bugs.webkit.org/show_bug.cgi?id=256570</a>
rdar://109130836

Reviewed by Jer Noble.

When we add a Managed Media Source to a media element, it should per
MSE spec changed the MSE&apos;s readyState to &quot;open&quot; and fire the `sourceopen` event.
We want to make sure that the developer hasn&apos;t left anything unchecked,
it is expected that either an alternative source is set and compatible with
remote playback, or by explicitly disabling remote playback
(either by using an attribute or using Remote Playback API).

To achieve this, we do not move the MSE&apos;s readyState to &quot;open&quot; until
all those conditions have been achieved. And the readyState will remain
at `closed` until then. Should one of the condition become fullfilled
after the Managed Media Source has been created, it will be unblocked and
can be used as usual.

The behaviour is placed behind a preference.

Fly-by fix: There were three different ways to disable AirPlay, each
working independently from the other. We combine them all together that
should one method be used to disable AirPlay, it will be disabled regardless
of what the other methods are doing.

* LayoutTests/TestExpectations:
* LayoutTests/media/media-source/media-managedmse-airplay-expected.txt: Added.
* LayoutTests/media/media-source/media-managedmse-airplay.html: Added.
* LayoutTests/media/media-source/media-managedmse-bufferedchange.html: Amended to explicitly disable AirPlay
* LayoutTests/media/media-source/media-managedmse-memorypressure-inactive.html: Amended to explicitly disable AirPlay
* LayoutTests/media/media-source/media-managedmse-memorypressure.html: Amended to explicitly disable AirPlay
* LayoutTests/media/media-source/media-managedmse-streaming-atend.html: Amended to explicitly disable AirPlay
* LayoutTests/media/media-source/media-managedmse-streaming.html: Amended to explicitly disable AirPlay
* LayoutTests/media/media-source/media-managedmse.html: Amended to explicitly disable AirPlay
* LayoutTests/platform/glib/TestExpectations:
* LayoutTests/platform/ios/TestExpectations:
* Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml:
* Source/WebCore/Modules/mediasource/ManagedMediaSource.cpp:
(WebCore::ManagedMediaSource::isOpen const):
* Source/WebCore/Modules/mediasource/ManagedMediaSource.h:
* Source/WebCore/Modules/mediasource/MediaSource.cpp:
(WebCore::MediaSource::setPrivateAndOpen):
(WebCore::MediaSource::isOpen const):
(WebCore::MediaSource::isClosed const):
(WebCore::MediaSource::isEnded const):
(WebCore::MediaSource::openIfDeferredOpen):
(WebCore::MediaSource::readyState const):
(WebCore::MediaSource::onReadyStateChange):
* Source/WebCore/Modules/mediasource/MediaSource.h:
(WebCore::MediaSource::readyState const): Deleted.
* Source/WebCore/Modules/remoteplayback/RemotePlayback.cpp:
(WebCore::RemotePlayback::watchAvailability): Use utility method on mediaElement
(WebCore::RemotePlayback::cancelWatchAvailability): ditto
(WebCore::RemotePlayback::prompt): ditto
* Source/WebCore/html/HTMLMediaElement.cpp:
(WebCore::HTMLMediaElement::attributeChanged): If remote playback gets
disabled, move the Managed Media Source state to open if needed
(WebCore::isAllowedToLoadMediaURL): make it take a const element
(WebCore::HTMLMediaElement::isSafeToLoadURL const): make method const and make logging conditional
(WebCore::HTMLMediaElement::sourceWasAdded): if a playable alternative source is added
move the Managed Media Source state to open if needed
(WebCore::HTMLMediaElement::hasWirelessPlaybackTargetAlternative const):
(WebCore::HTMLMediaElement::isWirelessPlaybackTargetDisabled const):
* Source/WebCore/html/HTMLMediaElement.h:
* Source/WebCore/html/HTMLVideoElement.cpp:
(WebCore::HTMLVideoElement::attributeChanged):
* Source/WebKit/Shared/WebPreferencesDefaultValues.cpp:
(WebKit::defaultManagedMediaSourceNeedsAirPlay):
* Source/WebKit/Shared/WebPreferencesDefaultValues.h:

Canonical link: <a href="https://commits.webkit.org/264270@main">https://commits.webkit.org/264270@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/43d9f95d58901ae90ac8ae772d7afaf9a9e84bae

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/6959 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/7194 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/7377 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/8566 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/7196 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/6965 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/8458 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/7132 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/10105 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/7082 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/7763 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/6412 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/8668 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/5136 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/6325 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/14103 "Passed tests") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/5875 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/6812 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/6416 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/9240 "Passed tests") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/6535 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/6890 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/5649 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/7094 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/6263 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/6235 "Passed tests") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/1660 "Passed tests") | 
| [❌ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/1704 "Failed to push commit to Webkit repository") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/10450 "Built successfully") | | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/24/builds/7294 "Built successfully") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/6645 "Built successfully") | | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/3/builds/1800 "Passed tests") | 
<!--EWS-Status-Bubble-End-->