### PR TITLE
[GPU Process] Ensure that only supported image decoders run in the WebProcess

### DIFF
--- a/Source/WebCore/platform/graphics/cg/UTIRegistry.cpp
+++ b/Source/WebCore/platform/graphics/cg/UTIRegistry.cpp
@@ -146,6 +146,20 @@ ALLOW_DEPRECATED_DECLARATIONS_BEGIN
 ALLOW_DEPRECATED_DECLARATIONS_END
 }
 
+Vector<String> allowableImageTypes()
+{
+    auto allowableImageTypes = copyToVector(defaultSupportedImageTypes());
+    auto additionalImageTypes = copyToVector(additionalSupportedImageTypes());
+    allowableImageTypes.appendVector(additionalImageTypes);
+#if HAVE(AVIF)
+    // AVIF might be embedded in a HEIF container. So HEIF/HEIC decoding have
+    // to be allowed to get AVIF decoded.
+    allowableImageTypes.append("public.heif"_s);
+    allowableImageTypes.append("public.heic"_s);
+#endif
+    return allowableImageTypes;
 }
 
-#endif
+} // namespace WebCore
+
+#endif // USE(CG)

--- a/Source/WebCore/platform/graphics/cg/UTIRegistry.h
+++ b/Source/WebCore/platform/graphics/cg/UTIRegistry.h
@@ -35,8 +35,9 @@ MemoryCompactRobinHoodHashSet<String>& additionalSupportedImageTypes();
 WEBCORE_EXPORT void setAdditionalSupportedImageTypes(const Vector<String>&);
 WEBCORE_EXPORT void setAdditionalSupportedImageTypesForTesting(const String&);
 WEBCORE_EXPORT bool isSupportedImageType(const String&);
+WEBCORE_EXPORT Vector<String> allowableImageTypes();
 bool isGIFImageType(StringView);
 String preferredExtensionForImageType(const String& type);
 String MIMETypeForImageType(const String& type);
 
-}
+} // namespace WebCore

--- a/Source/WebCore/platform/network/mac/UTIUtilities.h
+++ b/Source/WebCore/platform/network/mac/UTIUtilities.h
@@ -35,4 +35,6 @@ RetainPtr<CFStringRef> mimeTypeFromUTITree(CFStringRef);
 WEBCORE_EXPORT String UTIFromMIMEType(const String&);
 bool isDeclaredUTI(const String&);
 WEBCORE_EXPORT String UTIFromTag(const String& tagClass, const String& tag, const String& conformingToUTI);
-}
+WEBCORE_EXPORT void setImageSourceAllowableTypes(const Vector<String>&);
+
+} // namespace WebCore

--- a/Source/WebCore/platform/network/mac/UTIUtilities.mm
+++ b/Source/WebCore/platform/network/mac/UTIUtilities.mm
@@ -33,9 +33,14 @@
 #import <wtf/TinyLRUCache.h>
 #import <wtf/cf/TypeCastsCF.h>
 #import <wtf/text/WTFString.h>
+#include <wtf/cocoa/VectorCocoa.h>
 
 #if PLATFORM(IOS_FAMILY)
 #import <MobileCoreServices/MobileCoreServices.h>
+#endif
+
+#if HAVE(CGIMAGESOURCE_WITH_SET_ALLOWABLE_TYPES)
+#include <pal/spi/cg/ImageIOSPI.h>
 #endif
 
 namespace WebCore {
@@ -149,4 +154,14 @@ ALLOW_DEPRECATED_DECLARATIONS_END
     return u.get();
 }
 
+void setImageSourceAllowableTypes(const Vector<String>& supportedImageTypes)
+{
+#if HAVE(CGIMAGESOURCE_WITH_SET_ALLOWABLE_TYPES)
+    auto allowableTypes = createNSArray(supportedImageTypes);
+    CGImageSourceSetAllowableTypes((__bridge CFArrayRef)allowableTypes.get());
+#else
+    UNUSED_PARAM(supportedImageTypes);
+#endif
 }
+
+} // namespace WebCore

--- a/Source/WebKit/GPUProcess/GPUProcess.cpp
+++ b/Source/WebKit/GPUProcess/GPUProcess.cpp
@@ -74,11 +74,8 @@
 #if PLATFORM(COCOA)
 #include "ArgumentCodersCocoa.h"
 #include <WebCore/CoreAudioSharedUnit.h>
+#include <WebCore/UTIUtilities.h>
 #include <WebCore/VP9UtilitiesCocoa.h>
-#endif
-
-#if HAVE(CGIMAGESOURCE_WITH_SET_ALLOWABLE_TYPES)
-#include <pal/spi/cg/ImageIOSPI.h>
 #endif
 
 #if HAVE(SCREEN_CAPTURE_KIT)
@@ -274,9 +271,8 @@ void GPUProcess::initializeGPUProcess(GPUProcessCreationParameters&& parameters)
     SandboxExtension::consumePermanently(parameters.gpuToolsExtensionHandles);
 #endif
 
