### PR TITLE
Adjust heuristics for reported quota

### DIFF
--- a/Source/WebKit/NetworkProcess/NetworkSession.cpp
+++ b/Source/WebKit/NetworkProcess/NetworkSession.cpp
@@ -118,7 +118,7 @@ static Ref<NetworkStorageManager> createNetworkStorageManager(NetworkProcess& ne
     serviceWorkerStorageDirectory = parameters.serviceWorkerRegistrationDirectory;
     SandboxExtension::consumePermanently(parameters.serviceWorkerRegistrationDirectoryExtensionHandle);
 #endif
-    return NetworkStorageManager::create(networkProcess, parameters.sessionID, parameters.dataStoreIdentifier, connectionID, parameters.generalStorageDirectory, parameters.localStorageDirectory, parameters.indexedDBDirectory, parameters.cacheStorageDirectory, serviceWorkerStorageDirectory, parameters.perOriginStorageQuota, parameters.originQuotaRatio, parameters.totalQuotaRatio, parameters.volumeCapacityOverride, parameters.unifiedOriginStorageLevel);
+    return NetworkStorageManager::create(networkProcess, parameters.sessionID, parameters.dataStoreIdentifier, connectionID, parameters.generalStorageDirectory, parameters.localStorageDirectory, parameters.indexedDBDirectory, parameters.cacheStorageDirectory, serviceWorkerStorageDirectory, parameters.perOriginStorageQuota, parameters.originQuotaRatio, parameters.totalQuotaRatio, parameters.standardVolumeCapacity, parameters.volumeCapacityOverride, parameters.unifiedOriginStorageLevel);
 }
 
 NetworkSession::NetworkSession(NetworkProcess& networkProcess, const NetworkSessionCreationParameters& parameters)

--- a/Source/WebKit/NetworkProcess/NetworkSessionCreationParameters.cpp
+++ b/Source/WebKit/NetworkProcess/NetworkSessionCreationParameters.cpp
@@ -100,7 +100,7 @@ void NetworkSessionCreationParameters::encode(IPC::Encoder& encoder) const
     encoder << isBlobRegistryTopOriginPartitioningEnabled;
 
     encoder << unifiedOriginStorageLevel;
-    encoder << perOriginStorageQuota << originQuotaRatio << totalQuotaRatio << volumeCapacityOverride;
+    encoder << perOriginStorageQuota << originQuotaRatio << totalQuotaRatio << standardVolumeCapacity << volumeCapacityOverride;
     encoder << localStorageDirectory << localStorageDirectoryExtensionHandle;
     encoder << indexedDBDirectory << indexedDBDirectoryExtensionHandle;
     encoder << cacheStorageDirectory << cacheStorageDirectoryExtensionHandle;
@@ -382,6 +382,11 @@ std::optional<NetworkSessionCreationParameters> NetworkSessionCreationParameters
     if (!totalQuotaRatio)
         return std::nullopt;
 
+    std::optional<std::optional<uint64_t>> standardVolumeCapacity;
+    decoder >> standardVolumeCapacity;
+    if (!standardVolumeCapacity)
+        return std::nullopt;
+
     std::optional<std::optional<uint64_t>> volumeCapacityOverride;
     decoder >> volumeCapacityOverride;
     if (!volumeCapacityOverride)
@@ -512,6 +517,7 @@ std::optional<NetworkSessionCreationParameters> NetworkSessionCreationParameters
         , WTFMove(*perOriginStorageQuota)
         , WTFMove(*originQuotaRatio)
         , WTFMove(*totalQuotaRatio)
+        , WTFMove(*standardVolumeCapacity)
         , WTFMove(*volumeCapacityOverride)
         , WTFMove(*localStorageDirectory)
         , WTFMove(*localStorageDirectoryExtensionHandle)

