### PR TITLE
Rename coreAbstractFrame to coreFrame and coreFrame to coreLocalFrame

### DIFF
--- a/Source/WebKit/WebProcess/InjectedBundle/API/Cocoa/WKWebProcessPlugInFrame.mm
+++ b/Source/WebKit/WebProcess/InjectedBundle/API/Cocoa/WKWebProcessPlugInFrame.mm
@@ -147,7 +147,7 @@
 
 - (NSString *)_securityOrigin
 {
-    auto* coreFrame = _frame->coreFrame();
+    auto* coreFrame = _frame->coreLocalFrame();
     if (!coreFrame)
         return nil;
     return coreFrame->document()->securityOrigin().toString();
@@ -167,12 +167,12 @@ static RetainPtr<NSArray> collectIcons(WebCore::LocalFrame* frame, OptionSet<Web
 
 - (NSArray *)appleTouchIconURLs
 {
-    return collectIcons(_frame->coreFrame(), { WebCore::LinkIconType::TouchIcon, WebCore::LinkIconType::TouchPrecomposedIcon }).autorelease();
+    return collectIcons(_frame->coreLocalFrame(), { WebCore::LinkIconType::TouchIcon, WebCore::LinkIconType::TouchPrecomposedIcon }).autorelease();
 }
 
 - (NSArray *)faviconURLs
 {
-    return collectIcons(_frame->coreFrame(), WebCore::LinkIconType::Favicon).autorelease();
+    return collectIcons(_frame->coreLocalFrame(), WebCore::LinkIconType::Favicon).autorelease();
 }
 
 - (WKWebProcessPlugInFrame *)_parentFrame

--- a/Source/WebKit/WebProcess/InjectedBundle/API/c/WKBundleFrame.cpp
+++ b/Source/WebKit/WebProcess/InjectedBundle/API/c/WKBundleFrame.cpp
@@ -73,7 +73,7 @@ WKURLRef WKBundleFrameCopyProvisionalURL(WKBundleFrameRef frameRef)
 
 WKFrameLoadState WKBundleFrameGetFrameLoadState(WKBundleFrameRef frameRef)
 {
-    auto* coreFrame = WebKit::toImpl(frameRef)->coreFrame();
+    auto* coreFrame = WebKit::toImpl(frameRef)->coreLocalFrame();
     if (!coreFrame)
         return kWKFrameLoadStateFinished;
 
@@ -147,7 +147,7 @@ WKBundlePageRef WKBundleFrameGetPage(WKBundleFrameRef frameRef)
 
 void WKBundleFrameClearOpener(WKBundleFrameRef frameRef)
 {
-    auto* coreFrame = WebKit::toImpl(frameRef)->coreFrame();
+    auto* coreFrame = WebKit::toImpl(frameRef)->coreLocalFrame();
     if (coreFrame)
         coreFrame->loader().setOpener(0);
 }
@@ -260,7 +260,7 @@ WKDataRef WKBundleFrameCopyWebArchiveFilteringSubframes(WKBundleFrameRef frameRe
 
 bool WKBundleFrameCallShouldCloseOnWebView(WKBundleFrameRef frameRef)
 {
-    auto* coreFrame = WebKit::toImpl(frameRef)->coreFrame();
+    auto* coreFrame = WebKit::toImpl(frameRef)->coreLocalFrame();
     if (!coreFrame)
         return true;
 
@@ -274,7 +274,7 @@ WKBundleHitTestResultRef WKBundleFrameCreateHitTestResult(WKBundleFrameRef frame
 
 WKSecurityOriginRef WKBundleFrameCopySecurityOrigin(WKBundleFrameRef frameRef)
 {
-    auto* coreFrame = WebKit::toImpl(frameRef)->coreFrame();
+    auto* coreFrame = WebKit::toImpl(frameRef)->coreLocalFrame();
     if (!coreFrame)
         return 0;
 
@@ -283,7 +283,7 @@ WKSecurityOriginRef WKBundleFrameCopySecurityOrigin(WKBundleFrameRef frameRef)
 
 void WKBundleFrameFocus(WKBundleFrameRef frameRef)
 {
-    RefPtr coreFrame = WebKit::toImpl(frameRef)->coreFrame();
+    RefPtr coreFrame = WebKit::toImpl(frameRef)->coreLocalFrame();
     if (!coreFrame)
         return;
 
@@ -292,7 +292,7 @@ void WKBundleFrameFocus(WKBundleFrameRef frameRef)
 
 void _WKBundleFrameGenerateTestReport(WKBundleFrameRef frameRef, WKStringRef message, WKStringRef group)
 {
-    RefPtr coreFrame = WebKit::toImpl(frameRef)->coreFrame();
+    RefPtr coreFrame = WebKit::toImpl(frameRef)->coreLocalFrame();
     if (!coreFrame)
         return;
 

--- a/Source/WebKit/WebProcess/InjectedBundle/API/c/mac/WKBundlePageMac.mm
+++ b/Source/WebKit/WebProcess/InjectedBundle/API/c/mac/WKBundlePageMac.mm
@@ -38,7 +38,7 @@ WK_EXPORT PDFDocument *WKBundlePageGetPDFDocumentInFrame(WKBundlePageRef, WKBund
     UNUSED_PARAM(frame);
     return nil;
 #else
-    auto* pluginView = WebKit::WebPage::pluginViewForFrame(WebKit::toImpl(frame)->coreFrame());
+    auto* pluginView = WebKit::WebPage::pluginViewForFrame(WebKit::toImpl(frame)->coreLocalFrame());
     if (!pluginView)
         return nil;
 

--- a/Source/WebKit/WebProcess/InjectedBundle/API/glib/WebKitFrame.cpp
+++ b/Source/WebKit/WebProcess/InjectedBundle/API/glib/WebKitFrame.cpp
@@ -66,9 +66,9 @@ static void webkit_frame_class_init(WebKitFrameClass*)
 
 static CString getURL(WebFrame* webFrame)
 {
-    auto* documentLoader = webFrame->coreFrame()->loader().provisionalDocumentLoader();
+    auto* documentLoader = webFrame->coreLocalFrame()->loader().provisionalDocumentLoader();
     if (!documentLoader)
-        documentLoader = webFrame->coreFrame()->loader().documentLoader();
+        documentLoader = webFrame->coreLocalFrame()->loader().documentLoader();
 
     ASSERT(documentLoader);
 
@@ -104,7 +104,7 @@ Vector<GRefPtr<JSCValue>> webkitFrameGetJSCValuesForElementsInWorld(WebKitFrame*
 {
     auto* wkWorld = webkitScriptWorldGetInjectedBundleScriptWorld(world);
     auto jsContext = jscContextGetOrCreate(frame->priv->webFrame->jsContextForWorld(wkWorld));
-    auto* globalObject = frame->priv->webFrame->coreFrame()->script().globalObject(wkWorld->coreWorld());
+    auto* globalObject = frame->priv->webFrame->coreLocalFrame()->script().globalObject(wkWorld->coreWorld());
     return elements.map([&jsContext, globalObject](auto& element) -> GRefPtr<JSCValue> {
         JSValueRef jsValue = nullptr;
         {
@@ -307,7 +307,7 @@ JSCValue* webkit_frame_get_js_value_for_dom_object_in_script_world(WebKitFrame* 
 
     auto* wkWorld = webkitScriptWorldGetInjectedBundleScriptWorld(world);
     auto jsContext = jscContextGetOrCreate(frame->priv->webFrame->jsContextForWorld(wkWorld));
-    auto* globalObject = frame->priv->webFrame->coreFrame()->script().globalObject(wkWorld->coreWorld());
+    auto* globalObject = frame->priv->webFrame->coreLocalFrame()->script().globalObject(wkWorld->coreWorld());
     JSValueRef jsValue = nullptr;
     {
         JSC::JSLockHolder lock(globalObject);

--- a/Source/WebKit/WebProcess/InjectedBundle/API/glib/WebKitWebPage.cpp
+++ b/Source/WebKit/WebProcess/InjectedBundle/API/glib/WebKitWebPage.cpp
@@ -110,7 +110,7 @@ class WebKitFrameWrapper final: public FrameDestructionObserver {
     WTF_MAKE_FAST_ALLOCATED;
 public:
     WebKitFrameWrapper(WebFrame& webFrame)
-        : FrameDestructionObserver(webFrame.coreFrame())
+        : FrameDestructionObserver(webFrame.coreLocalFrame())
         , m_webkitFrame(adoptGRef(webkitFrameCreate(&webFrame)))
     {
     }
@@ -193,7 +193,7 @@ private:
         if (!webKitFrame && !frame.isMainFrame())
             return;
 
-        const auto uri = getDocumentLoaderURL(frame.coreFrame()->loader().provisionalDocumentLoader());
+        const auto uri = getDocumentLoaderURL(frame.coreLocalFrame()->loader().provisionalDocumentLoader());
 
         if (webKitFrame)
             webkitFrameSetURI(webKitFrame, uri);
@@ -208,7 +208,7 @@ private:
         if (!webKitFrame && !frame.isMainFrame())
             return;
 
-        const auto uri = getDocumentLoaderURL(frame.coreFrame()->loader().provisionalDocumentLoader());
+        const auto uri = getDocumentLoaderURL(frame.coreLocalFrame()->loader().provisionalDocumentLoader());
 
         if (webKitFrame)
             webkitFrameSetURI(webKitFrame, uri);
@@ -223,7 +223,7 @@ private:
         if (!webKitFrame && !frame.isMainFrame())
             return;
 
-        const auto uri = frame.coreFrame()->document()->url().string().utf8();
+        const auto uri = frame.coreLocalFrame()->document()->url().string().utf8();
 
         if (webKitFrame)
             webkitFrameSetURI(webKitFrame, uri);
@@ -238,7 +238,7 @@ private:
         if (!webKitFrame && !frame.isMainFrame())
             return;
 
-        const auto uri = getDocumentLoaderURL(frame.coreFrame()->loader().documentLoader());
+        const auto uri = getDocumentLoaderURL(frame.coreLocalFrame()->loader().documentLoader());
 
         if (webKitFrame)
             webkitFrameSetURI(webKitFrame, uri);

--- a/Source/WebKit/WebProcess/InjectedBundle/InjectedBundle.cpp
+++ b/Source/WebKit/WebProcess/InjectedBundle/InjectedBundle.cpp
@@ -179,7 +179,7 @@ void InjectedBundle::setAsynchronousSpellCheckingEnabled(bool enabled)
 
 int InjectedBundle::numberOfPages(WebFrame* frame, double pageWidthInPixels, double pageHeightInPixels)
 {
-    auto* coreFrame = frame ? frame->coreFrame() : nullptr;
+    auto* coreFrame = frame ? frame->coreLocalFrame() : nullptr;
     if (!coreFrame)
         return -1;
     if (!pageWidthInPixels)
@@ -192,7 +192,7 @@ int InjectedBundle::numberOfPages(WebFrame* frame, double pageWidthInPixels, dou
 
 int InjectedBundle::pageNumberForElementById(WebFrame* frame, const String& id, double pageWidthInPixels, double pageHeightInPixels)
 {
-    auto* coreFrame = frame ? frame->coreFrame() : nullptr;
+    auto* coreFrame = frame ? frame->coreLocalFrame() : nullptr;
     if (!coreFrame)
         return -1;
 
@@ -210,7 +210,7 @@ int InjectedBundle::pageNumberForElementById(WebFrame* frame, const String& id, 
 
 String InjectedBundle::pageSizeAndMarginsInPixels(WebFrame* frame, int pageIndex, int width, int height, int marginTop, int marginRight, int marginBottom, int marginLeft)
 {
-    auto* coreFrame = frame ? frame->coreFrame() : nullptr;
+    auto* coreFrame = frame ? frame->coreLocalFrame() : nullptr;
     if (!coreFrame)
         return String();
 
@@ -219,7 +219,7 @@ String InjectedBundle::pageSizeAndMarginsInPixels(WebFrame* frame, int pageIndex
 
 bool InjectedBundle::isPageBoxVisible(WebFrame* frame, int pageIndex)
 {
-    auto* coreFrame = frame ? frame->coreFrame() : nullptr;
+    auto* coreFrame = frame ? frame->coreLocalFrame() : nullptr;
     if (!coreFrame)
         return false;
 

--- a/Source/WebKit/WebProcess/InjectedBundle/InjectedBundleDOMWindowExtension.cpp
+++ b/Source/WebKit/WebProcess/InjectedBundle/InjectedBundleDOMWindowExtension.cpp
@@ -58,7 +58,7 @@ InjectedBundleDOMWindowExtension* InjectedBundleDOMWindowExtension::get(DOMWindo
 }
 
 InjectedBundleDOMWindowExtension::InjectedBundleDOMWindowExtension(WebFrame* frame, InjectedBundleScriptWorld* world)
-    : m_coreExtension(DOMWindowExtension::create(frame->coreFrame() ? frame->coreFrame()->window() : nullptr, world->coreWorld()))
+    : m_coreExtension(DOMWindowExtension::create(frame->coreLocalFrame() ? frame->coreLocalFrame()->window() : nullptr, world->coreWorld()))
 {
     allExtensions().add(m_coreExtension.get(), this);
 }

--- a/Source/WebKit/WebProcess/InjectedBundle/InjectedBundleHitTestResult.cpp
+++ b/Source/WebKit/WebProcess/InjectedBundle/InjectedBundleHitTestResult.cpp
@@ -154,7 +154,7 @@ IntRect InjectedBundleHitTestResult::imageRect() const
     if (!webFrame)
         return imageRect;
     
-    auto* coreFrame = webFrame->coreFrame();
+    auto* coreFrame = webFrame->coreLocalFrame();
     if (!coreFrame)
         return imageRect;
     

--- a/Source/WebKit/WebProcess/Inspector/WebInspector.cpp
+++ b/Source/WebKit/WebProcess/Inspector/WebInspector.cpp
@@ -190,7 +190,7 @@ void WebInspector::showMainResourceForFrame(WebCore::FrameIdentifier frameIdenti
 
     m_page->corePage()->inspectorController().show();
 
-    String inspectorFrameIdentifier = m_page->corePage()->inspectorController().ensurePageAgent().frameId(frame->coreFrame());
+    String inspectorFrameIdentifier = m_page->corePage()->inspectorController().ensurePageAgent().frameId(frame->coreLocalFrame());
 
     whenFrontendConnectionEstablished([=, this] {
         m_frontendConnection->send(Messages::WebInspectorUI::ShowMainResourceForFrame(inspectorFrameIdentifier), 0);

--- a/Source/WebKit/WebProcess/Network/WebLoaderStrategy.cpp
+++ b/Source/WebKit/WebProcess/Network/WebLoaderStrategy.cpp
@@ -743,7 +743,7 @@ void WebLoaderStrategy::loadResourceSynchronously(FrameLoader& frameLoader, WebC
     loadParameters.contentEncodingSniffingPolicy = ContentEncodingSniffingPolicy::Default;
     loadParameters.storedCredentialsPolicy = options.credentials == FetchOptions::Credentials::Omit ? StoredCredentialsPolicy::DoNotUse : StoredCredentialsPolicy::Use;
     loadParameters.clientCredentialPolicy = clientCredentialPolicy;
-    loadParameters.shouldClearReferrerOnHTTPSToHTTPRedirect = shouldClearReferrerOnHTTPSToHTTPRedirect(webFrame ? webFrame->coreFrame() : nullptr);
+    loadParameters.shouldClearReferrerOnHTTPSToHTTPRedirect = shouldClearReferrerOnHTTPSToHTTPRedirect(webFrame ? webFrame->coreLocalFrame() : nullptr);
     loadParameters.shouldRestrictHTTPResponseAccess = shouldPerformSecurityChecks();
 
     loadParameters.options = options;
@@ -758,7 +758,7 @@ void WebLoaderStrategy::loadResourceSynchronously(FrameLoader& frameLoader, WebC
     if (webFrame)
         loadParameters.isNavigatingToAppBoundDomain = webFrame->isTopFrameNavigatingToAppBoundDomain();
 #endif
-    addParametersShared(webFrame->coreFrame(), loadParameters);
+    addParametersShared(webFrame->coreLocalFrame(), loadParameters);
 
     data.shrink(0);
 

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebChromeClient.cpp
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebChromeClient.cpp
@@ -496,7 +496,7 @@ void WebChromeClient::closeWindow()
     m_page.corePage()->setGroupName(String());
 
     auto& frame = m_page.mainWebFrame();
-    if (auto* coreFrame = frame.coreFrame())
+    if (auto* coreFrame = frame.coreLocalFrame())
         coreFrame->loader().stopForUserCancel();
 
     m_page.sendClose();

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebFrameLoaderClient.cpp
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebFrameLoaderClient.cpp
@@ -107,7 +107,7 @@ void WebFrameLoaderClient::dispatchDecidePolicyForNavigationAction(const Navigat
     }
 
     // FIXME: Move all this DocumentLoader stuff to the caller, pass in the results.
-    RefPtr coreFrame = m_frame->coreFrame();
+    RefPtr coreFrame = m_frame->coreLocalFrame();
 
     WebDocumentLoader* documentLoader = coreFrame ? static_cast<WebDocumentLoader*>(coreFrame->loader().policyDocumentLoader()) : nullptr;
     if (!documentLoader) {

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebLocalFrameLoaderClient.cpp
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebLocalFrameLoaderClient.cpp
@@ -362,9 +362,9 @@ void WebLocalFrameLoaderClient::dispatchDidReceiveServerRedirectForProvisionalLo
     if (!webPage)
         return;
 
-    WebDocumentLoader* documentLoader = static_cast<WebDocumentLoader*>(m_frame->coreFrame()->loader().provisionalDocumentLoader());
+    WebDocumentLoader* documentLoader = static_cast<WebDocumentLoader*>(m_frame->coreLocalFrame()->loader().provisionalDocumentLoader());
     if (!documentLoader) {
-        WebLocalFrameLoaderClient_RELEASE_LOG_FAULT(Loading, "dispatchDidReceiveServerRedirectForProvisionalLoad: Called with no provisional DocumentLoader (frameState=%hhu, stateForDebugging=%i)", m_frame->coreFrame()->loader().state(), m_frame->coreFrame()->loader().stateMachine().stateForDebugging());
+        WebLocalFrameLoaderClient_RELEASE_LOG_FAULT(Loading, "dispatchDidReceiveServerRedirectForProvisionalLoad: Called with no provisional DocumentLoader (frameState=%hhu, stateForDebugging=%i)", m_frame->coreLocalFrame()->loader().state(), m_frame->coreLocalFrame()->loader().stateMachine().stateForDebugging());
         return;
     }
 
@@ -385,7 +385,7 @@ void WebLocalFrameLoaderClient::dispatchDidChangeProvisionalURL()
     if (!webPage)
         return;
 
-    WebDocumentLoader& documentLoader = static_cast<WebDocumentLoader&>(*m_frame->coreFrame()->loader().provisionalDocumentLoader());
+    WebDocumentLoader& documentLoader = static_cast<WebDocumentLoader&>(*m_frame->coreLocalFrame()->loader().provisionalDocumentLoader());
     webPage->send(Messages::WebPageProxy::DidChangeProvisionalURLForFrame(m_frame->frameID(), documentLoader.navigationID(), documentLoader.url()));
 }
 
@@ -423,13 +423,13 @@ void WebLocalFrameLoaderClient::dispatchDidChangeLocationWithinPage()
 
     RefPtr<API::Object> userData;
 
-    auto navigationID = static_cast<WebDocumentLoader&>(*m_frame->coreFrame()->loader().documentLoader()).navigationID();
+    auto navigationID = static_cast<WebDocumentLoader&>(*m_frame->coreLocalFrame()->loader().documentLoader()).navigationID();
 
     // Notify the bundle client.
     webPage->injectedBundleLoaderClient().didSameDocumentNavigationForFrame(*webPage, m_frame, SameDocumentNavigationType::AnchorNavigation, userData);
 
     // Notify the UIProcess.
-    webPage->send(Messages::WebPageProxy::DidSameDocumentNavigationForFrame(m_frame->frameID(), navigationID, SameDocumentNavigationType::AnchorNavigation, m_frame->coreFrame()->document()->url(), UserData(WebProcess::singleton().transformObjectsToHandles(userData.get()).get())));
+    webPage->send(Messages::WebPageProxy::DidSameDocumentNavigationForFrame(m_frame->frameID(), navigationID, SameDocumentNavigationType::AnchorNavigation, m_frame->coreLocalFrame()->document()->url(), UserData(WebProcess::singleton().transformObjectsToHandles(userData.get()).get())));
 }
 
 void WebLocalFrameLoaderClient::dispatchDidChangeMainDocument()
@@ -485,7 +485,7 @@ void WebLocalFrameLoaderClient::didSameDocumentNavigationForFrameViaJSHistoryAPI
         true, /* treatAsSameOriginNavigation */
         false, /* hasOpenedFrames */
         false, /* openedByDOMWithOpener */
-        !!m_frame->coreFrame()->loader().opener(), /* hasOpener */
+        !!m_frame->coreLocalFrame()->loader().opener(), /* hasOpener */
         { }, /* requesterOrigin */
         std::nullopt, /* targetBackForwardItemIdentifier */
         std::nullopt, /* sourceBackForwardItemIdentifier */
@@ -501,7 +501,7 @@ void WebLocalFrameLoaderClient::didSameDocumentNavigationForFrameViaJSHistoryAPI
     };
 
     // Notify the UIProcess.
-    webPage->send(Messages::WebPageProxy::DidSameDocumentNavigationForFrameViaJSHistoryAPI(m_frame->frameID(), navigationType, m_frame->coreFrame()->document()->url(), navigationActionData, UserData(WebProcess::singleton().transformObjectsToHandles(userData.get()).get())));
+    webPage->send(Messages::WebPageProxy::DidSameDocumentNavigationForFrameViaJSHistoryAPI(m_frame->frameID(), navigationType, m_frame->coreLocalFrame()->document()->url(), navigationActionData, UserData(WebProcess::singleton().transformObjectsToHandles(userData.get()).get())));
 
 }
 
@@ -542,7 +542,7 @@ void WebLocalFrameLoaderClient::dispatchDidStartProvisionalLoad()
         return;
 
 #if ENABLE(FULLSCREEN_API)
-    auto* document = m_frame->coreFrame()->document();
+    auto* document = m_frame->coreLocalFrame()->document();
     if (document && document->fullscreenManager().fullscreenElement())
         webPage->fullScreenManager()->exitFullScreenForElement(webPage->fullScreenManager()->element());
 #endif
@@ -554,7 +554,7 @@ void WebLocalFrameLoaderClient::dispatchDidStartProvisionalLoad()
 
     // Notify the bundle client.
     webPage->injectedBundleLoaderClient().didStartProvisionalLoadForFrame(*webPage, m_frame, userData);
-    RefPtr provisionalLoader = static_cast<WebDocumentLoader*>(m_frame->coreFrame()->loader().provisionalDocumentLoader());
+    RefPtr provisionalLoader = static_cast<WebDocumentLoader*>(m_frame->coreLocalFrame()->loader().provisionalDocumentLoader());
 
     if (!provisionalLoader || provisionalLoader->isContinuingLoadAfterProvisionalLoadStarted())
         return;
@@ -598,7 +598,7 @@ void WebLocalFrameLoaderClient::dispatchDidCommitLoad(std::optional<HasInsecureC
     if (!webPage)
         return;
 
-    WebDocumentLoader& documentLoader = static_cast<WebDocumentLoader&>(*m_frame->coreFrame()->loader().documentLoader());
+    WebDocumentLoader& documentLoader = static_cast<WebDocumentLoader&>(*m_frame->coreLocalFrame()->loader().documentLoader());
     RefPtr<API::Object> userData;
 
     // Notify the bundle client.
@@ -626,7 +626,7 @@ void WebLocalFrameLoaderClient::dispatchDidCommitLoad(std::optional<HasInsecureC
 #endif
 
     // Notify the UIProcess.
-    webPage->send(Messages::WebPageProxy::DidCommitLoadForFrame(m_frame->frameID(), m_frame->info(), documentLoader.request(), documentLoader.navigationID(), documentLoader.response().mimeType(), m_frameHasCustomContentProvider, m_frame->coreFrame()->loader().loadType(), certificateInfo, usedLegacyTLS, wasPrivateRelayed, m_frame->coreFrame()->document()->isPluginDocument(), *hasInsecureContent, documentLoader.mouseEventPolicy(), UserData(WebProcess::singleton().transformObjectsToHandles(userData.get()).get())));
+    webPage->send(Messages::WebPageProxy::DidCommitLoadForFrame(m_frame->frameID(), m_frame->info(), documentLoader.request(), documentLoader.navigationID(), documentLoader.response().mimeType(), m_frameHasCustomContentProvider, m_frame->coreLocalFrame()->loader().loadType(), certificateInfo, usedLegacyTLS, wasPrivateRelayed, m_frame->coreLocalFrame()->document()->isPluginDocument(), *hasInsecureContent, documentLoader.mouseEventPolicy(), UserData(WebProcess::singleton().transformObjectsToHandles(userData.get()).get())));
     webPage->didCommitLoad(m_frame.ptr());
 }
 
@@ -661,13 +661,13 @@ void WebLocalFrameLoaderClient::dispatchDidFailProvisionalLoad(const ResourceErr
     // the entire LocalFrameLoaderClient function was complete.
     uint64_t navigationID = 0;
     ResourceRequest request;
-    if (auto documentLoader = m_frame->coreFrame()->loader().provisionalDocumentLoader()) {
+    if (auto documentLoader = m_frame->coreLocalFrame()->loader().provisionalDocumentLoader()) {
         navigationID = static_cast<WebDocumentLoader*>(documentLoader)->navigationID();
         request = documentLoader->request();
     }
 
     // Notify the UIProcess.
-    auto* coreFrame = m_frame->coreFrame();
+    auto* coreFrame = m_frame->coreLocalFrame();
     webPage->send(Messages::WebPageProxy::DidFailProvisionalLoadForFrame(m_frame->frameID(), m_frame->info(), request, navigationID, coreFrame->loader().provisionalLoadErrorBeingHandledURL().string(), error, willContinueLoading, UserData(WebProcess::singleton().transformObjectsToHandles(userData.get()).get()), willInternallyHandleFailure));
 
     // If we have a load listener, notify it.
@@ -685,7 +685,7 @@ void WebLocalFrameLoaderClient::dispatchDidFailLoad(const ResourceError& error)
 
     RefPtr<API::Object> userData;
 
-    auto& documentLoader = static_cast<WebDocumentLoader&>(*m_frame->coreFrame()->loader().documentLoader());
+    auto& documentLoader = static_cast<WebDocumentLoader&>(*m_frame->coreLocalFrame()->loader().documentLoader());
     auto navigationID = documentLoader.navigationID();
 
     // Notify the bundle client.
@@ -713,7 +713,7 @@ void WebLocalFrameLoaderClient::dispatchDidFinishDocumentLoad()
 
     RefPtr<API::Object> userData;
 
-    auto navigationID = static_cast<WebDocumentLoader&>(*m_frame->coreFrame()->loader().documentLoader()).navigationID();
+    auto navigationID = static_cast<WebDocumentLoader&>(*m_frame->coreLocalFrame()->loader().documentLoader()).navigationID();
 
     // Notify the bundle client.
     webPage->injectedBundleLoaderClient().didFinishDocumentLoadForFrame(*webPage, m_frame, userData);
@@ -732,7 +732,7 @@ void WebLocalFrameLoaderClient::dispatchDidFinishLoad()
 
     RefPtr<API::Object> userData;
 
-    Ref documentLoader = static_cast<WebDocumentLoader&>(*m_frame->coreFrame()->loader().documentLoader());
+    Ref documentLoader = static_cast<WebDocumentLoader&>(*m_frame->coreLocalFrame()->loader().documentLoader());
     auto navigationID = documentLoader->navigationID();
 
     // Notify the bundle client.
@@ -786,7 +786,7 @@ void WebLocalFrameLoaderClient::dispatchDidReachLayoutMilestone(OptionSet<WebCor
 
 #if USE(COORDINATED_GRAPHICS)
         // Make sure viewport properties are dispatched on the main frame by the time the first layout happens.
-        ASSERT(!webPage->useFixedLayout() || m_frame.ptr() != &m_frame->page()->mainWebFrame() || m_frame->coreFrame()->document()->didDispatchViewportPropertiesChanged());
+        ASSERT(!webPage->useFixedLayout() || m_frame.ptr() != &m_frame->page()->mainWebFrame() || m_frame->coreLocalFrame()->document()->didDispatchViewportPropertiesChanged());
 #endif
     }
 
@@ -867,7 +867,7 @@ LocalFrame* WebLocalFrameLoaderClient::dispatchCreatePage(const NavigationAction
     // Just call through to the chrome client.
     WindowFeatures windowFeatures;
     windowFeatures.noopener = newFrameOpenerPolicy == NewFrameOpenerPolicy::Suppress;
-    Page* newPage = webPage->corePage()->chrome().createWindow(*m_frame->coreFrame(), windowFeatures, navigationAction);
+    Page* newPage = webPage->corePage()->chrome().createWindow(*m_frame->coreLocalFrame(), windowFeatures, navigationAction);
     if (!newPage)
         return nullptr;
     
@@ -910,7 +910,7 @@ void WebLocalFrameLoaderClient::dispatchDecidePolicyForResponse(const ResourceRe
 
     bool canShowResponse = webPage->canShowResponse(response);
 
-    auto* coreFrame = m_frame->coreFrame();
+    auto* coreFrame = m_frame->coreLocalFrame();
     auto* policyDocumentLoader = coreFrame ? coreFrame->loader().provisionalDocumentLoader() : nullptr;
     auto navigationID = policyDocumentLoader ? static_cast<WebDocumentLoader&>(*policyDocumentLoader).navigationID() : 0;
 
@@ -960,7 +960,7 @@ void WebLocalFrameLoaderClient::dispatchDecidePolicyForNewWindowAction(const Nav
         navigationAction.privateClickMeasurement(),
         { }, /* networkConnectionIntegrityPolicy */
 #if PLATFORM(MAC) || HAVE(UIKIT_WITH_MOUSE_SUPPORT)
-        WebHitTestResultData::fromNavigationActionAndLocalFrame(navigationAction, m_frame->coreFrame()),
+        WebHitTestResultData::fromNavigationActionAndLocalFrame(navigationAction, m_frame->coreLocalFrame()),
 #endif
     };
 
@@ -970,7 +970,7 @@ void WebLocalFrameLoaderClient::dispatchDecidePolicyForNewWindowAction(const Nav
 
 void WebLocalFrameLoaderClient::applyToDocumentLoader(WebsitePoliciesData&& websitePolicies)
 {
-    auto* coreFrame = m_frame->coreFrame();
+    auto* coreFrame = m_frame->coreLocalFrame();
     if (!coreFrame)
         return;
     WebDocumentLoader* documentLoader = static_cast<WebDocumentLoader*>(coreFrame->loader().policyDocumentLoader());
@@ -1117,7 +1117,7 @@ void WebLocalFrameLoaderClient::committedLoad(DocumentLoader* loader, const Shar
     // If the document is a stand-alone media document, now is the right time to cancel the WebKit load.
     // FIXME: This code should be shared across all ports. <http://webkit.org/b/48762>.
 #if ENABLE(VIDEO)
-    if (is<MediaDocument>(m_frame->coreFrame()->document()))
+    if (is<MediaDocument>(m_frame->coreLocalFrame()->document()))
         loader->cancelMainResourceLoad(pluginWillHandleLoadError(loader->response()));
 #endif
 
@@ -1180,7 +1180,7 @@ void WebLocalFrameLoaderClient::updateGlobalHistory()
     if (!webPage)
         return;
 
-    DocumentLoader* loader = m_frame->coreFrame()->loader().documentLoader();
+    DocumentLoader* loader = m_frame->coreLocalFrame()->loader().documentLoader();
 
     WebNavigationDataStore data;
     data.url = loader->url().string();
@@ -1198,7 +1198,7 @@ void WebLocalFrameLoaderClient::updateGlobalHistoryRedirectLinks()
     if (!webPage)
         return;
 
-    DocumentLoader* loader = m_frame->coreFrame()->loader().documentLoader();
+    DocumentLoader* loader = m_frame->coreLocalFrame()->loader().documentLoader();
     ASSERT(loader->unreachableURL().isEmpty());
 
     // Client redirect
@@ -1366,7 +1366,7 @@ void WebLocalFrameLoaderClient::saveViewStateToItem(HistoryItem& historyItem)
 void WebLocalFrameLoaderClient::restoreViewState()
 {
 #if PLATFORM(IOS_FAMILY)
-    auto& frame = *m_frame->coreFrame();
+    auto& frame = *m_frame->coreLocalFrame();
     auto* currentItem = frame.loader().history().currentItem();
     if (auto* view = frame.view()) {
         if (m_frame->isMainFrame())
@@ -1376,7 +1376,7 @@ void WebLocalFrameLoaderClient::restoreViewState()
     }
 #else
     // Inform the UI process of the scale factor.
-    double scaleFactor = m_frame->coreFrame()->loader().history().currentItem()->pageScaleFactor();
+    double scaleFactor = m_frame->coreLocalFrame()->loader().history().currentItem()->pageScaleFactor();
 
     // A scale factor of 0 means the history item has the default scale factor, thus we do not need to update it.
     if (scaleFactor)
@@ -1415,12 +1415,12 @@ void WebLocalFrameLoaderClient::prepareForDataSourceReplacement()
 
 Ref<DocumentLoader> WebLocalFrameLoaderClient::createDocumentLoader(const ResourceRequest& request, const SubstituteData& substituteData)
 {
-    return m_frame->page()->createDocumentLoader(*m_frame->coreFrame(), request, substituteData);
+    return m_frame->page()->createDocumentLoader(*m_frame->coreLocalFrame(), request, substituteData);
 }
 
 void WebLocalFrameLoaderClient::updateCachedDocumentLoader(WebCore::DocumentLoader& loader)
 {
-    m_frame->page()->updateCachedDocumentLoader(static_cast<WebDocumentLoader&>(loader), *m_frame->coreFrame());
+    m_frame->page()->updateCachedDocumentLoader(static_cast<WebDocumentLoader&>(loader), *m_frame->coreLocalFrame());
 }
 
 void WebLocalFrameLoaderClient::setTitle(const StringWithDirection& title, const URL& url)
@@ -1457,7 +1457,7 @@ void WebLocalFrameLoaderClient::savePlatformDataToCachedFrame(CachedFrame*)
 
 void WebLocalFrameLoaderClient::transitionToCommittedFromCachedFrame(CachedFrame*)
 {
-    const ResourceResponse& response = m_frame->coreFrame()->loader().documentLoader()->response();
+    const ResourceResponse& response = m_frame->coreLocalFrame()->loader().documentLoader()->response();
     m_frameHasCustomContentProvider = m_frame->isMainFrame() && m_frame->page()->shouldUseCustomContentProviderForResponse(response);
     m_frameCameFromBackForwardCache = true;
 }
@@ -1472,7 +1472,7 @@ void WebLocalFrameLoaderClient::transitionToCommittedForNewPage()
     bool shouldHideScrollbars = shouldDisableScrolling;
     IntRect fixedVisibleContentRect;
 
-    auto oldView = m_frame->coreFrame()->view();
+    auto oldView = m_frame->coreLocalFrame()->view();
 
     auto overrideSizeForCSSDefaultViewportUnits = oldView ? oldView->overrideSizeForCSSDefaultViewportUnits() : std::nullopt;
     auto overrideSizeForCSSSmallViewportUnits = oldView ? oldView->overrideSizeForCSSSmallViewportUnits() : std::nullopt;
@@ -1486,8 +1486,8 @@ void WebLocalFrameLoaderClient::transitionToCommittedForNewPage()
 #endif
 
     m_frameHasCustomContentProvider = isMainFrame
-        && m_frame->coreFrame()->loader().documentLoader()
-        && webPage->shouldUseCustomContentProviderForResponse(m_frame->coreFrame()->loader().documentLoader()->response());
+        && m_frame->coreLocalFrame()->loader().documentLoader()
+        && webPage->shouldUseCustomContentProviderForResponse(m_frame->coreLocalFrame()->loader().documentLoader()->response());
     m_frameCameFromBackForwardCache = false;
 
     ScrollbarMode defaultScrollbarMode = shouldHideScrollbars ? ScrollbarMode::AlwaysOff : ScrollbarMode::Auto;
@@ -1498,11 +1498,11 @@ void WebLocalFrameLoaderClient::transitionToCommittedForNewPage()
     bool horizontalLock = shouldHideScrollbars || webPage->alwaysShowsHorizontalScroller();
     bool verticalLock = shouldHideScrollbars || webPage->alwaysShowsVerticalScroller();
 
-    m_frame->coreFrame()->createView(webPage->size(), webPage->backgroundColor(),
+    m_frame->coreLocalFrame()->createView(webPage->size(), webPage->backgroundColor(),
         webPage->fixedLayoutSize(), fixedVisibleContentRect, shouldUseFixedLayout,
         horizontalScrollbarMode, horizontalLock, verticalScrollbarMode, verticalLock);
 
-    RefPtr view = m_frame->coreFrame()->view();
+    RefPtr view = m_frame->coreLocalFrame()->view();
 
     if (overrideSizeForCSSDefaultViewportUnits)
         view->setOverrideSizeForCSSDefaultViewportUnits(*overrideSizeForCSSDefaultViewportUnits);
@@ -1577,7 +1577,7 @@ RefPtr<LocalFrame> WebLocalFrameLoaderClient::createFrame(const AtomString& name
     auto* webPage = m_frame->page();
     ASSERT(webPage);
     auto subframe = WebFrame::createSubframe(*webPage, m_frame, name, ownerElement);
-    auto* coreSubframe = subframe->coreFrame();
+    auto* coreSubframe = subframe->coreLocalFrame();
     if (!coreSubframe)
         return nullptr;
 
@@ -1653,7 +1653,7 @@ ObjectContentType WebLocalFrameLoaderClient::objectContentType(const URL& url, c
         return ObjectContentType::Image;
 
     if (WebPage* webPage = m_frame->page()) {
-        auto allowedPluginTypes = webFrame().coreFrame()->arePluginsEnabled()
+        auto allowedPluginTypes = webFrame().coreLocalFrame()->arePluginsEnabled()
             ? PluginData::AllPlugins : PluginData::OnlyApplicationPlugins;
         if (webPage->corePage()->pluginData().supportsMimeType(mimeType, allowedPluginTypes))
             return ObjectContentType::PlugIn;
@@ -1807,7 +1807,7 @@ void WebLocalFrameLoaderClient::didChangeScrollOffset()
     if (!webPage)
         return;
 
-    webPage->didChangeScrollOffsetForFrame(m_frame->coreFrame());
+    webPage->didChangeScrollOffsetForFrame(m_frame->coreLocalFrame());
 }
 
 bool WebLocalFrameLoaderClient::allowScript(bool enabledPerSettings)
@@ -1835,7 +1835,7 @@ Ref<FrameNetworkingContext> WebLocalFrameLoaderClient::createNetworkingContext()
 void WebLocalFrameLoaderClient::contentFilterDidBlockLoad(WebCore::ContentFilterUnblockHandler unblockHandler)
 {
     if (!unblockHandler.needsUIProcess()) {
-        m_frame->coreFrame()->loader().policyChecker().setContentFilterUnblockHandler(WTFMove(unblockHandler));
+        m_frame->coreLocalFrame()->loader().policyChecker().setContentFilterUnblockHandler(WTFMove(unblockHandler));
         return;
     }
 

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebRemoteFrameClient.cpp
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebRemoteFrameClient.cpp
@@ -81,7 +81,7 @@ void WebRemoteFrameClient::changeLocation(WebCore::FrameLoadRequest&& request)
         if (policyAction != PolicyAction::Use)
             return;
         protectedFrame->transitionToLocal();
-        protectedFrame->coreAbstractFrame()->changeLocation(WTFMove(request));
+        protectedFrame->coreFrame()->changeLocation(WTFMove(request));
     });
 }
 

--- a/Source/WebKit/WebProcess/WebCoreSupport/curl/WebFrameNetworkingContext.cpp
+++ b/Source/WebKit/WebProcess/WebCoreSupport/curl/WebFrameNetworkingContext.cpp
@@ -43,7 +43,7 @@ void WebFrameNetworkingContext::ensureWebsiteDataStoreSession(const WebsiteDataS
 }
 
 WebFrameNetworkingContext::WebFrameNetworkingContext(WebFrame* frame)
-    : FrameNetworkingContext(frame->coreFrame())
+    : FrameNetworkingContext(frame->coreLocalFrame())
 {
 }
 

--- a/Source/WebKit/WebProcess/WebCoreSupport/mac/WebFrameNetworkingContext.h
+++ b/Source/WebKit/WebProcess/WebCoreSupport/mac/WebFrameNetworkingContext.h
@@ -46,7 +46,7 @@ public:
 
 private:
     WebFrameNetworkingContext(WebFrame* frame)
-        : WebCore::FrameNetworkingContext(frame->coreFrame())
+        : WebCore::FrameNetworkingContext(frame->coreLocalFrame())
     {
     }
 

--- a/Source/WebKit/WebProcess/WebCoreSupport/soup/WebFrameNetworkingContext.cpp
+++ b/Source/WebKit/WebProcess/WebCoreSupport/soup/WebFrameNetworkingContext.cpp
@@ -46,7 +46,7 @@ void WebFrameNetworkingContext::ensureWebsiteDataStoreSession(const WebsiteDataS
 }
 
 WebFrameNetworkingContext::WebFrameNetworkingContext(WebFrame* frame)
-    : FrameNetworkingContext(frame->coreFrame())
+    : FrameNetworkingContext(frame->coreLocalFrame())
 {
 }
 

--- a/Source/WebKit/WebProcess/WebPage/Cocoa/WebPageCocoa.mm
+++ b/Source/WebKit/WebProcess/WebPage/Cocoa/WebPageCocoa.mm
@@ -405,7 +405,7 @@ void WebPage::updateMockAccessibilityElementAfterCommittingLoad()
 
 RetainPtr<CFDataRef> WebPage::pdfSnapshotAtSize(IntRect rect, IntSize bitmapSize, SnapshotOptions options)
 {
-    auto* coreFrame = m_mainFrame->coreFrame();
+    auto* coreFrame = m_mainFrame->coreLocalFrame();
     if (!coreFrame)
         return nullptr;
 
@@ -577,7 +577,7 @@ void WebPage::getPDFFirstPageSize(WebCore::FrameIdentifier frameID, CompletionHa
     if (!webFrame)
         return completionHandler({ });
 
-    auto* pluginView = pluginViewForFrame(webFrame->coreFrame());
+    auto* pluginView = pluginViewForFrame(webFrame->coreLocalFrame());
     if (!pluginView)
         return completionHandler({ });
     

--- a/Source/WebKit/WebProcess/WebPage/IPCTestingAPI.cpp
+++ b/Source/WebKit/WebProcess/WebPage/IPCTestingAPI.cpp
@@ -2925,7 +2925,7 @@ JSC::JSObject* JSMessageListener::jsDescriptionFromDecoder(JSC::JSGlobalObject* 
 
 void inject(WebPage& webPage, WebFrame& webFrame, WebCore::DOMWrapperWorld& world)
 {
-    auto* globalObject = webFrame.coreFrame()->script().globalObject(world);
+    auto* globalObject = webFrame.coreLocalFrame()->script().globalObject(world);
 
     auto& vm = globalObject->vm();
     JSC::JSLockHolder lock(vm);

--- a/Source/WebKit/WebProcess/WebPage/WebFrame.h
+++ b/Source/WebKit/WebProcess/WebPage/WebFrame.h
@@ -91,9 +91,9 @@ public:
     WebPage* page() const;
 
     static WebFrame* fromCoreFrame(const WebCore::Frame&);
-    WebCore::LocalFrame* coreFrame() const;
+    WebCore::LocalFrame* coreLocalFrame() const;
     WebCore::RemoteFrame* coreRemoteFrame() const;
-    WebCore::Frame* coreAbstractFrame() const;
+    WebCore::Frame* coreFrame() const;
 
     void transitionToLocal(std::optional<WebCore::LayerHostingContextIdentifier> = std::nullopt);
 

--- a/Source/WebKit/WebProcess/WebPage/WebPage.cpp
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.cpp
@@ -764,7 +764,6 @@ WebPage::WebPage(PageIdentifier pageID, WebPageCreationParameters&& parameters)
     m_page->setDeviceScaleFactor(parameters.deviceScaleFactor);
 
     m_drawingArea = DrawingArea::create(*this, parameters);
-    // FIXME: Rename coreAbstractFrame to coreFrame and coreFrame to coreLocalFrame.
     // FIXME: Refactor frame construction and remove receivedMainFrameIdentifierFromUIProcess.
     if (!receivedMainFrameIdentifierFromUIProcess)
         m_drawingArea->addRootFrame(m_mainFrame->frameID());
@@ -1144,8 +1143,7 @@ void WebPage::reinitializeWebPage(WebPageCreationParameters&& parameters)
         oldDrawingArea->removeMessageReceiverIfNeeded();
 
         m_drawingArea = DrawingArea::create(*this, parameters);
-        // FIXME: Rename coreAbstractFrame to coreFrame and coreFrame to coreLocalFrame.
-        if (is<WebCore::LocalFrame>(m_mainFrame->coreAbstractFrame()))
+        if (is<WebCore::LocalFrame>(m_mainFrame->coreFrame()))
             m_drawingArea->addRootFrame(m_mainFrame->frameID());
         m_drawingArea->setShouldScaleViewToFitDocument(parameters.shouldScaleViewToFitDocument);
         m_drawingArea->updatePreferences(parameters.store);
@@ -1485,12 +1483,12 @@ static OptionSet<RenderAsTextFlag> toRenderAsTextFlags(unsigned options)
 
 String WebPage::renderTreeExternalRepresentation(unsigned options) const
 {
-    return externalRepresentation(m_mainFrame->coreFrame(), toRenderAsTextFlags(options));
+    return externalRepresentation(m_mainFrame->coreLocalFrame(), toRenderAsTextFlags(options));
 }
 
 String WebPage::renderTreeExternalRepresentationForPrinting() const
 {
-    return externalRepresentation(m_mainFrame->coreFrame(), { RenderAsTextFlag::PrintingMode });
+    return externalRepresentation(m_mainFrame->coreLocalFrame(), { RenderAsTextFlag::PrintingMode });
 }
 
 uint64_t WebPage::renderTreeSize() const
@@ -1727,7 +1725,7 @@ void WebPage::close()
 #endif
 
     m_printContext = nullptr;
-    m_mainFrame->coreFrame()->loader().detachFromParent();
+    m_mainFrame->coreLocalFrame()->loader().detachFromParent();
 
 #if ENABLE(SCROLLING_THREAD)
     if (m_useAsyncScrolling)
@@ -1786,7 +1784,7 @@ void WebPage::suspendForProcessSwap()
         send(Messages::WebPageProxy::DidFailToSuspendAfterProcessSwap());
     };
 
-    auto* currentHistoryItem = m_mainFrame->coreFrame()->loader().history().currentItem();
+    auto* currentHistoryItem = m_mainFrame->coreLocalFrame()->loader().history().currentItem();
     if (!currentHistoryItem) {
         failedToSuspend();
         return;
@@ -1800,8 +1798,8 @@ void WebPage::suspendForProcessSwap()
     // Back/forward cache does not break the opener link for the main frame (only does so for the subframes) because the
     // main frame is normally re-used for the navigation. However, in the case of process-swapping, the main frame
     // is now hosted in another process and the one in this process is in the cache.
-    if (m_mainFrame->coreFrame())
-        m_mainFrame->coreFrame()->loader().detachFromAllOpenedFrames();
+    if (m_mainFrame->coreLocalFrame())
+        m_mainFrame->coreLocalFrame()->loader().detachFromAllOpenedFrames();
 
     send(Messages::WebPageProxy::DidSuspendAfterProcessSwap());
 }
@@ -1812,7 +1810,7 @@ void WebPage::loadURLInFrame(URL&& url, const String& referrer, FrameIdentifier 
     if (!frame)
         return;
 
-    frame->coreFrame()->loader().load(FrameLoadRequest(*frame->coreFrame(), ResourceRequest(url, referrer)));
+    frame->coreLocalFrame()->loader().load(FrameLoadRequest(*frame->coreLocalFrame(), ResourceRequest(url, referrer)));
 }
 
 void WebPage::loadDataInFrame(IPC::DataReference&& data, String&& MIMEType, String&& encodingName, URL&& baseURL, FrameIdentifier frameID)
@@ -1825,7 +1823,7 @@ void WebPage::loadDataInFrame(IPC::DataReference&& data, String&& MIMEType, Stri
     auto sharedBuffer = SharedBuffer::create(data.data(), data.size());
     ResourceResponse response(baseURL, MIMEType, sharedBuffer->size(), encodingName);
     SubstituteData substituteData(WTFMove(sharedBuffer), baseURL, WTFMove(response), SubstituteData::SessionHistoryVisibility::Hidden);
-    frame->coreFrame()->loader().load(FrameLoadRequest(*frame->coreFrame(), ResourceRequest(baseURL), WTFMove(substituteData)));
+    frame->coreLocalFrame()->loader().load(FrameLoadRequest(*frame->coreLocalFrame(), ResourceRequest(baseURL), WTFMove(substituteData)));
 }
 
 #if !PLATFORM(COCOA)
@@ -1857,7 +1855,7 @@ void WebPage::loadRequest(LoadParameters&& loadParameters)
     WEBPAGE_RELEASE_LOG(Loading, "loadRequest: navigationID=%" PRIu64 ", shouldTreatAsContinuingLoad=%u, lastNavigationWasAppInitiated=%d, existingNetworkResourceLoadIdentifierToResume=%" PRIu64, loadParameters.navigationID, static_cast<unsigned>(loadParameters.shouldTreatAsContinuingLoad), loadParameters.request.isAppInitiated(), valueOrDefault(loadParameters.existingNetworkResourceLoadIdentifierToResume).toUInt64());
 
     RefPtr frame = loadParameters.frameIdentifier ? WebProcess::singleton().webFrame(*loadParameters.frameIdentifier) : m_mainFrame.ptr();
-    if (!frame || is<RemoteFrame>(frame->coreAbstractFrame())) {
+    if (!frame || is<RemoteFrame>(frame->coreFrame())) {
         ASSERT_NOT_REACHED();
         return;
     }
@@ -1888,9 +1886,9 @@ void WebPage::loadRequest(LoadParameters&& loadParameters)
 
     // Initate the load in WebCore.
     ASSERT(frame);
-    ASSERT(frame->coreFrame());
-    ASSERT(frame->coreFrame()->document());
-    FrameLoadRequest frameLoadRequest { *frame->coreFrame(), loadParameters.request };
+    ASSERT(frame->coreLocalFrame());
+    ASSERT(frame->coreLocalFrame()->document());
+    FrameLoadRequest frameLoadRequest { *frame->coreLocalFrame(), loadParameters.request };
     frameLoadRequest.setShouldOpenExternalURLsPolicy(loadParameters.shouldOpenExternalURLsPolicy);
     frameLoadRequest.setShouldTreatAsContinuingLoad(loadParameters.shouldTreatAsContinuingLoad);
     frameLoadRequest.setLockHistory(loadParameters.lockHistory);
@@ -1907,7 +1905,7 @@ void WebPage::loadRequest(LoadParameters&& loadParameters)
     if (frame.get() == m_mainFrame.ptr())
         corePage()->userInputBridge().loadRequest(WTFMove(frameLoadRequest));
     else
-        frame->coreFrame()->loader().load(WTFMove(frameLoadRequest));
+        frame->coreLocalFrame()->loader().load(WTFMove(frameLoadRequest));
 
     ASSERT(!m_pendingNavigationID);
     ASSERT(!m_pendingWebsitePolicies);
@@ -1937,11 +1935,11 @@ void WebPage::loadDataImpl(uint64_t navigationID, ShouldTreatAsContinuingLoad sh
     m_loaderClient->willLoadDataRequest(*this, request, substituteData.content(), substituteData.mimeType(), substituteData.textEncoding(), substituteData.failingURL(), WebProcess::singleton().transformHandlesToObjects(userData.object()).get());
 
     // Initate the load in WebCore.
-    FrameLoadRequest frameLoadRequest(*m_mainFrame->coreFrame(), request, substituteData);
+    FrameLoadRequest frameLoadRequest(*m_mainFrame->coreLocalFrame(), request, substituteData);
     frameLoadRequest.setShouldOpenExternalURLsPolicy(shouldOpenExternalURLsPolicy);
     frameLoadRequest.setShouldTreatAsContinuingLoad(shouldTreatAsContinuingLoad);
     frameLoadRequest.setIsRequestFromClientOrUserInput();
-    m_mainFrame->coreFrame()->loader().load(WTFMove(frameLoadRequest));
+    m_mainFrame->coreLocalFrame()->loader().load(WTFMove(frameLoadRequest));
 }
 
 void WebPage::loadData(LoadParameters&& loadParameters)
@@ -1976,11 +1974,11 @@ void WebPage::loadAlternateHTML(LoadParameters&& loadParameters)
     URL unreachableURL = loadParameters.unreachableURLString.isEmpty() ? URL() : URL { loadParameters.unreachableURLString };
     URL provisionalLoadErrorURL = loadParameters.provisionalLoadErrorURLString.isEmpty() ? URL() : URL { loadParameters.provisionalLoadErrorURLString };
     auto sharedBuffer = SharedBuffer::create(loadParameters.data.data(), loadParameters.data.size());
-    m_mainFrame->coreFrame()->loader().setProvisionalLoadErrorBeingHandledURL(provisionalLoadErrorURL);
+    m_mainFrame->coreLocalFrame()->loader().setProvisionalLoadErrorBeingHandledURL(provisionalLoadErrorURL);
 
     ResourceResponse response(URL(), loadParameters.MIMEType, sharedBuffer->size(), loadParameters.encodingName);
     loadDataImpl(loadParameters.navigationID, loadParameters.shouldTreatAsContinuingLoad, WTFMove(loadParameters.websitePolicies), WTFMove(sharedBuffer), ResourceRequest(baseURL), WTFMove(response), unreachableURL, loadParameters.userData, loadParameters.isNavigatingToAppBoundDomain, WebCore::SubstituteData::SessionHistoryVisibility::Hidden);
-    m_mainFrame->coreFrame()->loader().setProvisionalLoadErrorBeingHandledURL({ });
+    m_mainFrame->coreLocalFrame()->loader().setProvisionalLoadErrorBeingHandledURL({ });
 }
 
 void WebPage::loadSimulatedRequestAndResponse(LoadParameters&& loadParameters, ResourceResponse&& simulatedResponse)
@@ -1992,7 +1990,7 @@ void WebPage::loadSimulatedRequestAndResponse(LoadParameters&& loadParameters, R
 
 void WebPage::navigateToPDFLinkWithSimulatedClick(const String& url, IntPoint documentPoint, IntPoint screenPoint)
 {
-    auto* mainFrame = m_mainFrame->coreFrame();
+    auto* mainFrame = m_mainFrame->coreLocalFrame();
     auto* mainFrameDocument = mainFrame->document();
     if (!mainFrameDocument)
         return;
@@ -2008,12 +2006,12 @@ void WebPage::navigateToPDFLinkWithSimulatedClick(const String& url, IntPoint do
 
 void WebPage::stopLoading()
 {
-    if (!m_page || !m_mainFrame->coreFrame())
+    if (!m_page || !m_mainFrame->coreLocalFrame())
         return;
 
     SendStopResponsivenessTimer stopper;
 
-    Ref coreFrame = *m_mainFrame->coreFrame();
+    Ref coreFrame = *m_mainFrame->coreLocalFrame();
     m_page->userInputBridge().stopLoadingFrame(coreFrame.get());
     coreFrame->loader().completePageTransitionIfNeeded();
 }
@@ -2038,12 +2036,12 @@ void WebPage::reload(uint64_t navigationID, OptionSet<WebCore::ReloadOption> rel
 {
     SendStopResponsivenessTimer stopper;
 
-    ASSERT(!m_mainFrame->coreFrame()->loader().frameHasLoaded() || !m_pendingNavigationID);
+    ASSERT(!m_mainFrame->coreLocalFrame()->loader().frameHasLoaded() || !m_pendingNavigationID);
     m_pendingNavigationID = navigationID;
 
     m_sandboxExtensionTracker.beginReload(m_mainFrame.ptr(), WTFMove(sandboxExtensionHandle));
-    if (m_page && m_mainFrame->coreFrame())
-        m_page->userInputBridge().reloadFrame(*m_mainFrame->coreFrame(), reloadOptions);
+    if (m_page && m_mainFrame->coreLocalFrame())
+        m_page->userInputBridge().reloadFrame(*m_mainFrame->coreLocalFrame(), reloadOptions);
     else
         ASSERT_NOT_REACHED();
 
@@ -2214,7 +2212,7 @@ void WebPage::drawRect(GraphicsContext& graphicsContext, const IntRect& rect)
     GraphicsContextStateSaver stateSaver(graphicsContext);
     graphicsContext.clip(rect);
 
-    m_mainFrame->coreFrame()->view()->paint(graphicsContext, rect);
+    m_mainFrame->coreLocalFrame()->view()->paint(graphicsContext, rect);
 
 #if PLATFORM(GTK) || PLATFORM(WIN) || PLATFORM(PLAYSTATION)
     if (!m_page->settings().acceleratedCompositingEnabled() && m_page->inspectorController().enabled() && m_page->inspectorController().shouldShowOverlay()) {
@@ -2232,7 +2230,7 @@ double WebPage::textZoomFactor() const
         return pluginView->pageScaleFactor();
 #endif
 
-    auto* frame = m_mainFrame->coreFrame();
+    auto* frame = m_mainFrame->coreLocalFrame();
     if (!frame)
         return 1;
     return frame->textZoomFactor();
@@ -2247,7 +2245,7 @@ void WebPage::setTextZoomFactor(double zoomFactor)
     }
 #endif
 
-    auto* frame = m_mainFrame->coreFrame();
+    auto* frame = m_mainFrame->coreLocalFrame();
     if (!frame)
         return;
     frame->setTextZoomFactor(static_cast<float>(zoomFactor));
@@ -2260,7 +2258,7 @@ double WebPage::pageZoomFactor() const
         return pluginView->pageScaleFactor();
 #endif
 
-    auto* frame = m_mainFrame->coreFrame();
+    auto* frame = m_mainFrame->coreLocalFrame();
     if (!frame)
         return 1;
     return frame->pageZoomFactor();
@@ -2275,7 +2273,7 @@ void WebPage::setPageZoomFactor(double zoomFactor)
     }
 #endif
 
-    auto* frame = m_mainFrame->coreFrame();
+    auto* frame = m_mainFrame->coreLocalFrame();
     if (!frame)
         return;
     frame->setPageZoomFactor(static_cast<float>(zoomFactor));
@@ -2351,7 +2349,7 @@ void WebPage::setPageAndTextZoomFactors(double pageZoomFactor, double textZoomFa
     }
 #endif
 
-    auto* frame = m_mainFrame->coreFrame();
+    auto* frame = m_mainFrame->coreLocalFrame();
     if (!frame)
         return;
     return frame->setPageAndTextZoomFactors(static_cast<float>(pageZoomFactor), static_cast<float>(textZoomFactor));
@@ -2807,7 +2805,7 @@ void WebPage::setFooterBannerHeight(int height)
 void WebPage::takeSnapshot(IntRect snapshotRect, IntSize bitmapSize, uint32_t options, CompletionHandler<void(WebKit::ShareableBitmap::Handle&&)>&& completionHandler)
 {
     ShareableBitmap::Handle handle;
-    auto* coreFrame = m_mainFrame->coreFrame();
+    auto* coreFrame = m_mainFrame->coreLocalFrame();
     if (!coreFrame) {
         completionHandler(WTFMove(handle));
         return;
@@ -2841,7 +2839,7 @@ void WebPage::takeSnapshot(IntRect snapshotRect, IntSize bitmapSize, uint32_t op
 
 RefPtr<WebImage> WebPage::scaledSnapshotWithOptions(const IntRect& rect, double additionalScaleFactor, SnapshotOptions options)
 {
-    auto* coreFrame = m_mainFrame->coreFrame();
+    auto* coreFrame = m_mainFrame->coreLocalFrame();
     if (!coreFrame)
         return nullptr;
 
@@ -2953,7 +2951,7 @@ RefPtr<WebImage> WebPage::snapshotAtSize(const IntRect& rect, const IntSize& bit
 
 RefPtr<WebImage> WebPage::snapshotNode(WebCore::Node& node, SnapshotOptions options, unsigned maximumPixelCount)
 {
-    auto* coreFrame = m_mainFrame->coreFrame();
+    auto* coreFrame = m_mainFrame->coreLocalFrame();
     if (!coreFrame)
         return nullptr;
 
@@ -3023,7 +3021,7 @@ void WebPage::pageDidScroll()
 void WebPage::pageStoppedScrolling()
 {
     // Maintain the current history item's scroll position up-to-date.
-    if (auto* frame = m_mainFrame->coreFrame())
+    if (auto* frame = m_mainFrame->coreLocalFrame())
         frame->loader().history().saveScrollPositionAndViewStateToItem(frame->loader().history().currentItem());
 }
 
@@ -3118,7 +3116,7 @@ void WebPage::updateFrameSize(WebCore::FrameIdentifier frameID, WebCore::IntSize
     if (!webFrame)
         return;
 
-    auto* frame = webFrame->coreFrame();
+    auto* frame = webFrame->coreLocalFrame();
     if (!frame)
         return;
 
@@ -3861,7 +3859,7 @@ void WebPage::visibilityDidChange()
     if (!isVisible) {
         // We save the document / scroll state when backgrounding a tab so that we are able to restore it
         // if it gets terminated while in the background.
-        if (auto* frame = m_mainFrame->coreFrame())
+        if (auto* frame = m_mainFrame->coreLocalFrame())
             frame->loader().history().saveDocumentAndScrollState();
     }
 }
@@ -4021,7 +4019,7 @@ void WebPage::suspend(CompletionHandler<void(bool)>&& completionHandler)
 
     m_cachedPage = BackForwardCache::singleton().suspendPage(*m_page);
     ASSERT(m_cachedPage);
-    if (auto mainFrame = m_mainFrame->coreFrame())
+    if (auto mainFrame = m_mainFrame->coreLocalFrame())
         mainFrame->loader().detachFromAllOpenedFrames();
     completionHandler(true);
 }
@@ -4081,7 +4079,7 @@ void WebPage::runJavaScript(WebFrame* frame, RunJavaScriptParameters&& parameter
     // NOTE: We need to be careful when running scripts that the objects we depend on don't
     // disappear during script execution.
 
-    if (!frame || !frame->coreFrame()) {
+    if (!frame || !frame->coreLocalFrame()) {
         completionHandler({ }, ExceptionDetails { "Unable to execute JavaScript: Target frame could not be found in the page"_s, 0, 0, ExceptionDetails::Type::InvalidTargetFrame });
         return;
     }
@@ -4119,7 +4117,7 @@ void WebPage::runJavaScript(WebFrame* frame, RunJavaScriptParameters&& parameter
     }();
 
     SetForScope userIsInteractingChange { m_userIsInteracting, shouldAllowUserInteraction };
-    auto resolveFunction = [world = Ref { *world }, frame = Ref { *frame }, coreFrame = Ref { *frame->coreFrame() }, completionHandler = WTFMove(completionHandler)] (ValueOrException result) mutable {
+    auto resolveFunction = [world = Ref { *world }, frame = Ref { *frame }, coreFrame = Ref { *frame->coreLocalFrame() }, completionHandler = WTFMove(completionHandler)] (ValueOrException result) mutable {
         RefPtr<SerializedScriptValue> serializedResultValue;
         if (result) {
             serializedResultValue = SerializedScriptValue::create(frame->jsContextForWorld(world.ptr()),
@@ -4137,7 +4135,7 @@ void WebPage::runJavaScript(WebFrame* frame, RunJavaScriptParameters&& parameter
         completionHandler(dataReference, details);
     };
     JSLockHolder lock(commonVM());
-    frame->coreFrame()->script().executeAsynchronousUserAgentScriptInWorld(world->coreWorld(), WTFMove(parameters), WTFMove(resolveFunction));
+    frame->coreLocalFrame()->script().executeAsynchronousUserAgentScriptInWorld(world->coreWorld(), WTFMove(parameters), WTFMove(resolveFunction));
 }
 
 void WebPage::runJavaScriptInFrameInScriptWorld(RunJavaScriptParameters&& parameters, std::optional<WebCore::FrameIdentifier> frameID, const std::pair<ContentWorldIdentifier, String>& worldData, CompletionHandler<void(const IPC::DataReference&, const std::optional<WebCore::ExceptionDetails>&)>&& completionHandler)
@@ -4173,7 +4171,7 @@ void WebPage::getContentsAsString(ContentAsStringIncludesChildFrames includeChil
         break;
     case ContentAsStringIncludesChildFrames::Yes:
         StringBuilder builder;
-        for (RefPtr<Frame> frame = m_mainFrame->coreFrame(); frame; frame = frame->tree().traverseNextRendered()) {
+        for (RefPtr<Frame> frame = m_mainFrame->coreLocalFrame(); frame; frame = frame->tree().traverseNextRendered()) {
             if (auto webFrame = WebFrame::fromCoreFrame(*frame))
                 builder.append(builder.isEmpty() ? "" : "\n\n", webFrame->contentsAsString());
         }
@@ -4245,12 +4243,12 @@ void WebPage::getMainResourceDataOfFrame(FrameIdentifier frameID, CompletionHand
     RefPtr<FragmentedSharedBuffer> buffer;
     if (WebFrame* frame = WebProcess::singleton().webFrame(frameID)) {
 #if ENABLE(PDFKIT_PLUGIN)
-        if (PluginView* pluginView = pluginViewForFrame(frame->coreFrame()))
+        if (PluginView* pluginView = pluginViewForFrame(frame->coreLocalFrame()))
             buffer = pluginView->liveResourceData();
         if (!buffer)
 #endif
         {
-            if (DocumentLoader* loader = frame->coreFrame()->loader().documentLoader())
+            if (DocumentLoader* loader = frame->coreLocalFrame()->loader().documentLoader())
                 buffer = loader->mainResourceData();
         }
     }
@@ -4276,7 +4274,7 @@ void WebPage::getResourceDataFromFrame(FrameIdentifier frameID, const String& re
     RefPtr<FragmentedSharedBuffer> buffer;
     if (auto* frame = WebProcess::singleton().webFrame(frameID)) {
         URL resourceURL { resourceURLString };
-        buffer = resourceDataForFrame(frame->coreFrame(), resourceURL);
+        buffer = resourceDataForFrame(frame->coreLocalFrame(), resourceURL);
     }
 
     callback(IPC::SharedBufferReference(WTFMove(buffer)));
@@ -4635,7 +4633,7 @@ void WebPage::willCommitLayerTree(RemoteLayerTreeTransaction& layerTransaction, 
     if (!rootFrame)
         return;
 
-    auto* localRootFrame = rootFrame->coreFrame();
+    auto* localRootFrame = rootFrame->coreLocalFrame();
     if (!localRootFrame)
         return;
 
@@ -4899,7 +4897,7 @@ void WebPage::enqueueSecurityPolicyViolationEvent(FrameIdentifier frameID, Secur
     auto* frame = WebProcess::singleton().webFrame(frameID);
     if (!frame)
         return;
-    auto* coreFrame = frame->coreFrame();
+    auto* coreFrame = frame->coreLocalFrame();
     if (!coreFrame)
         return;
     if (auto* document = coreFrame->document())
@@ -4911,7 +4909,7 @@ void WebPage::notifyReportObservers(FrameIdentifier frameID, Ref<WebCore::Report
     auto* frame = WebProcess::singleton().webFrame(frameID);
     if (!frame)
         return;
-    auto* coreFrame = frame->coreFrame();
+    auto* coreFrame = frame->coreLocalFrame();
     if (!coreFrame)
         return;
     if (RefPtr document = coreFrame->document())
@@ -4925,19 +4923,19 @@ void WebPage::sendReportToEndpoints(FrameIdentifier frameID, URL&& baseURL, cons
         return;
 
     RefPtr frame = WebProcess::singleton().webFrame(frameID);
-    if (!frame || !frame->coreFrame())
+    if (!frame || !frame->coreLocalFrame())
         return;
 
     for (auto& url : endpointURIs)
-        PingLoader::sendViolationReport(*frame->coreFrame(), URL { baseURL, url }, Ref { *report.get() }, reportType);
+        PingLoader::sendViolationReport(*frame->coreLocalFrame(), URL { baseURL, url }, Ref { *report.get() }, reportType);
 
-    auto* document = frame->coreFrame()->document();
+    auto* document = frame->coreLocalFrame()->document();
     if (!document)
         return;
 
     for (auto& token : endpointTokens) {
         if (auto url = document->endpointURIForToken(token); !url.isEmpty())
-            PingLoader::sendViolationReport(*frame->coreFrame(), URL { baseURL, url }, Ref { *report.get() }, reportType);
+            PingLoader::sendViolationReport(*frame->coreLocalFrame(), URL { baseURL, url }, Ref { *report.get() }, reportType);
     }
 }
 
@@ -5687,7 +5685,7 @@ void WebPage::setMainFrameIsScrollable(bool isScrollable)
     m_mainFrameIsScrollable = isScrollable;
     m_drawingArea->mainFrameScrollabilityChanged(isScrollable);
 
-    if (auto* frameView = m_mainFrame->coreFrame()->view()) {
+    if (auto* frameView = m_mainFrame->coreLocalFrame()->view()) {
         frameView->setCanHaveScrollbars(isScrollable);
         frameView->setProhibitsScrolling(!isScrollable);
     }
@@ -5797,7 +5795,7 @@ bool WebPage::SandboxExtensionTracker::shouldReuseCommittedSandboxExtension(WebF
 {
     ASSERT(frame->isMainFrame());
 
-    FrameLoader& frameLoader = frame->coreFrame()->loader();
+    FrameLoader& frameLoader = frame->coreLocalFrame()->loader();
     FrameLoadType frameLoadType = frameLoader.loadType();
 
     // If the page is being reloaded, it should reuse whatever extension is committed.
@@ -5953,7 +5951,7 @@ void WebPage::beginPrinting(FrameIdentifier frameID, const PrintInfo& printInfo)
     if (!frame)
         return;
 
-    auto* coreFrame = frame->coreFrame();
+    auto* coreFrame = frame->coreLocalFrame();
     if (!coreFrame)
         return;
 
@@ -6096,7 +6094,7 @@ void WebPage::drawRectToImage(FrameIdentifier frameID, const PrintInfo& printInf
 {
     PrintContextAccessScope scope { *this };
     WebFrame* frame = WebProcess::singleton().webFrame(frameID);
-    auto* coreFrame = frame ? frame->coreFrame() : 0;
+    auto* coreFrame = frame ? frame->coreLocalFrame() : 0;
 
     RefPtr<WebImage> image;
 
@@ -6150,7 +6148,7 @@ void WebPage::drawPagesToPDF(FrameIdentifier frameID, const PrintInfo& printInfo
 void WebPage::drawPagesToPDFImpl(FrameIdentifier frameID, const PrintInfo& printInfo, uint32_t first, uint32_t count, RetainPtr<CFMutableDataRef>& pdfPageData)
 {
     WebFrame* frame = WebProcess::singleton().webFrame(frameID);
-    auto* coreFrame = frame ? frame->coreFrame() : 0;
+    auto* coreFrame = frame ? frame->coreLocalFrame() : 0;
 
     pdfPageData = adoptCF(CFDataCreateMutable(0, 0));
 
@@ -6718,7 +6716,7 @@ void WebPage::resetFocusedElementForFrame(WebFrame* frame)
     if (!m_focusedElement)
         return;
 
-    if (frame->isMainFrame() || m_focusedElement->document().frame() == frame->coreFrame()) {
+    if (frame->isMainFrame() || m_focusedElement->document().frame() == frame->coreLocalFrame()) {
 #if PLATFORM(IOS_FAMILY)
         m_sendAutocorrectionContextAfterFocusingElement = false;
         send(Messages::WebPageProxy::ElementDidBlur());
@@ -7099,7 +7097,7 @@ void WebPage::didCommitLoad(WebFrame* frame)
     resetFocusedElementForFrame(frame);
 
     if (m_textManipulationIncludesSubframes)
-        startTextManipulationForFrame(*frame->coreFrame());
+        startTextManipulationForFrame(*frame->coreLocalFrame());
 
     if (!frame->isRootFrame())
         return;
@@ -7107,7 +7105,7 @@ void WebPage::didCommitLoad(WebFrame* frame)
     if (m_drawingArea)
         m_drawingArea->sendEnterAcceleratedCompositingModeIfNeeded();
 
-    ASSERT(!frame->coreFrame()->loader().stateMachine().creatingInitialEmptyDocument());
+    ASSERT(!frame->coreLocalFrame()->loader().stateMachine().creatingInitialEmptyDocument());
     unfreezeLayerTree(LayerTreeFreezeReason::ProcessSwap);
 
 #if ENABLE(IMAGE_ANALYSIS)
@@ -7124,19 +7122,19 @@ void WebPage::didCommitLoad(WebFrame* frame)
     
     // If previous URL is invalid, then it's not a real page that's being navigated away from.
     // Most likely, this is actually the first load to be committed in this page.
-    if (frame->coreFrame()->loader().previousURL().isValid())
+    if (frame->coreLocalFrame()->loader().previousURL().isValid())
         reportUsedFeatures();
 
     // Only restore the scale factor for standard frame loads (of the main frame).
-    if (frame->coreFrame()->loader().loadType() == FrameLoadType::Standard) {
-        Page* page = frame->coreFrame()->page();
+    if (frame->coreLocalFrame()->loader().loadType() == FrameLoadType::Standard) {
+        Page* page = frame->coreLocalFrame()->page();
 
 #if PLATFORM(MAC)
         // As a very special case, we disable non-default layout modes in WKView for main-frame PluginDocuments.
         // Ideally we would only worry about this in WKView or the WKViewLayoutStrategies, but if we allow
         // a round-trip to the UI process, you'll see the wrong scale temporarily. So, we reset it here, and then
         // again later from the UI process.
-        if (frame->coreFrame()->document()->isPluginDocument()) {
+        if (frame->coreLocalFrame()->document()->isPluginDocument()) {
             scaleView(1);
             setUseFixedLayout(false);
         }
@@ -7170,7 +7168,7 @@ void WebPage::didCommitLoad(WebFrame* frame)
 
 #if ENABLE(META_VIEWPORT)
     resetViewportDefaultConfiguration(frame);
-    auto* coreFrame = frame->coreFrame();
+    auto* coreFrame = frame->coreLocalFrame();
     
     bool viewportChanged = false;
 
@@ -8005,7 +8003,7 @@ RefPtr<HTMLAttachmentElement> WebPage::attachmentElementWithIdentifier(const Str
 
 void WebPage::getApplicationManifest(CompletionHandler<void(const std::optional<WebCore::ApplicationManifest>&)>&& completionHandler)
 {
-    Document* mainFrameDocument = m_mainFrame->coreFrame()->document();
+    Document* mainFrameDocument = m_mainFrame->coreLocalFrame()->document();
     DocumentLoader* loader = mainFrameDocument ? mainFrameDocument->loader() : nullptr;
     if (!loader)
         return completionHandler(std::nullopt);
@@ -8017,12 +8015,12 @@ void WebPage::getApplicationManifest(CompletionHandler<void(const std::optional<
 
 void WebPage::getTextFragmentMatch(CompletionHandler<void(const String&)>&& completionHandler)
 {
-    if (!m_mainFrame->coreFrame()) {
+    if (!m_mainFrame->coreLocalFrame()) {
         completionHandler({ });
         return;
     }
 
-    Document* document = m_mainFrame->coreFrame()->document();
+    Document* document = m_mainFrame->coreLocalFrame()->document();
     if (!document) {
         completionHandler({ });
         return;
@@ -8110,9 +8108,9 @@ void WebPage::startTextManipulations(Vector<WebCore::TextManipulationController:
     m_textManipulationExclusionRules = WTFMove(exclusionRules);
     m_textManipulationIncludesSubframes = includeSubframes;
     if (m_textManipulationIncludesSubframes) {
-        for (RefPtr<Frame> frame = m_mainFrame->coreFrame(); frame; frame = frame->tree().traverseNextRendered())
+        for (RefPtr<Frame> frame = m_mainFrame->coreLocalFrame(); frame; frame = frame->tree().traverseNextRendered())
             startTextManipulationForFrame(*frame);
-    } else if (RefPtr frame = m_mainFrame->coreFrame())
+    } else if (RefPtr frame = m_mainFrame->coreLocalFrame())
         startTextManipulationForFrame(*frame);
 
     // For now, we assume startObservingParagraphs find all paragraphs synchronously at once.
@@ -8161,7 +8159,7 @@ void WebPage::completeTextManipulation(const Vector<WebCore::TextManipulationIte
         if (!frame)
             return std::nullopt;
 
-        RefPtr coreFrame = frame->coreFrame();
+        RefPtr coreFrame = frame->coreLocalFrame();
         if (!coreFrame)
             return std::nullopt;
 
@@ -8488,7 +8486,7 @@ void WebPage::updateWithTextRecognitionResult(const TextRecognitionResult& resul
 
 void WebPage::startVisualTranslation(const String& sourceLanguageIdentifier, const String& targetLanguageIdentifier)
 {
-    if (RefPtr document = m_mainFrame->coreFrame()->document())
+    if (RefPtr document = m_mainFrame->coreLocalFrame()->document())
         corePage()->imageAnalysisQueue().enqueueAllImagesIfNeeded(*document, sourceLanguageIdentifier, targetLanguageIdentifier);
 }
 
@@ -8627,7 +8625,7 @@ void WebPage::restoreAppHighlightsAndScrollToIndex(Vector<SharedMemory::Handle>&
 void WebPage::setAppHighlightsVisibility(WebCore::HighlightVisibility appHighlightVisibility)
 {
     m_appHighlightsVisible = appHighlightVisibility;
-    for (RefPtr<Frame> frame = m_mainFrame->coreFrame(); frame; frame = frame->tree().traverseNextRendered()) {
+    for (RefPtr<Frame> frame = m_mainFrame->coreLocalFrame(); frame; frame = frame->tree().traverseNextRendered()) {
         RefPtr localFrame = dynamicDowncast<LocalFrame>(frame.get());
         if (!localFrame)
             continue;
@@ -8641,7 +8639,7 @@ void WebPage::setAppHighlightsVisibility(WebCore::HighlightVisibility appHighlig
 #if ENABLE(MEDIA_SESSION_COORDINATOR)
 void WebPage::createMediaSessionCoordinator(const String& identifier, CompletionHandler<void(bool)>&& completionHandler)
 {
-    auto* document = m_mainFrame->coreFrame()->document();
+    auto* document = m_mainFrame->coreLocalFrame()->document();
     if (!document || !document->domWindow()) {
         completionHandler(false);
         return;

--- a/Source/WebKit/WebProcess/WebPage/gtk/WebPageGtk.cpp
+++ b/Source/WebKit/WebProcess/WebPage/gtk/WebPageGtk.cpp
@@ -105,12 +105,12 @@ OptionSet<PointerCharacteristics> WebPage::pointerCharacteristicsOfAllAvailableP
 void WebPage::collapseSelectionInFrame(FrameIdentifier frameID)
 {
     WebFrame* frame = WebProcess::singleton().webFrame(frameID);
-    if (!frame || !frame->coreFrame())
+    if (!frame || !frame->coreLocalFrame())
         return;
 
     // Collapse the selection without clearing it.
-    const VisibleSelection& selection = frame->coreFrame()->selection().selection();
-    frame->coreFrame()->selection().setBase(selection.extent(), selection.affinity());
+    const VisibleSelection& selection = frame->coreLocalFrame()->selection().selection();
+    frame->coreLocalFrame()->selection().setBase(selection.extent(), selection.affinity());
 }
 
 void WebPage::showEmojiPicker(LocalFrame& frame)

--- a/Source/WebKit/WebProcess/WebPage/ios/WebPageIOS.mm
+++ b/Source/WebKit/WebProcess/WebPage/ios/WebPageIOS.mm
@@ -1236,7 +1236,7 @@ void WebPage::cancelPotentialTapInFrame(WebFrame& frame)
 
     if (m_potentialTapNode) {
         auto* potentialTapFrame = m_potentialTapNode->document().frame();
-        if (potentialTapFrame && !potentialTapFrame->tree().isDescendantOf(frame.coreFrame()))
+        if (potentialTapFrame && !potentialTapFrame->tree().isDescendantOf(frame.coreLocalFrame()))
             return;
     }
 
@@ -4017,7 +4017,7 @@ void WebPage::resetViewportDefaultConfiguration(WebFrame* frame, bool hasMobileD
         return;
     }
 
-    auto* document = frame->coreFrame()->document();
+    auto* document = frame->coreLocalFrame()->document();
     if (document->isImageDocument())
         m_viewportConfiguration.setDefaultConfiguration(ViewportConfiguration::imageDocumentParameters());
     else if (document->isTextDocument())
@@ -4099,7 +4099,7 @@ void WebPage::shrinkToFitContent(ZoomToInitialScale zoomToInitialScale)
     if (m_viewportConfiguration.canIgnoreScalingConstraints())
         return;
 
-    RefPtr mainFrame = m_mainFrame->coreFrame();
+    RefPtr mainFrame = m_mainFrame->coreLocalFrame();
     if (!mainFrame)
         return;
 
@@ -4644,7 +4644,7 @@ String WebPage::platformUserAgent(const URL&) const
     if (!m_page->settings().needsSiteSpecificQuirks())
         return String();
 
-    auto* mainFrame = m_mainFrame->coreFrame();
+    auto* mainFrame = m_mainFrame->coreLocalFrame();
     if (!mainFrame) {
         // FIXME: Add a user agent for loads from iframe processes.
         return { };

--- a/Source/WebKit/WebProcess/WebPage/mac/WebPageMac.mm
+++ b/Source/WebKit/WebProcess/WebPage/mac/WebPageMac.mm
@@ -583,7 +583,7 @@ void WebPage::requestAcceptsFirstMouse(int eventNumber, const WebKit::WebMouseEv
 
 void WebPage::setTopOverhangImage(WebImage* image)
 {
-    auto* frameView = m_mainFrame->coreFrame()->view();
+    auto* frameView = m_mainFrame->coreLocalFrame()->view();
     if (!frameView)
         return;
 
@@ -602,7 +602,7 @@ void WebPage::setTopOverhangImage(WebImage* image)
 
 void WebPage::setBottomOverhangImage(WebImage* image)
 {
-    auto* frameView = m_mainFrame->coreFrame()->view();
+    auto* frameView = m_mainFrame->coreLocalFrame()->view();
     if (!frameView)
         return;
 
@@ -641,7 +641,7 @@ void WebPage::computePagesForPrintingPDFDocument(WebCore::FrameIdentifier frameI
 {
     ASSERT(resultPageRects.isEmpty());
     WebFrame* frame = WebProcess::singleton().webFrame(frameID);
-    auto* coreFrame = frame ? frame->coreFrame() : nullptr;
+    auto* coreFrame = frame ? frame->coreLocalFrame() : nullptr;
     RetainPtr<PDFDocument> pdfDocument = coreFrame ? pdfDocumentForPrintingFrame(coreFrame) : 0;
     if ([pdfDocument allowsPrinting]) {
         NSUInteger pageCount = [pdfDocument pageCount];

--- a/Source/WebKit/WebProcess/WebProcess.cpp
+++ b/Source/WebKit/WebProcess/WebProcess.cpp
@@ -1384,10 +1384,10 @@ void WebProcess::remotePostMessage(WebCore::FrameIdentifier identifier, std::opt
     if (!webFrame)
         return;
 
-    if (!webFrame->coreFrame())
+    if (!webFrame->coreLocalFrame())
         return;
 
-    auto* domWindow = webFrame->coreFrame()->window();
+    auto* domWindow = webFrame->coreLocalFrame()->window();
     if (!domWindow)
         return;
 


### PR DESCRIPTION
#### 1b1a76ca5fb0f041adea9b3382addd619f173cd9
<pre>
Rename coreAbstractFrame to coreFrame and coreFrame to coreLocalFrame
<a href="https://bugs.webkit.org/show_bug.cgi?id=256869">https://bugs.webkit.org/show_bug.cgi?id=256869</a>
rdar://109433121

Reviewed by Alex Christensen.

Rename coreAbstractFrame() to coreFrame() and coreFrame() to coreLocalFrame().

* Source/WebKit/WebProcess/Automation/WebAutomationSessionProxy.cpp:
(WebKit::WebAutomationSessionProxy::getAccessibilityObjectForNode):
(WebKit::WebAutomationSessionProxy::ensureObserverForFrame):
(WebKit::WebAutomationSessionProxy::evaluateJavaScriptFunction):
(WebKit::WebAutomationSessionProxy::resolveChildFrameWithOrdinal):
(WebKit::WebAutomationSessionProxy::resolveChildFrameWithName):
(WebKit::WebAutomationSessionProxy::computeElementLayout):
(WebKit::WebAutomationSessionProxy::selectOptionElement):
(WebKit::WebAutomationSessionProxy::setFilesForInputFileUpload):
(WebKit::WebAutomationSessionProxy::takeScreenshot):
(WebKit::WebAutomationSessionProxy::snapshotRectForScreenshot):
(WebKit::WebAutomationSessionProxy::getCookiesForFrame):
(WebKit::WebAutomationSessionProxy::deleteCookie):
* Source/WebKit/WebProcess/InjectedBundle/API/Cocoa/WKWebProcessPlugInFrame.mm:
(-[WKWebProcessPlugInFrame _securityOrigin]):
(-[WKWebProcessPlugInFrame appleTouchIconURLs]):
(-[WKWebProcessPlugInFrame faviconURLs]):
* Source/WebKit/WebProcess/InjectedBundle/API/c/WKBundleFrame.cpp:
(WKBundleFrameGetFrameLoadState):
(WKBundleFrameClearOpener):
(WKBundleFrameCallShouldCloseOnWebView):
(WKBundleFrameCopySecurityOrigin):
(WKBundleFrameFocus):
(_WKBundleFrameGenerateTestReport):
* Source/WebKit/WebProcess/InjectedBundle/API/c/mac/WKBundlePageMac.mm:
(WKBundlePageGetPDFDocumentInFrame):
* Source/WebKit/WebProcess/InjectedBundle/API/glib/WebKitFrame.cpp:
(getURL):
(webkitFrameGetJSCValuesForElementsInWorld):
(webkit_frame_get_js_value_for_dom_object_in_script_world):
* Source/WebKit/WebProcess/InjectedBundle/API/glib/WebKitWebPage.cpp:
* Source/WebKit/WebProcess/InjectedBundle/InjectedBundle.cpp:
(WebKit::InjectedBundle::numberOfPages):
(WebKit::InjectedBundle::pageNumberForElementById):
(WebKit::InjectedBundle::pageSizeAndMarginsInPixels):
(WebKit::InjectedBundle::isPageBoxVisible):
* Source/WebKit/WebProcess/InjectedBundle/InjectedBundleDOMWindowExtension.cpp:
(WebKit::InjectedBundleDOMWindowExtension::InjectedBundleDOMWindowExtension):
* Source/WebKit/WebProcess/InjectedBundle/InjectedBundleHitTestResult.cpp:
(WebKit::InjectedBundleHitTestResult::imageRect const):
* Source/WebKit/WebProcess/Inspector/WebInspector.cpp:
(WebKit::WebInspector::showMainResourceForFrame):
* Source/WebKit/WebProcess/Network/WebLoaderStrategy.cpp:
(WebKit::WebLoaderStrategy::loadResourceSynchronously):
* Source/WebKit/WebProcess/Plugins/PDF/PDFPlugin.mm:
(WebKit::PDFPlugin::PDFPlugin):
(WebKit::PDFPlugin::getResourceBytesAtPosition):
(WebKit::PDFPlugin::updateScrollbars):
(WebKit::PDFPlugin::createScrollbar):
(WebKit::PDFPlugin::isActive const):
(WebKit::PDFPlugin::forceUpdateScrollbarsOnMainThreadForPerformanceTesting const):
(WebKit::PDFPlugin::jsPDFDocPrint):
(WebKit::PDFPlugin::deviceScaleFactor const):
(WebKit::PDFPlugin::willDetachRenderer):
(WebKit::PDFPlugin::destroy):
(WebKit::PDFPlugin::paintControlForLayerInContext):
(WebKit::PDFPlugin::convertFromPDFViewToScreen const):
(WebKit::PDFPlugin::boundsOnScreen const):
(WebKit::PDFPlugin::showContextMenuAtPoint):
(WebKit::PDFPlugin::handleContextMenuEvent):
(WebKit::PDFPlugin::isFullFramePlugin const):
(WebKit::PDFPlugin::clickedLink):
(WebKit::PDFPlugin::writeItemsToPasteboard):
(WebKit::PDFPlugin::notifySelectionChanged):
(WebKit::PDFPlugin::axObjectCache const):
* Source/WebKit/WebProcess/WebCoreSupport/WebChromeClient.cpp:
(WebKit::WebChromeClient::closeWindow):
* Source/WebKit/WebProcess/WebCoreSupport/WebLocalFrameLoaderClient.cpp:
(WebKit::WebLocalFrameLoaderClient::dispatchDidReceiveServerRedirectForProvisionalLoad):
(WebKit::WebLocalFrameLoaderClient::dispatchDidChangeProvisionalURL):
(WebKit::WebLocalFrameLoaderClient::dispatchDidChangeLocationWithinPage):
(WebKit::WebLocalFrameLoaderClient::didSameDocumentNavigationForFrameViaJSHistoryAPI):
(WebKit::WebLocalFrameLoaderClient::dispatchDidStartProvisionalLoad):
(WebKit::WebLocalFrameLoaderClient::dispatchDidCommitLoad):
(WebKit::WebLocalFrameLoaderClient::dispatchDidFailProvisionalLoad):
(WebKit::WebLocalFrameLoaderClient::dispatchDidFailLoad):
(WebKit::WebLocalFrameLoaderClient::dispatchDidFinishDocumentLoad):
(WebKit::WebLocalFrameLoaderClient::dispatchDidFinishLoad):
(WebKit::WebLocalFrameLoaderClient::dispatchDidReachLayoutMilestone):
(WebKit::WebLocalFrameLoaderClient::dispatchCreatePage):
(WebKit::WebLocalFrameLoaderClient::dispatchDecidePolicyForResponse):
(WebKit::WebLocalFrameLoaderClient::dispatchDecidePolicyForNewWindowAction):
(WebKit::WebLocalFrameLoaderClient::applyToDocumentLoader):
(WebKit::WebLocalFrameLoaderClient::dispatchDecidePolicyForNavigationAction):
(WebKit::WebLocalFrameLoaderClient::committedLoad):
(WebKit::WebLocalFrameLoaderClient::updateGlobalHistory):
(WebKit::WebLocalFrameLoaderClient::updateGlobalHistoryRedirectLinks):
(WebKit::WebLocalFrameLoaderClient::restoreViewState):
(WebKit::WebLocalFrameLoaderClient::createDocumentLoader):
(WebKit::WebLocalFrameLoaderClient::updateCachedDocumentLoader):
(WebKit::WebLocalFrameLoaderClient::transitionToCommittedFromCachedFrame):
(WebKit::WebLocalFrameLoaderClient::transitionToCommittedForNewPage):
(WebKit::WebLocalFrameLoaderClient::createFrame):
(WebKit::WebLocalFrameLoaderClient::objectContentType):
(WebKit::WebLocalFrameLoaderClient::didChangeScrollOffset):
(WebKit::WebLocalFrameLoaderClient::contentFilterDidBlockLoad):
* Source/WebKit/WebProcess/WebCoreSupport/WebRemoteFrameClient.cpp:
(WebKit::WebRemoteFrameClient::frameDetached):
* Source/WebKit/WebProcess/WebCoreSupport/curl/WebFrameNetworkingContext.cpp:
(WebKit::WebFrameNetworkingContext::WebFrameNetworkingContext):
* Source/WebKit/WebProcess/WebCoreSupport/mac/WebFrameNetworkingContext.h:
(WebKit::WebFrameNetworkingContext::WebFrameNetworkingContext):
* Source/WebKit/WebProcess/WebCoreSupport/soup/WebFrameNetworkingContext.cpp:
(WebKit::WebFrameNetworkingContext::WebFrameNetworkingContext):
* Source/WebKit/WebProcess/WebPage/Cocoa/WebPageCocoa.mm:
(WebKit::WebPage::pdfSnapshotAtSize):
(WebKit::WebPage::getPDFFirstPageSize):
* Source/WebKit/WebProcess/WebPage/IPCTestingAPI.cpp:
(WebKit::IPCTestingAPI::inject):
* Source/WebKit/WebProcess/WebPage/WebFrame.cpp:
(WebKit::WebFrame::createRemoteSubframe):
(WebKit::WebFrame::coreLocalFrame const):
(WebKit::WebFrame::coreFrame const):
(WebKit::WebFrame::info const):
(WebKit::WebFrame::transitionToLocal):
(WebKit::WebFrame::webArchiveData):
(WebKit::WebFrame::createSelectionSnapshot const):
(WebKit::WebFrame::networkConnectionIntegrityPolicy const):
(WebKit::WebFrame::coreRemoteFrame const): Deleted.
(WebKit::WebFrame::coreAbstractFrame const): Deleted.
* Source/WebKit/WebProcess/WebPage/WebFrame.h:
* Source/WebKit/WebProcess/WebPage/WebPage.cpp:
(WebKit::m_appHighlightsVisible):
(WebKit::WebPage::reinitializeWebPage):
(WebKit::WebPage::renderTreeExternalRepresentation const):
(WebKit::WebPage::renderTreeExternalRepresentationForPrinting const):
(WebKit::WebPage::close):
(WebKit::WebPage::suspendForProcessSwap):
(WebKit::WebPage::loadURLInFrame):
(WebKit::WebPage::loadDataInFrame):
(WebKit::WebPage::loadRequest):
(WebKit::WebPage::loadDataImpl):
(WebKit::WebPage::loadAlternateHTML):
(WebKit::WebPage::navigateToPDFLinkWithSimulatedClick):
(WebKit::WebPage::stopLoading):
(WebKit::WebPage::reload):
(WebKit::WebPage::drawRect):
(WebKit::WebPage::textZoomFactor const):
(WebKit::WebPage::setTextZoomFactor):
(WebKit::WebPage::pageZoomFactor const):
(WebKit::WebPage::setPageZoomFactor):
(WebKit::WebPage::setPageAndTextZoomFactors):
(WebKit::WebPage::takeSnapshot):
(WebKit::WebPage::scaledSnapshotWithOptions):
(WebKit::WebPage::snapshotNode):
(WebKit::WebPage::pageStoppedScrolling):
(WebKit::WebPage::updateFrameSize):
(WebKit::WebPage::visibilityDidChange):
(WebKit::WebPage::suspend):
(WebKit::WebPage::runJavaScript):
(WebKit::WebPage::getContentsAsString):
(WebKit::WebPage::getMainResourceDataOfFrame):
(WebKit::WebPage::getResourceDataFromFrame):
(WebKit::WebPage::willCommitLayerTree):
(WebKit::WebPage::enqueueSecurityPolicyViolationEvent):
(WebKit::WebPage::notifyReportObservers):
(WebKit::WebPage::sendReportToEndpoints):
(WebKit::WebPage::setMainFrameIsScrollable):
(WebKit::WebPage::SandboxExtensionTracker::shouldReuseCommittedSandboxExtension):
(WebKit::WebPage::beginPrinting):
(WebKit::WebPage::drawRectToImage):
(WebKit::WebPage::drawPagesToPDFImpl):
(WebKit::WebPage::resetFocusedElementForFrame):
(WebKit::WebPage::didCommitLoad):
(WebKit::WebPage::getApplicationManifest):
(WebKit::WebPage::getTextFragmentMatch):
(WebKit::WebPage::startTextManipulations):
(WebKit::WebPage::completeTextManipulation):
(WebKit::WebPage::startVisualTranslation):
(WebKit::WebPage::setAppHighlightsVisibility):
(WebKit::WebPage::createMediaSessionCoordinator):
* Source/WebKit/WebProcess/WebPage/gtk/WebPageGtk.cpp:
(WebKit::WebPage::collapseSelectionInFrame):
* Source/WebKit/WebProcess/WebPage/ios/WebPageIOS.mm:
(WebKit::WebPage::cancelPotentialTapInFrame):
(WebKit::WebPage::resetViewportDefaultConfiguration):
(WebKit::WebPage::shrinkToFitContent):
(WebKit::WebPage::platformUserAgent const):
* Source/WebKit/WebProcess/WebPage/mac/WebPageMac.mm:
(WebKit::WebPage::setTopOverhangImage):
(WebKit::WebPage::setBottomOverhangImage):
(WebKit::WebPage::computePagesForPrintingPDFDocument):
* Source/WebKit/WebProcess/WebProcess.cpp:
(WebKit::WebProcess::remotePostMessage):

Canonical link: <a href="https://commits.webkit.org/264279@main">https://commits.webkit.org/264279@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/7082a2e56b45da1ece8548381291104b5e4dc2d3

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/7113 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/7358 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/7537 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/8727 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/7338 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/8619 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/7290 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/10235 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/7240 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/7892 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/6548 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/8832 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/5249 "Passed tests") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/14220 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/6913 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/6562 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/9440 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/7049 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/5766 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/6410 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/1713 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/10608 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/6793 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->