### PR TITLE
JSC::Yarr::Flags in RegularExpression

### DIFF
--- a/Source/JavaScriptCore/inspector/ContentSearchUtilities.cpp
+++ b/Source/JavaScriptCore/inspector/ContentSearchUtilities.cpp
@@ -143,7 +143,7 @@ RegularExpression createRegularExpressionForSearchString(const String& searchStr
         pattern = escapeStringForRegularExpressionSource(searchString);
         break;
     }
-    return RegularExpression(pattern, caseSensitive ? TextCaseSensitive : TextCaseInsensitive);
+    return caseSensitive ? RegularExpression(pattern) : RegularExpression(pattern, { Flags::IgnoreCase });
 }
 
 int countRegularExpressionMatches(const RegularExpression& regex, const String& content)

--- a/Source/JavaScriptCore/yarr/RegularExpression.h
+++ b/Source/JavaScriptCore/yarr/RegularExpression.h
@@ -25,18 +25,16 @@
 
 #pragma once
 
+#include "YarrFlags.h"
+#include <wtf/OptionSet.h>
 #include <wtf/text/WTFString.h>
 
 namespace JSC { namespace Yarr {
 
-enum MultilineMode { MultilineDisabled, MultilineEnabled };
-enum TextCaseSensitivity { TextCaseSensitive, TextCaseInsensitive };
-enum UnicodeMode { UnicodeUnawareMode, UnicodeAwareMode };
-
 class JS_EXPORT_PRIVATE RegularExpression {
     WTF_MAKE_FAST_ALLOCATED;
 public:
-    explicit RegularExpression(StringView, TextCaseSensitivity = TextCaseSensitive, MultilineMode = MultilineDisabled, UnicodeMode = UnicodeUnawareMode);
+    explicit RegularExpression(StringView, OptionSet<Flags> = { });
     ~RegularExpression();
 
     RegularExpression(const RegularExpression&);

--- a/Source/WebCore/html/BaseTextInputType.cpp
+++ b/Source/WebCore/html/BaseTextInputType.cpp
@@ -40,11 +40,11 @@ bool BaseTextInputType::patternMismatch(const String& value) const
     // FIXME: We should execute RegExp parser first to check validity instead of creating an actual RegularExpression.
     // https://bugs.webkit.org/show_bug.cgi?id=183361
     const AtomString& rawPattern = element()->attributeWithoutSynchronization(patternAttr);
-    if (rawPattern.isNull() || value.isEmpty() || !JSC::Yarr::RegularExpression(rawPattern, JSC::Yarr::TextCaseSensitive, JSC::Yarr::MultilineDisabled, JSC::Yarr::UnicodeAwareMode).isValid())
+    if (rawPattern.isNull() || value.isEmpty() || !JSC::Yarr::RegularExpression(rawPattern, { JSC::Yarr::Flags::Unicode }).isValid())
         return false;
 
     String pattern = makeString("^(?:", rawPattern, ")$");
-    JSC::Yarr::RegularExpression regex(pattern, JSC::Yarr::TextCaseSensitive, JSC::Yarr::MultilineDisabled, JSC::Yarr::UnicodeAwareMode);
+    JSC::Yarr::RegularExpression regex(pattern, { JSC::Yarr::Flags::Unicode });
     auto valuePatternMismatch = [&regex](auto& value) {
         int matchLength = 0;
         int valueLength = value.length();

--- a/Source/WebCore/html/EmailInputType.cpp
+++ b/Source/WebCore/html/EmailInputType.cpp
@@ -47,7 +47,7 @@ static bool isValidEmailAddress(const String& address)
     if (!addressLength)
         return false;
 
-    static NeverDestroyed<const JSC::Yarr::RegularExpression> regExp(StringView { emailPattern }, JSC::Yarr::TextCaseInsensitive);
+    static NeverDestroyed<const JSC::Yarr::RegularExpression> regExp(StringView { emailPattern }, OptionSet<JSC::Yarr::Flags> { JSC::Yarr::Flags::IgnoreCase });
 
     int matchLength;
     int matchOffset = regExp.get().match(address, 0, &matchLength);

--- a/Source/WebCore/inspector/InspectorStyleSheet.cpp
+++ b/Source/WebCore/inspector/InspectorStyleSheet.cpp
@@ -1304,7 +1304,7 @@ static Ref<Protocol::CSS::CSSSelector> buildObjectForSelectorHelper(const String
 
 static Ref<JSON::ArrayOf<Protocol::CSS::CSSSelector>> selectorsFromSource(const CSSRuleSourceData* sourceData, const String& sheetText, const Vector<const CSSSelector*> selectors)
 {
-    static NeverDestroyed<JSC::Yarr::RegularExpression> comment("/\\*[^]*?\\*/"_s, JSC::Yarr::TextCaseSensitive, JSC::Yarr::MultilineEnabled);
+    static NeverDestroyed<JSC::Yarr::RegularExpression> comment("/\\*[^]*?\\*/"_s, OptionSet<JSC::Yarr::Flags> { JSC::Yarr::Flags::Multiline });
 
     auto result = JSON::ArrayOf<Protocol::CSS::CSSSelector>::create();
     unsigned selectorIndex = 0;

--- a/Source/WebCore/page/LocalFrame.cpp
+++ b/Source/WebCore/page/LocalFrame.cpp
@@ -398,7 +398,7 @@ static JSC::Yarr::RegularExpression createRegExpForLabels(const Vector<String>& 
         pattern.append(i ? "|" : "", startsWithWordCharacter ? "\\b" : "", label, endsWithWordCharacter ? "\\b" : "");
     }
     pattern.append(')');
-    return JSC::Yarr::RegularExpression(pattern.toString(), JSC::Yarr::TextCaseInsensitive);
+    return JSC::Yarr::RegularExpression(pattern.toString(), { JSC::Yarr::Flags::IgnoreCase });
 }
 
 String LocalFrame::searchForLabelsAboveCell(const JSC::Yarr::RegularExpression& regExp, HTMLTableCellElement* cell, size_t* resultDistanceFromStartOfCell)

--- a/Source/WebCore/platform/graphics/avfoundation/CDMPrivateMediaSourceAVFObjC.mm
+++ b/Source/WebCore/platform/graphics/avfoundation/CDMPrivateMediaSourceAVFObjC.mm
@@ -45,7 +45,7 @@ namespace WebCore {
 
 auto CDMPrivateMediaSourceAVFObjC::parseKeySystem(const String& keySystem) -> std::optional<KeySystemParameters>
 {
-    static NeverDestroyed<RegularExpression> keySystemRE("^com\\.apple\\.fps\\.[23]_\\d+(?:,\\d+)*$"_s, JSC::Yarr::TextCaseInsensitive);
+    static NeverDestroyed<RegularExpression> keySystemRE("^com\\.apple\\.fps\\.[23]_\\d+(?:,\\d+)*$"_s, OptionSet<JSC::Yarr::Flags> { JSC::Yarr::Flags::IgnoreCase });
 
     if (keySystemRE.get().match(keySystem) < 0)
         return std::nullopt;

--- a/Source/WebCore/platform/mac/StringUtilities.mm
+++ b/Source/WebCore/platform/mac/StringUtilities.mm
@@ -56,7 +56,7 @@ static String wildcardRegexPatternString(const String& string)
     
 bool stringMatchesWildcardString(const String& string, const String& wildcardString)
 {
-    return JSC::Yarr::RegularExpression(wildcardRegexPatternString(wildcardString), JSC::Yarr::TextCaseInsensitive).match(string) != -1;
+    return JSC::Yarr::RegularExpression(wildcardRegexPatternString(wildcardString), { JSC::Yarr::Flags::IgnoreCase }).match(string) != -1;
 }
 
 }

--- a/Source/WebKitLegacy/mac/WebView/WebHTMLRepresentation.mm
+++ b/Source/WebKitLegacy/mac/WebView/WebHTMLRepresentation.mm
@@ -385,7 +385,7 @@ static RegularExpression* regExpForLabels(NSArray *labels)
             pattern.append(i ? "|" : "", startsWithWordCharacter ? "\\b" : "", label, endsWithWordCharacter ? "\\b" : "");
         }
         pattern.append(')');
-        result = new RegularExpression(pattern.toString(), JSC::Yarr::TextCaseInsensitive);
+        result = new RegularExpression(pattern.toString(), { JSC::Yarr::Flags::IgnoreCase });
     }
 
     // add regexp to the cache, making sure it is at the front for LRU ordering


### PR DESCRIPTION
#### 1083694fd4b7f1755a24f1b99b4eb01acbeec888
<pre>
JSC::Yarr::Flags in RegularExpression
<a href="https://bugs.webkit.org/show_bug.cgi?id=255982">https://bugs.webkit.org/show_bug.cgi?id=255982</a>
rdar://108836530

Reviewed by Ross Kirsling.

Replace the MultilineMode, TextCaseSensitivity, and UnicodeMode enums
with JSC::Yarr:Flags and add an assert that prevents using the other
flags mainly to ensure folks use them consciously.

Also remove the JSC::Yarr prefix when it&apos;s not needed.

* Source/JavaScriptCore/inspector/ContentSearchUtilities.cpp:
(Inspector::ContentSearchUtilities::createRegularExpressionForSearchString):
* Source/JavaScriptCore/yarr/RegularExpression.cpp:
(JSC::Yarr::RegularExpression::Private::compile):
* Source/JavaScriptCore/yarr/RegularExpression.h:
* Source/WebCore/html/BaseTextInputType.cpp:
(WebCore::BaseTextInputType::patternMismatch const):
* Source/WebCore/html/EmailInputType.cpp:
(WebCore::isValidEmailAddress):
* Source/WebCore/inspector/InspectorStyleSheet.cpp:
(WebCore::selectorsFromSource):
* Source/WebCore/page/LocalFrame.cpp:
(WebCore::createRegExpForLabels):
* Source/WebCore/platform/graphics/avfoundation/CDMPrivateMediaSourceAVFObjC.mm:
(WebCore::CDMPrivateMediaSourceAVFObjC::parseKeySystem):
* Source/WebCore/platform/mac/StringUtilities.mm:
(WebCore::stringMatchesWildcardString):
* Source/WebKitLegacy/mac/WebView/WebHTMLRepresentation.mm:
(regExpForLabels):

Canonical link: <a href="https://commits.webkit.org/264136@main">https://commits.webkit.org/264136@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b5302cff72ae421e08ea444f38572cd228d62d4f

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/6768 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/6986 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/7170 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/8357 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/7021 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/6766 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/8265 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/6929 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/9920 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/6885 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/7579 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/6210 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/8452 "Built successfully") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/39/builds/4987 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/6129 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/13939 "1 flakes 1 missing results 425 failures") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/5709 "Built successfully and passed tests") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/6703 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/6209 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/8982 "Passed tests") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/6346 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/6697 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/5488 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/6905 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/6082 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/1612 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/1616 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/10260 "Built successfully") | | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/24/builds/7095 "Built successfully") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/6457 "Built successfully") | | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/3/builds/1746 "Passed tests") | 
<!--EWS-Status-Bubble-End-->