### PR TITLE
Update WKWebsiteDataStore proxy setter.

### DIFF
--- a/Source/WebKit/NetworkProcess/NetworkProcess.h
+++ b/Source/WebKit/NetworkProcess/NetworkProcess.h
@@ -486,7 +486,7 @@ private:
 
 #if HAVE(NW_PROXY_CONFIG)
     void clearProxyConfigData(PAL::SessionID);
-    void setProxyConfigData(PAL::SessionID, const IPC::DataReference& proxyConfigData, const IPC::DataReference& proxyIdentifierData);
+    void setProxyConfigData(PAL::SessionID, Vector<std::pair<Vector<uint8_t>, UUID>>&& proxyConfigurations);
 #endif
     
 #if USE(SOUP)

--- a/Source/WebKit/NetworkProcess/NetworkProcess.messages.in
+++ b/Source/WebKit/NetworkProcess/NetworkProcess.messages.in
@@ -242,7 +242,7 @@ messages -> NetworkProcess LegacyReceiver {
 
 #if HAVE(NW_PROXY_CONFIG)
     ClearProxyConfigData(PAL::SessionID sessionID)
-    SetProxyConfigData(PAL::SessionID sessionID, IPC::DataReference proxyConfigData, IPC::DataReference proxyIdentifierData)
+    SetProxyConfigData(PAL::SessionID sessionID, Vector<std::pair<Vector<uint8_t>, UUID>> proxyConfigurations)
 #endif
 
 }

--- a/Source/WebKit/NetworkProcess/NetworkSession.h
+++ b/Source/WebKit/NetworkProcess/NetworkSession.h
@@ -272,7 +272,7 @@ public:
 
 #if HAVE(NW_PROXY_CONFIG)
     virtual void clearProxyConfigData() { }
-    virtual void setProxyConfigData(const IPC::DataReference&, const IPC::DataReference&) { }
+    virtual void setProxyConfigData(Vector<std::pair<Vector<uint8_t>, UUID>>&&) { };
 #endif
                                     
 protected:

--- a/Source/WebKit/NetworkProcess/cocoa/NetworkProcessCocoa.mm
+++ b/Source/WebKit/NetworkProcess/cocoa/NetworkProcessCocoa.mm
@@ -235,13 +235,13 @@ void NetworkProcess::clearProxyConfigData(PAL::SessionID sessionID)
     session->clearProxyConfigData();
 }
 
-void NetworkProcess::setProxyConfigData(PAL::SessionID sessionID, const IPC::DataReference& proxyConfigData, const IPC::DataReference& proxyIdentifierData)
+void NetworkProcess::setProxyConfigData(PAL::SessionID sessionID, Vector<std::pair<Vector<uint8_t>, UUID>>&& proxyConfigurations)
 {
     auto* session = networkSession(sessionID);
     if (!session)
         return;
 
-    session->setProxyConfigData(proxyConfigData, proxyIdentifierData);
+    session->setProxyConfigData(WTFMove(proxyConfigurations));
 }
 #endif // HAVE(NW_PROXY_CONFIG)
 

--- a/Source/WebKit/NetworkProcess/cocoa/NetworkSessionCocoa.h
+++ b/Source/WebKit/NetworkProcess/cocoa/NetworkSessionCocoa.h
@@ -148,9 +148,10 @@ public:
     void removeDataTask(DataTaskIdentifier);
 
 #if HAVE(NW_PROXY_CONFIG)
-    nw_proxy_config_t proxyConfig() const { return m_nwProxyConfig.get(); }
+    const Vector<RetainPtr<nw_proxy_config_t>> proxyConfigs() const { return m_nwProxyConfigs; }
+
     void clearProxyConfigData() final;
-    void setProxyConfigData(const IPC::DataReference& proxyConfigData, const IPC::DataReference& proxyIdentifierData) final;
+    void setProxyConfigData(Vector<std::pair<Vector<uint8_t>, UUID>>&&) final;
 #endif
 
 private:
