### PR TITLE
[GPU Process][Filters] Implement equality operator for FilterEffect

### DIFF
--- a/Source/WebCore/platform/graphics/SourceImage.cpp
+++ b/Source/WebCore/platform/graphics/SourceImage.cpp
@@ -35,6 +35,11 @@ SourceImage::SourceImage(ImageVariant&& imageVariant)
 {
 }
 
+bool SourceImage::operator==(const SourceImage& other) const
+{
+    return imageIdentifier() == other.imageIdentifier();
+}
+
 static inline NativeImage* nativeImageOf(const SourceImage::ImageVariant& imageVariant)
 {
     if (auto* nativeImage = std::get_if<Ref<NativeImage>>(&imageVariant))

--- a/Source/WebCore/platform/graphics/SourceImage.h
+++ b/Source/WebCore/platform/graphics/SourceImage.h
@@ -41,6 +41,8 @@ public:
 
     SourceImage(ImageVariant&&);
 
+    bool operator==(const SourceImage&) const;
+
     NativeImage* nativeImageIfExists() const;
     NativeImage* nativeImage() const;
 

--- a/Source/WebCore/platform/graphics/filters/DistantLightSource.cpp
+++ b/Source/WebCore/platform/graphics/filters/DistantLightSource.cpp
@@ -47,6 +47,13 @@ DistantLightSource::DistantLightSource(float azimuth, float elevation)
 {
 }
 
+bool DistantLightSource::operator==(const DistantLightSource& other) const
+{
+    return LightSource::operator==(other)
+        && m_azimuth == other.m_azimuth
+        && m_elevation == other.m_elevation;
+}
+
 void DistantLightSource::initPaintingData(const Filter&, const FilterImage&, PaintingData& paintingData) const
 {
     float azimuth = deg2rad(m_azimuth);

--- a/Source/WebCore/platform/graphics/filters/DistantLightSource.h
+++ b/Source/WebCore/platform/graphics/filters/DistantLightSource.h
@@ -29,8 +29,12 @@
 namespace WebCore {
 
 class DistantLightSource : public LightSource {
+    friend struct IPC::ArgumentCoder<DistantLightSource, void>;
+
 public:
     WEBCORE_EXPORT static Ref<DistantLightSource> create(float azimuth, float elevation);
+
+    bool operator==(const DistantLightSource&) const;
 
     // These are in degrees.
     float azimuth() const { return m_azimuth; }
@@ -45,8 +49,9 @@ public:
     WTF::TextStream& externalRepresentation(WTF::TextStream&) const override;
 
 private:
-    friend struct IPC::ArgumentCoder<DistantLightSource, void>;
     DistantLightSource(float azimuth, float elevation);
+
+    bool operator==(const LightSource& other) const override { return areEqual<DistantLightSource>(*this, other); }
 
     float m_azimuth;
     float m_elevation;

--- a/Source/WebCore/platform/graphics/filters/FEBlend.cpp
+++ b/Source/WebCore/platform/graphics/filters/FEBlend.cpp
@@ -44,6 +44,11 @@ FEBlend::FEBlend(BlendMode mode)
 {
 }
 
+bool FEBlend::operator==(const FEBlend& other) const
+{
+    return FilterEffect::operator==(other) && m_mode == other.m_mode;
+}
+
 bool FEBlend::setBlendMode(BlendMode mode)
 {
     if (m_mode == mode)

--- a/Source/WebCore/platform/graphics/filters/FEBlend.h
+++ b/Source/WebCore/platform/graphics/filters/FEBlend.h
@@ -32,11 +32,15 @@ class FEBlend : public FilterEffect {
 public:
     WEBCORE_EXPORT static Ref<FEBlend> create(BlendMode);
 
+    bool operator==(const FEBlend&) const;
+
     BlendMode blendMode() const { return m_mode; }
     bool setBlendMode(BlendMode);
 
 private:
     FEBlend(BlendMode);
+
+    bool operator==(const FilterEffect& other) const override { return areEqual<FEBlend>(*this, other); }
 
     unsigned numberOfEffectInputs() const override { return 2; }
 

--- a/Source/WebCore/platform/graphics/filters/FEColorMatrix.cpp
+++ b/Source/WebCore/platform/graphics/filters/FEColorMatrix.cpp
@@ -47,6 +47,13 @@ FEColorMatrix::FEColorMatrix(ColorMatrixType type, Vector<float>&& values)
 {
 }
 
+bool FEColorMatrix::operator==(const FEColorMatrix& other) const
+{
+    return FilterEffect::operator==(other)
+        && m_type == other.m_type
+        && m_values == other.m_values;
+}
+
 bool FEColorMatrix::setType(ColorMatrixType type)
 {
     if (m_type == type)

--- a/Source/WebCore/platform/graphics/filters/FEColorMatrix.h
+++ b/Source/WebCore/platform/graphics/filters/FEColorMatrix.h
@@ -39,6 +39,8 @@ class FEColorMatrix : public FilterEffect {
 public:
     WEBCORE_EXPORT static Ref<FEColorMatrix> create(ColorMatrixType, Vector<float>&&);
 
+    bool operator==(const FEColorMatrix&) const;
+
     ColorMatrixType type() const { return m_type; }
     bool setType(ColorMatrixType);
 
@@ -51,6 +53,8 @@ public:
 
 private:
     FEColorMatrix(ColorMatrixType, Vector<float>&&);
+
+    bool operator==(const FilterEffect& other) const override { return areEqual<FEColorMatrix>(*this, other); }
 
     bool resultIsAlphaImage(const FilterImageVector& inputs) const override;
 

--- a/Source/WebCore/platform/graphics/filters/FEComponentTransfer.cpp
+++ b/Source/WebCore/platform/graphics/filters/FEComponentTransfer.cpp
@@ -57,6 +57,11 @@ FEComponentTransfer::FEComponentTransfer(ComponentTransferFunctions&& functions)
 {
 }
 
+bool FEComponentTransfer::operator==(const FEComponentTransfer& other) const
+{
+    return FilterEffect::operator==(other) && m_functions == other.m_functions;
+}
+
 OptionSet<FilterRenderingMode> FEComponentTransfer::supportedFilterRenderingModes() const
 {
     OptionSet<FilterRenderingMode> modes = FilterRenderingMode::Software;

--- a/Source/WebCore/platform/graphics/filters/FEComponentTransfer.h
+++ b/Source/WebCore/platform/graphics/filters/FEComponentTransfer.h
@@ -47,6 +47,8 @@ struct ComponentTransferFunction {
     float offset { 0 };
 
     Vector<float> tableValues;
+
+    bool operator==(const ComponentTransferFunction&) const = default;
 };
 
 enum class ComponentTransferChannel : uint8_t { Red, Green, Blue, Alpha };
@@ -57,6 +59,8 @@ class FEComponentTransfer : public FilterEffect {
 public:
     WEBCORE_EXPORT static Ref<FEComponentTransfer> create(const ComponentTransferFunction& redFunc, const ComponentTransferFunction& greenFunc, const ComponentTransferFunction& blueFunc, const ComponentTransferFunction& alphaFunc);
     static Ref<FEComponentTransfer> create(ComponentTransferFunctions&&);
+
+    bool operator==(const FEComponentTransfer&) const;
 
     ComponentTransferFunction redFunction() const { return m_functions[ComponentTransferChannel::Red]; }
     ComponentTransferFunction greenFunction() const { return m_functions[ComponentTransferChannel::Green]; }
@@ -77,6 +81,8 @@ public:
 private:
     FEComponentTransfer(const ComponentTransferFunction& redFunc, const ComponentTransferFunction& greenFunc, const ComponentTransferFunction& blueFunc, const ComponentTransferFunction& alphaFunc);
     FEComponentTransfer(ComponentTransferFunctions&&);
+
+    bool operator==(const FilterEffect& other) const override { return areEqual<FEComponentTransfer>(*this, other); }
 
     OptionSet<FilterRenderingMode> supportedFilterRenderingModes() const override;
     std::unique_ptr<FilterEffectApplier> createAcceleratedApplier() const override;

--- a/Source/WebCore/platform/graphics/filters/FEComposite.cpp
+++ b/Source/WebCore/platform/graphics/filters/FEComposite.cpp
@@ -46,6 +46,16 @@ FEComposite::FEComposite(const CompositeOperationType& type, float k1, float k2,
 {
 }
 
+bool FEComposite::operator==(const FEComposite& other) const
+{
+    return FilterEffect::operator==(other)
+        && m_type == other.m_type
+        && m_k1 == other.m_k1
+        && m_k2 == other.m_k2
+        && m_k3 == other.m_k3
+        && m_k4 == other.m_k4;
+}
+
 bool FEComposite::setOperation(CompositeOperationType type)
 {
     if (m_type == type)

--- a/Source/WebCore/platform/graphics/filters/FEComposite.h
+++ b/Source/WebCore/platform/graphics/filters/FEComposite.h
@@ -42,6 +42,8 @@ class FEComposite : public FilterEffect {
 public:
     WEBCORE_EXPORT static Ref<FEComposite> create(const CompositeOperationType&, float k1, float k2, float k3, float k4);
 
+    bool operator==(const FEComposite&) const;
+
     CompositeOperationType operation() const { return m_type; }
     bool setOperation(CompositeOperationType);
 
@@ -59,6 +61,8 @@ public:
 
 private:
     FEComposite(const CompositeOperationType&, float k1, float k2, float k3, float k4);
+
+    bool operator==(const FilterEffect& other) const override { return areEqual<FEComposite>(*this, other); }
 
     unsigned numberOfEffectInputs() const override { return 2; }
 

--- a/Source/WebCore/platform/graphics/filters/FEConvolveMatrix.cpp
+++ b/Source/WebCore/platform/graphics/filters/FEConvolveMatrix.cpp
@@ -51,6 +51,19 @@ FEConvolveMatrix::FEConvolveMatrix(const IntSize& kernelSize, float divisor, flo
     ASSERT(m_kernelSize.height() > 0);
 }
 
+bool FEConvolveMatrix::operator==(const FEConvolveMatrix& other) const
+{
+    return FilterEffect::operator==(other)
+        && m_kernelSize == other.m_kernelSize
+        && m_divisor == other.m_divisor
+        && m_bias == other.m_bias
+        && m_targetOffset == other.m_targetOffset
+        && m_edgeMode == other.m_edgeMode
+        && m_kernelUnitLength == other.m_kernelUnitLength
+        && m_preserveAlpha == other.m_preserveAlpha
+        && m_kernelMatrix == other.m_kernelMatrix;
+}
+
 void FEConvolveMatrix::setKernelSize(const IntSize& kernelSize)
 {
     ASSERT(kernelSize.width() > 0);

--- a/Source/WebCore/platform/graphics/filters/FEConvolveMatrix.h
+++ b/Source/WebCore/platform/graphics/filters/FEConvolveMatrix.h
@@ -40,6 +40,8 @@ class FEConvolveMatrix : public FilterEffect {
 public:
     WEBCORE_EXPORT static Ref<FEConvolveMatrix> create(const IntSize& kernelSize, float divisor, float bias, const IntPoint& targetOffset, EdgeModeType, const FloatPoint& kernelUnitLength, bool preserveAlpha, const Vector<float>& kernelMatrix);
 
+    bool operator==(const FEConvolveMatrix&) const;
+
     IntSize kernelSize() const { return m_kernelSize; }
     void setKernelSize(const IntSize&);
 
@@ -66,6 +68,8 @@ public:
 
 private:
     FEConvolveMatrix(const IntSize& kernelSize, float divisor, float bias, const IntPoint& targetOffset, EdgeModeType, const FloatPoint& kernelUnitLength, bool preserveAlpha, const Vector<float>& kernelMatrix);
+
+    bool operator==(const FilterEffect& other) const override { return areEqual<FEConvolveMatrix>(*this, other); }
 
     FloatRect calculateImageRect(const Filter&, Span<const FloatRect> inputImageRects, const FloatRect& primitiveSubregion) const override;
 

--- a/Source/WebCore/platform/graphics/filters/FEDiffuseLighting.h
+++ b/Source/WebCore/platform/graphics/filters/FEDiffuseLighting.h
@@ -32,6 +32,8 @@ class FEDiffuseLighting : public FELighting {
 public:
     WEBCORE_EXPORT static Ref<FEDiffuseLighting> create(const Color& lightingColor, float surfaceScale, float diffuseConstant, float kernelUnitLengthX, float kernelUnitLengthY, Ref<LightSource>&&);
 
+    bool operator==(const FEDiffuseLighting& other) const { return FELighting::operator==(other); }
+
     float diffuseConstant() const { return m_diffuseConstant; }
     bool setDiffuseConstant(float);
 
@@ -39,6 +41,8 @@ public:
 
 private:
     FEDiffuseLighting(const Color& lightingColor, float surfaceScale, float diffuseConstant, float kernelUnitLengthX, float kernelUnitLengthY, Ref<LightSource>&&);
+
+    bool operator==(const FilterEffect& other) const override { return areEqual<FEDiffuseLighting>(*this, other); }
 };
 
 } // namespace WebCore

--- a/Source/WebCore/platform/graphics/filters/FEDisplacementMap.cpp
+++ b/Source/WebCore/platform/graphics/filters/FEDisplacementMap.cpp
@@ -44,6 +44,14 @@ FEDisplacementMap::FEDisplacementMap(ChannelSelectorType xChannelSelector, Chann
 {
 }
 
+bool FEDisplacementMap::operator==(const FEDisplacementMap& other) const
+{
+    return FilterEffect::operator==(other)
+        && m_xChannelSelector == other.m_xChannelSelector
+        && m_yChannelSelector == other.m_yChannelSelector
+        && m_scale == other.m_scale;
+}
+
 bool FEDisplacementMap::setXChannelSelector(const ChannelSelectorType xChannelSelector)
 {
     if (m_xChannelSelector == xChannelSelector)

--- a/Source/WebCore/platform/graphics/filters/FEDisplacementMap.h
+++ b/Source/WebCore/platform/graphics/filters/FEDisplacementMap.h
@@ -39,6 +39,8 @@ class FEDisplacementMap : public FilterEffect {
 public:
     WEBCORE_EXPORT static Ref<FEDisplacementMap> create(ChannelSelectorType xChannelSelector, ChannelSelectorType yChannelSelector, float scale);
 
+    bool operator==(const FEDisplacementMap&) const;
+
     ChannelSelectorType xChannelSelector() const { return m_xChannelSelector; }
     bool setXChannelSelector(const ChannelSelectorType);
 
@@ -50,6 +52,8 @@ public:
 
 private:
     FEDisplacementMap(ChannelSelectorType xChannelSelector, ChannelSelectorType yChannelSelector, float);
+
+    bool operator==(const FilterEffect& other) const override { return areEqual<FEDisplacementMap>(*this, other); }
 
     unsigned numberOfEffectInputs() const override { return 2; }
 

--- a/Source/WebCore/platform/graphics/filters/FEDropShadow.cpp
+++ b/Source/WebCore/platform/graphics/filters/FEDropShadow.cpp
@@ -45,6 +45,17 @@ FEDropShadow::FEDropShadow(float stdX, float stdY, float dx, float dy, const Col
 {
 }
 
+bool FEDropShadow::operator==(const FEDropShadow& other) const
+{
+    return FilterEffect::operator==(other)
+        && m_stdX == other.m_stdX
+        && m_stdY == other.m_stdY
+        && m_dx == other.m_dx
+        && m_dy == other.m_dy
+        && m_shadowColor == other.m_shadowColor
+        && m_shadowOpacity == other.m_shadowOpacity;
+}
+
 bool FEDropShadow::setStdDeviationX(float stdX)
 {
     if (m_stdX == stdX)

--- a/Source/WebCore/platform/graphics/filters/FEDropShadow.h
+++ b/Source/WebCore/platform/graphics/filters/FEDropShadow.h
@@ -29,6 +29,8 @@ class FEDropShadow : public FilterEffect {
 public:
     WEBCORE_EXPORT static Ref<FEDropShadow> create(float stdX, float stdY, float dx, float dy, const Color& shadowColor, float shadowOpacity);
 
+    bool operator==(const FEDropShadow&) const;
+
     float stdDeviationX() const { return m_stdX; }
     bool setStdDeviationX(float);
 
@@ -51,6 +53,8 @@ public:
 
 private:
     FEDropShadow(float stdX, float stdY, float dx, float dy, const Color& shadowColor, float shadowOpacity);
+
+    bool operator==(const FilterEffect& other) const override { return areEqual<FEDropShadow>(*this, other); }
 
     FloatRect calculateImageRect(const Filter&, Span<const FloatRect> inputImageRects, const FloatRect& primitiveSubregion) const override;
 

--- a/Source/WebCore/platform/graphics/filters/FEFlood.cpp
+++ b/Source/WebCore/platform/graphics/filters/FEFlood.cpp
@@ -43,6 +43,13 @@ FEFlood::FEFlood(const Color& floodColor, float floodOpacity)
 {
 }
 
+bool FEFlood::operator==(const FEFlood& other) const
+{
+    return FilterEffect::operator==(other)
+        && m_floodColor == other.m_floodColor
+        && m_floodOpacity == other.m_floodOpacity;
+}
+
 bool FEFlood::setFloodColor(const Color& color)
 {
     if (m_floodColor == color)

--- a/Source/WebCore/platform/graphics/filters/FEFlood.h
+++ b/Source/WebCore/platform/graphics/filters/FEFlood.h
@@ -31,6 +31,8 @@ class FEFlood : public FilterEffect {
 public:
     WEBCORE_EXPORT static Ref<FEFlood> create(const Color& floodColor, float floodOpacity);
 
+    bool operator==(const FEFlood&) const;
+
     const Color& floodColor() const { return m_floodColor; }
     bool setFloodColor(const Color&);
 
@@ -45,6 +47,8 @@ public:
 
 private:
     FEFlood(const Color& floodColor, float floodOpacity);
+
+    bool operator==(const FilterEffect& other) const override { return areEqual<FEFlood>(*this, other); }
 
     unsigned numberOfEffectInputs() const override { return 0; }
 

--- a/Source/WebCore/platform/graphics/filters/FEGaussianBlur.cpp
+++ b/Source/WebCore/platform/graphics/filters/FEGaussianBlur.cpp
@@ -45,6 +45,14 @@ FEGaussianBlur::FEGaussianBlur(float x, float y, EdgeModeType edgeMode)
 {
 }
 
+bool FEGaussianBlur::operator==(const FEGaussianBlur& other) const
+{
+    return FilterEffect::operator==(other)
+        && m_stdX == other.m_stdX
+        && m_stdY == other.m_stdY
+        && m_edgeMode == other.m_edgeMode;
+}
+
 bool FEGaussianBlur::setStdDeviationX(float stdX)
 {
     if (m_stdX == stdX)

--- a/Source/WebCore/platform/graphics/filters/FEGaussianBlur.h
+++ b/Source/WebCore/platform/graphics/filters/FEGaussianBlur.h
@@ -31,6 +31,8 @@ class FEGaussianBlur : public FilterEffect {
 public:
     WEBCORE_EXPORT static Ref<FEGaussianBlur> create(float x, float y, EdgeModeType);
 
+    bool operator==(const FEGaussianBlur&) const;
+
     float stdDeviationX() const { return m_stdX; }
     bool setStdDeviationX(float);
 
@@ -48,6 +50,8 @@ public:
 
 private:
     FEGaussianBlur(float x, float y, EdgeModeType);
+
+    bool operator==(const FilterEffect& other) const override { return areEqual<FEGaussianBlur>(*this, other); }
 
     FloatRect calculateImageRect(const Filter&, Span<const FloatRect> inputImageRects, const FloatRect& primitiveSubregion) const override;
 

--- a/Source/WebCore/platform/graphics/filters/FEImage.cpp
+++ b/Source/WebCore/platform/graphics/filters/FEImage.cpp
@@ -43,6 +43,14 @@ FEImage::FEImage(SourceImage&& sourceImage, const FloatRect& sourceImageRect, co
 {
 }
 
+bool FEImage::operator==(const FEImage& other) const
+{
+    return FilterEffect::operator==(other)
+        && m_sourceImage == other.m_sourceImage
+        && m_sourceImageRect == other.m_sourceImageRect
+        && m_preserveAspectRatio == other.m_preserveAspectRatio;
+}
+
 FloatRect FEImage::calculateImageRect(const Filter& filter, Span<const FloatRect>, const FloatRect& primitiveSubregion) const
 {
     if (m_sourceImage.nativeImageIfExists()) {

--- a/Source/WebCore/platform/graphics/filters/FEImage.h
+++ b/Source/WebCore/platform/graphics/filters/FEImage.h
@@ -38,6 +38,8 @@ class FEImage final : public FilterEffect {
 public:
     WEBCORE_EXPORT static Ref<FEImage> create(SourceImage&&, const FloatRect& sourceImageRect, const SVGPreserveAspectRatioValue&);
 
+    bool operator==(const FEImage&) const;
+
     const SourceImage& sourceImage() const { return m_sourceImage; }
     void setImageSource(SourceImage&& sourceImage) { m_sourceImage = WTFMove(sourceImage); }
 
@@ -46,6 +48,8 @@ public:
 
 private:
     FEImage(SourceImage&&, const FloatRect& sourceImageRect, const SVGPreserveAspectRatioValue&);
+
+    bool operator==(const FilterEffect& other) const override { return areEqual<FEImage>(*this, other); }
 
     unsigned numberOfEffectInputs() const override { return 0; }
 

--- a/Source/WebCore/platform/graphics/filters/FELighting.cpp
+++ b/Source/WebCore/platform/graphics/filters/FELighting.cpp
@@ -47,6 +47,19 @@ FELighting::FELighting(Type type, const Color& lightingColor, float surfaceScale
 {
 }
 
+bool FELighting::operator==(const FELighting& other) const
+{
+    return FilterEffect::operator==(other)
+        && m_lightingColor == other.m_lightingColor
+        && m_surfaceScale == other.m_surfaceScale
+        && m_diffuseConstant == other.m_diffuseConstant
+        && m_specularConstant == other.m_specularConstant
+        && m_specularExponent == other.m_specularExponent
+        && m_kernelUnitLengthX == other.m_kernelUnitLengthX
+        && m_kernelUnitLengthY == other.m_kernelUnitLengthY
+        && m_lightSource.get() == other.m_lightSource.get();
+}
+
 bool FELighting::setSurfaceScale(float surfaceScale)
 {
     if (m_surfaceScale == surfaceScale)

--- a/Source/WebCore/platform/graphics/filters/FELighting.h
+++ b/Source/WebCore/platform/graphics/filters/FELighting.h
@@ -39,6 +39,8 @@ struct FELightingPaintingDataForNeon;
 
 class FELighting : public FilterEffect {
 public:
+    bool operator==(const FELighting&) const;
+
     const Color& lightingColor() const { return m_lightingColor; }
     bool setLightingColor(const Color&);
 

--- a/Source/WebCore/platform/graphics/filters/FEMerge.cpp
+++ b/Source/WebCore/platform/graphics/filters/FEMerge.cpp
@@ -40,6 +40,11 @@ FEMerge::FEMerge(unsigned numberOfEffectInputs)
 {
 }
 
+bool FEMerge::operator==(const FEMerge& other) const
+{
+    return FilterEffect::operator==(other) && m_numberOfEffectInputs == other.m_numberOfEffectInputs;
+}
+
 std::unique_ptr<FilterEffectApplier> FEMerge::createSoftwareApplier() const
 {
     return FilterEffectApplier::create<FEMergeSoftwareApplier>(*this);

--- a/Source/WebCore/platform/graphics/filters/FEMerge.h
+++ b/Source/WebCore/platform/graphics/filters/FEMerge.h
@@ -30,10 +30,14 @@ class FEMerge : public FilterEffect {
 public:
     WEBCORE_EXPORT static Ref<FEMerge> create(unsigned numberOfEffectInputs);
 
+    bool operator==(const FEMerge&) const;
+
     unsigned numberOfEffectInputs() const override { return m_numberOfEffectInputs; }
 
 private:
     FEMerge(unsigned numberOfEffectInputs);
+
+    bool operator==(const FilterEffect& other) const override { return areEqual<FEMerge>(*this, other); }
 
     std::unique_ptr<FilterEffectApplier> createSoftwareApplier() const override;
 

--- a/Source/WebCore/platform/graphics/filters/FEMorphology.cpp
+++ b/Source/WebCore/platform/graphics/filters/FEMorphology.cpp
@@ -44,6 +44,14 @@ FEMorphology::FEMorphology(MorphologyOperatorType type, float radiusX, float rad
 {
 }
 
+bool FEMorphology::operator==(const FEMorphology& other) const
+{
+    return FilterEffect::operator==(other)
+        && m_type == other.m_type
+        && m_radiusX == other.m_radiusX
+        && m_radiusY == other.m_radiusY;
+}
+
 bool FEMorphology::setMorphologyOperator(MorphologyOperatorType type)
 {
     if (m_type == type)

--- a/Source/WebCore/platform/graphics/filters/FEMorphology.h
+++ b/Source/WebCore/platform/graphics/filters/FEMorphology.h
@@ -36,6 +36,8 @@ class FEMorphology : public FilterEffect {
 public:
     WEBCORE_EXPORT static Ref<FEMorphology> create(MorphologyOperatorType, float radiusX, float radiusY);
 
+    bool operator==(const FEMorphology&) const;
+
     MorphologyOperatorType morphologyOperator() const { return m_type; }
     bool setMorphologyOperator(MorphologyOperatorType);
 
@@ -47,6 +49,8 @@ public:
 
 private:
     FEMorphology(MorphologyOperatorType, float radiusX, float radiusY);
+
+    bool operator==(const FilterEffect& other) const override { return areEqual<FEMorphology>(*this, other); }
 
     FloatRect calculateImageRect(const Filter&, Span<const FloatRect> inputImageRects, const FloatRect& primitiveSubregion) const override;
 

--- a/Source/WebCore/platform/graphics/filters/FEOffset.cpp
+++ b/Source/WebCore/platform/graphics/filters/FEOffset.cpp
@@ -43,6 +43,13 @@ FEOffset::FEOffset(float dx, float dy)
 {
 }
 
+bool FEOffset::operator==(const FEOffset& other) const
+{
+    return FilterEffect::operator==(other)
+        && m_dx == other.m_dx
+        && m_dy == other.m_dy;
+}
+
 bool FEOffset::setDx(float dx)
 {
     if (m_dx == dx)

--- a/Source/WebCore/platform/graphics/filters/FEOffset.h
+++ b/Source/WebCore/platform/graphics/filters/FEOffset.h
@@ -30,6 +30,8 @@ class FEOffset : public FilterEffect {
 public:
     WEBCORE_EXPORT static Ref<FEOffset> create(float dx, float dy);
 
+    bool operator==(const FEOffset&) const;
+
     float dx() const { return m_dx; }
     bool setDx(float);
 
@@ -40,6 +42,8 @@ public:
 
 private:
     FEOffset(float dx, float dy);
+
+    bool operator==(const FilterEffect& other) const override { return areEqual<FEOffset>(*this, other); }
 
     FloatRect calculateImageRect(const Filter&, Span<const FloatRect> inputImageRects, const FloatRect& primitiveSubregion) const override;
 

--- a/Source/WebCore/platform/graphics/filters/FESpecularLighting.h
+++ b/Source/WebCore/platform/graphics/filters/FESpecularLighting.h
@@ -30,6 +30,8 @@ class FESpecularLighting : public FELighting {
 public:
     WEBCORE_EXPORT static Ref<FESpecularLighting> create(const Color& lightingColor, float surfaceScale, float specularConstant, float specularExponent, float kernelUnitLengthX, float kernelUnitLengthY, Ref<LightSource>&&);
 
+    bool operator==(const FESpecularLighting& other) const { return FELighting::operator==(other); }
+
     float specularConstant() const { return m_specularConstant; }
     bool setSpecularConstant(float);
 
@@ -40,6 +42,8 @@ public:
 
 private:
     FESpecularLighting(const Color& lightingColor, float surfaceScale, float specularConstant, float specularExponent, float kernelUnitLengthX, float kernelUnitLengthY, Ref<LightSource>&&);
+
+    bool operator==(const FilterEffect& other) const override { return areEqual<FESpecularLighting>(*this, other); }
 };
 
 } // namespace WebCore

--- a/Source/WebCore/platform/graphics/filters/FETurbulence.cpp
+++ b/Source/WebCore/platform/graphics/filters/FETurbulence.cpp
@@ -48,6 +48,17 @@ FETurbulence::FETurbulence(TurbulenceType type, float baseFrequencyX, float base
 {
 }
 
+bool FETurbulence::operator==(const FETurbulence& other) const
+{
+    return FilterEffect::operator==(other)
+        && m_type == other.m_type
+        && m_baseFrequencyX == other.m_baseFrequencyX
+        && m_baseFrequencyY == other.m_baseFrequencyY
+        && m_numOctaves == other.m_numOctaves
+        && m_seed == other.m_seed
+        && m_stitchTiles == other.m_stitchTiles;
+}
+
 bool FETurbulence::setType(TurbulenceType type)
 {
     if (m_type == type)

--- a/Source/WebCore/platform/graphics/filters/FETurbulence.h
+++ b/Source/WebCore/platform/graphics/filters/FETurbulence.h
@@ -39,6 +39,8 @@ class FETurbulence : public FilterEffect {
 public:
     WEBCORE_EXPORT static Ref<FETurbulence> create(TurbulenceType, float baseFrequencyX, float baseFrequencyY, int numOctaves, float seed, bool stitchTiles);
 
+    bool operator==(const FETurbulence&) const;
+
     TurbulenceType type() const { return m_type; }
     bool setType(TurbulenceType);
 
@@ -59,6 +61,8 @@ public:
 
 private:
     FETurbulence(TurbulenceType, float baseFrequencyX, float baseFrequencyY, int numOctaves, float seed, bool stitchTiles);
+
+    bool operator==(const FilterEffect& other) const override { return areEqual<FETurbulence>(*this, other); }
 
     unsigned numberOfEffectInputs() const override { return 0; }
 

--- a/Source/WebCore/platform/graphics/filters/FilterEffect.cpp
+++ b/Source/WebCore/platform/graphics/filters/FilterEffect.cpp
@@ -34,6 +34,13 @@
 
 namespace WebCore {
 
+bool FilterEffect::operator==(const FilterEffect& other) const
+{
+    if (filterType() != other.filterType())
+        return false;
+    return m_operatingColorSpace == other.m_operatingColorSpace;
+}
+
 FilterImageVector FilterEffect::takeImageInputs(FilterImageVector& stack) const
 {
     unsigned inputsSize = numberOfImageInputs();

--- a/Source/WebCore/platform/graphics/filters/FilterEffect.h
+++ b/Source/WebCore/platform/graphics/filters/FilterEffect.h
@@ -41,6 +41,8 @@ class FilterEffect : public FilterFunction {
     using FilterFunction::apply;
 
 public:
+    virtual bool operator==(const FilterEffect&) const;
+
     const DestinationColorSpace& operatingColorSpace() const { return m_operatingColorSpace; }
     virtual void setOperatingColorSpace(const DestinationColorSpace& colorSpace) { m_operatingColorSpace = colorSpace; }
 
@@ -54,6 +56,14 @@ public:
 
 protected:
     using FilterFunction::FilterFunction;
+
+    template<typename FilterEffectType>
+    static bool areEqual(const FilterEffectType& a, const FilterEffect& b)
+    {
+        if (!is<FilterEffectType>(b))
+            return false;
+        return a.operator==(downcast<FilterEffectType>(b));
+    }
 
     virtual unsigned numberOfEffectInputs() const { return 1; }
 

--- a/Source/WebCore/platform/graphics/filters/LightSource.h
+++ b/Source/WebCore/platform/graphics/filters/LightSource.h
@@ -64,6 +64,11 @@ public:
 
     virtual ~LightSource() = default;
 
+    virtual bool operator==(const LightSource& other) const
+    {
+        return m_type == other.m_type;
+    }
+
     LightType type() const { return m_type; }
     virtual WTF::TextStream& externalRepresentation(WTF::TextStream&) const = 0;
 
@@ -86,6 +91,15 @@ public:
     
     virtual bool setSpecularExponent(float) { return false; }
     virtual bool setLimitingConeAngle(float) { return false; }
+
+protected:
+    template<typename LightSourceType>
+    static bool areEqual(const LightSourceType& a, const LightSource& b)
+    {
+        if (!is<LightSourceType>(b))
+            return false;
+        return a.operator==(downcast<LightSourceType>(b));
+    }
 
 private:
     LightType m_type;

--- a/Source/WebCore/platform/graphics/filters/PointLightSource.cpp
+++ b/Source/WebCore/platform/graphics/filters/PointLightSource.cpp
@@ -49,6 +49,11 @@ PointLightSource::PointLightSource(const FloatPoint3D& position)
 {
 }
 
+bool PointLightSource::operator==(const PointLightSource& other) const
+{
+    return LightSource::operator==(other) && m_position == other.m_position;
+}
+
 void PointLightSource::initPaintingData(const Filter& filter, const FilterImage& result, PaintingData&) const
 {
     auto position = filter.resolvedPoint3D(m_position);

--- a/Source/WebCore/platform/graphics/filters/PointLightSource.h
+++ b/Source/WebCore/platform/graphics/filters/PointLightSource.h
@@ -32,6 +32,8 @@ class PointLightSource : public LightSource {
 public:
     WEBCORE_EXPORT static Ref<PointLightSource> create(const FloatPoint3D& position);
 
+    bool operator==(const PointLightSource&) const;
+
     const FloatPoint3D& position() const { return m_position; }
     bool setX(float) override;
     bool setY(float) override;
@@ -44,6 +46,8 @@ public:
 
 private:
     PointLightSource(const FloatPoint3D& position);
+
+    bool operator==(const LightSource& other) const override { return areEqual<PointLightSource>(*this, other); }
 
     FloatPoint3D m_position;
     mutable FloatPoint3D m_bufferPosition;

--- a/Source/WebCore/platform/graphics/filters/SpotLightSource.cpp
+++ b/Source/WebCore/platform/graphics/filters/SpotLightSource.cpp
@@ -58,6 +58,15 @@ SpotLightSource::SpotLightSource(const FloatPoint3D& position, const FloatPoint3
 {
 }
 
+bool SpotLightSource::operator==(const SpotLightSource& other) const
+{
+    return LightSource::operator==(other)
+        && m_position == other.m_position
+        && m_pointsAt == other.m_pointsAt
+        && m_specularExponent == other.m_specularExponent
+        && m_limitingConeAngle == other.m_limitingConeAngle;
+}
+
 void SpotLightSource::initPaintingData(const Filter& filter, const FilterImage& result, PaintingData& paintingData) const
 {
     auto position = filter.resolvedPoint3D(m_position);

--- a/Source/WebCore/platform/graphics/filters/SpotLightSource.h
+++ b/Source/WebCore/platform/graphics/filters/SpotLightSource.h
@@ -32,6 +32,8 @@ class SpotLightSource : public LightSource {
 public:
     WEBCORE_EXPORT static Ref<SpotLightSource> create(const FloatPoint3D& position, const FloatPoint3D& pointsAt, float specularExponent, float limitingConeAngle);
 
+    bool operator==(const SpotLightSource&) const;
+
     const FloatPoint3D& position() const { return m_position; }
     const FloatPoint3D& direction() const { return m_pointsAt; }
     float specularExponent() const { return m_specularExponent; }
@@ -54,6 +56,8 @@ public:
 
 private:
     SpotLightSource(const FloatPoint3D& position, const FloatPoint3D& direction, float specularExponent, float limitingConeAngle);
+
+    bool operator==(const LightSource& other) const override { return areEqual<SpotLightSource>(*this, other); }
 
     FloatPoint3D m_position;
     FloatPoint3D m_pointsAt;

--- a/Source/WebCore/svg/SVGPreserveAspectRatioValue.h
+++ b/Source/WebCore/svg/SVGPreserveAspectRatioValue.h
@@ -59,6 +59,8 @@ public:
     SVGPreserveAspectRatioValue(StringView);
     WEBCORE_EXPORT SVGPreserveAspectRatioValue(SVGPreserveAspectRatioType, SVGMeetOrSliceType);
 
+    bool operator==(const SVGPreserveAspectRatioValue&) const = default;
+
     ExceptionOr<void> setAlign(unsigned short);
     unsigned short align() const { return m_align; }
 


### PR DESCRIPTION
#### 5f6cc633dcd4bf0d0071443b0cc2af568a1b4508
<pre>
[GPU Process][Filters] Implement equality operator for FilterEffect
<a href="https://bugs.webkit.org/show_bug.cgi?id=256759">https://bugs.webkit.org/show_bug.cgi?id=256759</a>
rdar://109303025

Reviewed by Simon Fraser.

The FilterEffect::operator==() will be virtual and will be overridden by all the
superclasses. All the properties of the superclass and the properties of FilterEffect
will be compared for equality.

* Source/WebCore/platform/graphics/SourceImage.cpp:
(WebCore::SourceImage::operator== const):
* Source/WebCore/platform/graphics/SourceImage.h:
* Source/WebCore/platform/graphics/filters/DistantLightSource.cpp:
(WebCore::DistantLightSource::operator== const):
* Source/WebCore/platform/graphics/filters/DistantLightSource.h:
* Source/WebCore/platform/graphics/filters/FEBlend.cpp:
(WebCore::FEBlend::operator== const):
* Source/WebCore/platform/graphics/filters/FEBlend.h:
* Source/WebCore/platform/graphics/filters/FEColorMatrix.cpp:
(WebCore::FEColorMatrix::operator== const):
* Source/WebCore/platform/graphics/filters/FEColorMatrix.h:
* Source/WebCore/platform/graphics/filters/FEComponentTransfer.cpp:
(WebCore::FEComponentTransfer::operator== const):
* Source/WebCore/platform/graphics/filters/FEComponentTransfer.h:
* Source/WebCore/platform/graphics/filters/FEComposite.cpp:
(WebCore::FEComposite::operator== const):
* Source/WebCore/platform/graphics/filters/FEComposite.h:
* Source/WebCore/platform/graphics/filters/FEConvolveMatrix.cpp:
(WebCore::FEConvolveMatrix::operator== const):
* Source/WebCore/platform/graphics/filters/FEConvolveMatrix.h:
* Source/WebCore/platform/graphics/filters/FEDiffuseLighting.h:
(WebCore::FEDiffuseLighting::operator== const):
* Source/WebCore/platform/graphics/filters/FEDisplacementMap.cpp:
(WebCore::FEDisplacementMap::operator== const):
* Source/WebCore/platform/graphics/filters/FEDisplacementMap.h:
* Source/WebCore/platform/graphics/filters/FEDropShadow.cpp:
(WebCore::FEDropShadow::operator== const):
* Source/WebCore/platform/graphics/filters/FEDropShadow.h:
* Source/WebCore/platform/graphics/filters/FEFlood.cpp:
(WebCore::FEFlood::operator== const):
* Source/WebCore/platform/graphics/filters/FEFlood.h:
* Source/WebCore/platform/graphics/filters/FEGaussianBlur.cpp:
(WebCore::FEGaussianBlur::operator== const):
* Source/WebCore/platform/graphics/filters/FEGaussianBlur.h:
* Source/WebCore/platform/graphics/filters/FEImage.cpp:
(WebCore::FEImage::operator== const):
* Source/WebCore/platform/graphics/filters/FEImage.h:
* Source/WebCore/platform/graphics/filters/FELighting.cpp:
(WebCore::FELighting::operator== const):
* Source/WebCore/platform/graphics/filters/FELighting.h:
* Source/WebCore/platform/graphics/filters/FEMerge.cpp:
(WebCore::FEMerge::operator== const):
* Source/WebCore/platform/graphics/filters/FEMerge.h:
* Source/WebCore/platform/graphics/filters/FEMorphology.cpp:
(WebCore::FEMorphology::operator== const):
* Source/WebCore/platform/graphics/filters/FEMorphology.h:
* Source/WebCore/platform/graphics/filters/FEOffset.cpp:
(WebCore::FEOffset::operator== const):
* Source/WebCore/platform/graphics/filters/FEOffset.h:
* Source/WebCore/platform/graphics/filters/FESpecularLighting.h:
(WebCore::FESpecularLighting::operator== const):
* Source/WebCore/platform/graphics/filters/FETurbulence.cpp:
(WebCore::FETurbulence::operator== const):
* Source/WebCore/platform/graphics/filters/FETurbulence.h:
* Source/WebCore/platform/graphics/filters/FilterEffect.cpp:
(WebCore::FilterEffect::operator== const):
* Source/WebCore/platform/graphics/filters/FilterEffect.h:
(WebCore::FilterEffect::areEqual):
* Source/WebCore/platform/graphics/filters/LightSource.h:
(WebCore::LightSource::operator== const):
(WebCore::LightSource::areEqual):
* Source/WebCore/platform/graphics/filters/PointLightSource.cpp:
(WebCore::PointLightSource::operator== const):
* Source/WebCore/platform/graphics/filters/PointLightSource.h:
* Source/WebCore/platform/graphics/filters/SpotLightSource.cpp:
(WebCore::SpotLightSource::operator== const):
* Source/WebCore/platform/graphics/filters/SpotLightSource.h:
* Source/WebCore/svg/SVGPreserveAspectRatioValue.h:

Canonical link: <a href="https://commits.webkit.org/264050@main">https://commits.webkit.org/264050@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/66d53ed83daf6ccbbeff6de28ac32773780e6f1a

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/6543 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/6755 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/6935 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/8124 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/6827 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/6540 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/7197 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/6704 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/9725 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/6658 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/6791 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/5944 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/8212 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/4253 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/5913 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/13751 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/6220 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/5993 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/8392 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/6476 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/5299 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/5877 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/1541 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/10041 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/6249 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->