### PR TITLE
Refactor Canvas noise injection logic and improve support for gradients in post-processed ImageData

### DIFF
--- a/Source/WebCore/Headers.cmake
+++ b/Source/WebCore/Headers.cmake
@@ -953,6 +953,7 @@ set(WebCore_PRIVATE_FRAMEWORK_HEADERS
     html/CachedHTMLCollection.h
     html/CachedHTMLCollectionInlines.h
     html/CanvasBase.h
+    html/CanvasNoiseInjection.h
     html/CanvasObserver.h
     html/CollectionTraversal.h
     html/CollectionTraversalInlines.h

--- a/Source/WebCore/Sources.txt
+++ b/Source/WebCore/Sources.txt
@@ -1259,6 +1259,7 @@ html/BaseDateAndTimeInputType.cpp
 html/BaseTextInputType.cpp
 html/ButtonInputType.cpp
 html/CanvasBase.cpp
+html/CanvasNoiseInjection.cpp
 html/CheckboxInputType.cpp
 html/ColorInputType.cpp
 html/CustomPaintCanvas.cpp

--- a/Source/WebCore/html/CanvasBase.h
+++ b/Source/WebCore/html/CanvasBase.h
@@ -25,6 +25,7 @@
 
 #pragma once
 
+#include "CanvasNoiseInjection.h"
 #include "FloatRect.h"
 #include "IntSize.h"
 #include "PixelBuffer.h"
@@ -130,7 +131,7 @@ public:
     virtual void queueTaskKeepingObjectAlive(TaskSource, Function<void()>&&) = 0;
     virtual void dispatchEvent(Event&) = 0;
 
-    bool postProcessPixelBufferResults(Ref<PixelBuffer>&&, const HashSet<uint32_t>&) const;
+    bool postProcessPixelBufferResults(Ref<PixelBuffer>&&) const;
 
 protected:
     explicit CanvasBase(IntSize);
@@ -149,16 +150,15 @@ protected:
 
 private:
     bool shouldInjectNoiseBeforeReadback() const;
-    void postProcessDirtyCanvasBuffer() const;
     virtual void createImageBuffer() const { }
 
     mutable IntSize m_size;
-    mutable FloatRect m_postProcessDirtyRect;
     mutable Lock m_imageBufferAssignmentLock;
     mutable RefPtr<ImageBuffer> m_imageBuffer;
     mutable size_t m_imageBufferCost { 0 };
     mutable std::unique_ptr<GraphicsContextStateSaver> m_contextStateSaver;
 
+    CanvasNoiseInjection m_canvasNoiseInjection;
     bool m_originClean { true };
 #if ASSERT_ENABLED
     bool m_didNotifyObserversCanvasDestroyed { false };

--- a/Source/WebCore/html/CanvasNoiseInjection.cpp
+++ b/Source/WebCore/html/CanvasNoiseInjection.cpp
@@ -1,0 +1,232 @@
+/*
+ * Copyright (c) 2023 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "CanvasNoiseInjection.h"
+
+#include "ByteArrayPixelBuffer.h"
+#include "FloatRect.h"
+#include "ImageBuffer.h"
+#include "PixelBuffer.h"
+
+namespace WebCore {
+
+void CanvasNoiseInjection::updateDirtyRect(const IntRect& rect)
+{
+    m_postProcessDirtyRect.unite(rect);
+}
+
+static inline bool isIndexInBounds(int size, int index)
+{
+    ASSERT(index < size);
+    return index < size;
+};
+
+static inline void setTightnessBounds(const std::span<uint8_t>& bytes, std::array<int, 4>& tightestBoundingDiff, int index1, int index2)
+{
+    int redDiff = bytes[index1] - bytes[index2];
+    int greenDiff = bytes[index1 + 1] - bytes[index2 + 1];
+    int blueDiff = bytes[index1 + 2] - bytes[index2 + 2];
+    int alphaDiff = bytes[index1 + 3] - bytes[index2 + 3];
+
+    if (redDiff < tightestBoundingDiff[0]
+        && greenDiff < tightestBoundingDiff[1]
+        && blueDiff < tightestBoundingDiff[2]
+        && alphaDiff < tightestBoundingDiff[3]) {
+        tightestBoundingDiff[0] = redDiff;
+        tightestBoundingDiff[1] = greenDiff;
+        tightestBoundingDiff[2] = blueDiff;
+        tightestBoundingDiff[3] = alphaDiff;
+    }
+}
+
+static std::optional<std::pair<int, int>> getGradientNeighbors(int index, const std::span<uint8_t>& bytes, const IntSize& size)
+{
+    constexpr auto bytesPerPixel = 4U;
+    auto bufferSize = bytes.size_bytes();
+    auto pixelIndex = index / bytesPerPixel;
+    bool isInTopRow = pixelIndex < static_cast<size_t>(size.width());
+    bool isInBottomRow = pixelIndex > static_cast<size_t>((size.height() - 1) * size.width());
+    bool isInLeftColumn = !(pixelIndex % size.width());
+    bool isInRightColumn = (pixelIndex % size.width()) == static_cast<unsigned>(size.width()) - 1;
+    bool isInTopLeftCorner = isInTopRow && isInLeftColumn;
+    bool isInBottomLeftCorner = isInBottomRow && isInLeftColumn;
+    bool isInTopRightCorner = isInTopRow && isInRightColumn;
+    bool isInBotomRightCorner = isInBottomRow && isInRightColumn;
+
+    if (isInTopLeftCorner || isInBottomLeftCorner || isInTopRightCorner || isInBotomRightCorner)
+        return std::nullopt;
+
+    constexpr auto leftOffset = -bytesPerPixel;
+    constexpr auto rightOffset = bytesPerPixel;
+    const auto aboveOffset = -size.width() * bytesPerPixel;
+    const auto belowOffset = size.width() * bytesPerPixel;
+    const auto aboveLeftOffset = aboveOffset + leftOffset;
+    const auto aboveRightOffset = aboveOffset + rightOffset;
+    const auto belowLeftOffset = belowOffset + leftOffset;
+    const auto belowRightOffset = belowOffset + rightOffset;
+
+    const int leftIndex = index + leftOffset;
+    const int rightIndex = index + rightOffset;
+    const int aboveIndex = index + aboveOffset;
+    const int belowIndex = index + belowOffset;
+    const int aboveLeftIndex = index + aboveLeftOffset;
+    const int aboveRightIndex = index + aboveRightOffset;
+    const int belowLeftIndex = index + belowLeftOffset;
+    const int belowRightIndex = index + belowRightOffset;
+
+    const auto areColorsDescending = [&bytes, bufferSize](int index1, int index2, int index3) {
+        if (!isIndexInBounds(bufferSize, index1) || !isIndexInBounds(bufferSize, index1 + 3))
+            return false;
+        if (!isIndexInBounds(bufferSize, index2) || !isIndexInBounds(bufferSize, index2 + 3))
+            return false;
+        if (!isIndexInBounds(bufferSize, index3) || !isIndexInBounds(bufferSize, index3 + 3))
+            return false;
+        return bytes[index1] <= bytes[index2] && bytes[index2] <= bytes[index3]
+            && bytes[index1 + 1] <= bytes[index2 + 1] && bytes[index2 + 1] <= bytes[index3 + 1]
+            && bytes[index1 + 2] <= bytes[index2 + 2] && bytes[index2 + 2] <= bytes[index3 + 2]
+            && bytes[index1 + 3] <= bytes[index2 + 3] && bytes[index2 + 3] <= bytes[index3 + 3];
+    };
+
+    const auto compareColorsAndSetBounds = [&areColorsDescending](const auto& bytes, auto& tightestBoundingIndices, auto& tightestBoundingDiff, auto colorIndex, auto neighborIndex1, auto neighborIndex2) {
+        if (areColorsDescending(neighborIndex1, colorIndex, neighborIndex2)) {
+            tightestBoundingIndices = { neighborIndex1, neighborIndex2 };
+            setTightnessBounds(bytes, tightestBoundingDiff, neighborIndex1, neighborIndex2);
+        } else if (areColorsDescending(neighborIndex2, colorIndex, neighborIndex1)) {
+            tightestBoundingIndices = { neighborIndex2, neighborIndex1 };
+            setTightnessBounds(bytes, tightestBoundingDiff, neighborIndex2, neighborIndex1);
+        }
+    };
+
+    if (isInTopRow || isInBottomRow) {
+        if (areColorsDescending(leftIndex, index, rightIndex))
+            return { { leftIndex, rightIndex } };
+        if (areColorsDescending(rightIndex, index, leftIndex))
+            return { { rightIndex, leftIndex } };
+        return std::nullopt;
+    }
+
+    if (isInLeftColumn || isInRightColumn) {
+        if (areColorsDescending(aboveIndex, index, belowIndex))
+            return { { aboveIndex, belowIndex } };
+        if (areColorsDescending(belowIndex, index, aboveIndex))
+            return { { belowIndex, aboveIndex } };
+        return std::nullopt;
+    }
+
+    std::optional<std::pair<int, int>> tightestBoundingIndices;
+    std::array<int, 4> tightestBoundingDiff { 255, 255, 255, 255 };
+
+    compareColorsAndSetBounds(bytes, tightestBoundingIndices, tightestBoundingDiff, index, leftIndex, rightIndex);
+    compareColorsAndSetBounds(bytes, tightestBoundingIndices, tightestBoundingDiff, index, aboveIndex, belowIndex);
+    compareColorsAndSetBounds(bytes, tightestBoundingIndices, tightestBoundingDiff, index, aboveLeftIndex, belowRightIndex);
+    compareColorsAndSetBounds(bytes, tightestBoundingIndices, tightestBoundingDiff, index, aboveRightIndex, belowLeftIndex);
+
+    return tightestBoundingIndices;
+}
+
+void CanvasNoiseInjection::postProcessDirtyCanvasBuffer(ImageBuffer* imageBuffer, NoiseInjectionHashSalt salt)
+{
+    ASSERT(salt);
+
+    if (m_postProcessDirtyRect.isEmpty())
+        return;
+
+    if (!imageBuffer)
+        return;
+
+    PixelBufferFormat format { AlphaPremultiplication::Unpremultiplied, PixelFormat::RGBA8, imageBuffer->colorSpace() };
+    auto pixelBuffer = imageBuffer->getPixelBuffer(format, m_postProcessDirtyRect);
+    if (!is<ByteArrayPixelBuffer>(pixelBuffer))
+        return;
+
+    if (postProcessPixelBufferResults(*pixelBuffer, salt)) {
+        imageBuffer->putPixelBuffer(*pixelBuffer, m_postProcessDirtyRect, m_postProcessDirtyRect.location());
+        m_postProcessDirtyRect = { };
+    }
+}
+
+bool CanvasNoiseInjection::postProcessPixelBufferResults(PixelBuffer& pixelBuffer, NoiseInjectionHashSalt salt) const
+{
+    ASSERT(salt);
+    ASSERT(pixelBuffer.format().pixelFormat == PixelFormat::RGBA8);
+
+    constexpr int bytesPerPixel = 4;
+    std::span<uint8_t> bytes = makeSpan(pixelBuffer.bytes(), pixelBuffer.sizeInBytes());
+    bool wasPixelBufferModified { false };
+
+    for (size_t i = 0; i < bytes.size_bytes(); i += bytesPerPixel) {
+        auto& redChannel = bytes[i];
+        auto& greenChannel = bytes[i + 1];
+        auto& blueChannel = bytes[i + 2];
+        auto& alphaChannel = bytes[i + 3];
+        bool isBlack { !redChannel && !greenChannel && !blueChannel };
+
+        if (!alphaChannel)
+            continue;
+
+        const uint64_t pixelHash = computeHash(salt, redChannel, greenChannel, blueChannel, alphaChannel);
+        // +/- 3 is roughly ~1% of the 255 max value.
+        const auto clampedOnePercent = static_cast<int8_t>(((pixelHash * 6) / std::numeric_limits<uint32_t>::max()) - 3);
+
+        const auto clampedColorComponentOffset = [](int colorComponentOffset, int originalComponentValue, int minBoundingColor, int maxBoundingColor) {
+            if (colorComponentOffset + originalComponentValue > maxBoundingColor)
+                return maxBoundingColor - originalComponentValue;
+            if (colorComponentOffset + originalComponentValue < minBoundingColor)
+                return minBoundingColor - originalComponentValue;
+            return colorComponentOffset;
+        };
+
+        std::array<int, 4> minNeighborColor { 0, 0, 0, 0 };
+        std::array<int, 4> maxNeighborColor { 255, 255, 255, 255 };
+        if (auto neighbors = getGradientNeighbors(i, bytes, pixelBuffer.size())) {
+            auto [minNeighborColorIndex, maxNeighborColorIndex] = *neighbors;
+            minNeighborColor[0] = bytes[minNeighborColorIndex];
+            minNeighborColor[1] = bytes[minNeighborColorIndex + 1];
+            minNeighborColor[2] = bytes[minNeighborColorIndex + 2];
+            minNeighborColor[3] = bytes[minNeighborColorIndex + 3];
+
+            maxNeighborColor[0] = bytes[maxNeighborColorIndex];
+            maxNeighborColor[1] = bytes[maxNeighborColorIndex + 1];
+            maxNeighborColor[2] = bytes[maxNeighborColorIndex + 2];
+            maxNeighborColor[3] = bytes[maxNeighborColorIndex + 3];
+        }
+
+        // If alpha is non-zero and the color channels are zero, then only tweak the alpha channel's value;
+        if (isBlack)
+            alphaChannel += clampedColorComponentOffset(clampedOnePercent, alphaChannel, minNeighborColor[3], maxNeighborColor[3]);
+        else {
+            // If alpha and any of the color channels are non-zero, then tweak all of the channels;
+            redChannel += clampedColorComponentOffset(clampedOnePercent, redChannel, minNeighborColor[0], maxNeighborColor[0]);
+            greenChannel += clampedColorComponentOffset(clampedOnePercent, greenChannel, minNeighborColor[1], maxNeighborColor[1]);
+            blueChannel += clampedColorComponentOffset(clampedOnePercent, blueChannel, minNeighborColor[2], maxNeighborColor[2]);
+            alphaChannel += clampedColorComponentOffset(clampedOnePercent, alphaChannel, minNeighborColor[3], maxNeighborColor[3]);
+        }
+        wasPixelBufferModified = true;
+    }
+    return wasPixelBufferModified;
+}
+
+} // namespace WebCore

--- a/Source/WebCore/html/CanvasNoiseInjection.h
+++ b/Source/WebCore/html/CanvasNoiseInjection.h
@@ -1,0 +1,47 @@
+/*
+ * Copyright (c) 2023 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include "IntRect.h"
+
+namespace WebCore {
+
+class CanvasBase;
+class ImageBuffer;
+class PixelBuffer;
+
+using NoiseInjectionHashSalt = uint64_t;
+
+class CanvasNoiseInjection {
+public:
+    void postProcessDirtyCanvasBuffer(ImageBuffer*, NoiseInjectionHashSalt);
+    bool postProcessPixelBufferResults(PixelBuffer&, NoiseInjectionHashSalt) const;
+    void updateDirtyRect(const IntRect&);
+
+private:
+    IntRect m_postProcessDirtyRect;
+};
+} // namespace WebCore

--- a/Source/WebCore/html/HTMLCanvasElement.cpp
+++ b/Source/WebCore/html/HTMLCanvasElement.cpp
@@ -804,7 +804,7 @@ RefPtr<ImageData> HTMLCanvasElement::getImageData()
         return nullptr;
 
     if (pixelBuffer)
-        postProcessPixelBufferResults(*pixelBuffer, { });
+        postProcessPixelBufferResults(*pixelBuffer);
 
     return ImageData::create(static_reference_cast<ByteArrayPixelBuffer>(pixelBuffer.releaseNonNull()));
 #else


### PR DESCRIPTION
#### bfc25dc6ca1cf6a7213d58065c036c846beaddac
<pre>
Refactor Canvas noise injection logic and improve support for gradients in post-processed ImageData
<a href="https://bugs.webkit.org/show_bug.cgi?id=255993">https://bugs.webkit.org/show_bug.cgi?id=255993</a>
rdar://107371244

Reviewed by Kimmo Kinnunen.

Gradients present an interesting problem when post-processing canvas ImageData
because tweaking colors result in significant visual anomalies. This change
introduces some naive gradient detection by looking at all of the immediate
neighbors of a pixel. We decide that a pixel is within a gradient if the
current color is between its opposing adjacent colors (e.g., above and below,
left and right, etc). If a color is decided to be within a gradient, then we
set those adjacent colors as bounds within which we can tweak the current
color.

In addition, within this change, we move the noise injection logic into its own
class, it removes the dependency on supplied colors for post-processing, and it
reduces the magnitude of noise from ~5% to ~1%.

* Source/WebCore/Headers.cmake:
* Source/WebCore/Sources.txt:
* Source/WebCore/WebCore.xcodeproj/project.pbxproj:
* Source/WebCore/html/CanvasBase.cpp:
(WebCore::CanvasBase::makeRenderingResultsAvailable):
(WebCore::CanvasBase::didDraw): We clip the rect before passing it into
CanvasNoiseInjection, and if the rect is std::nullopt then we pass in the
entire canvas.

(WebCore::CanvasBase::postProcessPixelBufferResults const):
(WebCore::CanvasBase::postProcessDirtyCanvasBuffer const): Deleted.
* Source/WebCore/html/CanvasBase.h:
* Source/WebCore/html/CanvasNoiseInjection.cpp: Added.
(WebCore::CanvasNoiseInjection::updateDirtyRect):
(WebCore::isIndexInBounds):
(WebCore::setTightnessBounds):
(WebCore::getGradientNeighbors):
(WebCore::CanvasNoiseInjection::postProcessDirtyCanvasBuffer):
(WebCore::CanvasNoiseInjection::postProcessPixelBufferResults const):
* Source/WebCore/html/CanvasNoiseInjection.h: Added.
* Source/WebCore/html/HTMLCanvasElement.cpp:
(WebCore::HTMLCanvasElement::getImageData):

Canonical link: <a href="https://commits.webkit.org/264019@main">https://commits.webkit.org/264019@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/8e97b26857b4bb79e478b5b0d6fc4e02cb4239e7

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/6430 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/6637 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/6818 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/8007 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/6728 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/6425 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/6931 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/6587 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/9622 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/6542 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/6582 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/5821 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/8086 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/4046 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/5804 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/13661 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/5960 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/5883 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/8184 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/6366 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/5201 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/5773 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/1520 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/9932 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/6144 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->