### PR TITLE
Reland 263531@main without Speedometer regression

### DIFF
--- a/LayoutTests/TestExpectations
+++ b/LayoutTests/TestExpectations
@@ -6371,10 +6371,6 @@ webkit.org/b/255101 imported/w3c/web-platform-tests/css/css-backgrounds/box-shad
 webkit.org/b/255101 imported/w3c/web-platform-tests/css/css-backgrounds/box-shadow/slice-inline-fragmentation-002.html [ ImageOnlyFailure ]
 webkit.org/b/255101 imported/w3c/web-platform-tests/css/css-backgrounds/box-shadow/slice-inline-fragmentation-003.html [ ImageOnlyFailure ]
 
-imported/w3c/web-platform-tests/css/css-backgrounds/color-mix-currentcolor-border-repaint-parent.html [ Skip ]
-imported/w3c/web-platform-tests/css/css-backgrounds/color-mix-currentcolor-border-repaint.html [ Skip ]
-imported/w3c/web-platform-tests/css/css-backgrounds/currentcolor-border-repaint-parent.html [ Skip ]
-
 # Flaky test that sometimes passes and sometimes fails.
 imported/w3c/web-platform-tests/screen-orientation/nested-documents.html [ Pass Failure ]
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-backgrounds/color-mix-currentcolor-background-repaint-expected.xht
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-backgrounds/color-mix-currentcolor-background-repaint-expected.xht
@@ -1,0 +1,19 @@
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml">
+ <head>
+  <title>CSS Reftest Reference</title>
+  <link rel="author" title="Gérard Talbot" href="http://www.gtalbot.org/BrowserBugsSection/css21testsuite/" />
+  <style type="text/css"><![CDATA[
+  div
+  {
+  background-color: green;
+  height: 100px;
+  width: 100px;
+  }
+  ]]></style>
+ </head>
+ <body>
+  <p>Test passes if there is a filled green square and <strong>no red</strong>.</p>
+  <div></div>
+ </body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-backgrounds/color-mix-currentcolor-background-repaint-parent-expected.xht
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-backgrounds/color-mix-currentcolor-background-repaint-parent-expected.xht
@@ -1,0 +1,19 @@
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml">
+ <head>
+  <title>CSS Reftest Reference</title>
+  <link rel="author" title="Gérard Talbot" href="http://www.gtalbot.org/BrowserBugsSection/css21testsuite/" />
+  <style type="text/css"><![CDATA[
+  div
+  {
+  background-color: green;
+  height: 100px;
+  width: 100px;
+  }
+  ]]></style>
+ </head>
+ <body>
+  <p>Test passes if there is a filled green square and <strong>no red</strong>.</p>
+  <div></div>
+ </body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-backgrounds/color-mix-currentcolor-background-repaint-parent.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-backgrounds/color-mix-currentcolor-background-repaint-parent.html
@@ -1,0 +1,39 @@
+<!DOCTYPE html>
+<html class="reftest-wait">
+<title>currentColor in color-mix() used in background-color repaints properly when parent color changes</title>
+<link rel="author" title="Tim Nguyen" href="https://github.com/nt1m">
+<link rel="help" href="https://drafts.csswg.org/css-color/#currentcolor-color">
+<link rel="match" href="../reference/ref-filled-green-100px-square.xht">
+<style>
+    #container {
+        color: red;
+    }
+
+    #container.green {
+        color: green;
+    }
+
+    #target {
+        background-color: color-mix(in hsl, transparent 0%, currentColor 100%);
+        width: 100px;
+        height: 100px;
+    }
+</style>
+
+<p>Test passes if there is a filled green square and <strong>no red</strong>.</p>
+
+<div id="container">
+    <div id="target"></div>
+</div>
+
+<script>
+    addEventListener("load", () => {
+        setTimeout(() => {
+            requestAnimationFrame(() => {
+                container.classList.add("green");
+                document.documentElement.classList.remove("reftest-wait");
+            });
+        }, 0);
+    });
+</script>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-backgrounds/color-mix-currentcolor-background-repaint.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-backgrounds/color-mix-currentcolor-background-repaint.html
@@ -1,0 +1,34 @@
+<!DOCTYPE html>
+<html class="reftest-wait">
+<title>currentColor in color-mix() used in background-color repaints properly when color changes</title>
+<link rel="author" title="Tim Nguyen" href="https://github.com/nt1m">
+<link rel="help" href="https://drafts.csswg.org/css-color/#currentcolor-color">
+<link rel="match" href="../reference/ref-filled-green-100px-square.xht">
+<style>
+    #target {
+        color: red;
+        background-color: color-mix(in hsl, transparent 0%, currentColor 100%);
+        width: 100px;
+        height: 100px;
+    }
+
+    #target.green {
+        color: green;
+    }
+</style>
+
+<p>Test passes if there is a filled green square and <strong>no red</strong>.</p>
+
+<div id="target"></div>
+
+<script>
+    addEventListener("load", () => {
+        setTimeout(() => {
+            requestAnimationFrame(() => {
+                target.classList.add("green");
+                document.documentElement.classList.remove("reftest-wait");
+            });
+        }, 0);
+    });
+</script>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-backgrounds/color-mix-currentcolor-outline-repaint-expected.xht
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-backgrounds/color-mix-currentcolor-outline-repaint-expected.xht
@@ -1,0 +1,19 @@
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml">
+ <head>
+  <title>CSS Reftest Reference</title>
+  <link rel="author" title="Gérard Talbot" href="http://www.gtalbot.org/BrowserBugsSection/css21testsuite/" />
+  <style type="text/css"><![CDATA[
+  div
+  {
+  background-color: green;
+  height: 100px;
+  width: 100px;
+  }
+  ]]></style>
+ </head>
+ <body>
+  <p>Test passes if there is a filled green square and <strong>no red</strong>.</p>
+  <div></div>
+ </body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-backgrounds/color-mix-currentcolor-outline-repaint-parent-expected.xht
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-backgrounds/color-mix-currentcolor-outline-repaint-parent-expected.xht
@@ -1,0 +1,19 @@
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml">
+ <head>
+  <title>CSS Reftest Reference</title>
+  <link rel="author" title="Gérard Talbot" href="http://www.gtalbot.org/BrowserBugsSection/css21testsuite/" />
+  <style type="text/css"><![CDATA[
+  div
+  {
+  background-color: green;
+  height: 100px;
+  width: 100px;
+  }
+  ]]></style>
+ </head>
+ <body>
+  <p>Test passes if there is a filled green square and <strong>no red</strong>.</p>
+  <div></div>
+ </body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-backgrounds/color-mix-currentcolor-outline-repaint-parent.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-backgrounds/color-mix-currentcolor-outline-repaint-parent.html
@@ -1,0 +1,40 @@
+<!DOCTYPE html>
+<html class="reftest-wait">
+<title>currentColor in color-mix() used in outline repaints properly when parent color changes</title>
+<link rel="author" title="Tim Nguyen" href="https://github.com/nt1m">
+<link rel="help" href="https://drafts.csswg.org/css-color/#currentcolor-color">
+<link rel="match" href="../reference/ref-filled-green-100px-square.xht">
+<style>
+    #container {
+        color: red;
+    }
+
+    #container.green {
+        color: green;
+    }
+
+    #target {
+        outline: 50px solid color-mix(in hsl, transparent 0%, currentColor 100%);
+        outline-offset: -50px;
+        width: 100px;
+        height: 100px;
+    }
+</style>
+
+<p>Test passes if there is a filled green square and <strong>no red</strong>.</p>
+
+<div id="container">
+    <div id="target"></div>
+</div>
+
+<script>
+    addEventListener("load", () => {
+        setTimeout(() => {
+            requestAnimationFrame(() => {
+                container.classList.add("green");
+                document.documentElement.classList.remove("reftest-wait");
+            });
+        }, 0);
+    });
+</script>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-backgrounds/color-mix-currentcolor-outline-repaint.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-backgrounds/color-mix-currentcolor-outline-repaint.html
@@ -1,0 +1,35 @@
+<!DOCTYPE html>
+<html class="reftest-wait">
+<title>currentColor in color-mix() used in outline repaints properly when color changes</title>
+<link rel="author" title="Tim Nguyen" href="https://github.com/nt1m">
+<link rel="help" href="https://drafts.csswg.org/css-color/#currentcolor-color">
+<link rel="match" href="../reference/ref-filled-green-100px-square.xht">
+<style>
+    #target {
+        color: red;
+        outline: 50px solid color-mix(in hsl, transparent 0%, currentColor 100%);
+        outline-offset: -50px;
+        width: 100px;
+        height: 100px;
+    }
+
+    #target.green {
+        color: green;
+    }
+</style>
+
+<p>Test passes if there is a filled green square and <strong>no red</strong>.</p>
+
+<div id="target"></div>
+
+<script>
+    addEventListener("load", () => {
+        setTimeout(() => {
+            requestAnimationFrame(() => {
+                target.classList.add("green");
+                document.documentElement.classList.remove("reftest-wait");
+            });
+        }, 0);
+    });
+</script>
+</html>

