### PR TITLE
Compression Streams not handling large outputs during the flush stage

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/compression/compression-large-flush-output.any-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/compression/compression-large-flush-output.any-expected.txt
@@ -1,0 +1,5 @@
+
+PASS deflate compression with large flush output
+PASS gzip compression with large flush output
+PASS deflate-raw compression with large flush output
+

--- a/LayoutTests/imported/w3c/web-platform-tests/compression/compression-large-flush-output.any.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/compression/compression-large-flush-output.any.html
@@ -1,0 +1,1 @@
+<!-- This file is required for WebKit test infrastructure to run the templated test -->

--- a/LayoutTests/imported/w3c/web-platform-tests/compression/compression-large-flush-output.any.js
+++ b/LayoutTests/imported/w3c/web-platform-tests/compression/compression-large-flush-output.any.js
@@ -1,0 +1,59 @@
+// META: global=window,worker
+// META: script=third_party/pako/pako_inflate.min.js
+// META: timeout=long
+
+'use strict';
+
+// This test verifies that a large flush output will not truncate the
+// final results.
+
+async function compressData(chunk, format) {
+  const cs = new CompressionStream(format);
+  const writer = cs.writable.getWriter();
+ 
+  writer.write(chunk);
+
+  const closePromise = writer.close();
+  const out = [];
+  const reader = cs.readable.getReader();
+  let totalSize = 0;
+  while (true) {
+    const { value, done } = await reader.read();
+    if (done)
+      break;
+    out.push(value);
+    totalSize += value.byteLength;
+  }
+  await closePromise;
+  const concatenated = new Uint8Array(totalSize);
+  let offset = 0;
+  for (const array of out) {
+    concatenated.set(array, offset);
+    offset += array.byteLength;
+  }
+  return concatenated;
+}
+
+// JSON-encoded array of 10 thousands numbers ("[0,1,2,...]"). This produces 48_891 bytes of data.
+const fullData = new TextEncoder().encode(JSON.stringify(Array.from({ length: 10_000 }, (_, i) => i)));
+const data = fullData.subarray(0, 35_579);
+const expectedValue = data;
+
+promise_test(async t => {
+const compressedData = await compressData(data, 'deflate');
+// decompress with pako, and check that we got the same result as our original string
+assert_array_equals(expectedValue, pako.inflate(compressedData), 'value should match');
+}, `deflate compression with large flush output`);
+
+promise_test(async t => {
+const compressedData = await compressData(data, 'gzip');
+// decompress with pako, and check that we got the same result as our original string
+assert_array_equals(expectedValue, pako.inflate(compressedData), 'value should match');
+}, `gzip compression with large flush output`);
+
+promise_test(async t => {
+const compressedData = await compressData(data, 'deflate-raw');
+// decompress with pako, and check that we got the same result as our original string
+assert_array_equals(expectedValue, pako.inflateRaw(compressedData), 'value should match');
+}, `deflate-raw compression with large flush output`);
+

