### PR TITLE
[WGSL] Delete unused parseExpression function

### DIFF
--- a/Source/WebGPU/WGSL/Parser.cpp
+++ b/Source/WebGPU/WGSL/Parser.cpp
@@ -330,22 +330,6 @@ std::optional<Error> parse(ShaderModule& shaderModule)
 }
 
 template<typename Lexer>
-Result<AST::Expression::Ref> parseExpression(const String& source)
-{
-    ShaderModule shaderModule(source);
-    Lexer lexer(shaderModule.source());
-    Parser parser(shaderModule, lexer);
-    return parser.parseExpression();
-}
-
-Result<AST::Expression::Ref> parseExpression(const String& source)
-{
-    if (source.is8Bit())
-        return parseExpression<Lexer<LChar>>(source);
-    return parseExpression<Lexer<UChar>>(source);
-}
-
-template<typename Lexer>
 Expected<Token, TokenType> Parser<Lexer>::consumeType(TokenType type)
 {
     if (current().type == type) {

--- a/Source/WebGPU/WGSL/ParserPrivate.h
+++ b/Source/WebGPU/WGSL/ParserPrivate.h
@@ -109,6 +109,4 @@ private:
     Token m_current;
 };
 
-Result<AST::Expression::Ref> parseExpression(const String& source);
-
 } // namespace WGSL


### PR DESCRIPTION
#### a54540e1fb2dafaf5da2e996781dbcf848b1d25a
<pre>
[WGSL] Delete unused parseExpression function
<a href="https://bugs.webkit.org/show_bug.cgi?id=256596">https://bugs.webkit.org/show_bug.cgi?id=256596</a>
rdar://109162040

Reviewed by Dan Glastonbury.

The WGSL parser has a standalone parseExpression function that was used in testing,
but since AST nodes are now arena allocated, and the arenas&apos; lifecycle is controlled
by the ShaderModule instance, it&apos;s no longer valid to return an AST node after the
module is destroyed, so this function should no longer be used.

* Source/WebGPU/WGSL/Parser.cpp:
(WGSL::parseExpression): Deleted.
* Source/WebGPU/WGSL/ParserPrivate.h:

Canonical link: <a href="https://commits.webkit.org/263935@main">https://commits.webkit.org/263935@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ecc5741899b5d05c3ea327ecfa4a97cc77760836

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/6117 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/6302 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/6485 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/7680 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/6465 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/6521 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/6255 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/9339 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/6227 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/6244 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/5534 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/7742 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/3720 "Passed tests") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/13420 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/5585 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/5593 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/7824 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/6063 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/4963 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/5484 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/1460 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/9626 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/5852 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->