### PR TITLE
[GTK][WPE] Stop using `FONTS_CONF_DIR` environment variable

### DIFF
--- a/Tools/Scripts/webkitpy/port/glib.py
+++ b/Tools/Scripts/webkitpy/port/glib.py
@@ -88,7 +88,6 @@ class GLibPort(Port):
 
         environment['TEST_RUNNER_INJECTED_BUNDLE_FILENAME'] = self._build_path('lib', 'libTestRunnerInjectedBundle.so')
         environment['WEBKIT_EXEC_PATH'] = self._build_path('bin')
-        environment['WEBKIT_FONTS_CONF_DIR'] = self.path_from_webkit_base('Tools', 'WebKitTestRunner', 'glib', 'fonts')
         environment['LD_LIBRARY_PATH'] = self._prepend_to_env_value(self._build_path('lib'), environment.get('LD_LIBRAY_PATH', ''))
         self._copy_value_from_environ_if_set(environment, 'LIBGL_ALWAYS_SOFTWARE')
         self._copy_value_from_environ_if_set(environment, 'WEBKIT_OUTPUTDIR')

--- a/Tools/WebKitTestRunner/InjectedBundle/gtk/ActivateFontsGtk.cpp
+++ b/Tools/WebKitTestRunner/InjectedBundle/gtk/ActivateFontsGtk.cpp
@@ -38,14 +38,13 @@
 
 namespace WTR {
 
-void initializeFontConfigSetting()
+void activateFonts()
 {
     if (g_getenv("WEBKIT_SKIP_WEBKITTESTRUNNER_FONTCONFIG_INITIALIZATION"))
         return;
 
-    const char* webkitFontsConfDir = g_getenv("WEBKIT_FONTS_CONF_DIR");
-    if (!webkitFontsConfDir)
-        webkitFontsConfDir = FONTS_CONF_DIR;
+    GUniquePtr<gchar> relativeFontsDir(g_build_filename("Tools", "WebKitTestRunner", "glib", "fonts", nullptr));
+    GUniquePtr<gchar> absoluteFontsDir(g_canonicalize_filename(relativeFontsDir.get(), nullptr));
 
     FcInit();
 
@@ -59,23 +58,23 @@ void initializeFontConfigSetting()
     // Load our configuration file, which sets up proper aliases for family
     // names like sans, serif and monospace.
     FcConfig* config = FcConfigCreate();
-    GUniquePtr<gchar> fontConfigFilename(g_build_filename(webkitFontsConfDir, "fonts.conf", nullptr));
+    GUniquePtr<gchar> fontConfigFilename(g_build_filename(absoluteFontsDir.get(), "fonts.conf", nullptr));
     if (!g_file_test(fontConfigFilename.get(), G_FILE_TEST_IS_REGULAR))
         g_error("Cannot find fonts.conf at %s\n", fontConfigFilename.get());
     if (!FcConfigParseAndLoad(config, reinterpret_cast<FcChar8*>(fontConfigFilename.get()), true))
         g_error("Couldn't load font configuration file from: %s", fontConfigFilename.get());
 
-    GUniquePtr<GDir> fontsDirectory(g_dir_open(webkitFontsConfDir, 0, nullptr));
+    GUniquePtr<GDir> fontsDirectory(g_dir_open(absoluteFontsDir.get(), 0, nullptr));
     while (const char* directoryEntry = g_dir_read_name(fontsDirectory.get())) {
         if (!g_str_has_suffix(directoryEntry, ".ttf") && !g_str_has_suffix(directoryEntry, ".otf"))
             continue;
-        GUniquePtr<gchar> fontPath(g_build_filename(webkitFontsConfDir, directoryEntry, nullptr));
+        GUniquePtr<gchar> fontPath(g_build_filename(absoluteFontsDir.get(), directoryEntry, nullptr));
         if (!FcConfigAppFontAddFile(config, reinterpret_cast<const FcChar8*>(fontPath.get())))
             g_error("Could not load font at %s!", fontPath.get());
     }
 
     // Ahem is used by many layout tests.
-    GUniquePtr<gchar> ahemFontFilename(g_build_filename(webkitFontsConfDir, "AHEM____.TTF", nullptr));
+    GUniquePtr<gchar> ahemFontFilename(g_build_filename(absoluteFontsDir.get(), "AHEM____.TTF", nullptr));
     if (!FcConfigAppFontAddFile(config, reinterpret_cast<FcChar8*>(ahemFontFilename.get())))
         g_error("Could not load font at %s!", ahemFontFilename.get()); 
 
@@ -93,13 +92,13 @@ void initializeFontConfigSetting()
     };
 
     for (size_t i = 0; fontFilenames[i]; ++i) {
-        GUniquePtr<gchar> fontFilename(g_build_filename(webkitFontsConfDir, "..", "..", "fonts", fontFilenames[i], nullptr));
+        GUniquePtr<gchar> fontFilename(g_build_filename(absoluteFontsDir.get(), "..", "..", "fonts", fontFilenames[i], nullptr));
         if (!FcConfigAppFontAddFile(config, reinterpret_cast<FcChar8*>(fontFilename.get())))
             g_error("Could not load font at %s!", fontFilename.get()); 
     }
 
     // A font with no valid Fontconfig encoding to test https://bugs.webkit.org/show_bug.cgi?id=47452
-    GUniquePtr<gchar> fontWithNoValidEncodingFilename(g_build_filename(webkitFontsConfDir, "FontWithNoValidEncoding.fon", nullptr));
+    GUniquePtr<gchar> fontWithNoValidEncodingFilename(g_build_filename(absoluteFontsDir.get(), "FontWithNoValidEncoding.fon", nullptr));
     if (!FcConfigAppFontAddFile(config, reinterpret_cast<FcChar8*>(fontWithNoValidEncodingFilename.get())))
         g_error("Could not load font at %s!", fontWithNoValidEncodingFilename.get()); 
 
@@ -107,11 +106,6 @@ void initializeFontConfigSetting()
         g_error("Could not set the current font configuration!");
 
     numFonts = FcConfigGetFonts(config, FcSetApplication)->nfont;
-}
-
-void activateFonts()
-{
-    initializeFontConfigSetting();
 }
 
 void installFakeHelvetica(WKStringRef)

