### PR TITLE
PageshowEventPersistence and NodeListInvalidationType should be enum classes

### DIFF
--- a/Source/WebCore/dom/Document.cpp
+++ b/Source/WebCore/dom/Document.cpp
@@ -3323,7 +3323,7 @@ void Document::implicitClose()
     }
 
     dispatchWindowLoadEvent();
-    dispatchPageshowEvent(PageshowEventNotPersisted);
+    dispatchPageshowEvent(PageshowEventPersistence::NotPersisted);
 
     if (f)
         f->loader().dispatchOnloadEvents();
@@ -5127,7 +5127,7 @@ void Document::setCSSTarget(Element* newTarget)
 
 void Document::registerNodeListForInvalidation(LiveNodeList& list)
 {
-    m_nodeListAndCollectionCounts[list.invalidationType()]++;
+    m_nodeListAndCollectionCounts[static_cast<unsigned>(list.invalidationType())]++;
     if (!list.isRootedAtTreeScope())
         return;
     ASSERT(!list.isRegisteredForInvalidationAtDocument());
@@ -5137,7 +5137,7 @@ void Document::registerNodeListForInvalidation(LiveNodeList& list)
 
 void Document::unregisterNodeListForInvalidation(LiveNodeList& list)
 {
-    m_nodeListAndCollectionCounts[list.invalidationType()]--;
+    m_nodeListAndCollectionCounts[static_cast<unsigned>(list.invalidationType())]--;
     if (!list.isRegisteredForInvalidationAtDocument())
         return;
 
@@ -5148,15 +5148,15 @@ void Document::unregisterNodeListForInvalidation(LiveNodeList& list)
 
 void Document::registerCollection(HTMLCollection& collection)
 {
-    m_nodeListAndCollectionCounts[collection.invalidationType()]++;
+    m_nodeListAndCollectionCounts[static_cast<unsigned>(collection.invalidationType())]++;
     if (collection.isRootedAtTreeScope())
         m_collectionsInvalidatedAtDocument.add(&collection);
 }
 
 void Document::unregisterCollection(HTMLCollection& collection)
 {
-    ASSERT(m_nodeListAndCollectionCounts[collection.invalidationType()]);
-    m_nodeListAndCollectionCounts[collection.invalidationType()]--;
+    ASSERT(m_nodeListAndCollectionCounts[static_cast<unsigned>(collection.invalidationType())]);
+    m_nodeListAndCollectionCounts[static_cast<unsigned>(collection.invalidationType())]--;
     if (!collection.isRootedAtTreeScope())
         return;
 
@@ -5166,14 +5166,14 @@ void Document::unregisterCollection(HTMLCollection& collection)
 void Document::collectionCachedIdNameMap(const HTMLCollection& collection)
 {
     ASSERT_UNUSED(collection, collection.hasNamedElementCache());
-    m_nodeListAndCollectionCounts[InvalidateOnIdNameAttrChange]++;
+    m_nodeListAndCollectionCounts[static_cast<unsigned>(NodeListInvalidationType::InvalidateOnIdNameAttrChange)]++;
 }
 
 void Document::collectionWillClearIdNameMap(const HTMLCollection& collection)
 {
     ASSERT_UNUSED(collection, collection.hasNamedElementCache());
-    ASSERT(m_nodeListAndCollectionCounts[InvalidateOnIdNameAttrChange]);
-    m_nodeListAndCollectionCounts[InvalidateOnIdNameAttrChange]--;
+    ASSERT(m_nodeListAndCollectionCounts[static_cast<unsigned>(NodeListInvalidationType::InvalidateOnIdNameAttrChange)]);
+    m_nodeListAndCollectionCounts[static_cast<unsigned>(NodeListInvalidationType::InvalidateOnIdNameAttrChange)]--;
 }
 
 void Document::attachNodeIterator(NodeIterator& iterator)
@@ -7130,7 +7130,7 @@ void Document::dispatchPageshowEvent(PageshowEventPersistence persisted)
         return;
     m_lastPageStatus = PageStatus::Shown;
     // FIXME: https://bugs.webkit.org/show_bug.cgi?id=36334 Pageshow event needs to fire asynchronously.
-    dispatchWindowEvent(PageTransitionEvent::create(eventNames().pageshowEvent, persisted == PageshowEventPersisted), this);
+    dispatchWindowEvent(PageTransitionEvent::create(eventNames().pageshowEvent, persisted == PageshowEventPersistence::Persisted), this);
 }
 
 void Document::dispatchPagehideEvent(PageshowEventPersistence persisted)
@@ -7142,7 +7142,7 @@ void Document::dispatchPagehideEvent(PageshowEventPersistence persisted)
     if (m_lastPageStatus == PageStatus::Hidden)
         return;
     m_lastPageStatus = PageStatus::Hidden;
-    dispatchWindowEvent(PageTransitionEvent::create(eventNames().pagehideEvent, persisted == PageshowEventPersisted), this);
+    dispatchWindowEvent(PageTransitionEvent::create(eventNames().pagehideEvent, persisted == PageshowEventPersistence::Persisted), this);
 }
 
 void Document::enqueueSecurityPolicyViolationEvent(SecurityPolicyViolationEventInit&& eventInit)

--- a/Source/WebCore/dom/Document.h
+++ b/Source/WebCore/dom/Document.h
@@ -302,9 +302,9 @@ class Scope;
 class Update;
 }
 
