### PR TITLE
[UI-side compositing] Eliminate unnecessary invalidate of scrollbar layers when scrolling

### DIFF
--- a/Source/WebCore/platform/ScrollableArea.cpp
+++ b/Source/WebCore/platform/ScrollableArea.cpp
@@ -420,6 +420,9 @@ bool ScrollableArea::useDarkAppearanceForScrollbars() const
 
 void ScrollableArea::invalidateScrollbar(Scrollbar& scrollbar, const IntRect& rect)
 {
+    if (!scrollbarsController().shouldDrawIntoScrollbarLayer(scrollbar))
+        return;
+
     if (&scrollbar == horizontalScrollbar()) {
         if (GraphicsLayer* graphicsLayer = layerForHorizontalScrollbar()) {
             graphicsLayer->setNeedsDisplay();

--- a/Source/WebCore/platform/ScrollbarsController.h
+++ b/Source/WebCore/platform/ScrollbarsController.h
@@ -93,6 +93,8 @@ public:
     
     WEBCORE_EXPORT virtual void setScrollbarVisibilityState(ScrollbarOrientation, bool) { }
 
+    WEBCORE_EXPORT virtual bool shouldDrawIntoScrollbarLayer(Scrollbar&) const { return true; }
+
 private:
     ScrollableArea& m_scrollableArea;
     bool m_scrollbarAnimationsUnsuspendedByUserInteraction { true };

--- a/Source/WebKit/WebProcess/WebPage/RemoteLayerTree/RemoteScrollbarsController.h
+++ b/Source/WebKit/WebProcess/WebPage/RemoteLayerTree/RemoteScrollbarsController.h
@@ -48,8 +48,9 @@ public:
     void mouseEnteredScrollbar(WebCore::Scrollbar*) const final;
     void mouseExitedScrollbar(WebCore::Scrollbar*) const final;
     bool shouldScrollbarParticipateInHitTesting(WebCore::Scrollbar*) final;
-    
+
     void setScrollbarVisibilityState(WebCore::ScrollbarOrientation, bool) final;
+    bool shouldDrawIntoScrollbarLayer(WebCore::Scrollbar&) const final;
 
 private:
     bool m_horizontalOverlayScrollbarIsVisible { false };

--- a/Source/WebKit/WebProcess/WebPage/RemoteLayerTree/RemoteScrollbarsController.mm
+++ b/Source/WebKit/WebProcess/WebPage/RemoteLayerTree/RemoteScrollbarsController.mm
@@ -87,5 +87,12 @@ void RemoteScrollbarsController::setScrollbarVisibilityState(WebCore::ScrollbarO
         m_verticalOverlayScrollbarIsVisible = isVisible;
 }
 
+bool RemoteScrollbarsController::shouldDrawIntoScrollbarLayer(WebCore::Scrollbar& scrollbar) const
+{
+    // For UI-side compositing we only draw scrollbars in the web process
+    // for custom scrollbars
+    return scrollbar.isCustomScrollbar();
+}
+
 }
 #endif // PLATFORM(MAC)


### PR DESCRIPTION
#### d19192443a84fc6e6c00383118c8af3e16f78c8a
<pre>
[UI-side compositing] Eliminate unnecessary invalidate of scrollbar layers when scrolling
<a href="https://bugs.webkit.org/show_bug.cgi?id=256624">https://bugs.webkit.org/show_bug.cgi?id=256624</a>
rdar://109184266

Reviewed by Simon Fraser.

For UI-side compositing, we only paint into scrollbar layers in the WebProcess for
custom scrollbars. To reflect this, add RemoteScrollbarsController::shouldDrawIntoScrollbarLayer
and check before invalidating the scrollbar layers, to prevent unnecessary calls into
GraphicsLayerCA::platformCALayerPaintContents when we aren&apos;t actually going to paint anything.

* Source/WebCore/platform/ScrollableArea.cpp:
(WebCore::ScrollableArea::invalidateScrollbar):
* Source/WebCore/platform/ScrollbarsController.h:
(WebCore::ScrollbarsController::shouldDrawIntoScrollbarLayer const):
* Source/WebKit/WebProcess/WebPage/RemoteLayerTree/RemoteScrollbarsController.h:
* Source/WebKit/WebProcess/WebPage/RemoteLayerTree/RemoteScrollbarsController.mm:
(WebKit::RemoteScrollbarsController::shouldDrawIntoScrollbarLayer const):

Canonical link: <a href="https://commits.webkit.org/264094@main">https://commits.webkit.org/264094@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/29112f360678ee16c3803b122d4ce68dc2050818

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/6665 "1 style error") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/6881 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/7063 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/8256 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/6942 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/6664 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/8009 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/6829 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/9838 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/6783 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/15/builds/7349 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/6095 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/8374 "Built successfully") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/39/builds/4808 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/6023 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/13878 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/6591 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/6103 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/8848 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/6598 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/5406 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/5993 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/10165 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/778 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/6366 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->