### PR TITLE
Remove static strings and symbols

### DIFF
--- a/Source/JavaScriptCore/builtins/BuiltinExecutables.cpp
+++ b/Source/JavaScriptCore/builtins/BuiltinExecutables.cpp
@@ -30,6 +30,7 @@
 #include "BuiltinNames.h"
 #include "JSCJSValueInlines.h"
 #include "Parser.h"
+#include "SmallStrings.h"
 #include <wtf/NeverDestroyed.h>
 
 namespace JSC {
@@ -47,12 +48,10 @@ SourceCode BuiltinExecutables::defaultConstructorSourceCode(ConstructorKind cons
     case ConstructorKind::Naked:
         break;
     case ConstructorKind::Base: {
-        static NeverDestroyed<const String> baseConstructorCode(MAKE_STATIC_STRING_IMPL("(function () { })"));
-        return makeSource(baseConstructorCode, { });
+        return makeSource({ SmallString::baseConstructorString() }, { });
     }
     case ConstructorKind::Extends: {
-        static NeverDestroyed<const String> derivedConstructorCode(MAKE_STATIC_STRING_IMPL("(function (...args) { super(...args); })"));
-        return makeSource(derivedConstructorCode, { });
+        return makeSource({ SmallString::derivedConstructorString() }, { });
     }
     }
     RELEASE_ASSERT_NOT_REACHED();

--- a/Source/JavaScriptCore/builtins/BuiltinExecutables.h
+++ b/Source/JavaScriptCore/builtins/BuiltinExecutables.h
@@ -32,6 +32,8 @@
 #include "Weak.h"
 #include "WeakHandleOwner.h"
 
+#include <wtf/text/StringImpl.h>
+
 namespace JSC {
 
 class UnlinkedFunctionExecutable;

--- a/Source/JavaScriptCore/builtins/BuiltinNames.h
+++ b/Source/JavaScriptCore/builtins/BuiltinNames.h
@@ -40,7 +40,7 @@ namespace JSC {
     const JSC::Identifier& name##Symbol() const { return m_##name##Symbol; }
 #define DECLARE_BUILTIN_IDENTIFIER_ACCESSOR_IN_JSC(name) \
     const JSC::Identifier& name##PublicName() const { return m_##name; } \
-    JSC::Identifier name##PrivateName() const { return JSC::Identifier::fromUid(*bitwise_cast<SymbolImpl*>(&JSC::Symbols::name##PrivateName)); }
+    JSC::Identifier name##PrivateName() const { return JSC::Identifier::fromUid(*JSC::Symbols::name##PrivateName.get()); }
 
 
 #define JSC_COMMON_PRIVATE_IDENTIFIERS_EACH_PROPERTY_NAME(macro) \
@@ -215,17 +215,19 @@ namespace JSC {
 
 
 namespace Symbols {
-#define DECLARE_BUILTIN_STATIC_SYMBOLS(name) extern JS_EXPORT_PRIVATE SymbolImpl::StaticSymbolImpl name##Symbol;
+#define DECLARE_BUILTIN_STATIC_SYMBOLS(name) extern JS_EXPORT_PRIVATE LazyNeverDestroyed<SymbolImpl*> name##Symbol;
 JSC_COMMON_PRIVATE_IDENTIFIERS_EACH_WELL_KNOWN_SYMBOL(DECLARE_BUILTIN_STATIC_SYMBOLS)
 #undef DECLARE_BUILTIN_STATIC_SYMBOLS
 
-#define DECLARE_BUILTIN_PRIVATE_NAMES(name) extern JS_EXPORT_PRIVATE SymbolImpl::StaticSymbolImpl name##PrivateName;
+#define DECLARE_BUILTIN_PRIVATE_NAMES(name) extern JS_EXPORT_PRIVATE LazyNeverDestroyed<SymbolImpl*> name##PrivateName;
 JSC_FOREACH_BUILTIN_FUNCTION_NAME(DECLARE_BUILTIN_PRIVATE_NAMES)
 JSC_COMMON_PRIVATE_IDENTIFIERS_EACH_PROPERTY_NAME(DECLARE_BUILTIN_PRIVATE_NAMES)
 #undef DECLARE_BUILTIN_PRIVATE_NAMES
 
-extern JS_EXPORT_PRIVATE SymbolImpl::StaticSymbolImpl dollarVMPrivateName;
-extern JS_EXPORT_PRIVATE SymbolImpl::StaticSymbolImpl polyProtoPrivateName;
+extern JS_EXPORT_PRIVATE LazyNeverDestroyed<SymbolImpl*> dollarVMPrivateName;
+extern JS_EXPORT_PRIVATE LazyNeverDestroyed<SymbolImpl*> polyProtoPrivateName;
+
+JS_EXPORT_PRIVATE void initializeStaticSymbols();
 }
 
 class BuiltinNames {

--- a/Source/JavaScriptCore/runtime/InitializeThreading.cpp
+++ b/Source/JavaScriptCore/runtime/InitializeThreading.cpp
@@ -30,6 +30,7 @@
 #include "InitializeThreading.h"
 
 #include "AssemblyComments.h"
+#include "BuiltinNames.h"
 #include "ExecutableAllocator.h"
 #include "JITOperationList.h"
 #include "JSCConfig.h"
@@ -91,6 +92,8 @@ void initialize()
             StructureAlignedMemoryAllocator::initializeStructureAddressSpace();
         }
         Options::finalize();
+        SmallString::initializeJSStaticStrings();
+        Symbols::initializeStaticSymbols();
 
 #if !USE(SYSTEM_MALLOC)
 #if BUSE(LIBPAS)

--- a/Source/JavaScriptCore/runtime/JSString.h
+++ b/Source/JavaScriptCore/runtime/JSString.h
@@ -92,7 +92,10 @@ JSString* asString(JSValue);
 // JSRopeString [   ID      ][  header  ][   1st fiber         xyz][  length  ][2nd lower32][2nd upper16][3rd lower16][3rd upper32]
 //                                                               ^
 //                                            x:(is8Bit),y:(isSubstring),z:(isRope) bit flags
-class JSString : public JSCell {
+
+class alignas(16) JSString : public JSCell {
+    WTF_MAKE_NONCOPYABLE(JSString);
+    WTF_MAKE_NONMOVABLE(JSString);
 public:
     friend class JIT;
     friend class VM;
@@ -108,6 +111,8 @@ public:
     // Do we really need InterceptsGetOwnPropertySlotByIndexEvenWhenLengthIsNotZero?
     // FIXME: https://bugs.webkit.org/show_bug.cgi?id=212958
     static constexpr unsigned StructureFlags = Base::StructureFlags | OverridesGetOwnPropertySlot | InterceptsGetOwnPropertySlotByIndexEvenWhenLengthIsNotZero | StructureIsImmortal | OverridesToThis | OverridesPut;
+
+    static constexpr uint8_t numberOfLowerTierCells = 0;
 
     static constexpr bool needsDestruction = true;
     static ALWAYS_INLINE void destroy(JSCell* cell)
@@ -286,6 +291,8 @@ private:
 // from JSStringSubspace::
 class JSRopeString final : public JSString {
     friend class JSString;
+    WTF_MAKE_NONCOPYABLE(JSRopeString);
+    WTF_MAKE_NONMOVABLE(JSRopeString);
 public:
     template<typename, SubspaceAccess>
     static GCClient::IsoSubspace* subspaceFor(VM& vm)

--- a/Source/JavaScriptCore/runtime/SmallStrings.cpp
+++ b/Source/JavaScriptCore/runtime/SmallStrings.cpp
@@ -31,6 +31,13 @@
 
 namespace JSC {
 
+namespace SmallString {
+#define DEFINE_STATIC_STRING_IMPL(name, _) \
+    LazyNeverDestroyed<StringImpl*> s_##name;
+FOREACH_JS_STATIC_STRING_IMPL(DEFINE_STATIC_STRING_IMPL)
+#undef DEFINE_STATIC_STRING_IMPL
+};
+
 SmallStrings::SmallStrings()
 {
     static_assert(singleCharacterStringCount == sizeof(m_singleCharacterStrings) / sizeof(m_singleCharacterStrings[0]), "characters count is in sync with class usage");

--- a/Source/JavaScriptCore/runtime/SmallStrings.h
+++ b/Source/JavaScriptCore/runtime/SmallStrings.h
@@ -28,6 +28,7 @@
 #include "CollectionScope.h"
 #include "TypeofType.h"
 #include <wtf/Noncopyable.h>
+#include <wtf/text/StringImpl.h>
 
 #define JSC_COMMON_STRINGS_EACH_NAME(macro) \
     macro(default) \
@@ -48,6 +49,30 @@ class StringImpl;
 }
 
 namespace JSC {
+
+namespace SmallString {
+#define FOREACH_JS_STATIC_STRING_IMPL(macro) \
+    macro(baseConstructorString, "(function () { })") \
+    macro(derivedConstructorString, "(function (...args) { super(...args); })") \
+    macro(terminationErrorString, "JavaScript execution terminated.")
+
+#define DECLARE_STATIC_STRING_IMPL(name, characters) \
+    extern LazyNeverDestroyed<StringImpl*> s_##name; \
+    inline StringImpl* name() \
+    { \
+        return s_##name.get(); \
+    }
+FOREACH_JS_STATIC_STRING_IMPL(DECLARE_STATIC_STRING_IMPL)
+#undef DECLARE_STATIC_STRING_IMPL
+
+#define INITIALIZE_STRING(name, characters) \
+    s_##name.construct(&StringImpl::createStaticStringImplWithoutCopying(characters ""_s, (characters ""_s).length()).leakRef());
+inline void initializeJSStaticStrings()
+{
+    FOREACH_JS_STATIC_STRING_IMPL(INITIALIZE_STRING)
+}
+#undef INITIALIZE_STRING
+}
 
 class VM;
 class JSString;

--- a/Source/JavaScriptCore/runtime/VM.cpp
+++ b/Source/JavaScriptCore/runtime/VM.cpp
@@ -572,11 +572,10 @@ SamplingProfiler& VM::ensureSamplingProfiler(Ref<Stopwatch>&& stopwatch)
 }
 #endif // ENABLE(SAMPLING_PROFILER)
 
-static StringImpl::StaticStringImpl terminationErrorString { "JavaScript execution terminated." };
 Exception* VM::ensureTerminationException()
 {
     if (!m_terminationException) {
-        JSString* terminationError = jsNontrivialString(*this, terminationErrorString);
+        JSString* terminationError = jsNontrivialString(*this, SmallString::terminationErrorString());
         m_terminationException = Exception::create(*this, terminationError, Exception::DoNotCaptureStack);
     }
     return m_terminationException;

--- a/Source/WTF/wtf/CompactPtr.h
+++ b/Source/WTF/wtf/CompactPtr.h
@@ -33,19 +33,7 @@
 #include <wtf/RawPtrTraits.h>
 #include <wtf/StdLibExtras.h>
 
-#if OS(DARWIN)
-#include <mach/vm_param.h>
-#endif
-
 namespace WTF {
-
-#if CPU(ADDRESS64)
-#if CPU(ARM64) && OS(DARWIN)
-#if MACH_VM_MAX_ADDRESS_RAW < (1ULL << 36)
-#define HAVE_36BIT_ADDRESS 1
-#endif
-#endif
-#endif // CPU(ADDRESS64)
 
 template <typename T>
 class CompactPtr {
@@ -207,7 +195,14 @@ public:
         return a.m_ptr == b.m_ptr;
     }
 
-    StorageType storage() const { return m_ptr; }
+    template<typename U>
+    friend bool operator!=(const CompactPtr& a, const CompactPtr<U>& b)
+    {
+        return a.m_ptr != b.m_ptr;
+    }
+
+    const StorageType& storage() const { return m_ptr; }
+    StorageType& storage() { return m_ptr; }
 
 private:
     template <typename X>

--- a/Source/WTF/wtf/Threading.cpp
+++ b/Source/WTF/wtf/Threading.cpp
@@ -472,6 +472,8 @@ void initialize()
         setPermissionsOfConfigPage();
         Config::initialize();
         Gigacage::ensureGigacage();
+        String::initializeStrings();
+        AtomString::initializeStrings();
         Config::AssertNotFrozenScope assertScope;
 #if !HAVE(FAST_TLS) && !OS(WINDOWS)
         Thread::initializeTLSKey();

--- a/Source/WTF/wtf/URL.cpp
+++ b/Source/WTF/wtf/URL.cpp
@@ -41,6 +41,7 @@
 #include <wtf/text/CString.h>
 #include <wtf/text/StringBuilder.h>
 #include <wtf/text/StringHash.h>
+#include <wtf/text/StringImpl.h>
 #include <wtf/text/StringToIntegerConversion.h>
 #include <wtf/text/TextStream.h>
 
@@ -942,24 +943,26 @@ bool protocolIsInHTTPFamily(StringView url)
 }
 
 
-static StaticStringImpl aboutBlankString { "about:blank" };
 const URL& aboutBlankURL()
 {
+    static LazyNeverDestroyed<StringImpl*> aboutBlankString;
     static LazyNeverDestroyed<URL> staticBlankURL;
     static std::once_flag onceFlag;
     std::call_once(onceFlag, [&] {
-        staticBlankURL.construct(&aboutBlankString);
+        aboutBlankString.construct(&StringImpl::createStaticStringImplWithoutCopying("about:blank", "about:blank"_s.length()).leakRef());
+        staticBlankURL.construct(aboutBlankString.get());
     });
     return staticBlankURL;
 }
 
-static StaticStringImpl aboutSrcDocString { "about:srcdoc" };
 const URL& aboutSrcDocURL()
 {
+    static LazyNeverDestroyed<StringImpl*> aboutSrcDocString;
     static LazyNeverDestroyed<URL> staticSrcDocURL;
     static std::once_flag onceFlag;
     std::call_once(onceFlag, [&] {
-        staticSrcDocURL.construct(&aboutSrcDocString);
+        aboutSrcDocString.construct(&StringImpl::createStaticStringImplWithoutCopying("about:srcdoc", "about:srcdoc"_s.length()).leakRef());
+        staticSrcDocURL.construct(aboutSrcDocString.get());
     });
     return staticSrcDocURL;
 }

--- a/Source/WTF/wtf/spi/cocoa/MachVMSPI.h
+++ b/Source/WTF/wtf/spi/cocoa/MachVMSPI.h
@@ -31,7 +31,22 @@
 
 #if PLATFORM(MAC) || USE(APPLE_INTERNAL_SDK)
 #include <mach/mach_vm.h>
+#include <mach/vm_param.h>
 #endif
+
+#if CPU(ADDRESS64)
+#if CPU(ARM64) && OS(DARWIN)
+#if MACH_VM_MAX_ADDRESS_RAW < (1ULL << 36)
+#define HAVE_36BIT_ADDRESS 1
+#else
+#define HAVE_36BIT_ADDRESS 0
+#endif // MACH_VM_MAX_ADDRESS_RAW < (1ULL << 36)
+#else
+#define HAVE_36BIT_ADDRESS 0
+#endif // CPU(ARM64) && OS(DARWIN)
+#else
+#define HAVE_36BIT_ADDRESS 0
+#endif // CPU(ADDRESS64)
 
 WTF_EXTERN_C_BEGIN
 

--- a/Source/WTF/wtf/text/AtomString.cpp
+++ b/Source/WTF/wtf/text/AtomString.cpp
@@ -32,8 +32,17 @@
 
 namespace WTF {
 
-const StaticAtomString nullAtomData { nullptr };
-const StaticAtomString emptyAtomData { &StringImpl::s_emptyAtomString };
+static LazyNeverDestroyed<AtomString> s_emptyAtom;
+static LazyNeverDestroyed<AtomString> s_nullAtom;
+
+const AtomString& nullAtom() { return s_nullAtom.get(); }
+const AtomString& emptyAtom() { return s_emptyAtom.get(); }
+
+void AtomString::initializeStrings()
+{
+    s_emptyAtom.construct(StringImpl::empty());
+    s_nullAtom.construct(static_cast<StringImpl*>(nullptr));
+}
 
 template<AtomString::CaseConvertType type>
 ALWAYS_INLINE AtomString AtomString::convertASCIICase() const

--- a/Source/WTF/wtf/text/AtomString.h
+++ b/Source/WTF/wtf/text/AtomString.h
@@ -38,7 +38,6 @@ public:
     AtomString(AtomStringImpl*);
     AtomString(RefPtr<AtomStringImpl>&&);
     AtomString(Ref<AtomStringImpl>&&);
-    AtomString(const StaticStringImpl*);
     AtomString(StringImpl*);
     explicit AtomString(const String&);
     explicit AtomString(String&&);
@@ -143,6 +142,9 @@ private:
     WTF_EXPORT_PRIVATE static AtomString fromUTF8Internal(const char*, const char*);
 
     String m_string;
+
+public:
+    static void initializeStrings();
 };
 
 static_assert(sizeof(AtomString) == sizeof(String), "AtomString and String must be the same size!");
@@ -204,11 +206,6 @@ inline AtomString::AtomString(StringImpl* string)
 {
 }
 
-inline AtomString::AtomString(const StaticStringImpl* string)
-    : m_string(AtomStringImpl::add(string))
-{
-}
-
 inline AtomString::AtomString(const String& string)
     : m_string(AtomStringImpl::add(string.impl()))
 {
@@ -247,20 +244,8 @@ inline AtomString::AtomString(NSString *string)
 
 #endif
 
-struct StaticAtomString {
-    constexpr StaticAtomString(StringImpl::StaticStringImpl* pointer)
-        : m_pointer(pointer)
-    {
-    }
-
-    StringImpl::StaticStringImpl* m_pointer;
-};
-static_assert(sizeof(AtomString) == sizeof(StaticAtomString), "AtomString and StaticAtomString must be the same size!");
-extern WTF_EXPORT_PRIVATE const StaticAtomString nullAtomData;
-extern WTF_EXPORT_PRIVATE const StaticAtomString emptyAtomData;
-
-inline const AtomString& nullAtom() { return *reinterpret_cast<const AtomString*>(&nullAtomData); }
-inline const AtomString& emptyAtom() { return *reinterpret_cast<const AtomString*>(&emptyAtomData); }
+WTF_EXPORT_PRIVATE const AtomString& nullAtom();
+WTF_EXPORT_PRIVATE const AtomString& emptyAtom();
 
 inline AtomString::AtomString(ASCIILiteral literal)
     : m_string(literal.length() ? AtomStringImpl::add(literal.characters(), literal.length()) : Ref { *emptyAtom().impl() })

--- a/Source/WTF/wtf/text/AtomStringImpl.cpp
+++ b/Source/WTF/wtf/text/AtomStringImpl.cpp
@@ -352,13 +352,6 @@ static inline Ref<AtomStringImpl> addStatic(const StringImpl& base)
     return addStatic(locker, stringTable(), base);
 }
 
-RefPtr<AtomStringImpl> AtomStringImpl::add(const StaticStringImpl* string)
-{
-    auto s = reinterpret_cast<const StringImpl*>(string);
-    ASSERT(s->isStatic());
-    return addStatic(*s);
-}
-
 Ref<AtomStringImpl> AtomStringImpl::addSlowCase(StringImpl& string)
 {
     // This check is necessary for null symbols.

--- a/Source/WTF/wtf/text/AtomStringImpl.h
+++ b/Source/WTF/wtf/text/AtomStringImpl.h
@@ -55,7 +55,6 @@ public:
             return nullptr;
         return add(string.releaseNonNull());
     }
-    WTF_EXPORT_PRIVATE static RefPtr<AtomStringImpl> add(const StaticStringImpl*);
     ALWAYS_INLINE static Ref<AtomStringImpl> add(ASCIILiteral literal) { return addLiteral(literal.characters(), literal.length()); }
 
     // Not using the add() naming to encourage developers to call add(ASCIILiteral) when they have a string literal.
@@ -118,22 +117,6 @@ private:
 
     WTF_EXPORT_PRIVATE static RefPtr<AtomStringImpl> lookUpSlowCase(StringImpl&);
 };
-
-#if ASSERT_ENABLED
-
-// AtomStringImpls created from StaticStringImpl will ASSERT in the generic ValueCheck<T>::checkConsistency,
-// as they are not allocated by fastMalloc. We don't currently have any way to detect that case, so we don't
-// do any consistency check for AtomStringImpl*.
-
-template<> struct ValueCheck<AtomStringImpl*> {
-    static void checkConsistency(const AtomStringImpl*) { }
-};
-
-template<> struct ValueCheck<const AtomStringImpl*> {
-    static void checkConsistency(const AtomStringImpl*) { }
-};
-
-#endif // ASSERT_ENABLED
 
 }
 

--- a/Source/WTF/wtf/text/StringImpl.cpp
+++ b/Source/WTF/wtf/text/StringImpl.cpp
@@ -108,8 +108,6 @@ void StringStats::printStats()
 
 DEFINE_ALLOCATOR_WITH_HEAP_IDENTIFIER(StringImpl);
 
-StringImpl::StaticStringImpl StringImpl::s_emptyAtomString("", StringImpl::StringAtom);
-
 StringImpl::~StringImpl()
 {
     ASSERT(!isStatic());
@@ -273,12 +271,25 @@ Ref<StringImpl> StringImpl::create(const LChar* characters, unsigned length)
     return createInternal(characters, length);
 }
 
+Ref<StringImpl> StringImpl::createStaticStringImplWithoutCopying(const LChar* characters, unsigned length)
+{
+    ASSERT(length);
+    if (!length)
+        return *empty();
+    Ref<StringImpl> result = adoptRef(*new StringImpl(characters, length, ConstructWithoutCopying));
+    result->hash();
+    result->cost();
+    result->m_refCount |= s_refCountFlagIsStaticString;
+    return result;
+}
+
 Ref<StringImpl> StringImpl::createStaticStringImpl(const LChar* characters, unsigned length)
 {
     if (!length)
         return *empty();
     Ref<StringImpl> result = createInternal(characters, length);
     result->hash();
+    result->cost();
     result->m_refCount |= s_refCountFlagIsStaticString;
     return result;
 }
@@ -289,6 +300,7 @@ Ref<StringImpl> StringImpl::createStaticStringImpl(const UChar* characters, unsi
         return *empty();
     Ref<StringImpl> result = create8BitIfPossible(characters, length);
     result->hash();
+    result->cost();
     result->m_refCount |= s_refCountFlagIsStaticString;
     return result;
 }
@@ -1661,5 +1673,7 @@ bool equalIgnoringNullity(const UChar* a, size_t aLength, StringImpl* b)
     }
     return equal(a, b->characters16(), b->length());
 }
+
+LazyNeverDestroyed<Ref<StringImpl>> StringImpl::s_empty;
 
 } // namespace WTF

--- a/Source/WTF/wtf/text/StringImpl.h
+++ b/Source/WTF/wtf/text/StringImpl.h
@@ -30,6 +30,8 @@
 #include <wtf/DebugHeap.h>
 #include <wtf/Expected.h>
 #include <wtf/MathExtras.h>
+#include <wtf/NeverDestroyed.h>
+#include <wtf/Nonmovable.h>
 #include <wtf/Packed.h>
 #include <wtf/StdLibExtras.h>
 #include <wtf/Vector.h>
@@ -147,16 +149,13 @@ struct StringStats {
 
 class STRING_IMPL_ALIGNMENT StringImplShape {
     WTF_MAKE_NONCOPYABLE(StringImplShape);
+    WTF_MAKE_NONMOVABLE(StringImplShape);
 public:
     static constexpr unsigned MaxLength = std::numeric_limits<int32_t>::max();
 
 protected:
     StringImplShape(unsigned refCount, unsigned length, const LChar*, unsigned hashAndFlags);
     StringImplShape(unsigned refCount, unsigned length, const UChar*, unsigned hashAndFlags);
-
-    enum ConstructWithConstExprTag { ConstructWithConstExpr };
-    template<unsigned characterCount> constexpr StringImplShape(unsigned refCount, unsigned length, const char (&characters)[characterCount], unsigned hashAndFlags, ConstructWithConstExprTag);
-    template<unsigned characterCount> constexpr StringImplShape(unsigned refCount, unsigned length, const char16_t (&characters)[characterCount], unsigned hashAndFlags, ConstructWithConstExprTag);
 
     unsigned m_refCount;
     unsigned m_length;
@@ -180,6 +179,7 @@ protected:
 DECLARE_ALLOCATOR_WITH_HEAP_IDENTIFIER(StringImpl);
 class StringImpl : private StringImplShape {
     WTF_MAKE_NONCOPYABLE(StringImpl);
+    WTF_MAKE_NONMOVABLE(StringImpl);
     WTF_MAKE_FAST_ALLOCATED_WITH_HEAP_IDENTIFIER(StringImpl);
 
     friend class AtomStringImpl;
@@ -242,6 +242,9 @@ private:
     StringImpl(const UChar*, unsigned length, ConstructWithoutCopyingTag);
     StringImpl(const LChar*, unsigned length, ConstructWithoutCopyingTag);
 
+    enum ConstructEmptyTag { ConstructEmpty };
+    StringImpl(ConstructEmptyTag);
+
     // Used to create new strings that are a substring of an existing StringImpl (BufferSubstring).
     StringImpl(const LChar*, unsigned length, Ref<StringImpl>&&);
     StringImpl(const UChar*, unsigned length, Ref<StringImpl>&&);
@@ -278,6 +281,38 @@ public:
         ASSERT(charactersAreAllASCII(bitwise_cast<const LChar*>(characters), length));
         return createStaticStringImpl(bitwise_cast<const LChar*>(characters), length);
     }
+
+    // Used to construct static strings, which have an special refCount that can never hit zero.
+    // This means that the static string will never be destroyed, which is important because
+    // static strings will be shared across threads & ref-counted in a non-threadsafe manner.
+    //
+    // In order to be thread safe, we also need to ensure that the rest of
+    // the fields are never mutated by threads. We have this guarantee because:
+    //
+    // 1. m_length is only set on construction and never mutated thereafter.
+    //
+    // 2. m_data8 and m_data16 are only set on construction and never mutated thereafter.
+    //    We also know that a StringImpl never changes from 8 bit to 16 bit because there
+    //    is no way to set/clear the s_hashFlag8BitBuffer flag other than at construction.
+    //
+    // 3. m_hashAndFlags will not be mutated by different threads because:
+    //
+    //    a. This constructor calls StringImpl::cost() early, so it will return early when called again.
+    //       This means static StringImpl costs are not counted. But since there should only
+    //       be a finite set of static StringImpls, their cost can be aggregated into a single
+    //       system cost if needed.
+    //    b. setIsAtom() is never called on a static StringImpl.
+    //       setIsAtom() asserts !isStatic().
+    //    c. setHash() is never called on a static StringImpl.
+    //       This constructor sets the hash on construction.
+    //       StringImpl::hash() only sets a new hash iff !hasHash().
+    //       Additionally, StringImpl::setHash() asserts hasHash() and !isStatic().
+    static Ref<StringImpl> createStaticStringImplWithoutCopying(const char* characters, unsigned length)
+    {
+        ASSERT(charactersAreAllASCII(bitwise_cast<const LChar*>(characters), length));
+        return createStaticStringImplWithoutCopying(bitwise_cast<const LChar*>(characters), length);
+    }
+    WTF_EXPORT_PRIVATE static Ref<StringImpl> createStaticStringImplWithoutCopying(const LChar*, unsigned length);
     WTF_EXPORT_PRIVATE static Ref<StringImpl> createStaticStringImpl(const LChar*, unsigned length);
     WTF_EXPORT_PRIVATE static Ref<StringImpl> createStaticStringImpl(const UChar*, unsigned length);
 
@@ -367,43 +402,16 @@ public:
     void ref();
     void deref();
 
-    class StaticStringImpl : private StringImplShape {
-        WTF_MAKE_NONCOPYABLE(StaticStringImpl);
-    public:
-        // Used to construct static strings, which have an special refCount that can never hit zero.
-        // This means that the static string will never be destroyed, which is important because
-        // static strings will be shared across threads & ref-counted in a non-threadsafe manner.
-        //
-        // In order to make StaticStringImpl thread safe, we also need to ensure that the rest of
-        // the fields are never mutated by threads. We have this guarantee because:
-        //
-        // 1. m_length is only set on construction and never mutated thereafter.
-        //
-        // 2. m_data8 and m_data16 are only set on construction and never mutated thereafter.
-        //    We also know that a StringImpl never changes from 8 bit to 16 bit because there
-        //    is no way to set/clear the s_hashFlag8BitBuffer flag other than at construction.
-        //
-        // 3. m_hashAndFlags will not be mutated by different threads because:
-        //
-        //    a. StaticStringImpl's constructor sets the s_hashFlagDidReportCost flag to ensure
-        //       that StringImpl::cost() returns early.
-        //       This means StaticStringImpl costs are not counted. But since there should only
-        //       be a finite set of StaticStringImpls, their cost can be aggregated into a single
-        //       system cost if needed.
-        //    b. setIsAtom() is never called on a StaticStringImpl.
-        //       setIsAtom() asserts !isStatic().
-        //    c. setHash() is never called on a StaticStringImpl.
-        //       StaticStringImpl's constructor sets the hash on construction.
-        //       StringImpl::hash() only sets a new hash iff !hasHash().
-        //       Additionally, StringImpl::setHash() asserts hasHash() and !isStatic().
+    WTF_EXPORT_PRIVATE static LazyNeverDestroyed<Ref<StringImpl>> s_empty;
+    ALWAYS_INLINE static StringImpl* empty()
+    {
+        return &s_empty.get().get();
+    }
 
-        template<unsigned characterCount> explicit constexpr StaticStringImpl(const char (&characters)[characterCount], StringKind = StringNormal);
-        template<unsigned characterCount> explicit constexpr StaticStringImpl(const char16_t (&characters)[characterCount], StringKind = StringNormal);
-        operator StringImpl&();
-    };
-
-    WTF_EXPORT_PRIVATE static StaticStringImpl s_emptyAtomString;
-    ALWAYS_INLINE static StringImpl* empty() { return reinterpret_cast<StringImpl*>(&s_emptyAtomString); }
+    ALWAYS_INLINE static void initializeEmptyString()
+    {
+        s_empty.construct(adoptRef(*new StringImpl(ConstructEmpty)));
+    }
 
     // FIXME: Do these functions really belong in StringImpl?
     template<typename CharacterType> static void copyCharacters(CharacterType* destination, const CharacterType* source, unsigned length);
@@ -554,10 +562,6 @@ public:
     void assertHashIsCorrect() const;
 };
 
-using StaticStringImpl = StringImpl::StaticStringImpl;
-
-static_assert(sizeof(StringImpl) == sizeof(StaticStringImpl));
-
 template<typename CharacterType>
 struct HashTranslatorCharBuffer {
     const CharacterType* characters;
@@ -578,17 +582,6 @@ struct HashTranslatorCharBuffer {
     {
     }
 };
-
-#if ASSERT_ENABLED
-
-// StringImpls created from StaticStringImpl will ASSERT in the generic ValueCheck<T>::checkConsistency
-// as they are not allocated by fastMalloc. We don't currently have any way to detect that case
-// so we ignore the consistency check for all StringImpl*.
-template<> struct ValueCheck<StringImpl*> {
-    static void checkConsistency(const StringImpl*) { }
-};
-
-#endif // ASSERT_ENABLED
 
 WTF_EXPORT_PRIVATE bool equal(const StringImpl*, const StringImpl*);
 WTF_EXPORT_PRIVATE bool equal(const StringImpl*, const LChar*);
@@ -642,8 +635,7 @@ template<> struct DefaultHash<PackedPtr<StringImpl>>;
 template<> struct DefaultHash<CompactPtr<StringImpl>>;
 
 #define MAKE_STATIC_STRING_IMPL(characters) ([] { \
-        static StaticStringImpl impl(characters); \
-        return &impl; \
+        return &StringImpl::createStaticStringImplWithoutCopying(characters ""_s, (characters ""_s).length()).get(); \
     }())
 
 template<> ALWAYS_INLINE Ref<StringImpl> StringImpl::constructInternal<LChar>(StringImpl& string, unsigned length)
@@ -821,22 +813,6 @@ inline StringImplShape::StringImplShape(unsigned refCount, unsigned length, cons
 {
 }
 
-template<unsigned characterCount> constexpr StringImplShape::StringImplShape(unsigned refCount, unsigned length, const char (&characters)[characterCount], unsigned hashAndFlags, ConstructWithConstExprTag)
-    : m_refCount(refCount)
-    , m_length(length)
-    , m_data8Char(characters)
-    , m_hashAndFlags(hashAndFlags)
-{
-}
-
-template<unsigned characterCount> constexpr StringImplShape::StringImplShape(unsigned refCount, unsigned length, const char16_t (&characters)[characterCount], unsigned hashAndFlags, ConstructWithConstExprTag)
-    : m_refCount(refCount)
-    , m_length(length)
-    , m_data16Char(characters)
-    , m_hashAndFlags(hashAndFlags)
-{
-}
-
 inline Ref<StringImpl> StringImpl::isolatedCopy() const
 {
     if (!requiresCopy()) {
@@ -936,6 +912,14 @@ inline StringImpl::StringImpl(const LChar* characters, unsigned length, Construc
     ASSERT(m_length);
 
     STRING_STATS_ADD_8BIT_STRING(m_length);
+}
+
+inline StringImpl::StringImpl(ConstructEmptyTag)
+    : StringImplShape(s_refCountFlagIsStaticString, 0, bitwise_cast<const LChar*>(""), s_hashFlag8BitBuffer | StringAtom | s_hashFlagDidReportCost | (StringHasher::computeLiteralHashAndMaskTop8Bits("") << s_flagCount))
+{
+    ASSERT(m_data8);
+    ASSERT(!s_empty.isConstructed());
+    assertHashIsCorrect();
 }
 
 template<typename Malloc>
@@ -1056,12 +1040,10 @@ inline size_t StringImpl::cost() const
     if (bufferOwnership() == BufferSubstring)
         return substringBuffer()->cost();
 
-    // Note: we must not alter the m_hashAndFlags field in instances of StaticStringImpl.
-    // We ensure this by pre-setting the s_hashFlagDidReportCost bit in all instances of
-    // StaticStringImpl. As a result, StaticStringImpl instances will always return a cost of
-    // 0 here and avoid modifying m_hashAndFlags.
     if (m_hashAndFlags & s_hashFlagDidReportCost)
         return 0;
+
+    ASSERT(!isStatic());
 
     m_hashAndFlags |= s_hashFlagDidReportCost;
     size_t result = m_length;
@@ -1350,23 +1332,6 @@ inline void StringImpl::assertHashIsCorrect() const
     ASSERT(existingHash() == StringHasher::computeHashAndMaskTop8Bits(characters8(), length()));
 }
 
-template<unsigned characterCount> constexpr StringImpl::StaticStringImpl::StaticStringImpl(const char (&characters)[characterCount], StringKind stringKind)
-    : StringImplShape(s_refCountFlagIsStaticString, characterCount - 1, characters,
-        s_hashFlag8BitBuffer | s_hashFlagDidReportCost | stringKind | BufferInternal | (StringHasher::computeLiteralHashAndMaskTop8Bits(characters) << s_flagCount), ConstructWithConstExpr)
-{
-}
-
-template<unsigned characterCount> constexpr StringImpl::StaticStringImpl::StaticStringImpl(const char16_t (&characters)[characterCount], StringKind stringKind)
-    : StringImplShape(s_refCountFlagIsStaticString, characterCount - 1, characters,
-        s_hashFlagDidReportCost | stringKind | BufferInternal | (StringHasher::computeLiteralHashAndMaskTop8Bits(characters) << s_flagCount), ConstructWithConstExpr)
-{
-}
-
-inline StringImpl::StaticStringImpl::operator StringImpl&()
-{
-    return *reinterpret_cast<StringImpl*>(this);
-}
-
 inline bool equalIgnoringASCIICase(const StringImpl& a, const StringImpl& b)
 {
     return equalIgnoringASCIICaseCommon(a, b);
@@ -1553,7 +1518,6 @@ inline Expected<std::invoke_result_t<Func, std::span<const char>>, UTF8Conversio
 
 } // namespace WTF
 
-using WTF::StaticStringImpl;
 using WTF::StringImpl;
 using WTF::equal;
 using WTF::isNotSpaceOrNewline;

--- a/Source/WTF/wtf/text/SymbolImpl.cpp
+++ b/Source/WTF/wtf/text/SymbolImpl.cpp
@@ -42,6 +42,15 @@ unsigned SymbolImpl::nextHashForSymbol()
     return s_nextHashForSymbol;
 }
 
+Ref<SymbolImpl> SymbolImpl::createStatic(StringImpl& rep)
+{
+    auto result = create(rep);
+    result->hash();
+    result->cost();
+    result->m_refCount |= s_refCountFlagIsStaticString;
+    return result;
+}
+
 Ref<SymbolImpl> SymbolImpl::create(StringImpl& rep)
 {
     auto* ownerRep = (rep.bufferOwnership() == BufferSubstring) ? rep.substringBuffer() : &rep;
@@ -54,6 +63,14 @@ Ref<SymbolImpl> SymbolImpl::create(StringImpl& rep)
 Ref<SymbolImpl> SymbolImpl::createNullSymbol()
 {
     return adoptRef(*new SymbolImpl);
+}
+
+Ref<PrivateSymbolImpl> PrivateSymbolImpl::createStatic(StringImpl& rep)
+{
+    auto result = create(rep);
+    result->hash();
+    result->m_refCount |= s_refCountFlagIsStaticString;
+    return result;
 }
 
 Ref<PrivateSymbolImpl> PrivateSymbolImpl::create(StringImpl& rep)

--- a/Source/WTF/wtf/text/SymbolImpl.h
+++ b/Source/WTF/wtf/text/SymbolImpl.h
@@ -52,37 +52,9 @@ public:
 
     WTF_EXPORT_PRIVATE static Ref<SymbolImpl> createNullSymbol();
     WTF_EXPORT_PRIVATE static Ref<SymbolImpl> create(StringImpl& rep);
-
-    class StaticSymbolImpl final : private StringImplShape {
-        WTF_MAKE_NONCOPYABLE(StaticSymbolImpl);
-    public:
-        template<unsigned characterCount>
-        constexpr StaticSymbolImpl(const char (&characters)[characterCount], Flags flags = s_flagDefault)
-            : StringImplShape(s_refCountFlagIsStaticString, characterCount - 1, characters,
-                s_hashFlag8BitBuffer | s_hashFlagDidReportCost | StringSymbol | BufferInternal | (StringHasher::computeLiteralHashAndMaskTop8Bits(characters) << s_flagCount), ConstructWithConstExpr)
-            , m_hashForSymbolShiftedWithFlagCount(StringHasher::computeLiteralHashAndMaskTop8Bits(characters) << s_flagCount)
-            , m_flags(flags)
-        {
-        }
-
-        template<unsigned characterCount>
-        constexpr StaticSymbolImpl(const char16_t (&characters)[characterCount], Flags flags = s_flagDefault)
-            : StringImplShape(s_refCountFlagIsStaticString, characterCount - 1, characters,
-                s_hashFlagDidReportCost | StringSymbol | BufferInternal | (StringHasher::computeLiteralHashAndMaskTop8Bits(characters) << s_flagCount), ConstructWithConstExpr)
-            , m_hashForSymbolShiftedWithFlagCount(StringHasher::computeLiteralHashAndMaskTop8Bits(characters) << s_flagCount)
-            , m_flags(flags)
-        {
-        }
-
-        operator SymbolImpl&()
-        {
-            return *reinterpret_cast<SymbolImpl*>(this);
-        }
-
-        StringImpl* m_owner { nullptr }; // We do not make StaticSymbolImpl BufferSubstring. Thus we can make this nullptr.
-        unsigned m_hashForSymbolShiftedWithFlagCount;
-        Flags m_flags;
-    };
+    WTF_EXPORT_PRIVATE static Ref<SymbolImpl> createStatic(StringImpl& rep);
+    static inline Ref<SymbolImpl> create(const char* rep, unsigned length) { return create(StringImpl::createStaticStringImplWithoutCopying(rep, length).leakRef()); }
+    static inline Ref<SymbolImpl> createStatic(const char* rep, unsigned length) { return createStatic(StringImpl::createStaticStringImplWithoutCopying(rep, length).leakRef()); }
 
 protected:
     WTF_EXPORT_PRIVATE static unsigned nextHashForSymbol();
@@ -122,11 +94,13 @@ protected:
     unsigned m_hashForSymbolShiftedWithFlagCount;
     Flags m_flags { s_flagDefault };
 };
-static_assert(sizeof(SymbolImpl) == sizeof(SymbolImpl::StaticSymbolImpl));
 
 class PrivateSymbolImpl final : public SymbolImpl {
 public:
     WTF_EXPORT_PRIVATE static Ref<PrivateSymbolImpl> create(StringImpl& rep);
+    WTF_EXPORT_PRIVATE static Ref<PrivateSymbolImpl> createStatic(StringImpl& rep);
+    static inline Ref<PrivateSymbolImpl> create(const char* rep, unsigned length) { return PrivateSymbolImpl::create(StringImpl::createStaticStringImplWithoutCopying(rep, length).leakRef()); }
+    static inline Ref<PrivateSymbolImpl> createStatic(const char* rep, unsigned length) { return PrivateSymbolImpl::createStatic(StringImpl::createStaticStringImplWithoutCopying(rep, length).leakRef()); }
 
 private:
     PrivateSymbolImpl(const LChar* characters, unsigned length, Ref<StringImpl>&& base)
@@ -193,23 +167,6 @@ inline RegisteredSymbolImpl* SymbolImpl::asRegisteredSymbolImpl()
     ASSERT(isRegistered());
     return static_cast<RegisteredSymbolImpl*>(this);
 }
-
-#if ASSERT_ENABLED
-// SymbolImpls created from StaticStringImpl will ASSERT
-// in the generic ValueCheck<T>::checkConsistency
-// as they are not allocated by fastMalloc.
-// We don't currently have any way to detect that case
-// so we ignore the consistency check for all SymbolImpls*.
-template<> struct
-ValueCheck<SymbolImpl*> {
-    static void checkConsistency(const SymbolImpl*) { }
-};
-
-template<> struct
-ValueCheck<const SymbolImpl*> {
-    static void checkConsistency(const SymbolImpl*) { }
-};
-#endif // ASSERT_ENABLED
 
 } // namespace WTF
 

--- a/Source/WTF/wtf/text/UniquedStringImpl.h
+++ b/Source/WTF/wtf/text/UniquedStringImpl.h
@@ -40,23 +40,6 @@ protected:
     UniquedStringImpl(CreateSymbolTag) : StringImpl(CreateSymbol) { }
 };
 
-#if ASSERT_ENABLED
-// UniquedStringImpls created from StaticStringImpl will ASSERT
-// in the generic ValueCheck<T>::checkConsistency
-// as they are not allocated by fastMalloc.
-// We don't currently have any way to detect that case
-// so we ignore the consistency check for all UniquedStringImpls*.
-template<> struct
-ValueCheck<UniquedStringImpl*> {
-    static void checkConsistency(const UniquedStringImpl*) { }
-};
-
-template<> struct
-ValueCheck<const UniquedStringImpl*> {
-    static void checkConsistency(const UniquedStringImpl*) { }
-};
-#endif // ASSERT_ENABLED
-
 } // namespace WTF
 
 using WTF::UniquedStringImpl;

--- a/Source/WTF/wtf/text/WTFString.cpp
+++ b/Source/WTF/wtf/text/WTFString.cpp
@@ -39,6 +39,19 @@ namespace WTF {
 
 using namespace Unicode;
 
+static LazyNeverDestroyed<AtomString> s_emptyString;
+static LazyNeverDestroyed<AtomString> s_nullString;
+
+const String& nullString() { return s_nullString.get(); }
+const String& emptyString() { return s_emptyString.get(); }
+
+void String::initializeStrings()
+{
+    StringImpl::initializeEmptyString();
+    s_emptyString.construct(StringImpl::empty());
+    s_nullString.construct(static_cast<StringImpl*>(nullptr));
+}
+
 // Construct a string with UTF-16 data.
 String::String(const UChar* characters, unsigned length)
     : m_impl(characters ? RefPtr { StringImpl::create(characters, length) } : nullptr)
@@ -627,9 +640,6 @@ float charactersToFloat(const UChar* data, size_t length, size_t& parsedLength)
     // FIXME: This will return ok even when the string fits into a double but not a float.
     return static_cast<float>(toDoubleType<UChar, TrailingJunkPolicy::Allow>(data, length, nullptr, parsedLength));
 }
-
-const StaticString nullStringData { nullptr };
-const StaticString emptyStringData { &StringImpl::s_emptyAtomString };
 
 } // namespace WTF
 

--- a/Source/WTF/wtf/text/WTFString.h
+++ b/Source/WTF/wtf/text/WTFString.h
@@ -75,9 +75,6 @@ public:
     String(Ref<AtomStringImpl>&&);
     String(RefPtr<AtomStringImpl>&&);
 
-    String(StaticStringImpl&);
-    String(StaticStringImpl*);
-
     // Construct a string from a constant string literal.
     String(ASCIILiteral);
 
@@ -319,6 +316,9 @@ private:
     WTF_EXPORT_PRIVATE explicit String(const char* characters);
 
     RefPtr<StringImpl> m_impl;
+
+public:
+    static void initializeStrings();
 };
 
 static_assert(sizeof(String) == sizeof(void*), "String should effectively be a pointer to a StringImpl, and efficient to pass by value");
