### PR TITLE
Assertion failure in StyleGeneratedImage::removeClient

### DIFF
--- a/LayoutTests/fast/css/custom-property-deduplication-cross-fade-crash-expected.txt
+++ b/LayoutTests/fast/css/custom-property-deduplication-cross-fade-crash-expected.txt
@@ -1,0 +1,2 @@
+a
+This test passes if it doesn't crash.

--- a/LayoutTests/fast/css/custom-property-deduplication-cross-fade-crash.html
+++ b/LayoutTests/fast/css/custom-property-deduplication-cross-fade-crash.html
@@ -1,0 +1,30 @@
+<style>
+  @property --v {
+    syntax: '<number>';
+    inherits: false;
+    initial-value: 0;
+  }
+  :root {
+    grid-auto-rows: 0;
+  }
+  div {
+    shape-outside: cross-fade(url(.), url(), 0%);
+  }
+  #d:empty {
+    -webkit-column-axis: vertical;
+  }
+</style>
+<script>
+  if (window.testRunner)
+    testRunner.dumpAsText();
+  onload = () => {
+    document.styleSheets[0].insertRule(`:first-child { all: unset; }`);
+    document.head.append(document.createElement('div'));
+    document.body.offsetTop;
+    d.append('a');
+    document.body.offsetTop;
+    document.styleSheets[0].deleteRule(0);
+  };
+</script>
+<div></div><div id=d></div>
+This test passes if it doesn't crash.

--- a/Source/WebCore/rendering/style/RenderStyle.cpp
+++ b/Source/WebCore/rendering/style/RenderStyle.cpp
@@ -2734,8 +2734,6 @@ void RenderStyle::deduplicateCustomProperties(const RenderStyle& other)
         if (properties.ptr() == otherProperties.ptr() || *properties != *otherProperties)
             return;
         properties = otherProperties;
-        if (data == otherData)
-            const_cast<DataRef<T>&>(data) = otherData;
     };
 
     deduplicate(m_rareInheritedData, other.m_rareInheritedData);

--- a/Source/WebCore/rendering/style/StyleCrossfadeImage.cpp
+++ b/Source/WebCore/rendering/style/StyleCrossfadeImage.cpp
@@ -104,13 +104,15 @@ void StyleCrossfadeImage::load(CachedResourceLoader& loader, const ResourceLoade
     auto oldCachedToImage = m_cachedToImage;
 
     if (m_from) {
-        m_from->load(loader, options);
+        if (m_from->isPending())
+            m_from->load(loader, options);
         m_cachedFromImage = m_from->cachedImage();
     } else
         m_cachedFromImage = nullptr;
 
     if (m_to) {
-        m_to->load(loader, options);
+        if (m_to->isPending())
+            m_to->load(loader, options);
         m_cachedToImage = m_to->cachedImage();
     } else
         m_cachedToImage = nullptr;


### PR DESCRIPTION
#### 1a09d8d95ba6085df4ef44306c4bfc9fc86fdbc7
<pre>
Assertion failure in StyleGeneratedImage::removeClient
<a href="https://bugs.webkit.org/show_bug.cgi?id=256840">https://bugs.webkit.org/show_bug.cgi?id=256840</a>
rdar://107311467

Reviewed by Alan Baradlay.

* LayoutTests/fast/css/custom-property-deduplication-cross-fade-crash-expected.txt: Added.
* LayoutTests/fast/css/custom-property-deduplication-cross-fade-crash.html: Added.
* Source/WebCore/rendering/style/RenderStyle.cpp:
(WebCore::RenderStyle::deduplicateCustomProperties):

Remove an optimization where we would after successfully deduplicating custom properties also
try to deduplicate the whole rare data struct. This is dangerous since it will mutate style
in all renderers that are using the rare data instance. Images in style need to be registered per-renderer
and that happens via RenderElement::setStyle. If style changes silently we fail to do this
registration.

This was also probably not super valuable. The main goal here was deduplicating large custom property data
which is still happening.

* Source/WebCore/rendering/style/StyleCrossfadeImage.cpp:
(WebCore::StyleCrossfadeImage::load):

Ensure we only trigger load for to/from image if it has not already been loaded.
We may end up in this case because only one of the images needs loading.

Canonical link: <a href="https://commits.webkit.org/264116@main">https://commits.webkit.org/264116@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/361162db9658fd43bf0adf040d131bc71cc7d6d4

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/6762 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/6978 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/7163 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/8350 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/7015 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/6760 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/8140 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/6923 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/9915 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/6879 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/7469 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/6202 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/8445 "Built successfully") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/39/builds/4903 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/6122 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/13936 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/6647 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/6202 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/8977 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/6690 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/5484 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/6076 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/6045 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/1592 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/10253 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/6450 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->