### PR TITLE
GraphicsContext::resetClip does not maintain the clipping state in DisplayListRecorder correctly

### DIFF
--- a/Source/WebCore/platform/graphics/displaylists/DisplayListRecorder.cpp
+++ b/Source/WebCore/platform/graphics/displaylists/DisplayListRecorder.cpp
@@ -51,6 +51,7 @@ Recorder::Recorder(const GraphicsContextState& state, const FloatRect& initialCl
     , m_initialScale(initialCTM.xScale())
     , m_colorSpace(colorSpace)
     , m_drawGlyphsMode(drawGlyphsMode)
+    , m_initialClip(initialClip)
 {
     ASSERT(!state.changes());
     m_stateStack.append({ state, initialCTM, initialCTM.mapRect(initialClip) });
@@ -545,6 +546,8 @@ void Recorder::drawControlPart(ControlPart& part, const FloatRoundedRect& border
 
 void Recorder::resetClip()
 {
+    currentState().clipBounds = m_initialClip;
+
     recordResetClip();
 }
 

--- a/Source/WebCore/platform/graphics/displaylists/DisplayListRecorder.h
+++ b/Source/WebCore/platform/graphics/displaylists/DisplayListRecorder.h
@@ -293,6 +293,7 @@ private:
     float m_initialScale { 1 };
     DestinationColorSpace m_colorSpace;
     const DrawGlyphsMode m_drawGlyphsMode { DrawGlyphsMode::Normal };
+    const FloatRect m_initialClip;
 };
 
 } // namespace DisplayList

--- a/Tools/TestWebKitAPI/Tests/WebCore/DisplayListRecorderTests.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebCore/DisplayListRecorderTests.cpp
@@ -277,6 +277,19 @@ struct DrawSystemImage {
     }
 };
 
+struct ResetClipRect {
+    void operator()(WebCore::GraphicsContext& c)
+    {
+        c.resetClip();
+    }
+
+    static String description()
+    {
+        return R"DL(
+(reset-clip))DL"_s;
+    }
+};
+
 struct ChangeAntialiasBeforeClipRect {
     void operator()(WebCore::GraphicsContext& c)
     {
@@ -442,7 +455,7 @@ struct TrivialRotate {
 using AllOperations = testing::Types<NoCommands, ChangeAntialias, ChangeAntialiasBeforeSave,
     ChangeAntialiasBeforeAndAfterSave, ChangeAntialiasInEmptySaveRestore, DrawSystemImage, ChangeAntialiasBeforeClipRect,
     ChangeAntialiasBeforeClipOutRect, ChangeAntialiasBeforeClipOutPath, ChangeAntialiasBeforeClipPath,
-    ChangeAntialiasBeforeClipToImageBuffer, TrivialTranslate, TrivialScale, TrivialRotate>;
+    ChangeAntialiasBeforeClipToImageBuffer, TrivialTranslate, TrivialScale, TrivialRotate, ResetClipRect>;
 
 }
 


### PR DESCRIPTION
#### 748816bef2f391dee1204faa1f4f281bd034fe21
<pre>
GraphicsContext::resetClip does not maintain the clipping state in DisplayListRecorder correctly
<a href="https://bugs.webkit.org/show_bug.cgi?id=256374">https://bugs.webkit.org/show_bug.cgi?id=256374</a>
&lt;radar://108952047&gt;

Reviewed by Kimmo Kinnunen.

Maintain the clipping state correctly when resetClip is used.

* Source/WebCore/platform/graphics/displaylists/DisplayListRecorder.cpp:
(WebCore::DisplayList::Recorder::Recorder):
(WebCore::DisplayList::Recorder::resetClip):
* Source/WebCore/platform/graphics/displaylists/DisplayListRecorder.h:

* Tools/TestWebKitAPI/Tests/WebCore/DisplayListRecorderTests.cpp:
Add a test ensuring the behavior matches CoreGraphics.

Canonical link: <a href="https://commits.webkit.org/263973@main">https://commits.webkit.org/263973@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/26d2f02e28c4233e4ead4f4df26e9271e14c1659

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/6183 "2 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/6372 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/6553 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/7747 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/6518 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/6183 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/6592 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/6323 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/9401 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/6293 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/6312 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/5600 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/7815 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/3786 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/5579 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/13472 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/5651 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/5659 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/7903 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/6129 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/5012 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/5545 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/9690 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/740 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/5912 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->