### PR TITLE
JavaScriptCore InstallAPI includes broken path to unicode headers on open-source builds

### DIFF
--- a/Source/WTF/Configurations/WTF.xcconfig
+++ b/Source/WTF/Configurations/WTF.xcconfig
@@ -28,9 +28,9 @@ PRODUCT_NAME = WTF;
 GCC_SYMBOLS_PRIVATE_EXTERN = YES;
 STRIP_INSTALLED_PRODUCT = NO;
 
-EXCLUDED_SOURCE_FILE_NAMES = $(inherited) $(EXCLUDED_SOURCE_FILE_NAMES_$(USE_INTERNAL_SDK));
+// ICU headers don't have target membership in WTF, but they are visible to the "Generate TAPI filelist" build phase. Since they are not installed to /usr/local/include/wtf and not API, tell the script to ignore them.
+EXCLUDED_SOURCE_FILE_NAMES = $(inherited) icu/unicode/* $(EXCLUDED_SOURCE_FILE_NAMES_$(USE_INTERNAL_SDK));
 EXCLUDED_SOURCE_FILE_NAMES_[sdk=embedded*] = MachExceptions.defs;
-EXCLUDED_SOURCE_FILE_NAMES_YES = icu/unicode/*;
 
 INSTALLHDRS_SCRIPT_PHASE = YES;
 APPLY_RULES_IN_COPY_HEADERS = YES;


### PR DESCRIPTION
#### abdeae2f7a0890115899dc3876bd6dad1f60cadb
<pre>
JavaScriptCore InstallAPI includes broken path to unicode headers on open-source builds
<a href="https://bugs.webkit.org/show_bug.cgi?id=256810">https://bugs.webkit.org/show_bug.cgi?id=256810</a>

Reviewed by Alexey Proskuryakov.

In open-source builds, the tapi filelist generated by WTF contains broken paths
to ICU headers. This is because all-product-headers.yaml contains references to
*all* the headers in WTF.xcodeproj, despite being generated for a specific
target.

Fix by setting EXCLUDED_SOURCE_FILE_NAMES in the WTF target to always exclude
icu headers. The headers are members of the separate &quot;icu&quot; target already, so
their installation is unaffected. I think this setting is a holdover from when
there was a single target in the WTF project.

* Source/WTF/Configurations/WTF.xcconfig:

Canonical link: <a href="https://commits.webkit.org/264550@main">https://commits.webkit.org/264550@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5200a63440f2b471b47db014d358273d928d04e2

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/7971 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/8253 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/8466 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/9621 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/8083 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/10240 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/8165 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/10942 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/8114 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/9208 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/7293 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/9740 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/6509 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/7297 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/14878 "Passed tests") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/6795 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/7632 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/7420 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/10773 "Passed tests") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/7538 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/7887 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/6414 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/8135 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/7203 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/1859 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/1898 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/11411 "Built successfully") | | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/24/builds/8355 "Built successfully") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/7625 "Built successfully") | | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/3/builds/2007 "Passed tests") | 
<!--EWS-Status-Bubble-End-->