### PR TITLE
Mark ScrollingNodes as dirty as optimization for scrolling tree commit

### DIFF
--- a/Source/WebCore/page/scrolling/ScrollingStateNode.h
+++ b/Source/WebCore/page/scrolling/ScrollingStateNode.h
@@ -207,58 +207,59 @@ enum class ScrollingStateNodeProperty : uint64_t {
     // ScrollingStateNode
     Layer                                       = 1LLU << 0,
     ChildNodes                                  = 1LLU << 1,
+    HasDirtyChildNode                           = 1LLU << 2,
     // ScrollingStateScrollingNode
-    ScrollableAreaSize                          = 1LLU << 2,
-    TotalContentsSize                           = 1LLU << 3,
-    ReachableContentsSize                       = 1LLU << 4,
-    ScrollPosition                              = 1LLU << 5,
-    ScrollOrigin                                = 1LLU << 6,
-    ScrollableAreaParams                        = 1LLU << 7,
-    ReasonsForSynchronousScrolling              = 1LLU << 8,
-    RequestedScrollPosition                     = 1LLU << 9,
-    SnapOffsetsInfo                             = 1LLU << 10,
-    CurrentHorizontalSnapOffsetIndex            = 1LLU << 11,
-    CurrentVerticalSnapOffsetIndex              = 1LLU << 12,
-    IsMonitoringWheelEvents                     = 1LLU << 13,
-    ScrollContainerLayer                        = 1LLU << 14,
-    ScrolledContentsLayer                       = 1LLU << 15,
-    HorizontalScrollbarLayer                    = 1LLU << 16,
-    VerticalScrollbarLayer                      = 1LLU << 17,
-    PainterForScrollbar                         = 1LLU << 18,
-    ContentAreaHoverState                       = 1LLU << 19,
-    MouseActivityState                          = 1LLU << 20,
-    ScrollbarHoverState                         = 1LLU << 21,
+    ScrollableAreaSize                          = 1LLU << 3,
+    TotalContentsSize                           = 1LLU << 4,
+    ReachableContentsSize                       = 1LLU << 5,
+    ScrollPosition                              = 1LLU << 6,
+    ScrollOrigin                                = 1LLU << 7,
+    ScrollableAreaParams                        = 1LLU << 8,
+    ReasonsForSynchronousScrolling              = 1LLU << 9,
+    RequestedScrollPosition                     = 1LLU << 10,
+    SnapOffsetsInfo                             = 1LLU << 11,
+    CurrentHorizontalSnapOffsetIndex            = 1LLU << 12,
+    CurrentVerticalSnapOffsetIndex              = 1LLU << 13,
+    IsMonitoringWheelEvents                     = 1LLU << 14,
+    ScrollContainerLayer                        = 1LLU << 15,
+    ScrolledContentsLayer                       = 1LLU << 16,
+    HorizontalScrollbarLayer                    = 1LLU << 17,
+    VerticalScrollbarLayer                      = 1LLU << 18,
+    PainterForScrollbar                         = 1LLU << 19,
+    ContentAreaHoverState                       = 1LLU << 20,
+    MouseActivityState                          = 1LLU << 21,
+    ScrollbarHoverState                         = 1LLU << 22,
     // ScrollingStateFrameScrollingNode
-    FrameScaleFactor                            = 1LLU << 22,
-    EventTrackingRegion                         = 1LLU << 23,
-    RootContentsLayer                           = 1LLU << 24,
-    CounterScrollingLayer                       = 1LLU << 25,
-    InsetClipLayer                              = 1LLU << 26,
-    ContentShadowLayer                          = 1LLU << 27,
-    HeaderHeight                                = 1LLU << 28,
-    FooterHeight                                = 1LLU << 29,
-    HeaderLayer                                 = 1LLU << 30,
-    FooterLayer                                 = 1LLU << 31,
-    BehaviorForFixedElements                    = 1LLU << 32,
-    TopContentInset                             = 1LLU << 33,
-    FixedElementsLayoutRelativeToFrame          = 1LLU << 34,
-    VisualViewportIsSmallerThanLayoutViewport   = 1LLU << 35,
-    AsyncFrameOrOverflowScrollingEnabled        = 1LLU << 36,
-    WheelEventGesturesBecomeNonBlocking         = 1LLU << 37,
-    ScrollingPerformanceTestingEnabled          = 1LLU << 38,
-    LayoutViewport                              = 1LLU << 39,
-    MinLayoutViewportOrigin                     = 1LLU << 40,
-    MaxLayoutViewportOrigin                     = 1LLU << 41,
-    OverrideVisualViewportSize                  = 1LLU << 42,
-    OverlayScrollbarsEnabled                    = 1LLU << 43,
+    FrameScaleFactor                            = 1LLU << 23,
+    EventTrackingRegion                         = 1LLU << 24,
+    RootContentsLayer                           = 1LLU << 25,
+    CounterScrollingLayer                       = 1LLU << 26,
+    InsetClipLayer                              = 1LLU << 27,
+    ContentShadowLayer                          = 1LLU << 28,
+    HeaderHeight                                = 1LLU << 29,
+    FooterHeight                                = 1LLU << 30,
+    HeaderLayer                                 = 1LLU << 31,
+    FooterLayer                                 = 1LLU << 32,
+    BehaviorForFixedElements                    = 1LLU << 33,
+    TopContentInset                             = 1LLU << 34,
+    FixedElementsLayoutRelativeToFrame          = 1LLU << 35,
+    VisualViewportIsSmallerThanLayoutViewport   = 1LLU << 36,
+    AsyncFrameOrOverflowScrollingEnabled        = 1LLU << 37,
+    WheelEventGesturesBecomeNonBlocking         = 1LLU << 38,
+    ScrollingPerformanceTestingEnabled          = 1LLU << 39,
+    LayoutViewport                              = 1LLU << 40,
+    MinLayoutViewportOrigin                     = 1LLU << 41,
+    MaxLayoutViewportOrigin                     = 1LLU << 42,
+    OverrideVisualViewportSize                  = 1LLU << 43,
+    OverlayScrollbarsEnabled                    = 1LLU << 44,
     // ScrollingStatePositionedNode
-    RelatedOverflowScrollingNodes               = 1LLU << 44,
-    LayoutConstraintData                        = 1LLU << 45,
+    RelatedOverflowScrollingNodes               = 1LLU << 45,
+    LayoutConstraintData                        = 1LLU << 46,
     // ScrollingStateFixedNode, ScrollingStateStickyNode
-    ViewportConstraints                         = 1LLU << 46,
+    ViewportConstraints                         = 1LLU << 47,
     // ScrollingStateOverflowScrollProxyNode
-    OverflowScrollingNode                       = 1LLU << 47,
-    KeyboardScrollData                          = 1LLU << 48,
+    OverflowScrollingNode                       = 1LLU << 48,
+    KeyboardScrollData                          = 1LLU << 49,
 };
 
 class ScrollingStateNode : public ThreadSafeRefCountedAndCanMakeThreadSafeWeakPtr<ScrollingStateNode> {
@@ -285,7 +286,7 @@ public:
     
     bool hasChangedProperties() const { return !m_changedProperties.isEmpty(); }
     bool hasChangedProperty(Property property) const { return m_changedProperties.contains(property); }
-    void resetChangedProperties() { m_changedProperties = { }; }
+    void resetChangedProperties() { /* WTFLogAlways("ScrollingStateNode::resetChangedProperties: %llu", m_nodeID);*/  m_hasDirtyChildNode = false; m_changedProperties = { }; }
     void setPropertyChanged(Property);
 
     virtual void setPropertyChangesAfterReattach();
@@ -326,6 +327,9 @@ public:
 
     String scrollingStateTreeAsText(OptionSet<ScrollingStateTreeAsTextBehavior> = { }) const;
 
+    WEBCORE_EXPORT void setHasDirtyChildNode(bool flag);
+    bool hasDirtyChildNode() const { return m_hasDirtyChildNode; }
+
 protected:
     ScrollingStateNode(const ScrollingStateNode&, ScrollingStateTree&);
     ScrollingStateNode(ScrollingNodeType, ScrollingStateTree&, ScrollingNodeID);
@@ -338,6 +342,7 @@ protected:
 
 private:
     void dump(WTF::TextStream&, OptionSet<ScrollingStateTreeAsTextBehavior>) const;
+    void setDirtyBitForAncestorChain();
 
     const ScrollingNodeType m_nodeType;
     const ScrollingNodeID m_nodeID;
@@ -347,6 +352,8 @@ private:
 
     ThreadSafeWeakPtr<ScrollingStateNode> m_parent;
     std::unique_ptr<Vector<RefPtr<ScrollingStateNode>>> m_children;
+
+    bool m_hasDirtyChildNode { false };
 
     LayerRepresentation m_layer;
 #if ENABLE(INTERACTION_REGIONS_IN_EVENT_REGION)

--- a/Source/WebCore/page/scrolling/ScrollingStateTree.cpp
+++ b/Source/WebCore/page/scrolling/ScrollingStateTree.cpp
@@ -250,6 +250,7 @@ void ScrollingStateTree::unparentChildrenAndDestroyNode(ScrollingNodeID nodeID)
         }
     }
     
