### PR TITLE
[GStreamer][WebRTC] Notify end of ICE gathering when end-of-candidates is signaled in SDP

### DIFF
--- a/Source/WebCore/Modules/mediastream/gstreamer/GStreamerMediaEndpoint.h
+++ b/Source/WebCore/Modules/mediastream/gstreamer/GStreamerMediaEndpoint.h
@@ -151,6 +151,8 @@ private:
 
     GRefPtr<GstPad> requestPad(std::optional<unsigned> mlineIndex, const GRefPtr<GstCaps>&, const String& mediaStreamID);
 
+    std::optional<bool> isIceGatheringComplete(const String& currentLocalDescription);
+
 #if !RELEASE_LOG_DISABLED
     void gatherStatsForLogging();
     void startLoggingStats();

--- a/Source/WebCore/Modules/mediastream/gstreamer/GStreamerWebRTCUtils.cpp
+++ b/Source/WebCore/Modules/mediastream/gstreamer/GStreamerWebRTCUtils.cpp
@@ -578,7 +578,7 @@ GRefPtr<GstCaps> capsFromSDPMedia(const GstSDPMedia* media)
             // Remove attributes unrelated with codec preferences, potentially leading to internal
             // webrtcbin confusions such as duplicated RTP direction attributes for instance.
             gst_structure_remove_fields(structure, "a-setup", "a-ice-ufrag", "a-ice-pwd", "a-sendrecv", "a-inactive",
-                "a-sendonly", "a-recvonly", nullptr);
+                "a-sendonly", "a-recvonly", "a-end-of-candidates", nullptr);
 
             // Remove ssrc- attributes that end up being accumulated in fmtp SDP media parameters.
             gst_structure_filter_and_map_in_place(structure, reinterpret_cast<GstStructureFilterMapFunc>(+[](GQuark quark, GValue*, gpointer) -> gboolean {


### PR DESCRIPTION
#### f24a5bb839eeaba47c1f7dea55535f16043a1cba
<pre>
[GStreamer][WebRTC] Notify end of ICE gathering when end-of-candidates is signaled in SDP
<a href="https://bugs.webkit.org/show_bug.cgi?id=256709">https://bugs.webkit.org/show_bug.cgi?id=256709</a>

Reviewed by Xabier Rodriguez-Calvar.

Notify the backend in case all m-lines of the current local description have signaled all their ICE
candidates using the end-of-candidates SDP attribute.

* Source/WebCore/Modules/mediastream/gstreamer/GStreamerMediaEndpoint.cpp:
(WebCore::GStreamerMediaEndpoint::doSetLocalDescription):
(WebCore::GStreamerMediaEndpoint::doSetRemoteDescription):
(WebCore::GStreamerMediaEndpoint::isIceGatheringComplete):
(WebCore::GStreamerMediaEndpoint::onIceCandidate):
* Source/WebCore/Modules/mediastream/gstreamer/GStreamerMediaEndpoint.h:
* Source/WebCore/Modules/mediastream/gstreamer/GStreamerWebRTCUtils.cpp:
(WebCore::capsFromSDPMedia):

Canonical link: <a href="https://commits.webkit.org/264062@main">https://commits.webkit.org/264062@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4f965fe327327f4708b8c943128416296b161773

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/6434 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/6641 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/6822 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/8011 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/6732 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/6429 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/6939 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/6591 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/9625 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/6546 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/6590 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/5825 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/8090 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/4054 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/5807 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/13663 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/5975 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/5886 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/8188 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/6370 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/5207 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/5777 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/1551 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/9936 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/6148 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->