### PR TITLE
XPath: Fix context node of rhs of union operator

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/domxpath/node-sets-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/domxpath/node-sets-expected.txt
@@ -1,3 +1,3 @@
 
-FAIL | operator should evaluate both sides of expressions with the same context node assert_equals: expected 2 but got 1
+PASS | operator should evaluate both sides of expressions with the same context node
 

--- a/Source/WebCore/xml/XPathPredicate.cpp
+++ b/Source/WebCore/xml/XPathPredicate.cpp
@@ -252,11 +252,16 @@ Union::Union(std::unique_ptr<Expression> lhs, std::unique_ptr<Expression> rhs)
 
 Value Union::evaluate() const
 {
+    EvaluationContext clonedContext(Expression::evaluationContext());
     Value lhsResult = subexpression(0).evaluate();
-    Value rhs = subexpression(1).evaluate();
+    Value rhsResult = [&] {
+        SetForScope<EvaluationContext> contextForScope(Expression::evaluationContext(), clonedContext);
+        return subexpression(1).evaluate();
+    }();
+    Expression::evaluationContext().hadTypeConversionError |= clonedContext.hadTypeConversionError;
 
     NodeSet& resultSet = lhsResult.modifiableNodeSet();
-    const NodeSet& rhsNodes = rhs.toNodeSet();
+    const NodeSet& rhsNodes = rhsResult.toNodeSet();
 
     HashSet<RefPtr<Node>> nodes;
     for (auto& result : resultSet)


### PR DESCRIPTION
#### fe83c2f1044858d76d0795cd29f1607b36106b1e
<pre>
XPath: Fix context node of rhs of union operator
<a href="https://bugs.webkit.org/show_bug.cgi?id=256770">https://bugs.webkit.org/show_bug.cgi?id=256770</a>

Reviewed by Alexey Proskuryakov.

Use the right context node for rhs of union operator. This aligns our behavior
with Firefox and Chrome.

This is a cherry-pick of the following Blink commit:
- <a href="https://chromium-review.googlesource.com/c/chromium/src/+/1973333">https://chromium-review.googlesource.com/c/chromium/src/+/1973333</a>

* LayoutTests/imported/w3c/web-platform-tests/domxpath/node-sets-expected.txt:
* Source/WebCore/xml/XPathPredicate.cpp:
(WebCore::XPath::Union::evaluate const):

Canonical link: <a href="https://commits.webkit.org/264097@main">https://commits.webkit.org/264097@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c07dedecd60ec51f543d5ccf3c2d62b0622f0f4f

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/6680 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/6896 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/7078 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/8269 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/6952 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/6678 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/8019 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/6841 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/9849 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/6798 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/7355 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/6109 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/8372 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/4810 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/6037 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/13877 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/6593 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/6118 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/8847 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/6610 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/5419 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/6005 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/1579 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/10177 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/6378 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->