### PR TITLE
Deploy LayoutDisallowedScope in LayoutPhase::InRenderTreeLayout

### DIFF
--- a/Source/WebCore/page/LocalFrameViewLayoutContext.cpp
+++ b/Source/WebCore/page/LocalFrameViewLayoutContext.cpp
@@ -192,7 +192,7 @@ void LocalFrameViewLayoutContext::layout()
 void LocalFrameViewLayoutContext::performLayout()
 {
     RELEASE_ASSERT_WITH_SECURITY_IMPLICATION(!frame().document()->inRenderTreeUpdate());
-    ASSERT(LayoutDisallowedScope::isLayoutAllowed());
+    RELEASE_ASSERT(LayoutDisallowedScope::isLayoutAllowed());
     ASSERT(!view().isPainting());
     ASSERT(frame().view() == &view());
     ASSERT(frame().document());
@@ -246,6 +246,7 @@ void LocalFrameViewLayoutContext::performLayout()
     {
         SetForScope layoutPhase(m_layoutPhase, LayoutPhase::InRenderTreeLayout);
         ScriptDisallowedScope::InMainThread scriptDisallowedScope;
+        LayoutDisallowedScope layoutDisallowedScope(LayoutDisallowedScope::Reason::ReentrancyAvoidance);
         SubtreeLayoutStateMaintainer subtreeLayoutStateMaintainer(subtreeLayoutRoot());
         RenderView::RepaintRegionAccumulator repaintRegionAccumulator(renderView());
 #ifndef NDEBUG

--- a/Source/WebCore/rendering/LayoutDisallowedScope.cpp
+++ b/Source/WebCore/rendering/LayoutDisallowedScope.cpp
@@ -28,10 +28,6 @@
 
 namespace WebCore {
 
-#if ASSERT_ENABLED
-
-LayoutDisallowedScope* LayoutDisallowedScope::s_currentAssertion = nullptr;
-
-#endif
+unsigned LayoutDisallowedScope::s_currentScopeCount = 0;
 
 }

--- a/Source/WebCore/svg/graphics/SVGImage.cpp
+++ b/Source/WebCore/svg/graphics/SVGImage.cpp
@@ -39,6 +39,7 @@
 #include "ImageObserver.h"
 #include "IntRect.h"
 #include "JSDOMWindowBase.h"
+#include "LayoutDisallowedScope.h"
 #include "LegacyRenderSVGRoot.h"
 #include "LocalDOMWindow.h"
 #include "LocalFrame.h"
@@ -190,6 +191,8 @@ ImageDrawResult SVGImage::drawForContainer(GraphicsContext& context, const Float
     if (!m_page)
         return ImageDrawResult::DidNothing;
 
+    LayoutDisallowedScope::AllowedScope layoutAllowedScope; // Allow layout in the SVG document for this image.
+
     ImageObserver* observer = imageObserver();
     ASSERT(observer);
 
@@ -312,6 +315,7 @@ ImageDrawResult SVGImage::draw(GraphicsContext& context, const FloatRect& dstRec
 
     {
         ScriptDisallowedScope::DisableAssertionsInScope disabledScope;
+        LayoutDisallowedScope::AllowedScope layoutAllowedScope;
         if (view->needsLayout())
             view->layoutContext().layout();
     }


### PR DESCRIPTION
#### a5dadd583b2468fa821d3d5d9c7d37ed247fdca8
<pre>
Deploy LayoutDisallowedScope in LayoutPhase::InRenderTreeLayout
<a href="https://bugs.webkit.org/show_bug.cgi?id=256661">https://bugs.webkit.org/show_bug.cgi?id=256661</a>

Reviewed by Simon Fraser.

Deploy LayoutDisallowedScope in LayoutPhase::InRenderTreeLayout
and make the class prevent the layout in release builds as well.

Also introduce LayoutDisallowedScope::AllowedScope and deploy this
in SVGImage::drawForContainer as this code can trigger synchronous
layout in a SVG image.

* Source/WebCore/page/LocalFrameViewLayoutContext.cpp:
(WebCore::LocalFrameViewLayoutContext::performLayout):
* Source/WebCore/rendering/LayoutDisallowedScope.cpp:
* Source/WebCore/rendering/LayoutDisallowedScope.h:
(WebCore::LayoutDisallowedScope::isLayoutAllowed):
(WebCore::LayoutDisallowedScope::LayoutDisallowedScope):
(WebCore::LayoutDisallowedScope::~LayoutDisallowedScope):
(WebCore::LayoutDisallowedScope::AllowedScope): Added.
(WebCore::LayoutDisallowedScope::AllowedScope::AllowedScope):
(WebCore::LayoutDisallowedScope::AllowedScope::~AllowedScope):
* Source/WebCore/rendering/shapes/Shape.cpp:
(WebCore::Shape::createRasterShape):
* Source/WebCore/svg/graphics/SVGImage.cpp:
(WebCore::SVGImage::drawForContainer):
(WebCore::SVGImage::draw):

Canonical link: <a href="https://commits.webkit.org/264051@main">https://commits.webkit.org/264051@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/8f941008b76817a40290bf33f602a3e87cd6427c

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/6524 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/6734 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/6915 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/8103 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/6808 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/6520 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/7111 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/6685 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/9703 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/6638 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/6737 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/5918 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/8200 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/4197 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/5892 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/13738 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/6157 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/5972 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/8352 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/6455 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/5280 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/5858 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/10020 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/765 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/6230 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->