### PR TITLE
[WGSL] Convert declaration nodes to be arena allocated

### DIFF
--- a/Source/WebGPU/WGSL/AST/ASTDeclaration.h
+++ b/Source/WebGPU/WGSL/AST/ASTDeclaration.h
@@ -25,18 +25,19 @@
 
 #pragma once
 
+#include "ASTBuilder.h"
 #include "ASTNode.h"
-
+#include <wtf/ReferenceWrapperVector.h>
 #include <wtf/TypeCasts.h>
-#include <wtf/UniqueRefVector.h>
 
 namespace WGSL::AST {
 
 class Declaration : public Node {
-    WTF_MAKE_FAST_ALLOCATED;
+    WGSL_AST_BUILDER_NODE(Declaration);
 public:
-    using List = UniqueRefVector<Declaration>;
+    using List = ReferenceWrapperVector<Declaration>;
 
+protected:
     Declaration(SourceSpan span)
         : Node(span)
     { }

--- a/Source/WebGPU/WGSL/AST/ASTFunction.h
+++ b/Source/WebGPU/WGSL/AST/ASTFunction.h
@@ -30,26 +30,16 @@
 #include "ASTDeclaration.h"
 #include "ASTParameter.h"
 #include "ASTTypeName.h"
-#include "CompilationMessage.h"
 
 #include <wtf/UniqueRefVector.h>
 
 namespace WGSL::AST {
 
 class Function final : public Declaration {
-    WTF_MAKE_FAST_ALLOCATED;
+    WGSL_AST_BUILDER_NODE(Function);
 public:
-    using List = UniqueRefVector<Function>;
-
-    Function(SourceSpan span, Identifier&& name, Parameter::List&& parameters, TypeName::Ptr returnType, CompoundStatement&& body, Attribute::List&& attributes, Attribute::List&& returnAttributes)
-        : Declaration(span)
-        , m_name(WTFMove(name))
-        , m_parameters(WTFMove(parameters))
-        , m_attributes(WTFMove(attributes))
-        , m_returnAttributes(WTFMove(returnAttributes))
-        , m_returnType(returnType)
-        , m_body(WTFMove(body))
-    { }
+    using Ref = std::reference_wrapper<Function>;
+    using List = ReferenceWrapperVector<Function>;
 
     NodeKind kind() const override;
     Identifier& name() { return m_name; }
@@ -66,6 +56,16 @@ public:
     const CompoundStatement& body() const { return m_body; }
 
 private:
+    Function(SourceSpan span, Identifier&& name, Parameter::List&& parameters, TypeName::Ptr returnType, CompoundStatement&& body, Attribute::List&& attributes, Attribute::List&& returnAttributes)
+        : Declaration(span)
+        , m_name(WTFMove(name))
+        , m_parameters(WTFMove(parameters))
+        , m_attributes(WTFMove(attributes))
+        , m_returnAttributes(WTFMove(returnAttributes))
+        , m_returnType(returnType)
+        , m_body(WTFMove(body))
+    { }
+
     Identifier m_name;
     Parameter::List m_parameters;
     Attribute::List m_attributes;

--- a/Source/WebGPU/WGSL/AST/ASTStructure.h
+++ b/Source/WebGPU/WGSL/AST/ASTStructure.h
@@ -42,18 +42,10 @@ enum class StructureRole : uint8_t {
 };
 
 class Structure final : public Declaration {
-    WTF_MAKE_FAST_ALLOCATED;
+    WGSL_AST_BUILDER_NODE(Structure);
 public:
-    using Ref = UniqueRef<Structure>;
-    using List = UniqueRefVector<Structure>;
-
-    Structure(SourceSpan span, Identifier&& name, StructureMember::List&& members, Attribute::List&& attributes, StructureRole role)
-        : Declaration(span)
-        , m_name(WTFMove(name))
-        , m_attributes(WTFMove(attributes))
-        , m_members(WTFMove(members))
-        , m_role(role)
-    { }
+    using Ref = std::reference_wrapper<Structure>;
+    using List = ReferenceWrapperVector<Structure>;
 
     NodeKind kind() const override;
     StructureRole role() const { return m_role; }
@@ -65,6 +57,14 @@ public:
     void setRole(StructureRole role) { m_role = role; }
 
 private:
+    Structure(SourceSpan span, Identifier&& name, StructureMember::List&& members, Attribute::List&& attributes, StructureRole role)
+        : Declaration(span)
+        , m_name(WTFMove(name))
+        , m_attributes(WTFMove(attributes))
+        , m_members(WTFMove(members))
+        , m_role(role)
+    { }
+
     Identifier m_name;
     Attribute::List m_attributes;
     StructureMember::List m_members;

--- a/Source/WebGPU/WGSL/AST/ASTVariable.h
+++ b/Source/WebGPU/WGSL/AST/ASTVariable.h
@@ -42,20 +42,29 @@ enum class VariableFlavor : uint8_t {
 };
 
 class Variable final : public Declaration {
-    WTF_MAKE_FAST_ALLOCATED;
+    WGSL_AST_BUILDER_NODE(Variable);
 public:
-    using Ref = UniqueRef<Variable>;
-    using List = UniqueRefVector<Variable>;
+    using Ref = std::reference_wrapper<Variable>;
+    using List = ReferenceWrapperVector<Variable>;
 
+    NodeKind kind() const override;
+    VariableFlavor flavor() const { return m_flavor; };
+    Identifier& name() { return m_name; }
+    Attribute::List& attributes() { return m_attributes; }
+    VariableQualifier* maybeQualifier() { return m_qualifier; }
+    TypeName* maybeTypeName() { return m_type; }
+    Expression* maybeInitializer() { return m_initializer; }
+
+private:
     Variable(SourceSpan span, VariableFlavor flavor, Identifier&& name, TypeName::Ptr type, Expression::Ptr initializer)
         : Variable(span, flavor, WTFMove(name), { }, type, initializer, { })
     { }
 
-    Variable(SourceSpan span, VariableFlavor flavor, Identifier&& name, VariableQualifier::Ptr&& qualifier, TypeName::Ptr type, Expression::Ptr initializer, Attribute::List&& attributes)
+    Variable(SourceSpan span, VariableFlavor flavor, Identifier&& name, VariableQualifier::Ptr qualifier, TypeName::Ptr type, Expression::Ptr initializer, Attribute::List&& attributes)
         : Declaration(span)
         , m_name(WTFMove(name))
         , m_attributes(WTFMove(attributes))
-        , m_qualifier(WTFMove(qualifier))
+        , m_qualifier(qualifier)
         , m_type(type)
         , m_initializer(initializer)
         , m_flavor(flavor)
@@ -63,15 +72,6 @@ public:
         ASSERT(m_type || m_initializer);
     }
 
-    NodeKind kind() const override;
-    VariableFlavor flavor() const { return m_flavor; };
-    Identifier& name() { return m_name; }
-    Attribute::List& attributes() { return m_attributes; }
-    VariableQualifier* maybeQualifier() { return m_qualifier.get(); }
-    TypeName* maybeTypeName() { return m_type; }
-    Expression* maybeInitializer() { return m_initializer; }
-
-private:
     Identifier m_name;
     Attribute::List m_attributes;
     // Each of the following may be null

--- a/Source/WebGPU/WGSL/AST/ASTVariableQualifier.h
+++ b/Source/WebGPU/WGSL/AST/ASTVariableQualifier.h
@@ -25,6 +25,7 @@
 
 #pragma once
 
+#include "ASTBuilder.h"
 #include "ASTNode.h"
 
 namespace WGSL::AST {
@@ -45,21 +46,22 @@ enum class AccessMode : uint8_t {
 
 // FIXME: Perhaps this class is not needed if we have spanned identifier?
 class VariableQualifier final : public Node {
-    WTF_MAKE_FAST_ALLOCATED;
+    WGSL_AST_BUILDER_NODE(VariableQualifier);
 public:
-    using Ptr = std::unique_ptr<VariableQualifier>;
-
-    VariableQualifier(SourceSpan span, StorageClass storageClass, AccessMode accessMode)
-        : Node(span)
-        , m_storageClass(storageClass)
-        , m_accessMode(accessMode)
-    { }
+    using Ref = std::reference_wrapper<VariableQualifier>;
+    using Ptr = VariableQualifier*;
 
     NodeKind kind() const override;
     StorageClass storageClass() const { return m_storageClass; }
     AccessMode accessMode() const { return m_accessMode; }
 
 private:
+    VariableQualifier(SourceSpan span, StorageClass storageClass, AccessMode accessMode)
+        : Node(span)
+        , m_storageClass(storageClass)
+        , m_accessMode(accessMode)
+    { }
+
     StorageClass m_storageClass;
     AccessMode m_accessMode;
 };

--- a/Source/WebGPU/WGSL/EntryPointRewriter.cpp
+++ b/Source/WebGPU/WGSL/EntryPointRewriter.cpp
@@ -180,7 +180,7 @@ void EntryPointRewriter::constructInputStruct()
         break;
     }
 
-    m_shaderModule.append(m_shaderModule.structures(), makeUniqueRef<AST::Structure>(
+    m_shaderModule.append(m_shaderModule.structures(), m_shaderModule.astBuilder().construct<AST::Structure>(
         SourceSpan::empty(),
         AST::Identifier::make(m_structTypeName),
         WTFMove(structMembers),
@@ -206,7 +206,7 @@ void EntryPointRewriter::materialize(Vector<String>& path, MemberOrParameter& da
     if (!path.size()) {
         m_materializations.append(makeUniqueRef<AST::VariableStatement>(
             SourceSpan::empty(),
-            makeUniqueRef<AST::Variable>(
+            m_shaderModule.astBuilder().construct<AST::Variable>(
                 SourceSpan::empty(),
                 AST::VariableFlavor::Var,
                 AST::Identifier::make(data.name),
@@ -242,7 +242,7 @@ void EntryPointRewriter::visit(Vector<String>& path, MemberOrParameter&& data)
     if (auto* structType = std::get_if<Types::Struct>(data.type.resolvedType())) {
         m_materializations.append(makeUniqueRef<AST::VariableStatement>(
             SourceSpan::empty(),
-            makeUniqueRef<AST::Variable>(
+            m_shaderModule.astBuilder().construct<AST::Variable>(
                 SourceSpan::empty(),
                 AST::VariableFlavor::Var,
                 AST::Identifier::make(data.name),

--- a/Source/WebGPU/WGSL/GlobalVariableRewriter.cpp
+++ b/Source/WebGPU/WGSL/GlobalVariableRewriter.cpp
@@ -322,7 +322,7 @@ void RewriteGlobalVariables::insertStructs(const UsedGlobals& usedGlobals)
             ));
         }
 
-        m_callGraph.ast().append(m_callGraph.ast().structures(), makeUniqueRef<AST::Structure>(
+        m_callGraph.ast().append(m_callGraph.ast().structures(), m_callGraph.ast().astBuilder().construct<AST::Structure>(
             SourceSpan::empty(),
             WTFMove(structName),
             WTFMove(structMembers),

--- a/Source/WebGPU/WGSL/ParserPrivate.h
+++ b/Source/WebGPU/WGSL/ParserPrivate.h
@@ -67,10 +67,10 @@ public:
     Result<AST::TypeName::Ref> parseArrayType();
     Result<AST::Variable::Ref> parseVariable();
     Result<AST::Variable::Ref> parseVariableWithAttributes(AST::Attribute::List&&);
-    Result<AST::VariableQualifier> parseVariableQualifier();
+    Result<AST::VariableQualifier::Ref> parseVariableQualifier();
     Result<AST::StorageClass> parseStorageClass();
     Result<AST::AccessMode> parseAccessMode();
-    Result<AST::Function> parseFunction(AST::Attribute::List&&);
+    Result<AST::Function::Ref> parseFunction(AST::Attribute::List&&);
     Result<std::reference_wrapper<AST::Parameter>> parseParameter();
     Result<AST::Statement::Ref> parseStatement();
     Result<AST::CompoundStatement> parseCompoundStatement();


### PR DESCRIPTION
#### 51df1d376734659c3b98bbcdcb106ebb619cdcff
<pre>
[WGSL] Convert declaration nodes to be arena allocated
<a href="https://bugs.webkit.org/show_bug.cgi?id=256599">https://bugs.webkit.org/show_bug.cgi?id=256599</a>
rdar://109163094

Reviewed by Dan Glastonbury.

Continue converting nodes to be arena allocated

* Source/WebGPU/WGSL/AST/ASTDeclaration.h:
* Source/WebGPU/WGSL/AST/ASTFunction.h:
* Source/WebGPU/WGSL/AST/ASTStructure.h:
* Source/WebGPU/WGSL/AST/ASTVariable.h:
* Source/WebGPU/WGSL/AST/ASTVariableQualifier.h:
* Source/WebGPU/WGSL/EntryPointRewriter.cpp:
(WGSL::EntryPointRewriter::constructInputStruct):
(WGSL::EntryPointRewriter::materialize):
(WGSL::EntryPointRewriter::visit):
* Source/WebGPU/WGSL/GlobalVariableRewriter.cpp:
(WGSL::RewriteGlobalVariables::insertStructs):
* Source/WebGPU/WGSL/Parser.cpp:
(WGSL::Parser&lt;Lexer&gt;::parseGlobalDecl):
(WGSL::Parser&lt;Lexer&gt;::parseStructure):
(WGSL::Parser&lt;Lexer&gt;::parseVariableWithAttributes):
(WGSL::Parser&lt;Lexer&gt;::parseVariableQualifier):
(WGSL::Parser&lt;Lexer&gt;::parseFunction):
* Source/WebGPU/WGSL/ParserPrivate.h:

Canonical link: <a href="https://commits.webkit.org/263951@main">https://commits.webkit.org/263951@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d7f7fb61997280fc0b5156b0928bbbe73d03d1c0

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/6119 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/6304 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/6487 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/7682 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/6467 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/6523 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/6257 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/9343 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/6229 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/6255 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/5538 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/7744 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/3730 "Passed tests") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/13423 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/5595 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/5597 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/7828 "6 api tests failed or timed out") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/6065 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/4971 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/5486 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/1471 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/9628 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/5854 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->