### PR TITLE
Fragment blocks with non-visible overflow as normally when printing

### DIFF
--- a/LayoutTests/printing/overflow-auto-expected.html
+++ b/LayoutTests/printing/overflow-auto-expected.html
@@ -1,0 +1,29 @@
+<!DOCTYPE html>
+<script>
+if (window.testRunner)
+    testRunner.setPrinting();
+</script>
+<p>There should be some text below this paragraph, on this page. The text should flow nicely into
+    the next page. The number of pages should be 6.</p>
+<div style="font-size:4em; height:510vh; orphans:1; widows:1;">
+    Line of text.<br>
+    Line of text.<br>
+    Line of text.<br>
+    Line of text.<br>
+    Line of text.<br>
+    Line of text.<br>
+    Line of text.<br>
+    Line of text.<br>
+    Line of text.<br>
+    Line of text.<br>
+    Line of text.<br>
+    Line of text.<br>
+    Line of text.<br>
+    Line of text.<br>
+    Line of text.<br>
+    Line of text.<br>
+    Line of text.<br>
+    Line of text.<br>
+    Line of text.<br>
+    Line of text.<br>
+</div>

--- a/LayoutTests/printing/overflow-auto.html
+++ b/LayoutTests/printing/overflow-auto.html
@@ -1,0 +1,30 @@
+<!DOCTYPE html>
+<meta name="fuzzy" content="maxDifference=3-42; totalPixels=0-64" />
+<script>
+if (window.testRunner)
+    testRunner.setPrinting();
+</script>
+<p>There should be some text below this paragraph, on this page. The text should flow nicely into
+    the next page. The number of pages should be 6.</p>
+<div style="overflow:auto; font-size:4em; height:510vh; orphans:1; widows:1;">
+    Line of text.<br>
+    Line of text.<br>
+    Line of text.<br>
+    Line of text.<br>
+    Line of text.<br>
+    Line of text.<br>
+    Line of text.<br>
+    Line of text.<br>
+    Line of text.<br>
+    Line of text.<br>
+    Line of text.<br>
+    Line of text.<br>
+    Line of text.<br>
+    Line of text.<br>
+    Line of text.<br>
+    Line of text.<br>
+    Line of text.<br>
+    Line of text.<br>
+    Line of text.<br>
+    Line of text.<br>
+</div>

--- a/Source/WebCore/rendering/RenderBox.cpp
+++ b/Source/WebCore/rendering/RenderBox.cpp
@@ -5215,6 +5215,12 @@ bool RenderBox::hasUnsplittableScrollingOverflow() const
     if ((isHorizontal && !scrollsOverflowY()) || (!isHorizontal && !scrollsOverflowX()))
         return false;
     
+    // Fragmenting scrollbars is only problematic in interactive media, e.g. multicol on a
+    // screen. If we're printing, which is non-interactive media, we should allow objects with
+    // non-visible overflow to be paginated as normally.
+    if (document().printing())
+        return false;
+
     // We do have overflow. We'll still be willing to paginate as long as the block
     // has auto logical height, auto or undefined max-logical-height and a zero or auto min-logical-height.
     // Note this is just a heuristic, and it's still possible to have overflow under these


### PR DESCRIPTION
#### 73de3248842cc21f0547553fda5694324c4ce219
<pre>
Fragment blocks with non-visible overflow as normally when printing

<a href="https://bugs.webkit.org/show_bug.cgi?id=256701">https://bugs.webkit.org/show_bug.cgi?id=256701</a>

Reviewed by Alan Baradlay.

Merge: <a href="https://chromium.googlesource.com/chromium/src.git/+/054e1dec56f7a7a76f64adc9b3a27c94d0778e33">https://chromium.googlesource.com/chromium/src.git/+/054e1dec56f7a7a76f64adc9b3a27c94d0778e33</a>

Splitting scrollbars into multiple fragmentainers is only problematic
in interactive media.
We don&apos;t need to impose any such pagination restrictions when
printing, since printing is non-interactive.

* Source/WebCore/rendering/RenderBox.cpp:
(RenderBox::hasUnsplittableScrollingOverflow): As above
* LayoutTests/printing/overflow-auto.html: Add Test Case (with pixel tolerance)
* LayoutTests/printing/overflow-auto-expected.html: Add Test Case Expectation

Canonical link: <a href="https://commits.webkit.org/264059@main">https://commits.webkit.org/264059@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d176b13194858918284636714e3157e7b50b048c

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/6539 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/6750 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/6931 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/8119 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/6823 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/6536 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/7170 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/6700 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/9719 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/6654 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/6775 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/5937 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/8207 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/4236 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/5908 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/13744 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/6200 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/5988 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/8374 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/6471 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/5294 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/5873 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/5836 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/1547 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/10036 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/6245 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->