### PR TITLE
[ iOS ] fast/mediastream/MediaStream-video-element-video-tracks-disabled.html is a flaky ImageOnlyFailure

### DIFF
--- a/LayoutTests/fast/mediastream/MediaStream-video-element-video-tracks-disabled-expected.html
+++ b/LayoutTests/fast/mediastream/MediaStream-video-element-video-tracks-disabled-expected.html
@@ -4,14 +4,15 @@
 <head>
     <style>
         .video {
-            height: 240px;
-            width: 320px;
+            height: 100px;
+            width: 200px;
             background-color: black;
             will-change: transform;
         }
     </style>
 </head>
 <body>
+<div id=log>ok</div>
 <p>Tests that the video frames of an HTMLVideoElement are black if no video MediaStreamTrack is enabled.</p>
 <div class="video"></div>
 

--- a/LayoutTests/fast/mediastream/MediaStream-video-element-video-tracks-disabled.html
+++ b/LayoutTests/fast/mediastream/MediaStream-video-element-video-tracks-disabled.html
@@ -2,19 +2,15 @@
 <html>
 <head>
 <meta name="fuzzy" content="maxDifference=115;totalPixels=28000-29000" />
-<script src="../../webrtc/routines.js"></script>
 </head>
-
 <body>
+<div id=log></div>
 <p>Tests that the video frames of an HTMLVideoElement are black if no video MediaStreamTrack is enabled.</p>
-<video/>
-<canvas id="canvas"></div>
+<div style="width:200px;height:100px;overflow:hidden">
+<video id=video autoplay playsinline></video>
+</div>
 
 <script>
-    let mediaStream;
-    let video;
-    let canvas;
-
     function debug(msg)
     {
         let span = document.createElement('span');
@@ -22,51 +18,31 @@
         span.innerHTML = `${msg} <br />`;
     }
 
-    function canplaythrough()
+    async function start()
     {
-        mediaStream.getVideoTracks()[0].enabled = false;
-        setTimeout(() => {
-            waitForVideoSize(video, 320, 240).then(() => {
-                checkVideoIsEntirelyBlack(canvas, video).then(() => {
-                    window.testRunner.notifyDone();
-                });
-            });
-        }, 2000);
+        try {
+            const mediaStream = await navigator.mediaDevices.getUserMedia({video: {width: 320, height: 240}});
+            video.srcObject = mediaStream;
+            await video.play();
+
+            await new Promise(resolve => setTimeout(resolve, 1000));
+            log.innerHTML = 'muted';
+            mediaStream.getVideoTracks()[0].enabled = false;
+            await new Promise(resolve => setTimeout(resolve, 1000));
+
+            log.innerHTML = 'ok';
+        } catch (e) {
+            log.innerHTML = 'Failed with ' + e;
+        }
+        if (window.testRunner)
+            testRunner.notifyDone();
     }
 
-    function canplay()
-    {
-        video.play();
-    }
-
-    function setupStream(stream)
-    {
-        mediaStream = stream;
-        video.srcObject = mediaStream;
-    }
-
-    function failedToSetupStream()
-    {
-        debug('Failed to setup stream');
-    }
-
-    function start()
-    {
-        canvas = document.getElementById("canvas");
-
-        video = document.querySelector('video');
-        video.addEventListener('canplay', canplay, false);
-        video.addEventListener('canplaythrough', canplaythrough, false);
-        navigator.mediaDevices.getUserMedia({video: {width: 320, height: 240}})
-            .then(setupStream)
-            .catch(failedToSetupStream);
-    }
-
-    if (window.testRunner) {
+    if (window.testRunner)
         window.testRunner.waitUntilDone();
-        window.testRunner.setUserMediaPermission(true);
-        start();
-    }
+    window.onload = start;
+
+
 </script>
 </body>
 </html>

