### PR TITLE
REGRESSION(263628@main): [GStreamer] Broke fast/mediastream/captureStream/canvas3d.html

### DIFF
--- a/LayoutTests/platform/gtk/TestExpectations
+++ b/LayoutTests/platform/gtk/TestExpectations
@@ -2329,6 +2329,8 @@ webkit.org/b/246766 imported/w3c/web-platform-tests/reporting/generateTestReport
 # vertical form controls
 imported/w3c/web-platform-tests/css/css-writing-modes/forms/progress-appearance-native-computed-style.optional.html [ Failure ]
 
+webkit.org/b/256768 fast/mediastream/captureStream/canvas3d.html [ Failure ]
+
 webkit.org/b/249477 media/audioSession/audioSessionType.html [ Skip ]
 webkit.org/b/253832 media/media-source/media-source-webm-configuration-change.html [ Failure ]
 webkit.org/b/253832 media/media-source/media-source-webm-configuration-vp9-header-color.html [ Failure ]

--- a/LayoutTests/platform/wpe/fast/mediastream/captureStream/canvas3d-expected.txt
+++ b/LayoutTests/platform/wpe/fast/mediastream/captureStream/canvas3d-expected.txt
@@ -1,0 +1,6 @@
+
+
+
+FAIL captureStream with 3d context drawing - not buffered initially assert_true: expecting value 1 to be part of a green pixel expected true got false
+PASS captureStream with 3d context drawing - buffered initially
+

--- a/Source/WebCore/platform/graphics/gstreamer/VideoEncoderGStreamer.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/VideoEncoderGStreamer.cpp
@@ -54,7 +54,7 @@ public:
 
     String initialize(const VideoEncoder::Config&);
     void postTask(Function<void()>&& task) { m_postTaskCallback(WTFMove(task)); }
-    bool encode(VideoEncoder::RawFrame&&, bool shouldGenerateKeyFrame, VideoEncoder::EncodeCallback&&);
+    bool encode(VideoEncoder::RawFrame&&, bool shouldGenerateKeyFrame);
     void flush(Function<void()>&&);
     void close() { m_isClosed = true; }
 
