### PR TITLE
[WPE][GTK][CMake] The path to bwrap and xdg-dbus-proxy should not be auto-detected when cross-compiling

### DIFF
--- a/Source/cmake/BubblewrapSandboxChecks.cmake
+++ b/Source/cmake/BubblewrapSandboxChecks.cmake
@@ -1,19 +1,43 @@
 if (ENABLE_BUBBLEWRAP_SANDBOX)
-    find_program(BWRAP_EXECUTABLE bwrap)
-    if (NOT BWRAP_EXECUTABLE)
-        message(FATAL_ERROR "bwrap executable is needed for ENABLE_BUBBLEWRAP_SANDBOX")
-    endif ()
-
     find_package(Libseccomp)
     if (NOT Libseccomp_FOUND)
         message(FATAL_ERROR "libseccomp is needed for ENABLE_BUBBLEWRAP_SANDBOX")
     endif ()
 
-    find_program(DBUS_PROXY_EXECUTABLE xdg-dbus-proxy)
-    if (NOT DBUS_PROXY_EXECUTABLE)
-        message(FATAL_ERROR "xdg-dbus-proxy not found and is needed for ENABLE_BUBBLEWRAP_SANDBOX")
+    if (NOT DEFINED BWRAP_EXECUTABLE)
+        if (CMAKE_CROSSCOMPILING)
+            message(FATAL_ERROR "bwrap executable version 0.3.1 or newer is needed for ENABLE_BUBBLEWRAP_SANDBOX. Unable to autodetect the path when cross-compiling. "
+                                "Please define define the CMake variable BWRAP_EXECUTABLE with the run-time full-path to the 'bwrap' program.")
+        else ()
+            find_program(BWRAP_EXECUTABLE bwrap)
+            if (NOT BWRAP_EXECUTABLE)
+                message(FATAL_ERROR "bwrap executable is needed for ENABLE_BUBBLEWRAP_SANDBOX. "
+                       "Either install it or use the CMake variable BWRAP_EXECUTABLE to define the runtime path.")
+            endif ()
+        endif ()
     endif ()
 