-enum PageshowEventPersistence { PageshowEventNotPersisted, PageshowEventPersisted };
+enum class PageshowEventPersistence : bool { NotPersisted, Persisted };
 
-enum NodeListInvalidationType {
+enum class NodeListInvalidationType : uint8_t {
     DoNotInvalidateOnAttributeChanges,
     InvalidateOnClassAttrChange,
     InvalidateOnIdNameAttrChange,
@@ -314,7 +314,7 @@ enum NodeListInvalidationType {
     InvalidateOnHRefAttrChange,
     InvalidateOnAnyAttrChange,
 };
-const int numNodeListInvalidationTypes = InvalidateOnAnyAttrChange + 1;
+const uint8_t numNodeListInvalidationTypes = static_cast<uint8_t>(NodeListInvalidationType::InvalidateOnAnyAttrChange) + 1;
 
 enum class EventHandlerRemoval { One, All };
 using EventTargetSet = HashCountedSet<Node*>;

--- a/Source/WebCore/dom/LiveNodeListInlines.h
+++ b/Source/WebCore/dom/LiveNodeListInlines.h
@@ -33,22 +33,22 @@ namespace WebCore {
 ALWAYS_INLINE bool shouldInvalidateTypeOnAttributeChange(NodeListInvalidationType type, const QualifiedName& attrName)
 {
     switch (type) {
-    case InvalidateOnClassAttrChange:
+    case NodeListInvalidationType::InvalidateOnClassAttrChange:
         return attrName == HTMLNames::classAttr;
-    case InvalidateOnNameAttrChange:
+    case NodeListInvalidationType::InvalidateOnNameAttrChange:
         return attrName == HTMLNames::nameAttr;
-    case InvalidateOnIdNameAttrChange:
+    case NodeListInvalidationType::InvalidateOnIdNameAttrChange:
         return attrName == HTMLNames::idAttr || attrName == HTMLNames::nameAttr;
-    case InvalidateOnForTypeAttrChange:
+    case NodeListInvalidationType::InvalidateOnForTypeAttrChange:
         return attrName == HTMLNames::forAttr || attrName == HTMLNames::typeAttr;
-    case InvalidateForFormControls:
+    case NodeListInvalidationType::InvalidateForFormControls:
         return attrName == HTMLNames::nameAttr || attrName == HTMLNames::idAttr || attrName == HTMLNames::forAttr
             || attrName == HTMLNames::formAttr || attrName == HTMLNames::typeAttr;
-    case InvalidateOnHRefAttrChange:
+    case NodeListInvalidationType::InvalidateOnHRefAttrChange:
         return attrName == HTMLNames::hrefAttr;
-    case DoNotInvalidateOnAttributeChanges:
+    case NodeListInvalidationType::DoNotInvalidateOnAttributeChanges:
         return false;
-    case InvalidateOnAnyAttrChange:
+    case NodeListInvalidationType::InvalidateOnAnyAttrChange:
         return true;
     }
     return false;

--- a/Source/WebCore/dom/NameNodeList.cpp
+++ b/Source/WebCore/dom/NameNodeList.cpp
@@ -35,7 +35,7 @@ using namespace HTMLNames;
 WTF_MAKE_ISO_ALLOCATED_IMPL(NameNodeList);
 
 NameNodeList::NameNodeList(ContainerNode& rootNode, const AtomString& name)
-    : CachedLiveNodeList(rootNode, InvalidateOnNameAttrChange)
+    : CachedLiveNodeList(rootNode, NodeListInvalidationType::InvalidateOnNameAttrChange)
     , m_name(name)
 {
 }

--- a/Source/WebCore/dom/Node.cpp
+++ b/Source/WebCore/dom/Node.cpp
@@ -979,7 +979,7 @@ inline bool Document::shouldInvalidateNodeListAndCollectionCaches() const
 
 inline bool Document::shouldInvalidateNodeListAndCollectionCachesForAttribute(const QualifiedName& attrName) const
 {
-    return shouldInvalidateNodeListCachesForAttr<DoNotInvalidateOnAttributeChanges + 1>(m_nodeListAndCollectionCounts, attrName);
+    return shouldInvalidateNodeListCachesForAttr<static_cast<uint8_t>(NodeListInvalidationType::DoNotInvalidateOnAttributeChanges) + 1>(m_nodeListAndCollectionCounts, attrName);
 }
 
 template <typename InvalidationFunction>

--- a/Source/WebCore/history/CachedPage.cpp
+++ b/Source/WebCore/history/CachedPage.cpp
@@ -103,7 +103,7 @@ static void firePageShowEvent(Page& page)
         // This takes care of firing the visibilitychange event and making sure the document is reported as visible.
         document->setVisibilityHiddenDueToDismissal(false);
 
-        document->dispatchPageshowEvent(PageshowEventPersisted);
+        document->dispatchPageshowEvent(PageshowEventPersistence::Persisted);
     }
 }
 

--- a/Source/WebCore/html/HTMLCollection.cpp
+++ b/Source/WebCore/html/HTMLCollection.cpp
@@ -89,32 +89,32 @@ static NodeListInvalidationType invalidationTypeExcludingIdAndNameAttributes(Col
     case CollectionType::SelectOptions:
     case CollectionType::MapAreas:
     case CollectionType::DocEmpty:
-        return DoNotInvalidateOnAttributeChanges;
+        return NodeListInvalidationType::DoNotInvalidateOnAttributeChanges;
     case CollectionType::SelectedOptions:
     case CollectionType::DataListOptions:
         // FIXME: We can do better some day.
-        return InvalidateOnAnyAttrChange;
+        return NodeListInvalidationType::InvalidateOnAnyAttrChange;
     case CollectionType::ByClass:
-        return InvalidateOnClassAttrChange;
+        return NodeListInvalidationType::InvalidateOnClassAttrChange;
     case CollectionType::DocAnchors:
-        return InvalidateOnNameAttrChange;
+        return NodeListInvalidationType::InvalidateOnNameAttrChange;
     case CollectionType::DocLinks:
-        return InvalidateOnHRefAttrChange;
+        return NodeListInvalidationType::InvalidateOnHRefAttrChange;
     case CollectionType::WindowNamedItems:
     case CollectionType::DocumentNamedItems:
     case CollectionType::DocumentAllNamedItems:
-        return InvalidateOnIdNameAttrChange;
+        return NodeListInvalidationType::InvalidateOnIdNameAttrChange;
     case CollectionType::FieldSetElements:
     case CollectionType::FormControls:
-        return InvalidateForFormControls;
+        return NodeListInvalidationType::InvalidateForFormControls;
     }
     ASSERT_NOT_REACHED();
-    return DoNotInvalidateOnAttributeChanges;
+    return NodeListInvalidationType::DoNotInvalidateOnAttributeChanges;
 }
 
 HTMLCollection::HTMLCollection(ContainerNode& ownerNode, CollectionType type)
     : m_collectionType(static_cast<unsigned>(type))
-    , m_invalidationType(invalidationTypeExcludingIdAndNameAttributes(type))
+    , m_invalidationType(static_cast<unsigned>(invalidationTypeExcludingIdAndNameAttributes(type)))
     , m_rootType(rootTypeFromCollectionType(type))
     , m_ownerNode(ownerNode)
 {

--- a/Source/WebCore/html/LabelsNodeList.cpp
+++ b/Source/WebCore/html/LabelsNodeList.cpp
@@ -38,7 +38,7 @@ using namespace HTMLNames;
 WTF_MAKE_ISO_ALLOCATED_IMPL(LabelsNodeList);
 
 LabelsNodeList::LabelsNodeList(HTMLElement& element)
-    : CachedLiveNodeList(element, InvalidateOnForTypeAttrChange)
+    : CachedLiveNodeList(element, NodeListInvalidationType::InvalidateOnForTypeAttrChange)
 {
 }
 

--- a/Source/WebCore/html/RadioNodeList.cpp
+++ b/Source/WebCore/html/RadioNodeList.cpp
@@ -41,7 +41,7 @@ using namespace HTMLNames;
 WTF_MAKE_ISO_ALLOCATED_IMPL(RadioNodeList);
 
 RadioNodeList::RadioNodeList(ContainerNode& rootNode, const AtomString& name)
-    : CachedLiveNodeList(rootNode, InvalidateForFormControls)
+    : CachedLiveNodeList(rootNode, NodeListInvalidationType::InvalidateForFormControls)
     , m_name(name)
     , m_isRootedAtTreeScope(is<HTMLFormElement>(rootNode))
 {

--- a/Source/WebCore/loader/FrameLoader.cpp
+++ b/Source/WebCore/loader/FrameLoader.cpp
@@ -3520,7 +3520,7 @@ void FrameLoader::dispatchUnloadEvents(UnloadEventPolicy unloadEventPolicy)
         if (m_pageDismissalEventBeingDispatched == PageDismissalType::None) {
             if (unloadEventPolicy == UnloadEventPolicy::UnloadAndPageHide) {
                 m_pageDismissalEventBeingDispatched = PageDismissalType::PageHide;
-                m_frame.document()->dispatchPagehideEvent(m_frame.document()->backForwardCacheState() == Document::AboutToEnterBackForwardCache ? PageshowEventPersisted : PageshowEventNotPersisted);
+                m_frame.document()->dispatchPagehideEvent(m_frame.document()->backForwardCacheState() == Document::AboutToEnterBackForwardCache ? PageshowEventPersistence::Persisted : PageshowEventPersistence::NotPersisted);
             }
 
             // This takes care of firing the visibilitychange event and making sure the document is reported as hidden.

--- a/Source/WebCore/page/LocalDOMWindow.cpp
+++ b/Source/WebCore/page/LocalDOMWindow.cpp
@@ -306,7 +306,7 @@ void LocalDOMWindow::dispatchAllPendingUnloadEvents()
             continue;
 
         if (RefPtr document = window->document())
-            document->dispatchPagehideEvent(PageshowEventNotPersisted);
+            document->dispatchPagehideEvent(PageshowEventPersistence::NotPersisted);
         window->dispatchEvent(Event::create(eventNames.unloadEvent, Event::CanBubble::No, Event::IsCancelable::No), window->document());
 
         window->enableSuddenTermination();

--- a/Source/WebCore/page/ios/FrameIOS.mm
+++ b/Source/WebCore/page/ios/FrameIOS.mm
@@ -647,7 +647,7 @@ void LocalFrame::dispatchPageHideEventBeforePause()
         return;
 
     Page::forEachDocumentFromMainFrame(*this, [](Document& document) {
-        document.dispatchPagehideEvent(PageshowEventPersisted);
+        document.dispatchPagehideEvent(PageshowEventPersistence::Persisted);
     });
 }
 
@@ -658,7 +658,7 @@ void LocalFrame::dispatchPageShowEventBeforeResume()
         return;
 
     Page::forEachDocumentFromMainFrame(*this, [](Document& document) {
-        document.dispatchPageshowEvent(PageshowEventPersisted);
+        document.dispatchPageshowEvent(PageshowEventPersistence::Persisted);
     });
 }
 


### PR DESCRIPTION
#### 5929d8817e587561ff6a2663c24ceab7deebd10b
<pre>
PageshowEventPersistence and NodeListInvalidationType should be enum classes
<a href="https://bugs.webkit.org/show_bug.cgi?id=256628">https://bugs.webkit.org/show_bug.cgi?id=256628</a>

Reviewed by Antti Koivisto.

* Source/WebCore/dom/Document.cpp:
(WebCore::Document::implicitClose):
(WebCore::Document::registerNodeListForInvalidation):
(WebCore::Document::unregisterNodeListForInvalidation):
(WebCore::Document::registerCollection):
(WebCore::Document::unregisterCollection):
(WebCore::Document::collectionCachedIdNameMap):
(WebCore::Document::collectionWillClearIdNameMap):
(WebCore::Document::dispatchPageshowEvent):
(WebCore::Document::dispatchPagehideEvent):
* Source/WebCore/dom/Document.h:
* Source/WebCore/dom/LiveNodeListInlines.h:
(WebCore::shouldInvalidateTypeOnAttributeChange):
* Source/WebCore/dom/NameNodeList.cpp:
(WebCore::NameNodeList::NameNodeList):
* Source/WebCore/dom/Node.cpp:
(WebCore::Document::shouldInvalidateNodeListAndCollectionCachesForAttribute const):
* Source/WebCore/history/CachedPage.cpp:
(WebCore::firePageShowEvent):
* Source/WebCore/html/HTMLCollection.cpp:
(WebCore::invalidationTypeExcludingIdAndNameAttributes):
(WebCore::HTMLCollection::HTMLCollection):
* Source/WebCore/html/LabelsNodeList.cpp:
(WebCore::LabelsNodeList::LabelsNodeList):
* Source/WebCore/html/RadioNodeList.cpp:
(WebCore::RadioNodeList::RadioNodeList):
* Source/WebCore/loader/FrameLoader.cpp:
(WebCore::FrameLoader::dispatchUnloadEvents):
* Source/WebCore/page/LocalDOMWindow.cpp:
(WebCore::LocalDOMWindow::dispatchAllPendingUnloadEvents):
* Source/WebCore/page/ios/FrameIOS.mm:
(WebCore::LocalFrame::dispatchPageHideEventBeforePause):
(WebCore::LocalFrame::dispatchPageShowEventBeforeResume):

Canonical link: <a href="https://commits.webkit.org/263952@main">https://commits.webkit.org/263952@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/6cb105a955435926720383d720aa7a0f3f857638

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/6192 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/6382 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/6563 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/7757 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/6526 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/6192 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/6602 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/6333 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/9408 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/6302 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/6320 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/5607 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/7825 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/3794 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/5586 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/13481 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/5659 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/5666 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/7905 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/6138 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/5020 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/5554 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/9699 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/730 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/5921 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->