### PR TITLE
WebSocket's binaryType setter should not throw

### DIFF
--- a/LayoutTests/TestExpectations
+++ b/LayoutTests/TestExpectations
@@ -5357,7 +5357,7 @@ webkit.org/b/255287 fast/block/lineboxcontain/inline-box-vertical.html [ Failure
 fast/canvas/large-getImageData.html [ Skip ]
 
 webkit.org/b/237108 http/tests/websocket/tests/hybi/extensions.html [ Failure ]
-webkit.org/b/237108 http/tests/websocket/tests/hybi/deflate-frame-parameter.html [ Failure ] # <rdar://problem/33850189>
+webkit.org/b/237108 http/tests/websocket/tests/hybi/deflate-frame-parameter.html [ Failure ] # <rdar://33630526>
 webkit.org/b/237108 http/tests/websocket/tests/hybi/handshake-ok-with-legacy-sec-websocket-response-headers.html [ Pass Failure ]
 
 # Only certain ports have WebGPU implementations.

--- a/LayoutTests/http/tests/websocket/tests/hybi/binary-type-expected.txt
+++ b/LayoutTests/http/tests/websocket/tests/hybi/binary-type-expected.txt
@@ -1,6 +1,3 @@
-CONSOLE MESSAGE: 'Blob' is not a valid value for binaryType; binaryType remains unchanged.
-CONSOLE MESSAGE: 'ArrayBuffer' is not a valid value for binaryType; binaryType remains unchanged.
-CONSOLE MESSAGE: '' is not a valid value for binaryType; binaryType remains unchanged.
 Test WebSocket.binaryType attribute.
 
 On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
@@ -8,11 +5,8 @@ On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE
 PASS ws.binaryType is "blob"
 PASS ws.binaryType is "arraybuffer"
 PASS ws.binaryType is "blob"
-PASS ws.binaryType = 'Blob' threw exception SyntaxError: The string did not match the expected pattern..
 PASS ws.binaryType is "blob"
-PASS ws.binaryType = 'ArrayBuffer' threw exception SyntaxError: The string did not match the expected pattern..
 PASS ws.binaryType is "blob"
-PASS ws.binaryType = '' threw exception SyntaxError: The string did not match the expected pattern..
 PASS ws.binaryType is "blob"
 PASS successfullyParsed is true
 

--- a/LayoutTests/http/tests/websocket/tests/hybi/binary-type.html
+++ b/LayoutTests/http/tests/websocket/tests/hybi/binary-type.html
@@ -18,13 +18,13 @@ shouldBeEqualToString("ws.binaryType", "arraybuffer");
 ws.binaryType = "blob";
 shouldBeEqualToString("ws.binaryType", "blob");
 
-shouldThrowErrorName("ws.binaryType = 'Blob'", "SyntaxError");
+ws.binaryType = 'Blob';
 shouldBeEqualToString("ws.binaryType", "blob");
 
-shouldThrowErrorName("ws.binaryType = 'ArrayBuffer'", "SyntaxError");
+ws.binaryType = 'ArrayBuffer';
 shouldBeEqualToString("ws.binaryType", "blob");
 
-shouldThrowErrorName("ws.binaryType = ''", "SyntaxError");
+ws.binaryType = '';
 shouldBeEqualToString("ws.binaryType", "blob");
 
 </script>

--- a/LayoutTests/imported/w3c/web-platform-tests/websockets/binaryType-wrong-value.any.worker_wss-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/websockets/binaryType-wrong-value.any.worker_wss-expected.txt
@@ -1,3 +1,3 @@
 
-FAIL Create WebSocket - set binaryType to something other than blob or arraybuffer - SYNTAX_ERR is returned - Connection should be closed The string did not match the expected pattern.
+PASS Create WebSocket - set binaryType to something other than blob or arraybuffer - SYNTAX_ERR is returned - Connection should be closed
 

--- a/LayoutTests/imported/w3c/web-platform-tests/websockets/binaryType-wrong-value.any_wss-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/websockets/binaryType-wrong-value.any_wss-expected.txt
@@ -1,3 +1,3 @@
 
-FAIL Create WebSocket - set binaryType to something other than blob or arraybuffer - SYNTAX_ERR is returned - Connection should be closed The string did not match the expected pattern.
+PASS Create WebSocket - set binaryType to something other than blob or arraybuffer - SYNTAX_ERR is returned - Connection should be closed
 

--- a/Source/WebCore/Modules/websockets/WebSocket.cpp
+++ b/Source/WebCore/Modules/websockets/WebSocket.cpp
@@ -470,30 +470,10 @@ String WebSocket::extensions() const
     return m_extensions;
 }
 
