### PR TITLE
Media Stats should show the media element's source

### DIFF
--- a/Source/WebCore/Modules/mediacontrols/MediaControlsHost.cpp
+++ b/Source/WebCore/Modules/mediacontrols/MediaControlsHost.cpp
@@ -770,6 +770,36 @@ bool MediaControlsHost::showMediaControlsContextMenu(HTMLElement& target, String
 
 #endif // ENABLE(MEDIA_CONTROLS_CONTEXT_MENUS)
 
+auto MediaControlsHost::sourceType() const -> std::optional<SourceType>
+{
+    if (!m_mediaElement)
+        return std::nullopt;
+
+    if (m_mediaElement->hasMediaStreamSource())
+        return SourceType::MediaStream;
+
+#if ENABLE(MANAGED_MEDIA_SOURCE)
+    if (m_mediaElement->hasManagedMediaSource())
+        return SourceType::ManagedMediaSource;
+#endif
+
+#if ENABLE(MEDIA_SOURCE)
+    if (m_mediaElement->hasMediaSource())
+        return SourceType::MediaSource;
+#endif
+
+    switch (m_mediaElement->movieLoadType()) {
+    case HTMLMediaElement::MovieLoadType::Unknown: return std::nullopt;
+    case HTMLMediaElement::MovieLoadType::Download: return SourceType::File;
+    case HTMLMediaElement::MovieLoadType::StoredStream: return SourceType::LiveStream;
+    case HTMLMediaElement::MovieLoadType::LiveStream: return SourceType::StoredStream;
+    case HTMLMediaElement::MovieLoadType::HttpLiveStream: return SourceType::HLS;
+    }
+
+    ASSERT_NOT_REACHED();
+    return std::nullopt;
+}
+
 #endif // ENABLE(MODERN_MEDIA_CONTROLS)
 
 } // namespace WebCore

--- a/Source/WebCore/Modules/mediacontrols/MediaControlsHost.h
+++ b/Source/WebCore/Modules/mediacontrols/MediaControlsHost.h
@@ -105,6 +105,18 @@ public:
 #endif // ENABLE(MEDIA_CONTROLS_CONTEXT_MENUS)
 #endif // ENABLE(MODERN_MEDIA_CONTROLS)
 
+    enum class SourceType : uint8_t {
+        File,
+        HLS,
+        MediaSource,
+        ManagedMediaSource,
+        MediaStream,
+        LiveStream,
+        StoredStream,
+    };
+
+    std::optional<SourceType> sourceType() const;
+
 private:
     explicit MediaControlsHost(HTMLMediaElement&);
 

--- a/Source/WebCore/Modules/mediacontrols/MediaControlsHost.idl
+++ b/Source/WebCore/Modules/mediacontrols/MediaControlsHost.idl
@@ -29,6 +29,16 @@ enum DeviceType {
     "tvout"
 };
 
+enum SourceType {
+    "file",
+    "hls",
+    "media-source",
+    "managed-media-source",
+    "media-stream",
+    "live-stream",
+    "stored-stream",
+};
+
 [
     Conditional=MEDIA_CONTROLS_SCRIPT,
     LegacyNoInterfaceObject,
@@ -62,6 +72,8 @@ enum DeviceType {
     undefined exitedFullscreen();
 
     DOMString generateUUID();
+
+    readonly attribute SourceType? sourceType;
 
     [Conditional=MODERN_MEDIA_CONTROLS] readonly attribute DOMString shadowRootCSSText;
     [Conditional=MODERN_MEDIA_CONTROLS] DOMString base64StringForIconNameAndType(DOMString iconName, DOMString iconType);

--- a/Source/WebCore/Modules/modern-media-controls/media/media-controller.js
+++ b/Source/WebCore/Modules/modern-media-controls/media/media-controller.js
@@ -235,6 +235,7 @@ class MediaController
             let valueElement = rowElement.appendChild(document.createElement("td"));
             return valueElement;
         }
+        let sourceValueElement = createRow(UIString("Source"));
         let viewportValueElement = createRow(UIString("Viewport"));
         let framesValueElement = createRow(UIString("Frames"));
         let resolutionValueElement = createRow(UIString("Resolution"));
@@ -250,6 +251,7 @@ class MediaController
             let videoTrackConfiguration = videoTrack.configuration;
             let videoColorSpace = videoTrackConfiguration?.colorSpace;
 
+            sourceValueElement.textContent = UIString(this.host.sourceType ?? "none");
             viewportValueElement.textContent = UIString("%s\u00d7%s", this.controls.width, this.controls.height) + (window.devicePixelRatio !== 1 ? " " + UIString("(%s)", UIString("%s\u00d7", window.devicePixelRatio)) : "");
             framesValueElement.textContent = UIString("%s dropped of %s", quality.droppedVideoFrames, quality.totalVideoFrames);
             resolutionValueElement.textContent = UIString("%s\u00d7%s", videoTrackConfiguration?.width, videoTrackConfiguration?.height) + " " + UIString("(%s)", UIString("%sfps", Math.round(videoTrackConfiguration?.framerate * 1000) / 1000));

--- a/Source/WebCore/bindings/scripts/CodeGenerator.pm
+++ b/Source/WebCore/bindings/scripts/CodeGenerator.pm
@@ -986,6 +986,7 @@ sub WK_ucfirst
     $ret =~ s/Pq/PQ/ if $ret =~ /^Pq$/;
     $ret =~ s/Hlg/HLG/ if $ret =~ /^Hlg/;
     $ret =~ s/Ios/iOS/ if $ret =~ /^Ios/;
+    $ret =~ s/Hls/HLS/ if $ret =~ /^Hls/;
 
     return $ret;
 }

