### PR TITLE
More explicit error messages for new URL(url, base) Constructor

### DIFF
--- a/LayoutTests/fast/dom/DOMURL/parsing-expected.txt
+++ b/LayoutTests/fast/dom/DOMURL/parsing-expected.txt
@@ -13,7 +13,7 @@ PASS breakDownURL('file:///Users/darin') is 'protocol=file:, pathname=/Users/dar
 PASS breakDownURL('data:text/html,<b>foo</b>') is 'protocol=data:, pathname=text/html,<b>foo</b>, origin=null'
 PASS breakDownURL('http://a:b@c:1/e/f?g%h') is 'protocol=http:, username=a, password=b, hostname=c, host=c:1, port=1, pathname=/e/f, search=?g%h, origin=http://c:1'
 PASS breakDownURL('http://ex%61mple.com/') is 'protocol=http:, host=example.com, pathname=/, origin=http://example.com, toString=http://example.com/'
-PASS breakDownURL('http://ex%2fmple.com/') threw exception TypeError: Type error.
+PASS breakDownURL('http://ex%2fmple.com/') threw exception TypeError: "http://ex%2fmple.com/" cannot be parsed as a URL..
 PASS i is 100
 PASS successfullyParsed is true
 

--- a/LayoutTests/fast/dom/DOMURL/url-constructor-expected.txt
+++ b/LayoutTests/fast/dom/DOMURL/url-constructor-expected.txt
@@ -6,10 +6,10 @@ On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE
 One-parameter constructor - valid URL
 PASS url.href is 'http://user:pass@example.com/path?query#fragment'
 One-parameter constructor - invalid URL should throw
-PASS url = new URL("%^$#") threw exception TypeError: Type error.
-PASS url = new URL("#") threw exception TypeError: Type error.
+PASS url = new URL("%^$#") threw exception TypeError: "%^$#" cannot be parsed as a URL..
+PASS url = new URL("#") threw exception TypeError: "#" cannot be parsed as a URL..
 One-parameter constructor - relative URL not valid against default base
-PASS url = new URL("foobar") threw exception TypeError: Type error.
+PASS url = new URL("foobar") threw exception TypeError: "foobar" cannot be parsed as a URL..
 URL with string base
 PASS url.href is 'http://example.com/path/to/nowhere?ok'
 URL with URL base

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-values/urls/resolve-relative-to-base-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-values/urls/resolve-relative-to-base-expected.txt
@@ -1,4 +1,4 @@
 
-FAIL base-relative URL: relative-image-url Type error
-FAIL base-relative URL: relative-image-variable-url Type error
+FAIL base-relative URL: relative-image-url "images/test.png" cannot be parsed as a URL.
+FAIL base-relative URL: relative-image-variable-url "images/test.png" cannot be parsed as a URL.
 

--- a/LayoutTests/imported/w3c/web-platform-tests/url/url-constructor.any.worker_exclude=(file_javascript_mailto)-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/url/url-constructor.any.worker_exclude=(file_javascript_mailto)-expected.txt
@@ -432,7 +432,7 @@ PASS Parsing: <http://ho%5Dst/> without base
 PASS Parsing: <http://ho%7Cst/> without base
 PASS Parsing: <http://ho%7Fst/> without base
 PASS Parsing: <http://!"$&'()*+,-.;=_`{}~/> without base
-FAIL Parsing: <sc://!"$%&'()*+,-.;=_`{}~/> without base Type error
+FAIL Parsing: <sc://!"$%&'()*+,-.;=_`{}~/> without base "sc://!"$%&'()*+,-.;=_`{}~/" cannot be parsed as a URL.
 PASS Parsing: <ftp://example.com%80/> without base
 PASS Parsing: <ftp://example.com%A0/> without base
 PASS Parsing: <https://example.com%80/> without base