@@ -353,20 +353,8 @@ WTF_EXPORT_PRIVATE int codePointCompare(const String&, const String&);
 bool codePointCompareLessThan(const String&, const String&);
 
 // Shared global empty and null string.
-struct StaticString {
-    constexpr StaticString(StringImpl::StaticStringImpl* pointer)
-        : m_pointer(pointer)
-    {
-    }
-
-    StringImpl::StaticStringImpl* m_pointer;
-};
-static_assert(sizeof(String) == sizeof(StaticString), "String and StaticString must be the same size!");
-extern WTF_EXPORT_PRIVATE const StaticString nullStringData;
-extern WTF_EXPORT_PRIVATE const StaticString emptyStringData;
-
-inline const String& nullString() { return *reinterpret_cast<const String*>(&nullStringData); }
-inline const String& emptyString() { return *reinterpret_cast<const String*>(&emptyStringData); }
+WTF_EXPORT_PRIVATE const String& nullString();
+WTF_EXPORT_PRIVATE const String& emptyString();
 
 template<typename> struct DefaultHash;
 template<> struct DefaultHash<String>;
@@ -420,16 +408,6 @@ inline String::String(Ref<AtomStringImpl>&& string)
 
 inline String::String(RefPtr<AtomStringImpl>&& string)
     : m_impl(WTFMove(string))
