### PR TITLE
Don't add empty rects during addFocusRingRects

### DIFF
--- a/LayoutTests/fast/css/ignore-empty-focus-ring-rects-expected.html
+++ b/LayoutTests/fast/css/ignore-empty-focus-ring-rects-expected.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<style>
+.container {
+  position: absolute;
+  width: 100px;
+  margin-top: 50px;
+  height: 100px;
+  background-color: green;
+  outline: -webkit-focus-ring-color auto 5px;
+}
+</style>
+<div class="container"></div>

--- a/LayoutTests/fast/css/ignore-empty-focus-ring-rects.html
+++ b/LayoutTests/fast/css/ignore-empty-focus-ring-rects.html
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<style>
+.container {
+  position: absolute;
+  width: 100px;
+}
+.focus {
+  outline: -webkit-focus-ring-color auto 5px;
+}
+.sub {
+  margin-top: 50px;
+  width: 100px;
+  height: 100px;
+  background-color: green;
+}
+</style>
+<div class="container">
+  <span class="focus">
+    <div class="sub"></div>
+  </span>
+</div>

--- a/Source/WebCore/rendering/RenderInline.cpp
+++ b/Source/WebCore/rendering/RenderInline.cpp
@@ -1,7 +1,8 @@
 /*
  * Copyright (C) 1999 Lars Knoll (knoll@kde.org)
  *           (C) 1999 Antti Koivisto (koivisto@kde.org)
- * Copyright (C) 2003-2022 Apple Inc. All rights reserved.
+ * Copyright (C) 2003-2023 Apple Inc. All rights reserved.
+ * Copyright (C) 2014 Google Inc. All rights reserved.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Library General Public
@@ -918,9 +919,23 @@ void RenderInline::imageChanged(WrappedImagePtr, const IntRect*)
     repaint();
 }
 
+namespace {
+    class AbsoluteRectsIgnoringEmptyGeneratorContext : public AbsoluteRectsGeneratorContext {
+        public:
+            AbsoluteRectsIgnoringEmptyGeneratorContext(Vector<LayoutRect>& rects, const LayoutPoint& accumulatedOffset)
+                : AbsoluteRectsGeneratorContext(rects, accumulatedOffset) { }
+
+                void addRect(const FloatRect& rect)
+                {
+                    if (!rect.isEmpty())
+                        AbsoluteRectsGeneratorContext::addRect(rect);
+                }
+    };
+} // unnamed namespace
+
 void RenderInline::addFocusRingRects(Vector<LayoutRect>& rects, const LayoutPoint& additionalOffset, const RenderLayerModelObject* paintContainer) const
 {
-    AbsoluteRectsGeneratorContext context(rects, additionalOffset);
+    AbsoluteRectsIgnoringEmptyGeneratorContext context(rects, additionalOffset);
     generateLineBoxRects(context);
 
     for (auto& child : childrenOfType<RenderElement>(*this)) {


### PR DESCRIPTION
#### 9db465cd1226e45cbce6dc0c9e058b9bb59ff918
<pre>
Don&apos;t add empty rects during addFocusRingRects

<a href="https://bugs.webkit.org/show_bug.cgi?id=249930">https://bugs.webkit.org/show_bug.cgi?id=249930</a>
rdar://problem/103897005

Reviewed by Alan Baradlay.

Merge: <a href="https://chromium.googlesource.com/chromium/blink/+/2cf30f0fb85c90f6ae813264aa0d0dcc9a85ab58">https://chromium.googlesource.com/chromium/blink/+/2cf30f0fb85c90f6ae813264aa0d0dcc9a85ab58</a>

We don&apos;t add empty rects during addFocusRingRects except during
generateLineBoxRects in RenderInline::addFocusRingRects.

Empty rects in focus ring rects causes small circle drawn around
the top-left corner of the empty rects on Mac.

Added AbsoluteRectsIgnoringEmptyRectsGeneratorContext for
addFocusRingRects to ignore empty line box rects.

* Source/WebCore/rendering/RenderInline.cpp:
(AbsoluteRectsIgnoringEmptyGeneratorContext): new class in namespace
(RenderInline::addFocusRingRects): Use &apos;AbsoluteRectsIgnoringEmptyGeneratorContext&apos;
* LayoutTests/fast/css/ignore-empty-focus-ring-rects.html: Add Test Case
* LayoutTests/fast/css/ignore-empty-focus-ring-rects-expected.html: Add Test Case Expectation

Canonical link: <a href="https://commits.webkit.org/264058@main">https://commits.webkit.org/264058@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/98049a54b99d198e7157620df38cc4bcc7d38898

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/6549 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/6761 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/6941 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/8130 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/6833 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/6546 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/7365 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/6710 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/9729 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/6664 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/6901 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/5951 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/8218 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/4358 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/5917 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/13755 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/6310 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/5997 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/8419 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/6482 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/5302 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/5883 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/5845 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/1548 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/10047 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/6255 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->