@@ -133,7 +133,7 @@ String GStreamerVideoEncoder::initialize(const VideoEncoder::Config& config)
 void GStreamerVideoEncoder::encode(RawFrame&& frame, bool shouldGenerateKeyFrame, EncodeCallback&& callback)
 {
     gstEncoderWorkQueue().dispatch([frame = WTFMove(frame), shouldGenerateKeyFrame, encoder = m_internalEncoder, callback = WTFMove(callback)]() mutable {
-        auto result = encoder->encode(WTFMove(frame), shouldGenerateKeyFrame, WTFMove(callback));
+        auto result = encoder->encode(WTFMove(frame), shouldGenerateKeyFrame);
         if (encoder->isClosed())
             return;
 
@@ -141,7 +141,7 @@ void GStreamerVideoEncoder::encode(RawFrame&& frame, bool shouldGenerateKeyFrame
         if (result)
             encoder->harness()->processOutputBuffers();
         else
-            resultString = makeString("Encoding failed");
+            resultString = "Encoding failed"_s;
         callback(WTFMove(resultString));
     });
 }
@@ -232,7 +232,7 @@ String GStreamerInternalVideoEncoder::initialize(const VideoEncoder::Config& con
     return emptyString();
 }
 
-bool GStreamerInternalVideoEncoder::encode(VideoEncoder::RawFrame&& rawFrame, bool shouldGenerateKeyFrame, VideoEncoder::EncodeCallback&& callback)
+bool GStreamerInternalVideoEncoder::encode(VideoEncoder::RawFrame&& rawFrame, bool shouldGenerateKeyFrame)
 {
     if (!m_isInitialized) {
         GST_WARNING_OBJECT(m_harness->element(), "Encoder not initialized");
@@ -247,56 +247,13 @@ bool GStreamerInternalVideoEncoder::encode(VideoEncoder::RawFrame&& rawFrame, bo
         m_harness->pushEvent(gst_video_event_new_downstream_force_key_unit(GST_CLOCK_TIME_NONE, GST_CLOCK_TIME_NONE, GST_CLOCK_TIME_NONE, FALSE, 1));
     }
 
-    auto sample = downcast<VideoFrameGStreamer>(rawFrame.frame.get()).sample();
+    auto& gstVideoFrame = downcast<VideoFrameGStreamer>(rawFrame.frame.get());
 
-    bool result = false;
-    auto* buffer = gst_sample_get_buffer(sample);
+    auto* buffer = gst_sample_get_buffer(gstVideoFrame.sample());
     GST_BUFFER_PTS(buffer) = m_timestamp;
 
     // FIXME: The WebRTC encoder doesn't support GL memories ingesting yet, so until then we do a conversion here.
-#if USE(GSTREAMER_GL)
-    auto* memory = gst_buffer_peek_memory(buffer, 0);
-    if (gst_is_gl_memory(memory)) {
-        auto* inputCaps = gst_sample_get_caps(sample);
-        auto outputCaps = adoptGRef(gst_caps_copy(inputCaps));
-        auto* features = gst_caps_get_features(outputCaps.get(), 0);
-        gst_caps_features_remove(features, GST_CAPS_FEATURE_MEMORY_GL_MEMORY);
-
-        GstVideoInfo inputInfo, outputInfo;
-        if (!gst_video_info_from_caps(&outputInfo, outputCaps.get()) || !gst_video_info_from_caps(&inputInfo, inputCaps)) {
-            m_postTaskCallback([protectedThis = Ref { *this }, callback = WTFMove(callback)]() mutable {
-                if (protectedThis->m_isClosed)
-                    return;
-
-                callback("Unable to convert GL video frame"_s);
-            });
-            return false;
-        }
-
-        if (!m_colorConvertOutputCaps || !gst_caps_is_equal(m_colorConvertOutputCaps.get(), outputCaps.get())
-            || !m_colorConvertInputCaps || !gst_caps_is_equal(m_colorConvertInputCaps.get(), inputCaps)) {
-            m_colorConvert.reset(gst_video_converter_new(&inputInfo, &outputInfo, nullptr));
-            m_colorConvertInputCaps = adoptGRef(gst_caps_copy(inputCaps));
-            m_colorConvertOutputCaps = outputCaps;
-        }
-
-        auto outputBuffer = adoptGRef(gst_buffer_new_allocate(nullptr, GST_VIDEO_INFO_SIZE(&outputInfo), nullptr));
-        {
-            GstMappedFrame inputFrame(buffer, inputInfo, GST_MAP_READ);
-            GstMappedFrame outputFrame(outputBuffer.get(), outputInfo, GST_MAP_WRITE);
-            gst_video_converter_frame(m_colorConvert.get(), inputFrame.get(), outputFrame.get());
-        }
-
-        GST_BUFFER_PTS(outputBuffer.get()) = GST_BUFFER_PTS(buffer);
-        GST_BUFFER_DTS(outputBuffer.get()) = GST_BUFFER_DTS(buffer);
-        GST_BUFFER_DURATION(outputBuffer.get()) = GST_BUFFER_DURATION(buffer);
-        auto convertedSample = adoptGRef(gst_sample_new(outputBuffer.get(), outputCaps.get(), nullptr, nullptr));
-        result = m_harness->pushSample(WTFMove(convertedSample));
-    } else
-#endif
-        result = m_harness->pushSample(GRefPtr<GstSample>(sample));
-
-    return result;
+    return m_harness->pushSample(gstVideoFrame.downloadSample());
 }
 
 void GStreamerInternalVideoEncoder::flush(Function<void()> && callback)

--- a/Source/WebCore/platform/graphics/gstreamer/VideoFrameGStreamer.h
+++ b/Source/WebCore/platform/graphics/gstreamer/VideoFrameGStreamer.h
@@ -52,6 +52,8 @@ public:
 
     GRefPtr<GstSample> resizedSample(const IntSize&);
 
+    GRefPtr<GstSample> downloadSample(std::optional<GstVideoFormat> = { });
+
     GstSample* sample() const { return m_sample.get(); }
 
     RefPtr<ImageGStreamer> convertToImage();
@@ -64,6 +66,8 @@ private:
     VideoFrameGStreamer(const GRefPtr<GstSample>&, const FloatSize& presentationSize, const MediaTime& presentationTime, Rotation = Rotation::None, PlatformVideoColorSpace&& = { });
 
     bool isGStreamer() const final { return true; }
+
+    GRefPtr<GstSample> convert(GstVideoFormat, const IntSize&);
 
     GRefPtr<GstSample> m_sample;
     FloatSize m_presentationSize;


### PR DESCRIPTION
#### b1285c6fa5649d15553718a936cb49c1c2ab12bc
<pre>
REGRESSION(263628@main): [GStreamer] Broke fast/mediastream/captureStream/canvas3d.html
<a href="https://bugs.webkit.org/show_bug.cgi?id=256758">https://bugs.webkit.org/show_bug.cgi?id=256758</a>

Reviewed by Xabier Rodriguez-Calvar.

Video frame conversions are now performed with the gst_video_convert_sample API which also takes
care of downloading textures from GPU when needed. The test almost passes now in WPE, still one
graphics-related failure to debug. In GTK the test still fails, again due to weak graphics support.

* LayoutTests/platform/gtk/TestExpectations:
* LayoutTests/platform/wpe/fast/mediastream/captureStream/canvas3d-expected.txt: Added.
* Source/WebCore/platform/graphics/gstreamer/MediaPlayerPrivateGStreamer.cpp:
(WebCore::MediaPlayerPrivateGStreamer::videoFrameForCurrentTime):
* Source/WebCore/platform/graphics/gstreamer/VideoEncoderGStreamer.cpp:
(WebCore::GStreamerVideoEncoder::encode):
(WebCore::GStreamerInternalVideoEncoder::encode):
* Source/WebCore/platform/graphics/gstreamer/VideoFrameGStreamer.cpp:
(WebCore::convertSampleToImage):
(WebCore::VideoFrame::fromNativeImage):
(WebCore::VideoFrame::createNV12):
(WebCore::VideoFrame::createRGBA):
(WebCore::VideoFrame::createBGRA):
(WebCore::VideoFrame::createI420):
(WebCore::VideoFrameGStreamer::createFromPixelBuffer):
(WebCore::VideoFrame::copyTo):
(WebCore::VideoFrame::paintInContext):
(WebCore::VideoFrameGStreamer::resizedSample):
(WebCore::VideoFrameGStreamer::convert):
(WebCore::VideoFrameGStreamer::downloadSample):
(WebCore::VideoFrameGStreamer::convertToImage):
(WebCore::GstSampleColorConverter::singleton): Deleted.
(WebCore::GstSampleColorConverter::convertSample): Deleted.
(WebCore::GstSampleColorConverter::convertSampleToImage): Deleted.
* Source/WebCore/platform/graphics/gstreamer/VideoFrameGStreamer.h:

Canonical link: <a href="https://commits.webkit.org/265245@main">https://commits.webkit.org/265245@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/091e18ca90b8f034d769d21a286de76caa4fe1c2

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/10354 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/10588 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/10859 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/11999 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/9948 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/10366 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/12661 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/10540 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/12907 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/10512 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/15/builds/11292 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/8725 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/12395 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/8595 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/9379 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/16648 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/9689 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/9530 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/12779 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/7/builds/9970 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/8093 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/30/builds/9129 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/2486 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/13380 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/9821 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->