-{
-}
-
-inline String::String(StaticStringImpl& string)
-    : m_impl(reinterpret_cast<StringImpl*>(&string))
-{
-}
-
-inline String::String(StaticStringImpl* string)
-    : m_impl(reinterpret_cast<StringImpl*>(string))
 {
 }
 

--- a/Source/WebCore/bindings/scripts/StaticString.pm
+++ b/Source/WebCore/bindings/scripts/StaticString.pm
@@ -42,11 +42,12 @@ sub GenerateStrings($)
 END
 
     for my $name (sort keys %strings) {
-        my $value = $strings{$name};
-        push(@result, "static constexpr StringImpl::StaticStringImpl ${name}Data(\"${value}\");\n");
+        push(@result, "static LazyNeverDestroyed<StringImpl*> s_${name}Data;\n");
     }
 
     push(@result, <<END);
+
+#undef DECLARE_STATIC_STRING_IMPL
 
 #if COMPILER(MSVC)
 #pragma warning(pop)
@@ -64,13 +65,13 @@ sub GenerateStringAsserts($)
 
     my @result = ();
 
-    push(@result, "#ifndef NDEBUG\n");
-
     for my $name (sort keys %strings) {
-        push(@result, "    reinterpret_cast<const StringImpl*>(&${name}Data)->assertHashIsCorrect();\n");
+        my $value = $strings{$name};
+        push(@result, "    s_${name}Data.construct(&StringImpl::createStaticStringImplWithoutCopying(\"${value}\", \"${value}\"_s.length()).leakRef());\n");
+        push(@result, "#ifndef NDEBUG\n");
+        push(@result, "    s_${name}Data.get()->assertHashIsCorrect();\n");
+        push(@result, "#endif // NDEBUG\n");
     }
