### PR TITLE
[web-animations] Refactor Animation::AnimationDirection into an enum class

### DIFF
--- a/Source/WebCore/animation/CSSAnimation.cpp
+++ b/Source/WebCore/animation/CSSAnimation.cpp
@@ -84,16 +84,16 @@ void CSSAnimation::syncPropertiesWithBackingAnimation()
 
     if (!m_overriddenProperties.contains(Property::Direction)) {
         switch (animation.direction()) {
-        case Animation::AnimationDirectionNormal:
+        case Animation::Direction::Normal:
             animationEffect->setDirection(PlaybackDirection::Normal);
             break;
-        case Animation::AnimationDirectionAlternate:
+        case Animation::Direction::Alternate:
             animationEffect->setDirection(PlaybackDirection::Alternate);
             break;
-        case Animation::AnimationDirectionReverse:
+        case Animation::Direction::Reverse:
             animationEffect->setDirection(PlaybackDirection::Reverse);
             break;
-        case Animation::AnimationDirectionAlternateReverse:
+        case Animation::Direction::AlternateReverse:
             animationEffect->setDirection(PlaybackDirection::AlternateReverse);
             break;
         }

--- a/Source/WebCore/animation/KeyframeEffect.cpp
+++ b/Source/WebCore/animation/KeyframeEffect.cpp
@@ -2142,16 +2142,16 @@ Ref<const Animation> KeyframeEffect::backingAnimationForCompositedRenderer() con
 
     switch (direction()) {
     case PlaybackDirection::Normal:
-        animation->setDirection(Animation::AnimationDirectionNormal);
+        animation->setDirection(Animation::Direction::Normal);
         break;
     case PlaybackDirection::Alternate:
-        animation->setDirection(Animation::AnimationDirectionAlternate);
+        animation->setDirection(Animation::Direction::Alternate);
         break;
     case PlaybackDirection::Reverse:
-        animation->setDirection(Animation::AnimationDirectionReverse);
+        animation->setDirection(Animation::Direction::Reverse);
         break;
     case PlaybackDirection::AlternateReverse:
-        animation->setDirection(Animation::AnimationDirectionAlternateReverse);
+        animation->setDirection(Animation::Direction::AlternateReverse);
         break;
     }
 

--- a/Source/WebCore/css/CSSToStyleMap.cpp
+++ b/Source/WebCore/css/CSSToStyleMap.cpp
@@ -307,16 +307,16 @@ void CSSToStyleMap::mapAnimationDirection(Animation& layer, const CSSValue& valu
 
     switch (value.valueID()) {
     case CSSValueNormal:
-        layer.setDirection(Animation::AnimationDirectionNormal);
+        layer.setDirection(Animation::Direction::Normal);
         break;
     case CSSValueAlternate:
-        layer.setDirection(Animation::AnimationDirectionAlternate);
+        layer.setDirection(Animation::Direction::Alternate);
         break;
     case CSSValueReverse:
-        layer.setDirection(Animation::AnimationDirectionReverse);
+        layer.setDirection(Animation::Direction::Reverse);
         break;
     case CSSValueAlternateReverse:
-        layer.setDirection(Animation::AnimationDirectionAlternateReverse);
+        layer.setDirection(Animation::Direction::AlternateReverse);
         break;
     default:
         break;

--- a/Source/WebCore/css/ComputedStyleExtractor.cpp
+++ b/Source/WebCore/css/ComputedStyleExtractor.cpp
@@ -1454,16 +1454,16 @@ static Ref<CSSPrimitiveValue> valueForAnimationIterationCount(double iterationCo
     return CSSPrimitiveValue::create(iterationCount);
 }
 
-static Ref<CSSPrimitiveValue> valueForAnimationDirection(Animation::AnimationDirection direction)
+static Ref<CSSPrimitiveValue> valueForAnimationDirection(Animation::Direction direction)
 {
     switch (direction) {
-    case Animation::AnimationDirectionNormal:
+    case Animation::Direction::Normal:
         return CSSPrimitiveValue::create(CSSValueNormal);
-    case Animation::AnimationDirectionAlternate:
+    case Animation::Direction::Alternate:
         return CSSPrimitiveValue::create(CSSValueAlternate);
-    case Animation::AnimationDirectionReverse:
+    case Animation::Direction::Reverse:
         return CSSPrimitiveValue::create(CSSValueReverse);
-    case Animation::AnimationDirectionAlternateReverse:
+    case Animation::Direction::AlternateReverse:
         return CSSPrimitiveValue::create(CSSValueAlternateReverse);
     }
     RELEASE_ASSERT_NOT_REACHED();

--- a/Source/WebCore/platform/animation/Animation.cpp
+++ b/Source/WebCore/platform/animation/Animation.cpp
@@ -35,7 +35,7 @@ Animation::Animation()
     , m_delay(initialDelay())
     , m_duration(initialDuration())
     , m_timingFunction(initialTimingFunction())
-    , m_direction(initialDirection())
+    , m_direction(static_cast<unsigned>(initialDirection()))
     , m_fillMode(static_cast<unsigned>(initialFillMode()))
     , m_playState(static_cast<unsigned>(initialPlayState()))
     , m_compositeOperation(static_cast<unsigned>(initialCompositeOperation()))
@@ -146,13 +146,13 @@ TextStream& operator<<(TextStream& ts, Animation::TransitionProperty transitionP
     return ts;
 }
 
-TextStream& operator<<(TextStream& ts, Animation::AnimationDirection direction)
+TextStream& operator<<(TextStream& ts, Animation::Direction direction)
 {
     switch (direction) {
-    case Animation::AnimationDirectionNormal: ts << "normal"; break;
-    case Animation::AnimationDirectionAlternate: ts << "alternate"; break;
-    case Animation::AnimationDirectionReverse: ts << "reverse"; break;
-    case Animation::AnimationDirectionAlternateReverse: ts << "alternate-reverse"; break;
+    case Animation::Direction::Normal: ts << "normal"; break;
+    case Animation::Direction::Alternate: ts << "alternate"; break;
+    case Animation::Direction::Reverse: ts << "reverse"; break;
+    case Animation::Direction::AlternateReverse: ts << "alternate-reverse"; break;
     }
     return ts;
 }

--- a/Source/WebCore/platform/animation/Animation.h
+++ b/Source/WebCore/platform/animation/Animation.h
@@ -110,15 +110,15 @@ public:
         AnimatableProperty animatableProperty;
     };
 
-    enum AnimationDirection {
-        AnimationDirectionNormal,
-        AnimationDirectionAlternate,
-        AnimationDirectionReverse,
-        AnimationDirectionAlternateReverse
+    enum class Direction : uint8_t {
+        Normal,
+        Alternate,
+        Reverse,
+        AlternateReverse
     };
 
-    AnimationDirection direction() const { return static_cast<AnimationDirection>(m_direction); }
-    bool directionIsForwards() const { return m_direction == AnimationDirectionNormal || m_direction == AnimationDirectionAlternate; }
+    Direction direction() const { return static_cast<Direction>(m_direction); }
+    bool directionIsForwards() const { return direction() == Direction::Normal || direction() == Direction::Alternate; }
 
     AnimationFillMode fillMode() const { return static_cast<AnimationFillMode>(m_fillMode); }
 
@@ -140,7 +140,7 @@ public:
     TimingFunction* defaultTimingFunctionForKeyframes() const { return m_defaultTimingFunctionForKeyframes.get(); }
 
     void setDelay(double c) { m_delay = c; m_delaySet = true; }
-    void setDirection(AnimationDirection d) { m_direction = d; m_directionSet = true; }
+    void setDirection(Direction d) { m_direction = static_cast<unsigned>(d); m_directionSet = true; }
     void setDuration(double d) { ASSERT(d >= 0); m_duration = d; m_durationSet = true; }
     void setPlaybackRate(double d) { m_playbackRate = d; }
     void setFillMode(AnimationFillMode f) { m_fillMode = static_cast<unsigned>(f); m_fillModeSet = true; }
@@ -159,7 +159,7 @@ public:
     void setIsNoneAnimation(bool n) { m_isNone = n; }
 
     void fillDelay(double delay) { setDelay(delay); m_delayFilled = true; }
-    void fillDirection(AnimationDirection direction) { setDirection(direction); m_directionFilled = true; }
+    void fillDirection(Direction direction) { setDirection(direction); m_directionFilled = true; }
     void fillDuration(double duration) { setDuration(duration); m_durationFilled = true; }
     void fillFillMode(AnimationFillMode fillMode) { setFillMode(fillMode); m_fillModeFilled = true; }
     void fillIterationCount(double iterationCount) { setIterationCount(iterationCount); m_iterationCountFilled = true; }
@@ -207,7 +207,7 @@ private:
 
     Style::ScopeOrdinal m_nameStyleScopeOrdinal { Style::ScopeOrdinal::Element };
 
-    unsigned m_direction : 2; // AnimationDirection
+    unsigned m_direction : 2; // Direction
     unsigned m_fillMode : 2; // AnimationFillMode
     unsigned m_playState : 2; // AnimationPlayState
     unsigned m_compositeOperation : 2; // CompositeOperation
@@ -237,7 +237,7 @@ private:
 
 public:
     static double initialDelay() { return 0; }
-    static AnimationDirection initialDirection() { return AnimationDirectionNormal; }
+    static Direction initialDirection() { return Direction::Normal; }
     static double initialDuration() { return 0; }
     static AnimationFillMode initialFillMode() { return AnimationFillMode::None; }
     static double initialIterationCount() { return 1.0; }
@@ -250,7 +250,7 @@ public:
 
 WTF::TextStream& operator<<(WTF::TextStream&, AnimationPlayState);
 WTF::TextStream& operator<<(WTF::TextStream&, Animation::TransitionProperty);
-WTF::TextStream& operator<<(WTF::TextStream&, Animation::AnimationDirection);
+WTF::TextStream& operator<<(WTF::TextStream&, Animation::Direction);
 WTF::TextStream& operator<<(WTF::TextStream&, const Animation&);
 
 } // namespace WebCore

--- a/Source/WebCore/platform/graphics/ca/GraphicsLayerCA.cpp
+++ b/Source/WebCore/platform/graphics/ca/GraphicsLayerCA.cpp
@@ -3630,7 +3630,7 @@ void GraphicsLayerCA::setupAnimation(PlatformCAAnimation* propertyAnim, const An
     float repeatCount = anim->iterationCount();
     if (repeatCount == Animation::IterationCountInfinite)
         repeatCount = std::numeric_limits<float>::max();
-    else if (anim->direction() == Animation::AnimationDirectionAlternate || anim->direction() == Animation::AnimationDirectionAlternateReverse)
+    else if (anim->direction() == Animation::Direction::Alternate || anim->direction() == Animation::Direction::AlternateReverse)
         repeatCount /= 2;
 
     PlatformCAAnimation::FillModeType fillMode = PlatformCAAnimation::NoFillMode;
@@ -3651,7 +3651,7 @@ void GraphicsLayerCA::setupAnimation(PlatformCAAnimation* propertyAnim, const An
 
     propertyAnim->setDuration(duration);
     propertyAnim->setRepeatCount(repeatCount);
-    propertyAnim->setAutoreverses(anim->direction() == Animation::AnimationDirectionAlternate || anim->direction() == Animation::AnimationDirectionAlternateReverse);
+    propertyAnim->setAutoreverses(anim->direction() == Animation::Direction::Alternate || anim->direction() == Animation::Direction::AlternateReverse);
     propertyAnim->setRemovedOnCompletion(false);
     propertyAnim->setAdditive(additive);
     propertyAnim->setFillMode(fillMode);

--- a/Source/WebCore/platform/graphics/nicosia/NicosiaAnimation.cpp
+++ b/Source/WebCore/platform/graphics/nicosia/NicosiaAnimation.cpp
@@ -68,14 +68,14 @@ static FilterOperations applyFilterAnimation(const FilterOperations& from, const
     return result;
 }
 
-static bool shouldReverseAnimationValue(WebCore::Animation::AnimationDirection direction, int loopCount)
+static bool shouldReverseAnimationValue(WebCore::Animation::Direction direction, int loopCount)
 {
-    return (direction == WebCore::Animation::AnimationDirectionAlternate && loopCount & 1)
-        || (direction == WebCore::Animation::AnimationDirectionAlternateReverse && !(loopCount & 1))
-        || direction == WebCore::Animation::AnimationDirectionReverse;
+    return (direction == WebCore::Animation::Direction::Alternate && loopCount & 1)
+        || (direction == WebCore::Animation::Direction::AlternateReverse && !(loopCount & 1))
+        || direction == WebCore::Animation::Direction::Reverse;
 }
 
-static double normalizedAnimationValue(double runningTime, double duration, WebCore::Animation::AnimationDirection direction, double iterationCount)
+static double normalizedAnimationValue(double runningTime, double duration, WebCore::Animation::Direction direction, double iterationCount)
 {
     if (!duration)
         return 0;
@@ -89,11 +89,11 @@ static double normalizedAnimationValue(double runningTime, double duration, WebC
     return shouldReverseAnimationValue(direction, loopCount) ? 1 - normalized : normalized;
 }
 
-static double normalizedAnimationValueForFillsForwards(double iterationCount, WebCore::Animation::AnimationDirection direction)
+static double normalizedAnimationValueForFillsForwards(double iterationCount, WebCore::Animation::Direction direction)
 {
-    if (direction == WebCore::Animation::AnimationDirectionNormal)
+    if (direction == WebCore::Animation::Direction::Normal)
         return 1;
-    if (direction == WebCore::Animation::AnimationDirectionReverse)
+    if (direction == WebCore::Animation::Direction::Reverse)
         return 0;
     return shouldReverseAnimationValue(direction, iterationCount) ? 1 : 0;
 }

--- a/Source/WebCore/platform/graphics/nicosia/NicosiaAnimation.h
+++ b/Source/WebCore/platform/graphics/nicosia/NicosiaAnimation.h
@@ -69,7 +69,7 @@ private:
     RefPtr<WebCore::TimingFunction> m_timingFunction;
     double m_iterationCount;
     double m_duration;
-    WebCore::Animation::AnimationDirection m_direction;
+    WebCore::Animation::Direction m_direction;
     bool m_fillsForwards;
     MonotonicTime m_startTime;
     Seconds m_pauseTime;


### PR DESCRIPTION
#### 439e1e3a5a82fefbd6c0c1e86031a1e916b2800e
<pre>
[web-animations] Refactor Animation::AnimationDirection into an enum class
<a href="https://bugs.webkit.org/show_bug.cgi?id=256638">https://bugs.webkit.org/show_bug.cgi?id=256638</a>

Reviewed by Dean Jackson.

Animation::AnimationDirection is now Animation::Direction.

* Source/WebCore/animation/CSSAnimation.cpp:
(WebCore::CSSAnimation::syncPropertiesWithBackingAnimation):
* Source/WebCore/animation/KeyframeEffect.cpp:
(WebCore::KeyframeEffect::backingAnimationForCompositedRenderer const):
* Source/WebCore/css/CSSToStyleMap.cpp:
(WebCore::CSSToStyleMap::mapAnimationDirection):
* Source/WebCore/css/ComputedStyleExtractor.cpp:
(WebCore::valueForAnimationDirection):
* Source/WebCore/platform/animation/Animation.cpp:
(WebCore::Animation::Animation):
(WebCore::operator&lt;&lt;):
* Source/WebCore/platform/animation/Animation.h:
(WebCore::Animation::direction const):
(WebCore::Animation::directionIsForwards const):
(WebCore::Animation::setDirection):
(WebCore::Animation::fillDirection):
(WebCore::Animation::initialDirection):
* Source/WebCore/platform/graphics/ca/GraphicsLayerCA.cpp:
(WebCore::GraphicsLayerCA::setupAnimation):
* Source/WebCore/platform/graphics/nicosia/NicosiaAnimation.cpp:
(Nicosia::shouldReverseAnimationValue):
(Nicosia::normalizedAnimationValue):
(Nicosia::normalizedAnimationValueForFillsForwards):
* Source/WebCore/platform/graphics/nicosia/NicosiaAnimation.h:

Canonical link: <a href="https://commits.webkit.org/264700@main">https://commits.webkit.org/264700@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/79182db743c987d8bb23f09e2fa500b6ab657761

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/7028 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/7271 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/7450 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/8643 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/7262 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/7038 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/8533 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/7203 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/10173 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/7155 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/7822 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/6486 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/8746 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/5188 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/6393 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/14167 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/6852 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/6487 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/9355 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/6966 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/5705 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/6332 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/2022 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/10527 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/6715 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->