@@ -200,7 +201,7 @@ private:
     String m_sourceApplicationSecondaryIdentifier;
     RetainPtr<CFDictionaryRef> m_proxyConfiguration;
 #if HAVE(NW_PROXY_CONFIG)
-    RetainPtr<nw_proxy_config_t> m_nwProxyConfig;
+    Vector<RetainPtr<nw_proxy_config_t>> m_nwProxyConfigs;
 #endif
     RetainPtr<DMFWebsitePolicyMonitor> m_deviceManagementPolicyMonitor;
     bool m_deviceManagementRestrictionsEnabled { false };

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebsiteDataStore.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebsiteDataStore.mm
@@ -239,7 +239,9 @@ private:
     bool m_hasNotifyBackgroundFetchChangeSelector { false };
 };
 
-@implementation WKWebsiteDataStore
+@implementation WKWebsiteDataStore {
+    RetainPtr<NSArray> _proxyConfigurations;
+}
 
 + (WKWebsiteDataStore *)defaultDataStore
 {
@@ -384,20 +386,32 @@ static Vector<WebKit::WebsiteDataRecord> toWebsiteDataRecords(NSArray *dataRecor
 }
 
 #if HAVE(NW_PROXY_CONFIG)
-- (void)setProxyConfiguration:(nw_proxy_config_t)proxyConfig
+- (void)setProxyConfigurations:(NSArray<nw_proxy_config_t> *)proxyConfigurations
 {
-    if (!proxyConfig) {
+    _proxyConfigurations = [proxyConfigurations copy];
+    if (!_proxyConfigurations || !_proxyConfigurations.get().count) {
         _websiteDataStore->clearProxyConfigData();
         return;
     }
 
-    uuid_t proxyIdentifier;
-    nw_proxy_config_get_identifier(proxyConfig, proxyIdentifier);
+    Vector<std::pair<Vector<uint8_t>, UUID>> configDataVector;
+    for (nw_proxy_config_t proxyConfig in proxyConfigurations) {
+        RetainPtr<NSData> agentData = adoptNS((NSData *)nw_proxy_config_copy_agent_data(proxyConfig));
 
-    auto proxyConfigData = API::Data::createWithoutCopying((NSData *)nw_proxy_config_copy_agent_data(proxyConfig));
+        uuid_t proxyIdentifier;
+        nw_proxy_config_get_identifier(proxyConfig, proxyIdentifier);
+
+        configDataVector.append({ vectorFromNSData(agentData.get()), UUID(proxyIdentifier) });
+    }
     
-    _websiteDataStore->setProxyConfigData(proxyConfigData.get(), proxyIdentifier);
+    _websiteDataStore->setProxyConfigData(WTFMove(configDataVector));
 }
+
+- (NSArray<nw_proxy_config_t> *)proxyConfigurations
+{
+    return _proxyConfigurations.get();
+}
+
 #endif // HAVE(NW_PROXY_CONFIG)
 
 #pragma mark WKObject protocol implementation

--- a/Source/WebKit/UIProcess/WebsiteData/WebsiteDataStore.cpp
+++ b/Source/WebKit/UIProcess/WebsiteData/WebsiteDataStore.cpp
@@ -2427,10 +2427,9 @@ void WebsiteDataStore::clearProxyConfigData()
     networkProcess().send(Messages::NetworkProcess::ClearProxyConfigData(m_sessionID), 0);
 }
 
-void WebsiteDataStore::setProxyConfigData(const API::Data& data, uuid_t proxyIdentifier)
+void WebsiteDataStore::setProxyConfigData(Vector<std::pair<Vector<uint8_t>, UUID>>&& data)
 {
-    auto proxyIdentifierData = IPC::DataReference(reinterpret_cast<uint8_t *>(proxyIdentifier), sizeof(uuid_t));
-    networkProcess().send(Messages::NetworkProcess::SetProxyConfigData(m_sessionID, data.dataReference(), WTFMove(proxyIdentifierData)), 0);
+    networkProcess().send(Messages::NetworkProcess::SetProxyConfigData(m_sessionID, WTFMove(data)), 0);
 }
 #endif // HAVE(NW_PROXY_CONFIG)
 

--- a/Source/WebKit/UIProcess/WebsiteData/WebsiteDataStore.h
+++ b/Source/WebKit/UIProcess/WebsiteData/WebsiteDataStore.h
@@ -450,7 +450,7 @@ public:
 
 #if HAVE(NW_PROXY_CONFIG)
     void clearProxyConfigData();
-    void setProxyConfigData(const API::Data&, uuid_t proxyIdentifier);
+    void setProxyConfigData(Vector<std::pair<Vector<uint8_t>, UUID>>&&);
 #endif
     void setCompletionHandlerForRemovalFromNetworkProcess(CompletionHandler<void(String&&)>&&);
     

--- a/Source/WebKit/WebKit.xcodeproj/project.pbxproj
+++ b/Source/WebKit/WebKit.xcodeproj/project.pbxproj
@@ -2229,6 +2229,7 @@
 			fileType = pattern.proxy;
 			inputFiles = (
 				"$(SRCROOT)/Scripts/postprocess-header-rule",
+				"$(SRCROOT)/mac/replace-webkit-additions-includes.py",
 			);
 			isEditable = 1;
 			outputFiles = (


### PR DESCRIPTION
#### d010a339ff92d2d005176c14fea850bb1a5bc057
<pre>
Update WKWebsiteDataStore proxy setter.
<a href="https://bugs.webkit.org/show_bug.cgi?id=256594">https://bugs.webkit.org/show_bug.cgi?id=256594</a>
rdar://109159697

Reviewed by Geoff Garen.

Change this interface to:
- Be a property
- Of an array of configs, instead of just one config

And test it.

* Source/WebKit/NetworkProcess/NetworkProcess.h:
* Source/WebKit/NetworkProcess/NetworkProcess.messages.in:
* Source/WebKit/NetworkProcess/NetworkSession.h:

* Source/WebKit/NetworkProcess/cocoa/NetworkProcessCocoa.mm:
(WebKit::NetworkProcess::setProxyConfigData):

* Source/WebKit/NetworkProcess/cocoa/NetworkSessionCocoa.h:
* Source/WebKit/NetworkProcess/cocoa/NetworkSessionCocoa.mm:
(WebKit::SessionWrapper::initialize):
(WebKit::NetworkSessionCocoa::clearProxyConfigData):
(WebKit::NetworkSessionCocoa::setProxyConfigData):

* Source/WebKit/UIProcess/API/Cocoa/WKWebsiteDataStore.mm:
(-[WKWebsiteDataStore setProxyConfigurations:]):
(-[WKWebsiteDataStore proxyConfigurations]):
(-[WKWebsiteDataStore setProxyConfiguration:]): Deleted.

* Source/WebKit/UIProcess/WebsiteData/WebsiteDataStore.cpp:
(WebKit::WebsiteDataStore::setProxyConfigData):
* Source/WebKit/UIProcess/WebsiteData/WebsiteDataStore.h:

* Source/WebKit/WebKit.xcodeproj/project.pbxproj:

* Tools/TestWebKitAPI/Tests/WebKitCocoa/Proxy.mm:
(TestWebKitAPI::TEST):

Canonical link: <a href="https://commits.webkit.org/263940@main">https://commits.webkit.org/263940@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f673e762e6b6e8cfb03e9cf0c28222bf94af791d

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/6168 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/6356 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/6538 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/7731 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/6505 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/6168 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/6576 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/6308 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/9381 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/6278 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/6296 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/5585 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/7798 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/3770 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/5565 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/13457 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/5635 "Passed tests") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/5644 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/7876 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/6113 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/4999 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/5530 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/1464 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/9674 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/5897 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->