### PR TITLE
`marker orient="-1"` does not orient correctly (uses 'auto')

### DIFF
--- a/LayoutTests/svg/markers/marker-orientation-minus-one-expected.html
+++ b/LayoutTests/svg/markers/marker-orientation-minus-one-expected.html
@@ -1,0 +1,2 @@
+<!DOCTYPE html>
+<div style="width: 100px; height: 100px; background-color: green"></div>

--- a/LayoutTests/svg/markers/marker-orientation-minus-one.html
+++ b/LayoutTests/svg/markers/marker-orientation-minus-one.html
@@ -1,0 +1,7 @@
+<!DOCTYPE html>
+<svg>
+  <marker id="m" orient="-1" overflow="visible">
+    <rect width="100" height="100" fill="green"/>
+  </marker>
+  <path marker-start="url(#m)" d="M0,0v50" transform="rotate(1)" fill="none" stroke="red"/>
+</svg>

--- a/Source/WebCore/rendering/svg/RenderSVGResourceMarker.cpp
+++ b/Source/WebCore/rendering/svg/RenderSVGResourceMarker.cpp
@@ -2,6 +2,8 @@
  * Copyright (C) 2004, 2005, 2007, 2008 Nikolas Zimmermann <zimmermann@kde.org>
  * Copyright (C) 2004, 2005, 2006, 2007, 2008 Rob Buis <buis@kde.org>
  * Copyright (C) Research In Motion Limited 2009-2010. All rights reserved.
+ * Copyright (C) 2023 Apple Inc. All rights reserved.
+ * Copyright (C) 2016 Google Inc. All rights reserved.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Library General Public
@@ -92,23 +94,20 @@ FloatPoint RenderSVGResourceMarker::referencePoint() const
     return FloatPoint(markerElement().refX().value(lengthContext), markerElement().refY().value(lengthContext));
 }
 
-float RenderSVGResourceMarker::angle() const
+std::optional<float> RenderSVGResourceMarker::angle() const
 {
-    float angle = -1;
     if (markerElement().orientType() == SVGMarkerOrientAngle)
-        angle = markerElement().orientAngle().value();
-
-    return angle;
+        return markerElement().orientAngle().value();
+    return std::nullopt;
 }
 
 AffineTransform RenderSVGResourceMarker::markerTransformation(const FloatPoint& origin, float autoAngle, float strokeWidth) const
 {
-    float markerAngle = angle();
     bool useStrokeWidth = markerElement().markerUnits() == SVGMarkerUnitsStrokeWidth;
 
     AffineTransform transform;
     transform.translate(origin);
-    transform.rotate(markerAngle == -1 ? autoAngle : markerAngle);
+    transform.rotate(angle().value_or(autoAngle));
     transform = markerContentTransformation(transform, referencePoint(), useStrokeWidth ? strokeWidth : -1);
     return transform;
 }

--- a/Source/WebCore/rendering/svg/RenderSVGResourceMarker.h
+++ b/Source/WebCore/rendering/svg/RenderSVGResourceMarker.h
@@ -54,7 +54,7 @@ public:
     FloatRect resourceBoundingBox(const RenderObject&) override { return FloatRect(); }
 
     FloatPoint referencePoint() const;
-    float angle() const;
+    std::optional<float> angle() const;
     inline SVGMarkerUnitsType markerUnits() const;
 
     RenderSVGResourceType resourceType() const override { return MarkerResourceType; }

--- a/Source/WebCore/rendering/svg/SVGRenderTreeAsText.cpp
+++ b/Source/WebCore/rendering/svg/SVGRenderTreeAsText.cpp
@@ -1,5 +1,6 @@
 /*
  * Copyright (C) 2004-2023 Apple Inc. All rights reserved.
+ * Copyright (C) 2016 Google Inc. All rights reserved.
  *           (C) 2005 Rob Buis <buis@kde.org>
  *           (C) 2006 Alexander Kellett <lypanov@kde.org>
  * Copyright (C) Research In Motion Limited 2010. All rights reserved.
@@ -488,10 +489,10 @@ void writeSVGResourceContainer(TextStream& ts, const RenderSVGResourceContainer&
         writeNameValuePair(ts, "markerUnits", marker.markerUnits());
         ts << " [ref at " << marker.referencePoint() << "]";
         ts << " [angle=";
-        if (marker.angle() == -1)
-            ts << "auto" << "]\n";
+        if (auto angle = marker.angle())
+            ts << *angle << "]\n";
         else
-            ts << marker.angle() << "]\n";
+            ts << "auto" << "]\n";
     } else if (resource.resourceType() == PatternResourceType) {
         const auto& pattern = static_cast<const RenderSVGResourcePattern&>(resource);
 


### PR DESCRIPTION
#### 6bf2a1e9acdca0b3b54a5cb6332ecbf591ff565f
<pre>
`marker orient=&quot;-1&quot;` does not orient correctly (uses &apos;auto&apos;)

<a href="https://bugs.webkit.org/show_bug.cgi?id=256670">https://bugs.webkit.org/show_bug.cgi?id=256670</a>

Reviewed by Said Abou-Hallawa.

This patch aligns WebKit with Gecko / Firefox and Blink / Chromium.

Merge: <a href="https://chromium.googlesource.com/chromium/src.git/+/886546446df947816927a7757de45fab1646c919">https://chromium.googlesource.com/chromium/src.git/+/886546446df947816927a7757de45fab1646c919</a>

The value -1 (degrees) is a valid angle, so using it to indicate that
&apos;auto&apos; orientation should be used does not work out.
Just check &apos;orientType&apos; directly instead and simplify the angle getter.

* Source/WebCore/rendering/svg/RenderSVGResourceMarker.cpp:
(RenderSVGResourceMarker::angle): Simplify logic
(RenderSVGResourceMarker::markerTransformation): Call &apos;orient&apos; directly
* Source/WebCore/rendering/svg/RenderSVGResourceMarker.h: Update &apos;float angle&apos; to std::optional
* Source/WebCore/rendering/svg/SVGRenderTreeAsText.cpp: Add Text Tree dump support
* LayoutTests/svg/markers/marker-orientation-minus-one.html: Add Test Case
* LayoutTests/svg/markers/marker-orientation-minus-one-expected.html: Add Test Case Expectation

Canonical link: <a href="https://commits.webkit.org/264053@main">https://commits.webkit.org/264053@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/12c4debdc72640986a112560b267957d88115ece

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/6544 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/6756 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/6936 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/8125 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/6828 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/6541 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/7216 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/6705 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/9724 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/6659 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/6801 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/5943 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/8213 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/4264 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/5912 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/13750 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/6231 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/5992 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/8391 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/6477 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/5298 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/5878 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/5840 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/1543 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/10042 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/6250 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->