### PR TITLE
[import-w3c-tests] Import both match & mismatch refs

### DIFF
--- a/Tools/Scripts/webkitpy/w3c/test_importer.py
+++ b/Tools/Scripts/webkitpy/w3c/test_importer.py
@@ -340,7 +340,7 @@ class TestImporter(object):
                     # Skip it since, the corresponding reference test should have a link to this file
                     continue
 
-                if 'reference' in test_info.keys():
+                if 'match_reference' in test_info.keys() or 'mismatch_reference' in test_info.keys():
                     reftests += 1
                     total_tests += 1
                     test_basename = self.filesystem.basename(test_info['test'])
@@ -350,12 +350,16 @@ class TestImporter(object):
                     # directly rather than relying  on a naming convention.
                     # Using a naming convention creates duplicate copies of the
                     # reference files.
-                    ref_file = self.filesystem.splitext(test_basename)[0] + '-expected'
-                    if 'type' in test_info and test_info['type'] == 'mismatch':
-                        ref_file += '-mismatch'
-                    ref_file += self.filesystem.splitext(test_info['reference'])[1]
+                    if 'match_reference' in test_info.keys():
+                        ref_file = self.filesystem.splitext(test_basename)[0] + '-expected'
+                        ref_file += self.filesystem.splitext(test_info['match_reference'])[1]
+                        copy_list.append({'src': test_info['match_reference'], 'dest': ref_file, 'reference_support_info': test_info['match_reference_support_info']})
 
-                    copy_list.append({'src': test_info['reference'], 'dest': ref_file, 'reference_support_info': test_info['reference_support_info']})
+                    if 'mismatch_reference' in test_info.keys():
+                        ref_file = self.filesystem.splitext(test_basename)[0] + '-expected-mismatch'
+                        ref_file += self.filesystem.splitext(test_info['mismatch_reference'])[1]
+                        copy_list.append({'src': test_info['mismatch_reference'], 'dest': ref_file, 'reference_support_info': test_info['mismatch_reference_support_info']})
+
                     copy_list.append({'src': test_info['test'], 'dest': filename})
 
                 elif 'jstest' in test_info.keys():

--- a/Tools/Scripts/webkitpy/w3c/test_parser_unittest.py
+++ b/Tools/Scripts/webkitpy/w3c/test_parser_unittest.py
@@ -51,10 +51,8 @@ class TestParserTest(unittest.TestCase):
 
         self.assertNotEqual(test_info, None, 'did not find a test')
         self.assertTrue('test' in test_info.keys(), 'did not find a test file')
-        self.assertTrue('reference' in test_info.keys(), 'did not find a reference file')
-        self.assertTrue(test_info['reference'].startswith(test_path), 'reference path is not correct')
-        self.assertTrue('type' in test_info.keys(), 'did not find a reference type')
-        self.assertEqual(test_info['type'], 'match', 'reference type is not correct')
+        self.assertTrue('match_reference' in test_info.keys(), 'did not find a reference file')
+        self.assertTrue(test_info['match_reference'].startswith(test_path), 'reference path is not correct')
         self.assertFalse('refsupport' in test_info.keys(), 'there should be no refsupport files for this test')
         self.assertFalse('jstest' in test_info.keys(), 'test should not have been analyzed as a jstest')
 
@@ -69,10 +67,8 @@ class TestParserTest(unittest.TestCase):
 
         self.assertNotEqual(test_info, None, 'did not find a test')
         self.assertTrue('test' in test_info.keys(), 'did not find a test file')
-        self.assertTrue('reference' in test_info.keys(), 'did not find a reference file')
-        self.assertTrue(test_info['reference'].startswith(test_path), 'reference path is not correct')
-        self.assertTrue('type' in test_info.keys(), 'did not find a reference type')
-        self.assertEqual(test_info['type'], 'mismatch', 'reference type is not correct')
+        self.assertTrue('mismatch_reference' in test_info.keys(), 'did not find a reference file')
+        self.assertTrue(test_info['mismatch_reference'].startswith(test_path), 'reference path is not correct')
         self.assertFalse('refsupport' in test_info.keys(), 'there should be no refsupport files for this test')
         self.assertFalse('jstest' in test_info.keys(), 'test should not have been analyzed as a jstest')
 
@@ -90,14 +86,14 @@ class TestParserTest(unittest.TestCase):
 
         self.assertNotEqual(test_info, None, 'did not find a test')
         self.assertTrue('test' in test_info.keys(), 'did not find a test file')
-        self.assertTrue('reference' in test_info.keys(), 'did not find a reference file')
-        self.assertTrue(test_info['reference'].startswith(test_path), 'reference path is not correct')
+        self.assertTrue('match_reference' in test_info.keys(), 'did not find a reference file')
+        self.assertTrue(test_info['match_reference'].startswith(test_path), 'reference path is not correct')
         self.assertFalse('refsupport' in test_info.keys(), 'there should be no refsupport files for this test')
         self.assertFalse('jstest' in test_info.keys(), 'test should not have been analyzed as a jstest')
 
         self.assertEqual(
             captured.root.log.getvalue(),
-            'Multiple references are not supported. Importing the first ref defined in somefile.html\n',
+            'Multiple references of the same type are not supported. Importing the first ref defined in somefile.html\n',
         )
 
     def test_analyze_test_reftest_match_and_mismatch(self):