--- a/LayoutTests/imported/w3c/web-platform-tests/url/url-constructor.any_exclude=(file_javascript_mailto)-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/url/url-constructor.any_exclude=(file_javascript_mailto)-expected.txt
@@ -432,7 +432,7 @@ PASS Parsing: <http://ho%5Dst/> without base
 PASS Parsing: <http://ho%7Cst/> without base
 PASS Parsing: <http://ho%7Fst/> without base
 PASS Parsing: <http://!"$&'()*+,-.;=_`{}~/> without base
-FAIL Parsing: <sc://!"$%&'()*+,-.;=_`{}~/> without base Type error
+FAIL Parsing: <sc://!"$%&'()*+,-.;=_`{}~/> without base "sc://!"$%&'()*+,-.;=_`{}~/" cannot be parsed as a URL.
 PASS Parsing: <ftp://example.com%80/> without base
 PASS Parsing: <ftp://example.com%A0/> without base
 PASS Parsing: <https://example.com%80/> without base

--- a/LayoutTests/imported/w3c/web-platform-tests/url/url-origin.any-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/url/url-origin.any-expected.txt
@@ -266,7 +266,7 @@ PASS Origin parsing: <wow:%1G> without base
 PASS Origin parsing: <wow:￿> without base
 PASS Origin parsing: <http://example.com/U+d800𐟾U+dfff﷐﷏﷯ﷰ￾￿?U+d800𐟾U+dfff﷐﷏﷯ﷰ￾￿> without base
 PASS Origin parsing: <http://!"$&'()*+,-.;=_`{}~/> without base
-FAIL Origin parsing: <sc://!"$%&'()*+,-.;=_`{}~/> without base Type error
+FAIL Origin parsing: <sc://!"$%&'()*+,-.;=_`{}~/> without base "sc://!"$%&'()*+,-.;=_`{}~/" cannot be parsed as a URL.
 PASS Origin parsing: <ftp://%e2%98%83> without base
 PASS Origin parsing: <https://%e2%98%83> without base
 PASS Origin parsing: <http://127.0.0.1:10100/relative_import.html> without base

--- a/LayoutTests/imported/w3c/web-platform-tests/url/url-origin.any.worker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/url/url-origin.any.worker-expected.txt
@@ -266,7 +266,7 @@ PASS Origin parsing: <wow:%1G> without base
 PASS Origin parsing: <wow:￿> without base
 PASS Origin parsing: <http://example.com/U+d800𐟾U+dfff﷐﷏﷯ﷰ￾￿?U+d800𐟾U+dfff﷐﷏﷯ﷰ￾￿> without base
 PASS Origin parsing: <http://!"$&'()*+,-.;=_`{}~/> without base
-FAIL Origin parsing: <sc://!"$%&'()*+,-.;=_`{}~/> without base Type error
+FAIL Origin parsing: <sc://!"$%&'()*+,-.;=_`{}~/> without base "sc://!"$%&'()*+,-.;=_`{}~/" cannot be parsed as a URL.
 PASS Origin parsing: <ftp://%e2%98%83> without base
 PASS Origin parsing: <https://%e2%98%83> without base
 PASS Origin parsing: <http://127.0.0.1:10100/relative_import.html> without base

--- a/LayoutTests/imported/w3c/web-platform-tests/workers/modules/dedicated-worker-import-referrer-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/workers/modules/dedicated-worker-import-referrer-expected.txt
@@ -11,13 +11,13 @@ PASS Same-origin top-level module script loading with "same-origin" referrer pol
 PASS Same-origin static import with "no-referrer" referrer policy.
 PASS Same-origin static import with "origin" referrer policy.
 PASS Same-origin static import with "same-origin" referrer policy.
