### PR TITLE
ManagedMediaSource emits stream start and end events during live playback with short forward buffer

### DIFF
--- a/LayoutTests/media/media-source/media-managedmse-streaming-atend-expected.txt
+++ b/LayoutTests/media/media-source/media-managedmse-streaming-atend-expected.txt
@@ -1,0 +1,14 @@
+
+RUN(video.src = URL.createObjectURL(source))
+EVENT(sourceopen)
+EVENT(startstreaming)
+RUN(sourceBuffer = source.addSourceBuffer(loader.type()))
+RUN(sourceBuffer.appendBuffer(loader.initSegment()))
+EVENT(update)
+RUN(source.duration = 0.1)
+EVENT(durationchange)
+RUN(ended = true)
+RUN(source.endOfStream())
+EVENT(endstreaming)
+END OF TEST
+

--- a/LayoutTests/media/media-source/media-managedmse-streaming-atend.html
+++ b/LayoutTests/media/media-source/media-managedmse-streaming-atend.html
@@ -9,6 +9,7 @@
     var loader;
     var source;
     var sourceBuffer;
+    var ended = false;
 
     function loaderPromise(loader) {
         return new Promise((resolve, reject) => {
@@ -34,31 +35,31 @@
             source = new ManagedMediaSource();
             run('video.src = URL.createObjectURL(source)');
 
-            await waitFor(source, 'sourceopen');
-            testExpected('source.streaming', true);
-            await waitFor(source, 'startstreaming');
+            await Promise.all([ waitFor(source, 'sourceopen'), waitFor(source, 'startstreaming')]);
 
             run('sourceBuffer = source.addSourceBuffer(loader.type())');
 
             run('sourceBuffer.appendBuffer(loader.initSegment())');
             await waitFor(sourceBuffer, 'update');
+            run('source.duration = 0.1');
+            await waitFor(video, 'durationchange');
 
-            var done = false;
-            waitForEventOnceOn(source, 'endstreaming', () => { done = true; });
+            // The endstreaming event shouldn't be fired even if we have appended data past the element's duration
+            // unless the mediasource is ended.
+            waitFor(source, 'endstreaming').then(() => {
+                if (!ended)
+                    failTest();
+                else
+                    endTest();
+            });
 
             do {
                 sourceBuffer.appendBuffer(loader.mediaSegment(0));
                 await once(sourceBuffer, 'update');
                 sourceBuffer.timestampOffset = sourceBuffer.buffered.end(sourceBuffer.buffered.length - 1);
-            } while (!done);
-            testExpected('source.streaming', false);
-
-            waitForEventOnceOn(source, 'startstreaming', () => {
-                testExpected('source.streaming', true);
-                endTest();
-            });
-
-            sourceBuffer.remove(video.currentTime, video.currentTime + 5);
+            } while (source.duration <= 5);
+            run('ended = true');
+            run('source.endOfStream()');
         } catch (e) {
             failTest(`Caught exception: "${e}"`);
         }

--- a/Source/WebCore/Modules/mediasource/ManagedMediaSource.cpp
+++ b/Source/WebCore/Modules/mediasource/ManagedMediaSource.cpp
@@ -145,16 +145,18 @@ void ManagedMediaSource::monitorSourceBuffers()
 
     ensurePrefsRead();
 
+    auto limitAhead = [&] (double upper) {
+        MediaTime aheadTime = currentTime + MediaTime::createWithDouble(upper);
+        return isEnded() ? std::min(duration(), aheadTime) : aheadTime;
+    };
     if (!m_streaming) {
-        MediaTime aheadTime = std::min(duration(), currentTime + MediaTime::createWithDouble(*m_lowThreshold));
-        PlatformTimeRanges neededBufferedRange { currentTime, std::max(currentTime, aheadTime) };
+        PlatformTimeRanges neededBufferedRange { currentTime, std::max(currentTime, limitAhead(*m_lowThreshold)) };
         if (!isBuffered(neededBufferedRange))
             setStreaming(true);
         return;
     }
 
-    MediaTime aheadTime = std::min(duration(), currentTime + MediaTime::createWithDouble(*m_highThreshold));
-    PlatformTimeRanges neededBufferedRange { currentTime, aheadTime };
+    PlatformTimeRanges neededBufferedRange { currentTime, limitAhead(*m_highThreshold) };
     if (isBuffered(neededBufferedRange))
         setStreaming(false);
 }

--- a/Source/WebCore/Modules/mediasource/MediaSource.cpp
+++ b/Source/WebCore/Modules/mediasource/MediaSource.cpp
@@ -1046,11 +1046,10 @@ void MediaSource::onReadyStateChange(ReadyState oldState, ReadyState newState)
         // on the readyState.
         // https://w3c.github.io/media-source/#htmlmediaelement-extensions-buffered
         updateBufferedIfNeeded(true /* force */);
-        return;
+    } else {
+        ASSERT(isClosed());
+        scheduleEvent(eventNames().sourcecloseEvent);
     }
-
-    ASSERT(isClosed());
-    scheduleEvent(eventNames().sourcecloseEvent);
 
     monitorSourceBuffers();
 }


### PR DESCRIPTION
#### 252b97f1b34ba4e266b7419669db49631b7fae96
<pre>
ManagedMediaSource emits stream start and end events during live playback with short forward buffer
<a href="https://bugs.webkit.org/show_bug.cgi?id=256639">https://bugs.webkit.org/show_bug.cgi?id=256639</a>
rdar://108914679

Reviewed by Youenn Fablet.

Do not emit `endstreaming` event when we have buffered up-to media source&apos;s
duration unless the source is ended.
Per the MSE&apos;s specs; the duration of a media element can be extended
whenever new content is appended to the source buffer past the duration.
So having the video buffered all the way to the element&apos;s duration doesn&apos;t
indicate that no more data is to be fetched; only a call to `endOfStream`
should.

* LayoutTests/media/media-source/media-managedmse-streaming-atend-expected.txt: Added.
* LayoutTests/media/media-source/media-managedmse-streaming-atend.html: Copied from LayoutTests/media/media-source/media-managedmse-streaming.html.
* LayoutTests/media/media-source/media-managedmse-streaming.html: Remove unused variables.
* Source/WebCore/Modules/mediasource/ManagedMediaSource.cpp:
(WebCore::ManagedMediaSource::monitorSourceBuffers):
* Source/WebCore/Modules/mediasource/MediaSource.cpp:
(WebCore::MediaSource::onReadyStateChange): Force re-check when the mediasource ready state change.

Canonical link: <a href="https://commits.webkit.org/263984@main">https://commits.webkit.org/263984@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/17de41b0f154401bb8d7a9ef4e44edc59cc35376

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/6234 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/6426 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/6605 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/7802 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/6565 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/6233 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/6646 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/6376 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/9444 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/6344 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/6359 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/5644 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/7873 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/3832 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/5623 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/13516 "5 flakes 1 missing results 121 failures") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/5697 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/5703 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/7947 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/6181 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/5055 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/5594 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/5552 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/1493 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/9741 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/5961 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->