### PR TITLE
Camera and microphone should all have groupIds

### DIFF
--- a/LayoutTests/fast/mediastream/MediaStreamTrack-getCapabilities-expected.txt
+++ b/LayoutTests/fast/mediastream/MediaStreamTrack-getCapabilities-expected.txt
@@ -8,12 +8,14 @@ video track capabilities:
   capabilities.deviceId = <UUID>
   capabilities.facingMode = [ user ]
   capabilities.frameRate = { max: 30, min: 1 }
+  capabilities.groupId = <UUID>
   capabilities.height = { max: 1440, min: 1 }
   capabilities.width = { max: 2560, min: 1 }
 
 audio track capabilities:
   capabilities.deviceId = <UUID>
   capabilities.echoCancellation = [ true, false ]
+  capabilities.groupId = <UUID>
   capabilities.sampleRate = { max: 48000, min: 44100 }
   capabilities.volume = { max: 1, min: 0 }
 
@@ -23,6 +25,7 @@ video track capabilities:
   capabilities.facingMode = [ environment ]
   capabilities.focusDistance = { min: 0.200 }
   capabilities.frameRate = { max: 120, min: 1 }
+  capabilities.groupId = <UUID>
   capabilities.height = { max: 2160, min: 1 }
   capabilities.width = { max: 3840, min: 1 }
   capabilities.zoom = { max: 4, min: 1 }
@@ -30,6 +33,7 @@ video track capabilities:
 audio track capabilities:
   capabilities.deviceId = <UUID>
   capabilities.echoCancellation = [ true, false ]
+  capabilities.groupId = <UUID>
   capabilities.sampleRate = { max: 48000, min: 44100 }
   capabilities.volume = { max: 1, min: 0 }
 

--- a/LayoutTests/fast/mediastream/MediaStreamTrack-getCapabilities.html
+++ b/LayoutTests/fast/mediastream/MediaStreamTrack-getCapabilities.html
@@ -65,6 +65,8 @@
                     if (capabilities.hasOwnProperty(property) || capabilities.__proto__.hasOwnProperty(property))
                         if (property === "deviceId" && validateDeviceId(capabilities[property], track.kind))
                             value = "&lt;UUID>";
+                        else if (property === "groupId")
+                            value = "&lt;UUID>";
                         else if (typeof capabilities[property] === "object")
                             value = capabilityRange(property, capabilities[property]);
                         else

--- a/LayoutTests/fast/mediastream/MediaStreamTrack-getSettings-expected.txt
+++ b/LayoutTests/fast/mediastream/MediaStreamTrack-getSettings-expected.txt
@@ -8,12 +8,14 @@ video track settings:
   settings.deviceId = <UUID>
   settings.facingMode = user
   settings.frameRate = 30
+  settings.groupId = <UUID>
   settings.height = 480
   settings.width = 640
 
 audio track settings:
   settings.deviceId = <UUID>
   settings.echoCancellation = true
+  settings.groupId = <UUID>
   settings.sampleRate = 44100
   settings.volume = 1
 
@@ -23,16 +25,19 @@ PASS "aspectRatio" in track.getCapabilities() is true
 PASS "deviceId" in track.getCapabilities() is true
 PASS "facingMode" in track.getCapabilities() is true
 PASS "frameRate" in track.getCapabilities() is true
+PASS "groupId" in track.getCapabilities() is true
 PASS "height" in track.getCapabilities() is true
 PASS "width" in track.getCapabilities() is true
 PASS "deviceId" in track.getCapabilities() is true
 PASS "echoCancellation" in track.getCapabilities() is true
+PASS "groupId" in track.getCapabilities() is true
 PASS "sampleRate" in track.getCapabilities() is true
 PASS "volume" in track.getCapabilities() is true
 Validate sampleRate constraints appears correctly in track settings
 audio track settings:
   settings.deviceId = <UUID>
   settings.echoCancellation = true
+  settings.groupId = <UUID>
   settings.sampleRate = 48000
   settings.volume = 1
 

