### PR TITLE
[iOS] Spurious logging due to calling `-[UITextInteractionAssistant selectionView]` when running layout tests

### DIFF
--- a/Tools/TestWebKitAPI/cocoa/TestWKWebView.mm
+++ b/Tools/TestWebKitAPI/cocoa/TestWKWebView.mm
@@ -748,13 +748,12 @@ static UICalloutBar *suppressUICalloutBar()
 
 - (CGRect)caretViewRectInContentCoordinates
 {
-    UIView *caretView = [self.textInputContentView valueForKeyPath:@"interactionAssistant.selectionView.caretView"];
-
+    UIView *caretView = nil;
 #if HAVE(UI_TEXT_SELECTION_DISPLAY_INTERACTION)
-    if (!caretView) {
-        if (auto view = self.textSelectionDisplayInteraction.cursorView; !view.hidden)
-            caretView = view;
-    }
+    if (auto view = self.textSelectionDisplayInteraction.cursorView; !view.hidden)
+        caretView = view;
+#else
+    caretView = [self.textInputContentView valueForKeyPath:@"interactionAssistant.selectionView.caretView"];
 #endif
 
     return [caretView convertRect:caretView.bounds toView:self.textInputContentView];
@@ -763,13 +762,12 @@ static UICalloutBar *suppressUICalloutBar()
 - (NSArray<NSValue *> *)selectionViewRectsInContentCoordinates
 {
     NSMutableArray *selectionRects = [NSMutableArray array];
-    NSArray<UITextSelectionRect *> *rects = [self.textInputContentView valueForKeyPath:@"interactionAssistant.selectionView.rangeView.rects"];
-
+    NSArray<UITextSelectionRect *> *rects = nil;
 #if HAVE(UI_TEXT_SELECTION_DISPLAY_INTERACTION)
-    if (!rects) {
-        if (auto view = self.textSelectionDisplayInteraction.highlightView; !view.hidden)
-            rects = view.selectionRects;
-    }
+    if (auto view = self.textSelectionDisplayInteraction.highlightView; !view.hidden)
+        rects = view.selectionRects;
+#else
+    rects = [self.textInputContentView valueForKeyPath:@"interactionAssistant.selectionView.rangeView.rects"];
 #endif
 
     for (UITextSelectionRect *rect in rects)

--- a/Tools/WebKitTestRunner/ios/PlatformWebViewIOS.mm
+++ b/Tools/WebKitTestRunner/ios/PlatformWebViewIOS.mm
@@ -401,6 +401,7 @@ RetainPtr<CGImageRef> PlatformWebView::windowSnapshotImage()
     RELEASE_ASSERT(viewSize.height);
 
     // FIXME: Do we still require this workaround?
+#if !HAVE(UI_TEXT_SELECTION_DISPLAY_INTERACTION)
     UIView *selectionView = [platformView().contentView valueForKeyPath:@"interactionAssistant.selectionView"];
     UIView *startGrabberView = [selectionView valueForKeyPath:@"rangeView.startGrabber"];
     UIView *endGrabberView = [selectionView valueForKeyPath:@"rangeView.endGrabber"];
@@ -419,6 +420,7 @@ RetainPtr<CGImageRef> PlatformWebView::windowSnapshotImage()
         [endGrabberView setHidden:YES];
         viewsToUnhide.uncheckedAppend(endGrabberView);
     }
+#endif
 
     __block bool isDone = false;
     __block RetainPtr<CGImageRef> result;
@@ -439,8 +441,10 @@ RetainPtr<CGImageRef> PlatformWebView::windowSnapshotImage()
     while (!isDone)
         [[NSRunLoop currentRunLoop] runMode:NSDefaultRunLoopMode beforeDate:[NSDate distantPast]];
 
+#if !HAVE(UI_TEXT_SELECTION_DISPLAY_INTERACTION)
     for (auto view : viewsToUnhide)
         [view setHidden:NO];
+#endif
 
     return result;
 }

