### PR TITLE
[Cocoa] Extend access to the 'com.apple.gputools.service' mach service if Web Inspector is enabled

### DIFF
--- a/Source/WebKit/GPUProcess/GPUProcess.cpp
+++ b/Source/WebKit/GPUProcess/GPUProcess.cpp
@@ -262,6 +262,10 @@ void GPUProcess::initializeGPUProcess(GPUProcessCreationParameters&& parameters)
 
     populateMobileGestaltCache(WTFMove(parameters.mobileGestaltExtensionHandle));
 
+#if PLATFORM(COCOA) && ENABLE(REMOTE_INSPECTOR)
+    SandboxExtension::consumePermanently(parameters.gpuToolsExtensionHandles);
+#endif
+
 #if HAVE(CGIMAGESOURCE_WITH_SET_ALLOWABLE_TYPES)
     auto emptyArray = adoptCF(CFArrayCreate(kCFAllocatorDefault, nullptr, 0, &kCFTypeArrayCallBacks));
     CGImageSourceSetAllowableTypes(emptyArray.get());
@@ -375,6 +379,12 @@ GPUConnectionToWebProcess* GPUProcess::webProcessConnection(WebCore::ProcessIden
     return m_webProcessConnections.get(identifier);
 }
 
+void GPUProcess::updateSandboxAccess(const Vector<SandboxExtension::Handle>& extensions)
+{
+    for (auto& extension : extensions)
+        SandboxExtension::consumePermanently(extension);
+}
+
 #if ENABLE(MEDIA_STREAM)
 void GPUProcess::setMockCaptureDevicesEnabled(bool isEnabled)
 {
@@ -420,12 +430,6 @@ void GPUProcess::updateCaptureOrigin(const WebCore::SecurityOriginData& originDa
 {
     if (auto* connection = webProcessConnection(processID))
         connection->updateCaptureOrigin(originData);
-}
-
-void GPUProcess::updateSandboxAccess(const Vector<SandboxExtension::Handle>& extensions)
-{
-    for (auto& extension : extensions)
-        SandboxExtension::consumePermanently(extension);
 }
 
 void GPUProcess::addMockMediaDevice(const WebCore::MockMediaDevice& device)

--- a/Source/WebKit/GPUProcess/GPUProcess.h
+++ b/Source/WebKit/GPUProcess/GPUProcess.h
@@ -151,6 +151,7 @@ private:
     void createGPUConnectionToWebProcess(WebCore::ProcessIdentifier, PAL::SessionID, IPC::Connection::Handle&&, GPUProcessConnectionParameters&&, CompletionHandler<void()>&&);
     void addSession(PAL::SessionID, GPUProcessSessionParameters&&);
     void removeSession(PAL::SessionID);
+    void updateSandboxAccess(const Vector<SandboxExtension::Handle>&);
     
     bool updatePreference(std::optional<bool>& oldPreference, std::optional<bool>& newPreference);
     void userPreferredLanguagesChanged(Vector<String>&&);
@@ -161,7 +162,6 @@ private:
     void setOrientationForMediaCapture(WebCore::IntDegrees);
     void updateCaptureAccess(bool allowAudioCapture, bool allowVideoCapture, bool allowDisplayCapture, WebCore::ProcessIdentifier, CompletionHandler<void()>&&);
     void updateCaptureOrigin(const WebCore::SecurityOriginData&, WebCore::ProcessIdentifier);
-    void updateSandboxAccess(const Vector<SandboxExtension::Handle>&);
     void addMockMediaDevice(const WebCore::MockMediaDevice&);
     void clearMockMediaDevices();
     void removeMockMediaDevice(const String&);

--- a/Source/WebKit/GPUProcess/GPUProcess.messages.in
+++ b/Source/WebKit/GPUProcess/GPUProcess.messages.in
@@ -28,6 +28,7 @@ messages -> GPUProcess LegacyReceiver {
     CreateGPUConnectionToWebProcess(WebCore::ProcessIdentifier processIdentifier, PAL::SessionID sessionID, IPC::Connection::Handle connectionHandle, struct WebKit::GPUProcessConnectionParameters parameters) -> () AllowedWhenWaitingForSyncReply
     
     UpdateGPUProcessPreferences(struct WebKit::GPUProcessPreferences preferences)
+    UpdateSandboxAccess(Vector<WebKit::SandboxExtension::Handle> extensions);
 
     PrepareToSuspend(bool isSuspensionImminent, MonotonicTime estimatedSuspendTime) -> ()
     ProcessDidResume()
@@ -38,7 +39,6 @@ messages -> GPUProcess LegacyReceiver {
 #if ENABLE(MEDIA_STREAM)
     SetMockCaptureDevicesEnabled(bool isEnabled)
     SetOrientationForMediaCapture(WebCore::IntDegrees orientation);
-    UpdateSandboxAccess(Vector<WebKit::SandboxExtension::Handle> extensions);
     UpdateCaptureAccess(bool allowAudioCapture, bool allowVideoCapture, bool allowDisplayCapture, WebCore::ProcessIdentifier processID) -> ()
     UpdateCaptureOrigin(WebCore::SecurityOriginData originData, WebCore::ProcessIdentifier processID)
     AddMockMediaDevice(struct WebCore::MockMediaDevice device)

--- a/Source/WebKit/GPUProcess/GPUProcessCreationParameters.cpp
+++ b/Source/WebKit/GPUProcess/GPUProcessCreationParameters.cpp
@@ -62,6 +62,9 @@ void GPUProcessCreationParameters::encode(IPC::Encoder& encoder) const
     encoder << dynamicIOKitExtensionHandles;
 #endif
     encoder << mobileGestaltExtensionHandle;
+#if PLATFORM(COCOA) && ENABLE(REMOTE_INSPECTOR)
+    encoder << gpuToolsExtensionHandles;
+#endif
 
     encoder << applicationVisibleName;
 #if PLATFORM(COCOA)
@@ -127,6 +130,14 @@ bool GPUProcessCreationParameters::decode(IPC::Decoder& decoder, GPUProcessCreat
     if (!mobileGestaltExtensionHandle)
         return false;
     result.mobileGestaltExtensionHandle = WTFMove(*mobileGestaltExtensionHandle);
+
+#if PLATFORM(COCOA) && ENABLE(REMOTE_INSPECTOR)
+    std::optional<Vector<SandboxExtension::Handle>> gpuToolsExtensionHandles;
+    decoder >> gpuToolsExtensionHandles;
+    if (!gpuToolsExtensionHandles)
+        return false;
+    result.gpuToolsExtensionHandles = WTFMove(*gpuToolsExtensionHandles);
+#endif
 
     if (!decoder.decode(result.applicationVisibleName))
         return false;

--- a/Source/WebKit/GPUProcess/GPUProcessCreationParameters.h
+++ b/Source/WebKit/GPUProcess/GPUProcessCreationParameters.h
@@ -62,6 +62,9 @@ struct GPUProcessCreationParameters {
     Vector<SandboxExtension::Handle> dynamicIOKitExtensionHandles;
 #endif
     std::optional<SandboxExtension::Handle> mobileGestaltExtensionHandle;
+#if PLATFORM(COCOA) && ENABLE(REMOTE_INSPECTOR)
+    Vector<SandboxExtension::Handle> gpuToolsExtensionHandles;
+#endif
 
     String applicationVisibleName;
 #if PLATFORM(COCOA)

--- a/Source/WebKit/UIProcess/Cocoa/GPUProcessProxyCocoa.mm
+++ b/Source/WebKit/UIProcess/Cocoa/GPUProcessProxyCocoa.mm
@@ -32,6 +32,7 @@
 #include "GPUProcessCreationParameters.h"
 #include "GPUProcessMessages.h"
 #include "MediaPermissionUtilities.h"
+#include "WebProcessProxy.h"
 
 #if HAVE(POWERLOG_TASK_MODE_QUERY)
 #include <pal/spi/mac/PowerLogSPI.h>
@@ -45,6 +46,7 @@ namespace WebKit {
 void GPUProcessProxy::platformInitializeGPUProcessParameters(GPUProcessCreationParameters& parameters)
 {
     parameters.mobileGestaltExtensionHandle = createMobileGestaltSandboxExtensionIfNeeded();
+    parameters.gpuToolsExtensionHandles = createGPUToolsSandboxExtensionHandlesIfNeeded();
     parameters.applicationVisibleName = applicationVisibleName();
     parameters.strictSecureDecodingForAllObjCEnabled = IPC::strictSecureDecodingForAllObjCEnabled();
 }
@@ -75,6 +77,14 @@ void GPUProcessProxy::enablePowerLogging()
     send(Messages::GPUProcess::EnablePowerLogging(*handle), 0);
 }
 #endif // HAVE(POWERLOG_TASK_MODE_QUERY)
+
+Vector<SandboxExtension::Handle> GPUProcessProxy::createGPUToolsSandboxExtensionHandlesIfNeeded()
+{
+    if (!WebProcessProxy::shouldEnableRemoteInspector())
+        return { };
+
+    return SandboxExtension::createHandlesForMachLookup({ "com.apple.gputools.service"_s, }, std::nullopt);
+}
 
 }
 

--- a/Source/WebKit/UIProcess/Cocoa/WebProcessPoolCocoa.mm
+++ b/Source/WebKit/UIProcess/Cocoa/WebProcessPoolCocoa.mm
@@ -414,6 +414,15 @@ ALLOW_DEPRECATED_DECLARATIONS_END
     if (WebProcessProxy::shouldEnableRemoteInspector()) {
         auto handles = SandboxExtension::createHandlesForMachLookup({ "com.apple.webinspector"_s }, process.auditToken());
         parameters.enableRemoteWebInspectorExtensionHandles = WTFMove(handles);
+
+#if ENABLE(GPU_PROCESS)
+        if (auto* gpuProcess = GPUProcessProxy::singletonIfCreated()) {
+            if (!gpuProcess->hasSentGPUToolsSandboxExtensions()) {
+                auto gpuToolsHandle = GPUProcessProxy::createGPUToolsSandboxExtensionHandlesIfNeeded();
+                gpuProcess->send(Messages::GPUProcess::UpdateSandboxAccess(gpuToolsHandle), 0);
+            }
+        }
+#endif
     }
 #endif
 

--- a/Source/WebKit/UIProcess/GPU/GPUProcessProxy.cpp
+++ b/Source/WebKit/UIProcess/GPU/GPUProcessProxy.cpp
@@ -183,6 +183,10 @@ GPUProcessProxy::GPUProcessProxy()
     // Initialize the GPU process.
     send(Messages::GPUProcess::InitializeGPUProcess(parameters), 0);
 
+#if PLATFORM(COCOA)
+    m_hasSentGPUToolsSandboxExtensions = !parameters.gpuToolsExtensionHandles.isEmpty();
+#endif
+
 #if HAVE(AUDIO_COMPONENT_SERVER_REGISTRATIONS) && ENABLE(AUDIO_COMPONENT_SERVER_REGISTRATIONS_IN_GPU_PROCESS)
     auto registrations = fetchAudioComponentServerRegistrations();
     RELEASE_ASSERT(registrations);

--- a/Source/WebKit/UIProcess/GPU/GPUProcessProxy.h
+++ b/Source/WebKit/UIProcess/GPU/GPUProcessProxy.h
@@ -119,6 +119,11 @@ public:
     void requestBitmapImageForCurrentTime(WebCore::ProcessIdentifier, WebCore::MediaPlayerIdentifier, CompletionHandler<void(ShareableBitmap::Handle&&)>&&);
 #endif
 
+#if PLATFORM(COCOA) && ENABLE(REMOTE_INSPECTOR)
+    bool hasSentGPUToolsSandboxExtensions() const { return m_hasSentGPUToolsSandboxExtensions; }
+    static Vector<SandboxExtension::Handle> createGPUToolsSandboxExtensionHandlesIfNeeded();
+#endif
+
 private:
     explicit GPUProcessProxy();
 
@@ -182,6 +187,7 @@ private:
     bool m_hasSentCameraSandboxExtension { false };
     bool m_hasSentMicrophoneSandboxExtension { false };
     bool m_hasSentDisplayCaptureSandboxExtension { false };
+    bool m_hasSentGPUToolsSandboxExtensions { false };
 #endif
 
 #if HAVE(SCREEN_CAPTURE_KIT)


### PR DESCRIPTION
#### 20d3e87d72695d65ea71a557c33ba0f5148a2267
<pre>
[Cocoa] Extend access to the &apos;com.apple.gputools.service&apos; mach service if Web Inspector is enabled
<a href="https://bugs.webkit.org/show_bug.cgi?id=256673">https://bugs.webkit.org/show_bug.cgi?id=256673</a>
&lt;rdar://107631614&gt;

Reviewed by Per Arne Vollan.

Access to the `com.apple.gputools.service` mach service is denied to the GPU Process.
Unfortunately, some developer diagnostic tools for graphics investigation need this
access to work.

We should have the UI Process extend permission for the GPU Process to talk to relevant
services when the Web Inspector has been enabled.

* Source/WebKit/GPUProcess/GPUProcess.cpp:
(WebKit::GPUProcess::initializeGPUProcess): Consume the GPU tools extensions if present.
(WebKit::GPUProcess::updateSandboxAccess): Move outside the MEDIA_SESSION enablement macro
so we can use it for WebInspector purposes.
* Source/WebKit/GPUProcess/GPUProcess.h:
* Source/WebKit/GPUProcess/GPUProcess.messages.in: Ditto.
* Source/WebKit/GPUProcess/GPUProcessCreationParameters.cpp:
(WebKit::GPUProcessCreationParameters::encode const): Update for additional sandbox extensions.
(WebKit::GPUProcessCreationParameters::decode): Ditto.
* Source/WebKit/GPUProcess/GPUProcessCreationParameters.h:
* Source/WebKit/UIProcess/Cocoa/GPUProcessProxyCocoa.mm:
(WebKit::GPUProcessProxy::platformInitializeGPUProcessParameters): Add GPU tools extensions to
process launch parameters if needed.
(WebKit::GPUProcessProxy::createGPUToolsSandboxExtensionHandlesIfNeeded): Added.
* Source/WebKit/UIProcess/Cocoa/WebProcessPoolCocoa.mm:
(WebKit::WebProcessPool::platformInitializeWebProcess): Extend GPU tools extensions to the GPU
process if they haven&apos;t been sent before, but the WebInspector is now enabled.
* Source/WebKit/UIProcess/GPU/GPUProcessProxy.cpp:
(WebKit::GPUProcessProxy::GPUProcessProxy):
* Source/WebKit/UIProcess/GPU/GPUProcessProxy.h:

Canonical link: <a href="https://commits.webkit.org/264029@main">https://commits.webkit.org/264029@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/3a46a61645f591c8fc4a37cf3adc3840c4059ced

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/6457 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/6665 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/6846 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/8036 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/6752 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/6979 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/6616 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/9645 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/6570 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/6627 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/5850 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/8115 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/4092 "Passed tests") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/13680 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/6011 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/5909 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/8228 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/6393 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/5226 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/5799 "Built successfully") | | | 
| [❌ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/1526 "Failed to push commit to Webkit repository") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/9958 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/6170 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->