### PR TITLE
Add `-list` flag to testb3

### DIFF
--- a/Source/JavaScriptCore/b3/testb3.h
+++ b/Source/JavaScriptCore/b3/testb3.h
@@ -125,22 +125,24 @@ extern Lock crashLock;
 
 #define PREFIX "O", Options::defaultB3OptLevel(), ": "
 
-#define RUN(test) do {                             \
-    if (!shouldRun(filter, #test))                 \
-        break;                                     \
-    tasks.append(                                  \
-        createSharedTask<void()>(                  \
-            [&] () {                               \
-                dataLog(PREFIX #test "...\n");     \
-                test;                              \
-                dataLog(PREFIX #test ": OK!\n");   \
-            }));                                   \
+#define RUN(test)                                           \
+    do {                                                    \
+        CString testStr = toCString(PREFIX #test);          \
+        if (!shouldRun(config, testStr.data()))             \
+            break;                                          \
+        tasks.append(                                       \
+            createSharedTask<void()>(                       \
+                [=]() {                                     \
+                    dataLog(toCString(testStr, "...\n"));   \
+                    test;                                   \
+                    dataLog(toCString(testStr, ": OK!\n")); \
+                }));                                        \
     } while (false);
 
 #define RUN_UNARY(test, values) \
     for (auto a : values) {                             \
         CString testStr = toCString(PREFIX #test, "(", a.name, ")"); \
-        if (!shouldRun(filter, testStr.data()))         \
+        if (!shouldRun(config, testStr.data()))         \
             continue;                                   \
         tasks.append(createSharedTask<void()>(          \
             [=] () {                                    \
@@ -151,7 +153,7 @@ extern Lock crashLock;
     }
 
 #define RUN_NOW(test) do {                      \
-        if (!shouldRun(filter, #test))          \
+        if (!shouldRun(config, #test))          \
             break;                              \
         dataLog(PREFIX #test "...\n");          \
         test;                                   \
@@ -162,7 +164,7 @@ extern Lock crashLock;
     for (auto a : valuesA) {                                \
         for (auto b : valuesB) {                            \
             CString testStr = toCString(PREFIX #test, "(", a.name, ", ", b.name, ")"); \
-            if (!shouldRun(filter, testStr.data()))         \
+            if (!shouldRun(config, testStr.data()))         \
                 continue;                                   \
             tasks.append(createSharedTask<void()>(          \
                 [=] () {                                    \
@@ -176,8 +178,8 @@ extern Lock crashLock;
     for (auto a : valuesA) {                                    \
         for (auto b : valuesB) {                                \
             for (auto c : valuesC) {                            \
-                CString testStr = toCString(#test, "(", a.name, ", ", b.name, ",", c.name, ")"); \
-                if (!shouldRun(filter, testStr.data()))         \
+                CString testStr = toCString(PREFIX #test, "(", a.name, ", ", b.name, ",", c.name, ")"); \
+                if (!shouldRun(config, testStr.data()))         \
                     continue;                                   \
                 tasks.append(createSharedTask<void()>(          \
                     [=] () {                                    \
@@ -442,7 +444,16 @@ inline float modelLoad<float, float>(float value) { return value; }
 template<>
 inline double modelLoad<double, double>(double value) { return value; }
 
-void run(const char* filter);
+struct TestConfig {
+    enum class Mode {
+        ListTests,
+        RunTests,
+    } mode { Mode::RunTests };
+    char* filter { nullptr };
+    unsigned workerThreadCount { 1 };
+};
+
+void run(const TestConfig* filter);
 void testBitAndSExt32(int32_t value, int64_t mask);
 void testUbfx32ShiftAnd();
 void testUbfx32AndShift();
@@ -1173,17 +1184,17 @@ void testNegDouble(double);
 void testNegFloat(float);
 void testNegFloatWithUselessDoubleConversion(float);
 
-void addArgTests(const char* filter, Deque<RefPtr<SharedTask<void()>>>&);
-void addBitTests(const char* filter, Deque<RefPtr<SharedTask<void()>>>&);
-void addCallTests(const char* filter, Deque<RefPtr<SharedTask<void()>>>&);
-void addSExtTests(const char* filter, Deque<RefPtr<SharedTask<void()>>>&);
-void addSShrShTests(const char* filter, Deque<RefPtr<SharedTask<void()>>>&);
-void addShrTests(const char* filter, Deque<RefPtr<SharedTask<void()>>>&);
-void addAtomicTests(const char* filter, Deque<RefPtr<SharedTask<void()>>>&);
-void addLoadTests(const char* filter, Deque<RefPtr<SharedTask<void()>>>&);
-void addTupleTests(const char* filter, Deque<RefPtr<SharedTask<void()>>>&);
+void addArgTests(const TestConfig*, Deque<RefPtr<SharedTask<void()>>>&);
+void addBitTests(const TestConfig*, Deque<RefPtr<SharedTask<void()>>>&);
+void addCallTests(const TestConfig*, Deque<RefPtr<SharedTask<void()>>>&);
+void addSExtTests(const TestConfig*, Deque<RefPtr<SharedTask<void()>>>&);
+void addSShrShTests(const TestConfig*, Deque<RefPtr<SharedTask<void()>>>&);
+void addShrTests(const TestConfig*, Deque<RefPtr<SharedTask<void()>>>&);
+void addAtomicTests(const TestConfig*, Deque<RefPtr<SharedTask<void()>>>&);
+void addLoadTests(const TestConfig*, Deque<RefPtr<SharedTask<void()>>>&);
+void addTupleTests(const TestConfig*, Deque<RefPtr<SharedTask<void()>>>&);
 
-bool shouldRun(const char* filter, const char* testName);
+bool shouldRun(const TestConfig*, const char* testName);
 
 void testLoadPreIndex32();
 void testLoadPreIndex64();

--- a/Source/JavaScriptCore/b3/testb3_1.cpp
+++ b/Source/JavaScriptCore/b3/testb3_1.cpp
@@ -30,8 +30,14 @@
 
 Lock crashLock;
 
-bool shouldRun(const char* filter, const char* testName)
+bool shouldRun(const TestConfig* config, const char* testName)
 {
+    if (config->mode == TestConfig::Mode::ListTests) {
+        dataLogLn(testName);
+        return false;
+    }
+
+    const auto* filter = config->filter;
     // FIXME: These tests fail <https://bugs.webkit.org/show_bug.cgi?id=199330>.
     if (!filter && isARM64()) {
         for (auto& failingTest : {
@@ -126,7 +132,7 @@ void testComputeDivisionMagic(T value, T magicMultiplier, unsigned shift)
     CHECK(magic.shift == shift);
 }
 
-void run(const char* filter)
+void run(const TestConfig* config)
 {
     Deque<RefPtr<SharedTask<void()>>> tasks;
 
@@ -149,13 +155,13 @@ void run(const char* filter)
     RUN_UNARY(testAddTreeArg32, int32Operands());
     RUN_UNARY(testMulTreeArg32, int32Operands());
 
-    addArgTests(filter, tasks);
+    addArgTests(config, tasks);
 
     RUN_UNARY(testNegDouble, floatingPointOperands<double>());
     RUN_UNARY(testNegFloat, floatingPointOperands<float>());
     RUN_UNARY(testNegFloatWithUselessDoubleConversion, floatingPointOperands<float>());
 
-    addBitTests(filter, tasks);
+    addBitTests(config, tasks);
 
     RUN(testShlArgs(1, 0));
     RUN(testShlArgs(1, 1));
@@ -214,7 +220,7 @@ void run(const char* filter)
     RUN(testShlZShrArgImm32(0xffffffff, 1));
     RUN(testShlZShrArgImm32(0xffffffff, 63));
 
-    addShrTests(filter, tasks);
+    addShrTests(config, tasks);
 
     RUN_UNARY(testClzArg64, int64Operands());
     RUN_UNARY(testClzMem64, int64Operands());
@@ -533,8 +539,8 @@ void run(const char* filter)
     RUN(testEqualDouble(42, PNaN, false));
     RUN(testEqualDouble(PNaN, PNaN, false));
 
-    addLoadTests(filter, tasks);
-    addTupleTests(filter, tasks);
+    addLoadTests(config, tasks);
+    addTupleTests(config, tasks);
 
     RUN(testSpillGP());
     RUN(testSpillFP());
@@ -548,7 +554,7 @@ void run(const char* filter)
     RUN(testInt32ToDoublePartialRegisterStall());
     RUN(testInt32ToDoublePartialRegisterWithoutStall());
 
-    addCallTests(filter, tasks);
+    addCallTests(config, tasks);
 
     RUN(testLinearScanWithCalleeOnStack());
 
@@ -652,7 +658,7 @@ void run(const char* filter)
     RUN(testTruncSExt32(1000000000ll));
     RUN(testTruncSExt32(-1000000000ll));
 
-    addSExtTests(filter, tasks);
+    addSExtTests(config, tasks);
 
     RUN(testBasicSelect());
     RUN(testSelectTest());
@@ -711,7 +717,7 @@ void run(const char* filter)
     RUN(testStore16Load16Z(12345678));
     RUN(testStore16Load16Z(-123));
 
-    addSShrShTests(filter, tasks);
+    addSShrShTests(config, tasks);
 
     RUN(testCheckMul64SShr());
 
@@ -805,7 +811,7 @@ void run(const char* filter)
     RUN(testLICMReadsWritesOverlappingHeaps());
     RUN(testLICMDefaultCall());
 
-    addAtomicTests(filter, tasks);
+    addAtomicTests(config, tasks);
     RUN(testDepend32());
     RUN(testDepend64());
 
@@ -885,13 +891,10 @@ void run(const char* filter)
         }
     }
 
-    if (tasks.isEmpty())
-        usage();
-
     Lock lock;
 
     Vector<Ref<Thread>> threads;
-    for (unsigned i = filter ? 1 : WTF::numberOfProcessorCores(); i--;) {
+    for (unsigned i = config->workerThreadCount; i--;) {
         threads.append(
             Thread::create(
                 "testb3 thread",
@@ -916,15 +919,6 @@ void run(const char* filter)
     crashLock.unlock();
 }
 
-#else // ENABLE(B3_JIT)
-
-static void run(const char*)
-{
-    dataLog("B3 JIT is not enabled.\n");
-}
-
-#endif // ENABLE(B3_JIT)
-
 #if ENABLE(JIT_OPERATION_VALIDATION) || ENABLE(JIT_OPERATION_DISASSEMBLY)
 extern const JSC::JITOperationAnnotation startOfJITOperationsInTestB3 __asm("section$start$__DATA_CONST$__jsc_ops");
 extern const JSC::JITOperationAnnotation endOfJITOperationsInTestB3 __asm("section$end$__DATA_CONST$__jsc_ops");
@@ -932,17 +926,24 @@ extern const JSC::JITOperationAnnotation endOfJITOperationsInTestB3 __asm("secti
 
 int main(int argc, char** argv)
 {
-    const char* filter = nullptr;
-    switch (argc) {
-    case 1:
-        break;
-    case 2:
-        filter = argv[1];
-        break;
-    default:
-        usage();
-        break;
+    TestConfig config;
+    for (int i = 1; i < argc; i++) {
+        if (!strcmp(argv[i], "-filter")) {
+            if (i + 1 < argc) {
+                config.filter = argv[i + 1];
+                i += 1;
+            } else
+                usage();
+        } else if (!strcmp(argv[i], "-list"))
+            config.mode = TestConfig::Mode::ListTests;
+        else {
+            // for backwards compatibility
+            config.filter = argv[i];
+            break;
+        }
     }
+
+    config.workerThreadCount = config.filter ? 1 : WTF::numberOfProcessorCores();
 
     JSC::Config::configureForTesting();
 
@@ -959,7 +960,7 @@ int main(int argc, char** argv)
 
     for (unsigned i = 0; i <= 2; ++i) {
         JSC::Options::defaultB3OptLevel() = i;
-        run(filter);
+        run(&config);
     }
 
     return 0;
@@ -971,3 +972,13 @@ extern "C" __declspec(dllexport) int WINAPI dllLauncherEntryPoint(int argc, cons
     return main(argc, const_cast<char**>(argv));
 }
 #endif
+
+#else // ENABLE(B3_JIT)
+
+int main(int, char**)
+{
+    WTF::initializeMainThread();
+    dataLog("B3 JIT is not enabled.\n");
+}
+
+#endif // ENABLE(B3_JIT)

--- a/Source/JavaScriptCore/b3/testb3_2.cpp
+++ b/Source/JavaScriptCore/b3/testb3_2.cpp
@@ -7133,7 +7133,7 @@ static void testBitOrImmArg32(int a, int b)
     CHECK(compileAndRun<int>(proc, b) == (a | b));
 }
 
-void addBitTests(const char* filter, Deque<RefPtr<SharedTask<void()>>>& tasks)
+void addBitTests(const TestConfig* config, Deque<RefPtr<SharedTask<void()>>>& tasks)
 {
     RUN(testUbfx32ShiftAnd());
     RUN(testUbfx32AndShift());

--- a/Source/JavaScriptCore/b3/testb3_3.cpp
+++ b/Source/JavaScriptCore/b3/testb3_3.cpp
@@ -3735,7 +3735,7 @@ static double negativeZero()
     return -zero();
 }
 
-void addArgTests(const char* filter, Deque<RefPtr<SharedTask<void()>>>& tasks)
+void addArgTests(const TestConfig* config, Deque<RefPtr<SharedTask<void()>>>& tasks)
 {
     RUN(testAddArg(111));
     RUN(testAddArgs(1, 1));
@@ -3990,7 +3990,7 @@ void addArgTests(const char* filter, Deque<RefPtr<SharedTask<void()>>>& tasks)
     RUN_BINARY(testSubArgsFloatWithEffectfulDoubleConversion, floatingPointOperands<float>(), floatingPointOperands<float>());
 }
 
-void addCallTests(const char* filter, Deque<RefPtr<SharedTask<void()>>>& tasks)
+void addCallTests(const TestConfig* config, Deque<RefPtr<SharedTask<void()>>>& tasks)
 {
     RUN(testCallSimple(1, 2));
     RUN(testCallRare(1, 2));
@@ -4014,7 +4014,7 @@ void addCallTests(const char* filter, Deque<RefPtr<SharedTask<void()>>>& tasks)
     RUN(testCallFunctionWithHellaFloatArguments());
 }
 
-void addShrTests(const char* filter, Deque<RefPtr<SharedTask<void()>>>& tasks)
+void addShrTests(const TestConfig* config, Deque<RefPtr<SharedTask<void()>>>& tasks)
 {
     RUN(testSShrArgs(1, 0));
     RUN(testSShrArgs(1, 1));

--- a/Source/JavaScriptCore/b3/testb3_4.cpp
+++ b/Source/JavaScriptCore/b3/testb3_4.cpp
@@ -2915,7 +2915,7 @@ void testPatchpointAnyImm(ValueRep rep)
     CHECK(compileAndRun<int>(proc, 1) == 43);
 }
 
-void addSExtTests(const char* filter, Deque<RefPtr<SharedTask<void()>>>& tasks)
+void addSExtTests(const TestConfig* config, Deque<RefPtr<SharedTask<void()>>>& tasks)
 {
     RUN(testSExt8(0));
     RUN(testSExt8(1));

--- a/Source/JavaScriptCore/b3/testb3_6.cpp
+++ b/Source/JavaScriptCore/b3/testb3_6.cpp
@@ -2937,7 +2937,7 @@ void testPCOriginMapDoesntInsertNops()
     compileProc(proc);
 }
 
-void addSShrShTests(const char* filter, Deque<RefPtr<SharedTask<void()>>>& tasks)
+void addSShrShTests(const TestConfig* config, Deque<RefPtr<SharedTask<void()>>>& tasks)
 {
     RUN(testSShrShl32(42, 24, 24));
     RUN(testSShrShl32(-42, 24, 24));

--- a/Source/JavaScriptCore/b3/testb3_7.cpp
+++ b/Source/JavaScriptCore/b3/testb3_7.cpp
@@ -1894,7 +1894,7 @@ static void tupleNestedLoop(int32_t first, double second)
     CHECK_EQ(compileAndRun<double>(proc, first, second), first + second);
 }
 
-void addTupleTests(const char* filter, Deque<RefPtr<SharedTask<void()>>>& tasks)
+void addTupleTests(const TestConfig* config, Deque<RefPtr<SharedTask<void()>>>& tasks)
 {
     RUN_BINARY(testSimpleTuplePair, int32Operands(), int64Operands());
     RUN_BINARY(testSimpleTuplePairUnused, int32Operands(), int64Operands());

--- a/Source/JavaScriptCore/b3/testb3_8.cpp
+++ b/Source/JavaScriptCore/b3/testb3_8.cpp
@@ -750,7 +750,7 @@ void testAtomicXchg(B3::Opcode opcode)
     }
 }
 
-void addAtomicTests(const char* filter, Deque<RefPtr<SharedTask<void()>>>& tasks)
+void addAtomicTests(const TestConfig* config, Deque<RefPtr<SharedTask<void()>>>& tasks)
 {
     RUN(testAtomicWeakCAS<int8_t>());
     RUN(testAtomicWeakCAS<int16_t>());
@@ -885,7 +885,7 @@ void testLoad(B3::Type type, T value)
     return testLoad<T>(type, Load, value);
 }
 
-void addLoadTests(const char* filter, Deque<RefPtr<SharedTask<void()>>>& tasks)
+void addLoadTests(const TestConfig* config, Deque<RefPtr<SharedTask<void()>>>& tasks)
 {
     RUN(testLoad(Int32, 60));
     RUN(testLoad(Int32, -60));


### PR DESCRIPTION
#### 95ec7fc55b008cd504f2e8b6c178f5b864a51825
<pre>
Add `-list` flag to testb3
<a href="https://bugs.webkit.org/show_bug.cgi?id=256857">https://bugs.webkit.org/show_bug.cgi?id=256857</a>

Reviewed by Justin Michaud.

This is useful to write scripts that need to analyze runs of testb3 or to
continue past failures (which manifest as crashes).

`testb3` now can be invoked as:

    testb3 [-list] [-filter &lt;filter&gt;]

the `-list` flag causes testb3 to simply print the defined test cases; `-filter`
acts like the current argument (filtering the test cases to run).

`-filter` is ignored if `-list` was passed.

`testb3` will also continue to accept the current commandline:

    testb3 [filter]

To accomplish this, the `const char* filter` parameter has been replaced
everywhere with a TestConfig parameter that stores a filter and also now a run
mode.

* Source/JavaScriptCore/b3/testb3.h:
* Source/JavaScriptCore/b3/testb3_1.cpp:
(shouldRun):
(run):
(main):
* Source/JavaScriptCore/b3/testb3_2.cpp:
(testBitOrImms32):
* Source/JavaScriptCore/b3/testb3_3.cpp:
(testNegPtr):
(addArgTests):
* Source/JavaScriptCore/b3/testb3_4.cpp:
(testPatchpointAnyImm):
* Source/JavaScriptCore/b3/testb3_6.cpp:
(addSShrShTests):
* Source/JavaScriptCore/b3/testb3_7.cpp:
(tupleNestedLoop):
* Source/JavaScriptCore/b3/testb3_8.cpp:
(testAtomicXchg):
(testLoad):

Canonical link: <a href="https://commits.webkit.org/264339@main">https://commits.webkit.org/264339@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2f4622de73b489795a0fb1027b5e0f61b266c43b

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/6802 "4 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/7022 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/7206 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/8393 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/7055 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/8200 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/6964 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/9947 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/6921 "Passed tests") | [⏳ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/iOS-16-Simulator-WK2-Tests-EWS "Waiting to run tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/6243 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/8488 "Built successfully") | 
| | [⏳ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/iOS-16-Simulator-WPT-WK2-Tests-EWS "Waiting to run tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/6161 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/13960 "12 flakes 422 failures") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/5739 "Built successfully and passed tests") | [⏳ 🧪 api-ios](https://ews-build.webkit.org/#/builders/API-Tests-iOS-Simulator-EWS "Waiting to run tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/6242 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/9017 "Passed tests") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/6379 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/6732 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/5513 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/6940 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/6114 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/1622 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/1752 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/10294 "Built successfully") | | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/24/builds/7129 "Built successfully") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/6492 "Built successfully") | | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/3/builds/1757 "Passed tests") | 
<!--EWS-Status-Bubble-End-->