@@ -114,14 +110,16 @@ class TestParserTest(unittest.TestCase):
 
         self.assertNotEqual(test_info, None, 'did not find a test')
         self.assertTrue('test' in test_info.keys(), 'did not find a test file')
-        self.assertTrue('reference' in test_info.keys(), 'did not find a reference file')
-        self.assertTrue(test_info['reference'].startswith(test_path), 'reference path is not correct')
+        self.assertTrue('match_reference' in test_info.keys(), 'did not find a reference file')
+        self.assertTrue(test_info['match_reference'].startswith(test_path), 'reference path is not correct')
+        self.assertTrue('mismatch_reference' in test_info.keys(), 'did not find a reference file')
+        self.assertTrue(test_info['mismatch_reference'].startswith(test_path), 'reference path is not correct')
         self.assertFalse('refsupport' in test_info.keys(), 'there should be no refsupport files for this test')
         self.assertFalse('jstest' in test_info.keys(), 'test should not have been analyzed as a jstest')
 
         self.assertEqual(
             captured.root.log.getvalue(),
-            'Multiple references are not supported. Importing the first ref defined in somefile.html\n',
+            'Multiple references of the same type are not supported. Importing the first ref defined in somefile.html\n',
         )
 
     def test_analyze_test_reftest_with_ref_support_Files(self):
@@ -150,10 +148,10 @@ class TestParserTest(unittest.TestCase):
 
         self.assertNotEqual(test_info, None, 'did not find a test')
         self.assertTrue('test' in test_info.keys(), 'did not find a test file')
-        self.assertTrue('reference' in test_info.keys(), 'did not find a reference file')
-        self.assertTrue(test_info['reference'].startswith(test_path), 'reference path is not correct')
-        self.assertTrue('reference_support_info' in test_info.keys(), 'there should be reference_support_info for this test')
-        self.assertEqual(len(test_info['reference_support_info']['files']), 4, 'there should be 4 support files in this reference')
+        self.assertTrue('match_reference' in test_info.keys(), 'did not find a reference file')
+        self.assertTrue(test_info['match_reference'].startswith(test_path), 'reference path is not correct')
+        self.assertTrue('match_reference_support_info' in test_info.keys(), 'there should be reference_support_info for this test')
+        self.assertEqual(len(test_info['match_reference_support_info']['files']), 4, 'there should be 4 support files in this reference')
         self.assertFalse('jstest' in test_info.keys(), 'test should not have been analyzed as a jstest')
 
     def test_analyze_jstest(self):
@@ -170,7 +168,8 @@ class TestParserTest(unittest.TestCase):
 
         self.assertNotEqual(test_info, None, 'test_info is None')
         self.assertTrue('test' in test_info.keys(), 'did not find a test file')
-        self.assertFalse('reference' in test_info.keys(), 'shold not have found a reference file')
+        self.assertFalse('match_reference' in test_info.keys(), 'shold not have found a reference file')
+        self.assertFalse('mismatch_reference' in test_info.keys(), 'shold not have found a reference file')
         self.assertFalse('refsupport' in test_info.keys(), 'there should be no refsupport files for this test')
         self.assertTrue('jstest' in test_info.keys(), 'test should be a jstest')
 
@@ -286,7 +285,8 @@ CONTENT OF TEST
 
             self.assertNotEqual(test_info, None, 'test_info is None')
             self.assertTrue('test' in test_info.keys(), 'did not find a test file')
-            self.assertFalse('reference' in test_info.keys(), 'shold not have found a reference file')
+            self.assertFalse('match_reference' in test_info.keys(), 'shold not have found a reference file')
+            self.assertFalse('mismatch_reference' in test_info.keys(), 'shold not have found a reference file')
             self.assertFalse('refsupport' in test_info.keys(), 'there should be no refsupport files for this test')
             self.assertFalse('jstest' in test_info.keys(), 'test should not be a jstest')
         finally:


### PR DESCRIPTION
#### ab015861180ec0337513c33a1420491321350d61
<pre>
[import-w3c-tests] Import both match &amp; mismatch refs
<a href="https://bugs.webkit.org/show_bug.cgi?id=256849">https://bugs.webkit.org/show_bug.cgi?id=256849</a>

Reviewed by Youenn Fablet.

Currently we only support importing a single ref, even though we
support running thigns with both -expected.html and
-expected-mismatch.html. We should import both.

* Tools/Scripts/webkitpy/w3c/test_importer.py:
(TestImporter.find_importable_tests):
* Tools/Scripts/webkitpy/w3c/test_parser.py:
(TestParser.analyze_test):
* Tools/Scripts/webkitpy/w3c/test_parser_unittest.py:

Canonical link: <a href="https://commits.webkit.org/264144@main">https://commits.webkit.org/264144@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5fa29f70f3ce24d4a4e6f03e9f9c7475dfcdcadc

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/6785 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/7003 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/7187 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/8374 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/7038 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/6783 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/8276 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/6946 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/9932 "103 failures") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/6902 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/7591 "2 new passes 5 flakes 2 failures") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/6227 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/8469 "Built successfully") | 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/6889 "Passed tests") | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/4997 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/6145 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/13951 "Passed tests") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/6709 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/6226 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/9007 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/6714 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/5501 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/6099 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/10277 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/791 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/6474 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->