### PR TITLE
Add service worker logging to ease debugging of missing service workers/missing event processing

### DIFF
--- a/Source/WebCore/workers/service/context/SWContextManager.cpp
+++ b/Source/WebCore/workers/service/context/SWContextManager.cpp
@@ -101,8 +101,10 @@ RefPtr<ServiceWorkerThreadProxy> SWContextManager::serviceWorkerThreadProxyFromB
 void SWContextManager::fireInstallEvent(ServiceWorkerIdentifier identifier)
 {
     auto* serviceWorker = serviceWorkerThreadProxy(identifier);
-    if (!serviceWorker)
+    if (!serviceWorker) {
+        RELEASE_LOG_ERROR(ServiceWorker, "SWContextManager::fireInstallEvent but service worker %llu not found", identifier.toUInt64());
         return;
+    }
 
     serviceWorker->fireInstallEvent();
 }
@@ -110,8 +112,10 @@ void SWContextManager::fireInstallEvent(ServiceWorkerIdentifier identifier)
 void SWContextManager::fireActivateEvent(ServiceWorkerIdentifier identifier)
 {
     auto* serviceWorker = serviceWorkerThreadProxy(identifier);
-    if (!serviceWorker)
+    if (!serviceWorker) {
+        RELEASE_LOG_ERROR(ServiceWorker, "SWContextManager::fireActivateEvent but service worker %llu not found", identifier.toUInt64());
         return;
+    }
 
     serviceWorker->fireActivateEvent();
 }