--- a/Source/WebCore/en.lproj/modern-media-controls-localized-strings.js
+++ b/Source/WebCore/en.lproj/modern-media-controls-localized-strings.js
@@ -40,4 +40,11 @@ var UIStrings = {
     "Unmute": "Unmute",
     "Video Controls": "Video Controls",
     "Viewport": "Viewport",
+    "file": "File",
+    "hls": "HLS",
+    "media-source": "Media Source",
+    "managed-media-source": "Managed Media Source",
+    "media-stream": "Media Stream",
+    "live-stream": "Live Stream",
+    "stored-stream": "Stored Stream",
 };

--- a/Source/WebCore/html/HTMLMediaElement.cpp
+++ b/Source/WebCore/html/HTMLMediaElement.cpp
@@ -4148,6 +4148,24 @@ void HTMLMediaElement::pauseInternal()
     updatePlayState();
 }
 
+bool HTMLMediaElement::hasMediaSource() const
+{
+#if ENABLE(MEDIA_SOURCE)
+    return m_mediaSource;
+#else
+    return false;
+#endif
+}
+
+bool HTMLMediaElement::hasManagedMediaSource() const
+{
+#if ENABLE(MANAGED_MEDIA_SOURCE)
+    return is<ManagedMediaSource>(m_mediaSource);
+#else
+    return false;
+#endif
+}
+
 #if ENABLE(MEDIA_SOURCE)
 
 void HTMLMediaElement::detachMediaSource()

--- a/Source/WebCore/html/HTMLMediaElement.h
+++ b/Source/WebCore/html/HTMLMediaElement.h
@@ -969,6 +969,9 @@ private:
     void hardwareMutedStateDidChange(const AudioSession&) final;
 #endif
 
+    bool hasMediaSource() const;
+    bool hasManagedMediaSource() const;
+
     bool processingUserGestureForMedia() const;
 
     bool effectiveMuted() const;

--- a/Source/WebCore/platform/graphics/MediaPlayerEnums.h
+++ b/Source/WebCore/platform/graphics/MediaPlayerEnums.h
@@ -51,7 +51,8 @@ enum class MediaPlayerMovieLoadType : uint8_t {
     Unknown,
     Download,
     StoredStream,
-    LiveStream
+    LiveStream,
+    HttpLiveStream,
 };
 
 enum class MediaPlayerPreload : uint8_t {

--- a/Source/WebCore/platform/graphics/avfoundation/MediaPlayerPrivateAVFoundation.cpp
+++ b/Source/WebCore/platform/graphics/avfoundation/MediaPlayerPrivateAVFoundation.cpp
@@ -711,6 +711,9 @@ MediaPlayer::MovieLoadType MediaPlayerPrivateAVFoundation::movieLoadType() const
     if (!metaDataAvailable() || assetStatus() == MediaPlayerAVAssetStatusUnknown)
         return MediaPlayer::MovieLoadType::Unknown;
 
+    if (isHLS())
+        return MediaPlayer::MovieLoadType::HttpLiveStream;
+
     if (isLiveStream())
         return MediaPlayer::MovieLoadType::LiveStream;
 

--- a/Source/WebCore/platform/graphics/avfoundation/MediaPlayerPrivateAVFoundation.h
+++ b/Source/WebCore/platform/graphics/avfoundation/MediaPlayerPrivateAVFoundation.h
@@ -272,6 +272,8 @@ protected:
     virtual void updateVideoLayerGravity() = 0;
     virtual void resolvedURLChanged() = 0;
 
+    virtual bool isHLS() const { return false; }
+
     static bool isUnsupportedMIMEType(const String&);
     static const HashSet<String, ASCIICaseInsensitiveHash>& staticMIMETypeList();
 

--- a/Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateAVFoundationObjC.h
+++ b/Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateAVFoundationObjC.h
@@ -223,6 +223,8 @@ private:
     void sizeChanged() final;
     void resolvedURLChanged() final;
 
+    bool isHLS() const { return m_cachedAssetIsHLS.value_or(false); }
+
     bool hasAvailableVideoFrame() const final;
 
     void createContextVideoRenderer() final;
@@ -465,6 +467,7 @@ private:
     mutable bool m_cachedTracksAreLoaded { false };
     mutable std::optional<bool> m_cachedAssetIsPlayable;
     mutable std::optional<bool> m_cachedTracksArePlayable;
+    mutable std::optional<bool> m_cachedAssetIsHLS;
     bool m_muted { false };
     bool m_shouldObserveTimeControlStatus { false };
     mutable std::optional<bool> m_tracksArePlayable;

--- a/Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateAVFoundationObjC.mm
+++ b/Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateAVFoundationObjC.mm
@@ -1958,6 +1958,9 @@ MediaPlayerPrivateAVFoundation::AssetStatus MediaPlayerPrivateAVFoundationObjC::
             return MediaPlayerAVAssetStatusLoading;
     }
 
