### PR TITLE
[WGSL] Convert statement nodes to be arena allocated

### DIFF
--- a/Source/WebGPU/WGSL/AST/ASTAssignmentStatement.h
+++ b/Source/WebGPU/WGSL/AST/ASTAssignmentStatement.h
@@ -31,19 +31,19 @@
 namespace WGSL::AST {
 
 class AssignmentStatement final : public Statement {
-    WTF_MAKE_FAST_ALLOCATED;
+    WGSL_AST_BUILDER_NODE(AssignmentStatement);
 public:
+    NodeKind kind() const override;
+    Expression& lhs() { return m_lhs.get(); }
+    Expression& rhs() { return m_rhs.get(); }
+
+private:
     AssignmentStatement(SourceSpan span, Expression::Ref&& lhs, Expression::Ref&& rhs)
         : Statement(span)
         , m_lhs(WTFMove(lhs))
         , m_rhs(WTFMove(rhs))
     { }
 
-    NodeKind kind() const override;
-    Expression& lhs() { return m_lhs.get(); }
-    Expression& rhs() { return m_rhs.get(); }
-
-private:
     Expression::Ref m_lhs;
     Expression::Ref m_rhs;
 };

--- a/Source/WebGPU/WGSL/AST/ASTBreakStatement.h
+++ b/Source/WebGPU/WGSL/AST/ASTBreakStatement.h
@@ -33,13 +33,14 @@
 namespace WGSL::AST {
 
 class BreakStatement final : public Statement {
-    WTF_MAKE_FAST_ALLOCATED;
+    WGSL_AST_BUILDER_NODE(BreakStatement);
 public:
+    NodeKind kind() const override;
+
+private:
     BreakStatement(SourceSpan span)
         : Statement(span)
     { }
-
-    NodeKind kind() const override;
 };
 
 } // namespace WGSL::AST

--- a/Source/WebGPU/WGSL/AST/ASTCompoundAssignmentStatement.h
+++ b/Source/WebGPU/WGSL/AST/ASTCompoundAssignmentStatement.h
@@ -31,8 +31,14 @@
 namespace WGSL::AST {
 
 class CompoundAssignmentStatement : public Statement {
-    WTF_MAKE_FAST_ALLOCATED;
+    WGSL_AST_BUILDER_NODE(CompoundAssignmentStatement);
 public:
+    NodeKind kind() const override;
+    Expression& leftExpression() { return m_leftExpression; }
+    Expression& rightExpression() { return m_rightExpression; }
+    BinaryOperation operation() const { return m_operation; }
+
+private:
     CompoundAssignmentStatement(SourceSpan span, Expression::Ref&& lhs, Expression::Ref&& rhs, BinaryOperation operation)
         : Statement(span)
         , m_leftExpression(WTFMove(lhs))
@@ -40,12 +46,6 @@ public:
         , m_operation(operation)
     { }
 
-    NodeKind kind() const override;
-    Expression& leftExpression() { return m_leftExpression; }
-    Expression& rightExpression() { return m_rightExpression; }
-    BinaryOperation operation() const { return m_operation; }
-
-private:
     Expression::Ref m_leftExpression;
     Expression::Ref m_rightExpression;
     BinaryOperation m_operation;

--- a/Source/WebGPU/WGSL/AST/ASTCompoundStatement.h
+++ b/Source/WebGPU/WGSL/AST/ASTCompoundStatement.h
@@ -30,21 +30,20 @@
 namespace WGSL::AST {
 
 class CompoundStatement final : public Statement {
-    WTF_MAKE_FAST_ALLOCATED;
+    WGSL_AST_BUILDER_NODE(CompoundStatement);
 public:
-
-    using Ref = UniqueRef<CompoundStatement>;
-
-    CompoundStatement(SourceSpan span, Statement::List&& statements)
-        : Statement(span)
-        , m_statements(WTFMove(statements))
-    { }
+    using Ref = std::reference_wrapper<CompoundStatement>;
 
     NodeKind kind() const override;
     Statement::List& statements() { return m_statements; }
     const Statement::List& statements() const { return m_statements; }
 
 private:
+    CompoundStatement(SourceSpan span, Statement::List&& statements)
+        : Statement(span)
+        , m_statements(WTFMove(statements))
+    { }
+
     Statement::List m_statements;
 };
 

--- a/Source/WebGPU/WGSL/AST/ASTContinueStatement.h
+++ b/Source/WebGPU/WGSL/AST/ASTContinueStatement.h
@@ -32,13 +32,14 @@
 namespace WGSL::AST {
 
 class ContinueStatement final : public Statement {
-    WTF_MAKE_FAST_ALLOCATED;
+    WGSL_AST_BUILDER_NODE(ContinueStatement);
 public:
+    NodeKind kind() const override;
+
+private:
     ContinueStatement(SourceSpan span)
         : Statement(span)
     { }
-
-    NodeKind kind() const override;
 };
 
 } // namespace WGSL::AST

--- a/Source/WebGPU/WGSL/AST/ASTDecrementIncrementStatement.h
+++ b/Source/WebGPU/WGSL/AST/ASTDecrementIncrementStatement.h
@@ -31,23 +31,22 @@
 namespace WGSL::AST {
 
 class DecrementIncrementStatement final : public Statement {
-    WTF_MAKE_FAST_ALLOCATED;
+    WGSL_AST_BUILDER_NODE(DecrementIncrementStatement);
 public:
-
     enum class Operation : uint8_t {
         Decrement,
         Increment,
     };
 
+    NodeKind kind() const override;
+    Expression& expression() { return m_expression; }
+
+private:
     DecrementIncrementStatement(SourceSpan span, Expression::Ref&& expression)
         : Statement(span)
         , m_expression(WTFMove(expression))
     { }
 
-    NodeKind kind() const override;
-    Expression& expression() { return m_expression; }
-
-private:
     Expression::Ref m_expression;
 };
 

--- a/Source/WebGPU/WGSL/AST/ASTDiscardStatement.h
+++ b/Source/WebGPU/WGSL/AST/ASTDiscardStatement.h
@@ -25,20 +25,19 @@
 
 #pragma once
 
-#pragma once
-
 #include "ASTStatement.h"
 
 namespace WGSL::AST {
 
 class DiscardStatement final : public Statement {
-    WTF_MAKE_FAST_ALLOCATED;
+    WGSL_AST_BUILDER_NODE(DiscardStatement);
 public:
+    NodeKind kind() const override;
+
+private:
     DiscardStatement(SourceSpan span)
         : Statement(span)
     { }
-
-    NodeKind kind() const override;
 };
 
 } // namespace WGSL::AST

--- a/Source/WebGPU/WGSL/AST/ASTForStatement.h
+++ b/Source/WebGPU/WGSL/AST/ASTForStatement.h
@@ -31,27 +31,27 @@
 namespace WGSL::AST {
 
 class ForStatement final : public Statement {
-    WTF_MAKE_FAST_ALLOCATED;
+    WGSL_AST_BUILDER_NODE(ForStatement);
 public:
-    ForStatement(SourceSpan span, Statement::Ptr&& initializer, Expression::Ptr test, Statement::Ptr&& update, CompoundStatement&& body)
-        : Statement(span)
-        , m_initializer(WTFMove(initializer))
-        , m_test(test)
-        , m_update(WTFMove(update))
-        , m_body(WTFMove(body))
-    { }
-
     NodeKind kind() const override;
-    Statement* maybeInitializer() { return m_initializer.get(); }
+    Statement* maybeInitializer() { return m_initializer; }
     Expression* maybeTest() { return m_test; }
-    Statement* maybeUpdate() { return m_update.get(); }
+    Statement* maybeUpdate() { return m_update; }
     CompoundStatement& body() { return m_body; }
 
 private:
+    ForStatement(SourceSpan span, Statement::Ptr initializer, Expression::Ptr test, Statement::Ptr update, CompoundStatement::Ref&& body)
+        : Statement(span)
+        , m_initializer(initializer)
+        , m_test(test)
+        , m_update(update)
+        , m_body(WTFMove(body))
+    { }
+
     Statement::Ptr m_initializer;
     Expression::Ptr m_test;
     Statement::Ptr m_update;
-    CompoundStatement m_body;
+    CompoundStatement::Ref m_body;
 };
 
 } // namespace WGSL::AST

--- a/Source/WebGPU/WGSL/AST/ASTFunction.h
+++ b/Source/WebGPU/WGSL/AST/ASTFunction.h
@@ -47,16 +47,16 @@ public:
     Attribute::List& attributes() { return m_attributes; }
     Attribute::List& returnAttributes() { return m_returnAttributes; }
     TypeName* maybeReturnType() { return m_returnType; }
-    CompoundStatement& body() { return m_body; }
+    CompoundStatement& body() { return m_body.get(); }
     const Identifier& name() const { return m_name; }
     const Parameter::List& parameters() const { return m_parameters; }
     const Attribute::List& attributes() const { return m_attributes; }
     const Attribute::List& returnAttributes() const { return m_returnAttributes; }
     const TypeName* maybeReturnType() const { return m_returnType; }
-    const CompoundStatement& body() const { return m_body; }
+    const CompoundStatement& body() const { return m_body.get(); }
 
 private:
-    Function(SourceSpan span, Identifier&& name, Parameter::List&& parameters, TypeName::Ptr returnType, CompoundStatement&& body, Attribute::List&& attributes, Attribute::List&& returnAttributes)
+    Function(SourceSpan span, Identifier&& name, Parameter::List&& parameters, TypeName::Ptr returnType, CompoundStatement::Ref&& body, Attribute::List&& attributes, Attribute::List&& returnAttributes)
         : Declaration(span)
         , m_name(WTFMove(name))
         , m_parameters(WTFMove(parameters))
@@ -71,7 +71,7 @@ private:
     Attribute::List m_attributes;
     Attribute::List m_returnAttributes;
     TypeName::Ptr m_returnType;
-    CompoundStatement m_body;
+    CompoundStatement::Ref m_body;
 };
 
 } // namespace WGSL::AST

--- a/Source/WebGPU/WGSL/AST/ASTIfStatement.h
+++ b/Source/WebGPU/WGSL/AST/ASTIfStatement.h
@@ -32,25 +32,25 @@
 namespace WGSL::AST {
 
 class IfStatement final : public Statement {
-    WTF_MAKE_FAST_ALLOCATED;
+    WGSL_AST_BUILDER_NODE(IfStatement);
 public:
-    IfStatement(SourceSpan span, Expression::Ref&& test, CompoundStatement&& trueBody, Statement::Ptr&& falseBody, Attribute::List&& attributes)
-        : Statement(span)
-        , m_test(WTFMove(test))
-        , m_trueBody(WTFMove(trueBody))
-        , m_falseBody(WTFMove(falseBody))
-        , m_attributes(WTFMove(attributes))
-    { }
-
     NodeKind kind() const override;
     Expression& test() { return m_test.get(); }
-    CompoundStatement& trueBody() { return m_trueBody; }
-    Statement* maybeFalseBody() { return m_falseBody.get(); }
+    CompoundStatement& trueBody() { return m_trueBody.get(); }
+    Statement* maybeFalseBody() { return m_falseBody; }
     Attribute::List& attributes() { return m_attributes; }
 
 private:
+    IfStatement(SourceSpan span, Expression::Ref&& test, CompoundStatement::Ref&& trueBody, Statement::Ptr falseBody, Attribute::List&& attributes)
+        : Statement(span)
+        , m_test(WTFMove(test))
+        , m_trueBody(WTFMove(trueBody))
+        , m_falseBody(falseBody)
+        , m_attributes(WTFMove(attributes))
+    { }
+
     Expression::Ref m_test;
-    CompoundStatement m_trueBody;
+    CompoundStatement::Ref m_trueBody;
     Statement::Ptr m_falseBody;
     Attribute::List m_attributes;
 };

--- a/Source/WebGPU/WGSL/AST/ASTLoopStatement.h
+++ b/Source/WebGPU/WGSL/AST/ASTLoopStatement.h
@@ -31,19 +31,19 @@
 namespace WGSL::AST {
 
 class LoopStatement final : public Statement {
-    WTF_MAKE_FAST_ALLOCATED;
+    WGSL_AST_BUILDER_NODE(LoopStatement);
 public:
+    NodeKind kind() const override;
+    CompoundStatement& body() { return m_body.get(); }
+    CompoundStatement& continuingBody() { return m_continuingBody.get(); }
+
+private:
     LoopStatement(SourceSpan span, CompoundStatement::Ref&& body, CompoundStatement::Ref&& continuingBody)
         : Statement(span)
         , m_body(WTFMove(body))
         , m_continuingBody(WTFMove(continuingBody))
     { }
 
-    NodeKind kind() const override;
-    CompoundStatement& body() { return m_body.get(); }
-    CompoundStatement& continuingBody() { return m_continuingBody.get(); }
-
-private:
     CompoundStatement::Ref m_body;
     CompoundStatement::Ref m_continuingBody;
 };

--- a/Source/WebGPU/WGSL/AST/ASTPhonyStatement.h
+++ b/Source/WebGPU/WGSL/AST/ASTPhonyStatement.h
@@ -31,17 +31,17 @@
 namespace WGSL::AST {
 
 class PhonyAssignmentStatement final : public Statement {
-    WTF_MAKE_FAST_ALLOCATED;
+    WGSL_AST_BUILDER_NODE(PhonyAssignmentStatement);
 public:
+    NodeKind kind() const override;
+    Expression& rhs() { return m_rhs.get(); }
+
+private:
     PhonyAssignmentStatement(SourceSpan span, Expression::Ref&& rhs)
         : Statement(span)
         , m_rhs(WTFMove(rhs))
     { }
 
-    NodeKind kind() const override;
-    Expression& rhs() { return m_rhs.get(); }
-
-private:
     Expression::Ref m_rhs;
 };
 

--- a/Source/WebGPU/WGSL/AST/ASTReturnStatement.h
+++ b/Source/WebGPU/WGSL/AST/ASTReturnStatement.h
@@ -31,17 +31,17 @@
 namespace WGSL::AST {
 
 class ReturnStatement final : public Statement {
-    WTF_MAKE_FAST_ALLOCATED;
+    WGSL_AST_BUILDER_NODE(ReturnStatement);
 public:
+    NodeKind kind() const override;
+    Expression* maybeExpression() { return m_expression; }
+
+private:
     ReturnStatement(SourceSpan span, Expression::Ptr expression)
         : Statement(span)
         , m_expression(expression)
     { }
 
-    NodeKind kind() const override;
-    Expression* maybeExpression() { return m_expression; }
-
-private:
     Expression::Ptr m_expression;
 };
 

--- a/Source/WebGPU/WGSL/AST/ASTStatement.h
+++ b/Source/WebGPU/WGSL/AST/ASTStatement.h
@@ -25,19 +25,20 @@
 
 #pragma once
 
+#include "ASTBuilder.h"
 #include "ASTNode.h"
-
-#include <wtf/UniqueRefVector.h>
+#include <wtf/ReferenceWrapperVector.h>
 
 namespace WGSL::AST {
 
 class Statement : public Node {
-    WTF_MAKE_FAST_ALLOCATED;
+    WGSL_AST_BUILDER_NODE(Statement);
 public:
-    using Ref = UniqueRef<Statement>;
-    using Ptr = std::unique_ptr<Statement>;
-    using List = UniqueRefVector<Statement>;
+    using Ref = std::reference_wrapper<Statement>;
+    using Ptr = Statement*;
+    using List = ReferenceWrapperVector<Statement>;
 
+protected:
     Statement(SourceSpan span)
         : Node(span)
     { }

--- a/Source/WebGPU/WGSL/AST/ASTStaticAssertStatement.h
+++ b/Source/WebGPU/WGSL/AST/ASTStaticAssertStatement.h
@@ -31,17 +31,17 @@
 namespace WGSL::AST {
 
 class StaticAssertStatement final : public Statement {
-    WTF_MAKE_FAST_ALLOCATED;
+    WGSL_AST_BUILDER_NODE(StaticAssertStatement);
 public:
+    NodeKind kind() const final;
+    Expression& expression() { return m_expression.get(); }
+
+private:
     StaticAssertStatement(SourceSpan span, Expression::Ref&& expression)
         : Statement(span)
         , m_expression(WTFMove(expression))
     { }
 
-    NodeKind kind() const final;
-    Expression& expression() { return m_expression.get(); }
-
-private:
     Expression::Ref m_expression;
 };
 

--- a/Source/WebGPU/WGSL/AST/ASTSwitchStatement.h
+++ b/Source/WebGPU/WGSL/AST/ASTSwitchStatement.h
@@ -30,13 +30,14 @@
 namespace WGSL::AST {
 
 class SwitchStatement final : public Statement {
-    WTF_MAKE_FAST_ALLOCATED;
+    WGSL_AST_BUILDER_NODE(SwitchStatement);
 public:
+    NodeKind kind() const final;
+
+private:
     SwitchStatement(SourceSpan span)
         : Statement(span)
     { }
-
-    NodeKind kind() const final;
 };
 
 } // namespace WGSL::AST

--- a/Source/WebGPU/WGSL/AST/ASTVariable.h
+++ b/Source/WebGPU/WGSL/AST/ASTVariable.h
@@ -26,6 +26,7 @@
 #pragma once
 
 #include "ASTAttribute.h"
+#include "ASTAttribute.h"
 #include "ASTDeclaration.h"
 #include "ASTExpression.h"
 #include "ASTIdentifier.h"

--- a/Source/WebGPU/WGSL/AST/ASTVariableStatement.h
+++ b/Source/WebGPU/WGSL/AST/ASTVariableStatement.h
@@ -31,17 +31,17 @@
 namespace WGSL::AST {
 
 class VariableStatement final : public Statement {
-    WTF_MAKE_FAST_ALLOCATED;
+    WGSL_AST_BUILDER_NODE(VariableStatement);
 public:
+    NodeKind kind() const override;
+    Variable& variable() { return m_variable.get(); }
+
+private:
     VariableStatement(SourceSpan span, Variable::Ref&& variable)
         : Statement(span)
         , m_variable(WTFMove(variable))
     { }
 
-    NodeKind kind() const override;
-    Variable& variable() { return m_variable.get(); }
-
-private:
     Variable::Ref m_variable;
 };
 

--- a/Source/WebGPU/WGSL/AST/ASTWhileStatement.h
+++ b/Source/WebGPU/WGSL/AST/ASTWhileStatement.h
@@ -31,19 +31,19 @@
 namespace WGSL::AST {
 
 class WhileStatement final : public Statement {
-    WTF_MAKE_FAST_ALLOCATED;
+    WGSL_AST_BUILDER_NODE(WhileStatement);
 public:
+    NodeKind kind() const final;
+    Expression& test() { return m_test.get(); }
+    CompoundStatement& body() { return m_body.get(); }
+
+private:
     WhileStatement(SourceSpan span, Expression::Ref&& test, CompoundStatement::Ref&& body)
         : Statement(span)
         , m_test(WTFMove(test))
         , m_body(WTFMove(body))
     { }
 
-    NodeKind kind() const final;
-    Expression& test() { return m_test.get(); }
-    CompoundStatement& body() { return m_body.get(); }
-
-private:
     Expression::Ref m_test;
     CompoundStatement::Ref m_body;
 };

--- a/Source/WebGPU/WGSL/EntryPointRewriter.cpp
+++ b/Source/WebGPU/WGSL/EntryPointRewriter.cpp
@@ -204,7 +204,7 @@ void EntryPointRewriter::materialize(Vector<String>& path, MemberOrParameter& da
     }
 
     if (!path.size()) {
-        m_materializations.append(makeUniqueRef<AST::VariableStatement>(
+        m_materializations.append(m_shaderModule.astBuilder().construct<AST::VariableStatement>(
             SourceSpan::empty(),
             m_shaderModule.astBuilder().construct<AST::Variable>(
                 SourceSpan::empty(),
@@ -230,7 +230,7 @@ void EntryPointRewriter::materialize(Vector<String>& path, MemberOrParameter& da
         );
     }
     path.removeLast();
-    m_materializations.append(makeUniqueRef<AST::AssignmentStatement>(
+    m_materializations.append(m_shaderModule.astBuilder().construct<AST::AssignmentStatement>(
         SourceSpan::empty(),
         WTFMove(lhs),
         *rhs
@@ -240,7 +240,7 @@ void EntryPointRewriter::materialize(Vector<String>& path, MemberOrParameter& da
 void EntryPointRewriter::visit(Vector<String>& path, MemberOrParameter&& data)
 {
     if (auto* structType = std::get_if<Types::Struct>(data.type.resolvedType())) {
-        m_materializations.append(makeUniqueRef<AST::VariableStatement>(
+        m_materializations.append(m_shaderModule.astBuilder().construct<AST::VariableStatement>(
             SourceSpan::empty(),
             m_shaderModule.astBuilder().construct<AST::Variable>(
                 SourceSpan::empty(),

--- a/Source/WebGPU/WGSL/ParserPrivate.h
+++ b/Source/WebGPU/WGSL/ParserPrivate.h
@@ -73,11 +73,11 @@ public:
     Result<AST::Function::Ref> parseFunction(AST::Attribute::List&&);
     Result<std::reference_wrapper<AST::Parameter>> parseParameter();
     Result<AST::Statement::Ref> parseStatement();
-    Result<AST::CompoundStatement> parseCompoundStatement();
-    Result<AST::IfStatement> parseIfStatement();
-    Result<AST::IfStatement> parseIfStatementWithAttributes(AST::Attribute::List&&, SourcePosition _startOfElementPosition);
-    Result<AST::ForStatement> parseForStatement();
-    Result<AST::ReturnStatement> parseReturnStatement();
+    Result<AST::CompoundStatement::Ref> parseCompoundStatement();
+    Result<AST::Statement::Ref> parseIfStatement();
+    Result<AST::Statement::Ref> parseIfStatementWithAttributes(AST::Attribute::List&&, SourcePosition _startOfElementPosition);
+    Result<AST::Statement::Ref> parseForStatement();
+    Result<AST::Statement::Ref> parseReturnStatement();
     Result<AST::Expression::Ref> parseShortCircuitExpression(AST::Expression::Ref&&, TokenType, AST::BinaryOperation);
     Result<AST::Expression::Ref> parseRelationalExpression();
     Result<AST::Expression::Ref> parseRelationalExpressionPostUnary(AST::Expression::Ref&& lhs);


### PR DESCRIPTION
#### e911b9bcc1b3f3b67e8ee6766129f616d103cb23
<pre>
[WGSL] Convert statement nodes to be arena allocated
<a href="https://bugs.webkit.org/show_bug.cgi?id=256600">https://bugs.webkit.org/show_bug.cgi?id=256600</a>
rdar://109163279

Reviewed by Dan Glastonbury.

Continue incrementally converting nodes to be arena allocated

* Source/WebGPU/WGSL/AST/ASTAssignmentStatement.h:
* Source/WebGPU/WGSL/AST/ASTBreakStatement.h:
* Source/WebGPU/WGSL/AST/ASTCompoundAssignmentStatement.h:
(WGSL::AST::CompoundAssignmentStatement::leftExpression):
(WGSL::AST::CompoundAssignmentStatement::rightExpression):
(WGSL::AST::CompoundAssignmentStatement::operation const):
* Source/WebGPU/WGSL/AST/ASTCompoundStatement.h:
* Source/WebGPU/WGSL/AST/ASTContinueStatement.h:
* Source/WebGPU/WGSL/AST/ASTDecrementIncrementStatement.h:
* Source/WebGPU/WGSL/AST/ASTDiscardStatement.h:
* Source/WebGPU/WGSL/AST/ASTForStatement.h:
* Source/WebGPU/WGSL/AST/ASTFunction.h:
* Source/WebGPU/WGSL/AST/ASTIfStatement.h:
* Source/WebGPU/WGSL/AST/ASTLoopStatement.h:
* Source/WebGPU/WGSL/AST/ASTPhonyStatement.h:
* Source/WebGPU/WGSL/AST/ASTReturnStatement.h:
* Source/WebGPU/WGSL/AST/ASTStatement.h:
* Source/WebGPU/WGSL/AST/ASTStaticAssertStatement.h:
* Source/WebGPU/WGSL/AST/ASTSwitchStatement.h:
* Source/WebGPU/WGSL/AST/ASTVariable.h:
* Source/WebGPU/WGSL/AST/ASTVariableStatement.h:
* Source/WebGPU/WGSL/AST/ASTWhileStatement.h:
* Source/WebGPU/WGSL/EntryPointRewriter.cpp:
(WGSL::EntryPointRewriter::materialize):
(WGSL::EntryPointRewriter::visit):
* Source/WebGPU/WGSL/Parser.cpp:
(WGSL::Parser&lt;Lexer&gt;::parseStatement):
(WGSL::Parser&lt;Lexer&gt;::parseCompoundStatement):
(WGSL::Parser&lt;Lexer&gt;::parseIfStatement):
(WGSL::Parser&lt;Lexer&gt;::parseIfStatementWithAttributes):
(WGSL::Parser&lt;Lexer&gt;::parseForStatement):
(WGSL::Parser&lt;Lexer&gt;::parseReturnStatement):
* Source/WebGPU/WGSL/ParserPrivate.h:

Canonical link: <a href="https://commits.webkit.org/263956@main">https://commits.webkit.org/263956@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2bb5bdd143a4277759fd358b220ca8015e702ca0

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/6211 "1 style error") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/6402 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/6582 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/7779 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/6544 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/6622 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/6352 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/9430 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/6321 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/6337 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/5622 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/7850 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/3811 "Passed tests") | | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/13497 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/5676 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/5681 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/7924 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/6157 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/5035 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/5571 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/1473 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/9718 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/5939 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->