### PR TITLE
[JSC] Introduce MakeAtomString DFG node

### DIFF
--- a/JSTests/stress/make-atom-string.js
+++ b/JSTests/stress/make-atom-string.js
@@ -1,0 +1,31 @@
+function shouldBe(actual, expected) {
+    if (actual !== expected)
+        throw new Error('bad value: ' + actual);
+}
+
+function test2(object, string) {
+    return object["hello" + string];
+}
+noInline(test2);
+
+function test3(object, string) {
+    return object["hello" + string + "hello"];
+}
+noInline(test3);
+
+var array = [];
+for (var i = 0; i < 100; ++i) {
+    var object = {};
+    object["hello" + i] = i * 2;
+    object["hello" + i + "hello"] = i * 3;
+    array.push(object);
+}
+
+for (var i = 0; i < 1e4; ++i) {
+    for (var j = 0; j < 100; ++j) {
+        var key = String(j);
+        var object = array[j];
+        shouldBe(test2(object, key), j * 2);
+        shouldBe(test3(object, key), j * 3);
+    }
+}

--- a/Source/JavaScriptCore/CMakeLists.txt
+++ b/Source/JavaScriptCore/CMakeLists.txt
@@ -1138,6 +1138,8 @@ set(JavaScriptCore_PRIVATE_FRAMEWORK_HEADERS
     runtime/JSWeakMapInlines.h
     runtime/JSWithScope.h
     runtime/JSWrapperObject.h
+    runtime/KeyAtomStringCache.h
+    runtime/KeyAtomStringCacheInlines.h
     runtime/LazyClassStructure.h
     runtime/LazyProperty.h
     runtime/LeafExecutable.h

--- a/Source/JavaScriptCore/JavaScriptCore.xcodeproj/project.pbxproj
+++ b/Source/JavaScriptCore/JavaScriptCore.xcodeproj/project.pbxproj
@@ -1894,6 +1894,8 @@
 		E379006628F8F4E100206FD8 /* DFGValidateUnlinked.h in Headers */ = {isa = PBXBuildFile; fileRef = E379006428F8F4E100206FD8 /* DFGValidateUnlinked.h */; };
 		E3794E761B77EB97005543AE /* ModuleAnalyzer.h in Headers */ = {isa = PBXBuildFile; fileRef = E3794E741B77EB97005543AE /* ModuleAnalyzer.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		E379B59029834EC5007C4C0E /* SIMDShuffle.h in Headers */ = {isa = PBXBuildFile; fileRef = E379B58F29834EC5007C4C0E /* SIMDShuffle.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		E37F44C72A13088000E56D8D /* KeyAtomStringCacheInlines.h in Headers */ = {isa = PBXBuildFile; fileRef = E37F44C52A13088000E56D8D /* KeyAtomStringCacheInlines.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		E37F44C82A13088000E56D8D /* KeyAtomStringCache.h in Headers */ = {isa = PBXBuildFile; fileRef = E37F44C62A13088000E56D8D /* KeyAtomStringCache.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		E383500A2390D93B0036316D /* WasmGlobal.h in Headers */ = {isa = PBXBuildFile; fileRef = E38350092390D9370036316D /* WasmGlobal.h */; };
 		E3850B15226ED641009ABF9C /* DFGMinifiedIDInlines.h in Headers */ = {isa = PBXBuildFile; fileRef = E3850B14226ED63E009ABF9C /* DFGMinifiedIDInlines.h */; };
 		E38652E3237CA0C900E1D5EE /* BlockDirectoryBits.h in Headers */ = {isa = PBXBuildFile; fileRef = E38652E2237CA0C800E1D5EE /* BlockDirectoryBits.h */; settings = {ATTRIBUTES = (Private, ); }; };
@@ -5388,6 +5390,8 @@
 		E3794E741B77EB97005543AE /* ModuleAnalyzer.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ModuleAnalyzer.h; sourceTree = "<group>"; };
 		E379B58F29834EC5007C4C0E /* SIMDShuffle.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SIMDShuffle.h; sourceTree = "<group>"; };
 		E37CFB2D22F27C57009A7B38 /* WasmCompilationMode.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = WasmCompilationMode.cpp; sourceTree = "<group>"; };
+		E37F44C52A13088000E56D8D /* KeyAtomStringCacheInlines.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = KeyAtomStringCacheInlines.h; sourceTree = "<group>"; };
+		E37F44C62A13088000E56D8D /* KeyAtomStringCache.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = KeyAtomStringCache.h; sourceTree = "<group>"; };
 		E380A76B1DCD7195000F89E6 /* MacroAssemblerHelpers.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MacroAssemblerHelpers.h; sourceTree = "<group>"; };
 		E380D66B1F19249D00A59095 /* BuiltinNames.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = BuiltinNames.cpp; sourceTree = "<group>"; };
 		E38350082390D9370036316D /* WasmGlobal.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = WasmGlobal.cpp; sourceTree = "<group>"; };
@@ -8065,6 +8069,8 @@
 				1442566015EDE98D0066A49B /* JSWithScope.h */,
 				65C7A1710A8EAACB00FA37EA /* JSWrapperObject.cpp */,
 				65C7A1720A8EAACB00FA37EA /* JSWrapperObject.h */,
+				E37F44C62A13088000E56D8D /* KeyAtomStringCache.h */,
+				E37F44C52A13088000E56D8D /* KeyAtomStringCacheInlines.h */,
 				DCF3D5641CD29468003D5C65 /* LazyClassStructure.cpp */,
 				DCF3D5651CD29468003D5C65 /* LazyClassStructure.h */,
 				DCF3D5661CD29468003D5C65 /* LazyClassStructureInlines.h */,
@@ -10792,6 +10798,8 @@
 				86E3C619167BABEE006D760A /* JSWrapperMap.h in Headers */,
 				BC18C42E0E16F5CD00B34460 /* JSWrapperObject.h in Headers */,
 				BCFD8C930EEB2EE700283848 /* JumpTable.h in Headers */,
+				E37F44C82A13088000E56D8D /* KeyAtomStringCache.h in Headers */,
+				E37F44C72A13088000E56D8D /* KeyAtomStringCacheInlines.h in Headers */,
 				A72FFD64139985A800E5365A /* KeywordLookup.h in Headers */,
 				969A072A0ED1CE6900F1F681 /* Label.h in Headers */,
 				960097A60EBABB58007A7297 /* LabelScope.h in Headers */,

--- a/Source/JavaScriptCore/dfg/DFGClobberize.h
+++ b/Source/JavaScriptCore/dfg/DFGClobberize.h
@@ -251,6 +251,7 @@ void clobberize(Graph& graph, Node* node, const ReadFunctor& read, const WriteFu
     case BooleanToNumber:
     case FiatInt52:
     case MakeRope:
+    case MakeAtomString:
     case StrCat:
     case ValueToInt32:
     case GetExecutable:

--- a/Source/JavaScriptCore/dfg/DFGConstantFoldingPhase.cpp
+++ b/Source/JavaScriptCore/dfg/DFGConstantFoldingPhase.cpp
@@ -1099,7 +1099,8 @@ private:
                 FALLTHROUGH;
             }
 
-            case MakeRope: {
+            case MakeRope:
+            case MakeAtomString: {
                 for (unsigned i = 0; i < AdjacencyList::Size; ++i) {
                     Edge& edge = node->children.child(i);
                     if (!edge)
@@ -1122,8 +1123,10 @@ private:
 
                 if (!node->child2()) {
                     ASSERT(!node->child3());
-                    node->convertToIdentity();
-                    changed = true;
+                    if (node->op() != MakeAtomString) {
+                        node->convertToIdentity();
+                        changed = true;
+                    }
                 }
                 break;
             }

--- a/Source/JavaScriptCore/dfg/DFGDoesGC.cpp
+++ b/Source/JavaScriptCore/dfg/DFGDoesGC.cpp
@@ -392,6 +392,7 @@ bool doesGC(Graph& graph, Node* node)
     case NewStringObject:
     case NewSymbol:
     case MakeRope:
+    case MakeAtomString:
     case NewFunction:
     case NewGeneratorFunction:
     case NewAsyncGeneratorFunction:

--- a/Source/JavaScriptCore/dfg/DFGFixupPhase.cpp
+++ b/Source/JavaScriptCore/dfg/DFGFixupPhase.cpp
@@ -3074,6 +3074,7 @@ private:
         case InvalidationPoint:
         case GetWebAssemblyInstanceExports:
         case NewBoundFunction:
+        case MakeAtomString:
             break;
 #else // not ASSERT_ENABLED
         default:

--- a/Source/JavaScriptCore/dfg/DFGNodeType.h
+++ b/Source/JavaScriptCore/dfg/DFGNodeType.h
@@ -453,6 +453,7 @@ namespace JSC { namespace DFG {
     macro(FunctionToString, NodeResultJS) \
     macro(FunctionBind, NodeResultJS | NodeMustGenerate | NodeHasVarArgs) \
     macro(MakeRope, NodeResultJS) \
+    macro(MakeAtomString, NodeResultJS) \
     macro(InByVal, NodeResultBoolean | NodeMustGenerate) \
     macro(InById, NodeResultBoolean | NodeMustGenerate) \
     macro(HasPrivateName, NodeResultBoolean | NodeMustGenerate) \

--- a/Source/JavaScriptCore/dfg/DFGOperations.cpp
+++ b/Source/JavaScriptCore/dfg/DFGOperations.cpp
@@ -3080,6 +3080,33 @@ JSC_DEFINE_JIT_OPERATION(operationStrCat3, JSString*, (JSGlobalObject* globalObj
     RELEASE_AND_RETURN(scope, jsString(globalObject, str1, str2, str3));
 }
 
+JSC_DEFINE_JIT_OPERATION(operationMakeAtomString1, JSString*, (JSGlobalObject* globalObject, JSString* a))
+{
+    VM& vm = globalObject->vm();
+    CallFrame* callFrame = DECLARE_CALL_FRAME(vm);
+    JITOperationPrologueCallFrameTracer tracer(vm, callFrame);
+
+    return jsAtomString(globalObject, vm, a);
+}
+
+JSC_DEFINE_JIT_OPERATION(operationMakeAtomString2, JSString*, (JSGlobalObject* globalObject, JSString* a, JSString* b))
+{
+    VM& vm = globalObject->vm();
+    CallFrame* callFrame = DECLARE_CALL_FRAME(vm);
+    JITOperationPrologueCallFrameTracer tracer(vm, callFrame);
+
+    return jsAtomString(globalObject, vm, a, b);
+}
+
+JSC_DEFINE_JIT_OPERATION(operationMakeAtomString3, JSString*, (JSGlobalObject* globalObject, JSString* a, JSString* b, JSString* c))
+{
+    VM& vm = globalObject->vm();
+    CallFrame* callFrame = DECLARE_CALL_FRAME(vm);
+    JITOperationPrologueCallFrameTracer tracer(vm, callFrame);
+
+    return jsAtomString(globalObject, vm, a, b, c);
+}
+
 JSC_DEFINE_JIT_OPERATION(operationFindSwitchImmTargetForDouble, char*, (VM* vmPointer, EncodedJSValue encodedValue, size_t tableIndex, int32_t min))
 {
     VM& vm = *vmPointer;

--- a/Source/JavaScriptCore/dfg/DFGOperations.h
+++ b/Source/JavaScriptCore/dfg/DFGOperations.h
@@ -310,6 +310,9 @@ JSC_DECLARE_JIT_OPERATION(operationMakeRope2, JSString*, (JSGlobalObject*, JSStr
 JSC_DECLARE_JIT_OPERATION(operationMakeRope3, JSString*, (JSGlobalObject*, JSString*, JSString*, JSString*));
 JSC_DECLARE_JIT_OPERATION(operationStrCat2, JSString*, (JSGlobalObject*, EncodedJSValue, EncodedJSValue));
 JSC_DECLARE_JIT_OPERATION(operationStrCat3, JSString*, (JSGlobalObject*, EncodedJSValue, EncodedJSValue, EncodedJSValue));
+JSC_DECLARE_JIT_OPERATION(operationMakeAtomString1, JSString*, (JSGlobalObject*, JSString*));
+JSC_DECLARE_JIT_OPERATION(operationMakeAtomString2, JSString*, (JSGlobalObject*, JSString*, JSString*));
+JSC_DECLARE_JIT_OPERATION(operationMakeAtomString3, JSString*, (JSGlobalObject*, JSString*, JSString*, JSString*));
 JSC_DECLARE_JIT_OPERATION(operationFindSwitchImmTargetForDouble, char*, (VM*, EncodedJSValue, size_t tableIndex, int32_t));
 JSC_DECLARE_JIT_OPERATION(operationSwitchString, char*, (JSGlobalObject*, size_t tableIndex, const UnlinkedStringJumpTable*, JSString*));
 JSC_DECLARE_JIT_OPERATION(operationCompareStringImplLess, uintptr_t, (StringImpl*, StringImpl*));

--- a/Source/JavaScriptCore/dfg/DFGPredictionPropagationPhase.cpp
+++ b/Source/JavaScriptCore/dfg/DFGPredictionPropagationPhase.cpp
@@ -1258,6 +1258,10 @@ private:
             setPrediction(SpecString);
             break;
         }
+        case MakeAtomString: {
+            setPrediction(SpecStringIdent);
+            break;
+        }
         case NewStringObject: {
             setPrediction(SpecStringObject);
             break;

--- a/Source/JavaScriptCore/dfg/DFGSafeToExecute.h
+++ b/Source/JavaScriptCore/dfg/DFGSafeToExecute.h
@@ -282,6 +282,7 @@ bool safeToExecute(AbstractStateType& state, Graph& graph, Node* node, bool igno
     case StrCat:
     case CallStringConstructor:
     case MakeRope:
+    case MakeAtomString:
     case GetFromArguments:
     case GetArgument:
     case StringFromCharCode:

--- a/Source/JavaScriptCore/dfg/DFGSpeculativeJIT.h
+++ b/Source/JavaScriptCore/dfg/DFGSpeculativeJIT.h
@@ -1437,6 +1437,7 @@ public:
     void compileValueSub(Node*);
     void compileArithAdd(Node*);
     void compileMakeRope(Node*);
+    void compileMakeAtomString(Node*);
     void compileArithAbs(Node*);
     void compileArithClz32(Node*);
     void compileArithSub(Node*);

--- a/Source/JavaScriptCore/dfg/DFGSpeculativeJIT32_64.cpp
+++ b/Source/JavaScriptCore/dfg/DFGSpeculativeJIT32_64.cpp
@@ -2410,6 +2410,10 @@ void SpeculativeJIT::compile(Node* node)
         compileMakeRope(node);
         break;
 
+    case MakeAtomString:
+        compileMakeAtomString(node);
+        break;
+
     case ArithSub:
         compileArithSub(node);
         break;

--- a/Source/JavaScriptCore/dfg/DFGSpeculativeJIT64.cpp
+++ b/Source/JavaScriptCore/dfg/DFGSpeculativeJIT64.cpp
@@ -3335,6 +3335,10 @@ void SpeculativeJIT::compile(Node* node)
         compileMakeRope(node);
         break;
 
+    case MakeAtomString:
+        compileMakeAtomString(node);
+        break;
+
     case ArithSub:
         compileArithSub(node);
         break;

--- a/Source/JavaScriptCore/dfg/DFGStoreBarrierInsertionPhase.cpp
+++ b/Source/JavaScriptCore/dfg/DFGStoreBarrierInsertionPhase.cpp
@@ -390,6 +390,7 @@ private:
             case MaterializeNewObject:
             case MaterializeCreateActivation:
             case MakeRope:
+            case MakeAtomString:
             case CreateActivation:
             case CreateDirectArguments:
             case CreateScopedArguments:

--- a/Source/JavaScriptCore/dfg/DFGValidate.cpp
+++ b/Source/JavaScriptCore/dfg/DFGValidate.cpp
@@ -282,6 +282,7 @@ public:
                     }
                     break;
                 case MakeRope:
+                case MakeAtomString:
                 case ValueAdd:
                 case ValueSub:
                 case ValueMul:

--- a/Source/JavaScriptCore/ftl/FTLCapabilities.cpp
+++ b/Source/JavaScriptCore/ftl/FTLCapabilities.cpp
@@ -237,6 +237,7 @@ inline CapabilityLevel canCompile(Node* node)
     case ObjectToString:
     case ReflectOwnKeys:
     case MakeRope:
+    case MakeAtomString:
     case NewArrayWithSize:
     case NewArrayWithSpecies:
     case TryGetById:

--- a/Source/JavaScriptCore/ftl/FTLLowerDFGToB3.cpp
+++ b/Source/JavaScriptCore/ftl/FTLLowerDFGToB3.cpp
@@ -1276,6 +1276,9 @@ private:
         case MakeRope:
             compileMakeRope();
             break;
+        case MakeAtomString:
+            compileMakeAtomString();
+            break;
         case StringCharAt:
             compileStringCharAt();
             break;
@@ -9734,6 +9737,38 @@ IGNORE_CLANG_WARNINGS_END
         
         m_out.appendTo(continuation, lastNext);
         setJSValue(m_out.phi(Int64, fastResult, emptyResult, slowResult));
+    }
+
+    void compileMakeAtomString()
+    {
+        JSGlobalObject* globalObject = m_graph.globalObjectFor(m_origin.semantic);
+        LValue strings[3] { nullptr, nullptr, nullptr };
+        unsigned numberOfStrings;
+        strings[0] = lowCell(m_node->child1());
+        if (m_node->child2()) {
+            strings[1] = lowCell(m_node->child2());
+            if (m_node->child3()) {
+                strings[2] = lowCell(m_node->child3());
+                numberOfStrings = 3;
+            } else
+                numberOfStrings = 2;
+        } else
+            numberOfStrings = 1;
+
+        switch (numberOfStrings) {
+        case 1:
+            setJSValue(vmCall(pointerType(), operationMakeAtomString1, weakPointer(globalObject), strings[0]));
+            break;
+        case 2:
+            setJSValue(vmCall(pointerType(), operationMakeAtomString2, weakPointer(globalObject), strings[0], strings[1]));
+            break;
+        case 3:
+            setJSValue(vmCall(pointerType(), operationMakeAtomString3, weakPointer(globalObject), strings[0], strings[1], strings[2]));
+            break;
+        default:
+            RELEASE_ASSERT_NOT_REACHED();
+            break;
+        }
     }
     
     LValue compileStringCharAtImpl()

--- a/Source/JavaScriptCore/heap/Heap.cpp
+++ b/Source/JavaScriptCore/heap/Heap.cpp
@@ -2181,6 +2181,8 @@ void Heap::finalize()
 
     if (m_lastCollectionScope && m_lastCollectionScope.value() == CollectionScope::Full)
         vm().jsonAtomStringCache.clear();
+    vm().keyAtomStringCache.clear();
+    vm().numericStrings.clearOnGarbageCollection();
 
     m_possiblyAccessedStringsFromConcurrentThreads.clear();
 

--- a/Source/JavaScriptCore/runtime/JSCJSValue.cpp
+++ b/Source/JavaScriptCore/runtime/JSCJSValue.cpp
@@ -30,6 +30,7 @@
 #include "JSBigInt.h"
 #include "JSCInlines.h"
 #include "NumberObject.h"
+#include "NumberPrototype.h"
 #include "ParseInt.h"
 #include "TypeError.h"
 
@@ -379,14 +380,10 @@ JSString* JSValue::toStringSlowCase(JSGlobalObject* globalObject, bool returnEmp
     };
     
     ASSERT(!isString());
-    if (isInt32()) {
-        auto integer = asInt32();
-        if (static_cast<unsigned>(integer) <= 9)
-            return vm.smallStrings.singleCharacterString(integer + '0');
-        return jsNontrivialString(vm, vm.numericStrings.add(integer));
-    }
+    if (isInt32())
+        return int32ToString(vm, asInt32(), 10);
     if (isDouble())
-        return jsString(vm, vm.numericStrings.add(asDouble()));
+        return JSC::numberToString(vm, asDouble(), 10);
     if (isTrue())
         return vm.smallStrings.trueString();
     if (isFalse())
@@ -396,12 +393,8 @@ JSString* JSValue::toStringSlowCase(JSGlobalObject* globalObject, bool returnEmp
     if (isUndefined())
         return vm.smallStrings.undefinedString();
 #if USE(BIGINT32)
-    if (isBigInt32()) {
-        auto integer = bigInt32AsInt32();
-        if (static_cast<unsigned>(integer) <= 9)
-            return vm.smallStrings.singleCharacterString(integer + '0');
-        return jsNontrivialString(vm, vm.numericStrings.add(integer));
-    }
+    if (isBigInt32())
+        return int32ToString(vm, bigInt32AsInt32(), 10);
 #endif
     JSString* returnString = asCell()->toStringInline(globalObject);
     RETURN_IF_EXCEPTION(scope, errorValue());

--- a/Source/JavaScriptCore/runtime/JSString.cpp
+++ b/Source/JavaScriptCore/runtime/JSString.cpp
@@ -139,25 +139,10 @@ void JSString::visitChildrenImpl(JSCell* cell, Visitor& visitor)
 
 DEFINE_VISIT_CHILDREN(JSString);
 
-static constexpr unsigned maxLengthForOnStackResolve = 2048;
-
 template<typename CharacterType>
 void JSRopeString::resolveRopeInternalNoSubstring(CharacterType* buffer) const
 {
-    for (size_t i = 0; i < s_maxInternalRopeLength && fiber(i); ++i) {
-        if (fiber(i)->isRope()) {
-            resolveRopeSlowCase(buffer);
-            return;
-        }
-    }
-
-    CharacterType* position = buffer;
-    for (size_t i = 0; i < s_maxInternalRopeLength && fiber(i); ++i) {
-        StringView view = *fiber(i)->valueInternal().impl();
-        view.getCharacters(position);
-        position += view.length();
-    }
-    ASSERT((buffer + length()) == position);
+    resolveToBuffer(this, buffer, length());
 }
 
 AtomString JSRopeString::resolveRopeToAtomString(JSGlobalObject* globalObject) const
@@ -198,18 +183,6 @@ AtomString JSRopeString::resolveRopeToAtomString(JSGlobalObject* globalObject) c
     convertToNonRope(String { atomString });
 
     return atomString;
-}
-
-inline void JSRopeString::convertToNonRope(String&& string) const
-{
-    // Concurrent compiler threads can access String held by JSString. So we always emit
-    // store-store barrier here to ensure concurrent compiler threads see initialized String.
-    ASSERT(JSString::isRope());
-    WTF::storeStoreFence();
-    new (&uninitializedValueInternal()) String(WTFMove(string));
-    static_assert(sizeof(String) == sizeof(RefPtr<StringImpl>), "JSString's String initialization must be done in one pointer move.");
-    // We do not clear the trailing fibers and length information (fiber1 and fiber2) because we could be reading the length concurrently.
-    ASSERT(!JSString::isRope());
 }
 
 RefPtr<AtomStringImpl> JSRopeString::resolveRopeToExistingAtomString(JSGlobalObject* globalObject) const
@@ -293,53 +266,6 @@ const String& JSRopeString::resolveRope(JSGlobalObject* nullOrGlobalObjectForOOM
     return resolveRopeWithFunction(nullOrGlobalObjectForOOM, [] (Ref<StringImpl>&& newImpl) {
         return WTFMove(newImpl);
     });
-}
-
-// Overview: These functions convert a JSString from holding a string in rope form
-// down to a simple String representation. It does so by building up the string
-// backwards, since we want to avoid recursion, we expect that the tree structure
-// representing the rope is likely imbalanced with more nodes down the left side
-// (since appending to the string is likely more common) - and as such resolving
-// in this fashion should minimize work queue size.  (If we built the queue forwards
-// we would likely have to place all of the constituent StringImpls into the
-// Vector before performing any concatenation, but by working backwards we likely
-// only fill the queue with the number of substrings at any given level in a
-// rope-of-ropes.)
-template<typename CharacterType>
-void JSRopeString::resolveRopeSlowCase(CharacterType* buffer) const
-{
-    CharacterType* position = buffer + length(); // We will be working backwards over the rope.
-    Vector<JSString*, 32, UnsafeVectorOverflow> workQueue; // These strings are kept alive by the parent rope, so using a Vector is OK.
-
-    for (size_t i = 0; i < s_maxInternalRopeLength && fiber(i); ++i)
-        workQueue.append(fiber(i));
-
-    while (!workQueue.isEmpty()) {
-        JSString* currentFiber = workQueue.last();
-        workQueue.removeLast();
-
-        if (currentFiber->isRope()) {
-            JSRopeString* currentFiberAsRope = static_cast<JSRopeString*>(currentFiber);
-            if (currentFiberAsRope->isSubstring()) {
-                ASSERT(!currentFiberAsRope->substringBase()->isRope());
-                StringView view = *currentFiberAsRope->substringBase()->valueInternal().impl();
-                unsigned offset = currentFiberAsRope->substringOffset();
-                unsigned length = currentFiberAsRope->length();
-                position -= length;
-                view.substring(offset, length).getCharacters(position);
-                continue;
-            }
-            for (size_t i = 0; i < s_maxInternalRopeLength && currentFiberAsRope->fiber(i); ++i)
-                workQueue.append(currentFiberAsRope->fiber(i));
-            continue;
-        }
-
-        StringView view = *currentFiber->valueInternal().impl();
-        position -= view.length();
-        view.getCharacters(position);
-    }
-
-    ASSERT(buffer == position);
 }
 
 void JSRopeString::outOfMemory(JSGlobalObject* nullOrGlobalObjectForOOM) const

--- a/Source/JavaScriptCore/runtime/JSString.h
+++ b/Source/JavaScriptCore/runtime/JSString.h
@@ -136,6 +136,8 @@ public:
 
     static constexpr uintptr_t isRopeInPointer = 0x1;
 
+    static constexpr unsigned maxLengthForOnStackResolve = 2048;
+
 private:
     String& uninitializedValueInternal() const
     {
@@ -285,6 +287,9 @@ private:
     friend JSString* jsSubstring(VM&, JSGlobalObject*, JSString*, unsigned, unsigned);
     friend JSString* jsSubstringOfResolved(VM&, GCDeferralContext*, JSString*, unsigned, unsigned);
     friend JSString* jsOwnedString(VM&, const String&);
+    friend JSString* jsAtomString(JSGlobalObject*, VM&, JSString*);
+    friend JSString* jsAtomString(JSGlobalObject*, VM&, JSString*, JSString*);
+    friend JSString* jsAtomString(JSGlobalObject*, VM&, JSString*, JSString*, JSString*);
 };
 
 // NOTE: This class cannot override JSString's destructor. JSString's destructor is called directly
@@ -596,7 +601,13 @@ public:
     // The rope value will remain a null string in that case.
     JS_EXPORT_PRIVATE const String& resolveRope(JSGlobalObject* nullOrGlobalObjectForOOM) const;
 
+    template<typename Fibers, typename CharacterType>
+    static void resolveToBuffer(Fibers*, CharacterType* buffer, unsigned length);
+
 private:
+    template<typename Fibers, typename CharacterType>
+    static void resolveToBufferSlow(Fibers*, CharacterType* buffer, unsigned length);
+
     static JSRopeString* create(VM& vm, JSString* s1, JSString* s2)
     {
         JSRopeString* newString = new (NotNull, allocateCell<JSRopeString>(vm)) JSRopeString(vm, s1, s2);
@@ -628,7 +639,6 @@ private:
     template<typename Function> const String& resolveRopeWithFunction(JSGlobalObject* nullOrGlobalObjectForOOM, Function&&) const;
     JS_EXPORT_PRIVATE AtomString resolveRopeToAtomString(JSGlobalObject*) const;
     JS_EXPORT_PRIVATE RefPtr<AtomStringImpl> resolveRopeToExistingAtomString(JSGlobalObject*) const;
-    template<typename CharacterType> NEVER_INLINE void resolveRopeSlowCase(CharacterType*) const;
     template<typename CharacterType> void resolveRopeInternalNoSubstring(CharacterType*) const;
     Identifier toIdentifier(JSGlobalObject*) const;
     void outOfMemory(JSGlobalObject* nullOrGlobalObjectForOOM) const;
@@ -711,6 +721,9 @@ private:
     friend JSString* jsString(JSGlobalObject*, const String&, const String&, const String&);
     friend JSString* jsSubstringOfResolved(VM&, GCDeferralContext*, JSString*, unsigned, unsigned);
     friend JSString* jsSubstring(VM&, JSGlobalObject*, JSString*, unsigned, unsigned);
+    friend JSString* jsAtomString(JSGlobalObject*, VM&, JSString*);
+    friend JSString* jsAtomString(JSGlobalObject*, VM&, JSString*, JSString*);
+    friend JSString* jsAtomString(JSGlobalObject*, VM&, JSString*, JSString*, JSString*);
 };
 
 JS_EXPORT_PRIVATE JSString* jsStringWithCacheSlowCase(VM&, StringImpl&);

--- a/Source/JavaScriptCore/runtime/JSStringInlines.h
+++ b/Source/JavaScriptCore/runtime/JSStringInlines.h
@@ -27,6 +27,7 @@
 
 #include "JSGlobalObjectInlines.h"
 #include "JSString.h"
+#include "KeyAtomStringCacheInlines.h"
 
 namespace JSC {
     
@@ -97,6 +98,258 @@ inline JSString* repeatCharacter(JSGlobalObject* globalObject, CharacterType cha
     std::fill_n(buffer, repeatCount, character);
 
     RELEASE_AND_RETURN(scope, jsString(vm, impl.releaseNonNull()));
+}
+
+inline void JSRopeString::convertToNonRope(String&& string) const
+{
+    // Concurrent compiler threads can access String held by JSString. So we always emit
+    // store-store barrier here to ensure concurrent compiler threads see initialized String.
+    ASSERT(JSString::isRope());
+    WTF::storeStoreFence();
+    new (&uninitializedValueInternal()) String(WTFMove(string));
+    static_assert(sizeof(String) == sizeof(RefPtr<StringImpl>), "JSString's String initialization must be done in one pointer move.");
+    // We do not clear the trailing fibers and length information (fiber1 and fiber2) because we could be reading the length concurrently.
+    ASSERT(!JSString::isRope());
+}
+
+class JSStringFibers {
+public:
+    JSStringFibers(JSString* s1, JSString* s2, JSString* s3)
+        : m_fibers { s1, s2, s3 }
+    {
+    }
+
+    JSString* fiber(unsigned index) const { return m_fibers[index]; }
+
+private:
+    std::array<JSString*, JSRopeString::s_maxInternalRopeLength> m_fibers { };
+};
+
+// Overview: These functions convert a JSString from holding a string in rope form
+// down to a simple String representation. It does so by building up the string
+// backwards, since we want to avoid recursion, we expect that the tree structure
+// representing the rope is likely imbalanced with more nodes down the left side
+// (since appending to the string is likely more common) - and as such resolving
+// in this fashion should minimize work queue size.  (If we built the queue forwards
+// we would likely have to place all of the constituent StringImpls into the
+// Vector before performing any concatenation, but by working backwards we likely
+// only fill the queue with the number of substrings at any given level in a
+// rope-of-ropes.)
+template<typename Fibers, typename CharacterType>
+void JSRopeString::resolveToBufferSlow(Fibers* fibers, CharacterType* buffer, unsigned length)
+{
+    CharacterType* position = buffer + length; // We will be working backwards over the rope.
+    Vector<JSString*, 32, UnsafeVectorOverflow> workQueue; // These strings are kept alive by the parent rope, so using a Vector is OK.
+
+    for (size_t i = 0; i < JSRopeString::s_maxInternalRopeLength; ++i) {
+        JSString* fiber = fibers->fiber(i);
+        if (!fiber)
+            break;
+        workQueue.append(fiber);
+    }
+
+    while (!workQueue.isEmpty()) {
+        JSString* currentFiber = workQueue.last();
+        workQueue.removeLast();
+
+        if (currentFiber->isRope()) {
+            JSRopeString* currentFiberAsRope = static_cast<JSRopeString*>(currentFiber);
+            if (currentFiberAsRope->isSubstring()) {
+                ASSERT(!currentFiberAsRope->substringBase()->isRope());
+                StringView view = *currentFiberAsRope->substringBase()->valueInternal().impl();
+                unsigned offset = currentFiberAsRope->substringOffset();
+                unsigned length = currentFiberAsRope->length();
+                position -= length;
+                view.substring(offset, length).getCharacters(position);
+                continue;
+            }
+            for (size_t i = 0; i < JSRopeString::s_maxInternalRopeLength && currentFiberAsRope->fiber(i); ++i)
+                workQueue.append(currentFiberAsRope->fiber(i));
+            continue;
+        }
+
+        StringView view = *currentFiber->valueInternal().impl();
+        position -= view.length();
+        view.getCharacters(position);
+    }
+
+    ASSERT(buffer == position);
+}
+
+template<typename Fibers, typename CharacterType>
+inline void JSRopeString::resolveToBuffer(Fibers* fibers, CharacterType* buffer, unsigned length)
+{
+    for (size_t i = 0; i < JSRopeString::s_maxInternalRopeLength; ++i) {
+        JSString* fiber = fibers->fiber(i);
+        if (!fiber)
+            break;
+        if (fiber->isRope()) {
+            JSRopeString::resolveToBufferSlow(fibers, buffer, length);
+            return;
+        }
+    }
+
+    CharacterType* position = buffer;
+    for (size_t i = 0; i < JSRopeString::s_maxInternalRopeLength; ++i) {
+        JSString* fiber = fibers->fiber(i);
+        if (!fiber)
+            break;
+        StringView view = fiber->valueInternal().impl();
+        view.getCharacters(position);
+        position += view.length();
+    }
+    ASSERT((buffer + length) == position);
+}
+
+inline JSString* jsAtomString(JSGlobalObject* globalObject, VM& vm, JSString* string)
+{
+    auto scope = DECLARE_THROW_SCOPE(vm);
+
+    unsigned length = string->length();
+    if (length > KeyAtomStringCache::maxStringLengthForCache) {
+        scope.release();
+        string->toIdentifier(globalObject);
+        return string;
+    }
+
+    if (!string->isRope()) {
+        auto createFromNonRope = [&](VM& vm, auto&) {
+            AtomString atom(string->valueInternal());
+            if (!string->valueInternal().impl()->isAtom())
+                string->swapToAtomString(vm, RefPtr { atom.impl() });
+            return string;
+        };
+
+        if (string->valueInternal().is8Bit()) {
+            WTF::HashTranslatorCharBuffer<LChar> buffer { string->valueInternal().characters8(), length, string->valueInternal().hash() };
+            return vm.keyAtomStringCache.make(vm, buffer, createFromNonRope);
+        }
+
+        WTF::HashTranslatorCharBuffer<UChar> buffer { string->valueInternal().characters16(), length, string->valueInternal().hash() };
+        return vm.keyAtomStringCache.make(vm, buffer, createFromNonRope);
+    }
+
+    JSRopeString* ropeString = jsCast<JSRopeString*>(string);
+
+    auto createFromRope = [&](VM& vm, auto& buffer) {
+        auto impl = AtomStringImpl::add(buffer);
+        if (impl->hasOneRef())
+            vm.heap.reportExtraMemoryAllocated(impl->cost());
+        ropeString->convertToNonRope(String { WTFMove(impl) });
+        return ropeString;
+    };
+
+    AtomString atomString;
+    if (!ropeString->isSubstring()) {
+        if (ropeString->is8Bit()) {
+            LChar characters[KeyAtomStringCache::maxStringLengthForCache];
+            JSRopeString::resolveToBuffer(ropeString, characters, length);
+            WTF::HashTranslatorCharBuffer<LChar> buffer { characters, length };
+            return vm.keyAtomStringCache.make(vm, buffer, createFromRope);
+        }
+        UChar characters[KeyAtomStringCache::maxStringLengthForCache];
+        JSRopeString::resolveToBuffer(ropeString, characters, length);
+        WTF::HashTranslatorCharBuffer<UChar> buffer { characters, length };
+        return vm.keyAtomStringCache.make(vm, buffer, createFromRope);
+    }
+
+    auto view = StringView { ropeString->substringBase()->valueInternal() }.substring(ropeString->substringOffset(), length);
+    if (view.is8Bit()) {
+        WTF::HashTranslatorCharBuffer<LChar> buffer { view.characters8(), length };
+        return vm.keyAtomStringCache.make(vm, buffer, createFromRope);
+    }
+    WTF::HashTranslatorCharBuffer<UChar> buffer { view.characters16(), length };
+    return vm.keyAtomStringCache.make(vm, buffer, createFromRope);
+}
+
+inline JSString* jsAtomString(JSGlobalObject* globalObject, VM& vm, JSString* s1, JSString* s2)
+{
+    auto scope = DECLARE_THROW_SCOPE(vm);
+
+    unsigned length1 = s1->length();
+    if (!length1)
+        RELEASE_AND_RETURN(scope, jsAtomString(globalObject, vm, s2));
+    unsigned length2 = s2->length();
+    if (!length2)
+        RELEASE_AND_RETURN(scope, jsAtomString(globalObject, vm, s1));
+    static_assert(JSString::MaxLength == std::numeric_limits<int32_t>::max());
+    if (sumOverflows<int32_t>(length1, length2)) {
+        throwOutOfMemoryError(globalObject, scope);
+        return nullptr;
+    }
+
+    unsigned length = length1 + length2;
+    if (length > KeyAtomStringCache::maxStringLengthForCache) {
+        auto* ropeString = jsString(globalObject, s1, s2);
+        RETURN_IF_EXCEPTION(scope, nullptr);
+        ropeString->toIdentifier(globalObject);
+        RETURN_IF_EXCEPTION(scope, nullptr);
+        return ropeString;
+    }
+
+    auto createFromFibers = [&](VM& vm, auto& buffer) {
+        return jsString(vm, String { AtomStringImpl::add(buffer) });
+    };
+
+    JSStringFibers fibers(s1, s2, nullptr);
+    if (s1->is8Bit() && s2->is8Bit()) {
+        LChar characters[KeyAtomStringCache::maxStringLengthForCache];
+        JSRopeString::resolveToBuffer(&fibers, characters, length);
+        WTF::HashTranslatorCharBuffer<LChar> buffer { characters, length };
+        return vm.keyAtomStringCache.make(vm, buffer, createFromFibers);
+    }
+    UChar characters[KeyAtomStringCache::maxStringLengthForCache];
+    JSRopeString::resolveToBuffer(&fibers, characters, length);
+    WTF::HashTranslatorCharBuffer<UChar> buffer { characters, length };
+    return vm.keyAtomStringCache.make(vm, buffer, createFromFibers);
+}
+
+inline JSString* jsAtomString(JSGlobalObject* globalObject, VM& vm, JSString* s1, JSString* s2, JSString* s3)
+{
+    auto scope = DECLARE_THROW_SCOPE(vm);
+
+    unsigned length1 = s1->length();
+    if (!length1)
+        RELEASE_AND_RETURN(scope, jsAtomString(globalObject, vm, s2, s3));
+
+    unsigned length2 = s2->length();
+    if (!length2)
+        RELEASE_AND_RETURN(scope, jsAtomString(globalObject, vm, s1, s3));
+
+    unsigned length3 = s3->length();
+    if (!length3)
+        RELEASE_AND_RETURN(scope, jsAtomString(globalObject, vm, s1, s2));
+
+    static_assert(JSString::MaxLength == std::numeric_limits<int32_t>::max());
+    if (sumOverflows<int32_t>(length1, length2, length3)) {
+        throwOutOfMemoryError(globalObject, scope);
+        return nullptr;
+    }
+
+    unsigned length = length1 + length2 + length3;
+    if (length > KeyAtomStringCache::maxStringLengthForCache) {
+        auto* ropeString = jsString(globalObject, s1, s2, s3);
+        RETURN_IF_EXCEPTION(scope, nullptr);
+        ropeString->toIdentifier(globalObject);
+        RETURN_IF_EXCEPTION(scope, nullptr);
+        return ropeString;
+    }
+
+    auto createFromFibers = [&](VM& vm, auto& buffer) {
+        return jsString(vm, String { AtomStringImpl::add(buffer) });
+    };
+
+    JSStringFibers fibers(s1, s2, s3);
+    if (s1->is8Bit() && s2->is8Bit() && s3->is8Bit()) {
+        LChar characters[KeyAtomStringCache::maxStringLengthForCache];
+        JSRopeString::resolveToBuffer(&fibers, characters, length);
+        WTF::HashTranslatorCharBuffer<LChar> buffer { characters, length };
+        return vm.keyAtomStringCache.make(vm, buffer, createFromFibers);
+    }
+    UChar characters[KeyAtomStringCache::maxStringLengthForCache];
+    JSRopeString::resolveToBuffer(&fibers, characters, length);
+    WTF::HashTranslatorCharBuffer<UChar> buffer { characters, length };
+    return vm.keyAtomStringCache.make(vm, buffer, createFromFibers);
 }
 
 } // namespace JSC

--- a/Source/JavaScriptCore/runtime/KeyAtomStringCache.h
+++ b/Source/JavaScriptCore/runtime/KeyAtomStringCache.h
@@ -1,0 +1,52 @@
+/*
+ * Copyright (C) 2023 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include <wtf/text/AtomStringImpl.h>
+
+namespace JSC {
+
+class VM;
+
+class KeyAtomStringCache {
+public:
+    static constexpr auto maxStringLengthForCache = 64;
+    static constexpr auto capacity = 512;
+    using Cache = std::array<JSString*, capacity>;
+
+    template<typename Buffer, typename Func>
+    JSString* make(VM&, Buffer&, const Func&);
+
+    ALWAYS_INLINE void clear()
+    {
+        m_cache.fill({ });
+    }
+
+private:
+    Cache m_cache { };
+};
+
+} // namespace JSC

--- a/Source/JavaScriptCore/runtime/KeyAtomStringCacheInlines.h
+++ b/Source/JavaScriptCore/runtime/KeyAtomStringCacheInlines.h
@@ -1,0 +1,61 @@
+/*
+ * Copyright (C) 2023 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include "Identifier.h"
+#include "KeyAtomStringCache.h"
+#include "SmallStrings.h"
+#include "VM.h"
+
+namespace JSC {
+
+template<typename Buffer, typename Func>
+ALWAYS_INLINE JSString* KeyAtomStringCache::make(VM& vm, Buffer& buffer, const Func& func)
+{
+    if (!buffer.length)
+        return jsEmptyString(vm);
+
+    if (buffer.length == 1) {
+        auto firstCharacter = buffer.characters[0];
+        if (firstCharacter <= maxSingleCharacterString)
+            return vm.smallStrings.singleCharacterString(firstCharacter);
+    }
+
+    ASSERT(buffer.length <= maxStringLengthForCache);
+    auto& slot = m_cache[buffer.hash % capacity];
+    if (slot) {
+        auto* impl = slot->tryGetValueImpl();
+        if (impl->hash() == buffer.hash && equal(impl, buffer.characters, buffer.length))
+            return slot;
+    }
+
+    JSString* result = func(vm, buffer);
+    if (LIKELY(result))
+        slot = result;
+    return result;
+}
+
+} // namespace JSC

--- a/Source/JavaScriptCore/runtime/VM.h
+++ b/Source/JavaScriptCore/runtime/VM.h
@@ -45,6 +45,7 @@
 #include "JSDateMath.h"
 #include "JSLock.h"
 #include "JSONAtomStringCache.h"
+#include "KeyAtomStringCache.h"
 #include "Microtask.h"
 #include "NativeFunction.h"
 #include "NumericStrings.h"
@@ -562,6 +563,7 @@ public:
     Ref<StringImpl> lastAtomizedIdentifierStringImpl { *StringImpl::empty() };
     Ref<AtomStringImpl> lastAtomizedIdentifierAtomStringImpl { *static_cast<AtomStringImpl*>(StringImpl::empty()) };
     JSONAtomStringCache jsonAtomStringCache;
+    KeyAtomStringCache keyAtomStringCache;
 
     AtomStringTable* atomStringTable() const { return m_atomStringTable; }
     WTF::SymbolRegistry& symbolRegistry() { return m_symbolRegistry; }

--- a/Source/WTF/wtf/text/AtomStringImpl.cpp
+++ b/Source/WTF/wtf/text/AtomStringImpl.cpp
@@ -191,6 +191,17 @@ RefPtr<AtomStringImpl> AtomStringImpl::add(const UChar* characters, unsigned len
     return addToStringTable<UCharBuffer, UCharBufferTranslator>(buffer);
 }
 
+RefPtr<AtomStringImpl> AtomStringImpl::add(HashTranslatorCharBuffer<UChar>& buffer)
+{
+    if (!buffer.characters)
+        return nullptr;
+
+    if (!buffer.length)
+        return static_cast<AtomStringImpl*>(StringImpl::empty());
+
+    return addToStringTable<UCharBuffer, UCharBufferTranslator>(buffer);
+}
+
 struct SubstringLocation {
     StringImpl* baseString;
     unsigned start;
@@ -294,6 +305,17 @@ struct BufferFromStaticDataTranslator {
         location = pointer;
     }
 };
+
+RefPtr<AtomStringImpl> AtomStringImpl::add(HashTranslatorCharBuffer<LChar>& buffer)
+{
+    if (!buffer.characters)
+        return nullptr;
+
+    if (!buffer.length)
+        return static_cast<AtomStringImpl*>(StringImpl::empty());
+
+    return addToStringTable<LCharBuffer, LCharBufferTranslator>(buffer);
+}
 
 RefPtr<AtomStringImpl> AtomStringImpl::add(const LChar* characters, unsigned length)
 {

--- a/Source/WTF/wtf/text/AtomStringImpl.h
+++ b/Source/WTF/wtf/text/AtomStringImpl.h
@@ -42,6 +42,10 @@ public:
     WTF_EXPORT_PRIVATE static RefPtr<AtomStringImpl> add(const LChar*, unsigned length);
     WTF_EXPORT_PRIVATE static RefPtr<AtomStringImpl> add(const UChar*, unsigned length);
     ALWAYS_INLINE static RefPtr<AtomStringImpl> add(const char* s, unsigned length) { return add(reinterpret_cast<const LChar*>(s), length); }
+
+    WTF_EXPORT_PRIVATE static RefPtr<AtomStringImpl> add(HashTranslatorCharBuffer<LChar>&);
+    WTF_EXPORT_PRIVATE static RefPtr<AtomStringImpl> add(HashTranslatorCharBuffer<UChar>&);
+
     WTF_EXPORT_PRIVATE static RefPtr<AtomStringImpl> add(StringImpl*, unsigned offset, unsigned length);
     ALWAYS_INLINE static RefPtr<AtomStringImpl> add(StringImpl* string)
     {


### PR DESCRIPTION
#### e28cee6cd730b374c4fa86a91d238b5f0b9bb69e
<pre>
[JSC] Introduce MakeAtomString DFG node
<a href="https://bugs.webkit.org/show_bug.cgi?id=256821">https://bugs.webkit.org/show_bug.cgi?id=256821</a>
rdar://109383731

Reviewed by Justin Michaud.

This is common pattern that GetByVal / PutByVal / InByVal gets concatnated strings.

    object[&quot;property-&quot; + name]

Normally we create rope string, and GetByVal will resolve it to Identifier. This is nice in general
since we do not know whether this string will be resolved when creating a string. But in DFG / FTL,
we can do block local strength reduction analysis and we can identify very common pattern like the above: after
creating rope string, passing it to GetByVal etc. so immediately resolves it to non-rope atom string.

This patch adds strength reduction which does pattern matching GetByVal(MakeRope(...)) and change it to
GetByVal(MakeAtomString(...)). Instead of creating a rope, MakeAtomString resolves all strings, concatenate, atomize
and create normal JSString with this. Furhter we add quick KeyAtomStringCache since it can be possible that this
generated strings are already created before. This quick cache can reduce allocation of JSStrings significantly.

Block locality is conservative, but important since,

    var string = x + y + z;
    if (unlikely) {
        GetByVal(string);
    }

currently we do not want to resolve this case eagerly.

Further, we also refine NumericStrings cache to put JSString* for integer string caches. Both these caches are cleared
when GC happens. But still we can reduce # of allocated JSStrings for common cases.

* Source/JavaScriptCore/JavaScriptCore.xcodeproj/project.pbxproj:
* Source/JavaScriptCore/dfg/DFGAbstractInterpreterInlines.h:
(JSC::DFG::AbstractInterpreter&lt;AbstractStateType&gt;::executeEffects):
* Source/JavaScriptCore/dfg/DFGClobberize.h:
(JSC::DFG::clobberize):
* Source/JavaScriptCore/dfg/DFGConstantFoldingPhase.cpp:
(JSC::DFG::ConstantFoldingPhase::foldConstants):
* Source/JavaScriptCore/dfg/DFGDoesGC.cpp:
(JSC::DFG::doesGC):
* Source/JavaScriptCore/dfg/DFGNodeType.h:
* Source/JavaScriptCore/dfg/DFGOperations.cpp:
(JSC::DFG::JSC_DEFINE_JIT_OPERATION):
* Source/JavaScriptCore/dfg/DFGOperations.h:
* Source/JavaScriptCore/dfg/DFGPredictionPropagationPhase.cpp:
* Source/JavaScriptCore/dfg/DFGSafeToExecute.h:
(JSC::DFG::safeToExecute):
* Source/JavaScriptCore/dfg/DFGSpeculativeJIT.cpp:
* Source/JavaScriptCore/dfg/DFGSpeculativeJIT.h:
* Source/JavaScriptCore/dfg/DFGSpeculativeJIT32_64.cpp:
(JSC::DFG::SpeculativeJIT::compile):
* Source/JavaScriptCore/dfg/DFGSpeculativeJIT64.cpp:
(JSC::DFG::SpeculativeJIT::compile):
* Source/JavaScriptCore/dfg/DFGStoreBarrierInsertionPhase.cpp:
* Source/JavaScriptCore/dfg/DFGStrengthReductionPhase.cpp:
(JSC::DFG::StrengthReductionPhase::handleNode):
* Source/JavaScriptCore/dfg/DFGValidate.cpp:
* Source/JavaScriptCore/ftl/FTLCapabilities.cpp:
(JSC::FTL::canCompile):
* Source/JavaScriptCore/ftl/FTLLowerDFGToB3.cpp:
(JSC::FTL::DFG::LowerDFGToB3::compileNode):
(JSC::FTL::DFG::LowerDFGToB3::compileMakeAtomString):
* Source/JavaScriptCore/heap/Heap.cpp:
(JSC::Heap::finalize):
* Source/JavaScriptCore/runtime/JSString.cpp:
(JSC::JSRopeString::convertToNonRope const): Deleted.
* Source/JavaScriptCore/runtime/JSString.h:
* Source/JavaScriptCore/runtime/JSStringInlines.h:
(JSC::JSRopeString::convertToNonRope const):
(JSC::stringResolveToBufferSlow):
(JSC::stringResolveToBuffer):
(JSC::jsAtomString):
* Source/JavaScriptCore/runtime/KeyAtomStringCache.h: Added.
(JSC::KeyAtomStringCache::clear):
(JSC::KeyAtomStringCache::cacheSlot):
* Source/JavaScriptCore/runtime/KeyAtomStringCacheInlines.h: Added.
(JSC::KeyAtomStringCache::make):
* Source/JavaScriptCore/runtime/VM.h:

Canonical link: <a href="https://commits.webkit.org/264283@main">https://commits.webkit.org/264283@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/67fbed1dcdcd41b02284ca7bda489e2dd90a90b0

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/7254 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/7504 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/7680 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/8875 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/7462 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/8838 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/7432 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/10360 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/7381 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/8079 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/6673 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/8983 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/5422 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/6602 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/14329 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/6151 "Built successfully and passed tests") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/7050 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/6705 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/9587 "Passed tests") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/6838 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/7186 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/5869 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/7394 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/6543 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/1705 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/10744 "Built successfully") | | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/24/builds/7597 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/846 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/6924 "Built successfully") | | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/3/builds/1844 "Passed tests") | 
<!--EWS-Status-Bubble-End-->