+    if (!m_cachedAssetIsHLS)
+        m_cachedAssetIsHLS = [[m_avAsset variants] count] > 0;
+
     if (!m_cachedAssetIsPlayable)
         m_cachedAssetIsPlayable = [[m_avAsset valueForKey:@"playable"] boolValue] || containsDisabledTracks();
 
@@ -3900,6 +3903,7 @@ NSArray* assetMetadataKeyNames()
         @"tracks",
         @"availableMediaCharacteristicsWithMediaSelectionOptions",
         @"availableChapterLocales",
+        @"variants",
     nil];
     return keys;
 }

--- a/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
+++ b/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
@@ -3369,7 +3369,8 @@ enum class WebCore::MediaPlayerMovieLoadType : uint8_t {
     Unknown,
     Download,
     StoredStream,
-    LiveStream
+    LiveStream,
+    HttpLiveStream
 };
 
 enum class WebCore::MediaPlayerPreload : uint8_t {


### PR DESCRIPTION
#### 0ee37c4333af683443d1934d4cbb137bfcc7cb26
<pre>
Media Stats should show the media element&apos;s source
<a href="https://bugs.webkit.org/show_bug.cgi?id=256657">https://bugs.webkit.org/show_bug.cgi?id=256657</a>
rdar://109219273

Reviewed by Eric Carlson.

Media Stats currently shows a lot of great information about the codecs and properties of the
media element&apos;s video and audio tracks. Also useful would be information about the element itself,
such as whether it&apos;s current source was a file, stream, media source, etc.

Add a new attribute to MediaControlsHost which vends this information up to the media controls. Add
support for detecting whether the AVURLAsset is backed by a HLS stream to MediaplayerPrivateAVFoundationObjC.

* Source/WebCore/Modules/mediacontrols/MediaControlsHost.cpp:
(WebCore::MediaControlsHost::sourceType const):
* Source/WebCore/Modules/mediacontrols/MediaControlsHost.h:
* Source/WebCore/Modules/mediacontrols/MediaControlsHost.idl:
* Source/WebCore/Modules/modern-media-controls/media/media-controller.js:
(MediaController.prototype.setShowingStats):
* Source/WebCore/bindings/scripts/CodeGenerator.pm:
(WK_ucfirst):
* Source/WebCore/en.lproj/modern-media-controls-localized-strings.js:
* Source/WebCore/platform/graphics/MediaPlayerEnums.h:
* Source/WebCore/platform/graphics/avfoundation/MediaPlayerPrivateAVFoundation.cpp:
(WebCore::MediaPlayerPrivateAVFoundation::movieLoadType const):
* Source/WebCore/platform/graphics/avfoundation/MediaPlayerPrivateAVFoundation.h:
(WebCore::MediaPlayerPrivateAVFoundation::isHLS const):
* Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateAVFoundationObjC.h:
* Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateAVFoundationObjC.mm:
(WebCore::MediaPlayerPrivateAVFoundationObjC::assetStatus const):
(WebCore::assetMetadataKeyNames):
* Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in:

Canonical link: <a href="https://commits.webkit.org/264293@main">https://commits.webkit.org/264293@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/34667271eaae7098e492f8ec036e6c4281373651

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/6317 "1 style error") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/6514 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/6693 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/7892 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/6639 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/6318 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/6734 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/6463 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/9544 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/6429 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/6435 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/5721 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/7963 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/3907 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/5701 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/13586 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/5771 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/5784 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/8035 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/6266 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/5123 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/5676 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/1719 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/9831 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/6047 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->