### PR TITLE
Remove unused attributes from HTMLAttributeNames.in

### DIFF
--- a/Source/WebCore/html/HTMLAttributeNames.in
+++ b/Source/WebCore/html/HTMLAttributeNames.in
@@ -123,7 +123,6 @@ dirname
 disabled
 disablepictureinpicture
 disableremoteplayback
-disposition
 download
 draggable
 dropzone
@@ -164,11 +163,6 @@ integrity
 interactive
 is
 ismap
-itemid
-itemprop
-itemref
-itemscope
-itemtype
 keytype
 kind
 label
@@ -349,9 +343,6 @@ onwebkitmouseforcewillbegin
 onwebkitneedkey
 onwebkitplaybacktargetavailabilitychanged
 onwebkitpresentationmodechanged
-onwebkitsourceclose
-onwebkitsourceended
-onwebkitsourceopen
 onwebkittransitionend
 onwheel
 open
@@ -362,16 +353,12 @@ ping
 placeholder
 playcount
 playsinline
-pluginspage
-pluginurl
 popover
 popovertarget
 popovertargetaction
 poster
 preload
-primary
 progress
-prompt
 pseudo
 readonly
 referrerpolicy
@@ -400,8 +387,6 @@ shape
 size
 sizes
 slot
-sortable
-sortdirection
 span
 spellcheck
 src
@@ -415,11 +400,9 @@ style
 subtitle
 summary
 tabindex
-tableborder
 target
 text
 title
-top
 topmargin
 translate
 truespeed
@@ -447,7 +430,4 @@ x-apple-data-detectors-type
 x-apple-pdf-annotation
 x-itunes-inherit-uri-query-component
 x-webkit-airplay
-x-webkit-grammar
-x-webkit-imagemenu
-x-webkit-speech
 x-webkit-wirelessvideoplaybackdisabled


### PR DESCRIPTION
#### 5bca27238be0881170ba2db410382b96f9ec855f
<pre>
Remove unused attributes from HTMLAttributeNames.in
<a href="https://bugs.webkit.org/show_bug.cgi?id=250281">https://bugs.webkit.org/show_bug.cgi?id=250281</a>
rdar://104267186

Reviewed by Tim Nguyen.

Remove HTML attributes no longer referenced from anywhere.

* Source/WebCore/html/HTMLAttributeNames.in:

Canonical link: <a href="https://commits.webkit.org/264069@main">https://commits.webkit.org/264069@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/3b08189af7a628b178099956b0220948bd8766e5

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/6599 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/6815 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/6996 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/8189 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/6884 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/6598 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/7875 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/6763 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/9779 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/6716 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/15/builds/7235 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/6031 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/8275 "Built successfully") | 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/6703 "Passed tests") | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/39/builds/4707 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/5967 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/13806 "Passed tests") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/6531 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/6047 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/8688 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/6536 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/5350 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/5933 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/1558 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/10103 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/6305 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->