### PR TITLE
REGRESSION (263946@main): Scroll momentum broken

### DIFF
--- a/Source/WebCore/PAL/pal/HysteresisActivity.h
+++ b/Source/WebCore/PAL/pal/HysteresisActivity.h
@@ -71,8 +71,11 @@ public:
         if (m_active)
             return;
 
-        if (state() == HysteresisState::Stopped)
+        if (state() == HysteresisState::Stopped) {
+            m_active = true;
             m_callback(HysteresisState::Started);
+            m_active = false;
+        }
 
         m_timer.startOneShot(m_hysteresisSeconds);
     }

--- a/Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/project.pbxproj
+++ b/Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/project.pbxproj
@@ -84,6 +84,7 @@
 		0F5651F91FCE513500310FBC /* scroll-to-anchor.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = 0F5651F81FCE50E800310FBC /* scroll-to-anchor.html */; };
 		0FEFAF64271FC2CD005704D7 /* ScrollingCoordinatorTests.mm in Sources */ = {isa = PBXBuildFile; fileRef = 0FEFAF63271FC2CD005704D7 /* ScrollingCoordinatorTests.mm */; };
 		0FF1134E22D68679009A81DA /* ScrollViewScrollabilityTests.mm in Sources */ = {isa = PBXBuildFile; fileRef = 0FF1134D22D68679009A81DA /* ScrollViewScrollabilityTests.mm */; };
+		0FF332932A0EFCCF00C048D8 /* HysteresisActivityTests.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0FF3328B2A0EFCCF00C048D8 /* HysteresisActivityTests.cpp */; };
 		115EB3431EE0BA03003C2C0A /* ViewportSizeForViewportUnits.mm in Sources */ = {isa = PBXBuildFile; fileRef = 115EB3421EE0B720003C2C0A /* ViewportSizeForViewportUnits.mm */; };
 		1171B24F219F49CD00CB897D /* FirstMeaningfulPaintMilestone_Bundle.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 11B7FD21219F46DD0069B27F /* FirstMeaningfulPaintMilestone_Bundle.cpp */; };
 		118153442208B7AC00B2CCD2 /* deferred-script-load.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = 118153432208B7AC00B2CCD2 /* deferred-script-load.html */; };
@@ -2001,6 +2002,7 @@
 		0FEAE3671B7D19CB00CE17F2 /* Condition.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = Condition.cpp; sourceTree = "<group>"; };
 		0FEFAF63271FC2CD005704D7 /* ScrollingCoordinatorTests.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = ScrollingCoordinatorTests.mm; sourceTree = "<group>"; };
 		0FF1134D22D68679009A81DA /* ScrollViewScrollabilityTests.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = ScrollViewScrollabilityTests.mm; sourceTree = "<group>"; };
+		0FF3328B2A0EFCCF00C048D8 /* HysteresisActivityTests.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = HysteresisActivityTests.cpp; sourceTree = "<group>"; };
 		0FFC45A41B73EBE20085BD62 /* Lock.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = Lock.cpp; sourceTree = "<group>"; };
 		115EB3421EE0B720003C2C0A /* ViewportSizeForViewportUnits.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = ViewportSizeForViewportUnits.mm; sourceTree = "<group>"; };
 		118153432208B7AC00B2CCD2 /* deferred-script-load.html */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.html; path = "deferred-script-load.html"; sourceTree = "<group>"; };
@@ -4275,6 +4277,7 @@
 				5CA1DEC71F71F40700E71BD3 /* HTTPHeaderField.cpp */,
 				46FA2FED23846C9A000CCB0C /* HTTPHeaderMap.cpp */,
 				6B9ABE112086952F00D75DE6 /* HTTPParsers.cpp */,
+				0FF3328B2A0EFCCF00C048D8 /* HysteresisActivityTests.cpp */,
 				7B18417B2673860200ED4F8D /* ImageBufferTests.cpp */,
 				7A909A731D877475007E10F8 /* IntPointTests.cpp */,
 				7A909A741D877475007E10F8 /* IntRectTests.cpp */,