--- a/Source/WebCore/Modules/compression/CompressionStreamEncoder.cpp
+++ b/Source/WebCore/Modules/compression/CompressionStreamEncoder.cpp
@@ -53,7 +53,7 @@ ExceptionOr<RefPtr<Uint8Array>> CompressionStreamEncoder::encode(const BufferSou
 
 ExceptionOr<RefPtr<Uint8Array>> CompressionStreamEncoder::flush()
 {
-    m_finish = true;
+    m_didFinish = true;
 
     auto compressedDataCheck = compress(0, 0);
     if (compressedDataCheck.hasException())
@@ -95,9 +95,25 @@ ExceptionOr<bool> CompressionStreamEncoder::initialize()
     return true;
 }
 
+// The compression algorithm is broken up into 2 steps.
+// 1. Compression of Data
+// 2. Flush Remaining Data
+//
+// When avail_in is empty we can normally exit performing compression, but during the flush
+// step we may have data buffered and will need to continue to keep flushing out the rest.
+bool CompressionStreamEncoder::didDeflateFinish(int result) const
+{
+    return !m_zstream.avail_in && (!m_didFinish || (m_didFinish && result == Z_STREAM_END));
+}
+
+// See https://www.zlib.net/manual.html#Constants
+static bool didDeflateFail(int result)
+{
+    return result != Z_OK && result != Z_STREAM_END && result != Z_BUF_ERROR;
+}
+
 ExceptionOr<RefPtr<JSC::ArrayBuffer>> CompressionStreamEncoder::compress(const uint8_t* input, const size_t inputLength)
 {
-
     size_t allocateSize = (inputLength < startingAllocationSize) ? startingAllocationSize : inputLength;
     auto storage = SharedBufferBuilder();
 
@@ -129,11 +145,12 @@ ExceptionOr<RefPtr<JSC::ArrayBuffer>> CompressionStreamEncoder::compress(const u
         m_zstream.next_out = output.data();
         m_zstream.avail_out = output.size();
 
-        result = deflate(&m_zstream, (m_finish) ? Z_FINISH : Z_NO_FLUSH);
-        if (result != Z_OK && result != Z_STREAM_END && result != Z_BUF_ERROR)
+        result = deflate(&m_zstream, m_didFinish ? Z_FINISH : Z_NO_FLUSH);
+
+        if (didDeflateFail(result))
             return Exception { TypeError, "Failed to compress data."_s };
 
-        if (!m_zstream.avail_in) {
+        if (didDeflateFinish(result)) {
             shouldCompress = false;
             output.resize(allocateSize - m_zstream.avail_out);
         }

--- a/Source/WebCore/Modules/compression/CompressionStreamEncoder.h
+++ b/Source/WebCore/Modules/compression/CompressionStreamEncoder.h
@@ -52,26 +52,27 @@ public:
     }
 
 private:
+    bool didDeflateFinish(int) const;
+
+    ExceptionOr<RefPtr<JSC::ArrayBuffer>> compress(const uint8_t* input, const size_t inputLength);
+    ExceptionOr<bool> initialize();
+
+    explicit CompressionStreamEncoder(unsigned char format)
+        : m_format(static_cast<Formats::CompressionFormat>(format))
+    {
+        std::memset(&m_zstream, 0, sizeof(m_zstream));
+    }
+
     // If the user provides too small of an input size we will automatically allocate a page worth of memory instead.
     // Very small input sizes can result in a larger output than their input. This would require an additional 
     // encode call then, which is not desired.
     const size_t startingAllocationSize = 16384; // 16KB
     const size_t maxAllocationSize = 1073741824; // 1GB
 
-
     bool m_initialized { false };
-    bool m_finish { false };
+    bool m_didFinish { false };
     z_stream m_zstream;
 
     Formats::CompressionFormat m_format;
-
-    ExceptionOr<RefPtr<JSC::ArrayBuffer>> compress(const uint8_t* input, const size_t inputLength);
-    ExceptionOr<bool> initialize();
-
-    explicit CompressionStreamEncoder(unsigned char format) 
-        : m_format(static_cast<Formats::CompressionFormat>(format))
-    {
-        std::memset(&m_zstream, 0, sizeof(m_zstream));
-    }
 };
 } // namespace WebCore

--- a/Source/WebCore/Modules/compression/DecompressionStreamDecoder.h
+++ b/Source/WebCore/Modules/compression/DecompressionStreamDecoder.h
@@ -63,6 +63,17 @@ public:
     }
 
 private:
+    bool didInflateFinish(int) const;
+    bool didInflateContainExtraBytes(int) const;
+
+    ExceptionOr<RefPtr<JSC::ArrayBuffer>> decompressZlib(const uint8_t* input, const size_t inputLength);
+    ExceptionOr<bool> initialize();
+
+    explicit DecompressionStreamDecoder(unsigned char format)
+        : m_format(static_cast<Formats::CompressionFormat>(format))
+    {
+        std::memset(&m_zstream, 0, sizeof(m_zstream));
+    }
 
     // When given an encoded input, it is difficult to guess the output size.
     // My approach here is starting from one page and growing at a linear rate of x2 until the input data
