### PR TITLE
Change BaselineGroup's items HashSet to WeakHashSet.

### DIFF
--- a/Source/WebCore/rendering/BaselineAlignment.cpp
+++ b/Source/WebCore/rendering/BaselineAlignment.cpp
@@ -36,7 +36,7 @@ BaselineGroup::BaselineGroup(WritingMode blockFlow, ItemPosition childPreference
 
 void BaselineGroup::update(const RenderBox& child, LayoutUnit ascent)
 {
-    if (m_items.add(&child).isNewEntry)
+    if (m_items.add(child).isNewEntry)
         m_maxAscent = std::max(m_maxAscent, ascent);
 }
 
@@ -72,7 +72,7 @@ bool BaselineGroup::isOrthogonalBlockFlow(WritingMode blockFlow) const
 bool BaselineGroup::isCompatible(WritingMode childBlockFlow, ItemPosition childPreference) const
 {
     ASSERT(isBaselinePosition(childPreference));
-    ASSERT(size() > 0);
+    ASSERT(computeSize() > 0);
     return ((m_blockFlow == childBlockFlow || isOrthogonalBlockFlow(childBlockFlow)) && m_preference == childPreference) || (isOppositeBlockFlow(childBlockFlow) && m_preference != childPreference);
 }
 

--- a/Source/WebCore/rendering/BaselineAlignment.h
+++ b/Source/WebCore/rendering/BaselineAlignment.h
@@ -49,7 +49,7 @@ public:
     // baseline-sharing group.
     void update(const RenderBox&, LayoutUnit ascent);
     LayoutUnit maxAscent() const { return m_maxAscent; }
-    int size() const { return m_items.size(); }
+    int computeSize() const { return m_items.computeSize(); }
 
 private:
     friend class BaselineContext;
@@ -70,7 +70,7 @@ private:
     WritingMode m_blockFlow;
     ItemPosition m_preference;
     LayoutUnit m_maxAscent;
-    HashSet<const RenderBox*> m_items;
+    WeakHashSet<const RenderBox> m_items;
 };
 
 // https://drafts.csswg.org/css-align-3/#shared-alignment-context

--- a/Source/WebCore/rendering/GridBaselineAlignment.cpp
+++ b/Source/WebCore/rendering/GridBaselineAlignment.cpp
@@ -141,7 +141,7 @@ LayoutUnit GridBaselineAlignment::baselineOffsetForChild(ItemPosition preference
 {
     ASSERT(isBaselinePosition(preference));
     auto& group = baselineGroupForChild(preference, sharedContext, child, baselineAxis);
-    if (group.size() > 1)
+    if (group.computeSize() > 1)
         return group.maxAscent() - logicalAscentForChild(child, baselineAxis, preference);
     return LayoutUnit();
 }


### PR DESCRIPTION
#### 62aba919edb6ed15b57340857d66d55c4d6034df
<pre>
Change BaselineGroup&apos;s items HashSet to WeakHashSet.
<a href="https://bugs.webkit.org/show_bug.cgi?id=256795">https://bugs.webkit.org/show_bug.cgi?id=256795</a>
rdar://109363884

Reviewed by Tim Nguyen.

In order to keep track of items within a baseline sharing group, this
class currently stores raw pointers to renderers within a HashSet.
To improve upon this we can change the HashSet into a WeakHashSet
since the baseline alignment code does not need to express any
sort of ownership over the renderers.

The size() method on BaselineGroup was also changed to computeSize()
to make it clear that we will need to non-trivially determine the
number of items in the baseline sharing group.

* Source/WebCore/rendering/BaselineAlignment.cpp:
(WebCore::BaselineGroup::update):
(WebCore::BaselineGroup::isCompatible const):
* Source/WebCore/rendering/BaselineAlignment.h:
(WebCore::BaselineGroup::computeSize const):
(WebCore::BaselineGroup::size const): Deleted.
* Source/WebCore/rendering/GridBaselineAlignment.cpp:
(WebCore::GridBaselineAlignment::baselineOffsetForChild const):

Canonical link: <a href="https://commits.webkit.org/264132@main">https://commits.webkit.org/264132@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9b0d1335523ae6d24a2ab65cce1b4838e1542813

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/6805 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/7025 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/7209 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/8396 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/7058 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/6805 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/8203 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/6967 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/9951 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/6924 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/7524 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/6245 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/8491 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/4949 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/6163 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/13964 "Passed tests") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/6679 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/6244 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/9022 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/6735 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/5517 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/6117 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/1612 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/10296 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/6495 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->