### PR TITLE
Notifications API: default silent to platform convention

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/interfaces/notifications.idl
+++ b/LayoutTests/imported/w3c/web-platform-tests/interfaces/notifications.idl
@@ -28,7 +28,7 @@ interface Notification : EventTarget {
   [SameObject] readonly attribute FrozenArray<unsigned long> vibrate;
   readonly attribute DOMTimeStamp timestamp;
   readonly attribute boolean renotify;
-  readonly attribute boolean silent;
+  readonly attribute boolean? silent;
   readonly attribute boolean requireInteraction;
   [SameObject] readonly attribute any data;
   [SameObject] readonly attribute FrozenArray<NotificationAction> actions;
@@ -47,7 +47,7 @@ dictionary NotificationOptions {
   VibratePattern vibrate;
   DOMTimeStamp timestamp;
   boolean renotify = false;
-  boolean silent = false;
+  boolean? silent = null;
   boolean requireInteraction = false;
   any data = null;
   sequence<NotificationAction> actions = [];

--- a/LayoutTests/imported/w3c/web-platform-tests/notifications/constructor-basic.https-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/notifications/constructor-basic.https-expected.txt
@@ -1,3 +1,5 @@
 
 PASS Called the notification constructor with one argument.
+PASS Constructing a notification without a NotificationOptions defaults to null.
+PASS constructing a notification with a NotificationOptions dictionary correctly sets and reflects the silent attribute.
 

--- a/LayoutTests/imported/w3c/web-platform-tests/notifications/constructor-basic.https.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/notifications/constructor-basic.https.html
@@ -18,4 +18,34 @@ test(function() {
         notification.close()
     }
 }, "Called the notification constructor with one argument.")
+
+test(() => {
+    assert_equals(
+        new Notification("a").silent,
+        null,
+        "Expected null by default"
+    );
+}, "Constructing a notification without a NotificationOptions defaults to null.");
+
+test(() => {
+    for (const silent of [null, undefined]) {
+        assert_equals(
+            new Notification("a", { silent }).silent,
+            null,
+            `Expected silent to be null when initialized with ${silent}.`
+        );
+    }
+    for (const silent of [true, 1, 100, {}, [], "a string"]) {
+        assert_true(
+            new Notification("a", { silent }).silent,
+            `Expected silent to be true when initialized with ${silent}.`
+        );
+    }
+    for (const silent of [false, 0, "", NaN]) {
+        assert_false(
+            new Notification("a", { silent }).silent,
+            `Expected silent to be false when initialized with ${silent}.`
+        );
+    }
+}, "constructing a notification with a NotificationOptions dictionary correctly sets and reflects the silent attribute.");
 </script>

--- a/Source/WebCore/Modules/notifications/Notification.h
+++ b/Source/WebCore/Modules/notifications/Notification.h
@@ -88,7 +88,7 @@ public:
     const String& tag() const { return m_tag; }
     const URL& icon() const { return m_icon; }
     JSC::JSValue dataForBindings(JSC::JSGlobalObject&);
-    bool silent() const { return m_silent == std::nullopt ? false : *m_silent; }
+    std::optional<bool> silent() const { return m_silent; }
 
     TextDirection direction() const { return m_direction == Direction::Rtl ? TextDirection::RTL : TextDirection::LTR; }
 

--- a/Source/WebCore/Modules/notifications/Notification.idl
+++ b/Source/WebCore/Modules/notifications/Notification.idl
@@ -60,7 +60,7 @@
     // [SameObject] readonly attribute FrozenArray<unsigned long> vibrate;
     // readonly attribute EpochTimeStamp timestamp;
     // readonly attribute boolean renotify;
-    readonly attribute boolean silent;
+    readonly attribute boolean? silent;
     // readonly attribute boolean requireInteraction;
     [CallWith=CurrentGlobalObject, CachedAttribute, ImplementedAs=dataForBindings] readonly attribute any data;
     // [SameObject] readonly attribute FrozenArray<NotificationAction> actions;

--- a/Source/WebCore/Modules/notifications/NotificationOptions.idl
+++ b/Source/WebCore/Modules/notifications/NotificationOptions.idl
@@ -37,7 +37,7 @@
     // VibratePattern vibrate;
     // EpochTimeStamp timestamp;
     // boolean renotify = false;
-    boolean? silent;
+    boolean? silent = null;
     // boolean requireInteraction = false;
     any data = null;
     // sequence<NotificationAction> actions = [];

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/PushAPI.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/PushAPI.mm
@@ -450,7 +450,7 @@ TEST(PushAPI, testSilentFlag)
     pushMessageProcessed = false;
     [webView callAsyncJavaScript:@(getPersistentNotificationsScript) arguments:@{ @"theMessage" : @"getAllNotifications" } inFrame:nil inContentWorld:WKContentWorld.pageWorld completionHandler:^(id result, NSError *error) {
         EXPECT_NULL(error);
-        EXPECT_TRUE([result isEqualToString:@"nothing false nothingTag true true somethingTag false false somethingTag "]);
+        EXPECT_TRUE([result isEqualToString:@"nothing null nothingTag true true somethingTag false false somethingTag "]);
         pushMessageProcessed = true;
     }];
     TestWebKitAPI::Util::run(&pushMessageProcessed);
@@ -460,7 +460,7 @@ TEST(PushAPI, testSilentFlag)
     // but the results should be the same as not specifying a tag at all like in the previous test.
     [webView callAsyncJavaScript:@(getPersistentNotificationsScript) arguments:@{ @"theMessage" : @"" } inFrame:nil inContentWorld:WKContentWorld.pageWorld completionHandler:^(id result, NSError *error) {
         EXPECT_NULL(error);
-        EXPECT_TRUE([result isEqualToString:@"nothing false nothingTag true true somethingTag false false somethingTag "]);
+        EXPECT_TRUE([result isEqualToString:@"nothing null nothingTag true true somethingTag false false somethingTag "]);
         pushMessageProcessed = true;
     }];
     TestWebKitAPI::Util::run(&pushMessageProcessed);
@@ -468,7 +468,7 @@ TEST(PushAPI, testSilentFlag)
     pushMessageProcessed = false;
     [webView callAsyncJavaScript:@(getPersistentNotificationsScript) arguments:@{ @"theMessage" : @"nothingTag" } inFrame:nil inContentWorld:WKContentWorld.pageWorld completionHandler:^(id result, NSError *error) {
         EXPECT_NULL(error);
-        EXPECT_TRUE([result isEqualToString:@"nothing false nothingTag "]);
+        EXPECT_TRUE([result isEqualToString:@"nothing null nothingTag "]);
         pushMessageProcessed = true;
     }];
     TestWebKitAPI::Util::run(&pushMessageProcessed);


### PR DESCRIPTION
#### bb5a5fbce2e993ee60fbb3046b6e6c03693b49a0
<pre>
Notifications API: default silent to platform convention
<a href="https://bugs.webkit.org/show_bug.cgi?id=256828">https://bugs.webkit.org/show_bug.cgi?id=256828</a>
rdar://109390045

Reviewed by Brady Eidson.

Makes the silent member on the NotificationOption dictionary default to null.
This is then reflected by the silent attribute of the Notification interface.

Spec change:
<a href="https://github.com/whatwg/notifications/pull/194">https://github.com/whatwg/notifications/pull/194</a>

* LayoutTests/imported/w3c/web-platform-tests/interfaces/notifications.idl:
* LayoutTests/imported/w3c/web-platform-tests/notifications/constructor-basic.https-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/notifications/constructor-basic.https.html:
* Source/WebCore/Modules/notifications/Notification.h:
* Source/WebCore/Modules/notifications/Notification.idl:
* Source/WebCore/Modules/notifications/NotificationOptions.idl:

Canonical link: <a href="https://commits.webkit.org/264397@main">https://commits.webkit.org/264397@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/261808eeb5fa2bee591d8253427b14778130f4c6

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/7133 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/7380 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/7559 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/8749 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/7357 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/7143 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/8644 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/7312 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/10255 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/7260 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/7917 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/6571 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/8855 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/5272 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/6490 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/14235 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/6934 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/6598 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/9464 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/7069 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/5781 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/6429 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/6399 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/1780 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/10628 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/6812 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->