### PR TITLE
InteractionRegions: should not look for link ancestors if a button ancestor has been found

### DIFF
--- a/LayoutTests/interaction-region/button-in-link-expected.txt
+++ b/LayoutTests/interaction-region/button-in-link-expected.txt
@@ -1,0 +1,23 @@
+Some text but also a button
+(GraphicsLayer
+  (anchor 0.00 0.00)
+  (bounds 800.00 600.00)
+  (children 1
+    (GraphicsLayer
+      (bounds 800.00 600.00)
+      (contentsOpaque 1)
+      (drawsContent 1)
+      (backgroundColor #FFFFFF)
+      (event region
+        (rect (0,0) width=800 height=600)
+
+      (interaction regions [
+        (interaction (20,20) width=442 height=67)
+        (borderRadius 0.00),
+        (interaction (269,41) width=172 height=23)
+        (borderRadius 6.00)])
+      )
+    )
+  )
+)
+

--- a/LayoutTests/interaction-region/button-in-link.html
+++ b/LayoutTests/interaction-region/button-in-link.html
@@ -1,0 +1,38 @@
+<!DOCTYPE html>
+<html>
+<style>
+    body { margin: 20px; }
+    a {
+        display: block;
+        width: 400px;
+        border: 1px black solid;
+        padding: 20px;
+        line-height: 25px;
+    }
+    a button {
+        float: right;
+        appearance: none;
+        background: gray;
+        border-radius: 6px;
+        border: none;
+        font-size: 18px;
+    }
+</style>
+<body>
+<a href="#">
+    Some text
+    <button>but also a button</button>
+</a>
+
+<pre id="results"></pre>
+<script>
+if (window.testRunner)
+    testRunner.dumpAsText();
+
+window.onload = function () {
+    if (window.internals)
+       results.textContent = internals.layerTreeAsText(document, internals.LAYER_TREE_INCLUDES_EVENT_REGION | internals.LAYER_TREE_INCLUDES_ROOT_LAYER_PROPERTIES);
+};
+</script>
+</body>
+</html>

--- a/LayoutTests/interaction-region/layer-tree-expected.txt
+++ b/LayoutTests/interaction-region/layer-tree-expected.txt
@@ -113,7 +113,61 @@
                                               (layer bounds [x: 0 y: 0 width: 800 height: 20])
                                               (layer position [x: 400 y: 400]))))))))))))))))))
             (
-              (layer bounds [x: 0 y: 0 width: 0 height: 0]))))
+              (layer bounds [x: 0 y: 0 width: 0 height: 0]))
+            (
+              (layer bounds [x: 0 y: 0 width: 0 height: 0])
+              (sublayers
+                (
+                  (layer bounds [x: 0 y: 0 width: 0 height: 0]))))
+            (
+              (layer bounds [x: 0 y: 0 width: 0 height: 0])
+              (sublayers
+                (
+                  (layer bounds [x: 0 y: 0 width: 0 height: 0]))))
+            (
+              (layer bounds [x: 0 y: 0 width: 0 height: 0])
+              (layer opacity 0.32)
+              (sublayers
+                (
+                  (layer bounds [x: 0 y: 0 width: 0 height: 0]))))
+            (
+              (layer bounds [x: 0 y: 0 width: 0 height: 0])
+              (sublayers
+                (
+                  (layer bounds [x: 0 y: 0 width: 2 height: 0])
+                  (layer position [x: 1 y: 1]))
+                (
+                  (layer bounds [x: 0 y: 0 width: 0 height: 0])
+                  (sublayers
+                    (
+                      (layer bounds [x: 0 y: 0 width: 0 height: 0]))))))
+            (
+              (layer bounds [x: 0 y: 0 width: 0 height: 0])
+              (sublayers
+                (
+                  (layer bounds [x: 0 y: 0 width: 0 height: 0])
+                  (sublayers
+                    (
+                      (layer bounds [x: 0 y: 0 width: 0 height: 0]))
+                    (
+                      (layer bounds [x: 0 y: 0 width: 20 height: 20])
+                      (layer position [x: 0 y: 0]))))
+                (
+                  (layer bounds [x: 0 y: 0 width: 0 height: 0])
+                  (sublayers
+                    (
+                      (layer bounds [x: 0 y: 0 width: 0 height: 0]))
+                    (
+                      (layer bounds [x: 0 y: 0 width: 20 height: 20])
+                      (layer position [x: 0 y: 0]))))))
+            (
+              (layer bounds [x: 0 y: 0 width: 0 height: 0])
+              (sublayers
+                (
+                  (layer bounds [x: 0 y: 0 width: 0 height: 0])
+                  (sublayers
+                    (
+                      (layer bounds [x: 0 y: 0 width: 0 height: 0]))))))))
         (
           (layer bounds [x: 0 y: 0 width: 0 height: 0])
           (layer anchorPoint [x: 0 y: 0]))

