### PR TITLE
[CSS Nesting] Don't serialize first implicit style rule inside group rule

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-nesting/parsing-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-nesting/parsing-expected.txt
@@ -1,5 +1,7 @@
 
-PASS .foo { & { color: green; } }
+PASS .foo {
+  & { color: green; }
+}
 PASS .foo { //color: red; color: green; }
 PASS .foo {
   &.bar { color: green; }

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-nesting/parsing.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-nesting/parsing.html
@@ -15,7 +15,7 @@
   }
 
   const testRules = [
-    [`.foo { & { color: green; } }`, `.foo { color: green; }`], // 🐰
+    `.foo {\n  & { color: green; }\n}`,
     // nesting should not mess with single line comment legacy special case
     [`.foo { //color: red; color: green; }`,`.foo { color: green; }`],
     `.foo {\n  &.bar { color: green; }\n}`,
@@ -39,7 +39,7 @@
     `.foo {\n  :has(div) { color: green; }\n}`,
     `.foo {\n  .bar {\n  && { color: green; }\n}\n}`,
     [`.foo {\n color: red; ident { color: green; }\n}`, `.foo { color: red; }`],
-    [`.foo {\n //color: comment; & { color: green; }\n}`, `.foo { color: green; }`],
+    [`.foo {\n //color: comment; & { color: green; }\n}`, `.foo {\n  & { color: green; }\n}`],
     [`.foo {\n .bar {\n  functionalnotation(div) { color: green; }\n\n}`, `.foo {\n  .bar { }\n}`],
   ]
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-nesting/serialize-group-rules-with-decls.tentative-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-nesting/serialize-group-rules-with-decls.tentative-expected.txt
@@ -1,7 +1,7 @@
 
 PASS Serialization of declarations in group rules
-FAIL Serialization of declarations in group rules 1 assert_equals: expected "div {\n  @supports selector(&) {\n  color: red; background-color: green;\n  &:hover { color: navy; }\n}\n}" but got "div {\n  @supports selector(&) {\ncolor: red; background-color: green;\n  &:hover { color: navy; }\n}\n}"
-FAIL Serialization of declarations in group rules 2 assert_equals: expected "div {\n  @media screen {\n  &.cls { color: red; }\n  & { color: red; }\n}\n}" but got "div {\n  @media screen {\ncolor: red;\n  &.cls { color: red; }\n}\n}"
+PASS Serialization of declarations in group rules 1
+PASS Serialization of declarations in group rules 2
 PASS Serialization of declarations in group rules 3
 PASS Serialization of declarations in group rules 4
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-nesting/serialize-group-rules-with-decls.tentative.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-nesting/serialize-group-rules-with-decls.tentative.html
@@ -55,7 +55,7 @@
 
   //They are removed from regular rules.
   test(() => {
-    assert_becomes("div { & { color: red; } }", "div { color: red; }");
+    assert_becomes("div { & { color: red; } }", "div {\n  & { color: red; }\n}");
   });
 
   // Empty rules (confusingly?) serialize different between style rules

--- a/Source/WebCore/css/CSSGroupingRule.cpp
+++ b/Source/WebCore/css/CSSGroupingRule.cpp
@@ -140,7 +140,7 @@ void CSSGroupingRule::appendCSSTextForItems(StringBuilder& builder) const
         return;
     }
 
-    builder.append('\n', static_cast<StringView>(decls), static_cast<StringView>(rules), "\n}");
+    builder.append('\n', "  ", static_cast<StringView>(decls), static_cast<StringView>(rules), "\n}");
     return;
 }
 
