### PR TITLE
[WGSL] Add configuration and script to run wgslc tests

### DIFF
--- a/Source/WebGPU/WGSL/tests/invalid/array.wgsl
+++ b/Source/WebGPU/WGSL/tests/invalid/array.wgsl
@@ -1,3 +1,5 @@
+// RUN: %not %wgslc | %check
+
 fn testArrayLengthMismatch() {
   // CHECK-L: array count must be greater than 0
   let x1 = array<i32, 0>();

--- a/Source/WebGPU/WGSL/tests/invalid/for.wgsl
+++ b/Source/WebGPU/WGSL/tests/invalid/for.wgsl
@@ -1,3 +1,5 @@
+// RUN: %not %wgslc | %check
+
 fn testForStatement() {
   // CHECK-L: for-loop condition must be bool, got <AbstractInt>
   for (var i = 0; i;) {

--- a/Source/WebGPU/WGSL/tests/invalid/overload.wgsl
+++ b/Source/WebGPU/WGSL/tests/invalid/overload.wgsl
@@ -1,3 +1,5 @@
+// RUN: %not %wgslc | %check
+
 fn testExplicitTypeArguments() {
   // CHECK-L: no matching overload for initializer vec2<i32>(<AbstractFloat>, <AbstractFloat>)
   let v0 = vec2<i32>(0.0, 0.0);
@@ -33,9 +35,9 @@ fn testConstraints() {
 }
 
 fn testBottomOverload() {
-  // CHECK-L: no matching overload for initializer vec2<f32>(<AbstractInt>)
-  let m = vec2<f32>(0);
+  // CHECK-L: no matching overload for initializer vec2<f32>(i32)
+  let m = vec2<f32>(0i);
 
-  // CHECK-NOT-L: no matching overload for operator +(⊥, <AbstractInt>)
+  // CHECK-NOT-L: no matching overload for operator
   let x = m + 2;
 }

--- a/Source/WebGPU/WGSL/tests/invalid/vector.wgsl
+++ b/Source/WebGPU/WGSL/tests/invalid/vector.wgsl
@@ -1,3 +1,5 @@
+// RUN: %not %wgslc | %check
+
 fn testIndexAccess() {
   // CHECK-L: index must be of type 'i32' or 'u32', found: 'f32'
   let x1 = vec2(0)[1f];

--- a/Source/WebGPU/WGSL/tests/lit.cfg
+++ b/Source/WebGPU/WGSL/tests/lit.cfg
@@ -1,0 +1,25 @@
+# vi: ft=python
+
+import lit.formats
+import os
+import site
+import sys
+
+current_dir = os.path.dirname(os.path.abspath(__file__))
+sys.path.append(os.path.join(current_dir, '..', '..', '..', '..', 'Tools', 'Scripts'))
+
+from webkitpy.common.host import Host
+
+host = Host()
+port = host.port_factory.get()
+wgslc = port._build_path('wgslc')
+
+config.name = 'WGSL'
+config.suffixes = ['.wgsl']
+config.test_format = lit.formats.ShTest(True)
+config.test_exec_root = os.environ['LIT_TEST_DIR']
+config.environment['DYLD_FRAMEWORK_PATH'] = port._build_path()
+
+config.substitutions.append(('%check', '{}/bin/OutputCheck --comment=".*//" %s'.format(site.getuserbase())))
+config.substitutions.append(('%wgslc', '{} %s _ 2>&1'.format(wgslc)))
+config.substitutions.append(('%not', 'eval !'))

--- a/Source/WebGPU/WGSL/tests/requirements.txt
+++ b/Source/WebGPU/WGSL/tests/requirements.txt
@@ -1,0 +1,2 @@
+lit
+OutputCheck

--- a/Source/WebGPU/WGSL/tests/valid/concretization.wgsl
+++ b/Source/WebGPU/WGSL/tests/valid/concretization.wgsl
@@ -1,3 +1,5 @@
+// RUN: %wgslc
+
 fn testVariableInialization() {
   let x1: u32 = 0;
   let x2: vec2<u32> = vec2(0, 0);

--- a/Source/WebGPU/WGSL/tests/valid/for.wgsl
+++ b/Source/WebGPU/WGSL/tests/valid/for.wgsl
@@ -1,3 +1,5 @@
+// RUN: %wgslc
+
 fn testForStatement() {
     for (var x = -1; x <= 1;) {
     }

--- a/Source/WebGPU/WGSL/tests/valid/if.wgsl
+++ b/Source/WebGPU/WGSL/tests/valid/if.wgsl
@@ -1,3 +1,5 @@
+// RUN: %wgslc
+
 fn testIfStmt() -> i32 {
     if true {
         return 42;

--- a/Source/WebGPU/WGSL/tests/valid/overload.wgsl
+++ b/Source/WebGPU/WGSL/tests/valid/overload.wgsl
@@ -1,3 +1,5 @@
+// RUN: %wgslc
+
 fn testAdd() {
   {
     _ = 1 + 2;

--- a/Source/WebGPU/WGSL/tests/valid/scope.wgsl
+++ b/Source/WebGPU/WGSL/tests/valid/scope.wgsl
@@ -1,3 +1,5 @@
+// RUN: %wgslc
+
 fn testScope() {
     {
         let x : i32;

--- a/Tools/Scripts/run-wgslc-tests
+++ b/Tools/Scripts/run-wgslc-tests
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+
+set -eo pipefail
+
+BASE=$(python3 -m site --user-base)
+LIT=$BASE/bin/lit
+
+pushd "$(dirname "$0")/../.." &> /dev/null
+REPO_ROOT=$PWD
+popd &> /dev/null
+
+TESTS_PATH=$REPO_ROOT/Source/WebGPU/WGSL/tests
+
+if ! which "$LIT" &> /dev/null; then
+  echo "Installing requirements from \"$TESTS_PATH/requirements.txt\""
+  echo
+  pip3 install -r "$TESTS_PATH/requirements.txt"
+  echo
+
+  if ! which "$LIT" &> /dev/null; then
+    echo "ERROR: Failed to automatically install the requirements. Please run the following command:" >&2
+    echo "$ pip3 install -r \"$TESTS_PATH/requirements.txt\"" >&2
+    exit 1
+  fi
+fi
+
+LIT_TEST_DIR=$(mktemp -d)
+export LIT_TEST_DIR
+trap 'rm -rf -- "$LIT_TEST_DIR"' EXIT
+
+"$LIT" -v "$TESTS_PATH"


### PR DESCRIPTION
#### 23f5c9f7762a0dac590e519346eb8fbaccb1f5df
<pre>
[WGSL] Add configuration and script to run wgslc tests
<a href="https://bugs.webkit.org/show_bug.cgi?id=256631">https://bugs.webkit.org/show_bug.cgi?id=256631</a>
rdar://109195003

Reviewed by Dan Glastonbury.

We have been running the tests by hand, finally add some configuration and a helper
script to run all the tests using lit (<a href="https://llvm.org/docs/CommandGuide/lit.html)">https://llvm.org/docs/CommandGuide/lit.html)</a>

* Source/WebGPU/WGSL/tests/invalid/array.wgsl:
* Source/WebGPU/WGSL/tests/invalid/for.wgsl:
* Source/WebGPU/WGSL/tests/invalid/overload.wgsl:
* Source/WebGPU/WGSL/tests/invalid/vector.wgsl:
* Source/WebGPU/WGSL/tests/lit.cfg: Added.
* Source/WebGPU/WGSL/tests/requirements.txt: Added.
* Source/WebGPU/WGSL/tests/valid/concretization.wgsl:
* Source/WebGPU/WGSL/tests/valid/for.wgsl:
* Source/WebGPU/WGSL/tests/valid/if.wgsl:
* Source/WebGPU/WGSL/tests/valid/overload.wgsl:
* Source/WebGPU/WGSL/tests/valid/scope.wgsl:
* Tools/Scripts/run-wgslc-tests: Added.

Canonical link: <a href="https://commits.webkit.org/264063@main">https://commits.webkit.org/264063@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9de0254533c497acc7337aa4fdaa8282e13a1fbb

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/6216 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/6408 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/6587 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/7784 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/6548 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/6215 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/6628 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/6358 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/9425 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/6326 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/6341 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/5629 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/7855 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/3815 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/5608 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/13498 "1 flakes 1 missing results 157 failures") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/5680 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/5688 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/7926 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/6163 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/5037 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/5576 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/1555 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/9723 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/5944 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->