--- a/LayoutTests/fast/mediastream/getUserMedia-rvfc-expected.txt
+++ b/LayoutTests/fast/mediastream/getUserMedia-rvfc-expected.txt
@@ -3,4 +3,5 @@
 PASS Validate callbacks can be updated within a callback
 PASS Validate callbacks and metadata for getUserMedia
 PASS Validate callbacks are called only once
+PASS Validate callbacks are not called for enabled=false video track
 

--- a/LayoutTests/fast/mediastream/getUserMedia-rvfc.html
+++ b/LayoutTests/fast/mediastream/getUserMedia-rvfc.html
@@ -84,6 +84,25 @@ promise_test(async (test) => {
     await new Promise(resolve => video.requestVideoFrameCallback(resolve));
     assert_equals(counter, 1);
 }, "Validate callbacks are called only once");
+
+promise_test(async (test) => {
+    const localStream = await navigator.mediaDevices.getUserMedia({video: { width: 640, height: 480 } });
+    video.srcObject = localStream;
+    await video.play();
+    localStream.getVideoTracks()[0].enabled = false;
+
+    let counter = 0;
+    let wasCalled = true;
+    while (counter++ < 10 && wasCalled) {
+        wasCalled = await new Promise(resolve => {
+            video.requestVideoFrameCallback(() => resolve(true));
+            setTimeout(() => resolve(false), 500);
+        });
+        if (wasCalled)
+           await new Promise(resolve => setTimeout(resolve, 50));
+    }
+    assert_true(wasCalled);
+}, "Validate callbacks are not called for enabled=false video track");
         </script>
     </body>
 </html>

--- a/LayoutTests/platform/ios/TestExpectations
+++ b/LayoutTests/platform/ios/TestExpectations
@@ -4354,5 +4354,3 @@ webaudio/ScriptProcessor/scriptprocessor-offlineaudiocontext.html [ Failure ]
 webkit.org/b/256189 [ Debug ] ipc/wait-for-video-output-will-change.html [ Crash ]
 
 webkit.org/256217 [ Debug ] imported/w3c/web-platform-tests/background-fetch/port-blocking.https.window.html [ Pass Crash ]
-
-webkit.org/b/256602 fast/mediastream/MediaStream-video-element-video-tracks-disabled.html [ Pass ImageOnlyFailure ]

--- a/Source/WebCore/platform/graphics/avfoundation/SampleBufferDisplayLayer.h
+++ b/Source/WebCore/platform/graphics/avfoundation/SampleBufferDisplayLayer.h
@@ -73,6 +73,7 @@ public:
     virtual void play() = 0;
     virtual void pause() = 0;
 
+    virtual void enqueueBlackFrameFrom(const VideoFrame&) { };
     virtual void enqueueVideoFrame(VideoFrame&) = 0;
     virtual void clearVideoFrames() = 0;
 

--- a/Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateMediaStreamAVFObjC.h
+++ b/Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateMediaStreamAVFObjC.h
@@ -291,6 +291,8 @@ private:
     bool m_isVisibleInViewPort { false };
     bool m_haveSeenMetadata { false };
     bool m_waitingForFirstImage { false };
+    bool m_isActiveVideoTrackEnabled { true };
+    bool m_hasEnqueuedBlackFrame { false };
 
     uint64_t m_sampleCount { 0 };
     uint64_t m_lastVideoFrameMetadataSampleCount { 0 };

--- a/Source/WebKit/WebProcess/GPU/webrtc/SampleBufferDisplayLayer.cpp
+++ b/Source/WebKit/WebProcess/GPU/webrtc/SampleBufferDisplayLayer.cpp
@@ -128,6 +128,14 @@ void SampleBufferDisplayLayer::pause()
     m_connection->send(Messages::RemoteSampleBufferDisplayLayer::Pause { }, m_identifier);
 }
 
