### PR TITLE
[JSC] Not use Strong<> in VM and simplify jsString

### DIFF
--- a/Source/JavaScriptCore/dfg/DFGSafeToExecute.h
+++ b/Source/JavaScriptCore/dfg/DFGSafeToExecute.h
@@ -345,7 +345,7 @@ bool safeToExecute(AbstractStateType& state, Graph& graph, Node* node, bool igno
         if (value.isInfinite() || value.size() != 1)
             return false;
 
-        return value[0].get() == graph.m_vm.getterSetterStructure;
+        return value[0].get() == graph.m_vm.getterSetterStructure.get();
     }
 
     case BottomValue:

--- a/Source/JavaScriptCore/ftl/FTLLowerDFGToB3.cpp
+++ b/Source/JavaScriptCore/ftl/FTLLowerDFGToB3.cpp
@@ -22311,7 +22311,7 @@ IGNORE_CLANG_WARNINGS_END
         LValue maskedStructureID = structureID;
         if constexpr (structureHeapAddressSize < 4 * GB)
             maskedStructureID = m_out.bitAnd(structureID, m_out.constInt32(StructureID::structureIDMask));
-        return m_out.bitOr(m_out.constIntPtr(g_jscConfig.startOfStructureHeap), m_out.zeroExtPtr(maskedStructureID));
+        return m_out.bitOr(m_out.constIntPtr(startOfStructureHeap()), m_out.zeroExtPtr(maskedStructureID));
 #endif
     }
 

--- a/Source/JavaScriptCore/heap/Heap.cpp
+++ b/Source/JavaScriptCore/heap/Heap.cpp
@@ -2868,7 +2868,6 @@ void Heap::addCoreConstraints()
                 SetRootMarkReasonScope rootScope(visitor, RootMarkReason::StrongReferences);
                 if (vm.smallStrings.needsToBeVisited(*m_collectionScope))
                     vm.smallStrings.visitStrongReferences(visitor);
-                vm.visitAggregate(visitor);
             }
             
             {
@@ -2908,6 +2907,7 @@ void Heap::addCoreConstraints()
         MAKE_MARKING_CONSTRAINT_EXECUTOR_PAIR(([this] (auto& visitor) {
             SetRootMarkReasonScope rootScope(visitor, RootMarkReason::StrongHandles);
             m_handleSet.visitStrongHandles(visitor);
+            vm().visitAggregate(visitor);
         })),
         ConstraintVolatility::GreyedByExecution);
     

--- a/Source/JavaScriptCore/jit/AssemblyHelpers.cpp
+++ b/Source/JavaScriptCore/jit/AssemblyHelpers.cpp
@@ -545,7 +545,7 @@ void AssemblyHelpers::emitNonNullDecodeZeroExtendedStructureID(RegisterID source
         move(source, dest);
     } else
         and32(TrustedImm32(StructureID::structureIDMask), source, dest);
-    or64(TrustedImm64(g_jscConfig.startOfStructureHeap), dest);
+    or64(TrustedImm64(startOfStructureHeap()), dest);
 #else // not CPU(ADDRESS64)
     move(source, dest);
 #endif

--- a/Source/JavaScriptCore/runtime/JSCConfig.h
+++ b/Source/JavaScriptCore/runtime/JSCConfig.h
@@ -131,6 +131,11 @@ constexpr size_t offsetOfJSCConfigInitializeHasBeenCalled = offsetof(JSC::Config
 constexpr size_t offsetOfJSCConfigGateMap = offsetof(JSC::Config, llint.gateMap);
 constexpr size_t offsetOfJSCConfigStartOfStructureHeap = offsetof(JSC::Config, startOfStructureHeap);
 
+ALWAYS_INLINE PURE_FUNCTION uintptr_t startOfStructureHeap()
+{
+    return g_jscConfig.startOfStructureHeap;
+}
+
 } // namespace JSC
 
 #if !ENABLE(UNIFIED_AND_FREEZABLE_CONFIG_RECORD)

--- a/Source/JavaScriptCore/runtime/JSCell.h
+++ b/Source/JavaScriptCore/runtime/JSCell.h
@@ -110,7 +110,9 @@ public:
 
     enum CreatingEarlyCellTag { CreatingEarlyCell };
     JSCell(CreatingEarlyCellTag);
-    
+    enum CreatingWellDefinedBuiltinCellTag { CreatingWellDefinedBuiltinCell };
+    JSCell(CreatingWellDefinedBuiltinCellTag, StructureID, int32_t typeInfoBlob);
+
     JS_EXPORT_PRIVATE static void destroy(JSCell*);
 
 protected:

--- a/Source/JavaScriptCore/runtime/JSGlobalObject.h
+++ b/Source/JavaScriptCore/runtime/JSGlobalObject.h
@@ -722,6 +722,7 @@ public:
     Structure* scopedArgumentsStructure() const { return m_scopedArgumentsStructure.get(); }
     Structure* clonedArgumentsStructure() const { return m_clonedArgumentsStructure.get(); }
     Structure* objectStructureForObjectConstructor() const { return m_objectStructureForObjectConstructor.get(); }