-String WebSocket::binaryType() const
+ExceptionOr<void> WebSocket::setBinaryType(BinaryType binaryType)
 {
-    switch (m_binaryType) {
-    case BinaryType::Blob:
-        return "blob"_s;
-    case BinaryType::ArrayBuffer:
-        return "arraybuffer"_s;
-    }
-    ASSERT_NOT_REACHED();
-    return String();
-}
-
-ExceptionOr<void> WebSocket::setBinaryType(const String& binaryType)
-{
-    if (binaryType == "blob"_s) {
-        m_binaryType = BinaryType::Blob;
-        return { };
-    }
-    if (binaryType == "arraybuffer"_s) {
-        m_binaryType = BinaryType::ArrayBuffer;
-        return { };
-    }
-    scriptExecutionContext()->addConsoleMessage(MessageSource::JS, MessageLevel::Error, "'" + binaryType + "' is not a valid value for binaryType; binaryType remains unchanged.");
-    return Exception { SyntaxError };
+    m_binaryType = binaryType;
+    return { };
 }
 
 EventTargetInterface WebSocket::eventTargetInterface() const
@@ -602,7 +582,7 @@ void WebSocket::didReceiveBinaryData(Vector<uint8_t>&& binaryData)
             // FIXME: We just received the data from NetworkProcess, and are sending it back. This is inefficient.
             dispatchEvent(MessageEvent::create(Blob::create(scriptExecutionContext(), WTFMove(binaryData), emptyString()), SecurityOrigin::create(m_url)->toString()));
             break;
-        case BinaryType::ArrayBuffer:
+        case BinaryType::Arraybuffer:
             dispatchEvent(MessageEvent::create(ArrayBuffer::create(binaryData.data(), binaryData.size()), SecurityOrigin::create(m_url)->toString()));
             break;
         }

--- a/Source/WebCore/Modules/websockets/WebSocket.h
+++ b/Source/WebCore/Modules/websockets/WebSocket.h
@@ -88,8 +88,9 @@ public:
     String protocol() const;
     String extensions() const;
 
-    String binaryType() const;
-    ExceptionOr<void> setBinaryType(const String&);
+    enum class BinaryType : bool { Blob, Arraybuffer };
+    BinaryType binaryType() const { return m_binaryType; }
+    ExceptionOr<void> setBinaryType(BinaryType);
 
     ScriptExecutionContext* scriptExecutionContext() const final;
 
@@ -124,8 +125,6 @@ private:
     size_t getFramingOverhead(size_t payloadSize);
 
     void failAsynchronously();
-
-    enum class BinaryType { Blob, ArrayBuffer };
 
     static Lock s_allActiveWebSocketsLock;
     RefPtr<ThreadableWebSocketChannel> m_channel;

--- a/Source/WebCore/Modules/websockets/WebSocket.idl
+++ b/Source/WebCore/Modules/websockets/WebSocket.idl
@@ -29,7 +29,9 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-// https://html.spec.whatwg.org/multipage/comms.html#the-websocket-interface
+// https://websockets.spec.whatwg.org/#the-websocket-interface
+
+enum BinaryType { "blob", "arraybuffer" };
 
 [
     ActiveDOMObject,
@@ -38,31 +40,29 @@
 ] interface WebSocket : EventTarget {
     [CallWith=CurrentScriptExecutionContext] constructor(USVString url, optional sequence<DOMString> protocols = []);
     [CallWith=CurrentScriptExecutionContext] constructor(USVString url, DOMString protocol);
-
     readonly attribute USVString url;
 
+    // ready state
     const unsigned short CONNECTING = 0;
     const unsigned short OPEN = 1;
     const unsigned short CLOSING = 2;
     const unsigned short CLOSED = 3;
     readonly attribute unsigned short readyState;
-
     readonly attribute unsigned long bufferedAmount;
 
+    // networking
     attribute EventHandler onopen;
-    attribute EventHandler onmessage;
     attribute EventHandler onerror;
     attribute EventHandler onclose;
+    readonly attribute DOMString protocol;
+    readonly attribute DOMString extensions;
+    undefined close(optional [Clamp] unsigned short code, optional USVString reason);
 
-    readonly attribute DOMString? protocol;
-    readonly attribute DOMString? extensions;
-
-    attribute DOMString binaryType;
-
+    // messaging
+    attribute EventHandler onmessage;
+    attribute BinaryType binaryType;
     undefined send(ArrayBuffer data);
     undefined send(ArrayBufferView data);
     undefined send(Blob data);
     undefined send(USVString data);
-
-    undefined close(optional [Clamp] unsigned short code, optional USVString reason);
 };

