### PR TITLE
[iOS] Several API tests fail when run against an iPhone 12 simulator

### DIFF
--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/RestoreScrollPosition.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/RestoreScrollPosition.mm
@@ -32,18 +32,6 @@
 #import <WebKit/WKWebViewPrivate.h>
 #import <WebKit/_WKProcessPoolConfiguration.h>
 
-#if PLATFORM(IOS_FAMILY)
-@interface RestoreScrollPositionWithLargeContentInsetWebView : TestWKWebView
-@end
-
-@implementation RestoreScrollPositionWithLargeContentInsetWebView
-- (UIEdgeInsets)safeAreaInsets
-{
-    return UIEdgeInsetsMake(141, 0, 0, 0);
-}
-@end
-#endif
-
 namespace TestWebKitAPI {
 
 #if PLATFORM(IOS_FAMILY)
@@ -52,7 +40,8 @@ TEST(RestoreScrollPositionTests, RestoreScrollPositionWithLargeContentInset)
 {
     auto topInset = 1165;
 
-    auto webView = adoptNS([[RestoreScrollPositionWithLargeContentInsetWebView alloc] initWithFrame:CGRectMake(0, 0, 375, 1024)]);
+    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 375, 1024)]);
+    [webView setOverrideSafeAreaInset:UIEdgeInsetsMake(141, 0, 0, 0)];
     
     [webView synchronouslyLoadTestPageNamed:@"simple-tall"];
     

--- a/Tools/TestWebKitAPI/cocoa/TestWKWebView.h
+++ b/Tools/TestWebKitAPI/cocoa/TestWKWebView.h
@@ -124,6 +124,7 @@
 @end
 
 @interface TestWKWebView (IOSOnly)
+@property (nonatomic) UIEdgeInsets overrideSafeAreaInset;
 @property (nonatomic, readonly) CGRect caretViewRectInContentCoordinates;
 @property (nonatomic, readonly) NSArray<NSValue *> *selectionViewRectsInContentCoordinates;
 - (_WKActivatedElementInfo *)activatedElementAtPosition:(CGPoint)position;

--- a/Tools/TestWebKitAPI/cocoa/TestWKWebView.mm
+++ b/Tools/TestWebKitAPI/cocoa/TestWKWebView.mm
@@ -476,6 +476,7 @@ static InputSessionChangeCount nextInputSessionChangeCount()
 #if PLATFORM(IOS_FAMILY)
     std::unique_ptr<ClassMethodSwizzler> _sharedCalloutBarSwizzler;
     InputSessionChangeCount _inputSessionChangeCount;
+    UIEdgeInsets _overrideSafeAreaInset;
 #endif
 #if PLATFORM(MAC)
     BOOL _forceWindowToBecomeKey;
@@ -516,6 +517,9 @@ static UICalloutBar *suppressUICalloutBar()
     // FIXME: Remove this workaround once <https://webkit.org/b/175204> is fixed.
     _sharedCalloutBarSwizzler = makeUnique<ClassMethodSwizzler>([UICalloutBar class], @selector(sharedCalloutBar), reinterpret_cast<IMP>(suppressUICalloutBar));
     _inputSessionChangeCount = 0;
+    // We suppress safe area insets by default in order to ensure consistent results when running against device models
+    // that may or may not have safe area insets, have insets with different values (e.g. iOS devices with a notch).
+    _overrideSafeAreaInset = UIEdgeInsetsZero;
 #endif
 
     return self;
@@ -758,6 +762,21 @@ static UICalloutBar *suppressUICalloutBar()
         NSLog(@"Warning: expecting input session change count to differ from %lu", static_cast<unsigned long>(initialChangeCount));
         hasEmittedWarning = YES;
     }
+}
+
+- (UIEdgeInsets)overrideSafeAreaInset
+{
+    return _overrideSafeAreaInset;
+}
+
+- (void)setOverrideSafeAreaInset:(UIEdgeInsets)inset
+{
+    _overrideSafeAreaInset = inset;
+}
+
+- (UIEdgeInsets)safeAreaInsets
+{
+    return _overrideSafeAreaInset;
 }
 
 - (CGRect)caretViewRectInContentCoordinates


### PR DESCRIPTION
#### 90f6849617f00aa3e02bfd04742fb1dd14d24eea
<pre>
[iOS] Several API tests fail when run against an iPhone 12 simulator
<a href="https://bugs.webkit.org/show_bug.cgi?id=256860">https://bugs.webkit.org/show_bug.cgi?id=256860</a>
rdar://109230218

Reviewed by Aditya Keerthi.

Adjust several API tests and test infrastructure to be more robust to underlying platform changes,
and also ensure consistent test results when running a subset of API tests against notchless vs.
notched iPhone models when using `TestWKWebView`, by normalizing the safe area insets to 0 by
default.

* Tools/TestWebKitAPI/Tests/WebKitCocoa/RestoreScrollPosition.mm:
(-[RestoreScrollPositionWithLargeContentInsetWebView safeAreaInsets]): Deleted.

Remove this subclass entirely, and instead use the new `-setOverrideTopSafeAreaInset:` helper.

* Tools/TestWebKitAPI/Tests/ios/KeyboardInputTestsIOS.mm:
(-[TestWKWebView waitForCaretVisibility:]):

Make this test robust against platform differences on iOS in caret UI and whether or not we zoom
upon focusing an element, by making these tests check for the presence or absence of the caret
rather than specific caret rects. This was the original intent of the API test added in 203447@main,
anyways.

(-[TestWKWebView waitForCaretViewFrameToBecome:]): Deleted.
* Tools/TestWebKitAPI/cocoa/TestWKWebView.h:
* Tools/TestWebKitAPI/cocoa/TestWKWebView.mm:
(-[TestWKWebView initWithFrame:configuration:addToWindow:]):
(-[TestWKWebView overrideSafeAreaInset]):
(-[TestWKWebView setOverrideSafeAreaInset:]):
(-[TestWKWebView safeAreaInsets]):

Canonical link: <a href="https://commits.webkit.org/264150@main">https://commits.webkit.org/264150@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e69296ca551c29120ee0e20302f19a658fa8f62f

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/6838 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/7062 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/7246 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/8433 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/7088 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/6840 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/8277 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/7004 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/9981 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/6957 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/7590 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/6277 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/8528 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/4996 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/6196 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/13984 "7 flakes 427 failures") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/6708 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/6279 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/9054 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/6767 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/5536 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/6146 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/1627 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/10328 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/6525 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->