### PR TITLE
Make tracking which Animation properties are set or filled more efficient

### DIFF
--- a/Source/WebCore/platform/animation/Animation.cpp
+++ b/Source/WebCore/platform/animation/Animation.cpp
@@ -39,26 +39,6 @@ Animation::Animation()
     , m_fillMode(static_cast<unsigned>(initialFillMode()))
     , m_playState(static_cast<unsigned>(initialPlayState()))
     , m_compositeOperation(static_cast<unsigned>(initialCompositeOperation()))
-    , m_delaySet(false)
-    , m_directionSet(false)
-    , m_durationSet(false)
-    , m_fillModeSet(false)
-    , m_iterationCountSet(false)
-    , m_nameSet(false)
-    , m_playStateSet(false)
-    , m_propertySet(false)
-    , m_timingFunctionSet(false)
-    , m_compositeOperationSet(false)
-    , m_isNone(false)
-    , m_delayFilled(false)
-    , m_directionFilled(false)
-    , m_durationFilled(false)
-    , m_fillModeFilled(false)
-    , m_iterationCountFilled(false)
-    , m_playStateFilled(false)
-    , m_propertyFilled(false)
-    , m_timingFunctionFilled(false)
-    , m_compositeOperationFilled(false)
 {
 }
 
@@ -71,30 +51,13 @@ Animation::Animation(const Animation& o)
     , m_duration(o.m_duration)
     , m_timingFunction(o.m_timingFunction)
     , m_nameStyleScopeOrdinal(o.m_nameStyleScopeOrdinal)
+    , m_setProperties(o.m_setProperties)
+    , m_filledProperties(o.m_filledProperties)
     , m_direction(o.m_direction)
     , m_fillMode(o.m_fillMode)
     , m_playState(o.m_playState)
     , m_compositeOperation(o.m_compositeOperation)
-    , m_delaySet(o.m_delaySet)
-    , m_directionSet(o.m_directionSet)
-    , m_durationSet(o.m_durationSet)
-    , m_fillModeSet(o.m_fillModeSet)
-    , m_iterationCountSet(o.m_iterationCountSet)
-    , m_nameSet(o.m_nameSet)
-    , m_playStateSet(o.m_playStateSet)
-    , m_propertySet(o.m_propertySet)
-    , m_timingFunctionSet(o.m_timingFunctionSet)
-    , m_compositeOperationSet(o.m_compositeOperationSet)
     , m_isNone(o.m_isNone)
-    , m_delayFilled(o.m_delayFilled)
-    , m_directionFilled(o.m_directionFilled)
-    , m_durationFilled(o.m_durationFilled)
-    , m_fillModeFilled(o.m_fillModeFilled)
-    , m_iterationCountFilled(o.m_iterationCountFilled)
-    , m_playStateFilled(o.m_playStateFilled)
-    , m_propertyFilled(o.m_propertyFilled)
-    , m_timingFunctionFilled(o.m_timingFunctionFilled)
-    , m_compositeOperationFilled(o.m_compositeOperationFilled)
 {
 }
 
@@ -105,7 +68,6 @@ bool Animation::animationsMatch(const Animation& other, bool matchProperties) co
     bool result = m_name.string == other.m_name.string
         && m_playState == other.m_playState
         && m_compositeOperation == other.m_compositeOperation
-        && m_playStateSet == other.m_playStateSet
         && m_iterationCount == other.m_iterationCount
         && m_delay == other.m_delay
         && m_duration == other.m_duration
@@ -113,20 +75,21 @@ bool Animation::animationsMatch(const Animation& other, bool matchProperties) co
         && m_nameStyleScopeOrdinal == other.m_nameStyleScopeOrdinal
         && m_direction == other.m_direction
         && m_fillMode == other.m_fillMode
-        && m_delaySet == other.m_delaySet
-        && m_directionSet == other.m_directionSet
-        && m_durationSet == other.m_durationSet
-        && m_fillModeSet == other.m_fillModeSet
-        && m_iterationCountSet == other.m_iterationCountSet
-        && m_nameSet == other.m_nameSet
-        && m_timingFunctionSet == other.m_timingFunctionSet
-        && m_compositeOperationSet == other.m_compositeOperationSet
+        && isDelaySet() == other.isDelaySet()
+        && isDirectionSet() == other.isDirectionSet()
+        && isDurationSet() == other.isDurationSet()
+        && isFillModeSet() == other.isFillModeSet()
+        && isIterationCountSet() == other.isIterationCountSet()
+        && isNameSet() == other.isNameSet()
+        && isTimingFunctionSet() == other.isTimingFunctionSet()
+        && isCompositeOperationSet() == other.isCompositeOperationSet()
+        && isPlayStateSet() == other.isPlayStateSet()
         && m_isNone == other.m_isNone;
 
     if (!result)
         return false;
 
