### PR TITLE
[Cocoa] Reduce telemetry reports for virtual memory routines

### DIFF
--- a/Source/WebKit/GPUProcess/mac/com.apple.WebKit.GPUProcess.sb.in
+++ b/Source/WebKit/GPUProcess/mac/com.apple.WebKit.GPUProcess.sb.in
@@ -226,7 +226,8 @@
         "kern.osproductversion"
         "kern.osrelease"
         "kern.ostype"
-        "kern.version")
+        "kern.version"
+        "vm.malloc_ranges") ;; <rdar://problem/105161083>
     (sysctl-name-prefix "hw.optional.") ;; <rdar://problem/71462790>
     (sysctl-name-prefix "hw.perflevel") ;; <rdar://problem/76783596>
 )
@@ -1091,6 +1092,7 @@
                 mach_port_set_attributes
                 mach_vm_copy
                 mach_vm_map_external
+                (when (defined? 'mach_vm_range_create) mach_vm_range_create) ;; <rdar://105161083>
                 mach_vm_remap_external
                 semaphore_create
                 semaphore_destroy

--- a/Source/WebKit/NetworkProcess/mac/com.apple.WebKit.NetworkProcess.sb.in
+++ b/Source/WebKit/NetworkProcess/mac/com.apple.WebKit.NetworkProcess.sb.in
@@ -283,7 +283,8 @@
         "kern.ostype"
         "kern.osversion" ;; Needed by WebKit and ASL logging.
         "kern.tcsm_available" ;; Needed for IndexedDB support.
-        "kern.tcsm_enable")
+        "kern.tcsm_enable"
+        "vm.malloc_ranges") ;; <rdar://problem/105161083>
     (sysctl-name-prefix "kern.proc.pid.")
     (sysctl-name-prefix "net.routetable"))
 
@@ -755,6 +756,7 @@
                 mach_port_request_notification
                 mach_port_set_attributes
                 mach_vm_copy
+                (when (defined? 'mach_vm_range_create) mach_vm_range_create) ;; <rdar://105161083>
                 mach_vm_map_external
                 mach_vm_remap_external
                 semaphore_create

--- a/Source/WebKit/Resources/SandboxProfiles/ios/com.apple.WebKit.GPU.sb.in
+++ b/Source/WebKit/Resources/SandboxProfiles/ios/com.apple.WebKit.GPU.sb.in
@@ -595,7 +595,8 @@
         "kern.osvariant_status"
         "kern.secure_kernel"
         "kern.osversion"
-        "vm.footprint_suspend"))
+        "vm.footprint_suspend"
+        "vm.malloc_ranges")) ;; <rdar://problem/105161083>
 
 (allow iokit-get-properties
     (iokit-property "AAPL,DisplayPipe")
@@ -958,6 +959,7 @@
     mach_port_set_attributes
     mach_vm_copy
     mach_vm_map_external
+    (when (defined? 'mach_vm_range_create) mach_vm_range_create) ;; <rdar://105161083>
     mach_vm_region
     mach_vm_remap_external
     semaphore_create

--- a/Source/WebKit/Resources/SandboxProfiles/ios/com.apple.WebKit.Networking.sb.in
+++ b/Source/WebKit/Resources/SandboxProfiles/ios/com.apple.WebKit.Networking.sb.in
@@ -573,7 +573,8 @@
         "kern.osversion"
         "kern.secure_kernel"
         "kern.version"
-        "vm.footprint_suspend")
+        "vm.footprint_suspend"
+        "vm.malloc_ranges") ;; <rdar://problem/105161083>
     (sysctl-name-prefix "kern.proc.pid.")
 )
 
@@ -936,6 +937,7 @@
                 mach_port_set_attributes
                 mach_vm_copy
                 mach_vm_map_external
+                (when (defined? 'mach_vm_range_create) mach_vm_range_create) ;; <rdar://105161083>
                 mach_vm_remap_external
                 semaphore_create
                 semaphore_destroy

--- a/Source/WebKit/Resources/SandboxProfiles/ios/com.apple.WebKit.WebContent.sb.in
+++ b/Source/WebKit/Resources/SandboxProfiles/ios/com.apple.WebKit.WebContent.sb.in
@@ -718,6 +718,13 @@
 (deny sysctl-read (with no-report)
     (sysctl-name "vm.task_no_footprint_for_debug"))
 
+#if HAVE(SANDBOX_STATE_FLAGS)
+(with-filter (require-not (state-flag "WebContentProcessLaunched"))
+    (allow sysctl-read (sysctl-name "vm.malloc_ranges"))) ;; <rdar://problem/105161083>
+#else
+(allow sysctl-read (sysctl-name "vm.malloc_ranges")) ;; <rdar://problem/105161083>
+#endif
+
 (allow iokit-get-properties
     (iokit-property "AAPL,DisplayPipe")
     (iokit-property "AAPL,OpenCLdisabled")
@@ -1385,6 +1392,7 @@
         host_get_special_port
         host_info
         io_server_version
+        (when (defined? 'mach_vm_range_create) mach_vm_range_create) ;; <rdar://105161083>
         task_restartable_ranges_register
         task_set_special_port))
 

--- a/Source/WebKit/Resources/SandboxProfiles/ios/com.apple.WebKit.adattributiond.sb.in
+++ b/Source/WebKit/Resources/SandboxProfiles/ios/com.apple.WebKit.adattributiond.sb.in
@@ -107,7 +107,8 @@
         "kern.osversion"
         "kern.secure_kernel"
         "kern.version"
-        "vm.footprint_suspend")
+        "vm.footprint_suspend"
+        "vm.malloc_ranges") ;; <rdar://problem/105161083>
     (sysctl-name-prefix "kern.proc.pid.")
 )
 

