### PR TITLE
Stop treating text/xsl as an XML MIME type

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/xhr/responsexml-media-type-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/xhr/responsexml-media-type-expected.txt
@@ -9,7 +9,7 @@ PASS XMLHttpRequest: responseXML MIME type tests ('video/x-awesome+xml', should 
 PASS XMLHttpRequest: responseXML MIME type tests ('video/x-awesome', should not parse)
 PASS XMLHttpRequest: responseXML MIME type tests ('text/xml', should  parse)
 PASS XMLHttpRequest: responseXML MIME type tests ('application', should  parse)
-FAIL XMLHttpRequest: responseXML MIME type tests ('text/xsl', should not parse) assert_equals: expected null but got Document node with 1 child
+PASS XMLHttpRequest: responseXML MIME type tests ('text/xsl', should not parse)
 PASS XMLHttpRequest: responseXML MIME type tests ('text/plain', should not parse)
 PASS XMLHttpRequest: responseXML MIME type tests ('application/rdf', should not parse)
 PASS XMLHttpRequest: responseXML MIME type tests ('application/xhtml+xml', should  parse)

--- a/Source/WebCore/platform/MIMETypeRegistry.cpp
+++ b/Source/WebCore/platform/MIMETypeRegistry.cpp
@@ -603,7 +603,7 @@ static inline bool isValidXMLMIMETypeChar(UChar c)
 
 bool MIMETypeRegistry::isXMLMIMEType(const String& mimeType)
 {
-    if (equalLettersIgnoringASCIICase(mimeType, "text/xml"_s) || equalLettersIgnoringASCIICase(mimeType, "application/xml"_s) || equalLettersIgnoringASCIICase(mimeType, "text/xsl"_s))
+    if (equalLettersIgnoringASCIICase(mimeType, "text/xml"_s) || equalLettersIgnoringASCIICase(mimeType, "application/xml"_s))
         return true;
 
     if (!mimeType.endsWithIgnoringASCIICase("+xml"_s))


### PR DESCRIPTION
#### 2e9eb9b159ee5067d6be3de57ceaef8da6a141af
<pre>
Stop treating text/xsl as an XML MIME type
<a href="https://bugs.webkit.org/show_bug.cgi?id=256649">https://bugs.webkit.org/show_bug.cgi?id=256649</a>
rdar://109211253

Reviewed by NOBODY (OOPS!).

As the MIME Sniffing Standard requires and other browser behave.

* LayoutTests/imported/w3c/web-platform-tests/xhr/responsexml-media-type-expected.txt:
* Source/WebCore/platform/MIMETypeRegistry.cpp:
(WebCore::MIMETypeRegistry::isXMLMIMEType):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2e9eb9b159ee5067d6be3de57ceaef8da6a141af

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/6263 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/6458 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/6637 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/7836 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/6593 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/6266 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/6678 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/6408 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/9490 "1 missing results 107 failures") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/6375 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/6389 "2 new passes 4 flakes 6 failures") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/5674 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/7906 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/3861 "Passed tests") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/5653 "4 failures") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/13544 "2 flakes 1 missing results 122 failures") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/5725 "Passed tests") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/5736 "4 failures") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/7983 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/6213 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/5084 "1 failures") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/5625 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/9778 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/5993 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->