-#if HAVE(CGIMAGESOURCE_WITH_SET_ALLOWABLE_TYPES)
-    auto emptyArray = adoptCF(CFArrayCreate(kCFAllocatorDefault, nullptr, 0, &kCFTypeArrayCallBacks));
-    CGImageSourceSetAllowableTypes(emptyArray.get());
+#if PLATFORM(COCOA)
+    WebCore::setImageSourceAllowableTypes({ });
 #endif
 
 #if USE(GBM)

--- a/Source/WebKit/WebProcess/WebPage/Cocoa/WebPageCocoa.mm
+++ b/Source/WebKit/WebProcess/WebPage/Cocoa/WebPageCocoa.mm
@@ -69,6 +69,8 @@
 #import <WebCore/RenderLayer.h>
 #import <WebCore/RenderedDocumentMarker.h>
 #import <WebCore/TextIterator.h>
+#import <WebCore/UTIRegistry.h>
+#import <WebCore/UTIUtilities.h>
 #import <pal/spi/cocoa/LaunchServicesSPI.h>
 #import <pal/spi/cocoa/QuartzCoreSPI.h>
 
@@ -109,6 +111,8 @@ void WebPage::platformInitialize(const WebPageCreationParameters& parameters)
 #if PLATFORM(IOS_FAMILY)
     setInsertionPointColor(parameters.insertionPointColor);
 #endif
+    WebCore::setAdditionalSupportedImageTypes(parameters.additionalSupportedImageTypes);
+    WebCore::setImageSourceAllowableTypes(WebCore::allowableImageTypes());
 }
 
 void WebPage::platformDidReceiveLoadParameters(const LoadParameters& parameters)

--- a/Source/WebKit/WebProcess/WebPage/WebPage.cpp
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.cpp
@@ -334,7 +334,6 @@
 #include "WKStringCF.h"
 #include "WebRemoteObjectRegistry.h"
 #include <WebCore/LegacyWebArchive.h>
-#include <WebCore/UTIRegistry.h>
 #include <pal/spi/cg/ImageIOSPI.h>
 #include <wtf/MachSendRight.h>
 #include <wtf/spi/darwin/SandboxSPI.h>
@@ -966,7 +965,6 @@ WebPage::WebPage(PageIdentifier pageID, WebPageCreationParameters&& parameters)
 
 #if PLATFORM(COCOA)
     setSmartInsertDeleteEnabled(parameters.smartInsertDeleteEnabled);
-    WebCore::setAdditionalSupportedImageTypes(parameters.additionalSupportedImageTypes);
 #endif
 
 #if HAVE(APP_ACCENT_COLORS)


### PR DESCRIPTION
#### c9652add6ae4f3b544496ffde359510dd71b65ee
<pre>
[GPU Process] Ensure that only supported image decoders run in the WebProcess
<a href="https://bugs.webkit.org/show_bug.cgi?id=256852">https://bugs.webkit.org/show_bug.cgi?id=256852</a>
rdar://109414332

Reviewed by Brent Fulgham.

Ensure that ImageIO is allowed to decode only the (default + additional) supported
image types even outside WebKit rendering code path for example displaying a bitmap
image in a PDF document.

This work will be done for WK2 only. WK1 allows setting the prefrences only after
creating the WebView. And We use the prefrences to set the additional supported
image types. So there is no way to pass to know additional supported image types
when the WebView is created. And ImageIO expects CGImageSourceSetAllowableTypes()
to be called only once.

* Source/WebCore/platform/graphics/cg/ImageDecoderCG.cpp:
(WebCore::ImageDecoderCG::encodedDataStatus const):
* Source/WebCore/platform/graphics/cg/UTIRegistry.cpp:
(WebCore::allowableImageTypes):
* Source/WebCore/platform/graphics/cg/UTIRegistry.h:
* Source/WebCore/platform/network/mac/UTIUtilities.h:
* Source/WebCore/platform/network/mac/UTIUtilities.mm:
(WebCore::setImageSourceAllowableTypes):
* Source/WebKit/GPUProcess/GPUProcess.cpp:
(WebKit::GPUProcess::initializeGPUProcess):
* Source/WebKit/WebProcess/WebPage/Cocoa/WebPageCocoa.mm:
(WebKit::WebPage::platformInitialize):
* Source/WebKit/WebProcess/WebPage/WebPage.cpp:
(WebKit::m_appHighlightsVisible):

Canonical link: <a href="https://commits.webkit.org/268617@main">https://commits.webkit.org/268617@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/af752e57b97db317fb935c221456f574dda4d873

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/20162 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/20597 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/21222 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/22062 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/18816 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/20393 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/23838 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/20759 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/20277 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/20382 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/20285 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/17521 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/22912 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/17454 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/18321 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/24589 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/18531 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/18497 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/22559 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/19089 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/16205 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/18290 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/4840 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/22631 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/18914 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->