### PR TITLE
Remove `PKApplePayLaterAvailability` staging code

### DIFF
--- a/LayoutTests/http/tests/paymentrequest/paymentrequest-applePayLaterAvailability.https.html
+++ b/LayoutTests/http/tests/paymentrequest/paymentrequest-applePayLaterAvailability.https.html
@@ -46,7 +46,7 @@ user_activation_test(async (test) => {
 
 user_activation_test(async (test) => {
     const method = validPaymentMethod();
-    method.data.applePayLaterAvailability = "unavailableMerchantIneligible";
+    method.data.applePayLaterAvailability = "unavailableRecurringTransaction";
 
     let request = new PaymentRequest([method], validPaymentDetails());
     request.addEventListener("merchantvalidation", (event) => {

--- a/Source/WebCore/Modules/applepay/ApplePayLaterAvailability.h
+++ b/Source/WebCore/Modules/applepay/ApplePayLaterAvailability.h
@@ -33,7 +33,6 @@ namespace WebCore {
 
 enum class ApplePayLaterAvailability : uint8_t {
     Available,
-    UnavailableMerchantIneligible,
     UnavailableItemIneligible,
     UnavailableRecurringTransaction,
 };
@@ -46,7 +45,6 @@ template<> struct EnumTraits<WebCore::ApplePayLaterAvailability> {
     using values = EnumValues<
         WebCore::ApplePayLaterAvailability,
         WebCore::ApplePayLaterAvailability::Available,
-        WebCore::ApplePayLaterAvailability::UnavailableMerchantIneligible,
         WebCore::ApplePayLaterAvailability::UnavailableItemIneligible,
         WebCore::ApplePayLaterAvailability::UnavailableRecurringTransaction
     >;

--- a/Source/WebCore/Modules/applepay/ApplePayLaterAvailability.idl
+++ b/Source/WebCore/Modules/applepay/ApplePayLaterAvailability.idl
@@ -28,7 +28,6 @@
     ExportMacro=WEBCORE_EXPORT,
 ] enum ApplePayLaterAvailability {
     "available",
-    "unavailableMerchantIneligible",
     "unavailableItemIneligible",
     "unavailableRecurringTransaction"
 };

--- a/Source/WebCore/PAL/pal/spi/cocoa/PassKitSPI.h
+++ b/Source/WebCore/PAL/pal/spi/cocoa/PassKitSPI.h
@@ -300,6 +300,20 @@ typedef NS_ENUM(NSInteger, PKPaymentSetupFeatureType) {
 @end
 #endif
 
+#if HAVE(PASSKIT_APPLE_PAY_LATER_AVAILABILITY)
+
+typedef NS_ENUM(NSInteger, PKApplePayLaterAvailability) {
+    PKApplePayLaterAvailable,
+    PKApplePayLaterUnavailableItemIneligible,
+    PKApplePayLaterUnavailableRecurringTransaction,
+};
+
+@interface PKPaymentRequest ()
+@property (nonatomic, assign) PKApplePayLaterAvailability applePayLaterAvailability;
+@end
+
+#endif
+
 NS_ASSUME_NONNULL_END
 
 #endif // USE(APPLE_INTERNAL_SDK)
@@ -340,18 +354,6 @@ typedef void(^PKCanMakePaymentsCompletion)(BOOL isValid, NSError *);
 @interface PKDeferredPaymentRequest (Staging_104652810)
 @property (nonatomic, strong, nullable) NSTimeZone *freeCancellationDateTimeZone;
 @end
-#endif
-
-#if HAVE(PASSKIT_APPLE_PAY_LATER_AVAILABILITY)
-
-// FIXME: rdar://107955442 Remove staging code.
-
-typedef NS_ENUM(NSInteger, PKApplePayLaterAvailability);
-
-@interface PKPaymentRequest (Staging_107259773)
-@property (nonatomic, assign) PKApplePayLaterAvailability applePayLaterAvailability;
-@end
-
 #endif
 
 NS_ASSUME_NONNULL_END

--- a/Source/WebKit/Shared/ApplePay/cocoa/WebPaymentCoordinatorProxyCocoa.mm
+++ b/Source/WebKit/Shared/ApplePay/cocoa/WebPaymentCoordinatorProxyCocoa.mm
@@ -58,17 +58,6 @@
 @property (nonatomic, strong) NSURL *thumbnailURL;
 @end
 
-#if HAVE(PASSKIT_APPLE_PAY_LATER_AVAILABILITY)
-
-// FIXME: rdar://107955442 Remove staging code.
-
-#define PKApplePayLaterAvailable 0
-#define PKApplePayLaterUnavailableMerchantIneligible 1
-#define PKApplePayLaterUnavailableItemIneligible 2
-#define PKApplePayLaterUnavailableRecurringTransaction 3
-
-#endif
-
 namespace WebKit {
 
 WebPaymentCoordinatorProxy::WebPaymentCoordinatorProxy(WebPaymentCoordinatorProxy::Client& client)
@@ -261,19 +250,15 @@ ALLOW_DEPRECATED_DECLARATIONS_END
 
 static PKApplePayLaterAvailability toPKApplePayLaterAvailability(WebCore::ApplePayLaterAvailability applePayLaterAvailability)
 {
-    // FIXME: rdar://107955442 Remove staging code.
     switch (applePayLaterAvailability) {
     case WebCore::ApplePayLaterAvailability::Available:
-        return (PKApplePayLaterAvailability)PKApplePayLaterAvailable;
-
-    case WebCore::ApplePayLaterAvailability::UnavailableMerchantIneligible:
-        return (PKApplePayLaterAvailability)PKApplePayLaterUnavailableMerchantIneligible;
+        return PKApplePayLaterAvailable;
 
     case WebCore::ApplePayLaterAvailability::UnavailableItemIneligible:
-        return (PKApplePayLaterAvailability)PKApplePayLaterUnavailableItemIneligible;
+        return PKApplePayLaterUnavailableItemIneligible;
 
     case WebCore::ApplePayLaterAvailability::UnavailableRecurringTransaction:
-        return (PKApplePayLaterAvailability)PKApplePayLaterUnavailableRecurringTransaction;
+        return PKApplePayLaterUnavailableRecurringTransaction;
     }
 }
 
@@ -385,9 +370,7 @@ ALLOW_DEPRECATED_DECLARATIONS_END
 
 #if HAVE(PASSKIT_APPLE_PAY_LATER_AVAILABILITY)
     if (auto& applePayLaterAvailability = paymentRequest.applePayLaterAvailability()) {
-        // FIXME: rdar://107955442 Remove staging code.
-        if ([result respondsToSelector:@selector(setApplePayLaterAvailability:)])
-            [result setApplePayLaterAvailability:toPKApplePayLaterAvailability(*applePayLaterAvailability)];
+        [result setApplePayLaterAvailability:toPKApplePayLaterAvailability(*applePayLaterAvailability)];
     }
 #endif
 


### PR DESCRIPTION
#### 6529c84e61106eac2b3bb837cbcb2448b9a01102
<pre>
Remove `PKApplePayLaterAvailability` staging code
<a href="https://bugs.webkit.org/show_bug.cgi?id=255360">https://bugs.webkit.org/show_bug.cgi?id=255360</a>
rdar://107955442

Reviewed by Aditya Keerthi.

This commit removes the staging code and also removes the merchant
ineligible reason from PKApplePayLaterAvailability, mirroring recent
changes to the upstream PK API.

* LayoutTests/http/tests/paymentrequest/paymentrequest-applePayLaterAvailability.https.html:

Use a different PKApplePayLaterAvailability enumeration value. All of
them serve the same purpose in this test context.

* Source/WebCore/Modules/applepay/ApplePayLaterAvailability.h:
* Source/WebCore/Modules/applepay/ApplePayLaterAvailability.idl:
* Source/WebCore/PAL/pal/spi/cocoa/PassKitSPI.h:
* Source/WebKit/Shared/ApplePay/cocoa/WebPaymentCoordinatorProxyCocoa.mm:
(WebKit::toPKApplePayLaterAvailability):
(WebKit::WebPaymentCoordinatorProxy::platformPaymentRequest):

Canonical link: <a href="https://commits.webkit.org/264096@main">https://commits.webkit.org/264096@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a1800a4bbcfbb2ef1dac06187087415cbae58da6

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/6675 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/6891 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/7073 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/8264 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/6948 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/6674 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/7981 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/6837 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/9846 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/6793 "Passed tests") | [⏳ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/iOS-16-Simulator-WK2-Tests-EWS "Waiting to run tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/6111 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/8353 "Built successfully") | 
| | [⏳ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/iOS-16-Simulator-WPT-WK2-Tests-EWS "Waiting to run tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/6039 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/13868 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [⏳ 🧪 api-ios](https://ews-build.webkit.org/#/builders/API-Tests-iOS-Simulator-EWS "Waiting to run tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/6120 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/8825 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/6606 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/5411 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/6001 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/5967 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/1578 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/10173 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/6374 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->