### PR TITLE
Add SPI to delay a WKWebView's WebProcess launch

### DIFF
--- a/Source/WebKit/UIProcess/API/APIPageConfiguration.cpp
+++ b/Source/WebKit/UIProcess/API/APIPageConfiguration.cpp
@@ -28,6 +28,7 @@
 
 #include "APIProcessPoolConfiguration.h"
 #include "APIWebsitePolicies.h"
+#include "WebInspectorUtilities.h"
 #include "WebPageGroup.h"
 #include "WebPageProxy.h"
 #include "WebPreferences.h"
@@ -247,6 +248,21 @@ bool PageConfiguration::lockdownModeEnabled() const
     if (m_defaultWebsitePolicies)
         return m_defaultWebsitePolicies->lockdownModeEnabled();
     return lockdownModeEnabledBySystem();
+}
+
+bool PageConfiguration::delaysWebProcessLaunchUntilFirstLoad() const
+{
+    if (m_processPool && isInspectorProcessPool(*m_processPool)) {
+        // Never delay process launch for inspector pages as inspector pages do not know how to transition from a terminated process.
+        return false;
+    }
+    if (m_delaysWebProcessLaunchUntilFirstLoad) {
+        // If the client explicitly enabled / disabled the feature, then obey their directives.
+        return *m_delaysWebProcessLaunchUntilFirstLoad;
+    }
+    if (m_processPool)
+        return m_processPool->delaysWebProcessLaunchDefaultValue();
+    return WebProcessPool::globalDelaysWebProcessLaunchDefaultValue();
 }
 
 bool PageConfiguration::isLockdownModeExplicitlySet() const

--- a/Source/WebKit/UIProcess/API/APIPageConfiguration.h
+++ b/Source/WebKit/UIProcess/API/APIPageConfiguration.h
@@ -214,6 +214,9 @@ public:
     void setAllowTestOnlyIPC(bool enabled) { m_allowTestOnlyIPC = enabled; }
     bool allowTestOnlyIPC() const { return m_allowTestOnlyIPC; }
 
+    void setDelaysWebProcessLaunchUntilFirstLoad(bool delaysWebProcessLaunchUntilFirstLoad) { m_delaysWebProcessLaunchUntilFirstLoad = delaysWebProcessLaunchUntilFirstLoad; }
+    bool delaysWebProcessLaunchUntilFirstLoad() const;
+
     void setContentSecurityPolicyModeForExtension(WebCore::ContentSecurityPolicyModeForExtension mode) { m_contentSecurityPolicyModeForExtension = mode; }
     WebCore::ContentSecurityPolicyModeForExtension contentSecurityPolicyModeForExtension() const { return m_contentSecurityPolicyModeForExtension; }
 
@@ -244,6 +247,7 @@ private:
     bool m_drawsBackground { true };
     bool m_controlledByAutomation { false };
     bool m_allowTestOnlyIPC { false };
+    std::optional<bool> m_delaysWebProcessLaunchUntilFirstLoad;
     std::optional<double> m_cpuLimit;
 
     WTF::String m_overrideContentSecurityPolicy;

--- a/Source/WebKit/UIProcess/API/Cocoa/WKProcessGroup.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKProcessGroup.mm
@@ -239,10 +239,11 @@ ALLOW_DEPRECATED_DECLARATIONS_END
 {
     _delegate = delegate;
 
-    // If the client can observe when the connection to the WebProcess injected bundle is established, then we cannot
-    // safely delay the launch of the WebProcess until something is loaded in the web view.
+    // If the client can observe when the connection to the WebProcess injected bundle is established, then
+    // delaying the launch of the WebProcess until something is loaded in the web view may not be safe.
+    // As a result, we disable the feature by default and let the client opt-in via WKWebViewConfiguration.
     if ([delegate respondsToSelector:@selector(processGroup:didCreateConnectionToWebProcessPlugIn:)])
-        _processPool->disableDelayedWebProcessLaunch();
+        _processPool->setDelaysWebProcessLaunchDefaultValue(false);
 }
 
 @end

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebView.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebView.mm
@@ -3079,6 +3079,12 @@ static void convertAndAddHighlight(Vector<Ref<WebKit::SharedMemory>>& buffers, N
     _page->simulateDeviceOrientationChange(alpha, beta, gamma);
 }
 