-    return !matchProperties || (m_property.mode == other.m_property.mode && m_property.animatableProperty == other.m_property.animatableProperty && m_propertySet == other.m_propertySet);
+    return !matchProperties || (m_property.mode == other.m_property.mode && m_property.animatableProperty == other.m_property.animatableProperty && isPropertySet() == other.isPropertySet());
 }
 
 auto Animation::initialName() -> const Name&

--- a/Source/WebCore/platform/animation/Animation.h
+++ b/Source/WebCore/platform/animation/Animation.h
@@ -30,6 +30,7 @@
 #include "StyleScopeOrdinal.h"
 #include "TimingFunction.h"
 #include "WebAnimationTypes.h"
+#include <wtf/OptionSet.h>
 
 namespace WebCore {
 
@@ -40,16 +41,16 @@ public:
     static Ref<Animation> create() { return adoptRef(*new Animation); }
     static Ref<Animation> create(const Animation& other) { return adoptRef(*new Animation(other)); }
 
-    bool isDelaySet() const { return m_delaySet; }
-    bool isDirectionSet() const { return m_directionSet; }
-    bool isDurationSet() const { return m_durationSet; }
-    bool isFillModeSet() const { return m_fillModeSet; }
-    bool isIterationCountSet() const { return m_iterationCountSet; }
-    bool isNameSet() const { return m_nameSet; }
-    bool isPlayStateSet() const { return m_playStateSet; }
-    bool isPropertySet() const { return m_propertySet; }
-    bool isTimingFunctionSet() const { return m_timingFunctionSet; }
-    bool isCompositeOperationSet() const { return m_compositeOperationSet; }
+    bool isDelaySet() const { return m_setProperties.contains(SetOrFilledProperty::Delay); }
+    bool isDirectionSet() const { return m_setProperties.contains(SetOrFilledProperty::Direction); }
+    bool isDurationSet() const { return m_setProperties.contains(SetOrFilledProperty::Duration); }
+    bool isFillModeSet() const { return m_setProperties.contains(SetOrFilledProperty::FillMode); }
+    bool isIterationCountSet() const { return m_setProperties.contains(SetOrFilledProperty::IterationCount); }
+    bool isNameSet() const { return m_setProperties.contains(SetOrFilledProperty::Name); }
+    bool isPlayStateSet() const { return m_setProperties.contains(SetOrFilledProperty::PlayState); }
+    bool isPropertySet() const { return m_setProperties.contains(SetOrFilledProperty::Property); }
+    bool isTimingFunctionSet() const { return m_setProperties.contains(SetOrFilledProperty::TimingFunction); }
+    bool isCompositeOperationSet() const { return m_setProperties.contains(SetOrFilledProperty::CompositeOperation); }
 
     // Flags this to be the special "none" animation (animation-name: none)
     bool isNoneAnimation() const { return m_isNone; }
@@ -60,10 +61,10 @@ public:
 
     bool isEmpty() const
     {
-        return !m_directionSet && !m_durationSet && !m_fillModeSet
-            && !m_nameSet && !m_playStateSet && !m_iterationCountSet
-            && !m_delaySet && !m_timingFunctionSet && !m_propertySet
-            && !m_isNone && !m_compositeOperationSet;
+        return !isDirectionSet() && !isDurationSet() && !isFillModeSet()
+            && !isNameSet() && !isPlayStateSet() && !isIterationCountSet()
+            && !isDelaySet() && !isTimingFunctionSet() && !isPropertySet()
+            && !m_isNone && !isCompositeOperationSet();
     }
 
     bool isEmptyOrZeroDuration() const
@@ -71,29 +72,21 @@ public:
         return isEmpty() || (m_duration == 0 && m_delay <= 0);
     }
 