@@ -120,6 +124,7 @@ void SWContextManager::firePushEvent(ServiceWorkerIdentifier identifier, std::op
 {
     auto* serviceWorker = serviceWorkerThreadProxy(identifier);
     if (!serviceWorker) {
+        RELEASE_LOG_ERROR(ServiceWorker, "SWContextManager::firePushEvent but service worker %llu not found", identifier.toUInt64());
         callback(false);
         return;
     }
@@ -130,8 +135,10 @@ void SWContextManager::firePushEvent(ServiceWorkerIdentifier identifier, std::op
 void SWContextManager::firePushSubscriptionChangeEvent(ServiceWorkerIdentifier identifier, std::optional<PushSubscriptionData>&& newSubscriptionData, std::optional<PushSubscriptionData>&& oldSubscriptionData)
 {
     auto* serviceWorker = serviceWorkerThreadProxy(identifier);
-    if (!serviceWorker)
+    if (!serviceWorker) {
+        RELEASE_LOG_ERROR(ServiceWorker, "SWContextManager::firePushSubscriptionChangeEvent but service worker %llu not found", identifier.toUInt64());
         return;
+    }
 
     serviceWorker->firePushSubscriptionChangeEvent(WTFMove(newSubscriptionData), WTFMove(oldSubscriptionData));
 }
@@ -140,6 +147,7 @@ void SWContextManager::fireNotificationEvent(ServiceWorkerIdentifier identifier,
 {
     auto* serviceWorker = serviceWorkerThreadProxy(identifier);
     if (!serviceWorker) {
+        RELEASE_LOG_ERROR(ServiceWorker, "SWContextManager::fireNotificationEvent but service worker %llu not found", identifier.toUInt64());
         callback(false);
         return;
     }
@@ -151,6 +159,7 @@ void SWContextManager::fireBackgroundFetchEvent(ServiceWorkerIdentifier identifi
 {
     auto* serviceWorker = serviceWorkerThreadProxy(identifier);
     if (!serviceWorker) {
+        RELEASE_LOG_ERROR(ServiceWorker, "SWContextManager::fireBackgroundFetchEvent but service worker %llu not found", identifier.toUInt64());
         callback(false);
         return;
     }
@@ -162,6 +171,7 @@ void SWContextManager::fireBackgroundFetchClickEvent(ServiceWorkerIdentifier ide
 {
     auto* serviceWorker = serviceWorkerThreadProxy(identifier);
     if (!serviceWorker) {
+        RELEASE_LOG_ERROR(ServiceWorker, "SWContextManager::fireBackgroundFetchClickEvent but service worker %llu not found", identifier.toUInt64());
         callback(false);
         return;
     }
@@ -171,7 +181,7 @@ void SWContextManager::fireBackgroundFetchClickEvent(ServiceWorkerIdentifier ide
 
 void SWContextManager::terminateWorker(ServiceWorkerIdentifier identifier, Seconds timeout, Function<void()>&& completionHandler)
 {
-    RELEASE_LOG(ServiceWorker, "SWContextManager::terminateWorker");
+    RELEASE_LOG(ServiceWorker, "SWContextManager::terminateWorker %llu", identifier.toUInt64());
 
     RefPtr<ServiceWorkerThreadProxy> serviceWorker;
     {

--- a/Source/WebCore/workers/service/server/SWServer.cpp
+++ b/Source/WebCore/workers/service/server/SWServer.cpp
@@ -1384,7 +1384,7 @@ void SWServer::getAllOrigins(CompletionHandler<void(HashSet<ClientOrigin>&&)>&& 
 
 void SWServer::addContextConnection(SWServerToContextConnection& connection)
 {
-    RELEASE_LOG(ServiceWorker, "SWServer::addContextConnection");
+    RELEASE_LOG(ServiceWorker, "SWServer::addContextConnection %llu", connection.identifier().toUInt64());
 
     ASSERT(!m_contextConnections.contains(connection.registrableDomain()));
 
@@ -1395,7 +1395,7 @@ void SWServer::addContextConnection(SWServerToContextConnection& connection)
 
 void SWServer::removeContextConnection(SWServerToContextConnection& connection)
 {
-    RELEASE_LOG(ServiceWorker, "SWServer::removeContextConnection");
+    RELEASE_LOG(ServiceWorker, "SWServer::removeContextConnection %llu", connection.identifier().toUInt64());
 
     auto registrableDomain = connection.registrableDomain();
     auto serviceWorkerPageIdentifier = connection.serviceWorkerPageIdentifier();
@@ -1651,6 +1651,8 @@ void SWServer::fireFunctionalEvent(SWServerRegistration& registration, Completio
     }
 
     // FIXME: we should check whether we can skip the event and if skipping do a soft-update.
+
+    RELEASE_LOG(ServiceWorker, "SWServer::fireFunctionalEvent serviceWorkerID=%llu, state=%hhu", worker->identifier().toUInt64(), worker->state());
 
     worker->whenActivated([this, weakThis = WeakPtr { *this }, callback = WTFMove(callback), registrationIdentifier = registration.identifier(), serviceWorkerIdentifier = worker->identifier()](bool success) mutable {
         if (!weakThis) {

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/PushAPI.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/PushAPI.mm
@@ -642,19 +642,23 @@ TEST(PushAPI, firePushEventWithNoPagesTimeout)
 
     expectedMessage = "Ready"_s;
 
+    fprintf(stderr, "totot1\n");
     @autoreleasepool {
         auto webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
         [webView loadRequest:server.request()];
         TestWebKitAPI::Util::run(&done);
     }
 
+    fprintf(stderr, "totot2\n");
     terminateNetworkProcessWhileRegistrationIsStored(configuration.get());
 
     // Push event for service worker without any related page, should timeout so fail.
     pushMessageProcessed = false;
     pushMessageSuccessful = false;
     NSString *message = @"Timeless Potatoes";
+    fprintf(stderr, "totot3\n");
     [[configuration websiteDataStore] _processPushMessage:messageDictionary([message dataUsingEncoding:NSUTF8StringEncoding], [server.request() URL]) completionHandler:^(bool result) {
+        fprintf(stderr, "totot3.1\n");
         pushMessageSuccessful = result;
         pushMessageProcessed = true;
     }];
@@ -662,6 +666,7 @@ TEST(PushAPI, firePushEventWithNoPagesTimeout)
     EXPECT_TRUE(waitUntilEvaluatesToTrue([&] { return [[configuration websiteDataStore] _hasServiceWorkerBackgroundActivityForTesting]; }));
 
     TestWebKitAPI::Util::run(&pushMessageProcessed);
+    fprintf(stderr, "totot4\n");
     EXPECT_FALSE(pushMessageSuccessful);
     EXPECT_TRUE(waitUntilEvaluatesToTrue([&] { return ![[configuration websiteDataStore] _hasServiceWorkerBackgroundActivityForTesting]; }));
 


### PR DESCRIPTION
#### b39f7b61225c26bb90158a196fc0e1e1b54b0880
<pre>
Add service worker logging to ease debugging of missing service workers/missing event processing
<a href="https://bugs.webkit.org/show_bug.cgi?id=256890">https://bugs.webkit.org/show_bug.cgi?id=256890</a>
rdar://109455831

Reviewed by Ben Nham.

No functional change except additional and/or more precise service worker related logging.

* Source/WebCore/workers/service/context/SWContextManager.cpp:
(WebCore::SWContextManager::fireInstallEvent):
(WebCore::SWContextManager::fireActivateEvent):
(WebCore::SWContextManager::firePushSubscriptionChangeEvent):
(WebCore::SWContextManager::terminateWorker):
* Source/WebCore/workers/service/server/SWServer.cpp:
(WebCore::SWServer::addContextConnection):
(WebCore::SWServer::removeContextConnection):
(WebCore::SWServer::fireFunctionalEvent):

Canonical link: <a href="https://commits.webkit.org/264411@main">https://commits.webkit.org/264411@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/def54ee76c22f2d9f7b5b5a450f14a2cfcf19b73

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/7388 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/7646 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/7821 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/9017 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/7593 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/7398 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/9493 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/7571 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/10478 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/7517 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/8573 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/6836 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/9126 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/5885 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/6720 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/14446 "1 flakes 133 failures") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/7182 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/6853 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/10081 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/7322 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/5986 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/6674 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/1793 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/10880 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/7058 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->