-
-    push(@result, "#endif // NDEBUG\n");
 
     push(@result, "\n");
 

--- a/Source/WebCore/css/CSSFontFaceSet.cpp
+++ b/Source/WebCore/css/CSSFontFaceSet.cpp
@@ -390,7 +390,7 @@ ExceptionOr<Vector<std::reference_wrapper<CSSFontFace>>> CSSFontFaceSet::matchin
         AtomString familyAtom;
         WTF::switchOn(familyRaw, [&] (CSSValueID familyKeyword) {
             if (familyKeyword != CSSValueWebkitBody)
-                familyAtom = familyNamesData->at(CSSPropertyParserHelpers::genericFontFamilyIndex(familyKeyword));
+                familyAtom = familyNames->at(CSSPropertyParserHelpers::genericFontFamilyIndex(familyKeyword));
             else {
                 ASSERT(m_owningFontSelector && m_owningFontSelector->scriptExecutionContext());
                 familyAtom = AtomString { m_owningFontSelector->scriptExecutionContext()->settingsValues().fontGenericFamilies.standardFontFamily() };

--- a/Source/WebCore/css/CSSFontSelector.cpp
+++ b/Source/WebCore/css/CSSFontSelector.cpp
@@ -77,15 +77,9 @@ CSSFontSelector::CSSFontSelector(ScriptExecutionContext& context)
     , m_uniqueId(++fontSelectorId)
     , m_version(0)
 {
-    if (is<Document>(context)) {
-        m_fontFamilyNames.reserveInitialCapacity(familyNames->size());
-        for (auto& familyName : familyNames.get())
-            m_fontFamilyNames.uncheckedConstructAndAppend(familyName);
-    } else {
-        m_fontFamilyNames.reserveInitialCapacity(familyNamesData->size());
-        for (auto& familyName : familyNamesData.get())
-            m_fontFamilyNames.uncheckedAppend(familyName);
-    }
+    m_fontFamilyNames.reserveInitialCapacity(familyNames->size());
+    for (auto& familyName : familyNames.get())
+        m_fontFamilyNames.uncheckedConstructAndAppend(familyName);
 
     FontCache::forCurrentThread().addClient(*this);
     m_cssFontFaceSet->addFontModifiedObserver(m_fontModifiedObserver);

--- a/Source/WebCore/dom/Document.cpp
+++ b/Source/WebCore/dom/Document.cpp
@@ -5888,21 +5888,17 @@ bool Document::shouldMaskURLForBindingsInternal(const URL& urlToMask) const
     return maskedURLSchemes.contains<StringViewHashTranslator>(urlToMask.protocol());
 }
 
-static StaticStringImpl maskedURLString { "webkit-masked-url://hidden/" };
-StaticStringImpl& Document::maskedURLStringForBindings()
-{
-    return maskedURLString;
-}
-
 const URL& Document::maskedURLForBindings()
 {
     // This function can be called from GC heap thread, thus we need to use StaticStringImpl as a source of URL.
-    // StaticStringImpl is never converted to AtomString, and it is safe to be used in any threads.
+    // StaticStringImpl is never converted to AtomString, and it is safe to be used in any thread.
+    static LazyNeverDestroyed<StringImpl*> maskedURLStringForBindings;
     static LazyNeverDestroyed<URL> url;
     static std::once_flag onceFlag;
     std::call_once(onceFlag, [&] {
-        url.construct(maskedURLStringForBindings());
-        ASSERT(url->string().impl() == &static_cast<StringImpl&>(maskedURLStringForBindings()));
+        maskedURLStringForBindings.construct(&StringImpl::createStaticStringImplWithoutCopying("webkit-masked-url://hidden/", "webkit-masked-url://hidden/"_s.length()).leakRef());
+        url.construct(maskedURLStringForBindings.get());
+        ASSERT(url->string().impl() == static_cast<StringImpl*>(maskedURLStringForBindings.get()));
     });
     return url;
 }

--- a/Source/WebCore/dom/Document.h
+++ b/Source/WebCore/dom/Document.h
@@ -766,7 +766,6 @@ public:
 
     inline bool shouldMaskURLForBindings(const URL&) const;
     inline const URL& maskedURLForBindingsIfNeeded(const URL&) const;
-    static StaticStringImpl& maskedURLStringForBindings();
     static const URL& maskedURLForBindings();
 
     WEBCORE_EXPORT String userAgent(const URL&) const final;

--- a/Source/WebCore/dom/Element.cpp
+++ b/Source/WebCore/dom/Element.cpp
@@ -5042,7 +5042,7 @@ String Element::resolveURLStringIfNeeded(const String& urlString, ResolveURLs re
     if (resolveURLs == ResolveURLs::No)
         return urlString;
 
-    static MainThreadNeverDestroyed<const AtomString> maskedURLStringForBindings(document().maskedURLStringForBindings());
+    const auto& maskedURLStringForBindings = document().maskedURLForBindings().string();
     URL completeURL = base.isNull() ? document().completeURL(urlString) : URL(base, urlString);
 
     switch (resolveURLs) {
@@ -5051,7 +5051,7 @@ String Element::resolveURLStringIfNeeded(const String& urlString, ResolveURLs re
 
     case ResolveURLs::YesExcludingURLsForPrivacy: {
         if (document().shouldMaskURLForBindings(completeURL))
-            return maskedURLStringForBindings.get();
+            return maskedURLStringForBindings;
         if (!document().url().isLocalFile())
             return completeURL.string();
         break;
@@ -5059,7 +5059,7 @@ String Element::resolveURLStringIfNeeded(const String& urlString, ResolveURLs re
 
     case ResolveURLs::NoExcludingURLsForPrivacy:
         if (document().shouldMaskURLForBindings(completeURL))
-            return maskedURLStringForBindings.get();
+            return maskedURLStringForBindings;
         break;
 
     case ResolveURLs::No:

--- a/Source/WebCore/dom/make_names.pl
+++ b/Source/WebCore/dom/make_names.pl
@@ -122,9 +122,9 @@ END
     print F "        return Vector<T, inlineCapacity>::at(static_cast<size_t>(i));\n";
     print F "    }\n";
     print F "};\n\n";
-    print F "extern LazyNeverDestroyed<FamilyNamesList<const StaticStringImpl*, ", scalar(keys %parameters), ">> familyNamesData;\n";
-    print F "extern MainThreadLazyNeverDestroyed<FamilyNamesList<AtomStringImpl*, ", scalar(keys %parameters), ">> familyNames;\n\n";
-    printMacros($F, "extern MainThreadLazyNeverDestroyed<const AtomString>", "", \%parameters);
+    print F "extern LazyNeverDestroyed<FamilyNamesList<const StringImpl*, ", scalar(keys %parameters), ">> familyNamesData;\n";
+    print F "extern LazyNeverDestroyed<FamilyNamesList<AtomStringImpl*, ", scalar(keys %parameters), ">> familyNames;\n\n";
+    printMacros($F, "extern LazyNeverDestroyed<const AtomString>", "", \%parameters);
     print F "\n";
     print F "\n";
 
@@ -139,10 +139,10 @@ END
 
     print F StaticString::GenerateStrings(\%parameters);
 
-    print F "LazyNeverDestroyed<FamilyNamesList<const StaticStringImpl*, ", scalar(keys %parameters), ">> familyNamesData;\n";
-    print F "MainThreadLazyNeverDestroyed<FamilyNamesList<AtomStringImpl*, ", scalar(keys %parameters), ">> familyNames;\n\n";
+    print F "LazyNeverDestroyed<FamilyNamesList<const StringImpl*, ", scalar(keys %parameters), ">> familyNamesData;\n";
+    print F "LazyNeverDestroyed<FamilyNamesList<AtomStringImpl*, ", scalar(keys %parameters), ">> familyNames;\n\n";
 
-    printMacros($F, "MainThreadLazyNeverDestroyed<const AtomString>", "", \%parameters);
+    printMacros($F, "LazyNeverDestroyed<const AtomString>", "", \%parameters);
 
     printInit($F, 0);
 
@@ -151,12 +151,12 @@ END
 
     print F "    familyNamesData.construct();\n";
     for my $name (sort keys %parameters) {
-        print F "    familyNamesData->uncheckedAppend(&${name}Data);\n";
+        print F "    familyNamesData->uncheckedAppend(s_${name}Data.get());\n";
     }
 
     print F "\n";
     for my $name (sort keys %parameters) {
-        print F "    ${name}.construct(&${name}Data);\n";
+        print F "    ${name}.construct(s_${name}Data.get());\n";
     }
 
     print F "\n";
@@ -996,10 +996,18 @@ sub printTagNameCppFile
     }
     print F "};\n";
     print F "\n";
-    print F "static constexpr StringImpl::StaticStringImpl unadjustedTagNames[] = {\n";
+    my $unadjustedTagNamesCount = 0;
+    print F "static constexpr const char* const unadjustedTagNames[] = {\n";
     for my $elementKey (sort byElementNameOrder keys %allElements) {
         next if $allElements{$elementKey}{unadjustedTagEnumValue} eq "";
-        print F "    StringImpl::StaticStringImpl { \"$allElements{$elementKey}{parsedTagName}\" },\n";
+        ++$unadjustedTagNamesCount;
+        print F "    \"$allElements{$elementKey}{parsedTagName}\",\n";
+    }
+    print F "};\n";
+    print F "static constexpr size_t unadjustedTagNamesLengths[$unadjustedTagNamesCount] = {\n";
+    for my $elementKey (sort byElementNameOrder keys %allElements) {
+        next if $allElements{$elementKey}{unadjustedTagEnumValue} eq "";
+        print F "    \"$allElements{$elementKey}{parsedTagName}\"_s.length(),\n";
     }
     print F "};\n";
     print F "\n";
@@ -1013,9 +1021,10 @@ sub printTagNameCppFile
     print F "    ++tagNamesEntry; // Skip TagName::Unknown\n";
     print F "    for (auto* qualifiedName : tagQualifiedNamePointers)\n";
     print F "        *(tagNamesEntry++) = reinterpret_cast<LazyNeverDestroyed<QualifiedName>*>(qualifiedName)->get().localName();\n";
-    print F "    for (auto& string : unadjustedTagNames) {\n";
-    print F "        reinterpret_cast<const StringImpl&>(string).assertHashIsCorrect();\n";
-    print F "        *(tagNamesEntry++) = AtomString(&string);\n";
+    print F "    for (unsigned i = 0; i < $unadjustedTagNamesCount; ++i) {\n";
+    print F "        auto impl = StringImpl::createStaticStringImpl(unadjustedTagNames[i], unadjustedTagNamesLengths[i]);\n";
+    print F "        impl->assertHashIsCorrect();\n";
+    print F "        *(tagNamesEntry++) = AtomString(impl.get());\n";
     print F "    }\n";
     print F "    ASSERT(tagNamesEntry == tagNameStrings->end());\n";
     print F "}\n";
@@ -1615,7 +1624,7 @@ sub printDefinitions
 
     my @tableEntryFields = (
         "LazyNeverDestroyed<const QualifiedName>* targetAddress",
-        "const StaticStringImpl& name",
+        "StringImpl* name",
         "NodeName nodeName"
     );
 
@@ -1634,13 +1643,13 @@ sub printDefinitions
         my $identifier = $namesRef->{$key}{identifier};
         my $nodeNameEnumValue = $namesRef->{$key}{nodeNameEnumValue} || "Unknown";
         # Attribute names never correspond to a recognized NodeName.
-        print F "        { $cast&$identifier$shortCamelType, *(&${identifier}Data), NodeName::$nodeNameEnumValue },\n";
+        print F "        { $cast&$identifier$shortCamelType, s_${identifier}Data.get(), NodeName::$nodeNameEnumValue },\n";
     }
 
     print F "    };\n";
     print F "\n";
     print F "    for (auto& entry : ${type}Table)\n";
-    print F "        entry.targetAddress->construct(nullAtom(), AtomString(&entry.name), $namespaceURI, Namespace::$namespaceEnumValue, entry.nodeName);\n";
+    print F "        entry.targetAddress->construct(nullAtom(), AtomString(entry.name), $namespaceURI, Namespace::$namespaceEnumValue, entry.nodeName);\n";
 }
 
 ## ElementFactory routines

--- a/Source/WebCore/platform/graphics/FontCascadeFonts.cpp
+++ b/Source/WebCore/platform/graphics/FontCascadeFonts.cpp
@@ -189,7 +189,7 @@ const FontRanges& FontCascadeFonts::realizeFallbackRangesAt(const FontCascadeDes
     if (!index) {
         fontRanges = realizeNextFallback(description, m_lastRealizedFallbackIndex, m_fontSelector.get());
         if (fontRanges.isNull() && m_fontSelector)
-            fontRanges = m_fontSelector->fontRangesForFamily(description, familyNamesData->at(FamilyNamesIndex::StandardFamily));
+            fontRanges = m_fontSelector->fontRangesForFamily(description, familyNames->at(FamilyNamesIndex::StandardFamily));
         if (fontRanges.isNull())
             fontRanges = FontRanges(FontCache::forCurrentThread().lastResortFallbackFont(description));
         return fontRanges;

--- a/Source/WebCore/style/StyleResolveForFontRaw.cpp
+++ b/Source/WebCore/style/StyleResolveForFontRaw.cpp
@@ -75,7 +75,7 @@ std::optional<FontCascade> resolveForFontRaw(const FontRaw& fontRaw, FontCascade
         switchOn(item, [&] (CSSValueID ident) {
             isGenericFamily = ident != CSSValueWebkitBody;
             if (isGenericFamily)
-                family = familyNamesData->at(CSSPropertyParserHelpers::genericFontFamilyIndex(ident));
+                family = familyNames->at(CSSPropertyParserHelpers::genericFontFamilyIndex(ident));
             else
                 family = AtomString(context.settingsValues().fontGenericFamilies.standardFontFamily());
         }, [&] (const AtomString& familyString) {

--- a/Source/WebKit/Shared/EntryPointUtilities/Cocoa/XPCService/XPCServiceMain.mm
+++ b/Source/WebKit/Shared/EntryPointUtilities/Cocoa/XPCService/XPCServiceMain.mm
@@ -243,11 +243,13 @@ int XPCServiceMain(int, const char**)
             }
         }
 #endif
-        auto webKitBundleVersion = String::fromLatin1(xpc_dictionary_get_string(bootstrap.get(), "WebKitBundleVersion"));
-        String expectedBundleVersion = [NSBundle bundleWithIdentifier:@"com.apple.WebKit"].infoDictionary[(__bridge NSString *)kCFBundleVersionKey];
-        if (!webKitBundleVersion.isNull() && !expectedBundleVersion.isNull() && webKitBundleVersion != expectedBundleVersion) {
-            auto errorMessage = makeString("WebKit framework version mismatch: ", webKitBundleVersion, " != ", expectedBundleVersion);
-            logAndSetCrashLogMessage(errorMessage.utf8().data());
+        const char* webKitBundleVersion = xpc_dictionary_get_string(bootstrap.get(), "WebKitBundleVersion");
+        const char* expectedBundleVersion = [[NSBundle bundleWithIdentifier:@"com.apple.WebKit"].infoDictionary[(__bridge NSString *)kCFBundleVersionKey] cStringUsingEncoding:NSISOLatin1StringEncoding];
+        if (!webKitBundleVersion || !expectedBundleVersion || strncmp(webKitBundleVersion, expectedBundleVersion, strlen(expectedBundleVersion))) {
+            const int msgLen = strlen("WebKit framework version mismatch: %s != %s\n") + strlen(webKitBundleVersion) + strlen(expectedBundleVersion);
+            char* msg = (char*) malloc(sizeof(char) * msgLen);
+            snprintf(msg, msgLen, "WebKit framework version mismatch: %s != %s\n", webKitBundleVersion, expectedBundleVersion);
+            logAndSetCrashLogMessage(msg);
             crashDueWebKitFrameworkVersionMismatch();
         }
 #endif

--- a/Source/WebKit/UIProcess/API/Cocoa/WKPreferences.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKPreferences.mm
@@ -29,6 +29,7 @@
 #import "APIArray.h"
 #import "Logging.h"
 #import "WKNSArray.h"
+#import "WebKit2Initialize.h"
 #import "WebPreferences.h"
 #import "_WKFeatureInternal.h"
 #import <WebCore/SecurityOrigin.h>
@@ -564,12 +565,14 @@ static _WKStorageBlockingPolicy toAPI(WebCore::StorageBlockingPolicy policy)
 
 + (NSArray<_WKFeature *> *)_features
 {
+    WebKit::InitializeWebKit2();
     auto features = WebKit::WebPreferences::features();
     return wrapper(API::Array::create(WTFMove(features)));
 }
 
 + (NSArray<_WKFeature *> *)_internalDebugFeatures
 {
+    WebKit::InitializeWebKit2();
     auto features = WebKit::WebPreferences::internalDebugFeatures();
     return wrapper(API::Array::create(WTFMove(features)));
 }
@@ -586,6 +589,7 @@ static _WKStorageBlockingPolicy toAPI(WebCore::StorageBlockingPolicy policy)
 
 + (NSArray<_WKExperimentalFeature *> *)_experimentalFeatures
 {
+    WebKit::InitializeWebKit2();
     auto features = WebKit::WebPreferences::experimentalFeatures();
     return wrapper(API::Array::create(WTFMove(features)));
 }

--- a/Tools/TestWebKitAPI/Tests/WTF/JSONValue.cpp
+++ b/Tools/TestWebKitAPI/Tests/WTF/JSONValue.cpp
@@ -699,22 +699,14 @@ TEST(JSONValue, MemoryCost)
         Ref<JSON::Value> value = JSON::Value::create(makeString("test"_s));
         size_t memoryCost = value->memoryCost();
         EXPECT_GT(memoryCost, 0U);
-#if HAVE(36BIT_ADDRESS)
         EXPECT_LE(memoryCost, 44U);
-#else
-        EXPECT_LE(memoryCost, 36U);
-#endif
     }
 
     {
         Ref<JSON::Value> value = JSON::Value::create(emptyString());
         size_t memoryCost = value->memoryCost();
         EXPECT_GT(memoryCost, 0U);
-#if HAVE(36BIT_ADDRESS)
         EXPECT_LE(memoryCost, 40U);
-#else
-        EXPECT_LE(memoryCost, 32U);
-#endif
     }
 
     {

--- a/Tools/TestWebKitAPI/Tests/WTF/StringImpl.cpp
+++ b/Tools/TestWebKitAPI/Tests/WTF/StringImpl.cpp
@@ -615,11 +615,11 @@ TEST(WTF, StringImplNullSymbolToAtomString)
     ASSERT_TRUE(result2);
 }
 
-static StringImpl::StaticStringImpl staticString {"Cocoa"};
+static StringImpl* staticString = MAKE_STATIC_STRING_IMPL("Cocoa");
 
 TEST(WTF, StringImplStaticToAtomString)
 {
-    StringImpl& original = staticString;
+    StringImpl& original = *staticString;
     ASSERT_FALSE(original.isSymbol());
     ASSERT_FALSE(original.isAtom());
     ASSERT_TRUE(original.isStatic());
@@ -732,23 +732,6 @@ TEST(WTF, DynamicStaticStringImpl)
     String hello2 = StringImpl::createStaticStringImpl("hello", 5);
 
     doStaticStringImplTests(StaticStringImplTestSet::DynamicallyAllocatedImpl, hello, world, longer, hello2);
-}
-
-static SymbolImpl::StaticSymbolImpl staticSymbol {"Cocoa"};
-static SymbolImpl::StaticSymbolImpl staticPrivateSymbol {"Cocoa", SymbolImpl::s_flagIsPrivate };
-
-TEST(WTF, StaticSymbolImpl)
-{
-    auto& symbol = static_cast<SymbolImpl&>(staticSymbol);
-    ASSERT_TRUE(symbol.isSymbol());
-    ASSERT_FALSE(symbol.isPrivate());
-}
-
-TEST(WTF, StaticPrivateSymbolImpl)
-{
-    auto& symbol = static_cast<SymbolImpl&>(staticPrivateSymbol);
-    ASSERT_TRUE(symbol.isSymbol());
-    ASSERT_TRUE(symbol.isPrivate());
 }
 
 TEST(WTF, ExternalStringImplCreate8bit)

--- a/Tools/TestWebKitAPI/Tests/WebCore/FileMonitor.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebCore/FileMonitor.cpp
@@ -42,16 +42,15 @@
 using namespace WebCore;
 
 namespace TestWebKitAPI {
-    
-const String FileMonitorTestData("This is a test"_s);
-const String FileMonitorRevisedData("This is some changed text for the test"_s);
-const String FileMonitorSecondRevisedData("This is some changed text for the test"_s);
 
 class FileMonitorTest : public testing::Test {
 public:
     void SetUp() override
     {
         WTF::initializeMainThread();
+        const String FileMonitorTestData("This is a test"_s);
+        const String FileMonitorRevisedData("This is some changed text for the test"_s);
+        const String FileMonitorSecondRevisedData("This is some changed text for the test"_s);
         
         // create temp file
         FileSystem::PlatformFileHandle handle;
@@ -122,6 +121,10 @@ TEST_F(FileMonitorTest, DetectChange)
 
     WTF::initializeMainThread();
 
+    const String FileMonitorTestData("This is a test"_s);
+    const String FileMonitorRevisedData("This is some changed text for the test"_s);
+    const String FileMonitorSecondRevisedData("This is some changed text for the test"_s);
+
     auto testQueue = WorkQueue::create("Test Work Queue");
 
     auto monitor = makeUnique<FileMonitor>(tempFilePath(), testQueue.copyRef(), [] (FileMonitor::FileChangeType type) {
@@ -136,7 +139,7 @@ TEST_F(FileMonitorTest, DetectChange)
         }
     });
 
-    testQueue->dispatch([this] () mutable {
+    testQueue->dispatch([=, this] () mutable {
         String fileContents = readContentsOfFile(tempFilePath());
         EXPECT_STREQ(FileMonitorTestData.utf8().data(), fileContents.utf8().data());
 
@@ -163,6 +166,9 @@ TEST_F(FileMonitorTest, DetectMultipleChanges)
     EXPECT_TRUE(FileSystem::fileExists(tempFilePath()));
 
     WTF::initializeMainThread();
+    const String FileMonitorTestData("This is a test"_s);
+    const String FileMonitorRevisedData("This is some changed text for the test"_s);
+    const String FileMonitorSecondRevisedData("This is some changed text for the test"_s);
 
     auto testQueue = WorkQueue::create("Test Work Queue");
 
@@ -178,7 +184,7 @@ TEST_F(FileMonitorTest, DetectMultipleChanges)
         }
     });
     
-    testQueue->dispatch([this] () mutable {
+    testQueue->dispatch([=, this] () mutable {
         String fileContents = readContentsOfFile(tempFilePath());
         EXPECT_STREQ(FileMonitorTestData.utf8().data(), fileContents.utf8().data());
 
@@ -199,7 +205,7 @@ TEST_F(FileMonitorTest, DetectMultipleChanges)
 
     resetTestState();
 
-    testQueue->dispatch([this] () mutable {
+    testQueue->dispatch([=, this] () mutable {
         auto secondCommand = createCommand(tempFilePath(), FileMonitorSecondRevisedData);
         auto rc = system(secondCommand.utf8().data());
         ASSERT_NE(rc, -1);
@@ -258,6 +264,9 @@ TEST_F(FileMonitorTest, DetectChangeAndThenDelete)
     EXPECT_TRUE(FileSystem::fileExists(tempFilePath()));
 
     WTF::initializeMainThread();
+    const String FileMonitorTestData("This is a test"_s);
+    const String FileMonitorRevisedData("This is some changed text for the test"_s);
+    const String FileMonitorSecondRevisedData("This is some changed text for the test"_s);
 
     auto testQueue = WorkQueue::create("Test Work Queue");
 
@@ -273,7 +282,7 @@ TEST_F(FileMonitorTest, DetectChangeAndThenDelete)
         }
     });
 
-    testQueue->dispatch([this] () mutable {
+    testQueue->dispatch([=, this] () mutable {
         String fileContents = readContentsOfFile(tempFilePath());
         EXPECT_STREQ(FileMonitorTestData.utf8().data(), fileContents.utf8().data());
 
@@ -312,6 +321,10 @@ TEST_F(FileMonitorTest, DetectDeleteButNotSubsequentChange)
 
     WTF::initializeMainThread();
 
+    const String FileMonitorTestData("This is a test"_s);
+    const String FileMonitorRevisedData("This is some changed text for the test"_s);
+    const String FileMonitorSecondRevisedData("This is some changed text for the test"_s);
+
     auto testQueue = WorkQueue::create("Test Work Queue");
 
     auto monitor = makeUnique<FileMonitor>(tempFilePath(), testQueue.copyRef(), [] (FileMonitor::FileChangeType type) {
@@ -340,7 +353,7 @@ TEST_F(FileMonitorTest, DetectDeleteButNotSubsequentChange)
 
     resetTestState();
 
-    testQueue->dispatch([this] () mutable {
+    testQueue->dispatch([=, this] () mutable {
         EXPECT_FALSE(FileSystem::fileExists(tempFilePath()));
 
         auto handle = FileSystem::openFile(tempFilePath(), FileSystem::FileOpenMode::Truncate);

--- a/Tools/TestWebKitAPI/Tests/WebCore/PrivateClickMeasurement.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebCore/PrivateClickMeasurement.cpp
@@ -36,14 +36,13 @@ namespace TestWebKitAPI {
 
 constexpr uint32_t min6BitValue { 0 };
 
-const URL webKitURL { "https://webkit.org"_s };
-const URL exampleURL { "https://example.com"_s };
-const URL emptyURL { };
-
 // Positive test cases.
 
 TEST(PrivateClickMeasurement, WellKnownURLs)
 {
+    const URL webKitURL { "https://webkit.org"_s };
+    const URL exampleURL { "https://example.com"_s };
+    const URL emptyURL { };
     PrivateClickMeasurement attribution { PrivateClickMeasurement::SourceID(min6BitValue), PCM::SourceSite { webKitURL }, PCM::AttributionDestinationSite { exampleURL }, "test.bundle.identifier"_s, WallTime::now(), PCM::AttributionEphemeral::No };
     attribution.attributeAndGetEarliestTimeToSend(WebCore::PCM::AttributionTriggerData { min6BitValue, WebCore::PCM::AttributionTriggerData::Priority::PriorityValue(min6BitValue), { }, { }, { }, { }, { }, { } }, WebCore::PrivateClickMeasurement::IsRunningLayoutTest::No);
 
@@ -55,6 +54,9 @@ TEST(PrivateClickMeasurement, WellKnownURLs)
 
 TEST(PrivateClickMeasurement, ValidMinValues)
 {
+    const URL webKitURL { "https://webkit.org"_s };
+    const URL exampleURL { "https://example.com"_s };
+    const URL emptyURL { };
     PrivateClickMeasurement attribution { PrivateClickMeasurement::SourceID(min6BitValue), PCM::SourceSite { webKitURL }, PCM::AttributionDestinationSite { exampleURL }, "test.bundle.identifier"_s, WallTime::now(), PCM::AttributionEphemeral::No };
     attribution.attributeAndGetEarliestTimeToSend(WebCore::PCM::AttributionTriggerData { min6BitValue, WebCore::PCM::AttributionTriggerData::Priority::PriorityValue(min6BitValue), { }, { }, { }, { }, { }, { } }, WebCore::PrivateClickMeasurement::IsRunningLayoutTest::No);
 
@@ -63,6 +65,9 @@ TEST(PrivateClickMeasurement, ValidMinValues)
 
 TEST(PrivateClickMeasurement, ValidMidValues)
 {
+    const URL webKitURL { "https://webkit.org"_s };
+    const URL exampleURL { "https://example.com"_s };
+    const URL emptyURL { };
     PrivateClickMeasurement attribution { PrivateClickMeasurement::SourceID((uint32_t)192), PCM::SourceSite { webKitURL }, PCM::AttributionDestinationSite { exampleURL }, "test.bundle.identifier"_s, WallTime::now(), PCM::AttributionEphemeral::No };
     attribution.attributeAndGetEarliestTimeToSend(WebCore::PCM::AttributionTriggerData { (uint32_t)9, WebCore::PCM::AttributionTriggerData::Priority::PriorityValue((uint32_t)22), { }, { }, { }, { }, { }, { } }, WebCore::PrivateClickMeasurement::IsRunningLayoutTest::No);
 
@@ -71,6 +76,9 @@ TEST(PrivateClickMeasurement, ValidMidValues)
 
 TEST(PrivateClickMeasurement, ValidMaxValues)
 {
+    const URL webKitURL { "https://webkit.org"_s };
+    const URL exampleURL { "https://example.com"_s };
+    const URL emptyURL { };
     PrivateClickMeasurement attribution { PrivateClickMeasurement::SourceID(std::numeric_limits<uint8_t>::max()), PCM::SourceSite { webKitURL }, PCM::AttributionDestinationSite { exampleURL }, "test.bundle.identifier"_s, WallTime::now(), PCM::AttributionEphemeral::No };
     attribution.attributeAndGetEarliestTimeToSend(WebCore::PCM::AttributionTriggerData { WebCore::PCM::AttributionTriggerData::MaxEntropy, WebCore::PCM::AttributionTriggerData::Priority::PriorityValue(WebCore::PCM::AttributionTriggerData::Priority::MaxEntropy), { }, { }, { }, { }, { }, { } }, WebCore::PrivateClickMeasurement::IsRunningLayoutTest::No);
 
@@ -79,6 +87,9 @@ TEST(PrivateClickMeasurement, ValidMaxValues)
 
 TEST(PrivateClickMeasurement, EarliestTimeToSendAttributionMinimumDelay)
 {
+    const URL webKitURL { "https://webkit.org"_s };
+    const URL exampleURL { "https://example.com"_s };
+    const URL emptyURL { };
     PrivateClickMeasurement attribution { PrivateClickMeasurement::SourceID(std::numeric_limits<uint8_t>::max()), PCM::SourceSite { webKitURL }, PCM::AttributionDestinationSite { exampleURL }, "test.bundle.identifier"_s, WallTime::now(), PCM::AttributionEphemeral::No };
     auto now = WallTime::now();
     attribution.attributeAndGetEarliestTimeToSend(WebCore::PCM::AttributionTriggerData { WebCore::PCM::AttributionTriggerData::MaxEntropy, WebCore::PCM::AttributionTriggerData::Priority::PriorityValue(WebCore::PCM::AttributionTriggerData::Priority::MaxEntropy), { }, { }, { }, { }, { }, { } }, WebCore::PrivateClickMeasurement::IsRunningLayoutTest::No);
@@ -134,6 +145,9 @@ TEST(PrivateClickMeasurement, ValidSourceNonce)
 
 TEST(PrivateClickMeasurement, InvalidSourceHost)
 {
+    const URL webKitURL { "https://webkit.org"_s };
+    const URL exampleURL { "https://example.com"_s };
+    const URL emptyURL { };
     PrivateClickMeasurement attribution { PrivateClickMeasurement::SourceID(std::numeric_limits<uint8_t>::max()), PCM::SourceSite { emptyURL }, PCM::AttributionDestinationSite { exampleURL }, "test.bundle.identifier"_s, WallTime::now(), PCM::AttributionEphemeral::No };
     attribution.attributeAndGetEarliestTimeToSend(WebCore::PCM::AttributionTriggerData { WebCore::PCM::AttributionTriggerData::MaxEntropy, WebCore::PCM::AttributionTriggerData::Priority::PriorityValue(WebCore::PCM::AttributionTriggerData::Priority::MaxEntropy), { }, { }, { }, { }, { }, { } }, WebCore::PrivateClickMeasurement::IsRunningLayoutTest::No);
 
@@ -143,6 +157,9 @@ TEST(PrivateClickMeasurement, InvalidSourceHost)
 
 TEST(PrivateClickMeasurement, InvalidDestinationHost)
 {
+    const URL webKitURL { "https://webkit.org"_s };
+    const URL exampleURL { "https://example.com"_s };
+    const URL emptyURL { };
     PrivateClickMeasurement attribution { PrivateClickMeasurement::SourceID(std::numeric_limits<uint8_t>::max()), PCM::SourceSite { webKitURL }, PCM::AttributionDestinationSite { emptyURL }, "test.bundle.identifier"_s, WallTime::now(), PCM::AttributionEphemeral::No };
     attribution.attributeAndGetEarliestTimeToSend(WebCore::PCM::AttributionTriggerData { WebCore::PCM::AttributionTriggerData::MaxEntropy, WebCore::PCM::AttributionTriggerData::Priority::PriorityValue(WebCore::PCM::AttributionTriggerData::Priority::MaxEntropy), { }, { }, { }, { }, { }, { } }, WebCore::PrivateClickMeasurement::IsRunningLayoutTest::No);
 
@@ -152,6 +169,9 @@ TEST(PrivateClickMeasurement, InvalidDestinationHost)
 
 TEST(PrivateClickMeasurement, AttributionTriggerData)
 {
+    const URL webKitURL { "https://webkit.org"_s };
+    const URL exampleURL { "https://example.com"_s };
+    const URL emptyURL { };
     PrivateClickMeasurement attribution { PrivateClickMeasurement::SourceID(std::numeric_limits<uint8_t>::max()), PCM::SourceSite { webKitURL }, PCM::AttributionDestinationSite { exampleURL }, "test.bundle.identifier"_s, WallTime::now(), PCM::AttributionEphemeral::No };
     attribution.attributeAndGetEarliestTimeToSend(WebCore::PCM::AttributionTriggerData { (WebCore::PCM::AttributionTriggerData::MaxEntropy + 1), WebCore::PCM::AttributionTriggerData::Priority::PriorityValue(WebCore::PCM::AttributionTriggerData::Priority::MaxEntropy), { }, { }, { }, { }, { }, { } }, WebCore::PrivateClickMeasurement::IsRunningLayoutTest::No);
 
@@ -161,6 +181,9 @@ TEST(PrivateClickMeasurement, AttributionTriggerData)
 
 TEST(PrivateClickMeasurement, InvalidPriority)
 {
+    const URL webKitURL { "https://webkit.org"_s };
+    const URL exampleURL { "https://example.com"_s };
+    const URL emptyURL { };
     PrivateClickMeasurement attribution { PrivateClickMeasurement::SourceID(std::numeric_limits<uint8_t>::max()), PCM::SourceSite { webKitURL }, PCM::AttributionDestinationSite { exampleURL }, "test.bundle.identifier"_s, WallTime::now(), PCM::AttributionEphemeral::No };
     attribution.attributeAndGetEarliestTimeToSend(WebCore::PCM::AttributionTriggerData { WebCore::PCM::AttributionTriggerData::MaxEntropy, WebCore::PCM::AttributionTriggerData::Priority::PriorityValue(WebCore::PCM::AttributionTriggerData::Priority::MaxEntropy + 1), { }, { }, { }, { }, { }, { } }, WebCore::PrivateClickMeasurement::IsRunningLayoutTest::No);
 
@@ -170,6 +193,9 @@ TEST(PrivateClickMeasurement, InvalidPriority)
 
 TEST(PrivateClickMeasurement, InvalidMissingConversion)
 {
+    const URL webKitURL { "https://webkit.org"_s };
+    const URL exampleURL { "https://example.com"_s };
+    const URL emptyURL { };
     PrivateClickMeasurement attribution { PrivateClickMeasurement::SourceID(std::numeric_limits<uint8_t>::max()), PCM::SourceSite { webKitURL }, PCM::AttributionDestinationSite { exampleURL }, "test.bundle.identifier"_s, WallTime::now(), PCM::AttributionEphemeral::No };
 
     ASSERT_TRUE(attribution.attributionReportClickSourceURL().isEmpty());


### PR DESCRIPTION
#### 39a1ff098a4ebfd7b753243ba2d609fc5ef763eb
<pre>
Remove static strings and symbols
<a href="https://bugs.webkit.org/show_bug.cgi?id=256744">https://bugs.webkit.org/show_bug.cgi?id=256744</a>
rdar://109287900

Reviewed by Yusuke Suzuki.

We would like to make StringImpl*, JSString* and JSRopeString* fit into
32 bits.

Why?
- This has the potential to save memory and improve cache locallity.
- Previously, when Yusuke made JSRopeString smaller by squishing the ropes
    together, it was a 1% Speedometer regression. This will let us undo
    that change while keeping the size of JSRopeString small.

We need to:
1) Forbid precice allocation
2) Ensure 16-byte alignment

This patch does both of these things, and should be sufficient to enable
CompactPtr&lt;StringImpl&gt; to work on iOS (although this patch doesn&apos;t do that).

On macOS, pointers are 48-bit instead of 36-bit, so we have more work to do:
1) Make sure that all strings are allocated out of the same malloc region
2) Allocate a chunk of va space for them, and plumb the base pointer around

This patch does the first thing.

Isn&apos;t removing static strings going to be a memory regression?

Well, hopefully not. Today we still increment the ref count of static strings,
so the memory is dirtied. After applying this patch, the character data will
still be static, but the StringImpl itself (which remember, was always dirty)
will be placed next to its bretheren.

This patch might introduce some concurrency bugs though. By inspection I
have tried to match the existing invariants, but I don&apos;t know if I have
spotted everything.

* Source/JavaScriptCore/builtins/BuiltinExecutables.cpp:
(JSC::BuiltinExecutables::defaultConstructorSourceCode):
* Source/JavaScriptCore/builtins/BuiltinExecutables.h:
* Source/JavaScriptCore/builtins/BuiltinNames.cpp:
(JSC::Symbols::initializeStaticSymbols):
(JSC::BuiltinNames::BuiltinNames):
(): Deleted.
* Source/JavaScriptCore/builtins/BuiltinNames.h:
* Source/JavaScriptCore/runtime/InitializeThreading.cpp:
(JSC::initialize):
* Source/JavaScriptCore/runtime/JSString.h:
(JSC::JSString::destroy): Deleted.
(JSC::JSString::subspaceFor): Deleted.
(JSC::JSString::uninitializedValueInternal const): Deleted.
(JSC::JSString::valueInternal const): Deleted.
(JSC::JSString::JSString): Deleted.
(JSC::JSString::finishCreation): Deleted.
(JSC::JSString::create): Deleted.
(JSC::JSString::createHasOtherOwner): Deleted.
(JSC::JSString::toBoolean const): Deleted.
(JSC::JSString::canGetIndex): Deleted.
(JSC::JSString::offsetOfValue): Deleted.
(JSC::JSString::isRope const): Deleted.
(JSC::JSString::fiberConcurrently const): Deleted.
* Source/JavaScriptCore/runtime/SmallStrings.cpp:
* Source/JavaScriptCore/runtime/SmallStrings.h:
(JSC::SmallString::initializeJSStaticStrings):
* Source/JavaScriptCore/runtime/VM.cpp:
(JSC::VM::ensureTerminationException):
(): Deleted.
* Source/WTF/wtf/CompactPtr.h:
(WTF::CompactPtr::operator!=):
(WTF::CompactPtr::storage const):
(WTF::CompactPtr::storage):
* Source/WTF/wtf/Threading.cpp:
(WTF::initialize):
* Source/WTF/wtf/URL.cpp:
(WTF::aboutBlankURL):
(WTF::aboutSrcDocURL):
(): Deleted.
* Source/WTF/wtf/text/AtomString.cpp:
(WTF::nullAtom):
(WTF::emptyAtom):
(WTF::AtomString::initializeStrings):
(): Deleted.
* Source/WTF/wtf/text/AtomString.h:
(WTF::StaticAtomString::StaticAtomString): Deleted.
(WTF::nullAtom): Deleted.
(WTF::emptyAtom): Deleted.
* Source/WTF/wtf/text/AtomStringImpl.cpp:
* Source/WTF/wtf/text/AtomStringImpl.h:
(WTF::ValueCheck&lt;AtomStringImpl::checkConsistency): Deleted.
* Source/WTF/wtf/text/StringImpl.cpp:
(WTF::StringImpl::createStaticStringImplWithoutCopying):
(WTF::StringImpl::createStaticStringImpl):
* Source/WTF/wtf/text/StringImpl.h:
(WTF::StringImpl::createStaticStringImplWithoutCopying):
(WTF::StringImpl::empty):
(WTF::StringImpl::initializeEmptyString):
(WTF::StringImpl::StringImpl):
(WTF::StringImpl::cost const):
(WTF::ValueCheck&lt;StringImpl::checkConsistency): Deleted.
(WTF::StringImpl::StaticStringImpl::StaticStringImpl): Deleted.
(WTF::StringImpl::StaticStringImpl::operator StringImpl&amp;): Deleted.
* Source/WTF/wtf/text/SymbolImpl.cpp:
(WTF::SymbolImpl::createStatic):
(WTF::PrivateSymbolImpl::createStatic):
* Source/WTF/wtf/text/SymbolImpl.h:
(WTF::SymbolImpl::create):
(WTF::SymbolImpl::createStatic):
(WTF::ValueCheck&lt;SymbolImpl::checkConsistency): Deleted.
* Source/WTF/wtf/text/UniquedStringImpl.h:
(WTF::ValueCheck&lt;UniquedStringImpl::checkConsistency): Deleted.
(): Deleted.
* Source/WTF/wtf/text/WTFString.cpp:
(WTF::nullString):
(WTF::emptyString):
(WTF::String::initializeStrings):
* Source/WTF/wtf/text/WTFString.h:
(WTF::StaticString::StaticString): Deleted.
(WTF::nullString): Deleted.
(WTF::emptyString): Deleted.
* Source/WebCore/bindings/scripts/StaticString.pm:
(GenerateStrings):
(GenerateStringAsserts):
* Source/WebCore/css/CSSFontFaceSet.cpp:
(WebCore::CSSFontFaceSet::matchingFacesExcludingPreinstalledFonts):
* Source/WebCore/css/CSSFontSelector.cpp:
(WebCore::m_version):
* Source/WebCore/dom/Document.cpp:
(WebCore::Document::maskedURLForBindings):
(WebCore::Document::maskedURLStringForBindings): Deleted.
* Source/WebCore/dom/Document.h:
* Source/WebCore/dom/Element.cpp:
(WebCore::Element::resolveURLStringIfNeeded const):
* Source/WebCore/dom/make_names.pl:
(printTagNameCppFile):
(printDefinitions):
* Source/WebCore/platform/graphics/FontCascadeFonts.cpp:
(WebCore::FontCascadeFonts::realizeFallbackRangesAt):
* Source/WebCore/style/StyleResolveForFontRaw.cpp:
(WebCore::Style::resolveForFontRaw):
* Source/WebKit/Scripts/PreferencesTemplates/WebPreferencesFeatures.cpp.erb:
* Source/WebKit/Shared/EntryPointUtilities/Cocoa/XPCService/XPCServiceMain.mm:
(WebKit::XPCServiceMain):
* Tools/TestWebKitAPI/Tests/WTF/StringImpl.cpp:
(TestWebKitAPI::TEST):
(): Deleted.

Canonical link: <a href="https://commits.webkit.org/264265@main">https://commits.webkit.org/264265@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/422256def58aaa8f4b32e5a83d62c428e6052911

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/7125 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/7370 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/7549 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/8739 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/7349 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/7135 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/8632 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/7302 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/10247 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/7252 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/7906 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/6564 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/8845 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/5262 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/6482 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/14230 "Passed tests") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/6035 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/6926 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/6581 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/9455 "Passed tests") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/6707 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/7061 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/5775 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/7262 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/6421 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/1684 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/1702 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/10620 "Built successfully") | | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/24/builds/7463 "Built successfully") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/6804 "Built successfully") | | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/3/builds/1824 "Passed tests") | 
<!--EWS-Status-Bubble-End-->