### PR TITLE
[PlayStation] BCRASH should trigger SIGTRAP instead of accessing 0xbbadbeef

### DIFF
--- a/Source/bmalloc/bmalloc/BAssert.h
+++ b/Source/bmalloc/bmalloc/BAssert.h
@@ -32,7 +32,7 @@
 #include <os/log.h>
 #endif
 
-#if defined(NDEBUG) && BOS(DARWIN)
+#if defined(NDEBUG) && (BOS(DARWIN) || BPLATFORM(PLAYSTATION))
 
 #if BASAN_ENABLED
 #define BBreakpointTrap()  __builtin_trap()
@@ -54,7 +54,7 @@
         __builtin_unreachable(); \
     } while (false)
 
-#else // not defined(NDEBUG) && BOS(DARWIN)
+#else // not defined(NDEBUG) && (BOS(DARWIN) || BPLATFORM(PLAYSTATION))
 
 #if BASAN_ENABLED
 #define BCRASH() __builtin_trap()
@@ -73,7 +73,7 @@
 #endif // defined(__GNUC__)
 #endif // BASAN_ENABLED
 
-#endif // defined(NDEBUG) && BOS(DARWIN)
+#endif // defined(NDEBUG) && (BOS(DARWIN) || BPLATFORM(PLAYSTATION))
 
 #define BASSERT_IMPL(x) do { \
     if (!(x)) \


### PR DESCRIPTION
#### b1992957c9f0a50a1ec6add28fbaf334a92e8246
<pre>
[PlayStation] BCRASH should trigger SIGTRAP instead of accessing 0xbbadbeef
<a href="https://bugs.webkit.org/show_bug.cgi?id=256687">https://bugs.webkit.org/show_bug.cgi?id=256687</a>

Reviewed by Yusuke Suzuki.

BCRASH on PlayStation accesses 0xbbadbeef to make a process crash.
On the other hand, WTF&apos;s CRASH triggers SIGTRAP, which is same as OS(DARWIN) case.

We should make BCRASH triggers SIGTRAP for the consistent behavior.

* Source/bmalloc/bmalloc/BAssert.h: Make BPLATFORM(PLAYSTATION) share the same implementation as BOS(DARWIN).

Canonical link: <a href="https://commits.webkit.org/264060@main">https://commits.webkit.org/264060@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0c7a8daae6a30b78b6937b614cb7eb0e23cccdb9

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/6387 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/6589 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/6770 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/7959 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/6686 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/6844 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/6539 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/9584 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/6499 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/6519 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/5778 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/8037 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/3985 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/5763 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/13630 "Passed tests") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/5369 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/5875 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/5842 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/8114 "Passed tests") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/5975 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/6324 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/5170 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/6518 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/5729 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/1528 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/1549 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/9888 "Built successfully") | | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/24/builds/6696 "Built successfully") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/6101 "Built successfully") | | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/3/builds/1657 "Passed tests") | 
<!--EWS-Status-Bubble-End-->