@@ -73,7 +84,7 @@ private:
     const size_t maxAllocationSize = 1073741824; // 1GB
     
     bool m_initialized { false };
-    bool m_finish { false };
+    bool m_didFinish { false };
     z_stream m_zstream;
 
     bool m_usingAppleCompressionFramework { false };
@@ -87,14 +98,5 @@ private:
 #endif
 
     Formats::CompressionFormat m_format;
-
-    ExceptionOr<RefPtr<JSC::ArrayBuffer>> decompressZlib(const uint8_t* input, const size_t inputLength);
-    ExceptionOr<bool> initialize();
-
-    explicit DecompressionStreamDecoder(unsigned char format) 
-        : m_format(static_cast<Formats::CompressionFormat>(format))
-    {
-        std::memset(&m_zstream, 0, sizeof(m_zstream));
-    }
 };
 } // namespace WebCore


### PR DESCRIPTION
#### a30d9284f5b98bd5c389f28bfc4a710d9f256fa8
<pre>
Compression Streams not handling large outputs during the flush stage
<a href="https://bugs.webkit.org/show_bug.cgi?id=254021">https://bugs.webkit.org/show_bug.cgi?id=254021</a>

Reviewed by Chris Dumez and Brent Fulgham.

We missed an edge case where during the flush step we may have data longer than
the allocated output. Since the avail_in will be set to 0 we would just exit.
We need to verify that the stream has ended before exiting.

* LayoutTests/imported/w3c/web-platform-tests/compression/compression-large-flush-output.any-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/compression/compression-large-flush-output.any.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/compression/compression-large-flush-output.any.js: Added.
(async compressData):
(promise_test.async t):
* Source/WebCore/Modules/compression/CompressionStreamEncoder.cpp:
(WebCore::CompressionStreamEncoder::flush):
(WebCore::CompressionStreamEncoder::didDeflateFinish const):
(WebCore::didDeflateFail):
(WebCore::CompressionStreamEncoder::compress):
* Source/WebCore/Modules/compression/CompressionStreamEncoder.h:
(WebCore::CompressionStreamEncoder::CompressionStreamEncoder):
* Source/WebCore/Modules/compression/DecompressionStreamDecoder.cpp:
(WebCore::DecompressionStreamDecoder::flush):
(WebCore::DecompressionStreamDecoder::didInflateFinish const):
(WebCore::didInflateFail):
(WebCore::DecompressionStreamDecoder::didInflateContainExtraBytes const):
(WebCore::DecompressionStreamDecoder::decompressZlib):
(WebCore::DecompressionStreamDecoder::decompressAppleCompressionFramework):
* Source/WebCore/Modules/compression/DecompressionStreamDecoder.h:
(WebCore::DecompressionStreamDecoder::DecompressionStreamDecoder):

Canonical link: <a href="https://commits.webkit.org/263997@main">https://commits.webkit.org/263997@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ab429a7b4d3454bbfbc4c47e2856d499c1a9fb7a

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/6353 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/6551 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/6733 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/7923 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/6658 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/6348 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/6770 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/6500 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/9554 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/6465 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/6466 "Passed tests") | [⏳ 🧪 api-mac](https://ews-build.webkit.org/#/builders/API-Tests-macOS-EWS "Waiting to run tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/7997 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/3927 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/5729 "Passed tests") | [⏳ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/GTK-WK2-Tests-EWS "Waiting to run tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/5794 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/5809 "Passed tests") | [⏳ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/API-Tests-GTK-EWS "Waiting to run tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/6290 "Built successfully") | [⏳ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/macOS-AppleSilicon-Ventura-Debug-WK2-Tests-EWS "Waiting to run tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/5697 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/5657 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/1502 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/9855 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/6067 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->