### PR TITLE
[css-grid][masonry] Containing block for items in a masonry columns grid should be the grid's content box logical width

### DIFF
--- a/LayoutTests/TestExpectations
+++ b/LayoutTests/TestExpectations
@@ -1582,7 +1582,6 @@ imported/w3c/web-platform-tests/css/css-grid/masonry/tentative/align-tracks/maso
 imported/w3c/web-platform-tests/css/css-grid/masonry/tentative/align-tracks/masonry-align-tracks-stretch-002.html
 imported/w3c/web-platform-tests/css/css-grid/masonry/tentative/fragmentation/masonry-fragmentation-001.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/css/css-grid/masonry/tentative/fragmentation/masonry-fragmentation-002.html [ ImageOnlyFailure ]
-imported/w3c/web-platform-tests/css/css-grid/masonry/tentative/fragmentation/masonry-fragmentation-003.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/css/css-grid/masonry/tentative/fragmentation/masonry-fragmentation-004.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/css/css-grid/masonry/tentative/fragmentation/masonry-fragmentation-005.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/css/css-grid/masonry/tentative/fragmentation/masonry-fragmentation-006.html [ ImageOnlyFailure ]

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/masonry/tentative/masonry-columns-item-containing-block-is-grid-content-width-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/masonry/tentative/masonry-columns-item-containing-block-is-grid-content-width-expected.html
@@ -1,0 +1,3 @@
+<!DOCTYPE html>
+<p>Test passes if there is a filled green square.</p>
+<div style="width:100px; height:100px; background:green;"></div>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/masonry/tentative/masonry-columns-item-containing-block-is-grid-content-width.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/masonry/tentative/masonry-columns-item-containing-block-is-grid-content-width.html
@@ -1,0 +1,22 @@
+<!DOCTYPE html>
+<html>
+<head>
+<link rel="author" title="Sammy Gill" href="mailto:sammy.gill@apple.com">
+<link rel="help" href="https://drafts.csswg.org/css-grid-3/#containing-block">
+<link rel="match" href="/css/reference/ref-filled-green-100px-square-only.html">
+<meta name="assert" content="Svg should use grid's content logical width for its containing block size and get sized to 100px x 100px">
+<style>
+grid {
+    display: grid;
+    grid-template-columns:masonry;
+    grid-template-rows: auto;
+}
+</style>
+</head>
+<body>
+<p>Test passes if there is a filled green square.</p>
+<grid>
+    <svg width="100" height="100" viewBox="0 0 1 1" style="width: 100%; max-width: 100px; background: green;"></svg>
+</grid>
+</body>
+</html>

--- a/LayoutTests/platform/glib/TestExpectations
+++ b/LayoutTests/platform/glib/TestExpectations
@@ -340,8 +340,6 @@ imported/mozilla/svg/text/textpath-multiline.svg [ Pass ]
 imported/w3c/web-platform-tests/css/css-align/baseline-rules/grid-item-input-type-number.html [ Pass ]
 imported/w3c/web-platform-tests/css/css-align/baseline-rules/grid-item-input-type-text.html [ Pass ]
 
-imported/w3c/web-platform-tests/css/css-grid/masonry/tentative/align-content/masonry-align-content-004.html [ Pass ]
-
 imported/w3c/web-platform-tests/css/css-images/image-orientation/image-orientation-background-properties.html [ Pass ]
 imported/w3c/web-platform-tests/css/css-images/image-orientation/image-orientation-default.html [ Pass ]
 imported/w3c/web-platform-tests/css/css-images/image-orientation/image-orientation-from-image-composited-dynamic1.html [ Pass ]

