### PR TITLE
Improve error message for invalid selector

### DIFF
--- a/LayoutTests/fast/css/css3-nth-tokens-script-expected.txt
+++ b/LayoutTests/fast/css/css3-nth-tokens-script-expected.txt
@@ -16,10 +16,10 @@ PASS document.defaultView.getComputedStyle(el, null).getPropertyValue('color') i
 PASS document.defaultView.getComputedStyle(el, null).getPropertyValue('color') is 'rgb(0, 128, 0)'
 PASS document.defaultView.getComputedStyle(el, null).getPropertyValue('color') is 'rgb(255, 0, 0)'
 PASS document.defaultView.getComputedStyle(el, null).getPropertyValue('color') is 'rgb(0, 128, 0)'
-PASS document.querySelector("span.c3:nth-of-type(n3)") threw exception SyntaxError: The string did not match the expected pattern..
-PASS document.querySelector("span.c3:nth-of-type(foo)") threw exception SyntaxError: The string did not match the expected pattern..
-PASS document.querySelector("span.c3:nth-of-type(2n3)") threw exception SyntaxError: The string did not match the expected pattern..
-PASS document.querySelector("span.c3:nth-of-type(foon + bar)") threw exception SyntaxError: The string did not match the expected pattern..
+PASS document.querySelector("span.c3:nth-of-type(n3)") threw exception SyntaxError: 'span.c3:nth-of-type(n3)' is not a valid selector..
+PASS document.querySelector("span.c3:nth-of-type(foo)") threw exception SyntaxError: 'span.c3:nth-of-type(foo)' is not a valid selector..
+PASS document.querySelector("span.c3:nth-of-type(2n3)") threw exception SyntaxError: 'span.c3:nth-of-type(2n3)' is not a valid selector..
+PASS document.querySelector("span.c3:nth-of-type(foon + bar)") threw exception SyntaxError: 'span.c3:nth-of-type(foon + bar)' is not a valid selector..
 PASS successfullyParsed is true
 
 TEST COMPLETE

--- a/LayoutTests/fast/css/parsing-css-attribute-case-insensitive-value-3-expected.txt
+++ b/LayoutTests/fast/css/parsing-css-attribute-case-insensitive-value-3-expected.txt
@@ -4,786 +4,786 @@ On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE
 
 
 Invalid selectors.
-PASS document.querySelector("[foo i]") threw exception SyntaxError: The string did not match the expected pattern..
-PASS document.querySelector("[|foo i]") threw exception SyntaxError: The string did not match the expected pattern..
-PASS document.querySelector("[*|foo i]") threw exception SyntaxError: The string did not match the expected pattern..
-PASS document.querySelector("[WebKit|foo i]") threw exception SyntaxError: The string did not match the expected pattern..
+PASS document.querySelector("[foo i]") threw exception SyntaxError: '[foo i]' is not a valid selector..
+PASS document.querySelector("[|foo i]") threw exception SyntaxError: '[|foo i]' is not a valid selector..
+PASS document.querySelector("[*|foo i]") threw exception SyntaxError: '[*|foo i]' is not a valid selector..
+PASS document.querySelector("[WebKit|foo i]") threw exception SyntaxError: '[WebKit|foo i]' is not a valid selector..
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
-PASS document.querySelector("[foo I]") threw exception SyntaxError: The string did not match the expected pattern..
-PASS document.querySelector("[|foo I]") threw exception SyntaxError: The string did not match the expected pattern..
-PASS document.querySelector("[*|foo I]") threw exception SyntaxError: The string did not match the expected pattern..
-PASS document.querySelector("[WebKit|foo I]") threw exception SyntaxError: The string did not match the expected pattern..
+PASS document.querySelector("[foo I]") threw exception SyntaxError: '[foo I]' is not a valid selector..
+PASS document.querySelector("[|foo I]") threw exception SyntaxError: '[|foo I]' is not a valid selector..
+PASS document.querySelector("[*|foo I]") threw exception SyntaxError: '[*|foo I]' is not a valid selector..
+PASS document.querySelector("[WebKit|foo I]") threw exception SyntaxError: '[WebKit|foo I]' is not a valid selector..
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
-PASS document.querySelector("[foo=bar \"i\"]") threw exception SyntaxError: The string did not match the expected pattern..
-PASS document.querySelector("[|foo=bar \"i\"]") threw exception SyntaxError: The string did not match the expected pattern..
-PASS document.querySelector("[*|foo=bar \"i\"]") threw exception SyntaxError: The string did not match the expected pattern..
-PASS document.querySelector("[WebKit|foo=bar \"i\"]") threw exception SyntaxError: The string did not match the expected pattern..
+PASS document.querySelector("[foo=bar \"i\"]") threw exception SyntaxError: '[foo=bar "i"]' is not a valid selector..
+PASS document.querySelector("[|foo=bar \"i\"]") threw exception SyntaxError: '[|foo=bar "i"]' is not a valid selector..
+PASS document.querySelector("[*|foo=bar \"i\"]") threw exception SyntaxError: '[*|foo=bar "i"]' is not a valid selector..
+PASS document.querySelector("[WebKit|foo=bar \"i\"]") threw exception SyntaxError: '[WebKit|foo=bar "i"]' is not a valid selector..
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
-PASS document.querySelector("[foo=\"bar\" \"i\"]") threw exception SyntaxError: The string did not match the expected pattern..
-PASS document.querySelector("[|foo=\"bar\" \"i\"]") threw exception SyntaxError: The string did not match the expected pattern..
-PASS document.querySelector("[*|foo=\"bar\" \"i\"]") threw exception SyntaxError: The string did not match the expected pattern..
-PASS document.querySelector("[WebKit|foo=\"bar\" \"i\"]") threw exception SyntaxError: The string did not match the expected pattern..
+PASS document.querySelector("[foo=\"bar\" \"i\"]") threw exception SyntaxError: '[foo="bar" "i"]' is not a valid selector..
+PASS document.querySelector("[|foo=\"bar\" \"i\"]") threw exception SyntaxError: '[|foo="bar" "i"]' is not a valid selector..
+PASS document.querySelector("[*|foo=\"bar\" \"i\"]") threw exception SyntaxError: '[*|foo="bar" "i"]' is not a valid selector..
+PASS document.querySelector("[WebKit|foo=\"bar\" \"i\"]") threw exception SyntaxError: '[WebKit|foo="bar" "i"]' is not a valid selector..
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
-PASS document.querySelector("[foo~=bar \"i\"]") threw exception SyntaxError: The string did not match the expected pattern..
-PASS document.querySelector("[|foo~=bar \"i\"]") threw exception SyntaxError: The string did not match the expected pattern..
-PASS document.querySelector("[*|foo~=bar \"i\"]") threw exception SyntaxError: The string did not match the expected pattern..
-PASS document.querySelector("[WebKit|foo~=bar \"i\"]") threw exception SyntaxError: The string did not match the expected pattern..
+PASS document.querySelector("[foo~=bar \"i\"]") threw exception SyntaxError: '[foo~=bar "i"]' is not a valid selector..
+PASS document.querySelector("[|foo~=bar \"i\"]") threw exception SyntaxError: '[|foo~=bar "i"]' is not a valid selector..
+PASS document.querySelector("[*|foo~=bar \"i\"]") threw exception SyntaxError: '[*|foo~=bar "i"]' is not a valid selector..
+PASS document.querySelector("[WebKit|foo~=bar \"i\"]") threw exception SyntaxError: '[WebKit|foo~=bar "i"]' is not a valid selector..
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
-PASS document.querySelector("[foo~=\"bar\" \"i\"]") threw exception SyntaxError: The string did not match the expected pattern..
-PASS document.querySelector("[|foo~=\"bar\" \"i\"]") threw exception SyntaxError: The string did not match the expected pattern..
-PASS document.querySelector("[*|foo~=\"bar\" \"i\"]") threw exception SyntaxError: The string did not match the expected pattern..
-PASS document.querySelector("[WebKit|foo~=\"bar\" \"i\"]") threw exception SyntaxError: The string did not match the expected pattern..
+PASS document.querySelector("[foo~=\"bar\" \"i\"]") threw exception SyntaxError: '[foo~="bar" "i"]' is not a valid selector..
+PASS document.querySelector("[|foo~=\"bar\" \"i\"]") threw exception SyntaxError: '[|foo~="bar" "i"]' is not a valid selector..
+PASS document.querySelector("[*|foo~=\"bar\" \"i\"]") threw exception SyntaxError: '[*|foo~="bar" "i"]' is not a valid selector..
+PASS document.querySelector("[WebKit|foo~=\"bar\" \"i\"]") threw exception SyntaxError: '[WebKit|foo~="bar" "i"]' is not a valid selector..
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
-PASS document.querySelector("[foo|=bar \"i\"]") threw exception SyntaxError: The string did not match the expected pattern..
-PASS document.querySelector("[|foo|=bar \"i\"]") threw exception SyntaxError: The string did not match the expected pattern..
-PASS document.querySelector("[*|foo|=bar \"i\"]") threw exception SyntaxError: The string did not match the expected pattern..
-PASS document.querySelector("[WebKit|foo|=bar \"i\"]") threw exception SyntaxError: The string did not match the expected pattern..
+PASS document.querySelector("[foo|=bar \"i\"]") threw exception SyntaxError: '[foo|=bar "i"]' is not a valid selector..
+PASS document.querySelector("[|foo|=bar \"i\"]") threw exception SyntaxError: '[|foo|=bar "i"]' is not a valid selector..
+PASS document.querySelector("[*|foo|=bar \"i\"]") threw exception SyntaxError: '[*|foo|=bar "i"]' is not a valid selector..
+PASS document.querySelector("[WebKit|foo|=bar \"i\"]") threw exception SyntaxError: '[WebKit|foo|=bar "i"]' is not a valid selector..
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
-PASS document.querySelector("[foo|=\"bar\" \"i\"]") threw exception SyntaxError: The string did not match the expected pattern..
-PASS document.querySelector("[|foo|=\"bar\" \"i\"]") threw exception SyntaxError: The string did not match the expected pattern..
-PASS document.querySelector("[*|foo|=\"bar\" \"i\"]") threw exception SyntaxError: The string did not match the expected pattern..
-PASS document.querySelector("[WebKit|foo|=\"bar\" \"i\"]") threw exception SyntaxError: The string did not match the expected pattern..
+PASS document.querySelector("[foo|=\"bar\" \"i\"]") threw exception SyntaxError: '[foo|="bar" "i"]' is not a valid selector..
+PASS document.querySelector("[|foo|=\"bar\" \"i\"]") threw exception SyntaxError: '[|foo|="bar" "i"]' is not a valid selector..
+PASS document.querySelector("[*|foo|=\"bar\" \"i\"]") threw exception SyntaxError: '[*|foo|="bar" "i"]' is not a valid selector..
+PASS document.querySelector("[WebKit|foo|=\"bar\" \"i\"]") threw exception SyntaxError: '[WebKit|foo|="bar" "i"]' is not a valid selector..
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
-PASS document.querySelector("[foo^=bar \"i\"]") threw exception SyntaxError: The string did not match the expected pattern..
-PASS document.querySelector("[|foo^=bar \"i\"]") threw exception SyntaxError: The string did not match the expected pattern..
-PASS document.querySelector("[*|foo^=bar \"i\"]") threw exception SyntaxError: The string did not match the expected pattern..
-PASS document.querySelector("[WebKit|foo^=bar \"i\"]") threw exception SyntaxError: The string did not match the expected pattern..
+PASS document.querySelector("[foo^=bar \"i\"]") threw exception SyntaxError: '[foo^=bar "i"]' is not a valid selector..
+PASS document.querySelector("[|foo^=bar \"i\"]") threw exception SyntaxError: '[|foo^=bar "i"]' is not a valid selector..
+PASS document.querySelector("[*|foo^=bar \"i\"]") threw exception SyntaxError: '[*|foo^=bar "i"]' is not a valid selector..
+PASS document.querySelector("[WebKit|foo^=bar \"i\"]") threw exception SyntaxError: '[WebKit|foo^=bar "i"]' is not a valid selector..
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
-PASS document.querySelector("[foo^=\"bar\" \"i\"]") threw exception SyntaxError: The string did not match the expected pattern..
-PASS document.querySelector("[|foo^=\"bar\" \"i\"]") threw exception SyntaxError: The string did not match the expected pattern..
-PASS document.querySelector("[*|foo^=\"bar\" \"i\"]") threw exception SyntaxError: The string did not match the expected pattern..
-PASS document.querySelector("[WebKit|foo^=\"bar\" \"i\"]") threw exception SyntaxError: The string did not match the expected pattern..
+PASS document.querySelector("[foo^=\"bar\" \"i\"]") threw exception SyntaxError: '[foo^="bar" "i"]' is not a valid selector..
+PASS document.querySelector("[|foo^=\"bar\" \"i\"]") threw exception SyntaxError: '[|foo^="bar" "i"]' is not a valid selector..
+PASS document.querySelector("[*|foo^=\"bar\" \"i\"]") threw exception SyntaxError: '[*|foo^="bar" "i"]' is not a valid selector..
+PASS document.querySelector("[WebKit|foo^=\"bar\" \"i\"]") threw exception SyntaxError: '[WebKit|foo^="bar" "i"]' is not a valid selector..
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
-PASS document.querySelector("[foo$=bar \"i\"]") threw exception SyntaxError: The string did not match the expected pattern..
-PASS document.querySelector("[|foo$=bar \"i\"]") threw exception SyntaxError: The string did not match the expected pattern..
-PASS document.querySelector("[*|foo$=bar \"i\"]") threw exception SyntaxError: The string did not match the expected pattern..
-PASS document.querySelector("[WebKit|foo$=bar \"i\"]") threw exception SyntaxError: The string did not match the expected pattern..
+PASS document.querySelector("[foo$=bar \"i\"]") threw exception SyntaxError: '[foo$=bar "i"]' is not a valid selector..
+PASS document.querySelector("[|foo$=bar \"i\"]") threw exception SyntaxError: '[|foo$=bar "i"]' is not a valid selector..
+PASS document.querySelector("[*|foo$=bar \"i\"]") threw exception SyntaxError: '[*|foo$=bar "i"]' is not a valid selector..
+PASS document.querySelector("[WebKit|foo$=bar \"i\"]") threw exception SyntaxError: '[WebKit|foo$=bar "i"]' is not a valid selector..
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
-PASS document.querySelector("[foo$=\"bar\" \"i\"]") threw exception SyntaxError: The string did not match the expected pattern..
-PASS document.querySelector("[|foo$=\"bar\" \"i\"]") threw exception SyntaxError: The string did not match the expected pattern..
-PASS document.querySelector("[*|foo$=\"bar\" \"i\"]") threw exception SyntaxError: The string did not match the expected pattern..
-PASS document.querySelector("[WebKit|foo$=\"bar\" \"i\"]") threw exception SyntaxError: The string did not match the expected pattern..
+PASS document.querySelector("[foo$=\"bar\" \"i\"]") threw exception SyntaxError: '[foo$="bar" "i"]' is not a valid selector..
+PASS document.querySelector("[|foo$=\"bar\" \"i\"]") threw exception SyntaxError: '[|foo$="bar" "i"]' is not a valid selector..
+PASS document.querySelector("[*|foo$=\"bar\" \"i\"]") threw exception SyntaxError: '[*|foo$="bar" "i"]' is not a valid selector..
+PASS document.querySelector("[WebKit|foo$=\"bar\" \"i\"]") threw exception SyntaxError: '[WebKit|foo$="bar" "i"]' is not a valid selector..
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
-PASS document.querySelector("[foo*=bar \"i\"]") threw exception SyntaxError: The string did not match the expected pattern..
-PASS document.querySelector("[|foo*=bar \"i\"]") threw exception SyntaxError: The string did not match the expected pattern..
-PASS document.querySelector("[*|foo*=bar \"i\"]") threw exception SyntaxError: The string did not match the expected pattern..
-PASS document.querySelector("[WebKit|foo*=bar \"i\"]") threw exception SyntaxError: The string did not match the expected pattern..
+PASS document.querySelector("[foo*=bar \"i\"]") threw exception SyntaxError: '[foo*=bar "i"]' is not a valid selector..
+PASS document.querySelector("[|foo*=bar \"i\"]") threw exception SyntaxError: '[|foo*=bar "i"]' is not a valid selector..
+PASS document.querySelector("[*|foo*=bar \"i\"]") threw exception SyntaxError: '[*|foo*=bar "i"]' is not a valid selector..
+PASS document.querySelector("[WebKit|foo*=bar \"i\"]") threw exception SyntaxError: '[WebKit|foo*=bar "i"]' is not a valid selector..
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
-PASS document.querySelector("[foo*=\"bar\" \"i\"]") threw exception SyntaxError: The string did not match the expected pattern..
-PASS document.querySelector("[|foo*=\"bar\" \"i\"]") threw exception SyntaxError: The string did not match the expected pattern..
-PASS document.querySelector("[*|foo*=\"bar\" \"i\"]") threw exception SyntaxError: The string did not match the expected pattern..
-PASS document.querySelector("[WebKit|foo*=\"bar\" \"i\"]") threw exception SyntaxError: The string did not match the expected pattern..
+PASS document.querySelector("[foo*=\"bar\" \"i\"]") threw exception SyntaxError: '[foo*="bar" "i"]' is not a valid selector..
+PASS document.querySelector("[|foo*=\"bar\" \"i\"]") threw exception SyntaxError: '[|foo*="bar" "i"]' is not a valid selector..
+PASS document.querySelector("[*|foo*=\"bar\" \"i\"]") threw exception SyntaxError: '[*|foo*="bar" "i"]' is not a valid selector..
+PASS document.querySelector("[WebKit|foo*=\"bar\" \"i\"]") threw exception SyntaxError: '[WebKit|foo*="bar" "i"]' is not a valid selector..
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
-PASS document.querySelector("[foo=bar invalid]") threw exception SyntaxError: The string did not match the expected pattern..
-PASS document.querySelector("[|foo=bar invalid]") threw exception SyntaxError: The string did not match the expected pattern..
-PASS document.querySelector("[*|foo=bar invalid]") threw exception SyntaxError: The string did not match the expected pattern..
-PASS document.querySelector("[WebKit|foo=bar invalid]") threw exception SyntaxError: The string did not match the expected pattern..
+PASS document.querySelector("[foo=bar invalid]") threw exception SyntaxError: '[foo=bar invalid]' is not a valid selector..
+PASS document.querySelector("[|foo=bar invalid]") threw exception SyntaxError: '[|foo=bar invalid]' is not a valid selector..
+PASS document.querySelector("[*|foo=bar invalid]") threw exception SyntaxError: '[*|foo=bar invalid]' is not a valid selector..
+PASS document.querySelector("[WebKit|foo=bar invalid]") threw exception SyntaxError: '[WebKit|foo=bar invalid]' is not a valid selector..
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
-PASS document.querySelector("[foo=\"bar\" invalid]") threw exception SyntaxError: The string did not match the expected pattern..
-PASS document.querySelector("[|foo=\"bar\" invalid]") threw exception SyntaxError: The string did not match the expected pattern..
-PASS document.querySelector("[*|foo=\"bar\" invalid]") threw exception SyntaxError: The string did not match the expected pattern..
-PASS document.querySelector("[WebKit|foo=\"bar\" invalid]") threw exception SyntaxError: The string did not match the expected pattern..
+PASS document.querySelector("[foo=\"bar\" invalid]") threw exception SyntaxError: '[foo="bar" invalid]' is not a valid selector..
+PASS document.querySelector("[|foo=\"bar\" invalid]") threw exception SyntaxError: '[|foo="bar" invalid]' is not a valid selector..
+PASS document.querySelector("[*|foo=\"bar\" invalid]") threw exception SyntaxError: '[*|foo="bar" invalid]' is not a valid selector..
+PASS document.querySelector("[WebKit|foo=\"bar\" invalid]") threw exception SyntaxError: '[WebKit|foo="bar" invalid]' is not a valid selector..
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
-PASS document.querySelector("[foo~=bar invalid]") threw exception SyntaxError: The string did not match the expected pattern..
-PASS document.querySelector("[|foo~=bar invalid]") threw exception SyntaxError: The string did not match the expected pattern..
-PASS document.querySelector("[*|foo~=bar invalid]") threw exception SyntaxError: The string did not match the expected pattern..
-PASS document.querySelector("[WebKit|foo~=bar invalid]") threw exception SyntaxError: The string did not match the expected pattern..
+PASS document.querySelector("[foo~=bar invalid]") threw exception SyntaxError: '[foo~=bar invalid]' is not a valid selector..
+PASS document.querySelector("[|foo~=bar invalid]") threw exception SyntaxError: '[|foo~=bar invalid]' is not a valid selector..
+PASS document.querySelector("[*|foo~=bar invalid]") threw exception SyntaxError: '[*|foo~=bar invalid]' is not a valid selector..
+PASS document.querySelector("[WebKit|foo~=bar invalid]") threw exception SyntaxError: '[WebKit|foo~=bar invalid]' is not a valid selector..
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
-PASS document.querySelector("[foo~=\"bar\" invalid]") threw exception SyntaxError: The string did not match the expected pattern..
-PASS document.querySelector("[|foo~=\"bar\" invalid]") threw exception SyntaxError: The string did not match the expected pattern..
-PASS document.querySelector("[*|foo~=\"bar\" invalid]") threw exception SyntaxError: The string did not match the expected pattern..
-PASS document.querySelector("[WebKit|foo~=\"bar\" invalid]") threw exception SyntaxError: The string did not match the expected pattern..
+PASS document.querySelector("[foo~=\"bar\" invalid]") threw exception SyntaxError: '[foo~="bar" invalid]' is not a valid selector..
+PASS document.querySelector("[|foo~=\"bar\" invalid]") threw exception SyntaxError: '[|foo~="bar" invalid]' is not a valid selector..
+PASS document.querySelector("[*|foo~=\"bar\" invalid]") threw exception SyntaxError: '[*|foo~="bar" invalid]' is not a valid selector..
+PASS document.querySelector("[WebKit|foo~=\"bar\" invalid]") threw exception SyntaxError: '[WebKit|foo~="bar" invalid]' is not a valid selector..
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
-PASS document.querySelector("[foo|=bar invalid]") threw exception SyntaxError: The string did not match the expected pattern..
-PASS document.querySelector("[|foo|=bar invalid]") threw exception SyntaxError: The string did not match the expected pattern..
-PASS document.querySelector("[*|foo|=bar invalid]") threw exception SyntaxError: The string did not match the expected pattern..
-PASS document.querySelector("[WebKit|foo|=bar invalid]") threw exception SyntaxError: The string did not match the expected pattern..
+PASS document.querySelector("[foo|=bar invalid]") threw exception SyntaxError: '[foo|=bar invalid]' is not a valid selector..
+PASS document.querySelector("[|foo|=bar invalid]") threw exception SyntaxError: '[|foo|=bar invalid]' is not a valid selector..
+PASS document.querySelector("[*|foo|=bar invalid]") threw exception SyntaxError: '[*|foo|=bar invalid]' is not a valid selector..
+PASS document.querySelector("[WebKit|foo|=bar invalid]") threw exception SyntaxError: '[WebKit|foo|=bar invalid]' is not a valid selector..
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
-PASS document.querySelector("[foo|=\"bar\" invalid]") threw exception SyntaxError: The string did not match the expected pattern..
-PASS document.querySelector("[|foo|=\"bar\" invalid]") threw exception SyntaxError: The string did not match the expected pattern..
-PASS document.querySelector("[*|foo|=\"bar\" invalid]") threw exception SyntaxError: The string did not match the expected pattern..
-PASS document.querySelector("[WebKit|foo|=\"bar\" invalid]") threw exception SyntaxError: The string did not match the expected pattern..
+PASS document.querySelector("[foo|=\"bar\" invalid]") threw exception SyntaxError: '[foo|="bar" invalid]' is not a valid selector..
+PASS document.querySelector("[|foo|=\"bar\" invalid]") threw exception SyntaxError: '[|foo|="bar" invalid]' is not a valid selector..
+PASS document.querySelector("[*|foo|=\"bar\" invalid]") threw exception SyntaxError: '[*|foo|="bar" invalid]' is not a valid selector..
+PASS document.querySelector("[WebKit|foo|=\"bar\" invalid]") threw exception SyntaxError: '[WebKit|foo|="bar" invalid]' is not a valid selector..
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
-PASS document.querySelector("[foo^=bar invalid]") threw exception SyntaxError: The string did not match the expected pattern..
-PASS document.querySelector("[|foo^=bar invalid]") threw exception SyntaxError: The string did not match the expected pattern..
-PASS document.querySelector("[*|foo^=bar invalid]") threw exception SyntaxError: The string did not match the expected pattern..
-PASS document.querySelector("[WebKit|foo^=bar invalid]") threw exception SyntaxError: The string did not match the expected pattern..
+PASS document.querySelector("[foo^=bar invalid]") threw exception SyntaxError: '[foo^=bar invalid]' is not a valid selector..
+PASS document.querySelector("[|foo^=bar invalid]") threw exception SyntaxError: '[|foo^=bar invalid]' is not a valid selector..
+PASS document.querySelector("[*|foo^=bar invalid]") threw exception SyntaxError: '[*|foo^=bar invalid]' is not a valid selector..
+PASS document.querySelector("[WebKit|foo^=bar invalid]") threw exception SyntaxError: '[WebKit|foo^=bar invalid]' is not a valid selector..
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
-PASS document.querySelector("[foo^=\"bar\" invalid]") threw exception SyntaxError: The string did not match the expected pattern..
-PASS document.querySelector("[|foo^=\"bar\" invalid]") threw exception SyntaxError: The string did not match the expected pattern..
-PASS document.querySelector("[*|foo^=\"bar\" invalid]") threw exception SyntaxError: The string did not match the expected pattern..
-PASS document.querySelector("[WebKit|foo^=\"bar\" invalid]") threw exception SyntaxError: The string did not match the expected pattern..
+PASS document.querySelector("[foo^=\"bar\" invalid]") threw exception SyntaxError: '[foo^="bar" invalid]' is not a valid selector..
+PASS document.querySelector("[|foo^=\"bar\" invalid]") threw exception SyntaxError: '[|foo^="bar" invalid]' is not a valid selector..
+PASS document.querySelector("[*|foo^=\"bar\" invalid]") threw exception SyntaxError: '[*|foo^="bar" invalid]' is not a valid selector..
+PASS document.querySelector("[WebKit|foo^=\"bar\" invalid]") threw exception SyntaxError: '[WebKit|foo^="bar" invalid]' is not a valid selector..
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
-PASS document.querySelector("[foo$=bar invalid]") threw exception SyntaxError: The string did not match the expected pattern..
-PASS document.querySelector("[|foo$=bar invalid]") threw exception SyntaxError: The string did not match the expected pattern..
-PASS document.querySelector("[*|foo$=bar invalid]") threw exception SyntaxError: The string did not match the expected pattern..
-PASS document.querySelector("[WebKit|foo$=bar invalid]") threw exception SyntaxError: The string did not match the expected pattern..
+PASS document.querySelector("[foo$=bar invalid]") threw exception SyntaxError: '[foo$=bar invalid]' is not a valid selector..
+PASS document.querySelector("[|foo$=bar invalid]") threw exception SyntaxError: '[|foo$=bar invalid]' is not a valid selector..
+PASS document.querySelector("[*|foo$=bar invalid]") threw exception SyntaxError: '[*|foo$=bar invalid]' is not a valid selector..
+PASS document.querySelector("[WebKit|foo$=bar invalid]") threw exception SyntaxError: '[WebKit|foo$=bar invalid]' is not a valid selector..
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
-PASS document.querySelector("[foo$=\"bar\" invalid]") threw exception SyntaxError: The string did not match the expected pattern..
-PASS document.querySelector("[|foo$=\"bar\" invalid]") threw exception SyntaxError: The string did not match the expected pattern..
-PASS document.querySelector("[*|foo$=\"bar\" invalid]") threw exception SyntaxError: The string did not match the expected pattern..
-PASS document.querySelector("[WebKit|foo$=\"bar\" invalid]") threw exception SyntaxError: The string did not match the expected pattern..
+PASS document.querySelector("[foo$=\"bar\" invalid]") threw exception SyntaxError: '[foo$="bar" invalid]' is not a valid selector..
+PASS document.querySelector("[|foo$=\"bar\" invalid]") threw exception SyntaxError: '[|foo$="bar" invalid]' is not a valid selector..
+PASS document.querySelector("[*|foo$=\"bar\" invalid]") threw exception SyntaxError: '[*|foo$="bar" invalid]' is not a valid selector..
+PASS document.querySelector("[WebKit|foo$=\"bar\" invalid]") threw exception SyntaxError: '[WebKit|foo$="bar" invalid]' is not a valid selector..
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
-PASS document.querySelector("[foo*=bar invalid]") threw exception SyntaxError: The string did not match the expected pattern..
-PASS document.querySelector("[|foo*=bar invalid]") threw exception SyntaxError: The string did not match the expected pattern..
-PASS document.querySelector("[*|foo*=bar invalid]") threw exception SyntaxError: The string did not match the expected pattern..
-PASS document.querySelector("[WebKit|foo*=bar invalid]") threw exception SyntaxError: The string did not match the expected pattern..
+PASS document.querySelector("[foo*=bar invalid]") threw exception SyntaxError: '[foo*=bar invalid]' is not a valid selector..
+PASS document.querySelector("[|foo*=bar invalid]") threw exception SyntaxError: '[|foo*=bar invalid]' is not a valid selector..
+PASS document.querySelector("[*|foo*=bar invalid]") threw exception SyntaxError: '[*|foo*=bar invalid]' is not a valid selector..
+PASS document.querySelector("[WebKit|foo*=bar invalid]") threw exception SyntaxError: '[WebKit|foo*=bar invalid]' is not a valid selector..
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
-PASS document.querySelector("[foo*=\"bar\" invalid]") threw exception SyntaxError: The string did not match the expected pattern..
-PASS document.querySelector("[|foo*=\"bar\" invalid]") threw exception SyntaxError: The string did not match the expected pattern..
-PASS document.querySelector("[*|foo*=\"bar\" invalid]") threw exception SyntaxError: The string did not match the expected pattern..
-PASS document.querySelector("[WebKit|foo*=\"bar\" invalid]") threw exception SyntaxError: The string did not match the expected pattern..
+PASS document.querySelector("[foo*=\"bar\" invalid]") threw exception SyntaxError: '[foo*="bar" invalid]' is not a valid selector..
+PASS document.querySelector("[|foo*=\"bar\" invalid]") threw exception SyntaxError: '[|foo*="bar" invalid]' is not a valid selector..
+PASS document.querySelector("[*|foo*=\"bar\" invalid]") threw exception SyntaxError: '[*|foo*="bar" invalid]' is not a valid selector..
+PASS document.querySelector("[WebKit|foo*=\"bar\" invalid]") threw exception SyntaxError: '[WebKit|foo*="bar" invalid]' is not a valid selector..
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
-PASS document.querySelector("[foo=bar i i]") threw exception SyntaxError: The string did not match the expected pattern..
-PASS document.querySelector("[|foo=bar i i]") threw exception SyntaxError: The string did not match the expected pattern..
-PASS document.querySelector("[*|foo=bar i i]") threw exception SyntaxError: The string did not match the expected pattern..
-PASS document.querySelector("[WebKit|foo=bar i i]") threw exception SyntaxError: The string did not match the expected pattern..
+PASS document.querySelector("[foo=bar i i]") threw exception SyntaxError: '[foo=bar i i]' is not a valid selector..
+PASS document.querySelector("[|foo=bar i i]") threw exception SyntaxError: '[|foo=bar i i]' is not a valid selector..
+PASS document.querySelector("[*|foo=bar i i]") threw exception SyntaxError: '[*|foo=bar i i]' is not a valid selector..
+PASS document.querySelector("[WebKit|foo=bar i i]") threw exception SyntaxError: '[WebKit|foo=bar i i]' is not a valid selector..
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
-PASS document.querySelector("[foo=\"bar\" i i]") threw exception SyntaxError: The string did not match the expected pattern..
-PASS document.querySelector("[|foo=\"bar\" i i]") threw exception SyntaxError: The string did not match the expected pattern..
-PASS document.querySelector("[*|foo=\"bar\" i i]") threw exception SyntaxError: The string did not match the expected pattern..
-PASS document.querySelector("[WebKit|foo=\"bar\" i i]") threw exception SyntaxError: The string did not match the expected pattern..
+PASS document.querySelector("[foo=\"bar\" i i]") threw exception SyntaxError: '[foo="bar" i i]' is not a valid selector..
+PASS document.querySelector("[|foo=\"bar\" i i]") threw exception SyntaxError: '[|foo="bar" i i]' is not a valid selector..
+PASS document.querySelector("[*|foo=\"bar\" i i]") threw exception SyntaxError: '[*|foo="bar" i i]' is not a valid selector..
+PASS document.querySelector("[WebKit|foo=\"bar\" i i]") threw exception SyntaxError: '[WebKit|foo="bar" i i]' is not a valid selector..
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
-PASS document.querySelector("[foo~=bar i i]") threw exception SyntaxError: The string did not match the expected pattern..
-PASS document.querySelector("[|foo~=bar i i]") threw exception SyntaxError: The string did not match the expected pattern..
-PASS document.querySelector("[*|foo~=bar i i]") threw exception SyntaxError: The string did not match the expected pattern..
-PASS document.querySelector("[WebKit|foo~=bar i i]") threw exception SyntaxError: The string did not match the expected pattern..
+PASS document.querySelector("[foo~=bar i i]") threw exception SyntaxError: '[foo~=bar i i]' is not a valid selector..
+PASS document.querySelector("[|foo~=bar i i]") threw exception SyntaxError: '[|foo~=bar i i]' is not a valid selector..
+PASS document.querySelector("[*|foo~=bar i i]") threw exception SyntaxError: '[*|foo~=bar i i]' is not a valid selector..
+PASS document.querySelector("[WebKit|foo~=bar i i]") threw exception SyntaxError: '[WebKit|foo~=bar i i]' is not a valid selector..
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
-PASS document.querySelector("[foo~=\"bar\" i i]") threw exception SyntaxError: The string did not match the expected pattern..
-PASS document.querySelector("[|foo~=\"bar\" i i]") threw exception SyntaxError: The string did not match the expected pattern..
-PASS document.querySelector("[*|foo~=\"bar\" i i]") threw exception SyntaxError: The string did not match the expected pattern..
-PASS document.querySelector("[WebKit|foo~=\"bar\" i i]") threw exception SyntaxError: The string did not match the expected pattern..
+PASS document.querySelector("[foo~=\"bar\" i i]") threw exception SyntaxError: '[foo~="bar" i i]' is not a valid selector..
+PASS document.querySelector("[|foo~=\"bar\" i i]") threw exception SyntaxError: '[|foo~="bar" i i]' is not a valid selector..
+PASS document.querySelector("[*|foo~=\"bar\" i i]") threw exception SyntaxError: '[*|foo~="bar" i i]' is not a valid selector..
+PASS document.querySelector("[WebKit|foo~=\"bar\" i i]") threw exception SyntaxError: '[WebKit|foo~="bar" i i]' is not a valid selector..
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
-PASS document.querySelector("[foo|=bar i i]") threw exception SyntaxError: The string did not match the expected pattern..
-PASS document.querySelector("[|foo|=bar i i]") threw exception SyntaxError: The string did not match the expected pattern..
-PASS document.querySelector("[*|foo|=bar i i]") threw exception SyntaxError: The string did not match the expected pattern..
-PASS document.querySelector("[WebKit|foo|=bar i i]") threw exception SyntaxError: The string did not match the expected pattern..
+PASS document.querySelector("[foo|=bar i i]") threw exception SyntaxError: '[foo|=bar i i]' is not a valid selector..
+PASS document.querySelector("[|foo|=bar i i]") threw exception SyntaxError: '[|foo|=bar i i]' is not a valid selector..
+PASS document.querySelector("[*|foo|=bar i i]") threw exception SyntaxError: '[*|foo|=bar i i]' is not a valid selector..
+PASS document.querySelector("[WebKit|foo|=bar i i]") threw exception SyntaxError: '[WebKit|foo|=bar i i]' is not a valid selector..
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
-PASS document.querySelector("[foo|=\"bar\" i i]") threw exception SyntaxError: The string did not match the expected pattern..
-PASS document.querySelector("[|foo|=\"bar\" i i]") threw exception SyntaxError: The string did not match the expected pattern..
-PASS document.querySelector("[*|foo|=\"bar\" i i]") threw exception SyntaxError: The string did not match the expected pattern..
-PASS document.querySelector("[WebKit|foo|=\"bar\" i i]") threw exception SyntaxError: The string did not match the expected pattern..
+PASS document.querySelector("[foo|=\"bar\" i i]") threw exception SyntaxError: '[foo|="bar" i i]' is not a valid selector..
+PASS document.querySelector("[|foo|=\"bar\" i i]") threw exception SyntaxError: '[|foo|="bar" i i]' is not a valid selector..
+PASS document.querySelector("[*|foo|=\"bar\" i i]") threw exception SyntaxError: '[*|foo|="bar" i i]' is not a valid selector..
+PASS document.querySelector("[WebKit|foo|=\"bar\" i i]") threw exception SyntaxError: '[WebKit|foo|="bar" i i]' is not a valid selector..
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
-PASS document.querySelector("[foo^=bar i i]") threw exception SyntaxError: The string did not match the expected pattern..
-PASS document.querySelector("[|foo^=bar i i]") threw exception SyntaxError: The string did not match the expected pattern..
-PASS document.querySelector("[*|foo^=bar i i]") threw exception SyntaxError: The string did not match the expected pattern..
-PASS document.querySelector("[WebKit|foo^=bar i i]") threw exception SyntaxError: The string did not match the expected pattern..
+PASS document.querySelector("[foo^=bar i i]") threw exception SyntaxError: '[foo^=bar i i]' is not a valid selector..
+PASS document.querySelector("[|foo^=bar i i]") threw exception SyntaxError: '[|foo^=bar i i]' is not a valid selector..
+PASS document.querySelector("[*|foo^=bar i i]") threw exception SyntaxError: '[*|foo^=bar i i]' is not a valid selector..
+PASS document.querySelector("[WebKit|foo^=bar i i]") threw exception SyntaxError: '[WebKit|foo^=bar i i]' is not a valid selector..
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
-PASS document.querySelector("[foo^=\"bar\" i i]") threw exception SyntaxError: The string did not match the expected pattern..
-PASS document.querySelector("[|foo^=\"bar\" i i]") threw exception SyntaxError: The string did not match the expected pattern..
-PASS document.querySelector("[*|foo^=\"bar\" i i]") threw exception SyntaxError: The string did not match the expected pattern..
-PASS document.querySelector("[WebKit|foo^=\"bar\" i i]") threw exception SyntaxError: The string did not match the expected pattern..
+PASS document.querySelector("[foo^=\"bar\" i i]") threw exception SyntaxError: '[foo^="bar" i i]' is not a valid selector..
+PASS document.querySelector("[|foo^=\"bar\" i i]") threw exception SyntaxError: '[|foo^="bar" i i]' is not a valid selector..
+PASS document.querySelector("[*|foo^=\"bar\" i i]") threw exception SyntaxError: '[*|foo^="bar" i i]' is not a valid selector..
+PASS document.querySelector("[WebKit|foo^=\"bar\" i i]") threw exception SyntaxError: '[WebKit|foo^="bar" i i]' is not a valid selector..
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
-PASS document.querySelector("[foo$=bar i i]") threw exception SyntaxError: The string did not match the expected pattern..
-PASS document.querySelector("[|foo$=bar i i]") threw exception SyntaxError: The string did not match the expected pattern..
-PASS document.querySelector("[*|foo$=bar i i]") threw exception SyntaxError: The string did not match the expected pattern..
-PASS document.querySelector("[WebKit|foo$=bar i i]") threw exception SyntaxError: The string did not match the expected pattern..
+PASS document.querySelector("[foo$=bar i i]") threw exception SyntaxError: '[foo$=bar i i]' is not a valid selector..
+PASS document.querySelector("[|foo$=bar i i]") threw exception SyntaxError: '[|foo$=bar i i]' is not a valid selector..
+PASS document.querySelector("[*|foo$=bar i i]") threw exception SyntaxError: '[*|foo$=bar i i]' is not a valid selector..
+PASS document.querySelector("[WebKit|foo$=bar i i]") threw exception SyntaxError: '[WebKit|foo$=bar i i]' is not a valid selector..
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
-PASS document.querySelector("[foo$=\"bar\" i i]") threw exception SyntaxError: The string did not match the expected pattern..
-PASS document.querySelector("[|foo$=\"bar\" i i]") threw exception SyntaxError: The string did not match the expected pattern..
-PASS document.querySelector("[*|foo$=\"bar\" i i]") threw exception SyntaxError: The string did not match the expected pattern..
-PASS document.querySelector("[WebKit|foo$=\"bar\" i i]") threw exception SyntaxError: The string did not match the expected pattern..
+PASS document.querySelector("[foo$=\"bar\" i i]") threw exception SyntaxError: '[foo$="bar" i i]' is not a valid selector..
+PASS document.querySelector("[|foo$=\"bar\" i i]") threw exception SyntaxError: '[|foo$="bar" i i]' is not a valid selector..
+PASS document.querySelector("[*|foo$=\"bar\" i i]") threw exception SyntaxError: '[*|foo$="bar" i i]' is not a valid selector..
+PASS document.querySelector("[WebKit|foo$=\"bar\" i i]") threw exception SyntaxError: '[WebKit|foo$="bar" i i]' is not a valid selector..
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
-PASS document.querySelector("[foo*=bar i i]") threw exception SyntaxError: The string did not match the expected pattern..
-PASS document.querySelector("[|foo*=bar i i]") threw exception SyntaxError: The string did not match the expected pattern..
-PASS document.querySelector("[*|foo*=bar i i]") threw exception SyntaxError: The string did not match the expected pattern..
-PASS document.querySelector("[WebKit|foo*=bar i i]") threw exception SyntaxError: The string did not match the expected pattern..
+PASS document.querySelector("[foo*=bar i i]") threw exception SyntaxError: '[foo*=bar i i]' is not a valid selector..
+PASS document.querySelector("[|foo*=bar i i]") threw exception SyntaxError: '[|foo*=bar i i]' is not a valid selector..
+PASS document.querySelector("[*|foo*=bar i i]") threw exception SyntaxError: '[*|foo*=bar i i]' is not a valid selector..
+PASS document.querySelector("[WebKit|foo*=bar i i]") threw exception SyntaxError: '[WebKit|foo*=bar i i]' is not a valid selector..
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
-PASS document.querySelector("[foo*=\"bar\" i i]") threw exception SyntaxError: The string did not match the expected pattern..
-PASS document.querySelector("[|foo*=\"bar\" i i]") threw exception SyntaxError: The string did not match the expected pattern..
-PASS document.querySelector("[*|foo*=\"bar\" i i]") threw exception SyntaxError: The string did not match the expected pattern..
-PASS document.querySelector("[WebKit|foo*=\"bar\" i i]") threw exception SyntaxError: The string did not match the expected pattern..
+PASS document.querySelector("[foo*=\"bar\" i i]") threw exception SyntaxError: '[foo*="bar" i i]' is not a valid selector..
+PASS document.querySelector("[|foo*=\"bar\" i i]") threw exception SyntaxError: '[|foo*="bar" i i]' is not a valid selector..
+PASS document.querySelector("[*|foo*=\"bar\" i i]") threw exception SyntaxError: '[*|foo*="bar" i i]' is not a valid selector..
+PASS document.querySelector("[WebKit|foo*=\"bar\" i i]") threw exception SyntaxError: '[WebKit|foo*="bar" i i]' is not a valid selector..
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
-PASS document.querySelector("[foo=bar i first-child]") threw exception SyntaxError: The string did not match the expected pattern..
-PASS document.querySelector("[|foo=bar i first-child]") threw exception SyntaxError: The string did not match the expected pattern..
-PASS document.querySelector("[*|foo=bar i first-child]") threw exception SyntaxError: The string did not match the expected pattern..
-PASS document.querySelector("[WebKit|foo=bar i first-child]") threw exception SyntaxError: The string did not match the expected pattern..
+PASS document.querySelector("[foo=bar i first-child]") threw exception SyntaxError: '[foo=bar i first-child]' is not a valid selector..
+PASS document.querySelector("[|foo=bar i first-child]") threw exception SyntaxError: '[|foo=bar i first-child]' is not a valid selector..
+PASS document.querySelector("[*|foo=bar i first-child]") threw exception SyntaxError: '[*|foo=bar i first-child]' is not a valid selector..
+PASS document.querySelector("[WebKit|foo=bar i first-child]") threw exception SyntaxError: '[WebKit|foo=bar i first-child]' is not a valid selector..
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
-PASS document.querySelector("[foo=\"bar\" i first-child]") threw exception SyntaxError: The string did not match the expected pattern..
-PASS document.querySelector("[|foo=\"bar\" i first-child]") threw exception SyntaxError: The string did not match the expected pattern..
-PASS document.querySelector("[*|foo=\"bar\" i first-child]") threw exception SyntaxError: The string did not match the expected pattern..
-PASS document.querySelector("[WebKit|foo=\"bar\" i first-child]") threw exception SyntaxError: The string did not match the expected pattern..
+PASS document.querySelector("[foo=\"bar\" i first-child]") threw exception SyntaxError: '[foo="bar" i first-child]' is not a valid selector..
+PASS document.querySelector("[|foo=\"bar\" i first-child]") threw exception SyntaxError: '[|foo="bar" i first-child]' is not a valid selector..
+PASS document.querySelector("[*|foo=\"bar\" i first-child]") threw exception SyntaxError: '[*|foo="bar" i first-child]' is not a valid selector..
+PASS document.querySelector("[WebKit|foo=\"bar\" i first-child]") threw exception SyntaxError: '[WebKit|foo="bar" i first-child]' is not a valid selector..
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
-PASS document.querySelector("[foo~=bar i first-child]") threw exception SyntaxError: The string did not match the expected pattern..
-PASS document.querySelector("[|foo~=bar i first-child]") threw exception SyntaxError: The string did not match the expected pattern..
-PASS document.querySelector("[*|foo~=bar i first-child]") threw exception SyntaxError: The string did not match the expected pattern..
-PASS document.querySelector("[WebKit|foo~=bar i first-child]") threw exception SyntaxError: The string did not match the expected pattern..
+PASS document.querySelector("[foo~=bar i first-child]") threw exception SyntaxError: '[foo~=bar i first-child]' is not a valid selector..
+PASS document.querySelector("[|foo~=bar i first-child]") threw exception SyntaxError: '[|foo~=bar i first-child]' is not a valid selector..
+PASS document.querySelector("[*|foo~=bar i first-child]") threw exception SyntaxError: '[*|foo~=bar i first-child]' is not a valid selector..
+PASS document.querySelector("[WebKit|foo~=bar i first-child]") threw exception SyntaxError: '[WebKit|foo~=bar i first-child]' is not a valid selector..
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
-PASS document.querySelector("[foo~=\"bar\" i first-child]") threw exception SyntaxError: The string did not match the expected pattern..
-PASS document.querySelector("[|foo~=\"bar\" i first-child]") threw exception SyntaxError: The string did not match the expected pattern..
-PASS document.querySelector("[*|foo~=\"bar\" i first-child]") threw exception SyntaxError: The string did not match the expected pattern..
-PASS document.querySelector("[WebKit|foo~=\"bar\" i first-child]") threw exception SyntaxError: The string did not match the expected pattern..
+PASS document.querySelector("[foo~=\"bar\" i first-child]") threw exception SyntaxError: '[foo~="bar" i first-child]' is not a valid selector..
+PASS document.querySelector("[|foo~=\"bar\" i first-child]") threw exception SyntaxError: '[|foo~="bar" i first-child]' is not a valid selector..
+PASS document.querySelector("[*|foo~=\"bar\" i first-child]") threw exception SyntaxError: '[*|foo~="bar" i first-child]' is not a valid selector..
+PASS document.querySelector("[WebKit|foo~=\"bar\" i first-child]") threw exception SyntaxError: '[WebKit|foo~="bar" i first-child]' is not a valid selector..
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
-PASS document.querySelector("[foo|=bar i first-child]") threw exception SyntaxError: The string did not match the expected pattern..
-PASS document.querySelector("[|foo|=bar i first-child]") threw exception SyntaxError: The string did not match the expected pattern..
-PASS document.querySelector("[*|foo|=bar i first-child]") threw exception SyntaxError: The string did not match the expected pattern..
-PASS document.querySelector("[WebKit|foo|=bar i first-child]") threw exception SyntaxError: The string did not match the expected pattern..
+PASS document.querySelector("[foo|=bar i first-child]") threw exception SyntaxError: '[foo|=bar i first-child]' is not a valid selector..
+PASS document.querySelector("[|foo|=bar i first-child]") threw exception SyntaxError: '[|foo|=bar i first-child]' is not a valid selector..
+PASS document.querySelector("[*|foo|=bar i first-child]") threw exception SyntaxError: '[*|foo|=bar i first-child]' is not a valid selector..
+PASS document.querySelector("[WebKit|foo|=bar i first-child]") threw exception SyntaxError: '[WebKit|foo|=bar i first-child]' is not a valid selector..
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
-PASS document.querySelector("[foo|=\"bar\" i first-child]") threw exception SyntaxError: The string did not match the expected pattern..
-PASS document.querySelector("[|foo|=\"bar\" i first-child]") threw exception SyntaxError: The string did not match the expected pattern..
-PASS document.querySelector("[*|foo|=\"bar\" i first-child]") threw exception SyntaxError: The string did not match the expected pattern..
-PASS document.querySelector("[WebKit|foo|=\"bar\" i first-child]") threw exception SyntaxError: The string did not match the expected pattern..
+PASS document.querySelector("[foo|=\"bar\" i first-child]") threw exception SyntaxError: '[foo|="bar" i first-child]' is not a valid selector..
+PASS document.querySelector("[|foo|=\"bar\" i first-child]") threw exception SyntaxError: '[|foo|="bar" i first-child]' is not a valid selector..
+PASS document.querySelector("[*|foo|=\"bar\" i first-child]") threw exception SyntaxError: '[*|foo|="bar" i first-child]' is not a valid selector..
+PASS document.querySelector("[WebKit|foo|=\"bar\" i first-child]") threw exception SyntaxError: '[WebKit|foo|="bar" i first-child]' is not a valid selector..
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
-PASS document.querySelector("[foo^=bar i first-child]") threw exception SyntaxError: The string did not match the expected pattern..
-PASS document.querySelector("[|foo^=bar i first-child]") threw exception SyntaxError: The string did not match the expected pattern..
-PASS document.querySelector("[*|foo^=bar i first-child]") threw exception SyntaxError: The string did not match the expected pattern..
-PASS document.querySelector("[WebKit|foo^=bar i first-child]") threw exception SyntaxError: The string did not match the expected pattern..
+PASS document.querySelector("[foo^=bar i first-child]") threw exception SyntaxError: '[foo^=bar i first-child]' is not a valid selector..
+PASS document.querySelector("[|foo^=bar i first-child]") threw exception SyntaxError: '[|foo^=bar i first-child]' is not a valid selector..
+PASS document.querySelector("[*|foo^=bar i first-child]") threw exception SyntaxError: '[*|foo^=bar i first-child]' is not a valid selector..
+PASS document.querySelector("[WebKit|foo^=bar i first-child]") threw exception SyntaxError: '[WebKit|foo^=bar i first-child]' is not a valid selector..
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
-PASS document.querySelector("[foo^=\"bar\" i first-child]") threw exception SyntaxError: The string did not match the expected pattern..
-PASS document.querySelector("[|foo^=\"bar\" i first-child]") threw exception SyntaxError: The string did not match the expected pattern..
-PASS document.querySelector("[*|foo^=\"bar\" i first-child]") threw exception SyntaxError: The string did not match the expected pattern..
-PASS document.querySelector("[WebKit|foo^=\"bar\" i first-child]") threw exception SyntaxError: The string did not match the expected pattern..
+PASS document.querySelector("[foo^=\"bar\" i first-child]") threw exception SyntaxError: '[foo^="bar" i first-child]' is not a valid selector..
+PASS document.querySelector("[|foo^=\"bar\" i first-child]") threw exception SyntaxError: '[|foo^="bar" i first-child]' is not a valid selector..
+PASS document.querySelector("[*|foo^=\"bar\" i first-child]") threw exception SyntaxError: '[*|foo^="bar" i first-child]' is not a valid selector..
+PASS document.querySelector("[WebKit|foo^=\"bar\" i first-child]") threw exception SyntaxError: '[WebKit|foo^="bar" i first-child]' is not a valid selector..
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
-PASS document.querySelector("[foo$=bar i first-child]") threw exception SyntaxError: The string did not match the expected pattern..
-PASS document.querySelector("[|foo$=bar i first-child]") threw exception SyntaxError: The string did not match the expected pattern..
-PASS document.querySelector("[*|foo$=bar i first-child]") threw exception SyntaxError: The string did not match the expected pattern..
-PASS document.querySelector("[WebKit|foo$=bar i first-child]") threw exception SyntaxError: The string did not match the expected pattern..
+PASS document.querySelector("[foo$=bar i first-child]") threw exception SyntaxError: '[foo$=bar i first-child]' is not a valid selector..
+PASS document.querySelector("[|foo$=bar i first-child]") threw exception SyntaxError: '[|foo$=bar i first-child]' is not a valid selector..
+PASS document.querySelector("[*|foo$=bar i first-child]") threw exception SyntaxError: '[*|foo$=bar i first-child]' is not a valid selector..
+PASS document.querySelector("[WebKit|foo$=bar i first-child]") threw exception SyntaxError: '[WebKit|foo$=bar i first-child]' is not a valid selector..
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
-PASS document.querySelector("[foo$=\"bar\" i first-child]") threw exception SyntaxError: The string did not match the expected pattern..
-PASS document.querySelector("[|foo$=\"bar\" i first-child]") threw exception SyntaxError: The string did not match the expected pattern..
-PASS document.querySelector("[*|foo$=\"bar\" i first-child]") threw exception SyntaxError: The string did not match the expected pattern..
-PASS document.querySelector("[WebKit|foo$=\"bar\" i first-child]") threw exception SyntaxError: The string did not match the expected pattern..
+PASS document.querySelector("[foo$=\"bar\" i first-child]") threw exception SyntaxError: '[foo$="bar" i first-child]' is not a valid selector..
+PASS document.querySelector("[|foo$=\"bar\" i first-child]") threw exception SyntaxError: '[|foo$="bar" i first-child]' is not a valid selector..
+PASS document.querySelector("[*|foo$=\"bar\" i first-child]") threw exception SyntaxError: '[*|foo$="bar" i first-child]' is not a valid selector..
+PASS document.querySelector("[WebKit|foo$=\"bar\" i first-child]") threw exception SyntaxError: '[WebKit|foo$="bar" i first-child]' is not a valid selector..
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
-PASS document.querySelector("[foo*=bar i first-child]") threw exception SyntaxError: The string did not match the expected pattern..
-PASS document.querySelector("[|foo*=bar i first-child]") threw exception SyntaxError: The string did not match the expected pattern..
-PASS document.querySelector("[*|foo*=bar i first-child]") threw exception SyntaxError: The string did not match the expected pattern..
-PASS document.querySelector("[WebKit|foo*=bar i first-child]") threw exception SyntaxError: The string did not match the expected pattern..
+PASS document.querySelector("[foo*=bar i first-child]") threw exception SyntaxError: '[foo*=bar i first-child]' is not a valid selector..
+PASS document.querySelector("[|foo*=bar i first-child]") threw exception SyntaxError: '[|foo*=bar i first-child]' is not a valid selector..
+PASS document.querySelector("[*|foo*=bar i first-child]") threw exception SyntaxError: '[*|foo*=bar i first-child]' is not a valid selector..
+PASS document.querySelector("[WebKit|foo*=bar i first-child]") threw exception SyntaxError: '[WebKit|foo*=bar i first-child]' is not a valid selector..
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
-PASS document.querySelector("[foo*=\"bar\" i first-child]") threw exception SyntaxError: The string did not match the expected pattern..
-PASS document.querySelector("[|foo*=\"bar\" i first-child]") threw exception SyntaxError: The string did not match the expected pattern..
-PASS document.querySelector("[*|foo*=\"bar\" i first-child]") threw exception SyntaxError: The string did not match the expected pattern..
-PASS document.querySelector("[WebKit|foo*=\"bar\" i first-child]") threw exception SyntaxError: The string did not match the expected pattern..
+PASS document.querySelector("[foo*=\"bar\" i first-child]") threw exception SyntaxError: '[foo*="bar" i first-child]' is not a valid selector..
+PASS document.querySelector("[|foo*=\"bar\" i first-child]") threw exception SyntaxError: '[|foo*="bar" i first-child]' is not a valid selector..
+PASS document.querySelector("[*|foo*=\"bar\" i first-child]") threw exception SyntaxError: '[*|foo*="bar" i first-child]' is not a valid selector..
+PASS document.querySelector("[WebKit|foo*=\"bar\" i first-child]") threw exception SyntaxError: '[WebKit|foo*="bar" i first-child]' is not a valid selector..
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
-PASS document.querySelector("[foo=bar i \"empty\"]") threw exception SyntaxError: The string did not match the expected pattern..
-PASS document.querySelector("[|foo=bar i \"empty\"]") threw exception SyntaxError: The string did not match the expected pattern..
-PASS document.querySelector("[*|foo=bar i \"empty\"]") threw exception SyntaxError: The string did not match the expected pattern..
-PASS document.querySelector("[WebKit|foo=bar i \"empty\"]") threw exception SyntaxError: The string did not match the expected pattern..
+PASS document.querySelector("[foo=bar i \"empty\"]") threw exception SyntaxError: '[foo=bar i "empty"]' is not a valid selector..
+PASS document.querySelector("[|foo=bar i \"empty\"]") threw exception SyntaxError: '[|foo=bar i "empty"]' is not a valid selector..
+PASS document.querySelector("[*|foo=bar i \"empty\"]") threw exception SyntaxError: '[*|foo=bar i "empty"]' is not a valid selector..
+PASS document.querySelector("[WebKit|foo=bar i \"empty\"]") threw exception SyntaxError: '[WebKit|foo=bar i "empty"]' is not a valid selector..
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
-PASS document.querySelector("[foo=\"bar\" i \"empty\"]") threw exception SyntaxError: The string did not match the expected pattern..
-PASS document.querySelector("[|foo=\"bar\" i \"empty\"]") threw exception SyntaxError: The string did not match the expected pattern..
-PASS document.querySelector("[*|foo=\"bar\" i \"empty\"]") threw exception SyntaxError: The string did not match the expected pattern..
-PASS document.querySelector("[WebKit|foo=\"bar\" i \"empty\"]") threw exception SyntaxError: The string did not match the expected pattern..
+PASS document.querySelector("[foo=\"bar\" i \"empty\"]") threw exception SyntaxError: '[foo="bar" i "empty"]' is not a valid selector..
+PASS document.querySelector("[|foo=\"bar\" i \"empty\"]") threw exception SyntaxError: '[|foo="bar" i "empty"]' is not a valid selector..
+PASS document.querySelector("[*|foo=\"bar\" i \"empty\"]") threw exception SyntaxError: '[*|foo="bar" i "empty"]' is not a valid selector..
+PASS document.querySelector("[WebKit|foo=\"bar\" i \"empty\"]") threw exception SyntaxError: '[WebKit|foo="bar" i "empty"]' is not a valid selector..
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
-PASS document.querySelector("[foo~=bar i \"empty\"]") threw exception SyntaxError: The string did not match the expected pattern..
-PASS document.querySelector("[|foo~=bar i \"empty\"]") threw exception SyntaxError: The string did not match the expected pattern..
-PASS document.querySelector("[*|foo~=bar i \"empty\"]") threw exception SyntaxError: The string did not match the expected pattern..
-PASS document.querySelector("[WebKit|foo~=bar i \"empty\"]") threw exception SyntaxError: The string did not match the expected pattern..
+PASS document.querySelector("[foo~=bar i \"empty\"]") threw exception SyntaxError: '[foo~=bar i "empty"]' is not a valid selector..
+PASS document.querySelector("[|foo~=bar i \"empty\"]") threw exception SyntaxError: '[|foo~=bar i "empty"]' is not a valid selector..
+PASS document.querySelector("[*|foo~=bar i \"empty\"]") threw exception SyntaxError: '[*|foo~=bar i "empty"]' is not a valid selector..
+PASS document.querySelector("[WebKit|foo~=bar i \"empty\"]") threw exception SyntaxError: '[WebKit|foo~=bar i "empty"]' is not a valid selector..
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
-PASS document.querySelector("[foo~=\"bar\" i \"empty\"]") threw exception SyntaxError: The string did not match the expected pattern..
-PASS document.querySelector("[|foo~=\"bar\" i \"empty\"]") threw exception SyntaxError: The string did not match the expected pattern..
-PASS document.querySelector("[*|foo~=\"bar\" i \"empty\"]") threw exception SyntaxError: The string did not match the expected pattern..
-PASS document.querySelector("[WebKit|foo~=\"bar\" i \"empty\"]") threw exception SyntaxError: The string did not match the expected pattern..
+PASS document.querySelector("[foo~=\"bar\" i \"empty\"]") threw exception SyntaxError: '[foo~="bar" i "empty"]' is not a valid selector..
+PASS document.querySelector("[|foo~=\"bar\" i \"empty\"]") threw exception SyntaxError: '[|foo~="bar" i "empty"]' is not a valid selector..
+PASS document.querySelector("[*|foo~=\"bar\" i \"empty\"]") threw exception SyntaxError: '[*|foo~="bar" i "empty"]' is not a valid selector..
+PASS document.querySelector("[WebKit|foo~=\"bar\" i \"empty\"]") threw exception SyntaxError: '[WebKit|foo~="bar" i "empty"]' is not a valid selector..
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
-PASS document.querySelector("[foo|=bar i \"empty\"]") threw exception SyntaxError: The string did not match the expected pattern..
-PASS document.querySelector("[|foo|=bar i \"empty\"]") threw exception SyntaxError: The string did not match the expected pattern..
-PASS document.querySelector("[*|foo|=bar i \"empty\"]") threw exception SyntaxError: The string did not match the expected pattern..
-PASS document.querySelector("[WebKit|foo|=bar i \"empty\"]") threw exception SyntaxError: The string did not match the expected pattern..
+PASS document.querySelector("[foo|=bar i \"empty\"]") threw exception SyntaxError: '[foo|=bar i "empty"]' is not a valid selector..
+PASS document.querySelector("[|foo|=bar i \"empty\"]") threw exception SyntaxError: '[|foo|=bar i "empty"]' is not a valid selector..
+PASS document.querySelector("[*|foo|=bar i \"empty\"]") threw exception SyntaxError: '[*|foo|=bar i "empty"]' is not a valid selector..
+PASS document.querySelector("[WebKit|foo|=bar i \"empty\"]") threw exception SyntaxError: '[WebKit|foo|=bar i "empty"]' is not a valid selector..
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
-PASS document.querySelector("[foo|=\"bar\" i \"empty\"]") threw exception SyntaxError: The string did not match the expected pattern..
-PASS document.querySelector("[|foo|=\"bar\" i \"empty\"]") threw exception SyntaxError: The string did not match the expected pattern..
-PASS document.querySelector("[*|foo|=\"bar\" i \"empty\"]") threw exception SyntaxError: The string did not match the expected pattern..
-PASS document.querySelector("[WebKit|foo|=\"bar\" i \"empty\"]") threw exception SyntaxError: The string did not match the expected pattern..
+PASS document.querySelector("[foo|=\"bar\" i \"empty\"]") threw exception SyntaxError: '[foo|="bar" i "empty"]' is not a valid selector..
+PASS document.querySelector("[|foo|=\"bar\" i \"empty\"]") threw exception SyntaxError: '[|foo|="bar" i "empty"]' is not a valid selector..
+PASS document.querySelector("[*|foo|=\"bar\" i \"empty\"]") threw exception SyntaxError: '[*|foo|="bar" i "empty"]' is not a valid selector..
+PASS document.querySelector("[WebKit|foo|=\"bar\" i \"empty\"]") threw exception SyntaxError: '[WebKit|foo|="bar" i "empty"]' is not a valid selector..
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
-PASS document.querySelector("[foo^=bar i \"empty\"]") threw exception SyntaxError: The string did not match the expected pattern..
-PASS document.querySelector("[|foo^=bar i \"empty\"]") threw exception SyntaxError: The string did not match the expected pattern..
-PASS document.querySelector("[*|foo^=bar i \"empty\"]") threw exception SyntaxError: The string did not match the expected pattern..
-PASS document.querySelector("[WebKit|foo^=bar i \"empty\"]") threw exception SyntaxError: The string did not match the expected pattern..
+PASS document.querySelector("[foo^=bar i \"empty\"]") threw exception SyntaxError: '[foo^=bar i "empty"]' is not a valid selector..
+PASS document.querySelector("[|foo^=bar i \"empty\"]") threw exception SyntaxError: '[|foo^=bar i "empty"]' is not a valid selector..
+PASS document.querySelector("[*|foo^=bar i \"empty\"]") threw exception SyntaxError: '[*|foo^=bar i "empty"]' is not a valid selector..
+PASS document.querySelector("[WebKit|foo^=bar i \"empty\"]") threw exception SyntaxError: '[WebKit|foo^=bar i "empty"]' is not a valid selector..
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
-PASS document.querySelector("[foo^=\"bar\" i \"empty\"]") threw exception SyntaxError: The string did not match the expected pattern..
-PASS document.querySelector("[|foo^=\"bar\" i \"empty\"]") threw exception SyntaxError: The string did not match the expected pattern..
-PASS document.querySelector("[*|foo^=\"bar\" i \"empty\"]") threw exception SyntaxError: The string did not match the expected pattern..
-PASS document.querySelector("[WebKit|foo^=\"bar\" i \"empty\"]") threw exception SyntaxError: The string did not match the expected pattern..
+PASS document.querySelector("[foo^=\"bar\" i \"empty\"]") threw exception SyntaxError: '[foo^="bar" i "empty"]' is not a valid selector..
+PASS document.querySelector("[|foo^=\"bar\" i \"empty\"]") threw exception SyntaxError: '[|foo^="bar" i "empty"]' is not a valid selector..
+PASS document.querySelector("[*|foo^=\"bar\" i \"empty\"]") threw exception SyntaxError: '[*|foo^="bar" i "empty"]' is not a valid selector..
+PASS document.querySelector("[WebKit|foo^=\"bar\" i \"empty\"]") threw exception SyntaxError: '[WebKit|foo^="bar" i "empty"]' is not a valid selector..
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
-PASS document.querySelector("[foo$=bar i \"empty\"]") threw exception SyntaxError: The string did not match the expected pattern..
-PASS document.querySelector("[|foo$=bar i \"empty\"]") threw exception SyntaxError: The string did not match the expected pattern..
-PASS document.querySelector("[*|foo$=bar i \"empty\"]") threw exception SyntaxError: The string did not match the expected pattern..
-PASS document.querySelector("[WebKit|foo$=bar i \"empty\"]") threw exception SyntaxError: The string did not match the expected pattern..
+PASS document.querySelector("[foo$=bar i \"empty\"]") threw exception SyntaxError: '[foo$=bar i "empty"]' is not a valid selector..
+PASS document.querySelector("[|foo$=bar i \"empty\"]") threw exception SyntaxError: '[|foo$=bar i "empty"]' is not a valid selector..
+PASS document.querySelector("[*|foo$=bar i \"empty\"]") threw exception SyntaxError: '[*|foo$=bar i "empty"]' is not a valid selector..
+PASS document.querySelector("[WebKit|foo$=bar i \"empty\"]") threw exception SyntaxError: '[WebKit|foo$=bar i "empty"]' is not a valid selector..
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
-PASS document.querySelector("[foo$=\"bar\" i \"empty\"]") threw exception SyntaxError: The string did not match the expected pattern..
-PASS document.querySelector("[|foo$=\"bar\" i \"empty\"]") threw exception SyntaxError: The string did not match the expected pattern..
-PASS document.querySelector("[*|foo$=\"bar\" i \"empty\"]") threw exception SyntaxError: The string did not match the expected pattern..
-PASS document.querySelector("[WebKit|foo$=\"bar\" i \"empty\"]") threw exception SyntaxError: The string did not match the expected pattern..
+PASS document.querySelector("[foo$=\"bar\" i \"empty\"]") threw exception SyntaxError: '[foo$="bar" i "empty"]' is not a valid selector..
+PASS document.querySelector("[|foo$=\"bar\" i \"empty\"]") threw exception SyntaxError: '[|foo$="bar" i "empty"]' is not a valid selector..
+PASS document.querySelector("[*|foo$=\"bar\" i \"empty\"]") threw exception SyntaxError: '[*|foo$="bar" i "empty"]' is not a valid selector..
+PASS document.querySelector("[WebKit|foo$=\"bar\" i \"empty\"]") threw exception SyntaxError: '[WebKit|foo$="bar" i "empty"]' is not a valid selector..
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
-PASS document.querySelector("[foo*=bar i \"empty\"]") threw exception SyntaxError: The string did not match the expected pattern..
-PASS document.querySelector("[|foo*=bar i \"empty\"]") threw exception SyntaxError: The string did not match the expected pattern..
-PASS document.querySelector("[*|foo*=bar i \"empty\"]") threw exception SyntaxError: The string did not match the expected pattern..
-PASS document.querySelector("[WebKit|foo*=bar i \"empty\"]") threw exception SyntaxError: The string did not match the expected pattern..
+PASS document.querySelector("[foo*=bar i \"empty\"]") threw exception SyntaxError: '[foo*=bar i "empty"]' is not a valid selector..
+PASS document.querySelector("[|foo*=bar i \"empty\"]") threw exception SyntaxError: '[|foo*=bar i "empty"]' is not a valid selector..
+PASS document.querySelector("[*|foo*=bar i \"empty\"]") threw exception SyntaxError: '[*|foo*=bar i "empty"]' is not a valid selector..
+PASS document.querySelector("[WebKit|foo*=bar i \"empty\"]") threw exception SyntaxError: '[WebKit|foo*=bar i "empty"]' is not a valid selector..
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
-PASS document.querySelector("[foo*=\"bar\" i \"empty\"]") threw exception SyntaxError: The string did not match the expected pattern..
-PASS document.querySelector("[|foo*=\"bar\" i \"empty\"]") threw exception SyntaxError: The string did not match the expected pattern..
-PASS document.querySelector("[*|foo*=\"bar\" i \"empty\"]") threw exception SyntaxError: The string did not match the expected pattern..
-PASS document.querySelector("[WebKit|foo*=\"bar\" i \"empty\"]") threw exception SyntaxError: The string did not match the expected pattern..
+PASS document.querySelector("[foo*=\"bar\" i \"empty\"]") threw exception SyntaxError: '[foo*="bar" i "empty"]' is not a valid selector..
+PASS document.querySelector("[|foo*=\"bar\" i \"empty\"]") threw exception SyntaxError: '[|foo*="bar" i "empty"]' is not a valid selector..
+PASS document.querySelector("[*|foo*=\"bar\" i \"empty\"]") threw exception SyntaxError: '[*|foo*="bar" i "empty"]' is not a valid selector..
+PASS document.querySelector("[WebKit|foo*=\"bar\" i \"empty\"]") threw exception SyntaxError: '[WebKit|foo*="bar" i "empty"]' is not a valid selector..
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
-PASS document.querySelector("[foo=bar first-child i]") threw exception SyntaxError: The string did not match the expected pattern..
-PASS document.querySelector("[|foo=bar first-child i]") threw exception SyntaxError: The string did not match the expected pattern..
-PASS document.querySelector("[*|foo=bar first-child i]") threw exception SyntaxError: The string did not match the expected pattern..
-PASS document.querySelector("[WebKit|foo=bar first-child i]") threw exception SyntaxError: The string did not match the expected pattern..
+PASS document.querySelector("[foo=bar first-child i]") threw exception SyntaxError: '[foo=bar first-child i]' is not a valid selector..
+PASS document.querySelector("[|foo=bar first-child i]") threw exception SyntaxError: '[|foo=bar first-child i]' is not a valid selector..
+PASS document.querySelector("[*|foo=bar first-child i]") threw exception SyntaxError: '[*|foo=bar first-child i]' is not a valid selector..
+PASS document.querySelector("[WebKit|foo=bar first-child i]") threw exception SyntaxError: '[WebKit|foo=bar first-child i]' is not a valid selector..
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
-PASS document.querySelector("[foo=\"bar\" first-child i]") threw exception SyntaxError: The string did not match the expected pattern..
-PASS document.querySelector("[|foo=\"bar\" first-child i]") threw exception SyntaxError: The string did not match the expected pattern..
-PASS document.querySelector("[*|foo=\"bar\" first-child i]") threw exception SyntaxError: The string did not match the expected pattern..
-PASS document.querySelector("[WebKit|foo=\"bar\" first-child i]") threw exception SyntaxError: The string did not match the expected pattern..
+PASS document.querySelector("[foo=\"bar\" first-child i]") threw exception SyntaxError: '[foo="bar" first-child i]' is not a valid selector..
+PASS document.querySelector("[|foo=\"bar\" first-child i]") threw exception SyntaxError: '[|foo="bar" first-child i]' is not a valid selector..
+PASS document.querySelector("[*|foo=\"bar\" first-child i]") threw exception SyntaxError: '[*|foo="bar" first-child i]' is not a valid selector..
+PASS document.querySelector("[WebKit|foo=\"bar\" first-child i]") threw exception SyntaxError: '[WebKit|foo="bar" first-child i]' is not a valid selector..
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
-PASS document.querySelector("[foo~=bar first-child i]") threw exception SyntaxError: The string did not match the expected pattern..
-PASS document.querySelector("[|foo~=bar first-child i]") threw exception SyntaxError: The string did not match the expected pattern..
-PASS document.querySelector("[*|foo~=bar first-child i]") threw exception SyntaxError: The string did not match the expected pattern..
-PASS document.querySelector("[WebKit|foo~=bar first-child i]") threw exception SyntaxError: The string did not match the expected pattern..
+PASS document.querySelector("[foo~=bar first-child i]") threw exception SyntaxError: '[foo~=bar first-child i]' is not a valid selector..
+PASS document.querySelector("[|foo~=bar first-child i]") threw exception SyntaxError: '[|foo~=bar first-child i]' is not a valid selector..
+PASS document.querySelector("[*|foo~=bar first-child i]") threw exception SyntaxError: '[*|foo~=bar first-child i]' is not a valid selector..
+PASS document.querySelector("[WebKit|foo~=bar first-child i]") threw exception SyntaxError: '[WebKit|foo~=bar first-child i]' is not a valid selector..
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
-PASS document.querySelector("[foo~=\"bar\" first-child i]") threw exception SyntaxError: The string did not match the expected pattern..
-PASS document.querySelector("[|foo~=\"bar\" first-child i]") threw exception SyntaxError: The string did not match the expected pattern..
-PASS document.querySelector("[*|foo~=\"bar\" first-child i]") threw exception SyntaxError: The string did not match the expected pattern..
-PASS document.querySelector("[WebKit|foo~=\"bar\" first-child i]") threw exception SyntaxError: The string did not match the expected pattern..
+PASS document.querySelector("[foo~=\"bar\" first-child i]") threw exception SyntaxError: '[foo~="bar" first-child i]' is not a valid selector..
+PASS document.querySelector("[|foo~=\"bar\" first-child i]") threw exception SyntaxError: '[|foo~="bar" first-child i]' is not a valid selector..
+PASS document.querySelector("[*|foo~=\"bar\" first-child i]") threw exception SyntaxError: '[*|foo~="bar" first-child i]' is not a valid selector..
+PASS document.querySelector("[WebKit|foo~=\"bar\" first-child i]") threw exception SyntaxError: '[WebKit|foo~="bar" first-child i]' is not a valid selector..
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
-PASS document.querySelector("[foo|=bar first-child i]") threw exception SyntaxError: The string did not match the expected pattern..
-PASS document.querySelector("[|foo|=bar first-child i]") threw exception SyntaxError: The string did not match the expected pattern..
-PASS document.querySelector("[*|foo|=bar first-child i]") threw exception SyntaxError: The string did not match the expected pattern..
-PASS document.querySelector("[WebKit|foo|=bar first-child i]") threw exception SyntaxError: The string did not match the expected pattern..
+PASS document.querySelector("[foo|=bar first-child i]") threw exception SyntaxError: '[foo|=bar first-child i]' is not a valid selector..
+PASS document.querySelector("[|foo|=bar first-child i]") threw exception SyntaxError: '[|foo|=bar first-child i]' is not a valid selector..
+PASS document.querySelector("[*|foo|=bar first-child i]") threw exception SyntaxError: '[*|foo|=bar first-child i]' is not a valid selector..
+PASS document.querySelector("[WebKit|foo|=bar first-child i]") threw exception SyntaxError: '[WebKit|foo|=bar first-child i]' is not a valid selector..
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
-PASS document.querySelector("[foo|=\"bar\" first-child i]") threw exception SyntaxError: The string did not match the expected pattern..
-PASS document.querySelector("[|foo|=\"bar\" first-child i]") threw exception SyntaxError: The string did not match the expected pattern..
-PASS document.querySelector("[*|foo|=\"bar\" first-child i]") threw exception SyntaxError: The string did not match the expected pattern..
-PASS document.querySelector("[WebKit|foo|=\"bar\" first-child i]") threw exception SyntaxError: The string did not match the expected pattern..
+PASS document.querySelector("[foo|=\"bar\" first-child i]") threw exception SyntaxError: '[foo|="bar" first-child i]' is not a valid selector..
+PASS document.querySelector("[|foo|=\"bar\" first-child i]") threw exception SyntaxError: '[|foo|="bar" first-child i]' is not a valid selector..
+PASS document.querySelector("[*|foo|=\"bar\" first-child i]") threw exception SyntaxError: '[*|foo|="bar" first-child i]' is not a valid selector..
+PASS document.querySelector("[WebKit|foo|=\"bar\" first-child i]") threw exception SyntaxError: '[WebKit|foo|="bar" first-child i]' is not a valid selector..
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
-PASS document.querySelector("[foo^=bar first-child i]") threw exception SyntaxError: The string did not match the expected pattern..
-PASS document.querySelector("[|foo^=bar first-child i]") threw exception SyntaxError: The string did not match the expected pattern..
-PASS document.querySelector("[*|foo^=bar first-child i]") threw exception SyntaxError: The string did not match the expected pattern..
-PASS document.querySelector("[WebKit|foo^=bar first-child i]") threw exception SyntaxError: The string did not match the expected pattern..
+PASS document.querySelector("[foo^=bar first-child i]") threw exception SyntaxError: '[foo^=bar first-child i]' is not a valid selector..
+PASS document.querySelector("[|foo^=bar first-child i]") threw exception SyntaxError: '[|foo^=bar first-child i]' is not a valid selector..
+PASS document.querySelector("[*|foo^=bar first-child i]") threw exception SyntaxError: '[*|foo^=bar first-child i]' is not a valid selector..
+PASS document.querySelector("[WebKit|foo^=bar first-child i]") threw exception SyntaxError: '[WebKit|foo^=bar first-child i]' is not a valid selector..
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
-PASS document.querySelector("[foo^=\"bar\" first-child i]") threw exception SyntaxError: The string did not match the expected pattern..
-PASS document.querySelector("[|foo^=\"bar\" first-child i]") threw exception SyntaxError: The string did not match the expected pattern..
-PASS document.querySelector("[*|foo^=\"bar\" first-child i]") threw exception SyntaxError: The string did not match the expected pattern..
-PASS document.querySelector("[WebKit|foo^=\"bar\" first-child i]") threw exception SyntaxError: The string did not match the expected pattern..
+PASS document.querySelector("[foo^=\"bar\" first-child i]") threw exception SyntaxError: '[foo^="bar" first-child i]' is not a valid selector..
+PASS document.querySelector("[|foo^=\"bar\" first-child i]") threw exception SyntaxError: '[|foo^="bar" first-child i]' is not a valid selector..
+PASS document.querySelector("[*|foo^=\"bar\" first-child i]") threw exception SyntaxError: '[*|foo^="bar" first-child i]' is not a valid selector..
+PASS document.querySelector("[WebKit|foo^=\"bar\" first-child i]") threw exception SyntaxError: '[WebKit|foo^="bar" first-child i]' is not a valid selector..
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
-PASS document.querySelector("[foo$=bar first-child i]") threw exception SyntaxError: The string did not match the expected pattern..
-PASS document.querySelector("[|foo$=bar first-child i]") threw exception SyntaxError: The string did not match the expected pattern..
-PASS document.querySelector("[*|foo$=bar first-child i]") threw exception SyntaxError: The string did not match the expected pattern..
-PASS document.querySelector("[WebKit|foo$=bar first-child i]") threw exception SyntaxError: The string did not match the expected pattern..
+PASS document.querySelector("[foo$=bar first-child i]") threw exception SyntaxError: '[foo$=bar first-child i]' is not a valid selector..
+PASS document.querySelector("[|foo$=bar first-child i]") threw exception SyntaxError: '[|foo$=bar first-child i]' is not a valid selector..
+PASS document.querySelector("[*|foo$=bar first-child i]") threw exception SyntaxError: '[*|foo$=bar first-child i]' is not a valid selector..
+PASS document.querySelector("[WebKit|foo$=bar first-child i]") threw exception SyntaxError: '[WebKit|foo$=bar first-child i]' is not a valid selector..
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
-PASS document.querySelector("[foo$=\"bar\" first-child i]") threw exception SyntaxError: The string did not match the expected pattern..
-PASS document.querySelector("[|foo$=\"bar\" first-child i]") threw exception SyntaxError: The string did not match the expected pattern..
-PASS document.querySelector("[*|foo$=\"bar\" first-child i]") threw exception SyntaxError: The string did not match the expected pattern..
-PASS document.querySelector("[WebKit|foo$=\"bar\" first-child i]") threw exception SyntaxError: The string did not match the expected pattern..
+PASS document.querySelector("[foo$=\"bar\" first-child i]") threw exception SyntaxError: '[foo$="bar" first-child i]' is not a valid selector..
+PASS document.querySelector("[|foo$=\"bar\" first-child i]") threw exception SyntaxError: '[|foo$="bar" first-child i]' is not a valid selector..
+PASS document.querySelector("[*|foo$=\"bar\" first-child i]") threw exception SyntaxError: '[*|foo$="bar" first-child i]' is not a valid selector..
+PASS document.querySelector("[WebKit|foo$=\"bar\" first-child i]") threw exception SyntaxError: '[WebKit|foo$="bar" first-child i]' is not a valid selector..
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
-PASS document.querySelector("[foo*=bar first-child i]") threw exception SyntaxError: The string did not match the expected pattern..
-PASS document.querySelector("[|foo*=bar first-child i]") threw exception SyntaxError: The string did not match the expected pattern..
-PASS document.querySelector("[*|foo*=bar first-child i]") threw exception SyntaxError: The string did not match the expected pattern..
-PASS document.querySelector("[WebKit|foo*=bar first-child i]") threw exception SyntaxError: The string did not match the expected pattern..
+PASS document.querySelector("[foo*=bar first-child i]") threw exception SyntaxError: '[foo*=bar first-child i]' is not a valid selector..
+PASS document.querySelector("[|foo*=bar first-child i]") threw exception SyntaxError: '[|foo*=bar first-child i]' is not a valid selector..
+PASS document.querySelector("[*|foo*=bar first-child i]") threw exception SyntaxError: '[*|foo*=bar first-child i]' is not a valid selector..
+PASS document.querySelector("[WebKit|foo*=bar first-child i]") threw exception SyntaxError: '[WebKit|foo*=bar first-child i]' is not a valid selector..
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
-PASS document.querySelector("[foo*=\"bar\" first-child i]") threw exception SyntaxError: The string did not match the expected pattern..
-PASS document.querySelector("[|foo*=\"bar\" first-child i]") threw exception SyntaxError: The string did not match the expected pattern..
-PASS document.querySelector("[*|foo*=\"bar\" first-child i]") threw exception SyntaxError: The string did not match the expected pattern..
-PASS document.querySelector("[WebKit|foo*=\"bar\" first-child i]") threw exception SyntaxError: The string did not match the expected pattern..
+PASS document.querySelector("[foo*=\"bar\" first-child i]") threw exception SyntaxError: '[foo*="bar" first-child i]' is not a valid selector..
+PASS document.querySelector("[|foo*=\"bar\" first-child i]") threw exception SyntaxError: '[|foo*="bar" first-child i]' is not a valid selector..
+PASS document.querySelector("[*|foo*=\"bar\" first-child i]") threw exception SyntaxError: '[*|foo*="bar" first-child i]' is not a valid selector..
+PASS document.querySelector("[WebKit|foo*=\"bar\" first-child i]") threw exception SyntaxError: '[WebKit|foo*="bar" first-child i]' is not a valid selector..
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
-PASS document.querySelector("[foo=bar \"empty\" i]") threw exception SyntaxError: The string did not match the expected pattern..
-PASS document.querySelector("[|foo=bar \"empty\" i]") threw exception SyntaxError: The string did not match the expected pattern..
-PASS document.querySelector("[*|foo=bar \"empty\" i]") threw exception SyntaxError: The string did not match the expected pattern..
-PASS document.querySelector("[WebKit|foo=bar \"empty\" i]") threw exception SyntaxError: The string did not match the expected pattern..
+PASS document.querySelector("[foo=bar \"empty\" i]") threw exception SyntaxError: '[foo=bar "empty" i]' is not a valid selector..
+PASS document.querySelector("[|foo=bar \"empty\" i]") threw exception SyntaxError: '[|foo=bar "empty" i]' is not a valid selector..
+PASS document.querySelector("[*|foo=bar \"empty\" i]") threw exception SyntaxError: '[*|foo=bar "empty" i]' is not a valid selector..
+PASS document.querySelector("[WebKit|foo=bar \"empty\" i]") threw exception SyntaxError: '[WebKit|foo=bar "empty" i]' is not a valid selector..
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
-PASS document.querySelector("[foo=\"bar\" \"empty\" i]") threw exception SyntaxError: The string did not match the expected pattern..
-PASS document.querySelector("[|foo=\"bar\" \"empty\" i]") threw exception SyntaxError: The string did not match the expected pattern..
-PASS document.querySelector("[*|foo=\"bar\" \"empty\" i]") threw exception SyntaxError: The string did not match the expected pattern..
-PASS document.querySelector("[WebKit|foo=\"bar\" \"empty\" i]") threw exception SyntaxError: The string did not match the expected pattern..
+PASS document.querySelector("[foo=\"bar\" \"empty\" i]") threw exception SyntaxError: '[foo="bar" "empty" i]' is not a valid selector..
+PASS document.querySelector("[|foo=\"bar\" \"empty\" i]") threw exception SyntaxError: '[|foo="bar" "empty" i]' is not a valid selector..
+PASS document.querySelector("[*|foo=\"bar\" \"empty\" i]") threw exception SyntaxError: '[*|foo="bar" "empty" i]' is not a valid selector..
+PASS document.querySelector("[WebKit|foo=\"bar\" \"empty\" i]") threw exception SyntaxError: '[WebKit|foo="bar" "empty" i]' is not a valid selector..
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
-PASS document.querySelector("[foo~=bar \"empty\" i]") threw exception SyntaxError: The string did not match the expected pattern..
-PASS document.querySelector("[|foo~=bar \"empty\" i]") threw exception SyntaxError: The string did not match the expected pattern..
-PASS document.querySelector("[*|foo~=bar \"empty\" i]") threw exception SyntaxError: The string did not match the expected pattern..
-PASS document.querySelector("[WebKit|foo~=bar \"empty\" i]") threw exception SyntaxError: The string did not match the expected pattern..
+PASS document.querySelector("[foo~=bar \"empty\" i]") threw exception SyntaxError: '[foo~=bar "empty" i]' is not a valid selector..
+PASS document.querySelector("[|foo~=bar \"empty\" i]") threw exception SyntaxError: '[|foo~=bar "empty" i]' is not a valid selector..
+PASS document.querySelector("[*|foo~=bar \"empty\" i]") threw exception SyntaxError: '[*|foo~=bar "empty" i]' is not a valid selector..
+PASS document.querySelector("[WebKit|foo~=bar \"empty\" i]") threw exception SyntaxError: '[WebKit|foo~=bar "empty" i]' is not a valid selector..
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
-PASS document.querySelector("[foo~=\"bar\" \"empty\" i]") threw exception SyntaxError: The string did not match the expected pattern..
-PASS document.querySelector("[|foo~=\"bar\" \"empty\" i]") threw exception SyntaxError: The string did not match the expected pattern..
-PASS document.querySelector("[*|foo~=\"bar\" \"empty\" i]") threw exception SyntaxError: The string did not match the expected pattern..
-PASS document.querySelector("[WebKit|foo~=\"bar\" \"empty\" i]") threw exception SyntaxError: The string did not match the expected pattern..
+PASS document.querySelector("[foo~=\"bar\" \"empty\" i]") threw exception SyntaxError: '[foo~="bar" "empty" i]' is not a valid selector..
+PASS document.querySelector("[|foo~=\"bar\" \"empty\" i]") threw exception SyntaxError: '[|foo~="bar" "empty" i]' is not a valid selector..
+PASS document.querySelector("[*|foo~=\"bar\" \"empty\" i]") threw exception SyntaxError: '[*|foo~="bar" "empty" i]' is not a valid selector..
+PASS document.querySelector("[WebKit|foo~=\"bar\" \"empty\" i]") threw exception SyntaxError: '[WebKit|foo~="bar" "empty" i]' is not a valid selector..
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
-PASS document.querySelector("[foo|=bar \"empty\" i]") threw exception SyntaxError: The string did not match the expected pattern..
-PASS document.querySelector("[|foo|=bar \"empty\" i]") threw exception SyntaxError: The string did not match the expected pattern..
-PASS document.querySelector("[*|foo|=bar \"empty\" i]") threw exception SyntaxError: The string did not match the expected pattern..
-PASS document.querySelector("[WebKit|foo|=bar \"empty\" i]") threw exception SyntaxError: The string did not match the expected pattern..
+PASS document.querySelector("[foo|=bar \"empty\" i]") threw exception SyntaxError: '[foo|=bar "empty" i]' is not a valid selector..
+PASS document.querySelector("[|foo|=bar \"empty\" i]") threw exception SyntaxError: '[|foo|=bar "empty" i]' is not a valid selector..
+PASS document.querySelector("[*|foo|=bar \"empty\" i]") threw exception SyntaxError: '[*|foo|=bar "empty" i]' is not a valid selector..
+PASS document.querySelector("[WebKit|foo|=bar \"empty\" i]") threw exception SyntaxError: '[WebKit|foo|=bar "empty" i]' is not a valid selector..
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
-PASS document.querySelector("[foo|=\"bar\" \"empty\" i]") threw exception SyntaxError: The string did not match the expected pattern..
-PASS document.querySelector("[|foo|=\"bar\" \"empty\" i]") threw exception SyntaxError: The string did not match the expected pattern..
-PASS document.querySelector("[*|foo|=\"bar\" \"empty\" i]") threw exception SyntaxError: The string did not match the expected pattern..
-PASS document.querySelector("[WebKit|foo|=\"bar\" \"empty\" i]") threw exception SyntaxError: The string did not match the expected pattern..
+PASS document.querySelector("[foo|=\"bar\" \"empty\" i]") threw exception SyntaxError: '[foo|="bar" "empty" i]' is not a valid selector..
+PASS document.querySelector("[|foo|=\"bar\" \"empty\" i]") threw exception SyntaxError: '[|foo|="bar" "empty" i]' is not a valid selector..
+PASS document.querySelector("[*|foo|=\"bar\" \"empty\" i]") threw exception SyntaxError: '[*|foo|="bar" "empty" i]' is not a valid selector..
+PASS document.querySelector("[WebKit|foo|=\"bar\" \"empty\" i]") threw exception SyntaxError: '[WebKit|foo|="bar" "empty" i]' is not a valid selector..
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
-PASS document.querySelector("[foo^=bar \"empty\" i]") threw exception SyntaxError: The string did not match the expected pattern..
-PASS document.querySelector("[|foo^=bar \"empty\" i]") threw exception SyntaxError: The string did not match the expected pattern..
-PASS document.querySelector("[*|foo^=bar \"empty\" i]") threw exception SyntaxError: The string did not match the expected pattern..
-PASS document.querySelector("[WebKit|foo^=bar \"empty\" i]") threw exception SyntaxError: The string did not match the expected pattern..
+PASS document.querySelector("[foo^=bar \"empty\" i]") threw exception SyntaxError: '[foo^=bar "empty" i]' is not a valid selector..
+PASS document.querySelector("[|foo^=bar \"empty\" i]") threw exception SyntaxError: '[|foo^=bar "empty" i]' is not a valid selector..
+PASS document.querySelector("[*|foo^=bar \"empty\" i]") threw exception SyntaxError: '[*|foo^=bar "empty" i]' is not a valid selector..
+PASS document.querySelector("[WebKit|foo^=bar \"empty\" i]") threw exception SyntaxError: '[WebKit|foo^=bar "empty" i]' is not a valid selector..
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
-PASS document.querySelector("[foo^=\"bar\" \"empty\" i]") threw exception SyntaxError: The string did not match the expected pattern..
-PASS document.querySelector("[|foo^=\"bar\" \"empty\" i]") threw exception SyntaxError: The string did not match the expected pattern..
-PASS document.querySelector("[*|foo^=\"bar\" \"empty\" i]") threw exception SyntaxError: The string did not match the expected pattern..
-PASS document.querySelector("[WebKit|foo^=\"bar\" \"empty\" i]") threw exception SyntaxError: The string did not match the expected pattern..
+PASS document.querySelector("[foo^=\"bar\" \"empty\" i]") threw exception SyntaxError: '[foo^="bar" "empty" i]' is not a valid selector..
+PASS document.querySelector("[|foo^=\"bar\" \"empty\" i]") threw exception SyntaxError: '[|foo^="bar" "empty" i]' is not a valid selector..
+PASS document.querySelector("[*|foo^=\"bar\" \"empty\" i]") threw exception SyntaxError: '[*|foo^="bar" "empty" i]' is not a valid selector..
+PASS document.querySelector("[WebKit|foo^=\"bar\" \"empty\" i]") threw exception SyntaxError: '[WebKit|foo^="bar" "empty" i]' is not a valid selector..
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
-PASS document.querySelector("[foo$=bar \"empty\" i]") threw exception SyntaxError: The string did not match the expected pattern..
-PASS document.querySelector("[|foo$=bar \"empty\" i]") threw exception SyntaxError: The string did not match the expected pattern..
-PASS document.querySelector("[*|foo$=bar \"empty\" i]") threw exception SyntaxError: The string did not match the expected pattern..
-PASS document.querySelector("[WebKit|foo$=bar \"empty\" i]") threw exception SyntaxError: The string did not match the expected pattern..
+PASS document.querySelector("[foo$=bar \"empty\" i]") threw exception SyntaxError: '[foo$=bar "empty" i]' is not a valid selector..
+PASS document.querySelector("[|foo$=bar \"empty\" i]") threw exception SyntaxError: '[|foo$=bar "empty" i]' is not a valid selector..
+PASS document.querySelector("[*|foo$=bar \"empty\" i]") threw exception SyntaxError: '[*|foo$=bar "empty" i]' is not a valid selector..
+PASS document.querySelector("[WebKit|foo$=bar \"empty\" i]") threw exception SyntaxError: '[WebKit|foo$=bar "empty" i]' is not a valid selector..
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
-PASS document.querySelector("[foo$=\"bar\" \"empty\" i]") threw exception SyntaxError: The string did not match the expected pattern..
-PASS document.querySelector("[|foo$=\"bar\" \"empty\" i]") threw exception SyntaxError: The string did not match the expected pattern..
-PASS document.querySelector("[*|foo$=\"bar\" \"empty\" i]") threw exception SyntaxError: The string did not match the expected pattern..
-PASS document.querySelector("[WebKit|foo$=\"bar\" \"empty\" i]") threw exception SyntaxError: The string did not match the expected pattern..
+PASS document.querySelector("[foo$=\"bar\" \"empty\" i]") threw exception SyntaxError: '[foo$="bar" "empty" i]' is not a valid selector..
+PASS document.querySelector("[|foo$=\"bar\" \"empty\" i]") threw exception SyntaxError: '[|foo$="bar" "empty" i]' is not a valid selector..
+PASS document.querySelector("[*|foo$=\"bar\" \"empty\" i]") threw exception SyntaxError: '[*|foo$="bar" "empty" i]' is not a valid selector..
+PASS document.querySelector("[WebKit|foo$=\"bar\" \"empty\" i]") threw exception SyntaxError: '[WebKit|foo$="bar" "empty" i]' is not a valid selector..
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
-PASS document.querySelector("[foo*=bar \"empty\" i]") threw exception SyntaxError: The string did not match the expected pattern..
-PASS document.querySelector("[|foo*=bar \"empty\" i]") threw exception SyntaxError: The string did not match the expected pattern..
-PASS document.querySelector("[*|foo*=bar \"empty\" i]") threw exception SyntaxError: The string did not match the expected pattern..
-PASS document.querySelector("[WebKit|foo*=bar \"empty\" i]") threw exception SyntaxError: The string did not match the expected pattern..
+PASS document.querySelector("[foo*=bar \"empty\" i]") threw exception SyntaxError: '[foo*=bar "empty" i]' is not a valid selector..
+PASS document.querySelector("[|foo*=bar \"empty\" i]") threw exception SyntaxError: '[|foo*=bar "empty" i]' is not a valid selector..
+PASS document.querySelector("[*|foo*=bar \"empty\" i]") threw exception SyntaxError: '[*|foo*=bar "empty" i]' is not a valid selector..
+PASS document.querySelector("[WebKit|foo*=bar \"empty\" i]") threw exception SyntaxError: '[WebKit|foo*=bar "empty" i]' is not a valid selector..
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
-PASS document.querySelector("[foo*=\"bar\" \"empty\" i]") threw exception SyntaxError: The string did not match the expected pattern..
-PASS document.querySelector("[|foo*=\"bar\" \"empty\" i]") threw exception SyntaxError: The string did not match the expected pattern..
-PASS document.querySelector("[*|foo*=\"bar\" \"empty\" i]") threw exception SyntaxError: The string did not match the expected pattern..
-PASS document.querySelector("[WebKit|foo*=\"bar\" \"empty\" i]") threw exception SyntaxError: The string did not match the expected pattern..
+PASS document.querySelector("[foo*=\"bar\" \"empty\" i]") threw exception SyntaxError: '[foo*="bar" "empty" i]' is not a valid selector..
+PASS document.querySelector("[|foo*=\"bar\" \"empty\" i]") threw exception SyntaxError: '[|foo*="bar" "empty" i]' is not a valid selector..
+PASS document.querySelector("[*|foo*=\"bar\" \"empty\" i]") threw exception SyntaxError: '[*|foo*="bar" "empty" i]' is not a valid selector..
+PASS document.querySelector("[WebKit|foo*=\"bar\" \"empty\" i]") threw exception SyntaxError: '[WebKit|foo*="bar" "empty" i]' is not a valid selector..
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
-PASS document.querySelector("[foo=bar l]") threw exception SyntaxError: The string did not match the expected pattern..
-PASS document.querySelector("[|foo=bar l]") threw exception SyntaxError: The string did not match the expected pattern..
-PASS document.querySelector("[*|foo=bar l]") threw exception SyntaxError: The string did not match the expected pattern..
-PASS document.querySelector("[WebKit|foo=bar l]") threw exception SyntaxError: The string did not match the expected pattern..
+PASS document.querySelector("[foo=bar l]") threw exception SyntaxError: '[foo=bar l]' is not a valid selector..
+PASS document.querySelector("[|foo=bar l]") threw exception SyntaxError: '[|foo=bar l]' is not a valid selector..
+PASS document.querySelector("[*|foo=bar l]") threw exception SyntaxError: '[*|foo=bar l]' is not a valid selector..
+PASS document.querySelector("[WebKit|foo=bar l]") threw exception SyntaxError: '[WebKit|foo=bar l]' is not a valid selector..
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
-PASS document.querySelector("[foo=\"bar\" l]") threw exception SyntaxError: The string did not match the expected pattern..
-PASS document.querySelector("[|foo=\"bar\" l]") threw exception SyntaxError: The string did not match the expected pattern..
-PASS document.querySelector("[*|foo=\"bar\" l]") threw exception SyntaxError: The string did not match the expected pattern..
-PASS document.querySelector("[WebKit|foo=\"bar\" l]") threw exception SyntaxError: The string did not match the expected pattern..
+PASS document.querySelector("[foo=\"bar\" l]") threw exception SyntaxError: '[foo="bar" l]' is not a valid selector..
+PASS document.querySelector("[|foo=\"bar\" l]") threw exception SyntaxError: '[|foo="bar" l]' is not a valid selector..
+PASS document.querySelector("[*|foo=\"bar\" l]") threw exception SyntaxError: '[*|foo="bar" l]' is not a valid selector..
+PASS document.querySelector("[WebKit|foo=\"bar\" l]") threw exception SyntaxError: '[WebKit|foo="bar" l]' is not a valid selector..
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
-PASS document.querySelector("[foo~=bar l]") threw exception SyntaxError: The string did not match the expected pattern..
-PASS document.querySelector("[|foo~=bar l]") threw exception SyntaxError: The string did not match the expected pattern..
-PASS document.querySelector("[*|foo~=bar l]") threw exception SyntaxError: The string did not match the expected pattern..
-PASS document.querySelector("[WebKit|foo~=bar l]") threw exception SyntaxError: The string did not match the expected pattern..
+PASS document.querySelector("[foo~=bar l]") threw exception SyntaxError: '[foo~=bar l]' is not a valid selector..
+PASS document.querySelector("[|foo~=bar l]") threw exception SyntaxError: '[|foo~=bar l]' is not a valid selector..
+PASS document.querySelector("[*|foo~=bar l]") threw exception SyntaxError: '[*|foo~=bar l]' is not a valid selector..
+PASS document.querySelector("[WebKit|foo~=bar l]") threw exception SyntaxError: '[WebKit|foo~=bar l]' is not a valid selector..
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
-PASS document.querySelector("[foo~=\"bar\" l]") threw exception SyntaxError: The string did not match the expected pattern..
-PASS document.querySelector("[|foo~=\"bar\" l]") threw exception SyntaxError: The string did not match the expected pattern..
-PASS document.querySelector("[*|foo~=\"bar\" l]") threw exception SyntaxError: The string did not match the expected pattern..
-PASS document.querySelector("[WebKit|foo~=\"bar\" l]") threw exception SyntaxError: The string did not match the expected pattern..
+PASS document.querySelector("[foo~=\"bar\" l]") threw exception SyntaxError: '[foo~="bar" l]' is not a valid selector..
+PASS document.querySelector("[|foo~=\"bar\" l]") threw exception SyntaxError: '[|foo~="bar" l]' is not a valid selector..
+PASS document.querySelector("[*|foo~=\"bar\" l]") threw exception SyntaxError: '[*|foo~="bar" l]' is not a valid selector..
+PASS document.querySelector("[WebKit|foo~=\"bar\" l]") threw exception SyntaxError: '[WebKit|foo~="bar" l]' is not a valid selector..
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
-PASS document.querySelector("[foo|=bar l]") threw exception SyntaxError: The string did not match the expected pattern..
-PASS document.querySelector("[|foo|=bar l]") threw exception SyntaxError: The string did not match the expected pattern..
-PASS document.querySelector("[*|foo|=bar l]") threw exception SyntaxError: The string did not match the expected pattern..
-PASS document.querySelector("[WebKit|foo|=bar l]") threw exception SyntaxError: The string did not match the expected pattern..
+PASS document.querySelector("[foo|=bar l]") threw exception SyntaxError: '[foo|=bar l]' is not a valid selector..
+PASS document.querySelector("[|foo|=bar l]") threw exception SyntaxError: '[|foo|=bar l]' is not a valid selector..
+PASS document.querySelector("[*|foo|=bar l]") threw exception SyntaxError: '[*|foo|=bar l]' is not a valid selector..
+PASS document.querySelector("[WebKit|foo|=bar l]") threw exception SyntaxError: '[WebKit|foo|=bar l]' is not a valid selector..
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
-PASS document.querySelector("[foo|=\"bar\" l]") threw exception SyntaxError: The string did not match the expected pattern..
-PASS document.querySelector("[|foo|=\"bar\" l]") threw exception SyntaxError: The string did not match the expected pattern..
-PASS document.querySelector("[*|foo|=\"bar\" l]") threw exception SyntaxError: The string did not match the expected pattern..
-PASS document.querySelector("[WebKit|foo|=\"bar\" l]") threw exception SyntaxError: The string did not match the expected pattern..
+PASS document.querySelector("[foo|=\"bar\" l]") threw exception SyntaxError: '[foo|="bar" l]' is not a valid selector..
+PASS document.querySelector("[|foo|=\"bar\" l]") threw exception SyntaxError: '[|foo|="bar" l]' is not a valid selector..
+PASS document.querySelector("[*|foo|=\"bar\" l]") threw exception SyntaxError: '[*|foo|="bar" l]' is not a valid selector..
+PASS document.querySelector("[WebKit|foo|=\"bar\" l]") threw exception SyntaxError: '[WebKit|foo|="bar" l]' is not a valid selector..
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
-PASS document.querySelector("[foo^=bar l]") threw exception SyntaxError: The string did not match the expected pattern..
-PASS document.querySelector("[|foo^=bar l]") threw exception SyntaxError: The string did not match the expected pattern..
-PASS document.querySelector("[*|foo^=bar l]") threw exception SyntaxError: The string did not match the expected pattern..
-PASS document.querySelector("[WebKit|foo^=bar l]") threw exception SyntaxError: The string did not match the expected pattern..
+PASS document.querySelector("[foo^=bar l]") threw exception SyntaxError: '[foo^=bar l]' is not a valid selector..
+PASS document.querySelector("[|foo^=bar l]") threw exception SyntaxError: '[|foo^=bar l]' is not a valid selector..
+PASS document.querySelector("[*|foo^=bar l]") threw exception SyntaxError: '[*|foo^=bar l]' is not a valid selector..
+PASS document.querySelector("[WebKit|foo^=bar l]") threw exception SyntaxError: '[WebKit|foo^=bar l]' is not a valid selector..
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
-PASS document.querySelector("[foo^=\"bar\" l]") threw exception SyntaxError: The string did not match the expected pattern..
-PASS document.querySelector("[|foo^=\"bar\" l]") threw exception SyntaxError: The string did not match the expected pattern..
-PASS document.querySelector("[*|foo^=\"bar\" l]") threw exception SyntaxError: The string did not match the expected pattern..
-PASS document.querySelector("[WebKit|foo^=\"bar\" l]") threw exception SyntaxError: The string did not match the expected pattern..
+PASS document.querySelector("[foo^=\"bar\" l]") threw exception SyntaxError: '[foo^="bar" l]' is not a valid selector..
+PASS document.querySelector("[|foo^=\"bar\" l]") threw exception SyntaxError: '[|foo^="bar" l]' is not a valid selector..
+PASS document.querySelector("[*|foo^=\"bar\" l]") threw exception SyntaxError: '[*|foo^="bar" l]' is not a valid selector..
+PASS document.querySelector("[WebKit|foo^=\"bar\" l]") threw exception SyntaxError: '[WebKit|foo^="bar" l]' is not a valid selector..
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
-PASS document.querySelector("[foo$=bar l]") threw exception SyntaxError: The string did not match the expected pattern..
-PASS document.querySelector("[|foo$=bar l]") threw exception SyntaxError: The string did not match the expected pattern..
-PASS document.querySelector("[*|foo$=bar l]") threw exception SyntaxError: The string did not match the expected pattern..
-PASS document.querySelector("[WebKit|foo$=bar l]") threw exception SyntaxError: The string did not match the expected pattern..
+PASS document.querySelector("[foo$=bar l]") threw exception SyntaxError: '[foo$=bar l]' is not a valid selector..
+PASS document.querySelector("[|foo$=bar l]") threw exception SyntaxError: '[|foo$=bar l]' is not a valid selector..
+PASS document.querySelector("[*|foo$=bar l]") threw exception SyntaxError: '[*|foo$=bar l]' is not a valid selector..
+PASS document.querySelector("[WebKit|foo$=bar l]") threw exception SyntaxError: '[WebKit|foo$=bar l]' is not a valid selector..
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
-PASS document.querySelector("[foo$=\"bar\" l]") threw exception SyntaxError: The string did not match the expected pattern..
-PASS document.querySelector("[|foo$=\"bar\" l]") threw exception SyntaxError: The string did not match the expected pattern..
-PASS document.querySelector("[*|foo$=\"bar\" l]") threw exception SyntaxError: The string did not match the expected pattern..
-PASS document.querySelector("[WebKit|foo$=\"bar\" l]") threw exception SyntaxError: The string did not match the expected pattern..
+PASS document.querySelector("[foo$=\"bar\" l]") threw exception SyntaxError: '[foo$="bar" l]' is not a valid selector..
+PASS document.querySelector("[|foo$=\"bar\" l]") threw exception SyntaxError: '[|foo$="bar" l]' is not a valid selector..
+PASS document.querySelector("[*|foo$=\"bar\" l]") threw exception SyntaxError: '[*|foo$="bar" l]' is not a valid selector..
+PASS document.querySelector("[WebKit|foo$=\"bar\" l]") threw exception SyntaxError: '[WebKit|foo$="bar" l]' is not a valid selector..
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
-PASS document.querySelector("[foo*=bar l]") threw exception SyntaxError: The string did not match the expected pattern..
-PASS document.querySelector("[|foo*=bar l]") threw exception SyntaxError: The string did not match the expected pattern..
-PASS document.querySelector("[*|foo*=bar l]") threw exception SyntaxError: The string did not match the expected pattern..
-PASS document.querySelector("[WebKit|foo*=bar l]") threw exception SyntaxError: The string did not match the expected pattern..
+PASS document.querySelector("[foo*=bar l]") threw exception SyntaxError: '[foo*=bar l]' is not a valid selector..
+PASS document.querySelector("[|foo*=bar l]") threw exception SyntaxError: '[|foo*=bar l]' is not a valid selector..
+PASS document.querySelector("[*|foo*=bar l]") threw exception SyntaxError: '[*|foo*=bar l]' is not a valid selector..
+PASS document.querySelector("[WebKit|foo*=bar l]") threw exception SyntaxError: '[WebKit|foo*=bar l]' is not a valid selector..
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
-PASS document.querySelector("[foo*=\"bar\" l]") threw exception SyntaxError: The string did not match the expected pattern..
-PASS document.querySelector("[|foo*=\"bar\" l]") threw exception SyntaxError: The string did not match the expected pattern..
-PASS document.querySelector("[*|foo*=\"bar\" l]") threw exception SyntaxError: The string did not match the expected pattern..
-PASS document.querySelector("[WebKit|foo*=\"bar\" l]") threw exception SyntaxError: The string did not match the expected pattern..
+PASS document.querySelector("[foo*=\"bar\" l]") threw exception SyntaxError: '[foo*="bar" l]' is not a valid selector..
+PASS document.querySelector("[|foo*=\"bar\" l]") threw exception SyntaxError: '[|foo*="bar" l]' is not a valid selector..
+PASS document.querySelector("[*|foo*=\"bar\" l]") threw exception SyntaxError: '[*|foo*="bar" l]' is not a valid selector..
+PASS document.querySelector("[WebKit|foo*=\"bar\" l]") threw exception SyntaxError: '[WebKit|foo*="bar" l]' is not a valid selector..
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
 PASS document.getElementById('style-container').sheet.cssRules.length is 0

--- a/LayoutTests/fast/css/parsing-css-nth-child-of-3-expected.txt
+++ b/LayoutTests/fast/css/parsing-css-nth-child-of-3-expected.txt
@@ -4,603 +4,603 @@ On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE
 
 
 Test invalid selectors:
-PASS document.querySelector(":nth-child(even of)") threw exception SyntaxError: The string did not match the expected pattern..
+PASS document.querySelector(":nth-child(even of)") threw exception SyntaxError: ':nth-child(even of)' is not a valid selector..
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
-PASS document.querySelector(":nth-child(even of    )") threw exception SyntaxError: The string did not match the expected pattern..
+PASS document.querySelector(":nth-child(even of    )") threw exception SyntaxError: ':nth-child(even of    )' is not a valid selector..
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
-PASS document.querySelector(":nth-child(evenof .class)") threw exception SyntaxError: The string did not match the expected pattern..
+PASS document.querySelector(":nth-child(evenof .class)") threw exception SyntaxError: ':nth-child(evenof .class)' is not a valid selector..
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
-PASS document.querySelector(":nth-child(odd of)") threw exception SyntaxError: The string did not match the expected pattern..
+PASS document.querySelector(":nth-child(odd of)") threw exception SyntaxError: ':nth-child(odd of)' is not a valid selector..
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
-PASS document.querySelector(":nth-child(odd of    )") threw exception SyntaxError: The string did not match the expected pattern..
+PASS document.querySelector(":nth-child(odd of    )") threw exception SyntaxError: ':nth-child(odd of    )' is not a valid selector..
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
-PASS document.querySelector(":nth-child(oddof .class)") threw exception SyntaxError: The string did not match the expected pattern..
+PASS document.querySelector(":nth-child(oddof .class)") threw exception SyntaxError: ':nth-child(oddof .class)' is not a valid selector..
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
-PASS document.querySelector(":nth-child(n of)") threw exception SyntaxError: The string did not match the expected pattern..
+PASS document.querySelector(":nth-child(n of)") threw exception SyntaxError: ':nth-child(n of)' is not a valid selector..
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
-PASS document.querySelector(":nth-child(n of    )") threw exception SyntaxError: The string did not match the expected pattern..
+PASS document.querySelector(":nth-child(n of    )") threw exception SyntaxError: ':nth-child(n of    )' is not a valid selector..
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
-PASS document.querySelector(":nth-child(nof .class)") threw exception SyntaxError: The string did not match the expected pattern..
+PASS document.querySelector(":nth-child(nof .class)") threw exception SyntaxError: ':nth-child(nof .class)' is not a valid selector..
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
-PASS document.querySelector(":nth-child(-n of)") threw exception SyntaxError: The string did not match the expected pattern..
+PASS document.querySelector(":nth-child(-n of)") threw exception SyntaxError: ':nth-child(-n of)' is not a valid selector..
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
-PASS document.querySelector(":nth-child(-n of    )") threw exception SyntaxError: The string did not match the expected pattern..
+PASS document.querySelector(":nth-child(-n of    )") threw exception SyntaxError: ':nth-child(-n of    )' is not a valid selector..
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
-PASS document.querySelector(":nth-child(-nof .class)") threw exception SyntaxError: The string did not match the expected pattern..
+PASS document.querySelector(":nth-child(-nof .class)") threw exception SyntaxError: ':nth-child(-nof .class)' is not a valid selector..
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
-PASS document.querySelector(":nth-child(3 of)") threw exception SyntaxError: The string did not match the expected pattern..
+PASS document.querySelector(":nth-child(3 of)") threw exception SyntaxError: ':nth-child(3 of)' is not a valid selector..
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
-PASS document.querySelector(":nth-child(3 of    )") threw exception SyntaxError: The string did not match the expected pattern..
+PASS document.querySelector(":nth-child(3 of    )") threw exception SyntaxError: ':nth-child(3 of    )' is not a valid selector..
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
-PASS document.querySelector(":nth-child(3of .class)") threw exception SyntaxError: The string did not match the expected pattern..
+PASS document.querySelector(":nth-child(3of .class)") threw exception SyntaxError: ':nth-child(3of .class)' is not a valid selector..
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
-PASS document.querySelector(":nth-child(-3 of)") threw exception SyntaxError: The string did not match the expected pattern..
+PASS document.querySelector(":nth-child(-3 of)") threw exception SyntaxError: ':nth-child(-3 of)' is not a valid selector..
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
-PASS document.querySelector(":nth-child(-3 of    )") threw exception SyntaxError: The string did not match the expected pattern..
+PASS document.querySelector(":nth-child(-3 of    )") threw exception SyntaxError: ':nth-child(-3 of    )' is not a valid selector..
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
-PASS document.querySelector(":nth-child(-3of .class)") threw exception SyntaxError: The string did not match the expected pattern..
+PASS document.querySelector(":nth-child(-3of .class)") threw exception SyntaxError: ':nth-child(-3of .class)' is not a valid selector..
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
-PASS document.querySelector(":nth-child(n+0 of)") threw exception SyntaxError: The string did not match the expected pattern..
+PASS document.querySelector(":nth-child(n+0 of)") threw exception SyntaxError: ':nth-child(n+0 of)' is not a valid selector..
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
-PASS document.querySelector(":nth-child(n+0 of    )") threw exception SyntaxError: The string did not match the expected pattern..
+PASS document.querySelector(":nth-child(n+0 of    )") threw exception SyntaxError: ':nth-child(n+0 of    )' is not a valid selector..
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
-PASS document.querySelector(":nth-child(n+0of .class)") threw exception SyntaxError: The string did not match the expected pattern..
+PASS document.querySelector(":nth-child(n+0of .class)") threw exception SyntaxError: ':nth-child(n+0of .class)' is not a valid selector..
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
-PASS document.querySelector(":nth-child(n-0 of)") threw exception SyntaxError: The string did not match the expected pattern..
+PASS document.querySelector(":nth-child(n-0 of)") threw exception SyntaxError: ':nth-child(n-0 of)' is not a valid selector..
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
-PASS document.querySelector(":nth-child(n-0 of    )") threw exception SyntaxError: The string did not match the expected pattern..
+PASS document.querySelector(":nth-child(n-0 of    )") threw exception SyntaxError: ':nth-child(n-0 of    )' is not a valid selector..
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
-PASS document.querySelector(":nth-child(n-0of .class)") threw exception SyntaxError: The string did not match the expected pattern..
+PASS document.querySelector(":nth-child(n-0of .class)") threw exception SyntaxError: ':nth-child(n-0of .class)' is not a valid selector..
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
-PASS document.querySelector(":nth-child(0n of)") threw exception SyntaxError: The string did not match the expected pattern..
+PASS document.querySelector(":nth-child(0n of)") threw exception SyntaxError: ':nth-child(0n of)' is not a valid selector..
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
-PASS document.querySelector(":nth-child(0n of    )") threw exception SyntaxError: The string did not match the expected pattern..
+PASS document.querySelector(":nth-child(0n of    )") threw exception SyntaxError: ':nth-child(0n of    )' is not a valid selector..
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
-PASS document.querySelector(":nth-child(0nof .class)") threw exception SyntaxError: The string did not match the expected pattern..
+PASS document.querySelector(":nth-child(0nof .class)") threw exception SyntaxError: ':nth-child(0nof .class)' is not a valid selector..
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
-PASS document.querySelector(":nth-child(3n+5 of)") threw exception SyntaxError: The string did not match the expected pattern..
+PASS document.querySelector(":nth-child(3n+5 of)") threw exception SyntaxError: ':nth-child(3n+5 of)' is not a valid selector..
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
-PASS document.querySelector(":nth-child(3n+5 of    )") threw exception SyntaxError: The string did not match the expected pattern..
+PASS document.querySelector(":nth-child(3n+5 of    )") threw exception SyntaxError: ':nth-child(3n+5 of    )' is not a valid selector..
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
-PASS document.querySelector(":nth-child(3n+5of .class)") threw exception SyntaxError: The string did not match the expected pattern..
+PASS document.querySelector(":nth-child(3n+5of .class)") threw exception SyntaxError: ':nth-child(3n+5of .class)' is not a valid selector..
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
-PASS document.querySelector(":nth-child(-3n+5 of)") threw exception SyntaxError: The string did not match the expected pattern..
+PASS document.querySelector(":nth-child(-3n+5 of)") threw exception SyntaxError: ':nth-child(-3n+5 of)' is not a valid selector..
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
-PASS document.querySelector(":nth-child(-3n+5 of    )") threw exception SyntaxError: The string did not match the expected pattern..
+PASS document.querySelector(":nth-child(-3n+5 of    )") threw exception SyntaxError: ':nth-child(-3n+5 of    )' is not a valid selector..
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
-PASS document.querySelector(":nth-child(-3n+5of .class)") threw exception SyntaxError: The string did not match the expected pattern..
+PASS document.querySelector(":nth-child(-3n+5of .class)") threw exception SyntaxError: ':nth-child(-3n+5of .class)' is not a valid selector..
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
-PASS document.querySelector(":nth-child(3n-5 of)") threw exception SyntaxError: The string did not match the expected pattern..
+PASS document.querySelector(":nth-child(3n-5 of)") threw exception SyntaxError: ':nth-child(3n-5 of)' is not a valid selector..
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
-PASS document.querySelector(":nth-child(3n-5 of    )") threw exception SyntaxError: The string did not match the expected pattern..
+PASS document.querySelector(":nth-child(3n-5 of    )") threw exception SyntaxError: ':nth-child(3n-5 of    )' is not a valid selector..
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
-PASS document.querySelector(":nth-child(3n-5of .class)") threw exception SyntaxError: The string did not match the expected pattern..
+PASS document.querySelector(":nth-child(3n-5of .class)") threw exception SyntaxError: ':nth-child(3n-5of .class)' is not a valid selector..
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
-PASS document.querySelector(":nth-child(-3n-5 of)") threw exception SyntaxError: The string did not match the expected pattern..
+PASS document.querySelector(":nth-child(-3n-5 of)") threw exception SyntaxError: ':nth-child(-3n-5 of)' is not a valid selector..
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
-PASS document.querySelector(":nth-child(-3n-5 of    )") threw exception SyntaxError: The string did not match the expected pattern..
+PASS document.querySelector(":nth-child(-3n-5 of    )") threw exception SyntaxError: ':nth-child(-3n-5 of    )' is not a valid selector..
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
-PASS document.querySelector(":nth-child(-3n-5of .class)") threw exception SyntaxError: The string did not match the expected pattern..
+PASS document.querySelector(":nth-child(-3n-5of .class)") threw exception SyntaxError: ':nth-child(-3n-5of .class)' is not a valid selector..
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
-PASS document.querySelector(":nth-child(even empty .class)") threw exception SyntaxError: The string did not match the expected pattern..
+PASS document.querySelector(":nth-child(even empty .class)") threw exception SyntaxError: ':nth-child(even empty .class)' is not a valid selector..
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
-PASS document.querySelector(":nth-child(even from .class)") threw exception SyntaxError: The string did not match the expected pattern..
+PASS document.querySelector(":nth-child(even from .class)") threw exception SyntaxError: ':nth-child(even from .class)' is not a valid selector..
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
-PASS document.querySelector(":nth-child(even to .class)") threw exception SyntaxError: The string did not match the expected pattern..
+PASS document.querySelector(":nth-child(even to .class)") threw exception SyntaxError: ':nth-child(even to .class)' is not a valid selector..
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
-PASS document.querySelector(":nth-child(even webkit .class)") threw exception SyntaxError: The string did not match the expected pattern..
+PASS document.querySelector(":nth-child(even webkit .class)") threw exception SyntaxError: ':nth-child(even webkit .class)' is not a valid selector..
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
-PASS document.querySelector(":nth-child(odd empty .class)") threw exception SyntaxError: The string did not match the expected pattern..
+PASS document.querySelector(":nth-child(odd empty .class)") threw exception SyntaxError: ':nth-child(odd empty .class)' is not a valid selector..
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
-PASS document.querySelector(":nth-child(odd from .class)") threw exception SyntaxError: The string did not match the expected pattern..
+PASS document.querySelector(":nth-child(odd from .class)") threw exception SyntaxError: ':nth-child(odd from .class)' is not a valid selector..
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
-PASS document.querySelector(":nth-child(odd to .class)") threw exception SyntaxError: The string did not match the expected pattern..
+PASS document.querySelector(":nth-child(odd to .class)") threw exception SyntaxError: ':nth-child(odd to .class)' is not a valid selector..
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
-PASS document.querySelector(":nth-child(odd webkit .class)") threw exception SyntaxError: The string did not match the expected pattern..
+PASS document.querySelector(":nth-child(odd webkit .class)") threw exception SyntaxError: ':nth-child(odd webkit .class)' is not a valid selector..
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
-PASS document.querySelector(":nth-child(n empty .class)") threw exception SyntaxError: The string did not match the expected pattern..
+PASS document.querySelector(":nth-child(n empty .class)") threw exception SyntaxError: ':nth-child(n empty .class)' is not a valid selector..
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
-PASS document.querySelector(":nth-child(n from .class)") threw exception SyntaxError: The string did not match the expected pattern..
+PASS document.querySelector(":nth-child(n from .class)") threw exception SyntaxError: ':nth-child(n from .class)' is not a valid selector..
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
-PASS document.querySelector(":nth-child(n to .class)") threw exception SyntaxError: The string did not match the expected pattern..
+PASS document.querySelector(":nth-child(n to .class)") threw exception SyntaxError: ':nth-child(n to .class)' is not a valid selector..
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
-PASS document.querySelector(":nth-child(n webkit .class)") threw exception SyntaxError: The string did not match the expected pattern..
+PASS document.querySelector(":nth-child(n webkit .class)") threw exception SyntaxError: ':nth-child(n webkit .class)' is not a valid selector..
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
-PASS document.querySelector(":nth-child(-n empty .class)") threw exception SyntaxError: The string did not match the expected pattern..
+PASS document.querySelector(":nth-child(-n empty .class)") threw exception SyntaxError: ':nth-child(-n empty .class)' is not a valid selector..
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
-PASS document.querySelector(":nth-child(-n from .class)") threw exception SyntaxError: The string did not match the expected pattern..
+PASS document.querySelector(":nth-child(-n from .class)") threw exception SyntaxError: ':nth-child(-n from .class)' is not a valid selector..
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
-PASS document.querySelector(":nth-child(-n to .class)") threw exception SyntaxError: The string did not match the expected pattern..
+PASS document.querySelector(":nth-child(-n to .class)") threw exception SyntaxError: ':nth-child(-n to .class)' is not a valid selector..
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
-PASS document.querySelector(":nth-child(-n webkit .class)") threw exception SyntaxError: The string did not match the expected pattern..
+PASS document.querySelector(":nth-child(-n webkit .class)") threw exception SyntaxError: ':nth-child(-n webkit .class)' is not a valid selector..
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
-PASS document.querySelector(":nth-child(3 empty .class)") threw exception SyntaxError: The string did not match the expected pattern..
+PASS document.querySelector(":nth-child(3 empty .class)") threw exception SyntaxError: ':nth-child(3 empty .class)' is not a valid selector..
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
-PASS document.querySelector(":nth-child(3 from .class)") threw exception SyntaxError: The string did not match the expected pattern..
+PASS document.querySelector(":nth-child(3 from .class)") threw exception SyntaxError: ':nth-child(3 from .class)' is not a valid selector..
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
-PASS document.querySelector(":nth-child(3 to .class)") threw exception SyntaxError: The string did not match the expected pattern..
+PASS document.querySelector(":nth-child(3 to .class)") threw exception SyntaxError: ':nth-child(3 to .class)' is not a valid selector..
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
-PASS document.querySelector(":nth-child(3 webkit .class)") threw exception SyntaxError: The string did not match the expected pattern..
+PASS document.querySelector(":nth-child(3 webkit .class)") threw exception SyntaxError: ':nth-child(3 webkit .class)' is not a valid selector..
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
-PASS document.querySelector(":nth-child(-3 empty .class)") threw exception SyntaxError: The string did not match the expected pattern..
+PASS document.querySelector(":nth-child(-3 empty .class)") threw exception SyntaxError: ':nth-child(-3 empty .class)' is not a valid selector..
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
-PASS document.querySelector(":nth-child(-3 from .class)") threw exception SyntaxError: The string did not match the expected pattern..
+PASS document.querySelector(":nth-child(-3 from .class)") threw exception SyntaxError: ':nth-child(-3 from .class)' is not a valid selector..
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
-PASS document.querySelector(":nth-child(-3 to .class)") threw exception SyntaxError: The string did not match the expected pattern..
+PASS document.querySelector(":nth-child(-3 to .class)") threw exception SyntaxError: ':nth-child(-3 to .class)' is not a valid selector..
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
-PASS document.querySelector(":nth-child(-3 webkit .class)") threw exception SyntaxError: The string did not match the expected pattern..
+PASS document.querySelector(":nth-child(-3 webkit .class)") threw exception SyntaxError: ':nth-child(-3 webkit .class)' is not a valid selector..
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
-PASS document.querySelector(":nth-child(n+0 empty .class)") threw exception SyntaxError: The string did not match the expected pattern..
+PASS document.querySelector(":nth-child(n+0 empty .class)") threw exception SyntaxError: ':nth-child(n+0 empty .class)' is not a valid selector..
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
-PASS document.querySelector(":nth-child(n+0 from .class)") threw exception SyntaxError: The string did not match the expected pattern..
+PASS document.querySelector(":nth-child(n+0 from .class)") threw exception SyntaxError: ':nth-child(n+0 from .class)' is not a valid selector..
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
-PASS document.querySelector(":nth-child(n+0 to .class)") threw exception SyntaxError: The string did not match the expected pattern..
+PASS document.querySelector(":nth-child(n+0 to .class)") threw exception SyntaxError: ':nth-child(n+0 to .class)' is not a valid selector..
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
-PASS document.querySelector(":nth-child(n+0 webkit .class)") threw exception SyntaxError: The string did not match the expected pattern..
+PASS document.querySelector(":nth-child(n+0 webkit .class)") threw exception SyntaxError: ':nth-child(n+0 webkit .class)' is not a valid selector..
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
-PASS document.querySelector(":nth-child(n-0 empty .class)") threw exception SyntaxError: The string did not match the expected pattern..
+PASS document.querySelector(":nth-child(n-0 empty .class)") threw exception SyntaxError: ':nth-child(n-0 empty .class)' is not a valid selector..
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
-PASS document.querySelector(":nth-child(n-0 from .class)") threw exception SyntaxError: The string did not match the expected pattern..
+PASS document.querySelector(":nth-child(n-0 from .class)") threw exception SyntaxError: ':nth-child(n-0 from .class)' is not a valid selector..
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
-PASS document.querySelector(":nth-child(n-0 to .class)") threw exception SyntaxError: The string did not match the expected pattern..
+PASS document.querySelector(":nth-child(n-0 to .class)") threw exception SyntaxError: ':nth-child(n-0 to .class)' is not a valid selector..
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
-PASS document.querySelector(":nth-child(n-0 webkit .class)") threw exception SyntaxError: The string did not match the expected pattern..
+PASS document.querySelector(":nth-child(n-0 webkit .class)") threw exception SyntaxError: ':nth-child(n-0 webkit .class)' is not a valid selector..
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
-PASS document.querySelector(":nth-child(0n empty .class)") threw exception SyntaxError: The string did not match the expected pattern..
+PASS document.querySelector(":nth-child(0n empty .class)") threw exception SyntaxError: ':nth-child(0n empty .class)' is not a valid selector..
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
-PASS document.querySelector(":nth-child(0n from .class)") threw exception SyntaxError: The string did not match the expected pattern..
+PASS document.querySelector(":nth-child(0n from .class)") threw exception SyntaxError: ':nth-child(0n from .class)' is not a valid selector..
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
-PASS document.querySelector(":nth-child(0n to .class)") threw exception SyntaxError: The string did not match the expected pattern..
+PASS document.querySelector(":nth-child(0n to .class)") threw exception SyntaxError: ':nth-child(0n to .class)' is not a valid selector..
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
-PASS document.querySelector(":nth-child(0n webkit .class)") threw exception SyntaxError: The string did not match the expected pattern..
+PASS document.querySelector(":nth-child(0n webkit .class)") threw exception SyntaxError: ':nth-child(0n webkit .class)' is not a valid selector..
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
-PASS document.querySelector(":nth-child(3n+5 empty .class)") threw exception SyntaxError: The string did not match the expected pattern..
+PASS document.querySelector(":nth-child(3n+5 empty .class)") threw exception SyntaxError: ':nth-child(3n+5 empty .class)' is not a valid selector..
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
-PASS document.querySelector(":nth-child(3n+5 from .class)") threw exception SyntaxError: The string did not match the expected pattern..
+PASS document.querySelector(":nth-child(3n+5 from .class)") threw exception SyntaxError: ':nth-child(3n+5 from .class)' is not a valid selector..
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
-PASS document.querySelector(":nth-child(3n+5 to .class)") threw exception SyntaxError: The string did not match the expected pattern..
+PASS document.querySelector(":nth-child(3n+5 to .class)") threw exception SyntaxError: ':nth-child(3n+5 to .class)' is not a valid selector..
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
-PASS document.querySelector(":nth-child(3n+5 webkit .class)") threw exception SyntaxError: The string did not match the expected pattern..
+PASS document.querySelector(":nth-child(3n+5 webkit .class)") threw exception SyntaxError: ':nth-child(3n+5 webkit .class)' is not a valid selector..
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
-PASS document.querySelector(":nth-child(-3n+5 empty .class)") threw exception SyntaxError: The string did not match the expected pattern..
+PASS document.querySelector(":nth-child(-3n+5 empty .class)") threw exception SyntaxError: ':nth-child(-3n+5 empty .class)' is not a valid selector..
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
-PASS document.querySelector(":nth-child(-3n+5 from .class)") threw exception SyntaxError: The string did not match the expected pattern..
+PASS document.querySelector(":nth-child(-3n+5 from .class)") threw exception SyntaxError: ':nth-child(-3n+5 from .class)' is not a valid selector..
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
-PASS document.querySelector(":nth-child(-3n+5 to .class)") threw exception SyntaxError: The string did not match the expected pattern..
+PASS document.querySelector(":nth-child(-3n+5 to .class)") threw exception SyntaxError: ':nth-child(-3n+5 to .class)' is not a valid selector..
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
-PASS document.querySelector(":nth-child(-3n+5 webkit .class)") threw exception SyntaxError: The string did not match the expected pattern..
+PASS document.querySelector(":nth-child(-3n+5 webkit .class)") threw exception SyntaxError: ':nth-child(-3n+5 webkit .class)' is not a valid selector..
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
-PASS document.querySelector(":nth-child(3n-5 empty .class)") threw exception SyntaxError: The string did not match the expected pattern..
+PASS document.querySelector(":nth-child(3n-5 empty .class)") threw exception SyntaxError: ':nth-child(3n-5 empty .class)' is not a valid selector..
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
-PASS document.querySelector(":nth-child(3n-5 from .class)") threw exception SyntaxError: The string did not match the expected pattern..
+PASS document.querySelector(":nth-child(3n-5 from .class)") threw exception SyntaxError: ':nth-child(3n-5 from .class)' is not a valid selector..
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
-PASS document.querySelector(":nth-child(3n-5 to .class)") threw exception SyntaxError: The string did not match the expected pattern..
+PASS document.querySelector(":nth-child(3n-5 to .class)") threw exception SyntaxError: ':nth-child(3n-5 to .class)' is not a valid selector..
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
-PASS document.querySelector(":nth-child(3n-5 webkit .class)") threw exception SyntaxError: The string did not match the expected pattern..
+PASS document.querySelector(":nth-child(3n-5 webkit .class)") threw exception SyntaxError: ':nth-child(3n-5 webkit .class)' is not a valid selector..
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
-PASS document.querySelector(":nth-child(-3n-5 empty .class)") threw exception SyntaxError: The string did not match the expected pattern..
+PASS document.querySelector(":nth-child(-3n-5 empty .class)") threw exception SyntaxError: ':nth-child(-3n-5 empty .class)' is not a valid selector..
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
-PASS document.querySelector(":nth-child(-3n-5 from .class)") threw exception SyntaxError: The string did not match the expected pattern..
+PASS document.querySelector(":nth-child(-3n-5 from .class)") threw exception SyntaxError: ':nth-child(-3n-5 from .class)' is not a valid selector..
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
-PASS document.querySelector(":nth-child(-3n-5 to .class)") threw exception SyntaxError: The string did not match the expected pattern..
+PASS document.querySelector(":nth-child(-3n-5 to .class)") threw exception SyntaxError: ':nth-child(-3n-5 to .class)' is not a valid selector..
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
-PASS document.querySelector(":nth-child(-3n-5 webkit .class)") threw exception SyntaxError: The string did not match the expected pattern..
+PASS document.querySelector(":nth-child(-3n-5 webkit .class)") threw exception SyntaxError: ':nth-child(-3n-5 webkit .class)' is not a valid selector..
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
-PASS document.querySelector(":nth-child(even of ::first-letter)") threw exception SyntaxError: The string did not match the expected pattern..
+PASS document.querySelector(":nth-child(even of ::first-letter)") threw exception SyntaxError: ':nth-child(even of ::first-letter)' is not a valid selector..
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
-PASS document.querySelector(":nth-child(even of ::before)") threw exception SyntaxError: The string did not match the expected pattern..
+PASS document.querySelector(":nth-child(even of ::before)") threw exception SyntaxError: ':nth-child(even of ::before)' is not a valid selector..
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
-PASS document.querySelector(":nth-child(even of ::after)") threw exception SyntaxError: The string did not match the expected pattern..
+PASS document.querySelector(":nth-child(even of ::after)") threw exception SyntaxError: ':nth-child(even of ::after)' is not a valid selector..
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
-PASS document.querySelector(":nth-child(even of ::-webkit-custom)") threw exception SyntaxError: The string did not match the expected pattern..
+PASS document.querySelector(":nth-child(even of ::-webkit-custom)") threw exception SyntaxError: ':nth-child(even of ::-webkit-custom)' is not a valid selector..
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
-PASS document.querySelector(":nth-child(even of .foo, ::before)") threw exception SyntaxError: The string did not match the expected pattern..
+PASS document.querySelector(":nth-child(even of .foo, ::before)") threw exception SyntaxError: ':nth-child(even of .foo, ::before)' is not a valid selector..
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
-PASS document.querySelector(":nth-child(even of ::before, .foo)") threw exception SyntaxError: The string did not match the expected pattern..
+PASS document.querySelector(":nth-child(even of ::before, .foo)") threw exception SyntaxError: ':nth-child(even of ::before, .foo)' is not a valid selector..
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
-PASS document.querySelector(":nth-child(even of -webkit-any(::before, .foo))") threw exception SyntaxError: The string did not match the expected pattern..
+PASS document.querySelector(":nth-child(even of -webkit-any(::before, .foo))") threw exception SyntaxError: ':nth-child(even of -webkit-any(::before, .foo))' is not a valid selector..
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
-PASS document.querySelector(":nth-child(even of :nth-child(2n+1 of ::before))") threw exception SyntaxError: The string did not match the expected pattern..
+PASS document.querySelector(":nth-child(even of :nth-child(2n+1 of ::before))") threw exception SyntaxError: ':nth-child(even of :nth-child(2n+1 of ::before))' is not a valid selector..
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
-PASS document.querySelector(":nth-child(even of :not(::before))") threw exception SyntaxError: The string did not match the expected pattern..
+PASS document.querySelector(":nth-child(even of :not(::before))") threw exception SyntaxError: ':nth-child(even of :not(::before))' is not a valid selector..
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
-PASS document.querySelector(":nth-child(odd of ::first-letter)") threw exception SyntaxError: The string did not match the expected pattern..
+PASS document.querySelector(":nth-child(odd of ::first-letter)") threw exception SyntaxError: ':nth-child(odd of ::first-letter)' is not a valid selector..
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
-PASS document.querySelector(":nth-child(odd of ::before)") threw exception SyntaxError: The string did not match the expected pattern..
+PASS document.querySelector(":nth-child(odd of ::before)") threw exception SyntaxError: ':nth-child(odd of ::before)' is not a valid selector..
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
-PASS document.querySelector(":nth-child(odd of ::after)") threw exception SyntaxError: The string did not match the expected pattern..
+PASS document.querySelector(":nth-child(odd of ::after)") threw exception SyntaxError: ':nth-child(odd of ::after)' is not a valid selector..
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
-PASS document.querySelector(":nth-child(odd of ::-webkit-custom)") threw exception SyntaxError: The string did not match the expected pattern..
+PASS document.querySelector(":nth-child(odd of ::-webkit-custom)") threw exception SyntaxError: ':nth-child(odd of ::-webkit-custom)' is not a valid selector..
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
-PASS document.querySelector(":nth-child(odd of .foo, ::before)") threw exception SyntaxError: The string did not match the expected pattern..
+PASS document.querySelector(":nth-child(odd of .foo, ::before)") threw exception SyntaxError: ':nth-child(odd of .foo, ::before)' is not a valid selector..
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
-PASS document.querySelector(":nth-child(odd of ::before, .foo)") threw exception SyntaxError: The string did not match the expected pattern..
+PASS document.querySelector(":nth-child(odd of ::before, .foo)") threw exception SyntaxError: ':nth-child(odd of ::before, .foo)' is not a valid selector..
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
-PASS document.querySelector(":nth-child(odd of -webkit-any(::before, .foo))") threw exception SyntaxError: The string did not match the expected pattern..
+PASS document.querySelector(":nth-child(odd of -webkit-any(::before, .foo))") threw exception SyntaxError: ':nth-child(odd of -webkit-any(::before, .foo))' is not a valid selector..
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
-PASS document.querySelector(":nth-child(odd of :nth-child(2n+1 of ::before))") threw exception SyntaxError: The string did not match the expected pattern..
+PASS document.querySelector(":nth-child(odd of :nth-child(2n+1 of ::before))") threw exception SyntaxError: ':nth-child(odd of :nth-child(2n+1 of ::before))' is not a valid selector..
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
-PASS document.querySelector(":nth-child(odd of :not(::before))") threw exception SyntaxError: The string did not match the expected pattern..
+PASS document.querySelector(":nth-child(odd of :not(::before))") threw exception SyntaxError: ':nth-child(odd of :not(::before))' is not a valid selector..
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
-PASS document.querySelector(":nth-child(n of ::first-letter)") threw exception SyntaxError: The string did not match the expected pattern..
+PASS document.querySelector(":nth-child(n of ::first-letter)") threw exception SyntaxError: ':nth-child(n of ::first-letter)' is not a valid selector..
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
-PASS document.querySelector(":nth-child(n of ::before)") threw exception SyntaxError: The string did not match the expected pattern..
+PASS document.querySelector(":nth-child(n of ::before)") threw exception SyntaxError: ':nth-child(n of ::before)' is not a valid selector..
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
-PASS document.querySelector(":nth-child(n of ::after)") threw exception SyntaxError: The string did not match the expected pattern..
+PASS document.querySelector(":nth-child(n of ::after)") threw exception SyntaxError: ':nth-child(n of ::after)' is not a valid selector..
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
-PASS document.querySelector(":nth-child(n of ::-webkit-custom)") threw exception SyntaxError: The string did not match the expected pattern..
+PASS document.querySelector(":nth-child(n of ::-webkit-custom)") threw exception SyntaxError: ':nth-child(n of ::-webkit-custom)' is not a valid selector..
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
-PASS document.querySelector(":nth-child(n of .foo, ::before)") threw exception SyntaxError: The string did not match the expected pattern..
+PASS document.querySelector(":nth-child(n of .foo, ::before)") threw exception SyntaxError: ':nth-child(n of .foo, ::before)' is not a valid selector..
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
-PASS document.querySelector(":nth-child(n of ::before, .foo)") threw exception SyntaxError: The string did not match the expected pattern..
+PASS document.querySelector(":nth-child(n of ::before, .foo)") threw exception SyntaxError: ':nth-child(n of ::before, .foo)' is not a valid selector..
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
-PASS document.querySelector(":nth-child(n of -webkit-any(::before, .foo))") threw exception SyntaxError: The string did not match the expected pattern..
+PASS document.querySelector(":nth-child(n of -webkit-any(::before, .foo))") threw exception SyntaxError: ':nth-child(n of -webkit-any(::before, .foo))' is not a valid selector..
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
-PASS document.querySelector(":nth-child(n of :nth-child(2n+1 of ::before))") threw exception SyntaxError: The string did not match the expected pattern..
+PASS document.querySelector(":nth-child(n of :nth-child(2n+1 of ::before))") threw exception SyntaxError: ':nth-child(n of :nth-child(2n+1 of ::before))' is not a valid selector..
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
-PASS document.querySelector(":nth-child(n of :not(::before))") threw exception SyntaxError: The string did not match the expected pattern..
+PASS document.querySelector(":nth-child(n of :not(::before))") threw exception SyntaxError: ':nth-child(n of :not(::before))' is not a valid selector..
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
-PASS document.querySelector(":nth-child(-n of ::first-letter)") threw exception SyntaxError: The string did not match the expected pattern..
+PASS document.querySelector(":nth-child(-n of ::first-letter)") threw exception SyntaxError: ':nth-child(-n of ::first-letter)' is not a valid selector..
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
-PASS document.querySelector(":nth-child(-n of ::before)") threw exception SyntaxError: The string did not match the expected pattern..
+PASS document.querySelector(":nth-child(-n of ::before)") threw exception SyntaxError: ':nth-child(-n of ::before)' is not a valid selector..
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
-PASS document.querySelector(":nth-child(-n of ::after)") threw exception SyntaxError: The string did not match the expected pattern..
+PASS document.querySelector(":nth-child(-n of ::after)") threw exception SyntaxError: ':nth-child(-n of ::after)' is not a valid selector..
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
-PASS document.querySelector(":nth-child(-n of ::-webkit-custom)") threw exception SyntaxError: The string did not match the expected pattern..
+PASS document.querySelector(":nth-child(-n of ::-webkit-custom)") threw exception SyntaxError: ':nth-child(-n of ::-webkit-custom)' is not a valid selector..
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
-PASS document.querySelector(":nth-child(-n of .foo, ::before)") threw exception SyntaxError: The string did not match the expected pattern..
+PASS document.querySelector(":nth-child(-n of .foo, ::before)") threw exception SyntaxError: ':nth-child(-n of .foo, ::before)' is not a valid selector..
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
-PASS document.querySelector(":nth-child(-n of ::before, .foo)") threw exception SyntaxError: The string did not match the expected pattern..
+PASS document.querySelector(":nth-child(-n of ::before, .foo)") threw exception SyntaxError: ':nth-child(-n of ::before, .foo)' is not a valid selector..
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
-PASS document.querySelector(":nth-child(-n of -webkit-any(::before, .foo))") threw exception SyntaxError: The string did not match the expected pattern..
+PASS document.querySelector(":nth-child(-n of -webkit-any(::before, .foo))") threw exception SyntaxError: ':nth-child(-n of -webkit-any(::before, .foo))' is not a valid selector..
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
-PASS document.querySelector(":nth-child(-n of :nth-child(2n+1 of ::before))") threw exception SyntaxError: The string did not match the expected pattern..
+PASS document.querySelector(":nth-child(-n of :nth-child(2n+1 of ::before))") threw exception SyntaxError: ':nth-child(-n of :nth-child(2n+1 of ::before))' is not a valid selector..
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
-PASS document.querySelector(":nth-child(-n of :not(::before))") threw exception SyntaxError: The string did not match the expected pattern..
+PASS document.querySelector(":nth-child(-n of :not(::before))") threw exception SyntaxError: ':nth-child(-n of :not(::before))' is not a valid selector..
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
-PASS document.querySelector(":nth-child(3 of ::first-letter)") threw exception SyntaxError: The string did not match the expected pattern..
+PASS document.querySelector(":nth-child(3 of ::first-letter)") threw exception SyntaxError: ':nth-child(3 of ::first-letter)' is not a valid selector..
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
-PASS document.querySelector(":nth-child(3 of ::before)") threw exception SyntaxError: The string did not match the expected pattern..
+PASS document.querySelector(":nth-child(3 of ::before)") threw exception SyntaxError: ':nth-child(3 of ::before)' is not a valid selector..
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
-PASS document.querySelector(":nth-child(3 of ::after)") threw exception SyntaxError: The string did not match the expected pattern..
+PASS document.querySelector(":nth-child(3 of ::after)") threw exception SyntaxError: ':nth-child(3 of ::after)' is not a valid selector..
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
-PASS document.querySelector(":nth-child(3 of ::-webkit-custom)") threw exception SyntaxError: The string did not match the expected pattern..
+PASS document.querySelector(":nth-child(3 of ::-webkit-custom)") threw exception SyntaxError: ':nth-child(3 of ::-webkit-custom)' is not a valid selector..
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
-PASS document.querySelector(":nth-child(3 of .foo, ::before)") threw exception SyntaxError: The string did not match the expected pattern..
+PASS document.querySelector(":nth-child(3 of .foo, ::before)") threw exception SyntaxError: ':nth-child(3 of .foo, ::before)' is not a valid selector..
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
-PASS document.querySelector(":nth-child(3 of ::before, .foo)") threw exception SyntaxError: The string did not match the expected pattern..
+PASS document.querySelector(":nth-child(3 of ::before, .foo)") threw exception SyntaxError: ':nth-child(3 of ::before, .foo)' is not a valid selector..
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
-PASS document.querySelector(":nth-child(3 of -webkit-any(::before, .foo))") threw exception SyntaxError: The string did not match the expected pattern..
+PASS document.querySelector(":nth-child(3 of -webkit-any(::before, .foo))") threw exception SyntaxError: ':nth-child(3 of -webkit-any(::before, .foo))' is not a valid selector..
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
-PASS document.querySelector(":nth-child(3 of :nth-child(2n+1 of ::before))") threw exception SyntaxError: The string did not match the expected pattern..
+PASS document.querySelector(":nth-child(3 of :nth-child(2n+1 of ::before))") threw exception SyntaxError: ':nth-child(3 of :nth-child(2n+1 of ::before))' is not a valid selector..
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
-PASS document.querySelector(":nth-child(3 of :not(::before))") threw exception SyntaxError: The string did not match the expected pattern..
+PASS document.querySelector(":nth-child(3 of :not(::before))") threw exception SyntaxError: ':nth-child(3 of :not(::before))' is not a valid selector..
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
-PASS document.querySelector(":nth-child(-3 of ::first-letter)") threw exception SyntaxError: The string did not match the expected pattern..
+PASS document.querySelector(":nth-child(-3 of ::first-letter)") threw exception SyntaxError: ':nth-child(-3 of ::first-letter)' is not a valid selector..
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
-PASS document.querySelector(":nth-child(-3 of ::before)") threw exception SyntaxError: The string did not match the expected pattern..
+PASS document.querySelector(":nth-child(-3 of ::before)") threw exception SyntaxError: ':nth-child(-3 of ::before)' is not a valid selector..
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
-PASS document.querySelector(":nth-child(-3 of ::after)") threw exception SyntaxError: The string did not match the expected pattern..
+PASS document.querySelector(":nth-child(-3 of ::after)") threw exception SyntaxError: ':nth-child(-3 of ::after)' is not a valid selector..
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
-PASS document.querySelector(":nth-child(-3 of ::-webkit-custom)") threw exception SyntaxError: The string did not match the expected pattern..
+PASS document.querySelector(":nth-child(-3 of ::-webkit-custom)") threw exception SyntaxError: ':nth-child(-3 of ::-webkit-custom)' is not a valid selector..
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
-PASS document.querySelector(":nth-child(-3 of .foo, ::before)") threw exception SyntaxError: The string did not match the expected pattern..
+PASS document.querySelector(":nth-child(-3 of .foo, ::before)") threw exception SyntaxError: ':nth-child(-3 of .foo, ::before)' is not a valid selector..
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
-PASS document.querySelector(":nth-child(-3 of ::before, .foo)") threw exception SyntaxError: The string did not match the expected pattern..
+PASS document.querySelector(":nth-child(-3 of ::before, .foo)") threw exception SyntaxError: ':nth-child(-3 of ::before, .foo)' is not a valid selector..
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
-PASS document.querySelector(":nth-child(-3 of -webkit-any(::before, .foo))") threw exception SyntaxError: The string did not match the expected pattern..
+PASS document.querySelector(":nth-child(-3 of -webkit-any(::before, .foo))") threw exception SyntaxError: ':nth-child(-3 of -webkit-any(::before, .foo))' is not a valid selector..
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
-PASS document.querySelector(":nth-child(-3 of :nth-child(2n+1 of ::before))") threw exception SyntaxError: The string did not match the expected pattern..
+PASS document.querySelector(":nth-child(-3 of :nth-child(2n+1 of ::before))") threw exception SyntaxError: ':nth-child(-3 of :nth-child(2n+1 of ::before))' is not a valid selector..
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
-PASS document.querySelector(":nth-child(-3 of :not(::before))") threw exception SyntaxError: The string did not match the expected pattern..
+PASS document.querySelector(":nth-child(-3 of :not(::before))") threw exception SyntaxError: ':nth-child(-3 of :not(::before))' is not a valid selector..
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
-PASS document.querySelector(":nth-child(n+0 of ::first-letter)") threw exception SyntaxError: The string did not match the expected pattern..
+PASS document.querySelector(":nth-child(n+0 of ::first-letter)") threw exception SyntaxError: ':nth-child(n+0 of ::first-letter)' is not a valid selector..
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
-PASS document.querySelector(":nth-child(n+0 of ::before)") threw exception SyntaxError: The string did not match the expected pattern..
+PASS document.querySelector(":nth-child(n+0 of ::before)") threw exception SyntaxError: ':nth-child(n+0 of ::before)' is not a valid selector..
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
-PASS document.querySelector(":nth-child(n+0 of ::after)") threw exception SyntaxError: The string did not match the expected pattern..
+PASS document.querySelector(":nth-child(n+0 of ::after)") threw exception SyntaxError: ':nth-child(n+0 of ::after)' is not a valid selector..
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
-PASS document.querySelector(":nth-child(n+0 of ::-webkit-custom)") threw exception SyntaxError: The string did not match the expected pattern..
+PASS document.querySelector(":nth-child(n+0 of ::-webkit-custom)") threw exception SyntaxError: ':nth-child(n+0 of ::-webkit-custom)' is not a valid selector..
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
-PASS document.querySelector(":nth-child(n+0 of .foo, ::before)") threw exception SyntaxError: The string did not match the expected pattern..
+PASS document.querySelector(":nth-child(n+0 of .foo, ::before)") threw exception SyntaxError: ':nth-child(n+0 of .foo, ::before)' is not a valid selector..
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
-PASS document.querySelector(":nth-child(n+0 of ::before, .foo)") threw exception SyntaxError: The string did not match the expected pattern..
+PASS document.querySelector(":nth-child(n+0 of ::before, .foo)") threw exception SyntaxError: ':nth-child(n+0 of ::before, .foo)' is not a valid selector..
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
-PASS document.querySelector(":nth-child(n+0 of -webkit-any(::before, .foo))") threw exception SyntaxError: The string did not match the expected pattern..
+PASS document.querySelector(":nth-child(n+0 of -webkit-any(::before, .foo))") threw exception SyntaxError: ':nth-child(n+0 of -webkit-any(::before, .foo))' is not a valid selector..
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
-PASS document.querySelector(":nth-child(n+0 of :nth-child(2n+1 of ::before))") threw exception SyntaxError: The string did not match the expected pattern..
+PASS document.querySelector(":nth-child(n+0 of :nth-child(2n+1 of ::before))") threw exception SyntaxError: ':nth-child(n+0 of :nth-child(2n+1 of ::before))' is not a valid selector..
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
-PASS document.querySelector(":nth-child(n+0 of :not(::before))") threw exception SyntaxError: The string did not match the expected pattern..
+PASS document.querySelector(":nth-child(n+0 of :not(::before))") threw exception SyntaxError: ':nth-child(n+0 of :not(::before))' is not a valid selector..
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
-PASS document.querySelector(":nth-child(n-0 of ::first-letter)") threw exception SyntaxError: The string did not match the expected pattern..
+PASS document.querySelector(":nth-child(n-0 of ::first-letter)") threw exception SyntaxError: ':nth-child(n-0 of ::first-letter)' is not a valid selector..
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
-PASS document.querySelector(":nth-child(n-0 of ::before)") threw exception SyntaxError: The string did not match the expected pattern..
+PASS document.querySelector(":nth-child(n-0 of ::before)") threw exception SyntaxError: ':nth-child(n-0 of ::before)' is not a valid selector..
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
-PASS document.querySelector(":nth-child(n-0 of ::after)") threw exception SyntaxError: The string did not match the expected pattern..
+PASS document.querySelector(":nth-child(n-0 of ::after)") threw exception SyntaxError: ':nth-child(n-0 of ::after)' is not a valid selector..
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
-PASS document.querySelector(":nth-child(n-0 of ::-webkit-custom)") threw exception SyntaxError: The string did not match the expected pattern..
+PASS document.querySelector(":nth-child(n-0 of ::-webkit-custom)") threw exception SyntaxError: ':nth-child(n-0 of ::-webkit-custom)' is not a valid selector..
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
-PASS document.querySelector(":nth-child(n-0 of .foo, ::before)") threw exception SyntaxError: The string did not match the expected pattern..
+PASS document.querySelector(":nth-child(n-0 of .foo, ::before)") threw exception SyntaxError: ':nth-child(n-0 of .foo, ::before)' is not a valid selector..
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
-PASS document.querySelector(":nth-child(n-0 of ::before, .foo)") threw exception SyntaxError: The string did not match the expected pattern..
+PASS document.querySelector(":nth-child(n-0 of ::before, .foo)") threw exception SyntaxError: ':nth-child(n-0 of ::before, .foo)' is not a valid selector..
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
-PASS document.querySelector(":nth-child(n-0 of -webkit-any(::before, .foo))") threw exception SyntaxError: The string did not match the expected pattern..
+PASS document.querySelector(":nth-child(n-0 of -webkit-any(::before, .foo))") threw exception SyntaxError: ':nth-child(n-0 of -webkit-any(::before, .foo))' is not a valid selector..
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
-PASS document.querySelector(":nth-child(n-0 of :nth-child(2n+1 of ::before))") threw exception SyntaxError: The string did not match the expected pattern..
+PASS document.querySelector(":nth-child(n-0 of :nth-child(2n+1 of ::before))") threw exception SyntaxError: ':nth-child(n-0 of :nth-child(2n+1 of ::before))' is not a valid selector..
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
-PASS document.querySelector(":nth-child(n-0 of :not(::before))") threw exception SyntaxError: The string did not match the expected pattern..
+PASS document.querySelector(":nth-child(n-0 of :not(::before))") threw exception SyntaxError: ':nth-child(n-0 of :not(::before))' is not a valid selector..
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
-PASS document.querySelector(":nth-child(0n of ::first-letter)") threw exception SyntaxError: The string did not match the expected pattern..
+PASS document.querySelector(":nth-child(0n of ::first-letter)") threw exception SyntaxError: ':nth-child(0n of ::first-letter)' is not a valid selector..
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
-PASS document.querySelector(":nth-child(0n of ::before)") threw exception SyntaxError: The string did not match the expected pattern..
+PASS document.querySelector(":nth-child(0n of ::before)") threw exception SyntaxError: ':nth-child(0n of ::before)' is not a valid selector..
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
-PASS document.querySelector(":nth-child(0n of ::after)") threw exception SyntaxError: The string did not match the expected pattern..
+PASS document.querySelector(":nth-child(0n of ::after)") threw exception SyntaxError: ':nth-child(0n of ::after)' is not a valid selector..
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
-PASS document.querySelector(":nth-child(0n of ::-webkit-custom)") threw exception SyntaxError: The string did not match the expected pattern..
+PASS document.querySelector(":nth-child(0n of ::-webkit-custom)") threw exception SyntaxError: ':nth-child(0n of ::-webkit-custom)' is not a valid selector..
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
-PASS document.querySelector(":nth-child(0n of .foo, ::before)") threw exception SyntaxError: The string did not match the expected pattern..
+PASS document.querySelector(":nth-child(0n of .foo, ::before)") threw exception SyntaxError: ':nth-child(0n of .foo, ::before)' is not a valid selector..
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
-PASS document.querySelector(":nth-child(0n of ::before, .foo)") threw exception SyntaxError: The string did not match the expected pattern..
+PASS document.querySelector(":nth-child(0n of ::before, .foo)") threw exception SyntaxError: ':nth-child(0n of ::before, .foo)' is not a valid selector..
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
-PASS document.querySelector(":nth-child(0n of -webkit-any(::before, .foo))") threw exception SyntaxError: The string did not match the expected pattern..
+PASS document.querySelector(":nth-child(0n of -webkit-any(::before, .foo))") threw exception SyntaxError: ':nth-child(0n of -webkit-any(::before, .foo))' is not a valid selector..
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
-PASS document.querySelector(":nth-child(0n of :nth-child(2n+1 of ::before))") threw exception SyntaxError: The string did not match the expected pattern..
+PASS document.querySelector(":nth-child(0n of :nth-child(2n+1 of ::before))") threw exception SyntaxError: ':nth-child(0n of :nth-child(2n+1 of ::before))' is not a valid selector..
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
-PASS document.querySelector(":nth-child(0n of :not(::before))") threw exception SyntaxError: The string did not match the expected pattern..
+PASS document.querySelector(":nth-child(0n of :not(::before))") threw exception SyntaxError: ':nth-child(0n of :not(::before))' is not a valid selector..
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
-PASS document.querySelector(":nth-child(3n+5 of ::first-letter)") threw exception SyntaxError: The string did not match the expected pattern..
+PASS document.querySelector(":nth-child(3n+5 of ::first-letter)") threw exception SyntaxError: ':nth-child(3n+5 of ::first-letter)' is not a valid selector..
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
-PASS document.querySelector(":nth-child(3n+5 of ::before)") threw exception SyntaxError: The string did not match the expected pattern..
+PASS document.querySelector(":nth-child(3n+5 of ::before)") threw exception SyntaxError: ':nth-child(3n+5 of ::before)' is not a valid selector..
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
-PASS document.querySelector(":nth-child(3n+5 of ::after)") threw exception SyntaxError: The string did not match the expected pattern..
+PASS document.querySelector(":nth-child(3n+5 of ::after)") threw exception SyntaxError: ':nth-child(3n+5 of ::after)' is not a valid selector..
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
-PASS document.querySelector(":nth-child(3n+5 of ::-webkit-custom)") threw exception SyntaxError: The string did not match the expected pattern..
+PASS document.querySelector(":nth-child(3n+5 of ::-webkit-custom)") threw exception SyntaxError: ':nth-child(3n+5 of ::-webkit-custom)' is not a valid selector..
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
-PASS document.querySelector(":nth-child(3n+5 of .foo, ::before)") threw exception SyntaxError: The string did not match the expected pattern..
+PASS document.querySelector(":nth-child(3n+5 of .foo, ::before)") threw exception SyntaxError: ':nth-child(3n+5 of .foo, ::before)' is not a valid selector..
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
-PASS document.querySelector(":nth-child(3n+5 of ::before, .foo)") threw exception SyntaxError: The string did not match the expected pattern..
+PASS document.querySelector(":nth-child(3n+5 of ::before, .foo)") threw exception SyntaxError: ':nth-child(3n+5 of ::before, .foo)' is not a valid selector..
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
-PASS document.querySelector(":nth-child(3n+5 of -webkit-any(::before, .foo))") threw exception SyntaxError: The string did not match the expected pattern..
+PASS document.querySelector(":nth-child(3n+5 of -webkit-any(::before, .foo))") threw exception SyntaxError: ':nth-child(3n+5 of -webkit-any(::before, .foo))' is not a valid selector..
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
-PASS document.querySelector(":nth-child(3n+5 of :nth-child(2n+1 of ::before))") threw exception SyntaxError: The string did not match the expected pattern..
+PASS document.querySelector(":nth-child(3n+5 of :nth-child(2n+1 of ::before))") threw exception SyntaxError: ':nth-child(3n+5 of :nth-child(2n+1 of ::before))' is not a valid selector..
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
-PASS document.querySelector(":nth-child(3n+5 of :not(::before))") threw exception SyntaxError: The string did not match the expected pattern..
+PASS document.querySelector(":nth-child(3n+5 of :not(::before))") threw exception SyntaxError: ':nth-child(3n+5 of :not(::before))' is not a valid selector..
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
-PASS document.querySelector(":nth-child(-3n+5 of ::first-letter)") threw exception SyntaxError: The string did not match the expected pattern..
+PASS document.querySelector(":nth-child(-3n+5 of ::first-letter)") threw exception SyntaxError: ':nth-child(-3n+5 of ::first-letter)' is not a valid selector..
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
-PASS document.querySelector(":nth-child(-3n+5 of ::before)") threw exception SyntaxError: The string did not match the expected pattern..
+PASS document.querySelector(":nth-child(-3n+5 of ::before)") threw exception SyntaxError: ':nth-child(-3n+5 of ::before)' is not a valid selector..
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
-PASS document.querySelector(":nth-child(-3n+5 of ::after)") threw exception SyntaxError: The string did not match the expected pattern..
+PASS document.querySelector(":nth-child(-3n+5 of ::after)") threw exception SyntaxError: ':nth-child(-3n+5 of ::after)' is not a valid selector..
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
-PASS document.querySelector(":nth-child(-3n+5 of ::-webkit-custom)") threw exception SyntaxError: The string did not match the expected pattern..
+PASS document.querySelector(":nth-child(-3n+5 of ::-webkit-custom)") threw exception SyntaxError: ':nth-child(-3n+5 of ::-webkit-custom)' is not a valid selector..
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
-PASS document.querySelector(":nth-child(-3n+5 of .foo, ::before)") threw exception SyntaxError: The string did not match the expected pattern..
+PASS document.querySelector(":nth-child(-3n+5 of .foo, ::before)") threw exception SyntaxError: ':nth-child(-3n+5 of .foo, ::before)' is not a valid selector..
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
-PASS document.querySelector(":nth-child(-3n+5 of ::before, .foo)") threw exception SyntaxError: The string did not match the expected pattern..
+PASS document.querySelector(":nth-child(-3n+5 of ::before, .foo)") threw exception SyntaxError: ':nth-child(-3n+5 of ::before, .foo)' is not a valid selector..
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
-PASS document.querySelector(":nth-child(-3n+5 of -webkit-any(::before, .foo))") threw exception SyntaxError: The string did not match the expected pattern..
+PASS document.querySelector(":nth-child(-3n+5 of -webkit-any(::before, .foo))") threw exception SyntaxError: ':nth-child(-3n+5 of -webkit-any(::before, .foo))' is not a valid selector..
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
-PASS document.querySelector(":nth-child(-3n+5 of :nth-child(2n+1 of ::before))") threw exception SyntaxError: The string did not match the expected pattern..
+PASS document.querySelector(":nth-child(-3n+5 of :nth-child(2n+1 of ::before))") threw exception SyntaxError: ':nth-child(-3n+5 of :nth-child(2n+1 of ::before))' is not a valid selector..
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
-PASS document.querySelector(":nth-child(-3n+5 of :not(::before))") threw exception SyntaxError: The string did not match the expected pattern..
+PASS document.querySelector(":nth-child(-3n+5 of :not(::before))") threw exception SyntaxError: ':nth-child(-3n+5 of :not(::before))' is not a valid selector..
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
-PASS document.querySelector(":nth-child(3n-5 of ::first-letter)") threw exception SyntaxError: The string did not match the expected pattern..
+PASS document.querySelector(":nth-child(3n-5 of ::first-letter)") threw exception SyntaxError: ':nth-child(3n-5 of ::first-letter)' is not a valid selector..
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
-PASS document.querySelector(":nth-child(3n-5 of ::before)") threw exception SyntaxError: The string did not match the expected pattern..
+PASS document.querySelector(":nth-child(3n-5 of ::before)") threw exception SyntaxError: ':nth-child(3n-5 of ::before)' is not a valid selector..
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
-PASS document.querySelector(":nth-child(3n-5 of ::after)") threw exception SyntaxError: The string did not match the expected pattern..
+PASS document.querySelector(":nth-child(3n-5 of ::after)") threw exception SyntaxError: ':nth-child(3n-5 of ::after)' is not a valid selector..
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
-PASS document.querySelector(":nth-child(3n-5 of ::-webkit-custom)") threw exception SyntaxError: The string did not match the expected pattern..
+PASS document.querySelector(":nth-child(3n-5 of ::-webkit-custom)") threw exception SyntaxError: ':nth-child(3n-5 of ::-webkit-custom)' is not a valid selector..
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
-PASS document.querySelector(":nth-child(3n-5 of .foo, ::before)") threw exception SyntaxError: The string did not match the expected pattern..
+PASS document.querySelector(":nth-child(3n-5 of .foo, ::before)") threw exception SyntaxError: ':nth-child(3n-5 of .foo, ::before)' is not a valid selector..
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
-PASS document.querySelector(":nth-child(3n-5 of ::before, .foo)") threw exception SyntaxError: The string did not match the expected pattern..
+PASS document.querySelector(":nth-child(3n-5 of ::before, .foo)") threw exception SyntaxError: ':nth-child(3n-5 of ::before, .foo)' is not a valid selector..
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
-PASS document.querySelector(":nth-child(3n-5 of -webkit-any(::before, .foo))") threw exception SyntaxError: The string did not match the expected pattern..
+PASS document.querySelector(":nth-child(3n-5 of -webkit-any(::before, .foo))") threw exception SyntaxError: ':nth-child(3n-5 of -webkit-any(::before, .foo))' is not a valid selector..
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
-PASS document.querySelector(":nth-child(3n-5 of :nth-child(2n+1 of ::before))") threw exception SyntaxError: The string did not match the expected pattern..
+PASS document.querySelector(":nth-child(3n-5 of :nth-child(2n+1 of ::before))") threw exception SyntaxError: ':nth-child(3n-5 of :nth-child(2n+1 of ::before))' is not a valid selector..
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
-PASS document.querySelector(":nth-child(3n-5 of :not(::before))") threw exception SyntaxError: The string did not match the expected pattern..
+PASS document.querySelector(":nth-child(3n-5 of :not(::before))") threw exception SyntaxError: ':nth-child(3n-5 of :not(::before))' is not a valid selector..
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
-PASS document.querySelector(":nth-child(-3n-5 of ::first-letter)") threw exception SyntaxError: The string did not match the expected pattern..
+PASS document.querySelector(":nth-child(-3n-5 of ::first-letter)") threw exception SyntaxError: ':nth-child(-3n-5 of ::first-letter)' is not a valid selector..
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
-PASS document.querySelector(":nth-child(-3n-5 of ::before)") threw exception SyntaxError: The string did not match the expected pattern..
+PASS document.querySelector(":nth-child(-3n-5 of ::before)") threw exception SyntaxError: ':nth-child(-3n-5 of ::before)' is not a valid selector..
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
-PASS document.querySelector(":nth-child(-3n-5 of ::after)") threw exception SyntaxError: The string did not match the expected pattern..
+PASS document.querySelector(":nth-child(-3n-5 of ::after)") threw exception SyntaxError: ':nth-child(-3n-5 of ::after)' is not a valid selector..
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
-PASS document.querySelector(":nth-child(-3n-5 of ::-webkit-custom)") threw exception SyntaxError: The string did not match the expected pattern..
+PASS document.querySelector(":nth-child(-3n-5 of ::-webkit-custom)") threw exception SyntaxError: ':nth-child(-3n-5 of ::-webkit-custom)' is not a valid selector..
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
-PASS document.querySelector(":nth-child(-3n-5 of .foo, ::before)") threw exception SyntaxError: The string did not match the expected pattern..
+PASS document.querySelector(":nth-child(-3n-5 of .foo, ::before)") threw exception SyntaxError: ':nth-child(-3n-5 of .foo, ::before)' is not a valid selector..
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
-PASS document.querySelector(":nth-child(-3n-5 of ::before, .foo)") threw exception SyntaxError: The string did not match the expected pattern..
+PASS document.querySelector(":nth-child(-3n-5 of ::before, .foo)") threw exception SyntaxError: ':nth-child(-3n-5 of ::before, .foo)' is not a valid selector..
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
-PASS document.querySelector(":nth-child(-3n-5 of -webkit-any(::before, .foo))") threw exception SyntaxError: The string did not match the expected pattern..
+PASS document.querySelector(":nth-child(-3n-5 of -webkit-any(::before, .foo))") threw exception SyntaxError: ':nth-child(-3n-5 of -webkit-any(::before, .foo))' is not a valid selector..
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
-PASS document.querySelector(":nth-child(-3n-5 of :nth-child(2n+1 of ::before))") threw exception SyntaxError: The string did not match the expected pattern..
+PASS document.querySelector(":nth-child(-3n-5 of :nth-child(2n+1 of ::before))") threw exception SyntaxError: ':nth-child(-3n-5 of :nth-child(2n+1 of ::before))' is not a valid selector..
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
-PASS document.querySelector(":nth-child(-3n-5 of :not(::before))") threw exception SyntaxError: The string did not match the expected pattern..
+PASS document.querySelector(":nth-child(-3n-5 of :not(::before))") threw exception SyntaxError: ':nth-child(-3n-5 of :not(::before))' is not a valid selector..
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
-PASS document.querySelector(":nth-child(even of .123class)") threw exception SyntaxError: The string did not match the expected pattern..
+PASS document.querySelector(":nth-child(even of .123class)") threw exception SyntaxError: ':nth-child(even of .123class)' is not a valid selector..
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
-PASS document.querySelector(":nth-child(even of #123id)") threw exception SyntaxError: The string did not match the expected pattern..
+PASS document.querySelector(":nth-child(even of #123id)") threw exception SyntaxError: ':nth-child(even of #123id)' is not a valid selector..
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
-PASS document.querySelector(":nth-child(even of [])") threw exception SyntaxError: The string did not match the expected pattern..
+PASS document.querySelector(":nth-child(even of [])") threw exception SyntaxError: ':nth-child(even of [])' is not a valid selector..
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
-PASS document.querySelector(":nth-child(even of ())") threw exception SyntaxError: The string did not match the expected pattern..
+PASS document.querySelector(":nth-child(even of ())") threw exception SyntaxError: ':nth-child(even of ())' is not a valid selector..
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
-PASS document.querySelector(":nth-child(even of ))") threw exception SyntaxError: The string did not match the expected pattern..
+PASS document.querySelector(":nth-child(even of ))") threw exception SyntaxError: ':nth-child(even of ))' is not a valid selector..
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
-PASS document.querySelector(":nth-child(even of {})") threw exception SyntaxError: The string did not match the expected pattern..
+PASS document.querySelector(":nth-child(even of {})") threw exception SyntaxError: ':nth-child(even of {})' is not a valid selector..
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
-PASS document.querySelector(":nth-child(even of })") threw exception SyntaxError: The string did not match the expected pattern..
+PASS document.querySelector(":nth-child(even of })") threw exception SyntaxError: ':nth-child(even of })' is not a valid selector..
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
-PASS document.querySelector(":nth-child(odd of .123class)") threw exception SyntaxError: The string did not match the expected pattern..
+PASS document.querySelector(":nth-child(odd of .123class)") threw exception SyntaxError: ':nth-child(odd of .123class)' is not a valid selector..
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
-PASS document.querySelector(":nth-child(odd of #123id)") threw exception SyntaxError: The string did not match the expected pattern..
+PASS document.querySelector(":nth-child(odd of #123id)") threw exception SyntaxError: ':nth-child(odd of #123id)' is not a valid selector..
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
-PASS document.querySelector(":nth-child(odd of [])") threw exception SyntaxError: The string did not match the expected pattern..
+PASS document.querySelector(":nth-child(odd of [])") threw exception SyntaxError: ':nth-child(odd of [])' is not a valid selector..
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
-PASS document.querySelector(":nth-child(odd of ())") threw exception SyntaxError: The string did not match the expected pattern..
+PASS document.querySelector(":nth-child(odd of ())") threw exception SyntaxError: ':nth-child(odd of ())' is not a valid selector..
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
-PASS document.querySelector(":nth-child(odd of ))") threw exception SyntaxError: The string did not match the expected pattern..
+PASS document.querySelector(":nth-child(odd of ))") threw exception SyntaxError: ':nth-child(odd of ))' is not a valid selector..
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
-PASS document.querySelector(":nth-child(odd of {})") threw exception SyntaxError: The string did not match the expected pattern..
+PASS document.querySelector(":nth-child(odd of {})") threw exception SyntaxError: ':nth-child(odd of {})' is not a valid selector..
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
-PASS document.querySelector(":nth-child(odd of })") threw exception SyntaxError: The string did not match the expected pattern..
+PASS document.querySelector(":nth-child(odd of })") threw exception SyntaxError: ':nth-child(odd of })' is not a valid selector..
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
-PASS document.querySelector(":nth-child(n of .123class)") threw exception SyntaxError: The string did not match the expected pattern..
+PASS document.querySelector(":nth-child(n of .123class)") threw exception SyntaxError: ':nth-child(n of .123class)' is not a valid selector..
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
-PASS document.querySelector(":nth-child(n of #123id)") threw exception SyntaxError: The string did not match the expected pattern..
+PASS document.querySelector(":nth-child(n of #123id)") threw exception SyntaxError: ':nth-child(n of #123id)' is not a valid selector..
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
-PASS document.querySelector(":nth-child(n of [])") threw exception SyntaxError: The string did not match the expected pattern..
+PASS document.querySelector(":nth-child(n of [])") threw exception SyntaxError: ':nth-child(n of [])' is not a valid selector..
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
-PASS document.querySelector(":nth-child(n of ())") threw exception SyntaxError: The string did not match the expected pattern..
+PASS document.querySelector(":nth-child(n of ())") threw exception SyntaxError: ':nth-child(n of ())' is not a valid selector..
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
-PASS document.querySelector(":nth-child(n of ))") threw exception SyntaxError: The string did not match the expected pattern..
+PASS document.querySelector(":nth-child(n of ))") threw exception SyntaxError: ':nth-child(n of ))' is not a valid selector..
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
-PASS document.querySelector(":nth-child(n of {})") threw exception SyntaxError: The string did not match the expected pattern..
+PASS document.querySelector(":nth-child(n of {})") threw exception SyntaxError: ':nth-child(n of {})' is not a valid selector..
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
-PASS document.querySelector(":nth-child(n of })") threw exception SyntaxError: The string did not match the expected pattern..
+PASS document.querySelector(":nth-child(n of })") threw exception SyntaxError: ':nth-child(n of })' is not a valid selector..
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
-PASS document.querySelector(":nth-child(-n of .123class)") threw exception SyntaxError: The string did not match the expected pattern..
+PASS document.querySelector(":nth-child(-n of .123class)") threw exception SyntaxError: ':nth-child(-n of .123class)' is not a valid selector..
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
-PASS document.querySelector(":nth-child(-n of #123id)") threw exception SyntaxError: The string did not match the expected pattern..
+PASS document.querySelector(":nth-child(-n of #123id)") threw exception SyntaxError: ':nth-child(-n of #123id)' is not a valid selector..
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
-PASS document.querySelector(":nth-child(-n of [])") threw exception SyntaxError: The string did not match the expected pattern..
+PASS document.querySelector(":nth-child(-n of [])") threw exception SyntaxError: ':nth-child(-n of [])' is not a valid selector..
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
-PASS document.querySelector(":nth-child(-n of ())") threw exception SyntaxError: The string did not match the expected pattern..
+PASS document.querySelector(":nth-child(-n of ())") threw exception SyntaxError: ':nth-child(-n of ())' is not a valid selector..
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
-PASS document.querySelector(":nth-child(-n of ))") threw exception SyntaxError: The string did not match the expected pattern..
+PASS document.querySelector(":nth-child(-n of ))") threw exception SyntaxError: ':nth-child(-n of ))' is not a valid selector..
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
-PASS document.querySelector(":nth-child(-n of {})") threw exception SyntaxError: The string did not match the expected pattern..
+PASS document.querySelector(":nth-child(-n of {})") threw exception SyntaxError: ':nth-child(-n of {})' is not a valid selector..
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
-PASS document.querySelector(":nth-child(-n of })") threw exception SyntaxError: The string did not match the expected pattern..
+PASS document.querySelector(":nth-child(-n of })") threw exception SyntaxError: ':nth-child(-n of })' is not a valid selector..
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
-PASS document.querySelector(":nth-child(3 of .123class)") threw exception SyntaxError: The string did not match the expected pattern..
+PASS document.querySelector(":nth-child(3 of .123class)") threw exception SyntaxError: ':nth-child(3 of .123class)' is not a valid selector..
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
-PASS document.querySelector(":nth-child(3 of #123id)") threw exception SyntaxError: The string did not match the expected pattern..
+PASS document.querySelector(":nth-child(3 of #123id)") threw exception SyntaxError: ':nth-child(3 of #123id)' is not a valid selector..
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
-PASS document.querySelector(":nth-child(3 of [])") threw exception SyntaxError: The string did not match the expected pattern..
+PASS document.querySelector(":nth-child(3 of [])") threw exception SyntaxError: ':nth-child(3 of [])' is not a valid selector..
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
-PASS document.querySelector(":nth-child(3 of ())") threw exception SyntaxError: The string did not match the expected pattern..
+PASS document.querySelector(":nth-child(3 of ())") threw exception SyntaxError: ':nth-child(3 of ())' is not a valid selector..
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
-PASS document.querySelector(":nth-child(3 of ))") threw exception SyntaxError: The string did not match the expected pattern..
+PASS document.querySelector(":nth-child(3 of ))") threw exception SyntaxError: ':nth-child(3 of ))' is not a valid selector..
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
-PASS document.querySelector(":nth-child(3 of {})") threw exception SyntaxError: The string did not match the expected pattern..
+PASS document.querySelector(":nth-child(3 of {})") threw exception SyntaxError: ':nth-child(3 of {})' is not a valid selector..
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
-PASS document.querySelector(":nth-child(3 of })") threw exception SyntaxError: The string did not match the expected pattern..
+PASS document.querySelector(":nth-child(3 of })") threw exception SyntaxError: ':nth-child(3 of })' is not a valid selector..
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
-PASS document.querySelector(":nth-child(-3 of .123class)") threw exception SyntaxError: The string did not match the expected pattern..
+PASS document.querySelector(":nth-child(-3 of .123class)") threw exception SyntaxError: ':nth-child(-3 of .123class)' is not a valid selector..
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
-PASS document.querySelector(":nth-child(-3 of #123id)") threw exception SyntaxError: The string did not match the expected pattern..
+PASS document.querySelector(":nth-child(-3 of #123id)") threw exception SyntaxError: ':nth-child(-3 of #123id)' is not a valid selector..
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
-PASS document.querySelector(":nth-child(-3 of [])") threw exception SyntaxError: The string did not match the expected pattern..
+PASS document.querySelector(":nth-child(-3 of [])") threw exception SyntaxError: ':nth-child(-3 of [])' is not a valid selector..
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
-PASS document.querySelector(":nth-child(-3 of ())") threw exception SyntaxError: The string did not match the expected pattern..
+PASS document.querySelector(":nth-child(-3 of ())") threw exception SyntaxError: ':nth-child(-3 of ())' is not a valid selector..
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
-PASS document.querySelector(":nth-child(-3 of ))") threw exception SyntaxError: The string did not match the expected pattern..
+PASS document.querySelector(":nth-child(-3 of ))") threw exception SyntaxError: ':nth-child(-3 of ))' is not a valid selector..
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
-PASS document.querySelector(":nth-child(-3 of {})") threw exception SyntaxError: The string did not match the expected pattern..
+PASS document.querySelector(":nth-child(-3 of {})") threw exception SyntaxError: ':nth-child(-3 of {})' is not a valid selector..
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
-PASS document.querySelector(":nth-child(-3 of })") threw exception SyntaxError: The string did not match the expected pattern..
+PASS document.querySelector(":nth-child(-3 of })") threw exception SyntaxError: ':nth-child(-3 of })' is not a valid selector..
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
-PASS document.querySelector(":nth-child(n+0 of .123class)") threw exception SyntaxError: The string did not match the expected pattern..
+PASS document.querySelector(":nth-child(n+0 of .123class)") threw exception SyntaxError: ':nth-child(n+0 of .123class)' is not a valid selector..
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
-PASS document.querySelector(":nth-child(n+0 of #123id)") threw exception SyntaxError: The string did not match the expected pattern..
+PASS document.querySelector(":nth-child(n+0 of #123id)") threw exception SyntaxError: ':nth-child(n+0 of #123id)' is not a valid selector..
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
-PASS document.querySelector(":nth-child(n+0 of [])") threw exception SyntaxError: The string did not match the expected pattern..
+PASS document.querySelector(":nth-child(n+0 of [])") threw exception SyntaxError: ':nth-child(n+0 of [])' is not a valid selector..
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
-PASS document.querySelector(":nth-child(n+0 of ())") threw exception SyntaxError: The string did not match the expected pattern..
+PASS document.querySelector(":nth-child(n+0 of ())") threw exception SyntaxError: ':nth-child(n+0 of ())' is not a valid selector..
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
-PASS document.querySelector(":nth-child(n+0 of ))") threw exception SyntaxError: The string did not match the expected pattern..
+PASS document.querySelector(":nth-child(n+0 of ))") threw exception SyntaxError: ':nth-child(n+0 of ))' is not a valid selector..
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
-PASS document.querySelector(":nth-child(n+0 of {})") threw exception SyntaxError: The string did not match the expected pattern..
+PASS document.querySelector(":nth-child(n+0 of {})") threw exception SyntaxError: ':nth-child(n+0 of {})' is not a valid selector..
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
-PASS document.querySelector(":nth-child(n+0 of })") threw exception SyntaxError: The string did not match the expected pattern..
+PASS document.querySelector(":nth-child(n+0 of })") threw exception SyntaxError: ':nth-child(n+0 of })' is not a valid selector..
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
-PASS document.querySelector(":nth-child(n-0 of .123class)") threw exception SyntaxError: The string did not match the expected pattern..
+PASS document.querySelector(":nth-child(n-0 of .123class)") threw exception SyntaxError: ':nth-child(n-0 of .123class)' is not a valid selector..
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
-PASS document.querySelector(":nth-child(n-0 of #123id)") threw exception SyntaxError: The string did not match the expected pattern..
+PASS document.querySelector(":nth-child(n-0 of #123id)") threw exception SyntaxError: ':nth-child(n-0 of #123id)' is not a valid selector..
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
-PASS document.querySelector(":nth-child(n-0 of [])") threw exception SyntaxError: The string did not match the expected pattern..
+PASS document.querySelector(":nth-child(n-0 of [])") threw exception SyntaxError: ':nth-child(n-0 of [])' is not a valid selector..
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
-PASS document.querySelector(":nth-child(n-0 of ())") threw exception SyntaxError: The string did not match the expected pattern..
+PASS document.querySelector(":nth-child(n-0 of ())") threw exception SyntaxError: ':nth-child(n-0 of ())' is not a valid selector..
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
-PASS document.querySelector(":nth-child(n-0 of ))") threw exception SyntaxError: The string did not match the expected pattern..
+PASS document.querySelector(":nth-child(n-0 of ))") threw exception SyntaxError: ':nth-child(n-0 of ))' is not a valid selector..
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
-PASS document.querySelector(":nth-child(n-0 of {})") threw exception SyntaxError: The string did not match the expected pattern..
+PASS document.querySelector(":nth-child(n-0 of {})") threw exception SyntaxError: ':nth-child(n-0 of {})' is not a valid selector..
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
-PASS document.querySelector(":nth-child(n-0 of })") threw exception SyntaxError: The string did not match the expected pattern..
+PASS document.querySelector(":nth-child(n-0 of })") threw exception SyntaxError: ':nth-child(n-0 of })' is not a valid selector..
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
-PASS document.querySelector(":nth-child(0n of .123class)") threw exception SyntaxError: The string did not match the expected pattern..
+PASS document.querySelector(":nth-child(0n of .123class)") threw exception SyntaxError: ':nth-child(0n of .123class)' is not a valid selector..
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
-PASS document.querySelector(":nth-child(0n of #123id)") threw exception SyntaxError: The string did not match the expected pattern..
+PASS document.querySelector(":nth-child(0n of #123id)") threw exception SyntaxError: ':nth-child(0n of #123id)' is not a valid selector..
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
-PASS document.querySelector(":nth-child(0n of [])") threw exception SyntaxError: The string did not match the expected pattern..
+PASS document.querySelector(":nth-child(0n of [])") threw exception SyntaxError: ':nth-child(0n of [])' is not a valid selector..
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
-PASS document.querySelector(":nth-child(0n of ())") threw exception SyntaxError: The string did not match the expected pattern..
+PASS document.querySelector(":nth-child(0n of ())") threw exception SyntaxError: ':nth-child(0n of ())' is not a valid selector..
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
-PASS document.querySelector(":nth-child(0n of ))") threw exception SyntaxError: The string did not match the expected pattern..
+PASS document.querySelector(":nth-child(0n of ))") threw exception SyntaxError: ':nth-child(0n of ))' is not a valid selector..
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
-PASS document.querySelector(":nth-child(0n of {})") threw exception SyntaxError: The string did not match the expected pattern..
+PASS document.querySelector(":nth-child(0n of {})") threw exception SyntaxError: ':nth-child(0n of {})' is not a valid selector..
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
-PASS document.querySelector(":nth-child(0n of })") threw exception SyntaxError: The string did not match the expected pattern..
+PASS document.querySelector(":nth-child(0n of })") threw exception SyntaxError: ':nth-child(0n of })' is not a valid selector..
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
-PASS document.querySelector(":nth-child(3n+5 of .123class)") threw exception SyntaxError: The string did not match the expected pattern..
+PASS document.querySelector(":nth-child(3n+5 of .123class)") threw exception SyntaxError: ':nth-child(3n+5 of .123class)' is not a valid selector..
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
-PASS document.querySelector(":nth-child(3n+5 of #123id)") threw exception SyntaxError: The string did not match the expected pattern..
+PASS document.querySelector(":nth-child(3n+5 of #123id)") threw exception SyntaxError: ':nth-child(3n+5 of #123id)' is not a valid selector..
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
-PASS document.querySelector(":nth-child(3n+5 of [])") threw exception SyntaxError: The string did not match the expected pattern..
+PASS document.querySelector(":nth-child(3n+5 of [])") threw exception SyntaxError: ':nth-child(3n+5 of [])' is not a valid selector..
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
-PASS document.querySelector(":nth-child(3n+5 of ())") threw exception SyntaxError: The string did not match the expected pattern..
+PASS document.querySelector(":nth-child(3n+5 of ())") threw exception SyntaxError: ':nth-child(3n+5 of ())' is not a valid selector..
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
-PASS document.querySelector(":nth-child(3n+5 of ))") threw exception SyntaxError: The string did not match the expected pattern..
+PASS document.querySelector(":nth-child(3n+5 of ))") threw exception SyntaxError: ':nth-child(3n+5 of ))' is not a valid selector..
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
-PASS document.querySelector(":nth-child(3n+5 of {})") threw exception SyntaxError: The string did not match the expected pattern..
+PASS document.querySelector(":nth-child(3n+5 of {})") threw exception SyntaxError: ':nth-child(3n+5 of {})' is not a valid selector..
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
-PASS document.querySelector(":nth-child(3n+5 of })") threw exception SyntaxError: The string did not match the expected pattern..
+PASS document.querySelector(":nth-child(3n+5 of })") threw exception SyntaxError: ':nth-child(3n+5 of })' is not a valid selector..
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
-PASS document.querySelector(":nth-child(-3n+5 of .123class)") threw exception SyntaxError: The string did not match the expected pattern..
+PASS document.querySelector(":nth-child(-3n+5 of .123class)") threw exception SyntaxError: ':nth-child(-3n+5 of .123class)' is not a valid selector..
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
-PASS document.querySelector(":nth-child(-3n+5 of #123id)") threw exception SyntaxError: The string did not match the expected pattern..
+PASS document.querySelector(":nth-child(-3n+5 of #123id)") threw exception SyntaxError: ':nth-child(-3n+5 of #123id)' is not a valid selector..
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
-PASS document.querySelector(":nth-child(-3n+5 of [])") threw exception SyntaxError: The string did not match the expected pattern..
+PASS document.querySelector(":nth-child(-3n+5 of [])") threw exception SyntaxError: ':nth-child(-3n+5 of [])' is not a valid selector..
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
-PASS document.querySelector(":nth-child(-3n+5 of ())") threw exception SyntaxError: The string did not match the expected pattern..
+PASS document.querySelector(":nth-child(-3n+5 of ())") threw exception SyntaxError: ':nth-child(-3n+5 of ())' is not a valid selector..
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
-PASS document.querySelector(":nth-child(-3n+5 of ))") threw exception SyntaxError: The string did not match the expected pattern..
+PASS document.querySelector(":nth-child(-3n+5 of ))") threw exception SyntaxError: ':nth-child(-3n+5 of ))' is not a valid selector..
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
-PASS document.querySelector(":nth-child(-3n+5 of {})") threw exception SyntaxError: The string did not match the expected pattern..
+PASS document.querySelector(":nth-child(-3n+5 of {})") threw exception SyntaxError: ':nth-child(-3n+5 of {})' is not a valid selector..
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
-PASS document.querySelector(":nth-child(-3n+5 of })") threw exception SyntaxError: The string did not match the expected pattern..
+PASS document.querySelector(":nth-child(-3n+5 of })") threw exception SyntaxError: ':nth-child(-3n+5 of })' is not a valid selector..
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
-PASS document.querySelector(":nth-child(3n-5 of .123class)") threw exception SyntaxError: The string did not match the expected pattern..
+PASS document.querySelector(":nth-child(3n-5 of .123class)") threw exception SyntaxError: ':nth-child(3n-5 of .123class)' is not a valid selector..
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
-PASS document.querySelector(":nth-child(3n-5 of #123id)") threw exception SyntaxError: The string did not match the expected pattern..
+PASS document.querySelector(":nth-child(3n-5 of #123id)") threw exception SyntaxError: ':nth-child(3n-5 of #123id)' is not a valid selector..
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
-PASS document.querySelector(":nth-child(3n-5 of [])") threw exception SyntaxError: The string did not match the expected pattern..
+PASS document.querySelector(":nth-child(3n-5 of [])") threw exception SyntaxError: ':nth-child(3n-5 of [])' is not a valid selector..
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
-PASS document.querySelector(":nth-child(3n-5 of ())") threw exception SyntaxError: The string did not match the expected pattern..
+PASS document.querySelector(":nth-child(3n-5 of ())") threw exception SyntaxError: ':nth-child(3n-5 of ())' is not a valid selector..
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
-PASS document.querySelector(":nth-child(3n-5 of ))") threw exception SyntaxError: The string did not match the expected pattern..
+PASS document.querySelector(":nth-child(3n-5 of ))") threw exception SyntaxError: ':nth-child(3n-5 of ))' is not a valid selector..
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
-PASS document.querySelector(":nth-child(3n-5 of {})") threw exception SyntaxError: The string did not match the expected pattern..
+PASS document.querySelector(":nth-child(3n-5 of {})") threw exception SyntaxError: ':nth-child(3n-5 of {})' is not a valid selector..
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
-PASS document.querySelector(":nth-child(3n-5 of })") threw exception SyntaxError: The string did not match the expected pattern..
+PASS document.querySelector(":nth-child(3n-5 of })") threw exception SyntaxError: ':nth-child(3n-5 of })' is not a valid selector..
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
-PASS document.querySelector(":nth-child(-3n-5 of .123class)") threw exception SyntaxError: The string did not match the expected pattern..
+PASS document.querySelector(":nth-child(-3n-5 of .123class)") threw exception SyntaxError: ':nth-child(-3n-5 of .123class)' is not a valid selector..
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
-PASS document.querySelector(":nth-child(-3n-5 of #123id)") threw exception SyntaxError: The string did not match the expected pattern..
+PASS document.querySelector(":nth-child(-3n-5 of #123id)") threw exception SyntaxError: ':nth-child(-3n-5 of #123id)' is not a valid selector..
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
-PASS document.querySelector(":nth-child(-3n-5 of [])") threw exception SyntaxError: The string did not match the expected pattern..
+PASS document.querySelector(":nth-child(-3n-5 of [])") threw exception SyntaxError: ':nth-child(-3n-5 of [])' is not a valid selector..
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
-PASS document.querySelector(":nth-child(-3n-5 of ())") threw exception SyntaxError: The string did not match the expected pattern..
+PASS document.querySelector(":nth-child(-3n-5 of ())") threw exception SyntaxError: ':nth-child(-3n-5 of ())' is not a valid selector..
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
-PASS document.querySelector(":nth-child(-3n-5 of ))") threw exception SyntaxError: The string did not match the expected pattern..
+PASS document.querySelector(":nth-child(-3n-5 of ))") threw exception SyntaxError: ':nth-child(-3n-5 of ))' is not a valid selector..
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
-PASS document.querySelector(":nth-child(-3n-5 of {})") threw exception SyntaxError: The string did not match the expected pattern..
+PASS document.querySelector(":nth-child(-3n-5 of {})") threw exception SyntaxError: ':nth-child(-3n-5 of {})' is not a valid selector..
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
-PASS document.querySelector(":nth-child(-3n-5 of })") threw exception SyntaxError: The string did not match the expected pattern..
+PASS document.querySelector(":nth-child(-3n-5 of })") threw exception SyntaxError: ':nth-child(-3n-5 of })' is not a valid selector..
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
 PASS successfullyParsed is true
 

--- a/LayoutTests/fast/css/parsing-css-nth-last-child-of-3-expected.txt
+++ b/LayoutTests/fast/css/parsing-css-nth-last-child-of-3-expected.txt
@@ -4,603 +4,603 @@ On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE
 
 
 Test invalid selectors:
-PASS document.querySelector(":nth-last-child(even of)") threw exception SyntaxError: The string did not match the expected pattern..
+PASS document.querySelector(":nth-last-child(even of)") threw exception SyntaxError: ':nth-last-child(even of)' is not a valid selector..
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
-PASS document.querySelector(":nth-last-child(even of    )") threw exception SyntaxError: The string did not match the expected pattern..
+PASS document.querySelector(":nth-last-child(even of    )") threw exception SyntaxError: ':nth-last-child(even of    )' is not a valid selector..
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
-PASS document.querySelector(":nth-last-child(evenof .class)") threw exception SyntaxError: The string did not match the expected pattern..
+PASS document.querySelector(":nth-last-child(evenof .class)") threw exception SyntaxError: ':nth-last-child(evenof .class)' is not a valid selector..
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
-PASS document.querySelector(":nth-last-child(odd of)") threw exception SyntaxError: The string did not match the expected pattern..
+PASS document.querySelector(":nth-last-child(odd of)") threw exception SyntaxError: ':nth-last-child(odd of)' is not a valid selector..
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
-PASS document.querySelector(":nth-last-child(odd of    )") threw exception SyntaxError: The string did not match the expected pattern..
+PASS document.querySelector(":nth-last-child(odd of    )") threw exception SyntaxError: ':nth-last-child(odd of    )' is not a valid selector..
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
-PASS document.querySelector(":nth-last-child(oddof .class)") threw exception SyntaxError: The string did not match the expected pattern..
+PASS document.querySelector(":nth-last-child(oddof .class)") threw exception SyntaxError: ':nth-last-child(oddof .class)' is not a valid selector..
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
-PASS document.querySelector(":nth-last-child(n of)") threw exception SyntaxError: The string did not match the expected pattern..
+PASS document.querySelector(":nth-last-child(n of)") threw exception SyntaxError: ':nth-last-child(n of)' is not a valid selector..
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
-PASS document.querySelector(":nth-last-child(n of    )") threw exception SyntaxError: The string did not match the expected pattern..
+PASS document.querySelector(":nth-last-child(n of    )") threw exception SyntaxError: ':nth-last-child(n of    )' is not a valid selector..
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
-PASS document.querySelector(":nth-last-child(nof .class)") threw exception SyntaxError: The string did not match the expected pattern..
+PASS document.querySelector(":nth-last-child(nof .class)") threw exception SyntaxError: ':nth-last-child(nof .class)' is not a valid selector..
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
-PASS document.querySelector(":nth-last-child(-n of)") threw exception SyntaxError: The string did not match the expected pattern..
+PASS document.querySelector(":nth-last-child(-n of)") threw exception SyntaxError: ':nth-last-child(-n of)' is not a valid selector..
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
-PASS document.querySelector(":nth-last-child(-n of    )") threw exception SyntaxError: The string did not match the expected pattern..
+PASS document.querySelector(":nth-last-child(-n of    )") threw exception SyntaxError: ':nth-last-child(-n of    )' is not a valid selector..
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
-PASS document.querySelector(":nth-last-child(-nof .class)") threw exception SyntaxError: The string did not match the expected pattern..
+PASS document.querySelector(":nth-last-child(-nof .class)") threw exception SyntaxError: ':nth-last-child(-nof .class)' is not a valid selector..
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
-PASS document.querySelector(":nth-last-child(3 of)") threw exception SyntaxError: The string did not match the expected pattern..
+PASS document.querySelector(":nth-last-child(3 of)") threw exception SyntaxError: ':nth-last-child(3 of)' is not a valid selector..
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
-PASS document.querySelector(":nth-last-child(3 of    )") threw exception SyntaxError: The string did not match the expected pattern..
+PASS document.querySelector(":nth-last-child(3 of    )") threw exception SyntaxError: ':nth-last-child(3 of    )' is not a valid selector..
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
-PASS document.querySelector(":nth-last-child(3of .class)") threw exception SyntaxError: The string did not match the expected pattern..
+PASS document.querySelector(":nth-last-child(3of .class)") threw exception SyntaxError: ':nth-last-child(3of .class)' is not a valid selector..
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
-PASS document.querySelector(":nth-last-child(-3 of)") threw exception SyntaxError: The string did not match the expected pattern..
+PASS document.querySelector(":nth-last-child(-3 of)") threw exception SyntaxError: ':nth-last-child(-3 of)' is not a valid selector..
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
-PASS document.querySelector(":nth-last-child(-3 of    )") threw exception SyntaxError: The string did not match the expected pattern..
+PASS document.querySelector(":nth-last-child(-3 of    )") threw exception SyntaxError: ':nth-last-child(-3 of    )' is not a valid selector..
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
-PASS document.querySelector(":nth-last-child(-3of .class)") threw exception SyntaxError: The string did not match the expected pattern..
+PASS document.querySelector(":nth-last-child(-3of .class)") threw exception SyntaxError: ':nth-last-child(-3of .class)' is not a valid selector..
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
-PASS document.querySelector(":nth-last-child(n+0 of)") threw exception SyntaxError: The string did not match the expected pattern..
+PASS document.querySelector(":nth-last-child(n+0 of)") threw exception SyntaxError: ':nth-last-child(n+0 of)' is not a valid selector..
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
-PASS document.querySelector(":nth-last-child(n+0 of    )") threw exception SyntaxError: The string did not match the expected pattern..
+PASS document.querySelector(":nth-last-child(n+0 of    )") threw exception SyntaxError: ':nth-last-child(n+0 of    )' is not a valid selector..
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
-PASS document.querySelector(":nth-last-child(n+0of .class)") threw exception SyntaxError: The string did not match the expected pattern..
+PASS document.querySelector(":nth-last-child(n+0of .class)") threw exception SyntaxError: ':nth-last-child(n+0of .class)' is not a valid selector..
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
-PASS document.querySelector(":nth-last-child(n-0 of)") threw exception SyntaxError: The string did not match the expected pattern..
+PASS document.querySelector(":nth-last-child(n-0 of)") threw exception SyntaxError: ':nth-last-child(n-0 of)' is not a valid selector..
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
-PASS document.querySelector(":nth-last-child(n-0 of    )") threw exception SyntaxError: The string did not match the expected pattern..
+PASS document.querySelector(":nth-last-child(n-0 of    )") threw exception SyntaxError: ':nth-last-child(n-0 of    )' is not a valid selector..
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
-PASS document.querySelector(":nth-last-child(n-0of .class)") threw exception SyntaxError: The string did not match the expected pattern..
+PASS document.querySelector(":nth-last-child(n-0of .class)") threw exception SyntaxError: ':nth-last-child(n-0of .class)' is not a valid selector..
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
-PASS document.querySelector(":nth-last-child(0n of)") threw exception SyntaxError: The string did not match the expected pattern..
+PASS document.querySelector(":nth-last-child(0n of)") threw exception SyntaxError: ':nth-last-child(0n of)' is not a valid selector..
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
-PASS document.querySelector(":nth-last-child(0n of    )") threw exception SyntaxError: The string did not match the expected pattern..
+PASS document.querySelector(":nth-last-child(0n of    )") threw exception SyntaxError: ':nth-last-child(0n of    )' is not a valid selector..
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
-PASS document.querySelector(":nth-last-child(0nof .class)") threw exception SyntaxError: The string did not match the expected pattern..
+PASS document.querySelector(":nth-last-child(0nof .class)") threw exception SyntaxError: ':nth-last-child(0nof .class)' is not a valid selector..
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
-PASS document.querySelector(":nth-last-child(3n+5 of)") threw exception SyntaxError: The string did not match the expected pattern..
+PASS document.querySelector(":nth-last-child(3n+5 of)") threw exception SyntaxError: ':nth-last-child(3n+5 of)' is not a valid selector..
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
-PASS document.querySelector(":nth-last-child(3n+5 of    )") threw exception SyntaxError: The string did not match the expected pattern..
+PASS document.querySelector(":nth-last-child(3n+5 of    )") threw exception SyntaxError: ':nth-last-child(3n+5 of    )' is not a valid selector..
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
-PASS document.querySelector(":nth-last-child(3n+5of .class)") threw exception SyntaxError: The string did not match the expected pattern..
+PASS document.querySelector(":nth-last-child(3n+5of .class)") threw exception SyntaxError: ':nth-last-child(3n+5of .class)' is not a valid selector..
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
-PASS document.querySelector(":nth-last-child(-3n+5 of)") threw exception SyntaxError: The string did not match the expected pattern..
+PASS document.querySelector(":nth-last-child(-3n+5 of)") threw exception SyntaxError: ':nth-last-child(-3n+5 of)' is not a valid selector..
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
-PASS document.querySelector(":nth-last-child(-3n+5 of    )") threw exception SyntaxError: The string did not match the expected pattern..
+PASS document.querySelector(":nth-last-child(-3n+5 of    )") threw exception SyntaxError: ':nth-last-child(-3n+5 of    )' is not a valid selector..
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
-PASS document.querySelector(":nth-last-child(-3n+5of .class)") threw exception SyntaxError: The string did not match the expected pattern..
+PASS document.querySelector(":nth-last-child(-3n+5of .class)") threw exception SyntaxError: ':nth-last-child(-3n+5of .class)' is not a valid selector..
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
-PASS document.querySelector(":nth-last-child(3n-5 of)") threw exception SyntaxError: The string did not match the expected pattern..
+PASS document.querySelector(":nth-last-child(3n-5 of)") threw exception SyntaxError: ':nth-last-child(3n-5 of)' is not a valid selector..
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
-PASS document.querySelector(":nth-last-child(3n-5 of    )") threw exception SyntaxError: The string did not match the expected pattern..
+PASS document.querySelector(":nth-last-child(3n-5 of    )") threw exception SyntaxError: ':nth-last-child(3n-5 of    )' is not a valid selector..
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
-PASS document.querySelector(":nth-last-child(3n-5of .class)") threw exception SyntaxError: The string did not match the expected pattern..
+PASS document.querySelector(":nth-last-child(3n-5of .class)") threw exception SyntaxError: ':nth-last-child(3n-5of .class)' is not a valid selector..
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
-PASS document.querySelector(":nth-last-child(-3n-5 of)") threw exception SyntaxError: The string did not match the expected pattern..
+PASS document.querySelector(":nth-last-child(-3n-5 of)") threw exception SyntaxError: ':nth-last-child(-3n-5 of)' is not a valid selector..
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
-PASS document.querySelector(":nth-last-child(-3n-5 of    )") threw exception SyntaxError: The string did not match the expected pattern..
+PASS document.querySelector(":nth-last-child(-3n-5 of    )") threw exception SyntaxError: ':nth-last-child(-3n-5 of    )' is not a valid selector..
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
-PASS document.querySelector(":nth-last-child(-3n-5of .class)") threw exception SyntaxError: The string did not match the expected pattern..
+PASS document.querySelector(":nth-last-child(-3n-5of .class)") threw exception SyntaxError: ':nth-last-child(-3n-5of .class)' is not a valid selector..
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
-PASS document.querySelector(":nth-last-child(even empty .class)") threw exception SyntaxError: The string did not match the expected pattern..
+PASS document.querySelector(":nth-last-child(even empty .class)") threw exception SyntaxError: ':nth-last-child(even empty .class)' is not a valid selector..
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
-PASS document.querySelector(":nth-last-child(even from .class)") threw exception SyntaxError: The string did not match the expected pattern..
+PASS document.querySelector(":nth-last-child(even from .class)") threw exception SyntaxError: ':nth-last-child(even from .class)' is not a valid selector..
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
-PASS document.querySelector(":nth-last-child(even to .class)") threw exception SyntaxError: The string did not match the expected pattern..
+PASS document.querySelector(":nth-last-child(even to .class)") threw exception SyntaxError: ':nth-last-child(even to .class)' is not a valid selector..
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
-PASS document.querySelector(":nth-last-child(even webkit .class)") threw exception SyntaxError: The string did not match the expected pattern..
+PASS document.querySelector(":nth-last-child(even webkit .class)") threw exception SyntaxError: ':nth-last-child(even webkit .class)' is not a valid selector..
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
-PASS document.querySelector(":nth-last-child(odd empty .class)") threw exception SyntaxError: The string did not match the expected pattern..
+PASS document.querySelector(":nth-last-child(odd empty .class)") threw exception SyntaxError: ':nth-last-child(odd empty .class)' is not a valid selector..
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
-PASS document.querySelector(":nth-last-child(odd from .class)") threw exception SyntaxError: The string did not match the expected pattern..
+PASS document.querySelector(":nth-last-child(odd from .class)") threw exception SyntaxError: ':nth-last-child(odd from .class)' is not a valid selector..
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
-PASS document.querySelector(":nth-last-child(odd to .class)") threw exception SyntaxError: The string did not match the expected pattern..
+PASS document.querySelector(":nth-last-child(odd to .class)") threw exception SyntaxError: ':nth-last-child(odd to .class)' is not a valid selector..
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
-PASS document.querySelector(":nth-last-child(odd webkit .class)") threw exception SyntaxError: The string did not match the expected pattern..
+PASS document.querySelector(":nth-last-child(odd webkit .class)") threw exception SyntaxError: ':nth-last-child(odd webkit .class)' is not a valid selector..
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
-PASS document.querySelector(":nth-last-child(n empty .class)") threw exception SyntaxError: The string did not match the expected pattern..
+PASS document.querySelector(":nth-last-child(n empty .class)") threw exception SyntaxError: ':nth-last-child(n empty .class)' is not a valid selector..
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
-PASS document.querySelector(":nth-last-child(n from .class)") threw exception SyntaxError: The string did not match the expected pattern..
+PASS document.querySelector(":nth-last-child(n from .class)") threw exception SyntaxError: ':nth-last-child(n from .class)' is not a valid selector..
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
-PASS document.querySelector(":nth-last-child(n to .class)") threw exception SyntaxError: The string did not match the expected pattern..
+PASS document.querySelector(":nth-last-child(n to .class)") threw exception SyntaxError: ':nth-last-child(n to .class)' is not a valid selector..
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
-PASS document.querySelector(":nth-last-child(n webkit .class)") threw exception SyntaxError: The string did not match the expected pattern..
+PASS document.querySelector(":nth-last-child(n webkit .class)") threw exception SyntaxError: ':nth-last-child(n webkit .class)' is not a valid selector..
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
-PASS document.querySelector(":nth-last-child(-n empty .class)") threw exception SyntaxError: The string did not match the expected pattern..
+PASS document.querySelector(":nth-last-child(-n empty .class)") threw exception SyntaxError: ':nth-last-child(-n empty .class)' is not a valid selector..
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
-PASS document.querySelector(":nth-last-child(-n from .class)") threw exception SyntaxError: The string did not match the expected pattern..
+PASS document.querySelector(":nth-last-child(-n from .class)") threw exception SyntaxError: ':nth-last-child(-n from .class)' is not a valid selector..
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
-PASS document.querySelector(":nth-last-child(-n to .class)") threw exception SyntaxError: The string did not match the expected pattern..
+PASS document.querySelector(":nth-last-child(-n to .class)") threw exception SyntaxError: ':nth-last-child(-n to .class)' is not a valid selector..
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
-PASS document.querySelector(":nth-last-child(-n webkit .class)") threw exception SyntaxError: The string did not match the expected pattern..
+PASS document.querySelector(":nth-last-child(-n webkit .class)") threw exception SyntaxError: ':nth-last-child(-n webkit .class)' is not a valid selector..
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
-PASS document.querySelector(":nth-last-child(3 empty .class)") threw exception SyntaxError: The string did not match the expected pattern..
+PASS document.querySelector(":nth-last-child(3 empty .class)") threw exception SyntaxError: ':nth-last-child(3 empty .class)' is not a valid selector..
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
-PASS document.querySelector(":nth-last-child(3 from .class)") threw exception SyntaxError: The string did not match the expected pattern..
+PASS document.querySelector(":nth-last-child(3 from .class)") threw exception SyntaxError: ':nth-last-child(3 from .class)' is not a valid selector..
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
-PASS document.querySelector(":nth-last-child(3 to .class)") threw exception SyntaxError: The string did not match the expected pattern..
+PASS document.querySelector(":nth-last-child(3 to .class)") threw exception SyntaxError: ':nth-last-child(3 to .class)' is not a valid selector..
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
-PASS document.querySelector(":nth-last-child(3 webkit .class)") threw exception SyntaxError: The string did not match the expected pattern..
+PASS document.querySelector(":nth-last-child(3 webkit .class)") threw exception SyntaxError: ':nth-last-child(3 webkit .class)' is not a valid selector..
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
-PASS document.querySelector(":nth-last-child(-3 empty .class)") threw exception SyntaxError: The string did not match the expected pattern..
+PASS document.querySelector(":nth-last-child(-3 empty .class)") threw exception SyntaxError: ':nth-last-child(-3 empty .class)' is not a valid selector..
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
-PASS document.querySelector(":nth-last-child(-3 from .class)") threw exception SyntaxError: The string did not match the expected pattern..
+PASS document.querySelector(":nth-last-child(-3 from .class)") threw exception SyntaxError: ':nth-last-child(-3 from .class)' is not a valid selector..
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
-PASS document.querySelector(":nth-last-child(-3 to .class)") threw exception SyntaxError: The string did not match the expected pattern..
+PASS document.querySelector(":nth-last-child(-3 to .class)") threw exception SyntaxError: ':nth-last-child(-3 to .class)' is not a valid selector..
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
-PASS document.querySelector(":nth-last-child(-3 webkit .class)") threw exception SyntaxError: The string did not match the expected pattern..
+PASS document.querySelector(":nth-last-child(-3 webkit .class)") threw exception SyntaxError: ':nth-last-child(-3 webkit .class)' is not a valid selector..
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
-PASS document.querySelector(":nth-last-child(n+0 empty .class)") threw exception SyntaxError: The string did not match the expected pattern..
+PASS document.querySelector(":nth-last-child(n+0 empty .class)") threw exception SyntaxError: ':nth-last-child(n+0 empty .class)' is not a valid selector..
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
-PASS document.querySelector(":nth-last-child(n+0 from .class)") threw exception SyntaxError: The string did not match the expected pattern..
+PASS document.querySelector(":nth-last-child(n+0 from .class)") threw exception SyntaxError: ':nth-last-child(n+0 from .class)' is not a valid selector..
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
-PASS document.querySelector(":nth-last-child(n+0 to .class)") threw exception SyntaxError: The string did not match the expected pattern..
+PASS document.querySelector(":nth-last-child(n+0 to .class)") threw exception SyntaxError: ':nth-last-child(n+0 to .class)' is not a valid selector..
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
-PASS document.querySelector(":nth-last-child(n+0 webkit .class)") threw exception SyntaxError: The string did not match the expected pattern..
+PASS document.querySelector(":nth-last-child(n+0 webkit .class)") threw exception SyntaxError: ':nth-last-child(n+0 webkit .class)' is not a valid selector..
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
-PASS document.querySelector(":nth-last-child(n-0 empty .class)") threw exception SyntaxError: The string did not match the expected pattern..
+PASS document.querySelector(":nth-last-child(n-0 empty .class)") threw exception SyntaxError: ':nth-last-child(n-0 empty .class)' is not a valid selector..
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
-PASS document.querySelector(":nth-last-child(n-0 from .class)") threw exception SyntaxError: The string did not match the expected pattern..
+PASS document.querySelector(":nth-last-child(n-0 from .class)") threw exception SyntaxError: ':nth-last-child(n-0 from .class)' is not a valid selector..
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
-PASS document.querySelector(":nth-last-child(n-0 to .class)") threw exception SyntaxError: The string did not match the expected pattern..
+PASS document.querySelector(":nth-last-child(n-0 to .class)") threw exception SyntaxError: ':nth-last-child(n-0 to .class)' is not a valid selector..
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
-PASS document.querySelector(":nth-last-child(n-0 webkit .class)") threw exception SyntaxError: The string did not match the expected pattern..
+PASS document.querySelector(":nth-last-child(n-0 webkit .class)") threw exception SyntaxError: ':nth-last-child(n-0 webkit .class)' is not a valid selector..
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
-PASS document.querySelector(":nth-last-child(0n empty .class)") threw exception SyntaxError: The string did not match the expected pattern..
+PASS document.querySelector(":nth-last-child(0n empty .class)") threw exception SyntaxError: ':nth-last-child(0n empty .class)' is not a valid selector..
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
-PASS document.querySelector(":nth-last-child(0n from .class)") threw exception SyntaxError: The string did not match the expected pattern..
+PASS document.querySelector(":nth-last-child(0n from .class)") threw exception SyntaxError: ':nth-last-child(0n from .class)' is not a valid selector..
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
-PASS document.querySelector(":nth-last-child(0n to .class)") threw exception SyntaxError: The string did not match the expected pattern..
+PASS document.querySelector(":nth-last-child(0n to .class)") threw exception SyntaxError: ':nth-last-child(0n to .class)' is not a valid selector..
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
-PASS document.querySelector(":nth-last-child(0n webkit .class)") threw exception SyntaxError: The string did not match the expected pattern..
+PASS document.querySelector(":nth-last-child(0n webkit .class)") threw exception SyntaxError: ':nth-last-child(0n webkit .class)' is not a valid selector..
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
-PASS document.querySelector(":nth-last-child(3n+5 empty .class)") threw exception SyntaxError: The string did not match the expected pattern..
+PASS document.querySelector(":nth-last-child(3n+5 empty .class)") threw exception SyntaxError: ':nth-last-child(3n+5 empty .class)' is not a valid selector..
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
-PASS document.querySelector(":nth-last-child(3n+5 from .class)") threw exception SyntaxError: The string did not match the expected pattern..
+PASS document.querySelector(":nth-last-child(3n+5 from .class)") threw exception SyntaxError: ':nth-last-child(3n+5 from .class)' is not a valid selector..
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
-PASS document.querySelector(":nth-last-child(3n+5 to .class)") threw exception SyntaxError: The string did not match the expected pattern..
+PASS document.querySelector(":nth-last-child(3n+5 to .class)") threw exception SyntaxError: ':nth-last-child(3n+5 to .class)' is not a valid selector..
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
-PASS document.querySelector(":nth-last-child(3n+5 webkit .class)") threw exception SyntaxError: The string did not match the expected pattern..
+PASS document.querySelector(":nth-last-child(3n+5 webkit .class)") threw exception SyntaxError: ':nth-last-child(3n+5 webkit .class)' is not a valid selector..
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
-PASS document.querySelector(":nth-last-child(-3n+5 empty .class)") threw exception SyntaxError: The string did not match the expected pattern..
+PASS document.querySelector(":nth-last-child(-3n+5 empty .class)") threw exception SyntaxError: ':nth-last-child(-3n+5 empty .class)' is not a valid selector..
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
-PASS document.querySelector(":nth-last-child(-3n+5 from .class)") threw exception SyntaxError: The string did not match the expected pattern..
+PASS document.querySelector(":nth-last-child(-3n+5 from .class)") threw exception SyntaxError: ':nth-last-child(-3n+5 from .class)' is not a valid selector..
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
-PASS document.querySelector(":nth-last-child(-3n+5 to .class)") threw exception SyntaxError: The string did not match the expected pattern..
+PASS document.querySelector(":nth-last-child(-3n+5 to .class)") threw exception SyntaxError: ':nth-last-child(-3n+5 to .class)' is not a valid selector..
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
-PASS document.querySelector(":nth-last-child(-3n+5 webkit .class)") threw exception SyntaxError: The string did not match the expected pattern..
+PASS document.querySelector(":nth-last-child(-3n+5 webkit .class)") threw exception SyntaxError: ':nth-last-child(-3n+5 webkit .class)' is not a valid selector..
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
-PASS document.querySelector(":nth-last-child(3n-5 empty .class)") threw exception SyntaxError: The string did not match the expected pattern..
+PASS document.querySelector(":nth-last-child(3n-5 empty .class)") threw exception SyntaxError: ':nth-last-child(3n-5 empty .class)' is not a valid selector..
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
-PASS document.querySelector(":nth-last-child(3n-5 from .class)") threw exception SyntaxError: The string did not match the expected pattern..
+PASS document.querySelector(":nth-last-child(3n-5 from .class)") threw exception SyntaxError: ':nth-last-child(3n-5 from .class)' is not a valid selector..
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
-PASS document.querySelector(":nth-last-child(3n-5 to .class)") threw exception SyntaxError: The string did not match the expected pattern..
+PASS document.querySelector(":nth-last-child(3n-5 to .class)") threw exception SyntaxError: ':nth-last-child(3n-5 to .class)' is not a valid selector..
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
-PASS document.querySelector(":nth-last-child(3n-5 webkit .class)") threw exception SyntaxError: The string did not match the expected pattern..
+PASS document.querySelector(":nth-last-child(3n-5 webkit .class)") threw exception SyntaxError: ':nth-last-child(3n-5 webkit .class)' is not a valid selector..
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
-PASS document.querySelector(":nth-last-child(-3n-5 empty .class)") threw exception SyntaxError: The string did not match the expected pattern..
+PASS document.querySelector(":nth-last-child(-3n-5 empty .class)") threw exception SyntaxError: ':nth-last-child(-3n-5 empty .class)' is not a valid selector..
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
-PASS document.querySelector(":nth-last-child(-3n-5 from .class)") threw exception SyntaxError: The string did not match the expected pattern..
+PASS document.querySelector(":nth-last-child(-3n-5 from .class)") threw exception SyntaxError: ':nth-last-child(-3n-5 from .class)' is not a valid selector..
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
-PASS document.querySelector(":nth-last-child(-3n-5 to .class)") threw exception SyntaxError: The string did not match the expected pattern..
+PASS document.querySelector(":nth-last-child(-3n-5 to .class)") threw exception SyntaxError: ':nth-last-child(-3n-5 to .class)' is not a valid selector..
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
-PASS document.querySelector(":nth-last-child(-3n-5 webkit .class)") threw exception SyntaxError: The string did not match the expected pattern..
+PASS document.querySelector(":nth-last-child(-3n-5 webkit .class)") threw exception SyntaxError: ':nth-last-child(-3n-5 webkit .class)' is not a valid selector..
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
-PASS document.querySelector(":nth-last-child(even of ::first-letter)") threw exception SyntaxError: The string did not match the expected pattern..
+PASS document.querySelector(":nth-last-child(even of ::first-letter)") threw exception SyntaxError: ':nth-last-child(even of ::first-letter)' is not a valid selector..
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
-PASS document.querySelector(":nth-last-child(even of ::before)") threw exception SyntaxError: The string did not match the expected pattern..
+PASS document.querySelector(":nth-last-child(even of ::before)") threw exception SyntaxError: ':nth-last-child(even of ::before)' is not a valid selector..
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
-PASS document.querySelector(":nth-last-child(even of ::after)") threw exception SyntaxError: The string did not match the expected pattern..
+PASS document.querySelector(":nth-last-child(even of ::after)") threw exception SyntaxError: ':nth-last-child(even of ::after)' is not a valid selector..
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
-PASS document.querySelector(":nth-last-child(even of ::-webkit-custom)") threw exception SyntaxError: The string did not match the expected pattern..
+PASS document.querySelector(":nth-last-child(even of ::-webkit-custom)") threw exception SyntaxError: ':nth-last-child(even of ::-webkit-custom)' is not a valid selector..
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
-PASS document.querySelector(":nth-last-child(even of .foo, ::before)") threw exception SyntaxError: The string did not match the expected pattern..
+PASS document.querySelector(":nth-last-child(even of .foo, ::before)") threw exception SyntaxError: ':nth-last-child(even of .foo, ::before)' is not a valid selector..
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
-PASS document.querySelector(":nth-last-child(even of ::before, .foo)") threw exception SyntaxError: The string did not match the expected pattern..
+PASS document.querySelector(":nth-last-child(even of ::before, .foo)") threw exception SyntaxError: ':nth-last-child(even of ::before, .foo)' is not a valid selector..
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
-PASS document.querySelector(":nth-last-child(even of -webkit-any(::before, .foo))") threw exception SyntaxError: The string did not match the expected pattern..
+PASS document.querySelector(":nth-last-child(even of -webkit-any(::before, .foo))") threw exception SyntaxError: ':nth-last-child(even of -webkit-any(::before, .foo))' is not a valid selector..
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
-PASS document.querySelector(":nth-last-child(even of :nth-last-child(2n+1 of ::before))") threw exception SyntaxError: The string did not match the expected pattern..
+PASS document.querySelector(":nth-last-child(even of :nth-last-child(2n+1 of ::before))") threw exception SyntaxError: ':nth-last-child(even of :nth-last-child(2n+1 of ::before))' is not a valid selector..
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
-PASS document.querySelector(":nth-last-child(even of :not(::before))") threw exception SyntaxError: The string did not match the expected pattern..
+PASS document.querySelector(":nth-last-child(even of :not(::before))") threw exception SyntaxError: ':nth-last-child(even of :not(::before))' is not a valid selector..
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
-PASS document.querySelector(":nth-last-child(odd of ::first-letter)") threw exception SyntaxError: The string did not match the expected pattern..
+PASS document.querySelector(":nth-last-child(odd of ::first-letter)") threw exception SyntaxError: ':nth-last-child(odd of ::first-letter)' is not a valid selector..
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
-PASS document.querySelector(":nth-last-child(odd of ::before)") threw exception SyntaxError: The string did not match the expected pattern..
+PASS document.querySelector(":nth-last-child(odd of ::before)") threw exception SyntaxError: ':nth-last-child(odd of ::before)' is not a valid selector..
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
-PASS document.querySelector(":nth-last-child(odd of ::after)") threw exception SyntaxError: The string did not match the expected pattern..
+PASS document.querySelector(":nth-last-child(odd of ::after)") threw exception SyntaxError: ':nth-last-child(odd of ::after)' is not a valid selector..
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
-PASS document.querySelector(":nth-last-child(odd of ::-webkit-custom)") threw exception SyntaxError: The string did not match the expected pattern..
+PASS document.querySelector(":nth-last-child(odd of ::-webkit-custom)") threw exception SyntaxError: ':nth-last-child(odd of ::-webkit-custom)' is not a valid selector..
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
-PASS document.querySelector(":nth-last-child(odd of .foo, ::before)") threw exception SyntaxError: The string did not match the expected pattern..
+PASS document.querySelector(":nth-last-child(odd of .foo, ::before)") threw exception SyntaxError: ':nth-last-child(odd of .foo, ::before)' is not a valid selector..
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
-PASS document.querySelector(":nth-last-child(odd of ::before, .foo)") threw exception SyntaxError: The string did not match the expected pattern..
+PASS document.querySelector(":nth-last-child(odd of ::before, .foo)") threw exception SyntaxError: ':nth-last-child(odd of ::before, .foo)' is not a valid selector..
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
-PASS document.querySelector(":nth-last-child(odd of -webkit-any(::before, .foo))") threw exception SyntaxError: The string did not match the expected pattern..
+PASS document.querySelector(":nth-last-child(odd of -webkit-any(::before, .foo))") threw exception SyntaxError: ':nth-last-child(odd of -webkit-any(::before, .foo))' is not a valid selector..
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
-PASS document.querySelector(":nth-last-child(odd of :nth-last-child(2n+1 of ::before))") threw exception SyntaxError: The string did not match the expected pattern..
+PASS document.querySelector(":nth-last-child(odd of :nth-last-child(2n+1 of ::before))") threw exception SyntaxError: ':nth-last-child(odd of :nth-last-child(2n+1 of ::before))' is not a valid selector..
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
-PASS document.querySelector(":nth-last-child(odd of :not(::before))") threw exception SyntaxError: The string did not match the expected pattern..
+PASS document.querySelector(":nth-last-child(odd of :not(::before))") threw exception SyntaxError: ':nth-last-child(odd of :not(::before))' is not a valid selector..
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
-PASS document.querySelector(":nth-last-child(n of ::first-letter)") threw exception SyntaxError: The string did not match the expected pattern..
+PASS document.querySelector(":nth-last-child(n of ::first-letter)") threw exception SyntaxError: ':nth-last-child(n of ::first-letter)' is not a valid selector..
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
-PASS document.querySelector(":nth-last-child(n of ::before)") threw exception SyntaxError: The string did not match the expected pattern..
+PASS document.querySelector(":nth-last-child(n of ::before)") threw exception SyntaxError: ':nth-last-child(n of ::before)' is not a valid selector..
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
-PASS document.querySelector(":nth-last-child(n of ::after)") threw exception SyntaxError: The string did not match the expected pattern..
+PASS document.querySelector(":nth-last-child(n of ::after)") threw exception SyntaxError: ':nth-last-child(n of ::after)' is not a valid selector..
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
-PASS document.querySelector(":nth-last-child(n of ::-webkit-custom)") threw exception SyntaxError: The string did not match the expected pattern..
+PASS document.querySelector(":nth-last-child(n of ::-webkit-custom)") threw exception SyntaxError: ':nth-last-child(n of ::-webkit-custom)' is not a valid selector..
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
-PASS document.querySelector(":nth-last-child(n of .foo, ::before)") threw exception SyntaxError: The string did not match the expected pattern..
+PASS document.querySelector(":nth-last-child(n of .foo, ::before)") threw exception SyntaxError: ':nth-last-child(n of .foo, ::before)' is not a valid selector..
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
-PASS document.querySelector(":nth-last-child(n of ::before, .foo)") threw exception SyntaxError: The string did not match the expected pattern..
+PASS document.querySelector(":nth-last-child(n of ::before, .foo)") threw exception SyntaxError: ':nth-last-child(n of ::before, .foo)' is not a valid selector..
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
-PASS document.querySelector(":nth-last-child(n of -webkit-any(::before, .foo))") threw exception SyntaxError: The string did not match the expected pattern..
+PASS document.querySelector(":nth-last-child(n of -webkit-any(::before, .foo))") threw exception SyntaxError: ':nth-last-child(n of -webkit-any(::before, .foo))' is not a valid selector..
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
-PASS document.querySelector(":nth-last-child(n of :nth-last-child(2n+1 of ::before))") threw exception SyntaxError: The string did not match the expected pattern..
+PASS document.querySelector(":nth-last-child(n of :nth-last-child(2n+1 of ::before))") threw exception SyntaxError: ':nth-last-child(n of :nth-last-child(2n+1 of ::before))' is not a valid selector..
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
-PASS document.querySelector(":nth-last-child(n of :not(::before))") threw exception SyntaxError: The string did not match the expected pattern..
+PASS document.querySelector(":nth-last-child(n of :not(::before))") threw exception SyntaxError: ':nth-last-child(n of :not(::before))' is not a valid selector..
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
-PASS document.querySelector(":nth-last-child(-n of ::first-letter)") threw exception SyntaxError: The string did not match the expected pattern..
+PASS document.querySelector(":nth-last-child(-n of ::first-letter)") threw exception SyntaxError: ':nth-last-child(-n of ::first-letter)' is not a valid selector..
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
-PASS document.querySelector(":nth-last-child(-n of ::before)") threw exception SyntaxError: The string did not match the expected pattern..
+PASS document.querySelector(":nth-last-child(-n of ::before)") threw exception SyntaxError: ':nth-last-child(-n of ::before)' is not a valid selector..
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
-PASS document.querySelector(":nth-last-child(-n of ::after)") threw exception SyntaxError: The string did not match the expected pattern..
+PASS document.querySelector(":nth-last-child(-n of ::after)") threw exception SyntaxError: ':nth-last-child(-n of ::after)' is not a valid selector..
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
-PASS document.querySelector(":nth-last-child(-n of ::-webkit-custom)") threw exception SyntaxError: The string did not match the expected pattern..
+PASS document.querySelector(":nth-last-child(-n of ::-webkit-custom)") threw exception SyntaxError: ':nth-last-child(-n of ::-webkit-custom)' is not a valid selector..
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
-PASS document.querySelector(":nth-last-child(-n of .foo, ::before)") threw exception SyntaxError: The string did not match the expected pattern..
+PASS document.querySelector(":nth-last-child(-n of .foo, ::before)") threw exception SyntaxError: ':nth-last-child(-n of .foo, ::before)' is not a valid selector..
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
-PASS document.querySelector(":nth-last-child(-n of ::before, .foo)") threw exception SyntaxError: The string did not match the expected pattern..
+PASS document.querySelector(":nth-last-child(-n of ::before, .foo)") threw exception SyntaxError: ':nth-last-child(-n of ::before, .foo)' is not a valid selector..
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
-PASS document.querySelector(":nth-last-child(-n of -webkit-any(::before, .foo))") threw exception SyntaxError: The string did not match the expected pattern..
+PASS document.querySelector(":nth-last-child(-n of -webkit-any(::before, .foo))") threw exception SyntaxError: ':nth-last-child(-n of -webkit-any(::before, .foo))' is not a valid selector..
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
-PASS document.querySelector(":nth-last-child(-n of :nth-last-child(2n+1 of ::before))") threw exception SyntaxError: The string did not match the expected pattern..
+PASS document.querySelector(":nth-last-child(-n of :nth-last-child(2n+1 of ::before))") threw exception SyntaxError: ':nth-last-child(-n of :nth-last-child(2n+1 of ::before))' is not a valid selector..
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
-PASS document.querySelector(":nth-last-child(-n of :not(::before))") threw exception SyntaxError: The string did not match the expected pattern..
+PASS document.querySelector(":nth-last-child(-n of :not(::before))") threw exception SyntaxError: ':nth-last-child(-n of :not(::before))' is not a valid selector..
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
-PASS document.querySelector(":nth-last-child(3 of ::first-letter)") threw exception SyntaxError: The string did not match the expected pattern..
+PASS document.querySelector(":nth-last-child(3 of ::first-letter)") threw exception SyntaxError: ':nth-last-child(3 of ::first-letter)' is not a valid selector..
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
-PASS document.querySelector(":nth-last-child(3 of ::before)") threw exception SyntaxError: The string did not match the expected pattern..
+PASS document.querySelector(":nth-last-child(3 of ::before)") threw exception SyntaxError: ':nth-last-child(3 of ::before)' is not a valid selector..
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
-PASS document.querySelector(":nth-last-child(3 of ::after)") threw exception SyntaxError: The string did not match the expected pattern..
+PASS document.querySelector(":nth-last-child(3 of ::after)") threw exception SyntaxError: ':nth-last-child(3 of ::after)' is not a valid selector..
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
-PASS document.querySelector(":nth-last-child(3 of ::-webkit-custom)") threw exception SyntaxError: The string did not match the expected pattern..
+PASS document.querySelector(":nth-last-child(3 of ::-webkit-custom)") threw exception SyntaxError: ':nth-last-child(3 of ::-webkit-custom)' is not a valid selector..
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
-PASS document.querySelector(":nth-last-child(3 of .foo, ::before)") threw exception SyntaxError: The string did not match the expected pattern..
+PASS document.querySelector(":nth-last-child(3 of .foo, ::before)") threw exception SyntaxError: ':nth-last-child(3 of .foo, ::before)' is not a valid selector..
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
-PASS document.querySelector(":nth-last-child(3 of ::before, .foo)") threw exception SyntaxError: The string did not match the expected pattern..
+PASS document.querySelector(":nth-last-child(3 of ::before, .foo)") threw exception SyntaxError: ':nth-last-child(3 of ::before, .foo)' is not a valid selector..
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
-PASS document.querySelector(":nth-last-child(3 of -webkit-any(::before, .foo))") threw exception SyntaxError: The string did not match the expected pattern..
+PASS document.querySelector(":nth-last-child(3 of -webkit-any(::before, .foo))") threw exception SyntaxError: ':nth-last-child(3 of -webkit-any(::before, .foo))' is not a valid selector..
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
-PASS document.querySelector(":nth-last-child(3 of :nth-last-child(2n+1 of ::before))") threw exception SyntaxError: The string did not match the expected pattern..
+PASS document.querySelector(":nth-last-child(3 of :nth-last-child(2n+1 of ::before))") threw exception SyntaxError: ':nth-last-child(3 of :nth-last-child(2n+1 of ::before))' is not a valid selector..
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
-PASS document.querySelector(":nth-last-child(3 of :not(::before))") threw exception SyntaxError: The string did not match the expected pattern..
+PASS document.querySelector(":nth-last-child(3 of :not(::before))") threw exception SyntaxError: ':nth-last-child(3 of :not(::before))' is not a valid selector..
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
-PASS document.querySelector(":nth-last-child(-3 of ::first-letter)") threw exception SyntaxError: The string did not match the expected pattern..
+PASS document.querySelector(":nth-last-child(-3 of ::first-letter)") threw exception SyntaxError: ':nth-last-child(-3 of ::first-letter)' is not a valid selector..
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
-PASS document.querySelector(":nth-last-child(-3 of ::before)") threw exception SyntaxError: The string did not match the expected pattern..
+PASS document.querySelector(":nth-last-child(-3 of ::before)") threw exception SyntaxError: ':nth-last-child(-3 of ::before)' is not a valid selector..
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
-PASS document.querySelector(":nth-last-child(-3 of ::after)") threw exception SyntaxError: The string did not match the expected pattern..
+PASS document.querySelector(":nth-last-child(-3 of ::after)") threw exception SyntaxError: ':nth-last-child(-3 of ::after)' is not a valid selector..
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
-PASS document.querySelector(":nth-last-child(-3 of ::-webkit-custom)") threw exception SyntaxError: The string did not match the expected pattern..
+PASS document.querySelector(":nth-last-child(-3 of ::-webkit-custom)") threw exception SyntaxError: ':nth-last-child(-3 of ::-webkit-custom)' is not a valid selector..
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
-PASS document.querySelector(":nth-last-child(-3 of .foo, ::before)") threw exception SyntaxError: The string did not match the expected pattern..
+PASS document.querySelector(":nth-last-child(-3 of .foo, ::before)") threw exception SyntaxError: ':nth-last-child(-3 of .foo, ::before)' is not a valid selector..
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
-PASS document.querySelector(":nth-last-child(-3 of ::before, .foo)") threw exception SyntaxError: The string did not match the expected pattern..
+PASS document.querySelector(":nth-last-child(-3 of ::before, .foo)") threw exception SyntaxError: ':nth-last-child(-3 of ::before, .foo)' is not a valid selector..
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
-PASS document.querySelector(":nth-last-child(-3 of -webkit-any(::before, .foo))") threw exception SyntaxError: The string did not match the expected pattern..
+PASS document.querySelector(":nth-last-child(-3 of -webkit-any(::before, .foo))") threw exception SyntaxError: ':nth-last-child(-3 of -webkit-any(::before, .foo))' is not a valid selector..
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
-PASS document.querySelector(":nth-last-child(-3 of :nth-last-child(2n+1 of ::before))") threw exception SyntaxError: The string did not match the expected pattern..
+PASS document.querySelector(":nth-last-child(-3 of :nth-last-child(2n+1 of ::before))") threw exception SyntaxError: ':nth-last-child(-3 of :nth-last-child(2n+1 of ::before))' is not a valid selector..
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
-PASS document.querySelector(":nth-last-child(-3 of :not(::before))") threw exception SyntaxError: The string did not match the expected pattern..
+PASS document.querySelector(":nth-last-child(-3 of :not(::before))") threw exception SyntaxError: ':nth-last-child(-3 of :not(::before))' is not a valid selector..
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
-PASS document.querySelector(":nth-last-child(n+0 of ::first-letter)") threw exception SyntaxError: The string did not match the expected pattern..
+PASS document.querySelector(":nth-last-child(n+0 of ::first-letter)") threw exception SyntaxError: ':nth-last-child(n+0 of ::first-letter)' is not a valid selector..
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
-PASS document.querySelector(":nth-last-child(n+0 of ::before)") threw exception SyntaxError: The string did not match the expected pattern..
+PASS document.querySelector(":nth-last-child(n+0 of ::before)") threw exception SyntaxError: ':nth-last-child(n+0 of ::before)' is not a valid selector..
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
-PASS document.querySelector(":nth-last-child(n+0 of ::after)") threw exception SyntaxError: The string did not match the expected pattern..
+PASS document.querySelector(":nth-last-child(n+0 of ::after)") threw exception SyntaxError: ':nth-last-child(n+0 of ::after)' is not a valid selector..
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
-PASS document.querySelector(":nth-last-child(n+0 of ::-webkit-custom)") threw exception SyntaxError: The string did not match the expected pattern..
+PASS document.querySelector(":nth-last-child(n+0 of ::-webkit-custom)") threw exception SyntaxError: ':nth-last-child(n+0 of ::-webkit-custom)' is not a valid selector..
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
-PASS document.querySelector(":nth-last-child(n+0 of .foo, ::before)") threw exception SyntaxError: The string did not match the expected pattern..
+PASS document.querySelector(":nth-last-child(n+0 of .foo, ::before)") threw exception SyntaxError: ':nth-last-child(n+0 of .foo, ::before)' is not a valid selector..
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
-PASS document.querySelector(":nth-last-child(n+0 of ::before, .foo)") threw exception SyntaxError: The string did not match the expected pattern..
+PASS document.querySelector(":nth-last-child(n+0 of ::before, .foo)") threw exception SyntaxError: ':nth-last-child(n+0 of ::before, .foo)' is not a valid selector..
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
-PASS document.querySelector(":nth-last-child(n+0 of -webkit-any(::before, .foo))") threw exception SyntaxError: The string did not match the expected pattern..
+PASS document.querySelector(":nth-last-child(n+0 of -webkit-any(::before, .foo))") threw exception SyntaxError: ':nth-last-child(n+0 of -webkit-any(::before, .foo))' is not a valid selector..
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
-PASS document.querySelector(":nth-last-child(n+0 of :nth-last-child(2n+1 of ::before))") threw exception SyntaxError: The string did not match the expected pattern..
+PASS document.querySelector(":nth-last-child(n+0 of :nth-last-child(2n+1 of ::before))") threw exception SyntaxError: ':nth-last-child(n+0 of :nth-last-child(2n+1 of ::before))' is not a valid selector..
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
-PASS document.querySelector(":nth-last-child(n+0 of :not(::before))") threw exception SyntaxError: The string did not match the expected pattern..
+PASS document.querySelector(":nth-last-child(n+0 of :not(::before))") threw exception SyntaxError: ':nth-last-child(n+0 of :not(::before))' is not a valid selector..
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
-PASS document.querySelector(":nth-last-child(n-0 of ::first-letter)") threw exception SyntaxError: The string did not match the expected pattern..
+PASS document.querySelector(":nth-last-child(n-0 of ::first-letter)") threw exception SyntaxError: ':nth-last-child(n-0 of ::first-letter)' is not a valid selector..
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
-PASS document.querySelector(":nth-last-child(n-0 of ::before)") threw exception SyntaxError: The string did not match the expected pattern..
+PASS document.querySelector(":nth-last-child(n-0 of ::before)") threw exception SyntaxError: ':nth-last-child(n-0 of ::before)' is not a valid selector..
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
-PASS document.querySelector(":nth-last-child(n-0 of ::after)") threw exception SyntaxError: The string did not match the expected pattern..
+PASS document.querySelector(":nth-last-child(n-0 of ::after)") threw exception SyntaxError: ':nth-last-child(n-0 of ::after)' is not a valid selector..
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
-PASS document.querySelector(":nth-last-child(n-0 of ::-webkit-custom)") threw exception SyntaxError: The string did not match the expected pattern..
+PASS document.querySelector(":nth-last-child(n-0 of ::-webkit-custom)") threw exception SyntaxError: ':nth-last-child(n-0 of ::-webkit-custom)' is not a valid selector..
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
-PASS document.querySelector(":nth-last-child(n-0 of .foo, ::before)") threw exception SyntaxError: The string did not match the expected pattern..
+PASS document.querySelector(":nth-last-child(n-0 of .foo, ::before)") threw exception SyntaxError: ':nth-last-child(n-0 of .foo, ::before)' is not a valid selector..
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
-PASS document.querySelector(":nth-last-child(n-0 of ::before, .foo)") threw exception SyntaxError: The string did not match the expected pattern..
+PASS document.querySelector(":nth-last-child(n-0 of ::before, .foo)") threw exception SyntaxError: ':nth-last-child(n-0 of ::before, .foo)' is not a valid selector..
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
-PASS document.querySelector(":nth-last-child(n-0 of -webkit-any(::before, .foo))") threw exception SyntaxError: The string did not match the expected pattern..
+PASS document.querySelector(":nth-last-child(n-0 of -webkit-any(::before, .foo))") threw exception SyntaxError: ':nth-last-child(n-0 of -webkit-any(::before, .foo))' is not a valid selector..
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
-PASS document.querySelector(":nth-last-child(n-0 of :nth-last-child(2n+1 of ::before))") threw exception SyntaxError: The string did not match the expected pattern..
+PASS document.querySelector(":nth-last-child(n-0 of :nth-last-child(2n+1 of ::before))") threw exception SyntaxError: ':nth-last-child(n-0 of :nth-last-child(2n+1 of ::before))' is not a valid selector..
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
-PASS document.querySelector(":nth-last-child(n-0 of :not(::before))") threw exception SyntaxError: The string did not match the expected pattern..
+PASS document.querySelector(":nth-last-child(n-0 of :not(::before))") threw exception SyntaxError: ':nth-last-child(n-0 of :not(::before))' is not a valid selector..
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
-PASS document.querySelector(":nth-last-child(0n of ::first-letter)") threw exception SyntaxError: The string did not match the expected pattern..
+PASS document.querySelector(":nth-last-child(0n of ::first-letter)") threw exception SyntaxError: ':nth-last-child(0n of ::first-letter)' is not a valid selector..
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
-PASS document.querySelector(":nth-last-child(0n of ::before)") threw exception SyntaxError: The string did not match the expected pattern..
+PASS document.querySelector(":nth-last-child(0n of ::before)") threw exception SyntaxError: ':nth-last-child(0n of ::before)' is not a valid selector..
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
-PASS document.querySelector(":nth-last-child(0n of ::after)") threw exception SyntaxError: The string did not match the expected pattern..
+PASS document.querySelector(":nth-last-child(0n of ::after)") threw exception SyntaxError: ':nth-last-child(0n of ::after)' is not a valid selector..
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
-PASS document.querySelector(":nth-last-child(0n of ::-webkit-custom)") threw exception SyntaxError: The string did not match the expected pattern..
+PASS document.querySelector(":nth-last-child(0n of ::-webkit-custom)") threw exception SyntaxError: ':nth-last-child(0n of ::-webkit-custom)' is not a valid selector..
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
-PASS document.querySelector(":nth-last-child(0n of .foo, ::before)") threw exception SyntaxError: The string did not match the expected pattern..
+PASS document.querySelector(":nth-last-child(0n of .foo, ::before)") threw exception SyntaxError: ':nth-last-child(0n of .foo, ::before)' is not a valid selector..
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
-PASS document.querySelector(":nth-last-child(0n of ::before, .foo)") threw exception SyntaxError: The string did not match the expected pattern..
+PASS document.querySelector(":nth-last-child(0n of ::before, .foo)") threw exception SyntaxError: ':nth-last-child(0n of ::before, .foo)' is not a valid selector..
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
-PASS document.querySelector(":nth-last-child(0n of -webkit-any(::before, .foo))") threw exception SyntaxError: The string did not match the expected pattern..
+PASS document.querySelector(":nth-last-child(0n of -webkit-any(::before, .foo))") threw exception SyntaxError: ':nth-last-child(0n of -webkit-any(::before, .foo))' is not a valid selector..
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
-PASS document.querySelector(":nth-last-child(0n of :nth-last-child(2n+1 of ::before))") threw exception SyntaxError: The string did not match the expected pattern..
+PASS document.querySelector(":nth-last-child(0n of :nth-last-child(2n+1 of ::before))") threw exception SyntaxError: ':nth-last-child(0n of :nth-last-child(2n+1 of ::before))' is not a valid selector..
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
-PASS document.querySelector(":nth-last-child(0n of :not(::before))") threw exception SyntaxError: The string did not match the expected pattern..
+PASS document.querySelector(":nth-last-child(0n of :not(::before))") threw exception SyntaxError: ':nth-last-child(0n of :not(::before))' is not a valid selector..
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
-PASS document.querySelector(":nth-last-child(3n+5 of ::first-letter)") threw exception SyntaxError: The string did not match the expected pattern..
+PASS document.querySelector(":nth-last-child(3n+5 of ::first-letter)") threw exception SyntaxError: ':nth-last-child(3n+5 of ::first-letter)' is not a valid selector..
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
-PASS document.querySelector(":nth-last-child(3n+5 of ::before)") threw exception SyntaxError: The string did not match the expected pattern..
+PASS document.querySelector(":nth-last-child(3n+5 of ::before)") threw exception SyntaxError: ':nth-last-child(3n+5 of ::before)' is not a valid selector..
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
-PASS document.querySelector(":nth-last-child(3n+5 of ::after)") threw exception SyntaxError: The string did not match the expected pattern..
+PASS document.querySelector(":nth-last-child(3n+5 of ::after)") threw exception SyntaxError: ':nth-last-child(3n+5 of ::after)' is not a valid selector..
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
-PASS document.querySelector(":nth-last-child(3n+5 of ::-webkit-custom)") threw exception SyntaxError: The string did not match the expected pattern..
+PASS document.querySelector(":nth-last-child(3n+5 of ::-webkit-custom)") threw exception SyntaxError: ':nth-last-child(3n+5 of ::-webkit-custom)' is not a valid selector..
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
-PASS document.querySelector(":nth-last-child(3n+5 of .foo, ::before)") threw exception SyntaxError: The string did not match the expected pattern..
+PASS document.querySelector(":nth-last-child(3n+5 of .foo, ::before)") threw exception SyntaxError: ':nth-last-child(3n+5 of .foo, ::before)' is not a valid selector..
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
-PASS document.querySelector(":nth-last-child(3n+5 of ::before, .foo)") threw exception SyntaxError: The string did not match the expected pattern..
+PASS document.querySelector(":nth-last-child(3n+5 of ::before, .foo)") threw exception SyntaxError: ':nth-last-child(3n+5 of ::before, .foo)' is not a valid selector..
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
-PASS document.querySelector(":nth-last-child(3n+5 of -webkit-any(::before, .foo))") threw exception SyntaxError: The string did not match the expected pattern..
+PASS document.querySelector(":nth-last-child(3n+5 of -webkit-any(::before, .foo))") threw exception SyntaxError: ':nth-last-child(3n+5 of -webkit-any(::before, .foo))' is not a valid selector..
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
-PASS document.querySelector(":nth-last-child(3n+5 of :nth-last-child(2n+1 of ::before))") threw exception SyntaxError: The string did not match the expected pattern..
+PASS document.querySelector(":nth-last-child(3n+5 of :nth-last-child(2n+1 of ::before))") threw exception SyntaxError: ':nth-last-child(3n+5 of :nth-last-child(2n+1 of ::before))' is not a valid selector..
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
-PASS document.querySelector(":nth-last-child(3n+5 of :not(::before))") threw exception SyntaxError: The string did not match the expected pattern..
+PASS document.querySelector(":nth-last-child(3n+5 of :not(::before))") threw exception SyntaxError: ':nth-last-child(3n+5 of :not(::before))' is not a valid selector..
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
-PASS document.querySelector(":nth-last-child(-3n+5 of ::first-letter)") threw exception SyntaxError: The string did not match the expected pattern..
+PASS document.querySelector(":nth-last-child(-3n+5 of ::first-letter)") threw exception SyntaxError: ':nth-last-child(-3n+5 of ::first-letter)' is not a valid selector..
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
-PASS document.querySelector(":nth-last-child(-3n+5 of ::before)") threw exception SyntaxError: The string did not match the expected pattern..
+PASS document.querySelector(":nth-last-child(-3n+5 of ::before)") threw exception SyntaxError: ':nth-last-child(-3n+5 of ::before)' is not a valid selector..
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
-PASS document.querySelector(":nth-last-child(-3n+5 of ::after)") threw exception SyntaxError: The string did not match the expected pattern..
+PASS document.querySelector(":nth-last-child(-3n+5 of ::after)") threw exception SyntaxError: ':nth-last-child(-3n+5 of ::after)' is not a valid selector..
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
-PASS document.querySelector(":nth-last-child(-3n+5 of ::-webkit-custom)") threw exception SyntaxError: The string did not match the expected pattern..
+PASS document.querySelector(":nth-last-child(-3n+5 of ::-webkit-custom)") threw exception SyntaxError: ':nth-last-child(-3n+5 of ::-webkit-custom)' is not a valid selector..
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
-PASS document.querySelector(":nth-last-child(-3n+5 of .foo, ::before)") threw exception SyntaxError: The string did not match the expected pattern..
+PASS document.querySelector(":nth-last-child(-3n+5 of .foo, ::before)") threw exception SyntaxError: ':nth-last-child(-3n+5 of .foo, ::before)' is not a valid selector..
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
-PASS document.querySelector(":nth-last-child(-3n+5 of ::before, .foo)") threw exception SyntaxError: The string did not match the expected pattern..
+PASS document.querySelector(":nth-last-child(-3n+5 of ::before, .foo)") threw exception SyntaxError: ':nth-last-child(-3n+5 of ::before, .foo)' is not a valid selector..
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
-PASS document.querySelector(":nth-last-child(-3n+5 of -webkit-any(::before, .foo))") threw exception SyntaxError: The string did not match the expected pattern..
+PASS document.querySelector(":nth-last-child(-3n+5 of -webkit-any(::before, .foo))") threw exception SyntaxError: ':nth-last-child(-3n+5 of -webkit-any(::before, .foo))' is not a valid selector..
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
-PASS document.querySelector(":nth-last-child(-3n+5 of :nth-last-child(2n+1 of ::before))") threw exception SyntaxError: The string did not match the expected pattern..
+PASS document.querySelector(":nth-last-child(-3n+5 of :nth-last-child(2n+1 of ::before))") threw exception SyntaxError: ':nth-last-child(-3n+5 of :nth-last-child(2n+1 of ::before))' is not a valid selector..
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
-PASS document.querySelector(":nth-last-child(-3n+5 of :not(::before))") threw exception SyntaxError: The string did not match the expected pattern..
+PASS document.querySelector(":nth-last-child(-3n+5 of :not(::before))") threw exception SyntaxError: ':nth-last-child(-3n+5 of :not(::before))' is not a valid selector..
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
-PASS document.querySelector(":nth-last-child(3n-5 of ::first-letter)") threw exception SyntaxError: The string did not match the expected pattern..
+PASS document.querySelector(":nth-last-child(3n-5 of ::first-letter)") threw exception SyntaxError: ':nth-last-child(3n-5 of ::first-letter)' is not a valid selector..
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
-PASS document.querySelector(":nth-last-child(3n-5 of ::before)") threw exception SyntaxError: The string did not match the expected pattern..
+PASS document.querySelector(":nth-last-child(3n-5 of ::before)") threw exception SyntaxError: ':nth-last-child(3n-5 of ::before)' is not a valid selector..
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
-PASS document.querySelector(":nth-last-child(3n-5 of ::after)") threw exception SyntaxError: The string did not match the expected pattern..
+PASS document.querySelector(":nth-last-child(3n-5 of ::after)") threw exception SyntaxError: ':nth-last-child(3n-5 of ::after)' is not a valid selector..
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
-PASS document.querySelector(":nth-last-child(3n-5 of ::-webkit-custom)") threw exception SyntaxError: The string did not match the expected pattern..
+PASS document.querySelector(":nth-last-child(3n-5 of ::-webkit-custom)") threw exception SyntaxError: ':nth-last-child(3n-5 of ::-webkit-custom)' is not a valid selector..
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
-PASS document.querySelector(":nth-last-child(3n-5 of .foo, ::before)") threw exception SyntaxError: The string did not match the expected pattern..
+PASS document.querySelector(":nth-last-child(3n-5 of .foo, ::before)") threw exception SyntaxError: ':nth-last-child(3n-5 of .foo, ::before)' is not a valid selector..
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
-PASS document.querySelector(":nth-last-child(3n-5 of ::before, .foo)") threw exception SyntaxError: The string did not match the expected pattern..
+PASS document.querySelector(":nth-last-child(3n-5 of ::before, .foo)") threw exception SyntaxError: ':nth-last-child(3n-5 of ::before, .foo)' is not a valid selector..
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
-PASS document.querySelector(":nth-last-child(3n-5 of -webkit-any(::before, .foo))") threw exception SyntaxError: The string did not match the expected pattern..
+PASS document.querySelector(":nth-last-child(3n-5 of -webkit-any(::before, .foo))") threw exception SyntaxError: ':nth-last-child(3n-5 of -webkit-any(::before, .foo))' is not a valid selector..
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
-PASS document.querySelector(":nth-last-child(3n-5 of :nth-last-child(2n+1 of ::before))") threw exception SyntaxError: The string did not match the expected pattern..
+PASS document.querySelector(":nth-last-child(3n-5 of :nth-last-child(2n+1 of ::before))") threw exception SyntaxError: ':nth-last-child(3n-5 of :nth-last-child(2n+1 of ::before))' is not a valid selector..
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
-PASS document.querySelector(":nth-last-child(3n-5 of :not(::before))") threw exception SyntaxError: The string did not match the expected pattern..
+PASS document.querySelector(":nth-last-child(3n-5 of :not(::before))") threw exception SyntaxError: ':nth-last-child(3n-5 of :not(::before))' is not a valid selector..
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
-PASS document.querySelector(":nth-last-child(-3n-5 of ::first-letter)") threw exception SyntaxError: The string did not match the expected pattern..
+PASS document.querySelector(":nth-last-child(-3n-5 of ::first-letter)") threw exception SyntaxError: ':nth-last-child(-3n-5 of ::first-letter)' is not a valid selector..
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
-PASS document.querySelector(":nth-last-child(-3n-5 of ::before)") threw exception SyntaxError: The string did not match the expected pattern..
+PASS document.querySelector(":nth-last-child(-3n-5 of ::before)") threw exception SyntaxError: ':nth-last-child(-3n-5 of ::before)' is not a valid selector..
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
-PASS document.querySelector(":nth-last-child(-3n-5 of ::after)") threw exception SyntaxError: The string did not match the expected pattern..
+PASS document.querySelector(":nth-last-child(-3n-5 of ::after)") threw exception SyntaxError: ':nth-last-child(-3n-5 of ::after)' is not a valid selector..
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
-PASS document.querySelector(":nth-last-child(-3n-5 of ::-webkit-custom)") threw exception SyntaxError: The string did not match the expected pattern..
+PASS document.querySelector(":nth-last-child(-3n-5 of ::-webkit-custom)") threw exception SyntaxError: ':nth-last-child(-3n-5 of ::-webkit-custom)' is not a valid selector..
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
-PASS document.querySelector(":nth-last-child(-3n-5 of .foo, ::before)") threw exception SyntaxError: The string did not match the expected pattern..
+PASS document.querySelector(":nth-last-child(-3n-5 of .foo, ::before)") threw exception SyntaxError: ':nth-last-child(-3n-5 of .foo, ::before)' is not a valid selector..
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
-PASS document.querySelector(":nth-last-child(-3n-5 of ::before, .foo)") threw exception SyntaxError: The string did not match the expected pattern..
+PASS document.querySelector(":nth-last-child(-3n-5 of ::before, .foo)") threw exception SyntaxError: ':nth-last-child(-3n-5 of ::before, .foo)' is not a valid selector..
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
-PASS document.querySelector(":nth-last-child(-3n-5 of -webkit-any(::before, .foo))") threw exception SyntaxError: The string did not match the expected pattern..
+PASS document.querySelector(":nth-last-child(-3n-5 of -webkit-any(::before, .foo))") threw exception SyntaxError: ':nth-last-child(-3n-5 of -webkit-any(::before, .foo))' is not a valid selector..
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
-PASS document.querySelector(":nth-last-child(-3n-5 of :nth-last-child(2n+1 of ::before))") threw exception SyntaxError: The string did not match the expected pattern..
+PASS document.querySelector(":nth-last-child(-3n-5 of :nth-last-child(2n+1 of ::before))") threw exception SyntaxError: ':nth-last-child(-3n-5 of :nth-last-child(2n+1 of ::before))' is not a valid selector..
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
-PASS document.querySelector(":nth-last-child(-3n-5 of :not(::before))") threw exception SyntaxError: The string did not match the expected pattern..
+PASS document.querySelector(":nth-last-child(-3n-5 of :not(::before))") threw exception SyntaxError: ':nth-last-child(-3n-5 of :not(::before))' is not a valid selector..
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
-PASS document.querySelector(":nth-last-child(even of .123class)") threw exception SyntaxError: The string did not match the expected pattern..
+PASS document.querySelector(":nth-last-child(even of .123class)") threw exception SyntaxError: ':nth-last-child(even of .123class)' is not a valid selector..
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
-PASS document.querySelector(":nth-last-child(even of #123id)") threw exception SyntaxError: The string did not match the expected pattern..
+PASS document.querySelector(":nth-last-child(even of #123id)") threw exception SyntaxError: ':nth-last-child(even of #123id)' is not a valid selector..
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
-PASS document.querySelector(":nth-last-child(even of [])") threw exception SyntaxError: The string did not match the expected pattern..
+PASS document.querySelector(":nth-last-child(even of [])") threw exception SyntaxError: ':nth-last-child(even of [])' is not a valid selector..
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
-PASS document.querySelector(":nth-last-child(even of ())") threw exception SyntaxError: The string did not match the expected pattern..
+PASS document.querySelector(":nth-last-child(even of ())") threw exception SyntaxError: ':nth-last-child(even of ())' is not a valid selector..
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
-PASS document.querySelector(":nth-last-child(even of ))") threw exception SyntaxError: The string did not match the expected pattern..
+PASS document.querySelector(":nth-last-child(even of ))") threw exception SyntaxError: ':nth-last-child(even of ))' is not a valid selector..
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
-PASS document.querySelector(":nth-last-child(even of {})") threw exception SyntaxError: The string did not match the expected pattern..
+PASS document.querySelector(":nth-last-child(even of {})") threw exception SyntaxError: ':nth-last-child(even of {})' is not a valid selector..
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
-PASS document.querySelector(":nth-last-child(even of })") threw exception SyntaxError: The string did not match the expected pattern..
+PASS document.querySelector(":nth-last-child(even of })") threw exception SyntaxError: ':nth-last-child(even of })' is not a valid selector..
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
-PASS document.querySelector(":nth-last-child(odd of .123class)") threw exception SyntaxError: The string did not match the expected pattern..
+PASS document.querySelector(":nth-last-child(odd of .123class)") threw exception SyntaxError: ':nth-last-child(odd of .123class)' is not a valid selector..
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
-PASS document.querySelector(":nth-last-child(odd of #123id)") threw exception SyntaxError: The string did not match the expected pattern..
+PASS document.querySelector(":nth-last-child(odd of #123id)") threw exception SyntaxError: ':nth-last-child(odd of #123id)' is not a valid selector..
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
-PASS document.querySelector(":nth-last-child(odd of [])") threw exception SyntaxError: The string did not match the expected pattern..
+PASS document.querySelector(":nth-last-child(odd of [])") threw exception SyntaxError: ':nth-last-child(odd of [])' is not a valid selector..
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
-PASS document.querySelector(":nth-last-child(odd of ())") threw exception SyntaxError: The string did not match the expected pattern..
+PASS document.querySelector(":nth-last-child(odd of ())") threw exception SyntaxError: ':nth-last-child(odd of ())' is not a valid selector..
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
-PASS document.querySelector(":nth-last-child(odd of ))") threw exception SyntaxError: The string did not match the expected pattern..
+PASS document.querySelector(":nth-last-child(odd of ))") threw exception SyntaxError: ':nth-last-child(odd of ))' is not a valid selector..
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
-PASS document.querySelector(":nth-last-child(odd of {})") threw exception SyntaxError: The string did not match the expected pattern..
+PASS document.querySelector(":nth-last-child(odd of {})") threw exception SyntaxError: ':nth-last-child(odd of {})' is not a valid selector..
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
-PASS document.querySelector(":nth-last-child(odd of })") threw exception SyntaxError: The string did not match the expected pattern..
+PASS document.querySelector(":nth-last-child(odd of })") threw exception SyntaxError: ':nth-last-child(odd of })' is not a valid selector..
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
-PASS document.querySelector(":nth-last-child(n of .123class)") threw exception SyntaxError: The string did not match the expected pattern..
+PASS document.querySelector(":nth-last-child(n of .123class)") threw exception SyntaxError: ':nth-last-child(n of .123class)' is not a valid selector..
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
-PASS document.querySelector(":nth-last-child(n of #123id)") threw exception SyntaxError: The string did not match the expected pattern..
+PASS document.querySelector(":nth-last-child(n of #123id)") threw exception SyntaxError: ':nth-last-child(n of #123id)' is not a valid selector..
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
-PASS document.querySelector(":nth-last-child(n of [])") threw exception SyntaxError: The string did not match the expected pattern..
+PASS document.querySelector(":nth-last-child(n of [])") threw exception SyntaxError: ':nth-last-child(n of [])' is not a valid selector..
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
-PASS document.querySelector(":nth-last-child(n of ())") threw exception SyntaxError: The string did not match the expected pattern..
+PASS document.querySelector(":nth-last-child(n of ())") threw exception SyntaxError: ':nth-last-child(n of ())' is not a valid selector..
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
-PASS document.querySelector(":nth-last-child(n of ))") threw exception SyntaxError: The string did not match the expected pattern..
+PASS document.querySelector(":nth-last-child(n of ))") threw exception SyntaxError: ':nth-last-child(n of ))' is not a valid selector..
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
-PASS document.querySelector(":nth-last-child(n of {})") threw exception SyntaxError: The string did not match the expected pattern..
+PASS document.querySelector(":nth-last-child(n of {})") threw exception SyntaxError: ':nth-last-child(n of {})' is not a valid selector..
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
-PASS document.querySelector(":nth-last-child(n of })") threw exception SyntaxError: The string did not match the expected pattern..
+PASS document.querySelector(":nth-last-child(n of })") threw exception SyntaxError: ':nth-last-child(n of })' is not a valid selector..
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
-PASS document.querySelector(":nth-last-child(-n of .123class)") threw exception SyntaxError: The string did not match the expected pattern..
+PASS document.querySelector(":nth-last-child(-n of .123class)") threw exception SyntaxError: ':nth-last-child(-n of .123class)' is not a valid selector..
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
-PASS document.querySelector(":nth-last-child(-n of #123id)") threw exception SyntaxError: The string did not match the expected pattern..
+PASS document.querySelector(":nth-last-child(-n of #123id)") threw exception SyntaxError: ':nth-last-child(-n of #123id)' is not a valid selector..
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
-PASS document.querySelector(":nth-last-child(-n of [])") threw exception SyntaxError: The string did not match the expected pattern..
+PASS document.querySelector(":nth-last-child(-n of [])") threw exception SyntaxError: ':nth-last-child(-n of [])' is not a valid selector..
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
-PASS document.querySelector(":nth-last-child(-n of ())") threw exception SyntaxError: The string did not match the expected pattern..
+PASS document.querySelector(":nth-last-child(-n of ())") threw exception SyntaxError: ':nth-last-child(-n of ())' is not a valid selector..
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
-PASS document.querySelector(":nth-last-child(-n of ))") threw exception SyntaxError: The string did not match the expected pattern..
+PASS document.querySelector(":nth-last-child(-n of ))") threw exception SyntaxError: ':nth-last-child(-n of ))' is not a valid selector..
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
-PASS document.querySelector(":nth-last-child(-n of {})") threw exception SyntaxError: The string did not match the expected pattern..
+PASS document.querySelector(":nth-last-child(-n of {})") threw exception SyntaxError: ':nth-last-child(-n of {})' is not a valid selector..
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
-PASS document.querySelector(":nth-last-child(-n of })") threw exception SyntaxError: The string did not match the expected pattern..
+PASS document.querySelector(":nth-last-child(-n of })") threw exception SyntaxError: ':nth-last-child(-n of })' is not a valid selector..
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
-PASS document.querySelector(":nth-last-child(3 of .123class)") threw exception SyntaxError: The string did not match the expected pattern..
+PASS document.querySelector(":nth-last-child(3 of .123class)") threw exception SyntaxError: ':nth-last-child(3 of .123class)' is not a valid selector..
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
-PASS document.querySelector(":nth-last-child(3 of #123id)") threw exception SyntaxError: The string did not match the expected pattern..
+PASS document.querySelector(":nth-last-child(3 of #123id)") threw exception SyntaxError: ':nth-last-child(3 of #123id)' is not a valid selector..
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
-PASS document.querySelector(":nth-last-child(3 of [])") threw exception SyntaxError: The string did not match the expected pattern..
+PASS document.querySelector(":nth-last-child(3 of [])") threw exception SyntaxError: ':nth-last-child(3 of [])' is not a valid selector..
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
-PASS document.querySelector(":nth-last-child(3 of ())") threw exception SyntaxError: The string did not match the expected pattern..
+PASS document.querySelector(":nth-last-child(3 of ())") threw exception SyntaxError: ':nth-last-child(3 of ())' is not a valid selector..
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
-PASS document.querySelector(":nth-last-child(3 of ))") threw exception SyntaxError: The string did not match the expected pattern..
+PASS document.querySelector(":nth-last-child(3 of ))") threw exception SyntaxError: ':nth-last-child(3 of ))' is not a valid selector..
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
-PASS document.querySelector(":nth-last-child(3 of {})") threw exception SyntaxError: The string did not match the expected pattern..
+PASS document.querySelector(":nth-last-child(3 of {})") threw exception SyntaxError: ':nth-last-child(3 of {})' is not a valid selector..
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
-PASS document.querySelector(":nth-last-child(3 of })") threw exception SyntaxError: The string did not match the expected pattern..
+PASS document.querySelector(":nth-last-child(3 of })") threw exception SyntaxError: ':nth-last-child(3 of })' is not a valid selector..
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
-PASS document.querySelector(":nth-last-child(-3 of .123class)") threw exception SyntaxError: The string did not match the expected pattern..
+PASS document.querySelector(":nth-last-child(-3 of .123class)") threw exception SyntaxError: ':nth-last-child(-3 of .123class)' is not a valid selector..
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
-PASS document.querySelector(":nth-last-child(-3 of #123id)") threw exception SyntaxError: The string did not match the expected pattern..
+PASS document.querySelector(":nth-last-child(-3 of #123id)") threw exception SyntaxError: ':nth-last-child(-3 of #123id)' is not a valid selector..
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
-PASS document.querySelector(":nth-last-child(-3 of [])") threw exception SyntaxError: The string did not match the expected pattern..
+PASS document.querySelector(":nth-last-child(-3 of [])") threw exception SyntaxError: ':nth-last-child(-3 of [])' is not a valid selector..
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
-PASS document.querySelector(":nth-last-child(-3 of ())") threw exception SyntaxError: The string did not match the expected pattern..
+PASS document.querySelector(":nth-last-child(-3 of ())") threw exception SyntaxError: ':nth-last-child(-3 of ())' is not a valid selector..
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
-PASS document.querySelector(":nth-last-child(-3 of ))") threw exception SyntaxError: The string did not match the expected pattern..
+PASS document.querySelector(":nth-last-child(-3 of ))") threw exception SyntaxError: ':nth-last-child(-3 of ))' is not a valid selector..
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
-PASS document.querySelector(":nth-last-child(-3 of {})") threw exception SyntaxError: The string did not match the expected pattern..
+PASS document.querySelector(":nth-last-child(-3 of {})") threw exception SyntaxError: ':nth-last-child(-3 of {})' is not a valid selector..
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
-PASS document.querySelector(":nth-last-child(-3 of })") threw exception SyntaxError: The string did not match the expected pattern..
+PASS document.querySelector(":nth-last-child(-3 of })") threw exception SyntaxError: ':nth-last-child(-3 of })' is not a valid selector..
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
-PASS document.querySelector(":nth-last-child(n+0 of .123class)") threw exception SyntaxError: The string did not match the expected pattern..
+PASS document.querySelector(":nth-last-child(n+0 of .123class)") threw exception SyntaxError: ':nth-last-child(n+0 of .123class)' is not a valid selector..
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
-PASS document.querySelector(":nth-last-child(n+0 of #123id)") threw exception SyntaxError: The string did not match the expected pattern..
+PASS document.querySelector(":nth-last-child(n+0 of #123id)") threw exception SyntaxError: ':nth-last-child(n+0 of #123id)' is not a valid selector..
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
-PASS document.querySelector(":nth-last-child(n+0 of [])") threw exception SyntaxError: The string did not match the expected pattern..
+PASS document.querySelector(":nth-last-child(n+0 of [])") threw exception SyntaxError: ':nth-last-child(n+0 of [])' is not a valid selector..
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
-PASS document.querySelector(":nth-last-child(n+0 of ())") threw exception SyntaxError: The string did not match the expected pattern..
+PASS document.querySelector(":nth-last-child(n+0 of ())") threw exception SyntaxError: ':nth-last-child(n+0 of ())' is not a valid selector..
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
-PASS document.querySelector(":nth-last-child(n+0 of ))") threw exception SyntaxError: The string did not match the expected pattern..
+PASS document.querySelector(":nth-last-child(n+0 of ))") threw exception SyntaxError: ':nth-last-child(n+0 of ))' is not a valid selector..
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
-PASS document.querySelector(":nth-last-child(n+0 of {})") threw exception SyntaxError: The string did not match the expected pattern..
+PASS document.querySelector(":nth-last-child(n+0 of {})") threw exception SyntaxError: ':nth-last-child(n+0 of {})' is not a valid selector..
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
-PASS document.querySelector(":nth-last-child(n+0 of })") threw exception SyntaxError: The string did not match the expected pattern..
+PASS document.querySelector(":nth-last-child(n+0 of })") threw exception SyntaxError: ':nth-last-child(n+0 of })' is not a valid selector..
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
-PASS document.querySelector(":nth-last-child(n-0 of .123class)") threw exception SyntaxError: The string did not match the expected pattern..
+PASS document.querySelector(":nth-last-child(n-0 of .123class)") threw exception SyntaxError: ':nth-last-child(n-0 of .123class)' is not a valid selector..
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
-PASS document.querySelector(":nth-last-child(n-0 of #123id)") threw exception SyntaxError: The string did not match the expected pattern..
+PASS document.querySelector(":nth-last-child(n-0 of #123id)") threw exception SyntaxError: ':nth-last-child(n-0 of #123id)' is not a valid selector..
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
-PASS document.querySelector(":nth-last-child(n-0 of [])") threw exception SyntaxError: The string did not match the expected pattern..
+PASS document.querySelector(":nth-last-child(n-0 of [])") threw exception SyntaxError: ':nth-last-child(n-0 of [])' is not a valid selector..
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
-PASS document.querySelector(":nth-last-child(n-0 of ())") threw exception SyntaxError: The string did not match the expected pattern..
+PASS document.querySelector(":nth-last-child(n-0 of ())") threw exception SyntaxError: ':nth-last-child(n-0 of ())' is not a valid selector..
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
-PASS document.querySelector(":nth-last-child(n-0 of ))") threw exception SyntaxError: The string did not match the expected pattern..
+PASS document.querySelector(":nth-last-child(n-0 of ))") threw exception SyntaxError: ':nth-last-child(n-0 of ))' is not a valid selector..
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
-PASS document.querySelector(":nth-last-child(n-0 of {})") threw exception SyntaxError: The string did not match the expected pattern..
+PASS document.querySelector(":nth-last-child(n-0 of {})") threw exception SyntaxError: ':nth-last-child(n-0 of {})' is not a valid selector..
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
-PASS document.querySelector(":nth-last-child(n-0 of })") threw exception SyntaxError: The string did not match the expected pattern..
+PASS document.querySelector(":nth-last-child(n-0 of })") threw exception SyntaxError: ':nth-last-child(n-0 of })' is not a valid selector..
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
-PASS document.querySelector(":nth-last-child(0n of .123class)") threw exception SyntaxError: The string did not match the expected pattern..
+PASS document.querySelector(":nth-last-child(0n of .123class)") threw exception SyntaxError: ':nth-last-child(0n of .123class)' is not a valid selector..
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
-PASS document.querySelector(":nth-last-child(0n of #123id)") threw exception SyntaxError: The string did not match the expected pattern..
+PASS document.querySelector(":nth-last-child(0n of #123id)") threw exception SyntaxError: ':nth-last-child(0n of #123id)' is not a valid selector..
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
-PASS document.querySelector(":nth-last-child(0n of [])") threw exception SyntaxError: The string did not match the expected pattern..
+PASS document.querySelector(":nth-last-child(0n of [])") threw exception SyntaxError: ':nth-last-child(0n of [])' is not a valid selector..
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
-PASS document.querySelector(":nth-last-child(0n of ())") threw exception SyntaxError: The string did not match the expected pattern..
+PASS document.querySelector(":nth-last-child(0n of ())") threw exception SyntaxError: ':nth-last-child(0n of ())' is not a valid selector..
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
-PASS document.querySelector(":nth-last-child(0n of ))") threw exception SyntaxError: The string did not match the expected pattern..
+PASS document.querySelector(":nth-last-child(0n of ))") threw exception SyntaxError: ':nth-last-child(0n of ))' is not a valid selector..
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
-PASS document.querySelector(":nth-last-child(0n of {})") threw exception SyntaxError: The string did not match the expected pattern..
+PASS document.querySelector(":nth-last-child(0n of {})") threw exception SyntaxError: ':nth-last-child(0n of {})' is not a valid selector..
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
-PASS document.querySelector(":nth-last-child(0n of })") threw exception SyntaxError: The string did not match the expected pattern..
+PASS document.querySelector(":nth-last-child(0n of })") threw exception SyntaxError: ':nth-last-child(0n of })' is not a valid selector..
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
-PASS document.querySelector(":nth-last-child(3n+5 of .123class)") threw exception SyntaxError: The string did not match the expected pattern..
+PASS document.querySelector(":nth-last-child(3n+5 of .123class)") threw exception SyntaxError: ':nth-last-child(3n+5 of .123class)' is not a valid selector..
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
-PASS document.querySelector(":nth-last-child(3n+5 of #123id)") threw exception SyntaxError: The string did not match the expected pattern..
+PASS document.querySelector(":nth-last-child(3n+5 of #123id)") threw exception SyntaxError: ':nth-last-child(3n+5 of #123id)' is not a valid selector..
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
-PASS document.querySelector(":nth-last-child(3n+5 of [])") threw exception SyntaxError: The string did not match the expected pattern..
+PASS document.querySelector(":nth-last-child(3n+5 of [])") threw exception SyntaxError: ':nth-last-child(3n+5 of [])' is not a valid selector..
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
-PASS document.querySelector(":nth-last-child(3n+5 of ())") threw exception SyntaxError: The string did not match the expected pattern..
+PASS document.querySelector(":nth-last-child(3n+5 of ())") threw exception SyntaxError: ':nth-last-child(3n+5 of ())' is not a valid selector..
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
-PASS document.querySelector(":nth-last-child(3n+5 of ))") threw exception SyntaxError: The string did not match the expected pattern..
+PASS document.querySelector(":nth-last-child(3n+5 of ))") threw exception SyntaxError: ':nth-last-child(3n+5 of ))' is not a valid selector..
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
-PASS document.querySelector(":nth-last-child(3n+5 of {})") threw exception SyntaxError: The string did not match the expected pattern..
+PASS document.querySelector(":nth-last-child(3n+5 of {})") threw exception SyntaxError: ':nth-last-child(3n+5 of {})' is not a valid selector..
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
-PASS document.querySelector(":nth-last-child(3n+5 of })") threw exception SyntaxError: The string did not match the expected pattern..
+PASS document.querySelector(":nth-last-child(3n+5 of })") threw exception SyntaxError: ':nth-last-child(3n+5 of })' is not a valid selector..
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
-PASS document.querySelector(":nth-last-child(-3n+5 of .123class)") threw exception SyntaxError: The string did not match the expected pattern..
+PASS document.querySelector(":nth-last-child(-3n+5 of .123class)") threw exception SyntaxError: ':nth-last-child(-3n+5 of .123class)' is not a valid selector..
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
-PASS document.querySelector(":nth-last-child(-3n+5 of #123id)") threw exception SyntaxError: The string did not match the expected pattern..
+PASS document.querySelector(":nth-last-child(-3n+5 of #123id)") threw exception SyntaxError: ':nth-last-child(-3n+5 of #123id)' is not a valid selector..
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
-PASS document.querySelector(":nth-last-child(-3n+5 of [])") threw exception SyntaxError: The string did not match the expected pattern..
+PASS document.querySelector(":nth-last-child(-3n+5 of [])") threw exception SyntaxError: ':nth-last-child(-3n+5 of [])' is not a valid selector..
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
-PASS document.querySelector(":nth-last-child(-3n+5 of ())") threw exception SyntaxError: The string did not match the expected pattern..
+PASS document.querySelector(":nth-last-child(-3n+5 of ())") threw exception SyntaxError: ':nth-last-child(-3n+5 of ())' is not a valid selector..
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
-PASS document.querySelector(":nth-last-child(-3n+5 of ))") threw exception SyntaxError: The string did not match the expected pattern..
+PASS document.querySelector(":nth-last-child(-3n+5 of ))") threw exception SyntaxError: ':nth-last-child(-3n+5 of ))' is not a valid selector..
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
-PASS document.querySelector(":nth-last-child(-3n+5 of {})") threw exception SyntaxError: The string did not match the expected pattern..
+PASS document.querySelector(":nth-last-child(-3n+5 of {})") threw exception SyntaxError: ':nth-last-child(-3n+5 of {})' is not a valid selector..
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
-PASS document.querySelector(":nth-last-child(-3n+5 of })") threw exception SyntaxError: The string did not match the expected pattern..
+PASS document.querySelector(":nth-last-child(-3n+5 of })") threw exception SyntaxError: ':nth-last-child(-3n+5 of })' is not a valid selector..
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
-PASS document.querySelector(":nth-last-child(3n-5 of .123class)") threw exception SyntaxError: The string did not match the expected pattern..
+PASS document.querySelector(":nth-last-child(3n-5 of .123class)") threw exception SyntaxError: ':nth-last-child(3n-5 of .123class)' is not a valid selector..
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
-PASS document.querySelector(":nth-last-child(3n-5 of #123id)") threw exception SyntaxError: The string did not match the expected pattern..
+PASS document.querySelector(":nth-last-child(3n-5 of #123id)") threw exception SyntaxError: ':nth-last-child(3n-5 of #123id)' is not a valid selector..
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
-PASS document.querySelector(":nth-last-child(3n-5 of [])") threw exception SyntaxError: The string did not match the expected pattern..
+PASS document.querySelector(":nth-last-child(3n-5 of [])") threw exception SyntaxError: ':nth-last-child(3n-5 of [])' is not a valid selector..
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
-PASS document.querySelector(":nth-last-child(3n-5 of ())") threw exception SyntaxError: The string did not match the expected pattern..
+PASS document.querySelector(":nth-last-child(3n-5 of ())") threw exception SyntaxError: ':nth-last-child(3n-5 of ())' is not a valid selector..
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
-PASS document.querySelector(":nth-last-child(3n-5 of ))") threw exception SyntaxError: The string did not match the expected pattern..
+PASS document.querySelector(":nth-last-child(3n-5 of ))") threw exception SyntaxError: ':nth-last-child(3n-5 of ))' is not a valid selector..
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
-PASS document.querySelector(":nth-last-child(3n-5 of {})") threw exception SyntaxError: The string did not match the expected pattern..
+PASS document.querySelector(":nth-last-child(3n-5 of {})") threw exception SyntaxError: ':nth-last-child(3n-5 of {})' is not a valid selector..
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
-PASS document.querySelector(":nth-last-child(3n-5 of })") threw exception SyntaxError: The string did not match the expected pattern..
+PASS document.querySelector(":nth-last-child(3n-5 of })") threw exception SyntaxError: ':nth-last-child(3n-5 of })' is not a valid selector..
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
-PASS document.querySelector(":nth-last-child(-3n-5 of .123class)") threw exception SyntaxError: The string did not match the expected pattern..
+PASS document.querySelector(":nth-last-child(-3n-5 of .123class)") threw exception SyntaxError: ':nth-last-child(-3n-5 of .123class)' is not a valid selector..
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
-PASS document.querySelector(":nth-last-child(-3n-5 of #123id)") threw exception SyntaxError: The string did not match the expected pattern..
+PASS document.querySelector(":nth-last-child(-3n-5 of #123id)") threw exception SyntaxError: ':nth-last-child(-3n-5 of #123id)' is not a valid selector..
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
-PASS document.querySelector(":nth-last-child(-3n-5 of [])") threw exception SyntaxError: The string did not match the expected pattern..
+PASS document.querySelector(":nth-last-child(-3n-5 of [])") threw exception SyntaxError: ':nth-last-child(-3n-5 of [])' is not a valid selector..
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
-PASS document.querySelector(":nth-last-child(-3n-5 of ())") threw exception SyntaxError: The string did not match the expected pattern..
+PASS document.querySelector(":nth-last-child(-3n-5 of ())") threw exception SyntaxError: ':nth-last-child(-3n-5 of ())' is not a valid selector..
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
-PASS document.querySelector(":nth-last-child(-3n-5 of ))") threw exception SyntaxError: The string did not match the expected pattern..
+PASS document.querySelector(":nth-last-child(-3n-5 of ))") threw exception SyntaxError: ':nth-last-child(-3n-5 of ))' is not a valid selector..
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
-PASS document.querySelector(":nth-last-child(-3n-5 of {})") threw exception SyntaxError: The string did not match the expected pattern..
+PASS document.querySelector(":nth-last-child(-3n-5 of {})") threw exception SyntaxError: ':nth-last-child(-3n-5 of {})' is not a valid selector..
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
-PASS document.querySelector(":nth-last-child(-3n-5 of })") threw exception SyntaxError: The string did not match the expected pattern..
+PASS document.querySelector(":nth-last-child(-3n-5 of })") threw exception SyntaxError: ':nth-last-child(-3n-5 of })' is not a valid selector..
 PASS document.getElementById('style-container').sheet.cssRules.length is 0
 PASS successfullyParsed is true
 

--- a/LayoutTests/fast/css/pseudo-class-internal-expected.txt
+++ b/LayoutTests/fast/css/pseudo-class-internal-expected.txt
@@ -3,7 +3,7 @@ This tests that -internal- pseudo classes are not exposed
 On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
 
 
-PASS target.matches(":-internal-direct-focus") threw exception SyntaxError: The string did not match the expected pattern..
+PASS target.matches(":-internal-direct-focus") threw exception SyntaxError: ':-internal-direct-focus' is not a valid selector..
 PASS successfullyParsed is true
 
 TEST COMPLETE

--- a/LayoutTests/fast/dom/SelectorAPI/dumpNodeList-almost-strict-expected.txt
+++ b/LayoutTests/fast/dom/SelectorAPI/dumpNodeList-almost-strict-expected.txt
@@ -12,8 +12,8 @@ length: 0
 [object HTMLDivElement], [object HTMLDivElement], length: 2
 [object HTMLDivElement], [object HTMLDivElement], [object HTMLDivElement], [object HTMLParagraphElement], length: 4
 [object HTMLDivElement], [object HTMLDivElement], [object HTMLDivElement], [object HTMLDivElement], [object HTMLParagraphElement], length: 5
-SyntaxError: The string did not match the expected pattern.
-SyntaxError: The string did not match the expected pattern.
+SyntaxError: '@font-face' is not a valid selector.
+SyntaxError: '' is not a valid selector.
 length: 0
 length: 0
 [object HTMLDivElement], [object HTMLDivElement], [object HTMLDivElement], [object HTMLDivElement], length: 4
@@ -26,8 +26,8 @@ length: 0
 [object HTMLDivElement], [object HTMLDivElement], length: 2
 [object HTMLDivElement], [object HTMLParagraphElement], length: 2
 [object HTMLDivElement], [object HTMLParagraphElement], length: 2
-SyntaxError: The string did not match the expected pattern.
-SyntaxError: The string did not match the expected pattern.
+SyntaxError: '@font-face' is not a valid selector.
+SyntaxError: '' is not a valid selector.
 length: 0
 length: 0
 
@@ -39,8 +39,8 @@ length: 0
 [object HTMLDivElement], [object HTMLDivElement], length: 2
 [object HTMLDivElement], [object HTMLDivElement], [object HTMLParagraphElement], length: 3
 [object HTMLDivElement], [object HTMLDivElement], [object HTMLParagraphElement], length: 3
-SyntaxError: The string did not match the expected pattern.
-SyntaxError: The string did not match the expected pattern.
+SyntaxError: '@font-face' is not a valid selector.
+SyntaxError: '' is not a valid selector.
 length: 0
 length: 0
 
@@ -51,8 +51,8 @@ TypeError: null is not an object (evaluating 'node.querySelector(selectorString)
 [object HTMLDivElement]
 [object HTMLDivElement]
 [object HTMLDivElement]
-SyntaxError: The string did not match the expected pattern.
-SyntaxError: The string did not match the expected pattern.
+SyntaxError: '@font-face' is not a valid selector.
+SyntaxError: '' is not a valid selector.
 TypeError: null is not an object (evaluating 'node.querySelector(selectorString).dump')
 TypeError: null is not an object (evaluating 'node.querySelector(selectorString).dump')
 
@@ -64,8 +64,8 @@ TypeError: null is not an object (evaluating 'node.querySelector(selectorString)
 [object HTMLDivElement]
 [object HTMLDivElement]
 [object HTMLDivElement]
-SyntaxError: The string did not match the expected pattern.
-SyntaxError: The string did not match the expected pattern.
+SyntaxError: '@font-face' is not a valid selector.
+SyntaxError: '' is not a valid selector.
 TypeError: null is not an object (evaluating 'node.querySelector(selectorString).dump')
 TypeError: null is not an object (evaluating 'node.querySelector(selectorString).dump')
 
@@ -77,8 +77,8 @@ TypeError: null is not an object (evaluating 'node.querySelector(selectorString)
 [object HTMLDivElement]
 [object HTMLDivElement]
 [object HTMLDivElement]
-SyntaxError: The string did not match the expected pattern.
-SyntaxError: The string did not match the expected pattern.
+SyntaxError: '@font-face' is not a valid selector.
+SyntaxError: '' is not a valid selector.
 TypeError: null is not an object (evaluating 'node.querySelector(selectorString).dump')
 TypeError: null is not an object (evaluating 'node.querySelector(selectorString).dump')
 

--- a/LayoutTests/fast/dom/SelectorAPI/dumpNodeList-expected.txt
+++ b/LayoutTests/fast/dom/SelectorAPI/dumpNodeList-expected.txt
@@ -12,8 +12,8 @@ length: 0
 [object HTMLDivElement], [object HTMLDivElement], length: 2
 [object HTMLDivElement], [object HTMLDivElement], [object HTMLDivElement], [object HTMLParagraphElement], length: 4
 [object HTMLDivElement], [object HTMLDivElement], [object HTMLDivElement], [object HTMLDivElement], [object HTMLParagraphElement], length: 5
-SyntaxError: The string did not match the expected pattern.
-SyntaxError: The string did not match the expected pattern.
+SyntaxError: '@font-face' is not a valid selector.
+SyntaxError: '' is not a valid selector.
 length: 0
 length: 0
 [object HTMLDivElement], [object HTMLDivElement], [object HTMLDivElement], [object HTMLDivElement], length: 4
@@ -26,8 +26,8 @@ length: 0
 [object HTMLDivElement], [object HTMLDivElement], length: 2
 [object HTMLDivElement], [object HTMLParagraphElement], length: 2
 [object HTMLDivElement], [object HTMLParagraphElement], length: 2
-SyntaxError: The string did not match the expected pattern.
-SyntaxError: The string did not match the expected pattern.
+SyntaxError: '@font-face' is not a valid selector.
+SyntaxError: '' is not a valid selector.
 length: 0
 length: 0
 
@@ -39,8 +39,8 @@ length: 0
 [object HTMLDivElement], [object HTMLDivElement], length: 2
 [object HTMLDivElement], [object HTMLDivElement], [object HTMLParagraphElement], length: 3
 [object HTMLDivElement], [object HTMLDivElement], [object HTMLParagraphElement], length: 3
-SyntaxError: The string did not match the expected pattern.
-SyntaxError: The string did not match the expected pattern.
+SyntaxError: '@font-face' is not a valid selector.
+SyntaxError: '' is not a valid selector.
 length: 0
 length: 0
 
@@ -51,8 +51,8 @@ TypeError: null is not an object (evaluating 'node.querySelector(selectorString)
 [object HTMLDivElement]
 [object HTMLDivElement]
 [object HTMLDivElement]
-SyntaxError: The string did not match the expected pattern.
-SyntaxError: The string did not match the expected pattern.
+SyntaxError: '@font-face' is not a valid selector.
+SyntaxError: '' is not a valid selector.
 TypeError: null is not an object (evaluating 'node.querySelector(selectorString).dump')
 TypeError: null is not an object (evaluating 'node.querySelector(selectorString).dump')
 
@@ -64,8 +64,8 @@ TypeError: null is not an object (evaluating 'node.querySelector(selectorString)
 [object HTMLDivElement]
 [object HTMLDivElement]
 [object HTMLDivElement]
-SyntaxError: The string did not match the expected pattern.
-SyntaxError: The string did not match the expected pattern.
+SyntaxError: '@font-face' is not a valid selector.
+SyntaxError: '' is not a valid selector.
 TypeError: null is not an object (evaluating 'node.querySelector(selectorString).dump')
 TypeError: null is not an object (evaluating 'node.querySelector(selectorString).dump')
 
@@ -77,8 +77,8 @@ TypeError: null is not an object (evaluating 'node.querySelector(selectorString)
 [object HTMLDivElement]
 [object HTMLDivElement]
 [object HTMLDivElement]
-SyntaxError: The string did not match the expected pattern.
-SyntaxError: The string did not match the expected pattern.
+SyntaxError: '@font-face' is not a valid selector.
+SyntaxError: '' is not a valid selector.
 TypeError: null is not an object (evaluating 'node.querySelector(selectorString).dump')
 TypeError: null is not an object (evaluating 'node.querySelector(selectorString).dump')
 

--- a/LayoutTests/fast/dom/SelectorAPI/not-supported-namespace-in-selector-expected.txt
+++ b/LayoutTests/fast/dom/SelectorAPI/not-supported-namespace-in-selector-expected.txt
@@ -1,9 +1,9 @@
 This tests that we throw a NAMESPACE_ERR when parsing a selector string for querySelector and querySelectorAll that contains a namespace.
 
-PASS: document.querySelector('bbb|pre') throws: SyntaxError: The string did not match the expected pattern.
-PASS: document.querySelectorAll('bbb|pre') throws: SyntaxError: The string did not match the expected pattern.
-PASS: document.body.matches('bbb|pre') throws: SyntaxError: The string did not match the expected pattern.
-PASS: document.body.webkitMatchesSelector('bbb|pre') throws: SyntaxError: The string did not match the expected pattern.
+PASS: document.querySelector('bbb|pre') throws: SyntaxError: 'bbb|pre' is not a valid selector.
+PASS: document.querySelectorAll('bbb|pre') throws: SyntaxError: 'bbb|pre' is not a valid selector.
+PASS: document.body.matches('bbb|pre') throws: SyntaxError: 'bbb|pre' is not a valid selector.
+PASS: document.body.webkitMatchesSelector('bbb|pre') throws: SyntaxError: 'bbb|pre' is not a valid selector.
 PASS: document.querySelector('*|pre') did not throw
 PASS: document.querySelectorAll('*|pre') did not throw
 PASS: document.body.matches('*|pre') did not throw
@@ -12,10 +12,10 @@ PASS: document.querySelector('|pre') did not throw
 PASS: document.querySelectorAll('|pre') did not throw
 PASS: document.body.matches('|pre') did not throw
 PASS: document.body.webkitMatchesSelector('|pre') did not throw
-PASS: document.querySelector('div bbb|pre') throws: SyntaxError: The string did not match the expected pattern.
-PASS: document.querySelectorAll('div bbb|pre') throws: SyntaxError: The string did not match the expected pattern.
-PASS: document.body.matches('div bbb|pre') throws: SyntaxError: The string did not match the expected pattern.
-PASS: document.body.webkitMatchesSelector('div bbb|pre') throws: SyntaxError: The string did not match the expected pattern.
+PASS: document.querySelector('div bbb|pre') throws: SyntaxError: 'div bbb|pre' is not a valid selector.
+PASS: document.querySelectorAll('div bbb|pre') throws: SyntaxError: 'div bbb|pre' is not a valid selector.
+PASS: document.body.matches('div bbb|pre') throws: SyntaxError: 'div bbb|pre' is not a valid selector.
+PASS: document.body.webkitMatchesSelector('div bbb|pre') throws: SyntaxError: 'div bbb|pre' is not a valid selector.
 PASS: document.querySelector('div *|pre') did not throw
 PASS: document.querySelectorAll('div *|pre') did not throw
 PASS: document.body.matches('div *|pre') did not throw
@@ -24,10 +24,10 @@ PASS: document.querySelector('div |pre') did not throw
 PASS: document.querySelectorAll('div |pre') did not throw
 PASS: document.body.matches('div |pre') did not throw
 PASS: document.body.webkitMatchesSelector('div |pre') did not throw
-PASS: document.querySelector('[bbb|name=value]') throws: SyntaxError: The string did not match the expected pattern.
-PASS: document.querySelectorAll('[bbb|name=value]') throws: SyntaxError: The string did not match the expected pattern.
-PASS: document.body.matches('[bbb|name=value]') throws: SyntaxError: The string did not match the expected pattern.
-PASS: document.body.webkitMatchesSelector('[bbb|name=value]') throws: SyntaxError: The string did not match the expected pattern.
+PASS: document.querySelector('[bbb|name=value]') throws: SyntaxError: '[bbb|name=value]' is not a valid selector.
+PASS: document.querySelectorAll('[bbb|name=value]') throws: SyntaxError: '[bbb|name=value]' is not a valid selector.
+PASS: document.body.matches('[bbb|name=value]') throws: SyntaxError: '[bbb|name=value]' is not a valid selector.
+PASS: document.body.webkitMatchesSelector('[bbb|name=value]') throws: SyntaxError: '[bbb|name=value]' is not a valid selector.
 PASS: document.querySelector('[*|name=value]') did not throw
 PASS: document.querySelectorAll('[*|name=value]') did not throw
 PASS: document.body.matches('[*|name=value]') did not throw
@@ -37,10 +37,10 @@ PASS: document.querySelectorAll('[|name=value]') did not throw
 PASS: document.body.matches('[|name=value]') did not throw
 PASS: document.body.webkitMatchesSelector('[|name=value]') did not throw
 PASS: document.querySelector(':-webkit-any(bbb|pre)') did not throw
-PASS: document.querySelector('div [bbb|name=value]') throws: SyntaxError: The string did not match the expected pattern.
-PASS: document.querySelectorAll('div [bbb|name=value]') throws: SyntaxError: The string did not match the expected pattern.
-PASS: document.body.matches('div [bbb|name=value]') throws: SyntaxError: The string did not match the expected pattern.
-PASS: document.body.webkitMatchesSelector('div [bbb|name=value]') throws: SyntaxError: The string did not match the expected pattern.
+PASS: document.querySelector('div [bbb|name=value]') throws: SyntaxError: 'div [bbb|name=value]' is not a valid selector.
+PASS: document.querySelectorAll('div [bbb|name=value]') throws: SyntaxError: 'div [bbb|name=value]' is not a valid selector.
+PASS: document.body.matches('div [bbb|name=value]') throws: SyntaxError: 'div [bbb|name=value]' is not a valid selector.
+PASS: document.body.webkitMatchesSelector('div [bbb|name=value]') throws: SyntaxError: 'div [bbb|name=value]' is not a valid selector.
 PASS: document.querySelector('div [*|name=value]') did not throw
 PASS: document.querySelectorAll('div [*|name=value]') did not throw
 PASS: document.body.matches('div [*|name=value]') did not throw

--- a/LayoutTests/fast/selectors/closest-general-expected.txt
+++ b/LayoutTests/fast/selectors/closest-general-expected.txt
@@ -45,16 +45,16 @@ PASS sour.closest("a") is a
 PASS document.closest is undefined
 PASS document.closest() threw exception TypeError: document.closest is not a function. (In 'document.closest()', 'document.closest' is undefined).
 PASS theTarget.closest() threw exception TypeError: Not enough arguments.
-PASS theTarget.closest("") threw exception SyntaxError: The string did not match the expected pattern..
-PASS theTarget.closest(".123") threw exception SyntaxError: The string did not match the expected pattern..
-PASS theTarget.closest("    ") threw exception SyntaxError: The string did not match the expected pattern..
-PASS theTarget.closest(")") threw exception SyntaxError: The string did not match the expected pattern..
-PASS theTarget.closest("(") threw exception SyntaxError: The string did not match the expected pattern..
-PASS theTarget.closest("()") threw exception SyntaxError: The string did not match the expected pattern..
-PASS theTarget.closest("^_^") threw exception SyntaxError: The string did not match the expected pattern..
-PASS theTarget.closest("{") threw exception SyntaxError: The string did not match the expected pattern..
-PASS theTarget.closest("}") threw exception SyntaxError: The string did not match the expected pattern..
-PASS theTarget.closest("{}") threw exception SyntaxError: The string did not match the expected pattern..
+PASS theTarget.closest("") threw exception SyntaxError: '' is not a valid selector..
+PASS theTarget.closest(".123") threw exception SyntaxError: '.123' is not a valid selector..
+PASS theTarget.closest("    ") threw exception SyntaxError: '    ' is not a valid selector..
+PASS theTarget.closest(")") threw exception SyntaxError: ')' is not a valid selector..
+PASS theTarget.closest("(") threw exception SyntaxError: '(' is not a valid selector..
+PASS theTarget.closest("()") threw exception SyntaxError: '()' is not a valid selector..
+PASS theTarget.closest("^_^") threw exception SyntaxError: '^_^' is not a valid selector..
+PASS theTarget.closest("{") threw exception SyntaxError: '{' is not a valid selector..
+PASS theTarget.closest("}") threw exception SyntaxError: '}' is not a valid selector..
+PASS theTarget.closest("{}") threw exception SyntaxError: '{}' is not a valid selector..
 PASS successfullyParsed is true
 
 TEST COMPLETE

--- a/LayoutTests/fast/selectors/invalid-functional-pseudo-class-expected.txt
+++ b/LayoutTests/fast/selectors/invalid-functional-pseudo-class-expected.txt
@@ -4,31 +4,31 @@ On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE
 
 
 PASS document.querySelectorAll(":-webkit-any\").length threw exception SyntaxError: Unexpected EOF.
-PASS document.querySelectorAll(":-webkit-any\\").length threw exception SyntaxError: The string did not match the expected pattern..
+PASS document.querySelectorAll(":-webkit-any\\").length threw exception SyntaxError: ':-webkit-any\' is not a valid selector..
 PASS document.querySelectorAll(":-webkit-any\\\").length threw exception SyntaxError: Unexpected EOF.
-PASS document.querySelectorAll(":-webkit-any\\\\").length threw exception SyntaxError: The string did not match the expected pattern..
+PASS document.querySelectorAll(":-webkit-any\\\\").length threw exception SyntaxError: ':-webkit-any\\' is not a valid selector..
 PASS document.querySelectorAll(":-webkit-any\(").length did not throw exception.
-PASS document.querySelectorAll(":-webkit-any\\(").length threw exception SyntaxError: The string did not match the expected pattern..
-PASS document.querySelectorAll(":-webkit-any\\\(").length threw exception SyntaxError: The string did not match the expected pattern..
-PASS document.querySelectorAll(":-webkit-any\\\\(").length threw exception SyntaxError: The string did not match the expected pattern..
-PASS document.querySelectorAll(":-webkit-any\ .foo").length threw exception SyntaxError: The string did not match the expected pattern..
-PASS document.querySelectorAll(":-webkit-any\\ .foo").length threw exception SyntaxError: The string did not match the expected pattern..
-PASS document.querySelectorAll(":-webkit-any\\\ .foo").length threw exception SyntaxError: The string did not match the expected pattern..
-PASS document.querySelectorAll(":-webkit-any\\\\ .foo").length threw exception SyntaxError: The string did not match the expected pattern..
-PASS document.querySelectorAll(":-webkit-any\\( .foo").length threw exception SyntaxError: The string did not match the expected pattern..
-PASS document.querySelectorAll(":-webkit-any\\\( .foo").length threw exception SyntaxError: The string did not match the expected pattern..
-PASS document.querySelectorAll(":-webkit-any\\\\( .foo").length threw exception SyntaxError: The string did not match the expected pattern..
+PASS document.querySelectorAll(":-webkit-any\\(").length threw exception SyntaxError: ':-webkit-any\(' is not a valid selector..
+PASS document.querySelectorAll(":-webkit-any\\\(").length threw exception SyntaxError: ':-webkit-any\(' is not a valid selector..
+PASS document.querySelectorAll(":-webkit-any\\\\(").length threw exception SyntaxError: ':-webkit-any\\(' is not a valid selector..
+PASS document.querySelectorAll(":-webkit-any\ .foo").length threw exception SyntaxError: ':-webkit-any .foo' is not a valid selector..
+PASS document.querySelectorAll(":-webkit-any\\ .foo").length threw exception SyntaxError: ':-webkit-any\ .foo' is not a valid selector..
+PASS document.querySelectorAll(":-webkit-any\\\ .foo").length threw exception SyntaxError: ':-webkit-any\ .foo' is not a valid selector..
+PASS document.querySelectorAll(":-webkit-any\\\\ .foo").length threw exception SyntaxError: ':-webkit-any\\ .foo' is not a valid selector..
+PASS document.querySelectorAll(":-webkit-any\\( .foo").length threw exception SyntaxError: ':-webkit-any\( .foo' is not a valid selector..
+PASS document.querySelectorAll(":-webkit-any\\\( .foo").length threw exception SyntaxError: ':-webkit-any\( .foo' is not a valid selector..
+PASS document.querySelectorAll(":-webkit-any\\\\( .foo").length threw exception SyntaxError: ':-webkit-any\\( .foo' is not a valid selector..
 PASS document.querySelectorAll(":-webkit-any\()").length did not throw exception.
-PASS document.querySelectorAll(":-webkit-any\\()").length threw exception SyntaxError: The string did not match the expected pattern..
-PASS document.querySelectorAll(":-webkit-any\\\()").length threw exception SyntaxError: The string did not match the expected pattern..
-PASS document.querySelectorAll(":-webkit-any\\\\()").length threw exception SyntaxError: The string did not match the expected pattern..
-PASS document.querySelectorAll(":-webkit-any\ .foo)").length threw exception SyntaxError: The string did not match the expected pattern..
-PASS document.querySelectorAll(":-webkit-any\\ .foo)").length threw exception SyntaxError: The string did not match the expected pattern..
-PASS document.querySelectorAll(":-webkit-any\\\ .foo)").length threw exception SyntaxError: The string did not match the expected pattern..
-PASS document.querySelectorAll(":-webkit-any\\\\ .foo)").length threw exception SyntaxError: The string did not match the expected pattern..
-PASS document.querySelectorAll(":-webkit-any\\( .foo)").length threw exception SyntaxError: The string did not match the expected pattern..
-PASS document.querySelectorAll(":-webkit-any\\\( .foo)").length threw exception SyntaxError: The string did not match the expected pattern..
-PASS document.querySelectorAll(":-webkit-any\\\\( .foo)").length threw exception SyntaxError: The string did not match the expected pattern..
+PASS document.querySelectorAll(":-webkit-any\\()").length threw exception SyntaxError: ':-webkit-any\()' is not a valid selector..
+PASS document.querySelectorAll(":-webkit-any\\\()").length threw exception SyntaxError: ':-webkit-any\()' is not a valid selector..
+PASS document.querySelectorAll(":-webkit-any\\\\()").length threw exception SyntaxError: ':-webkit-any\\()' is not a valid selector..
+PASS document.querySelectorAll(":-webkit-any\ .foo)").length threw exception SyntaxError: ':-webkit-any .foo)' is not a valid selector..
+PASS document.querySelectorAll(":-webkit-any\\ .foo)").length threw exception SyntaxError: ':-webkit-any\ .foo)' is not a valid selector..
+PASS document.querySelectorAll(":-webkit-any\\\ .foo)").length threw exception SyntaxError: ':-webkit-any\ .foo)' is not a valid selector..
+PASS document.querySelectorAll(":-webkit-any\\\\ .foo)").length threw exception SyntaxError: ':-webkit-any\\ .foo)' is not a valid selector..
+PASS document.querySelectorAll(":-webkit-any\\( .foo)").length threw exception SyntaxError: ':-webkit-any\( .foo)' is not a valid selector..
+PASS document.querySelectorAll(":-webkit-any\\\( .foo)").length threw exception SyntaxError: ':-webkit-any\( .foo)' is not a valid selector..
+PASS document.querySelectorAll(":-webkit-any\\\\( .foo)").length threw exception SyntaxError: ':-webkit-any\\( .foo)' is not a valid selector..
 PASS document.styleSheets[1].cssRules.length is 0
 PASS document.styleSheets[1].cssRules.length is 0
 PASS document.styleSheets[1].cssRules.length is 0
@@ -56,31 +56,31 @@ PASS document.styleSheets[1].cssRules.length is 0
 PASS document.styleSheets[1].cssRules.length is 0
 PASS document.styleSheets[1].cssRules.length is 0
 PASS document.querySelectorAll(":dir\").length threw exception SyntaxError: Unexpected EOF.
-PASS document.querySelectorAll(":dir\\").length threw exception SyntaxError: The string did not match the expected pattern..
+PASS document.querySelectorAll(":dir\\").length threw exception SyntaxError: ':dir\' is not a valid selector..
 PASS document.querySelectorAll(":dir\\\").length threw exception SyntaxError: Unexpected EOF.
-PASS document.querySelectorAll(":dir\\\\").length threw exception SyntaxError: The string did not match the expected pattern..
-PASS document.querySelectorAll(":dir\(").length threw exception SyntaxError: The string did not match the expected pattern..
-PASS document.querySelectorAll(":dir\\(").length threw exception SyntaxError: The string did not match the expected pattern..
-PASS document.querySelectorAll(":dir\\\(").length threw exception SyntaxError: The string did not match the expected pattern..
-PASS document.querySelectorAll(":dir\\\\(").length threw exception SyntaxError: The string did not match the expected pattern..
-PASS document.querySelectorAll(":dir\ .foo").length threw exception SyntaxError: The string did not match the expected pattern..
-PASS document.querySelectorAll(":dir\\ .foo").length threw exception SyntaxError: The string did not match the expected pattern..
-PASS document.querySelectorAll(":dir\\\ .foo").length threw exception SyntaxError: The string did not match the expected pattern..
-PASS document.querySelectorAll(":dir\\\\ .foo").length threw exception SyntaxError: The string did not match the expected pattern..
-PASS document.querySelectorAll(":dir\\( .foo").length threw exception SyntaxError: The string did not match the expected pattern..
-PASS document.querySelectorAll(":dir\\\( .foo").length threw exception SyntaxError: The string did not match the expected pattern..
-PASS document.querySelectorAll(":dir\\\\( .foo").length threw exception SyntaxError: The string did not match the expected pattern..
-PASS document.querySelectorAll(":dir\()").length threw exception SyntaxError: The string did not match the expected pattern..
-PASS document.querySelectorAll(":dir\\()").length threw exception SyntaxError: The string did not match the expected pattern..
-PASS document.querySelectorAll(":dir\\\()").length threw exception SyntaxError: The string did not match the expected pattern..
-PASS document.querySelectorAll(":dir\\\\()").length threw exception SyntaxError: The string did not match the expected pattern..
-PASS document.querySelectorAll(":dir\ .foo)").length threw exception SyntaxError: The string did not match the expected pattern..
-PASS document.querySelectorAll(":dir\\ .foo)").length threw exception SyntaxError: The string did not match the expected pattern..
-PASS document.querySelectorAll(":dir\\\ .foo)").length threw exception SyntaxError: The string did not match the expected pattern..
-PASS document.querySelectorAll(":dir\\\\ .foo)").length threw exception SyntaxError: The string did not match the expected pattern..
-PASS document.querySelectorAll(":dir\\( .foo)").length threw exception SyntaxError: The string did not match the expected pattern..
-PASS document.querySelectorAll(":dir\\\( .foo)").length threw exception SyntaxError: The string did not match the expected pattern..
-PASS document.querySelectorAll(":dir\\\\( .foo)").length threw exception SyntaxError: The string did not match the expected pattern..
+PASS document.querySelectorAll(":dir\\\\").length threw exception SyntaxError: ':dir\\' is not a valid selector..
+PASS document.querySelectorAll(":dir\(").length threw exception SyntaxError: ':dir(' is not a valid selector..
+PASS document.querySelectorAll(":dir\\(").length threw exception SyntaxError: ':dir\(' is not a valid selector..
+PASS document.querySelectorAll(":dir\\\(").length threw exception SyntaxError: ':dir\(' is not a valid selector..
+PASS document.querySelectorAll(":dir\\\\(").length threw exception SyntaxError: ':dir\\(' is not a valid selector..
+PASS document.querySelectorAll(":dir\ .foo").length threw exception SyntaxError: ':dir .foo' is not a valid selector..
+PASS document.querySelectorAll(":dir\\ .foo").length threw exception SyntaxError: ':dir\ .foo' is not a valid selector..
+PASS document.querySelectorAll(":dir\\\ .foo").length threw exception SyntaxError: ':dir\ .foo' is not a valid selector..
+PASS document.querySelectorAll(":dir\\\\ .foo").length threw exception SyntaxError: ':dir\\ .foo' is not a valid selector..
+PASS document.querySelectorAll(":dir\\( .foo").length threw exception SyntaxError: ':dir\( .foo' is not a valid selector..
+PASS document.querySelectorAll(":dir\\\( .foo").length threw exception SyntaxError: ':dir\( .foo' is not a valid selector..
+PASS document.querySelectorAll(":dir\\\\( .foo").length threw exception SyntaxError: ':dir\\( .foo' is not a valid selector..
+PASS document.querySelectorAll(":dir\()").length threw exception SyntaxError: ':dir()' is not a valid selector..
+PASS document.querySelectorAll(":dir\\()").length threw exception SyntaxError: ':dir\()' is not a valid selector..
+PASS document.querySelectorAll(":dir\\\()").length threw exception SyntaxError: ':dir\()' is not a valid selector..
+PASS document.querySelectorAll(":dir\\\\()").length threw exception SyntaxError: ':dir\\()' is not a valid selector..
+PASS document.querySelectorAll(":dir\ .foo)").length threw exception SyntaxError: ':dir .foo)' is not a valid selector..
+PASS document.querySelectorAll(":dir\\ .foo)").length threw exception SyntaxError: ':dir\ .foo)' is not a valid selector..
+PASS document.querySelectorAll(":dir\\\ .foo)").length threw exception SyntaxError: ':dir\ .foo)' is not a valid selector..
+PASS document.querySelectorAll(":dir\\\\ .foo)").length threw exception SyntaxError: ':dir\\ .foo)' is not a valid selector..
+PASS document.querySelectorAll(":dir\\( .foo)").length threw exception SyntaxError: ':dir\( .foo)' is not a valid selector..
+PASS document.querySelectorAll(":dir\\\( .foo)").length threw exception SyntaxError: ':dir\( .foo)' is not a valid selector..
+PASS document.querySelectorAll(":dir\\\\( .foo)").length threw exception SyntaxError: ':dir\\( .foo)' is not a valid selector..
 PASS document.styleSheets[1].cssRules.length is 0
 PASS document.styleSheets[1].cssRules.length is 0
 PASS document.styleSheets[1].cssRules.length is 0
@@ -108,31 +108,31 @@ PASS document.styleSheets[1].cssRules.length is 0
 PASS document.styleSheets[1].cssRules.length is 0
 PASS document.styleSheets[1].cssRules.length is 0
 PASS document.querySelectorAll(":lang\").length threw exception SyntaxError: Unexpected EOF.
-PASS document.querySelectorAll(":lang\\").length threw exception SyntaxError: The string did not match the expected pattern..
+PASS document.querySelectorAll(":lang\\").length threw exception SyntaxError: ':lang\' is not a valid selector..
 PASS document.querySelectorAll(":lang\\\").length threw exception SyntaxError: Unexpected EOF.
-PASS document.querySelectorAll(":lang\\\\").length threw exception SyntaxError: The string did not match the expected pattern..
-PASS document.querySelectorAll(":lang\(").length threw exception SyntaxError: The string did not match the expected pattern..
-PASS document.querySelectorAll(":lang\\(").length threw exception SyntaxError: The string did not match the expected pattern..
-PASS document.querySelectorAll(":lang\\\(").length threw exception SyntaxError: The string did not match the expected pattern..
-PASS document.querySelectorAll(":lang\\\\(").length threw exception SyntaxError: The string did not match the expected pattern..
-PASS document.querySelectorAll(":lang\ .foo").length threw exception SyntaxError: The string did not match the expected pattern..
-PASS document.querySelectorAll(":lang\\ .foo").length threw exception SyntaxError: The string did not match the expected pattern..
-PASS document.querySelectorAll(":lang\\\ .foo").length threw exception SyntaxError: The string did not match the expected pattern..
-PASS document.querySelectorAll(":lang\\\\ .foo").length threw exception SyntaxError: The string did not match the expected pattern..
-PASS document.querySelectorAll(":lang\\( .foo").length threw exception SyntaxError: The string did not match the expected pattern..
-PASS document.querySelectorAll(":lang\\\( .foo").length threw exception SyntaxError: The string did not match the expected pattern..
-PASS document.querySelectorAll(":lang\\\\( .foo").length threw exception SyntaxError: The string did not match the expected pattern..
-PASS document.querySelectorAll(":lang\()").length threw exception SyntaxError: The string did not match the expected pattern..
-PASS document.querySelectorAll(":lang\\()").length threw exception SyntaxError: The string did not match the expected pattern..
-PASS document.querySelectorAll(":lang\\\()").length threw exception SyntaxError: The string did not match the expected pattern..
-PASS document.querySelectorAll(":lang\\\\()").length threw exception SyntaxError: The string did not match the expected pattern..
-PASS document.querySelectorAll(":lang\ .foo)").length threw exception SyntaxError: The string did not match the expected pattern..
-PASS document.querySelectorAll(":lang\\ .foo)").length threw exception SyntaxError: The string did not match the expected pattern..
-PASS document.querySelectorAll(":lang\\\ .foo)").length threw exception SyntaxError: The string did not match the expected pattern..
-PASS document.querySelectorAll(":lang\\\\ .foo)").length threw exception SyntaxError: The string did not match the expected pattern..
-PASS document.querySelectorAll(":lang\\( .foo)").length threw exception SyntaxError: The string did not match the expected pattern..
-PASS document.querySelectorAll(":lang\\\( .foo)").length threw exception SyntaxError: The string did not match the expected pattern..
-PASS document.querySelectorAll(":lang\\\\( .foo)").length threw exception SyntaxError: The string did not match the expected pattern..
+PASS document.querySelectorAll(":lang\\\\").length threw exception SyntaxError: ':lang\\' is not a valid selector..
+PASS document.querySelectorAll(":lang\(").length threw exception SyntaxError: ':lang(' is not a valid selector..
+PASS document.querySelectorAll(":lang\\(").length threw exception SyntaxError: ':lang\(' is not a valid selector..
+PASS document.querySelectorAll(":lang\\\(").length threw exception SyntaxError: ':lang\(' is not a valid selector..
+PASS document.querySelectorAll(":lang\\\\(").length threw exception SyntaxError: ':lang\\(' is not a valid selector..
+PASS document.querySelectorAll(":lang\ .foo").length threw exception SyntaxError: ':lang .foo' is not a valid selector..
+PASS document.querySelectorAll(":lang\\ .foo").length threw exception SyntaxError: ':lang\ .foo' is not a valid selector..
+PASS document.querySelectorAll(":lang\\\ .foo").length threw exception SyntaxError: ':lang\ .foo' is not a valid selector..
+PASS document.querySelectorAll(":lang\\\\ .foo").length threw exception SyntaxError: ':lang\\ .foo' is not a valid selector..
+PASS document.querySelectorAll(":lang\\( .foo").length threw exception SyntaxError: ':lang\( .foo' is not a valid selector..
+PASS document.querySelectorAll(":lang\\\( .foo").length threw exception SyntaxError: ':lang\( .foo' is not a valid selector..
+PASS document.querySelectorAll(":lang\\\\( .foo").length threw exception SyntaxError: ':lang\\( .foo' is not a valid selector..
+PASS document.querySelectorAll(":lang\()").length threw exception SyntaxError: ':lang()' is not a valid selector..
+PASS document.querySelectorAll(":lang\\()").length threw exception SyntaxError: ':lang\()' is not a valid selector..
+PASS document.querySelectorAll(":lang\\\()").length threw exception SyntaxError: ':lang\()' is not a valid selector..
+PASS document.querySelectorAll(":lang\\\\()").length threw exception SyntaxError: ':lang\\()' is not a valid selector..
+PASS document.querySelectorAll(":lang\ .foo)").length threw exception SyntaxError: ':lang .foo)' is not a valid selector..
+PASS document.querySelectorAll(":lang\\ .foo)").length threw exception SyntaxError: ':lang\ .foo)' is not a valid selector..
+PASS document.querySelectorAll(":lang\\\ .foo)").length threw exception SyntaxError: ':lang\ .foo)' is not a valid selector..
+PASS document.querySelectorAll(":lang\\\\ .foo)").length threw exception SyntaxError: ':lang\\ .foo)' is not a valid selector..
+PASS document.querySelectorAll(":lang\\( .foo)").length threw exception SyntaxError: ':lang\( .foo)' is not a valid selector..
+PASS document.querySelectorAll(":lang\\\( .foo)").length threw exception SyntaxError: ':lang\( .foo)' is not a valid selector..
+PASS document.querySelectorAll(":lang\\\\( .foo)").length threw exception SyntaxError: ':lang\\( .foo)' is not a valid selector..
 PASS document.styleSheets[1].cssRules.length is 0
 PASS document.styleSheets[1].cssRules.length is 0
 PASS document.styleSheets[1].cssRules.length is 0
@@ -160,31 +160,31 @@ PASS document.styleSheets[1].cssRules.length is 0
 PASS document.styleSheets[1].cssRules.length is 0
 PASS document.styleSheets[1].cssRules.length is 0
 PASS document.querySelectorAll(":not\").length threw exception SyntaxError: Unexpected EOF.
-PASS document.querySelectorAll(":not\\").length threw exception SyntaxError: The string did not match the expected pattern..
+PASS document.querySelectorAll(":not\\").length threw exception SyntaxError: ':not\' is not a valid selector..
 PASS document.querySelectorAll(":not\\\").length threw exception SyntaxError: Unexpected EOF.
-PASS document.querySelectorAll(":not\\\\").length threw exception SyntaxError: The string did not match the expected pattern..
-PASS document.querySelectorAll(":not\(").length threw exception SyntaxError: The string did not match the expected pattern..
-PASS document.querySelectorAll(":not\\(").length threw exception SyntaxError: The string did not match the expected pattern..
-PASS document.querySelectorAll(":not\\\(").length threw exception SyntaxError: The string did not match the expected pattern..
-PASS document.querySelectorAll(":not\\\\(").length threw exception SyntaxError: The string did not match the expected pattern..
-PASS document.querySelectorAll(":not\ .foo").length threw exception SyntaxError: The string did not match the expected pattern..
-PASS document.querySelectorAll(":not\\ .foo").length threw exception SyntaxError: The string did not match the expected pattern..
-PASS document.querySelectorAll(":not\\\ .foo").length threw exception SyntaxError: The string did not match the expected pattern..
-PASS document.querySelectorAll(":not\\\\ .foo").length threw exception SyntaxError: The string did not match the expected pattern..
-PASS document.querySelectorAll(":not\\( .foo").length threw exception SyntaxError: The string did not match the expected pattern..
-PASS document.querySelectorAll(":not\\\( .foo").length threw exception SyntaxError: The string did not match the expected pattern..
-PASS document.querySelectorAll(":not\\\\( .foo").length threw exception SyntaxError: The string did not match the expected pattern..
-PASS document.querySelectorAll(":not\()").length threw exception SyntaxError: The string did not match the expected pattern..
-PASS document.querySelectorAll(":not\\()").length threw exception SyntaxError: The string did not match the expected pattern..
-PASS document.querySelectorAll(":not\\\()").length threw exception SyntaxError: The string did not match the expected pattern..
-PASS document.querySelectorAll(":not\\\\()").length threw exception SyntaxError: The string did not match the expected pattern..
-PASS document.querySelectorAll(":not\ .foo)").length threw exception SyntaxError: The string did not match the expected pattern..
-PASS document.querySelectorAll(":not\\ .foo)").length threw exception SyntaxError: The string did not match the expected pattern..
-PASS document.querySelectorAll(":not\\\ .foo)").length threw exception SyntaxError: The string did not match the expected pattern..
-PASS document.querySelectorAll(":not\\\\ .foo)").length threw exception SyntaxError: The string did not match the expected pattern..
-PASS document.querySelectorAll(":not\\( .foo)").length threw exception SyntaxError: The string did not match the expected pattern..
-PASS document.querySelectorAll(":not\\\( .foo)").length threw exception SyntaxError: The string did not match the expected pattern..
-PASS document.querySelectorAll(":not\\\\( .foo)").length threw exception SyntaxError: The string did not match the expected pattern..
+PASS document.querySelectorAll(":not\\\\").length threw exception SyntaxError: ':not\\' is not a valid selector..
+PASS document.querySelectorAll(":not\(").length threw exception SyntaxError: ':not(' is not a valid selector..
+PASS document.querySelectorAll(":not\\(").length threw exception SyntaxError: ':not\(' is not a valid selector..
+PASS document.querySelectorAll(":not\\\(").length threw exception SyntaxError: ':not\(' is not a valid selector..
+PASS document.querySelectorAll(":not\\\\(").length threw exception SyntaxError: ':not\\(' is not a valid selector..
+PASS document.querySelectorAll(":not\ .foo").length threw exception SyntaxError: ':not .foo' is not a valid selector..
+PASS document.querySelectorAll(":not\\ .foo").length threw exception SyntaxError: ':not\ .foo' is not a valid selector..
+PASS document.querySelectorAll(":not\\\ .foo").length threw exception SyntaxError: ':not\ .foo' is not a valid selector..
+PASS document.querySelectorAll(":not\\\\ .foo").length threw exception SyntaxError: ':not\\ .foo' is not a valid selector..
+PASS document.querySelectorAll(":not\\( .foo").length threw exception SyntaxError: ':not\( .foo' is not a valid selector..
+PASS document.querySelectorAll(":not\\\( .foo").length threw exception SyntaxError: ':not\( .foo' is not a valid selector..
+PASS document.querySelectorAll(":not\\\\( .foo").length threw exception SyntaxError: ':not\\( .foo' is not a valid selector..
+PASS document.querySelectorAll(":not\()").length threw exception SyntaxError: ':not()' is not a valid selector..
+PASS document.querySelectorAll(":not\\()").length threw exception SyntaxError: ':not\()' is not a valid selector..
+PASS document.querySelectorAll(":not\\\()").length threw exception SyntaxError: ':not\()' is not a valid selector..
+PASS document.querySelectorAll(":not\\\\()").length threw exception SyntaxError: ':not\\()' is not a valid selector..
+PASS document.querySelectorAll(":not\ .foo)").length threw exception SyntaxError: ':not .foo)' is not a valid selector..
+PASS document.querySelectorAll(":not\\ .foo)").length threw exception SyntaxError: ':not\ .foo)' is not a valid selector..
+PASS document.querySelectorAll(":not\\\ .foo)").length threw exception SyntaxError: ':not\ .foo)' is not a valid selector..
+PASS document.querySelectorAll(":not\\\\ .foo)").length threw exception SyntaxError: ':not\\ .foo)' is not a valid selector..
+PASS document.querySelectorAll(":not\\( .foo)").length threw exception SyntaxError: ':not\( .foo)' is not a valid selector..
+PASS document.querySelectorAll(":not\\\( .foo)").length threw exception SyntaxError: ':not\( .foo)' is not a valid selector..
+PASS document.querySelectorAll(":not\\\\( .foo)").length threw exception SyntaxError: ':not\\( .foo)' is not a valid selector..
 PASS document.styleSheets[1].cssRules.length is 0
 PASS document.styleSheets[1].cssRules.length is 0
 PASS document.styleSheets[1].cssRules.length is 0
@@ -212,31 +212,31 @@ PASS document.styleSheets[1].cssRules.length is 0
 PASS document.styleSheets[1].cssRules.length is 0
 PASS document.styleSheets[1].cssRules.length is 0
 PASS document.querySelectorAll(":nth-child\").length threw exception SyntaxError: Unexpected EOF.
-PASS document.querySelectorAll(":nth-child\\").length threw exception SyntaxError: The string did not match the expected pattern..
+PASS document.querySelectorAll(":nth-child\\").length threw exception SyntaxError: ':nth-child\' is not a valid selector..
 PASS document.querySelectorAll(":nth-child\\\").length threw exception SyntaxError: Unexpected EOF.
-PASS document.querySelectorAll(":nth-child\\\\").length threw exception SyntaxError: The string did not match the expected pattern..
-PASS document.querySelectorAll(":nth-child\(").length threw exception SyntaxError: The string did not match the expected pattern..
-PASS document.querySelectorAll(":nth-child\\(").length threw exception SyntaxError: The string did not match the expected pattern..
-PASS document.querySelectorAll(":nth-child\\\(").length threw exception SyntaxError: The string did not match the expected pattern..
-PASS document.querySelectorAll(":nth-child\\\\(").length threw exception SyntaxError: The string did not match the expected pattern..
-PASS document.querySelectorAll(":nth-child\ .foo").length threw exception SyntaxError: The string did not match the expected pattern..
-PASS document.querySelectorAll(":nth-child\\ .foo").length threw exception SyntaxError: The string did not match the expected pattern..
-PASS document.querySelectorAll(":nth-child\\\ .foo").length threw exception SyntaxError: The string did not match the expected pattern..
-PASS document.querySelectorAll(":nth-child\\\\ .foo").length threw exception SyntaxError: The string did not match the expected pattern..
-PASS document.querySelectorAll(":nth-child\\( .foo").length threw exception SyntaxError: The string did not match the expected pattern..
-PASS document.querySelectorAll(":nth-child\\\( .foo").length threw exception SyntaxError: The string did not match the expected pattern..
-PASS document.querySelectorAll(":nth-child\\\\( .foo").length threw exception SyntaxError: The string did not match the expected pattern..
-PASS document.querySelectorAll(":nth-child\()").length threw exception SyntaxError: The string did not match the expected pattern..
-PASS document.querySelectorAll(":nth-child\\()").length threw exception SyntaxError: The string did not match the expected pattern..
-PASS document.querySelectorAll(":nth-child\\\()").length threw exception SyntaxError: The string did not match the expected pattern..
-PASS document.querySelectorAll(":nth-child\\\\()").length threw exception SyntaxError: The string did not match the expected pattern..
-PASS document.querySelectorAll(":nth-child\ .foo)").length threw exception SyntaxError: The string did not match the expected pattern..
-PASS document.querySelectorAll(":nth-child\\ .foo)").length threw exception SyntaxError: The string did not match the expected pattern..
-PASS document.querySelectorAll(":nth-child\\\ .foo)").length threw exception SyntaxError: The string did not match the expected pattern..
-PASS document.querySelectorAll(":nth-child\\\\ .foo)").length threw exception SyntaxError: The string did not match the expected pattern..
-PASS document.querySelectorAll(":nth-child\\( .foo)").length threw exception SyntaxError: The string did not match the expected pattern..
-PASS document.querySelectorAll(":nth-child\\\( .foo)").length threw exception SyntaxError: The string did not match the expected pattern..
-PASS document.querySelectorAll(":nth-child\\\\( .foo)").length threw exception SyntaxError: The string did not match the expected pattern..
+PASS document.querySelectorAll(":nth-child\\\\").length threw exception SyntaxError: ':nth-child\\' is not a valid selector..
+PASS document.querySelectorAll(":nth-child\(").length threw exception SyntaxError: ':nth-child(' is not a valid selector..
+PASS document.querySelectorAll(":nth-child\\(").length threw exception SyntaxError: ':nth-child\(' is not a valid selector..
+PASS document.querySelectorAll(":nth-child\\\(").length threw exception SyntaxError: ':nth-child\(' is not a valid selector..
+PASS document.querySelectorAll(":nth-child\\\\(").length threw exception SyntaxError: ':nth-child\\(' is not a valid selector..
+PASS document.querySelectorAll(":nth-child\ .foo").length threw exception SyntaxError: ':nth-child .foo' is not a valid selector..
+PASS document.querySelectorAll(":nth-child\\ .foo").length threw exception SyntaxError: ':nth-child\ .foo' is not a valid selector..
+PASS document.querySelectorAll(":nth-child\\\ .foo").length threw exception SyntaxError: ':nth-child\ .foo' is not a valid selector..
+PASS document.querySelectorAll(":nth-child\\\\ .foo").length threw exception SyntaxError: ':nth-child\\ .foo' is not a valid selector..
+PASS document.querySelectorAll(":nth-child\\( .foo").length threw exception SyntaxError: ':nth-child\( .foo' is not a valid selector..
+PASS document.querySelectorAll(":nth-child\\\( .foo").length threw exception SyntaxError: ':nth-child\( .foo' is not a valid selector..
+PASS document.querySelectorAll(":nth-child\\\\( .foo").length threw exception SyntaxError: ':nth-child\\( .foo' is not a valid selector..
+PASS document.querySelectorAll(":nth-child\()").length threw exception SyntaxError: ':nth-child()' is not a valid selector..
+PASS document.querySelectorAll(":nth-child\\()").length threw exception SyntaxError: ':nth-child\()' is not a valid selector..
+PASS document.querySelectorAll(":nth-child\\\()").length threw exception SyntaxError: ':nth-child\()' is not a valid selector..
+PASS document.querySelectorAll(":nth-child\\\\()").length threw exception SyntaxError: ':nth-child\\()' is not a valid selector..
+PASS document.querySelectorAll(":nth-child\ .foo)").length threw exception SyntaxError: ':nth-child .foo)' is not a valid selector..
+PASS document.querySelectorAll(":nth-child\\ .foo)").length threw exception SyntaxError: ':nth-child\ .foo)' is not a valid selector..
+PASS document.querySelectorAll(":nth-child\\\ .foo)").length threw exception SyntaxError: ':nth-child\ .foo)' is not a valid selector..
+PASS document.querySelectorAll(":nth-child\\\\ .foo)").length threw exception SyntaxError: ':nth-child\\ .foo)' is not a valid selector..
+PASS document.querySelectorAll(":nth-child\\( .foo)").length threw exception SyntaxError: ':nth-child\( .foo)' is not a valid selector..
+PASS document.querySelectorAll(":nth-child\\\( .foo)").length threw exception SyntaxError: ':nth-child\( .foo)' is not a valid selector..
+PASS document.querySelectorAll(":nth-child\\\\( .foo)").length threw exception SyntaxError: ':nth-child\\( .foo)' is not a valid selector..
 PASS document.styleSheets[1].cssRules.length is 0
 PASS document.styleSheets[1].cssRules.length is 0
 PASS document.styleSheets[1].cssRules.length is 0
@@ -264,31 +264,31 @@ PASS document.styleSheets[1].cssRules.length is 0
 PASS document.styleSheets[1].cssRules.length is 0
 PASS document.styleSheets[1].cssRules.length is 0
 PASS document.querySelectorAll(":nth-last-child\").length threw exception SyntaxError: Unexpected EOF.
-PASS document.querySelectorAll(":nth-last-child\\").length threw exception SyntaxError: The string did not match the expected pattern..
+PASS document.querySelectorAll(":nth-last-child\\").length threw exception SyntaxError: ':nth-last-child\' is not a valid selector..
 PASS document.querySelectorAll(":nth-last-child\\\").length threw exception SyntaxError: Unexpected EOF.
-PASS document.querySelectorAll(":nth-last-child\\\\").length threw exception SyntaxError: The string did not match the expected pattern..
-PASS document.querySelectorAll(":nth-last-child\(").length threw exception SyntaxError: The string did not match the expected pattern..
-PASS document.querySelectorAll(":nth-last-child\\(").length threw exception SyntaxError: The string did not match the expected pattern..
-PASS document.querySelectorAll(":nth-last-child\\\(").length threw exception SyntaxError: The string did not match the expected pattern..
-PASS document.querySelectorAll(":nth-last-child\\\\(").length threw exception SyntaxError: The string did not match the expected pattern..
-PASS document.querySelectorAll(":nth-last-child\ .foo").length threw exception SyntaxError: The string did not match the expected pattern..
-PASS document.querySelectorAll(":nth-last-child\\ .foo").length threw exception SyntaxError: The string did not match the expected pattern..
-PASS document.querySelectorAll(":nth-last-child\\\ .foo").length threw exception SyntaxError: The string did not match the expected pattern..
-PASS document.querySelectorAll(":nth-last-child\\\\ .foo").length threw exception SyntaxError: The string did not match the expected pattern..
-PASS document.querySelectorAll(":nth-last-child\\( .foo").length threw exception SyntaxError: The string did not match the expected pattern..
-PASS document.querySelectorAll(":nth-last-child\\\( .foo").length threw exception SyntaxError: The string did not match the expected pattern..
-PASS document.querySelectorAll(":nth-last-child\\\\( .foo").length threw exception SyntaxError: The string did not match the expected pattern..
-PASS document.querySelectorAll(":nth-last-child\()").length threw exception SyntaxError: The string did not match the expected pattern..
-PASS document.querySelectorAll(":nth-last-child\\()").length threw exception SyntaxError: The string did not match the expected pattern..
-PASS document.querySelectorAll(":nth-last-child\\\()").length threw exception SyntaxError: The string did not match the expected pattern..
-PASS document.querySelectorAll(":nth-last-child\\\\()").length threw exception SyntaxError: The string did not match the expected pattern..
-PASS document.querySelectorAll(":nth-last-child\ .foo)").length threw exception SyntaxError: The string did not match the expected pattern..
-PASS document.querySelectorAll(":nth-last-child\\ .foo)").length threw exception SyntaxError: The string did not match the expected pattern..
-PASS document.querySelectorAll(":nth-last-child\\\ .foo)").length threw exception SyntaxError: The string did not match the expected pattern..
-PASS document.querySelectorAll(":nth-last-child\\\\ .foo)").length threw exception SyntaxError: The string did not match the expected pattern..
-PASS document.querySelectorAll(":nth-last-child\\( .foo)").length threw exception SyntaxError: The string did not match the expected pattern..
-PASS document.querySelectorAll(":nth-last-child\\\( .foo)").length threw exception SyntaxError: The string did not match the expected pattern..
-PASS document.querySelectorAll(":nth-last-child\\\\( .foo)").length threw exception SyntaxError: The string did not match the expected pattern..
+PASS document.querySelectorAll(":nth-last-child\\\\").length threw exception SyntaxError: ':nth-last-child\\' is not a valid selector..
+PASS document.querySelectorAll(":nth-last-child\(").length threw exception SyntaxError: ':nth-last-child(' is not a valid selector..
+PASS document.querySelectorAll(":nth-last-child\\(").length threw exception SyntaxError: ':nth-last-child\(' is not a valid selector..
+PASS document.querySelectorAll(":nth-last-child\\\(").length threw exception SyntaxError: ':nth-last-child\(' is not a valid selector..
+PASS document.querySelectorAll(":nth-last-child\\\\(").length threw exception SyntaxError: ':nth-last-child\\(' is not a valid selector..
+PASS document.querySelectorAll(":nth-last-child\ .foo").length threw exception SyntaxError: ':nth-last-child .foo' is not a valid selector..
+PASS document.querySelectorAll(":nth-last-child\\ .foo").length threw exception SyntaxError: ':nth-last-child\ .foo' is not a valid selector..
+PASS document.querySelectorAll(":nth-last-child\\\ .foo").length threw exception SyntaxError: ':nth-last-child\ .foo' is not a valid selector..
+PASS document.querySelectorAll(":nth-last-child\\\\ .foo").length threw exception SyntaxError: ':nth-last-child\\ .foo' is not a valid selector..
+PASS document.querySelectorAll(":nth-last-child\\( .foo").length threw exception SyntaxError: ':nth-last-child\( .foo' is not a valid selector..
+PASS document.querySelectorAll(":nth-last-child\\\( .foo").length threw exception SyntaxError: ':nth-last-child\( .foo' is not a valid selector..
+PASS document.querySelectorAll(":nth-last-child\\\\( .foo").length threw exception SyntaxError: ':nth-last-child\\( .foo' is not a valid selector..
+PASS document.querySelectorAll(":nth-last-child\()").length threw exception SyntaxError: ':nth-last-child()' is not a valid selector..
+PASS document.querySelectorAll(":nth-last-child\\()").length threw exception SyntaxError: ':nth-last-child\()' is not a valid selector..
+PASS document.querySelectorAll(":nth-last-child\\\()").length threw exception SyntaxError: ':nth-last-child\()' is not a valid selector..
+PASS document.querySelectorAll(":nth-last-child\\\\()").length threw exception SyntaxError: ':nth-last-child\\()' is not a valid selector..
+PASS document.querySelectorAll(":nth-last-child\ .foo)").length threw exception SyntaxError: ':nth-last-child .foo)' is not a valid selector..
+PASS document.querySelectorAll(":nth-last-child\\ .foo)").length threw exception SyntaxError: ':nth-last-child\ .foo)' is not a valid selector..
+PASS document.querySelectorAll(":nth-last-child\\\ .foo)").length threw exception SyntaxError: ':nth-last-child\ .foo)' is not a valid selector..
+PASS document.querySelectorAll(":nth-last-child\\\\ .foo)").length threw exception SyntaxError: ':nth-last-child\\ .foo)' is not a valid selector..
+PASS document.querySelectorAll(":nth-last-child\\( .foo)").length threw exception SyntaxError: ':nth-last-child\( .foo)' is not a valid selector..
+PASS document.querySelectorAll(":nth-last-child\\\( .foo)").length threw exception SyntaxError: ':nth-last-child\( .foo)' is not a valid selector..
+PASS document.querySelectorAll(":nth-last-child\\\\( .foo)").length threw exception SyntaxError: ':nth-last-child\\( .foo)' is not a valid selector..
 PASS document.styleSheets[1].cssRules.length is 0
 PASS document.styleSheets[1].cssRules.length is 0
 PASS document.styleSheets[1].cssRules.length is 0
@@ -316,31 +316,31 @@ PASS document.styleSheets[1].cssRules.length is 0
 PASS document.styleSheets[1].cssRules.length is 0
 PASS document.styleSheets[1].cssRules.length is 0
 PASS document.querySelectorAll(":nth-last-of-type\").length threw exception SyntaxError: Unexpected EOF.
-PASS document.querySelectorAll(":nth-last-of-type\\").length threw exception SyntaxError: The string did not match the expected pattern..
+PASS document.querySelectorAll(":nth-last-of-type\\").length threw exception SyntaxError: ':nth-last-of-type\' is not a valid selector..
 PASS document.querySelectorAll(":nth-last-of-type\\\").length threw exception SyntaxError: Unexpected EOF.
-PASS document.querySelectorAll(":nth-last-of-type\\\\").length threw exception SyntaxError: The string did not match the expected pattern..
-PASS document.querySelectorAll(":nth-last-of-type\(").length threw exception SyntaxError: The string did not match the expected pattern..
-PASS document.querySelectorAll(":nth-last-of-type\\(").length threw exception SyntaxError: The string did not match the expected pattern..
-PASS document.querySelectorAll(":nth-last-of-type\\\(").length threw exception SyntaxError: The string did not match the expected pattern..
-PASS document.querySelectorAll(":nth-last-of-type\\\\(").length threw exception SyntaxError: The string did not match the expected pattern..
-PASS document.querySelectorAll(":nth-last-of-type\ .foo").length threw exception SyntaxError: The string did not match the expected pattern..
-PASS document.querySelectorAll(":nth-last-of-type\\ .foo").length threw exception SyntaxError: The string did not match the expected pattern..
-PASS document.querySelectorAll(":nth-last-of-type\\\ .foo").length threw exception SyntaxError: The string did not match the expected pattern..
-PASS document.querySelectorAll(":nth-last-of-type\\\\ .foo").length threw exception SyntaxError: The string did not match the expected pattern..
-PASS document.querySelectorAll(":nth-last-of-type\\( .foo").length threw exception SyntaxError: The string did not match the expected pattern..
-PASS document.querySelectorAll(":nth-last-of-type\\\( .foo").length threw exception SyntaxError: The string did not match the expected pattern..
-PASS document.querySelectorAll(":nth-last-of-type\\\\( .foo").length threw exception SyntaxError: The string did not match the expected pattern..
-PASS document.querySelectorAll(":nth-last-of-type\()").length threw exception SyntaxError: The string did not match the expected pattern..
-PASS document.querySelectorAll(":nth-last-of-type\\()").length threw exception SyntaxError: The string did not match the expected pattern..
-PASS document.querySelectorAll(":nth-last-of-type\\\()").length threw exception SyntaxError: The string did not match the expected pattern..
-PASS document.querySelectorAll(":nth-last-of-type\\\\()").length threw exception SyntaxError: The string did not match the expected pattern..
-PASS document.querySelectorAll(":nth-last-of-type\ .foo)").length threw exception SyntaxError: The string did not match the expected pattern..
-PASS document.querySelectorAll(":nth-last-of-type\\ .foo)").length threw exception SyntaxError: The string did not match the expected pattern..
-PASS document.querySelectorAll(":nth-last-of-type\\\ .foo)").length threw exception SyntaxError: The string did not match the expected pattern..
-PASS document.querySelectorAll(":nth-last-of-type\\\\ .foo)").length threw exception SyntaxError: The string did not match the expected pattern..
-PASS document.querySelectorAll(":nth-last-of-type\\( .foo)").length threw exception SyntaxError: The string did not match the expected pattern..
-PASS document.querySelectorAll(":nth-last-of-type\\\( .foo)").length threw exception SyntaxError: The string did not match the expected pattern..
-PASS document.querySelectorAll(":nth-last-of-type\\\\( .foo)").length threw exception SyntaxError: The string did not match the expected pattern..
+PASS document.querySelectorAll(":nth-last-of-type\\\\").length threw exception SyntaxError: ':nth-last-of-type\\' is not a valid selector..
+PASS document.querySelectorAll(":nth-last-of-type\(").length threw exception SyntaxError: ':nth-last-of-type(' is not a valid selector..
+PASS document.querySelectorAll(":nth-last-of-type\\(").length threw exception SyntaxError: ':nth-last-of-type\(' is not a valid selector..
+PASS document.querySelectorAll(":nth-last-of-type\\\(").length threw exception SyntaxError: ':nth-last-of-type\(' is not a valid selector..
+PASS document.querySelectorAll(":nth-last-of-type\\\\(").length threw exception SyntaxError: ':nth-last-of-type\\(' is not a valid selector..
+PASS document.querySelectorAll(":nth-last-of-type\ .foo").length threw exception SyntaxError: ':nth-last-of-type .foo' is not a valid selector..
+PASS document.querySelectorAll(":nth-last-of-type\\ .foo").length threw exception SyntaxError: ':nth-last-of-type\ .foo' is not a valid selector..
+PASS document.querySelectorAll(":nth-last-of-type\\\ .foo").length threw exception SyntaxError: ':nth-last-of-type\ .foo' is not a valid selector..
+PASS document.querySelectorAll(":nth-last-of-type\\\\ .foo").length threw exception SyntaxError: ':nth-last-of-type\\ .foo' is not a valid selector..
+PASS document.querySelectorAll(":nth-last-of-type\\( .foo").length threw exception SyntaxError: ':nth-last-of-type\( .foo' is not a valid selector..
+PASS document.querySelectorAll(":nth-last-of-type\\\( .foo").length threw exception SyntaxError: ':nth-last-of-type\( .foo' is not a valid selector..
+PASS document.querySelectorAll(":nth-last-of-type\\\\( .foo").length threw exception SyntaxError: ':nth-last-of-type\\( .foo' is not a valid selector..
+PASS document.querySelectorAll(":nth-last-of-type\()").length threw exception SyntaxError: ':nth-last-of-type()' is not a valid selector..
+PASS document.querySelectorAll(":nth-last-of-type\\()").length threw exception SyntaxError: ':nth-last-of-type\()' is not a valid selector..
+PASS document.querySelectorAll(":nth-last-of-type\\\()").length threw exception SyntaxError: ':nth-last-of-type\()' is not a valid selector..
+PASS document.querySelectorAll(":nth-last-of-type\\\\()").length threw exception SyntaxError: ':nth-last-of-type\\()' is not a valid selector..
+PASS document.querySelectorAll(":nth-last-of-type\ .foo)").length threw exception SyntaxError: ':nth-last-of-type .foo)' is not a valid selector..
+PASS document.querySelectorAll(":nth-last-of-type\\ .foo)").length threw exception SyntaxError: ':nth-last-of-type\ .foo)' is not a valid selector..
+PASS document.querySelectorAll(":nth-last-of-type\\\ .foo)").length threw exception SyntaxError: ':nth-last-of-type\ .foo)' is not a valid selector..
+PASS document.querySelectorAll(":nth-last-of-type\\\\ .foo)").length threw exception SyntaxError: ':nth-last-of-type\\ .foo)' is not a valid selector..
+PASS document.querySelectorAll(":nth-last-of-type\\( .foo)").length threw exception SyntaxError: ':nth-last-of-type\( .foo)' is not a valid selector..
+PASS document.querySelectorAll(":nth-last-of-type\\\( .foo)").length threw exception SyntaxError: ':nth-last-of-type\( .foo)' is not a valid selector..
+PASS document.querySelectorAll(":nth-last-of-type\\\\( .foo)").length threw exception SyntaxError: ':nth-last-of-type\\( .foo)' is not a valid selector..
 PASS document.styleSheets[1].cssRules.length is 0
 PASS document.styleSheets[1].cssRules.length is 0
 PASS document.styleSheets[1].cssRules.length is 0
@@ -368,31 +368,31 @@ PASS document.styleSheets[1].cssRules.length is 0
 PASS document.styleSheets[1].cssRules.length is 0
 PASS document.styleSheets[1].cssRules.length is 0
 PASS document.querySelectorAll(":nth-of-type\").length threw exception SyntaxError: Unexpected EOF.
-PASS document.querySelectorAll(":nth-of-type\\").length threw exception SyntaxError: The string did not match the expected pattern..
+PASS document.querySelectorAll(":nth-of-type\\").length threw exception SyntaxError: ':nth-of-type\' is not a valid selector..
 PASS document.querySelectorAll(":nth-of-type\\\").length threw exception SyntaxError: Unexpected EOF.
-PASS document.querySelectorAll(":nth-of-type\\\\").length threw exception SyntaxError: The string did not match the expected pattern..
-PASS document.querySelectorAll(":nth-of-type\(").length threw exception SyntaxError: The string did not match the expected pattern..
-PASS document.querySelectorAll(":nth-of-type\\(").length threw exception SyntaxError: The string did not match the expected pattern..
-PASS document.querySelectorAll(":nth-of-type\\\(").length threw exception SyntaxError: The string did not match the expected pattern..
-PASS document.querySelectorAll(":nth-of-type\\\\(").length threw exception SyntaxError: The string did not match the expected pattern..
-PASS document.querySelectorAll(":nth-of-type\ .foo").length threw exception SyntaxError: The string did not match the expected pattern..
-PASS document.querySelectorAll(":nth-of-type\\ .foo").length threw exception SyntaxError: The string did not match the expected pattern..
-PASS document.querySelectorAll(":nth-of-type\\\ .foo").length threw exception SyntaxError: The string did not match the expected pattern..
-PASS document.querySelectorAll(":nth-of-type\\\\ .foo").length threw exception SyntaxError: The string did not match the expected pattern..
-PASS document.querySelectorAll(":nth-of-type\\( .foo").length threw exception SyntaxError: The string did not match the expected pattern..
-PASS document.querySelectorAll(":nth-of-type\\\( .foo").length threw exception SyntaxError: The string did not match the expected pattern..
-PASS document.querySelectorAll(":nth-of-type\\\\( .foo").length threw exception SyntaxError: The string did not match the expected pattern..
-PASS document.querySelectorAll(":nth-of-type\()").length threw exception SyntaxError: The string did not match the expected pattern..
-PASS document.querySelectorAll(":nth-of-type\\()").length threw exception SyntaxError: The string did not match the expected pattern..
-PASS document.querySelectorAll(":nth-of-type\\\()").length threw exception SyntaxError: The string did not match the expected pattern..
-PASS document.querySelectorAll(":nth-of-type\\\\()").length threw exception SyntaxError: The string did not match the expected pattern..
-PASS document.querySelectorAll(":nth-of-type\ .foo)").length threw exception SyntaxError: The string did not match the expected pattern..
-PASS document.querySelectorAll(":nth-of-type\\ .foo)").length threw exception SyntaxError: The string did not match the expected pattern..
-PASS document.querySelectorAll(":nth-of-type\\\ .foo)").length threw exception SyntaxError: The string did not match the expected pattern..
-PASS document.querySelectorAll(":nth-of-type\\\\ .foo)").length threw exception SyntaxError: The string did not match the expected pattern..
-PASS document.querySelectorAll(":nth-of-type\\( .foo)").length threw exception SyntaxError: The string did not match the expected pattern..
-PASS document.querySelectorAll(":nth-of-type\\\( .foo)").length threw exception SyntaxError: The string did not match the expected pattern..
-PASS document.querySelectorAll(":nth-of-type\\\\( .foo)").length threw exception SyntaxError: The string did not match the expected pattern..
+PASS document.querySelectorAll(":nth-of-type\\\\").length threw exception SyntaxError: ':nth-of-type\\' is not a valid selector..
+PASS document.querySelectorAll(":nth-of-type\(").length threw exception SyntaxError: ':nth-of-type(' is not a valid selector..
+PASS document.querySelectorAll(":nth-of-type\\(").length threw exception SyntaxError: ':nth-of-type\(' is not a valid selector..
+PASS document.querySelectorAll(":nth-of-type\\\(").length threw exception SyntaxError: ':nth-of-type\(' is not a valid selector..
+PASS document.querySelectorAll(":nth-of-type\\\\(").length threw exception SyntaxError: ':nth-of-type\\(' is not a valid selector..
+PASS document.querySelectorAll(":nth-of-type\ .foo").length threw exception SyntaxError: ':nth-of-type .foo' is not a valid selector..
+PASS document.querySelectorAll(":nth-of-type\\ .foo").length threw exception SyntaxError: ':nth-of-type\ .foo' is not a valid selector..
+PASS document.querySelectorAll(":nth-of-type\\\ .foo").length threw exception SyntaxError: ':nth-of-type\ .foo' is not a valid selector..
+PASS document.querySelectorAll(":nth-of-type\\\\ .foo").length threw exception SyntaxError: ':nth-of-type\\ .foo' is not a valid selector..
+PASS document.querySelectorAll(":nth-of-type\\( .foo").length threw exception SyntaxError: ':nth-of-type\( .foo' is not a valid selector..
+PASS document.querySelectorAll(":nth-of-type\\\( .foo").length threw exception SyntaxError: ':nth-of-type\( .foo' is not a valid selector..
+PASS document.querySelectorAll(":nth-of-type\\\\( .foo").length threw exception SyntaxError: ':nth-of-type\\( .foo' is not a valid selector..
+PASS document.querySelectorAll(":nth-of-type\()").length threw exception SyntaxError: ':nth-of-type()' is not a valid selector..
+PASS document.querySelectorAll(":nth-of-type\\()").length threw exception SyntaxError: ':nth-of-type\()' is not a valid selector..
+PASS document.querySelectorAll(":nth-of-type\\\()").length threw exception SyntaxError: ':nth-of-type\()' is not a valid selector..
+PASS document.querySelectorAll(":nth-of-type\\\\()").length threw exception SyntaxError: ':nth-of-type\\()' is not a valid selector..
+PASS document.querySelectorAll(":nth-of-type\ .foo)").length threw exception SyntaxError: ':nth-of-type .foo)' is not a valid selector..
+PASS document.querySelectorAll(":nth-of-type\\ .foo)").length threw exception SyntaxError: ':nth-of-type\ .foo)' is not a valid selector..
+PASS document.querySelectorAll(":nth-of-type\\\ .foo)").length threw exception SyntaxError: ':nth-of-type\ .foo)' is not a valid selector..
+PASS document.querySelectorAll(":nth-of-type\\\\ .foo)").length threw exception SyntaxError: ':nth-of-type\\ .foo)' is not a valid selector..
+PASS document.querySelectorAll(":nth-of-type\\( .foo)").length threw exception SyntaxError: ':nth-of-type\( .foo)' is not a valid selector..
+PASS document.querySelectorAll(":nth-of-type\\\( .foo)").length threw exception SyntaxError: ':nth-of-type\( .foo)' is not a valid selector..
+PASS document.querySelectorAll(":nth-of-type\\\\( .foo)").length threw exception SyntaxError: ':nth-of-type\\( .foo)' is not a valid selector..
 PASS document.styleSheets[1].cssRules.length is 0
 PASS document.styleSheets[1].cssRules.length is 0
 PASS document.styleSheets[1].cssRules.length is 0

--- a/LayoutTests/fast/selectors/lang-empty-expected.txt
+++ b/LayoutTests/fast/selectors/lang-empty-expected.txt
@@ -3,8 +3,8 @@ Verify empty :lang() selectors.
 On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
 
 
-PASS document.querySelectorAll(":lang()").length threw exception SyntaxError: The string did not match the expected pattern..
-PASS document.querySelectorAll(":lang() *").length threw exception SyntaxError: The string did not match the expected pattern..
+PASS document.querySelectorAll(":lang()").length threw exception SyntaxError: ':lang()' is not a valid selector..
+PASS document.querySelectorAll(":lang() *").length threw exception SyntaxError: ':lang() *' is not a valid selector..
 PASS getComputedStyle(document.getElementById("target1")).color is "rgb(0, 0, 0)"
 PASS successfullyParsed is true
 

--- a/LayoutTests/fast/selectors/lang-extended-filtering-expected.txt
+++ b/LayoutTests/fast/selectors/lang-extended-filtering-expected.txt
@@ -140,12 +140,12 @@ PASS document.querySelectorAll(":lang(foÃ¶)").length is 0
 PASS document.querySelectorAll(":lang(fo)").length is 0
 PASS document.querySelectorAll(":lang(f)").length is 0
 
-PASS document.querySelectorAll(":lang(*)").length threw exception SyntaxError: The string did not match the expected pattern..
-PASS document.querySelectorAll(":lang(*foÃ¶Ã‰)").length threw exception SyntaxError: The string did not match the expected pattern..
-PASS document.querySelectorAll(":lang(--en--)").length threw exception SyntaxError: The string did not match the expected pattern..
-PASS document.querySelectorAll(":lang(---en---)").length threw exception SyntaxError: The string did not match the expected pattern..
-PASS document.querySelectorAll(":lang(en us- de- fr-).length") threw exception SyntaxError: The string did not match the expected pattern..
-PASS document.querySelectorAll(":lang(-\\* \\*-)").length threw exception SyntaxError: The string did not match the expected pattern..
+PASS document.querySelectorAll(":lang(*)").length threw exception SyntaxError: ':lang(*)' is not a valid selector..
+PASS document.querySelectorAll(":lang(*foÃ¶Ã‰)").length threw exception SyntaxError: ':lang(*foÃ¶Ã‰)' is not a valid selector..
+PASS document.querySelectorAll(":lang(--en--)").length threw exception SyntaxError: ':lang(--en--)' is not a valid selector..
+PASS document.querySelectorAll(":lang(---en---)").length threw exception SyntaxError: ':lang(---en---)' is not a valid selector..
+PASS document.querySelectorAll(":lang(en us- de- fr-).length") threw exception SyntaxError: ':lang(en us- de- fr-).length' is not a valid selector..
+PASS document.querySelectorAll(":lang(-\\* \\*-)").length threw exception SyntaxError: ':lang(-\* \*-)' is not a valid selector..
 PASS successfullyParsed is true
 
 TEST COMPLETE

--- a/LayoutTests/fast/selectors/lang-extended-filtering-with-string-arguments-expected.txt
+++ b/LayoutTests/fast/selectors/lang-extended-filtering-with-string-arguments-expected.txt
@@ -10,7 +10,7 @@ PASS document.querySelectorAll(":lang('')").length is 0
 PASS document.querySelectorAll(':lang("")').length is 0
 PASS document.querySelectorAll(':lang("en", "*-1997")').length is 2
 PASS document.querySelectorAll(':lang("", "*-1997")').length is 1
-PASS document.querySelectorAll(':lang("""")') threw exception SyntaxError: The string did not match the expected pattern..
+PASS document.querySelectorAll(':lang("""")') threw exception SyntaxError: ':lang("""")' is not a valid selector..
 PASS successfullyParsed is true
 
 TEST COMPLETE

--- a/LayoutTests/fast/selectors/lang-invalid-expected.txt
+++ b/LayoutTests/fast/selectors/lang-invalid-expected.txt
@@ -3,34 +3,34 @@ Verify invalid :lang() selectors.
 On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
 
 
-PASS document.querySelectorAll(":lang()").length threw exception SyntaxError: The string did not match the expected pattern..
-PASS document.querySelectorAll(":lang(lang()").length threw exception SyntaxError: The string did not match the expected pattern..
-PASS document.querySelectorAll(":lang(:lang(id)").length threw exception SyntaxError: The string did not match the expected pattern..
-PASS document.querySelectorAll(":lang(:lang(en, br)").length threw exception SyntaxError: The string did not match the expected pattern..
+PASS document.querySelectorAll(":lang()").length threw exception SyntaxError: ':lang()' is not a valid selector..
+PASS document.querySelectorAll(":lang(lang()").length threw exception SyntaxError: ':lang(lang()' is not a valid selector..
+PASS document.querySelectorAll(":lang(:lang(id)").length threw exception SyntaxError: ':lang(:lang(id)' is not a valid selector..
+PASS document.querySelectorAll(":lang(:lang(en, br)").length threw exception SyntaxError: ':lang(:lang(en, br)' is not a valid selector..
 
-PASS document.querySelectorAll(":lang(<0_0>)").length threw exception SyntaxError: The string did not match the expected pattern..
-PASS document.querySelectorAll(":lang(9)").length threw exception SyntaxError: The string did not match the expected pattern..
-PASS document.querySelectorAll(":lang(99)").length threw exception SyntaxError: The string did not match the expected pattern..
-PASS document.querySelectorAll(":lang(999)").length threw exception SyntaxError: The string did not match the expected pattern..
+PASS document.querySelectorAll(":lang(<0_0>)").length threw exception SyntaxError: ':lang(<0_0>)' is not a valid selector..
+PASS document.querySelectorAll(":lang(9)").length threw exception SyntaxError: ':lang(9)' is not a valid selector..
+PASS document.querySelectorAll(":lang(99)").length threw exception SyntaxError: ':lang(99)' is not a valid selector..
+PASS document.querySelectorAll(":lang(999)").length threw exception SyntaxError: ':lang(999)' is not a valid selector..
 
-PASS document.querySelectorAll(":lang(})").length threw exception SyntaxError: The string did not match the expected pattern..
-PASS document.querySelectorAll(":lang({)").length threw exception SyntaxError: The string did not match the expected pattern..
+PASS document.querySelectorAll(":lang(})").length threw exception SyntaxError: ':lang(})' is not a valid selector..
+PASS document.querySelectorAll(":lang({)").length threw exception SyntaxError: ':lang({)' is not a valid selector..
 PASS document.querySelectorAll(":lang({}")).length threw exception SyntaxError: Unexpected token ')'.
-PASS document.querySelectorAll(":lang(()").length threw exception SyntaxError: The string did not match the expected pattern..
-PASS document.querySelectorAll(":lang())").length threw exception SyntaxError: The string did not match the expected pattern..
+PASS document.querySelectorAll(":lang(()").length threw exception SyntaxError: ':lang(()' is not a valid selector..
+PASS document.querySelectorAll(":lang())").length threw exception SyntaxError: ':lang())' is not a valid selector..
 PASS document.querySelectorAll(":lang(()")).length threw exception SyntaxError: Unexpected token ')'.
-PASS document.querySelectorAll(":lang(])").length threw exception SyntaxError: The string did not match the expected pattern..
-PASS document.querySelectorAll(":lang([)").length threw exception SyntaxError: The string did not match the expected pattern..
-PASS document.querySelectorAll(":lang([])").length threw exception SyntaxError: The string did not match the expected pattern..
-PASS document.querySelectorAll(":lang(@media screen {})").length threw exception SyntaxError: The string did not match the expected pattern..
-PASS document.querySelectorAll(":lang(@font-face {})").length threw exception SyntaxError: The string did not match the expected pattern..
-PASS document.querySelectorAll(":lang(:)").length threw exception SyntaxError: The string did not match the expected pattern..
-PASS document.querySelectorAll(":lang(;)").length threw exception SyntaxError: The string did not match the expected pattern..
-PASS document.querySelectorAll(":lang(.)").length threw exception SyntaxError: The string did not match the expected pattern..
-PASS document.querySelectorAll(":lang(+)").length threw exception SyntaxError: The string did not match the expected pattern..
-PASS document.querySelectorAll(":lang(-)").length threw exception SyntaxError: The string did not match the expected pattern..
-PASS document.querySelectorAll(":lang(=)").length threw exception SyntaxError: The string did not match the expected pattern..
-PASS document.querySelectorAll(":lang(&&)").length threw exception SyntaxError: The string did not match the expected pattern..
+PASS document.querySelectorAll(":lang(])").length threw exception SyntaxError: ':lang(])' is not a valid selector..
+PASS document.querySelectorAll(":lang([)").length threw exception SyntaxError: ':lang([)' is not a valid selector..
+PASS document.querySelectorAll(":lang([])").length threw exception SyntaxError: ':lang([])' is not a valid selector..
+PASS document.querySelectorAll(":lang(@media screen {})").length threw exception SyntaxError: ':lang(@media screen {})' is not a valid selector..
+PASS document.querySelectorAll(":lang(@font-face {})").length threw exception SyntaxError: ':lang(@font-face {})' is not a valid selector..
+PASS document.querySelectorAll(":lang(:)").length threw exception SyntaxError: ':lang(:)' is not a valid selector..
+PASS document.querySelectorAll(":lang(;)").length threw exception SyntaxError: ':lang(;)' is not a valid selector..
+PASS document.querySelectorAll(":lang(.)").length threw exception SyntaxError: ':lang(.)' is not a valid selector..
+PASS document.querySelectorAll(":lang(+)").length threw exception SyntaxError: ':lang(+)' is not a valid selector..
+PASS document.querySelectorAll(":lang(-)").length threw exception SyntaxError: ':lang(-)' is not a valid selector..
+PASS document.querySelectorAll(":lang(=)").length threw exception SyntaxError: ':lang(=)' is not a valid selector..
+PASS document.querySelectorAll(":lang(&&)").length threw exception SyntaxError: ':lang(&&)' is not a valid selector..
 
 PASS getComputedStyle(document.getElementById("target1")).color is "rgb(0, 0, 0)"
 PASS successfullyParsed is true

--- a/LayoutTests/fast/selectors/lang-multiple-expected.txt
+++ b/LayoutTests/fast/selectors/lang-multiple-expected.txt
@@ -62,9 +62,9 @@ PASS document.querySelectorAll(":lang(id---, id---)").length is 0
 PASS document.querySelectorAll(":lang(tic-tac-toe, tic-tac)").length is 1
 PASS document.querySelectorAll(":lang(tic-toe-tac, tic-toe-tac-tac)").length is 0
 
-PASS document.querySelectorAll(":lang(--en--, --en--)").length threw exception SyntaxError: The string did not match the expected pattern..
-PASS document.querySelectorAll(":lang(---en---, ---en---)").length threw exception SyntaxError: The string did not match the expected pattern..
-PASS document.querySelectorAll(":lang(en us- de- fr-, en us- de- fr-).length") threw exception SyntaxError: The string did not match the expected pattern..
+PASS document.querySelectorAll(":lang(--en--, --en--)").length threw exception SyntaxError: ':lang(--en--, --en--)' is not a valid selector..
+PASS document.querySelectorAll(":lang(---en---, ---en---)").length threw exception SyntaxError: ':lang(---en---, ---en---)' is not a valid selector..
+PASS document.querySelectorAll(":lang(en us- de- fr-, en us- de- fr-).length") threw exception SyntaxError: ':lang(en us- de- fr-, en us- de- fr-).length' is not a valid selector..
 PASS successfullyParsed is true
 
 TEST COMPLETE

--- a/LayoutTests/fast/selectors/querySelector-pseudo-element-inside-functional-pseudo-class-not-expected.txt
+++ b/LayoutTests/fast/selectors/querySelector-pseudo-element-inside-functional-pseudo-class-not-expected.txt
@@ -3,7 +3,7 @@ This test makes sure that querySelector with pseudo-element inside functional ps
 On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
 
 
-PASS document.querySelectorAll("#test div :not(:first-line)") threw exception SyntaxError: The string did not match the expected pattern..
+PASS document.querySelectorAll("#test div :not(:first-line)") threw exception SyntaxError: '#test div :not(:first-line)' is not a valid selector..
 PASS successfullyParsed is true
 
 TEST COMPLETE

--- a/LayoutTests/fast/shadow-dom/direct-focus-pseudo-does-not-match-in-author-stylesheet-expected.txt
+++ b/LayoutTests/fast/shadow-dom/direct-focus-pseudo-does-not-match-in-author-stylesheet-expected.txt
@@ -4,9 +4,9 @@ On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE
 
 
 PASS defaultFocus.matches(":focus") is true
-PASS defaultFocus.matches(":-internal-direct-focus") threw exception SyntaxError: The string did not match the expected pattern..
+PASS defaultFocus.matches(":-internal-direct-focus") threw exception SyntaxError: ':-internal-direct-focus' is not a valid selector..
 PASS inputInShadowRoot.matches(":focus") is true
-PASS inputInShadowRoot.matches(":-internal-direct-focus") threw exception SyntaxError: The string did not match the expected pattern..
+PASS inputInShadowRoot.matches(":-internal-direct-focus") threw exception SyntaxError: ':-internal-direct-focus' is not a valid selector..
 PASS successfullyParsed is true
 
 TEST COMPLETE

--- a/LayoutTests/fast/text/text-combine-crash-expected.txt
+++ b/LayoutTests/fast/text/text-combine-crash-expected.txt
@@ -21,6 +21,6 @@ Errlog webtest_fn_25: ReferenceError: Can't find variable: node_16
 ￼￼Errlog webtest_fn_27: TypeError: undefined is not an object (evaluating 'document.body.contentDocument.execCommand')
 Errlog webtest_fn_31: NotSupportedError: The operation is not supported.
 ￼Errlog webtest_fn_32: TypeError: undefined is not an object (evaluating 'window.frames[2].querySelectorAll')
-Errlog webtest_fn_33: SyntaxError: The string did not match the expected pattern.
+Errlog webtest_fn_33: SyntaxError: ':first + :first-of-type > th:horizontal' is not a valid selector.
 
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-pseudo/parsing/highlight-pseudos-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-pseudo/parsing/highlight-pseudos-expected.txt
@@ -9,30 +9,30 @@ PASS "::selection div" should be an invalid selector
 PASS "::selection::after" should be an invalid selector
 PASS "::selection:hover" should be an invalid selector
 PASS ":not(::selection)" should be an invalid selector
-FAIL "::target-text" should be a valid selector The string did not match the expected pattern.
-FAIL ".a::target-text" should be a valid selector The string did not match the expected pattern.
-FAIL "div ::target-text" should be a valid selector The string did not match the expected pattern.
-FAIL "::part(my-part)::target-text" should be a valid selector The string did not match the expected pattern.
+FAIL "::target-text" should be a valid selector '::target-text' is not a valid selector.
+FAIL ".a::target-text" should be a valid selector '.a::target-text' is not a valid selector.
+FAIL "div ::target-text" should be a valid selector 'div ::target-text' is not a valid selector.
+FAIL "::part(my-part)::target-text" should be a valid selector '::part(my-part)::target-text' is not a valid selector.
 PASS "::before::target-text" should be an invalid selector
 PASS "::target-text.a" should be an invalid selector
 PASS "::target-text div" should be an invalid selector
 PASS "::target-text::after" should be an invalid selector
 PASS "::target-text:hover" should be an invalid selector
 PASS ":not(::target-text)" should be an invalid selector
-FAIL "::spelling-error" should be a valid selector The string did not match the expected pattern.
-FAIL ".a::spelling-error" should be a valid selector The string did not match the expected pattern.
-FAIL "div ::spelling-error" should be a valid selector The string did not match the expected pattern.
-FAIL "::part(my-part)::spelling-error" should be a valid selector The string did not match the expected pattern.
+FAIL "::spelling-error" should be a valid selector '::spelling-error' is not a valid selector.
+FAIL ".a::spelling-error" should be a valid selector '.a::spelling-error' is not a valid selector.
+FAIL "div ::spelling-error" should be a valid selector 'div ::spelling-error' is not a valid selector.
+FAIL "::part(my-part)::spelling-error" should be a valid selector '::part(my-part)::spelling-error' is not a valid selector.
 PASS "::before::spelling-error" should be an invalid selector
 PASS "::spelling-error.a" should be an invalid selector
 PASS "::spelling-error div" should be an invalid selector
 PASS "::spelling-error::after" should be an invalid selector
 PASS "::spelling-error:hover" should be an invalid selector
 PASS ":not(::spelling-error)" should be an invalid selector
-FAIL "::grammar-error" should be a valid selector The string did not match the expected pattern.
-FAIL ".a::grammar-error" should be a valid selector The string did not match the expected pattern.
-FAIL "div ::grammar-error" should be a valid selector The string did not match the expected pattern.
-FAIL "::part(my-part)::grammar-error" should be a valid selector The string did not match the expected pattern.
+FAIL "::grammar-error" should be a valid selector '::grammar-error' is not a valid selector.
+FAIL ".a::grammar-error" should be a valid selector '.a::grammar-error' is not a valid selector.
+FAIL "div ::grammar-error" should be a valid selector 'div ::grammar-error' is not a valid selector.
+FAIL "::part(my-part)::grammar-error" should be a valid selector '::part(my-part)::grammar-error' is not a valid selector.
 PASS "::before::grammar-error" should be an invalid selector
 PASS "::grammar-error.a" should be an invalid selector
 PASS "::grammar-error div" should be an invalid selector

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-pseudo/parsing/tree-abiding-pseudo-elements-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-pseudo/parsing/tree-abiding-pseudo-elements-expected.txt
@@ -11,15 +11,15 @@ PASS "::marker" should be a valid selector
 PASS "*::marker" should be a valid selector
 PASS "foo.bar[baz]::marker" should be a valid selector
 PASS "::marker *" should be an invalid selector
-FAIL "::placeholder" should be a valid selector The string did not match the expected pattern.
-FAIL "*::placeholder" should be a valid selector The string did not match the expected pattern.
-FAIL "foo.bar[baz]::placeholder" should be a valid selector The string did not match the expected pattern.
+FAIL "::placeholder" should be a valid selector '::placeholder' is not a valid selector.
+FAIL "*::placeholder" should be a valid selector '*::placeholder' is not a valid selector.
+FAIL "foo.bar[baz]::placeholder" should be a valid selector 'foo.bar[baz]::placeholder' is not a valid selector.
 PASS "::placeholder *" should be an invalid selector
-FAIL "::file-selector-button" should be a valid selector The string did not match the expected pattern.
-FAIL "::file-selector-button:hover" should be a valid selector The string did not match the expected pattern.
-FAIL "::file-selector-button:focus" should be a valid selector The string did not match the expected pattern.
-FAIL "::file-selector-button:active" should be a valid selector The string did not match the expected pattern.
-FAIL "::file-selector-button:is(:hover)" should be a valid selector The string did not match the expected pattern.
+FAIL "::file-selector-button" should be a valid selector '::file-selector-button' is not a valid selector.
+FAIL "::file-selector-button:hover" should be a valid selector '::file-selector-button:hover' is not a valid selector.
+FAIL "::file-selector-button:focus" should be a valid selector '::file-selector-button:focus' is not a valid selector.
+FAIL "::file-selector-button:active" should be a valid selector '::file-selector-button:active' is not a valid selector.
+FAIL "::file-selector-button:is(:hover)" should be a valid selector '::file-selector-button:is(:hover)' is not a valid selector.
 PASS "::file-selector-button::before" should be an invalid selector
 PASS "::file-selector-button#id" should be an invalid selector
 PASS "::file-selector-button#class" should be an invalid selector
@@ -32,8 +32,8 @@ PASS "::before::after" should be an invalid selector
 PASS "::after::after" should be an invalid selector
 PASS "::marker::after" should be an invalid selector
 PASS "::placeholder::after" should be an invalid selector
-FAIL "::before::marker" should be a valid selector The string did not match the expected pattern.
-FAIL "::after::marker" should be a valid selector The string did not match the expected pattern.
+FAIL "::before::marker" should be a valid selector '::before::marker' is not a valid selector.
+FAIL "::after::marker" should be a valid selector '::after::marker' is not a valid selector.
 PASS "::marker::marker" should be an invalid selector
 PASS "::placeholder::marker" should be an invalid selector
 PASS "::before::placeholder" should be an invalid selector

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-scoping/host-context-parsing-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-scoping/host-context-parsing-expected.txt
@@ -1,6 +1,6 @@
 
-FAIL ":host-context(.a)" should be a valid selector The string did not match the expected pattern.
-FAIL ":host-context(div.a)" should be a valid selector The string did not match the expected pattern.
+FAIL ":host-context(.a)" should be a valid selector ':host-context(.a)' is not a valid selector.
+FAIL ":host-context(div.a)" should be a valid selector ':host-context(div.a)' is not a valid selector.
 PASS ":host-context" should be an invalid selector
 PASS ":host-context()" should be an invalid selector
 PASS ":host-context(.a, .b)" should be an invalid selector

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-scoping/slotted-parsing-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-scoping/slotted-parsing-expected.txt
@@ -23,7 +23,7 @@ PASS "::slotted(*):where(:hover)" should be a valid selector
 PASS "::slotted(*):where(#id)" should be a valid selector
 PASS "::slotted(*)::before" should be a valid selector
 PASS "::slotted(*)::after" should be a valid selector
-FAIL "::slotted(*)::placeholder" should be a valid selector The string did not match the expected pattern.
+FAIL "::slotted(*)::placeholder" should be a valid selector '::slotted(*)::placeholder' is not a valid selector.
 PASS "::slotted(*)::marker" should be a valid selector
 PASS "::slotted(*)::first-line" should be an invalid selector
 PASS "::slotted(*)::first-letter" should be an invalid selector

--- a/LayoutTests/imported/w3c/web-platform-tests/css/selectors/attribute-selectors/attribute-case/semantics-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/selectors/attribute-selectors/attribute-case/semantics-expected.txt
@@ -58,38 +58,38 @@ PASS [foo='BAR'][foo='bar' i] <div foo="BAR"> with querySelector in standards mo
 PASS [foo='bar' i][foo='BAR'] <div foo="BAR"> in standards mode
 PASS [foo='bar' i][foo='BAR'] <div foo="BAR"> with querySelector in standards mode
 FAIL [foo='bar' s] <div foo="bar"> in standards mode assert_equals: rule didn't parse into CSSOM expected 1 but got 0
-FAIL [foo='bar' s] <div foo="bar"> with querySelector in standards mode The string did not match the expected pattern.
+FAIL [foo='bar' s] <div foo="bar"> with querySelector in standards mode '[foo='bar' s]' is not a valid selector.
 FAIL [foo='' s] <div foo=""> in standards mode assert_equals: rule didn't parse into CSSOM expected 1 but got 0
-FAIL [foo='' s] <div foo=""> with querySelector in standards mode The string did not match the expected pattern.
+FAIL [foo='' s] <div foo=""> with querySelector in standards mode '[foo='' s]' is not a valid selector.
 FAIL [foo='ä' s] /* COMBINING in both */ <div foo="ä"> in standards mode assert_equals: rule didn't parse into CSSOM expected 1 but got 0
-FAIL [foo='ä' s] /* COMBINING in both */ <div foo="ä"> with querySelector in standards mode The string did not match the expected pattern.
+FAIL [foo='ä' s] /* COMBINING in both */ <div foo="ä"> with querySelector in standards mode '[foo='ä' s] /* COMBINING in both */' is not a valid selector.
 FAIL [*|foo='bar' s] <div foo="x" {a}foo="x" {b}foo="bar" {c}foo="x"> in standards mode assert_equals: rule didn't parse into CSSOM expected 1 but got 0
-FAIL [*|foo='bar' s] <div foo="x" {a}foo="x" {b}foo="bar" {c}foo="x"> with querySelector in standards mode The string did not match the expected pattern.
+FAIL [*|foo='bar' s] <div foo="x" {a}foo="x" {b}foo="bar" {c}foo="x"> with querySelector in standards mode '[*|foo='bar' s]' is not a valid selector.
 FAIL [*|foo='bar' s] <div foo="bar" {a}foo="x" {b}foo="x" {c}foo="x"> in standards mode assert_equals: rule didn't parse into CSSOM expected 1 but got 0
-FAIL [*|foo='bar' s] <div foo="bar" {a}foo="x" {b}foo="x" {c}foo="x"> with querySelector in standards mode The string did not match the expected pattern.
+FAIL [*|foo='bar' s] <div foo="bar" {a}foo="x" {b}foo="x" {c}foo="x"> with querySelector in standards mode '[*|foo='bar' s]' is not a valid selector.
 FAIL [align='left' s] <div align="left"> in standards mode assert_equals: rule didn't parse into CSSOM expected 1 but got 0
-FAIL [align='left' s] <div align="left"> with querySelector in standards mode The string did not match the expected pattern.
+FAIL [align='left' s] <div align="left"> with querySelector in standards mode '[align='left' s]' is not a valid selector.
 FAIL [align='LEFT' s] <div align="LEFT"> in standards mode assert_equals: rule didn't parse into CSSOM expected 1 but got 0
-FAIL [align='LEFT' s] <div align="LEFT"> with querySelector in standards mode The string did not match the expected pattern.
+FAIL [align='LEFT' s] <div align="LEFT"> with querySelector in standards mode '[align='LEFT' s]' is not a valid selector.
 FAIL [class~='a' s] <div class="x a b"> in standards mode assert_equals: rule didn't parse into CSSOM expected 1 but got 0
-FAIL [class~='a' s] <div class="x a b"> with querySelector in standards mode The string did not match the expected pattern.
+FAIL [class~='a' s] <div class="x a b"> with querySelector in standards mode '[class~='a' s]' is not a valid selector.
 FAIL [class~='A' s] <div class="X A B"> in standards mode assert_equals: rule didn't parse into CSSOM expected 1 but got 0
-FAIL [class~='A' s] <div class="X A B"> with querySelector in standards mode The string did not match the expected pattern.
+FAIL [class~='A' s] <div class="X A B"> with querySelector in standards mode '[class~='A' s]' is not a valid selector.
 FAIL [id^='a' s] <div id="ab"> in standards mode assert_equals: rule didn't parse into CSSOM expected 1 but got 0
-FAIL [id^='a' s] <div id="ab"> with querySelector in standards mode The string did not match the expected pattern.
+FAIL [id^='a' s] <div id="ab"> with querySelector in standards mode '[id^='a' s]' is not a valid selector.
 FAIL [id$='A' s] <div id="XA"> in standards mode assert_equals: rule didn't parse into CSSOM expected 1 but got 0
-FAIL [id$='A' s] <div id="XA"> with querySelector in standards mode The string did not match the expected pattern.
+FAIL [id$='A' s] <div id="XA"> with querySelector in standards mode '[id$='A' s]' is not a valid selector.
 FAIL [lang|='a' s] <div lang="a-b"> in standards mode assert_equals: rule didn't parse into CSSOM expected 1 but got 0
-FAIL [lang|='a' s] <div lang="a-b"> with querySelector in standards mode The string did not match the expected pattern.
+FAIL [lang|='a' s] <div lang="a-b"> with querySelector in standards mode '[lang|='a' s]' is not a valid selector.
 FAIL [lang*='A' s] <div lang="XAB"> in standards mode assert_equals: rule didn't parse into CSSOM expected 1 but got 0
-FAIL [lang*='A' s] <div lang="XAB"> with querySelector in standards mode The string did not match the expected pattern.
+FAIL [lang*='A' s] <div lang="XAB"> with querySelector in standards mode '[lang*='A' s]' is not a valid selector.
 FAIL [*|lang='a' s] <div {http://www.w3.org/XML/1998/namespace}lang="a"> in standards mode assert_equals: rule didn't parse into CSSOM expected 1 but got 0
-FAIL [*|lang='a' s] <div {http://www.w3.org/XML/1998/namespace}lang="a"> with querySelector in standards mode The string did not match the expected pattern.
+FAIL [*|lang='a' s] <div {http://www.w3.org/XML/1998/namespace}lang="a"> with querySelector in standards mode '[*|lang='a' s]' is not a valid selector.
 FAIL [*|lang='A' s] <div {http://www.w3.org/XML/1998/namespace}lang="A"> in standards mode assert_equals: rule didn't parse into CSSOM expected 1 but got 0
-FAIL [*|lang='A' s] <div {http://www.w3.org/XML/1998/namespace}lang="A"> with querySelector in standards mode The string did not match the expected pattern.
+FAIL [*|lang='A' s] <div {http://www.w3.org/XML/1998/namespace}lang="A"> with querySelector in standards mode '[*|lang='A' s]' is not a valid selector.
 FAIL @namespace x 'http://www.w3.org/XML/1998/namespace'; [x|lang='A' s] <div {http://www.w3.org/XML/1998/namespace}lang="A"> in standards mode assert_equals: rule didn't parse into CSSOM expected 2 but got 1
 FAIL [foo='BAR' s][foo='BAR' s] <div foo="BAR"> in standards mode assert_equals: rule didn't parse into CSSOM expected 1 but got 0
-FAIL [foo='BAR' s][foo='BAR' s] <div foo="BAR"> with querySelector in standards mode The string did not match the expected pattern.
+FAIL [foo='BAR' s][foo='BAR' s] <div foo="BAR"> with querySelector in standards mode '[foo='BAR' s][foo='BAR' s]' is not a valid selector.
 PASS [align='left'] /* sanity check (match HTML) */ <div align="LEFT"> in standards mode
 PASS [align='left'] /* sanity check (match HTML) */ <div align="LEFT"> with querySelector in standards mode
 PASS [align='LEFT'] /* sanity check (match HTML) */ <div align="left"> in standards mode
@@ -206,120 +206,120 @@ PASS [foo*='É' i] <div foo="é"> with querySelector in standards mode
 PASS [foo|='É' i] <div foo="é"> in standards mode
 PASS [foo|='É' i] <div foo="é"> with querySelector in standards mode
 FAIL [foo='' s] <div foo="BAR"> in standards mode assert_equals: rule didn't parse into CSSOM expected 1 but got 0
-FAIL [foo='' s] <div foo="BAR"> with querySelector in standards mode The string did not match the expected pattern.
+FAIL [foo='' s] <div foo="BAR"> with querySelector in standards mode '[foo='' s]' is not a valid selector.
 FAIL [foo='\0' s] /* \0 in selector */ <div foo=""> in standards mode assert_equals: rule didn't parse into CSSOM expected 1 but got 0
-FAIL [foo='\0' s] /* \0 in selector */ <div foo=""> with querySelector in standards mode The string did not match the expected pattern.
+FAIL [foo='\0' s] /* \0 in selector */ <div foo=""> with querySelector in standards mode '[foo='\0' s] /* \0 in selector */' is not a valid selector.
 FAIL [foo='' s] /* \0 in attribute */ <div foo="\0"> in standards mode assert_equals: rule didn't parse into CSSOM expected 1 but got 0
-FAIL [foo='' s] /* \0 in attribute */ <div foo="\0"> with querySelector in standards mode The string did not match the expected pattern.
+FAIL [foo='' s] /* \0 in attribute */ <div foo="\0"> with querySelector in standards mode '[foo='' s] /* \0 in attribute */' is not a valid selector.
 FAIL [foo='ä' s] <div foo="Ä"> in standards mode assert_equals: rule didn't parse into CSSOM expected 1 but got 0
-FAIL [foo='ä' s] <div foo="Ä"> with querySelector in standards mode The string did not match the expected pattern.
+FAIL [foo='ä' s] <div foo="Ä"> with querySelector in standards mode '[foo='ä' s]' is not a valid selector.
 FAIL [foo='Ä' s] <div foo="ä"> in standards mode assert_equals: rule didn't parse into CSSOM expected 1 but got 0
-FAIL [foo='Ä' s] <div foo="ä"> with querySelector in standards mode The string did not match the expected pattern.
+FAIL [foo='Ä' s] <div foo="ä"> with querySelector in standards mode '[foo='Ä' s]' is not a valid selector.
 FAIL [foo='ä' s] /* COMBINING in selector */ <div foo="Ä"> in standards mode assert_equals: rule didn't parse into CSSOM expected 1 but got 0
-FAIL [foo='ä' s] /* COMBINING in selector */ <div foo="Ä"> with querySelector in standards mode The string did not match the expected pattern.
+FAIL [foo='ä' s] /* COMBINING in selector */ <div foo="Ä"> with querySelector in standards mode '[foo='ä' s] /* COMBINING in selector */' is not a valid selector.
 FAIL [foo~='ä' s] /* COMBINING in selector */ <div foo="ä"> in standards mode assert_equals: rule didn't parse into CSSOM expected 1 but got 0
-FAIL [foo~='ä' s] /* COMBINING in selector */ <div foo="ä"> with querySelector in standards mode The string did not match the expected pattern.
+FAIL [foo~='ä' s] /* COMBINING in selector */ <div foo="ä"> with querySelector in standards mode '[foo~='ä' s] /* COMBINING in selector */' is not a valid selector.
 FAIL [foo^='Ä' s] /* COMBINING in selector */ <div foo="Ä"> in standards mode assert_equals: rule didn't parse into CSSOM expected 1 but got 0
-FAIL [foo^='Ä' s] /* COMBINING in selector */ <div foo="Ä"> with querySelector in standards mode The string did not match the expected pattern.
+FAIL [foo^='Ä' s] /* COMBINING in selector */ <div foo="Ä"> with querySelector in standards mode '[foo^='Ä' s] /* COMBINING in selector */' is not a valid selector.
 FAIL [foo$='Ä' s] /* COMBINING in selector */ <div foo="ä"> in standards mode assert_equals: rule didn't parse into CSSOM expected 1 but got 0
-FAIL [foo$='Ä' s] /* COMBINING in selector */ <div foo="ä"> with querySelector in standards mode The string did not match the expected pattern.
+FAIL [foo$='Ä' s] /* COMBINING in selector */ <div foo="ä"> with querySelector in standards mode '[foo$='Ä' s] /* COMBINING in selector */' is not a valid selector.
 FAIL [foo*='ä' s] /* COMBINING in attribute */ <div foo="ä"> in standards mode assert_equals: rule didn't parse into CSSOM expected 1 but got 0
-FAIL [foo*='ä' s] /* COMBINING in attribute */ <div foo="ä"> with querySelector in standards mode The string did not match the expected pattern.
+FAIL [foo*='ä' s] /* COMBINING in attribute */ <div foo="ä"> with querySelector in standards mode '[foo*='ä' s] /* COMBINING in attribute */' is not a valid selector.
 FAIL [foo|='ä' s] /* COMBINING in attribute */ <div foo="Ä"> in standards mode assert_equals: rule didn't parse into CSSOM expected 1 but got 0
-FAIL [foo|='ä' s] /* COMBINING in attribute */ <div foo="Ä"> with querySelector in standards mode The string did not match the expected pattern.
+FAIL [foo|='ä' s] /* COMBINING in attribute */ <div foo="Ä"> with querySelector in standards mode '[foo|='ä' s] /* COMBINING in attribute */' is not a valid selector.
 FAIL [foo='Ä' s] /* COMBINING in attribute */ <div foo="ä"> in standards mode assert_equals: rule didn't parse into CSSOM expected 1 but got 0
-FAIL [foo='Ä' s] /* COMBINING in attribute */ <div foo="ä"> with querySelector in standards mode The string did not match the expected pattern.
+FAIL [foo='Ä' s] /* COMBINING in attribute */ <div foo="ä"> with querySelector in standards mode '[foo='Ä' s] /* COMBINING in attribute */' is not a valid selector.
 FAIL [foo='Ä' s] /* COMBINING in attribute */ <div foo="Ä"> in standards mode assert_equals: rule didn't parse into CSSOM expected 1 but got 0
-FAIL [foo='Ä' s] /* COMBINING in attribute */ <div foo="Ä"> with querySelector in standards mode The string did not match the expected pattern.
+FAIL [foo='Ä' s] /* COMBINING in attribute */ <div foo="Ä"> with querySelector in standards mode '[foo='Ä' s] /* COMBINING in attribute */' is not a valid selector.
 FAIL [foo='ä' s] /* COMBINING in selector */ <div foo="a"> in standards mode assert_equals: rule didn't parse into CSSOM expected 1 but got 0
-FAIL [foo='ä' s] /* COMBINING in selector */ <div foo="a"> with querySelector in standards mode The string did not match the expected pattern.
+FAIL [foo='ä' s] /* COMBINING in selector */ <div foo="a"> with querySelector in standards mode '[foo='ä' s] /* COMBINING in selector */' is not a valid selector.
 FAIL [foo='ä' s] /* COMBINING in selector */ <div foo="A"> in standards mode assert_equals: rule didn't parse into CSSOM expected 1 but got 0
-FAIL [foo='ä' s] /* COMBINING in selector */ <div foo="A"> with querySelector in standards mode The string did not match the expected pattern.
+FAIL [foo='ä' s] /* COMBINING in selector */ <div foo="A"> with querySelector in standards mode '[foo='ä' s] /* COMBINING in selector */' is not a valid selector.
 FAIL [foo='Ä' s] /* COMBINING in selector */ <div foo="a"> in standards mode assert_equals: rule didn't parse into CSSOM expected 1 but got 0
-FAIL [foo='Ä' s] /* COMBINING in selector */ <div foo="a"> with querySelector in standards mode The string did not match the expected pattern.
+FAIL [foo='Ä' s] /* COMBINING in selector */ <div foo="a"> with querySelector in standards mode '[foo='Ä' s] /* COMBINING in selector */' is not a valid selector.
 FAIL [foo='Ä' s] /* COMBINING in selector */ <div foo="A"> in standards mode assert_equals: rule didn't parse into CSSOM expected 1 but got 0
-FAIL [foo='Ä' s] /* COMBINING in selector */ <div foo="A"> with querySelector in standards mode The string did not match the expected pattern.
+FAIL [foo='Ä' s] /* COMBINING in selector */ <div foo="A"> with querySelector in standards mode '[foo='Ä' s] /* COMBINING in selector */' is not a valid selector.
 FAIL [foo='a' s] /* COMBINING in attribute */ <div foo="ä"> in standards mode assert_equals: rule didn't parse into CSSOM expected 1 but got 0
-FAIL [foo='a' s] /* COMBINING in attribute */ <div foo="ä"> with querySelector in standards mode The string did not match the expected pattern.
+FAIL [foo='a' s] /* COMBINING in attribute */ <div foo="ä"> with querySelector in standards mode '[foo='a' s] /* COMBINING in attribute */' is not a valid selector.
 FAIL [foo='A' s] /* COMBINING in attribute */ <div foo="ä"> in standards mode assert_equals: rule didn't parse into CSSOM expected 1 but got 0
-FAIL [foo='A' s] /* COMBINING in attribute */ <div foo="ä"> with querySelector in standards mode The string did not match the expected pattern.
+FAIL [foo='A' s] /* COMBINING in attribute */ <div foo="ä"> with querySelector in standards mode '[foo='A' s] /* COMBINING in attribute */' is not a valid selector.
 FAIL [foo='a' s] /* COMBINING in attribute */ <div foo="Ä"> in standards mode assert_equals: rule didn't parse into CSSOM expected 1 but got 0
-FAIL [foo='a' s] /* COMBINING in attribute */ <div foo="Ä"> with querySelector in standards mode The string did not match the expected pattern.
+FAIL [foo='a' s] /* COMBINING in attribute */ <div foo="Ä"> with querySelector in standards mode '[foo='a' s] /* COMBINING in attribute */' is not a valid selector.
 FAIL [foo='A' s] /* COMBINING in attribute */ <div foo="Ä"> in standards mode assert_equals: rule didn't parse into CSSOM expected 1 but got 0
-FAIL [foo='A' s] /* COMBINING in attribute */ <div foo="Ä"> with querySelector in standards mode The string did not match the expected pattern.
+FAIL [foo='A' s] /* COMBINING in attribute */ <div foo="Ä"> with querySelector in standards mode '[foo='A' s] /* COMBINING in attribute */' is not a valid selector.
 FAIL [foo='i' s] <div foo="İ"> in standards mode assert_equals: rule didn't parse into CSSOM expected 1 but got 0
-FAIL [foo='i' s] <div foo="İ"> with querySelector in standards mode The string did not match the expected pattern.
+FAIL [foo='i' s] <div foo="İ"> with querySelector in standards mode '[foo='i' s]' is not a valid selector.
 FAIL [foo='i' s] <div foo="ı"> in standards mode assert_equals: rule didn't parse into CSSOM expected 1 but got 0
-FAIL [foo='i' s] <div foo="ı"> with querySelector in standards mode The string did not match the expected pattern.
+FAIL [foo='i' s] <div foo="ı"> with querySelector in standards mode '[foo='i' s]' is not a valid selector.
 FAIL [foo='I' s] <div foo="İ"> in standards mode assert_equals: rule didn't parse into CSSOM expected 1 but got 0
-FAIL [foo='I' s] <div foo="İ"> with querySelector in standards mode The string did not match the expected pattern.
+FAIL [foo='I' s] <div foo="İ"> with querySelector in standards mode '[foo='I' s]' is not a valid selector.
 FAIL [foo='I' s] <div foo="ı"> in standards mode assert_equals: rule didn't parse into CSSOM expected 1 but got 0
-FAIL [foo='I' s] <div foo="ı"> with querySelector in standards mode The string did not match the expected pattern.
+FAIL [foo='I' s] <div foo="ı"> with querySelector in standards mode '[foo='I' s]' is not a valid selector.
 FAIL [foo='İ' s] <div foo="i"> in standards mode assert_equals: rule didn't parse into CSSOM expected 1 but got 0
-FAIL [foo='İ' s] <div foo="i"> with querySelector in standards mode The string did not match the expected pattern.
+FAIL [foo='İ' s] <div foo="i"> with querySelector in standards mode '[foo='İ' s]' is not a valid selector.
 FAIL [foo='ı' s] <div foo="i"> in standards mode assert_equals: rule didn't parse into CSSOM expected 1 but got 0
-FAIL [foo='ı' s] <div foo="i"> with querySelector in standards mode The string did not match the expected pattern.
+FAIL [foo='ı' s] <div foo="i"> with querySelector in standards mode '[foo='ı' s]' is not a valid selector.
 FAIL [foo='İ' s] <div foo="I"> in standards mode assert_equals: rule didn't parse into CSSOM expected 1 but got 0
-FAIL [foo='İ' s] <div foo="I"> with querySelector in standards mode The string did not match the expected pattern.
+FAIL [foo='İ' s] <div foo="I"> with querySelector in standards mode '[foo='İ' s]' is not a valid selector.
 FAIL [foo='ı' s] <div foo="I"> in standards mode assert_equals: rule didn't parse into CSSOM expected 1 but got 0
-FAIL [foo='ı' s] <div foo="I"> with querySelector in standards mode The string did not match the expected pattern.
+FAIL [foo='ı' s] <div foo="I"> with querySelector in standards mode '[foo='ı' s]' is not a valid selector.
 FAIL [foo='bar' s] <div foo="x" {a}foo="BAR"> in standards mode assert_equals: rule didn't parse into CSSOM expected 1 but got 0
-FAIL [foo='bar' s] <div foo="x" {a}foo="BAR"> with querySelector in standards mode The string did not match the expected pattern.
+FAIL [foo='bar' s] <div foo="x" {a}foo="BAR"> with querySelector in standards mode '[foo='bar' s]' is not a valid selector.
 FAIL [|foo='bar' s] <div foo="x" {a}foo="BAR"> in standards mode assert_equals: rule didn't parse into CSSOM expected 1 but got 0
-FAIL [|foo='bar' s] <div foo="x" {a}foo="BAR"> with querySelector in standards mode The string did not match the expected pattern.
+FAIL [|foo='bar' s] <div foo="x" {a}foo="BAR"> with querySelector in standards mode '[|foo='bar' s]' is not a valid selector.
 FAIL [foo='bar' s] <div FOO="bar"> in standards mode assert_equals: rule didn't parse into CSSOM expected 1 but got 0
-FAIL [foo='bar' s] <div FOO="bar"> with querySelector in standards mode The string did not match the expected pattern.
+FAIL [foo='bar' s] <div FOO="bar"> with querySelector in standards mode '[foo='bar' s]' is not a valid selector.
 FAIL [foo='	' s] /* tab in selector */ <div foo=" "> in standards mode assert_equals: rule didn't parse into CSSOM expected 1 but got 0
-FAIL [foo='	' s] /* tab in selector */ <div foo=" "> with querySelector in standards mode The string did not match the expected pattern.
+FAIL [foo='	' s] /* tab in selector */ <div foo=" "> with querySelector in standards mode '[foo='	' s] /* tab in selector */' is not a valid selector.
 FAIL [foo=' ' s] /* tab in attribute */ <div foo="	"> in standards mode assert_equals: rule didn't parse into CSSOM expected 1 but got 0
-FAIL [foo=' ' s] /* tab in attribute */ <div foo="	"> with querySelector in standards mode The string did not match the expected pattern.
+FAIL [foo=' ' s] /* tab in attribute */ <div foo="	"> with querySelector in standards mode '[foo=' ' s] /* tab in attribute */' is not a valid selector.
 FAIL @namespace x 'a'; [x|foo='' s] <div {A}foo=""> in standards mode assert_equals: rule didn't parse into CSSOM expected 2 but got 1
 FAIL @namespace x 'A'; [x|foo='' s] <div {a}foo=""> in standards mode assert_equals: rule didn't parse into CSSOM expected 2 but got 1
 FAIL [foo='bar' s][foo='bar'] <div foo="BAR"> in standards mode assert_equals: rule didn't parse into CSSOM expected 1 but got 0
-FAIL [foo='bar' s][foo='bar'] <div foo="BAR"> with querySelector in standards mode The string did not match the expected pattern.
+FAIL [foo='bar' s][foo='bar'] <div foo="BAR"> with querySelector in standards mode '[foo='bar' s][foo='bar']' is not a valid selector.
 FAIL [foo='bar' s] <div baz="BAR"> in standards mode assert_equals: rule didn't parse into CSSOM expected 1 but got 0
-FAIL [foo='bar' s] <div baz="BAR"> with querySelector in standards mode The string did not match the expected pattern.
+FAIL [foo='bar' s] <div baz="BAR"> with querySelector in standards mode '[foo='bar' s]' is not a valid selector.
 FAIL [foo='bar' s] <div foo="BAR"> in standards mode assert_equals: rule didn't parse into CSSOM expected 1 but got 0
-FAIL [foo='bar' s] <div foo="BAR"> with querySelector in standards mode The string did not match the expected pattern.
+FAIL [foo='bar' s] <div foo="BAR"> with querySelector in standards mode '[foo='bar' s]' is not a valid selector.
 FAIL [foo='ä' s] /* COMBINING in both */ <div foo="Ä"> in standards mode assert_equals: rule didn't parse into CSSOM expected 1 but got 0
-FAIL [foo='ä' s] /* COMBINING in both */ <div foo="Ä"> with querySelector in standards mode The string did not match the expected pattern.
+FAIL [foo='ä' s] /* COMBINING in both */ <div foo="Ä"> with querySelector in standards mode '[foo='ä' s] /* COMBINING in both */' is not a valid selector.
 FAIL [foo='Ä' s] /* COMBINING in both */ <div foo="ä"> in standards mode assert_equals: rule didn't parse into CSSOM expected 1 but got 0
-FAIL [foo='Ä' s] /* COMBINING in both */ <div foo="ä"> with querySelector in standards mode The string did not match the expected pattern.
+FAIL [foo='Ä' s] /* COMBINING in both */ <div foo="ä"> with querySelector in standards mode '[foo='Ä' s] /* COMBINING in both */' is not a valid selector.
 FAIL [*|foo='bar' s] <div foo="x" {a}foo="x" {b}foo="BAR" {c}foo="x"> in standards mode assert_equals: rule didn't parse into CSSOM expected 1 but got 0
-FAIL [*|foo='bar' s] <div foo="x" {a}foo="x" {b}foo="BAR" {c}foo="x"> with querySelector in standards mode The string did not match the expected pattern.
+FAIL [*|foo='bar' s] <div foo="x" {a}foo="x" {b}foo="BAR" {c}foo="x"> with querySelector in standards mode '[*|foo='bar' s]' is not a valid selector.
 FAIL [*|foo='bar' s] <div foo="BAR" {a}foo="x" {b}foo="x" {c}foo="x"> in standards mode assert_equals: rule didn't parse into CSSOM expected 1 but got 0
-FAIL [*|foo='bar' s] <div foo="BAR" {a}foo="x" {b}foo="x" {c}foo="x"> with querySelector in standards mode The string did not match the expected pattern.
+FAIL [*|foo='bar' s] <div foo="BAR" {a}foo="x" {b}foo="x" {c}foo="x"> with querySelector in standards mode '[*|foo='bar' s]' is not a valid selector.
 FAIL [align='left' s] <div align="LEFT"> in standards mode assert_equals: rule didn't parse into CSSOM expected 1 but got 0
-FAIL [align='left' s] <div align="LEFT"> with querySelector in standards mode The string did not match the expected pattern.
+FAIL [align='left' s] <div align="LEFT"> with querySelector in standards mode '[align='left' s]' is not a valid selector.
 FAIL [align='LEFT' s] <div align="left"> in standards mode assert_equals: rule didn't parse into CSSOM expected 1 but got 0
-FAIL [align='LEFT' s] <div align="left"> with querySelector in standards mode The string did not match the expected pattern.
+FAIL [align='LEFT' s] <div align="left"> with querySelector in standards mode '[align='LEFT' s]' is not a valid selector.
 FAIL [class~='a' s] <div class="X A B"> in standards mode assert_equals: rule didn't parse into CSSOM expected 1 but got 0
-FAIL [class~='a' s] <div class="X A B"> with querySelector in standards mode The string did not match the expected pattern.
+FAIL [class~='a' s] <div class="X A B"> with querySelector in standards mode '[class~='a' s]' is not a valid selector.
 FAIL [class~='A' s] <div class="x a b"> in standards mode assert_equals: rule didn't parse into CSSOM expected 1 but got 0
-FAIL [class~='A' s] <div class="x a b"> with querySelector in standards mode The string did not match the expected pattern.
+FAIL [class~='A' s] <div class="x a b"> with querySelector in standards mode '[class~='A' s]' is not a valid selector.
 FAIL [id^='a' s] <div id="AB"> in standards mode assert_equals: rule didn't parse into CSSOM expected 1 but got 0
-FAIL [id^='a' s] <div id="AB"> with querySelector in standards mode The string did not match the expected pattern.
+FAIL [id^='a' s] <div id="AB"> with querySelector in standards mode '[id^='a' s]' is not a valid selector.
 FAIL [id$='A' s] <div id="xa"> in standards mode assert_equals: rule didn't parse into CSSOM expected 1 but got 0
-FAIL [id$='A' s] <div id="xa"> with querySelector in standards mode The string did not match the expected pattern.
+FAIL [id$='A' s] <div id="xa"> with querySelector in standards mode '[id$='A' s]' is not a valid selector.
 FAIL [lang|='a' s] <div lang="A-B"> in standards mode assert_equals: rule didn't parse into CSSOM expected 1 but got 0
-FAIL [lang|='a' s] <div lang="A-B"> with querySelector in standards mode The string did not match the expected pattern.
+FAIL [lang|='a' s] <div lang="A-B"> with querySelector in standards mode '[lang|='a' s]' is not a valid selector.
 FAIL [lang*='A' s] <div lang="xab"> in standards mode assert_equals: rule didn't parse into CSSOM expected 1 but got 0
-FAIL [lang*='A' s] <div lang="xab"> with querySelector in standards mode The string did not match the expected pattern.
+FAIL [lang*='A' s] <div lang="xab"> with querySelector in standards mode '[lang*='A' s]' is not a valid selector.
 FAIL [*|lang='a' s] <div {http://www.w3.org/XML/1998/namespace}lang="A"> in standards mode assert_equals: rule didn't parse into CSSOM expected 1 but got 0
-FAIL [*|lang='a' s] <div {http://www.w3.org/XML/1998/namespace}lang="A"> with querySelector in standards mode The string did not match the expected pattern.
+FAIL [*|lang='a' s] <div {http://www.w3.org/XML/1998/namespace}lang="A"> with querySelector in standards mode '[*|lang='a' s]' is not a valid selector.
 FAIL [*|lang='A' s] <div {http://www.w3.org/XML/1998/namespace}lang="a"> in standards mode assert_equals: rule didn't parse into CSSOM expected 1 but got 0
-FAIL [*|lang='A' s] <div {http://www.w3.org/XML/1998/namespace}lang="a"> with querySelector in standards mode The string did not match the expected pattern.
+FAIL [*|lang='A' s] <div {http://www.w3.org/XML/1998/namespace}lang="a"> with querySelector in standards mode '[*|lang='A' s]' is not a valid selector.
 FAIL @namespace x 'http://www.w3.org/XML/1998/namespace'; [x|lang='A' s] <div {http://www.w3.org/XML/1998/namespace}lang="a"> in standards mode assert_equals: rule didn't parse into CSSOM expected 2 but got 1
 FAIL [foo='bar' s][foo='bar' s] <div foo="BAR"> in standards mode assert_equals: rule didn't parse into CSSOM expected 1 but got 0
-FAIL [foo='bar' s][foo='bar' s] <div foo="BAR"> with querySelector in standards mode The string did not match the expected pattern.
+FAIL [foo='bar' s][foo='bar' s] <div foo="BAR"> with querySelector in standards mode '[foo='bar' s][foo='bar' s]' is not a valid selector.
 FAIL [foo='BAR' s][foo='bar'] <div foo="BAR"> in standards mode assert_equals: rule didn't parse into CSSOM expected 1 but got 0
-FAIL [foo='BAR' s][foo='bar'] <div foo="BAR"> with querySelector in standards mode The string did not match the expected pattern.
+FAIL [foo='BAR' s][foo='bar'] <div foo="BAR"> with querySelector in standards mode '[foo='BAR' s][foo='bar']' is not a valid selector.
 FAIL [foo='bar'][foo='BAR' s] <div foo="BAR"> in standards mode assert_equals: rule didn't parse into CSSOM expected 1 but got 0
-FAIL [foo='bar'][foo='BAR' s] <div foo="BAR"> with querySelector in standards mode The string did not match the expected pattern.
+FAIL [foo='bar'][foo='BAR' s] <div foo="BAR"> with querySelector in standards mode '[foo='bar'][foo='BAR' s]' is not a valid selector.
 FAIL [foo='BAR'][foo='bar' s] <div foo="BAR"> in standards mode assert_equals: rule didn't parse into CSSOM expected 1 but got 0
-FAIL [foo='BAR'][foo='bar' s] <div foo="BAR"> with querySelector in standards mode The string did not match the expected pattern.
+FAIL [foo='BAR'][foo='bar' s] <div foo="BAR"> with querySelector in standards mode '[foo='BAR'][foo='bar' s]' is not a valid selector.
 FAIL [foo='bar' s][foo='BAR'] <div foo="bar"> in standards mode assert_equals: rule didn't parse into CSSOM expected 1 but got 0
-FAIL [foo='bar' s][foo='BAR'] <div foo="bar"> with querySelector in standards mode The string did not match the expected pattern.
+FAIL [foo='bar' s][foo='BAR'] <div foo="bar"> with querySelector in standards mode '[foo='bar' s][foo='BAR']' is not a valid selector.
 PASS [foo='BAR'] /* sanity check (match) */ <div foo="BAR"> in quirks mode
 PASS [foo='BAR'] /* sanity check (match) */ <div foo="BAR"> with querySelector in quirks mode
 PASS [foo='bar'] /* sanity check (match) */ <div foo="bar"> in quirks mode
@@ -379,38 +379,38 @@ PASS [foo='BAR'][foo='bar' i] <div foo="BAR"> with querySelector in quirks mode
 PASS [foo='bar' i][foo='BAR'] <div foo="BAR"> in quirks mode
 PASS [foo='bar' i][foo='BAR'] <div foo="BAR"> with querySelector in quirks mode
 FAIL [foo='bar' s] <div foo="bar"> in quirks mode assert_equals: rule didn't parse into CSSOM expected 1 but got 0
-FAIL [foo='bar' s] <div foo="bar"> with querySelector in quirks mode The string did not match the expected pattern.
+FAIL [foo='bar' s] <div foo="bar"> with querySelector in quirks mode '[foo='bar' s]' is not a valid selector.
 FAIL [foo='' s] <div foo=""> in quirks mode assert_equals: rule didn't parse into CSSOM expected 1 but got 0
-FAIL [foo='' s] <div foo=""> with querySelector in quirks mode The string did not match the expected pattern.
+FAIL [foo='' s] <div foo=""> with querySelector in quirks mode '[foo='' s]' is not a valid selector.
 FAIL [foo='ä' s] /* COMBINING in both */ <div foo="ä"> in quirks mode assert_equals: rule didn't parse into CSSOM expected 1 but got 0
-FAIL [foo='ä' s] /* COMBINING in both */ <div foo="ä"> with querySelector in quirks mode The string did not match the expected pattern.
+FAIL [foo='ä' s] /* COMBINING in both */ <div foo="ä"> with querySelector in quirks mode '[foo='ä' s] /* COMBINING in both */' is not a valid selector.
 FAIL [*|foo='bar' s] <div foo="x" {a}foo="x" {b}foo="bar" {c}foo="x"> in quirks mode assert_equals: rule didn't parse into CSSOM expected 1 but got 0
-FAIL [*|foo='bar' s] <div foo="x" {a}foo="x" {b}foo="bar" {c}foo="x"> with querySelector in quirks mode The string did not match the expected pattern.
+FAIL [*|foo='bar' s] <div foo="x" {a}foo="x" {b}foo="bar" {c}foo="x"> with querySelector in quirks mode '[*|foo='bar' s]' is not a valid selector.
 FAIL [*|foo='bar' s] <div foo="bar" {a}foo="x" {b}foo="x" {c}foo="x"> in quirks mode assert_equals: rule didn't parse into CSSOM expected 1 but got 0
-FAIL [*|foo='bar' s] <div foo="bar" {a}foo="x" {b}foo="x" {c}foo="x"> with querySelector in quirks mode The string did not match the expected pattern.
+FAIL [*|foo='bar' s] <div foo="bar" {a}foo="x" {b}foo="x" {c}foo="x"> with querySelector in quirks mode '[*|foo='bar' s]' is not a valid selector.
 FAIL [align='left' s] <div align="left"> in quirks mode assert_equals: rule didn't parse into CSSOM expected 1 but got 0
-FAIL [align='left' s] <div align="left"> with querySelector in quirks mode The string did not match the expected pattern.
+FAIL [align='left' s] <div align="left"> with querySelector in quirks mode '[align='left' s]' is not a valid selector.
 FAIL [align='LEFT' s] <div align="LEFT"> in quirks mode assert_equals: rule didn't parse into CSSOM expected 1 but got 0
-FAIL [align='LEFT' s] <div align="LEFT"> with querySelector in quirks mode The string did not match the expected pattern.
+FAIL [align='LEFT' s] <div align="LEFT"> with querySelector in quirks mode '[align='LEFT' s]' is not a valid selector.
 FAIL [class~='a' s] <div class="x a b"> in quirks mode assert_equals: rule didn't parse into CSSOM expected 1 but got 0
-FAIL [class~='a' s] <div class="x a b"> with querySelector in quirks mode The string did not match the expected pattern.
+FAIL [class~='a' s] <div class="x a b"> with querySelector in quirks mode '[class~='a' s]' is not a valid selector.
 FAIL [class~='A' s] <div class="X A B"> in quirks mode assert_equals: rule didn't parse into CSSOM expected 1 but got 0
-FAIL [class~='A' s] <div class="X A B"> with querySelector in quirks mode The string did not match the expected pattern.
+FAIL [class~='A' s] <div class="X A B"> with querySelector in quirks mode '[class~='A' s]' is not a valid selector.
 FAIL [id^='a' s] <div id="ab"> in quirks mode assert_equals: rule didn't parse into CSSOM expected 1 but got 0
-FAIL [id^='a' s] <div id="ab"> with querySelector in quirks mode The string did not match the expected pattern.
+FAIL [id^='a' s] <div id="ab"> with querySelector in quirks mode '[id^='a' s]' is not a valid selector.
 FAIL [id$='A' s] <div id="XA"> in quirks mode assert_equals: rule didn't parse into CSSOM expected 1 but got 0
-FAIL [id$='A' s] <div id="XA"> with querySelector in quirks mode The string did not match the expected pattern.
+FAIL [id$='A' s] <div id="XA"> with querySelector in quirks mode '[id$='A' s]' is not a valid selector.
 FAIL [lang|='a' s] <div lang="a-b"> in quirks mode assert_equals: rule didn't parse into CSSOM expected 1 but got 0
-FAIL [lang|='a' s] <div lang="a-b"> with querySelector in quirks mode The string did not match the expected pattern.
+FAIL [lang|='a' s] <div lang="a-b"> with querySelector in quirks mode '[lang|='a' s]' is not a valid selector.
 FAIL [lang*='A' s] <div lang="XAB"> in quirks mode assert_equals: rule didn't parse into CSSOM expected 1 but got 0
-FAIL [lang*='A' s] <div lang="XAB"> with querySelector in quirks mode The string did not match the expected pattern.
+FAIL [lang*='A' s] <div lang="XAB"> with querySelector in quirks mode '[lang*='A' s]' is not a valid selector.
 FAIL [*|lang='a' s] <div {http://www.w3.org/XML/1998/namespace}lang="a"> in quirks mode assert_equals: rule didn't parse into CSSOM expected 1 but got 0
-FAIL [*|lang='a' s] <div {http://www.w3.org/XML/1998/namespace}lang="a"> with querySelector in quirks mode The string did not match the expected pattern.
+FAIL [*|lang='a' s] <div {http://www.w3.org/XML/1998/namespace}lang="a"> with querySelector in quirks mode '[*|lang='a' s]' is not a valid selector.
 FAIL [*|lang='A' s] <div {http://www.w3.org/XML/1998/namespace}lang="A"> in quirks mode assert_equals: rule didn't parse into CSSOM expected 1 but got 0
-FAIL [*|lang='A' s] <div {http://www.w3.org/XML/1998/namespace}lang="A"> with querySelector in quirks mode The string did not match the expected pattern.
+FAIL [*|lang='A' s] <div {http://www.w3.org/XML/1998/namespace}lang="A"> with querySelector in quirks mode '[*|lang='A' s]' is not a valid selector.
 FAIL @namespace x 'http://www.w3.org/XML/1998/namespace'; [x|lang='A' s] <div {http://www.w3.org/XML/1998/namespace}lang="A"> in quirks mode assert_equals: rule didn't parse into CSSOM expected 2 but got 1
 FAIL [foo='BAR' s][foo='BAR' s] <div foo="BAR"> in quirks mode assert_equals: rule didn't parse into CSSOM expected 1 but got 0
-FAIL [foo='BAR' s][foo='BAR' s] <div foo="BAR"> with querySelector in quirks mode The string did not match the expected pattern.
+FAIL [foo='BAR' s][foo='BAR' s] <div foo="BAR"> with querySelector in quirks mode '[foo='BAR' s][foo='BAR' s]' is not a valid selector.
 PASS [align='left'] /* sanity check (match HTML) */ <div align="LEFT"> in quirks mode
 PASS [align='left'] /* sanity check (match HTML) */ <div align="LEFT"> with querySelector in quirks mode
 PASS [align='LEFT'] /* sanity check (match HTML) */ <div align="left"> in quirks mode
@@ -527,120 +527,120 @@ PASS [foo*='É' i] <div foo="é"> with querySelector in quirks mode
 PASS [foo|='É' i] <div foo="é"> in quirks mode
 PASS [foo|='É' i] <div foo="é"> with querySelector in quirks mode
 FAIL [foo='' s] <div foo="BAR"> in quirks mode assert_equals: rule didn't parse into CSSOM expected 1 but got 0
-FAIL [foo='' s] <div foo="BAR"> with querySelector in quirks mode The string did not match the expected pattern.
+FAIL [foo='' s] <div foo="BAR"> with querySelector in quirks mode '[foo='' s]' is not a valid selector.
 FAIL [foo='\0' s] /* \0 in selector */ <div foo=""> in quirks mode assert_equals: rule didn't parse into CSSOM expected 1 but got 0
-FAIL [foo='\0' s] /* \0 in selector */ <div foo=""> with querySelector in quirks mode The string did not match the expected pattern.
+FAIL [foo='\0' s] /* \0 in selector */ <div foo=""> with querySelector in quirks mode '[foo='\0' s] /* \0 in selector */' is not a valid selector.
 FAIL [foo='' s] /* \0 in attribute */ <div foo="\0"> in quirks mode assert_equals: rule didn't parse into CSSOM expected 1 but got 0
-FAIL [foo='' s] /* \0 in attribute */ <div foo="\0"> with querySelector in quirks mode The string did not match the expected pattern.
+FAIL [foo='' s] /* \0 in attribute */ <div foo="\0"> with querySelector in quirks mode '[foo='' s] /* \0 in attribute */' is not a valid selector.
 FAIL [foo='ä' s] <div foo="Ä"> in quirks mode assert_equals: rule didn't parse into CSSOM expected 1 but got 0
-FAIL [foo='ä' s] <div foo="Ä"> with querySelector in quirks mode The string did not match the expected pattern.
+FAIL [foo='ä' s] <div foo="Ä"> with querySelector in quirks mode '[foo='ä' s]' is not a valid selector.
 FAIL [foo='Ä' s] <div foo="ä"> in quirks mode assert_equals: rule didn't parse into CSSOM expected 1 but got 0
-FAIL [foo='Ä' s] <div foo="ä"> with querySelector in quirks mode The string did not match the expected pattern.
+FAIL [foo='Ä' s] <div foo="ä"> with querySelector in quirks mode '[foo='Ä' s]' is not a valid selector.
 FAIL [foo='ä' s] /* COMBINING in selector */ <div foo="Ä"> in quirks mode assert_equals: rule didn't parse into CSSOM expected 1 but got 0
-FAIL [foo='ä' s] /* COMBINING in selector */ <div foo="Ä"> with querySelector in quirks mode The string did not match the expected pattern.
+FAIL [foo='ä' s] /* COMBINING in selector */ <div foo="Ä"> with querySelector in quirks mode '[foo='ä' s] /* COMBINING in selector */' is not a valid selector.
 FAIL [foo~='ä' s] /* COMBINING in selector */ <div foo="ä"> in quirks mode assert_equals: rule didn't parse into CSSOM expected 1 but got 0
-FAIL [foo~='ä' s] /* COMBINING in selector */ <div foo="ä"> with querySelector in quirks mode The string did not match the expected pattern.
+FAIL [foo~='ä' s] /* COMBINING in selector */ <div foo="ä"> with querySelector in quirks mode '[foo~='ä' s] /* COMBINING in selector */' is not a valid selector.
 FAIL [foo^='Ä' s] /* COMBINING in selector */ <div foo="Ä"> in quirks mode assert_equals: rule didn't parse into CSSOM expected 1 but got 0
-FAIL [foo^='Ä' s] /* COMBINING in selector */ <div foo="Ä"> with querySelector in quirks mode The string did not match the expected pattern.
+FAIL [foo^='Ä' s] /* COMBINING in selector */ <div foo="Ä"> with querySelector in quirks mode '[foo^='Ä' s] /* COMBINING in selector */' is not a valid selector.
 FAIL [foo$='Ä' s] /* COMBINING in selector */ <div foo="ä"> in quirks mode assert_equals: rule didn't parse into CSSOM expected 1 but got 0
-FAIL [foo$='Ä' s] /* COMBINING in selector */ <div foo="ä"> with querySelector in quirks mode The string did not match the expected pattern.
+FAIL [foo$='Ä' s] /* COMBINING in selector */ <div foo="ä"> with querySelector in quirks mode '[foo$='Ä' s] /* COMBINING in selector */' is not a valid selector.
 FAIL [foo*='ä' s] /* COMBINING in attribute */ <div foo="ä"> in quirks mode assert_equals: rule didn't parse into CSSOM expected 1 but got 0
-FAIL [foo*='ä' s] /* COMBINING in attribute */ <div foo="ä"> with querySelector in quirks mode The string did not match the expected pattern.
+FAIL [foo*='ä' s] /* COMBINING in attribute */ <div foo="ä"> with querySelector in quirks mode '[foo*='ä' s] /* COMBINING in attribute */' is not a valid selector.
 FAIL [foo|='ä' s] /* COMBINING in attribute */ <div foo="Ä"> in quirks mode assert_equals: rule didn't parse into CSSOM expected 1 but got 0
-FAIL [foo|='ä' s] /* COMBINING in attribute */ <div foo="Ä"> with querySelector in quirks mode The string did not match the expected pattern.
+FAIL [foo|='ä' s] /* COMBINING in attribute */ <div foo="Ä"> with querySelector in quirks mode '[foo|='ä' s] /* COMBINING in attribute */' is not a valid selector.
 FAIL [foo='Ä' s] /* COMBINING in attribute */ <div foo="ä"> in quirks mode assert_equals: rule didn't parse into CSSOM expected 1 but got 0
-FAIL [foo='Ä' s] /* COMBINING in attribute */ <div foo="ä"> with querySelector in quirks mode The string did not match the expected pattern.
+FAIL [foo='Ä' s] /* COMBINING in attribute */ <div foo="ä"> with querySelector in quirks mode '[foo='Ä' s] /* COMBINING in attribute */' is not a valid selector.
 FAIL [foo='Ä' s] /* COMBINING in attribute */ <div foo="Ä"> in quirks mode assert_equals: rule didn't parse into CSSOM expected 1 but got 0
-FAIL [foo='Ä' s] /* COMBINING in attribute */ <div foo="Ä"> with querySelector in quirks mode The string did not match the expected pattern.
+FAIL [foo='Ä' s] /* COMBINING in attribute */ <div foo="Ä"> with querySelector in quirks mode '[foo='Ä' s] /* COMBINING in attribute */' is not a valid selector.
 FAIL [foo='ä' s] /* COMBINING in selector */ <div foo="a"> in quirks mode assert_equals: rule didn't parse into CSSOM expected 1 but got 0
-FAIL [foo='ä' s] /* COMBINING in selector */ <div foo="a"> with querySelector in quirks mode The string did not match the expected pattern.
+FAIL [foo='ä' s] /* COMBINING in selector */ <div foo="a"> with querySelector in quirks mode '[foo='ä' s] /* COMBINING in selector */' is not a valid selector.
 FAIL [foo='ä' s] /* COMBINING in selector */ <div foo="A"> in quirks mode assert_equals: rule didn't parse into CSSOM expected 1 but got 0
-FAIL [foo='ä' s] /* COMBINING in selector */ <div foo="A"> with querySelector in quirks mode The string did not match the expected pattern.
+FAIL [foo='ä' s] /* COMBINING in selector */ <div foo="A"> with querySelector in quirks mode '[foo='ä' s] /* COMBINING in selector */' is not a valid selector.
 FAIL [foo='Ä' s] /* COMBINING in selector */ <div foo="a"> in quirks mode assert_equals: rule didn't parse into CSSOM expected 1 but got 0
-FAIL [foo='Ä' s] /* COMBINING in selector */ <div foo="a"> with querySelector in quirks mode The string did not match the expected pattern.
+FAIL [foo='Ä' s] /* COMBINING in selector */ <div foo="a"> with querySelector in quirks mode '[foo='Ä' s] /* COMBINING in selector */' is not a valid selector.
 FAIL [foo='Ä' s] /* COMBINING in selector */ <div foo="A"> in quirks mode assert_equals: rule didn't parse into CSSOM expected 1 but got 0
-FAIL [foo='Ä' s] /* COMBINING in selector */ <div foo="A"> with querySelector in quirks mode The string did not match the expected pattern.
+FAIL [foo='Ä' s] /* COMBINING in selector */ <div foo="A"> with querySelector in quirks mode '[foo='Ä' s] /* COMBINING in selector */' is not a valid selector.
 FAIL [foo='a' s] /* COMBINING in attribute */ <div foo="ä"> in quirks mode assert_equals: rule didn't parse into CSSOM expected 1 but got 0
-FAIL [foo='a' s] /* COMBINING in attribute */ <div foo="ä"> with querySelector in quirks mode The string did not match the expected pattern.
+FAIL [foo='a' s] /* COMBINING in attribute */ <div foo="ä"> with querySelector in quirks mode '[foo='a' s] /* COMBINING in attribute */' is not a valid selector.
 FAIL [foo='A' s] /* COMBINING in attribute */ <div foo="ä"> in quirks mode assert_equals: rule didn't parse into CSSOM expected 1 but got 0
-FAIL [foo='A' s] /* COMBINING in attribute */ <div foo="ä"> with querySelector in quirks mode The string did not match the expected pattern.
+FAIL [foo='A' s] /* COMBINING in attribute */ <div foo="ä"> with querySelector in quirks mode '[foo='A' s] /* COMBINING in attribute */' is not a valid selector.
 FAIL [foo='a' s] /* COMBINING in attribute */ <div foo="Ä"> in quirks mode assert_equals: rule didn't parse into CSSOM expected 1 but got 0
-FAIL [foo='a' s] /* COMBINING in attribute */ <div foo="Ä"> with querySelector in quirks mode The string did not match the expected pattern.
+FAIL [foo='a' s] /* COMBINING in attribute */ <div foo="Ä"> with querySelector in quirks mode '[foo='a' s] /* COMBINING in attribute */' is not a valid selector.
 FAIL [foo='A' s] /* COMBINING in attribute */ <div foo="Ä"> in quirks mode assert_equals: rule didn't parse into CSSOM expected 1 but got 0
-FAIL [foo='A' s] /* COMBINING in attribute */ <div foo="Ä"> with querySelector in quirks mode The string did not match the expected pattern.
+FAIL [foo='A' s] /* COMBINING in attribute */ <div foo="Ä"> with querySelector in quirks mode '[foo='A' s] /* COMBINING in attribute */' is not a valid selector.
 FAIL [foo='i' s] <div foo="İ"> in quirks mode assert_equals: rule didn't parse into CSSOM expected 1 but got 0
-FAIL [foo='i' s] <div foo="İ"> with querySelector in quirks mode The string did not match the expected pattern.
+FAIL [foo='i' s] <div foo="İ"> with querySelector in quirks mode '[foo='i' s]' is not a valid selector.
 FAIL [foo='i' s] <div foo="ı"> in quirks mode assert_equals: rule didn't parse into CSSOM expected 1 but got 0
-FAIL [foo='i' s] <div foo="ı"> with querySelector in quirks mode The string did not match the expected pattern.
+FAIL [foo='i' s] <div foo="ı"> with querySelector in quirks mode '[foo='i' s]' is not a valid selector.
 FAIL [foo='I' s] <div foo="İ"> in quirks mode assert_equals: rule didn't parse into CSSOM expected 1 but got 0
-FAIL [foo='I' s] <div foo="İ"> with querySelector in quirks mode The string did not match the expected pattern.
+FAIL [foo='I' s] <div foo="İ"> with querySelector in quirks mode '[foo='I' s]' is not a valid selector.
 FAIL [foo='I' s] <div foo="ı"> in quirks mode assert_equals: rule didn't parse into CSSOM expected 1 but got 0
-FAIL [foo='I' s] <div foo="ı"> with querySelector in quirks mode The string did not match the expected pattern.
+FAIL [foo='I' s] <div foo="ı"> with querySelector in quirks mode '[foo='I' s]' is not a valid selector.
 FAIL [foo='İ' s] <div foo="i"> in quirks mode assert_equals: rule didn't parse into CSSOM expected 1 but got 0
-FAIL [foo='İ' s] <div foo="i"> with querySelector in quirks mode The string did not match the expected pattern.
+FAIL [foo='İ' s] <div foo="i"> with querySelector in quirks mode '[foo='İ' s]' is not a valid selector.
 FAIL [foo='ı' s] <div foo="i"> in quirks mode assert_equals: rule didn't parse into CSSOM expected 1 but got 0
-FAIL [foo='ı' s] <div foo="i"> with querySelector in quirks mode The string did not match the expected pattern.
+FAIL [foo='ı' s] <div foo="i"> with querySelector in quirks mode '[foo='ı' s]' is not a valid selector.
 FAIL [foo='İ' s] <div foo="I"> in quirks mode assert_equals: rule didn't parse into CSSOM expected 1 but got 0
-FAIL [foo='İ' s] <div foo="I"> with querySelector in quirks mode The string did not match the expected pattern.
+FAIL [foo='İ' s] <div foo="I"> with querySelector in quirks mode '[foo='İ' s]' is not a valid selector.
 FAIL [foo='ı' s] <div foo="I"> in quirks mode assert_equals: rule didn't parse into CSSOM expected 1 but got 0
-FAIL [foo='ı' s] <div foo="I"> with querySelector in quirks mode The string did not match the expected pattern.
+FAIL [foo='ı' s] <div foo="I"> with querySelector in quirks mode '[foo='ı' s]' is not a valid selector.
 FAIL [foo='bar' s] <div foo="x" {a}foo="BAR"> in quirks mode assert_equals: rule didn't parse into CSSOM expected 1 but got 0
-FAIL [foo='bar' s] <div foo="x" {a}foo="BAR"> with querySelector in quirks mode The string did not match the expected pattern.
+FAIL [foo='bar' s] <div foo="x" {a}foo="BAR"> with querySelector in quirks mode '[foo='bar' s]' is not a valid selector.
 FAIL [|foo='bar' s] <div foo="x" {a}foo="BAR"> in quirks mode assert_equals: rule didn't parse into CSSOM expected 1 but got 0
-FAIL [|foo='bar' s] <div foo="x" {a}foo="BAR"> with querySelector in quirks mode The string did not match the expected pattern.
+FAIL [|foo='bar' s] <div foo="x" {a}foo="BAR"> with querySelector in quirks mode '[|foo='bar' s]' is not a valid selector.
 FAIL [foo='bar' s] <div FOO="bar"> in quirks mode assert_equals: rule didn't parse into CSSOM expected 1 but got 0
-FAIL [foo='bar' s] <div FOO="bar"> with querySelector in quirks mode The string did not match the expected pattern.
+FAIL [foo='bar' s] <div FOO="bar"> with querySelector in quirks mode '[foo='bar' s]' is not a valid selector.
 FAIL [foo='	' s] /* tab in selector */ <div foo=" "> in quirks mode assert_equals: rule didn't parse into CSSOM expected 1 but got 0
-FAIL [foo='	' s] /* tab in selector */ <div foo=" "> with querySelector in quirks mode The string did not match the expected pattern.
+FAIL [foo='	' s] /* tab in selector */ <div foo=" "> with querySelector in quirks mode '[foo='	' s] /* tab in selector */' is not a valid selector.
 FAIL [foo=' ' s] /* tab in attribute */ <div foo="	"> in quirks mode assert_equals: rule didn't parse into CSSOM expected 1 but got 0
-FAIL [foo=' ' s] /* tab in attribute */ <div foo="	"> with querySelector in quirks mode The string did not match the expected pattern.
+FAIL [foo=' ' s] /* tab in attribute */ <div foo="	"> with querySelector in quirks mode '[foo=' ' s] /* tab in attribute */' is not a valid selector.
 FAIL @namespace x 'a'; [x|foo='' s] <div {A}foo=""> in quirks mode assert_equals: rule didn't parse into CSSOM expected 2 but got 1
 FAIL @namespace x 'A'; [x|foo='' s] <div {a}foo=""> in quirks mode assert_equals: rule didn't parse into CSSOM expected 2 but got 1
 FAIL [foo='bar' s][foo='bar'] <div foo="BAR"> in quirks mode assert_equals: rule didn't parse into CSSOM expected 1 but got 0
-FAIL [foo='bar' s][foo='bar'] <div foo="BAR"> with querySelector in quirks mode The string did not match the expected pattern.
+FAIL [foo='bar' s][foo='bar'] <div foo="BAR"> with querySelector in quirks mode '[foo='bar' s][foo='bar']' is not a valid selector.
 FAIL [foo='bar' s] <div baz="BAR"> in quirks mode assert_equals: rule didn't parse into CSSOM expected 1 but got 0
-FAIL [foo='bar' s] <div baz="BAR"> with querySelector in quirks mode The string did not match the expected pattern.
+FAIL [foo='bar' s] <div baz="BAR"> with querySelector in quirks mode '[foo='bar' s]' is not a valid selector.
 FAIL [foo='bar' s] <div foo="BAR"> in quirks mode assert_equals: rule didn't parse into CSSOM expected 1 but got 0
-FAIL [foo='bar' s] <div foo="BAR"> with querySelector in quirks mode The string did not match the expected pattern.
+FAIL [foo='bar' s] <div foo="BAR"> with querySelector in quirks mode '[foo='bar' s]' is not a valid selector.
 FAIL [foo='ä' s] /* COMBINING in both */ <div foo="Ä"> in quirks mode assert_equals: rule didn't parse into CSSOM expected 1 but got 0
-FAIL [foo='ä' s] /* COMBINING in both */ <div foo="Ä"> with querySelector in quirks mode The string did not match the expected pattern.
+FAIL [foo='ä' s] /* COMBINING in both */ <div foo="Ä"> with querySelector in quirks mode '[foo='ä' s] /* COMBINING in both */' is not a valid selector.
 FAIL [foo='Ä' s] /* COMBINING in both */ <div foo="ä"> in quirks mode assert_equals: rule didn't parse into CSSOM expected 1 but got 0
-FAIL [foo='Ä' s] /* COMBINING in both */ <div foo="ä"> with querySelector in quirks mode The string did not match the expected pattern.
+FAIL [foo='Ä' s] /* COMBINING in both */ <div foo="ä"> with querySelector in quirks mode '[foo='Ä' s] /* COMBINING in both */' is not a valid selector.
 FAIL [*|foo='bar' s] <div foo="x" {a}foo="x" {b}foo="BAR" {c}foo="x"> in quirks mode assert_equals: rule didn't parse into CSSOM expected 1 but got 0
-FAIL [*|foo='bar' s] <div foo="x" {a}foo="x" {b}foo="BAR" {c}foo="x"> with querySelector in quirks mode The string did not match the expected pattern.
+FAIL [*|foo='bar' s] <div foo="x" {a}foo="x" {b}foo="BAR" {c}foo="x"> with querySelector in quirks mode '[*|foo='bar' s]' is not a valid selector.
 FAIL [*|foo='bar' s] <div foo="BAR" {a}foo="x" {b}foo="x" {c}foo="x"> in quirks mode assert_equals: rule didn't parse into CSSOM expected 1 but got 0
-FAIL [*|foo='bar' s] <div foo="BAR" {a}foo="x" {b}foo="x" {c}foo="x"> with querySelector in quirks mode The string did not match the expected pattern.
+FAIL [*|foo='bar' s] <div foo="BAR" {a}foo="x" {b}foo="x" {c}foo="x"> with querySelector in quirks mode '[*|foo='bar' s]' is not a valid selector.
 FAIL [align='left' s] <div align="LEFT"> in quirks mode assert_equals: rule didn't parse into CSSOM expected 1 but got 0
-FAIL [align='left' s] <div align="LEFT"> with querySelector in quirks mode The string did not match the expected pattern.
+FAIL [align='left' s] <div align="LEFT"> with querySelector in quirks mode '[align='left' s]' is not a valid selector.
 FAIL [align='LEFT' s] <div align="left"> in quirks mode assert_equals: rule didn't parse into CSSOM expected 1 but got 0
-FAIL [align='LEFT' s] <div align="left"> with querySelector in quirks mode The string did not match the expected pattern.
+FAIL [align='LEFT' s] <div align="left"> with querySelector in quirks mode '[align='LEFT' s]' is not a valid selector.
 FAIL [class~='a' s] <div class="X A B"> in quirks mode assert_equals: rule didn't parse into CSSOM expected 1 but got 0
-FAIL [class~='a' s] <div class="X A B"> with querySelector in quirks mode The string did not match the expected pattern.
+FAIL [class~='a' s] <div class="X A B"> with querySelector in quirks mode '[class~='a' s]' is not a valid selector.
 FAIL [class~='A' s] <div class="x a b"> in quirks mode assert_equals: rule didn't parse into CSSOM expected 1 but got 0
-FAIL [class~='A' s] <div class="x a b"> with querySelector in quirks mode The string did not match the expected pattern.
+FAIL [class~='A' s] <div class="x a b"> with querySelector in quirks mode '[class~='A' s]' is not a valid selector.
 FAIL [id^='a' s] <div id="AB"> in quirks mode assert_equals: rule didn't parse into CSSOM expected 1 but got 0
-FAIL [id^='a' s] <div id="AB"> with querySelector in quirks mode The string did not match the expected pattern.
+FAIL [id^='a' s] <div id="AB"> with querySelector in quirks mode '[id^='a' s]' is not a valid selector.
 FAIL [id$='A' s] <div id="xa"> in quirks mode assert_equals: rule didn't parse into CSSOM expected 1 but got 0
-FAIL [id$='A' s] <div id="xa"> with querySelector in quirks mode The string did not match the expected pattern.
+FAIL [id$='A' s] <div id="xa"> with querySelector in quirks mode '[id$='A' s]' is not a valid selector.
 FAIL [lang|='a' s] <div lang="A-B"> in quirks mode assert_equals: rule didn't parse into CSSOM expected 1 but got 0
-FAIL [lang|='a' s] <div lang="A-B"> with querySelector in quirks mode The string did not match the expected pattern.
+FAIL [lang|='a' s] <div lang="A-B"> with querySelector in quirks mode '[lang|='a' s]' is not a valid selector.
 FAIL [lang*='A' s] <div lang="xab"> in quirks mode assert_equals: rule didn't parse into CSSOM expected 1 but got 0
-FAIL [lang*='A' s] <div lang="xab"> with querySelector in quirks mode The string did not match the expected pattern.
+FAIL [lang*='A' s] <div lang="xab"> with querySelector in quirks mode '[lang*='A' s]' is not a valid selector.
 FAIL [*|lang='a' s] <div {http://www.w3.org/XML/1998/namespace}lang="A"> in quirks mode assert_equals: rule didn't parse into CSSOM expected 1 but got 0
-FAIL [*|lang='a' s] <div {http://www.w3.org/XML/1998/namespace}lang="A"> with querySelector in quirks mode The string did not match the expected pattern.
+FAIL [*|lang='a' s] <div {http://www.w3.org/XML/1998/namespace}lang="A"> with querySelector in quirks mode '[*|lang='a' s]' is not a valid selector.
 FAIL [*|lang='A' s] <div {http://www.w3.org/XML/1998/namespace}lang="a"> in quirks mode assert_equals: rule didn't parse into CSSOM expected 1 but got 0
-FAIL [*|lang='A' s] <div {http://www.w3.org/XML/1998/namespace}lang="a"> with querySelector in quirks mode The string did not match the expected pattern.
+FAIL [*|lang='A' s] <div {http://www.w3.org/XML/1998/namespace}lang="a"> with querySelector in quirks mode '[*|lang='A' s]' is not a valid selector.
 FAIL @namespace x 'http://www.w3.org/XML/1998/namespace'; [x|lang='A' s] <div {http://www.w3.org/XML/1998/namespace}lang="a"> in quirks mode assert_equals: rule didn't parse into CSSOM expected 2 but got 1
 FAIL [foo='bar' s][foo='bar' s] <div foo="BAR"> in quirks mode assert_equals: rule didn't parse into CSSOM expected 1 but got 0
-FAIL [foo='bar' s][foo='bar' s] <div foo="BAR"> with querySelector in quirks mode The string did not match the expected pattern.
+FAIL [foo='bar' s][foo='bar' s] <div foo="BAR"> with querySelector in quirks mode '[foo='bar' s][foo='bar' s]' is not a valid selector.
 FAIL [foo='BAR' s][foo='bar'] <div foo="BAR"> in quirks mode assert_equals: rule didn't parse into CSSOM expected 1 but got 0
-FAIL [foo='BAR' s][foo='bar'] <div foo="BAR"> with querySelector in quirks mode The string did not match the expected pattern.
+FAIL [foo='BAR' s][foo='bar'] <div foo="BAR"> with querySelector in quirks mode '[foo='BAR' s][foo='bar']' is not a valid selector.
 FAIL [foo='bar'][foo='BAR' s] <div foo="BAR"> in quirks mode assert_equals: rule didn't parse into CSSOM expected 1 but got 0
-FAIL [foo='bar'][foo='BAR' s] <div foo="BAR"> with querySelector in quirks mode The string did not match the expected pattern.
+FAIL [foo='bar'][foo='BAR' s] <div foo="BAR"> with querySelector in quirks mode '[foo='bar'][foo='BAR' s]' is not a valid selector.
 FAIL [foo='BAR'][foo='bar' s] <div foo="BAR"> in quirks mode assert_equals: rule didn't parse into CSSOM expected 1 but got 0
-FAIL [foo='BAR'][foo='bar' s] <div foo="BAR"> with querySelector in quirks mode The string did not match the expected pattern.
+FAIL [foo='BAR'][foo='bar' s] <div foo="BAR"> with querySelector in quirks mode '[foo='BAR'][foo='bar' s]' is not a valid selector.
 FAIL [foo='bar' s][foo='BAR'] <div foo="bar"> in quirks mode assert_equals: rule didn't parse into CSSOM expected 1 but got 0
-FAIL [foo='bar' s][foo='BAR'] <div foo="bar"> with querySelector in quirks mode The string did not match the expected pattern.
+FAIL [foo='bar' s][foo='BAR'] <div foo="bar"> with querySelector in quirks mode '[foo='bar' s][foo='BAR']' is not a valid selector.
 PASS [foo='BAR'] /* sanity check (match) */ <div foo="BAR"> in XML
 PASS [foo='BAR'] /* sanity check (match) */ <div foo="BAR"> with querySelector in XML
 PASS [foo='bar'] /* sanity check (match) */ <div foo="bar"> in XML
@@ -700,38 +700,38 @@ PASS [foo='BAR'][foo='bar' i] <div foo="BAR"> with querySelector in XML
 PASS [foo='bar' i][foo='BAR'] <div foo="BAR"> in XML
 PASS [foo='bar' i][foo='BAR'] <div foo="BAR"> with querySelector in XML
 FAIL [foo='bar' s] <div foo="bar"> in XML assert_equals: rule didn't parse into CSSOM expected 1 but got 0
-FAIL [foo='bar' s] <div foo="bar"> with querySelector in XML The string did not match the expected pattern.
+FAIL [foo='bar' s] <div foo="bar"> with querySelector in XML '[foo='bar' s]' is not a valid selector.
 FAIL [foo='' s] <div foo=""> in XML assert_equals: rule didn't parse into CSSOM expected 1 but got 0
-FAIL [foo='' s] <div foo=""> with querySelector in XML The string did not match the expected pattern.
+FAIL [foo='' s] <div foo=""> with querySelector in XML '[foo='' s]' is not a valid selector.
 FAIL [foo='ä' s] /* COMBINING in both */ <div foo="ä"> in XML assert_equals: rule didn't parse into CSSOM expected 1 but got 0
-FAIL [foo='ä' s] /* COMBINING in both */ <div foo="ä"> with querySelector in XML The string did not match the expected pattern.
+FAIL [foo='ä' s] /* COMBINING in both */ <div foo="ä"> with querySelector in XML '[foo='ä' s] /* COMBINING in both */' is not a valid selector.
 FAIL [*|foo='bar' s] <div foo="x" {a}foo="x" {b}foo="bar" {c}foo="x"> in XML assert_equals: rule didn't parse into CSSOM expected 1 but got 0
-FAIL [*|foo='bar' s] <div foo="x" {a}foo="x" {b}foo="bar" {c}foo="x"> with querySelector in XML The string did not match the expected pattern.
+FAIL [*|foo='bar' s] <div foo="x" {a}foo="x" {b}foo="bar" {c}foo="x"> with querySelector in XML '[*|foo='bar' s]' is not a valid selector.
 FAIL [*|foo='bar' s] <div foo="bar" {a}foo="x" {b}foo="x" {c}foo="x"> in XML assert_equals: rule didn't parse into CSSOM expected 1 but got 0
-FAIL [*|foo='bar' s] <div foo="bar" {a}foo="x" {b}foo="x" {c}foo="x"> with querySelector in XML The string did not match the expected pattern.
+FAIL [*|foo='bar' s] <div foo="bar" {a}foo="x" {b}foo="x" {c}foo="x"> with querySelector in XML '[*|foo='bar' s]' is not a valid selector.
 FAIL [align='left' s] <div align="left"> in XML assert_equals: rule didn't parse into CSSOM expected 1 but got 0
-FAIL [align='left' s] <div align="left"> with querySelector in XML The string did not match the expected pattern.
+FAIL [align='left' s] <div align="left"> with querySelector in XML '[align='left' s]' is not a valid selector.
 FAIL [align='LEFT' s] <div align="LEFT"> in XML assert_equals: rule didn't parse into CSSOM expected 1 but got 0
-FAIL [align='LEFT' s] <div align="LEFT"> with querySelector in XML The string did not match the expected pattern.
+FAIL [align='LEFT' s] <div align="LEFT"> with querySelector in XML '[align='LEFT' s]' is not a valid selector.
 FAIL [class~='a' s] <div class="x a b"> in XML assert_equals: rule didn't parse into CSSOM expected 1 but got 0
-FAIL [class~='a' s] <div class="x a b"> with querySelector in XML The string did not match the expected pattern.
+FAIL [class~='a' s] <div class="x a b"> with querySelector in XML '[class~='a' s]' is not a valid selector.
 FAIL [class~='A' s] <div class="X A B"> in XML assert_equals: rule didn't parse into CSSOM expected 1 but got 0
-FAIL [class~='A' s] <div class="X A B"> with querySelector in XML The string did not match the expected pattern.
+FAIL [class~='A' s] <div class="X A B"> with querySelector in XML '[class~='A' s]' is not a valid selector.
 FAIL [id^='a' s] <div id="ab"> in XML assert_equals: rule didn't parse into CSSOM expected 1 but got 0
-FAIL [id^='a' s] <div id="ab"> with querySelector in XML The string did not match the expected pattern.
+FAIL [id^='a' s] <div id="ab"> with querySelector in XML '[id^='a' s]' is not a valid selector.
 FAIL [id$='A' s] <div id="XA"> in XML assert_equals: rule didn't parse into CSSOM expected 1 but got 0
-FAIL [id$='A' s] <div id="XA"> with querySelector in XML The string did not match the expected pattern.
+FAIL [id$='A' s] <div id="XA"> with querySelector in XML '[id$='A' s]' is not a valid selector.
 FAIL [lang|='a' s] <div lang="a-b"> in XML assert_equals: rule didn't parse into CSSOM expected 1 but got 0
-FAIL [lang|='a' s] <div lang="a-b"> with querySelector in XML The string did not match the expected pattern.
+FAIL [lang|='a' s] <div lang="a-b"> with querySelector in XML '[lang|='a' s]' is not a valid selector.
 FAIL [lang*='A' s] <div lang="XAB"> in XML assert_equals: rule didn't parse into CSSOM expected 1 but got 0
-FAIL [lang*='A' s] <div lang="XAB"> with querySelector in XML The string did not match the expected pattern.
+FAIL [lang*='A' s] <div lang="XAB"> with querySelector in XML '[lang*='A' s]' is not a valid selector.
 FAIL [*|lang='a' s] <div {http://www.w3.org/XML/1998/namespace}lang="a"> in XML assert_equals: rule didn't parse into CSSOM expected 1 but got 0
-FAIL [*|lang='a' s] <div {http://www.w3.org/XML/1998/namespace}lang="a"> with querySelector in XML The string did not match the expected pattern.
+FAIL [*|lang='a' s] <div {http://www.w3.org/XML/1998/namespace}lang="a"> with querySelector in XML '[*|lang='a' s]' is not a valid selector.
 FAIL [*|lang='A' s] <div {http://www.w3.org/XML/1998/namespace}lang="A"> in XML assert_equals: rule didn't parse into CSSOM expected 1 but got 0
-FAIL [*|lang='A' s] <div {http://www.w3.org/XML/1998/namespace}lang="A"> with querySelector in XML The string did not match the expected pattern.
+FAIL [*|lang='A' s] <div {http://www.w3.org/XML/1998/namespace}lang="A"> with querySelector in XML '[*|lang='A' s]' is not a valid selector.
 FAIL @namespace x 'http://www.w3.org/XML/1998/namespace'; [x|lang='A' s] <div {http://www.w3.org/XML/1998/namespace}lang="A"> in XML assert_equals: rule didn't parse into CSSOM expected 2 but got 1
 FAIL [foo='BAR' s][foo='BAR' s] <div foo="BAR"> in XML assert_equals: rule didn't parse into CSSOM expected 1 but got 0
-FAIL [foo='BAR' s][foo='BAR' s] <div foo="BAR"> with querySelector in XML The string did not match the expected pattern.
+FAIL [foo='BAR' s][foo='BAR' s] <div foo="BAR"> with querySelector in XML '[foo='BAR' s][foo='BAR' s]' is not a valid selector.
 PASS [missingattr] /* sanity check (no match) */ <div foo="BAR"> in XML
 PASS [missingattr] /* sanity check (no match) */ <div foo="BAR"> with querySelector in XML
 PASS [foo='bar'] /* sanity check (no match) */ <div foo="BAR"> in XML
@@ -840,119 +840,119 @@ PASS [foo*='É' i] <div foo="é"> with querySelector in XML
 PASS [foo|='É' i] <div foo="é"> in XML
 PASS [foo|='É' i] <div foo="é"> with querySelector in XML
 FAIL [foo='' s] <div foo="BAR"> in XML assert_equals: rule didn't parse into CSSOM expected 1 but got 0
-FAIL [foo='' s] <div foo="BAR"> with querySelector in XML The string did not match the expected pattern.
+FAIL [foo='' s] <div foo="BAR"> with querySelector in XML '[foo='' s]' is not a valid selector.
 FAIL [foo='\0' s] /* \0 in selector */ <div foo=""> in XML assert_equals: rule didn't parse into CSSOM expected 1 but got 0
-FAIL [foo='\0' s] /* \0 in selector */ <div foo=""> with querySelector in XML The string did not match the expected pattern.
+FAIL [foo='\0' s] /* \0 in selector */ <div foo=""> with querySelector in XML '[foo='\0' s] /* \0 in selector */' is not a valid selector.
 FAIL [foo='' s] /* \0 in attribute */ <div foo="\0"> in XML assert_equals: rule didn't parse into CSSOM expected 1 but got 0
-FAIL [foo='' s] /* \0 in attribute */ <div foo="\0"> with querySelector in XML The string did not match the expected pattern.
+FAIL [foo='' s] /* \0 in attribute */ <div foo="\0"> with querySelector in XML '[foo='' s] /* \0 in attribute */' is not a valid selector.
 FAIL [foo='ä' s] <div foo="Ä"> in XML assert_equals: rule didn't parse into CSSOM expected 1 but got 0
-FAIL [foo='ä' s] <div foo="Ä"> with querySelector in XML The string did not match the expected pattern.
+FAIL [foo='ä' s] <div foo="Ä"> with querySelector in XML '[foo='ä' s]' is not a valid selector.
 FAIL [foo='Ä' s] <div foo="ä"> in XML assert_equals: rule didn't parse into CSSOM expected 1 but got 0
-FAIL [foo='Ä' s] <div foo="ä"> with querySelector in XML The string did not match the expected pattern.
+FAIL [foo='Ä' s] <div foo="ä"> with querySelector in XML '[foo='Ä' s]' is not a valid selector.
 FAIL [foo='ä' s] /* COMBINING in selector */ <div foo="Ä"> in XML assert_equals: rule didn't parse into CSSOM expected 1 but got 0
-FAIL [foo='ä' s] /* COMBINING in selector */ <div foo="Ä"> with querySelector in XML The string did not match the expected pattern.
+FAIL [foo='ä' s] /* COMBINING in selector */ <div foo="Ä"> with querySelector in XML '[foo='ä' s] /* COMBINING in selector */' is not a valid selector.
 FAIL [foo~='ä' s] /* COMBINING in selector */ <div foo="ä"> in XML assert_equals: rule didn't parse into CSSOM expected 1 but got 0
-FAIL [foo~='ä' s] /* COMBINING in selector */ <div foo="ä"> with querySelector in XML The string did not match the expected pattern.
+FAIL [foo~='ä' s] /* COMBINING in selector */ <div foo="ä"> with querySelector in XML '[foo~='ä' s] /* COMBINING in selector */' is not a valid selector.
 FAIL [foo^='Ä' s] /* COMBINING in selector */ <div foo="Ä"> in XML assert_equals: rule didn't parse into CSSOM expected 1 but got 0
-FAIL [foo^='Ä' s] /* COMBINING in selector */ <div foo="Ä"> with querySelector in XML The string did not match the expected pattern.
+FAIL [foo^='Ä' s] /* COMBINING in selector */ <div foo="Ä"> with querySelector in XML '[foo^='Ä' s] /* COMBINING in selector */' is not a valid selector.
 FAIL [foo$='Ä' s] /* COMBINING in selector */ <div foo="ä"> in XML assert_equals: rule didn't parse into CSSOM expected 1 but got 0
-FAIL [foo$='Ä' s] /* COMBINING in selector */ <div foo="ä"> with querySelector in XML The string did not match the expected pattern.
+FAIL [foo$='Ä' s] /* COMBINING in selector */ <div foo="ä"> with querySelector in XML '[foo$='Ä' s] /* COMBINING in selector */' is not a valid selector.
 FAIL [foo*='ä' s] /* COMBINING in attribute */ <div foo="ä"> in XML assert_equals: rule didn't parse into CSSOM expected 1 but got 0
-FAIL [foo*='ä' s] /* COMBINING in attribute */ <div foo="ä"> with querySelector in XML The string did not match the expected pattern.
+FAIL [foo*='ä' s] /* COMBINING in attribute */ <div foo="ä"> with querySelector in XML '[foo*='ä' s] /* COMBINING in attribute */' is not a valid selector.
 FAIL [foo|='ä' s] /* COMBINING in attribute */ <div foo="Ä"> in XML assert_equals: rule didn't parse into CSSOM expected 1 but got 0
-FAIL [foo|='ä' s] /* COMBINING in attribute */ <div foo="Ä"> with querySelector in XML The string did not match the expected pattern.
+FAIL [foo|='ä' s] /* COMBINING in attribute */ <div foo="Ä"> with querySelector in XML '[foo|='ä' s] /* COMBINING in attribute */' is not a valid selector.
 FAIL [foo='Ä' s] /* COMBINING in attribute */ <div foo="ä"> in XML assert_equals: rule didn't parse into CSSOM expected 1 but got 0
-FAIL [foo='Ä' s] /* COMBINING in attribute */ <div foo="ä"> with querySelector in XML The string did not match the expected pattern.
+FAIL [foo='Ä' s] /* COMBINING in attribute */ <div foo="ä"> with querySelector in XML '[foo='Ä' s] /* COMBINING in attribute */' is not a valid selector.
 FAIL [foo='Ä' s] /* COMBINING in attribute */ <div foo="Ä"> in XML assert_equals: rule didn't parse into CSSOM expected 1 but got 0
-FAIL [foo='Ä' s] /* COMBINING in attribute */ <div foo="Ä"> with querySelector in XML The string did not match the expected pattern.
+FAIL [foo='Ä' s] /* COMBINING in attribute */ <div foo="Ä"> with querySelector in XML '[foo='Ä' s] /* COMBINING in attribute */' is not a valid selector.
 FAIL [foo='ä' s] /* COMBINING in selector */ <div foo="a"> in XML assert_equals: rule didn't parse into CSSOM expected 1 but got 0
-FAIL [foo='ä' s] /* COMBINING in selector */ <div foo="a"> with querySelector in XML The string did not match the expected pattern.
+FAIL [foo='ä' s] /* COMBINING in selector */ <div foo="a"> with querySelector in XML '[foo='ä' s] /* COMBINING in selector */' is not a valid selector.
 FAIL [foo='ä' s] /* COMBINING in selector */ <div foo="A"> in XML assert_equals: rule didn't parse into CSSOM expected 1 but got 0
-FAIL [foo='ä' s] /* COMBINING in selector */ <div foo="A"> with querySelector in XML The string did not match the expected pattern.
+FAIL [foo='ä' s] /* COMBINING in selector */ <div foo="A"> with querySelector in XML '[foo='ä' s] /* COMBINING in selector */' is not a valid selector.
 FAIL [foo='Ä' s] /* COMBINING in selector */ <div foo="a"> in XML assert_equals: rule didn't parse into CSSOM expected 1 but got 0
-FAIL [foo='Ä' s] /* COMBINING in selector */ <div foo="a"> with querySelector in XML The string did not match the expected pattern.
+FAIL [foo='Ä' s] /* COMBINING in selector */ <div foo="a"> with querySelector in XML '[foo='Ä' s] /* COMBINING in selector */' is not a valid selector.
 FAIL [foo='Ä' s] /* COMBINING in selector */ <div foo="A"> in XML assert_equals: rule didn't parse into CSSOM expected 1 but got 0
-FAIL [foo='Ä' s] /* COMBINING in selector */ <div foo="A"> with querySelector in XML The string did not match the expected pattern.
+FAIL [foo='Ä' s] /* COMBINING in selector */ <div foo="A"> with querySelector in XML '[foo='Ä' s] /* COMBINING in selector */' is not a valid selector.
 FAIL [foo='a' s] /* COMBINING in attribute */ <div foo="ä"> in XML assert_equals: rule didn't parse into CSSOM expected 1 but got 0
-FAIL [foo='a' s] /* COMBINING in attribute */ <div foo="ä"> with querySelector in XML The string did not match the expected pattern.
+FAIL [foo='a' s] /* COMBINING in attribute */ <div foo="ä"> with querySelector in XML '[foo='a' s] /* COMBINING in attribute */' is not a valid selector.
 FAIL [foo='A' s] /* COMBINING in attribute */ <div foo="ä"> in XML assert_equals: rule didn't parse into CSSOM expected 1 but got 0
-FAIL [foo='A' s] /* COMBINING in attribute */ <div foo="ä"> with querySelector in XML The string did not match the expected pattern.
+FAIL [foo='A' s] /* COMBINING in attribute */ <div foo="ä"> with querySelector in XML '[foo='A' s] /* COMBINING in attribute */' is not a valid selector.
 FAIL [foo='a' s] /* COMBINING in attribute */ <div foo="Ä"> in XML assert_equals: rule didn't parse into CSSOM expected 1 but got 0
-FAIL [foo='a' s] /* COMBINING in attribute */ <div foo="Ä"> with querySelector in XML The string did not match the expected pattern.
+FAIL [foo='a' s] /* COMBINING in attribute */ <div foo="Ä"> with querySelector in XML '[foo='a' s] /* COMBINING in attribute */' is not a valid selector.
 FAIL [foo='A' s] /* COMBINING in attribute */ <div foo="Ä"> in XML assert_equals: rule didn't parse into CSSOM expected 1 but got 0
-FAIL [foo='A' s] /* COMBINING in attribute */ <div foo="Ä"> with querySelector in XML The string did not match the expected pattern.
+FAIL [foo='A' s] /* COMBINING in attribute */ <div foo="Ä"> with querySelector in XML '[foo='A' s] /* COMBINING in attribute */' is not a valid selector.
 FAIL [foo='i' s] <div foo="İ"> in XML assert_equals: rule didn't parse into CSSOM expected 1 but got 0
-FAIL [foo='i' s] <div foo="İ"> with querySelector in XML The string did not match the expected pattern.
+FAIL [foo='i' s] <div foo="İ"> with querySelector in XML '[foo='i' s]' is not a valid selector.
 FAIL [foo='i' s] <div foo="ı"> in XML assert_equals: rule didn't parse into CSSOM expected 1 but got 0
-FAIL [foo='i' s] <div foo="ı"> with querySelector in XML The string did not match the expected pattern.
+FAIL [foo='i' s] <div foo="ı"> with querySelector in XML '[foo='i' s]' is not a valid selector.
 FAIL [foo='I' s] <div foo="İ"> in XML assert_equals: rule didn't parse into CSSOM expected 1 but got 0
-FAIL [foo='I' s] <div foo="İ"> with querySelector in XML The string did not match the expected pattern.
+FAIL [foo='I' s] <div foo="İ"> with querySelector in XML '[foo='I' s]' is not a valid selector.
 FAIL [foo='I' s] <div foo="ı"> in XML assert_equals: rule didn't parse into CSSOM expected 1 but got 0
-FAIL [foo='I' s] <div foo="ı"> with querySelector in XML The string did not match the expected pattern.
+FAIL [foo='I' s] <div foo="ı"> with querySelector in XML '[foo='I' s]' is not a valid selector.
 FAIL [foo='İ' s] <div foo="i"> in XML assert_equals: rule didn't parse into CSSOM expected 1 but got 0
-FAIL [foo='İ' s] <div foo="i"> with querySelector in XML The string did not match the expected pattern.
+FAIL [foo='İ' s] <div foo="i"> with querySelector in XML '[foo='İ' s]' is not a valid selector.
 FAIL [foo='ı' s] <div foo="i"> in XML assert_equals: rule didn't parse into CSSOM expected 1 but got 0
-FAIL [foo='ı' s] <div foo="i"> with querySelector in XML The string did not match the expected pattern.
+FAIL [foo='ı' s] <div foo="i"> with querySelector in XML '[foo='ı' s]' is not a valid selector.
 FAIL [foo='İ' s] <div foo="I"> in XML assert_equals: rule didn't parse into CSSOM expected 1 but got 0
-FAIL [foo='İ' s] <div foo="I"> with querySelector in XML The string did not match the expected pattern.
+FAIL [foo='İ' s] <div foo="I"> with querySelector in XML '[foo='İ' s]' is not a valid selector.
 FAIL [foo='ı' s] <div foo="I"> in XML assert_equals: rule didn't parse into CSSOM expected 1 but got 0
-FAIL [foo='ı' s] <div foo="I"> with querySelector in XML The string did not match the expected pattern.
+FAIL [foo='ı' s] <div foo="I"> with querySelector in XML '[foo='ı' s]' is not a valid selector.
 FAIL [foo='bar' s] <div foo="x" {a}foo="BAR"> in XML assert_equals: rule didn't parse into CSSOM expected 1 but got 0
-FAIL [foo='bar' s] <div foo="x" {a}foo="BAR"> with querySelector in XML The string did not match the expected pattern.
+FAIL [foo='bar' s] <div foo="x" {a}foo="BAR"> with querySelector in XML '[foo='bar' s]' is not a valid selector.
 FAIL [|foo='bar' s] <div foo="x" {a}foo="BAR"> in XML assert_equals: rule didn't parse into CSSOM expected 1 but got 0
-FAIL [|foo='bar' s] <div foo="x" {a}foo="BAR"> with querySelector in XML The string did not match the expected pattern.
+FAIL [|foo='bar' s] <div foo="x" {a}foo="BAR"> with querySelector in XML '[|foo='bar' s]' is not a valid selector.
 FAIL [foo='bar' s] <div FOO="bar"> in XML assert_equals: rule didn't parse into CSSOM expected 1 but got 0
-FAIL [foo='bar' s] <div FOO="bar"> with querySelector in XML The string did not match the expected pattern.
+FAIL [foo='bar' s] <div FOO="bar"> with querySelector in XML '[foo='bar' s]' is not a valid selector.
 FAIL [foo='	' s] /* tab in selector */ <div foo=" "> in XML assert_equals: rule didn't parse into CSSOM expected 1 but got 0
-FAIL [foo='	' s] /* tab in selector */ <div foo=" "> with querySelector in XML The string did not match the expected pattern.
+FAIL [foo='	' s] /* tab in selector */ <div foo=" "> with querySelector in XML '[foo='	' s] /* tab in selector */' is not a valid selector.
 FAIL [foo=' ' s] /* tab in attribute */ <div foo="	"> in XML assert_equals: rule didn't parse into CSSOM expected 1 but got 0
-FAIL [foo=' ' s] /* tab in attribute */ <div foo="	"> with querySelector in XML The string did not match the expected pattern.
+FAIL [foo=' ' s] /* tab in attribute */ <div foo="	"> with querySelector in XML '[foo=' ' s] /* tab in attribute */' is not a valid selector.
 FAIL @namespace x 'a'; [x|foo='' s] <div {A}foo=""> in XML assert_equals: rule didn't parse into CSSOM expected 2 but got 1
 FAIL @namespace x 'A'; [x|foo='' s] <div {a}foo=""> in XML assert_equals: rule didn't parse into CSSOM expected 2 but got 1
 FAIL [foo='bar' s][foo='bar'] <div foo="BAR"> in XML assert_equals: rule didn't parse into CSSOM expected 1 but got 0
-FAIL [foo='bar' s][foo='bar'] <div foo="BAR"> with querySelector in XML The string did not match the expected pattern.
+FAIL [foo='bar' s][foo='bar'] <div foo="BAR"> with querySelector in XML '[foo='bar' s][foo='bar']' is not a valid selector.
 FAIL [foo='bar' s] <div baz="BAR"> in XML assert_equals: rule didn't parse into CSSOM expected 1 but got 0
-FAIL [foo='bar' s] <div baz="BAR"> with querySelector in XML The string did not match the expected pattern.
+FAIL [foo='bar' s] <div baz="BAR"> with querySelector in XML '[foo='bar' s]' is not a valid selector.
 FAIL [foo='bar' s] <div foo="BAR"> in XML assert_equals: rule didn't parse into CSSOM expected 1 but got 0
-FAIL [foo='bar' s] <div foo="BAR"> with querySelector in XML The string did not match the expected pattern.
+FAIL [foo='bar' s] <div foo="BAR"> with querySelector in XML '[foo='bar' s]' is not a valid selector.
 FAIL [foo='ä' s] /* COMBINING in both */ <div foo="Ä"> in XML assert_equals: rule didn't parse into CSSOM expected 1 but got 0
-FAIL [foo='ä' s] /* COMBINING in both */ <div foo="Ä"> with querySelector in XML The string did not match the expected pattern.
+FAIL [foo='ä' s] /* COMBINING in both */ <div foo="Ä"> with querySelector in XML '[foo='ä' s] /* COMBINING in both */' is not a valid selector.
 FAIL [foo='Ä' s] /* COMBINING in both */ <div foo="ä"> in XML assert_equals: rule didn't parse into CSSOM expected 1 but got 0
-FAIL [foo='Ä' s] /* COMBINING in both */ <div foo="ä"> with querySelector in XML The string did not match the expected pattern.
+FAIL [foo='Ä' s] /* COMBINING in both */ <div foo="ä"> with querySelector in XML '[foo='Ä' s] /* COMBINING in both */' is not a valid selector.
 FAIL [*|foo='bar' s] <div foo="x" {a}foo="x" {b}foo="BAR" {c}foo="x"> in XML assert_equals: rule didn't parse into CSSOM expected 1 but got 0
-FAIL [*|foo='bar' s] <div foo="x" {a}foo="x" {b}foo="BAR" {c}foo="x"> with querySelector in XML The string did not match the expected pattern.
+FAIL [*|foo='bar' s] <div foo="x" {a}foo="x" {b}foo="BAR" {c}foo="x"> with querySelector in XML '[*|foo='bar' s]' is not a valid selector.
 FAIL [*|foo='bar' s] <div foo="BAR" {a}foo="x" {b}foo="x" {c}foo="x"> in XML assert_equals: rule didn't parse into CSSOM expected 1 but got 0
-FAIL [*|foo='bar' s] <div foo="BAR" {a}foo="x" {b}foo="x" {c}foo="x"> with querySelector in XML The string did not match the expected pattern.
+FAIL [*|foo='bar' s] <div foo="BAR" {a}foo="x" {b}foo="x" {c}foo="x"> with querySelector in XML '[*|foo='bar' s]' is not a valid selector.
 FAIL [align='left' s] <div align="LEFT"> in XML assert_equals: rule didn't parse into CSSOM expected 1 but got 0
-FAIL [align='left' s] <div align="LEFT"> with querySelector in XML The string did not match the expected pattern.
+FAIL [align='left' s] <div align="LEFT"> with querySelector in XML '[align='left' s]' is not a valid selector.
 FAIL [align='LEFT' s] <div align="left"> in XML assert_equals: rule didn't parse into CSSOM expected 1 but got 0
-FAIL [align='LEFT' s] <div align="left"> with querySelector in XML The string did not match the expected pattern.
+FAIL [align='LEFT' s] <div align="left"> with querySelector in XML '[align='LEFT' s]' is not a valid selector.
 FAIL [class~='a' s] <div class="X A B"> in XML assert_equals: rule didn't parse into CSSOM expected 1 but got 0
-FAIL [class~='a' s] <div class="X A B"> with querySelector in XML The string did not match the expected pattern.
+FAIL [class~='a' s] <div class="X A B"> with querySelector in XML '[class~='a' s]' is not a valid selector.
 FAIL [class~='A' s] <div class="x a b"> in XML assert_equals: rule didn't parse into CSSOM expected 1 but got 0
-FAIL [class~='A' s] <div class="x a b"> with querySelector in XML The string did not match the expected pattern.
+FAIL [class~='A' s] <div class="x a b"> with querySelector in XML '[class~='A' s]' is not a valid selector.
 FAIL [id^='a' s] <div id="AB"> in XML assert_equals: rule didn't parse into CSSOM expected 1 but got 0
-FAIL [id^='a' s] <div id="AB"> with querySelector in XML The string did not match the expected pattern.
+FAIL [id^='a' s] <div id="AB"> with querySelector in XML '[id^='a' s]' is not a valid selector.
 FAIL [id$='A' s] <div id="xa"> in XML assert_equals: rule didn't parse into CSSOM expected 1 but got 0
-FAIL [id$='A' s] <div id="xa"> with querySelector in XML The string did not match the expected pattern.
+FAIL [id$='A' s] <div id="xa"> with querySelector in XML '[id$='A' s]' is not a valid selector.
 FAIL [lang|='a' s] <div lang="A-B"> in XML assert_equals: rule didn't parse into CSSOM expected 1 but got 0
-FAIL [lang|='a' s] <div lang="A-B"> with querySelector in XML The string did not match the expected pattern.
+FAIL [lang|='a' s] <div lang="A-B"> with querySelector in XML '[lang|='a' s]' is not a valid selector.
 FAIL [lang*='A' s] <div lang="xab"> in XML assert_equals: rule didn't parse into CSSOM expected 1 but got 0
-FAIL [lang*='A' s] <div lang="xab"> with querySelector in XML The string did not match the expected pattern.
+FAIL [lang*='A' s] <div lang="xab"> with querySelector in XML '[lang*='A' s]' is not a valid selector.
 FAIL [*|lang='a' s] <div {http://www.w3.org/XML/1998/namespace}lang="A"> in XML assert_equals: rule didn't parse into CSSOM expected 1 but got 0
-FAIL [*|lang='a' s] <div {http://www.w3.org/XML/1998/namespace}lang="A"> with querySelector in XML The string did not match the expected pattern.
+FAIL [*|lang='a' s] <div {http://www.w3.org/XML/1998/namespace}lang="A"> with querySelector in XML '[*|lang='a' s]' is not a valid selector.
 FAIL [*|lang='A' s] <div {http://www.w3.org/XML/1998/namespace}lang="a"> in XML assert_equals: rule didn't parse into CSSOM expected 1 but got 0
-FAIL [*|lang='A' s] <div {http://www.w3.org/XML/1998/namespace}lang="a"> with querySelector in XML The string did not match the expected pattern.
+FAIL [*|lang='A' s] <div {http://www.w3.org/XML/1998/namespace}lang="a"> with querySelector in XML '[*|lang='A' s]' is not a valid selector.
 FAIL @namespace x 'http://www.w3.org/XML/1998/namespace'; [x|lang='A' s] <div {http://www.w3.org/XML/1998/namespace}lang="a"> in XML assert_equals: rule didn't parse into CSSOM expected 2 but got 1
 FAIL [foo='bar' s][foo='bar' s] <div foo="BAR"> in XML assert_equals: rule didn't parse into CSSOM expected 1 but got 0
-FAIL [foo='bar' s][foo='bar' s] <div foo="BAR"> with querySelector in XML The string did not match the expected pattern.
+FAIL [foo='bar' s][foo='bar' s] <div foo="BAR"> with querySelector in XML '[foo='bar' s][foo='bar' s]' is not a valid selector.
 FAIL [foo='BAR' s][foo='bar'] <div foo="BAR"> in XML assert_equals: rule didn't parse into CSSOM expected 1 but got 0
-FAIL [foo='BAR' s][foo='bar'] <div foo="BAR"> with querySelector in XML The string did not match the expected pattern.
+FAIL [foo='BAR' s][foo='bar'] <div foo="BAR"> with querySelector in XML '[foo='BAR' s][foo='bar']' is not a valid selector.
 FAIL [foo='bar'][foo='BAR' s] <div foo="BAR"> in XML assert_equals: rule didn't parse into CSSOM expected 1 but got 0
-FAIL [foo='bar'][foo='BAR' s] <div foo="BAR"> with querySelector in XML The string did not match the expected pattern.
+FAIL [foo='bar'][foo='BAR' s] <div foo="BAR"> with querySelector in XML '[foo='bar'][foo='BAR' s]' is not a valid selector.
 FAIL [foo='BAR'][foo='bar' s] <div foo="BAR"> in XML assert_equals: rule didn't parse into CSSOM expected 1 but got 0
-FAIL [foo='BAR'][foo='bar' s] <div foo="BAR"> with querySelector in XML The string did not match the expected pattern.
+FAIL [foo='BAR'][foo='bar' s] <div foo="BAR"> with querySelector in XML '[foo='BAR'][foo='bar' s]' is not a valid selector.
 FAIL [foo='bar' s][foo='BAR'] <div foo="bar"> in XML assert_equals: rule didn't parse into CSSOM expected 1 but got 0
-FAIL [foo='bar' s][foo='BAR'] <div foo="bar"> with querySelector in XML The string did not match the expected pattern.
+FAIL [foo='bar' s][foo='BAR'] <div foo="bar"> with querySelector in XML '[foo='bar' s][foo='BAR']' is not a valid selector.
 
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/selectors/attribute-selectors/attribute-case/syntax-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/selectors/attribute-selectors/attribute-case/syntax-expected.txt
@@ -56,57 +56,59 @@ PASS [|foo='bar' i] with querySelector in standards mode
 PASS [*|foo='bar' i] in standards mode
 PASS [*|foo='bar' i] with querySelector in standards mode
 FAIL [baz='quux' s] in standards mode assert_equals: valid rule didn't parse into CSSOM expected 1 but got 0
-FAIL [baz='quux' s] with querySelector in standards mode The string did not match the expected pattern.
+FAIL [baz='quux' s] with querySelector in standards mode '[baz='quux' s]' is not a valid selector.
 FAIL [baz='quux' S] in standards mode assert_equals: valid rule didn't parse into CSSOM expected 1 but got 0
-FAIL [baz='quux' S] with querySelector in standards mode The string did not match the expected pattern.
+FAIL [baz='quux' S] with querySelector in standards mode '[baz='quux' S]' is not a valid selector.
 FAIL [baz=quux s] in standards mode assert_equals: valid rule didn't parse into CSSOM expected 1 but got 0
-FAIL [baz=quux s] with querySelector in standards mode The string did not match the expected pattern.
+FAIL [baz=quux s] with querySelector in standards mode '[baz=quux s]' is not a valid selector.
 FAIL [baz="quux" s] in standards mode assert_equals: valid rule didn't parse into CSSOM expected 1 but got 0
-FAIL [baz="quux" s] with querySelector in standards mode The string did not match the expected pattern.
+FAIL [baz="quux" s] with querySelector in standards mode '[baz="quux" s]' is not a valid selector.
 FAIL [baz='quux's] in standards mode assert_equals: valid rule didn't parse into CSSOM expected 1 but got 0
-FAIL [baz='quux's] with querySelector in standards mode The string did not match the expected pattern.
+FAIL [baz='quux's] with querySelector in standards mode '[baz='quux's]' is not a valid selector.
 FAIL [baz='quux's ] in standards mode assert_equals: valid rule didn't parse into CSSOM expected 1 but got 0
-FAIL [baz='quux's ] with querySelector in standards mode The string did not match the expected pattern.
+FAIL [baz='quux's ] with querySelector in standards mode '[baz='quux's ]' is not a valid selector.
 FAIL [baz='quux' s ] in standards mode assert_equals: valid rule didn't parse into CSSOM expected 1 but got 0
-FAIL [baz='quux' s ] with querySelector in standards mode The string did not match the expected pattern.
+FAIL [baz='quux' s ] with querySelector in standards mode '[baz='quux' s ]' is not a valid selector.
 FAIL [baz='quux' /**/ s] in standards mode assert_equals: valid rule didn't parse into CSSOM expected 1 but got 0
-FAIL [baz='quux' /**/ s] with querySelector in standards mode The string did not match the expected pattern.
+FAIL [baz='quux' /**/ s] with querySelector in standards mode '[baz='quux' /**/ s]' is not a valid selector.
 FAIL [baz='quux' s /**/ ] in standards mode assert_equals: valid rule didn't parse into CSSOM expected 1 but got 0
-FAIL [baz='quux' s /**/ ] with querySelector in standards mode The string did not match the expected pattern.
+FAIL [baz='quux' s /**/ ] with querySelector in standards mode '[baz='quux' s /**/ ]' is not a valid selector.
 FAIL [baz='quux'/**/s/**/] in standards mode assert_equals: valid rule didn't parse into CSSOM expected 1 but got 0
-FAIL [baz='quux'/**/s/**/] with querySelector in standards mode The string did not match the expected pattern.
+FAIL [baz='quux'/**/s/**/] with querySelector in standards mode '[baz='quux'/**/s/**/]' is not a valid selector.
 FAIL [baz=quux/**/s] in standards mode assert_equals: valid rule didn't parse into CSSOM expected 1 but got 0
-FAIL [baz=quux/**/s] with querySelector in standards mode The string did not match the expected pattern.
+FAIL [baz=quux/**/s] with querySelector in standards mode '[baz=quux/**/s]' is not a valid selector.
 FAIL [baz='quux'	s	] /* \t */ in standards mode assert_equals: valid rule didn't parse into CSSOM expected 1 but got 0
-FAIL [baz='quux'	s	] /* \t */ with querySelector in standards mode The string did not match the expected pattern.
+FAIL [baz='quux'	s	] /* \t */ with querySelector in standards mode '[baz='quux'	s	] /* \t */' is not a valid selector.
 FAIL [baz='quux'
 s
 ] /* \n */ in standards mode assert_equals: valid rule didn't parse into CSSOM expected 1 but got 0
 FAIL [baz='quux'
 s
-] /* \n */ with querySelector in standards mode The string did not match the expected pattern.
+] /* \n */ with querySelector in standards mode '[baz='quux'
+s
+] /* \n */' is not a valid selector.
 FAIL [baz='quux'\rs\r] /* \r */ in standards mode assert_equals: valid rule didn't parse into CSSOM expected 1 but got 0
-FAIL [baz='quux'\rs\r] /* \r */ with querySelector in standards mode The string did not match the expected pattern.
+FAIL [baz='quux'\rs\r] /* \r */ with querySelector in standards mode '[baz='quux'\rs\r] /* \r */' is not a valid selector.
 FAIL [baz='quux' \s] in standards mode assert_equals: valid rule didn't parse into CSSOM expected 1 but got 0
-FAIL [baz='quux' \s] with querySelector in standards mode The string did not match the expected pattern.
+FAIL [baz='quux' \s] with querySelector in standards mode '[baz='quux' \s]' is not a valid selector.
 FAIL [baz='quux' \73] in standards mode assert_equals: valid rule didn't parse into CSSOM expected 1 but got 0
-FAIL [baz='quux' \73] with querySelector in standards mode The string did not match the expected pattern.
+FAIL [baz='quux' \73] with querySelector in standards mode '[baz='quux' \73]' is not a valid selector.
 FAIL [baz='quux' \53] in standards mode assert_equals: valid rule didn't parse into CSSOM expected 1 but got 0
-FAIL [baz='quux' \53] with querySelector in standards mode The string did not match the expected pattern.
+FAIL [baz='quux' \53] with querySelector in standards mode '[baz='quux' \53]' is not a valid selector.
 FAIL [baz~='quux' s] in standards mode assert_equals: valid rule didn't parse into CSSOM expected 1 but got 0
-FAIL [baz~='quux' s] with querySelector in standards mode The string did not match the expected pattern.
+FAIL [baz~='quux' s] with querySelector in standards mode '[baz~='quux' s]' is not a valid selector.
 FAIL [baz^='quux' s] in standards mode assert_equals: valid rule didn't parse into CSSOM expected 1 but got 0
-FAIL [baz^='quux' s] with querySelector in standards mode The string did not match the expected pattern.
+FAIL [baz^='quux' s] with querySelector in standards mode '[baz^='quux' s]' is not a valid selector.
 FAIL [baz$='quux' s] in standards mode assert_equals: valid rule didn't parse into CSSOM expected 1 but got 0
-FAIL [baz$='quux' s] with querySelector in standards mode The string did not match the expected pattern.
+FAIL [baz$='quux' s] with querySelector in standards mode '[baz$='quux' s]' is not a valid selector.
 FAIL [baz*='quux' s] in standards mode assert_equals: valid rule didn't parse into CSSOM expected 1 but got 0
-FAIL [baz*='quux' s] with querySelector in standards mode The string did not match the expected pattern.
+FAIL [baz*='quux' s] with querySelector in standards mode '[baz*='quux' s]' is not a valid selector.
 FAIL [baz|='quux' s] in standards mode assert_equals: valid rule didn't parse into CSSOM expected 1 but got 0
-FAIL [baz|='quux' s] with querySelector in standards mode The string did not match the expected pattern.
+FAIL [baz|='quux' s] with querySelector in standards mode '[baz|='quux' s]' is not a valid selector.
 FAIL [|baz='quux' s] in standards mode assert_equals: valid rule didn't parse into CSSOM expected 1 but got 0
-FAIL [|baz='quux' s] with querySelector in standards mode The string did not match the expected pattern.
+FAIL [|baz='quux' s] with querySelector in standards mode '[|baz='quux' s]' is not a valid selector.
 FAIL [*|baz='quux' s] in standards mode assert_equals: valid rule didn't parse into CSSOM expected 1 but got 0
-FAIL [*|baz='quux' s] with querySelector in standards mode The string did not match the expected pattern.
+FAIL [*|baz='quux' s] with querySelector in standards mode '[*|baz='quux' s]' is not a valid selector.
 PASS [foo[ /* sanity check (invalid) */ in standards mode
 PASS [foo[ /* sanity check (invalid) */ with querySelector in standards mode
 PASS [foo='bar' i i] in standards mode
@@ -240,57 +242,59 @@ PASS [|foo='bar' i] with querySelector in quirks mode
 PASS [*|foo='bar' i] in quirks mode
 PASS [*|foo='bar' i] with querySelector in quirks mode
 FAIL [baz='quux' s] in quirks mode assert_equals: valid rule didn't parse into CSSOM expected 1 but got 0
-FAIL [baz='quux' s] with querySelector in quirks mode The string did not match the expected pattern.
+FAIL [baz='quux' s] with querySelector in quirks mode '[baz='quux' s]' is not a valid selector.
 FAIL [baz='quux' S] in quirks mode assert_equals: valid rule didn't parse into CSSOM expected 1 but got 0
-FAIL [baz='quux' S] with querySelector in quirks mode The string did not match the expected pattern.
+FAIL [baz='quux' S] with querySelector in quirks mode '[baz='quux' S]' is not a valid selector.
 FAIL [baz=quux s] in quirks mode assert_equals: valid rule didn't parse into CSSOM expected 1 but got 0
-FAIL [baz=quux s] with querySelector in quirks mode The string did not match the expected pattern.
+FAIL [baz=quux s] with querySelector in quirks mode '[baz=quux s]' is not a valid selector.
 FAIL [baz="quux" s] in quirks mode assert_equals: valid rule didn't parse into CSSOM expected 1 but got 0
-FAIL [baz="quux" s] with querySelector in quirks mode The string did not match the expected pattern.
+FAIL [baz="quux" s] with querySelector in quirks mode '[baz="quux" s]' is not a valid selector.
 FAIL [baz='quux's] in quirks mode assert_equals: valid rule didn't parse into CSSOM expected 1 but got 0
-FAIL [baz='quux's] with querySelector in quirks mode The string did not match the expected pattern.
+FAIL [baz='quux's] with querySelector in quirks mode '[baz='quux's]' is not a valid selector.
 FAIL [baz='quux's ] in quirks mode assert_equals: valid rule didn't parse into CSSOM expected 1 but got 0
-FAIL [baz='quux's ] with querySelector in quirks mode The string did not match the expected pattern.
+FAIL [baz='quux's ] with querySelector in quirks mode '[baz='quux's ]' is not a valid selector.
 FAIL [baz='quux' s ] in quirks mode assert_equals: valid rule didn't parse into CSSOM expected 1 but got 0
-FAIL [baz='quux' s ] with querySelector in quirks mode The string did not match the expected pattern.
+FAIL [baz='quux' s ] with querySelector in quirks mode '[baz='quux' s ]' is not a valid selector.
 FAIL [baz='quux' /**/ s] in quirks mode assert_equals: valid rule didn't parse into CSSOM expected 1 but got 0
-FAIL [baz='quux' /**/ s] with querySelector in quirks mode The string did not match the expected pattern.
+FAIL [baz='quux' /**/ s] with querySelector in quirks mode '[baz='quux' /**/ s]' is not a valid selector.
 FAIL [baz='quux' s /**/ ] in quirks mode assert_equals: valid rule didn't parse into CSSOM expected 1 but got 0
-FAIL [baz='quux' s /**/ ] with querySelector in quirks mode The string did not match the expected pattern.
+FAIL [baz='quux' s /**/ ] with querySelector in quirks mode '[baz='quux' s /**/ ]' is not a valid selector.
 FAIL [baz='quux'/**/s/**/] in quirks mode assert_equals: valid rule didn't parse into CSSOM expected 1 but got 0
-FAIL [baz='quux'/**/s/**/] with querySelector in quirks mode The string did not match the expected pattern.
+FAIL [baz='quux'/**/s/**/] with querySelector in quirks mode '[baz='quux'/**/s/**/]' is not a valid selector.
 FAIL [baz=quux/**/s] in quirks mode assert_equals: valid rule didn't parse into CSSOM expected 1 but got 0
-FAIL [baz=quux/**/s] with querySelector in quirks mode The string did not match the expected pattern.
+FAIL [baz=quux/**/s] with querySelector in quirks mode '[baz=quux/**/s]' is not a valid selector.
 FAIL [baz='quux'	s	] /* \t */ in quirks mode assert_equals: valid rule didn't parse into CSSOM expected 1 but got 0
-FAIL [baz='quux'	s	] /* \t */ with querySelector in quirks mode The string did not match the expected pattern.
+FAIL [baz='quux'	s	] /* \t */ with querySelector in quirks mode '[baz='quux'	s	] /* \t */' is not a valid selector.
 FAIL [baz='quux'
 s
 ] /* \n */ in quirks mode assert_equals: valid rule didn't parse into CSSOM expected 1 but got 0
 FAIL [baz='quux'
 s
-] /* \n */ with querySelector in quirks mode The string did not match the expected pattern.
+] /* \n */ with querySelector in quirks mode '[baz='quux'
+s
+] /* \n */' is not a valid selector.
 FAIL [baz='quux'\rs\r] /* \r */ in quirks mode assert_equals: valid rule didn't parse into CSSOM expected 1 but got 0
-FAIL [baz='quux'\rs\r] /* \r */ with querySelector in quirks mode The string did not match the expected pattern.
+FAIL [baz='quux'\rs\r] /* \r */ with querySelector in quirks mode '[baz='quux'\rs\r] /* \r */' is not a valid selector.
 FAIL [baz='quux' \s] in quirks mode assert_equals: valid rule didn't parse into CSSOM expected 1 but got 0
-FAIL [baz='quux' \s] with querySelector in quirks mode The string did not match the expected pattern.
+FAIL [baz='quux' \s] with querySelector in quirks mode '[baz='quux' \s]' is not a valid selector.
 FAIL [baz='quux' \73] in quirks mode assert_equals: valid rule didn't parse into CSSOM expected 1 but got 0
-FAIL [baz='quux' \73] with querySelector in quirks mode The string did not match the expected pattern.
+FAIL [baz='quux' \73] with querySelector in quirks mode '[baz='quux' \73]' is not a valid selector.
 FAIL [baz='quux' \53] in quirks mode assert_equals: valid rule didn't parse into CSSOM expected 1 but got 0
-FAIL [baz='quux' \53] with querySelector in quirks mode The string did not match the expected pattern.
+FAIL [baz='quux' \53] with querySelector in quirks mode '[baz='quux' \53]' is not a valid selector.
 FAIL [baz~='quux' s] in quirks mode assert_equals: valid rule didn't parse into CSSOM expected 1 but got 0
-FAIL [baz~='quux' s] with querySelector in quirks mode The string did not match the expected pattern.
+FAIL [baz~='quux' s] with querySelector in quirks mode '[baz~='quux' s]' is not a valid selector.
 FAIL [baz^='quux' s] in quirks mode assert_equals: valid rule didn't parse into CSSOM expected 1 but got 0
-FAIL [baz^='quux' s] with querySelector in quirks mode The string did not match the expected pattern.
+FAIL [baz^='quux' s] with querySelector in quirks mode '[baz^='quux' s]' is not a valid selector.
 FAIL [baz$='quux' s] in quirks mode assert_equals: valid rule didn't parse into CSSOM expected 1 but got 0
-FAIL [baz$='quux' s] with querySelector in quirks mode The string did not match the expected pattern.
+FAIL [baz$='quux' s] with querySelector in quirks mode '[baz$='quux' s]' is not a valid selector.
 FAIL [baz*='quux' s] in quirks mode assert_equals: valid rule didn't parse into CSSOM expected 1 but got 0
-FAIL [baz*='quux' s] with querySelector in quirks mode The string did not match the expected pattern.
+FAIL [baz*='quux' s] with querySelector in quirks mode '[baz*='quux' s]' is not a valid selector.
 FAIL [baz|='quux' s] in quirks mode assert_equals: valid rule didn't parse into CSSOM expected 1 but got 0
-FAIL [baz|='quux' s] with querySelector in quirks mode The string did not match the expected pattern.
+FAIL [baz|='quux' s] with querySelector in quirks mode '[baz|='quux' s]' is not a valid selector.
 FAIL [|baz='quux' s] in quirks mode assert_equals: valid rule didn't parse into CSSOM expected 1 but got 0
-FAIL [|baz='quux' s] with querySelector in quirks mode The string did not match the expected pattern.
+FAIL [|baz='quux' s] with querySelector in quirks mode '[|baz='quux' s]' is not a valid selector.
 FAIL [*|baz='quux' s] in quirks mode assert_equals: valid rule didn't parse into CSSOM expected 1 but got 0
-FAIL [*|baz='quux' s] with querySelector in quirks mode The string did not match the expected pattern.
+FAIL [*|baz='quux' s] with querySelector in quirks mode '[*|baz='quux' s]' is not a valid selector.
 PASS [foo[ /* sanity check (invalid) */ in quirks mode
 PASS [foo[ /* sanity check (invalid) */ with querySelector in quirks mode
 PASS [foo='bar' i i] in quirks mode
@@ -424,57 +428,59 @@ PASS [|foo='bar' i] with querySelector in XML
 PASS [*|foo='bar' i] in XML
 PASS [*|foo='bar' i] with querySelector in XML
 FAIL [baz='quux' s] in XML assert_equals: valid rule didn't parse into CSSOM expected 1 but got 0
-FAIL [baz='quux' s] with querySelector in XML The string did not match the expected pattern.
+FAIL [baz='quux' s] with querySelector in XML '[baz='quux' s]' is not a valid selector.
 FAIL [baz='quux' S] in XML assert_equals: valid rule didn't parse into CSSOM expected 1 but got 0
-FAIL [baz='quux' S] with querySelector in XML The string did not match the expected pattern.
+FAIL [baz='quux' S] with querySelector in XML '[baz='quux' S]' is not a valid selector.
 FAIL [baz=quux s] in XML assert_equals: valid rule didn't parse into CSSOM expected 1 but got 0
-FAIL [baz=quux s] with querySelector in XML The string did not match the expected pattern.
+FAIL [baz=quux s] with querySelector in XML '[baz=quux s]' is not a valid selector.
 FAIL [baz="quux" s] in XML assert_equals: valid rule didn't parse into CSSOM expected 1 but got 0
-FAIL [baz="quux" s] with querySelector in XML The string did not match the expected pattern.
+FAIL [baz="quux" s] with querySelector in XML '[baz="quux" s]' is not a valid selector.
 FAIL [baz='quux's] in XML assert_equals: valid rule didn't parse into CSSOM expected 1 but got 0
-FAIL [baz='quux's] with querySelector in XML The string did not match the expected pattern.
+FAIL [baz='quux's] with querySelector in XML '[baz='quux's]' is not a valid selector.
 FAIL [baz='quux's ] in XML assert_equals: valid rule didn't parse into CSSOM expected 1 but got 0
-FAIL [baz='quux's ] with querySelector in XML The string did not match the expected pattern.
+FAIL [baz='quux's ] with querySelector in XML '[baz='quux's ]' is not a valid selector.
 FAIL [baz='quux' s ] in XML assert_equals: valid rule didn't parse into CSSOM expected 1 but got 0
-FAIL [baz='quux' s ] with querySelector in XML The string did not match the expected pattern.
+FAIL [baz='quux' s ] with querySelector in XML '[baz='quux' s ]' is not a valid selector.
 FAIL [baz='quux' /**/ s] in XML assert_equals: valid rule didn't parse into CSSOM expected 1 but got 0
-FAIL [baz='quux' /**/ s] with querySelector in XML The string did not match the expected pattern.
+FAIL [baz='quux' /**/ s] with querySelector in XML '[baz='quux' /**/ s]' is not a valid selector.
 FAIL [baz='quux' s /**/ ] in XML assert_equals: valid rule didn't parse into CSSOM expected 1 but got 0
-FAIL [baz='quux' s /**/ ] with querySelector in XML The string did not match the expected pattern.
+FAIL [baz='quux' s /**/ ] with querySelector in XML '[baz='quux' s /**/ ]' is not a valid selector.
 FAIL [baz='quux'/**/s/**/] in XML assert_equals: valid rule didn't parse into CSSOM expected 1 but got 0
-FAIL [baz='quux'/**/s/**/] with querySelector in XML The string did not match the expected pattern.
+FAIL [baz='quux'/**/s/**/] with querySelector in XML '[baz='quux'/**/s/**/]' is not a valid selector.
 FAIL [baz=quux/**/s] in XML assert_equals: valid rule didn't parse into CSSOM expected 1 but got 0
-FAIL [baz=quux/**/s] with querySelector in XML The string did not match the expected pattern.
+FAIL [baz=quux/**/s] with querySelector in XML '[baz=quux/**/s]' is not a valid selector.
 FAIL [baz='quux'	s	] /* \t */ in XML assert_equals: valid rule didn't parse into CSSOM expected 1 but got 0
-FAIL [baz='quux'	s	] /* \t */ with querySelector in XML The string did not match the expected pattern.
+FAIL [baz='quux'	s	] /* \t */ with querySelector in XML '[baz='quux'	s	] /* \t */' is not a valid selector.
 FAIL [baz='quux'
 s
 ] /* \n */ in XML assert_equals: valid rule didn't parse into CSSOM expected 1 but got 0
 FAIL [baz='quux'
 s
-] /* \n */ with querySelector in XML The string did not match the expected pattern.
+] /* \n */ with querySelector in XML '[baz='quux'
+s
+] /* \n */' is not a valid selector.
 FAIL [baz='quux'\rs\r] /* \r */ in XML assert_equals: valid rule didn't parse into CSSOM expected 1 but got 0
-FAIL [baz='quux'\rs\r] /* \r */ with querySelector in XML The string did not match the expected pattern.
+FAIL [baz='quux'\rs\r] /* \r */ with querySelector in XML '[baz='quux'\rs\r] /* \r */' is not a valid selector.
 FAIL [baz='quux' \s] in XML assert_equals: valid rule didn't parse into CSSOM expected 1 but got 0
-FAIL [baz='quux' \s] with querySelector in XML The string did not match the expected pattern.
+FAIL [baz='quux' \s] with querySelector in XML '[baz='quux' \s]' is not a valid selector.
 FAIL [baz='quux' \73] in XML assert_equals: valid rule didn't parse into CSSOM expected 1 but got 0
-FAIL [baz='quux' \73] with querySelector in XML The string did not match the expected pattern.
+FAIL [baz='quux' \73] with querySelector in XML '[baz='quux' \73]' is not a valid selector.
 FAIL [baz='quux' \53] in XML assert_equals: valid rule didn't parse into CSSOM expected 1 but got 0
-FAIL [baz='quux' \53] with querySelector in XML The string did not match the expected pattern.
+FAIL [baz='quux' \53] with querySelector in XML '[baz='quux' \53]' is not a valid selector.
 FAIL [baz~='quux' s] in XML assert_equals: valid rule didn't parse into CSSOM expected 1 but got 0
-FAIL [baz~='quux' s] with querySelector in XML The string did not match the expected pattern.
+FAIL [baz~='quux' s] with querySelector in XML '[baz~='quux' s]' is not a valid selector.
 FAIL [baz^='quux' s] in XML assert_equals: valid rule didn't parse into CSSOM expected 1 but got 0
-FAIL [baz^='quux' s] with querySelector in XML The string did not match the expected pattern.
+FAIL [baz^='quux' s] with querySelector in XML '[baz^='quux' s]' is not a valid selector.
 FAIL [baz$='quux' s] in XML assert_equals: valid rule didn't parse into CSSOM expected 1 but got 0
-FAIL [baz$='quux' s] with querySelector in XML The string did not match the expected pattern.
+FAIL [baz$='quux' s] with querySelector in XML '[baz$='quux' s]' is not a valid selector.
 FAIL [baz*='quux' s] in XML assert_equals: valid rule didn't parse into CSSOM expected 1 but got 0
-FAIL [baz*='quux' s] with querySelector in XML The string did not match the expected pattern.
+FAIL [baz*='quux' s] with querySelector in XML '[baz*='quux' s]' is not a valid selector.
 FAIL [baz|='quux' s] in XML assert_equals: valid rule didn't parse into CSSOM expected 1 but got 0
-FAIL [baz|='quux' s] with querySelector in XML The string did not match the expected pattern.
+FAIL [baz|='quux' s] with querySelector in XML '[baz|='quux' s]' is not a valid selector.
 FAIL [|baz='quux' s] in XML assert_equals: valid rule didn't parse into CSSOM expected 1 but got 0
-FAIL [|baz='quux' s] with querySelector in XML The string did not match the expected pattern.
+FAIL [|baz='quux' s] with querySelector in XML '[|baz='quux' s]' is not a valid selector.
 FAIL [*|baz='quux' s] in XML assert_equals: valid rule didn't parse into CSSOM expected 1 but got 0
-FAIL [*|baz='quux' s] with querySelector in XML The string did not match the expected pattern.
+FAIL [*|baz='quux' s] with querySelector in XML '[*|baz='quux' s]' is not a valid selector.
 PASS [foo[ /* sanity check (invalid) */ in XML
 PASS [foo[ /* sanity check (invalid) */ with querySelector in XML
 PASS [foo='bar' i i] in XML

--- a/LayoutTests/imported/w3c/web-platform-tests/css/selectors/webkit-pseudo-element-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/selectors/webkit-pseudo-element-expected.txt
@@ -1,6 +1,6 @@
 
 FAIL rules include webkit-prefixed pseudo-element should be cascaded assert_equals: expected "rgb(0, 255, 0)" but got "rgb(255, 0, 0)"
 FAIL webkit-prefixed pseudo-element selectors should be accessible from CSSOM undefined is not an object (evaluating 'sheet.cssRules[1].selectorText')
-FAIL qS and qSA shouldn't throw exception The string did not match the expected pattern.
+FAIL qS and qSA shouldn't throw exception 'span::-webkit-something-invalid' is not a valid selector.
 FAIL webkit-prefix without dash is invalid assert_equals: expected 2 but got 1
 

--- a/LayoutTests/imported/w3c/web-platform-tests/custom-elements/state.tentative/state-pseudo-class-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/custom-elements/state.tentative/state-pseudo-class-expected.txt
@@ -1,7 +1,7 @@
 
 PASS :state() parsing failures
 FAIL :state() serialization undefined is not an object (evaluating 'document.styleSheets[0].cssRules[1].cssText')
-FAIL :state() in simple cases The string did not match the expected pattern.
+FAIL :state() in simple cases ':state(foo)' is not a valid selector.
 FAIL :state() and other pseudo classes undefined is not an object (evaluating 'states.value = 'foo'')
 FAIL :state() and ::part() undefined is not an object (evaluating 'innerStates.add')
 FAIL :state() and :host() undefined is not an object (evaluating 'outer.i.states.toggle')

--- a/LayoutTests/imported/w3c/web-platform-tests/custom-elements/state/tentative/state-pseudo-class-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/custom-elements/state/tentative/state-pseudo-class-expected.txt
@@ -1,8 +1,8 @@
 
-FAIL :--foo parsing passes The string did not match the expected pattern.
+FAIL :--foo parsing passes ':--' is not a valid selector.
 PASS :--foo parsing failures
 FAIL :--foo serialization undefined is not an object (evaluating 'document.styleSheets[0].cssRules[1].cssText')
-FAIL :--foo in simple cases The string did not match the expected pattern.
+FAIL :--foo in simple cases ':--foo' is not a valid selector.
 FAIL :--foo and other pseudo classes undefined is not an object (evaluating 'states.add')
 FAIL :--foo and ::part() undefined is not an object (evaluating 'innerStates.add')
 FAIL :--foo and :host() undefined is not an object (evaluating 'outer.i.states.add')

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-selectmenu-element/selectmenu-parts-structure.tentative-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-selectmenu-element/selectmenu-parts-structure.tentative-expected.txt
@@ -15,8 +15,8 @@ button0
 
 FAIL HTMLOptionElements (and not other element types) should receive option controller code assert_equals: expected (string) "one" but got (undefined) undefined
 FAIL To receive option part controller code, an option must be a descendant of the listbox part in a flat tree traversal assert_equals: expected (string) "one" but got (undefined) undefined
-FAIL To receive button part controller code, an element labeled as a button must not be a descendant of the listbox part in a flat tree traversal promise_test: Unhandled rejection with value: object "SyntaxError: The string did not match the expected pattern."
-FAIL To receive listbox part controller code, an element labeled as a listbox must not be a descendant of the button part in a flat tree traversal promise_test: Unhandled rejection with value: object "SyntaxError: The string did not match the expected pattern."
+FAIL To receive button part controller code, an element labeled as a button must not be a descendant of the listbox part in a flat tree traversal promise_test: Unhandled rejection with value: object "SyntaxError: ':top-layer' is not a valid selector."
+FAIL To receive listbox part controller code, an element labeled as a listbox must not be a descendant of the button part in a flat tree traversal promise_test: Unhandled rejection with value: object "SyntaxError: ':top-layer' is not a valid selector."
 FAIL Button controller code should be applied in flat tree traversal order regardless of dynamic insertion order assert_false: expected false got undefined
 FAIL Listbox controller code should be applied in flat tree traversal order regardless of dynamic insertion order assert_false: expected false got undefined
 FAIL selected-value controller code should be applied in flat tree traversal order regardless of dynamic insertion order assert_false: expected false got undefined

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/scripting-1/the-script-element/moving-between-documents/ordering/delay-load-event-1-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/scripting-1/the-script-element/moving-between-documents/ordering/delay-load-event-1-expected.txt
@@ -1,4 +1,4 @@
-CONSOLE MESSAGE: SyntaxError: The string did not match the expected pattern.
+CONSOLE MESSAGE: SyntaxError: ':::not-going-to-be-valid' is not a valid selector.
 CONSOLE MESSAGE: Not executing script because it moved between documents during fetching
 
 

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/scripting-1/the-script-element/moving-between-documents/ordering/delay-load-event-2-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/scripting-1/the-script-element/moving-between-documents/ordering/delay-load-event-2-expected.txt
@@ -1,4 +1,4 @@
-CONSOLE MESSAGE: SyntaxError: The string did not match the expected pattern.
+CONSOLE MESSAGE: SyntaxError: ':::not-going-to-be-valid' is not a valid selector.
 CONSOLE MESSAGE: Not executing script because it moved between documents during fetching
 
 

--- a/Source/WebCore/dom/Document.cpp
+++ b/Source/WebCore/dom/Document.cpp
@@ -933,11 +933,11 @@ void Document::invalidateAccessKeyCacheSlowCase()
 ExceptionOr<SelectorQuery&> Document::selectorQueryForString(const String& selectorString)
 {
     if (selectorString.isEmpty())
-        return Exception { SyntaxError };
+        return Exception { SyntaxError, makeString("'", selectorString, "' is not a valid selector.") };
 
     auto* query = SelectorQueryCache::singleton().add(selectorString, *this);
     if (!query)
-        return Exception { SyntaxError };
+        return Exception { SyntaxError, makeString("'", selectorString, "' is not a valid selector.") };
 
     return *query;
 }


### PR DESCRIPTION
#### f7494e5433b34ac8860ce8773d75f5546b0cf164
<pre>
Improve error message for invalid selector
<a href="https://bugs.webkit.org/show_bug.cgi?id=240597">https://bugs.webkit.org/show_bug.cgi?id=240597</a>

Reviewed by Tim Nguyen.

This patch improves the error message for invalid selectors
(e.g. `Element.matches`, `document.querySelector` and so on).

* LayoutTests/fast/css/css3-nth-tokens-script-expected.txt:
* LayoutTests/fast/css/parsing-css-attribute-case-insensitive-value-3-expected.txt:
* LayoutTests/fast/css/parsing-css-nth-child-of-3-expected.txt:
* LayoutTests/fast/css/parsing-css-nth-last-child-of-3-expected.txt:
* LayoutTests/fast/css/pseudo-class-internal-expected.txt:
* LayoutTests/fast/dom/SelectorAPI/dumpNodeList-almost-strict-expected.txt:
* LayoutTests/fast/dom/SelectorAPI/dumpNodeList-expected.txt:
* LayoutTests/fast/dom/SelectorAPI/not-supported-namespace-in-selector-expected.txt:
* LayoutTests/fast/selectors/closest-general-expected.txt:
* LayoutTests/fast/selectors/invalid-functional-pseudo-class-expected.txt:
* LayoutTests/fast/selectors/lang-empty-expected.txt:
* LayoutTests/fast/selectors/lang-extended-filtering-expected.txt:
* LayoutTests/fast/selectors/lang-extended-filtering-with-string-arguments-expected.txt:
* LayoutTests/fast/selectors/lang-invalid-expected.txt:
* LayoutTests/fast/selectors/lang-multiple-expected.txt:
* LayoutTests/fast/selectors/querySelector-pseudo-element-inside-functional-pseudo-class-not-expected.txt:
* LayoutTests/fast/shadow-dom/direct-focus-pseudo-does-not-match-in-author-stylesheet-expected.txt:
* LayoutTests/fast/text/text-combine-crash-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-pseudo/parsing/highlight-pseudos-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-pseudo/parsing/tree-abiding-pseudo-elements-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-scoping/host-context-parsing-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-scoping/slotted-parsing-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/selectors/attribute-selectors/attribute-case/semantics-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/selectors/attribute-selectors/attribute-case/syntax-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/selectors/webkit-pseudo-element-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/custom-elements/state.tentative/state-pseudo-class-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/custom-elements/state/tentative/state-pseudo-class-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-selectmenu-element/selectmenu-parts-structure.tentative-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/scripting-1/the-script-element/moving-between-documents/ordering/delay-load-event-1-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/scripting-1/the-script-element/moving-between-documents/ordering/delay-load-event-2-expected.txt:
* Source/WebCore/dom/Document.cpp:

Canonical link: <a href="https://commits.webkit.org/264463@main">https://commits.webkit.org/264463@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/94f4682445cf57a214443dfc6c2a711737c1f924

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/7521 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/7788 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/7971 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/9160 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/7714 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/7532 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/9875 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/7713 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/10592 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/7652 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/8952 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/6953 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/9267 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/6204 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/6843 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/14555 "Passed tests") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/7429 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/6964 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/10293 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/7457 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/6095 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/6798 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/1838 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/11006 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/7191 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->