### PR TITLE
RemoteDisplayListRecorder is unsubscribed from the IPC twice

### DIFF
--- a/Source/WebKit/GPUProcess/GPUConnectionToWebProcess.h
+++ b/Source/WebKit/GPUProcess/GPUConnectionToWebProcess.h
@@ -208,7 +208,7 @@ public:
 
     void lowMemoryHandler(WTF::Critical, WTF::Synchronous);
 
-    ThreadSafeObjectHeap<RemoteSerializedImageBufferIdentifier, RefPtr<RemoteSerializedImageBuffer>>& serializedImageBufferHeap() { return m_remoteSerializedImageBufferObjectHeap; }
+    ThreadSafeObjectHeap<RemoteSerializedImageBufferIdentifier, RefPtr<RemoteImageBuffer>>& serializedImageBufferHeap() { return m_remoteSerializedImageBufferObjectHeap; }
 
 #if ENABLE(WEBGL)
     void releaseGraphicsContextGLForTesting(GraphicsContextGLIdentifier);
@@ -350,7 +350,7 @@ private:
     using RemoteGraphicsContextGLMap = HashMap<GraphicsContextGLIdentifier, IPC::ScopedActiveMessageReceiveQueue<RemoteGraphicsContextGL>>;
     RemoteGraphicsContextGLMap m_remoteGraphicsContextGLMap;
 #endif
-    ThreadSafeObjectHeap<RemoteSerializedImageBufferIdentifier, RefPtr<RemoteSerializedImageBuffer>> m_remoteSerializedImageBufferObjectHeap;
+    ThreadSafeObjectHeap<RemoteSerializedImageBufferIdentifier, RefPtr<RemoteImageBuffer>> m_remoteSerializedImageBufferObjectHeap;
 #if ENABLE(ENCRYPTED_MEDIA)
     std::unique_ptr<RemoteCDMFactoryProxy> m_cdmFactoryProxy;
 #endif

--- a/Source/WebKit/GPUProcess/graphics/RemoteDisplayListRecorder.cpp
+++ b/Source/WebKit/GPUProcess/graphics/RemoteDisplayListRecorder.cpp
@@ -75,11 +75,6 @@ void RemoteDisplayListRecorder::stopListeningForIPC()
         renderingBackend->streamConnection().stopReceivingMessages(Messages::RemoteDisplayListRecorder::messageReceiverName(), m_imageBufferIdentifier.object().toUInt64());
 }
 
-void RemoteDisplayListRecorder::clearImageBufferReference()
-{
-    m_imageBuffer.clear();
-}
-
 void RemoteDisplayListRecorder::save()
 {
     handleItem(DisplayList::Save());

--- a/Source/WebKit/GPUProcess/graphics/RemoteDisplayListRecorder.h
+++ b/Source/WebKit/GPUProcess/graphics/RemoteDisplayListRecorder.h
@@ -55,7 +55,6 @@ public:
     }
 
     void stopListeningForIPC();
-    void clearImageBufferReference();
 
     void save();
     void restore();

--- a/Source/WebKit/GPUProcess/graphics/RemoteImageBuffer.h
+++ b/Source/WebKit/GPUProcess/graphics/RemoteImageBuffer.h
@@ -27,52 +27,18 @@
 
 #if ENABLE(GPU_PROCESS)
 
-#include "QualifiedRenderingResourceIdentifier.h"
-#include "RemoteRenderingBackend.h"
-#include "ScopedActiveMessageReceiveQueue.h"
 #include "ScopedRenderingResourcesRequest.h"
 #include <WebCore/ImageBuffer.h>
 
 namespace WebKit {
 
-class RemoteDisplayListRecorder;
-class RemoteRenderingBackend;
-
 class RemoteImageBuffer : public WebCore::ImageBuffer {
 public:
-    template<typename BackendType>
-    static RefPtr<RemoteImageBuffer> create(const WebCore::FloatSize& size, float resolutionScale, const WebCore::DestinationColorSpace& colorSpace, WebCore::PixelFormat pixelFormat, WebCore::RenderingPurpose purpose, RemoteRenderingBackend& remoteRenderingBackend, QualifiedRenderingResourceIdentifier renderingResourceIdentifier, WebCore::ImageBufferCreationContext context)
-    {
-        auto imageBuffer = ImageBuffer::create<BackendType, RemoteImageBuffer>(size, resolutionScale, colorSpace, pixelFormat, purpose, context, remoteRenderingBackend, renderingResourceIdentifier);
-        if (!imageBuffer)
-            return nullptr;
-
-        auto backend = static_cast<BackendType*>(imageBuffer->backend());
-        ASSERT(backend);
-
-        remoteRenderingBackend.didCreateImageBufferBackend(backend->createBackendHandle(), renderingResourceIdentifier, *imageBuffer->m_remoteDisplayList.get());
-        return imageBuffer;
-    }
-
-    static RefPtr<RemoteImageBuffer> createTransfer(std::unique_ptr<WebCore::ImageBufferBackend>&&, const WebCore::ImageBufferBackend::Info&, RemoteRenderingBackend&, QualifiedRenderingResourceIdentifier);
-
-    RemoteImageBuffer(const WebCore::ImageBufferBackend::Parameters&, const WebCore::ImageBufferBackend::Info&, std::unique_ptr<WebCore::ImageBufferBackend>&&, RemoteRenderingBackend&, QualifiedRenderingResourceIdentifier);
+    using WebCore::ImageBuffer::ImageBuffer;
     ~RemoteImageBuffer();
 
 private:
-    QualifiedRenderingResourceIdentifier m_renderingResourceIdentifier;
-    IPC::ScopedActiveMessageReceiveQueue<RemoteDisplayListRecorder> m_remoteDisplayList;
-    ScopedRenderingResourcesRequest m_renderingResourcesRequest;
-};
-
-struct RemoteSerializedImageBuffer : public ThreadSafeRefCounted<RemoteSerializedImageBuffer> {
-    RemoteSerializedImageBuffer(std::unique_ptr<WebCore::ImageBufferBackend>&& backend, const WebCore::ImageBufferBackend::Info& info)
-        : m_backend(WTFMove(backend))
-        , m_info(info)
-    { }
-
-    std::unique_ptr<WebCore::ImageBufferBackend> m_backend;
-    WebCore::ImageBufferBackend::Info m_info;
+    ScopedRenderingResourcesRequest m_renderingResourcesRequest { ScopedRenderingResourcesRequest::acquire() };
 };
 
 } // namespace WebKit