@@ -149,16 +149,19 @@ void CSSGroupingRule::cssTextForDeclsAndRules(StringBuilder& decls, StringBuilde
     auto& childRules = m_groupRule->childRules();
     for (unsigned index = 0 ; index < childRules.size() ; index++) {
         // We put the declarations at the upper level when the rule:
-        // - is a style rule
+        // - is the first rule
         // - has just "&" as original selector
         // - has no child rules
-        auto childRule = childRules[index];
-        ASSERT(childRule);
-        if (childRule->isStyleRuleWithNesting()) {
-            auto& nestedStyleRule = downcast<StyleRuleWithNesting>(*childRule);
-            if (nestedStyleRule.originalSelectorList().hasOnlyNestingSelector() && nestedStyleRule.nestedRules().isEmpty()) {
-                decls.append(nestedStyleRule.properties().asText());
-                continue;
+        if (!index) {
+            // It's the first rule.
+            auto childRule = childRules[index];
+            ASSERT(childRule);
+            if (childRule->isStyleRuleWithNesting()) {
+                auto& nestedStyleRule = downcast<StyleRuleWithNesting>(*childRule);
+                if (nestedStyleRule.originalSelectorList().hasOnlyNestingSelector() && nestedStyleRule.nestedRules().isEmpty()) {
+                    decls.append(nestedStyleRule.properties().asText());
+                    continue;
+                }
             }
         }
         // Otherwise we print the child rule

--- a/Source/WebCore/css/CSSStyleRule.cpp
+++ b/Source/WebCore/css/CSSStyleRule.cpp
@@ -182,28 +182,13 @@ String CSSStyleRule::cssText() const
     return builder.toString();
 }
 
-// FIXME: share all methods below with CSSGroupingRule.
-
-void CSSStyleRule::cssTextForDeclsAndRules(StringBuilder& decls, StringBuilder& rules) const
+void CSSStyleRule::cssTextForDeclsAndRules(StringBuilder&, StringBuilder& rules) const
 {
-    for (unsigned index = 0 ; index < nestedRules().size() ; index++) {
-        // We put the declarations at the upper level when the rule:
-        // - is a style rule
-        // - has just "&" as selector
-        // - has no child rules
-        auto childRule = nestedRules()[index];
-        if (childRule->isStyleRuleWithNesting()) {
-            auto& nestedStyleRule = downcast<StyleRuleWithNesting>(childRule);
-            if (nestedStyleRule.originalSelectorList().hasOnlyNestingSelector() && nestedStyleRule.nestedRules().isEmpty()) {
-                decls.append(nestedStyleRule.properties().asText());
-                continue;
-            }
-        }
-        // Otherwise we print the child rule
-        auto wrappedRule = item(index);
-        rules.append("\n  ", wrappedRule->cssText());
-    }
+    for (unsigned index = 0 ; index < nestedRules().size() ; index++)
+        rules.append("\n  ", item(index)->cssText());
 }
+
+// FIXME: share all methods below with CSSGroupingRule.
 
 void CSSStyleRule::reattach(StyleRuleBase& rule)
 {


### PR DESCRIPTION
#### e07871e21ea87327296cc3bc0003266655fa1bc0
<pre>
[CSS Nesting] Don&apos;t serialize first implicit style rule inside group rule
<a href="https://bugs.webkit.org/show_bug.cgi?id=256647">https://bugs.webkit.org/show_bug.cgi?id=256647</a>
rdar://109208359

Reviewed by Antti Koivisto.

Orphaned properties in group rule are implicitly added
to a style rule with &apos;&amp;&apos; as selector ;
this implicit style rule should not be serialized.

* LayoutTests/imported/w3c/web-platform-tests/css/css-nesting/parsing-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-nesting/parsing.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-nesting/serialize-group-rules-with-decls.tentative-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-nesting/serialize-group-rules-with-decls.tentative.html:

 Import from WPT

* Source/WebCore/css/CSSGroupingRule.cpp:
(WebCore::CSSGroupingRule::appendCSSTextForItems const):
(WebCore::CSSGroupingRule::cssTextForDeclsAndRules const):
* Source/WebCore/css/CSSStyleRule.cpp:
(WebCore::CSSStyleRule::cssTextForDeclsAndRules const):

This behavior only concerns group rule, not style rule (where a property can&apos;t be orphaned)

Canonical link: <a href="https://commits.webkit.org/264003@main">https://commits.webkit.org/264003@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5c8e400d0cace044705e488042aa9d6414d2968c

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/6267 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/6462 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/6641 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/7840 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/6596 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/6270 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/6682 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/6412 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/9491 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/6379 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/6390 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/5675 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/7910 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/3862 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/5654 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/13545 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/5726 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/5737 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/7984 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/6217 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/5085 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/5629 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/5582 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/1506 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/9782 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/5997 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->