### PR TITLE
Charts on sixcolors.com flicker when zooming in

### DIFF
--- a/LayoutTests/fast/images/decode-decoding-change-image-src-expected.html
+++ b/LayoutTests/fast/images/decode-decoding-change-image-src-expected.html
@@ -1,0 +1,4 @@
+<body>
+    <p>This test ensures if an image with decoding="async" is decoded after the first paint, it will not flicker.</p>
+    <img src="resources/green-400x400.png">
+</body>

--- a/LayoutTests/fast/images/decode-decoding-change-image-src.html
+++ b/LayoutTests/fast/images/decode-decoding-change-image-src.html
@@ -1,0 +1,22 @@
+<body>
+    <p>This test ensures if an image with decoding="async" is decoded after the first paint, it will not flicker.</p>
+    <img id="image" decoding="async" src="">
+    <script>
+        if (window.internals && window.testRunner) {
+            internals.clearMemoryCache();
+            testRunner.waitUntilDone();
+        }
+
+        function setImageSrc() {
+            var image = document.getElementById("image");
+            image.onload = (() => {
+                // Force layout and display so the image frame starts decoding.
+                document.body.offsetHeight;
+                if (window.testRunner)
+                    testRunner.notifyDone();
+            });
+            image.src = "resources/green-400x400.png";
+        }
+        requestAnimationFrame(setImageSrc);
+    </script>
+</body>

--- a/LayoutTests/fast/images/decoding-attribute-async-small-image.html
+++ b/LayoutTests/fast/images/decoding-attribute-async-small-image.html
@@ -5,6 +5,12 @@
         function loadImage(image, src) {
             return new Promise((resolve) => {
                 image.onload = (() => {
+                    // Move the image to a new separate layer.
+                    var box = document.createElement("div");
+                    box.style.willChange = "transform";
+                    box.appendChild(image);
+                    document.body.appendChild(box);
+
                     if (window.internals && window.testRunner) {
                         // Force layout and display so the image gets drawn.
                         document.body.offsetHeight;

--- a/LayoutTests/fast/images/decoding-attribute-dynamic-async-small-image.html
+++ b/LayoutTests/fast/images/decoding-attribute-dynamic-async-small-image.html
@@ -5,6 +5,12 @@
         function loadImage(image, src) {
             return new Promise((resolve) => {
                 image.onload = (() => {
+                    // Move the image to a new separate layer.
+                    var box = document.createElement("div");
+                    box.style.willChange = "transform";
+                    box.appendChild(image);
+                    document.body.appendChild(box);
+
                     if (window.internals && window.testRunner) {
                         // Force layout and display so the image gets drawn.
                         document.body.offsetHeight;


### PR DESCRIPTION
#### 36adb36a799fae4fd51fe20e40916487d4d3ecb5
<pre>
Charts on sixcolors.com flicker when zooming in
<a href="https://bugs.webkit.org/show_bug.cgi?id=256620">https://bugs.webkit.org/show_bug.cgi?id=256620</a>
rdar://108930635

Reviewed by Simon Fraser.

If
        1. An image is in the current viewport,
        2. It has the attribute decoding=&quot;async&quot;,
        3. The layer has already painted at least once,
        4. And the image frame is being re-decoded

Then the decoding=&quot;async&quot; attribute should be ignored to avoid flickering.

RenderBoxModelObject::decodingModeForImageDraw() is re-factored such that caces
which return DecodingMode::Synchronous are checked first. Then flickering case
is checked. Then cases which return DecodingMode::Asynchronous are checked last.

Two layout tests are changed to ensure the image is displayed on a fresh layer
when the image has the decoding=&quot;async&quot;.

* LayoutTests/fast/images/decode-decoding-change-image-src-expected.html: Added.
* LayoutTests/fast/images/decode-decoding-change-image-src.html: Added.
* Source/WebCore/rendering/RenderBoxModelObject.cpp:
(WebCore::RenderBoxModelObject::decodingModeForImageDraw const):

Canonical link: <a href="https://commits.webkit.org/264433@main">https://commits.webkit.org/264433@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c02495f97fb9add731b5f0cf1af6d978ce399396

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/7480 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/7746 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/7925 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/9114 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/7677 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/7491 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/9691 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/7669 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/10563 "1 flakes 96 failures") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/7611 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/8729 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/6922 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/9225 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/6037 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/6801 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/14527 "Passed tests") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/7279 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/6921 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/10241 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/7416 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/6066 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/6760 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/6711 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/1810 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/10969 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/7149 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->