### PR TITLE
FrameLoader::m_frame should be a Frame

### DIFF
--- a/Source/WebCore/loader/FrameLoader.h
+++ b/Source/WebCore/loader/FrameLoader.h
@@ -106,7 +106,7 @@ public:
     WEBCORE_EXPORT void init();
     void initForSynthesizedDocument(const URL&);
 
-    LocalFrame& frame() const { return m_frame; }
+    Frame& frame() const { return m_frame; }
 
     class PolicyChecker;
     PolicyChecker& policyChecker() const { return *m_policyChecker; }
@@ -440,7 +440,7 @@ private:
     void clearProvisionalLoadForPolicyCheck();
     bool hasOpenedFrames() const;
 
-    LocalFrame& m_frame;
+    Frame& m_frame;
     UniqueRef<FrameLoaderClient> m_client;
 
     const std::unique_ptr<PolicyChecker> m_policyChecker;

--- a/Source/WebCore/loader/ResourceLoader.cpp
+++ b/Source/WebCore/loader/ResourceLoader.cpp
@@ -257,7 +257,8 @@ void ResourceLoader::start()
 
     RefPtr<SecurityOrigin> sourceOrigin = is<SubresourceLoader>(*this) ? downcast<SubresourceLoader>(*this).origin() : nullptr;
     if (!sourceOrigin && frameLoader()) {
-        auto* document = frameLoader()->frame().document();
+        auto* localFrame = dynamicDowncast<LocalFrame>(frameLoader()->frame());
+        auto* document = localFrame ? localFrame->document() : nullptr;
         sourceOrigin =  document ? &document->securityOrigin() : nullptr;
     }
 