-    void clearDelay() { m_delaySet = false; m_delayFilled = false; }
-    void clearDirection() { m_directionSet = false; m_directionFilled = false; }
-    void clearDuration() { m_durationSet = false; m_durationFilled = false; }
-    void clearFillMode() { m_fillModeSet = false; m_fillModeFilled = false; }
-    void clearIterationCount() { m_iterationCountSet = false; m_iterationCountFilled = false; }
-    void clearName() { m_nameSet = false; }
-    void clearPlayState() { m_playStateSet = false; m_playStateFilled = false; }
-    void clearProperty() { m_propertySet = false; m_propertyFilled = false; }
-    void clearTimingFunction() { m_timingFunctionSet = false; m_timingFunctionFilled = false; }
-    void clearCompositeOperation() { m_compositeOperationSet = false; m_compositeOperationFilled = false; }
+    void clearDelay() { m_setProperties.remove(SetOrFilledProperty::Delay); m_filledProperties.remove(SetOrFilledProperty::Delay); }
+    void clearDirection() { m_setProperties.remove(SetOrFilledProperty::Direction); m_filledProperties.remove(SetOrFilledProperty::Direction); }
+    void clearDuration() { m_setProperties.remove(SetOrFilledProperty::Duration); m_filledProperties.remove(SetOrFilledProperty::Duration); }
+    void clearFillMode() { m_setProperties.remove(SetOrFilledProperty::FillMode); m_filledProperties.remove(SetOrFilledProperty::FillMode); }
+    void clearIterationCount() { m_setProperties.remove(SetOrFilledProperty::IterationCount); m_filledProperties.remove(SetOrFilledProperty::IterationCount); }
+    void clearName() { m_setProperties.remove(SetOrFilledProperty::Name); m_filledProperties.remove(SetOrFilledProperty::Name); }
+    void clearPlayState() { m_setProperties.remove(SetOrFilledProperty::PlayState); m_filledProperties.remove(SetOrFilledProperty::PlayState); }
+    void clearProperty() { m_setProperties.remove(SetOrFilledProperty::Property); m_filledProperties.remove(SetOrFilledProperty::Property); }
+    void clearTimingFunction() { m_setProperties.remove(SetOrFilledProperty::TimingFunction); m_filledProperties.remove(SetOrFilledProperty::TimingFunction); }
+    void clearCompositeOperation() { m_setProperties.remove(SetOrFilledProperty::CompositeOperation); m_filledProperties.remove(SetOrFilledProperty::CompositeOperation); }
 
     void clearAll()
     {
-        clearDelay();
-        clearDirection();
-        clearDuration();
-        clearFillMode();
-        clearIterationCount();
-        clearName();
-        clearPlayState();
-        clearProperty();
-        clearTimingFunction();
-        clearCompositeOperation();
+        m_setProperties = { };
+        m_filledProperties = { };
     }
 
     double delay() const { return m_delay; }
@@ -139,44 +132,44 @@ public:
     TimingFunction* timingFunction() const { return m_timingFunction.get(); }
     TimingFunction* defaultTimingFunctionForKeyframes() const { return m_defaultTimingFunctionForKeyframes.get(); }
 
-    void setDelay(double c) { m_delay = c; m_delaySet = true; }
-    void setDirection(Direction d) { m_direction = static_cast<unsigned>(d); m_directionSet = true; }
-    void setDuration(double d) { ASSERT(d >= 0); m_duration = d; m_durationSet = true; }
+    void setDelay(double c) { m_delay = c; m_setProperties.add(SetOrFilledProperty::Delay); }
+    void setDirection(Direction d) { m_direction = d; m_setProperties.add(SetOrFilledProperty::Direction); }
+    void setDuration(double d) { ASSERT(d >= 0); m_duration = d; m_setProperties.add(SetOrFilledProperty::Duration); }
     void setPlaybackRate(double d) { m_playbackRate = d; }
-    void setFillMode(AnimationFillMode f) { m_fillMode = static_cast<unsigned>(f); m_fillModeSet = true; }
-    void setIterationCount(double c) { m_iterationCount = c; m_iterationCountSet = true; }
+    void setFillMode(AnimationFillMode f) { m_fillMode = static_cast<unsigned>(f); m_setProperties.add(SetOrFilledProperty::FillMode); }
+    void setIterationCount(double c) { m_iterationCount = c; m_setProperties.add(SetOrFilledProperty::IterationCount); }
     void setName(const Name& name, Style::ScopeOrdinal scope = Style::ScopeOrdinal::Element)
     {
         m_name = name;
         m_nameStyleScopeOrdinal = scope;
-        m_nameSet = true;
+        m_setProperties.add(SetOrFilledProperty::Name);
     }
