### PR TITLE
[popover] Reset the invoker in `showPopover()`

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/popovers/popover-invoker-reset-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/popovers/popover-invoker-reset-expected.txt
@@ -1,0 +1,4 @@
+Popover 2
+
+PASS Invoker gets reset appropriately
+

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/popovers/popover-invoker-reset.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/popovers/popover-invoker-reset.html
@@ -1,0 +1,34 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<link rel="author" href="mailto:masonf@chromium.org">
+<link rel=help href="https://open-ui.org/components/popover.research.explainer">
+<link rel=help href="https://github.com/whatwg/html/issues/9152">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/resources/testdriver.js"></script>
+<script src="/resources/testdriver-actions.js"></script>
+<script src="/resources/testdriver-vendor.js"></script>
+<script src="resources/popover-utils.js"></script>
+
+<div id=p1 popover>Popover 1
+  <button popovertarget=p2>Button</button>
+</div>
+<div id=p2 popover>Popover 2</div>
+
+<script>
+  test((t) => {
+    p1.showPopover();
+    assert_true(p1.matches(':popover-open'));
+    const invoker = p1.querySelector('button');
+    p2.addEventListener('beforetoggle',(e) => {
+      assert_equals(e.newState,'open');
+      e.preventDefault();
+    },{once:true});
+    invoker.click(); // Will be cancelled
+    assert_false(p2.matches(':popover-open'));
+    assert_true(p1.matches(':popover-open'));
+    p2.showPopover();
+    assert_true(p2.matches(':popover-open'));
+    assert_false(p1.matches(':popover-open'),'invoker was not used to show p2, so p1 should close');
+  },'Invoker gets reset appropriately');
+</script>

--- a/Source/WebCore/html/HTMLElement.cpp
+++ b/Source/WebCore/html/HTMLElement.cpp
@@ -1351,8 +1351,11 @@ void HTMLElement::queuePopoverToggleEventTask(PopoverVisibilityState oldState, P
     });
 }
 
-ExceptionOr<void> HTMLElement::showPopover()
+ExceptionOr<void> HTMLElement::showPopover(const HTMLFormControlElement* invoker)
 {
+    if (popoverData())
+        popoverData()->setInvoker(invoker);
+
     auto check = checkPopoverValidity(*this, PopoverVisibilityState::Hidden);
     if (check.hasException())
         return check.releaseException();

--- a/Source/WebCore/html/HTMLElement.h
+++ b/Source/WebCore/html/HTMLElement.h
@@ -37,6 +37,7 @@ namespace WebCore {
 class ElementInternals;
 class FormListedElement;
 class FormAssociatedElement;
+class HTMLFormControlElement;
 class HTMLFormElement;
 class VisibleSelection;
 
@@ -148,7 +149,7 @@ public:
     WEBCORE_EXPORT ExceptionOr<Ref<ElementInternals>> attachInternals();
 
     void queuePopoverToggleEventTask(PopoverVisibilityState oldState, PopoverVisibilityState newState);
-    ExceptionOr<void> showPopover();
+    ExceptionOr<void> showPopover(const HTMLFormControlElement* = nullptr);
     ExceptionOr<void> hidePopover();
     ExceptionOr<void> hidePopoverInternal(FocusPreviousElement, FireEvents);
     ExceptionOr<void> togglePopover(std::optional<bool> force);

--- a/Source/WebCore/html/HTMLFormControlElement.cpp
+++ b/Source/WebCore/html/HTMLFormControlElement.cpp
@@ -399,10 +399,8 @@ void HTMLFormControlElement::handlePopoverTargetAction() const
     bool canShow = action == showAtom() || action == toggleAtom();
     if (canHide && target->popoverData()->visibilityState() == PopoverVisibilityState::Showing)
         target->hidePopover();
-    else if (canShow && target->popoverData()->visibilityState() == PopoverVisibilityState::Hidden) {
-        target->popoverData()->setInvoker(this);
-        target->showPopover();
-    }
+    else if (canShow && target->popoverData()->visibilityState() == PopoverVisibilityState::Hidden)
+        target->showPopover(this);
 }
 
 // FIXME: We should remove the quirk once <rdar://problem/47334655> is fixed.


### PR DESCRIPTION
#### cdbb7d862f659bdcbafb020705e2311e43cd35f6
<pre>
[popover] Reset the invoker in `showPopover()`
<a href="https://bugs.webkit.org/show_bug.cgi?id=256636">https://bugs.webkit.org/show_bug.cgi?id=256636</a>

Reviewed by Tim Nguyen.

Address this issue:
<a href="https://github.com/whatwg/html/issues/9152">https://github.com/whatwg/html/issues/9152</a>

* LayoutTests/imported/w3c/web-platform-tests/html/semantics/popovers/popover-invoker-reset-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/popovers/popover-invoker-reset.html: Added.
* Source/WebCore/html/HTMLElement.cpp:
(WebCore::HTMLElement::showPopover):
* Source/WebCore/html/HTMLElement.h:
* Source/WebCore/html/HTMLFormControlElement.cpp:
(WebCore::HTMLFormControlElement::handlePopoverTargetAction const):

Canonical link: <a href="https://commits.webkit.org/264006@main">https://commits.webkit.org/264006@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/74ae765123287b21ec89109ac57e74b730467576

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/6402 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/6607 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/6789 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/7978 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/6701 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/6397 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/6869 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/6557 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/9597 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/6514 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/6532 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/5790 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/8056 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/3998 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/5774 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/13639 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/5894 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/5853 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/8130 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/6338 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/5179 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/5745 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/5702 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/1509 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/9904 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/6116 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->