--- a/Source/WebCore/loader/cache/CachedResourceLoader.cpp
+++ b/Source/WebCore/loader/cache/CachedResourceLoader.cpp
@@ -882,18 +882,20 @@ void CachedResourceLoader::updateHTTPRequestHeaders(FrameLoader& frameLoader, Ca
     // FIXME: We should reconcile handling of MainResource with other resources.
     if (type != CachedResource::Type::MainResource)
         request.updateReferrerAndOriginHeaders(frameLoader);
+
+    auto* localFrame = dynamicDowncast<LocalFrame>(frameLoader.frame());
 #if ENABLE(PUBLIC_SUFFIX_LIST)
     // FetchMetadata depends on PSL to determine same-site relationships and without this
     // ability it is best to not set any FetchMetadata headers as sites generally expect
     // all of them or none.
-    if (frameLoader.frame().settings().fetchMetadataEnabled() && (!frameLoader.frame().document() || !frameLoader.frame().document()->quirks().shouldDisableFetchMetadata())) {
-        auto site = computeFetchMetadataSite(request.resourceRequest(), type, request.options().mode, frameLoader.frame().document()->securityOrigin());
+    if (localFrame && frameLoader.frame().settings().fetchMetadataEnabled() && (!localFrame->document() || !localFrame->document()->quirks().shouldDisableFetchMetadata())) {
+        auto site = computeFetchMetadataSite(request.resourceRequest(), type, request.options().mode, localFrame->document()->securityOrigin());
         updateRequestFetchMetadataHeaders(request.resourceRequest(), request.options(), site);
     }
 #endif // ENABLE(PUBLIC_SUFFIX_LIST)
     request.updateUserAgentHeader(frameLoader);
 
-    if (frameLoader.frame().loader().loadType() == FrameLoadType::ReloadFromOrigin)
+    if (localFrame && localFrame->loader().loadType() == FrameLoadType::ReloadFromOrigin)
         request.updateCacheModeIfNeeded(cachePolicy(type, request.resourceRequest().url()));
     request.updateAccordingCacheMode();
     request.updateAcceptEncodingHeader();

--- a/Source/WebCore/loader/cache/CachedResourceRequest.cpp
+++ b/Source/WebCore/loader/cache/CachedResourceRequest.cpp
@@ -299,7 +299,8 @@ void CachedResourceRequest::updateReferrerAndOriginHeaders(FrameLoader& frameLoa
     if (!m_resourceRequest.httpOrigin().isEmpty())
         return;
 
-    auto* document = frameLoader.frame().document();
+    auto* localFrame = dynamicDowncast<LocalFrame>(frameLoader.frame());
+    auto* document = localFrame ? localFrame->document() : nullptr;
     auto actualOrigin = (document && m_options.destination == FetchOptionsDestination::EmptyString && m_initiatorType == cachedResourceRequestInitiatorTypes().fetch) ? Ref { document->securityOrigin() } : SecurityOrigin::createFromString(outgoingReferrer);
     String outgoingOrigin;
     if (m_options.mode == FetchOptions::Mode::Cors)

--- a/Source/WebKit/WebProcess/Network/WebLoaderStrategy.cpp
+++ b/Source/WebKit/WebProcess/Network/WebLoaderStrategy.cpp
@@ -705,7 +705,8 @@ void WebLoaderStrategy::loadResourceSynchronously(FrameLoader& frameLoader, WebC
     trackingParameters.frameID = frameID;
     trackingParameters.resourceID = resourceLoadIdentifier;
 
-    auto* document = frameLoader.frame().document();
+    auto* localFrame = dynamicDowncast<LocalFrame>(frameLoader.frame());
+    auto* document = localFrame ? localFrame->document() : nullptr;
     if (!document) {
         WEBLOADERSTRATEGY_WITH_FRAMELOADER_RELEASE_LOG_ERROR("loadResourceSynchronously: no document");
         error = internalError(request.url());

--- a/Source/WebKitLegacy/WebCoreSupport/WebResourceLoadScheduler.cpp
+++ b/Source/WebKitLegacy/WebCoreSupport/WebResourceLoadScheduler.cpp
@@ -109,7 +109,8 @@ void WebResourceLoadScheduler::loadResource(LocalFrame& frame, CachedResource& r
 
 void WebResourceLoadScheduler::loadResourceSynchronously(FrameLoader& frameLoader, ResourceLoaderIdentifier, const ResourceRequest& request, ClientCredentialPolicy, const FetchOptions& options, const HTTPHeaderMap&, ResourceError& error, ResourceResponse& response, Vector<uint8_t>& data)
 {
-    auto* document = frameLoader.frame().document();
+    auto* localFrame = dynamicDowncast<LocalFrame>(frameLoader.frame());
+    auto* document = localFrame ? localFrame->document() : nullptr;
     auto* sourceOrigin = document ? &document->securityOrigin() : nullptr;
     ResourceHandle::loadResourceSynchronously(frameLoader.networkingContext(), request, options.credentials == FetchOptions::Credentials::Omit ? StoredCredentialsPolicy::DoNotUse : StoredCredentialsPolicy::Use, sourceOrigin, error, response, data);
 }
@@ -267,7 +268,8 @@ void WebResourceLoadScheduler::servePendingRequests(HostInformation* host, Resou
             // For named hosts - which are only http(s) hosts - we should always enforce the connection limit.
             // For non-named hosts - everything but http(s) - we should only enforce the limit if the document isn't done parsing 
             // and we don't know all stylesheets yet.
-            Document* document = resourceLoader->frameLoader() ? resourceLoader->frameLoader()->frame().document() : 0;
+            auto* localFrame = resourceLoader->frameLoader() ? dynamicDowncast<LocalFrame>(resourceLoader->frameLoader()->frame()) : nullptr;
+            auto* document = localFrame ? localFrame->document() : nullptr;
             bool shouldLimitRequests = !host->name().isNull() || (document && (document->parsing() || !document->haveStylesheetsLoaded()));
             if (shouldLimitRequests && host->limitRequests(priority))
                 return;


### PR DESCRIPTION
#### 16bdc2ce622691151ac0b9d88b92a163cd8f285b
<pre>
FrameLoader::m_frame should be a Frame
<a href="https://bugs.webkit.org/show_bug.cgi?id=256705">https://bugs.webkit.org/show_bug.cgi?id=256705</a>
rdar://109265956

Reviewed by NOBODY (OOPS!).

This is in preparation for parent frames being able to navigate child RemoteFrames
with site isolation enabled.  FrameLoader will need to be owned by Frame rather than
LocalFrame.  This does not change any functional behavior with site isolation
disabled because all frames are LocalFrames in that case.  A generous sprinkling of
downcast&lt;LocalFrame&gt; keeps it compiling.  Each one will need to be audited as part
of our audit of all dynamicDowncast&lt;LocalFrame&gt; and downcast&lt;LocalFrame&gt;, so there&apos;s
a lot of work to be done later before we can enable site isolation, but this is a
step in the right direction.  We will also need to separate the loading parts of
FrameLoader and FrameLoaderClient that are needed for LocalFrames and RemoteFrames
from the other parts.

* Source/WebCore/loader/FrameLoader.cpp:
(WebCore::FrameLoader::init):
(WebCore::FrameLoader::initForSynthesizedDocument):
(WebCore::FrameLoader::changeLocation):
(WebCore::FrameLoader::submitForm):
(WebCore::FrameLoader::stopLoading):
(WebCore::FrameLoader::stop):
(WebCore::FrameLoader::closeURL):
(WebCore::FrameLoader::didOpenURL):
(WebCore::FrameLoader::didExplicitOpen):
(WebCore::FrameLoader::clear):
(WebCore::FrameLoader::receivedFirstData):
(WebCore::FrameLoader::didBeginDocument):
(WebCore::FrameLoader::finishedParsing):
(WebCore::FrameLoader::checkCompleted):
(WebCore::FrameLoader::checkCallImplicitClose):
(WebCore::FrameLoader::loadURLIntoChildFrame):
(WebCore::FrameLoader::outgoingOrigin const):
(WebCore::FrameLoader::checkIfFormActionAllowedByCSP const):
(WebCore::FrameLoader::setOpener):
(WebCore::FrameLoader::updateFirstPartyForCookies):
(WebCore::FrameLoader::loadInSameDocument):
(WebCore::FrameLoader::prepareForLoadStart):
(WebCore::FrameLoader::loadFrameRequest):
(WebCore::FrameLoader::isNavigationAllowed const):
(WebCore::FrameLoader::loadURL):
(WebCore::FrameLoader::load):
(WebCore::FrameLoader::loadWithNavigationAction):
(WebCore::FrameLoader::loadWithDocumentLoader):
(WebCore::FrameLoader::reloadWithOverrideEncoding):
(WebCore::FrameLoader::reload):
(WebCore::FrameLoader::stopAllLoaders):
(WebCore::FrameLoader::stopForUserCancel):
(WebCore::FrameLoader::setPolicyDocumentLoader):
(WebCore::FrameLoader::commitProvisionalLoad):
(WebCore::FrameLoader::transitionToCommitted):
(WebCore::FrameLoader::willRestoreFromCachedPage):
(WebCore::FrameLoader::open):
(WebCore::FrameLoader::handleLoadFailureRecovery):
(WebCore::FrameLoader::checkLoadCompleteForThisFrame):
(WebCore::FrameLoader::setOriginalURLForDownloadRequest):
(WebCore::FrameLoader::restoreScrollPositionAndViewStateSoon):
(WebCore::FrameLoader::detachChildren):
(WebCore::FrameLoader::numPendingOrLoadingRequests const):
(WebCore::FrameLoader::userAgent const):
(WebCore::FrameLoader::frameDetached):
(WebCore::FrameLoader::detachFromParent):
(WebCore::FrameLoader::updateRequestAndAddExtraFields):
(WebCore::FrameLoader::loadPostRequest):
(WebCore::FrameLoader::loadResourceSynchronously):
(WebCore::FrameLoader::shouldPerformFragmentNavigation):
(WebCore::FrameLoader::scrollToFragmentWithParentBoundary):
(WebCore::FrameLoader::shouldClose):
(WebCore::FrameLoader::dispatchUnloadEvents):
(WebCore::FrameLoader::dispatchBeforeUnloadEvent):
(WebCore::FrameLoader::executeJavaScriptURL):
(WebCore::FrameLoader::continueLoadAfterNewWindowPolicy):
(WebCore::FrameLoader::shouldInterruptLoadForXFrameOptions):
(WebCore::FrameLoader::shouldTreatURLAsSameAsCurrent const):
(WebCore::FrameLoader::findFrameForNavigation):
(WebCore::FrameLoader::loadSameDocumentItem):
(WebCore::FrameLoader::loadDifferentDocumentItem):
(WebCore::FrameLoader::dispatchDidClearWindowObjectsInAllWorlds):
(WebCore::FrameLoader::dispatchDidClearWindowObjectInWorld):
(WebCore::FrameLoader::dispatchDidCommitLoad):
(WebCore::FrameLoader::switchBrowsingContextsGroup):
* Source/WebCore/loader/FrameLoader.h:
* Source/WebCore/loader/ResourceLoader.cpp:
(WebCore::ResourceLoader::start):
* Source/WebCore/loader/cache/CachedResourceLoader.cpp:
(WebCore::CachedResourceLoader::updateHTTPRequestHeaders):
* Source/WebCore/loader/cache/CachedResourceRequest.cpp:
(WebCore::CachedResourceRequest::updateReferrerAndOriginHeaders):
* Source/WebKit/WebProcess/Network/WebLoaderStrategy.cpp:
(WebKit::WebLoaderStrategy::loadResourceSynchronously):
* Source/WebKitLegacy/WebCoreSupport/WebResourceLoadScheduler.cpp:
(WebResourceLoadScheduler::loadResourceSynchronously):
(WebResourceLoadScheduler::servePendingRequests):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/16bdc2ce622691151ac0b9d88b92a163cd8f285b

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/6428 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/6635 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/6816 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/8005 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/6726 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/6423 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/6926 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/6585 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/9621 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/6540 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/6580 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/5819 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/8084 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/4044 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/5802 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/13660 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/5958 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/5881 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/8182 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/6364 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/5203 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/5771 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/9930 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/6142 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->