### PR TITLE
Don't show App Store link previews when network connection integrity is enabled

### DIFF
--- a/Source/WebKit/UIProcess/WebPageProxy.cpp
+++ b/Source/WebKit/UIProcess/WebPageProxy.cpp
@@ -5723,6 +5723,8 @@ void WebPageProxy::didCommitLoadForFrame(FrameIdentifier frameID, FrameInfoData&
 #endif
 #if ENABLE(NETWORK_CONNECTION_INTEGRITY)
         updateAllowedLookalikeCharacterStringsIfNeeded();
+        if (navigation && navigation->websitePolicies())
+            m_networkConnectionIntegrityPolicies = navigation->websitePolicies()->networkConnectionIntegrityPolicy();
 #endif
     }
 
@@ -9006,6 +9008,10 @@ void WebPageProxy::resetState(ResetStateReason resetStateReason)
 
 #if ENABLE(MOMENTUM_EVENT_DISPATCHER)
     internals().lastSentScrollingAccelerationCurve = std::nullopt;
+#endif
+
+#if ENABLE(NETWORK_CONNECTION_INTEGRITY)
+    m_networkConnectionIntegrityPolicies = { };
 #endif
 }
 

--- a/Source/WebKit/UIProcess/WebPageProxy.h
+++ b/Source/WebKit/UIProcess/WebPageProxy.h
@@ -166,6 +166,7 @@ enum class MediaProducerMutedState : uint8_t;
 enum class ModalContainerControlType : uint8_t;
 enum class ModalContainerDecision : uint8_t;
 enum class MouseEventPolicy : uint8_t;
+enum class NetworkConnectionIntegrity : uint16_t;
 enum class PermissionState : uint8_t;
 enum class PolicyAction : uint8_t;
 enum class ReasonForDismissingAlternativeText : uint8_t;
@@ -2252,6 +2253,10 @@ public:
 
     WebPopupMenuProxyClient& popupMenuClient();
 
+#if ENABLE(NETWORK_CONNECTION_INTEGRITY)
+    OptionSet<WebCore::NetworkConnectionIntegrity> networkConnectionIntegrityPolicies() const { return m_networkConnectionIntegrityPolicies; }
+#endif
+
 private:
     WebPageProxy(PageClient&, WebProcessProxy&, Ref<API::PageConfiguration>&&);
     void platformInitialize();
@@ -3281,6 +3286,7 @@ private:
     RefPtr<LookalikeCharactersObserver> m_lookalikeCharacterUpdateObserver;
     bool m_needsInitialLookalikeCharacterStrings { true };
     bool m_shouldUpdateAllowedLookalikeCharacterStrings { false };
+    OptionSet<WebCore::NetworkConnectionIntegrity> m_networkConnectionIntegrityPolicies;
 #endif
 
 #if ENABLE(APP_HIGHLIGHTS)

--- a/Source/WebKit/UIProcess/ios/WKContentViewInteraction.h
+++ b/Source/WebKit/UIProcess/ios/WKContentViewInteraction.h
@@ -382,6 +382,7 @@ struct ImageAnalysisContextMenuActionData {
     BOOL _contextMenuActionProviderDelegateNeedsOverride;
     BOOL _contextMenuIsUsingAlternateURLForImage;
     BOOL _isDisplayingContextMenuWithAnimation;
+    BOOL _useCompactMenuForContextMenuInteraction;
 #endif
     RetainPtr<UIPreviewItemController> _previewItemController;
 #endif

--- a/Source/WebKit/UIProcess/ios/WKContentViewInteraction.mm
+++ b/Source/WebKit/UIProcess/ios/WKContentViewInteraction.mm
@@ -12196,6 +12196,8 @@ ALLOW_DEPRECATED_DECLARATIONS_END
 
 - (void)_contextMenuInteraction:(UIContextMenuInteraction *)interaction configurationForMenuAtLocation:(CGPoint)location completion:(void(^)(UIContextMenuConfiguration *))completion
 {
+    _useCompactMenuForContextMenuInteraction = NO;
+
 #if ENABLE(IMAGE_ANALYSIS)
     BOOL triggeredByImageAnalysisTimeout = std::exchange(_contextMenuWasTriggeredByImageAnalysisTimeout, NO);
 #else
@@ -12328,6 +12330,13 @@ ALLOW_DEPRECATED_DECLARATIONS_END
 
 #if ENABLE(DATA_DETECTION)
     if ([(NSURL *)linkURL iTunesStoreURL]) {
+        _useCompactMenuForContextMenuInteraction = !_page->websiteDataStore().isPersistent();
+
+#if ENABLE(NETWORK_CONNECTION_INTEGRITY)
+        if (_page->networkConnectionIntegrityPolicies().contains(WebCore::NetworkConnectionIntegrity::Enabled))
+            _useCompactMenuForContextMenuInteraction = YES;
+#endif
+
         [self continueContextMenuInteractionWithDataDetectors:continueWithContextMenuConfiguration];
         return;
     }
@@ -12541,6 +12550,12 @@ ALLOW_DEPRECATED_DECLARATIONS_END
 
 - (_UIContextMenuStyle *)_contextMenuInteraction:(UIContextMenuInteraction *)interaction styleForMenuWithConfiguration:(UIContextMenuConfiguration *)configuration
 {
+    if (_useCompactMenuForContextMenuInteraction) {
+        _UIContextMenuStyle *style = [_UIContextMenuStyle defaultStyle];
+        style.preferredLayout = _UIContextMenuLayoutCompactMenu;
+        return style;
+    }
+
 #if defined(DD_CONTEXT_MENU_SPI_VERSION) && DD_CONTEXT_MENU_SPI_VERSION >= 2
     if ([configuration isKindOfClass:PAL::getDDContextMenuConfigurationClass()]) {
         DDContextMenuConfiguration *ddConfiguration = static_cast<DDContextMenuConfiguration *>(configuration);


### PR DESCRIPTION
#### 12df7c45b790c57f59631375a2d59ecbc6f1d4ec
<pre>
Don&apos;t show App Store link previews when network connection integrity is enabled
<a href="https://bugs.webkit.org/show_bug.cgi?id=256723">https://bugs.webkit.org/show_bug.cgi?id=256723</a>
rdar://103849151

Reviewed by Wenson Hsieh.

If network connection integrity is enabled, and if the link is an App Store or iTunes link,
do not show the link preview.

* Source/WebKit/UIProcess/WebPageProxy.cpp:
(WebKit::WebPageProxy::didCommitLoadForFrame):
* Source/WebKit/UIProcess/WebPageProxy.h:
* Source/WebKit/UIProcess/ios/WKContentViewInteraction.mm:
(-[WKContentView continueContextMenuInteraction:]):

Canonical link: <a href="https://commits.webkit.org/264553@main">https://commits.webkit.org/264553@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5bc11f7cdcdc85276000b54f0b67274e3f4c9ded

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/7655 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/7924 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/8108 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/9298 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/7834 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/9923 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/7849 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/10700 "1 flakes 98 failures") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/7788 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/8925 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/7047 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/9408 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/6233 "Passed tests") | | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/14659 "6 flakes 110 failures") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/7396 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/7092 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/10512 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/7591 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/6192 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/6924 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/1900 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/11135 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/7322 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->