+    m_nodesRemovedSinceLastCommit.add(nodeID);
     protectedNode->removeFromParent();
     m_unparentedNodes.remove(nodeID);
     willRemoveNode(*protectedNode);
@@ -300,6 +301,7 @@ std::unique_ptr<ScrollingStateTree> ScrollingStateTree::commit(LayerRepresentati
     // Now the clone tree has changed properties, and the original tree does not.
     treeStateClone->m_hasChangedProperties = std::exchange(m_hasChangedProperties, false);
     treeStateClone->m_hasNewRootStateNode = std::exchange(m_hasNewRootStateNode, false);
+    treeStateClone->m_nodesRemovedSinceLastCommit = std::exchange(m_nodesRemovedSinceLastCommit, { });
 
     return treeStateClone;
 }

--- a/Source/WebCore/page/scrolling/ScrollingStateTree.h
+++ b/Source/WebCore/page/scrolling/ScrollingStateTree.h
@@ -87,6 +87,9 @@ public:
 
     String scrollingStateTreeAsText(OptionSet<ScrollingStateTreeAsTextBehavior>) const;
 
+    HashSet<ScrollingNodeID> nodesRemovedSinceLastCommit() { return m_nodesRemovedSinceLastCommit; }
+    void setNodesRemovedSinceLastCommit(HashSet<ScrollingNodeID> nodes) { m_nodesRemovedSinceLastCommit = nodes; }
+
 private:
     void setRootStateNode(Ref<ScrollingStateFrameScrollingNode>&&);
     void addNode(ScrollingStateNode&);
