### PR TITLE
[WPT] New test for CSS Nesting with relative selector

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-nesting/implicit-nesting-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-nesting/implicit-nesting-expected.html
@@ -23,4 +23,5 @@
   <div class="test"></div>
   <div class="test"></div>
   <div class="test"></div>
+  <div class="test"></div>
 </body>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-nesting/implicit-nesting-ref.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-nesting/implicit-nesting-ref.html
@@ -23,4 +23,5 @@
   <div class="test"></div>
   <div class="test"></div>
   <div class="test"></div>
+  <div class="test"></div>
 </body>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-nesting/implicit-nesting.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-nesting/implicit-nesting.html
@@ -41,20 +41,26 @@
     }
   }
 
-  .test {
+  .test-5 {
     :is(.test-5, &.does-not-exist) {
       background-color: green;
     }
   }
 
-  .test {
-    > .foo,.test-6,+ .bar {
+  .test-6 {
+    > .foo,.test-6-child,+ .bar {
       background-color: green;
     }
   }
 
-  .test {
-    > .foo, .bar, + .test-7 {
+  .test-7 {
+    > .foo, .bar, + .test-7-sibling {
+      background-color: green;
+    }
+  }
+
+  .test-8 {
+    > .foo, .test-8-child, + .bar {
       background-color: green;
     }
   }
@@ -69,7 +75,8 @@
   <div class="test test-2"><div class="test-2-child"></div></div>
   <div class="test test-3"><div class="test-3-child"></div></div>
   <div class="test test-4"></div>
-  <div class="test test-5"></div>
-  <div class="test"><div><div class="test test-6"></div></div></div>
-  <div class="test" style="display:none"></div><div class="test test-7"></div>
+  <div class="test test-5"><div class="test-5"></div></div>
+  <div class="test test-6"><div class="test-6-child"></div></div>
+  <div class="test test-7" style="display:none"></div><div class="test test-7-sibling"></div>
+  <div class="test test-8"><div class="test-8-child"></div></div>
 </body>


### PR DESCRIPTION
#### 9fa506cddc457dfbd3894ee2cacfc739ec177c75
<pre>
[WPT] New test for CSS Nesting with relative selector
<a href="https://bugs.webkit.org/show_bug.cgi?id=256635">https://bugs.webkit.org/show_bug.cgi?id=256635</a>
rdar://109198284

Reviewed by Antti Koivisto.

* LayoutTests/imported/w3c/web-platform-tests/css/css-nesting/implicit-nesting-expected.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-nesting/implicit-nesting-ref.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-nesting/implicit-nesting.html:

Canonical link: <a href="https://commits.webkit.org/263961@main">https://commits.webkit.org/263961@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/70aa0ad5bc5a5b48d7716ceb269d101f30175502

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/6225 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/6417 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/6596 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/7793 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/6556 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/6637 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/6367 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/9436 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/6335 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/6350 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/5636 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/7864 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/3823 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/5615 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/13509 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/5688 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/5695 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/7939 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/6172 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/5046 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/5585 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/5544 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/1477 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/9732 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/5952 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->