--- a/Source/WebKit/Resources/SandboxProfiles/ios/com.apple.WebKit.webpushd.sb.in
+++ b/Source/WebKit/Resources/SandboxProfiles/ios/com.apple.WebKit.webpushd.sb.in
@@ -73,7 +73,8 @@
         "kern.osversion"
         "kern.secure_kernel"
         "kern.version"
-        "vm.footprint_suspend")
+        "vm.footprint_suspend"
+        "vm.malloc_ranges") ;; <rdar://problem/105161083>
     (sysctl-name-prefix "kern.proc.pid.")
 )
 

--- a/Source/WebKit/WebProcess/com.apple.WebProcess.sb.in
+++ b/Source/WebKit/WebProcess/com.apple.WebProcess.sb.in
@@ -666,6 +666,13 @@
 (deny sysctl-read (with no-report)
     (sysctl-name "vm.task_no_footprint_for_debug"))
 
+#if HAVE(SANDBOX_STATE_FLAGS)
+(with-filter (require-not (state-flag "WebContentProcessLaunched"))
+    (allow sysctl-read (sysctl-name "vm.malloc_ranges"))) ;; <rdar://problem/105161083>
+#else
+(allow sysctl-read (sysctl-name "vm.malloc_ranges")) ;; <rdar://problem/105161083>
+#endif
+
 (allow sysctl-write
     (sysctl-name
         "kern.tcsm_enable"))
@@ -2115,6 +2122,10 @@
                 (mach-bootstrap-message-numbers)))))
 #endif
 
+(define (kernel-mig-routine-only-in-use-during-launch)
+    (kernel-mig-routine
+        (when (defined? 'mach_vm_range_create) mach_vm_range_create))) ;; <rdar://105161083>
+
 (define (kernel-mig-routines-common) (kernel-mig-routine
     _mach_make_memory_entry
     host_get_io_master
@@ -2193,7 +2204,13 @@
             (with-filter (require-not (lockdown-mode))
                 (allow mach-message-send (kernel-mig-routine thread_set_exception_ports)))
 
-            (allow mach-message-send (kernel-mig-routines-common)))))
+            (allow mach-message-send (kernel-mig-routines-common))
+                
+#if HAVE(SANDBOX_STATE_FLAGS)
+            (with-filter (require-not (state-flag "WebContentProcessLaunched"))
+                (allow mach-message-send (kernel-mig-routine-only-in-use-during-launch)))
+#endif
+        )))
 
 (define (syscall-mach-common) (machtrap-number
     MSC__kernelrpc_mach_port_allocate_trap

--- a/Source/WebKit/webpushd/mac/com.apple.WebKit.webpushd.mac.sb.in
+++ b/Source/WebKit/webpushd/mac/com.apple.WebKit.webpushd.mac.sb.in
@@ -150,7 +150,8 @@
         "security.mac.sandbox.sentinel"
         "kern.tcsm_enable"
         "kern.tcsm_available"
-        "vm.footprint_suspend")
+        "vm.footprint_suspend"
+        "vm.malloc_ranges") ;; <rdar://problem/105161083>
     (sysctl-name-prefix "net.routetable")
     (sysctl-name-prefix "hw.optional.") ;; <rdar://problem/71462790>
     (sysctl-name-prefix "hw.perflevel") ;; <rdar://problem/76783596>


### PR DESCRIPTION
#### d3c7b8f39ab3b9c551adbaec0bc039834573b9c6
<pre>
[Cocoa] Reduce telemetry reports for virtual memory routines
<a href="https://bugs.webkit.org/show_bug.cgi?id=256736">https://bugs.webkit.org/show_bug.cgi?id=256736</a>
&lt;rdar://105161083&gt;

Reviewed by Per Arne Vollan.

Add additional rules for VM handling features to reduce sandbox telemetry.

* Source/WebKit/GPUProcess/mac/com.apple.WebKit.GPUProcess.sb.in:
* Source/WebKit/NetworkProcess/mac/com.apple.WebKit.NetworkProcess.sb.in:
* Source/WebKit/Resources/SandboxProfiles/ios/com.apple.WebKit.GPU.sb.in:
* Source/WebKit/Resources/SandboxProfiles/ios/com.apple.WebKit.Networking.sb.in:
* Source/WebKit/Resources/SandboxProfiles/ios/com.apple.WebKit.WebContent.sb.in:
* Source/WebKit/Resources/SandboxProfiles/ios/com.apple.WebKit.adattributiond.sb.in:
* Source/WebKit/Resources/SandboxProfiles/ios/com.apple.WebKit.webpushd.sb.in:
* Source/WebKit/WebProcess/com.apple.WebProcess.sb.in:
* Source/WebKit/webpushd/mac/com.apple.WebKit.webpushd.mac.sb.in:

Canonical link: <a href="https://commits.webkit.org/264130@main">https://commits.webkit.org/264130@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ec95ec5713b58b3994a5fc62f9230c0dd528ba03

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/6812 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/7032 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/7216 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/8403 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/7065 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/6812 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/8211 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/6976 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/9956 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/6931 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/7531 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/6250 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/8498 "Built successfully") | 
| [❌ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/6922 "webkitpy-tests (failure)") | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/39/builds/4955 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/6168 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/13970 "Passed tests") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/6683 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/6250 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/9028 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/6742 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/5521 "Passed tests") | | 
| [✅ 🧪 services](https://ews-build.webkit.org/#/builders/28/builds/6774 "Passed tests") | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/6124 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/6083 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/1609 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/10303 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/6502 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->