--- a/Tools/WebKitTestRunner/ios/TestControllerIOS.mm
+++ b/Tools/WebKitTestRunner/ios/TestControllerIOS.mm
@@ -134,10 +134,12 @@ static void handleMenuDidHideNotification(CFNotificationCenterRef, void*, CFStri
 
 void TestController::notifyDone()
 {
-    UIView *contentView = mainWebView()->platformView().contentView;
     // FIXME: Do we still require this workaround?
+#if !HAVE(UI_TEXT_SELECTION_DISPLAY_INTERACTION)
+    UIView *contentView = mainWebView()->platformView().contentView;
     UIView *selectionView = [contentView valueForKeyPath:@"interactionAssistant.selectionView"];
     [selectionView _removeAllAnimations:YES];
+#endif
 }
 
 void TestController::platformInitialize(const Options& options)

--- a/Tools/WebKitTestRunner/ios/UIScriptControllerIOS.mm
+++ b/Tools/WebKitTestRunner/ios/UIScriptControllerIOS.mm
@@ -849,13 +849,13 @@ static void clipSelectionViewRectToContentView(CGRect& rect, UIView *contentView
 JSObjectRef UIScriptControllerIOS::selectionStartGrabberViewRect() const
 {
     UIView *contentView = platformContentView();
-    UIView *handleView = [contentView valueForKeyPath:@"interactionAssistant.selectionView.rangeView.startGrabber"];
+    UIView *handleView = nil;
 
 #if HAVE(UI_TEXT_SELECTION_DISPLAY_INTERACTION)
-    if (!handleView) {
-        if (auto view = textSelectionDisplayInteraction().handleViews.firstObject; !isHiddenOrHasHiddenAncestor(view))
-            handleView = view;
-    }
+    if (auto view = textSelectionDisplayInteraction().handleViews.firstObject; !isHiddenOrHasHiddenAncestor(view))
+        handleView = view;
+#else
+    handleView = [contentView valueForKeyPath:@"interactionAssistant.selectionView.rangeView.startGrabber"];
 #endif
 
     auto frameInContentViewCoordinates = [handleView convertRect:handleView.bounds toView:contentView];
@@ -867,13 +867,13 @@ JSObjectRef UIScriptControllerIOS::selectionStartGrabberViewRect() const
 JSObjectRef UIScriptControllerIOS::selectionEndGrabberViewRect() const
 {
     UIView *contentView = platformContentView();
-    UIView *handleView = [contentView valueForKeyPath:@"interactionAssistant.selectionView.rangeView.endGrabber"];
+    UIView *handleView = nil;
 
 #if HAVE(UI_TEXT_SELECTION_DISPLAY_INTERACTION)
-    if (!handleView) {
-        if (auto view = textSelectionDisplayInteraction().handleViews.lastObject; !isHiddenOrHasHiddenAncestor(view))
-            handleView = view;
-    }
+    if (auto view = textSelectionDisplayInteraction().handleViews.lastObject; !isHiddenOrHasHiddenAncestor(view))
+        handleView = view;
+#else
+    handleView = [contentView valueForKeyPath:@"interactionAssistant.selectionView.rangeView.endGrabber"];
 #endif
 
     auto frameInContentViewCoordinates = [handleView convertRect:handleView.bounds toView:contentView];
@@ -885,13 +885,13 @@ JSObjectRef UIScriptControllerIOS::selectionEndGrabberViewRect() const
 JSObjectRef UIScriptControllerIOS::selectionCaretViewRect() const
 {
     UIView *contentView = platformContentView();
-    UIView *caretView = [contentView valueForKeyPath:@"interactionAssistant.selectionView.caretView"];
+    UIView *caretView = nil;
 
 #if HAVE(UI_TEXT_SELECTION_DISPLAY_INTERACTION)
-    if (!caretView) {
-        if (auto view = textSelectionDisplayInteraction().cursorView; !isHiddenOrHasHiddenAncestor(view))
-            caretView = view;
-    }
+    if (auto view = textSelectionDisplayInteraction().cursorView; !isHiddenOrHasHiddenAncestor(view))
+        caretView = view;
+#else
+    caretView = [contentView valueForKeyPath:@"interactionAssistant.selectionView.caretView"];
 #endif
 
     auto rectInContentViewCoordinates = CGRectIntersection([caretView convertRect:caretView.bounds toView:contentView], contentView.bounds);
@@ -902,17 +902,20 @@ JSObjectRef UIScriptControllerIOS::selectionCaretViewRect() const
 JSObjectRef UIScriptControllerIOS::selectionRangeViewRects() const
 {
     UIView *contentView = platformContentView();
-    UIView *rangeView = [contentView valueForKeyPath:@"interactionAssistant.selectionView.rangeView"];
+    UIView *rangeView = nil;
     auto rectsAsDictionaries = adoptNS([[NSMutableArray alloc] init]);
-    NSArray<UITextSelectionRect *> *textRectInfoArray = [rangeView valueForKeyPath:@"rects"];
+    NSArray<UITextSelectionRect *> *textRectInfoArray = nil;
 
 #if HAVE(UI_TEXT_SELECTION_DISPLAY_INTERACTION)
     if (!textRectInfoArray) {
         if (auto view = textSelectionDisplayInteraction().highlightView; !isHiddenOrHasHiddenAncestor(view)) {
-            textRectInfoArray = view.selectionRects;
             rangeView = view;
+            textRectInfoArray = view.selectionRects;
         }
     }
+#else
+    rangeView = [contentView valueForKeyPath:@"interactionAssistant.selectionView.rangeView"];
+    textRectInfoArray = [rangeView valueForKeyPath:@"rects"];
 #endif
 
     for (UITextSelectionRect *textRectInfo in textRectInfoArray) {
@@ -1327,13 +1330,13 @@ bool UIScriptControllerIOS::isAnimatingDragCancel() const
 
 JSRetainPtr<JSStringRef> UIScriptControllerIOS::selectionCaretBackgroundColor() const
 {
-    auto contentView = platformContentView();
-    UIColor *backgroundColor = [contentView valueForKeyPath:@"textInteractionAssistant.selectionView.caretView.backgroundColor"];
+    UIColor *backgroundColor = nil;
 #if HAVE(UI_TEXT_SELECTION_DISPLAY_INTERACTION)
-    if (!backgroundColor) {
-        if (auto view = textSelectionDisplayInteraction().cursorView; !isHiddenOrHasHiddenAncestor(view))
-            backgroundColor = view.tintColor;
-    }
+    if (auto view = textSelectionDisplayInteraction().cursorView; !isHiddenOrHasHiddenAncestor(view))
+        backgroundColor = view.tintColor;
+#else
+    auto contentView = platformContentView();
+    backgroundColor = [contentView valueForKeyPath:@"textInteractionAssistant.selectionView.caretView.backgroundColor"];
 #endif
 
     if (!backgroundColor)


### PR DESCRIPTION
#### fcc5abf6afac8fa170661622c030198e0da614df
<pre>
[iOS] Spurious logging due to calling `-[UITextInteractionAssistant selectionView]` when running layout tests
<a href="https://bugs.webkit.org/show_bug.cgi?id=256733">https://bugs.webkit.org/show_bug.cgi?id=256733</a>
rdar://109281412

Reviewed by Wenson Hsieh.

When `UITextSelectionDisplayInteraction` is available, `-[UITextInteractionAssistant selectionView]`
logs a warning, saying it returns `nil`. This is frequently observed during layout tests,
particularly since `TestController::notifyDone` modifies the selection view.

To fix, guard all use of `-[UITextInteractionAssistant selectionView]` behind
`!HAVE(UI_TEXT_SELECTION_DISPLAY_INTERACTION)`.

* Tools/TestWebKitAPI/cocoa/TestWKWebView.mm:
(-[TestWKWebView caretViewRectInContentCoordinates]):
(-[TestWKWebView selectionViewRectsInContentCoordinates]):
* Tools/WebKitTestRunner/ios/PlatformWebViewIOS.mm:
(WTR::PlatformWebView::windowSnapshotImage):
* Tools/WebKitTestRunner/ios/TestControllerIOS.mm:
(WTR::TestController::notifyDone):
* Tools/WebKitTestRunner/ios/UIScriptControllerIOS.mm:
(WTR::UIScriptControllerIOS::selectionStartGrabberViewRect const):
(WTR::UIScriptControllerIOS::selectionEndGrabberViewRect const):
(WTR::UIScriptControllerIOS::selectionCaretViewRect const):
(WTR::UIScriptControllerIOS::selectionRangeViewRects const):
(WTR::UIScriptControllerIOS::selectionCaretBackgroundColor const):

Canonical link: <a href="https://commits.webkit.org/264039@main">https://commits.webkit.org/264039@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/94a3983e28ff2895020ad36c70ebf2a6bdf3403e

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/6483 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/6692 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/6873 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/8064 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/6774 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/6479 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/7024 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/6644 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/9669 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/6596 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/6659 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/5876 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/8144 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/4123 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/5854 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/13702 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/6054 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/5933 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/8268 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/6419 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/5251 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/5824 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/1537 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/9984 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/6196 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->