### PR TITLE
Resync html/browsers/browsing-the-web/navigating-across-documents/replace-before-load WPT

### DIFF
--- a/LayoutTests/TestExpectations
+++ b/LayoutTests/TestExpectations
@@ -6335,6 +6335,10 @@ imported/w3c/web-platform-tests/css/css-ruby/ruby-whitespace-002.html [ ImageOnl
 imported/w3c/web-platform-tests/css/css-ruby/ruby-with-floats-002.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/css/css-ruby/ruby-with-floats-003.html [ ImageOnlyFailure ]
 
+# These tests are trying to use a WPT domain that are infrastructure doesn't support.
+imported/w3c/web-platform-tests/html/browsers/browsing-the-web/navigating-across-documents/replace-before-load/form-submit-cross-frame-crossorigin.sub.html [ Skip ]
+imported/w3c/web-platform-tests/html/browsers/browsing-the-web/navigating-across-documents/replace-before-load/form-submit-popup-crossorigin.sub.html [ Skip ]
+
 webkit.org/b/242658 http/tests/media/user-gesture-preserved-across-xmlhttprequest.html [ Slow Pass Failure ]
 
 # This test is crashing in debug since its import.

--- a/LayoutTests/imported/w3c/web-platform-tests/html/browsers/browsing-the-web/navigating-across-documents/replace-before-load/form-submit-cross-frame-crossorigin.sub-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/browsers/browsing-the-web/navigating-across-documents/replace-before-load/form-submit-cross-frame-crossorigin.sub-expected.txt
@@ -1,0 +1,7 @@
+Blocked access to external URL http://www.localhost:8800/html/browsers/browsing-the-web/navigating-across-documents/replace-before-load/resources/slow-message-source-with-history-and-location.html?pushed=
+
+
+Harness Error (TIMEOUT), message = null
+
+TIMEOUT No replace before load, triggered by cross-iframe formElement.submit() [iframe is cross-origin] Test timed out
+

--- a/LayoutTests/imported/w3c/web-platform-tests/html/browsers/browsing-the-web/navigating-across-documents/replace-before-load/form-submit-cross-frame-crossorigin.sub.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/browsers/browsing-the-web/navigating-across-documents/replace-before-load/form-submit-cross-frame-crossorigin.sub.html
@@ -1,0 +1,42 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="resources/helpers.js"></script>
+
+<form target="the-frame">
+  <input type="hidden" name="pushed">
+</form>
+
+<script>
+"use strict";
+promise_test(async t => {
+  const startingHistoryLength = history.length;
+
+  const form = document.querySelector("form");
+  const frameEndingURL = changeURLHost(
+    absoluteURL("resources/slow-message-source-with-history-and-location.html?pushed="),
+    "{{hosts[][www]}}"
+  );
+  form.action = frameEndingURL;
+
+  const frameStartingCode = `
+    parent.postMessage({ historyLength: history.length, locationHref: location.href }, "*");
+  `;
+
+  const frameStartingURL = codeInjectorURL(frameStartingCode);
+  const frame = insertIframe(t, frameStartingURL, "the-frame");
+  t.add_cleanup(() => frame.remove()); // helps avoid waiting for the slow load to finish the tests
+  assert_equals(history.length, startingHistoryLength, "Inserting frame must not change history.length");
+
+  const frameBeforeLoadedMessage = await waitForMessage();
+  assert_equals(frameBeforeLoadedMessage.historyLength, startingHistoryLength, "frame's starting history.length");
+  assert_equals(frameBeforeLoadedMessage.locationHref, frame.src, "frame's starting location.href");
+
+  form.submit();
+
+  const frameAfterFormSubmitMessage = await waitForMessage();
+  assert_equals(frameAfterFormSubmitMessage.historyLength, startingHistoryLength + 1, "frame's after-submit history.length");
+  assert_equals(frameAfterFormSubmitMessage.locationHref, frameEndingURL, "frame's after-submit location.href");
+}, "No replace before load, triggered by cross-iframe formElement.submit() [iframe is cross-origin]");
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/html/browsers/browsing-the-web/navigating-across-documents/replace-before-load/form-submit-cross-frame-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/browsers/browsing-the-web/navigating-across-documents/replace-before-load/form-submit-cross-frame-expected.txt
@@ -1,0 +1,3 @@
+
+FAIL No replace before load, triggered by cross-iframe formElement.submit() assert_equals: frame's after-submit history.length expected 3 but got 2
+

--- a/LayoutTests/imported/w3c/web-platform-tests/html/browsers/browsing-the-web/navigating-across-documents/replace-before-load/form-submit-cross-frame.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/browsers/browsing-the-web/navigating-across-documents/replace-before-load/form-submit-cross-frame.html
@@ -1,0 +1,40 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="resources/helpers.js"></script>
+
+<form target="the-frame">
+  <input type="hidden" name="pushed">
+</form>
+
+<script>
+"use strict";
+promise_test(async t => {
+  const startingHistoryLength = history.length;
+
+  const form = document.querySelector("form");
+  const frameEndingURL = absoluteURL("resources/slow-message-source-with-history-and-location.html?pushed=");
+  form.action = frameEndingURL;
+
+  const frameStartingCode = `
+    window.onload = () => { window.onloadFired = true; };
+    parent.postMessage({ historyLength: history.length, locationHref: location.href }, "*");
+    parent.document.querySelector("form").submit();
+  `;
+
+  const frameStartingURL = codeInjectorURL(frameStartingCode);
+  const frame = insertIframe(t, frameStartingURL, "the-frame");
+  t.add_cleanup(() => frame.remove()); // helps avoid waiting for the slow load to finish the tests
+  assert_equals(history.length, startingHistoryLength, "Inserting frame must not change history.length");
+
+  const frameBeforeLoadedMessage = await waitForMessage();
+  assert_equals(frameBeforeLoadedMessage.historyLength, startingHistoryLength, "frame's starting history.length");
+  assert_equals(frameBeforeLoadedMessage.locationHref, frame.src, "frame's starting location.href");
+  assert_equals(frame.contentWindow.onloadFired, undefined, "frame's onload not fired yet");
+
+  const frameAfterFormSubmitMessage = await waitForMessage();
+  assert_equals(frameAfterFormSubmitMessage.historyLength, startingHistoryLength + 1, "frame's after-submit history.length");
+  assert_equals(frameAfterFormSubmitMessage.locationHref, frameEndingURL, "frame's after-submit location.href");
+}, "No replace before load, triggered by cross-iframe formElement.submit()");
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/html/browsers/browsing-the-web/navigating-across-documents/replace-before-load/form-submit-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/browsers/browsing-the-web/navigating-across-documents/replace-before-load/form-submit-expected.txt
@@ -1,4 +1,4 @@
 
 
-PASS Replace before load, triggered by formElement.submit()
+PASS Replace before load, triggered by same-document formElement.submit()
 

--- a/LayoutTests/imported/w3c/web-platform-tests/html/browsers/browsing-the-web/navigating-across-documents/replace-before-load/form-submit-popup-crossorigin.sub-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/browsers/browsing-the-web/navigating-across-documents/replace-before-load/form-submit-popup-crossorigin.sub-expected.txt
@@ -1,0 +1,6 @@
+Blocked access to external URL http://www.localhost:8800/html/browsers/browsing-the-web/navigating-across-documents/replace-before-load/resources/slow-message-source-with-history-and-location.html?pushed=
+
+Harness Error (TIMEOUT), message = null
+
+TIMEOUT No replace before load, triggered by formElement.submit() in the opener window, after the opener has loaded [window is cross-origin] Test timed out
+

--- a/LayoutTests/imported/w3c/web-platform-tests/html/browsers/browsing-the-web/navigating-across-documents/replace-before-load/form-submit-popup-crossorigin.sub.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/browsers/browsing-the-web/navigating-across-documents/replace-before-load/form-submit-popup-crossorigin.sub.html
@@ -1,0 +1,39 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="resources/helpers.js"></script>
+
+<form target="the-window">
+  <input type="hidden" name="pushed">
+</form>
+
+<script>
+"use strict";
+promise_test(async t => {
+  const form = document.querySelector("form");
+  const wEndingURL = changeURLHost(
+    absoluteURL("resources/slow-message-source-with-history-and-location.html?pushed="),
+    "{{hosts[][www]}}"
+  );
+  form.action = wEndingURL;
+
+  const wStartingCode = `
+    opener.postMessage({ historyLength: history.length, locationHref: location.href }, "*");
+  `;
+
+  const wStartingURL = codeInjectorURL(wStartingCode);
+  const w = window.open(wStartingURL, "the-window");
+  t.add_cleanup(() => w.close());
+
+  const wBeforeLoadedMessage = await waitForMessage();
+  assert_equals(wBeforeLoadedMessage.historyLength, 1, "window's starting history.length");
+  assert_equals(wBeforeLoadedMessage.locationHref, wStartingURL, "window's starting location.href");
+
+  form.submit();
+
+  const wAfterFormSubmitMessage = await waitForMessage();
+  assert_equals(wAfterFormSubmitMessage.historyLength, 2, "window's after-submit history.length");
+  assert_equals(wAfterFormSubmitMessage.locationHref, wEndingURL, "window's after-submit location.href");
+}, "No replace before load, triggered by formElement.submit() in the opener window, after the opener has loaded [window is cross-origin]");
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/html/browsers/browsing-the-web/navigating-across-documents/replace-before-load/form-submit-popup-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/browsers/browsing-the-web/navigating-across-documents/replace-before-load/form-submit-popup-expected.txt
@@ -1,0 +1,3 @@
+
+FAIL No replace before load, triggered by formElement.submit() in the opener window, after the opener has loaded assert_equals: window's after-submit history.length expected 2 but got 1
+

--- a/LayoutTests/imported/w3c/web-platform-tests/html/browsers/browsing-the-web/navigating-across-documents/replace-before-load/form-submit-popup.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/browsers/browsing-the-web/navigating-across-documents/replace-before-load/form-submit-popup.html
@@ -1,0 +1,37 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="resources/helpers.js"></script>
+
+<form target="the-window">
+  <input type="hidden" name="pushed">
+</form>
+
+<script>
+"use strict";
+promise_test(async t => {
+  const form = document.querySelector("form");
+  const wEndingURL = absoluteURL("resources/slow-message-source-with-history-and-location.html?pushed=");
+  form.action = wEndingURL;
+
+  const wStartingCode = `
+    window.onload = () => { window.onloadFired = true; };
+    opener.postMessage({ historyLength: history.length, locationHref: location.href }, "*");
+    opener.document.querySelector("form").submit();
+  `;
+
+  const wStartingURL = codeInjectorURL(wStartingCode);
+  const w = window.open(wStartingURL, "the-window");
+  t.add_cleanup(() => w.close());
+
+  const wBeforeLoadedMessage = await waitForMessage();
+  assert_equals(wBeforeLoadedMessage.historyLength, 1, "window's starting history.length");
+  assert_equals(wBeforeLoadedMessage.locationHref, wStartingURL, "window's starting location.href");
+  assert_equals(w.onloadFired, undefined, "window's onload not fired yet");
+
+  const wAfterFormSubmitMessage = await waitForMessage();
+  assert_equals(wAfterFormSubmitMessage.historyLength, 2, "window's after-submit history.length");
+  assert_equals(wAfterFormSubmitMessage.locationHref, wEndingURL, "window's after-submit location.href");
+}, "No replace before load, triggered by formElement.submit() in the opener window, after the opener has loaded");
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/html/browsers/browsing-the-web/navigating-across-documents/replace-before-load/form-submit.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/browsers/browsing-the-web/navigating-across-documents/replace-before-load/form-submit.html
@@ -35,5 +35,5 @@ promise_test(async t => {
 
   await checkSentinelIframe(t, sentinelIframe);
   assert_equals(history.length, startingHistoryLength, "history.length must not change after checking the sentinel iframe");
-}, "Replace before load, triggered by formElement.submit()");
+}, "Replace before load, triggered by same-document formElement.submit()");
 </script>

