### PR TITLE
Fix repainting for animated carets

### DIFF
--- a/Source/WebCore/editing/FrameSelection.cpp
+++ b/Source/WebCore/editing/FrameSelection.cpp
@@ -1757,14 +1757,25 @@ IntRect FrameSelection::absoluteCaretBounds(bool* insideFixed)
     return m_absCaretBounds;
 }
 
+static LayoutBoxExtent computeOutsetFromInnerOuterRect(const LayoutRect& innerRect, const LayoutRect& outerRect)
+{
+    LayoutBoxExtent result;
+    result.setLeft(std::max<LayoutUnit>(0, innerRect.x() - outerRect.x()));
+    result.setTop(std::max<LayoutUnit>(0, innerRect.y() - outerRect.y()));
+    result.setRight(std::max<LayoutUnit>(0, outerRect.width() - innerRect.width()));
+    result.setBottom(std::max<LayoutUnit>(0, outerRect.height() - innerRect.height()));
+
+    return result;
+}
+
 static void repaintCaretForLocalRect(Node* node, const LayoutRect& rect, CaretAnimator* caretAnimator)
 {
     if (auto* caretPainter = rendererForCaretPainting(node)) {
         LayoutRect adjustedRect = caretAnimator ? caretAnimator->caretRepaintRectForLocalRect(rect) : rect;
         if (adjustedRect == rect)
-            caretPainter->repaintRectangle(adjustedRect);
+            caretPainter->repaintRectangle(rect);
         else
-            caretPainter->repaintRectangle(adjustedRect, RenderObject::ClipRepaintToLayer::No, RenderObject::ForceRepaint::Yes, RenderObject::ClipRepaintToContainer::No);
+            caretPainter->repaintRectangle(rect, RenderObject::ClipRepaintToLayer::No, RenderObject::ForceRepaint::Yes, computeOutsetFromInnerOuterRect(rect, adjustedRect));
     }
 }
 

--- a/Source/WebCore/rendering/RenderObject.h
+++ b/Source/WebCore/rendering/RenderObject.h
@@ -661,10 +661,9 @@ public:
     // Repaint a specific subrectangle within a given object.  The rect |r| is in the object's coordinate space.
     WEBCORE_EXPORT void repaintRectangle(const LayoutRect&, bool shouldClipToLayer = true) const;
 
-    enum class ClipRepaintToContainer : bool { No, Yes };
     enum class ClipRepaintToLayer : bool { No, Yes };
     enum class ForceRepaint : bool { No, Yes };
-    void repaintRectangle(const LayoutRect&, ClipRepaintToLayer, ForceRepaint, ClipRepaintToContainer) const;
+    void repaintRectangle(const LayoutRect&, ClipRepaintToLayer, ForceRepaint, std::optional<LayoutBoxExtent> additionalRepaintOutsets = std::nullopt) const;
 
     // Repaint a slow repaint object, which, at this time, means we are repainting an object with background-attachment:fixed.
     void repaintSlowRepaintObject() const;
@@ -832,7 +831,7 @@ protected:
 
     bool isSetNeedsLayoutForbidden() const;
 
-    void issueRepaint(std::optional<LayoutRect> partialRepaintRect = std::nullopt, ClipRepaintToLayer = ClipRepaintToLayer::No, ForceRepaint = ForceRepaint::No, ClipRepaintToContainer = ClipRepaintToContainer::Yes) const;
+    void issueRepaint(std::optional<LayoutRect> partialRepaintRect = std::nullopt, ClipRepaintToLayer = ClipRepaintToLayer::No, ForceRepaint = ForceRepaint::No, std::optional<LayoutBoxExtent> additionalRepaintOutsets = std::nullopt) const;
 
 private:
     void addAbsoluteRectForLayer(LayoutRect& result);


### PR DESCRIPTION
#### 6adf3d29d4b6bd80d164bdc6a4e15edb36bb0b9c
<pre>
Fix repainting for animated carets
<a href="https://bugs.webkit.org/show_bug.cgi?id=256619">https://bugs.webkit.org/show_bug.cgi?id=256619</a>
&lt;radar://109174040&gt;

Reviewed by Simon Fraser.

Simply using *partialRepaintRect is wrong. We should still be calling
computeRectForRepaint(...) and adjusting the rect as needed.

* Source/WebCore/editing/FrameSelection.cpp:
(WebCore::computeOutsetsFromInnerOuterRect):
(WebCore::repaintCaretForLocalRect):
Pass margins of the expanded rectangle.

* Source/WebCore/rendering/RenderObject.cpp:
(WebCore::RenderObject::issueRepaint const):
(WebCore::RenderObject::repaintRectangle const):
* Source/WebCore/rendering/RenderObject.h:
Expand the rectangle after calling computeRectForRepaint

Canonical link: <a href="https://commits.webkit.org/264023@main">https://commits.webkit.org/264023@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e6beaddfda149267bf070a8163a99b56e3bc3ab8

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/6455 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/6663 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/6844 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/8034 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/6750 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/6451 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/6974 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/6614 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/9644 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/6568 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/6618 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/5849 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/8113 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/4083 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/5829 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/13679 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/6000 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/5908 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/8225 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/6391 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/5224 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/5797 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/1522 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/9956 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/6168 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->