### PR TITLE
Add basic WebInspector support for PlaceholderRenderingContext.

### DIFF
--- a/Source/JavaScriptCore/inspector/protocol/Canvas.json
+++ b/Source/JavaScriptCore/inspector/protocol/Canvas.json
@@ -23,7 +23,7 @@
         {
             "id": "ContextType",
             "type": "string",
-            "enum": ["canvas-2d", "offscreen-canvas-2d", "bitmaprenderer", "webgl", "webgl2"],
+            "enum": ["canvas-2d", "offscreen-canvas-2d", "bitmaprenderer", "webgl", "webgl2", "placeholder"],
             "description": "The type of rendering context backing the canvas element."
         },
         {

--- a/Source/WebCore/inspector/InspectorCanvas.cpp
+++ b/Source/WebCore/inspector/InspectorCanvas.cpp
@@ -100,6 +100,7 @@
 #include "JSOffscreenCanvasRenderingContext2D.h"
 #include "OffscreenCanvas.h"
 #include "OffscreenCanvasRenderingContext2D.h"
+#include "PlaceholderRenderingContext.h"
 #endif
 
 namespace WebCore {
@@ -883,6 +884,8 @@ Ref<Protocol::Canvas::Canvas> InspectorCanvas::buildObjectForCanvas(bool capture
 #if ENABLE(OFFSCREEN_CANVAS)
         if (is<OffscreenCanvasRenderingContext2D>(m_context))
             return Protocol::Canvas::ContextType::OffscreenCanvas2D;
+        if (is<PlaceholderRenderingContext>(m_context))
+            return Protocol::Canvas::ContextType::Placeholder;
 #endif
         if (is<ImageBitmapRenderingContext>(m_context))
             return Protocol::Canvas::ContextType::BitmapRenderer;

--- a/Source/WebInspectorUI/Localizations/en.lproj/localizedStrings.js
+++ b/Source/WebInspectorUI/Localizations/en.lproj/localizedStrings.js
@@ -1218,6 +1218,7 @@ localizedStrings["Pick color from screen"] = "Pick color from screen";
 localizedStrings["Ping"] = "Ping";
 localizedStrings["Ping Frame"] = "Ping Frame";
 localizedStrings["Pings"] = "Pings";
+localizedStrings["Placeholder"] = "Placeholder";
 localizedStrings["Play Sound"] = "Play Sound";
 /* Tooltip for a time range bar that represents when the playback of a audio/video element is running */
 localizedStrings["Playing"] = "Playing";

--- a/Source/WebInspectorUI/UserInterface/Models/Canvas.js
+++ b/Source/WebInspectorUI/UserInterface/Models/Canvas.js
@@ -82,6 +82,9 @@ WI.Canvas = class Canvas extends WI.Object
         case InspectorBackend.Enum.Canvas.ContextType.WebMetal:
             contextType = WI.Canvas.ContextType.WebMetal;
             break;
+        case InspectorBackend.Enum.Canvas.ContextType.Placeholder:
+            contextType = WI.Canvas.ContextType.Placeholder;
+            break;
         default:
             console.error("Invalid canvas context type", payload.contextType);
         }
@@ -116,6 +119,8 @@ WI.Canvas = class Canvas extends WI.Object
             return WI.unlocalizedString("Web GPU");
         case WI.Canvas.ContextType.WebMetal:
             return WI.unlocalizedString("WebMetal");
+        case WI.Canvas.ContextType.Placeholder:
+            return WI.unlocalizedString("Placeholder");
         }
 
         console.assert(false, "Unknown canvas context type", contextType);
@@ -481,6 +486,7 @@ WI.Canvas.ContextType = {
     WebGL2: "webgl2",
     WebGPU: "webgpu",
     WebMetal: "webmetal",
+    Placeholder: "placeholder",
 };
 
 WI.Canvas.ColorSpace = {


### PR DESCRIPTION
#### 254bbc29a13819e2ce3ddfe68e6de977ab438c69
<pre>
Add basic support for PlaceholderRenderingContext.
https://bugs.webkit.org/show_bug.cgi?id=256773

Reviewed by NOBODY (OOPS!).

This doesn't add support for recording, since this type isn't exposed to JS and can't be created directly.

We just get an image set each from (asynchronously from the OffscreenCanvas), so we could in theory record
those.

* Source/JavaScriptCore/inspector/protocol/Canvas.json:
* Source/WebCore/inspector/InspectorCanvas.cpp:
(WebCore::InspectorCanvas::buildObjectForCanvas):
* Source/WebInspectorUI/Localizations/en.lproj/localizedStrings.js:
* Source/WebInspectorUI/UserInterface/Models/Canvas.js:
(WI.Canvas.fromPayload):
(WI.Canvas.displayNameForContextType):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/254bbc29a13819e2ce3ddfe68e6de977ab438c69

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/6578 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/6791 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/6973 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/8162 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/6863 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/6576 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/7715 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/6741 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/9755 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/6694 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/7115 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/6001 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/8250 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/4599 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/5945 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/13782 "Passed tests") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/5548 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/6486 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/6025 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/8605 "Passed tests") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/6166 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/6512 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/5330 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/6714 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/5912 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/1564 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/10079 "Built successfully") | | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/24/builds/6898 "Built successfully") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/6284 "Built successfully") | | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/3/builds/1694 "Passed tests") | 
<!--EWS-Status-Bubble-End-->