-    void setPlayState(AnimationPlayState d) { m_playState = static_cast<unsigned>(d); m_playStateSet = true; }
-    void setProperty(TransitionProperty t) { m_property = t; m_propertySet = true; }
-    void setTimingFunction(RefPtr<TimingFunction>&& function) { m_timingFunction = WTFMove(function); m_timingFunctionSet = true; }
+    void setPlayState(AnimationPlayState d) { m_playState = static_cast<unsigned>(d); m_setProperties.add(SetOrFilledProperty::PlayState); }
+    void setProperty(TransitionProperty t) { m_property = t; m_setProperties.add(SetOrFilledProperty::Property); }
+    void setTimingFunction(RefPtr<TimingFunction>&& function) { m_timingFunction = WTFMove(function); m_setProperties.add(SetOrFilledProperty::TimingFunction); }
     void setDefaultTimingFunctionForKeyframes(RefPtr<TimingFunction>&& function) { m_defaultTimingFunctionForKeyframes = WTFMove(function); }
 
     void setIsNoneAnimation(bool n) { m_isNone = n; }
 
-    void fillDelay(double delay) { setDelay(delay); m_delayFilled = true; }
-    void fillDirection(Direction direction) { setDirection(direction); m_directionFilled = true; }
-    void fillDuration(double duration) { setDuration(duration); m_durationFilled = true; }
-    void fillFillMode(AnimationFillMode fillMode) { setFillMode(fillMode); m_fillModeFilled = true; }
-    void fillIterationCount(double iterationCount) { setIterationCount(iterationCount); m_iterationCountFilled = true; }
-    void fillPlayState(AnimationPlayState playState) { setPlayState(playState); m_playStateFilled = true; }
-    void fillProperty(TransitionProperty property) { setProperty(property); m_propertyFilled = true; }
-    void fillTimingFunction(RefPtr<TimingFunction>&& timingFunction) { setTimingFunction(WTFMove(timingFunction)); m_timingFunctionFilled = true; }
-    void fillCompositeOperation(CompositeOperation compositeOperation) { setCompositeOperation(compositeOperation); m_compositeOperationFilled = true; }
+    void fillDelay(double delay) { setDelay(delay); m_filledProperties.add(SetOrFilledProperty::Delay); }
+    void fillDirection(Direction direction) { setDirection(direction); m_filledProperties.add(SetOrFilledProperty::Direction); }
+    void fillDuration(double duration) { setDuration(duration); m_filledProperties.add(SetOrFilledProperty::Duration); }
+    void fillFillMode(AnimationFillMode fillMode) { setFillMode(fillMode); m_filledProperties.add(SetOrFilledProperty::FillMode); }
+    void fillIterationCount(double iterationCount) { setIterationCount(iterationCount); m_filledProperties.add(SetOrFilledProperty::IterationCount); }
+    void fillPlayState(AnimationPlayState playState) { setPlayState(playState); m_filledProperties.add(SetOrFilledProperty::PlayState); }
+    void fillProperty(TransitionProperty property) { setProperty(property); m_filledProperties.add(SetOrFilledProperty::Property); }
+    void fillTimingFunction(RefPtr<TimingFunction>&& timingFunction) { setTimingFunction(WTFMove(timingFunction)); m_filledProperties.add(SetOrFilledProperty::TimingFunction); }
+    void fillCompositeOperation(CompositeOperation compositeOperation) { setCompositeOperation(compositeOperation); m_filledProperties.add(SetOrFilledProperty::CompositeOperation); }
 
-    bool isDelayFilled() const { return m_delayFilled; }
-    bool isDirectionFilled() const { return m_directionFilled; }
-    bool isDurationFilled() const { return m_durationFilled; }
-    bool isFillModeFilled() const { return m_fillModeFilled; }
-    bool isIterationCountFilled() const { return m_iterationCountFilled; }
-    bool isPlayStateFilled() const { return m_playStateFilled; }
-    bool isPropertyFilled() const { return m_propertyFilled; }
-    bool isTimingFunctionFilled() const { return m_timingFunctionFilled; }
-    bool isCompositeOperationFilled() const { return m_compositeOperationFilled; }
+    bool isDelayFilled() const { return m_filledProperties.contains(SetOrFilledProperty::Delay); }
+    bool isDirectionFilled() const { return m_filledProperties.contains(SetOrFilledProperty::Direction); }
+    bool isDurationFilled() const { return m_filledProperties.contains(SetOrFilledProperty::Duration); }
+    bool isFillModeFilled() const { return m_filledProperties.contains(SetOrFilledProperty::FillMode); }
+    bool isIterationCountFilled() const { return m_filledProperties.contains(SetOrFilledProperty::IterationCount); }
+    bool isPlayStateFilled() const { return m_filledProperties.contains(SetOrFilledProperty::PlayState); }
+    bool isPropertyFilled() const { return m_filledProperties.contains(SetOrFilledProperty::Property); }
+    bool isTimingFunctionFilled() const { return m_filledProperties.contains(SetOrFilledProperty::TimingFunction); }
+    bool isCompositeOperationFilled() const { return m_filledProperties.contains(SetOrFilledProperty::CompositeOperation); }
 
     // return true if all members of this class match (excluding m_next)
     bool animationsMatch(const Animation&, bool matchProperties = true) const;
