### PR TITLE
[WGSL] Remove leftover references to Ref and RefCounted

### DIFF
--- a/Source/WebGPU/WGSL/AST/ASTAttribute.h
+++ b/Source/WebGPU/WGSL/AST/ASTAttribute.h
@@ -27,7 +27,6 @@
 
 #include "ASTNode.h"
 
-#include <wtf/RefCounted.h>
 #include <wtf/ReferenceWrapperVector.h>
 
 namespace WGSL::AST {

--- a/Source/WebGPU/WGSL/AST/ASTParameter.h
+++ b/Source/WebGPU/WGSL/AST/ASTParameter.h
@@ -29,7 +29,6 @@
 #include "ASTBuilder.h"
 #include "ASTIdentifier.h"
 #include "ASTTypeName.h"
-#include <wtf/RefCounted.h>
 #include <wtf/ReferenceWrapperVector.h>
 
 namespace WGSL::AST {

--- a/Source/WebGPU/WGSL/Parser.cpp
+++ b/Source/WebGPU/WGSL/Parser.cpp
@@ -83,9 +83,6 @@ struct TemplateTypes<TT> {
 #define RETURN_ARENA_NODE(type, ...) \
     return { MAKE_ARENA_NODE(type __VA_OPT__(,) __VA_ARGS__) }; /* NOLINT */
 
-#define RETURN_NODE_REF(type, ...) \
-    return { adoptRef(*new AST::type(CURRENT_SOURCE_SPAN(), __VA_ARGS__)) };
-
 #define RETURN_NODE_UNIQUE_REF(type, ...) \
     return { MAKE_NODE_UNIQUE_REF(type __VA_OPT__(,) __VA_ARGS__) }; /* NOLINT */
 


### PR DESCRIPTION
#### 9a162e2f2fa38c495c43a6c78300ea1dc373821f
<pre>
[WGSL] Remove leftover references to Ref and RefCounted
<a href="https://bugs.webkit.org/show_bug.cgi?id=256597">https://bugs.webkit.org/show_bug.cgi?id=256597</a>
rdar://109162910

Reviewed by Mike Wyrzykowski and Dan Glastonbury.

Since moving to arena allocated nodes, we no longer use WTF::Ref or RefCounted,
but there were some leftover references.

* Source/WebGPU/WGSL/AST/ASTAttribute.h:
* Source/WebGPU/WGSL/AST/ASTParameter.h:
* Source/WebGPU/WGSL/Parser.cpp:

Canonical link: <a href="https://commits.webkit.org/263950@main">https://commits.webkit.org/263950@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d94b2d32e6e761bfa567d1eb9e5710170589bf02

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/6118 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/6303 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/6486 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/7681 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/6466 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/6522 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/6256 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/9340 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/6228 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/6246 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/5535 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/7743 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/3722 "Passed tests") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/13422 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/5587 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/5594 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/7827 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/6064 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/4964 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/5485 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/1470 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/9627 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/5853 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->