### PR TITLE
Fix signed division bias for power-of-two divisor in BBQ JIT

### DIFF
--- a/JSTests/wasm/stress/divide-by-constant-power-of-two.js
+++ b/JSTests/wasm/stress/divide-by-constant-power-of-two.js
@@ -1,0 +1,377 @@
+import { instantiate } from "../wabt-wrapper.js";
+import * as assert from "../assert.js";
+
+let wat = `
+(module
+    (func (export "testI32DivU_2") (param i32) (result i32)
+        local.get 0
+        i32.const 2
+        i32.div_u
+    )
+
+    (func (export "testI32DivS_2") (param i32) (result i32)
+        local.get 0
+        i32.const 2
+        i32.div_s
+    )
+
+    (func (export "testI32DivU_32") (param i32) (result i32)
+        local.get 0
+        i32.const 32
+        i32.div_u
+    )
+
+    (func (export "testI32DivS_32") (param i32) (result i32)
+        local.get 0
+        i32.const 32
+        i32.div_s
+    )
+
+    (func (export "testI32DivU_512") (param i32) (result i32)
+        local.get 0
+        i32.const 512
+        i32.div_u
+    )
+
+    (func (export "testI32DivS_512") (param i32) (result i32)
+        local.get 0
+        i32.const 512
+        i32.div_s
+    )
+
+    (func (export "testI32DivU_131072") (param i32) (result i32)
+        local.get 0
+        i32.const 131072
+        i32.div_u
+    )
+
+    (func (export "testI32DivS_131072") (param i32) (result i32)
+        local.get 0
+        i32.const 131072
+        i32.div_s
+    )
+
+    (func (export "testI32DivU_134217728") (param i32) (result i32)
+        local.get 0
+        i32.const 134217728
+        i32.div_u
+    )
+
+    (func (export "testI32DivS_134217728") (param i32) (result i32)
+        local.get 0
+        i32.const 134217728
+        i32.div_s
+    )
+
+    (func (export "testI64DivU_2") (param i64) (result i64)
+        local.get 0
+        i64.const 2
+        i64.div_u
+    )
+
+    (func (export "testI64DivS_2") (param i64) (result i64)
+        local.get 0
+        i64.const 2
+        i64.div_s
+    )
+
+    (func (export "testI64DivU_32") (param i64) (result i64)
+        local.get 0
+        i64.const 32
+        i64.div_u
+    )
+
+    (func (export "testI64DivS_32") (param i64) (result i64)
+        local.get 0
+        i64.const 32
+        i64.div_s
+    )
+
+    (func (export "testI64DivU_512") (param i64) (result i64)
+        local.get 0
+        i64.const 512
+        i64.div_u
+    )
+
+    (func (export "testI64DivS_512") (param i64) (result i64)
+        local.get 0
+        i64.const 512
+        i64.div_s
+    )
+
+    (func (export "testI64DivU_131072") (param i64) (result i64)
+        local.get 0
+        i64.const 131072
+        i64.div_u
+    )
+
+    (func (export "testI64DivS_131072") (param i64) (result i64)
+        local.get 0
+        i64.const 131072
+        i64.div_s
+    )
+
+    (func (export "testI64DivU_134217728") (param i64) (result i64)
+        local.get 0
+        i64.const 134217728
+        i64.div_u
+    )
+
+    (func (export "testI64DivS_134217728") (param i64) (result i64)
+        local.get 0
+        i64.const 134217728
+        i64.div_s
+    )
+
+    (func (export "testI64DivU_8796093022208") (param i64) (result i64)
+        local.get 0
+        i64.const 8796093022208
+        i64.div_u
+    )
+
+    (func (export "testI64DivS_8796093022208") (param i64) (result i64)
+        local.get 0
+        i64.const 8796093022208
+        i64.div_s
+    )
+)
+`;
+
+async function test() {
+    const instance = await instantiate(wat, {}, {});
+    const { 
+        testI32DivU_2,
+        testI32DivS_2,
+        testI32DivU_32,
+        testI32DivS_32,
+        testI32DivU_512,
+        testI32DivS_512,
+        testI32DivU_131072,
+        testI32DivS_131072,
+        testI32DivU_134217728,
+        testI32DivS_134217728,
+        testI64DivU_2,
+        testI64DivS_2,
+        testI64DivU_32,
+        testI64DivS_32,
+        testI64DivU_512,
+        testI64DivS_512,
+        testI64DivU_131072,
+        testI64DivS_131072,
+        testI64DivU_134217728,
+        testI64DivS_134217728,
+        testI64DivU_8796093022208,
+        testI64DivS_8796093022208
+    } = instance.exports;
+
+    assert.eq(testI32DivU_2(0), 0);
+    assert.eq(testI32DivU_2(1), 0);
+    assert.eq(testI32DivU_2(2), 1);
+    assert.eq(testI32DivU_2(7), 3);
+    assert.eq(testI32DivU_2(8), 4);
+    assert.eq(testI32DivU_2(9), 4);
+
+    assert.eq(testI32DivS_2(0), 0);
+    assert.eq(testI32DivS_2(1), 0);
+    assert.eq(testI32DivS_2(2), 1);
+    assert.eq(testI32DivS_2(7), 3);
+    assert.eq(testI32DivS_2(8), 4);
+    assert.eq(testI32DivS_2(9), 4);
+    assert.eq(testI32DivS_2(-1), 0);
+    assert.eq(testI32DivS_2(-2), -1);
+    assert.eq(testI32DivS_2(-7), -3);
+    assert.eq(testI32DivS_2(-8), -4);
+    assert.eq(testI32DivS_2(-9), -4);
+
+    assert.eq(testI64DivU_2(0n), 0n);
+    assert.eq(testI64DivU_2(1n), 0n);
+    assert.eq(testI64DivU_2(2n), 1n);
+    assert.eq(testI64DivU_2(7n), 3n);
+    assert.eq(testI64DivU_2(8n), 4n);
+    assert.eq(testI64DivU_2(9n), 4n);
+
+    assert.eq(testI64DivS_2(0n), 0n);
+    assert.eq(testI64DivS_2(1n), 0n);
+    assert.eq(testI64DivS_2(2n), 1n);
+    assert.eq(testI64DivS_2(7n), 3n);
+    assert.eq(testI64DivS_2(8n), 4n);
+    assert.eq(testI64DivS_2(9n), 4n);
+    assert.eq(testI64DivS_2(-1n), 0n);
+    assert.eq(testI64DivS_2(-2n), -1n);
+    assert.eq(testI64DivS_2(-7n), -3n);
+    assert.eq(testI64DivS_2(-8n), -4n);
+    assert.eq(testI64DivS_2(-9n), -4n);
+
+    assert.eq(testI32DivU_32(0), 0);
+    assert.eq(testI32DivU_32(1), 0);
+    assert.eq(testI32DivU_32(32), 1);
+    assert.eq(testI32DivU_32(127), 3);
+    assert.eq(testI32DivU_32(128), 4);
+    assert.eq(testI32DivU_32(129), 4);
+
+    assert.eq(testI32DivS_32(0), 0);
+    assert.eq(testI32DivS_32(1), 0);
+    assert.eq(testI32DivS_32(32), 1);
+    assert.eq(testI32DivS_32(127), 3);
+    assert.eq(testI32DivS_32(128), 4);
+    assert.eq(testI32DivS_32(129), 4);
+    assert.eq(testI32DivS_32(-1), 0);
+    assert.eq(testI32DivS_32(-32), -1);
+    assert.eq(testI32DivS_32(-127), -3);
+    assert.eq(testI32DivS_32(-128), -4);
+    assert.eq(testI32DivS_32(-129), -4);
+
+    assert.eq(testI64DivU_32(0n), 0n);
+    assert.eq(testI64DivU_32(1n), 0n);
+    assert.eq(testI64DivU_32(32n), 1n);
+    assert.eq(testI64DivU_32(127n), 3n);
+    assert.eq(testI64DivU_32(128n), 4n);
+    assert.eq(testI64DivU_32(129n), 4n);
+
+    assert.eq(testI64DivS_32(0n), 0n);
+    assert.eq(testI64DivS_32(1n), 0n);
+    assert.eq(testI64DivS_32(32n), 1n);
+    assert.eq(testI64DivS_32(127n), 3n);
+    assert.eq(testI64DivS_32(128n), 4n);
+    assert.eq(testI64DivS_32(129n), 4n);
+    assert.eq(testI64DivS_32(-1n), 0n);
+    assert.eq(testI64DivS_32(-32n), -1n);
+    assert.eq(testI64DivS_32(-127n), -3n);
+    assert.eq(testI64DivS_32(-128n), -4n);
+    assert.eq(testI64DivS_32(-129n), -4n);
+
+    assert.eq(testI32DivU_512(0), 0);
+    assert.eq(testI32DivU_512(1), 0);
+    assert.eq(testI32DivU_512(512), 1);
+    assert.eq(testI32DivU_512(4095), 7);
+    assert.eq(testI32DivU_512(4096), 8);
+    assert.eq(testI32DivU_512(4097), 8);
+
+    assert.eq(testI32DivS_512(0), 0);
+    assert.eq(testI32DivS_512(1), 0);
+    assert.eq(testI32DivS_512(512), 1);
+    assert.eq(testI32DivS_512(4095), 7);
+    assert.eq(testI32DivS_512(4096), 8);
+    assert.eq(testI32DivS_512(4097), 8);
+    assert.eq(testI32DivS_512(-1), 0);
+    assert.eq(testI32DivS_512(-512), -1);
+    assert.eq(testI32DivS_512(-4095), -7);
+    assert.eq(testI32DivS_512(-4096), -8);
+    assert.eq(testI32DivS_512(-4097), -8);
+
+    assert.eq(testI64DivU_512(0n), 0n);
+    assert.eq(testI64DivU_512(1n), 0n);
+    assert.eq(testI64DivU_512(512n), 1n);
+    assert.eq(testI64DivU_512(4095n), 7n);
+    assert.eq(testI64DivU_512(4096n), 8n);
+    assert.eq(testI64DivU_512(4097n), 8n);
+
+    assert.eq(testI64DivS_512(0n), 0n);
+    assert.eq(testI64DivS_512(1n), 0n);
+    assert.eq(testI64DivS_512(512n), 1n);
+    assert.eq(testI64DivS_512(4095n), 7n);
+    assert.eq(testI64DivS_512(4096n), 8n);
+    assert.eq(testI64DivS_512(4097n), 8n);
+    assert.eq(testI64DivS_512(-1n), 0n);
+    assert.eq(testI64DivS_512(-512n), -1n);
+    assert.eq(testI64DivS_512(-4095n), -7n);
+    assert.eq(testI64DivS_512(-4096n), -8n);
+    assert.eq(testI64DivS_512(-4097n), -8n);
+
+    assert.eq(testI32DivU_131072(0), 0);
+    assert.eq(testI32DivU_131072(1), 0);
+    assert.eq(testI32DivU_131072(131072), 1);
+    assert.eq(testI32DivU_131072(2097151), 15);
+    assert.eq(testI32DivU_131072(2097152), 16);
+    assert.eq(testI32DivU_131072(2097153), 16);
+
+    assert.eq(testI32DivS_131072(0), 0);
+    assert.eq(testI32DivS_131072(1), 0);
+    assert.eq(testI32DivS_131072(131072), 1);
+    assert.eq(testI32DivS_131072(2097151), 15);
+    assert.eq(testI32DivS_131072(2097152), 16);
+    assert.eq(testI32DivS_131072(2097153), 16);
+    assert.eq(testI32DivS_131072(-1), 0);
+    assert.eq(testI32DivS_131072(-131072), -1);
+    assert.eq(testI32DivS_131072(-2097151), -15);
+    assert.eq(testI32DivS_131072(-2097152), -16);
+    assert.eq(testI32DivS_131072(-2097153), -16);
+
+    assert.eq(testI64DivU_131072(0n), 0n);
+    assert.eq(testI64DivU_131072(1n), 0n);
+    assert.eq(testI64DivU_131072(131072n), 1n);
+    assert.eq(testI64DivU_131072(2097151n), 15n);
+    assert.eq(testI64DivU_131072(2097152n), 16n);
+    assert.eq(testI64DivU_131072(2097153n), 16n);
+
+    assert.eq(testI64DivS_131072(0n), 0n);
+    assert.eq(testI64DivS_131072(1n), 0n);
+    assert.eq(testI64DivS_131072(131072n), 1n);
+    assert.eq(testI64DivS_131072(2097151n), 15n);
+    assert.eq(testI64DivS_131072(2097152n), 16n);
+    assert.eq(testI64DivS_131072(2097153n), 16n);
+    assert.eq(testI64DivS_131072(-1n), 0n);
+    assert.eq(testI64DivS_131072(-131072n), -1n);
+    assert.eq(testI64DivS_131072(-2097151n), -15n);
+    assert.eq(testI64DivS_131072(-2097152n), -16n);
+    assert.eq(testI64DivS_131072(-2097153n), -16n);
+
+    assert.eq(testI32DivU_134217728(0), 0);
+    assert.eq(testI32DivU_134217728(1), 0);
+    assert.eq(testI32DivU_134217728(134217728), 1);
+    assert.eq(testI32DivU_134217728(536870911), 3);
+    assert.eq(testI32DivU_134217728(536870912), 4);
+    assert.eq(testI32DivU_134217728(536870913), 4);
+
+    assert.eq(testI32DivS_134217728(0), 0);
+    assert.eq(testI32DivS_134217728(1), 0);
+    assert.eq(testI32DivS_134217728(134217728), 1);
+    assert.eq(testI32DivS_134217728(536870911), 3);
+    assert.eq(testI32DivS_134217728(536870912), 4);
+    assert.eq(testI32DivS_134217728(536870913), 4);
+    assert.eq(testI32DivS_134217728(-1), 0);
+    assert.eq(testI32DivS_134217728(-134217728), -1);
+    assert.eq(testI32DivS_134217728(-536870911), -3);
+    assert.eq(testI32DivS_134217728(-536870912), -4);
+    assert.eq(testI32DivS_134217728(-536870913), -4);
+
+    assert.eq(testI64DivU_134217728(0n), 0n);
+    assert.eq(testI64DivU_134217728(1n), 0n);
+    assert.eq(testI64DivU_134217728(134217728n), 1n);
+    assert.eq(testI64DivU_134217728(536870911n), 3n);
+    assert.eq(testI64DivU_134217728(536870912n), 4n);
+    assert.eq(testI64DivU_134217728(536870913n), 4n);
+
+    assert.eq(testI64DivS_134217728(0n), 0n);
+    assert.eq(testI64DivS_134217728(1n), 0n);
+    assert.eq(testI64DivS_134217728(134217728n), 1n);
+    assert.eq(testI64DivS_134217728(536870911n), 3n);
+    assert.eq(testI64DivS_134217728(536870912n), 4n);
+    assert.eq(testI64DivS_134217728(536870913n), 4n);
+    assert.eq(testI64DivS_134217728(-1n), 0n);
+    assert.eq(testI64DivS_134217728(-134217728n), -1n);
+    assert.eq(testI64DivS_134217728(-536870911n), -3n);
+    assert.eq(testI64DivS_134217728(-536870912n), -4n);
+    assert.eq(testI64DivS_134217728(-536870913n), -4n);
+
+    assert.eq(testI64DivU_8796093022208(0n), 0n);
+    assert.eq(testI64DivU_8796093022208(1n), 0n);
+    assert.eq(testI64DivU_8796093022208(8796093022208n), 1n);
+    assert.eq(testI64DivU_8796093022208(562949953421311n), 63n);
+    assert.eq(testI64DivU_8796093022208(562949953421312n), 64n);
+    assert.eq(testI64DivU_8796093022208(562949953421313n), 64n);
+
+    assert.eq(testI64DivS_8796093022208(0n), 0n);
+    assert.eq(testI64DivS_8796093022208(1n), 0n);
+    assert.eq(testI64DivS_8796093022208(8796093022208n), 1n);
+    assert.eq(testI64DivS_8796093022208(562949953421311n), 63n);
+    assert.eq(testI64DivS_8796093022208(562949953421312n), 64n);
+    assert.eq(testI64DivS_8796093022208(562949953421313n), 64n);
+    assert.eq(testI64DivS_8796093022208(-1n), 0n);
+    assert.eq(testI64DivS_8796093022208(-8796093022208n), -1n);
+    assert.eq(testI64DivS_8796093022208(-562949953421311n), -63n);
+    assert.eq(testI64DivS_8796093022208(-562949953421312n), -64n);
+    assert.eq(testI64DivS_8796093022208(-562949953421313n), -64n);
+}
+
+assert.asyncTest(test());

