### PR TITLE
[build.webkit.org] Add ARM32 and ARM64 build post-commit bots for WPE

### DIFF
--- a/Tools/CISupport/build-webkit-org/config.json
+++ b/Tools/CISupport/build-webkit-org/config.json
@@ -122,7 +122,9 @@
                   { "name": "wpe-linux-bot-11", "platform": "wpe" },
                   { "name": "wpe-linux-bot-12", "platform": "wpe" },
                   { "name": "wpe-linux-bot-13", "platform": "wpe" },
-                  { "name": "wpe-linux-bot-14", "platform": "wpe" }
+                  { "name": "wpe-linux-bot-14", "platform": "wpe" },
+                  { "name": "wpe-linux-bot-15", "platform": "wpe" },
+                  { "name": "wpe-linux-bot-16", "platform": "wpe" }
                 ],
 
   "builders":   [
@@ -579,6 +581,18 @@
                     "name": "WPE-Linux-64-bit-Debug-WebDriver-Tests", "factory": "TestWebDriverFactory",
                     "platform": "wpe", "configuration": "debug", "architectures": ["x86_64"],
                     "workernames": ["wpe-linux-bot-14"]
+                  },
+                  {
+                    "name": "WPE-Linux-ARM64-bit-Release-Debian-Stable-Build", "factory": "BuildFactory",
+                    "platform": "wpe", "configuration": "release", "architectures": ["arm64"],
+                    "additionalArguments": ["--no-experimental-features"],
+                    "workernames": ["wpe-linux-bot-15"]
+                  },
+                  {
+                    "name": "WPE-Linux-ARM32-bit-Release-Debian-Stable-Build", "factory": "BuildFactory",
+                    "platform": "wpe", "configuration": "release", "architectures": ["armv7"],
+                    "additionalArguments": ["--no-experimental-features"],
+                    "workernames": ["wpe-linux-bot-16"]
                   }
                 ],
 

--- a/Tools/CISupport/build-webkit-org/factories_unittest.py
+++ b/Tools/CISupport/build-webkit-org/factories_unittest.py
@@ -1565,6 +1565,28 @@ class TestExpectedBuildSteps(unittest.TestCase):
             'jhbuild',
             'compile-webkit'
         ],
+        'WPE-Linux-ARM32-bit-Release-Debian-Stable-Build': [
+            'configure-build',
+            'configuration',
+            'clean-and-update-working-directory',
+            'checkout-specific-revision',
+            'show-identifier',
+            'kill-old-processes',
+            'delete-WebKitBuild-directory',
+            'delete-stale-build-files',
+            'compile-webkit'
+        ],
+        'WPE-Linux-ARM64-bit-Release-Debian-Stable-Build': [
+            'configure-build',
+            'configuration',
+            'clean-and-update-working-directory',
+            'checkout-specific-revision',
+            'show-identifier',
+            'kill-old-processes',
+            'delete-WebKitBuild-directory',
+            'delete-stale-build-files',
+            'compile-webkit'
+        ],
     }
 
     def setUp(self):

--- a/Tools/glib/dependencies/apt
+++ b/Tools/glib/dependencies/apt
@@ -41,10 +41,12 @@ PACKAGES=(
     libasound2-dev
     libatk1.0-dev
     $(aptIfExists libavif-dev)
+    libdrm-dev
     $(aptIfExists libenchant-2-dev)
     libepoxy-dev
     libevent-dev
     libfile-copy-recursive-perl
+    libinput-dev
     $(aptIfElse libgcrypt20-dev libgcrypt11-dev)
     libgstreamer1.0-dev
     libgstreamer-plugins-bad1.0-dev
@@ -94,7 +96,7 @@ PACKAGES=(
     gyp
     libegl1-mesa-dev
     libexpat1-dev
-    libfdk-aac-dev
+    $(aptIfExists libfdk-aac-dev)
     libgles2-mesa-dev
     liborc-0.4-dev
     libproxy-dev

--- a/Tools/gtk/dependencies/apt
+++ b/Tools/gtk/dependencies/apt
@@ -55,12 +55,10 @@ PACKAGES+=(
     gobject-introspection
     icon-naming-utils
     libcups2-dev
-    libdrm-dev
     libevdev-dev
     libgbm-dev
     libgnutls28-dev
     libgpg-error-dev
-    libinput-dev
     libjson-glib-dev
     libmtdev-dev
     libp11-kit-dev


### PR DESCRIPTION
#### eebb6eeec1e6be4160bab5f0552647e292b5c46b
<pre>
[build.webkit.org] Add ARM32 and ARM64 build post-commit bots for WPE
<a href="https://bugs.webkit.org/show_bug.cgi?id=256830">https://bugs.webkit.org/show_bug.cgi?id=256830</a>

Reviewed by Carlos Alberto Lopez Perez.

Add two new build post-commit bots for WPE targeting ARM32 and ARM64
architectures. These bots build with system libraries.

* Tools/CISupport/build-webkit-org/config.json:
* Tools/CISupport/build-webkit-org/factories_unittest.py:
* Tools/gtk/dependencies/apt: Mode dependencies needed to build both
  WebKitGTK and WPE to glib dependencies.
* Tools/glib/dependencies/apt:

Canonical link: <a href="https://commits.webkit.org/264145@main">https://commits.webkit.org/264145@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/7bf7e8428f23b9f1ba2fd57355131bb8cb02d3e9

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/6741 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/6958 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/7143 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/8329 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/6995 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/6740 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/8097 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/6902 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/9897 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/6858 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/7429 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/6179 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/8423 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/4867 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/6103 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/13914 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/6626 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/6182 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/8939 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/6670 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/5463 "Passed tests") | | 
| [✅ 🧪 services](https://ews-build.webkit.org/#/builders/28/builds/6703 "Passed tests") | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/6056 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/1624 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/10233 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/6429 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->