@@ -184,16 +177,29 @@ public:
     // return true every Animation in the chain (defined by m_next) match 
     bool operator==(const Animation& o) const { return animationsMatch(o); }
 
-    bool fillsBackwards() const { return m_fillModeSet && (fillMode() == AnimationFillMode::Backwards || fillMode() == AnimationFillMode::Both); }
-    bool fillsForwards() const { return m_fillModeSet && (fillMode() == AnimationFillMode::Forwards || fillMode() == AnimationFillMode::Both); }
+    bool fillsBackwards() const { return isFillModeSet() && (fillMode() == AnimationFillMode::Backwards || fillMode() == AnimationFillMode::Both); }
+    bool fillsForwards() const { return isFillModeSet() && (fillMode() == AnimationFillMode::Forwards || fillMode() == AnimationFillMode::Both); }
 
     CompositeOperation compositeOperation() const { return static_cast<CompositeOperation>(m_compositeOperation); }
-    void setCompositeOperation(CompositeOperation op) { m_compositeOperation = static_cast<unsigned>(op); m_compositeOperationSet = true; }
+    void setCompositeOperation(CompositeOperation op) { m_compositeOperation = static_cast<unsigned>(op); m_setProperties.add(SetOrFilledProperty::CompositeOperation); }
 
 private:
     WEBCORE_EXPORT Animation();
     Animation(const Animation&);
-    
+
+    enum class SetOrFilledProperty : uint16_t {
+        Delay = 1 << 0,
+        Direction = 1 << 1,
+        Duration = 1 << 2,
+        FillMode = 1 << 3,
+        IterationCount = 1 << 4,
+        Name = 1 << 5,
+        PlayState = 1 << 6,
+        Property = 1 << 7,
+        TimingFunction = 1 << 8,
+        CompositeOperation = 1 << 9
+    };
+
     // Packs with m_refCount from the base class.
     TransitionProperty m_property { TransitionMode::All, CSSPropertyInvalid };
 
@@ -207,33 +213,15 @@ private:
 
     Style::ScopeOrdinal m_nameStyleScopeOrdinal { Style::ScopeOrdinal::Element };
 
+    OptionSet<SetOrFilledProperty> m_setProperties { };
+    OptionSet<SetOrFilledProperty> m_filledProperties { };
+
     unsigned m_direction : 2; // Direction
     unsigned m_fillMode : 2; // AnimationFillMode
     unsigned m_playState : 2; // AnimationPlayState
     unsigned m_compositeOperation : 2; // CompositeOperation
 
-    bool m_delaySet : 1;
-    bool m_directionSet : 1;
-    bool m_durationSet : 1;
-    bool m_fillModeSet : 1;
-    bool m_iterationCountSet : 1;
-    bool m_nameSet : 1;
-    bool m_playStateSet : 1;
-    bool m_propertySet : 1;
-    bool m_timingFunctionSet : 1;
-    bool m_compositeOperationSet : 1;
-
     bool m_isNone : 1;
-
-    bool m_delayFilled : 1;
-    bool m_directionFilled : 1;
-    bool m_durationFilled : 1;
-    bool m_fillModeFilled : 1;
-    bool m_iterationCountFilled : 1;
-    bool m_playStateFilled : 1;
-    bool m_propertyFilled : 1;
-    bool m_timingFunctionFilled : 1;
-    bool m_compositeOperationFilled : 1;
 
 public:
     static double initialDelay() { return 0; }


### PR DESCRIPTION
#### 82aadbb46095be3e628884a4c69f65a09c7fad20
<pre>
Make tracking which Animation properties are set or filled more efficient
<a href="https://bugs.webkit.org/show_bug.cgi?id=167041">https://bugs.webkit.org/show_bug.cgi?id=167041</a>

Reviewed by NOBODY (OOPS!).

