### PR TITLE
REGRESSION(r258464): SVG use element doesn't render if it references a subsequent element after a style resolution

### DIFF
--- a/LayoutTests/svg/dom/use-element-refers-subsequent-image-element-after-style-update-expected.svg
+++ b/LayoutTests/svg/dom/use-element-refers-subsequent-image-element-after-style-update-expected.svg
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg viewBox="0 0 100 100" xmlns="http://www.w3.org/2000/svg">
+<path id="x1" d="M 0 0 H 100 V 100 H 0 L 0 0" fill="green"/>
+</svg>

--- a/LayoutTests/svg/dom/use-element-refers-subsequent-image-element-after-style-update.svg
+++ b/LayoutTests/svg/dom/use-element-refers-subsequent-image-element-after-style-update.svg
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg viewBox="0 0 100 100" xmlns="http://www.w3.org/2000/svg">
+<use href="#x1" x="0" y="0" />
+<script>
+document.querySelector('use').getBoundingClientRect();
+</script>
+<defs>
+    <image id="x1" width="100" height="100" href="use-element-refers-subsequent-image-element-after-style-update-expected.svg"/>
+</defs>
+</svg>

--- a/LayoutTests/svg/dom/use-element-refers-subsequent-path-element-after-style-update-expected.svg
+++ b/LayoutTests/svg/dom/use-element-refers-subsequent-path-element-after-style-update-expected.svg
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg viewBox="0 0 100 100" xmlns="http://www.w3.org/2000/svg">
+<path id="x1" d="M 0 0 H 100 V 100 H 0 L 0 0" fill="green"/>
+</svg>

--- a/LayoutTests/svg/dom/use-element-refers-subsequent-path-element-after-style-update.svg
+++ b/LayoutTests/svg/dom/use-element-refers-subsequent-path-element-after-style-update.svg
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg viewBox="0 0 100 100" xmlns="http://www.w3.org/2000/svg">
+<use href="#x1" x="0" y="0" />
+<script>
+document.querySelector('use').getBoundingClientRect();
+</script>
+<defs>
+    <path id="x1" d="M 0 0 H 100 V 100 H 0 L 0 0" fill="green"/>
+</defs>
+</svg>