+void SampleBufferDisplayLayer::enqueueBlackFrameFrom(const VideoFrame& videoFrame)
+{
+    auto size = videoFrame.presentationSize();
+    WebCore::IntSize blackFrameSize { static_cast<int>(size.width()), static_cast<int>(size.height()) };
+    SharedVideoFrame sharedVideoFrame { videoFrame.presentationTime(), false, videoFrame.rotation(), blackFrameSize };
+    m_connection->send(Messages::RemoteSampleBufferDisplayLayer::EnqueueVideoFrame { sharedVideoFrame }, m_identifier);
+}
+
 void SampleBufferDisplayLayer::enqueueVideoFrame(VideoFrame& videoFrame)
 {
     if (m_paused)

--- a/Source/WebKit/WebProcess/GPU/webrtc/SampleBufferDisplayLayer.h
+++ b/Source/WebKit/WebProcess/GPU/webrtc/SampleBufferDisplayLayer.h
@@ -74,6 +74,7 @@ private:
     void flushAndRemoveImage() final;
     void play() final;
     void pause() final;
+    void enqueueBlackFrameFrom(const WebCore::VideoFrame&) final;
     void enqueueVideoFrame(WebCore::VideoFrame&) final;
     void clearVideoFrames() final;
     PlatformLayer* rootLayer() final;


### PR DESCRIPTION
#### 907131a79e54384f312826d3bc8969d03f14d7e8
<pre>
[ iOS ] fast/mediastream/MediaStream-video-element-video-tracks-disabled.html is a flaky ImageOnlyFailure
<a href="https://bugs.webkit.org/show_bug.cgi?id=256602">https://bugs.webkit.org/show_bug.cgi?id=256602</a>
rdar://109163885

Reviewed by Eric Carlson.

This fails sometimes on iOS and macOS if the track is disabled before getting the first frame on the video element.
To prevent this, we are making sure to have video playing before muting the track.
We also modernize a bit the test.

The resizing of the video element is also sometimes taking some time, for that reason, we clip the video element to improve stability.
Additional work should be done to understand why the resizing is taking sometimes more than a second.

The reactiveness of making the video element black is also not very fast.
We do an optimization to remove sending frames to GPUProcess when the track is not enabled.
This reduces CPU usage and makes the transition to black faster.

* LayoutTests/fast/mediastream/MediaStream-video-element-video-tracks-disabled-expected.html:
* LayoutTests/fast/mediastream/MediaStream-video-element-video-tracks-disabled.html:
* LayoutTests/fast/mediastream/getUserMedia-rvfc-expected.txt:
* LayoutTests/fast/mediastream/getUserMedia-rvfc.html:
* LayoutTests/platform/ios/TestExpectations:
* Source/WebCore/platform/graphics/avfoundation/SampleBufferDisplayLayer.h:
(WebCore::SampleBufferDisplayLayer::enqueueBlackFrameFrom):
* Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateMediaStreamAVFObjC.h:
* Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateMediaStreamAVFObjC.mm:
(WebCore::MediaPlayerPrivateMediaStreamAVFObjC::enqueueVideoFrame):
(WebCore::MediaPlayerPrivateMediaStreamAVFObjC::checkSelectedVideoTrack):
* Source/WebKit/WebProcess/GPU/webrtc/SampleBufferDisplayLayer.cpp:
(WebKit::SampleBufferDisplayLayer::enqueueBlackFrameFrom):
* Source/WebKit/WebProcess/GPU/webrtc/SampleBufferDisplayLayer.h:

Canonical link: <a href="https://commits.webkit.org/264012@main">https://commits.webkit.org/264012@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/370a174a61f0d6f7491b60f63aab8cb13a329e29

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/6376 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/6576 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/6759 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/7946 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/6677 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/6370 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/6821 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/6526 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/9575 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/6488 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/6506 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/5764 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/8023 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/3972 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/5750 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/13620 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/5858 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/5829 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/8096 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/6313 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/5157 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/5718 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/5678 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/1515 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/9877 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/6088 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->