### PR TITLE
ARM64 MacroAssembler should support populationCount functions

### DIFF
--- a/Source/JavaScriptCore/assembler/MacroAssemblerARM64.h
+++ b/Source/JavaScriptCore/assembler/MacroAssemblerARM64.h
@@ -869,6 +869,22 @@ public:
         m_assembler.illegalInstruction();
     }
 
+    void countPopulation32(RegisterID src, RegisterID dst)
+    {
+        move32ToFloat(src, fpTempRegister);
+        m_assembler.vectorCnt(fpTempRegister, fpTempRegister, SIMDLane::i8x16);
+        m_assembler.addv(fpTempRegister, fpTempRegister, SIMDLane::i8x16);
+        moveFloatTo32(fpTempRegister, dst);
+    }
+
+    void countPopulation64(RegisterID src, RegisterID dst)
+    {
+        move64ToDouble(src, fpTempRegister);
+        m_assembler.vectorCnt(fpTempRegister, fpTempRegister, SIMDLane::i8x16);
+        m_assembler.addv(fpTempRegister, fpTempRegister, SIMDLane::i8x16);
+        moveDoubleTo64(fpTempRegister, dst);
+    }
+
     void lshift32(RegisterID src, RegisterID shiftAmount, RegisterID dest)
     {
         m_assembler.lsl<32>(dest, src, shiftAmount);
@@ -2357,7 +2373,7 @@ public:
     static bool supportsFloatingPointSqrt() { return true; }
     static bool supportsFloatingPointAbs() { return true; }
     static bool supportsFloatingPointRounding() { return true; }
-    static bool supportsCountPopulation() { return false; }
+    static bool supportsCountPopulation() { return true; }
 
     enum BranchTruncateType { BranchIfTruncateFailed, BranchIfTruncateSuccessful };
 

--- a/Source/JavaScriptCore/wasm/WasmAirIRGeneratorBase.h
+++ b/Source/JavaScriptCore/wasm/WasmAirIRGeneratorBase.h
@@ -4105,7 +4105,7 @@ auto AirIRGeneratorBase<Derived, ExpressionType>::addI32Popcnt(ExpressionType ar
 {
     result = self().g32();
 
-#if CPU(X86_64)
+#if CPU(X86_64) || CPU(ARM64)
     if (MacroAssembler::supportsCountPopulation()) {
         auto* patchpoint = addPatchpoint(B3::Int32);
         patchpoint->effects = B3::Effects::none();
@@ -4126,7 +4126,7 @@ auto AirIRGeneratorBase<Derived, ExpressionType>::addI64Popcnt(ExpressionType ar
 {
     result = self().g64();
 
-#if CPU(X86_64)
+#if CPU(X86_64) || CPU(ARM64)
     if (MacroAssembler::supportsCountPopulation()) {
         auto* patchpoint = addPatchpoint(B3::Int64);
         patchpoint->effects = B3::Effects::none();

--- a/Source/JavaScriptCore/wasm/WasmB3IRGenerator.cpp
+++ b/Source/JavaScriptCore/wasm/WasmB3IRGenerator.cpp
@@ -5218,7 +5218,6 @@ auto B3IRGenerator::addI64Ctz(ExpressionType argVar, ExpressionType& result) -> 
 auto B3IRGenerator::addI32Popcnt(ExpressionType argVar, ExpressionType& result) -> PartialResult
 {
     Value* arg = get(argVar);
-#if CPU(X86_64)
     if (MacroAssembler::supportsCountPopulation()) {
         PatchpointValue* patchpoint = m_currentBlock->appendNew<PatchpointValue>(m_proc, Int32, origin());
         patchpoint->append(arg, ValueRep::SomeRegister);
@@ -5229,7 +5228,6 @@ auto B3IRGenerator::addI32Popcnt(ExpressionType argVar, ExpressionType& result) 
         result = push(patchpoint);
         return { };
     }
-#endif
 
     // Pure math function does not need to call emitPrepareWasmOperation.
     Value* funcAddress = m_currentBlock->appendNew<ConstPtrValue>(m_proc, origin(), tagCFunction<OperationPtrTag>(operationPopcount32));
@@ -5240,7 +5238,6 @@ auto B3IRGenerator::addI32Popcnt(ExpressionType argVar, ExpressionType& result) 
 auto B3IRGenerator::addI64Popcnt(ExpressionType argVar, ExpressionType& result) -> PartialResult
 {
     Value* arg = get(argVar);
-#if CPU(X86_64)
     if (MacroAssembler::supportsCountPopulation()) {
         PatchpointValue* patchpoint = m_currentBlock->appendNew<PatchpointValue>(m_proc, Int64, origin());
         patchpoint->append(arg, ValueRep::SomeRegister);
@@ -5251,7 +5248,6 @@ auto B3IRGenerator::addI64Popcnt(ExpressionType argVar, ExpressionType& result) 
         result = push(patchpoint);
         return { };
     }
-#endif
 
     // Pure math function does not need to call emitPrepareWasmOperation.
     Value* funcAddress = m_currentBlock->appendNew<ConstPtrValue>(m_proc, origin(), tagCFunction<OperationPtrTag>(operationPopcount64));

--- a/Source/JavaScriptCore/wasm/WasmBBQJIT.cpp
+++ b/Source/JavaScriptCore/wasm/WasmBBQJIT.cpp
@@ -5447,11 +5447,9 @@ public:
             "I32Popcnt", TypeKind::I32,
             BLOCK(Value::fromI32(__builtin_popcount(operand.asI32()))),
             BLOCK(
-#if CPU(X86_64)
                 if (m_jit.supportsCountPopulation())
                     m_jit.countPopulation32(operandLocation.asGPR(), resultLocation.asGPR());
                 else
-#endif
                     emitCCall(&operationPopcount32, Vector<Value> { operand }, TypeKind::I32, result);
             )
         )
@@ -5463,11 +5461,9 @@ public:
             "I64Popcnt", TypeKind::I64,
             BLOCK(Value::fromI64(__builtin_popcountll(operand.asI64()))),
             BLOCK(
-#if CPU(X86_64)
                 if (m_jit.supportsCountPopulation())
                     m_jit.countPopulation64(operandLocation.asGPR(), resultLocation.asGPR());
                 else
-#endif
                     emitCCall(&operationPopcount64, Vector<Value> { operand }, TypeKind::I32, result);
             )
         )


### PR DESCRIPTION
#### c20c54c79ae66f9d644a52d2331702492da083e2
<pre>
ARM64 MacroAssembler should support populationCount functions
<a href="https://bugs.webkit.org/show_bug.cgi?id=256771">https://bugs.webkit.org/show_bug.cgi?id=256771</a>

Reviewed by Yusuke Suzuki.

Now that we have vector instructions we should support emitting inline code for population count. The new code matches the assembly emitted by GCC to do the population count. Clang uses a different instruction to sum the vector that we don&apos;t implement yet addlv vs GCC&apos;s addv. Although, those could be the synonyms for the same instruction, I didn&apos;t check.

* Source/JavaScriptCore/assembler/ARM64Assembler.h:
* Source/JavaScriptCore/assembler/MacroAssemblerARM64.h:
(JSC::MacroAssemblerARM64::countPopulation32):
(JSC::MacroAssemblerARM64::countPopulation64):
(JSC::MacroAssemblerARM64::supportsCountPopulation):
* Source/JavaScriptCore/wasm/WasmAirIRGeneratorBase.h:
(JSC::Wasm::ExpressionType&gt;::addI32Popcnt):
(JSC::Wasm::ExpressionType&gt;::addI64Popcnt):
* Source/JavaScriptCore/wasm/WasmB3IRGenerator.cpp:
(JSC::Wasm::B3IRGenerator::addI32Popcnt):
(JSC::Wasm::B3IRGenerator::addI64Popcnt):
* Source/JavaScriptCore/wasm/WasmBBQJIT.cpp:
(JSC::Wasm::BBQJIT::addI32Popcnt):
(JSC::Wasm::BBQJIT::addI64Popcnt):

Canonical link: <a href="https://commits.webkit.org/264068@main">https://commits.webkit.org/264068@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/cf4b7ba164c6890860f03dee22bde6829c4d2690

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/6579 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/6792 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/6974 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/8163 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/6864 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/7849 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/6742 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/9757 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/6695 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/7210 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/6003 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/8251 "Built successfully") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/39/builds/4687 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/5947 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/13783 "Passed tests") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/5549 "Built successfully and passed tests") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/6523 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/6027 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/8609 "Passed tests") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/6167 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/6513 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/5331 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/6715 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/5913 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/1565 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/1557 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/10080 "Built successfully") | | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/24/builds/6899 "Built successfully") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/6285 "Built successfully") | | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/3/builds/1695 "Passed tests") | 
<!--EWS-Status-Bubble-End-->