### PR TITLE
[WebGPU] Initial WGSL support for texture_external

### DIFF
--- a/Source/WebGPU/WGSL/Constraints.cpp
+++ b/Source/WebGPU/WGSL/Constraints.cpp
@@ -54,6 +54,7 @@ bool satisfies(const Type* type, Constraint constraint)
 
     case Types::Primitive::Void:
     case Types::Primitive::Sampler:
+    case Types::Primitive::TextureExternal:
         return false;
     }
 }
@@ -118,6 +119,7 @@ Type* satisfyOrPromote(Type* type, Constraint constraint, const TypeStore& types
 
     case Types::Primitive::Void:
     case Types::Primitive::Sampler:
+    case Types::Primitive::TextureExternal:
         return nullptr;
     }
 }

--- a/Source/WebGPU/WGSL/Metal/MetalFunctionWriter.cpp
+++ b/Source/WebGPU/WGSL/Metal/MetalFunctionWriter.cpp
@@ -170,6 +170,16 @@ void FunctionDefinitionWriter::visit(AST::Structure& structDecl)
     {
         IndentationScope scope(m_indent);
         for (auto& member : structDecl.members()) {
+            auto* type = member.type().resolvedType();
+            if (auto* primitive = std::get_if<Types::Primitive>(type); primitive && primitive->kind == Types::Primitive::TextureExternal) {
+                auto& name = member.name();
+                m_stringBuilder.append(m_indent, "texture2d<half> ", name, "_FirstPlane;\n");
+                m_stringBuilder.append(m_indent, "texture2d<half> ", name, "_SecondPlane;\n");
+                m_stringBuilder.append(m_indent, "float3x2 ", name, "_UVRemapMatrix;\n");
+                m_stringBuilder.append(m_indent, "float4x3 ", name, "_ColorSpaceConversionMatrix;\n");
+                continue;
+            }
+
             m_stringBuilder.append(m_indent);
             visit(member.type());
             m_stringBuilder.append(" ", member.name());
@@ -350,6 +360,9 @@ void FunctionDefinitionWriter::visit(const Type* type)
             case Types::Primitive::Sampler:
                 m_stringBuilder.append(*type);
                 break;
+
+            case Types::Primitive::TextureExternal:
+                RELEASE_ASSERT_NOT_REACHED();
             }
         },
         [&](const Vector& vector) {

--- a/Source/WebGPU/WGSL/TypeCheck.cpp
+++ b/Source/WebGPU/WGSL/TypeCheck.cpp
@@ -126,6 +126,7 @@ TypeChecker::TypeChecker(ShaderModule& shaderModule)
     introduceVariable(AST::Identifier::make("u32"_s), m_types.u32Type());
     introduceVariable(AST::Identifier::make("f32"_s), m_types.f32Type());
     introduceVariable(AST::Identifier::make("sampler"_s), m_types.samplerType());
+    introduceVariable(AST::Identifier::make("texture_external"_s), m_types.textureExternalType());
 
     // This file contains the declarations generated from `TypeDeclarations.rb`
 #include "TypeDeclarations.h" // NOLINT

--- a/Source/WebGPU/WGSL/TypeStore.cpp
+++ b/Source/WebGPU/WGSL/TypeStore.cpp
@@ -106,6 +106,7 @@ TypeStore::TypeStore()
     m_u32 = allocateType<Primitive>(Primitive::U32);
     m_f32 = allocateType<Primitive>(Primitive::F32);
     m_sampler = allocateType<Primitive>(Primitive::Sampler);
+    m_textureExternal = allocateType<Primitive>(Primitive::TextureExternal);
 
     allocateConstructor(&TypeStore::vectorType, AST::ParameterizedTypeName::Base::Vec2, 2);
     allocateConstructor(&TypeStore::vectorType, AST::ParameterizedTypeName::Base::Vec3, 3);

--- a/Source/WebGPU/WGSL/TypeStore.h
+++ b/Source/WebGPU/WGSL/TypeStore.h
@@ -54,6 +54,7 @@ public:
     Type* abstractFloatType() const { return m_abstractFloat; }
     Type* f32Type() const { return m_f32; }
     Type* samplerType() const { return m_sampler; }
+    Type* textureExternalType() const { return m_textureExternal; }
 
     Type* structType(AST::Structure&);
     Type* arrayType(Type*, std::optional<unsigned>);
@@ -99,6 +100,7 @@ private:
     Type* m_u32;
     Type* m_f32;
     Type* m_sampler;
+    Type* m_textureExternal;
 };
 
 } // namespace WGSL