--- a/JSTests/wasm/stress/remainder-by-constant-power-of-two.js
+++ b/JSTests/wasm/stress/remainder-by-constant-power-of-two.js
@@ -1,0 +1,377 @@
+import { instantiate } from "../wabt-wrapper.js";
+import * as assert from "../assert.js";
+
+let wat = `
+(module
+    (func (export "testI32RemU_2") (param i32) (result i32)
+        local.get 0
+        i32.const 2
+        i32.rem_u
+    )
+
+    (func (export "testI32RemS_2") (param i32) (result i32)
+        local.get 0
+        i32.const 2
+        i32.rem_s
+    )
+
+    (func (export "testI32RemU_32") (param i32) (result i32)
+        local.get 0
+        i32.const 32
+        i32.rem_u
+    )
+
+    (func (export "testI32RemS_32") (param i32) (result i32)
+        local.get 0
+        i32.const 32
+        i32.rem_s
+    )
+
+    (func (export "testI32RemU_512") (param i32) (result i32)
+        local.get 0
+        i32.const 512
+        i32.rem_u
+    )
+
+    (func (export "testI32RemS_512") (param i32) (result i32)
+        local.get 0
+        i32.const 512
+        i32.rem_s
+    )
+
+    (func (export "testI32RemU_131072") (param i32) (result i32)
+        local.get 0
+        i32.const 131072
+        i32.rem_u
+    )
+
+    (func (export "testI32RemS_131072") (param i32) (result i32)
+        local.get 0
+        i32.const 131072
+        i32.rem_s
+    )
+
+    (func (export "testI32RemU_134217728") (param i32) (result i32)
+        local.get 0
+        i32.const 134217728
+        i32.rem_u
+    )
+
+    (func (export "testI32RemS_134217728") (param i32) (result i32)
+        local.get 0
+        i32.const 134217728
+        i32.rem_s
+    )
+
+    (func (export "testI64RemU_2") (param i64) (result i64)
+        local.get 0
+        i64.const 2
+        i64.rem_u
+    )
+
+    (func (export "testI64RemS_2") (param i64) (result i64)
+        local.get 0
+        i64.const 2
+        i64.rem_s
+    )
+
+    (func (export "testI64RemU_32") (param i64) (result i64)
+        local.get 0
+        i64.const 32
+        i64.rem_u
+    )
+
+    (func (export "testI64RemS_32") (param i64) (result i64)
+        local.get 0
+        i64.const 32
+        i64.rem_s
+    )
+
+    (func (export "testI64RemU_512") (param i64) (result i64)
+        local.get 0
+        i64.const 512
+        i64.rem_u
+    )
+
+    (func (export "testI64RemS_512") (param i64) (result i64)
+        local.get 0
+        i64.const 512
+        i64.rem_s
+    )
+
+    (func (export "testI64RemU_131072") (param i64) (result i64)
+        local.get 0
+        i64.const 131072
+        i64.rem_u
+    )
+
+    (func (export "testI64RemS_131072") (param i64) (result i64)
+        local.get 0
+        i64.const 131072
+        i64.rem_s
+    )
+
+    (func (export "testI64RemU_134217728") (param i64) (result i64)
+        local.get 0
+        i64.const 134217728
+        i64.rem_u
+    )
+
+    (func (export "testI64RemS_134217728") (param i64) (result i64)
+        local.get 0
+        i64.const 134217728
+        i64.rem_s
+    )
+
+    (func (export "testI64RemU_8796093022208") (param i64) (result i64)
+        local.get 0
+        i64.const 8796093022208
+        i64.rem_u
+    )
+
+    (func (export "testI64RemS_8796093022208") (param i64) (result i64)
+        local.get 0
+        i64.const 8796093022208
+        i64.rem_s
+    )
+)
+`;
+
+async function test() {
+    const instance = await instantiate(wat, {}, {});
+    const { 
+        testI32RemU_2,
+        testI32RemS_2,
+        testI32RemU_32,
+        testI32RemS_32,
+        testI32RemU_512,
+        testI32RemS_512,
+        testI32RemU_131072,
+        testI32RemS_131072,
+        testI32RemU_134217728,
+        testI32RemS_134217728,
+        testI64RemU_2,
+        testI64RemS_2,
+        testI64RemU_32,
+        testI64RemS_32,
+        testI64RemU_512,
+        testI64RemS_512,
+        testI64RemU_131072,
+        testI64RemS_131072,
+        testI64RemU_134217728,
+        testI64RemS_134217728,
+        testI64RemU_8796093022208,
+        testI64RemS_8796093022208
+    } = instance.exports;
+
+    assert.eq(testI32RemU_2(0), 0);
+    assert.eq(testI32RemU_2(1), 1);
+    assert.eq(testI32RemU_2(2), 0);
+    assert.eq(testI32RemU_2(7), 1);
+    assert.eq(testI32RemU_2(8), 0);
+    assert.eq(testI32RemU_2(9), 1);
+
+    assert.eq(testI32RemS_2(0), 0);
+    assert.eq(testI32RemS_2(1), 1);
+    assert.eq(testI32RemS_2(2), 0);
+    assert.eq(testI32RemS_2(7), 1);
+    assert.eq(testI32RemS_2(8), 0);
+    assert.eq(testI32RemS_2(9), 1);
+    assert.eq(testI32RemS_2(-1), -1);
+    assert.eq(testI32RemS_2(-2), 0);
+    assert.eq(testI32RemS_2(-7), -1);
+    assert.eq(testI32RemS_2(-8), 0);
+    assert.eq(testI32RemS_2(-9), -1);
+
+    assert.eq(testI64RemU_2(0n), 0n);
+    assert.eq(testI64RemU_2(1n), 1n);
+    assert.eq(testI64RemU_2(2n), 0n);
+    assert.eq(testI64RemU_2(7n), 1n);
+    assert.eq(testI64RemU_2(8n), 0n);
+    assert.eq(testI64RemU_2(9n), 1n);
+
+    assert.eq(testI64RemS_2(0n), 0n);
+    assert.eq(testI64RemS_2(1n), 1n);
+    assert.eq(testI64RemS_2(2n), 0n);
+    assert.eq(testI64RemS_2(7n), 1n);
+    assert.eq(testI64RemS_2(8n), 0n);
+    assert.eq(testI64RemS_2(9n), 1n);
+    assert.eq(testI64RemS_2(-1n), -1n);
+    assert.eq(testI64RemS_2(-2n), 0n);
+    assert.eq(testI64RemS_2(-7n), -1n);
+    assert.eq(testI64RemS_2(-8n), 0n);
+    assert.eq(testI64RemS_2(-9n), -1n);
+
+    assert.eq(testI32RemU_32(0), 0);
+    assert.eq(testI32RemU_32(1), 1);
+    assert.eq(testI32RemU_32(32), 0);
+    assert.eq(testI32RemU_32(127), 31);
+    assert.eq(testI32RemU_32(128), 0);
+    assert.eq(testI32RemU_32(129), 1);
+
+    assert.eq(testI32RemS_32(0), 0);
+    assert.eq(testI32RemS_32(1), 1);
+    assert.eq(testI32RemS_32(32), 0);
+    assert.eq(testI32RemS_32(127), 31);
+    assert.eq(testI32RemS_32(128), 0);
+    assert.eq(testI32RemS_32(129), 1);
+    assert.eq(testI32RemS_32(-1), -1);
+    assert.eq(testI32RemS_32(-32), 0);
+    assert.eq(testI32RemS_32(-127), -31);
+    assert.eq(testI32RemS_32(-128), 0);
+    assert.eq(testI32RemS_32(-129), -1);
+
+    assert.eq(testI64RemU_32(0n), 0n);
+    assert.eq(testI64RemU_32(1n), 1n);
+    assert.eq(testI64RemU_32(32n), 0n);
+    assert.eq(testI64RemU_32(127n), 31n);
+    assert.eq(testI64RemU_32(128n), 0n);
+    assert.eq(testI64RemU_32(129n), 1n);
+
+    assert.eq(testI64RemS_32(0n), 0n);
+    assert.eq(testI64RemS_32(1n), 1n);
+    assert.eq(testI64RemS_32(32n), 0n);
+    assert.eq(testI64RemS_32(127n), 31n);
+    assert.eq(testI64RemS_32(128n), 0n);
+    assert.eq(testI64RemS_32(129n), 1n);
+    assert.eq(testI64RemS_32(-1n), -1n);
+    assert.eq(testI64RemS_32(-32n), 0n);
+    assert.eq(testI64RemS_32(-127n), -31n);
+    assert.eq(testI64RemS_32(-128n), 0n);
+    assert.eq(testI64RemS_32(-129n), -1n);
+
+    assert.eq(testI32RemU_512(0), 0);
+    assert.eq(testI32RemU_512(1), 1);
+    assert.eq(testI32RemU_512(512), 0);
+    assert.eq(testI32RemU_512(4095), 511);
+    assert.eq(testI32RemU_512(4096), 0);
+    assert.eq(testI32RemU_512(4097), 1);
+
+    assert.eq(testI32RemS_512(0), 0);
+    assert.eq(testI32RemS_512(1), 1);
+    assert.eq(testI32RemS_512(512), 0);
+    assert.eq(testI32RemS_512(4095), 511);
+    assert.eq(testI32RemS_512(4096), 0);
+    assert.eq(testI32RemS_512(4097), 1);
+    assert.eq(testI32RemS_512(-1), -1);
+    assert.eq(testI32RemS_512(-512), 0);
+    assert.eq(testI32RemS_512(-4095), -511);
+    assert.eq(testI32RemS_512(-4096), 0);
+    assert.eq(testI32RemS_512(-4097), -1);
+
+    assert.eq(testI64RemU_512(0n), 0n);
+    assert.eq(testI64RemU_512(1n), 1n);
+    assert.eq(testI64RemU_512(512n), 0n);
+    assert.eq(testI64RemU_512(4095n), 511n);
+    assert.eq(testI64RemU_512(4096n), 0n);
+    assert.eq(testI64RemU_512(4097n), 1n);
+
+    assert.eq(testI64RemS_512(0n), 0n);
+    assert.eq(testI64RemS_512(1n), 1n);
+    assert.eq(testI64RemS_512(512n), 0n);
+    assert.eq(testI64RemS_512(4095n), 511n);
+    assert.eq(testI64RemS_512(4096n), 0n);
+    assert.eq(testI64RemS_512(4097n), 1n);
+    assert.eq(testI64RemS_512(-1n), -1n);
+    assert.eq(testI64RemS_512(-512n), 0n);
+    assert.eq(testI64RemS_512(-4095n), -511n);
+    assert.eq(testI64RemS_512(-4096n), 0n);
+    assert.eq(testI64RemS_512(-4097n), -1n);
+
+    assert.eq(testI32RemU_131072(0), 0);
+    assert.eq(testI32RemU_131072(1), 1);
+    assert.eq(testI32RemU_131072(131072), 0);
+    assert.eq(testI32RemU_131072(2097151), 131071);
+    assert.eq(testI32RemU_131072(2097152), 0);
+    assert.eq(testI32RemU_131072(2097153), 1);
+
+    assert.eq(testI32RemS_131072(0), 0);
+    assert.eq(testI32RemS_131072(1), 1);
+    assert.eq(testI32RemS_131072(131072), 0);
+    assert.eq(testI32RemS_131072(2097151), 131071);
+    assert.eq(testI32RemS_131072(2097152), 0);
+    assert.eq(testI32RemS_131072(2097153), 1);
+    assert.eq(testI32RemS_131072(-1), -1);
+    assert.eq(testI32RemS_131072(-131072), 0);
+    assert.eq(testI32RemS_131072(-2097151), -131071);
+    assert.eq(testI32RemS_131072(-2097152), 0);
+    assert.eq(testI32RemS_131072(-2097153), -1);
+
+    assert.eq(testI64RemU_131072(0n), 0n);
+    assert.eq(testI64RemU_131072(1n), 1n);
+    assert.eq(testI64RemU_131072(131072n), 0n);
+    assert.eq(testI64RemU_131072(2097151n), 131071n);
+    assert.eq(testI64RemU_131072(2097152n), 0n);
+    assert.eq(testI64RemU_131072(2097153n), 1n);
+
+    assert.eq(testI64RemS_131072(0n), 0n);
+    assert.eq(testI64RemS_131072(1n), 1n);
+    assert.eq(testI64RemS_131072(131072n), 0n);
+    assert.eq(testI64RemS_131072(2097151n), 131071n);
+    assert.eq(testI64RemS_131072(2097152n), 0n);
+    assert.eq(testI64RemS_131072(2097153n), 1n);
+    assert.eq(testI64RemS_131072(-1n), -1n);
+    assert.eq(testI64RemS_131072(-131072n), 0n);
+    assert.eq(testI64RemS_131072(-2097151n), -131071n);
+    assert.eq(testI64RemS_131072(-2097152n), 0n);
+    assert.eq(testI64RemS_131072(-2097153n), -1n);
+
+    assert.eq(testI32RemU_134217728(0), 0);
+    assert.eq(testI32RemU_134217728(1), 1);
+    assert.eq(testI32RemU_134217728(134217728), 0);
+    assert.eq(testI32RemU_134217728(536870911), 134217727);
+    assert.eq(testI32RemU_134217728(536870912), 0);
+    assert.eq(testI32RemU_134217728(536870913), 1);
+
+    assert.eq(testI32RemS_134217728(0), 0);
+    assert.eq(testI32RemS_134217728(1), 1);
+    assert.eq(testI32RemS_134217728(134217728), 0);
+    assert.eq(testI32RemS_134217728(536870911), 134217727);
+    assert.eq(testI32RemS_134217728(536870912), 0);
+    assert.eq(testI32RemS_134217728(536870913), 1);
+    assert.eq(testI32RemS_134217728(-1), -1);
+    assert.eq(testI32RemS_134217728(-134217728), 0);
+    assert.eq(testI32RemS_134217728(-536870911), -134217727);
+    assert.eq(testI32RemS_134217728(-536870912), 0);
+    assert.eq(testI32RemS_134217728(-536870913), -1);
+
+    assert.eq(testI64RemU_134217728(0n), 0n);
+    assert.eq(testI64RemU_134217728(1n), 1n);
+    assert.eq(testI64RemU_134217728(134217728n), 0n);
+    assert.eq(testI64RemU_134217728(536870911n), 134217727n);
+    assert.eq(testI64RemU_134217728(536870912n), 0n);
+    assert.eq(testI64RemU_134217728(536870913n), 1n);
+
+    assert.eq(testI64RemS_134217728(0n), 0n);
+    assert.eq(testI64RemS_134217728(1n), 1n);
+    assert.eq(testI64RemS_134217728(134217728n), 0n);
+    assert.eq(testI64RemS_134217728(536870911n), 134217727n);
+    assert.eq(testI64RemS_134217728(536870912n), 0n);
+    assert.eq(testI64RemS_134217728(536870913n), 1n);
+    assert.eq(testI64RemS_134217728(-1n), -1n);
+    assert.eq(testI64RemS_134217728(-134217728n), 0n);
+    assert.eq(testI64RemS_134217728(-536870911n), -134217727n);
+    assert.eq(testI64RemS_134217728(-536870912n), 0n);
+    assert.eq(testI64RemS_134217728(-536870913n), -1n);
+
+    assert.eq(testI64RemU_8796093022208(0n), 0n);
+    assert.eq(testI64RemU_8796093022208(1n), 1n);
+    assert.eq(testI64RemU_8796093022208(8796093022208n), 0n);
+    assert.eq(testI64RemU_8796093022208(562949953421311n), 8796093022207n);
+    assert.eq(testI64RemU_8796093022208(562949953421312n), 0n);
+    assert.eq(testI64RemU_8796093022208(562949953421313n), 1n);
+
+    assert.eq(testI64RemS_8796093022208(0n), 0n);
+    assert.eq(testI64RemS_8796093022208(1n), 1n);
+    assert.eq(testI64RemS_8796093022208(8796093022208n), 0n);
+    assert.eq(testI64RemS_8796093022208(562949953421311n), 8796093022207n);
+    assert.eq(testI64RemS_8796093022208(562949953421312n), 0n);
+    assert.eq(testI64RemS_8796093022208(562949953421313n), 1n);
+    assert.eq(testI64RemS_8796093022208(-1n), -1n);
+    assert.eq(testI64RemS_8796093022208(-8796093022208n), 0n);
+    assert.eq(testI64RemS_8796093022208(-562949953421311n), -8796093022207n);
+    assert.eq(testI64RemS_8796093022208(-562949953421312n), 0n);
+    assert.eq(testI64RemS_8796093022208(-562949953421313n), -1n);
+}
+
+assert.asyncTest(test());

