### PR TITLE
TouchListType should be an enum class

### DIFF
--- a/Source/WebCore/dom/EventContext.h
+++ b/Source/WebCore/dom/EventContext.h
@@ -64,7 +64,7 @@ public:
     void setRelatedTarget(Node*);
 
 #if ENABLE(TOUCH_EVENTS)
-    enum TouchListType { Touches, TargetTouches, ChangedTouches };
+    enum class TouchListType : uint8_t { Touches, TargetTouches, ChangedTouches };
     TouchList& touchList(TouchListType);
 #endif
 
@@ -136,11 +136,11 @@ inline void EventContext::setRelatedTarget(Node* relatedTarget)
 inline TouchList& EventContext::touchList(TouchListType type)
 {
     switch (type) {
-    case Touches:
+    case TouchListType::Touches:
         return *m_touches;
-    case TargetTouches:
+    case TouchListType::TargetTouches:
         return *m_targetTouches;
-    case ChangedTouches:
+    case TouchListType::ChangedTouches:
         return *m_changedTouches;
     }
     ASSERT_NOT_REACHED();


### PR DESCRIPTION
#### 9ec6f7558d3624bfed651c48cd4572947436e801
<pre>
TouchListType should be an enum class
<a href="https://bugs.webkit.org/show_bug.cgi?id=256827">https://bugs.webkit.org/show_bug.cgi?id=256827</a>

Reviewed by Wenson Hsieh.

* Source/WebCore/dom/EventContext.h:
(WebCore::EventContext::touchList):

Canonical link: <a href="https://commits.webkit.org/264105@main">https://commits.webkit.org/264105@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ae4e44ba81bcbe866894d6d1eec4f8bfc6f50f29

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/6719 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/6936 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/7119 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/8308 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/32/builds/6981 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/6717 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/8065 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/6881 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/9881 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/6837 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/7395 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/6155 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/8402 "Built successfully") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/39/builds/4841 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/6081 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/13900 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/6608 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/6159 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/8894 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/6650 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/5445 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/6042 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/10215 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/782 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/6415 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->