-FAIL Cross-origin static import with "no-referrer" referrer policy. promise_test: Unhandled rejection with value: object "TypeError: Type error"
-FAIL Cross-origin static import with "origin" referrer policy. promise_test: Unhandled rejection with value: object "TypeError: Type error"
-FAIL Cross-origin static import with "same-origin" referrer policy. promise_test: Unhandled rejection with value: object "TypeError: Type error"
+FAIL Cross-origin static import with "no-referrer" referrer policy. promise_test: Unhandled rejection with value: object "TypeError: "ERROR" cannot be parsed as a URL."
+FAIL Cross-origin static import with "origin" referrer policy. promise_test: Unhandled rejection with value: object "TypeError: "ERROR" cannot be parsed as a URL."
+FAIL Cross-origin static import with "same-origin" referrer policy. promise_test: Unhandled rejection with value: object "TypeError: "ERROR" cannot be parsed as a URL."
 PASS Same-origin dynamic import with "no-referrer" referrer policy.
 PASS Same-origin dynamic import with "origin" referrer policy.
 PASS Same-origin dynamic import with "same-origin" referrer policy.
-FAIL Cross-origin dynamic import with "no-referrer" referrer policy. promise_test: Unhandled rejection with value: object "TypeError: Type error"
-FAIL Cross-origin dynamic import with "origin" referrer policy. promise_test: Unhandled rejection with value: object "TypeError: Type error"
-FAIL Cross-origin dynamic import with "same-origin" referrer policy. promise_test: Unhandled rejection with value: object "TypeError: Type error"
+FAIL Cross-origin dynamic import with "no-referrer" referrer policy. promise_test: Unhandled rejection with value: object "TypeError: "Import failed: TypeError: Cross-origin script load denied by Cross-Origin Resource Sharing policy." cannot be parsed as a URL."
+FAIL Cross-origin dynamic import with "origin" referrer policy. promise_test: Unhandled rejection with value: object "TypeError: "Import failed: TypeError: Cross-origin script load denied by Cross-Origin Resource Sharing policy." cannot be parsed as a URL."
+FAIL Cross-origin dynamic import with "same-origin" referrer policy. promise_test: Unhandled rejection with value: object "TypeError: "Import failed: TypeError: Cross-origin script load denied by Cross-Origin Resource Sharing policy." cannot be parsed as a URL."
 

--- a/LayoutTests/imported/w3c/web-platform-tests/workers/modules/shared-worker-import-referrer-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/workers/modules/shared-worker-import-referrer-expected.txt
@@ -5,13 +5,13 @@ PASS Same-origin top-level module script loading with "same-origin" referrer pol
 FAIL Same-origin static import with "no-referrer" referrer policy. assert_equals: expected "" but got "http://localhost:8800/workers/modules/resources/static-import-same-origin-referrer-checker-worker.js"
 FAIL Same-origin static import with "origin" referrer policy. assert_equals: expected "http://localhost:8800/" but got "http://localhost:8800/workers/modules/resources/static-import-same-origin-referrer-checker-worker.js"
 PASS Same-origin static import with "same-origin" referrer policy.
-FAIL Cross-origin static import with "no-referrer" referrer policy. promise_test: Unhandled rejection with value: object "TypeError: Type error"
-FAIL Cross-origin static import with "origin" referrer policy. promise_test: Unhandled rejection with value: object "TypeError: Type error"
-FAIL Cross-origin static import with "same-origin" referrer policy. promise_test: Unhandled rejection with value: object "TypeError: Type error"
+FAIL Cross-origin static import with "no-referrer" referrer policy. promise_test: Unhandled rejection with value: object "TypeError: "ERROR" cannot be parsed as a URL."
+FAIL Cross-origin static import with "origin" referrer policy. promise_test: Unhandled rejection with value: object "TypeError: "ERROR" cannot be parsed as a URL."
+FAIL Cross-origin static import with "same-origin" referrer policy. promise_test: Unhandled rejection with value: object "TypeError: "ERROR" cannot be parsed as a URL."
 PASS Same-origin dynamic import with "no-referrer" referrer policy.
 PASS Same-origin dynamic import with "origin" referrer policy.
 PASS Same-origin dynamic import with "same-origin" referrer policy.
