### PR TITLE
[GTK][WPE] generate-bundle: improve how the mesa libraries are detected

### DIFF
--- a/Tools/Scripts/generate-bundle
+++ b/Tools/Scripts/generate-bundle
@@ -482,19 +482,24 @@ class BundleCreator(object):
         return libc_libraries
 
     def _get_mesa_libraries(self):
-        mesa_library_names = ['libglapi', 'libEGL', 'libGL', 'libGLESv2', 'libEGL_mesa']
+        mesa_library_names = ['libglapi', 'libEGL', 'libGL', 'libGLESv2', 'libGLX', 'libdrm', 'libgbm', 'libMesaOpenCL']
         mesa_libraries = []
         lib_dir_dri = self._get_pkg_config_var('dri', 'libdir')
-        # Some versions of the flatpak SDK ships the Mesa libraries into a non-standard path.
+        # Some versions of the flatpak SDK ship the Mesa libraries into a non-standard path.
         candidate_lib_dirs = [ lib_dir_dri, os.path.join(lib_dir_dri, 'GL/default/lib') ]
         for lib_dir in candidate_lib_dirs:
             if os.path.isdir(lib_dir):
                 for entry in os.listdir(lib_dir):
-                    if any(entry.startswith(l+'.so.') for l in mesa_library_names):
-                        mesa_libraries.append(os.path.join(lib_dir, entry))
-        for mesa_library_prefix in mesa_library_names:
-            if not any(os.path.basename(l).startswith(mesa_library_prefix+'.so.') for l in mesa_libraries):
-                raise RuntimeError('Unable to find mesa library %s' % mesa_library_prefix)
+                    if '.so.' in entry:
+                        entry_libname = entry.split('.so.', 1)[0]
+                        # Mesa libraries are either named as "libNAME.so.1" or have a suffix like "libNAME_mesa.so.0" or "libNAME_indirect.so.0"
+                        # Hypothetical future suffixes are unknown so we match any library named "libNAME" or any library that starts with "libNAME_"
+                        if any((entry_libname == l or entry_libname.startswith(l+'_')) for l in mesa_library_names):
+                            mesa_libraries.append(os.path.join(lib_dir, entry))
+        _log.debug('Found the following mesa libraries: %s' % ', '.join(mesa_libraries))
+        for required_mesa_library_prefix in ['libGL', 'libGLESv2']:
+            if not any(os.path.basename(l).startswith(required_mesa_library_prefix+'.so.') for l in mesa_libraries):
+                raise RuntimeError('Unable to find mesa library with prefix %s' % required_mesa_library_prefix)
         return mesa_libraries
 
     def _get_mesa_dri_drivers(self):


### PR DESCRIPTION
#### 3583a57df187178ad2205b6c624259a125d29ce7
<pre>
[GTK][WPE] generate-bundle: improve how the mesa libraries are detected
<a href="https://bugs.webkit.org/show_bug.cgi?id=256672">https://bugs.webkit.org/show_bug.cgi?id=256672</a>

Reviewed by Michael Catanzaro.

The new Mesa version library shipped on the Flatpak SDK contains library
names from Mesa that are not expected by the current generate-bundle script.
This causes that not all the needed Mesa libraries are copied into the
bundle, leading to run-time crashes in some cases when executing the browser.

Fix that by adding the new expected Mesa library names and also by improving
how the libraries are detected so it includes names with any suffix and is
not needed to list all the possible combinations of suffixes.

* Tools/Scripts/generate-bundle:

Canonical link: <a href="https://commits.webkit.org/264020@main">https://commits.webkit.org/264020@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a05a23f5638d6f2c6f7952f547b93012bb0e7ee7

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/6328 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/6524 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/6705 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/7903 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/6646 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/6327 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/6744 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/6474 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/9539 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/6440 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/6440 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/5730 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/7974 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/3912 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/5711 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/13588 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/5776 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/5794 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/8038 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/6275 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/5129 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/5684 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/9841 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/755 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/6055 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->