### PR TITLE
[macOS] `-[WKWebView acceptsFirstMouse:]` deadlocks when launching the GPU process

### DIFF
--- a/Source/WebKit/UIProcess/mac/WebPageProxyMac.mm
+++ b/Source/WebKit/UIProcess/mac/WebPageProxyMac.mm
@@ -372,6 +372,9 @@ bool WebPageProxy::acceptsFirstMouse(int eventNumber, const WebKit::WebMouseEven
     if (!m_process->hasConnection())
         return false;
 
+    if (shouldAvoidSynchronouslyWaitingToPreventDeadlock())
+        return false;
+
     send(Messages::WebPage::RequestAcceptsFirstMouse(eventNumber, event), IPC::SendOption::DispatchMessageEvenWhenWaitingForUnboundedSyncReply);
     bool receivedReply = m_process->connection()->waitForAndDispatchImmediately<Messages::WebPageProxy::HandleAcceptsFirstMouse>(webPageID(), 3_s, IPC::WaitForOption::InterruptWaitingIfSyncMessageArrives);
 


### PR DESCRIPTION
#### d390171291c8e77d5d90ab818b200f5601f84c17
<pre>
[macOS] `-[WKWebView acceptsFirstMouse:]` deadlocks when launching the GPU process
<a href="https://bugs.webkit.org/show_bug.cgi?id=256618">https://bugs.webkit.org/show_bug.cgi?id=256618</a>
rdar://108567032

Reviewed by Wenson Hsieh.

Following the enablement of the GPU process on macOS, an increased number of
hangs are being observed in `-[WKWebView acceptsFirstMouse:]`.

`acceptsFirstMouse` synchronously waits on IPC from the Web process. This is
necessary as the return value depends on the web content that is being clicked
on, and the AppKit API is synchronous. Specifically, returning true allows the
user to click on a view in an inactive window and activate it with a single
click. Returning false means that the user would have to click twice: once to
make the window active, and then to interact with the web view. WebKit only
returns true when the event might begin a drag.

The deadlock observed here is similar to a deadlock that was observed on iOS,
and fixed in 252568@main. The Web process may be attempting to launch the GPU
process at the same time `RequestAcceptsFirstMouse` is received.  This results
in a sync wait under ``RemoteRenderingBackendProxy::DidInitialize`. While that
method allows for interruptions due to receiving sync messages, the
`RequestAcceptsFirstMouse` message itself is not sync, it is async, and paired
with `HandleAcceptsFirstMouse` (see 240322@main for more details on that design).

Similar to 252568@main, the UI process is then unable to initialize the GPU
process, since the message will be added to `m_pendingMessages` on
`AuxiliaryProcessProxy` while waiting for the GPU process to launch. These
messages are dispatched asynchronously, but there is no chance to do so, as the
UI process is waiting for `HandleAcceptsFirstMouse` from the blocked Web process.

To fix, simply return false from `acceptsFirstMouse` when the GPU process has
yet to be initialized. This is low risk, since there would not be any painted
content to interact with if the GPU process does not exist.

* Source/WebKit/UIProcess/mac/WebPageProxyMac.mm:
(WebKit::WebPageProxy::acceptsFirstMouse):

Leverage the helper method added 252568@main to detect this scenario.

Canonical link: <a href="https://commits.webkit.org/263992@main">https://commits.webkit.org/263992@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b6e9f78e17da763556b93e484ae42316ccde6bfe

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/6166 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/6353 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/6536 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/7728 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/6503 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/6573 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/6305 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/9380 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/6276 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/6293 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/5580 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/7795 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/3767 "Passed tests") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/13456 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/5632 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/5639 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/7874 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/6110 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/4998 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/5528 "Built successfully") | | | 
| [❌ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/1495 "Failed to push commit to Webkit repository") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/9671 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/5895 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->