### PR TITLE
[build.webkit.org] Replace shell.ShellCommand with new-style

### DIFF
--- a/Tools/CISupport/build-webkit-org/steps_unittest.py
+++ b/Tools/CISupport/build-webkit-org/steps_unittest.py
@@ -523,6 +523,7 @@ class TestShowIdentifier(BuildStepMixinAdditions, unittest.TestCase):
     def tearDown(self):
         return self.tearDownBuildStep()
 
+    @defer.inlineCallbacks
     def test_success(self):
         self.setupStep(ShowIdentifier())
         self.setProperty('got_revision', 'd3f2b739b65eda1eeb651991a3554dfaeebdfe0b')
@@ -531,13 +532,13 @@ class TestShowIdentifier(BuildStepMixinAdditions, unittest.TestCase):
                         timeout=600,
                         logEnviron=False,
                         command=['python3', 'Tools/Scripts/git-webkit', 'find', 'd3f2b739b65eda1eeb651991a3554dfaeebdfe0b']) +
-            ExpectShell.log('stdio', stdout='Identifier: 233939@main') +
+            ExpectShell.log('stdio', stdout='Identifier: 233939@main\n') +
             0,
         )
         self.expectOutcome(result=SUCCESS, state_string='Identifier: 233939@main')
-        rc = self.runStep()
+        rc = yield self.runStep()
         self.assertEqual(self.getProperty('identifier'), '233939@main')
-        return rc
+        defer.returnValue(rc)
 
     def test_failure(self):
         self.setupStep(ShowIdentifier())


### PR DESCRIPTION
#### 81e4e7cf4e5723042e5bd7cf97d60d530e92af14
<pre>
[build.webkit.org] Replace shell.ShellCommand with new-style
<a href="https://bugs.webkit.org/show_bug.cgi?id=256799">https://bugs.webkit.org/show_bug.cgi?id=256799</a>
rdar://109367941

Reviewed by Aakash Jain.

In an effort to modernize our buildbot code, we should deprecate
shell.ShellCommand in favor of shell.ShellCommandNewStyle.

* Tools/CISupport/build-webkit-org/steps.py:
(CleanUpGitIndexLock):
(CheckOutSpecificRevision):
(PruneCoreSymbolicationdCacheIfTooLarge):
(InstallWinCairoDependencies):
(InstallGtkDependencies):
(InstallWpeDependencies):
(InstallBuiltProduct):
(ArchiveBuiltProduct):
(UploadBuiltProductViaSftp):
(UploadMiniBrowserBundleViaSftp):
(UploadJSCBundleViaSftp):
(GenerateJSCBundle):
(GenerateMiniBrowserBundle):
(ExtractBuiltProduct):
(DownloadBuiltProduct):
(ArchiveTestResults):
(ShowIdentifier):
* Tools/CISupport/build-webkit-org/steps_unittest.py:
(TestShowIdentifier):
(TestShowIdentifier.test_success):

Canonical link: <a href="https://commits.webkit.org/264202@main">https://commits.webkit.org/264202@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5b4943f3bbb1a1fe78b003f32f6228660190a04b

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/6654 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/6870 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/7052 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/8245 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/6935 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/6653 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/7953 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/6818 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/9830 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/6772 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/7300 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/6089 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/8332 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/4767 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/6017 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/13851 "Passed tests") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/6564 "Build was cancelled. Recent messages:OS: Ventura (13.3), Xcode: 14.3; Skipping applying patch since patch_id isn't provided; Checked out pull request; run-api-tests (cancelled)") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/6097 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/8788 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/6588 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/5398 "Passed tests") | | 
| [✅ 🧪 services](https://ews-build.webkit.org/#/builders/28/builds/6615 "Passed tests") | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/5984 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/10156 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/815 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/6357 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->