### PR TITLE
[WGSL] Implement built-in function textureSampleBaseClampToEdge

### DIFF
--- a/Source/WebGPU/WGSL/TypeDeclarations.rb
+++ b/Source/WebGPU/WGSL/TypeDeclarations.rb
@@ -100,6 +100,11 @@ operator :textureSample, {
     # https://bugs.webkit.org/show_bug.cgi?id=254515
 }
 
+operator :textureSampleBaseClampToEdge, {
+  [].(TextureExternal, Sampler, Vector[F32, 2]) => Vector[F32, 4],
+  [].(Texture[F32, Texture2d], Sampler, Vector[F32, 2]) => Vector[F32, 4],
+}
+
 operator :vec2, {
     [T < Scalar].(T) => Vector[T, 2],
     [T < ConcreteScalar, S < Scalar].(Vector[S, 2]) => Vector[T, 2],


### PR DESCRIPTION
#### 6c82c6b0b1521fef0e4f7cd0136f7f2d11ac1f20
<pre>
[WGSL] Implement built-in function textureSampleBaseClampToEdge
<a href="https://bugs.webkit.org/show_bug.cgi?id=256724">https://bugs.webkit.org/show_bug.cgi?id=256724</a>
rdar://109273173

Reviewed by Mike Wyrzykowski.

Implement `textureSampleBaseClampToEdge` which expands into two samples when
sampling a `texture_external`.

* Source/WebGPU/WGSL/Metal/MetalFunctionWriter.cpp:
(WGSL::Metal::FunctionDefinitionWriter::indent):
(WGSL::Metal::FunctionDefinitionWriter::visit):
* Source/WebGPU/WGSL/TypeDeclarations.rb:

Canonical link: <a href="https://commits.webkit.org/264141@main">https://commits.webkit.org/264141@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/51c210322d2616db2519f1d99c6fd950acef9fa2

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/6859 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/7088 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/7272 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/8457 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/7107 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/8295 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/7028 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/10004 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/6980 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/7609 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/6308 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/8555 "Built successfully") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/39/builds/5012 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/14009 "4 flakes 432 failures") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/6716 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/6309 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/9090 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/6791 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/5557 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/6167 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/1622 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/10352 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/6545 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->