### PR TITLE
Make sure to run a service worker before firing its activate event

### DIFF
--- a/LayoutTests/TestExpectations
+++ b/LayoutTests/TestExpectations
@@ -1023,6 +1023,9 @@ webkit.org/b/248735 http/wpt/service-workers/fetch-service-worker-preload.https.
 webkit.org/b/248743 http/wpt/service-workers/fetch-service-worker-preload-download.https.html [ Pass Failure ]
 webkit.org/b/248743 http/wpt/service-workers/file-upload.html [ Pass Failure ]
 
+# Test file
+http/wpt/service-workers/changing-service-worker-lengthy-worker.py [ Skip ]
+
 [ Debug ] http/tests/workers/worker-messageport-2.html [ Slow ]
 
 # Skip workers tests that are timing out or are SharedWorker related only

--- a/LayoutTests/http/wpt/service-workers/changing-service-worker-lengthy-worker.py
+++ b/LayoutTests/http/wpt/service-workers/changing-service-worker-lengthy-worker.py
@@ -1,0 +1,25 @@
+import random
+
+def main(request, response):
+    response.headers.set(b"Content-type", b"text/javascript")
+    response.headers.append(b"Cache-Control", b"no-store")
+    response.write_status_headers()
+
+    response.writer.write_content("//" + str(random.random()) + "\n")
+    response.writer.write_content("function doFetch(event)\n")
+    response.writer.write_content("{\n")
+    response.writer.write_content("    event.respondWith(fetch('/WebKit/service-workers/resources/lengthy-pass.py?delay=0.5'));\n")
+    response.writer.write_content("}\n")
+    response.writer.write_content("self.addEventListener('fetch', doFetch);\n")
+
+    response.writer.write_content("function doMessage(event)\n")
+    response.writer.write_content("{\n")
+    response.writer.write_content("    event.source.postMessage(!!self.didActivateEventFired);\n")
+    response.writer.write_content("}\n")
+    response.writer.write_content("self.addEventListener('message', doMessage);\n")
+
+    response.writer.write_content("function doActivate(event)\n")
+    response.writer.write_content("{\n")
+    response.writer.write_content("    self.didActivateEventFired = true;\n")
+    response.writer.write_content("}\n")
+    response.writer.write_content("self.addEventListener('activate', doActivate);")

--- a/LayoutTests/http/wpt/service-workers/service-worker-process-crashing-between-installed-and-activating-expected.txt
+++ b/LayoutTests/http/wpt/service-workers/service-worker-process-crashing-between-installed-and-activating-expected.txt
@@ -1,0 +1,4 @@
+
+PASS Setup worker
+PASS Service worker process crashes between installed and activating
+

--- a/LayoutTests/http/wpt/service-workers/service-worker-process-crashing-between-installed-and-activating.html
+++ b/LayoutTests/http/wpt/service-workers/service-worker-process-crashing-between-installed-and-activating.html
@@ -1,0 +1,69 @@
+<!doctype html>
+<html>
+<head>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="resources/routines.js"></script>
+</head>
+<body>
+<script>
+var activeWorker;
+var waitingWorker;
+var registration;
+
+promise_test(async (test) => {
+    if (window.testRunner) {
+        testRunner.setUseSeparateServiceWorkerProcess(true);
+        await fetch("").then(() => { }, () => { });
+    }
+
+    registration = await navigator.serviceWorker.register("changing-service-worker-lengthy-worker.py", { scope : "lengthy-fetch" });
+    activeWorker = registration.active;
+    if (activeWorker)
+        return;
+    activeWorker = registration.installing;
+    return new Promise(resolve => {
+        activeWorker.addEventListener('statechange', () => {
+            if (activeWorker.state === "activated")
+                resolve();
+        });
+    });
+}, "Setup worker");
+
+promise_test(async (test) => {
+    const promise = withIframe("lengthy-fetch");
+
+    await new Promise(resolve => setTimeout(resolve, 50));
+
+    let counter1 = 0;
+    while (!registration.waiting && counter1++ < 100) {
+        await new Promise(resolve => setTimeout(resolve, 50));
+    }
+    assert_not_equals(registration.waiting, null);
+    waitingWorker = registration.waiting;
+
+    const frame = await promise;
+
+    // We now have an active worker and a waiting worker
+    // Let's kill the service worker process.
+    if (window.testRunner)
+        testRunner.terminateServiceWorkers();
+
+    // Let's now remove frame to trigger activation of the waiting worker.
+    await new Promise(resolve => setTimeout(resolve, 50));
+    frame.remove();
+
+    let counter2 = 0;
+    while (registration.activeWorker != waitingWorker && counter2++ < 100)
+        await new Promise(resolve => setTimeout(resolve, 50));
+
+    // The waiting worker should have been activated.
+    assert_equals(registration.active, waitingWorker);
+    registration.active.postMessage("get_didActivateEventFired")
+
+    // Let's send a message to the worker to ensure it receives the activate event.
+    assert_true(await new Promise(resolve => navigator.serviceWorker.onmessage = (e) => resolve(e.data)));
+}, "Service worker process crashes between installed and activating");
+</script>
+</body>
+</html>

