### PR TITLE
[iOS] AVCatpureDeviceManager should set userPreferrerCamera

### DIFF
--- a/Source/WebCore/platform/mediastream/mac/AVCaptureDeviceManager.h
+++ b/Source/WebCore/platform/mediastream/mac/AVCaptureDeviceManager.h
@@ -50,7 +50,7 @@ class AVCaptureDeviceManager final : public CaptureDeviceManager {
 public:
     static AVCaptureDeviceManager& singleton();
 
-    void refreshCaptureDevices(CompletionHandler<void()>&& = [] { });
+    void refreshCaptureDevices() { refreshCaptureDevicesInternal([] { }, ShouldSetUserPreferredCamera::No); };
 
 private:
     static bool isAvailable();
@@ -65,6 +65,10 @@ private:
     void updateCachedAVCaptureDevices();
     Vector<CaptureDevice> retrieveCaptureDevices();
     RetainPtr<NSArray> currentCameras();
+
+    enum class ShouldSetUserPreferredCamera : bool { No, Yes };
+    void refreshCaptureDevicesInternal(CompletionHandler<void()>&&, ShouldSetUserPreferredCamera);
+    void setUserPreferredCamera();
 
     RetainPtr<WebCoreAVCaptureDeviceManagerObserver> m_objcObserver;
     Vector<CaptureDevice> m_devices;


### PR DESCRIPTION
#### 49ad76ecb745e2f45446cd460699aa4af071a704
<pre>
[iOS] AVCatpureDeviceManager should set userPreferrerCamera
<a href="https://bugs.webkit.org/show_bug.cgi?id=256882">https://bugs.webkit.org/show_bug.cgi?id=256882</a>
rdar://109220107

Reviewed by Eric Carlson.

Before <a href="https://bugs.webkit.org/show_bug.cgi?id=255451">https://bugs.webkit.org/show_bug.cgi?id=255451</a>, we were forcing the default camera to be the front camera using media constraints.
This was blocking edfaulting to higher priority cameras, hence the fix.
The drawback is that we are now fully relying on systemPreferredCamera to select the default camera.
systemPreferredCamera might change depending on which camera was last used by the application.
We do not want that behavior, so we use userPreferredCamera to state that we are more interested in the front camera than in the back cameras.
Other camneras should still be higher priority if available.

Manually tested.

* Source/WebCore/platform/mediastream/mac/AVCaptureDeviceManager.h:
* Source/WebCore/platform/mediastream/mac/AVCaptureDeviceManager.mm:
(WebCore::AVCaptureDeviceManager::computeCaptureDevices):
(WebCore::AVCaptureDeviceManager::refreshCaptureDevicesInternal):
(WebCore::AVCaptureDeviceManager::setUserPreferredCamera):
(WebCore::AVCaptureDeviceManager::refreshCaptureDevices): Deleted.

Canonical link: <a href="https://commits.webkit.org/264165@main">https://commits.webkit.org/264165@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d8a3499a0375b61f5093af8be240cd6d2e877616

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/6864 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/7093 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/7277 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/8462 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/7111 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/6868 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/8323 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/7033 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/10008 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/6985 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/7637 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/6307 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/8561 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/5032 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/6223 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/14013 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/6731 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/6333 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/9096 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/6795 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/5560 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/6172 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/1642 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/10356 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/6550 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->