Instead of using three instance variables per animation property, one to track
the value, one to track whether it was set explicitly and one to track whether
it was filled to repeat a value in lists with mismatched lengths, we now use one
instance variable per property to store the value and store whether a property was
set or filled in an OptionSet.

* Source/WebCore/platform/animation/Animation.cpp:
(WebCore::Animation::Animation):
(WebCore::Animation::animationsMatch const):
* Source/WebCore/platform/animation/Animation.h:
(WebCore::Animation::isDelaySet const):
(WebCore::Animation::isDirectionSet const):
(WebCore::Animation::isDurationSet const):
(WebCore::Animation::isFillModeSet const):
(WebCore::Animation::isIterationCountSet const):
(WebCore::Animation::isNameSet const):
(WebCore::Animation::isPlayStateSet const):
(WebCore::Animation::isPropertySet const):
(WebCore::Animation::isTimingFunctionSet const):
(WebCore::Animation::isCompositeOperationSet const):
(WebCore::Animation::isEmpty const):
(WebCore::Animation::clearDelay):
(WebCore::Animation::clearDirection):
(WebCore::Animation::clearDuration):
(WebCore::Animation::clearFillMode):
(WebCore::Animation::clearIterationCount):
(WebCore::Animation::clearName):
(WebCore::Animation::clearPlayState):
(WebCore::Animation::clearProperty):
(WebCore::Animation::clearTimingFunction):
(WebCore::Animation::clearCompositeOperation):
(WebCore::Animation::clearAll):
(WebCore::Animation::setDelay):
(WebCore::Animation::setDirection):
(WebCore::Animation::setDuration):
(WebCore::Animation::setFillMode):
(WebCore::Animation::setIterationCount):
(WebCore::Animation::setName):
(WebCore::Animation::setPlayState):
(WebCore::Animation::setProperty):
(WebCore::Animation::setTimingFunction):
(WebCore::Animation::fillDelay):
(WebCore::Animation::fillDirection):
(WebCore::Animation::fillDuration):
(WebCore::Animation::fillFillMode):
(WebCore::Animation::fillIterationCount):
(WebCore::Animation::fillPlayState):
(WebCore::Animation::fillProperty):
(WebCore::Animation::fillTimingFunction):
(WebCore::Animation::fillCompositeOperation):
(WebCore::Animation::isDelayFilled const):
(WebCore::Animation::isDirectionFilled const):
(WebCore::Animation::isDurationFilled const):
(WebCore::Animation::isFillModeFilled const):
(WebCore::Animation::isIterationCountFilled const):
(WebCore::Animation::isPlayStateFilled const):
(WebCore::Animation::isPropertyFilled const):
(WebCore::Animation::isTimingFunctionFilled const):
(WebCore::Animation::isCompositeOperationFilled const):
(WebCore::Animation::fillsBackwards const):
(WebCore::Animation::fillsForwards const):
(WebCore::Animation::setCompositeOperation):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5c2c3cde5f42c17461b8d7a8695189321418fe3f

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/8872 "Passed style check") | [❌ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/9160 "Failed to compile WebKit") | [❌ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/9378 "Failed to compile WebKit") | [❌ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/10525 "Failed to compile WebKit") | [❌ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/8852 "Failed to compile WebKit") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/8880 "Passed tests") | [❌ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/11147 "Failed to compile WebKit") | [❌ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/9127 "Failed to compile WebKit") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/5/builds/10525 "Failed to compile WebKit") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/9018 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/23/builds/11147 "Failed to compile WebKit") | [❌ 🧪 api-mac](https://ews-build.webkit.org/#/builders/14/builds/9378 "Failed to compile WebKit") | [❌ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/10683 "Failed to compile WebKit") | 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/23/builds/11147 "Failed to compile WebKit") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/14/builds/9378 "Failed to compile WebKit") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/2/builds/10683 "Failed to compile WebKit") | 
| | [❌ 🧪 api-ios](https://ews-build.webkit.org/#/builders/23/builds/11147 "Failed to compile WebKit") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/14/builds/9378 "Failed to compile WebKit") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/2/builds/10683 "Failed to compile WebKit") | 
| | [❌ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/8749 "Failed to compile WebKit") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/16/builds/9127 "Failed to compile WebKit") | | 
| | [❌ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/8005 "Failed to compile WebKit") | [❌ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/14/builds/9378 "Failed to compile WebKit") | | 
| | [❌ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/12216 "Failed to compile WebKit") | | | 
| | [❌ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/8497 "Failed to compile WebKit") | | | 
<!--EWS-Status-Bubble-End-->