@@ -6390,6 +6393,7 @@
 				46FA2FEE23846CA5000CCB0C /* HTTPHeaderMap.cpp in Sources */,
 				6B9ABE122086952F00D75DE6 /* HTTPParsers.cpp in Sources */,
 				5C7C24FC237C975400599C91 /* HTTPServer.mm in Sources */,
+				0FF332932A0EFCCF00C048D8 /* HysteresisActivityTests.cpp in Sources */,
 				7B18417C2673860200ED4F8D /* ImageBufferTests.cpp in Sources */,
 				41EBA9F228ABA06700953013 /* ImageRotationSessionVT.cpp in Sources */,
 				F44A9AF72649BBDD00E7CB16 /* ImmediateActionTests.mm in Sources */,

--- a/Tools/TestWebKitAPI/Tests/WebCore/HysteresisActivityTests.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebCore/HysteresisActivityTests.cpp
@@ -1,0 +1,177 @@
+/*
+ * Copyright (C) 2023 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+
+#include "PlatformUtilities.h"
+#include "Test.h"
+#include <pal/HysteresisActivity.h>
+#include <wtf/Assertions.h>
+#include <wtf/MainThread.h>
+
+namespace TestWebKitAPI {
+
+static const Seconds hysteresisDuration { 2_ms };
+
+static bool hysteresisTestDone;
+static bool endTestInCallback;
+
+TEST(HysteresisActivity, BasicState)
+{
+    PAL::HysteresisActivity activity([](PAL::HysteresisState state) {
+        if (endTestInCallback)
+            hysteresisTestDone = true;
+    }, hysteresisDuration);
+
+    hysteresisTestDone = false;
+    endTestInCallback = false;
+
+    EXPECT_EQ(activity.state(), PAL::HysteresisState::Stopped);
+    activity.start();
+    EXPECT_EQ(activity.state(), PAL::HysteresisState::Started);
+
+    endTestInCallback = true;
+    activity.stop();
+    EXPECT_EQ(activity.state(), PAL::HysteresisState::Started);
+
+    TestWebKitAPI::Util::run(&hysteresisTestDone);
+    EXPECT_EQ(activity.state(), PAL::HysteresisState::Stopped);
+}
+
+TEST(HysteresisActivity, ImpulseState)
+{
+    PAL::HysteresisActivity activity([](PAL::HysteresisState state) {
+        if (endTestInCallback)
+            hysteresisTestDone = true;
+    }, hysteresisDuration);
+
+    hysteresisTestDone = false;
+    endTestInCallback = false;
+
+    activity.impulse();
+    EXPECT_EQ(activity.state(), PAL::HysteresisState::Started);
+
+    endTestInCallback = true;
+    TestWebKitAPI::Util::run(&hysteresisTestDone);
+    EXPECT_EQ(activity.state(), PAL::HysteresisState::Stopped);
+
+    hysteresisTestDone = false;
+    endTestInCallback = false;
+
+    activity.start();
+    activity.impulse();
+    EXPECT_EQ(activity.state(), PAL::HysteresisState::Started);
+    activity.stop();
+    endTestInCallback = true;
+    TestWebKitAPI::Util::run(&hysteresisTestDone);
+    EXPECT_EQ(activity.state(), PAL::HysteresisState::Stopped);
+
+    hysteresisTestDone = false;
+    endTestInCallback = false;
+
+    activity.impulse();
+    EXPECT_EQ(activity.state(), PAL::HysteresisState::Started);
+    endTestInCallback = true;
+    TestWebKitAPI::Util::run(&hysteresisTestDone);
+    EXPECT_EQ(activity.state(), PAL::HysteresisState::Stopped);
+}
+
+TEST(HysteresisActivity, StateInCallback)
+{
+    std::optional<PAL::HysteresisState> callbackState;
+    PAL::HysteresisActivity activity([&callbackState](PAL::HysteresisState state) {
+        callbackState = state;
+        if (endTestInCallback)
+            hysteresisTestDone = true;
+    }, hysteresisDuration);
+
+    hysteresisTestDone = false;
+    endTestInCallback = false;
+
+    activity.start();
+    EXPECT_TRUE(callbackState);
+    EXPECT_EQ(*callbackState, PAL::HysteresisState::Started);
+
+    callbackState = { };
+    activity.stop();
+    endTestInCallback = true;
+    TestWebKitAPI::Util::run(&hysteresisTestDone);
+    EXPECT_TRUE(callbackState);
+    EXPECT_EQ(*callbackState, PAL::HysteresisState::Stopped);
+}
+
+TEST(HysteresisActivity, ImpulseStateInCallback)
+{
+    std::optional<PAL::HysteresisState> callbackState;
+    PAL::HysteresisActivity activity([&callbackState](PAL::HysteresisState state) {
+        callbackState = state;
+        if (endTestInCallback)
+            hysteresisTestDone = true;
+    }, hysteresisDuration);
+
+    hysteresisTestDone = false;
+    endTestInCallback = false;
+
+    activity.impulse();
+    EXPECT_TRUE(callbackState);
+    EXPECT_EQ(*callbackState, PAL::HysteresisState::Started);
+
+    callbackState = { };
+    endTestInCallback = true;
+    TestWebKitAPI::Util::run(&hysteresisTestDone);
+    EXPECT_TRUE(callbackState);
+    EXPECT_EQ(*callbackState, PAL::HysteresisState::Stopped);
+}
+
+TEST(HysteresisActivity, ActiveInCallback)
+{
+    struct CallbackData {
+        std::optional<PAL::HysteresisState> state;
+        PAL::HysteresisActivity* activity;
+    } callbackData;
+
+    PAL::HysteresisActivity activity([&callbackData](PAL::HysteresisState) {
+        callbackData.state = callbackData.activity->state();
+        if (endTestInCallback)
+            hysteresisTestDone = true;
+    }, hysteresisDuration);
+
+    callbackData.activity = &activity;
+
+    hysteresisTestDone = false;
+    endTestInCallback = false;
+
+    activity.impulse();
+    EXPECT_TRUE(callbackData.state);
+    EXPECT_EQ(*callbackData.state, PAL::HysteresisState::Started);
+
+    callbackData.state = { };
+    endTestInCallback = true;
+    TestWebKitAPI::Util::run(&hysteresisTestDone);
+    EXPECT_TRUE(callbackData.state);
+    EXPECT_EQ(*callbackData.state, PAL::HysteresisState::Stopped);
+}
+
+} // namespace TestWebKitAPI


### PR DESCRIPTION
#### 373d24af71c6ad6f1c03e521fa42de23dc98490a
<pre>
REGRESSION (263946@main): Scroll momentum broken
<a href="https://bugs.webkit.org/show_bug.cgi?id=256748">https://bugs.webkit.org/show_bug.cgi?id=256748</a>
rdar://109274749

Reviewed by Chris Dumez.

After 263946@main, reading HysteresisActivity::state() inside of the `started` callback, triggered
from a call to HysteresisActivity::impulse() returned HysteresisState::Stopped when it should have
returned HysteresisState::Started. This is because we no longer toggled m_active to true, and the
time wasn&apos;t started yet.

Fix by toggling m_active to true around the callback. I tried just swapping ordering with the timer
start, but that also caused in behavior changes, as indicated by the new API tests.

Add a set of API tests for HysteresisActivity so we don&apos;t mess up again in future.

* Source/WebCore/PAL/pal/HysteresisActivity.h:
(PAL::HysteresisActivity::impulse):
* Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/project.pbxproj:
* Tools/TestWebKitAPI/Tests/WebCore/HysteresisActivityTests.cpp: Added.
(TestWebKitAPI::TEST):

Canonical link: <a href="https://commits.webkit.org/264049@main">https://commits.webkit.org/264049@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/7826f0b5c8c233c8dc5299a7a1d112573e684887

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/6519 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/6729 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/6910 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/8098 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/6803 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/6515 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/7081 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/6680 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/9698 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/6633 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/6705 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/5910 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/8178 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/4167 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/5887 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/13728 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/6116 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/5967 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/8320 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/6450 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/5275 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/5853 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/1540 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/10015 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/6225 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->