--- a/Source/WebCore/workers/service/server/SWServer.h
+++ b/Source/WebCore/workers/service/server/SWServer.h
@@ -182,7 +182,7 @@ public:
 
     void updateWorker(const ServiceWorkerJobDataIdentifier&, const std::optional<ProcessIdentifier>&, SWServerRegistration&, const URL&, const ScriptBuffer&, const CertificateInfo&, const ContentSecurityPolicyResponseHeaders&, const CrossOriginEmbedderPolicy&, const String& referrerPolicy, WorkerType, MemoryCompactRobinHoodHashMap<URL, ServiceWorkerContextData::ImportedScript>&&, std::optional<ScriptExecutionContextIdentifier> serviceWorkerPageIdentifier);
     void fireInstallEvent(SWServerWorker&);
-    void fireActivateEvent(SWServerWorker&);
+    void runServiceWorkerAndFireActivateEvent(SWServerWorker&);
 
     WEBCORE_EXPORT SWServerWorker* workerByID(ServiceWorkerIdentifier) const;
     WEBCORE_EXPORT std::optional<ServiceWorkerClientData> serviceWorkerClientWithOriginByID(const ClientOrigin&, const ScriptExecutionContextIdentifier&) const;
@@ -308,7 +308,9 @@ private:
     void clearInternal(Function<bool(const ServiceWorkerRegistrationKey&)>&& matches, CompletionHandler<void()>&&);
 
     WEBCORE_EXPORT SWServerRegistration* doRegistrationMatching(const SecurityOriginData& topOrigin, const URL& clientURL);
+    void runServiceWorkerIfNecessary(SWServerWorker&, RunServiceWorkerCallback&&);
     bool runServiceWorker(ServiceWorkerIdentifier);
+    bool runServiceWorker(SWServerWorker&);
 
     void tryInstallContextData(const std::optional<ProcessIdentifier>&, ServiceWorkerContextData&&);
     void installContextData(const ServiceWorkerContextData&);

--- a/Source/WebCore/workers/service/server/SWServerRegistration.cpp
+++ b/Source/WebCore/workers/service/server/SWServerRegistration.cpp
@@ -315,11 +315,10 @@ void SWServerRegistration::activate()
     // - Invoke Notify Controller Change algorithm with client as the argument.
     notifyClientsOfControllerChange();
 
-    // FIXME: Invoke Run Service Worker algorithm with activeWorker as the argument.
-
+    // Invoke Run Service Worker algorithm with activeWorker as the argument.
     // Queue a task to fire the activate event.
     ASSERT(activeWorker());
-    m_server.fireActivateEvent(*activeWorker());
+    m_server.runServiceWorkerAndFireActivateEvent(*activeWorker());
 }
 
 // https://w3c.github.io/ServiceWorker/#activate (post activate event steps).


### PR DESCRIPTION
#### ff4eced3ff239c434ef397c0c059a8a027a54db5
<pre>
Make sure to run a service worker before firing its activate event
<a href="https://bugs.webkit.org/show_bug.cgi?id=256893">https://bugs.webkit.org/show_bug.cgi?id=256893</a>
rdar://109411104

Reviewed by Ben Nham.

As per spec, we should run the service worker before firing the activate event.
We were not doing so and there might be cases where the service worker will no longer be running between installed and activating steps.
This happens for instance in case the process is terminated due to memory issues.
We align the implementation with the spec by renaming fireActivateEvent to runServiceWorkerAndFireActivateEvent.
Internally, it calls runServiceWorkerIfNecessary before firing the event.
Small refactoring to allow either running a service worker from its object or from its ID.

* LayoutTests/TestExpectations:
* LayoutTests/http/wpt/service-workers/changing-service-worker-lengthy-worker.py: Added.
(main):
* LayoutTests/http/wpt/service-workers/service-worker-process-crashing-between-installed-and-activating-expected.txt: Added.
* LayoutTests/http/wpt/service-workers/service-worker-process-crashing-between-installed-and-activating.html: Added.
* Source/WebCore/workers/service/server/SWServer.cpp:
(WebCore::SWServer::runServiceWorkerIfNecessary):
(WebCore::SWServer::runServiceWorker):
(WebCore::SWServer::runServiceWorkerAndFireActivateEvent):
(WebCore::SWServer::fireActivateEvent): Deleted.
* Source/WebCore/workers/service/server/SWServer.h:
* Source/WebCore/workers/service/server/SWServerRegistration.cpp:
(WebCore::SWServerRegistration::activate):

Canonical link: <a href="https://commits.webkit.org/264242@main">https://commits.webkit.org/264242@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c4071ecc80a97dda8f348338472018ebbc5f080d

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/6899 "1 style error") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/7129 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/7312 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/8498 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/7146 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/6904 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/8422 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/7068 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/10046 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/7021 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/7727 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/6350 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/8598 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/5114 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/6260 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/14053 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/6790 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/6347 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/9159 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/6831 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/5596 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/6207 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/6174 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/1688 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/10392 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/6585 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->