### PR TITLE
[git-webkit] Speed up Branch.branch_point

### DIFF
--- a/Tools/Scripts/libraries/webkitscmpy/setup.py
+++ b/Tools/Scripts/libraries/webkitscmpy/setup.py
@@ -29,7 +29,7 @@ def readme():
 
 setup(
     name='webkitscmpy',
-    version='6.4.6',
+    version='6.4.7',
     description='Library designed to interact with git and svn repositories.',
     long_description=readme(),
     classifiers=[

--- a/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/__init__.py
+++ b/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/__init__.py
@@ -46,7 +46,7 @@ except ImportError:
         "Please install webkitcorepy with `pip install webkitcorepy --extra-index-url <package index URL>`"
     )
 
-version = Version(6, 4, 6)
+version = Version(6, 4, 7)
 
 AutoInstall.register(Package('fasteners', Version(0, 15, 0)))
 AutoInstall.register(Package('jinja2', Version(2, 11, 3)))

--- a/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/mocks/git-repo.json
+++ b/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/mocks/git-repo.json
@@ -186,6 +186,7 @@
             "timestamp": 1601672000, 
             "branch": "eng/squash-branch", 
             "message": "Changed something 1",
+            "identifier": "5.1@eng/squash-branch",
             "changeFiles": {
                 "a.cpp": "diff --git a/a.cpp b/a.cpp"
             }
@@ -201,6 +202,7 @@
             "timestamp": 1601674000, 
             "branch": "eng/squash-branch", 
             "message": "Changed something 2",
+            "identifier": "5.2@eng/squash-branch",
             "changeFiles": {
                 "c.cpp": "diff --git a/c.cpp b/c.cpp"
             }
@@ -216,6 +218,7 @@
             "timestamp": 1601677000, 
             "branch": "eng/squash-branch", 
             "message": "Changed something 3",
+            "identifier": "5.3@eng/squash-branch",
             "changeFiles": {
                 "a.cpp": "diff --git a/a.cpp b/a.cpp",
                 "b.cpp": "diff --git a/b.cpp b/b.cpp"

--- a/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/program/pull_request.py
+++ b/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/program/pull_request.py
@@ -213,6 +213,9 @@ class PullRequest(Command):
             return None
 
         branch_point = Branch.branch_point(repository)
+        if not branch_point:
+            sys.stderr.write('Failed to determine where pull-request diverged from production branch\n')
+            return None
         source_remote = args.remote
         if not source_remote:
             bp_remotes = set(repository.branches_for(hash=branch_point.hash, remote=None).keys())

--- a/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/test/branch_unittest.py
+++ b/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/test/branch_unittest.py
@@ -501,3 +501,29 @@ Created the local development branch 'eng/4'
         )
         self.assertEqual(captured.stdout.getvalue(), "Created the local development branch 'eng/1234'\n")
         self.assertEqual(captured.stderr.getvalue(), "")
+
+    def test_branch_point(self):
+        with OutputCapture(level=logging.INFO) as captured, mocks.local.Git(self.path) as repo, mocks.local.Svn():
+            repo.commits['eng/1234'] = [
+                repo.commits[repo.default_branch][-1],
+                Commit(
+                    hash='06de5d56554e693db72313f4ca1fb969c30b8ccb',
+                    branch='eng/1234',
+                    author=dict(name='Tim Contributor', emails=['tcontributor@example.com']),
+                    identifier="5.1@eng/1234",
+                    timestamp=int(time.time()),
+                    message='[Testing] Existing commit\n'
+                )
+            ]
+            repo.head = repo.commits['eng/1234'][-1]
+            self.assertEqual(program.Branch.branch_point(local.Git(self.path)).hash, 'd8bce26fa65c6fc8f39c17927abb77f69fab82fc')
+        self.assertEqual(captured.root.log.getvalue(), '')
+        self.assertEqual(captured.stdout.getvalue(), '')
+        self.assertEqual(captured.stderr.getvalue(), '')
+
+    def test_branch_point_main(self):
+        with OutputCapture(level=logging.INFO) as captured, mocks.local.Git(self.path), mocks.local.Svn():
+            self.assertEqual(program.Branch.branch_point(local.Git(self.path)).hash, 'd8bce26fa65c6fc8f39c17927abb77f69fab82fc')
+        self.assertEqual(captured.root.log.getvalue(), '')
+        self.assertEqual(captured.stdout.getvalue(), '')
+        self.assertEqual(captured.stderr.getvalue(), '')

--- a/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/test/land_unittest.py
+++ b/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/test/land_unittest.py
@@ -100,7 +100,6 @@ class TestLand(testing.PathTestCase):
         log = captured.root.log.getvalue().splitlines()
         self.assertEqual(
             [line for line in log if 'Mock process' not in line], [
-                '    Found 1 commit...',
                 'Using committed changes...'
             ],
         )
@@ -122,7 +121,6 @@ class TestLand(testing.PathTestCase):
         log = captured.root.log.getvalue().splitlines()
         self.assertEqual(
             [line for line in log if 'Mock process' not in line], [
-                '    Found 1 commit...',
                 'Using committed changes...',
                 "Rebasing 'eng/example' from 'main' to 'main'...",
                 "Rebased 'eng/example' from 'main' to 'main'!",
@@ -158,7 +156,6 @@ class TestLand(testing.PathTestCase):
         log = captured.root.log.getvalue().splitlines()
         self.assertEqual(
             [line for line in log if 'Mock process' not in line], [
-                '    Found 1 commit...',
                 'Using committed changes...',
                 "Rebasing 'eng/example' from 'main' to 'main'...",
                 "Rebased 'eng/example' from 'main' to 'main'!",
@@ -204,7 +201,6 @@ class TestLand(testing.PathTestCase):
         log = captured.root.log.getvalue().splitlines()
         self.assertEqual(
             [line for line in log if 'Mock process' not in line], [
-                '    Found 1 commit...',
                 'Using committed changes...',
                 "Rebasing 'eng/example' from 'main' to 'main'...",
                 "Rebased 'eng/example' from 'main' to 'main'!",
@@ -240,7 +236,6 @@ class TestLand(testing.PathTestCase):
         log = captured.root.log.getvalue().splitlines()
         self.assertEqual(
             [line for line in log if 'Mock process' not in line], [
-                '    Found 1 commit...',
                 'Using committed changes...',
                 "Rebasing 'eng/example' from 'main' to 'main'...",
                 "Rebased 'eng/example' from 'main' to 'main'!",
@@ -290,7 +285,6 @@ class TestLand(testing.PathTestCase):
         log = captured.root.log.getvalue().splitlines()
         self.assertEqual(
             [line for line in log if 'Mock process' not in line], [
-                '    Found 1 commit...',
                 'Using committed changes...',
                 "Rebasing 'eng/example' from 'main' to 'main'...",
                 "Rebased 'eng/example' from 'main' to 'main'!",
@@ -337,7 +331,6 @@ class TestLand(testing.PathTestCase):
         log = captured.root.log.getvalue().splitlines()
         self.assertEqual(
             [line for line in log if 'Mock process' not in line], [
-                '    Found 1 commit...',
                 'Using committed changes...',
                 "Rebasing 'eng/example' from 'main' to 'main'...",
                 "Rebased 'eng/example' from 'main' to 'main'!",
@@ -419,7 +412,6 @@ class TestLandGitHub(testing.PathTestCase):
         log = captured.root.log.getvalue().splitlines()
         self.assertEqual(
             [line for line in log if 'Mock process' not in line], [
-                '    Found 1 commit...',
                 'Using committed changes...',
             ],
         )
@@ -442,7 +434,6 @@ class TestLandGitHub(testing.PathTestCase):
         log = captured.root.log.getvalue().splitlines()
         self.assertEqual(
             [line for line in log if 'Mock process' not in line], [
-                '    Found 1 commit...',
                 'Using committed changes...',
             ],
         )
@@ -471,7 +462,6 @@ class TestLandGitHub(testing.PathTestCase):
         log = captured.root.log.getvalue().splitlines()
         self.assertEqual(
             [line for line in log if 'Mock process' not in line], [
-                '    Found 1 commit...',
                 'Using committed changes...',
                 'Setting Ricky Reviewer as reviewer',
                 "Rebasing 'eng/example' from 'main' to 'main'...",
@@ -507,7 +497,6 @@ class TestLandGitHub(testing.PathTestCase):
         log = captured.root.log.getvalue().splitlines()
         self.assertEqual(
             [line for line in log if 'Mock process' not in line], [
-                '    Found 1 commit...',
                 'Using committed changes...',
                 'Detected merging automation, using that instead of local git tooling',
                 "Rebasing 'eng/example' on 'main'...",
@@ -561,7 +550,6 @@ class TestLandGitHub(testing.PathTestCase):
         log = captured.root.log.getvalue().splitlines()
         self.assertEqual(
             [line for line in log if 'Mock process' not in line], [
-                '    Found 1 commit...',
                 'Using committed changes...',
                 'Detected merging automation, using that instead of local git tooling',
                 "Rebasing 'eng/example' on 'main'...",
@@ -649,7 +637,6 @@ class TestLandBitBucket(testing.PathTestCase):
         log = captured.root.log.getvalue().splitlines()
         self.assertEqual(
             [line for line in log if 'Mock process' not in line], [
-                '    Found 1 commit...',
                 'Using committed changes...',
             ],
         )
@@ -674,7 +661,6 @@ class TestLandBitBucket(testing.PathTestCase):
         log = captured.root.log.getvalue().splitlines()
         self.assertEqual(
             [line for line in log if 'Mock process' not in line], [
-                '    Found 1 commit...',
                 'Using committed changes...',
             ],
         )
@@ -704,7 +690,6 @@ class TestLandBitBucket(testing.PathTestCase):
         log = captured.root.log.getvalue().splitlines()
         self.assertEqual(
             [line for line in log if 'Mock process' not in line], [
-                '    Found 1 commit...',
                 'Using committed changes...',
                 'Setting Ricky Reviewer as reviewer',
                 "Rebasing 'eng/example' from 'main' to 'main'...",

--- a/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/test/pull_request_unittest.py
+++ b/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/test/pull_request_unittest.py
@@ -451,7 +451,6 @@ No pre-PR checks to run""")
         log = captured.root.log.getvalue().splitlines()
         self.assertEqual(
             [line for line in log if 'Mock process' not in line], [
-                '    Found 1 commit...',
                 "Amending commit...",
                 "Rebasing 'eng/pr-branch' on 'main'...",
                 "Rebased 'eng/pr-branch' on 'main!'",
@@ -500,7 +499,6 @@ No pre-PR checks to run""")
         log = captured.root.log.getvalue().splitlines()
         self.assertEqual(
             [line for line in log if 'Mock process' not in line], [
-                '    Found 1 commit...',
                 "Amending commit...",
                 "Rebasing 'eng/pr-branch' on 'main'...",
                 "Rebased 'eng/pr-branch' on 'main!'",
@@ -548,7 +546,6 @@ No pre-PR checks to run""")
         log = captured.root.log.getvalue().splitlines()
         self.assertEqual(
             [line for line in log if 'Mock process' not in line], [
-                '    Found 1 commit...',
                 "Amending commit...",
                 "Rebasing 'eng/pr-branch' on 'main'...",
                 "Rebased 'eng/pr-branch' on 'main!'",
@@ -591,7 +588,6 @@ No pre-PR checks to run""")
         log = captured.root.log.getvalue().splitlines()
         self.assertEqual(
             [line for line in log if 'Mock process' not in line], [
-                '    Found 1 commit...',
                 'Creating commit...',
                 "Rebasing 'eng/pr-branch' on 'main'...",
                 "Rebased 'eng/pr-branch' on 'main!'",
@@ -641,7 +637,6 @@ No pre-PR checks to run""")
         log = captured.root.log.getvalue().splitlines()
         self.assertEqual(
             [line for line in log if 'Mock process' not in line], [
-                '    Found 1 commit...',
                 "Amending commit...",
                 "Rebasing 'eng/pr-branch' on 'main'...",
                 "Rebased 'eng/pr-branch' on 'main!'",
@@ -705,7 +700,6 @@ No pre-PR checks to run""")
         log = captured.root.log.getvalue().splitlines()
         self.assertEqual(
             [line for line in log if 'Mock process' not in line], [
-                '    Found 1 commit...',
                 "Using committed changes...",
                 "Rebasing 'eng/pr-branch' on 'main'...",
                 "Rebased 'eng/pr-branch' on 'main!'",
@@ -969,7 +963,6 @@ No pre-PR checks to run""")
         log = captured.root.log.getvalue().splitlines()
         self.assertEqual(
             [line for line in log if 'Mock process' not in line], [
-                '    Found 1 commit...',
                 'Using committed changes...',
                 "Rebasing 'eng/pr-branch' on 'main'...",
                 "Rebased 'eng/pr-branch' on 'main!'",
@@ -1040,7 +1033,6 @@ No pre-PR checks to run""")
         log = captured.root.log.getvalue().splitlines()
         self.assertEqual(
             [line for line in log if 'Mock process' not in line], [
-                '    Found 1 commit...',
                 'Using committed changes...',
                 "Rebasing 'eng/pr-branch' on 'main'...",
                 "Rebased 'eng/pr-branch' on 'main!'",
@@ -1105,7 +1097,6 @@ No pre-PR checks to run""")
         log = captured.root.log.getvalue().splitlines()
         self.assertEqual(
             [line for line in log if 'Mock process' not in line], [
-                '    Found 1 commit...',
                 "Using committed changes...",
                 "Rebasing 'eng/pr-branch' on 'main'...",
                 "Rebased 'eng/pr-branch' on 'main!'",
@@ -1180,7 +1171,6 @@ No pre-PR checks to run""")
         log = captured.root.log.getvalue().splitlines()
         self.assertEqual(
             [line for line in log if 'Mock process' not in line], [
-                '    Found 1 commit...',
                 "Using committed changes...",
                 "Rebasing 'eng/pr-branch' on 'main'...",
                 "Rebased 'eng/pr-branch' on 'main!'",
@@ -1257,7 +1247,6 @@ No pre-PR checks to run""")
         log = captured.root.log.getvalue().splitlines()
         self.assertEqual(
             [line for line in log if 'Mock process' not in line], [
-                '    Found 1 commit...',
                 "Using committed changes...",
                 "Rebasing 'eng/pr-branch' on 'main'...",
                 "Rebased 'eng/pr-branch' on 'main!'",
@@ -1337,7 +1326,6 @@ No pre-PR checks to run""")
         log = captured.root.log.getvalue().splitlines()
         self.assertEqual(
             [line for line in log if 'Mock process' not in line], [
-                '    Found 1 commit...',
                 "Using committed changes...",
                 "Rebasing 'eng/pr-branch' on 'main'...",
                 "Rebased 'eng/pr-branch' on 'main!'",
@@ -1408,7 +1396,6 @@ No pre-PR checks to run""")
         log = captured.root.log.getvalue().splitlines()
         self.assertEqual(
             [line for line in log if 'Mock process' not in line], [
-                '    Found 1 commit...',
                 "Using committed changes...",
                 "Rebasing 'eng/pr-branch' on 'main'...",
                 "Rebased 'eng/pr-branch' on 'main!'",
@@ -1522,7 +1509,6 @@ No pre-PR checks to run""")
         log = captured.root.log.getvalue().splitlines()
         self.assertEqual(
             [line for line in log if 'Mock process' not in line], [
-                '    Found 1 commit...',
                 "Amending commit...",
                 "Rebasing 'eng/pr-branch' on 'main'...",
                 "Rebased 'eng/pr-branch' on 'main!'",
@@ -1562,7 +1548,6 @@ No pre-PR checks to run""")
         log = captured.root.log.getvalue().splitlines()
         self.assertEqual(
             [line for line in log if 'Mock process' not in line], [
-                '    Found 1 commit...',
                 'Creating commit...',
                 "Rebasing 'eng/pr-branch' on 'main'...",
                 "Rebased 'eng/pr-branch' on 'main!'",
@@ -1609,7 +1594,6 @@ No pre-PR checks to run""")
         log = captured.root.log.getvalue().splitlines()
         self.assertEqual(
             [line for line in log if 'Mock process' not in line], [
-                '    Found 1 commit...',
                 "Amending commit...",
                 "Rebasing 'eng/pr-branch' on 'main'...",
                 "Rebased 'eng/pr-branch' on 'main!'",
@@ -1659,7 +1643,6 @@ No pre-PR checks to run""")
         log = captured.root.log.getvalue().splitlines()
         self.assertEqual(
             [line for line in log if 'Mock process' not in line], [
-                '    Found 1 commit...',
                 "Using committed changes...",
                 "Rebasing 'eng/pr-branch' on 'main'...",
                 "Rebased 'eng/pr-branch' on 'main!'",
@@ -1712,7 +1695,6 @@ No pre-PR checks to run""")
         log = captured.root.log.getvalue().splitlines()
         self.assertEqual(
             [line for line in log if 'Mock process' not in line], [
-                '    Found 1 commit...',
                 "Using committed changes...",
                 "Rebasing 'eng/pr-branch' on 'main'...",
                 "Rebased 'eng/pr-branch' on 'main!'",

--- a/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/test/revert_unittest.py
+++ b/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/test/revert_unittest.py
@@ -109,7 +109,6 @@ class TestRevert(testing.PathTestCase):
             [line for line in log if 'Mock process' not in line], [
                 "Creating the local development branch 'eng/pr-branch'...",
                 'Reverted d8bce26fa65c6fc8f39c17927abb77f69fab82fc',
-                '    Found 1 commit...',
                 'Using committed changes...',
                 "Rebasing 'eng/pr-branch' on 'main'...",
                 "Rebased 'eng/pr-branch' on 'main!'",
@@ -191,7 +190,6 @@ index 05e8751..0bf3c85 100644
                 "Creating 'eng/pr-branch-1' as a reference branch",
                 "Creating pull-request for 'eng/pr-branch'...",
                 'Adding comment for reverted commits...',
-                '    Found 1 commit...',
                 'Using committed changes...',
                 "Rebasing 'eng/pr-branch' on 'main'...",
                 "Rebased 'eng/pr-branch' on 'main!'",

--- a/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/test/squash_unittest.py
+++ b/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/test/squash_unittest.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2022 Apple Inc. All rights reserved.
+# Copyright (C) 2022-2023 Apple Inc. All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -70,9 +70,6 @@ class TestSquash(testing.PathTestCase):
         log = captured.root.log.getvalue().splitlines()
         self.assertEqual(
             [line for line in log if 'Mock process' not in line], [
-                '    Found 1 commit...',
-                '    Found 2 commits...',
-                '    Found 3 commits...',
                 'Using committed changes...',
                 '    Squashed 3 commits',
                 "Rebasing 'eng/squash-branch' on 'main'...",
@@ -118,9 +115,6 @@ class TestSquash(testing.PathTestCase):
         log = captured.root.log.getvalue().splitlines()
         self.assertEqual(
             [line for line in log if 'Mock process' not in line], [
-                '    Found 1 commit...',
-                '    Found 2 commits...',
-                '    Found 3 commits...',
                 'Using committed changes...',
                 '    Squashed 3 commits',
                 "Rebasing 'eng/squash-branch' on 'main'...",
@@ -162,11 +156,7 @@ class TestSquash(testing.PathTestCase):
         log = captured.root.log.getvalue().splitlines()
         self.assertEqual(
             [line for line in log if 'Mock process' not in line], [
-                '    Found 1 commit...',
-                '    Found 2 commits...',
-                '    Found 3 commits...',
                 '    Squashed 3 commits',
-                '    Found 1 commit...',
                 'Using committed changes...',
                 "Rebasing 'eng/squash-branch' on 'main'...",
                 "Rebased 'eng/squash-branch' on 'main!'",

--- a/Tools/Scripts/webkitpy/common/checkout/scm/git.py
+++ b/Tools/Scripts/webkitpy/common/checkout/scm/git.py
@@ -557,7 +557,7 @@ class Git(SCM, SVNRepository):
     def remote_branch_ref(self, find_branch=False):
         if find_branch:
             repository = local.Git(self.checkout_root)
-            branch_point = branch.Branch.branch_point(repository, limit=10)
+            branch_point = branch.Branch.branch_point(repository)
             if branch_point:
                 # First, look for a remote branch that contains the branch point
                 for remote in repository.source_remotes():


### PR DESCRIPTION
#### 295115e98b2ed780c75595560254ee048755717a
<pre>
[git-webkit] Speed up Branch.branch_point
<a href="https://bugs.webkit.org/show_bug.cgi?id=256855">https://bugs.webkit.org/show_bug.cgi?id=256855</a>
rdar://109419012

Reviewed by Elliott Williams.

Calculating the merge-base of a commit and all production branches is actually faster than checking
which branches that commit is a member of. Re-implement branch-point using this techinque.

* Tools/Scripts/libraries/webkitscmpy/setup.py: Bump version.
* Tools/Scripts/libraries/webkitscmpy/webkitscmpy/__init__.py: Ditto.
* Tools/Scripts/libraries/webkitscmpy/webkitscmpy/mocks/git-repo.json: Add identifiers to all commits.
* Tools/Scripts/libraries/webkitscmpy/webkitscmpy/mocks/local/git.py:
(Git.__init__): Pass all arguments to merge-base
(Git.merge_base): Support multiple branch arguments.
* Tools/Scripts/libraries/webkitscmpy/webkitscmpy/program/branch.py:
(Branch.branch_point): Calculate the merge-base between the current commit and all potential production branches.
* Tools/Scripts/libraries/webkitscmpy/webkitscmpy/program/pull_request.py:
(PullRequest.pull_request_branch_point): Early-exit function if branch-point is undefined.
* Tools/Scripts/libraries/webkitscmpy/webkitscmpy/test/branch_unittest.py:
(TestBranch.test_branch_point):
(TestBranch.test_branch_point_main):
* Tools/Scripts/libraries/webkitscmpy/webkitscmpy/test/land_unittest.py:
* Tools/Scripts/libraries/webkitscmpy/webkitscmpy/test/pull_request_unittest.py:
* Tools/Scripts/libraries/webkitscmpy/webkitscmpy/test/revert_unittest.py:
* Tools/Scripts/libraries/webkitscmpy/webkitscmpy/test/squash_unittest.py:

Canonical link: <a href="https://commits.webkit.org/264536@main">https://commits.webkit.org/264536@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/7a5c161eec0d824e54be8e80b62e8a6f3c73a590

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [  ~~🧪 style~~](https://ews-build.webkit.org/#/builders/38/builds/7942 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 ios~~](https://ews-build.webkit.org/#/builders/26/builds/8221 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/14/builds/8408 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/9590 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/32/builds/8061 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [  ~~🧪 bindings~~](https://ews-build.webkit.org/#/builders/9/builds/7946 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/23/builds/10212 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/16/builds/8136 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/9590 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [  ~~🧪 webkitperl~~](https://ews-build.webkit.org/#/builders/11/builds/8083 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/23/builds/10212 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/14/builds/8408 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/2/builds/9709 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [  ~~🧪 webkitpy~~](https://ews-build.webkit.org/#/builders/6/builds/8068 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/23/builds/10212 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/14/builds/8408 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/2/builds/9709 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/23/builds/10212 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/14/builds/8408 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/2/builds/9709 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/7/builds/7859 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/16/builds/8136 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [  ~~🧪 services~~](https://ews-build.webkit.org/#/builders/28/builds/7903 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/30/builds/7176 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/14/builds/8408 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/4/builds/11386 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/947 "Built successfully and passed tests") | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/31/builds/7595 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->