### PR TITLE
[webkitpy] Support Python 2 buildbot

### DIFF
--- a/Tools/Scripts/webkitpy/autoinstalled/buildbot.py
+++ b/Tools/Scripts/webkitpy/autoinstalled/buildbot.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2020-2021 Apple Inc. All rights reserved.
+# Copyright (C) 2020-2023 Apple Inc. All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -26,28 +26,38 @@ from webkitscmpy import AutoInstall, Package, Version
 from webkitpy.autoinstalled import twisted
 
 AutoInstall.install(Package('attrs', Version(21, 4, 0)))
-AutoInstall.install(Package('autobahn', Version(20, 7, 1)))
-AutoInstall.install(Package('automat', Version(20, 2, 0), pypi_name='Automat'))
 AutoInstall.install(Package('constantly', Version(15, 1, 0)))
 AutoInstall.install(Package('dateutil', Version(2, 8, 1), pypi_name='python-dateutil'))
-AutoInstall.install(Package('decorator', Version(5, 1, 1)))
 AutoInstall.install(Package('future', Version(0, 18, 2)))
-AutoInstall.install(Package('hyperlink', Version(21, 0, 0)))
-AutoInstall.install(Package('incremental', Version(21, 3, 0)))
 AutoInstall.install(Package('jinja2', Version(2, 11, 3), pypi_name='Jinja2'))
 AutoInstall.install(Package('pbr', Version(5, 9, 0)))
-AutoInstall.install(Package('PyHamcrest', Version(2, 0, 3)))
 AutoInstall.install(Package('PyJWT', Version(1, 7, 1), pypi_name='PyJWT', aliases=['jwt']))
 AutoInstall.install(Package('pyyaml', Version(5, 3, 1), pypi_name='PyYAML'))
-AutoInstall.install(Package('sqlalchemy', Version(1, 3, 20), pypi_name='SQLAlchemy'))
-AutoInstall.install(Package('sqlalchemy-migrate', Version(0, 13, 0)))
-AutoInstall.install(Package('sqlparse', Version(0, 4, 2)))
 AutoInstall.install(Package('Tempita', Version(0, 4, 0)))
-AutoInstall.install(Package('txaio', Version(20, 4, 1)))
 
-AutoInstall.install(Package('buildbot', Version(2, 10, 5)))
-AutoInstall.install(Package('buildbot-worker', Version(2, 10, 5)))
+if sys.version_info >= (3, 0):
+    AutoInstall.install(Package('autobahn', Version(20, 7, 1)))
+    AutoInstall.install(Package('automat', Version(20, 2, 0), pypi_name='Automat'))
+    AutoInstall.install(Package('decorator', Version(5, 1, 1)))
+    AutoInstall.install(Package('PyHamcrest', Version(2, 0, 3)))
+    AutoInstall.install(Package('sqlalchemy', Version(1, 3, 20), pypi_name='SQLAlchemy'))
+    AutoInstall.install(Package('sqlalchemy-migrate', Version(0, 13, 0)))
+    AutoInstall.install(Package('sqlparse', Version(0, 4, 2)))
+    AutoInstall.install(Package('txaio', Version(20, 4, 1)))
 
-from buildbot import statistics
+    AutoInstall.install(Package('buildbot', Version(2, 10, 5)))
+    AutoInstall.install(Package('buildbot-worker', Version(2, 10, 5)))
+
+    from buildbot import statistics
+else:
+    AutoInstall.install(Package('autobahn', Version(17, 8, 1)))
+    AutoInstall.install(Package('automat', Version(0, 6, 0), pypi_name='Automat'))
+    AutoInstall.install(Package('decorator', Version(3, 4, 0)))
+    AutoInstall.install(Package('sqlalchemy-migrate', Version(0, 11, 0)))
+    AutoInstall.install(Package('sqlparse', Version(0, 2, 3)))
+    AutoInstall.install(Package('txaio', Version(2, 8, 1)))
+
+    AutoInstall.install(Package('buildbot', Version(1, 1, 1)))
+    AutoInstall.install(Package('buildbot-worker', Version(1, 1, 1)))
 
 sys.modules[__name__] = __import__('buildbot')

