### PR TITLE
[WebGPU] Include texture_external's missing fields in BindGroup

### DIFF
--- a/Source/WebGPU/WebGPU/BindGroup.mm
+++ b/Source/WebGPU/WebGPU/BindGroup.mm
@@ -205,14 +205,12 @@ Ref<BindGroup> Device::createBindGroup(const WGPUBindGroupDescriptor& descriptor
                     resources.append({ textureData.texture0, MTLResourceUsageRead, metalRenderStage(stage) });
                 if (textureData.texture1)
                     resources.append({ textureData.texture1, MTLResourceUsageRead, metalRenderStage(stage) });
-                // FIXME: encode CSC and UV remapping after https://bugs.webkit.org/show_bug.cgi?id=256721 is implemented
-                // simd::float3x2* uvRemapAddress =  (simd::float3x2*)[argumentEncoder[stage] constantDataAtIndex:index++];
-                // *uvRemapAddress = textureData.uvRemappingMatrix;
-                index++;
 
-                // simd::float4x3* cscMatrixAddress =  (simd::float4x3*)[argumentEncoder[stage] constantDataAtIndex:index++];
-                // *cscMatrixAddress = textureData.colorSpaceConversionMatrix;
-                index++;
+                simd::float3x2* uvRemapAddress =  (simd::float3x2*)[argumentEncoder[stage] constantDataAtIndex:index++];
+                *uvRemapAddress = textureData.uvRemappingMatrix;
+
+                simd::float4x3* cscMatrixAddress =  (simd::float4x3*)[argumentEncoder[stage] constantDataAtIndex:index++];
+                *cscMatrixAddress = textureData.colorSpaceConversionMatrix;
             }
         }
     }


### PR DESCRIPTION
#### b54763b0a44828d94c319fafbace6ecc349e7354
<pre>
[WebGPU] Include texture_external&apos;s missing fields in BindGroup
<a href="https://bugs.webkit.org/show_bug.cgi?id=256836">https://bugs.webkit.org/show_bug.cgi?id=256836</a>
rdar://109403008

Reviewed by Mike Wyrzykowski.

Remove the FIXME added on 264108@main since texture_external is being added to
WGSL in PR#13878

* Source/WebGPU/WebGPU/BindGroup.mm:
(WebGPU::Device::createBindGroup):

Canonical link: <a href="https://commits.webkit.org/264140@main">https://commits.webkit.org/264140@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0a691d1cce404440d2a0d4dbf08ec78db0acf871

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/6757 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/6973 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/7158 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/8345 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/7010 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/8133 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/6918 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/9913 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/6874 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/7462 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/6198 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/8440 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/4898 "Passed tests") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/13933 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/6643 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/6198 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/8972 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/6685 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/5479 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/6071 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/1621 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/10248 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/6445 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->