@@ -101,6 +104,7 @@ private:
     bool isValid() const;
     void traverse(const ScrollingStateNode&, const Function<void(const ScrollingStateNode&)>&) const;
 
+    HashSet<ScrollingNodeID> m_nodesRemovedSinceLastCommit;
     AsyncScrollingCoordinator* m_scrollingCoordinator;
     // Contains all the nodes we know about (those in the m_rootStateNode tree, and in m_unparentedNodes subtrees).
     StateNodeMap m_stateNodeMap;

--- a/Source/WebCore/page/scrolling/ScrollingTree.h
+++ b/Source/WebCore/page/scrolling/ScrollingTree.h
@@ -300,6 +300,8 @@ private:
 
     RelatedNodesMap m_overflowRelatedNodesMap;
 
+    HashSet<ScrollingNodeID> m_nodesScrolledSinceLastCommit;
+
     HashSet<Ref<ScrollingTreeOverflowScrollProxyNode>> m_activeOverflowScrollProxyNodes;
     HashSet<Ref<ScrollingTreePositionedNode>> m_activePositionedNodes;
 

--- a/Source/WebCore/page/scrolling/ScrollingTreeNode.h
+++ b/Source/WebCore/page/scrolling/ScrollingTreeNode.h
@@ -72,7 +72,6 @@ public:
 
     virtual bool commitStateBeforeChildren(const ScrollingStateNode&) = 0;
     virtual bool commitStateAfterChildren(const ScrollingStateNode&) { return true; }
-    virtual void didCompleteCommitForNode() { }
     
     virtual void willBeDestroyed() { }
 

--- a/Source/WebCore/page/scrolling/ScrollingTreeScrollingNode.cpp
+++ b/Source/WebCore/page/scrolling/ScrollingTreeScrollingNode.cpp
@@ -125,11 +125,6 @@ bool ScrollingTreeScrollingNode::commitStateAfterChildren(const ScrollingStateNo
     return true;
 }
 
