### PR TITLE
ReadyState should be an enum class

### DIFF
--- a/Source/WebCore/dom/Document.cpp
+++ b/Source/WebCore/dom/Document.cpp
@@ -1408,7 +1408,7 @@ void Document::setReadyState(ReadyState readyState)
         return;
 
     switch (readyState) {
-    case Loading:
+    case ReadyState::Loading:
         if (!m_eventTiming.domLoading) {
             auto now = MonotonicTime::now();
             m_eventTiming.domLoading = now;
@@ -1416,7 +1416,7 @@ void Document::setReadyState(ReadyState readyState)
                 eventTiming->domLoading = now;
         }
         break;
-    case Complete:
+    case ReadyState::Complete:
         if (!m_eventTiming.domComplete) {
             auto now = MonotonicTime::now();
             m_eventTiming.domComplete = now;
@@ -1424,7 +1424,7 @@ void Document::setReadyState(ReadyState readyState)
                 eventTiming->domComplete = now;
         }
         FALLTHROUGH;
-    case Interactive:
+    case ReadyState::Interactive:
         if (!m_eventTiming.domInteractive) {
             auto now = MonotonicTime::now();
             m_eventTiming.domInteractive = now;
@@ -1447,15 +1447,15 @@ void Document::setVisualUpdatesAllowed(ReadyState readyState)
 {
     ASSERT(settings().suppressesIncrementalRendering());
     switch (readyState) {
-    case Loading:
+    case ReadyState::Loading:
         ASSERT(!m_visualUpdatesSuppressionTimer.isActive());
         ASSERT(m_visualUpdatesAllowed);
         setVisualUpdatesAllowed(false);
         break;
-    case Interactive:
+    case ReadyState::Interactive:
         ASSERT(m_visualUpdatesSuppressionTimer.isActive() || m_visualUpdatesAllowed);
         break;
-    case Complete:
+    case ReadyState::Complete:
         if (m_visualUpdatesSuppressionTimer.isActive()) {
             ASSERT(!m_visualUpdatesAllowed);
 
@@ -3163,7 +3163,7 @@ void Document::implicitOpen()
         m_parser->didBeginYieldingParser();
 
     setParsing(true);
-    setReadyState(Loading);
+    setReadyState(ReadyState::Loading);
 }
 
 std::unique_ptr<FontLoadRequest> Document::fontLoadRequest(const String& url, bool isSVG, bool isInitiatingElementInUserAgentShadowTree, LoadedFromOpaqueSource loadedFromOpaqueSource)
@@ -3259,7 +3259,7 @@ void Document::explicitClose()
         // Because we have no frame, we don't know if all loading has completed,
         // so we just call implicitClose() immediately. FIXME: This might fire
         // the load event prematurely <http://bugs.webkit.org/show_bug.cgi?id=14568>.
-        setReadyState(Complete);
+        setReadyState(ReadyState::Complete);
         implicitClose();
         return;
     }
@@ -6444,7 +6444,7 @@ Ref<HTMLCollection> Document::documentNamedItems(const AtomString& name)
 void Document::finishedParsing()
 {
     ASSERT(!scriptableDocumentParser() || !m_parser->isParsing());
-    ASSERT(!scriptableDocumentParser() || m_readyState != Loading);
+    ASSERT(!scriptableDocumentParser() || m_readyState != ReadyState::Loading);
     setParsing(false);
 
     Ref<Document> protectedThis(*this);
@@ -8526,7 +8526,7 @@ void Document::updateIntersectionObservations()
 
 void Document::scheduleInitialIntersectionObservationUpdate()
 {
-    if (m_readyState == Complete)
+    if (m_readyState == ReadyState::Complete)
         scheduleRenderingUpdate(RenderingUpdateStep::IntersectionObservations);
     else if (!m_intersectionObserversInitialUpdateTimer.isActive())
         m_intersectionObserversInitialUpdateTimer.startOneShot(intersectionObserversInitialUpdateDelay);

--- a/Source/WebCore/dom/Document.h
+++ b/Source/WebCore/dom/Document.h
@@ -474,7 +474,7 @@ public:
     WEBCORE_EXPORT Element* scrollingElementForAPI();
     WEBCORE_EXPORT Element* scrollingElement();
 
-    enum ReadyState : uint8_t { Loading, Interactive,  Complete };
+    enum class ReadyState : uint8_t { Loading, Interactive, Complete };
     ReadyState readyState() const { return m_readyState; }
 
     WEBCORE_EXPORT String defaultCharsetForLegacyBindings() const;
@@ -2276,7 +2276,7 @@ private:
 
     DesignMode m_designMode { DesignMode::Off };
     BackForwardCacheState m_backForwardCacheState { NotInBackForwardCache };
-    ReadyState m_readyState { Complete };
+    ReadyState m_readyState { ReadyState::Complete };
 
     MutationObserverOptions m_mutationObserverTypes;
 

--- a/Source/WebCore/html/parser/HTMLDocumentParser.cpp
+++ b/Source/WebCore/html/parser/HTMLDocumentParser.cpp
@@ -140,7 +140,7 @@ void HTMLDocumentParser::prepareToStopParsing()
 
     // We will not have a scriptRunner when parsing a DocumentFragment.
     if (m_scriptRunner)
-        document()->setReadyState(Document::Interactive);
+        document()->setReadyState(Document::ReadyState::Interactive);
 
     // Setting the ready state above can fire mutation event and detach us
     // from underneath. In that case, just bail out.

--- a/Source/WebCore/loader/FrameLoader.cpp
+++ b/Source/WebCore/loader/FrameLoader.cpp
@@ -759,7 +759,7 @@ void FrameLoader::didBeginDocument(bool dispatch)
     m_needsClear = true;
     m_isComplete = false;
     m_didCallImplicitClose = false;
-    m_frame.document()->setReadyState(Document::Loading);
+    m_frame.document()->setReadyState(Document::ReadyState::Loading);
 
     if (dispatch)
         dispatchDidClearWindowObjectsInAllWorlds();
@@ -922,7 +922,7 @@ void FrameLoader::checkCompleted()
     // OK, completed.
     m_isComplete = true;
     m_requestedHistoryItem = nullptr;
-    m_frame.document()->setReadyState(Document::Complete);
+    m_frame.document()->setReadyState(Document::ReadyState::Complete);
 
     checkCallImplicitClose(); // if we didn't do it before
 

--- a/Source/WebCore/page/LocalFrameView.cpp
+++ b/Source/WebCore/page/LocalFrameView.cpp
@@ -5062,7 +5062,8 @@ void LocalFrameView::checkAndDispatchDidReachVisuallyNonEmptyState()
         if (document.styleScope().hasPendingSheetsBeforeBody())
             return false;
 
-        auto finishedParsingMainDocument = m_frame->loader().stateMachine().committedFirstRealDocumentLoad() && (document.readyState() == Document::Interactive || document.readyState() == Document::Complete);
+        auto finishedParsingMainDocument = m_frame->loader().stateMachine().committedFirstRealDocumentLoad()
+            && (document.readyState() == Document::ReadyState::Interactive || document.readyState() == Document::ReadyState::Complete);
         // Ensure that we always fire visually non-empty milestone eventually.
         if (finishedParsingMainDocument && m_frame->loader().isComplete())
             return true;

--- a/Source/WebCore/xml/parser/XMLDocumentParser.cpp
+++ b/Source/WebCore/xml/parser/XMLDocumentParser.cpp
@@ -202,7 +202,7 @@ void XMLDocumentParser::end()
 
     if (isParsing())
         prepareToStopParsing();
-    document()->setReadyState(Document::Interactive);
+    document()->setReadyState(Document::ReadyState::Interactive);
     clearCurrentNodeStack();
     document()->finishedParsing();
 }

--- a/Source/WebKitLegacy/mac/DOM/DOMDocument.mm
+++ b/Source/WebKitLegacy/mac/DOM/DOMDocument.mm
@@ -307,11 +307,11 @@
     WebCore::JSMainThreadNullState state;
     auto readyState = IMPL->readyState();
     switch (readyState) {
-    case WebCore::Document::Loading:
+    case WebCore::Document::ReadyState::Loading:
         return @"loading";
-    case WebCore::Document::Interactive:
+    case WebCore::Document::ReadyState::Interactive:
         return @"interactive";
-    case WebCore::Document::Complete:
+    case WebCore::Document::ReadyState::Complete:
         return @"complete";
     }
     ASSERT_NOT_REACHED();


### PR DESCRIPTION
#### b070127d47422f42671c99ff1eef5d8788038aeb
<pre>
ReadyState should be an enum class
<a href="https://bugs.webkit.org/show_bug.cgi?id=256741">https://bugs.webkit.org/show_bug.cgi?id=256741</a>

Reviewed by Chris Dumez.

* Source/WebCore/dom/Document.cpp:
(WebCore::Document::setReadyState):
(WebCore::Document::setVisualUpdatesAllowed):
(WebCore::Document::implicitOpen):
(WebCore::Document::explicitClose):
(WebCore::Document::finishedParsing):
(WebCore::Document::scheduleInitialIntersectionObservationUpdate):
* Source/WebCore/dom/Document.h:
* Source/WebCore/html/parser/HTMLDocumentParser.cpp:
(WebCore::HTMLDocumentParser::prepareToStopParsing):
* Source/WebCore/loader/FrameLoader.cpp:
(WebCore::FrameLoader::didBeginDocument):
(WebCore::FrameLoader::checkCompleted):
* Source/WebCore/page/LocalFrameView.cpp:
(WebCore::LocalFrameView::checkAndDispatchDidReachVisuallyNonEmptyState):
* Source/WebCore/xml/parser/XMLDocumentParser.cpp:
(WebCore::XMLDocumentParser::end):
* Source/WebKitLegacy/mac/DOM/DOMDocument.mm:
(-[DOMDocument readyState]):

Canonical link: <a href="https://commits.webkit.org/264044@main">https://commits.webkit.org/264044@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/fab44884822146b5920a0637827bc0b8946b6df5

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/6497 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/6707 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/6887 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/8077 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/6787 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/6493 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/7038 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/6658 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/9686 "1 missing results 101 failures") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/6611 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/6672 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/5890 "Passed tests") | [❌ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/8157 "Failed to compile WebKit") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/4136 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/5868 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/2/builds/8157 "Failed to compile WebKit") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/6076 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/5947 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/2/builds/8157 "Failed to compile WebKit") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/6432 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/5262 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/5836 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/9997 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/762 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/6208 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->