### PR TITLE
[WGSL] Fix type declaration for vector type conversion

### DIFF
--- a/Source/WebGPU/WGSL/TypeDeclarations.rb
+++ b/Source/WebGPU/WGSL/TypeDeclarations.rb
@@ -102,14 +102,14 @@ operator :textureSample, {
 
 operator :vec2, {
     [T < Scalar].(T) => Vector[T, 2],
-    [S < Scalar, T < ConcreteScalar].(Vector[S, 2]) => Vector[T, 2],
+    [T < ConcreteScalar, S < Scalar].(Vector[S, 2]) => Vector[T, 2],
     [S < Scalar].(Vector[S, 2]) => Vector[S, 2],
     [T < Scalar].(T, T) => Vector[T, 2],
 }
 
 operator :vec3, {
     [T < Scalar].(T) => Vector[T, 3],
-    [S < Scalar, T < ConcreteScalar].(Vector[S, 3]) => Vector[T, 3],
+    [T < ConcreteScalar, S < Scalar].(Vector[S, 3]) => Vector[T, 3],
     [S < Scalar].(Vector[S, 3]) => Vector[S, 3],
     [T < Scalar].(T, T, T) => Vector[T, 3],
     [T < Scalar].(Vector[T, 2], T) => Vector[T, 3],
@@ -118,7 +118,7 @@ operator :vec3, {
 
 operator :vec4, {
     [T < Scalar].(T) => Vector[T, 4],
-    [S < Scalar, T < ConcreteScalar].(Vector[S, 4]) => Vector[T, 4],
+    [T < ConcreteScalar, S < Scalar].(Vector[S, 4]) => Vector[T, 4],
     [S < Scalar].(Vector[S, 4]) => Vector[S, 4],
     [T < Scalar].(T, T, T, T) => Vector[T, 4],
     [T < Scalar].(T, Vector[T, 2], T) => Vector[T, 4],

--- a/Source/WebGPU/WGSL/tests/valid/overload.wgsl
+++ b/Source/WebGPU/WGSL/tests/valid/overload.wgsl
@@ -149,7 +149,7 @@ fn testTextureSample() {
 fn testVec2() {
   _ = vec2<f32>(0);
   _ = vec2<f32>(0, 0);
-  _ = vec2<i32>(vec2(0, 0));
+  _ = vec2<i32>(vec2<f32>(0));
   _ = vec2(vec2(0, 0));
   _ = vec2(0, 0);
 }
@@ -157,7 +157,7 @@ fn testVec2() {
 fn testVec3() {
   _ = vec3<f32>(0);
   _ = vec3<f32>(0, 0, 0);
-  _ = vec3<i32>(vec3(0, 0, 0));
+  _ = vec3<i32>(vec3<f32>(0));
   _ = vec3(vec3(0, 0, 0));
   _ = vec3(0, 0, 0);
   _ = vec3(vec2(0, 0), 0);
@@ -167,7 +167,7 @@ fn testVec3() {
 fn testVec4() {
   _ = vec4<f32>(0);
   _ = vec4<f32>(0, 0, 0, 0);
-  _ = vec4<i32>(vec4(0, 0, 0, 0));
+  _ = vec4<i32>(vec4<f32>(0));
   _ = vec4(vec4(0, 0, 0, 0));
   _ = vec4(0, 0, 0, 0);
   _ = vec4(0, vec2(0, 0), 0);


### PR DESCRIPTION
#### ccb4ec32c21cb2079dca3d1840e0bc2a6e599459
<pre>
[WGSL] Fix type declaration for vector type conversion
<a href="https://bugs.webkit.org/show_bug.cgi?id=256783">https://bugs.webkit.org/show_bug.cgi?id=256783</a>
rdar://109351633

Reviewed by Myles C. Maxfield and Dan Glastonbury.

The type variable that is only used in the return type, and therefore can&apos;t be
inferred, has to be the first type argument so it can explicitly provided when
calling the function while still inferring the second type variable.

* Source/WebGPU/WGSL/TypeDeclarations.rb:
* Source/WebGPU/WGSL/tests/valid/overload.wgsl:

Canonical link: <a href="https://commits.webkit.org/264092@main">https://commits.webkit.org/264092@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a8523cf22fcfe252a97755e1bc4999b2e99d2b1c

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/6612 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/6828 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/7009 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/8202 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/6897 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/7900 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/6776 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/9791 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/6729 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/7255 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/6048 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/8288 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/4726 "Passed tests") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/13817 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/6543 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/6061 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/8719 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/6549 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/5363 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/5946 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/1575 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/10116 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/6318 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->