### PR TITLE
Sync 'SVGAnimatedNumber.idl' with IDL Web-Spec

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/svg/types/scripted/SVGAnimatedNumber-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/svg/types/scripted/SVGAnimatedNumber-expected.txt
@@ -1,3 +1,3 @@
 
-FAIL SVGAnimatedNumber interface - utilizing the surfaceScale property of SVGFESpecularLightingElement assert_throws_js: function "function () { feSpecularLightingElement.surfaceScale.baseVal = 'aString'; }" did not throw
+PASS SVGAnimatedNumber interface - utilizing the surfaceScale property of SVGFESpecularLightingElement
 

--- a/LayoutTests/svg/dom/SVGAnimatedNumber-expected.txt
+++ b/LayoutTests/svg/dom/SVGAnimatedNumber-expected.txt
@@ -16,15 +16,15 @@ PASS feSpecularLightingElement.surfaceScale.baseVal is 1
 Check assigning various valid and invalid values
 PASS feSpecularLightingElement.surfaceScale.baseVal = -1 is -1
 PASS feSpecularLightingElement.surfaceScale.baseVal = 300 is 300
-PASS feSpecularLightingElement.surfaceScale.baseVal = 'aString' is 'aString'
-PASS feSpecularLightingElement.surfaceScale.baseVal is NaN
-PASS feSpecularLightingElement.surfaceScale.baseVal = 0 is 0
-PASS feSpecularLightingElement.surfaceScale.baseVal = feSpecularLightingElement is feSpecularLightingElement
-PASS feSpecularLightingElement.surfaceScale.baseVal is NaN
-PASS feSpecularLightingElement.surfaceScale.baseVal = 300 is 300
-
-Check that the surfaceScale value remained 300
+PASS feSpecularLightingElement.surfaceScale.baseVal = 'aString' threw exception TypeError: The provided value is non-finite.
 PASS feSpecularLightingElement.surfaceScale.baseVal is 300
+PASS feSpecularLightingElement.surfaceScale.baseVal = 0 is 0
+PASS feSpecularLightingElement.surfaceScale.baseVal = feSpecularLightingElement threw exception TypeError: The provided value is non-finite.
+PASS feSpecularLightingElement.surfaceScale.baseVal is 0
+PASS feSpecularLightingElement.surfaceScale.baseVal = 0 is 0
+
+Check that the surfaceScale value do not remain 300
+PASS feSpecularLightingElement.surfaceScale.baseVal is 0
 PASS successfullyParsed is true
 
 TEST COMPLETE

--- a/LayoutTests/svg/dom/SVGAnimatedNumber.html
+++ b/LayoutTests/svg/dom/SVGAnimatedNumber.html
@@ -1,7 +1,7 @@
 <!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML//EN">
 <html>
 <head>
-<script src="../../resources/js-test-pre.js"></script>
+<script src="../../resources/js-test.js"></script>
 </head>
 <body>
 <p id="description"></p>
@@ -29,19 +29,18 @@ debug("Check assigning various valid and invalid values");
 shouldBe("feSpecularLightingElement.surfaceScale.baseVal = -1", "-1"); // Negative values are allowed from SVG DOM, but should lead to an error when rendering (disable the filter)
 shouldBe("feSpecularLightingElement.surfaceScale.baseVal = 300", "300");
 // ECMA-262, 9.3, "ToNumber"
-shouldBe("feSpecularLightingElement.surfaceScale.baseVal = 'aString'", "'aString'");
-shouldBe("feSpecularLightingElement.surfaceScale.baseVal", "NaN");
+shouldThrow("feSpecularLightingElement.surfaceScale.baseVal = 'aString'", "'TypeError: The provided value is non-finite'");
+shouldBe("feSpecularLightingElement.surfaceScale.baseVal", "300");
 shouldBe("feSpecularLightingElement.surfaceScale.baseVal = 0", "0");
-shouldBe("feSpecularLightingElement.surfaceScale.baseVal = feSpecularLightingElement", "feSpecularLightingElement");
-shouldBe("feSpecularLightingElement.surfaceScale.baseVal", "NaN");
-shouldBe("feSpecularLightingElement.surfaceScale.baseVal = 300", "300");
+shouldThrow("feSpecularLightingElement.surfaceScale.baseVal = feSpecularLightingElement", "'TypeError: The provided value is non-finite'");
+shouldBe("feSpecularLightingElement.surfaceScale.baseVal", "0");
+shouldBe("feSpecularLightingElement.surfaceScale.baseVal = 0", "0");
 
 debug("");
-debug("Check that the surfaceScale value remained 300");
-shouldBe("feSpecularLightingElement.surfaceScale.baseVal", "300");
+debug("Check that the surfaceScale value do not remain 300");
+shouldBe("feSpecularLightingElement.surfaceScale.baseVal", "0");
 
 successfullyParsed = true;
 </script>
-<script src="../../resources/js-test-post.js"></script>
 </body>
 </html>

--- a/Source/WebCore/svg/SVGAnimatedNumber.idl
+++ b/Source/WebCore/svg/SVGAnimatedNumber.idl
@@ -1,6 +1,6 @@
 /*
  * Copyright (C) 2006 Samuel Weinig <sam.weinig@gmail.com>
- * Copyright (C) 2006 Apple Inc. All rights reserved.
+ * Copyright (C) 2006-2023 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -24,11 +24,13 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE. 
  */
 
+// https://svgwg.org/svg2-draft/types.html#InterfaceSVGAnimatedNumber
+
 [
     SkipVTableValidation,
     Exposed=Window
 ] interface SVGAnimatedNumber {
-    attribute unrestricted float baseVal;
-    readonly attribute unrestricted float animVal;
+    attribute float baseVal;
+    readonly attribute float animVal;
 };
 


### PR DESCRIPTION
#### 300c734d4a81735113dc5cfd69d327715a96b883
<pre>
Sync &apos;SVGAnimatedNumber.idl&apos; with IDL Web-Spec

<a href="https://bugs.webkit.org/show_bug.cgi?id=256617">https://bugs.webkit.org/show_bug.cgi?id=256617</a>

Reviewed by Ryosuke Niwa.

This patch aligns WebKit with Web-Spec [1], Blink / Chromium and Gecko / Firefox.

[1] <a href="https://svgwg.org/svg2-draft/types.html#InterfaceSVGAnimatedNumber">https://svgwg.org/svg2-draft/types.html#InterfaceSVGAnimatedNumber</a>

This patch removes &apos;unrestricted&apos; since it is not in web-spec.

* Source/WebCore/svg/SVGAnimatedNumber.idl: As above
* LayoutTests/imported/w3c/web-platform-tests/svg/types/scripted/SVGAnimatedNumber-expected.txt: Rebaselined
* LayoutTests/svg/dom/SVGAnimatedNumber.html: Rebaselined
* LayoutTests/svg/dom/SVGAnimatedNumber-expected.txt: Rebaselined

Canonical link: <a href="https://commits.webkit.org/263954@main">https://commits.webkit.org/263954@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/953767c01c715a3e9eaa65cda0915d0633e9b906

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/6170 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/6358 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/6540 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/7733 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/6507 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/6170 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/6578 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/6310 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/9385 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/6280 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/6298 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/5584 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/7800 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/3772 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/5564 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/13460 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/5637 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/5643 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/7880 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/6115 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/5002 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/5532 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/5493 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/1472 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/9676 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/5899 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->