--- a/Source/WebKit/NetworkProcess/NetworkSessionCreationParameters.h
+++ b/Source/WebKit/NetworkProcess/NetworkSessionCreationParameters.h
@@ -121,6 +121,7 @@ struct NetworkSessionCreationParameters {
     uint64_t perOriginStorageQuota;
     std::optional<double> originQuotaRatio;
     std::optional<double> totalQuotaRatio;
+    std::optional<uint64_t> standardVolumeCapacity;
     std::optional<uint64_t> volumeCapacityOverride;
     String localStorageDirectory;
     SandboxExtension::Handle localStorageDirectoryExtensionHandle;

--- a/Source/WebKit/NetworkProcess/storage/NetworkStorageManager.h
+++ b/Source/WebKit/NetworkProcess/storage/NetworkStorageManager.h
@@ -84,7 +84,7 @@ class StorageAreaRegistry;
 
 class NetworkStorageManager final : public IPC::WorkQueueMessageReceiver {
 public:
-    static Ref<NetworkStorageManager> create(NetworkProcess&, PAL::SessionID, Markable<UUID>, IPC::Connection::UniqueID, const String& path, const String& customLocalStoragePath, const String& customIDBStoragePath, const String& customCacheStoragePath, const String& customServiceWorkerStoragePath, uint64_t defaultOriginQuota, std::optional<double> originQuotaRatio, std::optional<double> totalQuotaRatio, std::optional<uint64_t> volumeCapacityOverride, UnifiedOriginStorageLevel);
+    static Ref<NetworkStorageManager> create(NetworkProcess&, PAL::SessionID, Markable<UUID>, IPC::Connection::UniqueID, const String& path, const String& customLocalStoragePath, const String& customIDBStoragePath, const String& customCacheStoragePath, const String& customServiceWorkerStoragePath, uint64_t defaultOriginQuota, std::optional<double> originQuotaRatio, std::optional<double> totalQuotaRatio, std::optional<uint64_t> standardVolumeCapacity, std::optional<uint64_t> volumeCapacityOverride, UnifiedOriginStorageLevel);
     static bool canHandleTypes(OptionSet<WebsiteDataType>);
     static OptionSet<WebsiteDataType> allManagedTypes();
 
@@ -127,7 +127,7 @@ public:
 #endif // ENABLE(SERVICE_WORKER)
 
 private:
-    NetworkStorageManager(NetworkProcess&, PAL::SessionID, Markable<UUID>, IPC::Connection::UniqueID, const String& path, const String& customLocalStoragePath, const String& customIDBStoragePath, const String& customCacheStoragePath, const String& customServiceWorkerStoragePath, uint64_t defaultOriginQuota, std::optional<double> originQuotaRatio, std::optional<double> totalQuotaRatio, std::optional<uint64_t> volumeCapacityOverride, UnifiedOriginStorageLevel);
+    NetworkStorageManager(NetworkProcess&, PAL::SessionID, Markable<UUID>, IPC::Connection::UniqueID, const String& path, const String& customLocalStoragePath, const String& customIDBStoragePath, const String& customCacheStoragePath, const String& customServiceWorkerStoragePath, uint64_t defaultOriginQuota, std::optional<double> originQuotaRatio, std::optional<double> totalQuotaRatio, std::optional<uint64_t> standardVolumeCapacity, std::optional<uint64_t> volumeCapacityOverride, UnifiedOriginStorageLevel);
     ~NetworkStorageManager();
     void writeOriginToFileIfNecessary(const WebCore::ClientOrigin&, StorageAreaBase* = nullptr);
     enum class ShouldWriteOriginFile : bool { No, Yes };
@@ -262,6 +262,7 @@ private:
     uint64_t m_defaultOriginQuota;
     std::optional<double> m_originQuotaRatio;
     std::optional<double> m_totalQuotaRatio;
+    std::optional<uint64_t> m_standardVolumeCapacity;
     std::optional<uint64_t> m_volumeCapacityOverride;
     std::optional<uint64_t> m_totalUsage;
     uint64_t m_totalQuota;

--- a/Source/WebKit/NetworkProcess/storage/OriginQuotaManager.h
+++ b/Source/WebKit/NetworkProcess/storage/OriginQuotaManager.h
@@ -39,7 +39,7 @@ public:
     using IncreaseQuotaFunction = Function<void(QuotaIncreaseRequestIdentifier, uint64_t currentQuota, uint64_t currentUsage, uint64_t requestedIncrease)>;
     using NotifySpaceGrantedFunction = Function<void(uint64_t)>;
     static Ref<OriginQuotaManager> create(uint64_t quota, uint64_t standardReportedQuota, GetUsageFunction&&, IncreaseQuotaFunction&& = { }, NotifySpaceGrantedFunction&& = { });
-    uint64_t reportedQuota() const;
+    uint64_t reportedQuota();
     uint64_t usage();
     enum class Decision : bool { Deny, Grant };
     using RequestCallback = CompletionHandler<void(Decision)>;

--- a/Source/WebKit/UIProcess/API/Cocoa/_WKWebsiteDataStoreConfiguration.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKWebsiteDataStoreConfiguration.h
@@ -54,6 +54,7 @@ WK_CLASS_AVAILABLE(macos(10.13), ios(11.0))
 @property (nonatomic) NSUInteger perOriginStorageQuota WK_API_AVAILABLE(macos(10.15.4), ios(13.4));
 @property (nonatomic, nullable, copy) NSNumber *originQuotaRatio WK_API_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA));
 @property (nonatomic, nullable, copy) NSNumber *totalQuotaRatio WK_API_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA));