-void ScrollingTreeScrollingNode::didCompleteCommitForNode()
-{
-    m_scrolledSinceLastCommit = false;
-}
-
 bool ScrollingTreeScrollingNode::isLatchedNode() const
 {
     return scrollingTree().latchedNodeID() == scrollingNodeID();
@@ -359,7 +354,6 @@ void ScrollingTreeScrollingNode::scrollTo(const FloatPoint& position, ScrollType
 
 void ScrollingTreeScrollingNode::currentScrollPositionChanged(ScrollType, ScrollingLayerPositionAction action)
 {
-    m_scrolledSinceLastCommit = true;
     scrollingTree().scrollingTreeNodeDidScroll(*this, action);
 }
 

--- a/Source/WebCore/page/scrolling/ScrollingTreeScrollingNode.h
+++ b/Source/WebCore/page/scrolling/ScrollingTreeScrollingNode.h
@@ -61,7 +61,6 @@ public:
 
     bool commitStateBeforeChildren(const ScrollingStateNode&) override;
     bool commitStateAfterChildren(const ScrollingStateNode&) override;
-    void didCompleteCommitForNode() final;
 
     virtual bool canHandleWheelEvent(const PlatformWheelEvent&, EventTargeting) const;
     virtual WheelEventHandlingResult handleWheelEvent(const PlatformWheelEvent&, EventTargeting = EventTargeting::Propagate);
@@ -123,8 +122,6 @@ public:
 
     bool eventCanScrollContents(const PlatformWheelEvent&) const;
     
-    bool scrolledSinceLastCommit() const { return m_scrolledSinceLastCommit; }
-
     const LayerRepresentation& scrollContainerLayer() const { return m_scrollContainerLayer; }
     const LayerRepresentation& scrolledContentsLayer() const { return m_scrolledContentsLayer; }
     
@@ -204,7 +201,6 @@ private:
     OptionSet<SynchronousScrollingReason> m_synchronousScrollingReasons;
 #endif
     bool m_isFirstCommit { true };
-    bool m_scrolledSinceLastCommit { false };
 
     LayerRepresentation m_scrollContainerLayer;
     LayerRepresentation m_scrolledContentsLayer;

--- a/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
+++ b/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
@@ -3060,6 +3060,7 @@ header: <WebCore/ScrollingStateNode.h>
 [OptionSet] enum class WebCore::ScrollingStateNodeProperty : uint64_t {
     Layer
     ChildNodes
+    HasDirtyChildNode
     ScrollableAreaSize
     TotalContentsSize
     ReachableContentsSize


### PR DESCRIPTION
#### 358ba2e1aa61dd81e74a781ffe044bf21add45e3
<pre>
Mark ScrollingNodes as dirty as optimization for scrolling tree commit
<a href="https://bugs.webkit.org/show_bug.cgi?id=256655">https://bugs.webkit.org/show_bug.cgi?id=256655</a>
rdar://109218372

Reviewed by NOBODY (OOPS!).

When a property on a ScrollingNode is changed, iterate up the ancestor
chain and mark each node as having a child with a changed property. When
committing the scrolling tree, ignore the branches with a node without
having a child with an update. The previous commit code used an unvisited
nodes vector to know when a node was removed. Since this requires visiting
every node, replace this with a vector on the scrolling state tree that tracks
nodes removed since the last commit. Remove use of univsited nodes list in favor
of using this new list of removed nodes. ScrollingStateNodes also had a property
m_scrolledSinceLastCommit. Since not every node is visited anymore, create a new
map on ScrollingTree m_nodesScrolledSinceLastCommit, which is added to after each
node is scrolled and cleared after each commit. There is still work needed for
OverflowScrollProxyNodes, as the maps containing active proxy nodes and their
related nodes are invalidated after each commit, and expect that we recreate them
as we iterate through the tree. We need a similar fix for positioned nodes as well.

* Source/WebCore/page/scrolling/ScrollingStateNode.cpp:
(WebCore::ScrollingStateNode::ScrollingStateNode):
(WebCore::ScrollingStateNode::setPropertyChanged):
(WebCore::ScrollingStateNode::setDirtyBitForAncestorChain):
(WebCore::ScrollingStateNode::dumpProperties const):
* Source/WebCore/page/scrolling/ScrollingStateNode.h:
(WebCore::ScrollingStateNode::resetChangedProperties):
(WebCore::ScrollingStateNode::setDirty):
(WebCore::ScrollingStateNode::hasDirtyChildren const):
* Source/WebCore/page/scrolling/ScrollingTree.cpp:
(WebCore::ScrollingTree::commitTreeState):
(WebCore::ScrollingTree::updateTreeFromStateNodeRecursive):
* Source/WebKit/Shared/RemoteLayerTree/RemoteScrollingCoordinatorTransaction.cpp:
(ArgumentCoder&lt;ScrollingStateScrollingNode&gt;::encode):
(ArgumentCoder&lt;ScrollingStateScrollingNode&gt;::decode):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/358ba2e1aa61dd81e74a781ffe044bf21add45e3

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/10104 "1 style error") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/10348 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/10601 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/11755 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/9788 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/10113 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/12338 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/10300 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/12707 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/10259 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/11027 "2 new passes 8 flakes 6 failures") | [❌ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/8544 "55 api tests failed or timed out") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/12140 "Built successfully") | 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/8332 "8 flakes 3 failures") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/9155 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/16470 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/9433 "Passed tests") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/9306 "3 failures") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/12567 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/9790 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/7952 "3 failures") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/8949 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/13187 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/9591 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->