### PR TITLE
[WGSL] Add support for struct constructors

### DIFF
--- a/Source/WebGPU/WGSL/Metal/MetalFunctionWriter.cpp
+++ b/Source/WebGPU/WGSL/Metal/MetalFunctionWriter.cpp
@@ -467,7 +467,14 @@ static void visitArguments(FunctionDefinitionWriter* writer, AST::CallExpression
 
 void FunctionDefinitionWriter::visit(AST::CallExpression& call)
 {
-    if (is<AST::ArrayTypeName>(call.target())) {
+    auto isArray = is<AST::ArrayTypeName>(call.target());
+    auto isStruct = !isArray && std::holds_alternative<Types::Struct>(*call.target().resolvedType());
+    if (isArray || isStruct) {
+        if (isStruct) {
+            visit(call.target().resolvedType());
+            m_stringBuilder.append(" ");
+        }
+
         m_stringBuilder.append("{\n");
         {
             IndentationScope scope(m_indent);

--- a/Source/WebGPU/WGSL/tests/invalid/struct.wgsl
+++ b/Source/WebGPU/WGSL/tests/invalid/struct.wgsl
@@ -1,0 +1,21 @@
+// RUN: %not %wgslc | %check
+
+struct S {
+    x: f32,
+    y: i32,
+}
+
+fn testStructConstructor()
+{
+    // CHECK-L: struct initializer has too few inputs: expected 2, found 1
+    _ = S(0);
+
+    // CHECK-L: struct initializer has too many inputs: expected 2, found 3
+    _ = S(0, 0, 0);
+
+    // CHECK-L: type in struct initializer does not match struct member type: expected 'f32', found 'i32'
+    _ = S(0i, 0);
+
+    // CHECK-L: type in struct initializer does not match struct member type: expected 'i32', found 'f32'
+    _ = S(0f, 0f);
+}

--- a/Source/WebGPU/WGSL/tests/valid/struct.wgsl
+++ b/Source/WebGPU/WGSL/tests/valid/struct.wgsl
@@ -1,0 +1,13 @@
+// RUN: %wgslc
+
+struct S {
+    x: f32,
+    y: i32,
+}
+
+fn testStructConstructor()
+{
+    _ = S(0, 0);
+    _ = S(0.0, 0);
+    _ = S(0f, 0i);
+}


### PR DESCRIPTION
#### 65a2d2ebf19f54e0bb8067314673cd2320aad781
<pre>
[WGSL] Add support for struct constructors
<a href="https://bugs.webkit.org/show_bug.cgi?id=256704">https://bugs.webkit.org/show_bug.cgi?id=256704</a>
rdar://109265280

Reviewed by Myles C. Maxfield and Dan Glastonbury.

Add type checking and code generation for struct constructors.

* Source/WebGPU/WGSL/Metal/MetalFunctionWriter.cpp:
(WGSL::Metal::FunctionDefinitionWriter::visit):
* Source/WebGPU/WGSL/TypeCheck.cpp:
(WGSL::TypeChecker::visit):
* Source/WebGPU/WGSL/tests/invalid/struct.wgsl: Added.
* Source/WebGPU/WGSL/tests/valid/struct.wgsl: Added.

Canonical link: <a href="https://commits.webkit.org/264066@main">https://commits.webkit.org/264066@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/02108def0ffbab5eaefa469d0bbea09433510712

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/6427 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/6634 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/6815 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/8004 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/6725 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/6925 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/6584 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/9620 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/6539 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/6579 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/5818 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/8083 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/4043 "Passed tests") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/13659 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/5957 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/5880 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/8178 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/6363 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/5200 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/5770 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/1554 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/9929 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/6141 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->