--- a/LayoutTests/fast/mediastream/MediaStreamTrack-getSettings.html
+++ b/LayoutTests/fast/mediastream/MediaStreamTrack-getSettings.html
@@ -25,7 +25,7 @@
             {
                 debug(`${track.kind} track settings:`);
                 forEachNativeProperty(track.getSettings(), (property, value) => {
-                    if (property == "deviceId")
+                    if (property == "deviceId" || property == "groupId")
                         value = "&lt;UUID>";
                     else
                         value = limitPrecision(value, 3);

--- a/LayoutTests/fast/mediastream/get-user-media-device-id.html
+++ b/LayoutTests/fast/mediastream/get-user-media-device-id.html
@@ -53,7 +53,6 @@
                 var ids = devices.map(device => device.deviceId);
                 assert_true(ids.indexOf(videoTrack.getSettings().deviceId) !== -1 , "deviceId for video track should be respected");
                 assert_true(ids.indexOf(audioTrack.getSettings().deviceId) !== -1 , "deviceId for audio track should be respected");
-                assert_equals(audioTrack.getSettings().groupId, videoTrack.getSettings().groupId, "groupId should match");
             })
 
     }, "Pass device IDs as exact constraints");

--- a/LayoutTests/fast/mediastream/media-device-info-expected.txt
+++ b/LayoutTests/fast/mediastream/media-device-info-expected.txt
@@ -1,4 +1,5 @@
 
 PASS Test properties of MediaDeviceInfo
 PASS Ensure enumerateDevices exposes both microphone and camera
+PASS Ensure enumerateDevices and getUserMedia MediaStreamTrack expose the same deviceId and groupIds
 

--- a/LayoutTests/fast/mediastream/media-device-info.html
+++ b/LayoutTests/fast/mediastream/media-device-info.html
@@ -11,7 +11,7 @@
             .then((devices) => {
                 assert_greater_than(devices.length, 0);
                 let device = devices[0];
-                
+
                 assert_true(device instanceof MediaDeviceInfo);
                 assert_class_string(device, "InputDeviceInfo");
                 assert_true('deviceId' in device);
@@ -19,7 +19,7 @@
                 assert_true('label' in device);
                 assert_true('groupId' in device);
                 assert_true('toJSON' in device);
-                
+
                 let serializedResult = device.toJSON();
                 assert_equals(serializedResult['deviceId'], device.deviceId);
                 assert_equals(serializedResult['kind'], device.kind);
@@ -35,6 +35,40 @@
         assert_equals(devices[0].kind, "audioinput");
         assert_equals(devices[1].kind, "videoinput");
     }, "Ensure enumerateDevices exposes both microphone and camera");
+
+    function getDeviceFromTrack(track, devices)
+    {
+        let matchingDevice;
+        const settings = track.getSettings();
+        devices.forEach(device => {
+            if (device.deviceId === settings.deviceId)
+                matchingDevice = device;
+        });
+        return matchingDevice;
+    }
+
+    promise_test(async (test) => {
+        const stream = await navigator.mediaDevices.getUserMedia({ audio:true, video:true });
+        const devices = await navigator.mediaDevices.enumerateDevices();
+
+        const audioTrack = stream.getAudioTracks()[0];
+        assert_equals(audioTrack.getSettings().deviceId, audioTrack.getCapabilities().deviceId, "audio deviceId");
+        assert_equals(audioTrack.getSettings().groupId, audioTrack.getCapabilities().groupId, "audio groupId");
+
+        const videoTrack = stream.getVideoTracks()[0];
+        assert_equals(videoTrack.getSettings().deviceId, videoTrack.getCapabilities().deviceId, "video deviceId");
+        assert_equals(videoTrack.getSettings().groupId, videoTrack.getCapabilities().groupId, "video groupId");
+
+        const audioDevice = getDeviceFromTrack(audioTrack, devices);
+        assert_true(audioDevice !== undefined, "audio device found");
+        assert_equals(audioDevice.deviceId, audioTrack.getSettings().deviceId, "audio device info deviceId");
+        assert_equals(audioDevice.groupId, audioTrack.getSettings().groupId, "audio device info groupId");
+
+        const videoDevice = getDeviceFromTrack(videoTrack, devices);
+        assert_true(videoDevice !== undefined, "video device found");
+        assert_equals(videoDevice.deviceId, videoTrack.getSettings().deviceId, "video device info deviceId");
+        assert_equals(videoDevice.groupId, videoTrack.getSettings().groupId, "video device info groupId");
+    }, "Ensure enumerateDevices and getUserMedia MediaStreamTrack expose the same deviceId and groupIds");
     </script>
 </head>
 <body>

