### PR TITLE
Remove obsolete webrtc stats

### DIFF
--- a/LayoutTests/webrtc/candidate-stats.html
+++ b/LayoutTests/webrtc/candidate-stats.html
@@ -26,7 +26,7 @@ promise_test(async (test) => {
     assert_true(!stats.address, "address is not exposed");
     assert_true(!stats.networkType, "networkType is not exposed");
 
-    assert_array_equals(Object.keys(stats), ["id","timestamp","type","candidateType","deleted","port","priority","protocol","transportId"], "local");
+    assert_array_equals(Object.keys(stats), ["id","timestamp","type","candidateType","port","priority","protocol","transportId"], "local");
 
     stats = await getTypedStats(firstConnection, "remote-candidate");
 
@@ -34,7 +34,7 @@ promise_test(async (test) => {
     assert_true(!stats.address, "address is not exposed");
     assert_true(!stats.networkType, "networkType is not exposed");
 
-    assert_array_equals(Object.keys(stats), ["id","timestamp","type","candidateType","deleted","port","priority","protocol","transportId"], "remote");
+    assert_array_equals(Object.keys(stats), ["id","timestamp","type","candidateType","port","priority","protocol","transportId"], "remote");
 }, "ICE candidate data channel stats");
         </script>
     </body>

--- a/Source/WebCore/Modules/mediastream/RTCStatsReport.h
+++ b/Source/WebCore/Modules/mediastream/RTCStatsReport.h
@@ -62,7 +62,6 @@ public:
     struct RtpStreamStats : Stats {
         uint32_t ssrc { 0 };
         String kind;
-        String mediaType;
         String transportId;
         String codecId;
     };
@@ -257,7 +256,6 @@ public:
         String localCandidateId;
         String remoteCandidateId;
         IceCandidatePairState state;
-        std::optional<uint64_t> priority;
         std::optional<bool> nominated;
         std::optional<bool> writable;
         std::optional<bool> readable;
@@ -287,7 +285,6 @@ public:
         std::optional<RTCIceCandidateType> candidateType;
         std::optional<int32_t> priority;
         String url;
-        bool deleted { false };
     };
 
     struct CertificateStats : Stats {

--- a/Source/WebCore/Modules/mediastream/RTCStatsReport.idl
+++ b/Source/WebCore/Modules/mediastream/RTCStatsReport.idl
@@ -60,8 +60,6 @@ dictionary RTCStats {
 dictionary RTCRtpStreamStats : RTCStats {
     required unsigned long ssrc;
     required DOMString kind;
-    // We should obsolete this field
-    required DOMString mediaType;
     DOMString transportId;
     DOMString codecId;
 };
@@ -258,7 +256,6 @@ dictionary RTCIceCandidatePairStats : RTCStats {
     DOMString localCandidateId;
     DOMString remoteCandidateId;
     RTCStatsIceCandidatePairState state;
-    unsigned long long priority;
     boolean nominated;
     boolean writable;
     boolean readable;
@@ -286,7 +283,6 @@ dictionary RTCIceCandidateStats : RTCStats {
     RTCIceCandidateType candidateType;
     long priority;
     DOMString url;
-    boolean deleted = false;
 };
 
 [ JSGenerateToJSObject ]
@@ -366,5 +362,3 @@ dictionary RTCVideoSourceStats : RTCMediaSourceStats {
     unsigned long frames;
     double framesPerSecond;
 };
-
-// FIXME 169662: missing RTCMediaStreamStats

--- a/Source/WebCore/Modules/mediastream/gstreamer/GStreamerStatsCollector.cpp
+++ b/Source/WebCore/Modules/mediastream/gstreamer/GStreamerStatsCollector.cpp
@@ -57,10 +57,8 @@ static inline void fillRTCRTPStreamStats(RTCStatsReport::RtpStreamStats& stats, 
     if (gst_structure_get_uint(structure, "ssrc", &value))
         stats.ssrc = value;
 
-    if (const char* kind = gst_structure_get_string(structure, "kind")) {
+    if (const char* kind = gst_structure_get_string(structure, "kind"))
         stats.kind = String::fromLatin1(kind);
-        stats.mediaType = stats.kind;
-    }
 }
 
 static inline void fillRTCCodecStats(RTCStatsReport::CodecStats& stats, const GstStructure* structure)
@@ -287,10 +285,6 @@ static inline void fillRTCCandidateStats(RTCStatsReport::IceCandidateStats& stat
 
     auto candidateType = String::fromLatin1(gst_structure_get_string(structure, "candidate-type"));
     stats.candidateType = iceCandidateType(candidateType);
-
-    uint64_t priority;
-    if (gst_structure_get_uint64(structure, "priority", &priority))
-        stats.priority = priority;
 }
 
 static inline void fillRTCCandidatePairStats(RTCStatsReport::IceCandidatePairStats& stats, const GstStructure* structure)

--- a/Source/WebCore/Modules/mediastream/libwebrtc/LibWebRTCStatsCollector.cpp
+++ b/Source/WebCore/Modules/mediastream/libwebrtc/LibWebRTCStatsCollector.cpp
@@ -66,10 +66,8 @@ static inline void fillRtpStreamStats(RTCStatsReport::RtpStreamStats& stats, con
         stats.transportId = fromStdString(*rtcStats.transport_id);
     if (rtcStats.codec_id.is_defined())
         stats.codecId = fromStdString(*rtcStats.codec_id);
-    if (rtcStats.media_type.is_defined()) {
-        stats.mediaType = fromStdString(*rtcStats.media_type);
-        stats.kind = stats.mediaType;
-    }
+    if (rtcStats.media_type.is_defined())
+        stats.kind = fromStdString(*rtcStats.kind);
 }
 
 static inline void fillReceivedRtpStreamStats(RTCStatsReport::ReceivedRtpStreamStats& stats, const webrtc::RTCReceivedRtpStreamStats& rtcStats)
@@ -366,8 +364,6 @@ static inline void fillRTCIceCandidatePairStats(RTCStatsReport::IceCandidatePair
     if (rtcStats.state.is_defined())
         stats.state = iceCandidatePairState(*rtcStats.state);
 
-    if (rtcStats.priority.is_defined())
-        stats.priority = *rtcStats.priority;
     if (rtcStats.nominated.is_defined())
         stats.nominated = *rtcStats.nominated;
     if (rtcStats.writable.is_defined())


### PR DESCRIPTION
#### bc18af2122edaa89bbec6b93a6404c01ea626276
<pre>
Remove obsolete webrtc stats
<a href="https://bugs.webkit.org/show_bug.cgi?id=256645">https://bugs.webkit.org/show_bug.cgi?id=256645</a>
rdar://109206360

Reviewed by Eric Carlson.

These stats are now removed from the spec, let&apos;s remove them from WebKit.

* LayoutTests/webrtc/candidate-stats.html:
* Source/WebCore/Modules/mediastream/RTCStatsReport.h:
* Source/WebCore/Modules/mediastream/RTCStatsReport.idl:
* Source/WebCore/Modules/mediastream/gstreamer/GStreamerStatsCollector.cpp:
(WebCore::fillRTCRTPStreamStats):
(WebCore::fillRTCCandidateStats):
* Source/WebCore/Modules/mediastream/libwebrtc/LibWebRTCStatsCollector.cpp:
(WebCore::fillRtpStreamStats):
(WebCore::fillRTCIceCandidatePairStats):

Canonical link: <a href="https://commits.webkit.org/264013@main">https://commits.webkit.org/264013@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2ad02881c19a1cbd0071a4909bfcc77c8d61e795

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/6395 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/6600 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/6782 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/7971 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/6694 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/6390 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/6857 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/6550 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/9588 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/6507 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/6528 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/5785 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/8049 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/3994 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/5770 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/13634 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/5887 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/5849 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/8119 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/6331 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/5174 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/5738 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/5698 "Passed tests") | | 
| [❌ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/1516 "Failed to push commit to Webkit repository") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/9897 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/6109 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->