### PR TITLE
Live Text text selection in image goes offscreen in Mail

### DIFF
--- a/LayoutTests/fast/images/text-recognition/image-overlay-with-attachment-element-expected.txt
+++ b/LayoutTests/fast/images/text-recognition/image-overlay-with-attachment-element-expected.txt
@@ -1,0 +1,5 @@
+PASS transform is not 'none'
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/fast/images/text-recognition/image-overlay-with-attachment-element.html
+++ b/LayoutTests/fast/images/text-recognition/image-overlay-with-attachment-element.html
@@ -1,0 +1,51 @@
+<!DOCTYPE html><!-- webkit-test-runner [ AttachmentElementEnabled=true AttachmentWideLayoutEnabled=true ] -->
+<html>
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<head>
+<script src="../../../resources/js-test.js"></script>
+<style>
+img {
+    width: 100px;
+    height: 100px;
+    box-sizing: border-box;
+    border: 1px solid black;
+    display: block;
+}
+</style>
+<script>
+addEventListener("load", () => {
+    let image = document.querySelector("img");
+    internals.ensureUserAgentShadowRoot(image);
+    const attachment = document.createElement('attachment');
+    attachment.setAttribute('type', 'public.jpeg');
+    attachment.setAttribute('title', 'green-400x400.png');
+    attachment.setAttribute('style', 'display:none !important');
+    internals.shadowRoot(image).appendChild(attachment)
+    internals.installImageOverlay(image, [
+        {
+            topLeft : new DOMPointReadOnly(0, 0.3),
+            topRight : new DOMPointReadOnly(1, 0.3),
+            bottomRight : new DOMPointReadOnly(1, 0.7),
+            bottomLeft : new DOMPointReadOnly(0, 0.7),
+            children: [{
+                text : "Hello",
+                topLeft : new DOMPointReadOnly(0, 0.3),
+                topRight : new DOMPointReadOnly(1, 0.3),
+                bottomRight : new DOMPointReadOnly(1, 0.7),
+                bottomLeft : new DOMPointReadOnly(0, 0.7),
+            }],
+        }
+    ]);
+    const rect = image.getBoundingClientRect();
+    eventSender.mouseMoveTo(rect.left + rect.width / 2, rect.top + rect.height / 2);
+    const overlay = internals.shadowRoot(image).getElementById("image-overlay");
+    transform = getComputedStyle(overlay.childNodes[0].childNodes[0]).transform;
+    shouldNotBe("transform", "'none'");
+});
+</script>
+</head>
+<body>
+<img src="../resources/green-400x400.png">
+</img>
+</body>
+</html>

--- a/Source/WebCore/dom/ImageOverlay.cpp
+++ b/Source/WebCore/dom/ImageOverlay.cpp
@@ -280,6 +280,9 @@ static Elements updateSubtree(HTMLElement& element, const TextRecognitionResult&
 #endif // ENABLE(MODERN_MEDIA_CONTROLS)
 
     if (RefPtr shadowRoot = element.shadowRoot()) {
+        if (auto* renderer = dynamicDowncast<RenderImage>(element.renderer()))
+            renderer->setHasImageOverlay();
+
         if (hasOverlay(element)) {
             RefPtr<ContainerNode> containerForImageOverlay;
             if (mediaControlsContainer)


### PR DESCRIPTION
#### 9477772ce229c822b9fffd49ea9889569cd9496f
<pre>
Live Text text selection in image goes offscreen in Mail
<a href="https://bugs.webkit.org/show_bug.cgi?id=256772">https://bugs.webkit.org/show_bug.cgi?id=256772</a>
rdar://108597859

Reviewed by Wenson Hsieh.

In `ImageOverlay::updateWithTextRecognitionResult`, the `sizeBeforeTransform` is empty in the case
of selecting text in an image in Mail. This is because the renderer returned by `textContainer-&gt;renderBoxModelObject()`
is `nullptr`, so `sizeBeforeTransform` is never set.

This renderer is null because it is never created, because `shouldCreateRenderer` returns `false`,
ultimately because `RenderImage::hasShadowContent` returns `false`. This method returns `false`
because `m_hasImageOverlay` is `false`.

In the constructor of `RenderImage`, `m_hasImageOverlay` is initialized to the result of
`ImageOverlay::hasOverlay`. _This_ method returns `false` because the shadow root has no element
who&apos;s id is that of `imageOverlayElementIdentifier`.

`updateSubtree` in `ImageOverlay` is what is responsible for setting the id of the root shadow
element to `imageOverlayElementIdentifier`.

In the case of Safari, `updateSubtree` is called first, and then the constructor of `RenderImage`
is called, which ensures that the renderer is ultimately created. However, in Mail, the `RenderImage`
constructor is called first, and so at that time there&apos;s no `imageOverlayElementIdentifier` element,
which leads to the renderer never being created.

This PR fixes this by ensuring that `RenderImage::hasShadowContent` returns `true` if the element
has a shadow root in `updateSubtree`, by setting `RenderImage::setHasImageOverlay`.

* LayoutTests/fast/images/text-recognition/image-overlay-with-attachment-element-expected.txt: Added.
* LayoutTests/fast/images/text-recognition/image-overlay-with-attachment-element.html: Added.
* Source/WebCore/dom/ImageOverlay.cpp:
(WebCore::ImageOverlay::updateSubtree):

Canonical link: <a href="https://commits.webkit.org/264156@main">https://commits.webkit.org/264156@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/14221b09b3cf0d893a771aede92b012d7304b507

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/6803 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/7023 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/7207 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/8394 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/7056 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/6803 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/8201 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/6965 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/9949 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/6922 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/7520 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/6242 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/8489 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/4945 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/6160 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/13962 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/6676 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/6241 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/9019 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/6733 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/5516 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/6115 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/6075 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/1631 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/10295 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/6493 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->