### PR TITLE
[CSS] StyleRuleWithNesting is a StyleRule (through inheritance)

### DIFF
--- a/LayoutTests/fast/css/rule-selector-nesting-overflow-expected.txt
+++ b/LayoutTests/fast/css/rule-selector-nesting-overflow-expected.txt
@@ -1,0 +1,38 @@
+This test tests and documents the behavior of CSS style rules with a massive number of selectors. Rules with >8192 selector components get split into multiple rules at the parsing stage. Setting a rule's selectorText via CSSOM will do nothing if there are more than 8192 components.
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+PASS rule().selectorText = selectorListWithLength(1); rule().selectorText is selectorListWithLength(1)
+PASS rule().selectorText = selectorListWithLength(8192); rule().selectorText is selectorListWithLength(8192)
+PASS rule().selectorText = '.reset'; rule().selectorText is '.reset'
+PASS rule().selectorText = selectorListWithLength(8193); rule().selectorText is '.reset'
+PASS rule().selectorText = '.reset'; rule().selectorText is '.reset'
+PASS rule().selectorText = selectorListWithLength(8193); sheet().rules.length is 1
+PASS rule().selectorText = selectorListWithLength(8192); rule().selectorText is selectorListWithLength(8192)
+PASS rule().selectorText = selectorListWithLength(8192); sheet().rules.length is 1
+PASS rule().selectorText = '.reset'; rule().selectorText is '.reset'
+PASS rule().selectorText = selectorListWithLength(8193); rule().selectorText is '.reset'
+PASS rule().selectorText = selectorListWithLength(8193); sheet().rules.length is 1
+PASS rule().selectorText = fatSelectorListWithLength(1); sheet().rules.length is 1
+PASS rule().selectorText = fatSelectorListWithLength(1); rule().selectorText is fatSelectorListWithLength(1)
+PASS rule().selectorText = fatSelectorListWithLength(2048); rule().selectorText is fatSelectorListWithLength(2048)
+PASS rule().selectorText = '.reset'; rule().selectorText is '.reset'
+PASS rule().selectorText = fatSelectorListWithLength(2049); rule().selectorText is '.reset'
+PASS styleElement.innerText = styleSheetWithSelectorLength(1); rule().selectorText is selectorListWithLength(1)
+PASS styleElement.innerText = styleSheetWithSelectorLength(8192); sheet().rules.length is 1
+PASS styleElement.innerText = styleSheetWithSelectorLength(8193); sheet().rules.length is 0
+PASS styleElement.innerText = styleSheetWithSelectorLength(16384); sheet().rules.length is 0
+PASS styleElement.innerText = styleSheetWithSelectorLength(16385); sheet().rules.length is 0
+PASS styleElement.innerText = fatStyleSheetWithSelectorLength(1); sheet().rules.length is 1
+PASS styleElement.innerText = fatStyleSheetWithSelectorLength(2048); sheet().rules.length is 1
+PASS styleElement.innerText = fatStyleSheetWithSelectorLength(2049); sheet().rules.length is 0
+PASS styleElement.innerText = fatStyleSheetWithSelectorLength(4096); sheet().rules.length is 0
+PASS styleElement.innerText = fatStyleSheetWithSelectorLength(4097); sheet().rules.length is 0
+PASS styleElement.innerText = fatStyleSheetWithSelectorLength(16385); sheet().rules.length is 0
+PASS styleElement.innerText = fatStyleSheetWithSelectorLength(16384); sheet().rules.length is 0
+PASS styleElement.innerText = fatStyleSheetWithSelectorLength(16385); sheet().rules.length is 0
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/fast/css/rule-selector-nesting-overflow.html
+++ b/LayoutTests/fast/css/rule-selector-nesting-overflow.html
@@ -1,0 +1,96 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<script src="../../resources/js-test-pre.js"></script>
+<style id="stylebro" type="text/css">
+& .peb {
+    color: red;
+    & .foo {
+        color: green;
+    }
+}
+</style>
+</head>
+<body>
+<script>
+
+styleElement = document.getElementById("stylebro");
+
+function repeatAndJoin(s, count)
+{
+    var a = new Array();
+    for (i = 0; i < count; ++i)
+        a.push(s);
+    return a.join(", ");
+}
+
+function selectorListWithLength(length)
+{
+    return repeatAndJoin(".x", length);
+}
+
+function fatSelectorListWithLength(length)
+{
+    return repeatAndJoin(".x .y .z .q", length);
+}
+
+function styleSheetWithSelectorLength(length)
+{
+    return selectorListWithLength(length) + " { color: red; & .foo { color: green; }}";
+}
+
+function fatStyleSheetWithSelectorLength(length)
+{
+    return fatSelectorListWithLength(length) + " { color: red; & .foo { color: green; }}";
+}
+
+function sheet()
+{
+    return styleElement.sheet;
+}
+
+function rule()
+{
+    return sheet().cssRules[0];
+}
+
+description("This test tests and documents the behavior of CSS style rules with a massive number of selectors. Rules with >8192 selector components get split into multiple rules at the parsing stage. Setting a rule's selectorText via CSSOM will do nothing if there are more than 8192 components.");
+
+shouldBe("rule().selectorText = selectorListWithLength(1); rule().selectorText", "selectorListWithLength(1)");
+shouldBe("rule().selectorText = selectorListWithLength(8192); rule().selectorText", "selectorListWithLength(8192)");
+shouldBe("rule().selectorText = '.reset'; rule().selectorText", "'.reset'");
+shouldBe("rule().selectorText = selectorListWithLength(8193); rule().selectorText", "'.reset'");
+shouldBe("rule().selectorText = '.reset'; rule().selectorText", "'.reset'");
+shouldBe("rule().selectorText = selectorListWithLength(8193); sheet().rules.length", "1");
+shouldBe("rule().selectorText = selectorListWithLength(8192); rule().selectorText", "selectorListWithLength(8192)");
+shouldBe("rule().selectorText = selectorListWithLength(8192); sheet().rules.length", "1");
+shouldBe("rule().selectorText = '.reset'; rule().selectorText", "'.reset'");
+shouldBe("rule().selectorText = selectorListWithLength(8193); rule().selectorText", "'.reset'");
+shouldBe("rule().selectorText = selectorListWithLength(8193); sheet().rules.length", "1");
+
+shouldBe("rule().selectorText = fatSelectorListWithLength(1); sheet().rules.length", "1");
+shouldBe("rule().selectorText = fatSelectorListWithLength(1); rule().selectorText", "fatSelectorListWithLength(1)");
+shouldBe("rule().selectorText = fatSelectorListWithLength(2048); rule().selectorText", "fatSelectorListWithLength(2048)");
+shouldBe("rule().selectorText = '.reset'; rule().selectorText", "'.reset'");
+shouldBe("rule().selectorText = fatSelectorListWithLength(2049); rule().selectorText", "'.reset'");
+
+shouldBe("styleElement.innerText = styleSheetWithSelectorLength(1); rule().selectorText", "selectorListWithLength(1)");
+shouldBe("styleElement.innerText = styleSheetWithSelectorLength(8192); sheet().rules.length", "1");
+shouldBe("styleElement.innerText = styleSheetWithSelectorLength(8193); sheet().rules.length", "0");
+shouldBe("styleElement.innerText = styleSheetWithSelectorLength(16384); sheet().rules.length", "0");
+shouldBe("styleElement.innerText = styleSheetWithSelectorLength(16385); sheet().rules.length", "0");
+
+shouldBe("styleElement.innerText = fatStyleSheetWithSelectorLength(1); sheet().rules.length", "1");
+shouldBe("styleElement.innerText = fatStyleSheetWithSelectorLength(2048); sheet().rules.length", "1");
+shouldBe("styleElement.innerText = fatStyleSheetWithSelectorLength(2049); sheet().rules.length", "0");
+shouldBe("styleElement.innerText = fatStyleSheetWithSelectorLength(4096); sheet().rules.length", "0");
+shouldBe("styleElement.innerText = fatStyleSheetWithSelectorLength(4097); sheet().rules.length", "0");
+shouldBe("styleElement.innerText = fatStyleSheetWithSelectorLength(16385); sheet().rules.length", "0");
+shouldBe("styleElement.innerText = fatStyleSheetWithSelectorLength(16384); sheet().rules.length", "0");
+shouldBe("styleElement.innerText = fatStyleSheetWithSelectorLength(16385); sheet().rules.length", "0");
+
+</script>
+<script src="../../resources/js-test-post.js"></script>
+</body>
+</html>