+@property (nonatomic, nullable, copy) NSNumber *standardVolumeCapacity WK_API_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA));
 @property (nonatomic, nullable, copy) NSString *boundInterfaceIdentifier WK_API_AVAILABLE(macos(10.15.4), ios(13.4));
 @property (nonatomic) BOOL allowsCellularAccess WK_API_AVAILABLE(macos(10.15.4), ios(14.0));
 @property (nonatomic) BOOL legacyTLSEnabled WK_API_AVAILABLE(macos(10.15.4), ios(13.4));

--- a/Source/WebKit/UIProcess/API/Cocoa/_WKWebsiteDataStoreConfiguration.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKWebsiteDataStoreConfiguration.mm
@@ -544,6 +544,24 @@ static WebKit::UnifiedOriginStorageLevel toUnifiedOriginStorageLevel(_WKUnifiedO
     _configuration->setTotalQuotaRatio(ratio);
 }
 
+- (NSNumber *)standardVolumeCapacity
+{
+    auto capacity = _configuration->standardVolumeCapacity();
+    if (!capacity)
+        return nil;
+
+    return [NSNumber numberWithUnsignedLongLong:*capacity];
+}
+
+- (void)setStandardVolumeCapacity:(NSNumber *)standardVolumeCapacity
+{
+    std::optional<uint64_t> capacity;
+    if (standardVolumeCapacity)
+        capacity = [standardVolumeCapacity unsignedLongLongValue];
+
+    _configuration->setStandardVolumeCapacity(capacity);
+}
+
 - (NSNumber *)volumeCapacityOverride
 {
     auto capacity = _configuration->volumeCapacityOverride();

--- a/Source/WebKit/UIProcess/WebsiteData/WebsiteDataStore.cpp
+++ b/Source/WebKit/UIProcess/WebsiteData/WebsiteDataStore.cpp
@@ -1930,6 +1930,7 @@ WebsiteDataStoreParameters WebsiteDataStore::parameters()
     networkSessionParameters.perOriginStorageQuota = perOriginStorageQuota();
     networkSessionParameters.originQuotaRatio = originQuotaRatio();
     networkSessionParameters.totalQuotaRatio = m_configuration->totalQuotaRatio();
+    networkSessionParameters.standardVolumeCapacity = m_configuration->standardVolumeCapacity();
     networkSessionParameters.volumeCapacityOverride = m_configuration->volumeCapacityOverride();
     networkSessionParameters.localStorageDirectory = resolvedLocalStorageDirectory();
     createHandleFromResolvedPathIfPossible(networkSessionParameters.localStorageDirectory, networkSessionParameters.localStorageDirectoryExtensionHandle);

--- a/Source/WebKit/UIProcess/WebsiteData/WebsiteDataStore.h
+++ b/Source/WebKit/UIProcess/WebsiteData/WebsiteDataStore.h
@@ -385,6 +385,15 @@ public:
     static String defaultJavaScriptConfigurationDirectory(const String& baseDataDirectory = nullString());
 
     static constexpr uint64_t defaultPerOriginQuota() { return 1000 * MB; }
+    static constexpr uint64_t defaultStandardVolumeCapacity() {
+#if PLATFORM(MAC)
+        return 128 * GB;
+#elif PLATFORM(IOS)
+        return 64 * GB;
+#else
+        return 16 * GB;
+#endif
+    }
     static std::optional<double> defaultOriginQuotaRatio();
     static std::optional<double> defaultTotalQuotaRatio();
     static UnifiedOriginStorageLevel defaultUnifiedOriginStorageLevel();

--- a/Source/WebKit/UIProcess/WebsiteData/WebsiteDataStoreConfiguration.cpp
+++ b/Source/WebKit/UIProcess/WebsiteData/WebsiteDataStoreConfiguration.cpp
@@ -38,6 +38,7 @@ WebsiteDataStoreConfiguration::WebsiteDataStoreConfiguration(IsPersistent isPers
     , m_perOriginStorageQuota(WebsiteDataStore::defaultPerOriginQuota())
     , m_originQuotaRatio(WebsiteDataStore::defaultOriginQuotaRatio())
     , m_totalQuotaRatio(WebsiteDataStore::defaultTotalQuotaRatio())
+    , m_standardVolumeCapacity(WebsiteDataStore::defaultStandardVolumeCapacity())
 {
     if (isPersistent == IsPersistent::Yes && shouldInitializePaths == ShouldInitializePaths::Yes) {
 #if PLATFORM(GTK) || PLATFORM(WPE)
@@ -66,6 +67,7 @@ WebsiteDataStoreConfiguration::WebsiteDataStoreConfiguration(const UUID& identif
     , m_perOriginStorageQuota(WebsiteDataStore::defaultPerOriginQuota())
     , m_originQuotaRatio(WebsiteDataStore::defaultOriginQuotaRatio())
     , m_totalQuotaRatio(WebsiteDataStore::defaultTotalQuotaRatio())
+    , m_standardVolumeCapacity(WebsiteDataStore::defaultStandardVolumeCapacity())
 #if PLATFORM(IOS)
     , m_pcmMachServiceName("com.apple.webkit.adattributiond.service"_s)
 #endif
@@ -86,6 +88,7 @@ WebsiteDataStoreConfiguration::WebsiteDataStoreConfiguration(const String& baseC
     , m_perOriginStorageQuota(WebsiteDataStore::defaultPerOriginQuota())
     , m_originQuotaRatio(WebsiteDataStore::defaultOriginQuotaRatio())
     , m_totalQuotaRatio(WebsiteDataStore::defaultTotalQuotaRatio())
+    , m_standardVolumeCapacity(WebsiteDataStore::defaultStandardVolumeCapacity())
 {
     initializePaths();
 }
@@ -134,6 +137,7 @@ Ref<WebsiteDataStoreConfiguration> WebsiteDataStoreConfiguration::copy() const
     copy->m_perOriginStorageQuota = this->m_perOriginStorageQuota;
     copy->m_originQuotaRatio = this->m_originQuotaRatio;
     copy->m_totalQuotaRatio = this->m_totalQuotaRatio;
+    copy->m_standardVolumeCapacity = this->m_standardVolumeCapacity;
     copy->m_volumeCapacityOverride = this->m_volumeCapacityOverride;
     copy->m_networkCacheDirectory = this->m_networkCacheDirectory;
     copy->m_applicationCacheDirectory = this->m_applicationCacheDirectory;

--- a/Source/WebKit/UIProcess/WebsiteData/WebsiteDataStoreConfiguration.h
+++ b/Source/WebKit/UIProcess/WebsiteData/WebsiteDataStoreConfiguration.h
@@ -72,6 +72,9 @@ public:
     std::optional<double> totalQuotaRatio() const { return m_totalQuotaRatio; }
     void setTotalQuotaRatio(std::optional<double> ratio) { m_totalQuotaRatio = ratio; }
 
+    std::optional<uint64_t> standardVolumeCapacity() const { return m_standardVolumeCapacity; }
+    void setStandardVolumeCapacity(std::optional<uint64_t> capacity) { m_standardVolumeCapacity = capacity; }
+
     std::optional<uint64_t> volumeCapacityOverride() const { return m_volumeCapacityOverride; }
     void setVolumeCapacityOverride(std::optional<uint64_t> capacity) { m_volumeCapacityOverride = capacity; }
 
@@ -258,6 +261,7 @@ private:
     uint64_t m_perOriginStorageQuota;
     std::optional<double> m_originQuotaRatio;
     std::optional<double> m_totalQuotaRatio;
+    std::optional<uint64_t> m_standardVolumeCapacity;
     std::optional<uint64_t> m_volumeCapacityOverride;
     String m_networkCacheDirectory;
     String m_applicationCacheDirectory;

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebsiteDatastore.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebsiteDatastore.mm
@@ -1054,6 +1054,90 @@ TEST(WKWebsiteDataStoreConfiguration, QuotaRatioDefaultValue)
     EXPECT_EQ([[websiteDataStoreConfiguration.get() totalQuotaRatio] doubleValue], 0.8);
 }
 
+TEST(WKWebsiteDataStoreConfiguration, StandardVolumeCapacity)
+{
+    auto uuid = adoptNS([[NSUUID alloc] initWithUUIDString:@"68753a44-4d6f-1226-9c60-0050e4c00067"]);
+    readyToContinue = false;
+    [WKWebsiteDataStore _removeDataStoreWithIdentifier:uuid.get() completionHandler:^(NSError *error) {
+        readyToContinue = true;
+    }];
+    TestWebKitAPI::Util::run(&readyToContinue);
+
+    auto websiteDataStoreConfiguration = adoptNS([[_WKWebsiteDataStoreConfiguration alloc] initWithIdentifier:uuid.get()]);
+    // Origin quota is 7 MB; standard reported origin quota is 1 MB.
+    [websiteDataStoreConfiguration.get() setVolumeCapacityOverride:[NSNumber numberWithInteger:14 * MB]];
+    [websiteDataStoreConfiguration.get() setStandardVolumeCapacity:[NSNumber numberWithInteger:2 * MB]];
+    [websiteDataStoreConfiguration.get() setOriginQuotaRatio:[NSNumber numberWithDouble:0.5]];
+    auto websiteDataStore = adoptNS([[WKWebsiteDataStore alloc] _initWithConfiguration:websiteDataStoreConfiguration.get()]);
+    auto handler = adoptNS([[WKWebsiteDataStoreMessageHandler alloc] init]);
+    auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    [[configuration userContentController] addScriptMessageHandler:handler.get() name:@"testHandler"];
+    [configuration setWebsiteDataStore:websiteDataStore.get()];
+    auto webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
+    NSString *htmlString = @"<script> \
+        var db = null; \
+        var number = 0; \
+        function checkQuota() { \
+            navigator.storage.estimate().then((estimate) => { \
+                window.webkit.messageHandlers.testHandler.postMessage(estimate.quota.toString()); \
+            }); \
+        } \
+        function storeMB(n) { \
+        try { \
+            const size = Math.ceil(n * 1024 * 1024); \
+            const item = new Array(size).join('x'); \
+            const os = db.transaction('os', 'readwrite').objectStore('os'); \
+            var putRequest = os.put(item, ++number); \
+            putRequest.onsuccess = checkQuota; \
+            putRequest.onerror = function(event) { window.webkit.messageHandlers.testHandler.postMessage('Error'); }; \
+        } catch(e) { \
+            window.webkit.messageHandlers.testHandler.postMessage(e.toString()); \
+        } \
+        } \
+        var request = indexedDB.open('testReportedQuota'); \
+        request.onupgradeneeded = function(event) { \
+            db = event.target.result; \
+            db.createObjectStore('os'); \
+        }; \
+        request.onsuccess = function() { window.webkit.messageHandlers.testHandler.postMessage('Opened'); }; \
+        request.onerror = function(event) { window.webkit.messageHandlers.testHandler.postMessage(event.target.error.name); }; \
+    </script>";
+    receivedScriptMessage = false;
+    [webView loadHTMLString:htmlString baseURL:[NSURL URLWithString:@"https://webkit.org/"]];
+    TestWebKitAPI::Util::run(&receivedScriptMessage);
+    EXPECT_WK_STREQ(@"Opened", [lastScriptMessage body]);
+
+    // Usage is 0.
+    receivedScriptMessage = false;
+    [webView evaluateJavaScript:@"checkQuota()" completionHandler:nil];
+    TestWebKitAPI::Util::run(&receivedScriptMessage);
+    EXPECT_WK_STREQ([[NSNumber numberWithInteger:1 * MB] stringValue], [lastScriptMessage body]);
+
+    // Increase usage to a little over 0.8 MB - reported quota is doubled.
+    receivedScriptMessage = false;
+    [webView evaluateJavaScript:@"storeMB(0.8)" completionHandler:nil];
+    TestWebKitAPI::Util::run(&receivedScriptMessage);
+    EXPECT_WK_STREQ([[NSNumber numberWithInteger:2 * MB] stringValue], [lastScriptMessage body]);
+
+    // Increase usage to over 1.8 MB - reported quota is doubled.
+    receivedScriptMessage = false;
+    [webView evaluateJavaScript:@"storeMB(1)" completionHandler:nil];
+    TestWebKitAPI::Util::run(&receivedScriptMessage);
+    EXPECT_WK_STREQ([[NSNumber numberWithInteger:4 * MB] stringValue], [lastScriptMessage body]);
+
+    // Increase usage to over 2.8 MB - reported quota is actual quota.
+    receivedScriptMessage = false;
+    [webView evaluateJavaScript:@"storeMB(1)" completionHandler:nil];
+    TestWebKitAPI::Util::run(&receivedScriptMessage);
+    EXPECT_WK_STREQ([[NSNumber numberWithInteger:7 * MB] stringValue], [lastScriptMessage body]);
+
+    // Increase usage to over 3.8 MB - reported quota is actual quota.
+    receivedScriptMessage = false;
+    [webView evaluateJavaScript:@"storeMB(1)" completionHandler:nil];
+    TestWebKitAPI::Util::run(&receivedScriptMessage);
+    EXPECT_WK_STREQ([[NSNumber numberWithInteger:7 * MB] stringValue], [lastScriptMessage body]);
+}
+
 TEST(WKWebsiteDataStorePrivate, CompletionHandlerForRemovalFromNetworkProcess)
 {
     __block bool done = false;


### PR DESCRIPTION
#### 222e49e258bd16148526d2fc81ea7e98f55aa39a
<pre>
Adjust heuristics for reported quota
<a href="https://bugs.webkit.org/show_bug.cgi?id=256615">https://bugs.webkit.org/show_bug.cgi?id=256615</a>
rdar://problem/109173368

Reviewed by Youenn Fablet.

In existing implementation, StorageManager API returns a fixed value when existing usage is smaller than the fixed value
(standardReportedQuota, and default value is 10 GB). This patch makes a few improvements:
1. Calculate standardReportedQuota based on originQuotaRatio and standardVolumeCapacity, instead of directly setting
value for standardReportedQuota -- standardReportedQuota = standardVolumeCapacity * originQuotaRatio.
2. Unlike defaultStandardReportedQuota, defaultStandardVolumeCapacity is different on different platforms by default,
which will make the reported quota value more reasonable.
3. Ensure reported quota is at least twice the current usage. A problem in existing implementation is client needs to
store over 10 GB to find out the quota that is bigger than 10 GB, but if client sees the reported quota as 10 GB, they
may never store over that.
4. OriginQuotaManager::reportedQuota() uses reported usage (`OriginQuotaManager::usage()`) instead of actual disk usage
(`m_usage`). Reported usage tracks the realtime usage which includes the granted space, and we use that in
quota check for storage operation.

Test: WKWebsiteDataStoreConfiguration.StandardVolumeCapacity

* Source/WebKit/NetworkProcess/NetworkSession.cpp:
(WebKit::createNetworkStorageManager):
* Source/WebKit/NetworkProcess/NetworkSessionCreationParameters.cpp:
(WebKit::NetworkSessionCreationParameters::encode const):
(WebKit::NetworkSessionCreationParameters::decode):
* Source/WebKit/NetworkProcess/NetworkSessionCreationParameters.h:
* Source/WebKit/NetworkProcess/storage/NetworkStorageManager.cpp:
(WebKit::NetworkStorageManager::create):
(WebKit::NetworkStorageManager::NetworkStorageManager):
(WebKit::NetworkStorageManager::originStorageManager):
* Source/WebKit/NetworkProcess/storage/NetworkStorageManager.h:
* Source/WebKit/NetworkProcess/storage/OriginQuotaManager.cpp:
(WebKit::OriginQuotaManager::reportedQuota):
(WebKit::OriginQuotaManager::reportedQuota const): Deleted.
* Source/WebKit/NetworkProcess/storage/OriginQuotaManager.h:
* Source/WebKit/UIProcess/API/Cocoa/_WKWebsiteDataStoreConfiguration.h:
* Source/WebKit/UIProcess/API/Cocoa/_WKWebsiteDataStoreConfiguration.mm:
(-[_WKWebsiteDataStoreConfiguration standardVolumeCapacity]):
(-[_WKWebsiteDataStoreConfiguration setStandardVolumeCapacity:]):
* Source/WebKit/UIProcess/WebsiteData/WebsiteDataStore.cpp:
(WebKit::WebsiteDataStore::parameters):
* Source/WebKit/UIProcess/WebsiteData/WebsiteDataStore.h:
(WebKit::WebsiteDataStore::defaultStandardVolumeCapacity):
* Source/WebKit/UIProcess/WebsiteData/WebsiteDataStoreConfiguration.cpp:
(WebKit::WebsiteDataStoreConfiguration::WebsiteDataStoreConfiguration):
(WebKit::WebsiteDataStoreConfiguration::copy const):
* Source/WebKit/UIProcess/WebsiteData/WebsiteDataStoreConfiguration.h:
(WebKit::WebsiteDataStoreConfiguration::standardVolumeCapacity const):
(WebKit::WebsiteDataStoreConfiguration::setStandardVolumeCapacity):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebsiteDatastore.mm:
(TestWebKitAPI::TEST):

Canonical link: <a href="https://commits.webkit.org/264446@main">https://commits.webkit.org/264446@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b7a4ea363ce2986881125063bed72dd16ccdf1ea

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/7593 "6 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/7861 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/8045 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/9236 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/7782 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/7605 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/9903 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/7788 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/10657 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/7726 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/15/builds/8915 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/7005 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/9345 "Built successfully") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/39/builds/6223 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/6915 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/14614 "23 flakes 96 failures") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/7386 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/7038 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/10432 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/7531 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/6150 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/6869 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/1821 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/11080 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/7262 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->