### PR TITLE
Implement AbortSignal.any()

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/dom/abort/abort-signal-any.any-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/dom/abort/abort-signal-any.any-expected.txt
@@ -1,12 +1,12 @@
 
-FAIL AbortSignal.any() works with an empty array of signals signalInterface.any is not a function. (In 'signalInterface.any([])', 'signalInterface.any' is undefined)
-FAIL AbortSignal.any() follows a single signal (using AbortController) signalInterface.any is not a function. (In 'signalInterface.any([signal])', 'signalInterface.any' is undefined)
-FAIL AbortSignal.any() follows multiple signals (using AbortController) signalInterface.any is not a function. (In 'signalInterface.any(controllers.map(c => c.signal))', 'signalInterface.any' is undefined)
-FAIL AbortSignal.any() returns an aborted signal if passed an aborted signal (using AbortController) signalInterface.any is not a function. (In 'signalInterface.any(controllers.map(c => c.signal))', 'signalInterface.any' is undefined)
-FAIL AbortSignal.any() can be passed the same signal more than once (using AbortController) signalInterface.any is not a function. (In 'signalInterface.any([controller.signal, controller.signal])', 'signalInterface.any' is undefined)
-FAIL AbortSignal.any() uses the first instance of a duplicate signal (using AbortController) signalInterface.any is not a function. (In 'signalInterface.any([controller1.signal, controller2.signal, controller1.signal])', 'signalInterface.any' is undefined)
-FAIL AbortSignal.any() signals are composable (using AbortController) signalInterface.any is not a function. (In 'signalInterface.any([controllers[0].signal, controllers[1].signal])', 'signalInterface.any' is undefined)
-FAIL AbortSignal.any() works with signals returned by AbortSignal.timeout() (using AbortController) signalInterface.any is not a function. (In 'signalInterface.any([controller.signal, timeoutSignal])', 'signalInterface.any' is undefined)
-FAIL AbortSignal.any() works with intermediate signals (using AbortController) signalInterface.any is not a function. (In 'signalInterface.any([controller.signal])', 'signalInterface.any' is undefined)
-FAIL Abort events for AbortSignal.any() signals fire in the right order (using AbortController) signalInterface.any is not a function. (In 'signalInterface.any([controller.signal])', 'signalInterface.any' is undefined)
+PASS AbortSignal.any() works with an empty array of signals
+PASS AbortSignal.any() follows a single signal (using AbortController)
+PASS AbortSignal.any() follows multiple signals (using AbortController)
+PASS AbortSignal.any() returns an aborted signal if passed an aborted signal (using AbortController)
+PASS AbortSignal.any() can be passed the same signal more than once (using AbortController)
+PASS AbortSignal.any() uses the first instance of a duplicate signal (using AbortController)
+PASS AbortSignal.any() signals are composable (using AbortController)
+PASS AbortSignal.any() works with signals returned by AbortSignal.timeout() (using AbortController)
+PASS AbortSignal.any() works with intermediate signals (using AbortController)
+PASS Abort events for AbortSignal.any() signals fire in the right order (using AbortController)
 

--- a/LayoutTests/imported/w3c/web-platform-tests/dom/abort/abort-signal-any.any.worker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/dom/abort/abort-signal-any.any.worker-expected.txt
@@ -1,12 +1,12 @@
 
-FAIL AbortSignal.any() works with an empty array of signals signalInterface.any is not a function. (In 'signalInterface.any([])', 'signalInterface.any' is undefined)
-FAIL AbortSignal.any() follows a single signal (using AbortController) signalInterface.any is not a function. (In 'signalInterface.any([signal])', 'signalInterface.any' is undefined)
-FAIL AbortSignal.any() follows multiple signals (using AbortController) signalInterface.any is not a function. (In 'signalInterface.any(controllers.map(c => c.signal))', 'signalInterface.any' is undefined)
-FAIL AbortSignal.any() returns an aborted signal if passed an aborted signal (using AbortController) signalInterface.any is not a function. (In 'signalInterface.any(controllers.map(c => c.signal))', 'signalInterface.any' is undefined)
-FAIL AbortSignal.any() can be passed the same signal more than once (using AbortController) signalInterface.any is not a function. (In 'signalInterface.any([controller.signal, controller.signal])', 'signalInterface.any' is undefined)
-FAIL AbortSignal.any() uses the first instance of a duplicate signal (using AbortController) signalInterface.any is not a function. (In 'signalInterface.any([controller1.signal, controller2.signal, controller1.signal])', 'signalInterface.any' is undefined)
-FAIL AbortSignal.any() signals are composable (using AbortController) signalInterface.any is not a function. (In 'signalInterface.any([controllers[0].signal, controllers[1].signal])', 'signalInterface.any' is undefined)
-FAIL AbortSignal.any() works with signals returned by AbortSignal.timeout() (using AbortController) signalInterface.any is not a function. (In 'signalInterface.any([controller.signal, timeoutSignal])', 'signalInterface.any' is undefined)
-FAIL AbortSignal.any() works with intermediate signals (using AbortController) signalInterface.any is not a function. (In 'signalInterface.any([controller.signal])', 'signalInterface.any' is undefined)
-FAIL Abort events for AbortSignal.any() signals fire in the right order (using AbortController) signalInterface.any is not a function. (In 'signalInterface.any([controller.signal])', 'signalInterface.any' is undefined)
+PASS AbortSignal.any() works with an empty array of signals
+PASS AbortSignal.any() follows a single signal (using AbortController)
+PASS AbortSignal.any() follows multiple signals (using AbortController)
+PASS AbortSignal.any() returns an aborted signal if passed an aborted signal (using AbortController)
+PASS AbortSignal.any() can be passed the same signal more than once (using AbortController)
+PASS AbortSignal.any() uses the first instance of a duplicate signal (using AbortController)
+PASS AbortSignal.any() signals are composable (using AbortController)
+PASS AbortSignal.any() works with signals returned by AbortSignal.timeout() (using AbortController)
+PASS AbortSignal.any() works with intermediate signals (using AbortController)
+PASS Abort events for AbortSignal.any() signals fire in the right order (using AbortController)
 