--- a/LayoutTests/imported/w3c/web-platform-tests/html/browsers/browsing-the-web/navigating-across-documents/replace-before-load/history-pushstate-during-pageshow.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/browsers/browsing-the-web/navigating-across-documents/replace-before-load/history-pushstate-during-pageshow.html
@@ -23,7 +23,7 @@ promise_test(async t => {
   const iframe = insertIframe(t, startURL);
   assert_equals(history.length, startingHistoryLength, "Inserting the under-test iframe must not change history.length");
 
-  await waitForMessage(t, "done");
+  assert_equals(await waitForMessage(), "done");
   assert_equals(history.length, startingHistoryLength + 1, "history.length must change after waiting for the replacement");
 }, "history.pushState() during the pageshow event must NOT replace");
 </script>

--- a/LayoutTests/imported/w3c/web-platform-tests/html/browsers/browsing-the-web/navigating-across-documents/replace-before-load/location-setter-during-pageshow.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/browsers/browsing-the-web/navigating-across-documents/replace-before-load/location-setter-during-pageshow.html
@@ -68,7 +68,7 @@ promise_test(async t => {
   const iframe = insertIframe(t, startURL);
   assert_equals(history.length, startingHistoryLength, "Inserting the under-test iframe must not change history.length");
 
-  await waitForMessage(t, "done");
+  assert_equals(await waitForMessage(), "done");
   assert_equals(history.length, startingHistoryLength, "history.length must not change after waiting for the replacement");
 
   await checkSentinelIframe(t, sentinelIframe);

--- a/LayoutTests/imported/w3c/web-platform-tests/html/browsers/browsing-the-web/navigating-across-documents/replace-before-load/resources/slow-message-source-with-history-and-location.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/browsers/browsing-the-web/navigating-across-documents/replace-before-load/resources/slow-message-source-with-history-and-location.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>Subframe or popup</title>
+
+<script>
+"use strict";
+(window.opener || window.parent).postMessage(
+  { historyLength: history.length, locationHref: location.href },
+  "*"
+);
+</script>
+
+<!--
+  This delays the load event, hopefully long enough that we can do whatever before-load action we're aiming for.
+-->
+<img src="/common/slow.py">

--- a/LayoutTests/imported/w3c/web-platform-tests/html/browsers/browsing-the-web/navigating-across-documents/replace-before-load/resources/w3c-import.log
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/browsers/browsing-the-web/navigating-across-documents/replace-before-load/resources/w3c-import.log
@@ -18,3 +18,4 @@ List of files:
 /LayoutTests/imported/w3c/web-platform-tests/html/browsers/browsing-the-web/navigating-across-documents/replace-before-load/resources/helpers.js
 /LayoutTests/imported/w3c/web-platform-tests/html/browsers/browsing-the-web/navigating-across-documents/replace-before-load/resources/message-opener.html
 /LayoutTests/imported/w3c/web-platform-tests/html/browsers/browsing-the-web/navigating-across-documents/replace-before-load/resources/slow-code-injector.html
+/LayoutTests/imported/w3c/web-platform-tests/html/browsers/browsing-the-web/navigating-across-documents/replace-before-load/resources/slow-message-source-with-history-and-location.html

--- a/LayoutTests/imported/w3c/web-platform-tests/html/browsers/browsing-the-web/navigating-across-documents/replace-before-load/w3c-import.log
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/browsers/browsing-the-web/navigating-across-documents/replace-before-load/w3c-import.log
@@ -26,8 +26,12 @@ List of files:
 /LayoutTests/imported/w3c/web-platform-tests/html/browsers/browsing-the-web/navigating-across-documents/replace-before-load/form-submit-button-click-during-load.html
 /LayoutTests/imported/w3c/web-platform-tests/html/browsers/browsing-the-web/navigating-across-documents/replace-before-load/form-submit-button-click-during-pageshow.html
 /LayoutTests/imported/w3c/web-platform-tests/html/browsers/browsing-the-web/navigating-across-documents/replace-before-load/form-submit-button-click.html
+/LayoutTests/imported/w3c/web-platform-tests/html/browsers/browsing-the-web/navigating-across-documents/replace-before-load/form-submit-cross-frame-crossorigin.sub.html
+/LayoutTests/imported/w3c/web-platform-tests/html/browsers/browsing-the-web/navigating-across-documents/replace-before-load/form-submit-cross-frame.html
 /LayoutTests/imported/w3c/web-platform-tests/html/browsers/browsing-the-web/navigating-across-documents/replace-before-load/form-submit-during-load.html
 /LayoutTests/imported/w3c/web-platform-tests/html/browsers/browsing-the-web/navigating-across-documents/replace-before-load/form-submit-during-pageshow.html
+/LayoutTests/imported/w3c/web-platform-tests/html/browsers/browsing-the-web/navigating-across-documents/replace-before-load/form-submit-popup-crossorigin.sub.html
+/LayoutTests/imported/w3c/web-platform-tests/html/browsers/browsing-the-web/navigating-across-documents/replace-before-load/form-submit-popup.html
 /LayoutTests/imported/w3c/web-platform-tests/html/browsers/browsing-the-web/navigating-across-documents/replace-before-load/form-submit.html
 /LayoutTests/imported/w3c/web-platform-tests/html/browsers/browsing-the-web/navigating-across-documents/replace-before-load/history-pushstate-during-load.html
 /LayoutTests/imported/w3c/web-platform-tests/html/browsers/browsing-the-web/navigating-across-documents/replace-before-load/history-pushstate-during-pageshow.html

--- a/LayoutTests/platform/mac-wk1/imported/w3c/web-platform-tests/html/browsers/browsing-the-web/navigating-across-documents/replace-before-load/form-submit-cross-frame-expected.txt
+++ b/LayoutTests/platform/mac-wk1/imported/w3c/web-platform-tests/html/browsers/browsing-the-web/navigating-across-documents/replace-before-load/form-submit-cross-frame-expected.txt
@@ -1,0 +1,3 @@
+
+FAIL No replace before load, triggered by cross-iframe formElement.submit() assert_equals: frame's after-submit history.length expected 101 but got 100
+


### PR DESCRIPTION
#### 67b3e5cb9983cf1db362420f04e6277c8b0d5c77
<pre>
Resync html/browsers/browsing-the-web/navigating-across-documents/replace-before-load WPT
<a href="https://bugs.webkit.org/show_bug.cgi?id=256863">https://bugs.webkit.org/show_bug.cgi?id=256863</a>

Reviewed by Tim Nguyen.

Resync html/browsers/browsing-the-web/navigating-across-documents/replace-before-load WPT
from upstream cb1e54222a206b4cbb.

* LayoutTests/imported/w3c/web-platform-tests/html/browsers/browsing-the-web/navigating-across-documents/replace-before-load/form-submit-cross-frame-crossorigin.sub-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/html/browsers/browsing-the-web/navigating-across-documents/replace-before-load/form-submit-cross-frame-crossorigin.sub.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/html/browsers/browsing-the-web/navigating-across-documents/replace-before-load/form-submit-cross-frame-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/html/browsers/browsing-the-web/navigating-across-documents/replace-before-load/form-submit-cross-frame.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/html/browsers/browsing-the-web/navigating-across-documents/replace-before-load/form-submit-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/html/browsers/browsing-the-web/navigating-across-documents/replace-before-load/form-submit-popup-crossorigin.sub-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/html/browsers/browsing-the-web/navigating-across-documents/replace-before-load/form-submit-popup-crossorigin.sub.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/html/browsers/browsing-the-web/navigating-across-documents/replace-before-load/form-submit-popup-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/html/browsers/browsing-the-web/navigating-across-documents/replace-before-load/form-submit-popup.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/html/browsers/browsing-the-web/navigating-across-documents/replace-before-load/form-submit.html:
* LayoutTests/imported/w3c/web-platform-tests/html/browsers/browsing-the-web/navigating-across-documents/replace-before-load/history-pushstate-during-pageshow.html:
* LayoutTests/imported/w3c/web-platform-tests/html/browsers/browsing-the-web/navigating-across-documents/replace-before-load/location-setter-during-pageshow.html:
* LayoutTests/imported/w3c/web-platform-tests/html/browsers/browsing-the-web/navigating-across-documents/replace-before-load/resources/helpers.js:
(window.waitForMessage):
(window.insertIframe):
(window.changeURLHost):
* LayoutTests/imported/w3c/web-platform-tests/html/browsers/browsing-the-web/navigating-across-documents/replace-before-load/resources/slow-message-source-with-history-and-location.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/html/browsers/browsing-the-web/navigating-across-documents/replace-before-load/resources/w3c-import.log:
* LayoutTests/imported/w3c/web-platform-tests/html/browsers/browsing-the-web/navigating-across-documents/replace-before-load/w3c-import.log:

Canonical link: <a href="https://commits.webkit.org/264177@main">https://commits.webkit.org/264177@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/6e363f733d0cb2450bf91fdc2e7e6e32eb1ff925

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/6918 "Failed to checkout and rebase branch from PR 13941") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/7148 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/7331 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/8522 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/7164 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/8404 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/7087 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/10070 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/7040 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/7711 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/6372 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/8620 "Built successfully") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/39/builds/5091 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/6282 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/14075 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/6776 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/6372 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/9205 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/6850 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/5618 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/6226 "Built successfully") | [💥 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/6194 "An unexpected error occured. Recent messages:OS: Monterey (12.6.3), Xcode: 13.4.1; Skipping applying patch since patch_id isn't provided; Checked out pull request") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/1648 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/10411 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/6610 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->