--- a/Source/WebGPU/WGSL/Types.h
+++ b/Source/WebGPU/WGSL/Types.h
@@ -46,6 +46,7 @@ namespace Types {
     f(Void, "void") \
     f(Bool, "bool") \
     f(Sampler, "sampler") \
+    f(TextureExternal, "texture_external") \
 
 struct Primitive {
     enum Kind : uint8_t {

--- a/Source/WebGPU/WGSL/generator/main.rb
+++ b/Source/WebGPU/WGSL/generator/main.rb
@@ -278,6 +278,7 @@ module DSL
         U32 = PrimitiveType.new(:U32)
         F32 = PrimitiveType.new(:F32)
         Sampler = PrimitiveType.new(:Sampler)
+        TextureExternal = PrimitiveType.new(:TextureExternal)
         AbstractInt = PrimitiveType.new(:AbstractInt)
         AbstractFloat = PrimitiveType.new(:AbstractFloat)
 


### PR DESCRIPTION
#### 030158c424b9bb4b9a9df1b3982a419393990435
<pre>
[WebGPU] Initial WGSL support for texture_external
<a href="https://bugs.webkit.org/show_bug.cgi?id=256721">https://bugs.webkit.org/show_bug.cgi?id=256721</a>
rdar://109270814

Reviewed by Mike Wyrzykowski.

Add a new builtin type to represent `texture_external`, keep track of whether the
shader being compile uses external textures and emit a structure to represent it
in Metal if necessary.

* Source/WebGPU/WGSL/Constraints.cpp:
(WGSL::satisfies):
(WGSL::satisfyOrPromote):
* Source/WebGPU/WGSL/GlobalVariableRewriter.cpp:
(WGSL::RewriteGlobalVariables::usesOverride):
(WGSL::RewriteGlobalVariables::insertStructs):
* Source/WebGPU/WGSL/Metal/MetalFunctionWriter.cpp:
(WGSL::Metal::FunctionDefinitionWriter::write):
(WGSL::Metal::FunctionDefinitionWriter::visit):
* Source/WebGPU/WGSL/TypeCheck.cpp:
(WGSL::TypeChecker::TypeChecker):
* Source/WebGPU/WGSL/TypeStore.cpp:
(WGSL::TypeStore::TypeStore):
* Source/WebGPU/WGSL/TypeStore.h:
(WGSL::TypeStore::textureExternalType const):
* Source/WebGPU/WGSL/Types.h:
* Source/WebGPU/WGSL/WGSLShaderModule.h:
(WGSL::ShaderModule::ShaderModule):
(WGSL::ShaderModule::usesExternalTextures const):
(WGSL::ShaderModule::setUsesExternalTextures):
* Source/WebGPU/WGSL/generator/main.rb:

Canonical link: <a href="https://commits.webkit.org/264138@main">https://commits.webkit.org/264138@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/600b5d3d773eb6e879e67aa1ce02f38ee2373a9b

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/6774 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/6992 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/7176 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/8363 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/7027 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/8227 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/6935 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/9926 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/6891 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/7543 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/6215 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/8458 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/4962 "Passed tests") | | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/13942 "8 flakes 1 missing results 396 failures") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/6687 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/6213 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/8992 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/6703 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/5493 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/6088 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/1620 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/10266 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/6463 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->