--- a/LayoutTests/interaction-region/paused-video-regions.html
+++ b/LayoutTests/interaction-region/paused-video-regions.html
@@ -7,13 +7,16 @@
 <pre id="results"></pre>
 <script src="../media/media-file.js"></script>
 <script src="../media/video-test.js"></script>
+<script src="../resources/ui-helper.js"></script>
 <script>
     if (window.testRunner) {
         testRunner.waitUntilDone();
         testRunner.dumpAsText();
     }
 
-    waitForEvent('canplaythrough', function () {
+    waitForEvent('canplaythrough', async function () {
+        await UIHelper.animationFrame();
+
         if (window.internals)
             results.textContent = internals.layerTreeAsText(document, internals.LAYER_TREE_INCLUDES_EVENT_REGION | internals.LAYER_TREE_INCLUDES_ROOT_LAYER_PROPERTIES);
         

--- a/Source/WebCore/page/InteractionRegion.cpp
+++ b/Source/WebCore/page/InteractionRegion.cpp
@@ -193,14 +193,15 @@ std::optional<InteractionRegion> interactionRegionForRenderedRegion(RenderObject
     if (!matchedElement)
         return std::nullopt;
 
-    if (auto* linkElement = matchedElement->enclosingLinkEventParentOrSelf())
-        matchedElement = linkElement;
-    if (auto* buttonElement = ancestorsOfType<HTMLButtonElement>(*matchedElement).first())
-        matchedElement = buttonElement;
-
-    if (is<HTMLElement>(originalElement) && downcast<HTMLElement>(originalElement)->isLabelable()) {
-        if (auto* labelElement = ancestorsOfType<HTMLLabelElement>(*originalElement).first())
-            matchedElement = labelElement;
+    bool isLabelable = is<HTMLElement>(matchedElement) && downcast<HTMLElement>(matchedElement)->isLabelable();
+    for (Node* node = matchedElement; node; node = node->parentInComposedTree()) {
+        bool matchedButton = is<HTMLButtonElement>(node);
+        bool matchedLabel = isLabelable && is<HTMLLabelElement>(node);
+        bool matchedLink = node->isLink();
+        if (matchedButton || matchedLabel || matchedLink) {
+            matchedElement = downcast<Element>(node);
+            break;
+        }
     }
 
     if (!shouldAllowElement(*matchedElement))


### PR DESCRIPTION
#### 9217f7af3356a9dc4440f84d16d37718b3e937b4
<pre>
InteractionRegions: should not look for link ancestors if a button ancestor has been found
<a href="https://bugs.webkit.org/show_bug.cgi?id=256718">https://bugs.webkit.org/show_bug.cgi?id=256718</a>
&lt;rdar://107958544&gt;

Reviewed by Tim Horton.

Move all the `ancestorsOfType` matching to a single loop. Break when a
match is found.

* Source/WebCore/page/InteractionRegion.cpp:
(WebCore::interactionRegionForRenderedRegion):

* LayoutTests/interaction-region/button-in-link-expected.txt: Added.
* LayoutTests/interaction-region/button-in-link.html: Added.
New test covering this change.

* LayoutTests/interaction-region/layer-tree-expected.txt:
* LayoutTests/interaction-region/paused-video-regions.html:
Test gardening.

Canonical link: <a href="https://commits.webkit.org/264041@main">https://commits.webkit.org/264041@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5dd4b9fe656489e992a6936e673c9f3b6add894d

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/6489 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/6698 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/6879 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/8070 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/6780 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/6485 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/7030 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/6650 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/9676 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/6602 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/6662 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/5875 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/8150 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/4126 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/5853 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/13706 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/6058 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/5932 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/8274 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/6425 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/5254 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/5829 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/5781 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/1538 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/9990 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/6201 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->