### PR TITLE
Mark a number of boolean enum classes as bool

### DIFF
--- a/Source/JavaScriptCore/API/APIUtils.h
+++ b/Source/JavaScriptCore/API/APIUtils.h
@@ -32,7 +32,7 @@
 #include "JSGlobalObjectInspectorController.h"
 #include "JSValueRef.h"
 
-enum class ExceptionStatus {
+enum class ExceptionStatus : bool {
     DidThrow,
     DidNotThrow
 };

--- a/Source/JavaScriptCore/assembler/CodeLocation.h
+++ b/Source/JavaScriptCore/assembler/CodeLocation.h
@@ -29,7 +29,7 @@
 
 namespace JSC {
 
-enum class NearCallMode : uint8_t { Regular, Tail };
+enum class NearCallMode : bool { Regular, Tail };
 
 template<PtrTag> class CodeLocationInstruction;
 template<PtrTag> class CodeLocationLabel;

--- a/Source/JavaScriptCore/assembler/MacroAssembler.h
+++ b/Source/JavaScriptCore/assembler/MacroAssembler.h
@@ -103,7 +103,7 @@ namespace JSC {
 
 namespace Probe {
 
-enum class SavedFPWidth {
+enum class SavedFPWidth : bool {
     SaveVectors,
     DontSaveVectors
 };

--- a/Source/JavaScriptCore/assembler/MacroAssemblerARM64.h
+++ b/Source/JavaScriptCore/assembler/MacroAssemblerARM64.h
@@ -796,7 +796,7 @@ public:
         clearBits64WithMask(scratchForMask, dest);
     }
 
-    enum class ClearBitsAttributes {
+    enum class ClearBitsAttributes : bool {
         OKToClobberMask,
         MustPreserveMask
     };

--- a/Source/JavaScriptCore/assembler/MacroAssemblerMIPS.h
+++ b/Source/JavaScriptCore/assembler/MacroAssemblerMIPS.h
@@ -115,7 +115,7 @@ public:
         DoubleLessThanOrEqualOrUnordered
     };
 
-    enum class LoadAddressMode {
+    enum class LoadAddressMode : bool {
         ScaleAndAddOffsetIfOffsetIsOutOfBounds,
         Scale
     };

--- a/Source/JavaScriptCore/assembler/MacroAssemblerX86_64.h
+++ b/Source/JavaScriptCore/assembler/MacroAssemblerX86_64.h
@@ -522,7 +522,7 @@ public:
         m_assembler.btrq_rr(dst, bitToClear);
     }
 
-    enum class ClearBitsAttributes {
+    enum class ClearBitsAttributes : bool {
         OKToClobberMask,
         MustPreserveMask
     };

--- a/Source/JavaScriptCore/b3/B3Validate.cpp
+++ b/Source/JavaScriptCore/b3/B3Validate.cpp
@@ -834,7 +834,7 @@ private:
             validateStackmapConstraint(stackmap, child);
     }
     
-    enum class ConstraintRole {
+    enum class ConstraintRole : bool {
         Use,
         Def
     };

--- a/Source/JavaScriptCore/bytecode/HandlerInfo.h
+++ b/Source/JavaScriptCore/bytecode/HandlerInfo.h
@@ -37,7 +37,7 @@ enum class HandlerType : uint8_t {
     SynthesizedFinally = 3
 };
 
-enum class RequiredHandler {
+enum class RequiredHandler : bool {
     CatchHandler,
     AnyHandler
 };

--- a/Source/JavaScriptCore/bytecode/Repatch.h
+++ b/Source/JavaScriptCore/bytecode/Repatch.h
@@ -60,7 +60,7 @@ enum class PutByKind {
     SetPrivateNameByVal,
 };
 
-enum class DelByKind {
+enum class DelByKind : bool {
     ById,
     ByVal
 };

--- a/Source/JavaScriptCore/bytecompiler/BytecodeGenerator.h
+++ b/Source/JavaScriptCore/bytecompiler/BytecodeGenerator.h
@@ -72,8 +72,8 @@ namespace JSC {
     enum class EmitAwait : bool { No, Yes };
 
     enum class DebuggableCall : bool { No, Yes };
-    enum class ThisResolutionType { Local, Scoped };
-    enum class InvalidPrototypeMode : uint8_t { Throw, Ignore };
+    enum class ThisResolutionType : bool { Local, Scoped };
+    enum class InvalidPrototypeMode : bool { Throw, Ignore };
     enum class LinkTimeConstant : int32_t;
     
     class CallArguments {
@@ -831,7 +831,7 @@ namespace JSC {
         RegisterID* emitGetTemplateObject(RegisterID* dst, TaggedTemplateNode*);
         RegisterID* emitGetGlobalPrivate(RegisterID* dst, const Identifier& property);
 
-        enum class ReturnFrom { Normal, Finally };
+        enum class ReturnFrom : bool { Normal, Finally };
         RegisterID* emitReturn(RegisterID* src, ReturnFrom = ReturnFrom::Normal);
         RegisterID* emitEnd(RegisterID* src);
 
@@ -1033,12 +1033,12 @@ namespace JSC {
         bool isDerivedClassContext() { return m_derivedContextType == DerivedContextType::DerivedMethodContext; }
         bool isArrowFunction() { return m_codeBlock->isArrowFunction(); }
 
-        enum class TDZCheckOptimization { Optimize, DoNotOptimize };
-        enum class NestedScopeType { IsNested, IsNotNested };
+        enum class TDZCheckOptimization : bool { Optimize, DoNotOptimize };
+        enum class NestedScopeType : bool { IsNested, IsNotNested };
         enum class ScopeType { CatchScope, LetConstScope, FunctionNameScope, ClassScope };
     private:
-        enum class TDZRequirement { UnderTDZ, NotUnderTDZ };
-        enum class ScopeRegisterType { Var, Block };
+        enum class TDZRequirement : bool { UnderTDZ, NotUnderTDZ };
+        enum class ScopeRegisterType : bool { Var, Block };
         void pushLexicalScopeInternal(VariableEnvironment&, TDZCheckOptimization, NestedScopeType, RegisterID** constantSymbolTableResult, TDZRequirement, ScopeType, ScopeRegisterType);
         void initializeBlockScopedFunctions(VariableEnvironment&, FunctionStack&, RegisterID* constantSymbolTable);
         void popLexicalScopeInternal(VariableEnvironment&);

--- a/Source/JavaScriptCore/debugger/Debugger.h
+++ b/Source/JavaScriptCore/debugger/Debugger.h
@@ -118,7 +118,7 @@ public:
     void stepOverStatement();
     void stepOutOfFunction();
 
-    enum class BlackboxType { Deferred, Ignored };
+    enum class BlackboxType : bool { Deferred, Ignored };
     void setBlackboxType(SourceID, std::optional<BlackboxType>);
     void setBlackboxBreakpointEvaluations(bool);
     void clearBlackbox();

--- a/Source/JavaScriptCore/dfg/DFGCommon.h
+++ b/Source/JavaScriptCore/dfg/DFGCommon.h
@@ -250,7 +250,7 @@ inline KillStatus killStatusForDoesKill(bool doesKill)
     return doesKill ? DoesKill : DoesNotKill;
 }
 
-enum class PlanStage {
+enum class PlanStage : bool {
     Initial,
     AfterFixup
 };

--- a/Source/JavaScriptCore/dfg/DFGDesiredWatchpoints.h
+++ b/Source/JavaScriptCore/dfg/DFGDesiredWatchpoints.h
@@ -42,7 +42,7 @@ namespace JSC { namespace DFG {
 class Graph;
 struct Prefix;
 
-enum class WatchpointRegistrationMode : uint8_t { Collect, Add };
+enum class WatchpointRegistrationMode : bool { Collect, Add };
 class WatchpointCollector final {
     WTF_MAKE_NONCOPYABLE(WatchpointCollector);
 public:

--- a/Source/JavaScriptCore/dfg/DFGNode.h
+++ b/Source/JavaScriptCore/dfg/DFGNode.h
@@ -296,7 +296,7 @@ struct CallDOMGetterData {
     const ClassInfo* requiredClassInfo { nullptr };
 };
 
-enum class BucketOwnerType : uint32_t {
+enum class BucketOwnerType : bool {
     Map,
     Set
 };

--- a/Source/JavaScriptCore/dfg/DFGSlowPathGenerator.h
+++ b/Source/JavaScriptCore/dfg/DFGSlowPathGenerator.h
@@ -98,7 +98,7 @@ protected:
     MacroAssembler::Label m_to;
 };
 
-enum class ExceptionCheckRequirement : uint8_t {
+enum class ExceptionCheckRequirement : bool {
     CheckNeeded,
     CheckNotNeeded
 };

--- a/Source/JavaScriptCore/dfg/DFGVariableEventStream.h
+++ b/Source/JavaScriptCore/dfg/DFGVariableEventStream.h
@@ -53,7 +53,7 @@ public:
     unsigned reconstruct(CodeBlock*, CodeOrigin, MinifiedGraph&, unsigned index, Operands<ValueRecovery>&, Vector<UndefinedOperandSpan>*) const;
 
 private:
-    enum class ReconstructionStyle {
+    enum class ReconstructionStyle : bool {
         Combined,
         Separated
     };

--- a/Source/JavaScriptCore/ftl/FTLThunks.cpp
+++ b/Source/JavaScriptCore/ftl/FTLThunks.cpp
@@ -40,7 +40,7 @@ namespace JSC { namespace FTL {
 
 using namespace DFG;
 
-enum class FrameAndStackAdjustmentRequirement {
+enum class FrameAndStackAdjustmentRequirement : bool {
     Needed, 
     NotNeeded 
 };

--- a/Source/JavaScriptCore/heap/AllocationFailureMode.h
+++ b/Source/JavaScriptCore/heap/AllocationFailureMode.h
@@ -27,7 +27,7 @@
 
 namespace JSC {
 
-enum class AllocationFailureMode {
+enum class AllocationFailureMode : bool {
     Assert,
     ReturnNull
 };

--- a/Source/JavaScriptCore/heap/CollectionScope.h
+++ b/Source/JavaScriptCore/heap/CollectionScope.h
@@ -27,7 +27,7 @@
 
 namespace JSC {
 
-enum class CollectionScope : uint8_t { Eden, Full };
+enum class CollectionScope : bool { Eden, Full };
 
 const char* collectionScopeName(CollectionScope);
 

--- a/Source/JavaScriptCore/heap/ConstraintConcurrency.h
+++ b/Source/JavaScriptCore/heap/ConstraintConcurrency.h
@@ -29,7 +29,7 @@
 
 namespace JSC {
 
-enum class ConstraintConcurrency : uint8_t {
+enum class ConstraintConcurrency : bool {
     Sequential,
     Concurrent
 };

--- a/Source/JavaScriptCore/heap/ConstraintParallelism.h
+++ b/Source/JavaScriptCore/heap/ConstraintParallelism.h
@@ -29,7 +29,7 @@
 
 namespace JSC {
 
-enum class ConstraintParallelism : uint8_t {
+enum class ConstraintParallelism : bool {
     Sequential,
     Parallel
 };

--- a/Source/JavaScriptCore/heap/GCConductor.h
+++ b/Source/JavaScriptCore/heap/GCConductor.h
@@ -30,7 +30,7 @@ namespace JSC {
 // Either the mutator has the conn (https://en.wikipedia.org/wiki/Conn_(nautical)), meaning that the
 // mutator will incrementally drive the collector when it calls into slow paths; or the collector has the
 // conn, meaning that the collector thread will drive the collector.
-enum class GCConductor : uint8_t {
+enum class GCConductor : bool {
     Mutator,
     Collector
 };

--- a/Source/JavaScriptCore/heap/Heap.h
+++ b/Source/JavaScriptCore/heap/Heap.h
@@ -280,7 +280,7 @@ class Heap;
 typedef HashCountedSet<JSCell*> ProtectCountSet;
 typedef HashCountedSet<const char*> TypeCountSet;
 
-enum class HeapType : uint8_t { Small, Large };
+enum class HeapType : bool { Small, Large };
 
 class HeapUtil;
 
@@ -727,7 +727,7 @@ private:
     
     void addCoreConstraints();
 
-    enum class MemoryThresholdCallType {
+    enum class MemoryThresholdCallType : bool {
         Cached,
         Direct
     };

--- a/Source/JavaScriptCore/heap/SlotVisitor.h
+++ b/Source/JavaScriptCore/heap/SlotVisitor.h
@@ -134,7 +134,7 @@ public:
     void donateAndDrain(MonotonicTime timeout = MonotonicTime::infinity());
     
     enum SharedDrainMode { HelperDrain, MainDrain };
-    enum class SharedDrainResult { Done, TimedOut };
+    enum class SharedDrainResult : bool { Done, TimedOut };
     SharedDrainResult drainFromShared(SharedDrainMode, MonotonicTime timeout = MonotonicTime::infinity());
 
     SharedDrainResult drainInParallel(MonotonicTime timeout = MonotonicTime::infinity());

--- a/Source/JavaScriptCore/inspector/InspectorAgentBase.h
+++ b/Source/JavaScriptCore/inspector/InspectorAgentBase.h
@@ -56,7 +56,7 @@ struct JSAgentContext : public AgentContext {
     JSC::JSGlobalObject& inspectedGlobalObject;
 };
 
-enum class DisconnectReason {
+enum class DisconnectReason : bool {
     InspectedTargetDestroyed,
     InspectorDestroyed
 };

--- a/Source/JavaScriptCore/inspector/InspectorAgentRegistry.h
+++ b/Source/JavaScriptCore/inspector/InspectorAgentRegistry.h
@@ -35,7 +35,7 @@ class BackendDispatcher;
 class FrontendRouter;
 class InspectorAgentBase;
 
-enum class DisconnectReason;
+enum class DisconnectReason : bool;
 
 class JS_EXPORT_PRIVATE AgentRegistry {
 public:

--- a/Source/JavaScriptCore/inspector/InspectorFrontendChannel.h
+++ b/Source/JavaScriptCore/inspector/InspectorFrontendChannel.h
@@ -35,7 +35,7 @@ namespace Inspector {
 class FrontendChannel {
 public:
 
-    enum class ConnectionType {
+    enum class ConnectionType : bool {
         Remote,
         Local
     };

--- a/Source/JavaScriptCore/inspector/remote/RemoteInspector.h
+++ b/Source/JavaScriptCore/inspector/remote/RemoteInspector.h
@@ -187,7 +187,7 @@ private:
 
     TargetID nextAvailableTargetIdentifier();
 
-    enum class StopSource { API, XPCMessage };
+    enum class StopSource : bool { API, XPCMessage };
     void stopInternal(StopSource) WTF_REQUIRES_LOCK(m_mutex);
 
 #if PLATFORM(COCOA)

--- a/Source/JavaScriptCore/jit/AssemblyHelpers.h
+++ b/Source/JavaScriptCore/jit/AssemblyHelpers.h
@@ -2040,7 +2040,7 @@ public:
 protected:
     void copyCalleeSavesToEntryFrameCalleeSavesBufferImpl(GPRReg calleeSavesBuffer);
 
-    enum class TypedArrayField { Length, ByteLength };
+    enum class TypedArrayField : bool { Length, ByteLength };
     void loadTypedArrayByteLengthImpl(GPRReg baseGPR, GPRReg valueGPR, GPRReg scratchGPR, GPRReg scratch2GPR, std::optional<TypedArrayType>, TypedArrayField);
 
     CodeBlock* const m_codeBlock;

--- a/Source/JavaScriptCore/jit/AssemblyHelpersSpoolers.h
+++ b/Source/JavaScriptCore/jit/AssemblyHelpersSpoolers.h
@@ -296,7 +296,7 @@ public:
         template<typename RegType> RegType getReg() { return RegDispatch<RegType>::get(reg); };
     };
 
-    enum class BufferRegs {
+    enum class BufferRegs : bool {
         NeedPreservation,
         AllowModification
     };

--- a/Source/JavaScriptCore/jit/JIT.h
+++ b/Source/JavaScriptCore/jit/JIT.h
@@ -834,7 +834,7 @@ namespace JSC {
             return call;
         }
 
-        enum class ProfilingPolicy {
+        enum class ProfilingPolicy : bool {
             ShouldEmitProfiling,
             NoProfiling
         };

--- a/Source/JavaScriptCore/jit/JITCode.h
+++ b/Source/JavaScriptCore/jit/JITCode.h
@@ -164,7 +164,7 @@ public:
     virtual bool canSwapCodeRefForDebugger() const { return false; }
     virtual CodeRef<JSEntryPtrTag> swapCodeRefForDebugger(CodeRef<JSEntryPtrTag>);
     
-    enum class ShareAttribute : uint8_t {
+    enum class ShareAttribute : bool {
         NotShared,
         Shared
     };

--- a/Source/JavaScriptCore/jit/JITOperations.cpp
+++ b/Source/JavaScriptCore/jit/JITOperations.cpp
@@ -2383,7 +2383,7 @@ JSC_DEFINE_JIT_OPERATION(operationTryOSREnterAtCatchAndValueProfile, UGPRPair, (
 
 #endif
 
-enum class AccessorType {
+enum class AccessorType : bool {
     Getter,
     Setter
 };

--- a/Source/JavaScriptCore/jit/ScratchRegisterAllocator.h
+++ b/Source/JavaScriptCore/jit/ScratchRegisterAllocator.h
@@ -65,7 +65,7 @@ public:
 
     RegisterSet usedRegisters() const { return m_usedRegisters; }
     
-    enum class ExtraStackSpace { SpaceForCCall, NoExtraSpace };
+    enum class ExtraStackSpace : bool { SpaceForCCall, NoExtraSpace };
 
     struct PreservedState {
         PreservedState()

--- a/Source/JavaScriptCore/jit/ThunkGenerators.cpp
+++ b/Source/JavaScriptCore/jit/ThunkGenerators.cpp
@@ -372,7 +372,7 @@ MacroAssemblerCodeRef<JITStubRoutinePtrTag> virtualThunkFor(VM& vm, CallMode cal
 }
 
 enum ThunkEntryType { EnterViaCall, EnterViaJumpWithSavedTags, EnterViaJumpWithoutSavedTags };
-enum class ThunkFunctionType { JSFunction, InternalFunction };
+enum class ThunkFunctionType : bool { JSFunction, InternalFunction };
 enum class IncludeDebuggerHook : bool { No, Yes };
 
 static MacroAssemblerCodeRef<JITThunkPtrTag> nativeForGenerator(VM& vm, ThunkFunctionType thunkFunctionType, CodeSpecializationKind kind, ThunkEntryType entryType = EnterViaCall, IncludeDebuggerHook includeDebuggerHook = IncludeDebuggerHook::No)

--- a/Source/JavaScriptCore/jsc.cpp
+++ b/Source/JavaScriptCore/jsc.cpp
@@ -404,17 +404,17 @@ static JSC_DECLARE_HOST_FUNCTION(functionAsDoubleNumber);
 static JSC_DECLARE_HOST_FUNCTION(functionDropAllLocks);
 
 struct Script {
-    enum class StrictMode {
+    enum class StrictMode : bool {
         Strict,
         Sloppy
     };
 
-    enum class ScriptType {
+    enum class ScriptType : bool {
         Script,
         Module
     };
 
-    enum class CodeSource {
+    enum class CodeSource : bool {
         File,
         CommandLine
     };

--- a/Source/JavaScriptCore/llint/LLIntSlowPaths.cpp
+++ b/Source/JavaScriptCore/llint/LLIntSlowPaths.cpp
@@ -2043,7 +2043,7 @@ LLINT_SLOW_PATH_DECL(slow_path_size_frame_for_forward_arguments)
     LLINT_RETURN_CALLEE_FRAME(calleeFrame);
 }
 
-enum class SetArgumentsWith {
+enum class SetArgumentsWith : bool {
     Object,
     CurrentArguments
 };

--- a/Source/JavaScriptCore/parser/Lexer.h
+++ b/Source/JavaScriptCore/parser/Lexer.h
@@ -79,7 +79,7 @@ public:
     int lastLineNumber() const { return m_lastLineNumber; }
     bool hasLineTerminatorBeforeToken() const { return m_hasLineTerminatorBeforeToken; }
     JSTokenType scanRegExp(JSToken*, UChar patternPrefix = 0);
-    enum class RawStringsBuildMode { BuildRawStrings, DontBuildRawStrings };
+    enum class RawStringsBuildMode : bool { BuildRawStrings, DontBuildRawStrings };
     JSTokenType scanTemplateString(JSToken*, RawStringsBuildMode);
 
     // Functions for use after parsing.

--- a/Source/JavaScriptCore/parser/Nodes.h
+++ b/Source/JavaScriptCore/parser/Nodes.h
@@ -77,7 +77,7 @@ namespace JSC {
         URShift
     };
     
-    enum class LogicalOperator : uint8_t {
+    enum class LogicalOperator : bool {
         And,
         Or
     };
@@ -878,7 +878,7 @@ namespace JSC {
         bool m_subscriptHasAssignments;
     };
 
-    enum class DotType { Name, PrivateMember };
+    enum class DotType : bool { Name, PrivateMember };
     class BaseDotNode : public ExpressionNode {
     public:
         BaseDotNode(const JSTokenLocation&, ExpressionNode* base, const Identifier&, DotType);
@@ -1063,7 +1063,7 @@ namespace JSC {
 
     class BytecodeIntrinsicNode final : public ExpressionNode, public ThrowableExpressionData {
     public:
-        enum class Type : uint8_t {
+        enum class Type : bool {
             Constant,
             Function
         };
@@ -2505,7 +2505,7 @@ namespace JSC {
         JSC_MAKE_PARSER_ARENA_DELETABLE_ALLOCATED(ObjectPatternNode);
     public:
         ObjectPatternNode();
-        enum class BindingType : uint8_t {
+        enum class BindingType : bool {
             Element,
             RestElement
         };

--- a/Source/JavaScriptCore/parser/Parser.h
+++ b/Source/JavaScriptCore/parser/Parser.h
@@ -493,7 +493,7 @@ public:
         return result;
     }
 
-    enum class PrivateAccessorType { Setter, Getter };
+    enum class PrivateAccessorType : bool { Setter, Getter };
 
     DeclarationResultMask declarePrivateAccessor(const Identifier& ident, ClassElementTag tag, PrivateAccessorType accessorType)
     {
@@ -972,7 +972,7 @@ private:
     unsigned m_index;
 };
 
-enum class ArgumentType { Normal, Spread };
+enum class ArgumentType : bool { Normal, Spread };
 enum class ParsingContext { Program, FunctionConstructor, Eval };
 
 template <typename LexerType>
@@ -1748,9 +1748,9 @@ private:
     template <class TreeBuilder> TreeSourceElements parseClassFieldInitializerSourceElements(TreeBuilder&, const FixedVector<JSTextPosition>&);
     template <class TreeBuilder> TreeStatement parseStatementListItem(TreeBuilder&, const Identifier*& directive, unsigned* directiveLiteralLength);
     template <class TreeBuilder> TreeStatement parseStatement(TreeBuilder&, const Identifier*& directive, unsigned* directiveLiteralLength = nullptr);
-    enum class ExportType { Exported, NotExported };
+    enum class ExportType : bool { Exported, NotExported };
     template <class TreeBuilder> TreeStatement parseClassDeclaration(TreeBuilder&, ExportType = ExportType::NotExported, DeclarationDefaultContext = DeclarationDefaultContext::Standard);
-    enum class FunctionDeclarationType { Declaration, Statement };
+    enum class FunctionDeclarationType : bool { Declaration, Statement };
     template <class TreeBuilder> TreeStatement parseFunctionDeclaration(TreeBuilder&, FunctionDeclarationType = FunctionDeclarationType::Declaration, ExportType = ExportType::NotExported, DeclarationDefaultContext = DeclarationDefaultContext::Standard, std::optional<int> functionConstructorParametersEndPosition = std::nullopt);
     template <class TreeBuilder> TreeStatement parseFunctionDeclarationStatement(TreeBuilder&, bool parentAllowsFunctionDeclarationAsStatement);
     template <class TreeBuilder> TreeStatement parseAsyncFunctionDeclaration(TreeBuilder&, ExportType = ExportType::NotExported, DeclarationDefaultContext = DeclarationDefaultContext::Standard, std::optional<int> functionConstructorParametersEndPosition = std::nullopt);
@@ -1976,7 +1976,7 @@ private:
         return *m_token.m_data.ident == m_vm.propertyNames->arguments;
     }
 
-    enum class FunctionParsePhase { Parameters, Body };
+    enum class FunctionParsePhase : bool { Parameters, Body };
     struct ParserState {
         int assignmentCount { 0 };
         int nonLHSCount { 0 };

--- a/Source/JavaScriptCore/parser/ParserModes.h
+++ b/Source/JavaScriptCore/parser/ParserModes.h
@@ -31,13 +31,13 @@
 
 namespace JSC {
 
-enum class JSParserStrictMode { NotStrict, Strict };
-enum class JSParserBuiltinMode { NotBuiltin, Builtin };
-enum class JSParserScriptMode { Classic, Module };
+enum class JSParserStrictMode : bool { NotStrict, Strict };
+enum class JSParserBuiltinMode : bool { NotBuiltin, Builtin };
+enum class JSParserScriptMode : bool { Classic, Module };
 
-enum class SuperBinding { Needed, NotNeeded };
+enum class SuperBinding : bool { Needed, NotNeeded };
 
-enum class PrivateBrandRequirement { None, Needed };
+enum class PrivateBrandRequirement : bool { None, Needed };
 
 enum class CodeGenerationMode : uint8_t {
     Debugger = 1 << 0,

--- a/Source/JavaScriptCore/runtime/AbstractModuleRecord.h
+++ b/Source/JavaScriptCore/runtime/AbstractModuleRecord.h
@@ -89,7 +89,7 @@ public:
         Identifier localName;
     };
 
-    enum class ImportEntryType { Single, Namespace };
+    enum class ImportEntryType : bool { Single, Namespace };
     struct ImportEntry {
         ImportEntryType type;
         Identifier moduleRequest;

--- a/Source/JavaScriptCore/runtime/ArgList.h
+++ b/Source/JavaScriptCore/runtime/ArgList.h
@@ -37,7 +37,7 @@ class alignas(alignof(EncodedJSValue)) MarkedVectorBase {
     friend class ArgList;
 
 protected:
-    enum class Status { Success, Overflowed };
+    enum class Status : bool { Success, Overflowed };
 public:
     typedef HashSet<MarkedVectorBase*> ListSet;
 

--- a/Source/JavaScriptCore/runtime/ArgumentsMode.h
+++ b/Source/JavaScriptCore/runtime/ArgumentsMode.h
@@ -27,7 +27,7 @@
 
 namespace JSC {
 
-enum class ArgumentsMode {
+enum class ArgumentsMode : bool {
     Cloned,
     FakeValues
 };

--- a/Source/JavaScriptCore/runtime/ArrayBuffer.h
+++ b/Source/JavaScriptCore/runtime/ArrayBuffer.h
@@ -234,7 +234,7 @@ private:
 
     friend class ArrayBuffer;
 
-    enum class InitializationPolicy : uint8_t {
+    enum class InitializationPolicy : bool {
         ZeroInitialize,
         DontInitialize
     };

--- a/Source/JavaScriptCore/runtime/ArrayPrototype.cpp
+++ b/Source/JavaScriptCore/runtime/ArrayPrototype.cpp
@@ -1223,7 +1223,7 @@ JSC_DEFINE_HOST_FUNCTION(arrayProtoFuncUnShift, (JSGlobalObject* globalObject, C
     return JSValue::encode(jsNumber(newLength));
 }
 
-enum class IndexOfDirection { Forward, Backward };
+enum class IndexOfDirection : bool { Forward, Backward };
 template<IndexOfDirection direction>
 ALWAYS_INLINE JSValue fastIndexOf(JSGlobalObject* globalObject, VM& vm, JSArray* array, uint64_t length64, JSValue searchElement, uint64_t index64)
 {

--- a/Source/JavaScriptCore/runtime/AtomicsObject.cpp
+++ b/Source/JavaScriptCore/runtime/AtomicsObject.cpp
@@ -136,7 +136,7 @@ static unsigned validateAtomicAccess(JSGlobalObject* globalObject, VM& vm, JSArr
     return accessIndex;
 }
 
-enum class TypedArrayOperationMode { ReadWrite, Wait };
+enum class TypedArrayOperationMode : bool { ReadWrite, Wait };
 template<TypedArrayOperationMode mode>
 inline JSArrayBufferView* validateIntegerTypedArray(JSGlobalObject* globalObject, JSValue typedArrayValue)
 {

--- a/Source/JavaScriptCore/runtime/EnumerationMode.h
+++ b/Source/JavaScriptCore/runtime/EnumerationMode.h
@@ -33,12 +33,12 @@ enum class PropertyNameMode : uint8_t {
     StringsAndSymbols = Symbols | Strings,
 };
 
-enum class PrivateSymbolMode : uint8_t {
+enum class PrivateSymbolMode : bool {
     Include,
     Exclude
 };
 
-enum class DontEnumPropertiesMode : uint8_t {
+enum class DontEnumPropertiesMode : bool {
     Include,
     Exclude
 };

--- a/Source/JavaScriptCore/runtime/ExceptionExpectation.h
+++ b/Source/JavaScriptCore/runtime/ExceptionExpectation.h
@@ -27,7 +27,7 @@
 
 namespace JSC {
 
-enum class ExceptionExpectation {
+enum class ExceptionExpectation : bool {
     CanThrow,
     ShouldNotThrow
 };

--- a/Source/JavaScriptCore/runtime/HashMapImpl.h
+++ b/Source/JavaScriptCore/runtime/HashMapImpl.h
@@ -34,7 +34,7 @@ namespace JSC {
 JS_EXPORT_PRIVATE const ClassInfo* getHashMapBucketKeyClassInfo();
 JS_EXPORT_PRIVATE const ClassInfo* getHashMapBucketKeyValueClassInfo();
 
-enum class HashTableType {
+enum class HashTableType : bool {
     Key,
     KeyValue
 };
@@ -359,7 +359,7 @@ private:
 
     ALWAYS_INLINE HashMapBucketType** findBucketAlreadyHashedAndNormalized(JSGlobalObject*, JSValue key, uint32_t hash);
 
-    enum class RehashMode { BeforeAddition, AfterRemoval };
+    enum class RehashMode : bool { BeforeAddition, AfterRemoval };
     void rehash(JSGlobalObject*, RehashMode);
 
     ALWAYS_INLINE void checkConsistency() const;

--- a/Source/JavaScriptCore/runtime/ISO8601.cpp
+++ b/Source/JavaScriptCore/runtime/ISO8601.cpp
@@ -252,7 +252,7 @@ std::optional<Duration> parseDuration(StringView string)
 }
 
 
-enum class Second60Mode { Accept, Reject };
+enum class Second60Mode : bool { Accept, Reject };
 template<typename CharacterType>
 static std::optional<PlainTime> parseTimeSpec(StringParsingBuffer<CharacterType>& buffer, Second60Mode second60Mode)
 {

--- a/Source/JavaScriptCore/runtime/InternalFunction.h
+++ b/Source/JavaScriptCore/runtime/InternalFunction.h
@@ -86,7 +86,7 @@ public:
 protected:
     JS_EXPORT_PRIVATE InternalFunction(VM&, Structure*, NativeFunction functionForCall, NativeFunction functionForConstruct = nullptr);
 
-    enum class PropertyAdditionMode { WithStructureTransition, WithoutStructureTransition };
+    enum class PropertyAdditionMode : bool { WithStructureTransition, WithoutStructureTransition };
     JS_EXPORT_PRIVATE void finishCreation(VM&, unsigned length, const String& name, PropertyAdditionMode = PropertyAdditionMode::WithStructureTransition);
     DECLARE_DEFAULT_FINISH_CREATION;
 

--- a/Source/JavaScriptCore/runtime/IntlCollator.h
+++ b/Source/JavaScriptCore/runtime/IntlCollator.h
@@ -88,7 +88,7 @@ private:
     static Vector<String> sortLocaleData(const String&, RelevantExtensionKey);
     static Vector<String> searchLocaleData(const String&, RelevantExtensionKey);
 
-    enum class Usage : uint8_t { Sort, Search };
+    enum class Usage : bool { Sort, Search };
     enum class Sensitivity : uint8_t { Base, Accent, Case, Variant };
     enum class CaseFirst : uint8_t { Upper, Lower, False };
 

--- a/Source/JavaScriptCore/runtime/IntlDisplayNames.h
+++ b/Source/JavaScriptCore/runtime/IntlDisplayNames.h
@@ -66,8 +66,8 @@ private:
 
     enum class Style : uint8_t { Narrow, Short, Long };
     enum class Type : uint8_t { Language, Region, Script, Currency, Calendar, DateTimeField };
-    enum class Fallback : uint8_t { Code, None };
-    enum class LanguageDisplay : uint8_t { Dialect, Standard };
+    enum class Fallback : bool { Code, None };
+    enum class LanguageDisplay : bool { Dialect, Standard };
 
     static ASCIILiteral styleString(Style);
     static ASCIILiteral typeString(Type);

--- a/Source/JavaScriptCore/runtime/IntlDurationFormat.h
+++ b/Source/JavaScriptCore/runtime/IntlDurationFormat.h
@@ -63,7 +63,7 @@ public:
     JSValue formatToParts(JSGlobalObject*, ISO8601::Duration) const;
     JSObject* resolvedOptions(JSGlobalObject*) const;
 
-    enum class Display : uint8_t { Always, Auto };
+    enum class Display : bool { Always, Auto };
     enum class Style : uint8_t { Long, Short, Narrow, Digital };
     enum class UnitStyle : uint8_t { Long, Short, Narrow, Numeric, TwoDigit };
     static constexpr unsigned numberOfUnitStyles = 5;

--- a/Source/JavaScriptCore/runtime/IntlNumberFormat.h
+++ b/Source/JavaScriptCore/runtime/IntlNumberFormat.h
@@ -220,11 +220,11 @@ private:
     static Vector<String> localeData(const String&, RelevantExtensionKey);
 
     enum class CurrencyDisplay : uint8_t { Code, Symbol, NarrowSymbol, Name };
-    enum class CurrencySign : uint8_t { Standard, Accounting };
+    enum class CurrencySign : bool { Standard, Accounting };
     enum class UnitDisplay : uint8_t { Short, Narrow, Long };
-    enum class CompactDisplay : uint8_t { Short, Long };
+    enum class CompactDisplay : bool { Short, Long };
     enum class SignDisplay : uint8_t { Auto, Never, Always, ExceptZero, Negative };
-    enum class TrailingZeroDisplay : uint8_t { Auto, StripIfInteger };
+    enum class TrailingZeroDisplay : bool { Auto, StripIfInteger };
     enum class UseGrouping : uint8_t { False, Min2, Auto, Always };
 
     static ASCIILiteral styleString(Style);

--- a/Source/JavaScriptCore/runtime/JSBigInt.h
+++ b/Source/JavaScriptCore/runtime/JSBigInt.h
@@ -58,7 +58,7 @@ public:
         return &vm.bigIntSpace();
     }
 
-    enum class InitializationType { None, WithZero };
+    enum class InitializationType : bool { None, WithZero };
     void initialize(InitializationType);
 
     static size_t estimatedSize(JSCell*, VM&);
@@ -130,13 +130,13 @@ public:
         return JSBigInt::createFrom(globalObject, value);
     }
 
-    enum class ErrorParseMode {
+    enum class ErrorParseMode : bool {
         ThrowExceptions,
         IgnoreExceptions
     };
 
-    enum class ParseIntMode { DisallowEmptyString, AllowEmptyString };
-    enum class ParseIntSign { Unsigned, Signed };
+    enum class ParseIntMode : bool { DisallowEmptyString, AllowEmptyString };
+    enum class ParseIntSign : bool { Unsigned, Signed };
 
     static JSValue parseInt(JSGlobalObject*, VM&, StringView, uint8_t radix, ErrorParseMode = ErrorParseMode::ThrowExceptions, ParseIntSign = ParseIntSign::Unsigned);
     static JSValue parseInt(JSGlobalObject*, StringView, ErrorParseMode = ErrorParseMode::ThrowExceptions);
@@ -146,7 +146,7 @@ public:
 
     String toString(JSGlobalObject*, unsigned radix);
     
-    enum class ComparisonMode {
+    enum class ComparisonMode : bool {
         LessThan,
         LessThanOrEqual
     };
@@ -516,7 +516,7 @@ private:
     template <typename BigIntImpl1>
     static void absoluteDivWithBigIntDivisor(JSGlobalObject*, BigIntImpl1 dividend, JSBigInt* divisor, JSBigInt** quotient, JSBigInt** remainder);
     
-    enum class LeftShiftMode {
+    enum class LeftShiftMode : bool {
         SameSizeResult,
         AlwaysAddOneDigit
     };
@@ -537,7 +537,7 @@ private:
 
     static RoundingResult decideRounding(JSBigInt*, int32_t mantissaBitsUnset, int32_t digitIndex, uint64_t currentDigit);
 
-    enum class ExtraDigitsHandling {
+    enum class ExtraDigitsHandling : bool {
         Copy,
         Skip
     };
@@ -554,7 +554,7 @@ private:
     template <typename BigIntImpl1, typename BigIntImpl2>
     static JSBigInt* absoluteXor(JSGlobalObject*, BigIntImpl1 x, BigIntImpl2 y);
 
-    enum class SignOption {
+    enum class SignOption : bool {
         Signed,
         Unsigned
     };

--- a/Source/JavaScriptCore/runtime/JSCell.h
+++ b/Source/JavaScriptCore/runtime/JSCell.h
@@ -54,7 +54,7 @@ class PropertyNameArray;
 class Structure;
 class JSCellLock;
 
-enum class GCDeferralContextArgPresense {
+enum class GCDeferralContextArgPresense : bool {
     HasArg,
     DoesNotHaveArg
 };

--- a/Source/JavaScriptCore/runtime/JSGlobalObject.cpp
+++ b/Source/JavaScriptCore/runtime/JSGlobalObject.cpp
@@ -1960,7 +1960,7 @@ IterationStatus GlobalObjectDependencyFinder::operator()(HeapCell* cell, HeapCel
     return IterationStatus::Continue;
 }
 
-enum class BadTimeFinderMode {
+enum class BadTimeFinderMode : bool {
     SingleGlobal,
     MultipleGlobals
 };

--- a/Source/JavaScriptCore/runtime/JSGlobalObjectDebuggable.h
+++ b/Source/JavaScriptCore/runtime/JSGlobalObjectDebuggable.h
@@ -32,7 +32,7 @@
 
 namespace Inspector {
 class FrontendChannel;
-enum class DisconnectReason;
+enum class DisconnectReason : bool;
 }
 
 namespace JSC {

--- a/Source/JavaScriptCore/runtime/JSSymbolTableObject.h
+++ b/Source/JavaScriptCore/runtime/JSSymbolTableObject.h
@@ -134,7 +134,7 @@ ALWAYS_INLINE void symbolTablePutInvalidateWatchpointSet(VM& vm, SymbolTableObje
         set->invalidate(vm, VariableWriteFireDetail(object, propertyName)); // Don't mess around - if we had found this statically, we would have invalidated it.
 }
 
-enum class SymbolTablePutMode {
+enum class SymbolTablePutMode : bool {
     Touch,
     Invalidate
 };

--- a/Source/JavaScriptCore/runtime/LiteralParser.cpp
+++ b/Source/JavaScriptCore/runtime/LiteralParser.cpp
@@ -831,7 +831,7 @@ ALWAYS_INLINE void setParserTokenString<UChar>(LiteralParserToken<UChar>& token,
     token.stringStart16 = string;
 }
 
-enum class SafeStringCharacterSet { Strict, Sloppy };
+enum class SafeStringCharacterSet : bool { Strict, Sloppy };
 
 template <SafeStringCharacterSet set>
 static ALWAYS_INLINE bool isSafeStringCharacter(LChar c, LChar terminator)

--- a/Source/JavaScriptCore/runtime/ObjectConstructor.cpp
+++ b/Source/JavaScriptCore/runtime/ObjectConstructor.cpp
@@ -791,7 +791,7 @@ JSC_DEFINE_HOST_FUNCTION(objectConstructorCreate, (JSGlobalObject* globalObject,
     RELEASE_AND_RETURN(scope, JSValue::encode(defineProperties(globalObject, newObject, properties)));
 }
 
-enum class IntegrityLevel {
+enum class IntegrityLevel : bool {
     Sealed,
     Frozen
 };

--- a/Source/JavaScriptCore/runtime/VMTraps.h
+++ b/Source/JavaScriptCore/runtime/VMTraps.h
@@ -206,7 +206,7 @@ public:
     ALWAYS_INLINE bool maybeNeedHandling() const { return m_trapBits.loadRelaxed(); }
     void* trapBitsAddress() { return &m_trapBits; }
 
-    enum class DeferAction {
+    enum class DeferAction : bool {
         DeferForAWhile,
         DeferUntilEndOfScope
     };

--- a/Source/JavaScriptCore/runtime/WaiterListManager.h
+++ b/Source/JavaScriptCore/runtime/WaiterListManager.h
@@ -33,8 +33,8 @@
 
 namespace JSC {
 
-enum class AtomicsWaitType : uint8_t { Sync, Async };
-enum class AtomicsWaitValidation : uint8_t { Pass, Fail };
+enum class AtomicsWaitType : bool { Sync, Async };
+enum class AtomicsWaitValidation : bool { Pass, Fail };
 
 class Waiter final : public WTF::BasicRawSentinelNode<Waiter>, public ThreadSafeRefCounted<Waiter> {
     WTF_MAKE_FAST_ALLOCATED;
@@ -218,7 +218,7 @@ public:
     JS_EXPORT_PRIVATE JSValue waitAsync(JSGlobalObject*, VM&, int32_t* ptr, int32_t expected, Seconds timeout);
     JS_EXPORT_PRIVATE JSValue waitAsync(JSGlobalObject*, VM&, int64_t* ptr, int64_t expected, Seconds timeout);
 
-    enum class ResolveResult : uint8_t { Ok, Timeout };
+    enum class ResolveResult : bool { Ok, Timeout };
     unsigned notifyWaiter(void* ptr, unsigned count);
 
     size_t waiterListSize(void* ptr);

--- a/Source/JavaScriptCore/runtime/WeakMapImpl.h
+++ b/Source/JavaScriptCore/runtime/WeakMapImpl.h
@@ -303,7 +303,7 @@ private:
         return m_buffer->buffer();
     }
 
-    enum class IterationState { Continue, Stop };
+    enum class IterationState : bool { Continue, Stop };
     template<typename Functor>
     void forEach(Functor functor)
     {
@@ -369,7 +369,7 @@ private:
         return nullptr;
     }
 
-    enum class RehashMode { Normal, RemoveBatching };
+    enum class RehashMode : bool { Normal, RemoveBatching };
     void rehash(RehashMode = RehashMode::Normal);
 
     ALWAYS_INLINE void checkConsistency() const

--- a/Source/JavaScriptCore/tools/VMInspector.h
+++ b/Source/JavaScriptCore/tools/VMInspector.h
@@ -39,7 +39,7 @@ class VMInspector {
     WTF_MAKE_NONCOPYABLE(VMInspector);
     VMInspector() = default;
 public:
-    enum class Error {
+    enum class Error : bool {
         None,
         TimedOut
     };

--- a/Source/JavaScriptCore/wasm/WasmAirIRGeneratorBase.h
+++ b/Source/JavaScriptCore/wasm/WasmAirIRGeneratorBase.h
@@ -319,7 +319,7 @@ struct AirIRGeneratorBase {
         B3::ValueRep rep;
     };
 
-    enum class CastKind { Cast, Test };
+    enum class CastKind : bool { Cast, Test };
 
     ////////////////////////////////////////////////////////////////////////////////
     // Get concrete instance
@@ -896,7 +896,7 @@ protected:
     template <typename IntType>
     void emitChecksForModOrDiv(bool isSignedDiv, ExpressionType left, ExpressionType right);
 
-    enum class MinOrMax { Min, Max };
+    enum class MinOrMax : bool { Min, Max };
     PartialResult addFloatingPointMinOrMax(Type, MinOrMax, ExpressionType lhs, ExpressionType rhs, ExpressionType& result);
 
     int32_t WARN_UNUSED_RETURN fixupPointerPlusOffset(ExpressionType&, uint32_t);

--- a/Source/JavaScriptCore/wasm/WasmB3IRGenerator.cpp
+++ b/Source/JavaScriptCore/wasm/WasmB3IRGenerator.cpp
@@ -313,7 +313,7 @@ public:
 
     static ExpressionType emptyExpression() { return nullptr; };
 
-    enum class CastKind { Cast, Test };
+    enum class CastKind : bool { Cast, Test };
 
     template <typename ...Args>
     NEVER_INLINE UnexpectedResult WARN_UNUSED_RETURN fail(Args... args) const

--- a/Source/JavaScriptCore/wasm/WasmCreationMode.h
+++ b/Source/JavaScriptCore/wasm/WasmCreationMode.h
@@ -29,7 +29,7 @@
 
 namespace JSC { namespace Wasm {
 
-enum class CreationMode {
+enum class CreationMode : bool {
     FromJS,
     FromModuleLoader
 };

--- a/Source/JavaScriptCore/wasm/WasmFormat.h
+++ b/Source/JavaScriptCore/wasm/WasmFormat.h
@@ -57,7 +57,7 @@ struct UnlinkedHandlerInfo;
 
 using BlockSignature = const TypeDefinition*;
 
-enum class TableElementType : uint8_t {
+enum class TableElementType : bool {
     Externref,
     Funcref
 };

--- a/Source/JavaScriptCore/wasm/WasmSectionParser.h
+++ b/Source/JavaScriptCore/wasm/WasmSectionParser.h
@@ -64,7 +64,7 @@ private:
     PartialResult WARN_UNUSED_RETURN parseGlobalType(GlobalInformation&);
     PartialResult WARN_UNUSED_RETURN parseMemoryHelper(bool isImport);
     PartialResult WARN_UNUSED_RETURN parseTableHelper(bool isImport);
-    enum class LimitsType { Memory, Table };
+    enum class LimitsType : bool { Memory, Table };
     PartialResult WARN_UNUSED_RETURN parseResizableLimits(uint32_t& initial, std::optional<uint32_t>& maximum, bool& isShared, LimitsType);
     PartialResult WARN_UNUSED_RETURN parseInitExpr(uint8_t&, uint64_t&, v128_t&, Type& initExprType);
     PartialResult WARN_UNUSED_RETURN parseI32InitExpr(std::optional<I32InitExpr>&, ASCIILiteral failMessage);

--- a/Source/JavaScriptCore/wasm/WasmSlowPaths.cpp
+++ b/Source/JavaScriptCore/wasm/WasmSlowPaths.cpp
@@ -85,7 +85,7 @@ namespace JSC { namespace LLInt {
         : callFrame->r(virtualRegister))
 
 #if ENABLE(WEBASSEMBLY_B3JIT)
-enum class RequiredWasmJIT { Any, OMG };
+enum class RequiredWasmJIT : bool { Any, OMG };
 
 extern "C" void wasm_log_crash(CallFrame*, Wasm::Instance* instance)
 {

--- a/Source/JavaScriptCore/wasm/WasmStreamingParser.h
+++ b/Source/JavaScriptCore/wasm/WasmStreamingParser.h
@@ -38,7 +38,7 @@ namespace JSC { namespace Wasm {
 struct FunctionData;
 struct ModuleInformation;
 
-enum class CompilerMode : uint8_t { FullCompile, Validation };
+enum class CompilerMode : bool { FullCompile, Validation };
 
 class StreamingParserClient {
 public:

--- a/Source/JavaScriptCore/yarr/Yarr.h
+++ b/Source/JavaScriptCore/yarr/Yarr.h
@@ -49,7 +49,7 @@ static constexpr unsigned offsetNoMatch = std::numeric_limits<unsigned>::max();
 // avoid spending exponential time on complex regular expressions.
 static constexpr unsigned matchLimit = 1000000;
 
-enum class MatchFrom { VMThread, CompilerThread };
+enum class MatchFrom : bool { VMThread, CompilerThread };
 
 enum class JSRegExpResult {
     Match = 1,
@@ -61,7 +61,7 @@ enum class JSRegExpResult {
     ErrorInternal = -5,
 };
 
-enum class CharSize : uint8_t {
+enum class CharSize : bool {
     Char8,
     Char16
 };

--- a/Source/JavaScriptCore/yarr/YarrCanonicalize.h
+++ b/Source/JavaScriptCore/yarr/YarrCanonicalize.h
@@ -59,7 +59,7 @@ extern const size_t UNICODE_CANONICALIZATION_RANGES;
 extern const UChar32* const unicodeCharacterSetInfo[];
 extern const CanonicalizationRange unicodeRangeInfo[];
 
-enum class CanonicalMode { UCS2, Unicode };
+enum class CanonicalMode : bool { UCS2, Unicode };
 
 inline const UChar32* canonicalCharacterSetInfo(unsigned index, CanonicalMode canonicalMode)
 {

--- a/Source/JavaScriptCore/yarr/YarrDisassembler.h
+++ b/Source/JavaScriptCore/yarr/YarrDisassembler.h
@@ -74,7 +74,7 @@ public:
     void dump(PrintStream&, LinkBuffer&);
 
 private:
-    enum class VectorOrder {
+    enum class VectorOrder : bool {
         IterateForward,
         IterateReverse
     };

--- a/Source/JavaScriptCore/yarr/YarrParser.h
+++ b/Source/JavaScriptCore/yarr/YarrParser.h
@@ -36,7 +36,7 @@
 
 namespace JSC { namespace Yarr {
 
-enum class CreateDisjunctionPurpose : uint8_t { NotForNextAlternative, ForNextAlternative };
+enum class CreateDisjunctionPurpose : bool { NotForNextAlternative, ForNextAlternative };
 
 enum class CharacterClassSetOp : uint8_t {
     Default,
@@ -52,7 +52,7 @@ private:
     template<class FriendDelegate>
     friend ErrorCode parse(FriendDelegate&, StringView pattern, CompileMode, unsigned backReferenceLimit, bool isNamedForwardReferenceAllowed);
 
-    enum class UnicodeParseContext : uint8_t { PatternCodePoint, GroupName };
+    enum class UnicodeParseContext : bool { PatternCodePoint, GroupName };
 
     enum class ParseEscapeMode : uint8_t { Normal, CharacterClass, ClassStringDisjunction };
 

--- a/Source/bmalloc/bmalloc/FailureAction.h
+++ b/Source/bmalloc/bmalloc/FailureAction.h
@@ -27,6 +27,6 @@
 
 namespace bmalloc {
 
-enum class FailureAction { Crash, ReturnNull };
+enum class FailureAction : bool { Crash, ReturnNull };
 
 } // namespace bmalloc

--- a/Source/bmalloc/bmalloc/IsoPageTrigger.h
+++ b/Source/bmalloc/bmalloc/IsoPageTrigger.h
@@ -29,7 +29,7 @@
 
 namespace bmalloc {
 
-enum class IsoPageTrigger {
+enum class IsoPageTrigger : bool {
     Eligible,
     Empty
 };

--- a/Source/bmalloc/bmalloc/ObjectType.h
+++ b/Source/bmalloc/bmalloc/ObjectType.h
@@ -35,7 +35,7 @@ namespace bmalloc {
 
 class Heap;
 
-enum class ObjectType : unsigned char { Small, Large };
+enum class ObjectType : bool { Small, Large };
 
 ObjectType objectType(Heap&, void*);
 


### PR DESCRIPTION
#### 2080163c3fbc50bc34599b331aac32203f49a4fa
<pre>
Mark a number of boolean enum classes as bool
<a href="https://bugs.webkit.org/show_bug.cgi?id=256880">https://bugs.webkit.org/show_bug.cgi?id=256880</a>
rdar://109446105

Reviewed by NOBODY (OOPS!).

Found by searching for

    enum class \w+.+{\s+\w+,\s+\w+\s+};

and not continuing past bmalloc and JavaScriptCore.

* Source/JavaScriptCore/API/APIUtils.h:
* Source/JavaScriptCore/assembler/CodeLocation.h:
* Source/JavaScriptCore/assembler/MacroAssembler.h:
* Source/JavaScriptCore/assembler/MacroAssemblerARM64.h:
* Source/JavaScriptCore/assembler/MacroAssemblerMIPS.h:
* Source/JavaScriptCore/assembler/MacroAssemblerX86_64.h:
* Source/JavaScriptCore/b3/B3Validate.cpp:
* Source/JavaScriptCore/bytecode/HandlerInfo.h:
* Source/JavaScriptCore/bytecode/Repatch.h:
* Source/JavaScriptCore/bytecompiler/BytecodeGenerator.h:
* Source/JavaScriptCore/debugger/Debugger.h:
* Source/JavaScriptCore/dfg/DFGCommon.h:
* Source/JavaScriptCore/dfg/DFGDesiredWatchpoints.h:
* Source/JavaScriptCore/dfg/DFGNode.h:
* Source/JavaScriptCore/dfg/DFGSlowPathGenerator.h:
* Source/JavaScriptCore/dfg/DFGVariableEventStream.h:
* Source/JavaScriptCore/ftl/FTLThunks.cpp:
* Source/JavaScriptCore/heap/AllocationFailureMode.h:
* Source/JavaScriptCore/heap/CollectionScope.h:
* Source/JavaScriptCore/heap/ConstraintConcurrency.h:
* Source/JavaScriptCore/heap/ConstraintParallelism.h:
* Source/JavaScriptCore/heap/GCConductor.h:
* Source/JavaScriptCore/heap/Heap.h:
* Source/JavaScriptCore/heap/SlotVisitor.h:
* Source/JavaScriptCore/inspector/InspectorAgentBase.h:
* Source/JavaScriptCore/inspector/InspectorAgentRegistry.h:
* Source/JavaScriptCore/inspector/InspectorFrontendChannel.h:
* Source/JavaScriptCore/inspector/remote/RemoteInspector.h:
* Source/JavaScriptCore/jit/AssemblyHelpers.h:
* Source/JavaScriptCore/jit/AssemblyHelpersSpoolers.h:
* Source/JavaScriptCore/jit/JIT.h:
* Source/JavaScriptCore/jit/JITCode.h:
* Source/JavaScriptCore/jit/JITOperations.cpp:
* Source/JavaScriptCore/jit/ScratchRegisterAllocator.h:
* Source/JavaScriptCore/jit/ThunkGenerators.cpp:
* Source/JavaScriptCore/jsc.cpp:
* Source/JavaScriptCore/llint/LLIntSlowPaths.cpp:
* Source/JavaScriptCore/parser/Lexer.h:
* Source/JavaScriptCore/parser/Nodes.h:
* Source/JavaScriptCore/parser/Parser.h:
* Source/JavaScriptCore/parser/ParserModes.h:
* Source/JavaScriptCore/runtime/AbstractModuleRecord.h:
* Source/JavaScriptCore/runtime/ArgList.h:
* Source/JavaScriptCore/runtime/ArgumentsMode.h:
* Source/JavaScriptCore/runtime/ArrayBuffer.h:
* Source/JavaScriptCore/runtime/ArrayPrototype.cpp:
* Source/JavaScriptCore/runtime/AtomicsObject.cpp:
* Source/JavaScriptCore/runtime/EnumerationMode.h:
* Source/JavaScriptCore/runtime/ExceptionExpectation.h:
* Source/JavaScriptCore/runtime/HashMapImpl.h:
* Source/JavaScriptCore/runtime/ISO8601.cpp:
* Source/JavaScriptCore/runtime/InternalFunction.h:
* Source/JavaScriptCore/runtime/IntlCollator.h:
* Source/JavaScriptCore/runtime/IntlDisplayNames.h:
* Source/JavaScriptCore/runtime/IntlDurationFormat.h:
* Source/JavaScriptCore/runtime/IntlNumberFormat.h:
* Source/JavaScriptCore/runtime/JSBigInt.h:
* Source/JavaScriptCore/runtime/JSCell.h:
* Source/JavaScriptCore/runtime/JSGlobalObject.cpp:
* Source/JavaScriptCore/runtime/JSGlobalObjectDebuggable.h:
* Source/JavaScriptCore/runtime/JSSymbolTableObject.h:
* Source/JavaScriptCore/runtime/LiteralParser.cpp:
* Source/JavaScriptCore/runtime/ObjectConstructor.cpp:
* Source/JavaScriptCore/runtime/VMTraps.h:
* Source/JavaScriptCore/runtime/WaiterListManager.h:
* Source/JavaScriptCore/runtime/WeakMapImpl.h:
* Source/JavaScriptCore/tools/VMInspector.h:
* Source/JavaScriptCore/wasm/WasmAirIRGeneratorBase.h:
* Source/JavaScriptCore/wasm/WasmB3IRGenerator.cpp:
* Source/JavaScriptCore/wasm/WasmCreationMode.h:
* Source/JavaScriptCore/wasm/WasmFormat.h:
* Source/JavaScriptCore/wasm/WasmSectionParser.h:
* Source/JavaScriptCore/wasm/WasmSlowPaths.cpp:
* Source/JavaScriptCore/wasm/WasmStreamingParser.h:
* Source/JavaScriptCore/yarr/Yarr.h:
* Source/JavaScriptCore/yarr/YarrCanonicalize.h:
* Source/JavaScriptCore/yarr/YarrDisassembler.h:
* Source/JavaScriptCore/yarr/YarrParser.h:
* Source/bmalloc/bmalloc/FailureAction.h:
* Source/bmalloc/bmalloc/IsoPageTrigger.h:
* Source/bmalloc/bmalloc/ObjectType.h:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2080163c3fbc50bc34599b331aac32203f49a4fa

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/6857 "3 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/7086 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/7270 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/8455 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/7105 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/6861 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/8293 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/7026 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/10003 "2 flakes 5 failures") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/6978 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/7608 "2 new passes 2 flakes 3 failures") | [❌ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/6304 "10 api tests failed or timed out") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/8553 "Built successfully") | 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/5011 "layout-tests (failure)") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/6220 "8 flakes 2 failures") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/14008 "1 flakes 1 failures") | 
| [❌ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/5781 "Found 26733 jsc stress test failures: ChakraCore.yaml/ChakraCore/test/Bugs/blue_532460.js.default, ChakraCore.yaml/ChakraCore/test/ControlFlow/forInMisc.js.default, ChakraCore.yaml/ChakraCore/test/LetConst/h.js.default, ChakraCore.yaml/ChakraCore/test/Miscellaneous/HasOnlyWritableDataPropertiesCache.js.default, ChakraCore.yaml/ChakraCore/test/Object/propertyStrings.js.default ..., JSC test binary failure: testapi") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/6715 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/6305 "19 flakes 1 failures") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/9089 "2 api tests failed or timed out") | 
| [❌ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/6433 "Found 26720 jsc stress test failures: ChakraCore.yaml/ChakraCore/test/Bugs/blue_532460.js.default, ChakraCore.yaml/ChakraCore/test/ControlFlow/forInMisc.js.default, ChakraCore.yaml/ChakraCore/test/LetConst/h.js.default, ChakraCore.yaml/ChakraCore/test/Miscellaneous/HasOnlyWritableDataPropertiesCache.js.default, ChakraCore.yaml/ChakraCore/test/Object/propertyStrings.js.default ..., JSC test binary failure: testapi") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/6789 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/5555 "Exiting early after 60 failures. 1236 tests run. 60 failures") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/6997 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/6165 "Built successfully") | | [❌ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/1640 "Found 3575 jsc stress test failures: ChakraCore.yaml/ChakraCore/test/Bugs/blue_532460.js.default, ChakraCore.yaml/ChakraCore/test/ControlFlow/forInMisc.js.default, ChakraCore.yaml/ChakraCore/test/LetConst/h.js.default, ChakraCore.yaml/ChakraCore/test/Miscellaneous/HasOnlyWritableDataPropertiesCache.js.default, ChakraCore.yaml/ChakraCore/test/Object/propertyStrings.js.default ..., JSC test binary failure: testapi") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/10350 "Built successfully") | | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/24/builds/7188 "Built successfully") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/6543 "Built successfully") | | [❌ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/3/builds/1776 "Found 3300 jsc stress test failures: ChakraCore.yaml/ChakraCore/test/Bugs/blue_532460.js.default, ChakraCore.yaml/ChakraCore/test/ControlFlow/forInMisc.js.default, ChakraCore.yaml/ChakraCore/test/LetConst/h.js.default, ChakraCore.yaml/ChakraCore/test/Miscellaneous/HasOnlyWritableDataPropertiesCache.js.default, ChakraCore.yaml/ChakraCore/test/Object/propertyStrings.js.default ...") | 
<!--EWS-Status-Bubble-End-->