+    if (NOT DEFINED DBUS_PROXY_EXECUTABLE)
+        if (CMAKE_CROSSCOMPILING)
+            message(FATAL_ERROR "xdg-dbus-proxy executable is needed for ENABLE_BUBBLEWRAP_SANDBOX.  Unable to autodetect the path when cross-compiling. "
+                                "Please define define the CMake variable DBUS_PROXY_EXECUTABLE with the run-time full-path to the 'xdg-dbus-proxy' program.")
+        else ()
+            find_program(DBUS_PROXY_EXECUTABLE xdg-dbus-proxy)
+            if (NOT DBUS_PROXY_EXECUTABLE)
+                message(FATAL_ERROR "xdg-dbus-proxy executable not found and is needed for ENABLE_BUBBLEWRAP_SANDBOX. "
+                       "Either install it or use the CMake variable DBUS_PROXY_EXECUTABLE to define the runtime path.")
+            endif ()
+        endif ()
+    endif ()
+
+    # Do some extra sanity checks
+    if (NOT IS_ABSOLUTE "${BWRAP_EXECUTABLE}")
+        message(FATAL_ERROR "The value for BWRAP_EXECUTABLE should be a full path.")
+    endif ()
+    if (NOT IS_ABSOLUTE "${DBUS_PROXY_EXECUTABLE}")
+        message(FATAL_ERROR "The value for DBUS_PROXY_EXECUTABLE should be a full path.")
+    endif ()
+    # This version check can only be done when not cross-compiling
     if (NOT CMAKE_CROSSCOMPILING)
         execute_process(
             COMMAND "${BWRAP_EXECUTABLE}" --version
@@ -27,16 +51,6 @@ if (ENABLE_BUBBLEWRAP_SANDBOX)
         if (NOT "${BWRAP_VERSION}" VERSION_GREATER_EQUAL "0.3.1")
             message(FATAL_ERROR "bwrap must be >= 0.3.1 but ${BWRAP_VERSION} found")
         endif ()
-    elseif (NOT SILENCE_CROSS_COMPILATION_NOTICES)
-        message(NOTICE
-            "***--------------------------------------------------------***\n"
-            "***  Cannot check Bubblewrap version when cross-compiling. ***\n"
-            "***  The target system MUST have version 0.3.1 or newer.   ***\n"
-            "***  Use the BWRAP_EXECUTABLE and DBUS_PROXY_EXECUTABLE    ***\n"
-            "***  variables to set the run-time paths for the 'bwrap'   ***\n"
-            "***  and 'xdg-dbus-proxy' programs.                        ***\n"
-            "***--------------------------------------------------------***"
-        )
     endif ()
 
     add_definitions(-DBWRAP_EXECUTABLE="${BWRAP_EXECUTABLE}")

--- a/Tools/yocto/targets.conf
+++ b/Tools/yocto/targets.conf
@@ -39,7 +39,7 @@ conf_local_path = rpi/local-rpi3-32bits-mesa.conf
 patch_file_path = rpi/fix-nativesdk-image-defs.patch
 image_basename = webkit-dev-ci-tools
 image_types = tar.xz wic.xz wic.bmap
-environment[BUILD_WEBKIT_ARGS] = --no-fatal-warnings --cmakeargs="-DENABLE_WPE_QT_API=OFF -DENABLE_DOCUMENTATION=OFF -DENABLE_INTROSPECTION=OFF -DWPE_COG_PLATFORMS=drm,headless,wayland"
+environment[BUILD_WEBKIT_ARGS] = --no-fatal-warnings --cmakeargs="-DENABLE_WPE_QT_API=OFF -DENABLE_DOCUMENTATION=OFF -DENABLE_INTROSPECTION=OFF -DWPE_COG_PLATFORMS=drm,headless,wayland -DBWRAP_EXECUTABLE=/usr/bin/bwrap -DDBUS_PROXY_EXECUTABLE=/usr/bin/xdg-dbus-proxy"
 
 [rpi3-32bits-userland]
 repo_manifest_path = rpi/manifest.xml
@@ -49,7 +49,7 @@ patch_file_path = rpi/fix-nativesdk-image-defs.patch
 image_basename = webkit-dev-ci-tools
 image_types = tar.xz wic.xz wic.bmap
 # WTR and MiniBrowser require wpbackend-fdo, with wpbackend-rdk we can only build cog
-environment[BUILD_WEBKIT_ARGS] = --no-fatal-warnings --cmakeargs="-DENABLE_WPE_QT_API=OFF -DENABLE_DOCUMENTATION=OFF -DENABLE_INTROSPECTION=OFF -DENABLE_MINIBROWSER=OFF -DENABLE_API_TESTS=OFF -DENABLE_LAYOUT_TESTS=OFF -DWPE_COG_PLATFORMS=none"
+environment[BUILD_WEBKIT_ARGS] = --no-fatal-warnings --cmakeargs="-DENABLE_WPE_QT_API=OFF -DENABLE_DOCUMENTATION=OFF -DENABLE_INTROSPECTION=OFF -DENABLE_MINIBROWSER=OFF -DENABLE_API_TESTS=OFF -DENABLE_LAYOUT_TESTS=OFF -DWPE_COG_PLATFORMS=none -DBWRAP_EXECUTABLE=/usr/bin/bwrap -DDBUS_PROXY_EXECUTABLE=/usr/bin/xdg-dbus-proxy"
 
 [rpi4-32bits-mesa]
 repo_manifest_path = rpi/manifest.xml
@@ -58,7 +58,7 @@ conf_local_path = rpi/local-rpi4-32bits-mesa.conf
 patch_file_path = rpi/fix-nativesdk-image-defs.patch
 image_basename = webkit-dev-ci-tools
 image_types = tar.xz wic.xz wic.bmap
-environment[BUILD_WEBKIT_ARGS] = --no-fatal-warnings --cmakeargs="-DENABLE_WPE_QT_API=OFF -DENABLE_DOCUMENTATION=OFF -DENABLE_INTROSPECTION=OFF -DWPE_COG_PLATFORMS=drm,headless,wayland"
+environment[BUILD_WEBKIT_ARGS] = --no-fatal-warnings --cmakeargs="-DENABLE_WPE_QT_API=OFF -DENABLE_DOCUMENTATION=OFF -DENABLE_INTROSPECTION=OFF -DWPE_COG_PLATFORMS=drm,headless,wayland -DBWRAP_EXECUTABLE=/usr/bin/bwrap -DDBUS_PROXY_EXECUTABLE=/usr/bin/xdg-dbus-proxy"
 
 # ARM 64-bits targets (AArch64)
 
@@ -69,7 +69,7 @@ conf_local_path = rpi/local-rpi3-64bits-mesa.conf
 patch_file_path = rpi/fix-nativesdk-image-defs.patch
 image_basename = webkit-dev-ci-tools
 image_types = tar.xz wic.xz wic.bmap
-environment[BUILD_WEBKIT_ARGS] = --no-fatal-warnings --cmakeargs="-DENABLE_WPE_QT_API=OFF -DENABLE_DOCUMENTATION=OFF -DENABLE_INTROSPECTION=OFF -DWPE_COG_PLATFORMS=drm,headless,wayland"
+environment[BUILD_WEBKIT_ARGS] = --no-fatal-warnings --cmakeargs="-DENABLE_WPE_QT_API=OFF -DENABLE_DOCUMENTATION=OFF -DENABLE_INTROSPECTION=OFF -DWPE_COG_PLATFORMS=drm,headless,wayland -DBWRAP_EXECUTABLE=/usr/bin/bwrap -DDBUS_PROXY_EXECUTABLE=/usr/bin/xdg-dbus-proxy"
 
 [rpi4-64bits-mesa]
 repo_manifest_path = rpi/manifest.xml
@@ -78,4 +78,4 @@ conf_local_path = rpi/local-rpi4-64bits-mesa.conf
 patch_file_path = rpi/fix-nativesdk-image-defs.patch
 image_basename = webkit-dev-ci-tools
 image_types = tar.xz wic.xz wic.bmap
-environment[BUILD_WEBKIT_ARGS] = --no-fatal-warnings --cmakeargs="-DENABLE_WPE_QT_API=OFF -DENABLE_DOCUMENTATION=OFF -DENABLE_INTROSPECTION=OFF -DWPE_COG_PLATFORMS=drm,headless,wayland"
+environment[BUILD_WEBKIT_ARGS] = --no-fatal-warnings --cmakeargs="-DENABLE_WPE_QT_API=OFF -DENABLE_DOCUMENTATION=OFF -DENABLE_INTROSPECTION=OFF -DWPE_COG_PLATFORMS=drm,headless,wayland -DBWRAP_EXECUTABLE=/usr/bin/bwrap -DDBUS_PROXY_EXECUTABLE=/usr/bin/xdg-dbus-proxy"


### PR DESCRIPTION
#### a84036c6d1d66d723f217a4c29eee76f2039a353
<pre>
[WPE][GTK][CMake] The path to bwrap and xdg-dbus-proxy should not be auto-detected when cross-compiling
<a href="https://bugs.webkit.org/show_bug.cgi?id=256679">https://bugs.webkit.org/show_bug.cgi?id=256679</a>

Reviewed by Adrian Perez de Castro.

When enabling -DENABLE_BUBBLEWRAP_SANDBOX=ON is needed to define to the build
the paths (full-paths) to the bwrap and xdg-dbus-proxy binaries.

The current CMake code is auto-detecting those paths by calling the CMake
function find_program(): so it is defining the paths to those programs with
the values from the host system.

But when cross-compiling that is wrong because the target binaries end with the
values for the paths from the host system which don&apos;t necessary have to match
the values from the target system.

I can&apos;t see how it will be possible to auto-detect the value that this programs
will have in the target system from the host system, so the only sane way of
dealing with this seems to be to give an error at configure time and ask for
those paths to be defined manually.

This patch changes the code to only try to auto-detect those binaries when no
cross-compiling.

Also update the default build parameters for the cross-building of targets
with cross-toolchain-helper to define the right paths that those targets will
have at run-time.

* Source/cmake/BubblewrapSandboxChecks.cmake:
* Tools/yocto/targets.conf:

Canonical link: <a href="https://commits.webkit.org/264244@main">https://commits.webkit.org/264244@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a2f14723cc49b8b58b7f23f1865aad656926da9c

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/6451 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/6659 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/6840 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/8030 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/6746 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/6447 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/6965 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/6610 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/9639 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/6564 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/6607 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/5841 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/8109 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/4073 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/5822 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/13676 "Passed tests") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/5429 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/5992 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/5901 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/8215 "Passed tests") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/6042 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/6387 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/5222 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/6585 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/5793 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/1535 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/9952 "Built successfully") | | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/24/builds/6767 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/831 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/6164 "Built successfully") | | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/3/builds/1664 "Passed tests") | 
<!--EWS-Status-Bubble-End-->