--- a/LayoutTests/imported/w3c/web-platform-tests/mediacapture-streams/MediaStreamTrack-getCapabilities.https-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/mediacapture-streams/MediaStreamTrack-getCapabilities.https-expected.txt
@@ -49,8 +49,8 @@ FAIL Audio track getCapabilities() channelCount property present. assert_true: e
 FAIL Audio track getCapabilities() channelCount properly supported. assert_equals: expected "object" but got "undefined"
 PASS Audio track getCapabilities() deviceId property present.
 PASS Audio track getCapabilities() deviceId properly supported.
-FAIL Audio track getCapabilities() groupId property present. assert_true: expected true got false
-FAIL Audio track getCapabilities() groupId properly supported. assert_equals: expected "string" but got "undefined"
+PASS Audio track getCapabilities() groupId property present.
+PASS Audio track getCapabilities() groupId properly supported.
 PASS Video track getCapabilities() width property present.
 PASS Video track getCapabilities() width properly supported.
 PASS Video track getCapabilities() height property present.
@@ -67,8 +67,8 @@ FAIL Video track getCapabilities() resizeMode properly supported. Value: none un
 FAIL Video track getCapabilities() resizeMode properly supported. Value: crop-and-scale undefined is not an object (evaluating 'expected.indexOf')
 PASS Video track getCapabilities() deviceId property present.
 PASS Video track getCapabilities() deviceId properly supported.
-FAIL Video track getCapabilities() groupId property present. assert_true: expected true got false
-FAIL Video track getCapabilities() groupId properly supported. assert_equals: expected "string" but got "undefined"
+PASS Video track getCapabilities() groupId property present.
+PASS Video track getCapabilities() groupId properly supported.
 PASS Audio device getCapabilities() sampleRate property present.
 PASS Audio device getCapabilities() sampleRate properly supported.
 FAIL Audio device getCapabilities() sampleSize property present. assert_true: expected true got false
@@ -85,8 +85,8 @@ FAIL Audio device getCapabilities() channelCount property present. assert_true: 
 FAIL Audio device getCapabilities() channelCount properly supported. assert_equals: expected "object" but got "undefined"
 PASS Audio device getCapabilities() deviceId property present.
 PASS Audio device getCapabilities() deviceId properly supported.
-FAIL Audio device getCapabilities() groupId property present. assert_true: expected true got false
-FAIL Audio device getCapabilities() groupId properly supported. assert_equals: expected "string" but got "undefined"
+PASS Audio device getCapabilities() groupId property present.
+PASS Audio device getCapabilities() groupId properly supported.
 PASS Video device getCapabilities() width property present.
 PASS Video device getCapabilities() width properly supported.
 PASS Video device getCapabilities() height property present.
@@ -103,6 +103,6 @@ FAIL Video device getCapabilities() resizeMode properly supported. Value: none u
 FAIL Video device getCapabilities() resizeMode properly supported. Value: crop-and-scale undefined is not an object (evaluating 'expected.indexOf')
 PASS Video device getCapabilities() deviceId property present.
 PASS Video device getCapabilities() deviceId properly supported.
-FAIL Video device getCapabilities() groupId property present. assert_true: expected true got false
-FAIL Video device getCapabilities() groupId properly supported. assert_equals: expected "string" but got "undefined"
+PASS Video device getCapabilities() groupId property present.
+PASS Video device getCapabilities() groupId properly supported.
 

--- a/LayoutTests/imported/w3c/web-platform-tests/mediacapture-streams/MediaStreamTrack-getSettings.https-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/mediacapture-streams/MediaStreamTrack-getSettings.https-expected.txt
@@ -3,9 +3,9 @@ When prompted, accept to share your video stream.
 
 PASS A device can be opened twice and have the same device ID
 PASS A device can be opened twice with different resolutions requested
-FAIL groupId is correctly reported by getSettings() for all input devices assert_true: device groupId expected true got false
+PASS groupId is correctly reported by getSettings() for all input devices
 PASS deviceId is reported by getSettings() for getUserMedia() audio tracks
-FAIL groupId is reported by getSettings() for getUserMedia() audio tracks assert_equals: groupId should exist and it should be a string. expected "string" but got "undefined"
+PASS groupId is reported by getSettings() for getUserMedia() audio tracks
 PASS sampleRate is reported by getSettings() for getUserMedia() audio tracks
 FAIL sampleSize is reported by getSettings() for getUserMedia() audio tracks assert_equals: sampleSize should exist and it should be a number. expected "number" but got "undefined"
 PASS echoCancellation is reported by getSettings() for getUserMedia() audio tracks