--- a/Tools/WebKitTestRunner/PlatformGTK.cmake
+++ b/Tools/WebKitTestRunner/PlatformGTK.cmake
@@ -57,6 +57,5 @@ list(APPEND TestRunnerInjectedBundle_INCLUDE_DIRECTORIES
 )
 
 add_definitions(
-    -DFONTS_CONF_DIR="${TOOLS_DIR}/WebKitTestRunner/glib/fonts"
     -DTOP_LEVEL_DIR="${CMAKE_SOURCE_DIR}"
 )

--- a/Tools/WebKitTestRunner/PlatformWPE.cmake
+++ b/Tools/WebKitTestRunner/PlatformWPE.cmake
@@ -60,6 +60,5 @@ list(APPEND TestRunnerInjectedBundle_INCLUDE_DIRECTORIES
 )
 
 add_definitions(
-    -DFONTS_CONF_DIR="${TOOLS_DIR}/WebKitTestRunner/glib/fonts"
     -DTOP_LEVEL_DIR="${CMAKE_SOURCE_DIR}"
 )


### PR DESCRIPTION
#### dc42c0d5cf9645c3e99859a735ec55514a7b1029
<pre>
[GTK][WPE] Stop using `FONTS_CONF_DIR` environment variable
<a href="https://bugs.webkit.org/show_bug.cgi?id=256634">https://bugs.webkit.org/show_bug.cgi?id=256634</a>

Reviewed by Carlos Garcia Campos.

Since `263863@main` we always know the test fonts directory path and
`FONTS_CONF_DIR` is not needed anymore.

* Tools/Scripts/webkitpy/port/glib.py:
(GLibPort.setup_environ_for_server):
* Tools/WebKitTestRunner/InjectedBundle/gtk/ActivateFontsGtk.cpp:
(WTR::activateFonts):
(WTR::initializeFontConfigSetting): Deleted.
* Tools/WebKitTestRunner/InjectedBundle/wpe/ActivateFontsWPE.cpp:
(WTR::activateFonts):
* Tools/WebKitTestRunner/PlatformGTK.cmake:
* Tools/WebKitTestRunner/PlatformWPE.cmake:

Canonical link: <a href="https://commits.webkit.org/263967@main">https://commits.webkit.org/263967@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e4777e28ef121ba67150e7e331327e50d010642c

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/6235 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/6427 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/6606 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/7803 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/6566 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/6234 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/6647 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/6377 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/9445 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/6345 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/6360 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/5645 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/7874 "Built successfully") | 
| [❌ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/6338 "webkitpy-tests (failure)") | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/3833 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/5624 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/13515 "11 flakes 1 missing results 118 failures") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/5698 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/5704 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/7946 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/6182 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/5054 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/5595 "Built successfully") | | | 
| [  ~~🛠 🧪 merge~~](https://ews-build.webkit.org/#/builders/19/builds/1480 "The change is no longer eligible for processing.") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/9742 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/738 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/5962 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->