### PR DESCRIPTION
#### 36918915823b165e1b4b12026347c4397628e78f
<pre>
RemoteDisplayListRecorder is unsubscribed from the IPC twice
<a href="https://bugs.webkit.org/show_bug.cgi?id=256633">https://bugs.webkit.org/show_bug.cgi?id=256633</a>
rdar://109196807

Reviewed by Matt Woodrow.

RemoteDisplayListRecorder was referenced twice:
- From a map in RemoteRenderingBackend
- From RemoteImageBuffer
Since the reference was made through ScopedActiveMessageReceiveQueue,
stopListeningForIPC() was called twice.

RemoteDisplayListRecorder is the client that uses ImageBuffer, e.g.
the party that does buffer.context().drawImage(...). It does not
make sense that the client is held inside the very buffer the client
uses.

Instead, hold the RemoteDisplayListRecorder in a map in
RemoteRenderingBackend, similar to any other instance that is created
in GPUP.

Simplify the invocation of didCreateImageBufferBackend. It was
called from the RemoteImageBuffer constructing functions, which
is overly complex. The invocation is linear from RemoteRenderingBackend,
and the logic is internal logic of RemoteRenderingBackend. Thus just
invoke the logic from RemoteRenderingBackend directly.

* Source/WebKit/GPUProcess/graphics/RemoteDisplayListRecorder.cpp:
(WebKit::RemoteDisplayListRecorder::clearImageBufferReference): Deleted.
* Source/WebKit/GPUProcess/graphics/RemoteDisplayListRecorder.h:
* Source/WebKit/GPUProcess/graphics/RemoteImageBuffer.cpp:
(WebKit::RemoteImageBuffer::RemoteImageBuffer):
(WebKit::RemoteImageBuffer::createTransfer):
(WebKit::m_renderingResourcesRequest): Deleted.
* Source/WebKit/GPUProcess/graphics/RemoteImageBuffer.h:
(WebKit::RemoteImageBuffer::create):
* Source/WebKit/GPUProcess/graphics/RemoteRenderingBackend.cpp:
(WebKit::RemoteRenderingBackend::startListeningForIPC):
(WebKit::RemoteRenderingBackend::stopListeningForIPC):
(WebKit::RemoteRenderingBackend::workQueueInitialize):
(WebKit::RemoteRenderingBackend::workQueueUninitialize):
(WebKit::RemoteRenderingBackend::dispatch):
(WebKit::RemoteRenderingBackend::didCreateImageBuffer):
(WebKit::RemoteRenderingBackend::moveToSerializedBuffer):
(WebKit::RemoteRenderingBackend::moveToImageBuffer):
(WebKit::RemoteRenderingBackend::createImageBufferWithQualifiedIdentifier):
(WebKit::RemoteRenderingBackend::releaseRenderingResourceWithQualifiedIdentifier):
(WebKit::RemoteRenderingBackend::didCreateImageBufferBackend): Deleted.
* Source/WebKit/GPUProcess/graphics/RemoteRenderingBackend.h:
(WebKit::RemoteRenderingBackend::workQueue const):
(WebKit::RemoteRenderingBackend::WTF_GUARDED_BY_LOCK): Deleted.

Canonical link: <a href="https://commits.webkit.org/264007@main">https://commits.webkit.org/264007@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b210e5ebb4af8729d0b66c3f78b07bb0d53a1e58

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/6405 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/6611 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/6793 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/7981 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/6704 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/6876 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/6561 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/9596 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/6517 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/6541 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/5801 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/8060 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/4007 "Passed tests") | | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/13640 "1 missing results 120 failures") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/5908 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/5863 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/8135 "1 api test failed or timed out") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/6341 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/5182 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/5748 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/1510 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/9907 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/6119 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->