--- a/Source/WebCore/rendering/style/RenderStyle.cpp
+++ b/Source/WebCore/rendering/style/RenderStyle.cpp
@@ -1281,13 +1281,13 @@ bool RenderStyle::changeRequiresRepaint(const RenderStyle& other, OptionSet<Styl
         return true;
 
 
-    if (m_nonInheritedData.ptr() != other.m_nonInheritedData.ptr()) {
-        if (m_nonInheritedData->backgroundData.ptr() != other.m_nonInheritedData->backgroundData.ptr()) {
+    if (currentColorDiffers || m_nonInheritedData.ptr() != other.m_nonInheritedData.ptr()) {
+        if (currentColorDiffers || m_nonInheritedData->backgroundData.ptr() != other.m_nonInheritedData->backgroundData.ptr()) {
             if (!m_nonInheritedData->backgroundData->isEquivalentForPainting(*other.m_nonInheritedData->backgroundData, currentColorDiffers))
                 return true;
         }
 
-        if (m_nonInheritedData->surroundData.ptr() != other.m_nonInheritedData->surroundData.ptr()) {
+        if (currentColorDiffers || m_nonInheritedData->surroundData.ptr() != other.m_nonInheritedData->surroundData.ptr()) {
             if (!m_nonInheritedData->surroundData->border.isEquivalentForPainting(other.m_nonInheritedData->surroundData->border, currentColorDiffers))
                 return true;
         }

--- a/Source/WebCore/rendering/style/StyleBackgroundData.cpp
+++ b/Source/WebCore/rendering/style/StyleBackgroundData.cpp
@@ -58,11 +58,11 @@ bool StyleBackgroundData::isEquivalentForPainting(const StyleBackgroundData& oth
 {
     if (background != other.background || color != other.color)
         return false;
-    if (currentColorDiffers && color.isCurrentColor())
+    if (currentColorDiffers && color.containsCurrentColor())
         return false;
     if (!outline.isVisible() && !other.outline.isVisible())
         return true;
-    if (currentColorDiffers && outline.color().isCurrentColor())
+    if (currentColorDiffers && outline.color().containsCurrentColor())
         return false;
     return outline == other.outline;
 }


### PR DESCRIPTION
#### 0fcccfdd39fb158061c2eb8eb6dc1d0c220f568d
<pre>
Reland 263531@main without Speedometer regression
<a href="https://bugs.webkit.org/show_bug.cgi?id=256674">https://bugs.webkit.org/show_bug.cgi?id=256674</a>
rdar://109234330

Reviewed by Simon Fraser.

The ElementRuleCollector.cpp change was causing the perf regression, reland without it for now, since it&apos;s not strictly necessary to fix the repaint issue.

Also fix similar repaint issues with background/outline which were not fixed by the original patch.

* LayoutTests/TestExpectations:
* LayoutTests/imported/w3c/web-platform-tests/css/css-backgrounds/color-mix-currentcolor-background-repaint-expected.xht: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-backgrounds/color-mix-currentcolor-background-repaint-parent-expected.xht: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-backgrounds/color-mix-currentcolor-background-repaint-parent.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-backgrounds/color-mix-currentcolor-background-repaint.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-backgrounds/color-mix-currentcolor-outline-repaint-expected.xht: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-backgrounds/color-mix-currentcolor-outline-repaint-parent-expected.xht: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-backgrounds/color-mix-currentcolor-outline-repaint-parent.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-backgrounds/color-mix-currentcolor-outline-repaint.html: Added.
* Source/WebCore/rendering/style/RenderStyle.cpp:
(WebCore::RenderStyle::changeRequiresRepaint const):
* Source/WebCore/rendering/style/StyleBackgroundData.cpp:
(WebCore::StyleBackgroundData::isEquivalentForPainting const):

Canonical link: <a href="https://commits.webkit.org/264218@main">https://commits.webkit.org/264218@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/383dea690a26a2cf7c7aba172fb2c91c99c27a19

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/7003 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/7244 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/7424 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/8616 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/7237 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/7012 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/8506 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/7178 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/10146 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/7129 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/7799 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/6463 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/8719 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/5167 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/6371 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/14144 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/6836 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/6465 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/9312 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/6939 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/5686 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/6307 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/6281 "Passed tests") | | 
| [❌ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/1669 "Failed to push commit to Webkit repository") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/10501 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/6689 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->