### PR TITLE
[WebGPU] Report errors instead of crashing when shader compilation fails

### DIFF
--- a/Source/WebGPU/WebGPU/BindGroup.mm
+++ b/Source/WebGPU/WebGPU/BindGroup.mm
@@ -75,8 +75,12 @@ Ref<BindGroup> Device::createBindGroup(const WGPUBindGroupDescriptor& descriptor
     constexpr size_t stageCount = std::size(stages);
     ShaderStageArray<NSUInteger> bindingIndexForStage = std::array<NSUInteger, stageCount>();
     const auto& bindGroupLayout = WebGPU::fromAPI(descriptor.layout);
-    Vector<BindableResource> resources;
+    if (!bindGroupLayout.isValid()) {
+        generateAValidationError("invalid BindGroupLayout createBindGroup"_s);
+        return BindGroup::createInvalid(*this);
+    }
 
+    Vector<BindableResource> resources;
     ShaderStageArray<id<MTLArgumentEncoder>> argumentEncoder = std::array<id<MTLArgumentEncoder>, stageCount>({ bindGroupLayout.vertexArgumentEncoder(), bindGroupLayout.fragmentArgumentEncoder(), bindGroupLayout.computeArgumentEncoder() });
     ShaderStageArray<id<MTLBuffer>> argumentBuffer;
     for (ShaderStage stage : stages) {

--- a/Source/WebGPU/WebGPU/ComputePassEncoder.h
+++ b/Source/WebGPU/WebGPU/ComputePassEncoder.h
@@ -79,7 +79,7 @@ private:
 
     bool validatePopDebugGroup() const;
 
-    void makeInvalid() { m_computeCommandEncoder = nil; }
+    void makeInvalid();
 
     id<MTLComputeCommandEncoder> m_computeCommandEncoder { nil };
 

--- a/Source/WebGPU/WebGPU/ComputePassEncoder.mm
+++ b/Source/WebGPU/WebGPU/ComputePassEncoder.mm
@@ -115,6 +115,12 @@ bool ComputePassEncoder::validatePopDebugGroup() const
     return true;
 }
 
+void ComputePassEncoder::makeInvalid()
+{
+    [m_computeCommandEncoder endEncoding];
+    m_computeCommandEncoder = nil;
+}
+
 void ComputePassEncoder::popDebugGroup()
 {
     // https://gpuweb.github.io/gpuweb/#dom-gpudebugcommandsmixin-popdebuggroup
@@ -151,6 +157,12 @@ void ComputePassEncoder::setBindGroup(uint32_t groupIndex, const BindGroup& grou
 
 void ComputePassEncoder::setPipeline(const ComputePipeline& pipeline)
 {
+    if (!pipeline.isValid()) {
+        m_device->generateAValidationError("invalid ComputePipeline in ComputePassEncoder.setPipeline"_s);
+        makeInvalid();
+        return;
+    }
+
     ASSERT(pipeline.computePipelineState());
     [m_computeCommandEncoder setComputePipelineState:pipeline.computePipelineState()];
     m_threadsPerThreadgroup = pipeline.threadsPerThreadgroup();

--- a/Source/WebGPU/WebGPU/Pipeline.mm
+++ b/Source/WebGPU/WebGPU/Pipeline.mm
@@ -42,8 +42,7 @@ std::optional<LibraryCreationResult> createLibrary(id<MTLDevice> device, const S
     }
 
     auto* ast = shaderModule.ast();
-    if (!ast)
-        return std::nullopt;
+    RELEASE_ASSERT(ast);
 
     std::optional<WGSL::PipelineLayout> wgslPipelineLayout { std::nullopt };
     if (pipelineLayout)

--- a/Source/WebGPU/WebGPU/RenderPassEncoder.h
+++ b/Source/WebGPU/WebGPU/RenderPassEncoder.h
@@ -91,7 +91,7 @@ private:
 
     bool validatePopDebugGroup() const;
 
-    void makeInvalid() { m_renderCommandEncoder = nil; }
+    void makeInvalid();
 
     id<MTLRenderCommandEncoder> m_renderCommandEncoder { nil };
 

--- a/Source/WebGPU/WebGPU/RenderPassEncoder.mm
+++ b/Source/WebGPU/WebGPU/RenderPassEncoder.mm
@@ -163,6 +163,12 @@ bool RenderPassEncoder::validatePopDebugGroup() const
     return true;
 }
 
+void RenderPassEncoder::makeInvalid()
+{
+    [m_renderCommandEncoder endEncoding];
+    m_renderCommandEncoder = nil;
+}
+
 void RenderPassEncoder::popDebugGroup()
 {
     // https://gpuweb.github.io/gpuweb/#dom-gpudebugcommandsmixin-popdebuggroup
@@ -219,6 +225,12 @@ void RenderPassEncoder::setPipeline(const RenderPipeline& pipeline)
 {
     // FIXME: validation according to
     // https://gpuweb.github.io/gpuweb/#dom-gpurendercommandsmixin-setpipeline.
+    if (!pipeline.isValid()) {
+        m_device->generateAValidationError("invalid RenderPipeline in RenderPassEncoder.setPipeline"_s);
+        makeInvalid();
+        return;
+    }
+
     if (!pipeline.validateDepthStencilState(m_depthReadOnly, m_stencilReadOnly))
         return;
 

--- a/Source/WebGPU/WebGPU/ShaderModule.mm
+++ b/Source/WebGPU/WebGPU/ShaderModule.mm
@@ -32,6 +32,7 @@
 
 #import <WebGPU/WebGPU.h>
 #import <wtf/DataLog.h>
+#import <wtf/StringPrintStream.h>
 
 namespace WebGPU {
 
@@ -123,10 +124,12 @@ Ref<ShaderModule> Device::createShaderModule(const WGPUShaderModuleDescriptor& d
         }
     } else {
         auto& failedCheck = std::get<WGSL::FailedCheck>(checkResult);
+        StringPrintStream message;
+        message.print(String::number(failedCheck.errors.size()), " error", failedCheck.errors.size() != 1 ? "s" : "", " generated while compiling the shader:"_s);
         for (const auto& error : failedCheck.errors) {
-            // FIXME: https://bugs.webkit.org/show_bug.cgi?id=250442
-            dataLogLn(error);
+            message.print("\n"_s, error);
         }
+        generateAValidationError(message.toString());
         return ShaderModule::createInvalid(*this);
     }
 


### PR DESCRIPTION
#### ec60ea32b263b02ba212296b8cbccf8d45007038
<pre>
[WebGPU] Report errors instead of crashing when shader compilation fails
<a href="https://bugs.webkit.org/show_bug.cgi?id=256719">https://bugs.webkit.org/show_bug.cgi?id=256719</a>
rdar://109270536

Reviewed by Mike Wyrzykowski and Dan Glastonbury.

Handle the errors that arise as a consequence of shader compilation failure:
- invalid BindGroupLayout in createBindGroup (when trying to use the generated
  auto layout)
- invalid pipeline in (Compute|Render)PassEncoder::setPipeline (as a consequence
  of the invalid BindGroup)

* Source/WebGPU/WebGPU/BindGroup.mm:
(WebGPU::Device::createBindGroup):
* Source/WebGPU/WebGPU/ComputePassEncoder.h:
(WebGPU::ComputePassEncoder::makeInvalid): Deleted.
* Source/WebGPU/WebGPU/ComputePassEncoder.mm:
(WebGPU::ComputePassEncoder::makeInvalid):
(WebGPU::ComputePassEncoder::setPipeline):
* Source/WebGPU/WebGPU/Pipeline.mm:
(WebGPU::createLibrary):
* Source/WebGPU/WebGPU/RenderPassEncoder.h:
(WebGPU::RenderPassEncoder::makeInvalid): Deleted.
* Source/WebGPU/WebGPU/RenderPassEncoder.mm:
(WebGPU::RenderPassEncoder::makeInvalid):
(WebGPU::RenderPassEncoder::setPipeline):
* Source/WebGPU/WebGPU/ShaderModule.mm:
(WebGPU::Device::createShaderModule):

Canonical link: <a href="https://commits.webkit.org/264065@main">https://commits.webkit.org/264065@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c792176b0c7fc3db2cacb3ae044e30b2a5c6e018

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/6444 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/6652 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/6833 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/8023 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/6739 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/6970 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/6603 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/9632 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/6557 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/6621 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/5834 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/8102 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/4086 "Passed tests") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/13670 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/6003 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/5895 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/8209 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/6380 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/5216 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/5786 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/1553 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/9945 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/6157 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->