+- (void)_launchInitialProcessIfNecessary
+{
+    THROW_IF_SUSPENDED;
+    _page->launchInitialProcessIfNecessary();
+}
+
 + (BOOL)_handlesSafeBrowsing
 {
     return true;

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebViewConfiguration.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebViewConfiguration.mm
@@ -1410,6 +1410,16 @@ static WebKit::AttributionOverrideTesting toAttributionOverrideTesting(_WKAttrib
     _pageConfiguration->setAllowTestOnlyIPC(allowTestOnlyIPC);
 }
 
+- (BOOL)_delaysWebProcessLaunchUntilFirstLoad
+{
+    return _pageConfiguration->delaysWebProcessLaunchUntilFirstLoad();
+}
+
+- (void)_setDelaysWebProcessLaunchUntilFirstLoad:(BOOL)delaysWebProcessLaunchUntilFirstLoad
+{
+    _pageConfiguration->setDelaysWebProcessLaunchUntilFirstLoad(delaysWebProcessLaunchUntilFirstLoad);
+}
+
 - (BOOL)_shouldRelaxThirdPartyCookieBlocking
 {
     return _pageConfiguration->shouldRelaxThirdPartyCookieBlocking() == WebCore::ShouldRelaxThirdPartyCookieBlocking::Yes;

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebViewConfigurationPrivate.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebViewConfigurationPrivate.h
@@ -146,6 +146,9 @@ typedef NS_ENUM(NSUInteger, _WKContentSecurityPolicyModeForExtension) {
 
 @property (nonatomic, setter=_setAllowTestOnlyIPC:) BOOL _allowTestOnlyIPC WK_API_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA));
 
+// Default value is YES on macOS and NO on iOS.
+@property (nonatomic, setter=_setDelaysWebProcessLaunchUntilFirstLoad:) BOOL _delaysWebProcessLaunchUntilFirstLoad WK_API_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA));
+
 // The maximum Lab color difference allowed between two consecutive page top snapshots.
 // Expects 0 (disables page top color sampling entirely) or any positive number.
 @property (nonatomic, setter=_setSampledPageTopColorMaxDifference:) double _sampledPageTopColorMaxDifference WK_API_AVAILABLE(macos(12.0), ios(15.0));

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebViewPrivate.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebViewPrivate.h
@@ -256,6 +256,8 @@ for this property.
 - (_WKAttachment *)_insertAttachmentWithFileWrapper:(NSFileWrapper *)fileWrapper contentType:(NSString *)contentType completion:(void(^)(BOOL success))completionHandler WK_API_AVAILABLE(macos(10.14.4), ios(12.2));
 - (_WKAttachment *)_attachmentForIdentifier:(NSString *)identifier WK_API_AVAILABLE(macos(10.14.4), ios(12.2));
 
+- (void)_launchInitialProcessIfNecessary WK_API_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA));
+
 - (void)_simulateDeviceOrientationChangeWithAlpha:(double)alpha beta:(double)beta gamma:(double)gamma WK_API_AVAILABLE(macos(10.14.4), ios(12.2));
 
 + (BOOL)_willUpgradeToHTTPS:(NSURL *)url WK_API_AVAILABLE(macos(12.0), ios(15.0));

--- a/Source/WebKit/UIProcess/Inspector/WebInspectorUtilities.cpp
+++ b/Source/WebKit/UIProcess/Inspector/WebInspectorUtilities.cpp
@@ -97,9 +97,6 @@ WebProcessPool& defaultInspectorProcessPool(unsigned inspectionLevel)
 
 void prepareProcessPoolForInspector(WebProcessPool& processPool)
 {
-    // Do not delay process launch for inspector pages as inspector pages do not know how to transition from a terminated process.
-    processPool.disableDelayedWebProcessLaunch();
-
     allInspectorProcessPools().add(processPool);
 }
 

--- a/Source/WebKit/UIProcess/WebProcessPool.h
+++ b/Source/WebKit/UIProcess/WebProcessPool.h
@@ -485,7 +485,9 @@ public:
     WebProcessWithAudibleMediaToken webProcessWithAudibleMediaToken() const;
     WebProcessWithMediaStreamingToken webProcessWithMediaStreamingToken() const;
 
