### PR TITLE
ServiceWorkerStorageManager should only delete its own files when clearing registrations

### DIFF
--- a/Source/WebCore/workers/service/server/SWRegistrationDatabase.cpp
+++ b/Source/WebCore/workers/service/server/SWRegistrationDatabase.cpp
@@ -203,11 +203,17 @@ SWRegistrationDatabase::SWRegistrationDatabase(const String& path)
 
 SWRegistrationDatabase::~SWRegistrationDatabase()
 {
+    close();
+}
+
+void SWRegistrationDatabase::close()
+{
     ASSERT(!isMainRunLoop());
 
     for (size_t i = 0; i < static_cast<size_t>(StatementType::Invalid); ++i)
         m_cachedStatements[i] = nullptr;
     m_database = nullptr;
+    m_scriptStorage = nullptr;
 }
 
 SWScriptStorage& SWRegistrationDatabase::scriptStorage()
@@ -485,6 +491,14 @@ std::optional<Vector<ServiceWorkerScripts>> SWRegistrationDatabase::updateRegist
     }
 
     return result;
+}
+
+void SWRegistrationDatabase::clearAllRegistrations()
+{
+    close();
+    FileSystem::deleteFile(databaseFilePath(m_directory));
+    FileSystem::deleteNonEmptyDirectory(scriptDirectoryPath(m_directory));
+    FileSystem::deleteEmptyDirectory(m_directory);
 }
 
 } // namespace WebCore

--- a/Source/WebCore/workers/service/server/SWRegistrationDatabase.h
+++ b/Source/WebCore/workers/service/server/SWRegistrationDatabase.h
@@ -49,8 +49,10 @@ public:
     
     WEBCORE_EXPORT std::optional<Vector<ServiceWorkerContextData>> importRegistrations();
     WEBCORE_EXPORT std::optional<Vector<ServiceWorkerScripts>> updateRegistrations(const Vector<ServiceWorkerContextData>&, const Vector<ServiceWorkerRegistrationKey>&);
+    WEBCORE_EXPORT void clearAllRegistrations();
     
 private:
+    void close();
     SWScriptStorage& scriptStorage();
     enum class StatementType : uint8_t {
         GetAllRecords,
@@ -63,7 +65,7 @@ private:
     enum class ShouldCreateIfNotExists : bool { No, Yes };
     bool prepareDatabase(ShouldCreateIfNotExists);
     bool ensureValidRecordsTable();
-    
+
     String m_directory;
     std::unique_ptr<SQLiteDatabase> m_database;
     Vector<std::unique_ptr<SQLiteStatement>> m_cachedStatements;

--- a/Source/WebKit/NetworkProcess/storage/ServiceWorkerStorageManager.cpp
+++ b/Source/WebKit/NetworkProcess/storage/ServiceWorkerStorageManager.cpp
@@ -54,8 +54,8 @@ void ServiceWorkerStorageManager::closeFiles()
 
 void ServiceWorkerStorageManager::clearAllRegistrations()
 {
-    m_database = nullptr;
-    FileSystem::deleteNonEmptyDirectory(m_path);
+    if (auto database = ensureDatabase())
+        database->clearAllRegistrations();
 }
 
 std::optional<Vector<WebCore::ServiceWorkerContextData>> ServiceWorkerStorageManager::importRegistrations()

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/WebsiteDataStoreCustomPaths.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/WebsiteDataStoreCustomPaths.mm
@@ -1126,6 +1126,7 @@ TEST(WKWebsiteDataStoreConfiguration, SameCustomPathForDifferentTypes)
     websiteDataStoreConfiguration.get()._webSQLDatabaseDirectory = sharedDirectory;
     websiteDataStoreConfiguration.get()._webStorageDirectory = sharedDirectory;
     websiteDataStoreConfiguration.get()._indexedDBDatabaseDirectory = sharedDirectory;
+    websiteDataStoreConfiguration.get()._serviceWorkerRegistrationDirectory = sharedDirectory;
     websiteDataStoreConfiguration.get()._cookieStorageFile = [sharedDirectory URLByAppendingPathComponent:@"Cookies.binarycookies" isDirectory:NO];
     websiteDataStoreConfiguration.get().generalStorageDirectory = [sharedDirectory URLByAppendingPathComponent:@"Default" isDirectory:YES];
 


### PR DESCRIPTION
#### abde730eecbb2d02dd8346c149c246ed28a78905
<pre>
ServiceWorkerStorageManager should only delete its own files when clearing registrations
<a href="https://bugs.webkit.org/show_bug.cgi?id=256725">https://bugs.webkit.org/show_bug.cgi?id=256725</a>
rdar://108841865

Reviewed by Chris Dumez.

Existing SPI allows clients to set the same path for different data types, so directory of ServiceWorkerStorageManager
might contain files for other types. Therefore, ServiceWorkerStorageManager should not remove the directory when
clearing registrations.

Test: WKWebsiteDataStoreConfiguration.SameCustomPathForDifferentTypes

* Source/WebCore/workers/service/server/SWRegistrationDatabase.cpp:
(WebCore::SWRegistrationDatabase::~SWRegistrationDatabase):
(WebCore::SWRegistrationDatabase::close):
(WebCore::SWRegistrationDatabase::clearAllRegistrations):
* Source/WebCore/workers/service/server/SWRegistrationDatabase.h:
* Source/WebKit/NetworkProcess/storage/ServiceWorkerStorageManager.cpp:
(WebKit::ServiceWorkerStorageManager::clearAllRegistrations):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/WebsiteDataStoreCustomPaths.mm:
(TEST):

Canonical link: <a href="https://commits.webkit.org/264036@main">https://commits.webkit.org/264036@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e47bc7ea63eb45817037cd85c90f808bba589edb

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/6449 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/6657 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/6838 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/8028 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/6744 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/6445 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/6962 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/6608 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/9636 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/6562 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/6606 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/5839 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/8107 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/4072 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/5820 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/13675 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/5991 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/5899 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/8214 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/6385 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/5219 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/5791 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/1536 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/9950 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/6162 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->