@@ -14,7 +14,7 @@ FAIL noiseSuppression is reported by getSettings() for getUserMedia() audio trac
 FAIL latency is reported by getSettings() for getUserMedia() audio tracks assert_equals: latency should exist and it should be a number. expected "number" but got "undefined"
 FAIL channelCount is reported by getSettings() for getUserMedia() audio tracks assert_equals: channelCount should exist and it should be a number. expected "number" but got "undefined"
 PASS deviceId is reported by getSettings() for getUserMedia() video tracks
-FAIL groupId is reported by getSettings() for getUserMedia() video tracks assert_equals: groupId should exist and it should be a string. expected "string" but got "undefined"
+PASS groupId is reported by getSettings() for getUserMedia() video tracks
 PASS width is reported by getSettings() for getUserMedia() video tracks
 PASS height is reported by getSettings() for getUserMedia() video tracks
 PASS aspectRatio is reported by getSettings() for getUserMedia() video tracks

--- a/Source/WebCore/Modules/mediastream/InputDeviceInfo.cpp
+++ b/Source/WebCore/Modules/mediastream/InputDeviceInfo.cpp
@@ -43,7 +43,7 @@ InputDeviceInfo::InputDeviceInfo(CaptureDeviceWithCapabilities&& deviceWithCapab
 
 MediaTrackCapabilities InputDeviceInfo::getCapabilities() const
 {
-    return toMediaTrackCapabilities(m_capabilities);
+    return toMediaTrackCapabilities(m_capabilities, groupId());
 }
 
 } // namespace WebCore