--- a/Source/WebCore/rendering/GridTrackSizingAlgorithm.cpp
+++ b/Source/WebCore/rendering/GridTrackSizingAlgorithm.cpp
@@ -639,6 +639,9 @@ std::optional<LayoutUnit> GridTrackSizingAlgorithm::estimatedGridAreaBreadthForC
 
 std::optional<LayoutUnit> GridTrackSizingAlgorithm::gridAreaBreadthForChild(const RenderBox& child, GridTrackSizingDirection direction) const
 {
+    if (m_renderGrid->areMasonryColumns())
+        return m_renderGrid->contentLogicalWidth();
+
     bool addContentAlignmentOffset =
         direction == ForColumns && (m_sizingState == RowSizingFirstIteration || m_sizingState == RowSizingExtraIterationForSizeContainment);
     // To determine the column track's size based on an orthogonal grid item we need it's logical

--- a/Source/WebCore/rendering/GridTrackSizingAlgorithm.h
+++ b/Source/WebCore/rendering/GridTrackSizingAlgorithm.h
@@ -28,6 +28,7 @@
 #include "GridBaselineAlignment.h"
 #include "GridTrackSize.h"
 #include "LayoutSize.h"
+#include "RenderBoxInlines.h"
 
 namespace WebCore {
 

--- a/Source/WebCore/rendering/RenderGrid.cpp
+++ b/Source/WebCore/rendering/RenderGrid.cpp
@@ -426,9 +426,6 @@ void RenderGrid::layoutMasonry(bool relayoutChildren)
 
         LayoutUnit availableSpaceForColumns = availableLogicalWidth();
         placeItemsOnGrid(availableSpaceForColumns);
-        // Size in the masonry axis is the masonry content size
-        if (areMasonryColumns() && style().logicalWidth().isAuto())
-            setLogicalWidth(m_masonryLayout.gridContentSize() + borderAndPaddingLogicalWidth());
 
         m_trackSizingAlgorithm.setAvailableSpace(ForColumns, availableSpaceForColumns);
         performGridItemsPreLayout(m_trackSizingAlgorithm);


### PR DESCRIPTION
#### ff409be22993805de88d0d684204696e8e2dd32b
<pre>
[css-grid][masonry] Containing block for items in a masonry columns grid should be the grid&apos;s content box logical width
<a href="https://bugs.webkit.org/show_bug.cgi?id=256611">https://bugs.webkit.org/show_bug.cgi?id=256611</a>
rdar://109170495

Reviewed by Matt Woodrow.

The masonry spec states, &quot;The containing block for a grid item is
formed by its grid area in the grid axis and the grid container’s
content-box in the masonry axis.&quot;

This means that for a grid that has masonry columns specified, the
masonry axis will be in the logical width direction of the grid. The
items should have their containing block set to the content box logical
box of the grid.

We can modify GridTrackSizingAlgorithm::gridAreaBreadthForChild to
return this value when the grid is a masonry columns grid since normally
the grid area would be used as the containing block in non-masonry
grids. This allows the rest of the code to use the grid area sizes of
the containing block in both masonry and non-masonry scenarios.
Previously, this function would have attempted to compute the
value by iterating over the tracks in the specified direction, but there
are no tracks in the masonry direction so we use the logic specified by
the masonry spec instead.

However, in order for this change to work properly we had to make a
change in RenderGrid::layoutMasonry by removing code that was
incorrectly overriding the logical width of the grid. The previous code
was attempting to set the logical width of the grid to the masonry
content size when the grid had masonry columns specified and an auto
logical width. There were 2 main issues with this piece of code:
1.) m_masonryLayout.gridContentSize() will always return 0 since we
actually haven&apos;t performed masonry layout at this point
2.) The grid shouldn&apos;t be overriding its logical width like this anyways
and it should instead be set by sized by the rules of the formatting
context it is participating in (e.g. block or inline layout).

By removing this code we can get the actual width of the grid later on
when we call m_renderGrid-&gt;contentLogicalWidth() rather than the
incorrect 0 value that it was being set to.

The following example highlights the changes that were made.
&lt;style&gt;
grid {
    display: grid;
    grid-template-columns:masonry;
    grid-template-rows: auto;
}
&lt;/style&gt;
&lt;grid&gt;
    &lt;svg width=&quot;100&quot; height=&quot;100&quot; viewBox=&quot;0 0 1 1&quot; style=&quot;width: 100%; max-width: 100px; background: green;&quot;&gt;&lt;/svg&gt;
&lt;/grid&gt;

By removing the extra code in RenderGrid::layoutMasonry, the grid will
get sizes as a block level box in the block formatting context it is
participating in, giving it a logical width that takes up its available
space. The svg&apos;s containing block logical width is set to its value so
it is able to resolve its percentage width to the correct value whereas
before the containing block logical width would have been 0px.

<a href="https://drafts.csswg.org/css-grid-3/#containing-block">https://drafts.csswg.org/css-grid-3/#containing-block</a>

* LayoutTests/TestExpectations:
* LayoutTests/imported/w3c/web-platform-tests/css/css-grid/masonry/tentative/masonry-columns-item-containing-block-is-grid-content-width-expected.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-grid/masonry/tentative/masonry-columns-item-containing-block-is-grid-content-width.html: Added.
* LayoutTests/platform/glib/TestExpectations:
* Source/WebCore/rendering/GridTrackSizingAlgorithm.cpp:
(WebCore::GridTrackSizingAlgorithm::gridAreaBreadthForChild const):
* Source/WebCore/rendering/GridTrackSizingAlgorithm.h:
* Source/WebCore/rendering/RenderGrid.cpp:
(WebCore::RenderGrid::layoutMasonry):

Canonical link: <a href="https://commits.webkit.org/264011@main">https://commits.webkit.org/264011@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0a7a8f8e10fb64fac1d641a7e1d4067a2ddbc16f

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/6322 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/6519 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/6698 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/7897 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/6643 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/6322 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/6739 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/6468 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/9535 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/6434 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/6436 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/5724 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/7968 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/3908 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/5703 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/13582 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/5772 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/5786 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/8030 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/6270 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/5124 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/5680 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/5631 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/1513 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/9836 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/6051 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->