-    void disableDelayedWebProcessLaunch() { m_isDelayedWebProcessLaunchDisabled = true; }
+    static bool globalDelaysWebProcessLaunchDefaultValue();
+    bool delaysWebProcessLaunchDefaultValue() const { return m_delaysWebProcessLaunchDefaultValue; }
+    void setDelaysWebProcessLaunchDefaultValue(bool delaysWebProcessLaunchDefaultValue) { m_delaysWebProcessLaunchDefaultValue = delaysWebProcessLaunchDefaultValue; }
 
     void setJavaScriptConfigurationDirectory(String&& directory) { m_javaScriptConfigurationDirectory = directory; }
     const String& javaScriptConfigurationDirectory() const { return m_javaScriptConfigurationDirectory; }
@@ -809,12 +811,8 @@ private:
     int32_t m_userId { -1 };
 #endif
 
-#if PLATFORM(IOS)
-    // FIXME: Delayed process launch is currently disabled on iOS for performance reasons (rdar://problem/49074131).
-    bool m_isDelayedWebProcessLaunchDisabled { true };
-#else
-    bool m_isDelayedWebProcessLaunchDisabled { false };
-#endif
+    bool m_delaysWebProcessLaunchDefaultValue { globalDelaysWebProcessLaunchDefaultValue() };
+
     static bool s_useSeparateServiceWorkerProcess;
     static bool s_didGlobalStaticInitialization;
 


### PR DESCRIPTION
#### 7f048d704b87bd5c9393eb86a8d8bc4fe710dfc4
<pre>
Add SPI to delay a WKWebView&apos;s WebProcess launch
<a href="https://bugs.webkit.org/show_bug.cgi?id=256727">https://bugs.webkit.org/show_bug.cgi?id=256727</a>
rdar://109277324

Reviewed by Ben Nham.

Add SPI to delay a WKWebView&apos;s WebProcess launch. We already have this
preference internally but it could not be controlled by the client application.

* Source/WebKit/UIProcess/API/APIPageConfiguration.cpp:
(API::PageConfiguration::delaysWebProcessLaunchUntilFirstLoad const):
* Source/WebKit/UIProcess/API/APIPageConfiguration.h:
(API::PageConfiguration::setDelaysWebProcessLaunchUntilFirstLoad):
* Source/WebKit/UIProcess/API/Cocoa/WKProcessGroup.mm:
(-[WKProcessGroup setDelegate:]):
* Source/WebKit/UIProcess/API/Cocoa/WKWebView.mm:
(-[WKWebView _launchInitialProcessIfNecessary]):
* Source/WebKit/UIProcess/API/Cocoa/WKWebViewConfiguration.mm:
(-[WKWebViewConfiguration _delaysWebProcessLaunchUntilFirstLoad]):
(-[WKWebViewConfiguration _setDelaysWebProcessLaunchUntilFirstLoad:]):
* Source/WebKit/UIProcess/API/Cocoa/WKWebViewConfigurationPrivate.h:
* Source/WebKit/UIProcess/API/Cocoa/WKWebViewPrivate.h:
* Source/WebKit/UIProcess/Inspector/WebInspectorUtilities.cpp:
(WebKit::prepareProcessPoolForInspector):
* Source/WebKit/UIProcess/WebProcessPool.cpp:
(WebKit::WebProcessPool::globalDelaysWebProcessLaunchDefaultValue):
(WebKit::WebProcessPool::createWebPage):
* Source/WebKit/UIProcess/WebProcessPool.h:
* Tools/TestWebKitAPI/Tests/WebKitCocoa/ProcessSwapOnNavigation.mm:

Canonical link: <a href="https://commits.webkit.org/264031@main">https://commits.webkit.org/264031@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5646087938adc8496170d872bf88d1ac0a01f54d

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/6466 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/6674 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/6855 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/8045 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/6761 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/6462 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/6996 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/6625 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/9654 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/6579 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/6638 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/5858 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/8124 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/4103 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/5838 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/13687 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/6025 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/5917 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/8241 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/6402 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/5233 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/5808 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/1531 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/9967 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/6179 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->