+    StructureID objectStructureIDForObjectConstructor() const { return m_objectStructureForObjectConstructor.value(); }
     Structure* originalArrayStructureForIndexingType(IndexingType indexingType) const
     {
         ASSERT(indexingType & IsArray);

--- a/Source/JavaScriptCore/runtime/JSObjectInlines.h
+++ b/Source/JavaScriptCore/runtime/JSObjectInlines.h
@@ -861,8 +861,9 @@ bool JSObject::fastForEachPropertyWithSideEffectFreeFunctor(VM& vm, const Functo
 ALWAYS_INLINE JSFinalObject* JSFinalObject::createDefaultEmptyObject(JSGlobalObject* globalObject)
 {
     VM& vm = getVM(globalObject);
-    JSFinalObject* finalObject = new (NotNull, allocateCell<JSFinalObject>(vm, allocationSize(defaultInlineCapacity))) JSFinalObject(vm, globalObject->objectStructureForObjectConstructor(), nullptr, defaultInlineCapacity);
+    JSFinalObject* finalObject = new (NotNull, allocateCell<JSFinalObject>(vm, allocationSize(defaultInlineCapacity))) JSFinalObject(CreatingWellDefinedBuiltinCell, globalObject->objectStructureIDForObjectConstructor());
     finalObject->finishCreation(vm);
+    ASSERT(globalObject->objectStructureForObjectConstructor()->id() == globalObject->objectStructureIDForObjectConstructor());
     ASSERT(globalObject->objectStructureForObjectConstructor()->inlineCapacity() == defaultInlineCapacity);
     return finalObject;
 }

--- a/Source/JavaScriptCore/runtime/JSString.cpp
+++ b/Source/JavaScriptCore/runtime/JSString.cpp
@@ -36,7 +36,7 @@ const ClassInfo JSString::s_info = { "string"_s, nullptr, nullptr, nullptr, CREA
 
 Structure* JSString::createStructure(VM& vm, JSGlobalObject* globalObject, JSValue proto)
 {
-    return Structure::create(vm, globalObject, proto, TypeInfo(StringType, StructureFlags), info());
+    return Structure::create(vm, globalObject, proto, defaultTypeInfo(), info());
 }
 
 JSString* JSString::createEmptyString(VM& vm)
@@ -399,7 +399,7 @@ JSString* jsStringWithCacheSlowCase(VM& vm, StringImpl& stringImpl)
 {
     ASSERT(stringImpl.length() > 1 || (stringImpl.length() == 1 && stringImpl[0] > maxSingleCharacterString));
     JSString* string = JSString::create(vm, stringImpl);
-    vm.lastCachedString.set(vm, string);
+    vm.lastCachedString.setWithoutWriteBarrier(string);
     return string;
 }
 

--- a/Source/JavaScriptCore/runtime/JSString.h
+++ b/Source/JavaScriptCore/runtime/JSString.h
@@ -143,14 +143,20 @@ private:
         return uninitializedValueInternal();
     }
 
+    static constexpr TypeInfo defaultTypeInfo() { return TypeInfo(StringType, StructureFlags); }
+    static constexpr int32_t defaultTypeInfoBlob()
+    {
+        return TypeInfoBlob::typeInfoBlob(NonArray, defaultTypeInfo().type(), defaultTypeInfo().inlineTypeFlags());
+    }
+
     JSString(VM& vm, Ref<StringImpl>&& value)
-        : JSCell(vm, vm.stringStructure.get())
+        : JSCell(CreatingWellDefinedBuiltinCell, vm.stringStructure.get()->id(), defaultTypeInfoBlob())
     {
         new (&uninitializedValueInternal()) String(WTFMove(value));
     }
 
     JSString(VM& vm)
-        : JSCell(vm, vm.stringStructure.get())
+        : JSCell(CreatingWellDefinedBuiltinCell, vm.stringStructure.get()->id(), defaultTypeInfoBlob())
         , m_fiber(isRopeInPointer)
     {
     }

--- a/Source/JavaScriptCore/runtime/JSTypeInfo.h
+++ b/Source/JavaScriptCore/runtime/JSTypeInfo.h
@@ -70,20 +70,20 @@ public:
     typedef uint8_t InlineTypeFlags;
     typedef uint16_t OutOfLineTypeFlags;
 
-    TypeInfo(JSType type, unsigned flags)
+    constexpr TypeInfo(JSType type, unsigned flags)
         : TypeInfo(type, flags & 0xff, flags >> numberOfInlineBits)
     {
-        ASSERT(!(flags >> 24));
+        ASSERT_UNDER_CONSTEXPR_CONTEXT(!(flags >> 24));
     }
 
-    TypeInfo(JSType type, InlineTypeFlags inlineTypeFlags, OutOfLineTypeFlags outOfLineTypeFlags)
+    constexpr TypeInfo(JSType type, InlineTypeFlags inlineTypeFlags, OutOfLineTypeFlags outOfLineTypeFlags)
         : m_type(type)
         , m_flags(inlineTypeFlags)
         , m_flags2(outOfLineTypeFlags)
     {
     }
 
-    JSType type() const { return static_cast<JSType>(m_type); }
+    constexpr JSType type() const { return static_cast<JSType>(m_type); }
     bool isObject() const { return isObject(type()); }
     static bool isObject(JSType type) { return type >= ObjectType; }
     bool isFinalObject() const { return type() == FinalObjectType; }
@@ -138,8 +138,8 @@ public:
         return structureFlags | (oldCellFlags & static_cast<InlineTypeFlags>(TypeInfoPerCellBit));
     }
 
-    InlineTypeFlags inlineTypeFlags() const { return m_flags; }
-    OutOfLineTypeFlags outOfLineTypeFlags() const { return m_flags2; }
+    constexpr InlineTypeFlags inlineTypeFlags() const { return m_flags; }
+    constexpr OutOfLineTypeFlags outOfLineTypeFlags() const { return m_flags2; }
 
 private:
     friend class LLIntOffsetsExtractor;

--- a/Source/JavaScriptCore/runtime/StructureID.h
+++ b/Source/JavaScriptCore/runtime/StructureID.h
@@ -129,7 +129,7 @@ ALWAYS_INLINE Structure* StructureID::decode() const
 {
     // Take care to only use the bits from m_bits in the structure's address reservation.
     ASSERT(decontaminate());
-    return reinterpret_cast<Structure*>((static_cast<uintptr_t>(decontaminate().m_bits) & structureIDMask) + g_jscConfig.startOfStructureHeap);
+    return reinterpret_cast<Structure*>((static_cast<uintptr_t>(decontaminate().m_bits) & structureIDMask) + startOfStructureHeap());
 }
 
 ALWAYS_INLINE Structure* StructureID::tryDecode() const
@@ -138,13 +138,13 @@ ALWAYS_INLINE Structure* StructureID::tryDecode() const
     uintptr_t offset = static_cast<uintptr_t>(decontaminate().m_bits);
     if (offset < MarkedBlock::blockSize || offset >= g_jscConfig.sizeOfStructureHeap)
         return nullptr;
-    return reinterpret_cast<Structure*>((offset & structureIDMask) + g_jscConfig.startOfStructureHeap);
+    return reinterpret_cast<Structure*>((offset & structureIDMask) + startOfStructureHeap());
 }
 
 ALWAYS_INLINE StructureID StructureID::encode(const Structure* structure)
 {
     ASSERT(structure);
-    ASSERT(g_jscConfig.startOfStructureHeap <= reinterpret_cast<uintptr_t>(structure) && reinterpret_cast<uintptr_t>(structure) < g_jscConfig.startOfStructureHeap + structureHeapAddressSize);
+    ASSERT(g_jscConfig.startOfStructureHeap <= reinterpret_cast<uintptr_t>(structure) && reinterpret_cast<uintptr_t>(structure) < startOfStructureHeap() + structureHeapAddressSize);
     auto result = StructureID(reinterpret_cast<uintptr_t>(structure) & structureIDMask);
     ASSERT(result.decode() == structure);
     return result;

--- a/Source/JavaScriptCore/runtime/TypeInfoBlob.h
+++ b/Source/JavaScriptCore/runtime/TypeInfoBlob.h
@@ -59,6 +59,15 @@ public:
     TypeInfo typeInfo(TypeInfo::OutOfLineTypeFlags outOfLineTypeFlags) const { return TypeInfo(type(), inlineTypeFlags(), outOfLineTypeFlags); }
     CellState defaultCellState() const { return u.fields.defaultCellState; }
 
+    static constexpr int32_t typeInfoBlob(IndexingType indexingModeIncludingHistory, JSType type, TypeInfo::InlineTypeFlags inlineTypeFlags)
+    {
+#if CPU(LITTLE_ENDIAN)
+        return static_cast<int32_t>((static_cast<uint32_t>(indexingModeIncludingHistory) << 0) | (static_cast<uint32_t>(type) << 8) | (static_cast<uint32_t>(inlineTypeFlags) << 16) | (static_cast<uint32_t>(CellState::DefinitelyWhite) << 24));
+#else
+        return static_cast<int32_t>((static_cast<uint32_t>(indexingModeIncludingHistory) << 24) | (static_cast<uint32_t>(type) << 16) | (static_cast<uint32_t>(inlineTypeFlags) << 8) | (static_cast<uint32_t>(CellState::DefinitelyWhite) << 0));
+#endif
+    }
+
     int32_t blob() const { return u.word; }
 
     static ptrdiff_t indexingModeIncludingHistoryOffset()

--- a/Source/JavaScriptCore/runtime/VM.cpp
+++ b/Source/JavaScriptCore/runtime/VM.cpp
@@ -231,55 +231,54 @@ VM::VM(VMType vmType, HeapType heapType, WTF::RunLoop* runLoop, bool* success)
     // Need to be careful to keep everything consistent here
     JSLockHolder lock(this);
     AtomStringTable* existingEntryAtomStringTable = Thread::current().setCurrentAtomStringTable(m_atomStringTable);
-    structureStructure.set(*this, Structure::createStructure(*this));
-    structureRareDataStructure.set(*this, StructureRareData::createStructure(*this, nullptr, jsNull()));
-    stringStructure.set(*this, JSString::createStructure(*this, nullptr, jsNull()));
+    structureStructure.setWithoutWriteBarrier(Structure::createStructure(*this));
+    structureRareDataStructure.setWithoutWriteBarrier(StructureRareData::createStructure(*this, nullptr, jsNull()));
+    stringStructure.setWithoutWriteBarrier(JSString::createStructure(*this, nullptr, jsNull()));
 
     smallStrings.initializeCommonStrings(*this);
 
     propertyNames = new CommonIdentifiers(*this);
-    propertyNameEnumeratorStructure.set(*this, JSPropertyNameEnumerator::createStructure(*this, nullptr, jsNull()));
-    getterSetterStructure.set(*this, GetterSetter::createStructure(*this, nullptr, jsNull()));
-    customGetterSetterStructure.set(*this, CustomGetterSetter::createStructure(*this, nullptr, jsNull()));
-    domAttributeGetterSetterStructure.set(*this, DOMAttributeGetterSetter::createStructure(*this, nullptr, jsNull()));
-    scopedArgumentsTableStructure.set(*this, ScopedArgumentsTable::createStructure(*this, nullptr, jsNull()));
-    apiWrapperStructure.set(*this, JSAPIValueWrapper::createStructure(*this, nullptr, jsNull()));
-    nativeExecutableStructure.set(*this, NativeExecutable::createStructure(*this, nullptr, jsNull()));
-    evalExecutableStructure.set(*this, EvalExecutable::createStructure(*this, nullptr, jsNull()));
-    programExecutableStructure.set(*this, ProgramExecutable::createStructure(*this, nullptr, jsNull()));
-    functionExecutableStructure.set(*this, FunctionExecutable::createStructure(*this, nullptr, jsNull()));
-    moduleProgramExecutableStructure.set(*this, ModuleProgramExecutable::createStructure(*this, nullptr, jsNull()));
-    regExpStructure.set(*this, RegExp::createStructure(*this, nullptr, jsNull()));
-    symbolStructure.set(*this, Symbol::createStructure(*this, nullptr, jsNull()));
-    symbolTableStructure.set(*this, SymbolTable::createStructure(*this, nullptr, jsNull()));
+    propertyNameEnumeratorStructure.setWithoutWriteBarrier(JSPropertyNameEnumerator::createStructure(*this, nullptr, jsNull()));
+    getterSetterStructure.setWithoutWriteBarrier(GetterSetter::createStructure(*this, nullptr, jsNull()));
+    customGetterSetterStructure.setWithoutWriteBarrier(CustomGetterSetter::createStructure(*this, nullptr, jsNull()));
+    domAttributeGetterSetterStructure.setWithoutWriteBarrier(DOMAttributeGetterSetter::createStructure(*this, nullptr, jsNull()));
+    scopedArgumentsTableStructure.setWithoutWriteBarrier(ScopedArgumentsTable::createStructure(*this, nullptr, jsNull()));
+    apiWrapperStructure.setWithoutWriteBarrier(JSAPIValueWrapper::createStructure(*this, nullptr, jsNull()));
+    nativeExecutableStructure.setWithoutWriteBarrier(NativeExecutable::createStructure(*this, nullptr, jsNull()));
+    evalExecutableStructure.setWithoutWriteBarrier(EvalExecutable::createStructure(*this, nullptr, jsNull()));
+    programExecutableStructure.setWithoutWriteBarrier(ProgramExecutable::createStructure(*this, nullptr, jsNull()));
+    functionExecutableStructure.setWithoutWriteBarrier(FunctionExecutable::createStructure(*this, nullptr, jsNull()));
+    moduleProgramExecutableStructure.setWithoutWriteBarrier(ModuleProgramExecutable::createStructure(*this, nullptr, jsNull()));
+    regExpStructure.setWithoutWriteBarrier(RegExp::createStructure(*this, nullptr, jsNull()));
+    symbolStructure.setWithoutWriteBarrier(Symbol::createStructure(*this, nullptr, jsNull()));
+    symbolTableStructure.setWithoutWriteBarrier(SymbolTable::createStructure(*this, nullptr, jsNull()));
 
-    immutableButterflyStructures[arrayIndexFromIndexingType(CopyOnWriteArrayWithInt32) - NumberOfIndexingShapes].set(*this, JSImmutableButterfly::createStructure(*this, nullptr, jsNull(), CopyOnWriteArrayWithInt32));
+    immutableButterflyStructures[arrayIndexFromIndexingType(CopyOnWriteArrayWithInt32) - NumberOfIndexingShapes].setWithoutWriteBarrier(JSImmutableButterfly::createStructure(*this, nullptr, jsNull(), CopyOnWriteArrayWithInt32));
     Structure* copyOnWriteArrayWithContiguousStructure = JSImmutableButterfly::createStructure(*this, nullptr, jsNull(), CopyOnWriteArrayWithContiguous);
-    immutableButterflyStructures[arrayIndexFromIndexingType(CopyOnWriteArrayWithDouble) - NumberOfIndexingShapes].set(*this,
-        Options::allowDoubleShape() ? JSImmutableButterfly::createStructure(*this, nullptr, jsNull(), CopyOnWriteArrayWithDouble) : copyOnWriteArrayWithContiguousStructure);
-    immutableButterflyStructures[arrayIndexFromIndexingType(CopyOnWriteArrayWithContiguous) - NumberOfIndexingShapes].set(*this, copyOnWriteArrayWithContiguousStructure);
+    immutableButterflyStructures[arrayIndexFromIndexingType(CopyOnWriteArrayWithDouble) - NumberOfIndexingShapes].setWithoutWriteBarrier(Options::allowDoubleShape() ? JSImmutableButterfly::createStructure(*this, nullptr, jsNull(), CopyOnWriteArrayWithDouble) : copyOnWriteArrayWithContiguousStructure);
+    immutableButterflyStructures[arrayIndexFromIndexingType(CopyOnWriteArrayWithContiguous) - NumberOfIndexingShapes].setWithoutWriteBarrier(copyOnWriteArrayWithContiguousStructure);
 
-    sourceCodeStructure.set(*this, JSSourceCode::createStructure(*this, nullptr, jsNull()));
-    scriptFetcherStructure.set(*this, JSScriptFetcher::createStructure(*this, nullptr, jsNull()));
-    scriptFetchParametersStructure.set(*this, JSScriptFetchParameters::createStructure(*this, nullptr, jsNull()));
-    structureChainStructure.set(*this, StructureChain::createStructure(*this, nullptr, jsNull()));
-    sparseArrayValueMapStructure.set(*this, SparseArrayValueMap::createStructure(*this, nullptr, jsNull()));
-    templateObjectDescriptorStructure.set(*this, JSTemplateObjectDescriptor::createStructure(*this, nullptr, jsNull()));
-    unlinkedFunctionExecutableStructure.set(*this, UnlinkedFunctionExecutable::createStructure(*this, nullptr, jsNull()));
-    unlinkedProgramCodeBlockStructure.set(*this, UnlinkedProgramCodeBlock::createStructure(*this, nullptr, jsNull()));
-    unlinkedEvalCodeBlockStructure.set(*this, UnlinkedEvalCodeBlock::createStructure(*this, nullptr, jsNull()));
-    unlinkedFunctionCodeBlockStructure.set(*this, UnlinkedFunctionCodeBlock::createStructure(*this, nullptr, jsNull()));
-    unlinkedModuleProgramCodeBlockStructure.set(*this, UnlinkedModuleProgramCodeBlock::createStructure(*this, nullptr, jsNull()));
-    propertyTableStructure.set(*this, PropertyTable::createStructure(*this, nullptr, jsNull()));
-    functionRareDataStructure.set(*this, FunctionRareData::createStructure(*this, nullptr, jsNull()));
-    exceptionStructure.set(*this, Exception::createStructure(*this, nullptr, jsNull()));
-    programCodeBlockStructure.set(*this, ProgramCodeBlock::createStructure(*this, nullptr, jsNull()));
-    moduleProgramCodeBlockStructure.set(*this, ModuleProgramCodeBlock::createStructure(*this, nullptr, jsNull()));
-    evalCodeBlockStructure.set(*this, EvalCodeBlock::createStructure(*this, nullptr, jsNull()));
-    functionCodeBlockStructure.set(*this, FunctionCodeBlock::createStructure(*this, nullptr, jsNull()));
-    hashMapBucketSetStructure.set(*this, HashMapBucket<HashMapBucketDataKey>::createStructure(*this, nullptr, jsNull()));
-    hashMapBucketMapStructure.set(*this, HashMapBucket<HashMapBucketDataKeyValue>::createStructure(*this, nullptr, jsNull()));
-    bigIntStructure.set(*this, JSBigInt::createStructure(*this, nullptr, jsNull()));
+    sourceCodeStructure.setWithoutWriteBarrier(JSSourceCode::createStructure(*this, nullptr, jsNull()));
+    scriptFetcherStructure.setWithoutWriteBarrier(JSScriptFetcher::createStructure(*this, nullptr, jsNull()));
+    scriptFetchParametersStructure.setWithoutWriteBarrier(JSScriptFetchParameters::createStructure(*this, nullptr, jsNull()));
+    structureChainStructure.setWithoutWriteBarrier(StructureChain::createStructure(*this, nullptr, jsNull()));
+    sparseArrayValueMapStructure.setWithoutWriteBarrier(SparseArrayValueMap::createStructure(*this, nullptr, jsNull()));
+    templateObjectDescriptorStructure.setWithoutWriteBarrier(JSTemplateObjectDescriptor::createStructure(*this, nullptr, jsNull()));
+    unlinkedFunctionExecutableStructure.setWithoutWriteBarrier(UnlinkedFunctionExecutable::createStructure(*this, nullptr, jsNull()));
+    unlinkedProgramCodeBlockStructure.setWithoutWriteBarrier(UnlinkedProgramCodeBlock::createStructure(*this, nullptr, jsNull()));
+    unlinkedEvalCodeBlockStructure.setWithoutWriteBarrier(UnlinkedEvalCodeBlock::createStructure(*this, nullptr, jsNull()));
+    unlinkedFunctionCodeBlockStructure.setWithoutWriteBarrier(UnlinkedFunctionCodeBlock::createStructure(*this, nullptr, jsNull()));
+    unlinkedModuleProgramCodeBlockStructure.setWithoutWriteBarrier(UnlinkedModuleProgramCodeBlock::createStructure(*this, nullptr, jsNull()));
+    propertyTableStructure.setWithoutWriteBarrier(PropertyTable::createStructure(*this, nullptr, jsNull()));
+    functionRareDataStructure.setWithoutWriteBarrier(FunctionRareData::createStructure(*this, nullptr, jsNull()));
+    exceptionStructure.setWithoutWriteBarrier(Exception::createStructure(*this, nullptr, jsNull()));
+    programCodeBlockStructure.setWithoutWriteBarrier(ProgramCodeBlock::createStructure(*this, nullptr, jsNull()));
+    moduleProgramCodeBlockStructure.setWithoutWriteBarrier(ModuleProgramCodeBlock::createStructure(*this, nullptr, jsNull()));
+    evalCodeBlockStructure.setWithoutWriteBarrier(EvalCodeBlock::createStructure(*this, nullptr, jsNull()));
+    functionCodeBlockStructure.setWithoutWriteBarrier(FunctionCodeBlock::createStructure(*this, nullptr, jsNull()));
+    hashMapBucketSetStructure.setWithoutWriteBarrier(HashMapBucket<HashMapBucketDataKey>::createStructure(*this, nullptr, jsNull()));
+    hashMapBucketMapStructure.setWithoutWriteBarrier(HashMapBucket<HashMapBucketDataKeyValue>::createStructure(*this, nullptr, jsNull()));
+    bigIntStructure.setWithoutWriteBarrier(JSBigInt::createStructure(*this, nullptr, jsNull()));
 
     // Eagerly initialize constant cells since the concurrent compiler can access them.
     if (Options::useJIT()) {
@@ -291,7 +290,7 @@ VM::VM(VMType vmType, HeapType heapType, WTF::RunLoop* runLoop, bool* success)
     {
         auto* bigInt = JSBigInt::tryCreateFrom(*this, 1);
         if (bigInt)
-            heapBigIntConstantOne.set(*this, bigInt);
+            heapBigIntConstantOne.setWithoutWriteBarrier(bigInt);
         else {
             if (success)
                 *success = false;
@@ -681,7 +680,7 @@ NativeExecutable* VM::getBoundFunction(bool isJSFunction)
 {
     bool slowCase = !isJSFunction;
 
-    auto getOrCreate = [&](Strong<NativeExecutable>& slot) -> NativeExecutable* {
+    auto getOrCreate = [&](WriteBarrier<NativeExecutable>& slot) -> NativeExecutable* {
         if (auto* cached = slot.get())
             return cached;
         NativeExecutable* result = getHostFunction(
@@ -689,7 +688,7 @@ NativeExecutable* VM::getBoundFunction(bool isJSFunction)
             ImplementationVisibility::Private, // Bound function's visibility is private on the stack.
             slowCase ? NoIntrinsic : BoundFunctionCallIntrinsic,
             boundFunctionConstruct, nullptr, String());
-        slot.set(*this, result);
+        slot.setWithoutWriteBarrier(result);
         return result;
     };
 
@@ -1409,7 +1408,7 @@ JSCell* VM::sentinelSetBucketSlow()
 {
     ASSERT(!m_sentinelSetBucket);
     auto* sentinel = JSSet::BucketType::createSentinel(*this);
-    m_sentinelSetBucket.set(*this, sentinel);
+    m_sentinelSetBucket.setWithoutWriteBarrier(sentinel);
     return sentinel;
 }
 
@@ -1417,7 +1416,7 @@ JSCell* VM::sentinelMapBucketSlow()
 {
     ASSERT(!m_sentinelMapBucket);
     auto* sentinel = JSMap::BucketType::createSentinel(*this);
-    m_sentinelMapBucket.set(*this, sentinel);
+    m_sentinelMapBucket.setWithoutWriteBarrier(sentinel);
     return sentinel;
 }
 
@@ -1426,7 +1425,7 @@ JSPropertyNameEnumerator* VM::emptyPropertyNameEnumeratorSlow()
     ASSERT(!m_emptyPropertyNameEnumerator);
     PropertyNameArray propertyNames(*this, PropertyNameMode::Strings, PrivateSymbolMode::Exclude);
     auto* enumerator = JSPropertyNameEnumerator::create(*this, nullptr, 0, 0, WTFMove(propertyNames));
-    m_emptyPropertyNameEnumerator.set(*this, enumerator);
+    m_emptyPropertyNameEnumerator.setWithoutWriteBarrier(enumerator);
     return enumerator;
 }
 
@@ -1539,6 +1538,58 @@ template<typename Visitor>
 void VM::visitAggregateImpl(Visitor& visitor)
 {
     m_microtaskQueue.visitAggregate(visitor);
+
+    visitor.append(structureStructure);
+    visitor.append(structureRareDataStructure);
+    visitor.append(stringStructure);
+    visitor.append(propertyNameEnumeratorStructure);
+    visitor.append(getterSetterStructure);
+    visitor.append(customGetterSetterStructure);
+    visitor.append(domAttributeGetterSetterStructure);
+    visitor.append(scopedArgumentsTableStructure);
+    visitor.append(apiWrapperStructure);
+    visitor.append(nativeExecutableStructure);
+    visitor.append(evalExecutableStructure);
+    visitor.append(programExecutableStructure);
+    visitor.append(functionExecutableStructure);
+#if ENABLE(WEBASSEMBLY)
+    visitor.append(webAssemblyCalleeGroupStructure);
+#endif
+    visitor.append(moduleProgramExecutableStructure);
+    visitor.append(regExpStructure);
+    visitor.append(symbolStructure);
+    visitor.append(symbolTableStructure);
+    for (auto& structure : immutableButterflyStructures)
+        visitor.append(structure);
+    visitor.append(sourceCodeStructure);
+    visitor.append(scriptFetcherStructure);
+    visitor.append(scriptFetchParametersStructure);
+    visitor.append(structureChainStructure);
+    visitor.append(sparseArrayValueMapStructure);
+    visitor.append(templateObjectDescriptorStructure);
+    visitor.append(unlinkedFunctionExecutableStructure);
+    visitor.append(unlinkedProgramCodeBlockStructure);
+    visitor.append(unlinkedEvalCodeBlockStructure);
+    visitor.append(unlinkedFunctionCodeBlockStructure);
+    visitor.append(unlinkedModuleProgramCodeBlockStructure);
+    visitor.append(propertyTableStructure);
+    visitor.append(functionRareDataStructure);
+    visitor.append(exceptionStructure);
+    visitor.append(programCodeBlockStructure);
+    visitor.append(moduleProgramCodeBlockStructure);
+    visitor.append(evalCodeBlockStructure);
+    visitor.append(functionCodeBlockStructure);
+    visitor.append(hashMapBucketSetStructure);
+    visitor.append(hashMapBucketMapStructure);
+    visitor.append(bigIntStructure);
+
+    visitor.append(m_emptyPropertyNameEnumerator);
+    visitor.append(m_sentinelSetBucket);
+    visitor.append(m_sentinelMapBucket);
+    visitor.append(m_fastCanConstructBoundExecutable);
+    visitor.append(m_slowCanConstructBoundExecutable);
+    visitor.append(lastCachedString);
+    visitor.append(heapBigIntConstantOne);
 }
 DEFINE_VISIT_AGGREGATE(VM);
 

--- a/Source/JavaScriptCore/runtime/VM.h
+++ b/Source/JavaScriptCore/runtime/VM.h
@@ -56,6 +56,7 @@
 #include "VMTraps.h"
 #include "WasmContext.h"
 #include "WeakGCMap.h"
+#include "WriteBarrier.h"
 #include <variant>
 #include <wtf/BumpPointerAllocator.h>
 #include <wtf/CheckedArithmetic.h>
@@ -490,56 +491,56 @@ public:
 #if ENABLE(WEBASSEMBLY)
     Wasm::Context wasmContext;
 #endif
-    Strong<Structure> structureStructure;
-    Strong<Structure> structureRareDataStructure;
-    Strong<Structure> stringStructure;
-    Strong<Structure> propertyNameEnumeratorStructure;
-    Strong<Structure> getterSetterStructure;
-    Strong<Structure> customGetterSetterStructure;
-    Strong<Structure> domAttributeGetterSetterStructure;
-    Strong<Structure> scopedArgumentsTableStructure;
-    Strong<Structure> apiWrapperStructure;
-    Strong<Structure> nativeExecutableStructure;
-    Strong<Structure> evalExecutableStructure;
-    Strong<Structure> programExecutableStructure;
-    Strong<Structure> functionExecutableStructure;
+    WriteBarrier<Structure> structureStructure;
+    WriteBarrier<Structure> structureRareDataStructure;
+    WriteBarrier<Structure> stringStructure;
+    WriteBarrier<Structure> propertyNameEnumeratorStructure;
+    WriteBarrier<Structure> getterSetterStructure;
+    WriteBarrier<Structure> customGetterSetterStructure;
+    WriteBarrier<Structure> domAttributeGetterSetterStructure;
+    WriteBarrier<Structure> scopedArgumentsTableStructure;
+    WriteBarrier<Structure> apiWrapperStructure;
+    WriteBarrier<Structure> nativeExecutableStructure;
+    WriteBarrier<Structure> evalExecutableStructure;
+    WriteBarrier<Structure> programExecutableStructure;
+    WriteBarrier<Structure> functionExecutableStructure;
 #if ENABLE(WEBASSEMBLY)
-    Strong<Structure> webAssemblyCalleeGroupStructure;
+    WriteBarrier<Structure> webAssemblyCalleeGroupStructure;
 #endif
-    Strong<Structure> moduleProgramExecutableStructure;
-    Strong<Structure> regExpStructure;
-    Strong<Structure> symbolStructure;
-    Strong<Structure> symbolTableStructure;
-    Strong<Structure> immutableButterflyStructures[NumberOfCopyOnWriteIndexingModes];
-    Strong<Structure> sourceCodeStructure;
-    Strong<Structure> scriptFetcherStructure;
-    Strong<Structure> scriptFetchParametersStructure;
-    Strong<Structure> structureChainStructure;
-    Strong<Structure> sparseArrayValueMapStructure;
-    Strong<Structure> templateObjectDescriptorStructure;
-    Strong<Structure> unlinkedFunctionExecutableStructure;
-    Strong<Structure> unlinkedProgramCodeBlockStructure;
-    Strong<Structure> unlinkedEvalCodeBlockStructure;
-    Strong<Structure> unlinkedFunctionCodeBlockStructure;
-    Strong<Structure> unlinkedModuleProgramCodeBlockStructure;
-    Strong<Structure> propertyTableStructure;
-    Strong<Structure> functionRareDataStructure;
-    Strong<Structure> exceptionStructure;
-    Strong<Structure> programCodeBlockStructure;
-    Strong<Structure> moduleProgramCodeBlockStructure;
-    Strong<Structure> evalCodeBlockStructure;
-    Strong<Structure> functionCodeBlockStructure;
-    Strong<Structure> hashMapBucketSetStructure;
-    Strong<Structure> hashMapBucketMapStructure;
-    Strong<Structure> bigIntStructure;
+    WriteBarrier<Structure> moduleProgramExecutableStructure;
+    WriteBarrier<Structure> regExpStructure;
+    WriteBarrier<Structure> symbolStructure;
+    WriteBarrier<Structure> symbolTableStructure;
+    WriteBarrier<Structure> immutableButterflyStructures[NumberOfCopyOnWriteIndexingModes];
+    WriteBarrier<Structure> sourceCodeStructure;
+    WriteBarrier<Structure> scriptFetcherStructure;
+    WriteBarrier<Structure> scriptFetchParametersStructure;
+    WriteBarrier<Structure> structureChainStructure;
+    WriteBarrier<Structure> sparseArrayValueMapStructure;
+    WriteBarrier<Structure> templateObjectDescriptorStructure;
+    WriteBarrier<Structure> unlinkedFunctionExecutableStructure;
+    WriteBarrier<Structure> unlinkedProgramCodeBlockStructure;
+    WriteBarrier<Structure> unlinkedEvalCodeBlockStructure;
+    WriteBarrier<Structure> unlinkedFunctionCodeBlockStructure;
+    WriteBarrier<Structure> unlinkedModuleProgramCodeBlockStructure;
+    WriteBarrier<Structure> propertyTableStructure;
+    WriteBarrier<Structure> functionRareDataStructure;
+    WriteBarrier<Structure> exceptionStructure;
+    WriteBarrier<Structure> programCodeBlockStructure;
+    WriteBarrier<Structure> moduleProgramCodeBlockStructure;
+    WriteBarrier<Structure> evalCodeBlockStructure;
+    WriteBarrier<Structure> functionCodeBlockStructure;
+    WriteBarrier<Structure> hashMapBucketSetStructure;
+    WriteBarrier<Structure> hashMapBucketMapStructure;
+    WriteBarrier<Structure> bigIntStructure;
 
-    Strong<JSPropertyNameEnumerator> m_emptyPropertyNameEnumerator;
+    WriteBarrier<JSPropertyNameEnumerator> m_emptyPropertyNameEnumerator;
 
-    Strong<JSCell> m_sentinelSetBucket;
-    Strong<JSCell> m_sentinelMapBucket;
+    WriteBarrier<JSCell> m_sentinelSetBucket;
+    WriteBarrier<JSCell> m_sentinelMapBucket;
 
-    Strong<NativeExecutable> m_fastCanConstructBoundExecutable;
-    Strong<NativeExecutable> m_slowCanConstructBoundExecutable;
+    WriteBarrier<NativeExecutable> m_fastCanConstructBoundExecutable;
+    WriteBarrier<NativeExecutable> m_slowCanConstructBoundExecutable;
 
     Weak<NativeExecutable> m_fastRemoteFunctionExecutable;
     Weak<NativeExecutable> m_slowRemoteFunctionExecutable;
@@ -557,7 +558,7 @@ public:
     SmallStrings smallStrings;
     NumericStrings numericStrings;
     std::unique_ptr<SimpleStats> machineCodeBytesPerBytecodeWordForBaselineJIT;
-    Strong<JSString> lastCachedString;
+    WriteBarrier<JSString> lastCachedString;
     Ref<StringImpl> lastAtomizedIdentifierStringImpl { *StringImpl::empty() };
     Ref<AtomStringImpl> lastAtomizedIdentifierAtomStringImpl { *static_cast<AtomStringImpl*>(StringImpl::empty()) };
     JSONAtomStringCache jsonAtomStringCache;
@@ -566,7 +567,7 @@ public:
     WTF::SymbolRegistry& symbolRegistry() { return m_symbolRegistry; }
     WTF::SymbolRegistry& privateSymbolRegistry() { return m_privateSymbolRegistry; }
 
-    Strong<JSBigInt> heapBigIntConstantOne;
+    WriteBarrier<JSBigInt> heapBigIntConstantOne;
 
     JSCell* sentinelSetBucket()
     {


### PR DESCRIPTION
#### 3a4d06abddc5454fa6a5e44567ed2033836a1a0f
<pre>
[JSC] Not use Strong&lt;&gt; in VM and simplify jsString
<a href="https://bugs.webkit.org/show_bug.cgi?id=256808">https://bugs.webkit.org/show_bug.cgi?id=256808</a>
rdar://109373540

Reviewed by Mark Lam.

Let&apos;s avoid using Strong&lt;&gt; in VM since Strong&lt;&gt; is very costly generic abstraction.
Every access to this will cause one-level indirect load. Since we know these Strong&lt;&gt;
in VM are strong roots, we should just mark them explicitly and not using Strong&lt;&gt;
abstraction. This will wipe indirect load in some of critical functions, including
JSC::jsString.

                                                         ToT                     Patched

    vanilla-es2015-babel-webpack-todomvc-json-parse
                                                   58.6031+-0.1165     ^     57.9270+-0.0610        ^ definitely 1.0117x faster
    vanilla-es2015-todomvc-json-parse              58.6226+-0.1470     ^     57.9199+-0.0991        ^ definitely 1.0121x faster
    vanilla-todomvc-json-parse                     43.5747+-0.0433     ^     43.0709+-0.0276        ^ definitely 1.0117x faster

* Source/JavaScriptCore/dfg/DFGSafeToExecute.h:
(JSC::DFG::safeToExecute):
* Source/JavaScriptCore/ftl/FTLLowerDFGToB3.cpp:
(JSC::FTL::DFG::LowerDFGToB3::compileCompareStrictEq):
* Source/JavaScriptCore/heap/Heap.cpp:
(JSC::Heap::addCoreConstraints):
* Source/JavaScriptCore/jit/AssemblyHelpers.cpp:
(JSC::AssemblyHelpers::emitNonNullDecodeZeroExtendedStructureID):
* Source/JavaScriptCore/runtime/JSCConfig.h:
(JSC::startOfStructureHeap):
* Source/JavaScriptCore/runtime/JSString.cpp:
(JSC::jsStringWithCacheSlowCase):
* Source/JavaScriptCore/runtime/StructureID.h:
(JSC::StructureID::decode const):
(JSC::StructureID::tryDecode const):
(JSC::StructureID::encode):
* Source/JavaScriptCore/runtime/VM.cpp:
(JSC::VM::VM):
(JSC::VM::getBoundFunction):
(JSC::VM::sentinelSetBucketSlow):
(JSC::VM::sentinelMapBucketSlow):
(JSC::VM::emptyPropertyNameEnumeratorSlow):
(JSC::VM::visitAggregateImpl):
* Source/JavaScriptCore/runtime/VM.h:

Canonical link: <a href="https://commits.webkit.org/264099@main">https://commits.webkit.org/264099@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/be0c36c3375b0a9ee753b8b6d81b595777f36636

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/6699 "1 style error") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/6916 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/7098 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/8288 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/6966 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/8025 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/6861 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/9865 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/6817 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/7362 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/6133 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/8381 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/4816 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/6062 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/13885 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/5653 "Built successfully and passed tests") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/6596 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/6140 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/8864 "Passed tests") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/6281 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/6630 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/5432 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/6836 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/6022 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/1591 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/10195 "Built successfully") | | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/24/builds/7020 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/779 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/6395 "Built successfully") | | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/3/builds/1721 "Passed tests") | 
<!--EWS-Status-Bubble-End-->