### PR TITLE
[iOS] Page sometimes flashes white after exiting element fullscreen

### DIFF
--- a/Source/WebKit/UIProcess/API/ios/WKWebViewIOS.mm
+++ b/Source/WebKit/UIProcess/API/ios/WKWebViewIOS.mm
@@ -1325,8 +1325,8 @@ static WebCore::FloatPoint constrainContentOffset(WebCore::FloatPoint contentOff
             contentOffsetInScrollViewCoordinates.y = scrollViewContentOffset.y;
 
         [_scrollView setContentOffset:contentOffsetInScrollViewCoordinates animated:animated];
-    } else {
-        // If we haven't changed anything, there would not be any VisibleContentRect update sent to the content.
+    } else if (!_perProcessState.didDeferUpdateVisibleContentRectsForAnyReason) {
+        // If we haven't changed anything, and are not deferring updates, there would not be any VisibleContentRect update sent to the content.
         // The WebProcess would keep the invalid contentOffset as its scroll position.
         // To synchronize the WebProcess with what is on screen, we send the VisibleContentRect again.
         _page->resendLastVisibleContentRects();


### PR DESCRIPTION
#### 07b06490caa2089f50c5811b87051b5d65dadf81
<pre>
[iOS] Page sometimes flashes white after exiting element fullscreen
<a href="https://bugs.webkit.org/show_bug.cgi?id=256662">https://bugs.webkit.org/show_bug.cgi?id=256662</a>
rdar://104149279

Reviewed by Tim Horton.

While performing an &quot;animated resize&quot;, geometry updates are deferred until the
resize has completed. This ensures that the Web process does not receive any
visible content rect updates during resize. The geometry update is then
triggered once the resize is complete.

However, it is also possible for visible content rect updates to be sent
outside of the normal scheduling flow, through
`WebPageProxy::resendLastVisibleContentRects`. The last visible content rect
update is resent when attempting to perform a programmatic scroll that does not
change modify the scroll view&apos;s position. This logic was added in 152880@main,
to ensure the Web process state was not out-of-sync with the UI process state.

When exiting element fullscreen, both an &quot;animated resize&quot; and programmatic
scroll are performed. The purpose of the scroll is to restore the web view&apos;s
original scroll position prior to entering fullscreen. Once the resize is
complete, a geometry update is scheduled (asynchronously). Then, the Web process
notifies the UI process that a scroll needs to occur. If the scroll does not
end up modifying the scroll view&apos;s position, the last visible content rect
update, which still contains the fullscreen viewport information, is resent.
Finally, the scheduled geometry update (with the correct viewport information) is
sent.

Consequently, exiting fullscreen can result in two successive visible
content rect updates, the first of which is incorrect. Flashing is observed as
a result of temporarily incorrect viewport information.

To fix, suppress resending visible content rect updates during the period of
time where geometry updates have stopped being deferred, but the scheduled
update is still pending. This ensures that spurious viewport information is not
send to the Web process, removing a source of flashing.

* Source/WebKit/UIProcess/API/ios/WKWebViewIOS.mm:
(-[WKWebView _scrollToContentScrollPosition:scrollOrigin:animated:]):

Consult `didDeferUpdateVisibleContentRectsForAnyReason` to identify the period
of time described above. This is safe to do, since a geometry update will
eventually occur once deferral has ended. Furthermore, the bit is reset once the
next update is dispatched.

* Tools/TestWebKitAPI/Tests/WebKitCocoa/AnimatedResize.mm:
(TEST):

Add a API test to exercise the codepaths that result in incorrect viewport
information being sent to the Web process. Without this fix, the test fails
as the window&apos;s `innerWidth`/`innerHeight` is observed to be size prior to
resizing, even though the resize is complete.

Canonical link: <a href="https://commits.webkit.org/264024@main">https://commits.webkit.org/264024@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/80bb9daef9135d414aee11bbca334ef862f395c1

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/6308 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/6504 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/6683 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/7882 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/6634 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/6309 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/6724 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/6453 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/9526 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/6420 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/6425 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/5716 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/7952 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/3897 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/5694 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/13575 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/5761 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/5777 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/8018 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/6257 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/5120 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/5668 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/1524 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/9823 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/6038 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->