--- a/Source/WebCore/svg/SVGFEImageElement.cpp
+++ b/Source/WebCore/svg/SVGFEImageElement.cpp
@@ -150,6 +150,7 @@ Node::InsertedIntoAncestorResult SVGFEImageElement::insertedIntoAncestor(Inserti
 
 void SVGFEImageElement::didFinishInsertingNode()
 {
+    SVGFilterPrimitiveStandardAttributes::didFinishInsertingNode();
     buildPendingResource();
 }
 

--- a/Source/WebCore/svg/SVGFontFaceElement.cpp
+++ b/Source/WebCore/svg/SVGFontFaceElement.cpp
@@ -300,7 +300,7 @@ void SVGFontFaceElement::rebuildFontFace()
 
 Node::InsertedIntoAncestorResult SVGFontFaceElement::insertedIntoAncestor(InsertionType insertionType, ContainerNode& parentOfInsertedTree)
 {
-    SVGElement::insertedIntoAncestor(insertionType, parentOfInsertedTree);
+    auto result = SVGElement::insertedIntoAncestor(insertionType, parentOfInsertedTree);
     if (!insertionType.connectedToDocument) {
         ASSERT(!m_fontElement);
         return InsertedIntoAncestorResult::Done;
@@ -308,7 +308,7 @@ Node::InsertedIntoAncestorResult SVGFontFaceElement::insertedIntoAncestor(Insert
     document().accessSVGExtensions().registerSVGFontFaceElement(*this);
 
     rebuildFontFace();
-    return InsertedIntoAncestorResult::Done;
+    return result;
 }
 
 void SVGFontFaceElement::removedFromAncestor(RemovalType removalType, ContainerNode& oldParentOfRemovedTree)

--- a/Source/WebCore/svg/SVGImageElement.cpp
+++ b/Source/WebCore/svg/SVGImageElement.cpp
@@ -184,13 +184,13 @@ void SVGImageElement::didAttachRenderers()
 
 Node::InsertedIntoAncestorResult SVGImageElement::insertedIntoAncestor(InsertionType insertionType, ContainerNode& parentOfInsertedTree)
 {
-    SVGGraphicsElement::insertedIntoAncestor(insertionType, parentOfInsertedTree);
+    auto result = SVGGraphicsElement::insertedIntoAncestor(insertionType, parentOfInsertedTree);
     if (!insertionType.connectedToDocument)
         return InsertedIntoAncestorResult::Done;
     // Update image loader, as soon as we're living in the tree.
     // We can only resolve base URIs properly, after that!
     m_imageLoader.updateFromElement();
-    return InsertedIntoAncestorResult::Done;
+    return result;
 }
 
 const AtomString& SVGImageElement::imageSourceURL() const

--- a/Source/WebCore/svg/SVGMPathElement.cpp
+++ b/Source/WebCore/svg/SVGMPathElement.cpp
@@ -79,14 +79,15 @@ void SVGMPathElement::clearResourceReferences()
 
 Node::InsertedIntoAncestorResult SVGMPathElement::insertedIntoAncestor(InsertionType insertionType, ContainerNode& parentOfInsertedTree)
 {
-    SVGElement::insertedIntoAncestor(insertionType, parentOfInsertedTree);
+    auto result = SVGElement::insertedIntoAncestor(insertionType, parentOfInsertedTree);
     if (insertionType.connectedToDocument)
         return InsertedIntoAncestorResult::NeedsPostInsertionCallback;
-    return InsertedIntoAncestorResult::Done;
+    return result;
 }
 
 void SVGMPathElement::didFinishInsertingNode()
 {
+    SVGElement::didFinishInsertingNode();
     buildPendingResource();
 }
 

--- a/Source/WebCore/svg/SVGPathElement.cpp
+++ b/Source/WebCore/svg/SVGPathElement.cpp
@@ -95,9 +95,9 @@ void SVGPathElement::invalidateMPathDependencies()
 
 Node::InsertedIntoAncestorResult SVGPathElement::insertedIntoAncestor(InsertionType insertionType, ContainerNode& parentOfInsertedTree)
 {
-    SVGGeometryElement::insertedIntoAncestor(insertionType, parentOfInsertedTree);
+    auto result = SVGGeometryElement::insertedIntoAncestor(insertionType, parentOfInsertedTree);
     invalidateMPathDependencies();
-    return InsertedIntoAncestorResult::Done;
+    return result;
 }
 
 void SVGPathElement::removedFromAncestor(RemovalType removalType, ContainerNode& oldParentOfRemovedTree)

--- a/Source/WebCore/svg/SVGScriptElement.cpp
+++ b/Source/WebCore/svg/SVGScriptElement.cpp
@@ -64,8 +64,9 @@ void SVGScriptElement::svgAttributeChanged(const QualifiedName& attrName)
 
 Node::InsertedIntoAncestorResult SVGScriptElement::insertedIntoAncestor(InsertionType insertionType, ContainerNode& parentOfInsertedTree)
 {
-    SVGElement::insertedIntoAncestor(insertionType, parentOfInsertedTree);
-    return ScriptElement::insertedIntoAncestor(insertionType, parentOfInsertedTree);
+    auto result1 = SVGElement::insertedIntoAncestor(insertionType, parentOfInsertedTree);
+    auto result2 = ScriptElement::insertedIntoAncestor(insertionType, parentOfInsertedTree);
+    return result1 == InsertedIntoAncestorResult::NeedsPostInsertionCallback ? result1 : result2;
 }
 
 void SVGScriptElement::didFinishInsertingNode()

--- a/Source/WebCore/svg/SVGTRefElement.cpp
+++ b/Source/WebCore/svg/SVGTRefElement.cpp
@@ -248,14 +248,15 @@ void SVGTRefElement::buildPendingResource()
 
 Node::InsertedIntoAncestorResult SVGTRefElement::insertedIntoAncestor(InsertionType insertionType, ContainerNode& parentOfInsertedTree)
 {
-    SVGElement::insertedIntoAncestor(insertionType, parentOfInsertedTree);
+    auto result = SVGElement::insertedIntoAncestor(insertionType, parentOfInsertedTree);
     if (insertionType.connectedToDocument)
         return InsertedIntoAncestorResult::NeedsPostInsertionCallback;
-    return InsertedIntoAncestorResult::Done;
+    return result;
 }
 
 void SVGTRefElement::didFinishInsertingNode()
 {
+    SVGTextPositioningElement::didFinishInsertingNode();
     buildPendingResource();
 }
 

--- a/Source/WebCore/svg/SVGTextPathElement.cpp
+++ b/Source/WebCore/svg/SVGTextPathElement.cpp
@@ -168,6 +168,7 @@ Node::InsertedIntoAncestorResult SVGTextPathElement::insertedIntoAncestor(Insert
 
 void SVGTextPathElement::didFinishInsertingNode()
 {
+    SVGTextContentElement::buildPendingResource();
     buildPendingResource();
 }
 

--- a/Source/WebCore/svg/SVGTitleElement.cpp
+++ b/Source/WebCore/svg/SVGTitleElement.cpp
@@ -43,9 +43,9 @@ Ref<SVGTitleElement> SVGTitleElement::create(const QualifiedName& tagName, Docum
 
 Node::InsertedIntoAncestorResult SVGTitleElement::insertedIntoAncestor(InsertionType insertionType, ContainerNode& parentOfInsertedTree)
 {
-    SVGElement::insertedIntoAncestor(insertionType, parentOfInsertedTree);
+    auto result = SVGElement::insertedIntoAncestor(insertionType, parentOfInsertedTree);
     document().titleElementAdded(*this);
-    return InsertedIntoAncestorResult::Done;
+    return result;
 }
 
 void SVGTitleElement::removedFromAncestor(RemovalType removalType, ContainerNode& oldParentOfRemovedTree)

--- a/Source/WebCore/svg/SVGUseElement.cpp
+++ b/Source/WebCore/svg/SVGUseElement.cpp
@@ -109,7 +109,7 @@ void SVGUseElement::attributeChanged(const QualifiedName& name, const AtomString
 
 Node::InsertedIntoAncestorResult SVGUseElement::insertedIntoAncestor(InsertionType insertionType, ContainerNode& parentOfInsertedTree)
 {
-    SVGGraphicsElement::insertedIntoAncestor(insertionType, parentOfInsertedTree);
+    auto result = SVGGraphicsElement::insertedIntoAncestor(insertionType, parentOfInsertedTree);
     if (insertionType.connectedToDocument) {
         if (m_shadowTreeNeedsUpdate)
             document().addElementWithPendingUserAgentShadowTreeUpdate(*this);
@@ -117,11 +117,12 @@ Node::InsertedIntoAncestorResult SVGUseElement::insertedIntoAncestor(InsertionTy
         // FIXME: Move back the call to updateExternalDocument() here once notifyFinished is made always async.
         return InsertedIntoAncestorResult::NeedsPostInsertionCallback;
     }
-    return InsertedIntoAncestorResult::Done;
+    return result;
 }
 
 void SVGUseElement::didFinishInsertingNode()
 {
+    SVGGraphicsElement::didFinishInsertingNode();
     updateExternalDocument();
 }
 

--- a/Source/WebCore/svg/animation/SVGSMILElement.cpp
+++ b/Source/WebCore/svg/animation/SVGSMILElement.cpp
@@ -291,6 +291,7 @@ Node::InsertedIntoAncestorResult SVGSMILElement::insertedIntoAncestor(InsertionT
 
 void SVGSMILElement::didFinishInsertingNode()
 {
+    SVGElement::didFinishInsertingNode();
     buildPendingResource();
 }
 


### PR DESCRIPTION
#### a6a7aa5aca7b2269950a5a5d039aea10e314ac30
<pre>
REGRESSION(r258464): SVG use element doesn&apos;t render if it references a subsequent element after a style resolution
<a href="https://bugs.webkit.org/show_bug.cgi?id=216363">https://bugs.webkit.org/show_bug.cgi?id=216363</a>

Reviewed by Said Abou-Hallawa.

The bug was caused by SVGPathElement::insertedIntoAncestor and a few other insertedIntoAncestor functions
ignoring the value returned by SVGElement::insertedIntoAncestor requesting a post insertion callback,
and SVGMPathElement::didFinishInsertingNode not calling SVGMPathElement::didFinishInsertingNode,
which updates SVG elements referencing the element.

This PR fixes all insertedIntoAncestor functions in SVG to respect the value returned by super class&apos;
insertedIntoAncestor but many of them don&apos;t have any consequences at the moment.

* LayoutTests/svg/dom/use-element-refers-subsequent-image-element-after-style-update-expected.svg: Added.
* LayoutTests/svg/dom/use-element-refers-subsequent-image-element-after-style-update.svg: Added.
* LayoutTests/svg/dom/use-element-refers-subsequent-path-element-after-style-update-expected.svg: Added.
* LayoutTests/svg/dom/use-element-refers-subsequent-path-element-after-style-update.svg: Added.
* Source/WebCore/svg/SVGFEImageElement.cpp:
(WebCore::SVGFEImageElement::didFinishInsertingNode):
* Source/WebCore/svg/SVGFontFaceElement.cpp:
(WebCore::SVGFontFaceElement::insertedIntoAncestor):
* Source/WebCore/svg/SVGImageElement.cpp:
(WebCore::SVGImageElement::insertedIntoAncestor):
* Source/WebCore/svg/SVGMPathElement.cpp:
(WebCore::SVGMPathElement::insertedIntoAncestor):
(WebCore::SVGMPathElement::didFinishInsertingNode):
* Source/WebCore/svg/SVGPathElement.cpp:
(WebCore::SVGPathElement::insertedIntoAncestor):
* Source/WebCore/svg/SVGScriptElement.cpp:
(WebCore::SVGScriptElement::insertedIntoAncestor):
* Source/WebCore/svg/SVGTRefElement.cpp:
(WebCore::SVGTRefElement::insertedIntoAncestor):
(WebCore::SVGTRefElement::didFinishInsertingNode):
* Source/WebCore/svg/SVGTextPathElement.cpp:
(WebCore::SVGTextPathElement::didFinishInsertingNode):
* Source/WebCore/svg/SVGTitleElement.cpp:
(WebCore::SVGTitleElement::insertedIntoAncestor):
* Source/WebCore/svg/SVGUseElement.cpp:
(WebCore::SVGUseElement::insertedIntoAncestor):
(WebCore::SVGUseElement::didFinishInsertingNode):
* Source/WebCore/svg/animation/SVGSMILElement.cpp:
(WebCore::SVGSMILElement::didFinishInsertingNode):

Canonical link: <a href="https://commits.webkit.org/264085@main">https://commits.webkit.org/264085@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/424289b39f43d2ddc946632b2292e2247a154b50

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/6659 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/6875 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/7057 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/8250 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/6938 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/6658 "Passed tests") | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/23/builds/7998 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/6823 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/9834 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/6777 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/7305 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/6094 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/8337 "Built successfully") | 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/4770 "layout-tests (failure)") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/6022 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/13854 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/6566 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/6102 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/8801 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/6593 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/5401 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/5989 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/10161 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/775 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/6362 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->