### PR TITLE
[WGSL] Convert remaining AST nodes to be arena allocated

### DIFF
--- a/Source/WebGPU/WGSL/AST/ASTBuilder.cpp
+++ b/Source/WebGPU/WGSL/AST/ASTBuilder.cpp
@@ -26,6 +26,8 @@
 #include "config.h"
 #include "ASTBuilder.h"
 
+#include "ASTNode.h"
+
 namespace WGSL::AST {
 
 DEFINE_ALLOCATOR_WITH_HEAP_IDENTIFIER(WGSLAST);

--- a/Source/WebGPU/WGSL/AST/ASTBuilder.h
+++ b/Source/WebGPU/WGSL/AST/ASTBuilder.h
@@ -25,7 +25,6 @@
 
 #pragma once
 
-#include "ASTNode.h"
 #include <wtf/MallocPtr.h>
 #include <wtf/Noncopyable.h>
 #include <wtf/Nonmovable.h>
@@ -46,6 +45,8 @@ namespace WGSL {
 class ShaderModule;
 
 namespace AST {
+
+class Node;
 
 DECLARE_ALLOCATOR_WITH_HEAP_IDENTIFIER(WGSLAST);
 

--- a/Source/WebGPU/WGSL/AST/ASTDirective.h
+++ b/Source/WebGPU/WGSL/AST/ASTDirective.h
@@ -26,25 +26,23 @@
 #pragma once
 
 #include "ASTIdentifier.h"
-
-#include <wtf/UniqueRefVector.h>
-#include <wtf/text/WTFString.h>
+#include <wtf/ReferenceWrapperVector.h>
 
 namespace WGSL::AST {
 
 class Directive : public Node {
-    WTF_MAKE_FAST_ALLOCATED;
+    WGSL_AST_BUILDER_NODE(Directive);
 public:
-    using List = UniqueRefVector<Directive>;
+    using List = ReferenceWrapperVector<Directive>;
 
+    const String& name() const { return m_name.id(); }
+
+private:
     Directive(SourceSpan span, Identifier&& name)
         : Node(span)
         , m_name(WTFMove(name))
     { }
 
-    const String& name() const { return m_name.id(); }
-
-private:
     Identifier m_name;
 };
 

--- a/Source/WebGPU/WGSL/AST/ASTIdentifier.h
+++ b/Source/WebGPU/WGSL/AST/ASTIdentifier.h
@@ -26,14 +26,14 @@
 #pragma once
 
 #include "ASTNode.h"
-
+#include <wtf/ForbidHeapAllocation.h>
 #include <wtf/PrintStream.h>
 #include <wtf/text/WTFString.h>
 
 namespace WGSL::AST {
 
 class Identifier : public Node {
-    WTF_MAKE_FAST_ALLOCATED;
+    WTF_FORBID_HEAP_ALLOCATION;
 public:
     static Identifier make(String& id) { return { SourceSpan::empty(), String(id) }; }
     static Identifier make(String&& id) { return { SourceSpan::empty(), WTFMove(id) }; }
@@ -49,12 +49,12 @@ public:
     void dump(PrintStream&) const;
 
 private:
-    Identifier(SourceSpan span, String&& id)
+    Identifier(const SourceSpan& span, String&& id)
         : Node(span)
         , m_id(WTFMove(id))
     { }
 
-    Identifier(SourceSpan span, StringView id)
+    Identifier(const SourceSpan& span, StringView id)
         : Identifier(span, id.toString())
     { }
 

--- a/Source/WebGPU/WGSL/AST/ASTNode.h
+++ b/Source/WebGPU/WGSL/AST/ASTNode.h
@@ -25,12 +25,9 @@
 
 #pragma once
 
+#include "ASTBuilder.h"
 #include "SourceSpan.h"
-
-#include <wtf/FastMalloc.h>
 #include <wtf/TypeCasts.h>
-#include <wtf/UniqueRef.h>
-#include <wtf/UniqueRefVector.h>
 
 namespace WGSL::AST {
 
@@ -115,19 +112,17 @@ enum class NodeKind : uint8_t {
 };
 
 class Node {
-    WTF_MAKE_FAST_ALLOCATED;
+    WGSL_AST_BUILDER_NODE(Node);
 public:
-    using Ref = UniqueRef<Node>;
-    using List = UniqueRefVector<Node, 2>;
-
-    Node(SourceSpan span)
-        : m_span(span)
-    { }
     virtual ~Node() = default;
 
     virtual NodeKind kind() const { return NodeKind::Unknown; };
-
     const SourceSpan& span() const { return m_span; }
+
+protected:
+    Node(SourceSpan span)
+        : m_span(span)
+    { }
 
 private:
     SourceSpan m_span;

--- a/Source/WebGPU/WGSL/AST/ASTPointerDereference.h
+++ b/Source/WebGPU/WGSL/AST/ASTPointerDereference.h
@@ -30,17 +30,17 @@
 namespace WGSL::AST {
 
 class PointerDereferenceExpression final : public Expression {
-    WTF_MAKE_FAST_ALLOCATED;
+    WGSL_AST_BUILDER_NODE(PointerDereferenceExpression);
 public:
+    NodeKind kind() const override;
+    Expression& target() { return m_target.get(); }
+
+private:
     PointerDereferenceExpression(SourceSpan span, Expression::Ref&& target)
         : Expression(span)
         , m_target(WTFMove(target))
     { }
 
-    NodeKind kind() const override;
-    Expression& target() { return m_target.get(); }
-
-private:
     Expression::Ref m_target;
 };
 

--- a/Source/WebGPU/WGSL/Parser.cpp
+++ b/Source/WebGPU/WGSL/Parser.cpp
@@ -68,23 +68,11 @@ struct TemplateTypes<TT> {
 #define CURRENT_SOURCE_SPAN() \
     SourceSpan(_startOfElementPosition, m_lexer.currentPosition())
 
-#define MAKE_NODE_UNIQUE_REF(type, ...) \
-    makeUniqueRef<AST::type>(CURRENT_SOURCE_SPAN() __VA_OPT__(,) __VA_ARGS__) /* NOLINT */
-
 #define MAKE_ARENA_NODE(type, ...) \
     m_builder.construct<AST::type>(CURRENT_SOURCE_SPAN() __VA_OPT__(,) __VA_ARGS__) /* NOLINT */
 
-#define RETURN_NODE(type, ...) \
-    do { \
-        AST::type astNodeResult(CURRENT_SOURCE_SPAN() __VA_OPT__(,) __VA_ARGS__); /* NOLINT */ \
-        return { WTFMove(astNodeResult) }; \
-    } while (false)
-
 #define RETURN_ARENA_NODE(type, ...) \
     return { MAKE_ARENA_NODE(type __VA_OPT__(,) __VA_ARGS__) }; /* NOLINT */
-
-#define RETURN_NODE_UNIQUE_REF(type, ...) \
-    return { MAKE_NODE_UNIQUE_REF(type __VA_OPT__(,) __VA_ARGS__) }; /* NOLINT */
 
 #define FAIL(string) \
     return makeUnexpected(Error(string, CURRENT_SOURCE_SPAN()));


### PR DESCRIPTION
#### b136ade70f10f05b050607e8ebcf4ea1436cd6d1
<pre>
[WGSL] Convert remaining AST nodes to be arena allocated
<a href="https://bugs.webkit.org/show_bug.cgi?id=256603">https://bugs.webkit.org/show_bug.cgi?id=256603</a>
rdar://109163635

Reviewed by Dan Glastonbury.

Convert the final remaining nodes and remove the (now unused) parser helper macros

* Source/WebGPU/WGSL/AST/ASTBuilder.cpp:
* Source/WebGPU/WGSL/AST/ASTBuilder.h:
* Source/WebGPU/WGSL/AST/ASTDirective.h:
(WGSL::AST::Directive::name const):
* Source/WebGPU/WGSL/AST/ASTIdentifier.h:
(WGSL::AST::Identifier::Identifier):
* Source/WebGPU/WGSL/AST/ASTNode.h:
(WGSL::AST::Node::kind const):
(WGSL::AST::Node::Node):
* Source/WebGPU/WGSL/AST/ASTPointerDereference.h:
* Source/WebGPU/WGSL/Parser.cpp:

Canonical link: <a href="https://commits.webkit.org/263958@main">https://commits.webkit.org/263958@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/34faaf62d0771ac569b5c53e4a2e9180a0087ac2

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/6221 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/6413 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/6592 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/7789 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/6553 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/6633 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/6363 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/9432 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/6331 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/6347 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/5632 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/7860 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/3820 "Passed tests") | | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/13506 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/5685 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/5691 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/7936 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/6168 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/5043 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/5581 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/1474 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/9728 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/5949 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->