### PR TITLE
Expose WKBackForwardListItem._wasCreatedByJSWithoutUserInteraction as SPI

### DIFF
--- a/Source/WebKit/UIProcess/API/Cocoa/WKBackForwardListItem.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKBackForwardListItem.mm
@@ -73,9 +73,14 @@
     return nullptr;
 }
 
-- (CGPoint) _scrollPosition
+- (CGPoint)_scrollPosition
 {
     return CGPointMake(_item->pageState().mainFrameState.scrollPosition.x(), _item->pageState().mainFrameState.scrollPosition.y());
+}
+
+- (BOOL)_wasCreatedByJSWithoutUserInteraction
+{
+    return _item->wasCreatedByJSWithoutUserInteraction();
 }
 
 #pragma mark WKObject protocol implementation

--- a/Source/WebKit/UIProcess/API/Cocoa/WKBackForwardListItemPrivate.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKBackForwardListItemPrivate.h
@@ -31,5 +31,6 @@
 - (CGImageRef)_copySnapshotForTesting WK_API_AVAILABLE(macos(10.12.3), ios(10.3));
 
 @property (nonatomic) CGPoint _scrollPosition WK_API_AVAILABLE(macos(10.14.4), ios(12.2));
+@property (nonatomic, readonly) BOOL _wasCreatedByJSWithoutUserInteraction WK_API_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA));
 
 @end


### PR DESCRIPTION
#### 168fc8d9d4cf8ecc403c5fd070375821983c8d4b
<pre>
Expose WKBackForwardListItem._wasCreatedByJSWithoutUserInteraction as SPI
<a href="https://bugs.webkit.org/show_bug.cgi?id=256798">https://bugs.webkit.org/show_bug.cgi?id=256798</a>
rdar://109366865

Reviewed by Brent Fulgham.

Expose WKBackForwardListItem._wasCreatedByJSWithoutUserInteraction as SPI. We
use this flag internally to determine whether or not we should skip a
particular back/forward list item when navigating back / forward.

* Source/WebKit/UIProcess/API/Cocoa/WKBackForwardListItem.mm:
(-[WKBackForwardListItem _scrollPosition]):
(-[WKBackForwardListItem _wasCreatedByJSWithoutUserInteraction]):
* Source/WebKit/UIProcess/API/Cocoa/WKBackForwardListItemPrivate.h:
* Tools/TestWebKitAPI/Tests/WebKit/WKBackForwardListTests.mm:
(runBackForwardNavigationSkipsItemsWithoutUserGestureTest):
(runBackForwardNavigationDoesNotSkipItemsWithUserGestureTest):
(TEST):

Canonical link: <a href="https://commits.webkit.org/264082@main">https://commits.webkit.org/264082@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9a20a610342fff38112f6da4551aebaba14a436b

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/6653 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/6869 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/7051 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/8244 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/6934 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/6652 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/7952 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/6817 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/9829 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/6771 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/7296 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/6090 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/8331 "Built successfully") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/39/builds/4762 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/6018 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/13850 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/6563 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/6098 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/8786 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/6587 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/5396 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/5983 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/10155 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/773 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/6356 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->