### PR TITLE
Clean up after 263887@main

### DIFF
--- a/Source/WebKit/Shared/Cocoa/ArgumentCodersCocoa.mm
+++ b/Source/WebKit/Shared/Cocoa/ArgumentCodersCocoa.mm
@@ -708,9 +708,9 @@ static bool shouldEnableStrictMode(Decoder& decoder, NSArray<Class> *allowedClas
     if ([allowedClasses containsObject:NSParagraphStyle.class])
         return haveStrictDecodableNSTextTable() && strictSecureDecodingForAllObjCEnabled();
 
-    // rdar://109121874 don't reintroduce crash in rdar://105853449 added test
+    // rdar://109121874
     if ([allowedClasses containsObject:NSPresentationIntent.class])
-        return haveStrictDecodableNSTextTable() && strictSecureDecodingForAllObjCEnabled();
+        return strictSecureDecodingForAllObjCEnabled();
 
     // rdar://107553194, Don't reintroduce rdar://108339450
     if ([allowedClasses containsObject:NSMutableURLRequest.class])
@@ -730,6 +730,9 @@ static bool shouldEnableStrictMode(Decoder& decoder, NSArray<Class> *allowedClas
         || ([allowedClasses containsObject:NSURLCredential.class] && isDecodingKnownNSURLCredentialMessage(decoder))) // rdar://107553367
         return true;
 
+    // Note: Do not add more classes to the list of strict decoded classes.
+    // If you want to serialize something new, extract its contents into a
+    // struct and use a *.serialization.in file to serialize its contents.
     RELEASE_LOG_FAULT(SecureCoding, "Strict mode check found unknown classes %@", allowedClasses);
     ASSERT_NOT_REACHED();
     return true;


### PR DESCRIPTION
#### f5fbd8dd5a51365f538be33dc846deaf3ed23506
<pre>
Clean up after 263887@main
<a href="https://bugs.webkit.org/show_bug.cgi?id=256627">https://bugs.webkit.org/show_bug.cgi?id=256627</a>
rdar://109187838

Reviewed by Wenson Hsieh.

A call to haveStrictDecodableNSTextTable was incorrectly added.
NSPresentationIntent doesn&apos;t serialize an NSTextTable like NSParagraphStyle does.
Also, the comment indicating that a test and crash referred to an assertion that
was hit without a change to shouldEnableStrictMode.

To help other developers know what to do when they hit that assertion, I add a
comment indicating how they should proceed instead of expanding the list of ObjC
classes that are serialized.

* Source/WebKit/Shared/Cocoa/ArgumentCodersCocoa.mm:
(IPC::shouldEnableStrictMode):

Canonical link: <a href="https://commits.webkit.org/263947@main">https://commits.webkit.org/263947@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1f4502cd2f3da543c25418a106eed3949a2a8be5

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/6190 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/6380 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/6561 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/7755 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/6524 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/6600 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/6331 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/9405 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/6300 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/6318 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/5605 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/7822 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/3792 "Passed tests") | | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/13478 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/5657 "Passed tests") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/5664 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/7901 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/6136 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/5019 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/5552 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/9697 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/727 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/5919 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->