--- a/Source/WebCore/Modules/mediastream/MediaDevices.cpp
+++ b/Source/WebCore/Modules/mediastream/MediaDevices.cpp
@@ -316,7 +316,7 @@ void MediaDevices::exposeDevices(Vector<CaptureDeviceWithCapabilities>&& newDevi
             deviceId = center.hashStringWithSalt(newDevice.persistentId(), deviceIDHashSalts.ephemeralDeviceSalt);
         else
             deviceId = center.hashStringWithSalt(newDevice.persistentId(), deviceIDHashSalts.persistentDeviceSalt);
-        auto groupId = center.hashStringWithSalt(newDevice.groupId(), m_groupIdHashSalt);
+        auto groupId = hashedGroupId(newDevice.groupId());
 
         if (newDevice.type() == CaptureDevice::DeviceType::Speaker) {
             m_audioOutputDeviceIdToPersistentId.add(deviceId, newDevice.persistentId());
@@ -325,6 +325,11 @@ void MediaDevices::exposeDevices(Vector<CaptureDeviceWithCapabilities>&& newDevi
             devices.append(RefPtr<InputDeviceInfo> { InputDeviceInfo::create(WTFMove(newDeviceWithCapabilities), WTFMove(deviceId), WTFMove(groupId)) });
     }
     promise.resolve(WTFMove(devices));
+}
+
+String MediaDevices::hashedGroupId(const String& groupId)
+{
+    return RealtimeMediaSourceCenter::singleton().hashStringWithSalt(groupId, m_groupIdHashSalt);
 }
 
 void MediaDevices::enumerateDevices(EnumerateDevicesPromise&& promise)

--- a/Source/WebCore/Modules/mediastream/MediaDevices.h
+++ b/Source/WebCore/Modules/mediastream/MediaDevices.h
@@ -92,6 +92,7 @@ public:
     MediaTrackSupportedConstraints getSupportedConstraints();
 
     String deviceIdToPersistentId(const String& deviceId) const { return m_audioOutputDeviceIdToPersistentId.get(deviceId); }
+    String hashedGroupId(const String& groupId);
 
     using RefCounted<MediaDevices>::ref;
     using RefCounted<MediaDevices>::deref;

--- a/Source/WebCore/Modules/mediastream/MediaStreamTrack.h
+++ b/Source/WebCore/Modules/mediastream/MediaStreamTrack.h
@@ -197,6 +197,7 @@ private:
 
     MediaTrackConstraints m_constraints;
 
+    String m_groupId;
     State m_readyState { State::Live };
     bool m_muted { false };
     bool m_ended { false };

--- a/Source/WebCore/Modules/mediastream/MediaTrackCapabilities.cpp
+++ b/Source/WebCore/Modules/mediastream/MediaTrackCapabilities.cpp
@@ -98,7 +98,7 @@ static Vector<bool> capabilityBooleanVector(RealtimeMediaSourceCapabilities::Ech
     return result;
 }
 
-MediaTrackCapabilities toMediaTrackCapabilities(const RealtimeMediaSourceCapabilities& capabilities)
+MediaTrackCapabilities toMediaTrackCapabilities(const RealtimeMediaSourceCapabilities& capabilities, const String& groupId)
 {
     MediaTrackCapabilities result;
     if (capabilities.supportsWidth())
@@ -122,7 +122,7 @@ MediaTrackCapabilities toMediaTrackCapabilities(const RealtimeMediaSourceCapabil
     if (capabilities.supportsDeviceId())
         result.deviceId = capabilities.deviceId();
     if (capabilities.supportsGroupId())
-        result.groupId = capabilities.groupId();
+        result.groupId = groupId;
     if (capabilities.supportsFocusDistance())
         result.focusDistance = capabilityDoubleRange(capabilities.focusDistance());
     if (capabilities.supportsZoom())

--- a/Source/WebCore/Modules/mediastream/MediaTrackCapabilities.h
+++ b/Source/WebCore/Modules/mediastream/MediaTrackCapabilities.h
@@ -52,7 +52,7 @@ struct MediaTrackCapabilities {
     std::optional<DoubleRange> zoom;
 };
 
-MediaTrackCapabilities toMediaTrackCapabilities(const RealtimeMediaSourceCapabilities&);
+MediaTrackCapabilities toMediaTrackCapabilities(const RealtimeMediaSourceCapabilities&, const String& groupId);
 } // namespace WebCore
 
 #endif // ENABLE(MEDIA_STREAM)

--- a/Source/WebCore/platform/mediastream/CaptureDevice.h
+++ b/Source/WebCore/platform/mediastream/CaptureDevice.h
@@ -63,7 +63,7 @@ public:
     }
 
     void setGroupId(const String& groupId) { m_groupId = groupId; }
-    const String& groupId() const { return m_groupId; }
+    const String& groupId() const { return m_groupId.isEmpty() ? m_persistentId : m_groupId; }
 
     DeviceType type() const { return m_type; }
 

--- a/Source/WebCore/platform/mediastream/RealtimeMediaSourceSettings.h
+++ b/Source/WebCore/platform/mediastream/RealtimeMediaSourceSettings.h
@@ -79,7 +79,7 @@ public:
     WEBCORE_EXPORT OptionSet<RealtimeMediaSourceSettings::Flag> difference(const RealtimeMediaSourceSettings&) const;
 
     RealtimeMediaSourceSettings() = default;
-    RealtimeMediaSourceSettings(uint32_t width, uint32_t height, float frameRate, VideoFacingMode facingMode, double volume, uint32_t sampleRate, uint32_t sampleSize, bool echoCancellation, AtomString&& deviceId, AtomString&& groupId, AtomString&& label, DisplaySurfaceType displaySurface, bool logicalSurface, double zoom, RealtimeMediaSourceSupportedConstraints&& supportedConstraints)
+    RealtimeMediaSourceSettings(uint32_t width, uint32_t height, float frameRate, VideoFacingMode facingMode, double volume, uint32_t sampleRate, uint32_t sampleSize, bool echoCancellation, AtomString&& deviceId, String&& groupId, AtomString&& label, DisplaySurfaceType displaySurface, bool logicalSurface, double zoom, RealtimeMediaSourceSupportedConstraints&& supportedConstraints)
         : m_width(width)
         , m_height(height)
         , m_frameRate(frameRate)
@@ -137,8 +137,8 @@ public:
     void setDeviceId(const AtomString& deviceId) { m_deviceId = deviceId; }
 
     bool supportsGroupId() const { return m_supportedConstraints.supportsGroupId(); }
-    const AtomString& groupId() const { return m_groupId; }
-    void setGroupId(const AtomString& groupId) { m_groupId = groupId; }
+    const String& groupId() const { return m_groupId; }
+    void setGroupId(const String& groupId) { m_groupId = groupId; }
 
     bool supportsDisplaySurface() const { return m_supportedConstraints.supportsDisplaySurface(); }
     DisplaySurfaceType displaySurface() const { return m_displaySurface; }
@@ -171,7 +171,7 @@ private:
     bool m_echoCancellation { 0 };
 
     AtomString m_deviceId;
-    AtomString m_groupId;
+    String m_groupId;
     AtomString m_label;
 
     DisplaySurfaceType m_displaySurface { DisplaySurfaceType::Invalid };

--- a/Source/WebCore/platform/mediastream/mac/AVVideoCaptureSource.mm
+++ b/Source/WebCore/platform/mediastream/mac/AVVideoCaptureSource.mm
@@ -281,9 +281,11 @@ const RealtimeMediaSourceSettings& AVVideoCaptureSource::settings()
     settings.setWidth(size.width());
     settings.setHeight(size.height());
     settings.setDeviceId(hashedId());
+    settings.setGroupId(captureDevice().groupId());
 
     RealtimeMediaSourceSupportedConstraints supportedConstraints;
     supportedConstraints.setSupportsDeviceId(true);
+    supportedConstraints.setSupportsGroupId(true);
     supportedConstraints.setSupportsFacingMode([device() position] != AVCaptureDevicePositionUnspecified);
     supportedConstraints.setSupportsWidth(true);
     supportedConstraints.setSupportsHeight(true);

--- a/Source/WebCore/platform/mediastream/mac/CoreAudioCaptureSource.cpp
+++ b/Source/WebCore/platform/mediastream/mac/CoreAudioCaptureSource.cpp
@@ -286,11 +286,13 @@ const RealtimeMediaSourceSettings& CoreAudioCaptureSource::settings()
         settings.setVolume(volume());
         settings.setSampleRate(unit().isRenderingAudio() ? unit().actualSampleRate() : sampleRate());
         settings.setDeviceId(hashedId());
+        settings.setGroupId(captureDevice().groupId());
         settings.setLabel(name());
         settings.setEchoCancellation(echoCancellation());
 
         RealtimeMediaSourceSupportedConstraints supportedConstraints;
         supportedConstraints.setSupportsDeviceId(true);
+        supportedConstraints.setSupportsGroupId(true);
         supportedConstraints.setSupportsEchoCancellation(true);
         supportedConstraints.setSupportsVolume(true);
         supportedConstraints.setSupportsSampleRate(true);

--- a/Source/WebCore/platform/mock/MockRealtimeAudioSource.cpp
+++ b/Source/WebCore/platform/mock/MockRealtimeAudioSource.cpp
@@ -92,6 +92,7 @@ const RealtimeMediaSourceSettings& MockRealtimeAudioSource::settings()
     if (!m_currentSettings) {
         RealtimeMediaSourceSettings settings;
         settings.setDeviceId(hashedId());
+        settings.setGroupId(captureDevice().groupId());
         settings.setVolume(volume());
         settings.setEchoCancellation(echoCancellation());
         settings.setSampleRate(sampleRate());
@@ -99,6 +100,7 @@ const RealtimeMediaSourceSettings& MockRealtimeAudioSource::settings()
 
         RealtimeMediaSourceSupportedConstraints supportedConstraints;
         supportedConstraints.setSupportsDeviceId(true);
+        supportedConstraints.setSupportsGroupId(true);
         supportedConstraints.setSupportsVolume(true);
         supportedConstraints.setSupportsEchoCancellation(true);
         supportedConstraints.setSupportsSampleRate(true);

--- a/Source/WebCore/platform/mock/MockRealtimeVideoSource.cpp
+++ b/Source/WebCore/platform/mock/MockRealtimeVideoSource.cpp
@@ -190,6 +190,8 @@ const RealtimeMediaSourceSettings& MockRealtimeVideoSource::settings()
         settings.setLogicalSurface(false);
     }
     settings.setDeviceId(hashedId());
+    settings.setGroupId(captureDevice().groupId());
+
     settings.setFrameRate(frameRate());
     auto size = this->size();
     if (mockCamera()) {
@@ -206,6 +208,7 @@ const RealtimeMediaSourceSettings& MockRealtimeVideoSource::settings()
     if (mockCamera())
         supportedConstraints.setSupportsAspectRatio(true);
     supportedConstraints.setSupportsDeviceId(true);
+    supportedConstraints.setSupportsGroupId(true);
     if (mockCamera()) {
         if (facingMode() != VideoFacingMode::Unknown)
             supportedConstraints.setSupportsFacingMode(true);

--- a/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
+++ b/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
@@ -4273,7 +4273,7 @@ class WebCore::RealtimeMediaSourceSettings {
     uint32_t sampleSize();
     bool echoCancellation();
     AtomString deviceId();
-    AtomString groupId();
+    String groupId();
     AtomString label();
     WebCore::DisplaySurfaceType displaySurface();
     bool logicalSurface();


### PR DESCRIPTION
#### 2c7efa4c85e283b4c1b31caaa981a3acf02b70b8
<pre>
Camera and microphone should all have groupIds
<a href="https://bugs.webkit.org/show_bug.cgi?id=256787">https://bugs.webkit.org/show_bug.cgi?id=256787</a>
rdar://109355290

Reviewed by Eric Carlson.

Add support for groupId in MediaStreamTrack settings and capabilities.
This aligns the support with Chrome and Firefox.
In case CaptureDevice does not have a groupId, we use the persistentId instead.

* LayoutTests/fast/mediastream/MediaStreamTrack-getCapabilities-expected.txt:
* LayoutTests/fast/mediastream/MediaStreamTrack-getSettings-expected.txt:
* LayoutTests/fast/mediastream/get-user-media-device-id.html:
* LayoutTests/fast/mediastream/media-device-info-expected.txt:
* LayoutTests/fast/mediastream/media-device-info.html:
* LayoutTests/imported/w3c/web-platform-tests/mediacapture-streams/MediaStreamTrack-getCapabilities.https-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/mediacapture-streams/MediaStreamTrack-getSettings.https-expected.txt:
* Source/WebCore/Modules/mediastream/InputDeviceInfo.cpp:
(WebCore::InputDeviceInfo::getCapabilities const):
* Source/WebCore/Modules/mediastream/MediaDevices.cpp:
(WebCore::MediaDevices::exposeDevices):
(WebCore::MediaDevices::hashedGroupId):
* Source/WebCore/Modules/mediastream/MediaDevices.h:
* Source/WebCore/Modules/mediastream/MediaStreamTrack.cpp:
(WebCore::MediaStreamTrack::MediaStreamTrack):
(WebCore::MediaStreamTrack::getSettings const):
(WebCore::MediaStreamTrack::getCapabilities const):
* Source/WebCore/Modules/mediastream/MediaStreamTrack.h:
* Source/WebCore/Modules/mediastream/MediaTrackCapabilities.cpp:
(WebCore::toMediaTrackCapabilities):
* Source/WebCore/Modules/mediastream/MediaTrackCapabilities.h:
* Source/WebCore/platform/mediastream/CaptureDevice.h:
(WebCore::CaptureDevice::groupId const):
* Source/WebCore/platform/mediastream/RealtimeMediaSourceSettings.h:
(WebCore::RealtimeMediaSourceSettings::RealtimeMediaSourceSettings):
(WebCore::RealtimeMediaSourceSettings::groupId const):
(WebCore::RealtimeMediaSourceSettings::setGroupId):
* Source/WebCore/platform/mediastream/mac/AVVideoCaptureSource.mm:
(WebCore::AVVideoCaptureSource::settings):
* Source/WebCore/platform/mediastream/mac/CoreAudioCaptureSource.cpp:
(WebCore::CoreAudioCaptureSource::settings):
* Source/WebCore/platform/mock/MockRealtimeAudioSource.cpp:
(WebCore::MockRealtimeAudioSource::settings):
* Source/WebCore/platform/mock/MockRealtimeVideoSource.cpp:
(WebCore::MockRealtimeVideoSource::settings):
* Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in:

Canonical link: <a href="https://commits.webkit.org/264112@main">https://commits.webkit.org/264112@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/21021aa55abd7357c3b2be43dfd17379b5b74a49

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/6746 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/6963 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/7148 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/8334 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/7000 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/6745 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/8110 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/6907 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/9903 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/6863 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/7447 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/6188 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/8428 "Built successfully") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/39/builds/4885 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/6110 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/13921 "Passed tests") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/6635 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/6190 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/8945 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/6675 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/5469 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/6061 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/6033 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/1589 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/10238 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/6434 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->