--- a/Source/WebCore/css/CSSGroupingRule.cpp
+++ b/Source/WebCore/css/CSSGroupingRule.cpp
@@ -85,7 +85,7 @@ ExceptionOr<unsigned> CSSGroupingRule::insertRule(const String& ruleString, unsi
     }
 
     // Nesting inside style rule only accepts style rule or group rule
-    if (hasStyleRuleAncestor() && !newRule->isStyleRuleWithNesting() && !newRule->isStyleRule() && !newRule->isGroupRule())
+    if (hasStyleRuleAncestor() && !newRule->isStyleRule() && !newRule->isGroupRule())
         return Exception { HierarchyRequestError };
 
     CSSStyleSheet::RuleMutationScope mutationScope(this);

--- a/Source/WebCore/css/CSSStyleRule.cpp
+++ b/Source/WebCore/css/CSSStyleRule.cpp
@@ -213,10 +213,10 @@ ExceptionOr<unsigned> CSSStyleRule::insertRule(const String& ruleString, unsigne
     if (!newRule)
         return Exception { SyntaxError };
     // We only accepts style rule or group rule (@media,...) inside style rules.
-    if (!newRule->isStyleRuleWithNesting() && !newRule->isGroupRule())
+    if (!newRule->isStyleRule() && !newRule->isGroupRule())
         return Exception { HierarchyRequestError };
 
-    if (m_styleRule->isStyleRule()) {
+    if (!m_styleRule->isStyleRuleWithNesting()) {
         // Call the parent rule (or parent stylesheet if top-level) to transform the current StyleRule to StyleRuleWithNesting.
         auto parent = parentRule();
         auto styleRuleWithNesting = parent ? parent->prepareChildStyleRuleForNesting(m_styleRule) : styleSheet->prepareChildStyleRuleForNesting(WTFMove(m_styleRule.get()));

--- a/Source/WebCore/css/StyleRule.h
+++ b/Source/WebCore/css/StyleRule.h
@@ -64,7 +64,7 @@ public:
     bool isNamespaceRule() const { return type() == StyleRuleType::Namespace; }
     bool isMediaRule() const { return type() == StyleRuleType::Media; }
     bool isPageRule() const { return type() == StyleRuleType::Page; }
-    bool isStyleRule() const { return type() == StyleRuleType::Style; }
+    bool isStyleRule() const { return type() == StyleRuleType::Style || type() == StyleRuleType::StyleWithNesting; }
     bool isStyleRuleWithNesting() const { return type() == StyleRuleType::StyleWithNesting; }
     bool isGroupRule() const { return type() == StyleRuleType::Media || type() == StyleRuleType::Supports || type() == StyleRuleType::LayerBlock || type() == StyleRuleType::Container; }
     bool isSupportsRule() const { return type() == StyleRuleType::Supports; }
@@ -454,11 +454,11 @@ inline CompiledSelector& StyleRule::compiledSelectorForListIndex(unsigned index)
 } // namespace WebCore
 
 SPECIALIZE_TYPE_TRAITS_BEGIN(WebCore::StyleRule)
-    static bool isType(const WebCore::StyleRuleBase& rule) { return rule.type() == WebCore::StyleRuleType::Style; }
+    static bool isType(const WebCore::StyleRuleBase& rule) { return rule.isStyleRule(); }
 SPECIALIZE_TYPE_TRAITS_END()
 
 SPECIALIZE_TYPE_TRAITS_BEGIN(WebCore::StyleRuleWithNesting)
-    static bool isType(const WebCore::StyleRuleBase& rule) { return rule.type() == WebCore::StyleRuleType::StyleWithNesting; }
+    static bool isType(const WebCore::StyleRuleBase& rule) { return rule.isStyleRuleWithNesting(); }
 SPECIALIZE_TYPE_TRAITS_END()
 
 SPECIALIZE_TYPE_TRAITS_BEGIN(WebCore::StyleRuleGroup)

--- a/Source/WebCore/css/parser/CSSParserImpl.cpp
+++ b/Source/WebCore/css/parser/CSSParserImpl.cpp
@@ -1166,7 +1166,7 @@ void CSSParserImpl::consumeDeclarationListOrStyleBlockHelper(CSSParserTokenRange
                 auto rule = consumeQualifiedRule(range, AllowedRulesType::RegularRules);
                 if (!rule)
                     break;
-                if (!rule->isStyleRuleWithNesting())
+                if (!rule->isStyleRule())
                     break;
                 topContext().m_parsedRules.append(*rule);
                 break;

--- a/Source/WebCore/style/RuleFeature.h
+++ b/Source/WebCore/style/RuleFeature.h
@@ -75,7 +75,7 @@ struct RuleFeature : public RuleAndSelector {
     MatchElement matchElement;
     IsNegation isNegation; // Whether the selector is in a (non-paired) :not() context.
 };
-static_assert(sizeof(RuleFeature) <= 16, "RuleFeature is a frquently alocated object. Keep it small.");
+static_assert(sizeof(RuleFeature) <= 16, "RuleFeature is a frequently allocated object. Keep it small.");
 
 struct RuleFeatureWithInvalidationSelector : public RuleFeature {
     RuleFeatureWithInvalidationSelector(const RuleData&, MatchElement, IsNegation, const CSSSelector* invalidationSelector);

--- a/Source/WebCore/style/RuleSetBuilder.cpp
+++ b/Source/WebCore/style/RuleSetBuilder.cpp
@@ -47,11 +47,12 @@
 namespace WebCore {
 namespace Style {
 
-RuleSetBuilder::RuleSetBuilder(RuleSet& ruleSet, const MQ::MediaQueryEvaluator& evaluator, Resolver* resolver, ShrinkToFit shrinkToFit)
+RuleSetBuilder::RuleSetBuilder(RuleSet& ruleSet, const MQ::MediaQueryEvaluator& evaluator, Resolver* resolver, ShrinkToFit shrinkToFit, ShouldResolveNesting shouldResolveNesting)
     : m_ruleSet(&ruleSet)
     , m_mediaQueryCollector({ evaluator })
     , m_resolver(resolver)
     , m_shrinkToFit(shrinkToFit)
+    , m_shouldResolveNesting(shouldResolveNesting)
 {
 }
 
@@ -245,7 +246,8 @@ void RuleSetBuilder::addStyleRuleWithSelectorList(const CSSSelectorList& selecto
 
 void RuleSetBuilder::addStyleRule(StyleRuleWithNesting& rule)
 {
-    resolveSelectorListWithNesting(rule);
+    if (m_shouldResolveNesting == ShouldResolveNesting::Yes)
+        resolveSelectorListWithNesting(rule);
 
     auto& selectorList = rule.selectorList();
     addStyleRuleWithSelectorList(selectorList, rule);

--- a/Source/WebCore/style/RuleSetBuilder.h
+++ b/Source/WebCore/style/RuleSetBuilder.h
@@ -29,8 +29,9 @@ namespace Style {
 
 class RuleSetBuilder {
 public:
-    enum class ShrinkToFit { Enable, Disable };
-    RuleSetBuilder(RuleSet&, const MQ::MediaQueryEvaluator&, Resolver* = nullptr, ShrinkToFit = ShrinkToFit::Enable);
+    enum class ShrinkToFit : bool { Enable, Disable };
+    enum class ShouldResolveNesting : bool { No, Yes };
+    RuleSetBuilder(RuleSet&, const MQ::MediaQueryEvaluator&, Resolver* = nullptr, ShrinkToFit = ShrinkToFit::Enable, ShouldResolveNesting = ShouldResolveNesting::No);
     ~RuleSetBuilder();
 
     void addRulesFromSheet(const StyleSheetContents&, const MQ::MediaQueryList& sheetQuery = { });
@@ -85,6 +86,7 @@ private:
     HashMap<CascadeLayerName, RuleSet::CascadeLayerIdentifier> m_cascadeLayerIdentifierMap;
     RuleSet::CascadeLayerIdentifier m_currentCascadeLayerIdentifier { 0 };
     Vector<const CSSSelectorList*> m_styleRuleStack;
+    const ShouldResolveNesting m_shouldResolveNesting { ShouldResolveNesting::No };
 
     RuleSet::ContainerQueryIdentifier m_currentContainerQueryIdentifier { 0 };
 

--- a/Source/WebCore/style/StyleInvalidator.cpp
+++ b/Source/WebCore/style/StyleInvalidator.cpp
@@ -54,6 +54,15 @@ static bool shouldDirtyAllStyle(const Vector<RefPtr<StyleRuleBase>>& rules)
                 return true;
             continue;
         }
+        if (is<StyleRuleWithNesting>(*rule)) {
+            auto childRules = downcast<StyleRuleWithNesting>(*rule).nestedRules().map(
+                [](auto& rule) {
+                    return RefPtr { rule.ptr() };
+                });
+            if (shouldDirtyAllStyle(childRules))
+                return true;
+            continue;
+        }
         // FIXME: At least font faces don't need full recalc in all cases.
         if (!is<StyleRule>(*rule))
             return true;

--- a/Source/WebCore/style/StyleScopeRuleSets.cpp
+++ b/Source/WebCore/style/StyleScopeRuleSets.cpp
@@ -218,7 +218,7 @@ std::optional<DynamicMediaQueryEvaluationChanges> ScopeRuleSets::evaluateDynamic
 
 void ScopeRuleSets::appendAuthorStyleSheets(const Vector<RefPtr<CSSStyleSheet>>& styleSheets, MQ::MediaQueryEvaluator* mediaQueryEvaluator, InspectorCSSOMWrappers& inspectorCSSOMWrappers)
 {
-    RuleSetBuilder builder(*m_authorStyle, *mediaQueryEvaluator, &m_styleResolver);
+    RuleSetBuilder builder(*m_authorStyle, *mediaQueryEvaluator, &m_styleResolver, RuleSetBuilder::ShrinkToFit::Enable, RuleSetBuilder::ShouldResolveNesting::Yes);
 
     for (auto& cssSheet : styleSheets) {
         ASSERT(!cssSheet->disabled());


### PR DESCRIPTION
#### f347660f0196893c4a9f7cab0beb4ed732da00fd
<pre>
[CSS] StyleRuleWithNesting is a StyleRule (through inheritance)
<a href="https://bugs.webkit.org/show_bug.cgi?id=256693">https://bugs.webkit.org/show_bug.cgi?id=256693</a>
rdar://109254000

Reviewed by Antti Koivisto.

StyleRuleWithNesting should be treated like a StyleRule
in the codebase.

* LayoutTests/fast/css/rule-selector-nesting-overflow-expected.txt: Added.
* LayoutTests/fast/css/rule-selector-nesting-overflow.html: Added.
* Source/WebCore/css/CSSGroupingRule.cpp:
(WebCore::CSSGroupingRule::insertRule):
* Source/WebCore/css/CSSStyleRule.cpp:
(WebCore::CSSStyleRule::insertRule):
* Source/WebCore/css/StyleRule.h:
(WebCore::StyleRuleBase::isStyleRule const):
(isType):
* Source/WebCore/css/StyleSheetContents.cpp:
(WebCore::StyleSheetContents::parserAppendRule):
(WebCore::traverseRulesInVector):
* Source/WebCore/css/parser/CSSParserImpl.cpp:
(WebCore::CSSParserImpl::consumeDeclarationListOrStyleBlockHelper):
* Source/WebCore/style/RuleFeature.h:
* Source/WebCore/style/RuleSetBuilder.cpp:
(WebCore::Style::RuleSetBuilder::RuleSetBuilder):
(WebCore::Style::m_shouldResolveNesting):

Invalidation selectors assume that the RuleSet doesn&apos;t mutate.
We need to be careful not to resolve the nesting selector more than once.

(WebCore::Style::RuleSetBuilder::addStyleRule):
* Source/WebCore/style/RuleSetBuilder.h:
* Source/WebCore/style/StyleInvalidator.cpp:
(WebCore::Style::shouldDirtyAllStyle):
* Source/WebCore/style/StyleScope.cpp:
(WebCore::Style::Scope::updateActiveStyleSheets):
* Source/WebCore/style/StyleScopeRuleSets.cpp:
(WebCore::Style::ScopeRuleSets::appendAuthorStyleSheets):

Canonical link: <a href="https://commits.webkit.org/265028@main">https://commits.webkit.org/265028@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/3a435bd154d6aaf3a96201e07c6b8738697dbebe

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/9526 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/9787 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/10027 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/11187 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/9347 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/9536 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/11764 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/9743 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/12248 "1 flakes 96 failures") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/9677 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/10550 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/8134 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/11345 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/7844 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/8666 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/16087 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/8940 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/8816 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/12153 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/9311 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/7567 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/8513 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/8572 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/2297 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/12736 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/9079 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->