--- a/Source/WebCore/xml/XMLHttpRequest.h
+++ b/Source/WebCore/xml/XMLHttpRequest.h
@@ -77,7 +77,7 @@ public:
     const URL& url() const { return m_url; }
     String statusText() const;
     int status() const;
-    State readyState() const;
+    State readyState() const { return static_cast<State>(m_readyState); }
     bool withCredentials() const { return m_includeCredentials; }
     ExceptionOr<void> setWithCredentials(bool);
     ExceptionOr<void> open(const String& method, const String& url);
@@ -117,7 +117,7 @@ public:
         Text = 5,
     };
     ExceptionOr<void> setResponseType(ResponseType);
-    ResponseType responseType() const;
+    ResponseType responseType() const { return static_cast<ResponseType>(m_responseType); }
 
     String responseURL() const;
 
@@ -256,15 +256,5 @@ private:
     std::atomic<bool> m_hasRelevantEventListener;
     bool m_wasDidSendDataCalledForTotalBytes { false };
 };
-
-inline auto XMLHttpRequest::responseType() const -> ResponseType
-{
-    return static_cast<ResponseType>(m_responseType);
-}
-
-inline auto XMLHttpRequest::readyState() const -> State
-{
-    return static_cast<State>(m_readyState);
-}
 
 } // namespace WebCore


### PR DESCRIPTION
#### 6e89039cfb2d2f7701a6c33cab9c24055d9291f6
<pre>
WebSocket&apos;s binaryType setter should not throw
<a href="https://bugs.webkit.org/show_bug.cgi?id=256580">https://bugs.webkit.org/show_bug.cgi?id=256580</a>
rdar://109192086

Reviewed by Antti Koivisto.

Align WebSocket.idl with the WebSockets Standard. In particular:

- binaryType is now an enum
- protocol and extensions are no longer nullable (I don&apos;t think they ever returned null)

* LayoutTests/TestExpectations:
* LayoutTests/http/tests/websocket/tests/hybi/binary-type-expected.txt:
* LayoutTests/http/tests/websocket/tests/hybi/binary-type.html:
* LayoutTests/imported/w3c/web-platform-tests/websockets/binaryType-wrong-value.any.worker_wss-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/websockets/binaryType-wrong-value.any_wss-expected.txt:
* Source/WebCore/Modules/websockets/WebSocket.cpp:
(WebCore::WebSocket::setBinaryType):
(WebCore::WebSocket::didReceiveBinaryData):
(WebCore::WebSocket::binaryType const): Deleted.
* Source/WebCore/Modules/websockets/WebSocket.h:
(WebCore::WebSocket::binaryType const):
* Source/WebCore/Modules/websockets/WebSocket.idl:
* Source/WebCore/xml/XMLHttpRequest.h:
(WebCore::XMLHttpRequest::responseType const): Deleted.
(WebCore::XMLHttpRequest::readyState const): Deleted.

Inline these into their declaration as well, matching WebSocket&apos;s binaryType(), per a review nit.

Canonical link: <a href="https://commits.webkit.org/263963@main">https://commits.webkit.org/263963@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a91633eed46e0138ff86f664f8ffbafd859e71fe

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/6244 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/6438 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/6617 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/7814 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/6576 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/6245 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/6658 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/6388 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/9461 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/6356 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/6367 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/5652 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/7885 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/3840 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/5631 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/13523 "Failed to checkout and rebase branch from PR 13742") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/5705 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/5712 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/7958 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/6193 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/5066 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/5604 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/5560 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/1478 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/9753 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/5972 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->