--- a/Tools/Scripts/webkitpy/autoinstalled/twisted.py
+++ b/Tools/Scripts/webkitpy/autoinstalled/twisted.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2020 Apple Inc. All rights reserved.
+# Copyright (C) 2020-2023 Apple Inc. All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -24,16 +24,25 @@ import sys
 
 from webkitscmpy import AutoInstall, Package, Version
 
-AutoInstall.install(Package('hyperlink', Version(21, 0, 0), pypi_name='hyperlink'))
 AutoInstall.install(Package('constantly', Version(15, 1, 0), pypi_name='constantly'))
-AutoInstall.install(Package('incremental', Version(21, 3, 0), pypi_name='incremental'))
-AutoInstall.install(Package('twisted', Version(20, 3, 0), pypi_name='Twisted'))
 
-AutoInstall.install(Package('pyOpenSSL', Version(20, 0, 0)))
-AutoInstall.install(Package('bcrypt', Version(4), wheel=True))
-AutoInstall.install(Package('pycparser', Version(2, 21), wheel=True))
+if sys.version_info >= (3, 0):
+    AutoInstall.install(Package('hyperlink', Version(21, 0, 0), pypi_name='hyperlink'))
+    AutoInstall.install(Package('incremental', Version(21, 3, 0), pypi_name='incremental'))
+    AutoInstall.install(Package('twisted', Version(20, 3, 0), pypi_name='Twisted'))
 
-from twisted.protocols.tls import TLSMemoryBIOFactory
-from twisted.python import threadpool
+    AutoInstall.install(Package('pyOpenSSL', Version(20, 0, 0)))
+    AutoInstall.install(Package('bcrypt', Version(4), wheel=True))
+    AutoInstall.install(Package('pycparser', Version(2, 21), wheel=True))
+
+    from twisted.protocols.tls import TLSMemoryBIOFactory
+    from twisted.python import threadpool
+else:
+    AutoInstall.install(Package('hyperlink', Version(17, 3, 0), pypi_name='hyperlink'))
+    AutoInstall.install(Package('incremental', Version(17, 5, 0), pypi_name='incremental'))
+    AutoInstall.install(Package('twisted', Version(17, 5, 0), pypi_name='Twisted'))
+
+    AutoInstall.install(Package('pyOpenSSL', Version(17, 2, 0)))
+    AutoInstall.install(Package('pycparser', Version(2, 18)))
 
 sys.modules[__name__] = __import__('twisted')


### PR DESCRIPTION
#### d804797056765ee5fc83e25209b53c73ec817d53
<pre>
[webkitpy] Support Python 2 buildbot
<a href="https://bugs.webkit.org/show_bug.cgi?id=256601">https://bugs.webkit.org/show_bug.cgi?id=256601</a>
rdar://109163377

Reviewed by Aakash Jain.

Support Python 2 buildbot autoinstalled to aid in migrating
away from Python 2.

* Tools/Scripts/webkitpy/autoinstalled/buildbot.py:
* Tools/Scripts/webkitpy/autoinstalled/twisted.py:

Canonical link: <a href="https://commits.webkit.org/263926@main">https://commits.webkit.org/263926@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/11822861848bdc115d05f479bb87086e0b8cfa0d

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [  ~~🧪 style~~](https://ews-build.webkit.org/#/builders/38/builds/6137 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 ios~~](https://ews-build.webkit.org/#/builders/26/builds/6323 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/14/builds/6505 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/7700 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/32/builds/6480 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [  ~~🧪 bindings~~](https://ews-build.webkit.org/#/builders/9/builds/6136 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/23/builds/6542 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/16/builds/6275 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/7700 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [  ~~🧪 webkitperl~~](https://ews-build.webkit.org/#/builders/11/builds/6247 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/23/builds/6542 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/14/builds/6505 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/2/builds/7764 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [  ~~🧪 webkitpy~~](https://ews-build.webkit.org/#/builders/6/builds/6241 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/23/builds/6542 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/14/builds/6505 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/2/builds/7764 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/23/builds/6542 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/14/builds/6505 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/2/builds/7764 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/7/builds/6082 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/16/builds/6275 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/30/builds/5501 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/14/builds/6505 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/4/builds/9645 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/721 "Built successfully and passed tests") | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/31/builds/5869 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->