### PR TITLE
Delete unused LocalFrameViewLayoutContext's startDisallowingLayout and endDisallowingLayout

### DIFF
--- a/Source/WebCore/page/LocalFrameView.h
+++ b/Source/WebCore/page/LocalFrameView.h
@@ -443,9 +443,6 @@ public:
 
     WEBCORE_EXPORT Color documentBackgroundColor() const;
 
-    void startDisallowingLayout() { layoutContext().startDisallowingLayout(); }
-    void endDisallowingLayout() { layoutContext().endDisallowingLayout(); }
-
     static MonotonicTime currentPaintTimeStamp() { return sCurrentPaintTimeStamp; } // returns 0 if not painting
     
     WEBCORE_EXPORT void updateLayoutAndStyleIfNeededRecursive();

--- a/Source/WebCore/page/LocalFrameViewLayoutContext.cpp
+++ b/Source/WebCore/page/LocalFrameViewLayoutContext.cpp
@@ -503,9 +503,6 @@ bool LocalFrameViewLayoutContext::canPerformLayout() const
     if (isInRenderTreeLayout())
         return false;
 
-    if (layoutDisallowed())
-        return false;
-
     if (view().isPainting())
         return false;
 

--- a/Source/WebCore/page/LocalFrameViewLayoutContext.h
+++ b/Source/WebCore/page/LocalFrameViewLayoutContext.h
@@ -63,9 +63,6 @@ public:
     void scheduleSubtreeLayout(RenderElement& layoutRoot);
     void unscheduleLayout();
 
-    void startDisallowingLayout() { ++m_layoutDisallowedCount; }
-    void endDisallowingLayout() { ASSERT(m_layoutDisallowedCount > 0); --m_layoutDisallowedCount; }
-    
     void disableSetNeedsLayout();
     void enableSetNeedsLayout();
 
@@ -125,7 +122,6 @@ private:
 
     void performLayout();
     bool canPerformLayout() const;
-    bool layoutDisallowed() const { return m_layoutDisallowedCount; }
     bool isLayoutSchedulingEnabled() const { return m_layoutSchedulingIsEnabled; }
 
     void layoutTimerFired();
@@ -176,7 +172,6 @@ private:
     LayoutNestedState m_layoutNestedState { LayoutNestedState::NotInLayout };
     unsigned m_layoutCount { 0 };
     unsigned m_disableSetNeedsLayoutCount { 0 };
-    int m_layoutDisallowedCount { 0 };
     unsigned m_paintOffsetCacheDisableCount { 0 };
     LayoutStateStack m_layoutStateStack;
     std::unique_ptr<Layout::LayoutTree> m_layoutTree;


### PR DESCRIPTION
#### 51a237c46065e305f9073c88da9fc387fda98356
<pre>
Delete unused LocalFrameViewLayoutContext&apos;s startDisallowingLayout and endDisallowingLayout
<a href="https://bugs.webkit.org/show_bug.cgi?id=256630">https://bugs.webkit.org/show_bug.cgi?id=256630</a>

Reviewed by Antti Koivisto.

Deleted the unused code.

* Source/WebCore/page/LocalFrameView.h:
* Source/WebCore/page/LocalFrameViewLayoutContext.cpp:
(WebCore::LocalFrameViewLayoutContext::performLayout):
(WebCore::LocalFrameViewLayoutContext::canPerformLayout const):
* Source/WebCore/page/LocalFrameViewLayoutContext.h:
(WebCore::LocalFrameViewLayoutContext::startDisallowingLayout): Deleted.
(WebCore::LocalFrameViewLayoutContext::endDisallowingLayout): Deleted.
(WebCore::LocalFrameViewLayoutContext::layoutDisallowed const): Deleted.

Canonical link: <a href="https://commits.webkit.org/263955@main">https://commits.webkit.org/263955@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f5f04bee2906bce7c78df058e50e456878b7ddce

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/6204 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/6395 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/6575 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/7772 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/6538 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/6203 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/6615 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/6345 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/9419 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/6314 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/6332 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/5618 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/7841 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/3806 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/5597 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/13493 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/5671 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/5677 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/7919 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/6151 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/5030 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/5565 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/9711 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/732 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/5933 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->