### PR TITLE
[macOS] Silence telemetry for WebContent process attempting to open graphics accelerator

### DIFF
--- a/Source/WebKit/WebProcess/com.apple.WebProcess.sb.in
+++ b/Source/WebKit/WebProcess/com.apple.WebProcess.sb.in
@@ -2385,7 +2385,10 @@
     (deny mach-lookup (with telemetry-backtrace)
         (require-all
             (require-not (extension "com.apple.webkit.extension.mach"))
-            (xpc-service-name "com.apple.MTLCompilerService"))))
+            (xpc-service-name "com.apple.MTLCompilerService")))
+    (deny iokit-open-service (with no-report)
+        (iokit-registry-entry-class
+            "AMDRadeonX6000_AMDNavi14GraphicsAccelerator"))) ;; <rdar://104970117>
 #endif
 
 #if __MAC_OS_X_VERSION_MIN_REQUIRED > 110000


### PR DESCRIPTION
#### 5103c9ee591fab2194a935b0481a5275f36f143a
<pre>
[macOS] Silence telemetry for WebContent process attempting to open graphics accelerator
<a href="https://bugs.webkit.org/show_bug.cgi?id=256738">https://bugs.webkit.org/show_bug.cgi?id=256738</a>
&lt;rdar://104970117&gt;

Reviewed by NOBODY (OOPS!).

We explicitly block access to graphics hardware in the WebContent process whenever
the GPU Process is enabled.

This change silences telemetry reports about one such case, which has been investigated
and found to be expected.

* Source/WebKit/WebProcess/com.apple.WebProcess.sb.in:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5103c9ee591fab2194a935b0481a5275f36f143a

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/6487 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/6696 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/6877 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/8068 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/6778 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/7028 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/6648 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/9675 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/6600 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/6661 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/5882 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/8148 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/4125 "Passed tests") | | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/13704 "4 flakes 1 missing results 120 failures") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/6057 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/5939 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/8270 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/6423 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/5252 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/5828 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/9988 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/6200 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->