### PR TITLE
[WebGPU] Update watchlist directories for WebGPU

### DIFF
--- a/Tools/Scripts/webkitpy/common/config/watchlist
+++ b/Tools/Scripts/webkitpy/common/config/watchlist
@@ -381,8 +381,11 @@
         },
         "WebGPU": {
             "filename": r"Source/WebCore/Modules/webgpu/"
-                        r"|Source/WebCore/platform/graphics/gpu/"
-                        r"|Source/WebCore/platform/graphics/gpu/cocoa/",
+                        r"|Source/WebCore/PAL/pal/graphics/WebGPU/"
+                        r"|Source/WebGPU/"
+                        r"|Source/WebKit/Shared/WebGPU/"
+                        r"|Source/WebKit/WebProcess/GPU/graphics/WebGPU/"
+                        r"|Source/WebKit/GPUProcess/graphics/WebGPU/",
         },
         "WebPlatformTests": {
             "filename": r"LayoutTests/imported/w3c/web-platform-tests/((?!-expected\.txt).)*$",


### PR DESCRIPTION
#### 8fa7bb2e518c16be852521f7537422d1ae4d621d
<pre>
[WebGPU] Update watchlist directories for WebGPU
<a href="https://bugs.webkit.org/show_bug.cgi?id=256731">https://bugs.webkit.org/show_bug.cgi?id=256731</a>
rdar://109282926

Reviewed by Mike Wyrzykowski.

The paths to implement WebGPU have changed.

* Tools/Scripts/webkitpy/common/config/watchlist:

Canonical link: <a href="https://commits.webkit.org/264034@main">https://commits.webkit.org/264034@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/dff8dcb0954c7269086a536362ef86a433713539

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/6470 "6 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/6678 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/6859 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/8049 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/6765 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/6466 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/7008 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/6629 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/9660 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/6583 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/15/builds/6646 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/5863 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/8128 "Built successfully") | 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/6571 "Passed tests") | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/39/builds/4110 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/5842 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/13691 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/6034 "Passed tests") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/5921 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/8250 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/6406 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/5240 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/5811 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/1533 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/9971 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/6183 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->