### PR TITLE
Add WebWorkerAnimationController that uses EventDispatcher to drive refreshes

### DIFF
--- a/Source/WebCore/page/ChromeClient.h
+++ b/Source/WebCore/page/ChromeClient.h
@@ -394,6 +394,7 @@ public:
     virtual void triggerRenderingUpdate() = 0;
     // Schedule a rendering update that coordinates with display refresh. Returns true if scheduled. (This is only used by SVGImageChromeClient.)
     virtual bool scheduleRenderingUpdate() { return false; }
+    virtual void renderingUpdateFrequencyChanged() { }
 
     virtual unsigned remoteImagesCountForTesting() const { return 0; }
 

--- a/Source/WebCore/page/Page.h
+++ b/Source/WebCore/page/Page.h
@@ -510,8 +510,8 @@ public:
         IncludeAnimationsFrameRate  = 1 << 1
     };
     static constexpr OptionSet<PreferredRenderingUpdateOption> allPreferredRenderingUpdateOptions = { PreferredRenderingUpdateOption::IncludeThrottlingReasons, PreferredRenderingUpdateOption::IncludeAnimationsFrameRate };
-    std::optional<FramesPerSecond> preferredRenderingUpdateFramesPerSecond(OptionSet<PreferredRenderingUpdateOption> = allPreferredRenderingUpdateOptions) const;
-    Seconds preferredRenderingUpdateInterval() const;
+    WEBCORE_EXPORT std::optional<FramesPerSecond> preferredRenderingUpdateFramesPerSecond(OptionSet<PreferredRenderingUpdateOption> = allPreferredRenderingUpdateOptions) const;
+    WEBCORE_EXPORT Seconds preferredRenderingUpdateInterval() const;
 
     float topContentInset() const { return m_topContentInset; }
     WEBCORE_EXPORT void setTopContentInset(float);