--- a/Source/JavaScriptCore/assembler/MacroAssemblerARM64.h
+++ b/Source/JavaScriptCore/assembler/MacroAssemblerARM64.h
@@ -300,6 +300,23 @@ public:
         m_assembler.add<64>(dest, src, dataTempRegister);
     }
 
+    void add64(TrustedImm64 imm, RegisterID src, RegisterID dest)
+    {
+        intptr_t immediate = imm.m_value;
+
+        if (isUInt12(immediate)) {
+            m_assembler.add<64>(dest, src, UInt12(static_cast<int32_t>(immediate)));
+            return;
+        }
+        if (isUInt12(-immediate)) {
+            m_assembler.sub<64>(dest, src, UInt12(static_cast<int32_t>(-immediate)));
+            return;
+        }
+
+        move(imm, getCachedDataTempRegisterIDAndInvalidate());
+        m_assembler.add<64>(dest, src, dataTempRegister);
+    }
+
     void add64(TrustedImm32 imm, Address address)
     {
         load64(address, getCachedDataTempRegisterIDAndInvalidate());


### PR DESCRIPTION
#### acb670a0a6d0437d39ba904083ee21ad89799a43
<pre>
Fix signed division bias for power-of-two divisor in BBQ JIT
<a href="https://bugs.webkit.org/show_bug.cgi?id=256569">https://bugs.webkit.org/show_bug.cgi?id=256569</a>
rdar://108073980

Reviewed by Yusuke Suzuki.

Fixes instruction selection for integer division and remainder
in BBQ JIT when the divisor is a constant power of two, with new
tests for the edge cases previously not covered by our suite.

* JSTests/wasm/stress/divide-by-constant-power-of-two.js: Added.
(async test):
* JSTests/wasm/stress/remainder-by-constant-power-of-two.js: Added.
(async test):
* Source/JavaScriptCore/assembler/MacroAssemblerARM64.h:
(JSC::MacroAssemblerARM64::add64):
* Source/JavaScriptCore/wasm/WasmBBQJIT.cpp:
(JSC::Wasm::BBQJIT::emitModOrDiv):

Canonical link: <a href="https://commits.webkit.org/263925@main">https://commits.webkit.org/263925@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e1a0b38a5200545f4081aa8346653b5bf62b800b

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/6109 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/6294 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/6477 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/7672 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/6457 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/6512 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/6247 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/9331 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/6219 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/6236 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/5525 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/7734 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/3712 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/5506 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/13415 "Passed tests") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/5133 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/5577 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/5584 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/7818 "run-api-tests-without-change (failure)") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/5701 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/6055 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/4957 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/6230 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/5476 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/1488 "Passed tests") | 
| [❌ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/1450 "Failed to push commit to Webkit repository") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/9616 "Built successfully") | | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/24/builds/6403 "Built successfully") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/5844 "Built successfully") | | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/3/builds/1613 "Passed tests") | 
<!--EWS-Status-Bubble-End-->