-FAIL Cross-origin dynamic import with "no-referrer" referrer policy. promise_test: Unhandled rejection with value: object "TypeError: Type error"
-FAIL Cross-origin dynamic import with "origin" referrer policy. promise_test: Unhandled rejection with value: object "TypeError: Type error"
-FAIL Cross-origin dynamic import with "same-origin" referrer policy. promise_test: Unhandled rejection with value: object "TypeError: Type error"
+FAIL Cross-origin dynamic import with "no-referrer" referrer policy. promise_test: Unhandled rejection with value: object "TypeError: "Import failed: TypeError: Importing a module script failed." cannot be parsed as a URL."
+FAIL Cross-origin dynamic import with "origin" referrer policy. promise_test: Unhandled rejection with value: object "TypeError: "Import failed: TypeError: Importing a module script failed." cannot be parsed as a URL."
+FAIL Cross-origin dynamic import with "same-origin" referrer policy. promise_test: Unhandled rejection with value: object "TypeError: "Import failed: TypeError: Importing a module script failed." cannot be parsed as a URL."
 

--- a/Source/WebCore/html/DOMURL.cpp
+++ b/Source/WebCore/html/DOMURL.cpp
@@ -50,7 +50,7 @@ ExceptionOr<Ref<DOMURL>> DOMURL::create(const String& url, const URL& base)
     ASSERT(base.isValid() || base.isNull());
     URL completeURL { base, url };
     if (!completeURL.isValid())
-        return Exception { TypeError };
+        return Exception { TypeError, makeString("\"", url, "\" cannot be parsed as a URL.") };
     return adoptRef(*new DOMURL(WTFMove(completeURL), base));
 }
 
@@ -58,7 +58,7 @@ ExceptionOr<Ref<DOMURL>> DOMURL::create(const String& url, const String& base)
 {
     URL baseURL { base };
     if (!base.isNull() && !baseURL.isValid())
-        return Exception { TypeError };
+        return Exception { TypeError, makeString("\"", url, "\" cannot be parsed as a URL against \"", base, "\".") };
     return create(url, baseURL);
 }
 


### PR DESCRIPTION
#### e60a65f91bc5b4ae4c6cd886c0a88b510dd8e103
<pre>
More explicit error messages for new URL(url, base) Constructor
<a href="https://bugs.webkit.org/show_bug.cgi?id=256692">https://bugs.webkit.org/show_bug.cgi?id=256692</a>
rdar://109253920

Reviewed by Tim Nguyen.

This gives a more explicit message for `new URL()` instead of just
TypeError. It is also more readable in the console.

* LayoutTests/fast/dom/DOMURL/parsing-expected.txt:
* LayoutTests/fast/dom/DOMURL/url-constructor-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-values/urls/resolve-relative-to-base-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/url/url-constructor.any_exclude=(file_javascript_mailto)-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/url/url-constructor.any.worker_exclude=(file_javascript_mailto)-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/url/url-origin.any-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/url/url-origin.any.worker-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/workers/modules/dedicated-worker-import-referrer-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/workers/modules/shared-worker-import-referrer-expected.txt:
* Source/WebCore/html/DOMURL.cpp:
(WebCore::DOMURL::create):
(WebCore::DOMURL::create):

Canonical link: <a href="https://commits.webkit.org/264129@main">https://commits.webkit.org/264129@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c4e878e811058f1d7c06f782566b999148e55d5c

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/6691 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/6908 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/7090 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/8280 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/6961 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/6689 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/8007 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/6853 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/9857 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/6809 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/7346 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/6124 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/8371 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/4805 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/6054 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/13882 "1 missing results 120 failures") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/6588 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/6131 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/8856 "run-api-tests-without-change (failure)") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/6622 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/5425 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/6015 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/1608 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/10187 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/6388 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->