--- a/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
+++ b/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
@@ -84,6 +84,20 @@ AVFoundationEnabled:
       "PLATFORM(WATCHOS)": false
       default: true
 
+AbortSignalAnyOperationEnabled:
+  type: bool
+  category: dom
+  status: preview
+  humanReadableName: "AbortSignal.any() API"
+  humanReadableDescription: "Enable AbortSignal.any() API"
+  defaultValue:
+    WebKitLegacy:
+      default: false
+    WebKit:
+      default: false
+    WebCore:
+      default: false
+
 AcceleratedCompositingEnabled:
   type: bool
   status: embedder

--- a/Source/WebCore/bindings/js/JSAbortSignalCustom.cpp
+++ b/Source/WebCore/bindings/js/JSAbortSignalCustom.cpp
@@ -1,5 +1,5 @@
 /*
-* Copyright (C) 2019-2022 Apple Inc. All rights reserved.
+* Copyright (C) 2019-2023 Apple Inc. All rights reserved.
 *
 * Redistribution and use in source and binary forms, with or without
 * modification, are permitted provided that the following conditions
@@ -42,10 +42,17 @@ bool JSAbortSignalOwner::isReachableFromOpaqueRoots(JSC::Handle<JSC::Unknown> ha
         return true;
     }
 
-    if (abortSignal.hasAbortEventListener() && abortSignal.hasActiveTimeoutTimer()) {
-        if (UNLIKELY(reason))
-            *reason = "Has Active Abort Listener";
-        return true;
+    if (abortSignal.hasAbortEventListener()) {
+        if (abortSignal.hasActiveTimeoutTimer()) {
+            if (UNLIKELY(reason))
+                *reason = "Has Timeout And Abort Event Listener";
+            return true;
+        }
+        if (!abortSignal.sourceSignals().isEmptyIgnoringNullReferences()) {
+            if (UNLIKELY(reason))
+                *reason = "Has Source Signals And Abort Event Listener";
+            return true;
+        }
     }
 
     return containsWebCoreOpaqueRoot(visitor, abortSignal);

--- a/Source/WebCore/dom/AbortSignal.idl
+++ b/Source/WebCore/dom/AbortSignal.idl
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2022 Apple Inc. All rights reserved.
+ * Copyright (C) 2017-2023 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -32,6 +32,7 @@
 ] interface AbortSignal : EventTarget {
     [NewObject, CallWith=CurrentScriptExecutionContext&CurrentGlobalObject] static AbortSignal abort(optional any reason);
     [Exposed=(Window, Worker), NewObject, CallWith=CurrentScriptExecutionContext] static AbortSignal timeout([EnforceRange] unsigned long long milliseconds);
+    [NewObject, CallWith=CurrentScriptExecutionContext, EnabledBySetting=AbortSignalAnyOperationEnabled] static AbortSignal _any(sequence<AbortSignal> signals);
 
     readonly attribute boolean aborted;
     readonly attribute any reason;


### PR DESCRIPTION
#### b194103750b661e619135309652b481fe9704103
<pre>
Implement AbortSignal.any()
<a href="https://bugs.webkit.org/show_bug.cgi?id=256176">https://bugs.webkit.org/show_bug.cgi?id=256176</a>
rdar://109056627

Reviewed by Brent Fulgham.

Implement AbortSignal.any() as per:
- <a href="https://github.com/whatwg/dom/pull/1152">https://github.com/whatwg/dom/pull/1152</a>

The feature is behind a runtime flag, disabled by default.

* LayoutTests/imported/w3c/web-platform-tests/dom/abort/abort-signal-any.any-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/dom/abort/abort-signal-any.any.worker-expected.txt:
* Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml:
* Source/WebCore/bindings/js/JSAbortSignalCustom.cpp:
(WebCore::JSAbortSignalOwner::isReachableFromOpaqueRoots):
* Source/WebCore/dom/AbortSignal.cpp:
(WebCore::AbortSignal::any):
(WebCore::AbortSignal::addSourceSignal):
(WebCore::AbortSignal::addDependentSignal):
(WebCore::AbortSignal::signalAbort):
* Source/WebCore/dom/AbortSignal.h:
* Source/WebCore/dom/AbortSignal.idl:

Canonical link: <a href="https://commits.webkit.org/264163@main">https://commits.webkit.org/264163@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/8c410bb1da167786771d994464e4e83596ea2586

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/6898 "1 style error") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/7128 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/7311 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/8497 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/7145 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/6903 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/8375 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/7067 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/10045 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/7020 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/7686 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/6353 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/8597 "Built successfully") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/39/builds/5067 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/6263 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/14051 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/5822 "Built successfully and passed tests") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/6752 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/6350 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/9156 "Passed tests") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/6473 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/6830 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/5600 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/7038 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/6206 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/1647 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/1635 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/10391 "Built successfully") | | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/24/builds/7229 "Built successfully") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/6584 "Built successfully") | | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/3/builds/1783 "Passed tests") | 
<!--EWS-Status-Bubble-End-->