### PR TITLE
XPath: Apply ignore-case matching to attribute names

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/domxpath/002-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/domxpath/002-expected.txt
@@ -1,12 +1,12 @@
 
 PASS Select html element based on attribute
-FAIL Select html element based on attribute mixed case assert_array_equals: lengths differ, expected array [Element node <div id="log" nonÄsciiattribute=""><span></span></div>] length 1, got [] length 0
+PASS Select html element based on attribute mixed case
 PASS Select both HTML and SVG elements based on attribute
 PASS Select HTML element with non-ascii attribute 1
 PASS Select HTML element with non-ascii attribute 2
-FAIL Select HTML element with non-ascii attribute 3 assert_array_equals: lengths differ, expected array [Element node <div id="log" nonÄsciiattribute=""><span></span></div>] length 1, got [] length 0
+PASS Select HTML element with non-ascii attribute 3
 PASS Select SVG element based on mixed case attribute
-FAIL Select both HTML and SVG elements based on mixed case attribute assert_array_equals: lengths differ, expected array [Element node <div id="log" nonÄsciiattribute=""><span></span></div>] length 1, got [] length 0
+PASS Select both HTML and SVG elements based on mixed case attribute
 PASS Select SVG elements with refX attribute
 PASS Select SVG elements with refX attribute incorrect case
 PASS Select SVG elements with refX attribute lowercase


### PR DESCRIPTION
#### 0386e818321f7e2823b58e1d6de85f514bdd31c1
<pre>
XPath: Apply ignore-case matching to attribute names
<a href="https://bugs.webkit.org/show_bug.cgi?id=256536">https://bugs.webkit.org/show_bug.cgi?id=256536</a>

Reviewed by Ryosuke Niwa.

Cherry-pick the following Blink change:
<a href="https://chromium.googlesource.com/chromium/src.git/+/0292ac42f12b0d7725ed1a311cce46290217a3bb">https://chromium.googlesource.com/chromium/src.git/+/0292ac42f12b0d7725ed1a311cce46290217a3bb</a>

Apply ignore-case matching to attribute names if attribute&apos;s owner element is
an HTML element and its owner document is an HTML document and it has no
namespaceURI.

* LayoutTests/imported/w3c/web-platform-tests/domxpath/002-expected.txt:
* Source/WebCore/xml/XPathStep.cpp:
(WebCore::XPath::nodeMatchesBasicTest):
(WebCore::XPath::Step::nodesInAxis const):

Canonical link: <a href="https://commits.webkit.org/264030@main">https://commits.webkit.org/264030@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2ee7ecd5b717be2bca728b90c4469362e77aa577

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/6426 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/6633 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/6814 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/8003 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/6724 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/6421 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/6922 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/6583 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/9619 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/6538 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/6577 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/5815 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/8082 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/4041 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/5798 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/13658 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/5953 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/5877 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/8174 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/6362 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/5199 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/5769 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/1529 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/9928 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/6140 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->