--- a/Source/WebCore/page/RenderingUpdateScheduler.cpp
+++ b/Source/WebCore/page/RenderingUpdateScheduler.cpp
@@ -53,11 +53,15 @@ bool RenderingUpdateScheduler::scheduleAnimation()
 void RenderingUpdateScheduler::adjustRenderingUpdateFrequency()
 {
     auto renderingUpdateFramesPerSecond = m_page.preferredRenderingUpdateFramesPerSecond();
-    if (renderingUpdateFramesPerSecond) {
-        setPreferredFramesPerSecond(renderingUpdateFramesPerSecond.value());
-        m_useTimer = false;
-    } else
-        m_useTimer = true;
+    std::optional<FramesPerSecond> previousRenderingUpdateFramesPerSecond = m_useTimer ? std::nullopt : std::optional<FramesPerSecond>(preferredFramesPerSecond());
+    if (renderingUpdateFramesPerSecond != previousRenderingUpdateFramesPerSecond) {
+        if (renderingUpdateFramesPerSecond) {
+            setPreferredFramesPerSecond(renderingUpdateFramesPerSecond.value());
+            m_useTimer = false;
+        } else
+            m_useTimer = true;
+        m_page.chrome().client().renderingUpdateFrequencyChanged();
+    }
 
     if (isScheduled()) {
         clearScheduled();

--- a/Source/WebCore/page/WorkerClient.h
+++ b/Source/WebCore/page/WorkerClient.h
@@ -31,11 +31,16 @@
 
 namespace WebCore {
 
+class WorkerAnimationController;
+class WorkerGlobalScope;
+
 class WorkerClient : public GraphicsClient {
     WTF_MAKE_FAST_ALLOCATED;
 public:
 
     virtual std::unique_ptr<WorkerClient> clone(SerialFunctionDispatcher&) = 0;
+
+    virtual RefPtr<WorkerAnimationController> createAnimationController(WorkerGlobalScope&) = 0;
 
     virtual ~WorkerClient() = default;
 };

--- a/Source/WebCore/workers/DedicatedWorkerGlobalScope.cpp
+++ b/Source/WebCore/workers/DedicatedWorkerGlobalScope.cpp
@@ -113,8 +113,12 @@ DedicatedWorkerThread& DedicatedWorkerGlobalScope::thread()
 #if ENABLE(OFFSCREEN_CANVAS_IN_WORKERS)
 CallbackId DedicatedWorkerGlobalScope::requestAnimationFrame(Ref<RequestAnimationFrameCallback>&& callback)
 {
-    if (!m_workerAnimationController)
-        m_workerAnimationController = WorkerAnimationController::create(*this);
+    if (!m_workerAnimationController) {
+        if (workerClient())
+            m_workerAnimationController = workerClient()->createAnimationController(*this);
+        if (!m_workerAnimationController)
+            m_workerAnimationController = TimerWorkerAnimationController::create(*this);
+    }
     return m_workerAnimationController->requestAnimationFrame(WTFMove(callback));
 }
 

--- a/Source/WebKit/Shared/DisplayLinkObserverID.h
+++ b/Source/WebKit/Shared/DisplayLinkObserverID.h
@@ -30,6 +30,6 @@
 namespace WebKit {
 
 struct DisplayLinkObserverIDType;
-using DisplayLinkObserverID = ObjectIdentifier<DisplayLinkObserverIDType>;
+using DisplayLinkObserverID = AtomicObjectIdentifier<DisplayLinkObserverIDType>;
 
 } // namespace WebKit

--- a/Source/WebKit/UIProcess/WebProcessProxy.h
+++ b/Source/WebKit/UIProcess/WebProcessProxy.h
@@ -343,8 +343,8 @@ public:
     DisplayLink::Client& displayLinkClient() { return m_displayLinkClient; }
     std::optional<unsigned> nominalFramesPerSecondForDisplay(WebCore::PlatformDisplayID);
 
-    void startDisplayLink(DisplayLinkObserverID, WebCore::PlatformDisplayID, WebCore::FramesPerSecond);
-    void stopDisplayLink(DisplayLinkObserverID, WebCore::PlatformDisplayID);
+    void startDisplayLink(DisplayLinkObserverID, WebCore::PlatformDisplayID, WebCore::FramesPerSecond, bool sendToEventDispatcher);
+    void stopDisplayLink(DisplayLinkObserverID, WebCore::PlatformDisplayID, bool sendToEventDispatcher);
     void setDisplayLinkPreferredFramesPerSecond(DisplayLinkObserverID, WebCore::PlatformDisplayID, WebCore::FramesPerSecond);
     void setDisplayLinkForDisplayWantsFullSpeedUpdates(WebCore::PlatformDisplayID, bool wantsFullSpeedUpdates);
 #endif
@@ -669,6 +669,7 @@ private:
 
 #if HAVE(CVDISPLAYLINK)
     DisplayLinkProcessProxyClient m_displayLinkClient;
+    uint32_t m_observersWantingSendToEventDispatcher { 0 };
 #endif
 
 #if ENABLE(ROUTING_ARBITRATION)

--- a/Source/WebKit/UIProcess/WebProcessProxy.messages.in
+++ b/Source/WebKit/UIProcess/WebProcessProxy.messages.in
@@ -60,8 +60,8 @@ messages -> WebProcessProxy LegacyReceiver {
 #endif
 
 #if HAVE(CVDISPLAYLINK)
-    StartDisplayLink(WebKit::DisplayLinkObserverID observerID, uint32_t displayID, unsigned preferredFramesPerSecond)
-    StopDisplayLink(WebKit::DisplayLinkObserverID observerID, uint32_t displayID)
+    StartDisplayLink(WebKit::DisplayLinkObserverID observerID, uint32_t displayID, unsigned preferredFramesPerSecond, bool sendToEventDispatcher)
+    StopDisplayLink(WebKit::DisplayLinkObserverID observerID, uint32_t displayID, bool sendToEventDispatcher)
     SetDisplayLinkPreferredFramesPerSecond(WebKit::DisplayLinkObserverID observerID, uint32_t displayID, unsigned preferredFramesPerSecond);
 #endif
 

--- a/Source/WebKit/UIProcess/mac/DisplayLinkProcessProxyClient.cpp
+++ b/Source/WebKit/UIProcess/mac/DisplayLinkProcessProxyClient.cpp
@@ -41,6 +41,11 @@ void DisplayLinkProcessProxyClient::setConnection(RefPtr<IPC::Connection>&& conn
     m_connection = WTFMove(connection);
 }
 
+void DisplayLinkProcessProxyClient::setSendToEventDispatcher(bool sendToEventDispatcher)
+{
+    m_sendToEventDispatcher = sendToEventDispatcher;
+}
+
 // This is called off the main thread.
 void DisplayLinkProcessProxyClient::displayLinkFired(WebCore::PlatformDisplayID displayID, WebCore::DisplayUpdate displayUpdate, bool wantsFullSpeedUpdates, bool anyObserverWantsCallback)
 {
@@ -53,8 +58,8 @@ void DisplayLinkProcessProxyClient::displayLinkFired(WebCore::PlatformDisplayID 
     if (!connection)
         return;
 
-    if (wantsFullSpeedUpdates)
-        connection->send(Messages::EventDispatcher::DisplayDidRefresh(displayID, displayUpdate, anyObserverWantsCallback), 0, { }, Thread::QOS::UserInteractive);
+    if (wantsFullSpeedUpdates || m_sendToEventDispatcher)
+        connection->send(Messages::EventDispatcher::DisplayDidRefresh(displayID, displayUpdate, wantsFullSpeedUpdates, anyObserverWantsCallback), 0, { }, Thread::QOS::UserInteractive);
     else if (anyObserverWantsCallback)
         connection->send(Messages::WebProcess::DisplayDidRefresh(displayID, displayUpdate), 0, { }, Thread::QOS::UserInteractive);
 }

--- a/Source/WebKit/UIProcess/mac/DisplayLinkProcessProxyClient.h
+++ b/Source/WebKit/UIProcess/mac/DisplayLinkProcessProxyClient.h
@@ -43,12 +43,14 @@ public:
     ~DisplayLinkProcessProxyClient() = default;
     
     void setConnection(RefPtr<IPC::Connection>&&);
+    void setSendToEventDispatcher(bool);
 
 private:
     void displayLinkFired(WebCore::PlatformDisplayID, WebCore::DisplayUpdate, bool wantsFullSpeedUpdates, bool anyObserverWantsCallback) override;
 
     Lock m_connectionLock;
     RefPtr<IPC::Connection> m_connection;
+    bool m_sendToEventDispatcher { false };
 };
 
 }

--- a/Source/WebKit/UIProcess/mac/WebProcessProxyMac.mm
+++ b/Source/WebKit/UIProcess/mac/WebProcessProxyMac.mm
@@ -64,15 +64,21 @@ std::optional<unsigned> WebProcessProxy::nominalFramesPerSecondForDisplay(WebCor
     return processPool().displayLinks().nominalFramesPerSecondForDisplay(displayID);
 }
 
-void WebProcessProxy::startDisplayLink(DisplayLinkObserverID observerID, WebCore::PlatformDisplayID displayID, WebCore::FramesPerSecond preferredFramesPerSecond)
+void WebProcessProxy::startDisplayLink(DisplayLinkObserverID observerID, WebCore::PlatformDisplayID displayID, WebCore::FramesPerSecond preferredFramesPerSecond, bool sendToEventDispatcher)
 {
     ASSERT(hasProcessPrivilege(ProcessPrivilege::CanCommunicateWithWindowServer));
     processPool().displayLinks().startDisplayLink(m_displayLinkClient, observerID, displayID, preferredFramesPerSecond);
+    if (sendToEventDispatcher)
+        m_observersWantingSendToEventDispatcher++;
+    m_displayLinkClient.setSendToEventDispatcher(m_observersWantingSendToEventDispatcher > 0);
 }
 
-void WebProcessProxy::stopDisplayLink(DisplayLinkObserverID observerID, WebCore::PlatformDisplayID displayID)
+void WebProcessProxy::stopDisplayLink(DisplayLinkObserverID observerID, WebCore::PlatformDisplayID displayID, bool sendToEventDispatcher)
 {
     processPool().displayLinks().stopDisplayLink(m_displayLinkClient, observerID, displayID);
+    if (sendToEventDispatcher)
+        m_observersWantingSendToEventDispatcher--;
+    m_displayLinkClient.setSendToEventDispatcher(m_observersWantingSendToEventDispatcher > 0);
 }
 
 void WebProcessProxy::setDisplayLinkPreferredFramesPerSecond(DisplayLinkObserverID observerID, WebCore::PlatformDisplayID displayID, WebCore::FramesPerSecond preferredFramesPerSecond)

--- a/Source/WebKit/WebKit.xcodeproj/project.pbxproj
+++ b/Source/WebKit/WebKit.xcodeproj/project.pbxproj
@@ -1757,6 +1757,8 @@
 		A5E391FD2183C1F800C8FB31 /* InspectorTargetProxy.h in Headers */ = {isa = PBXBuildFile; fileRef = A5E391FC2183C1E900C8FB31 /* InspectorTargetProxy.h */; };
 		A5EC6AD42151BD7B00677D17 /* WebPageDebuggable.h in Headers */ = {isa = PBXBuildFile; fileRef = A5EC6AD32151BD6900677D17 /* WebPageDebuggable.h */; };
 		A5EFD38C16B0E88C00B2F0E8 /* WKPageVisibilityTypes.h in Headers */ = {isa = PBXBuildFile; fileRef = A5EFD38B16B0E88C00B2F0E8 /* WKPageVisibilityTypes.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		A70FBDCA29F22928007615D7 /* WebWorkerAnimationController.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A70FBDC829F22928007615D7 /* WebWorkerAnimationController.cpp */; };
+		A70FBDCB29F22928007615D7 /* WebWorkerAnimationController.h in Headers */ = {isa = PBXBuildFile; fileRef = A70FBDC929F22928007615D7 /* WebWorkerAnimationController.h */; };
 		A7A3D555289395E2008D683D /* WebWorkerClient.h in Headers */ = {isa = PBXBuildFile; fileRef = A7A3D553289395E2008D683D /* WebWorkerClient.h */; };
 		A7D792D81767CCA300881CBE /* ActivityAssertion.h in Headers */ = {isa = PBXBuildFile; fileRef = A7D792D41767CB0900881CBE /* ActivityAssertion.h */; };
 		AAB145E6223F931200E489D8 /* PrefetchCache.h in Headers */ = {isa = PBXBuildFile; fileRef = AAB145E4223F931200E489D8 /* PrefetchCache.h */; };
@@ -6310,6 +6312,8 @@
 		A5EC6AD22151BD6900677D17 /* WebPageDebuggable.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = WebPageDebuggable.cpp; sourceTree = "<group>"; };
 		A5EC6AD32151BD6900677D17 /* WebPageDebuggable.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = WebPageDebuggable.h; sourceTree = "<group>"; };
 		A5EFD38B16B0E88C00B2F0E8 /* WKPageVisibilityTypes.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = WKPageVisibilityTypes.h; sourceTree = "<group>"; };
+		A70FBDC829F22928007615D7 /* WebWorkerAnimationController.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = WebWorkerAnimationController.cpp; sourceTree = "<group>"; };
+		A70FBDC929F22928007615D7 /* WebWorkerAnimationController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = WebWorkerAnimationController.h; sourceTree = "<group>"; };
 		A72D5D7F1236CBA800A88B15 /* APISerializedScriptValue.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = APISerializedScriptValue.h; sourceTree = "<group>"; };
 		A78CCDD8193AC9E3005ECC25 /* com.apple.WebKit.Networking.sb.in */ = {isa = PBXFileReference; lastKnownFileType = text; path = com.apple.WebKit.Networking.sb.in; sourceTree = "<group>"; };
 		A7A3D552289395E2008D683D /* WebWorkerClient.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = WebWorkerClient.cpp; sourceTree = "<group>"; };
@@ -12621,6 +12625,8 @@
 				BCC43AC6127B99DE00317F16 /* WebPopupMenuMac.mm */,
 				C11A9ED021403B4000CFB20A /* WebSwitchingGPUClient.cpp */,
 				C11A9ECB214035F800CFB20A /* WebSwitchingGPUClient.h */,
+				A70FBDC829F22928007615D7 /* WebWorkerAnimationController.cpp */,
+				A70FBDC929F22928007615D7 /* WebWorkerAnimationController.h */,
 			);
 			path = mac;
 			sourceTree = "<group>";
@@ -15045,6 +15051,7 @@
 				83EE575C1DB7D61100C74C50 /* WebValidationMessageClient.h in Headers */,
 				572FD44322265CE200A1ECC3 /* WebViewDidMoveToWindowObserver.h in Headers */,
 				0FD07E5028A3414700B38C81 /* WebViewImpl.h in Headers */,
+				A70FBDCB29F22928007615D7 /* WebWorkerAnimationController.h in Headers */,
 				A7A3D555289395E2008D683D /* WebWorkerClient.h in Headers */,
 				29CD55AA128E294F00133C85 /* WKAccessibilityWebPageObjectBase.h in Headers */,
 				29232DF418B29D6800D0596F /* WKAccessibilityWebPageObjectMac.h in Headers */,
@@ -17371,6 +17378,7 @@
 				515262BD1FB951610070E579 /* WebSWServerToContextConnectionMessageReceiver.cpp in Sources */,
 				1AAF08B719269E6D00B6390C /* WebUserContentControllerMessageReceiver.cpp in Sources */,
 				7C361D78192803BD0036A59D /* WebUserContentControllerProxyMessageReceiver.cpp in Sources */,
+				A70FBDCA29F22928007615D7 /* WebWorkerAnimationController.cpp in Sources */,
 				C6A4CA0C2252899800169289 /* WKBundlePageMac.mm in Sources */,
 				2D931169212F61B200044BFE /* WKContentView.mm in Sources */,
 				2D93116A212F61B500044BFE /* WKContentViewInteraction.mm in Sources */,

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebChromeClient.cpp
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebChromeClient.cpp
@@ -1063,6 +1063,11 @@ void WebChromeClient::triggerRenderingUpdate()
         m_page.drawingArea()->triggerRenderingUpdate();
 }
 
+void WebChromeClient::renderingUpdateFrequencyChanged()
+{
+    WebProcess::singleton().eventDispatcher().renderingUpdateFrequencyChanged(m_page.identifier());
+}
+
 unsigned WebChromeClient::remoteImagesCountForTesting() const
 {
     return m_page.remoteImagesCountForTesting();

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebChromeClient.h
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebChromeClient.h
@@ -231,6 +231,7 @@ private:
     void setNeedsOneShotDrawingSynchronization() final;
     bool shouldTriggerRenderingUpdate(unsigned rescheduledRenderingUpdateCount) const final;
     void triggerRenderingUpdate() final;
+    void renderingUpdateFrequencyChanged() final;
     unsigned remoteImagesCountForTesting() const final; 
 
     void contentRuleListNotification(const URL&, const WebCore::ContentRuleListResults&) final;

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebWorkerClient.cpp
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebWorkerClient.cpp
@@ -26,12 +26,14 @@
 #include "config.h"
 #include "WebWorkerClient.h"
 
+#include "EventDispatcher.h"
 #include "ImageBufferShareableBitmapBackend.h"
 #include "RemoteImageBufferProxy.h"
 #include "RemoteRenderingBackendProxy.h"
 #include "WebPage.h"
 #include "WebProcess.h"
 #include <WebCore/Page.h>
+#include <WebCore/WorkerAnimationController.h>
 
 #if ENABLE(WEBGL) && ENABLE(GPU_PROCESS)
 #include "RemoteGraphicsContextGLProxy.h"
@@ -105,6 +107,11 @@ std::unique_ptr<WorkerClient> WebWorkerClient::clone(SerialFunctionDispatcher& d
 #else
     return makeUnique<WebWorkerClient>(dispatcher, m_displayID);
 #endif
+}
+
+RefPtr<WorkerAnimationController> WebWorkerClient::createAnimationController(WorkerGlobalScope& workerGlobalScope)
+{
+    return nullptr;
 }
 
 PlatformDisplayID WebWorkerClient::displayID() const

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebWorkerClient.cpp
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebWorkerClient.cpp
@@ -32,6 +32,9 @@
 #include "RemoteRenderingBackendProxy.h"
 #include "WebPage.h"
 #include "WebProcess.h"
+#if HAVE(CVDISPLAYLINK)
+#include "WebWorkerAnimationController.h"
+#endif
 #include <WebCore/Page.h>
 #include <WebCore/WorkerAnimationController.h>
 
@@ -111,7 +114,11 @@ std::unique_ptr<WorkerClient> WebWorkerClient::clone(SerialFunctionDispatcher& d
 
 RefPtr<WorkerAnimationController> WebWorkerClient::createAnimationController(WorkerGlobalScope& workerGlobalScope)
 {
+#if HAVE(CVDISPLAYLINK)
+    return WebWorkerAnimationController::create(workerGlobalScope, m_creationParameters.pageID, m_dispatcher);
+#else
     return nullptr;
+#endif
 }
 
 PlatformDisplayID WebWorkerClient::displayID() const

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebWorkerClient.h
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebWorkerClient.h
@@ -59,6 +59,7 @@ public:
 #endif
 
     std::unique_ptr<WorkerClient> clone(SerialFunctionDispatcher&) final;
+    RefPtr<WebCore::WorkerAnimationController> createAnimationController(WebCore::WorkerGlobalScope&) final;
 
     WebCore::PlatformDisplayID displayID() const final;
 

--- a/Source/WebKit/WebProcess/WebCoreSupport/mac/WebWorkerAnimationController.cpp
+++ b/Source/WebKit/WebProcess/WebCoreSupport/mac/WebWorkerAnimationController.cpp
@@ -1,0 +1,96 @@
+/*
+ * Copyright (C) 2023 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "WebWorkerAnimationController.h"
+
+#if HAVE(CVDISPLAYLINK)
+
+#include "EventDispatcher.h"
+#include "WebProcess.h"
+
+namespace WebKit {
+using namespace WebCore;
+
+class WebWorkerAsyncRenderingRefreshObserver : public EventDispatcher::AsyncRenderingRefreshObserver {
+public:
+    WebWorkerAsyncRenderingRefreshObserver(WebWorkerAnimationController* controller)
+        : m_controller(controller)
+    { }
+
+    void displayDidRefresh() final
+    {
+        if (m_controller)
+            m_controller->displayDidRefresh();
+    }
+
+    void disconnect()
+    {
+        m_controller = nullptr;
+    }
+
+private:
+    WebWorkerAnimationController* m_controller;
+};
+
+Ref<WebWorkerAnimationController> WebWorkerAnimationController::create(WorkerGlobalScope& workerGlobalScope, WebCore::PageIdentifier identifier, FunctionDispatcher& dispatcher)
+{
+    auto controller = adoptRef(*new WebWorkerAnimationController(workerGlobalScope, identifier, dispatcher));
+    controller->suspendIfNeeded();
+    return controller;
+}
+
+WebWorkerAnimationController::WebWorkerAnimationController(WorkerGlobalScope& workerGlobalScope, WebCore::PageIdentifier identifier, FunctionDispatcher& dispatcher)
+    : WorkerAnimationController(workerGlobalScope)
+    , m_identifier(identifier)
+    , m_dispatcher(dispatcher)
+{ }
+
+WebWorkerAnimationController::~WebWorkerAnimationController() = default;
+
+void WebWorkerAnimationController::displayDidRefresh()
+{
+    animationTimerFired();
+}
+
+void WebWorkerAnimationController::scheduleAnimation()
+{
+    if (!m_observer) {
+        m_observer = adoptRef(new WebWorkerAsyncRenderingRefreshObserver(this));
+        WebProcess::singleton().eventDispatcher().addAsyncRenderingRefreshObserver(m_identifier, m_dispatcher, *m_observer);
+    }
+}
+void WebWorkerAnimationController::stopAnimation()
+{
+    if (m_observer) {
+        WebProcess::singleton().eventDispatcher().removeAsyncRenderingRefreshObserver(m_identifier, *m_observer);
+        m_observer->disconnect();
+        m_observer = nullptr;
+    }
+}
+
+} // namespace WebKit
+
+#endif // AVE(CVDISPLAYLINK)

--- a/Source/WebKit/WebProcess/WebCoreSupport/mac/WebWorkerAnimationController.h
+++ b/Source/WebKit/WebProcess/WebCoreSupport/mac/WebWorkerAnimationController.h
@@ -1,0 +1,59 @@
+/*
+ * Copyright (C) 2023 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#if HAVE(CVDISPLAYLINK)
+
+#include <WebCore/PageIdentifier.h>
+#include <WebCore/WorkerAnimationController.h>
+#include <wtf/FunctionDispatcher.h>
+
+namespace WebKit {
+
+class WebWorkerAsyncRenderingRefreshObserver;
+
+class WebWorkerAnimationController : public WebCore::WorkerAnimationController {
+public:
+    static Ref<WebWorkerAnimationController> create(WebCore::WorkerGlobalScope&, WebCore::PageIdentifier, FunctionDispatcher&);
+
+    void displayDidRefresh();
+
+private:
+    WebWorkerAnimationController(WebCore::WorkerGlobalScope&, WebCore::PageIdentifier, FunctionDispatcher&);
+    ~WebWorkerAnimationController();
+
+    void scheduleAnimation() final;
+    void stopAnimation() final;
+    bool isActive() const final { return m_observer; }
+
+    WebCore::PageIdentifier m_identifier;
+    FunctionDispatcher& m_dispatcher;
+    RefPtr<WebWorkerAsyncRenderingRefreshObserver> m_observer;
+};
+
+} // namespace WebKit
+
+#endif // HAVE(CVDISPLAYLINK)

--- a/Source/WebKit/WebProcess/WebPage/EventDispatcher.messages.in
+++ b/Source/WebKit/WebProcess/WebPage/EventDispatcher.messages.in
@@ -30,7 +30,7 @@ messages -> EventDispatcher NotRefCounted {
     GestureEvent(WebCore::PageIdentifier pageID, WebKit::WebGestureEvent event)
 #endif
 #if HAVE(CVDISPLAYLINK)
-    DisplayDidRefresh(uint32_t displayID, struct WebCore::DisplayUpdate update, bool sendToMainThread)
+    DisplayDidRefresh(uint32_t displayID, struct WebCore::DisplayUpdate update, bool wantsFullSpeedUpdates, bool anyObserverWantsCallback)
 #endif
 
 #if ENABLE(MOMENTUM_EVENT_DISPATCHER)

--- a/Source/WebKit/WebProcess/WebPage/mac/DisplayRefreshMonitorMac.cpp
+++ b/Source/WebKit/WebProcess/WebPage/mac/DisplayRefreshMonitorMac.cpp
@@ -76,7 +76,7 @@ bool DisplayRefreshMonitorMac::startNotificationMechanism()
         return true;
 
     LOG_WITH_STREAM(DisplayLink, stream << "[Web] DisplayRefreshMonitorMac::requestRefreshCallback for display " << displayID() << " - starting");
-    WebProcess::singleton().parentProcessConnection()->send(Messages::WebProcessProxy::StartDisplayLink(m_observerID, displayID(), maxClientPreferredFramesPerSecond().value_or(FullSpeedFramesPerSecond)), 0);
+    WebProcess::singleton().parentProcessConnection()->send(Messages::WebProcessProxy::StartDisplayLink(m_observerID, displayID(), maxClientPreferredFramesPerSecond().value_or(FullSpeedFramesPerSecond), false), 0);
     if (!m_runLoopObserver) {
         // The RunLoopObserver repeats.
         m_runLoopObserver = makeUnique<RunLoopObserver>(kCFRunLoopEntry, [this]() {
@@ -96,7 +96,7 @@ void DisplayRefreshMonitorMac::stopNotificationMechanism()
         return;
 
     LOG_WITH_STREAM(DisplayLink, stream << "[Web] DisplayRefreshMonitorMac::requestRefreshCallback - stopping");
-    WebProcess::singleton().parentProcessConnection()->send(Messages::WebProcessProxy::StopDisplayLink(m_observerID, displayID()), 0);
+    WebProcess::singleton().parentProcessConnection()->send(Messages::WebProcessProxy::StopDisplayLink(m_observerID, displayID(), false), 0);
     m_runLoopObserver->invalidate();
     
     m_displayLinkIsActive = false;


### PR DESCRIPTION
#### 58a9a5078d0be3d36f2cc3a90f8df32054e99e2d
<pre>
Add WebWorkerAnimationController that uses EventDispatcher to drive refreshes
<a href="https://bugs.webkit.org/show_bug.cgi?id=232918">https://bugs.webkit.org/show_bug.cgi?id=232918</a>

Reviewed by NOBODY (OOPS!).

* Source/WebCore/WebCore.xcodeproj/project.pbxproj:
* Source/WebKit/WebKit.xcodeproj/project.pbxproj:
* Source/WebKit/WebProcess/WebCoreSupport/WebWorkerClient.cpp:
(WebKit::WebWorkerClient::createAnimationController):
* Source/WebKit/WebProcess/WebCoreSupport/mac/WebWorkerAnimationController.cpp: Added.
(WebKit::WebWorkerAsyncRenderingRefreshObserver::WebWorkerAsyncRenderingRefreshObserver):
(WebKit::WebWorkerAsyncRenderingRefreshObserver::disconnect):
(WebKit::WebWorkerAnimationController::WebWorkerAnimationController):
(WebKit::WebWorkerAnimationController::displayDidRefresh):
(WebKit::WebWorkerAnimationController::scheduleAnimation):
(WebKit::WebWorkerAnimationController::stopAnimation):
* Source/WebKit/WebProcess/WebCoreSupport/mac/WebWorkerAnimationController.h: Added.
</pre>
----------------------------------------------------------------------
#### 42edee86ffc908c7a9593697e19e30ebcd481b69
<pre>
Add API to EventDispatcher for observing rendering update refreshes.
<a href="https://bugs.webkit.org/show_bug.cgi?id=257295">https://bugs.webkit.org/show_bug.cgi?id=257295</a>
&lt;rdar://problem/109804872&gt;

Reviewed by NOBODY (OOPS!).

In order to deliver displayDidRefresh for WorkerThread requestAnimationFrame, we want a version of displayDidRefresh/DisplayRefreshMonitor that allows notifications without blocking on the main thread. We also likely want to match whatever framerate/throttling the underlying WebCore::Page is using, so that we slow down when hidden etc.

DisplayRefreshMonitor is heavily hardcoded towards using the main thread, so this adds an API to EventDispatcher which handles this.

* Source/WebCore/page/ChromeClient.h:
(WebCore::ChromeClient::renderingUpdateFrequencyChanged):
* Source/WebCore/page/Page.h:
* Source/WebCore/page/RenderingUpdateScheduler.cpp:
(WebCore::RenderingUpdateScheduler::adjustRenderingUpdateFrequency):
* Source/WebKit/Shared/DisplayLinkObserverID.h:
* Source/WebKit/WebProcess/WebCoreSupport/WebChromeClient.cpp:
(WebKit::WebChromeClient::renderingUpdateFrequencyChanged):
* Source/WebKit/WebProcess/WebCoreSupport/WebChromeClient.h:
* Source/WebKit/WebProcess/WebPage/EventDispatcher.cpp:
(WebKit::EventDispatcher::displayDidRefresh):
(WebKit::EventDispatcher::pageScreenDidChange):
(WebKit::EventDispatcher::renderingUpdateFrequencyChanged):
(WebKit::EventDispatcher::PageObservers::PageObservers):
(WebKit::EventDispatcher::updateAsyncRenderingRefreshObservers):
(WebKit::EventDispatcher::startTimerForPage):
(WebKit::EventDispatcher::stopTimerForPage):
(WebKit::EventDispatcher::notifyAsyncRenderingRefreshObserversDisplayDidRefresh):
(WebKit::EventDispatcher::notifyPageObserversDisplayDidRefresh):
(WebKit::EventDispatcher::addAsyncRenderingRefreshObserver):
(WebKit::EventDispatcher::removeAsyncRenderingRefreshObserver):
* Source/WebKit/WebProcess/WebPage/EventDispatcher.h:
</pre>
----------------------------------------------------------------------
#### 16202d86c675ce99fac647d152bc5e04186bbf45
<pre>
Allow WebKit to override WorkerAnimationController and provide their own implementations
<a href="https://bugs.webkit.org/show_bug.cgi?id=257098">https://bugs.webkit.org/show_bug.cgi?id=257098</a>

Reviewed by NOBODY (OOPS!).

This is a prerequisite to adding a WebKit implementation that uses display link callbacks to
drive the animation frame rate.

* Source/WebCore/page/WorkerClient.h:
* Source/WebCore/workers/DedicatedWorkerGlobalScope.cpp:
(WebCore::DedicatedWorkerGlobalScope::requestAnimationFrame):
* Source/WebCore/workers/WorkerAnimationController.cpp:
(WebCore::WorkerAnimationController::WorkerAnimationController):
(WebCore::WorkerAnimationController::virtualHasPendingActivity const):
(WebCore::WorkerAnimationController::stop):
(WebCore::TimerWorkerAnimationController::TimerWorkerAnimationController):
(WebCore::TimerWorkerAnimationController::~TimerWorkerAnimationController):
(WebCore::TimerWorkerAnimationController::isActive const):
(WebCore::TimerWorkerAnimationController::stopAnimation):
(WebCore::TimerWorkerAnimationController::scheduleAnimation):
(WebCore::TimerWorkerAnimationController::create):
(WebCore::WorkerAnimationController::create): Deleted.
(WebCore::WorkerAnimationController::~WorkerAnimationController): Deleted.
(WebCore::WorkerAnimationController::scheduleAnimation): Deleted.
* Source/WebCore/workers/WorkerAnimationController.h:
* Source/WebKit/WebProcess/WebCoreSupport/WebWorkerClient.cpp:
(WebKit::WebWorkerClient::createAnimationController):
* Source/WebKit/WebProcess/WebCoreSupport/WebWorkerClient.h:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/58a9a5078d0be3d36f2cc3a90f8df32054e99e2d

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/8390 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/8683 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/8900 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/10057 "Built successfully") | [❌ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/8453 "Failed to compile WebKit") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/8399 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/10671 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/8787 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/11315 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/8536 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/9587 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/7597 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/10210 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/6885 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/7674 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/15241 "2 flakes 134 failures") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/8006 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/7817 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/11175 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/8293 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/6890 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/7582 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/11792 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/8037 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->