### PR TITLE
Use RenderAttachment for wide-layout attachments, with some modified layout and rendering

### DIFF
--- a/LayoutTests/fast/attachment/cocoa/wide-attachment-save-event-expected.txt
+++ b/LayoutTests/fast/attachment/cocoa/wide-attachment-save-event-expected.txt
@@ -1,3 +1,4 @@
+
 This tests that clicking on the save button sends a save event.
 
 On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".

--- a/LayoutTests/fast/attachment/mac/wide-attachment-image-controls-basic-expected.txt
+++ b/LayoutTests/fast/attachment/mac/wide-attachment-image-controls-basic-expected.txt
@@ -1,20 +1,19 @@
 layer at (0,0) size 800x600
   RenderView at (0,0) size 800x600
-layer at (0,0) size 800x128
-  RenderBlock {HTML} at (0,0) size 800x128
-    RenderBody {BODY} at (8,8) size 784x112
-      RenderBlock {ATTACHMENT} at (0,0) size 268x112
-        RenderGrid {DIV} at (1,1) size 266x80 [bgcolor=#0000000D]
+layer at (0,0) size 800x98
+  RenderBlock {HTML} at (0,0) size 800x98
+    RenderBody {BODY} at (8,8) size 784x82
+      RenderAttachment {ATTACHMENT} at (1,1) size 266x80
+        RenderGrid {DIV} at (0,0) size 266x80 [bgcolor=#0000000D]
           RenderGrid {DIV} at (0,0) size 68x80
             RenderAttachment {ATTACHMENT} at (8,14) size 52x52
           RenderGrid {DIV} at (68,0) size 198x80
             RenderGrid {DIV} at (4,40) size 170x0
-        RenderBlock (anonymous) at (0,82) size 268x30
-      RenderText {#text} at (268,94) size 4x18
-        text run at (268,94) width 4: " "
-      RenderImage {IMG} at (272,88) size 20x20
+      RenderText {#text} at (268,54) size 4x18
+        text run at (268,54) width 4: " "
+      RenderImage {IMG} at (272,48) size 20x20
       RenderText {#text} at (0,0) size 0x0
-layer at (8,90) size 28x26
-  RenderBlock (relative positioned) {DIV} at (0,0) size 28x26 [color=#00000000]
-layer at (8,90) size 28x26
-  RenderButton {BUTTON} at (0,0) size 28x26 [color=#000000D8] [bgcolor=#C0C0C0] [border: (2px outset #C0C0C0)]
+layer at (9,9) size 266x80
+  RenderBlock (relative positioned) {DIV} at (0,0) size 266x80 [color=#00000000]
+layer at (247,9) size 28x26
+  RenderButton {BUTTON} at (238,0) size 28x26 [color=#000000D8] [bgcolor=#C0C0C0] [border: (2px outset #C0C0C0)]

--- a/LayoutTests/platform/ios-wk2/fast/attachment/cocoa/wide-attachment-rendering-expected.txt
+++ b/LayoutTests/platform/ios-wk2/fast/attachment/cocoa/wide-attachment-rendering-expected.txt
@@ -1,49 +1,49 @@
-layer at (0,0) size 800x768
+layer at (0,0) size 800x888
   RenderView at (0,0) size 800x600
-layer at (0,0) size 800x768
-  RenderBlock {HTML} at (0,0) size 800x768
-    RenderBody {BODY} at (8,8) size 784x752
-      RenderBlock {DIV} at (0,0) size 784x94
-        RenderText {#text} at (0,68) size 47x19
-          text run at (0,68) width 47: "Blank: "
-        RenderBlock {ATTACHMENT} at (46,0) size 341x94 [color=#007AFF]
-          RenderGrid {DIV} at (1,1) size 338x92 [bgcolor=#74748014]
+layer at (0,0) size 800x888
+  RenderBlock {HTML} at (0,0) size 800x888
+    RenderBody {BODY} at (8,8) size 784x872
+      RenderBlock {DIV} at (0,0) size 784x109
+        RenderText {#text} at (0,0) size 47x19
+          text run at (0,0) width 47: "Blank: "
+        RenderAttachment {ATTACHMENT} at (47,16) size 339x92 [color=#007AFF]
+          RenderGrid {DIV} at (0,0) size 338x92 [bgcolor=#74748014]
             RenderGrid {DIV} at (0,0) size 76x92
               RenderAttachment {ATTACHMENT} at (10,10) size 56x72
             RenderGrid {DIV} at (76,0) size 262x92
               RenderGrid {DIV} at (6,46) size 230x0
-      RenderBlock {DIV} at (0,94) size 784x94
-        RenderText {#text} at (0,68) size 39x19
-          text run at (0,68) width 39: "Title: "
-        RenderBlock {ATTACHMENT} at (38,0) size 341x94 [color=#007AFF]
-          RenderGrid {DIV} at (1,1) size 338x92 [bgcolor=#74748014]
+      RenderBlock {DIV} at (0,109) size 784x109
+        RenderText {#text} at (0,0) size 39x19
+          text run at (0,0) width 39: "Title: "
+        RenderAttachment {ATTACHMENT} at (39,16) size 339x92 [color=#007AFF]
+          RenderGrid {DIV} at (0,0) size 338x92 [bgcolor=#74748014]
             RenderGrid {DIV} at (0,0) size 76x92
               RenderAttachment {ATTACHMENT} at (10,10) size 56x72
             RenderGrid {DIV} at (76,0) size 262x92
               RenderGrid {DIV} at (6,31) size 230x30
-      RenderBlock {DIV} at (0,188) size 784x94
-        RenderText {#text} at (0,68) size 83x19
-          text run at (0,68) width 83: "and subtitle: "
-        RenderBlock {ATTACHMENT} at (82,0) size 341x94 [color=#007AFF]
-          RenderGrid {DIV} at (1,1) size 338x92 [bgcolor=#74748014]
+      RenderBlock {DIV} at (0,218) size 784x109
+        RenderText {#text} at (0,0) size 83x19
+          text run at (0,0) width 83: "and subtitle: "
+        RenderAttachment {ATTACHMENT} at (83,16) size 339x92 [color=#007AFF]
+          RenderGrid {DIV} at (0,0) size 338x92 [bgcolor=#74748014]
             RenderGrid {DIV} at (0,0) size 76x92
               RenderAttachment {ATTACHMENT} at (10,10) size 56x72
             RenderGrid {DIV} at (76,0) size 262x92
               RenderGrid {DIV} at (6,31) size 230x30
-      RenderBlock {DIV} at (0,282) size 784x94
-        RenderText {#text} at (0,68) size 52x19
-          text run at (0,68) width 52: "Action: "
-        RenderBlock {ATTACHMENT} at (51,0) size 341x94 [color=#007AFF]
-          RenderGrid {DIV} at (1,1) size 338x92 [bgcolor=#74748014]
+      RenderBlock {DIV} at (0,327) size 784x109
+        RenderText {#text} at (0,0) size 52x19
+          text run at (0,0) width 52: "Action: "
+        RenderAttachment {ATTACHMENT} at (52,16) size 339x92 [color=#007AFF]
+          RenderGrid {DIV} at (0,0) size 338x92 [bgcolor=#74748014]
             RenderGrid {DIV} at (0,0) size 76x92
               RenderAttachment {ATTACHMENT} at (10,10) size 56x72
             RenderGrid {DIV} at (76,0) size 262x92
               RenderGrid {DIV} at (6,22) size 230x48
-      RenderBlock {DIV} at (0,376) size 784x94
-        RenderText {#text} at (0,68) size 40x19
-          text run at (0,68) width 40: "Save: "
-        RenderBlock {ATTACHMENT} at (39,0) size 341x94 [color=#007AFF]
-          RenderGrid {DIV} at (1,1) size 338x92 [bgcolor=#74748014]
+      RenderBlock {DIV} at (0,436) size 784x109
+        RenderText {#text} at (0,0) size 40x19
+          text run at (0,0) width 40: "Save: "
+        RenderAttachment {ATTACHMENT} at (40,16) size 339x92 [color=#007AFF]
+          RenderGrid {DIV} at (0,0) size 338x92 [bgcolor=#74748014]
             RenderGrid {DIV} at (0,0) size 76x92
               RenderAttachment {ATTACHMENT} at (10,10) size 56x72
             RenderGrid {DIV} at (76,0) size 262x92
@@ -51,93 +51,93 @@ layer at (0,0) size 800x768
                 RenderBlock {DIV} at (190,0) size 40x40
                   RenderButton {BUTTON} at (0,0) size 40x40 [bgcolor=#7676801F]
                     RenderBlock (anonymous) at (11,0) size 18x40
-      RenderBlock {DIV} at (0,470) size 784x94
-        RenderText {#text} at (0,60) size 97x19
-          text run at (0,60) width 97: "Zero progress: "
-        RenderBlock {ATTACHMENT} at (96,0) size 341x94 [color=#007AFF]
-          RenderGrid {DIV} at (1,1) size 338x92 [bgcolor=#74748014]
+      RenderBlock {DIV} at (0,545) size 784x109
+        RenderText {#text} at (0,0) size 97x19
+          text run at (0,0) width 97: "Zero progress: "
+        RenderAttachment {ATTACHMENT} at (97,16) size 339x92 [color=#007AFF]
+          RenderGrid {DIV} at (0,0) size 338x92 [bgcolor=#74748014]
             RenderGrid {DIV} at (0,0) size 76x92
               RenderBlock {DIV} at (10,18) size 56x56
             RenderGrid {DIV} at (76,0) size 262x92
               RenderGrid {DIV} at (6,37) size 230x18
-      RenderBlock {DIV} at (0,564) size 784x94
-        RenderText {#text} at (0,60) size 96x19
-          text run at (0,60) width 96: "75% progress: "
-        RenderBlock {ATTACHMENT} at (95,0) size 341x94 [color=#007AFF]
-          RenderGrid {DIV} at (1,1) size 338x92 [bgcolor=#74748014]
+      RenderBlock {DIV} at (0,654) size 784x109
+        RenderText {#text} at (0,0) size 96x19
+          text run at (0,0) width 96: "75% progress: "
+        RenderAttachment {ATTACHMENT} at (96,16) size 339x92 [color=#007AFF]
+          RenderGrid {DIV} at (0,0) size 338x92 [bgcolor=#74748014]
             RenderGrid {DIV} at (0,0) size 76x92
               RenderBlock {DIV} at (10,18) size 56x56 [color=#3C3C4399]
                 RenderBlock {DIV} at (0,0) size 56x56 [border: (4px solid #3C3C4399)]
             RenderGrid {DIV} at (76,0) size 262x92
               RenderGrid {DIV} at (6,37) size 230x18
-      RenderBlock {DIV} at (0,658) size 784x94
-        RenderText {#text} at (0,60) size 104x19
-          text run at (0,60) width 104: "100% progress: "
-        RenderBlock {ATTACHMENT} at (103,0) size 341x94 [color=#007AFF]
-          RenderGrid {DIV} at (1,1) size 338x92 [bgcolor=#74748014]
+      RenderBlock {DIV} at (0,763) size 784x109
+        RenderText {#text} at (0,0) size 104x19
+          text run at (0,0) width 104: "100% progress: "
+        RenderAttachment {ATTACHMENT} at (104,16) size 339x92 [color=#007AFF]
+          RenderGrid {DIV} at (0,0) size 338x92 [bgcolor=#74748014]
             RenderGrid {DIV} at (0,0) size 76x92
               RenderBlock {DIV} at (10,18) size 56x56 [color=#3C3C4399]
                 RenderBlock {DIV} at (0,0) size 56x56 [border: (4px solid #3C3C4399)]
             RenderGrid {DIV} at (76,0) size 262x92
               RenderGrid {DIV} at (6,37) size 230x18
-layer at (129,134) size 230x17
+layer at (129,164) size 230x17
   RenderDeprecatedFlexibleBox {DIV} at (0,0) size 230x17 [color=#000000]
     RenderBlock (anonymous) at (0,0) size 230x17
       RenderText {#text} at (0,0) size 29x17
         text run at (0,0) width 29: "Title"
-layer at (129,151) size 230x13
+layer at (129,181) size 230x13
   RenderDeprecatedFlexibleBox {DIV} at (0,17) size 230x13 [color=#3C3C4399]
     RenderBlock (anonymous) at (0,0) size 230x13
       RenderText {#text} at (0,0) size 38x13
         text run at (0,0) width 38: "Subtitle"
-layer at (174,228) size 230x17
+layer at (174,273) size 230x17
   RenderDeprecatedFlexibleBox {DIV} at (0,0) size 230x17 [color=#000000]
     RenderBlock (anonymous) at (0,0) size 230x17
       RenderText {#text} at (0,0) size 29x17
         text run at (0,0) width 29: "Title"
-layer at (174,245) size 230x13
+layer at (174,290) size 230x13
   RenderDeprecatedFlexibleBox {DIV} at (0,17) size 230x13 [color=#3C3C4399]
     RenderBlock (anonymous) at (0,0) size 230x13
       RenderText {#text} at (0,0) size 38x13
         text run at (0,0) width 38: "Subtitle"
-layer at (143,314) size 230x17
+layer at (143,374) size 230x17
   RenderDeprecatedFlexibleBox {DIV} at (0,0) size 230x17 [color=#3C3C4399]
     RenderBlock (anonymous) at (0,0) size 230x17
       RenderText {#text} at (0,0) size 106x17
         text run at (0,0) width 106: "Tap to download"
-layer at (143,331) size 230x17
+layer at (143,391) size 230x17
   RenderDeprecatedFlexibleBox {DIV} at (0,17) size 230x17 [color=#000000]
     RenderBlock (anonymous) at (0,0) size 230x17
       RenderText {#text} at (0,0) size 52x17
         text run at (0,0) width 52: "\x{200E}\x{2068}Title\x{2069}\x{200B}.txt"
-layer at (143,348) size 230x13
+layer at (143,408) size 230x13
   RenderDeprecatedFlexibleBox {DIV} at (0,34) size 230x13 [color=#3C3C4399]
     RenderBlock (anonymous) at (0,0) size 230x13
       RenderText {#text} at (0,0) size 38x13
         text run at (0,0) width 38: "Subtitle"
-layer at (131,411) size 118x8 backgroundClip at (131,411) size 117x8 clip at (131,411) size 117x8
+layer at (131,486) size 118x8 backgroundClip at (131,486) size 117x8 clip at (131,486) size 117x8
   RenderDeprecatedFlexibleBox {DIV} at (0,0) size 118x8 [color=#3C3C4399]
-layer at (131,419) size 118x24 backgroundClip at (131,419) size 117x24 clip at (131,419) size 117x24
+layer at (131,494) size 118x24 backgroundClip at (131,494) size 117x24 clip at (131,494) size 117x24
   RenderDeprecatedFlexibleBox {DIV} at (0,7) size 118x26 [color=#000000]
     RenderBlock (anonymous) at (0,0) size 118x17
       RenderText {#text} at (0,0) size 56x17
         text run at (0,0) width 56: "\x{200E}\x{2068}Title\x{2069}\x{200B}.pdf"
-layer at (131,443) size 118x8 backgroundClip at (131,443) size 117x8 clip at (131,443) size 117x8
+layer at (131,518) size 118x8 backgroundClip at (131,518) size 117x8 clip at (131,518) size 117x8
   RenderDeprecatedFlexibleBox {DIV} at (0,32) size 118x8 [color=#3C3C4399]
-layer at (188,517) size 230x17
+layer at (188,607) size 230x17
   RenderDeprecatedFlexibleBox {DIV} at (0,0) size 230x17 [color=#000000]
     RenderBlock (anonymous) at (0,0) size 230x17
       RenderText {#text} at (0,0) size 56x17
         text run at (0,0) width 56: "\x{200E}\x{2068}Title\x{2069}\x{200B}.pdf"
-layer at (187,611) size 230x17
+layer at (187,716) size 230x17
   RenderDeprecatedFlexibleBox {DIV} at (0,0) size 230x17 [color=#000000]
     RenderBlock (anonymous) at (0,0) size 230x17
       RenderText {#text} at (0,0) size 56x17
         text run at (0,0) width 56: "\x{200E}\x{2068}Title\x{2069}\x{200B}.pdf"
-layer at (195,705) size 230x17
+layer at (195,825) size 230x17
   RenderDeprecatedFlexibleBox {DIV} at (0,0) size 230x17 [color=#000000]
     RenderBlock (anonymous) at (0,0) size 230x17
       RenderText {#text} at (0,0) size 56x17
         text run at (0,0) width 56: "\x{200E}\x{2068}Title\x{2069}\x{200B}.pdf"
-layer at (332,411) size 18x40
+layer at (332,486) size 18x40
   RenderBlock {DIV} at (0,0) size 18x40 [bgcolor=#007AFF]

--- a/LayoutTests/platform/mac-wk2/fast/attachment/cocoa/wide-attachment-rendering-expected.txt
+++ b/LayoutTests/platform/mac-wk2/fast/attachment/cocoa/wide-attachment-rendering-expected.txt
@@ -4,46 +4,46 @@ layer at (0,0) size 785x672
   RenderBlock {HTML} at (0,0) size 785x672
     RenderBody {BODY} at (8,8) size 769x656
       RenderBlock {DIV} at (0,0) size 769x82
-        RenderText {#text} at (0,53) size 47x18
-          text run at (0,53) width 47: "Blank: "
-        RenderBlock {ATTACHMENT} at (46,0) size 269x82
-          RenderGrid {DIV} at (1,1) size 266x80 [bgcolor=#0000000D]
+        RenderText {#text} at (0,54) size 47x18
+          text run at (0,54) width 47: "Blank: "
+        RenderAttachment {ATTACHMENT} at (47,1) size 267x80
+          RenderGrid {DIV} at (0,0) size 266x80 [bgcolor=#0000000D]
             RenderGrid {DIV} at (0,0) size 68x80
               RenderAttachment {ATTACHMENT} at (8,14) size 52x52
             RenderGrid {DIV} at (68,0) size 198x80
               RenderGrid {DIV} at (4,40) size 170x0
       RenderBlock {DIV} at (0,82) size 769x82
-        RenderText {#text} at (0,53) size 39x18
-          text run at (0,53) width 39: "Title: "
-        RenderBlock {ATTACHMENT} at (38,0) size 269x82
-          RenderGrid {DIV} at (1,1) size 266x80 [bgcolor=#0000000D]
+        RenderText {#text} at (0,54) size 39x18
+          text run at (0,54) width 39: "Title: "
+        RenderAttachment {ATTACHMENT} at (39,1) size 267x80
+          RenderGrid {DIV} at (0,0) size 266x80 [bgcolor=#0000000D]
             RenderGrid {DIV} at (0,0) size 68x80
               RenderAttachment {ATTACHMENT} at (8,14) size 52x52
             RenderGrid {DIV} at (68,0) size 198x80
               RenderGrid {DIV} at (4,26) size 170x28
       RenderBlock {DIV} at (0,164) size 769x82
-        RenderText {#text} at (0,53) size 83x18
-          text run at (0,53) width 83: "and subtitle: "
-        RenderBlock {ATTACHMENT} at (82,0) size 269x82
-          RenderGrid {DIV} at (1,1) size 266x80 [bgcolor=#0000000D]
+        RenderText {#text} at (0,54) size 83x18
+          text run at (0,54) width 83: "and subtitle: "
+        RenderAttachment {ATTACHMENT} at (83,1) size 267x80
+          RenderGrid {DIV} at (0,0) size 266x80 [bgcolor=#0000000D]
             RenderGrid {DIV} at (0,0) size 68x80
               RenderAttachment {ATTACHMENT} at (8,14) size 52x52
             RenderGrid {DIV} at (68,0) size 198x80
               RenderGrid {DIV} at (4,26) size 170x28
       RenderBlock {DIV} at (0,246) size 769x82
-        RenderText {#text} at (0,53) size 52x18
-          text run at (0,53) width 52: "Action: "
-        RenderBlock {ATTACHMENT} at (51,0) size 269x82
-          RenderGrid {DIV} at (1,1) size 266x80 [bgcolor=#0000000D]
+        RenderText {#text} at (0,54) size 52x18
+          text run at (0,54) width 52: "Action: "
+        RenderAttachment {ATTACHMENT} at (52,1) size 267x80
+          RenderGrid {DIV} at (0,0) size 266x80 [bgcolor=#0000000D]
             RenderGrid {DIV} at (0,0) size 68x80
               RenderAttachment {ATTACHMENT} at (8,14) size 52x52
             RenderGrid {DIV} at (68,0) size 198x80
               RenderGrid {DIV} at (4,18) size 170x44
       RenderBlock {DIV} at (0,328) size 769x82
-        RenderText {#text} at (0,53) size 40x18
-          text run at (0,53) width 40: "Save: "
-        RenderBlock {ATTACHMENT} at (39,0) size 269x82
-          RenderGrid {DIV} at (1,1) size 266x80 [bgcolor=#0000000D]
+        RenderText {#text} at (0,54) size 40x18
+          text run at (0,54) width 40: "Save: "
+        RenderAttachment {ATTACHMENT} at (40,1) size 267x80
+          RenderGrid {DIV} at (0,0) size 266x80 [bgcolor=#0000000D]
             RenderGrid {DIV} at (0,0) size 68x80
               RenderAttachment {ATTACHMENT} at (8,14) size 52x52
             RenderGrid {DIV} at (68,0) size 198x80
@@ -52,29 +52,29 @@ layer at (0,0) size 785x672
                   RenderButton {BUTTON} at (0,0) size 28x28 [color=#00000019] [border: (1px solid #00000019)]
                     RenderBlock (anonymous) at (7,3) size 14x21
       RenderBlock {DIV} at (0,410) size 769x82
-        RenderText {#text} at (0,47) size 97x18
-          text run at (0,47) width 97: "Zero progress: "
-        RenderBlock {ATTACHMENT} at (96,0) size 269x82
-          RenderGrid {DIV} at (1,1) size 266x80 [bgcolor=#0000000D]
+        RenderText {#text} at (0,54) size 97x18
+          text run at (0,54) width 97: "Zero progress: "
+        RenderAttachment {ATTACHMENT} at (97,1) size 267x80
+          RenderGrid {DIV} at (0,0) size 266x80 [bgcolor=#0000000D]
             RenderGrid {DIV} at (0,0) size 68x80
               RenderBlock {DIV} at (14,20) size 40x40
             RenderGrid {DIV} at (68,0) size 198x80
               RenderGrid {DIV} at (4,32) size 170x16
       RenderBlock {DIV} at (0,492) size 769x82
-        RenderText {#text} at (0,47) size 96x18
-          text run at (0,47) width 96: "75% progress: "
-        RenderBlock {ATTACHMENT} at (95,0) size 269x82
-          RenderGrid {DIV} at (1,1) size 266x80 [bgcolor=#0000000D]
+        RenderText {#text} at (0,54) size 96x18
+          text run at (0,54) width 96: "75% progress: "
+        RenderAttachment {ATTACHMENT} at (96,1) size 267x80
+          RenderGrid {DIV} at (0,0) size 266x80 [bgcolor=#0000000D]
             RenderGrid {DIV} at (0,0) size 68x80
               RenderBlock {DIV} at (14,20) size 40x40 [color=#0000007F]
                 RenderBlock {DIV} at (0,0) size 40x40 [border: (4px solid #0000007F)]
             RenderGrid {DIV} at (68,0) size 198x80
               RenderGrid {DIV} at (4,32) size 170x16
       RenderBlock {DIV} at (0,574) size 769x82
-        RenderText {#text} at (0,47) size 104x18
-          text run at (0,47) width 104: "100% progress: "
-        RenderBlock {ATTACHMENT} at (103,0) size 269x82
-          RenderGrid {DIV} at (1,1) size 266x80 [bgcolor=#0000000D]
+        RenderText {#text} at (0,54) size 104x18
+          text run at (0,54) width 104: "100% progress: "
+        RenderAttachment {ATTACHMENT} at (104,1) size 267x80
+          RenderGrid {DIV} at (0,0) size 266x80 [bgcolor=#0000000D]
             RenderGrid {DIV} at (0,0) size 68x80
               RenderBlock {DIV} at (14,20) size 40x40 [color=#0000007F]
                 RenderBlock {DIV} at (0,0) size 40x40 [border: (4px solid #0000007F)]

--- a/Source/WebCore/html/HTMLAttachmentElement.cpp
+++ b/Source/WebCore/html/HTMLAttachmentElement.cpp
@@ -30,6 +30,8 @@
 
 #include "AddEventListenerOptions.h"
 #include "AttachmentElementClient.h"
+#include "CSSPropertyNames.h"
+#include "CSSUnits.h"
 #include "DOMRectReadOnly.h"
 #include "DOMURL.h"
 #include "Document.h"
@@ -356,11 +358,8 @@ DOMRectReadOnly* HTMLAttachmentElement::saveButtonClientRect() const
     return m_saveButtonClientRect.get();
 }
 
-RenderPtr<RenderElement> HTMLAttachmentElement::createElementRenderer(RenderStyle&& style, const RenderTreePosition& position)
+RenderPtr<RenderElement> HTMLAttachmentElement::createElementRenderer(RenderStyle&& style, const RenderTreePosition&)
 {
-    if (m_implementation == Implementation::Modern)
-        return HTMLElement::createElementRenderer(WTFMove(style), position);
-
     return createRenderer<RenderAttachment>(*this, WTFMove(style));
 }
 
@@ -434,6 +433,12 @@ void HTMLAttachmentElement::setFile(RefPtr<File>&& file, UpdateDisplayAttributes
 Node::InsertedIntoAncestorResult HTMLAttachmentElement::insertedIntoAncestor(InsertionType type, ContainerNode& ancestor)
 {
     auto result = HTMLElement::insertedIntoAncestor(type, ancestor);
+    if (isWideLayout()) {
+        setInlineStyleProperty(CSSPropertyMarginLeft, 1, CSSUnitType::CSS_PX);
+        setInlineStyleProperty(CSSPropertyMarginRight, 1, CSSUnitType::CSS_PX);
+        setInlineStyleProperty(CSSPropertyMarginTop, 1, CSSUnitType::CSS_PX);
+        setInlineStyleProperty(CSSPropertyMarginBottom, 1, CSSUnitType::CSS_PX);
+    }
     if (type.connectedToDocument)
         document().didInsertAttachmentElement(*this);
     return result;

--- a/Source/WebCore/html/HTMLAttachmentElement.h
+++ b/Source/WebCore/html/HTMLAttachmentElement.h
@@ -90,6 +90,9 @@ public:
 
     bool isImageOnly() const { return m_implementation == Implementation::ImageOnly; }
 
+    bool isWideLayout() const { return m_implementation == Implementation::Modern; }
+    HTMLElement* wideLayoutShadowContainer() const { return m_containerElement.get(); }
+
 private:
     friend class AttachmentSaveEventListener;
 

--- a/Source/WebCore/html/shadow/attachmentElementShadow.css
+++ b/Source/WebCore/html/shadow/attachmentElementShadow.css
@@ -36,16 +36,11 @@ div#attachment-container {
     height: 80px;
     background-color: -apple-system-tertiary-fill;
 #endif
-    margin: 1px;
     border-radius: 8px;
     font: caption;
     pointer-events: none;
     user-select: none;
     -webkit-user-select: none;
-}
-
-div#attachment-container::selection {
-    background-color: -apple-system-selected-content-background;
 }
 
 div#attachment-preview-area {

--- a/Source/WebCore/rendering/RenderAttachment.h
+++ b/Source/WebCore/rendering/RenderAttachment.h
@@ -42,18 +42,23 @@ public:
     void setShouldDrawBorder(bool drawBorder) { m_shouldDrawBorder = drawBorder; }
     bool shouldDrawBorder() const;
 
-    bool hasShadowContent() const { return m_hasShadowControls; }
     void setHasShadowControls(bool hasShadowControls) { m_hasShadowControls = hasShadowControls; }
-    bool canHaveGeneratedChildren() const override { return m_hasShadowControls; }
-    bool canHaveChildren() const override { return m_hasShadowControls; }
+    bool hasShadowControls() const { return m_hasShadowControls; }
+    bool isWideLayout() const { return m_isWideLayout; }
+    bool hasShadowContent() const { return hasShadowControls() || isWideLayout(); }
+    bool canHaveGeneratedChildren() const override { return hasShadowContent(); }
+    bool canHaveChildren() const override { return hasShadowContent(); }
+
+    bool paintWideLayoutAttachmentOnly(const PaintInfo&, const LayoutPoint& offset) const;
 
 private:
     void element() const = delete;
     bool isAttachment() const override { return true; }
     ASCIILiteral renderName() const override { return "RenderAttachment"_s; }
+    LayoutSize layoutWideLayoutAttachmentOnly();
     void layoutShadowContent(const LayoutSize&);
 
-    bool shouldDrawSelectionTint() const override { return false; }
+    bool shouldDrawSelectionTint() const override { return isWideLayout(); }
     void paintReplaced(PaintInfo&, const LayoutPoint& offset) final;
 
     void layout() override;
@@ -63,6 +68,7 @@ private:
     LayoutUnit m_minimumIntrinsicWidth;
     bool m_shouldDrawBorder { true };
     bool m_hasShadowControls { false };
+    bool m_isWideLayout;
 };
 
 } // namespace WebCore

--- a/Source/WebCore/rendering/RenderThemeIOS.mm
+++ b/Source/WebCore/rendering/RenderThemeIOS.mm
@@ -1710,6 +1710,9 @@ bool RenderThemeIOS::paintAttachment(const RenderObject& renderer, const PaintIn
 
     const RenderAttachment& attachment = downcast<RenderAttachment>(renderer);
 
+    if (attachment.paintWideLayoutAttachmentOnly(paintInfo, paintRect.location()))
+        return true;
+
     AttachmentLayout info(attachment);
 
     GraphicsContext& context = paintInfo.context();

--- a/Source/WebCore/rendering/RenderThemeMac.mm
+++ b/Source/WebCore/rendering/RenderThemeMac.mm
@@ -1597,6 +1597,10 @@ bool RenderThemeMac::paintAttachment(const RenderObject& renderer, const PaintIn
         return false;
 
     const RenderAttachment& attachment = downcast<RenderAttachment>(renderer);
+
+    if (attachment.paintWideLayoutAttachmentOnly(paintInfo, paintRect.location()))
+        return true;
+
     HTMLAttachmentElement& element = attachment.attachmentElement();
 
     auto layoutStyle = AttachmentLayoutStyle::NonSelected;


### PR DESCRIPTION
#### 333b4b2030a128aebb08c23403fb50e4465172ca
<pre>
Use RenderAttachment for wide-layout attachments, with some modified layout and rendering
<a href="https://bugs.webkit.org/show_bug.cgi?id=256637">https://bugs.webkit.org/show_bug.cgi?id=256637</a>
rdar://108157331

Reviewed by Alan Baradlay.

A lot of the editor code interacting with attachments relies on the renderer being exactly `RenderAttachment`, which led to some misbehavior when the wide-layout attachment was using the more generic `RenderBlockFlow`.
So now the renderer is always `RenderAttachment`, but the layout and rendering paths redirect to special wide-layout-only functions.

* LayoutTests/fast/attachment/cocoa/wide-attachment-save-event-expected.txt:
* LayoutTests/fast/attachment/mac/wide-attachment-image-controls-basic-expected.txt:
* LayoutTests/platform/ios-wk2/fast/attachment/cocoa/wide-attachment-rendering-expected.txt:
* LayoutTests/platform/mac-wk2/fast/attachment/cocoa/wide-attachment-rendering-expected.txt:
* Source/WebCore/html/HTMLAttachmentElement.cpp:
(WebCore::HTMLAttachmentElement::createElementRenderer):
Always return a `RenderAttachment`, like it was before introducing the wide-layout styling.

(WebCore::HTMLAttachmentElement::insertedIntoAncestor):
Because of how the root element does the layout, the shadow root element&apos;s margins were ignored, so now the margins are added here in the root element.

* Source/WebCore/html/HTMLAttachmentElement.h:
* Source/WebCore/html/shadow/attachmentElementShadow.css:
(div#attachment-container):
Since the margin is now in the top-level element outside the shadow tree, it is not needed here anymore.

(div#attachment-container::selection): Deleted.
The selection coloring is handled by the `RenderReplaced` painting code, so this styling was ignored anyway.

* Source/WebCore/rendering/RenderAttachment.cpp:
(WebCore::RenderAttachment::RenderAttachment):
(WebCore::RenderAttachment::layoutWideLayoutAttachmentOnly):
(WebCore::RenderAttachment::layout):
Layout the wide-layout shadow tree if present, the &quot;replaced&quot; and shadow content layouts are still performed to handle all the necessary sizing and optional image controls.

(WebCore::RenderAttachment::paintWideLayoutAttachmentOnly const):
New wide-layout paint code, handling the full Foreground and Selection phases and painting everything in the shadow tree.

* Source/WebCore/rendering/RenderAttachment.h:
Cleaned up &quot;Shadow&quot; functions, to separate just &quot;shadow controls&quot; (like image controls) and any &quot;shadow content&quot; that may include the wide-layout shadow tree.
Also let the `RenderReplaced` painting code handle the selection tint.

* Source/WebCore/rendering/RenderThemeIOS.mm:
(WebCore::RenderThemeIOS::paintAttachment):
* Source/WebCore/rendering/RenderThemeMac.mm:
(WebCore::RenderThemeMac::paintAttachment):
When actually painting a wide-layout attachment, skip the legacy painting.

Canonical link: <a href="https://commits.webkit.org/264914@main">https://commits.webkit.org/264914@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0dd380f473287c94c6bdc3917320e4128f61199f

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/9012 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/9299 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/9518 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/10665 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/8974 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/9020 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/11286 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/9267 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/11826 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/9158 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/10134 "1 flakes 2 failures") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/7904 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/10824 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/7429 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/8239 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/15719 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/8538 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/8387 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/11708 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/8883 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/7244 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/8127 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/2209 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/12342 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/8633 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->