### PR TITLE
[Yarr] ASSERTION FAILED: m_setOp == CharacterClassSetOp::Default || m_setOp == setOp

### DIFF
--- a/JSTests/stress/regexp-vflag-property-of-strings.js
+++ b/JSTests/stress/regexp-vflag-property-of-strings.js
@@ -330,120 +330,130 @@ testRegExpSyntaxError("[a\\q{a{b}]", "v", "SyntaxError: Invalid regular expressi
 testRegExpSyntaxError("[a\\q{a/b}]", "v", "SyntaxError: Invalid regular expression: invalid class set character");
 testRegExpSyntaxError("[a\\q{a-b}]", "v", "SyntaxError: Invalid regular expression: invalid class set character");
 testRegExpSyntaxError("[\p{ASCII}---]", "v", "SyntaxError: Invalid regular expression: invalid class set character");
-testRegExp(/[\p{ASCII}&&\&]/v, "a&b", ["&"]);
-testRegExp(/[\p{ASCII}&&\-]/v, "a-b", ["-"]);
+testRegExpSyntaxError("[--]", "v", "SyntaxError: Invalid regular expression: invalid operation in class set");
+testRegExpSyntaxError("[ab][--]", "v", "SyntaxError: Invalid regular expression: invalid operation in class set");
 
 // Test 126
+testRegExpSyntaxError("[&&]", "v", "SyntaxError: Invalid regular expression: invalid operation in class set");
+testRegExpSyntaxError("[ab][&&]", "v", "SyntaxError: Invalid regular expression: invalid operation in class set");
+testRegExpSyntaxError("[++]", "v", "SyntaxError: Invalid regular expression: invalid operation in class set");
+testRegExpSyntaxError("[ab][++]", "v", "SyntaxError: Invalid regular expression: invalid operation in class set");
+testRegExpSyntaxError("[\\d\\q{x}-a]", "v", "SyntaxError: Invalid regular expression: invalid operation in class set");
+
+// Test 131
+testRegExpSyntaxError("[\\p{ASCII}-a]", "v", "SyntaxError: Invalid regular expression: invalid range in character class for Unicode pattern");
+testRegExp(/[\p{ASCII}&&\&]/v, "a&b", ["&"]);
+testRegExp(/[\p{ASCII}&&\-]/v, "a-b", ["-"]);
 testRegExp(/[\p{ASCII}--\&]/v, "&b", ["b"]);
 testRegExp(/[\p{ASCII}--&]/v, "&b", ["b"]);
+
+// Test 136
 testRegExp(/[\p{ASCII}--\-]/v, "-b", ["b"]);
 testRegExp(/[\p{RGI_Emoji_Tag_Sequence}a]/, "a", ["a"]);
 testRegExp(/[\p{RGI_Emoji_Tag_Sequence}a]/v, "a", ["a"]);
-
-// Test 131
 testRegExp(/(?:\u{1f3f4}\u{e0067}\u{e0062}\u{e0065}\u{e006e}\u{e0067}\u{e007F}|\u{1f3f4}\u{e0067}\u{e0062}\u{e0073}\u{e0063}\u{e0074}\u{e007f}|\u{1f3f4}\u{e0067}\u{e0062}\u{e0077}\u{e006C}\u{e0073}\u{e007F}|[a])/v, "\u{1f3f4}\u{e0067}\u{e0062}\u{e0073}\u{e0063}\u{e0074}\u{e007f}", ["\u{1f3f4}\u{e0067}\u{e0062}\u{e0073}\u{e0063}\u{e0074}\u{e007f}"]);
 testRegExp(/[\p{RGI_Emoji_Tag_Sequence}a]/v, "\u{1f3f4}\u{e0067}\u{e0062}\u{e0073}\u{e0063}\u{e0074}\u{e007f}", ["\u{1f3f4}\u{e0067}\u{e0062}\u{e0073}\u{e0063}\u{e0074}\u{e007f}"]);
+
+// Test 141
 testRegExp(/[a\p{RGI_Emoji_Tag_Sequence}]/v, "a", ["a"]);
 testRegExp(/[\p{RGI_Emoji_Tag_Sequence}\q{\u{1f1fa}\u{1f1f8}}]/v, "\u{1f3f4}\u{e0067}\u{e0062}\u{e0073}\u{e0063}\u{e0074}\u{e007f}", ["\u{1f3f4}\u{e0067}\u{e0062}\u{e0073}\u{e0063}\u{e0074}\u{e007f}"]);
 testRegExp(/[\p{RGI_Emoji_Tag_Sequence}\q{\u{1f1fa}\u{1f1f8}}]/v, "\u{1f1fa}\u{1f1f8}", ["\u{1f1fa}\u{1f1f8}"]);
-
-// Test 136
 testRegExp(/[\p{RGI_Emoji_Tag_Sequence}\q{\u{1f1fa}\u{1f1f8}}]/v, "a", null);
 testRegExp(/[\q{\u{1f1fa}\u{1f1f8}}a]/v, "a", ["a"]);
+
+// Test 146
 testRegExp(/[\q{\u{1f1fa}\u{1f1f8}}a]/v, "\u{1f1fa}\u{1f1f8}", ["\u{1f1fa}\u{1f1f8}"]);
 testRegExp(/[\q{\u{1f1fa}}\q{\u{1f1fa}\u{1f1f8}}]/v, "\u{1f1fa}\u{1f1f8}", ["\u{1f1fa}\u{1f1f8}"]);
 testRegExp(/[\q{\u{1f3f4}\u{e0067}\u{e0062}\u{e0073}\u{e0063}\u{e0074}}\p{RGI_Emoji_Tag_Sequence}]/v, "\u{1f3f4}\u{e0067}\u{e0062}\u{e0073}\u{e0063}\u{e0074}\u{e007f}", ["\u{1f3f4}\u{e0067}\u{e0062}\u{e0073}\u{e0063}\u{e0074}\u{e007f}"]);
-
-// Test 141
 testRegExp(/[\p{RGI_Emoji_Tag_Sequence}[\q{\u{1f1fa}\u{1f1f8}}a]]/v, "\u{1f1fa}\u{1f1f8}", ["\u{1f1fa}\u{1f1f8}"]);
 testRegExp(/[\p{RGI_Emoji_Tag_Sequence}[\q{\u{1f1fa}\u{1f1f8}}a]]/v, "a", ["a"]);
+
+// Test 151
 testRegExp(/[b-z[a]]/v, "a", ["a"]);
 testRegExp(/[[a-z]--k]/v, "a", ["a"]);
 testRegExp(/[\p{RGI_Emoji_Tag_Sequence}--\q{\u{1F3f4}\u{e0067}\u{e0062}\u{e0077}\u{e006c}\u{e0073}\u{e007f}}]/v, "\u{1f3f4}\u{e0067}\u{e0062}\u{e0073}\u{e0063}\u{e0074}\u{e007f}", ["\u{1f3f4}\u{e0067}\u{e0062}\u{e0073}\u{e0063}\u{e0074}\u{e007f}"]);
-
-// Test 146
 testRegExp(/[a-z\q{X}]/v, "X", ["X"]);
 testRegExp(/[[a-z]--\q{k}]/v, "a", ["a"]);
+
+// Test 156
 testRegExp(/[\p{RGI_Emoji_Tag_Sequence}\q{\u{1f1fa}\u{1f1f8}|abc|a|\u{1f1fa}}]/v, "a", ["a"]);
 testRegExp(/[\p{RGI_Emoji_Tag_Sequence}--\q{\u{1f3f4}\u{e0067}\u{e0062}\u{e0073}\u{e0063}\u{e0074}\u{e007f}}]/v, "\u{1f3f4}\u{e0067}\u{e0062}\u{e0073}\u{e0063}\u{e0074}\u{e007f}", null);
 testRegExp(/[\p{RGI_Emoji_Tag_Sequence}--\q{\u{1f3f4}\u{e0067}\u{e0062}\u{e0073}\u{e0063}\u{e0074}\u{e007f}}]/v, "\u{1f3f4}\u{e0067}\u{e0062}\u{e0077}\u{e006c}\u{e0073}\u{e007f}", ["\u{1f3f4}\u{e0067}\u{e0062}\u{e0077}\u{e006c}\u{e0073}\u{e007f}"]);
-
-// Test 151
 testRegExp(/[\p{RGI_Emoji_Tag_Sequence}&&\q{\u{1f3f4}\u{e0067}\u{e0062}\u{e0073}\u{e0063}\u{e0074}\u{e007f}}]/v, "\u{1f3f4}\u{e0067}\u{e0062}\u{e0073}\u{e0063}\u{e0074}\u{e007f}", ["\u{1f3f4}\u{e0067}\u{e0062}\u{e0073}\u{e0063}\u{e0074}\u{e007f}"]);
 testRegExp(/[\p{RGI_Emoji_Tag_Sequence}&&\q{\u{1f3f4}\u{e0067}\u{e0062}\u{e0073}\u{e0063}\u{e0074}\u{e007f}}]/v, "\u{1f3f4}\u{e0067}\u{e0062}\u{e0077}\u{e006c}\u{e0073}\u{e007f}", null);
+
+// Test 161
 testRegExp(/[[a-z]&&\q{a|e|i|o|u|X|Y|Z}]/v, "a", ["a"]);
 testRegExp(/[\p{White_Space}&&\p{ASCII}]/v, " ", [" "]);
 testRegExp(/[\p{White_Space}&&\p{ASCII}]/v, "\u2028", null);
-
-// Test 156
 testRegExp(/[\p{White_Space}--\p{ASCII}]/v, " ", null);
 testRegExp(/[\p{White_Space}--\p{ASCII}]/v, "\u2028", ["\u2028"]);
+
+// Test 166
 testRegExp(/^[[0-9]&&\d]+$/v, "0", ["0"]);
 testRegExp(/^[_--[0-9]]+$/v, "_", ["_"]);
 testRegExp(/[[a-z]--[a]]/v, "a", null);
-
-// Test 161
 testRegExp(/^\p{RGI_Emoji_Flag_Sequence}+$/v, "\u{1F1E6}\u{1F1E8}", ["\u{1F1E6}\u{1F1E8}"]);
 testRegExp(/^\p{RGI_Emoji_Flag_Sequence}+$/v, "\u{1F1E6}\u{1F1E8}\u{1f1e7}\u{1f1f1}", ["\u{1f1e6}\u{1f1e8}\u{1f1e7}\u{1f1f1}"]);
+
+// Test 171
 testRegExp(/^\p{RGI_Emoji_Flag_Sequence}+$/v, "\u{1f1f9}\u{1f1ef}\u{1F1E6}\u{1F1E8}\u{1f1f9}\u{1f1f7}", ["\u{1f1f9}\u{1f1ef}\u{1F1E6}\u{1F1E8}\u{1f1f9}\u{1f1f7}"]);
 testRegExp(/^\p{Emoji_Keycap_Sequence}+$/v, "#\u{fe0f}\u{20e3}", ["#\u{fe0f}\u{20e3}"]);
 testRegExp(/^\p{RGI_Emoji}+$/v, "#\u{fe0f}\u{20e3}", ["#\u{fe0f}\u{20e3}"]);
-
-// Test 166
 testRegExp(/[a\(\)]+/v, "a()", ["a()"]);
 testRegExp(/[a\q{\(\)}]{2}/v, "()a()", ["()a"]);
+
+// Test 176
 testRegExp(/[a\q{\(\)}]+/v, "()a()", ["()a()"]);
 testRegExp(/[a\q{\=\=}]+/v, "==a==", ["==a=="]);
 testRegExp(/[\q{\u{3373}}\q{\u{1813}}\q{\u{0250}}a]/v, "a", ["a"]);
-
-// Test 171
 testRegExp(/[\q{\u{3373}}\q{\u{1813}}\q{\u{0250}}a]/v, "\u{0250}", ["\u{0250}"]);
 testRegExp(/[\q{\u{3373}}\q{\u{1813}}\q{\u{0250}}a]/v, "\u{1813}", ["\u{1813}"]);
+
+// Test 181
 testRegExp(/[\q{\u{3373}}\q{\u{1813}}\q{\u{0250}}a]/v, "\u{3373}", ["\u{3373}"]);
 testRegExp(/[[\u{0250}-\u{3373}a]--[\q{\u{3373}}\q{\u{1813}}\q{\u{0250}}]]/v, "a", ["a"]);
 testRegExp(/[[\u{0250}-\u{3373}a]--[\q{\u{3373}}\q{\u{1813}}\q{\u{0250}}]]/v, "\u{0250}", null);
-
-// Test 176
 testRegExp(/[[\u{0250}-\u{3373}a]--[\q{\u{3373}}\q{\u{1813}}\q{\u{0250}}]]/v, "\u{1813}", null);
 testRegExp(/[[\u{0250}-\u{3373}a]--[\q{\u{3373}}\q{\u{1813}}\q{\u{0250}}]]/v, "\u{3373}", null);
+
+// Test 186
 testRegExp(/[[\u{0250}-\u{3373}a]--[\q{\u{3373}}\q{\u{1813}}a]]/v, "a", null);
 testRegExp(/[[\u{0250}-\u{3373}a]--[\q{\u{3373}}\q{\u{1813}}a]]/v, "\u{0250}", ["\u{0250}"]);
 testRegExp(/[[\u{0250}-\u{3373}a]--[\q{\u{3373}}\q{\u{1813}}a]]/v, "\u{1813}", null);
-
-// Test 181
 testRegExp(/[[\u{0250}-\u{3373}a]--[\q{\u{3373}}\q{\u{1813}}a]]/v, "\u{3373}", null);
 testRegExp(/[[\u{0250}-\u{3373}a]--[\q{\u{3373}}\q{\u{0250}}a]]/v, "a", null);
+
+// Test 191
 testRegExp(/[[\u{0250}-\u{3373}a]--[\q{\u{3373}}\q{\u{0250}}a]]/v, "\u{0250}", null);
 testRegExp(/[[\u{0250}-\u{3373}a]--[\q{\u{3373}}\q{\u{0250}}a]]/v, "\u{1813}", ["\u{1813}"]);
 testRegExp(/[[\u{0250}-\u{3373}a]--[\q{\u{3373}}\q{\u{0250}}a]]/v, "\u{3373}", null);
-
-// Test 186
 testRegExp(/[[\u{0250}-\u{3373}a]--[\q{\u{1813}}\q{\u{0250}}a]]/v, "a", null);
 testRegExp(/[[\u{0250}-\u{3373}a]--[\q{\u{1813}}\q{\u{0250}}a]]/v, "\u{0250}", null);
+
+// Test 196
 testRegExp(/[[\u{0250}-\u{3373}a]--[\q{\u{1813}}\q{\u{0250}}a]]/v, "\u{1813}", null);
 testRegExp(/[[\u{0250}-\u{3373}a]--[\q{\u{1813}}\q{\u{0250}}a]]/v, "\u{3373}", ["\u{3373}"]);
 testRegExp(/[[\u{0250}-\u{3373}a]&&[a]]/v, "a", ["a"]);
-
-// Test 191
 testRegExp(/[[\u{0250}-\u{3373}a]&&[a]]/v, "\u{0250}", null);
 testRegExp(/[[\u{0250}-\u{3373}a]&&[a]]/v, "\u{1813}", null);
+
+// Test 201
 testRegExp(/[[\u{0250}-\u{3373}a]&&[a]]/v, "\u{3373}", null);
 testRegExp(/[[\u{0250}-\u{3373}a]&&[\q{\u{0250}}]]/v, "a", null);
 testRegExp(/[[\u{0250}-\u{3373}a]&&[\q{\u{0250}}]]/v, "\u{0250}", ["\u{0250}"]);
-
-// Test 196
 testRegExp(/[[\u{0250}-\u{3373}a]&&[\q{\u{0250}}]]/v, "\u{1813}", null);
 testRegExp(/[[\u{0250}-\u{3373}a]&&[\q{\u{0250}}]]/v, "\u{3373}", null);
+
+// Test 206
 testRegExp(/[[\u{0250}-\u{3373}a]&&[\q{\u{1813}}]]/v, "a", null);
 testRegExp(/[[\u{0250}-\u{3373}a]&&[\q{\u{1813}}]]/v, "\u{0250}", null);
 testRegExp(/[[\u{0250}-\u{3373}a]&&[\q{\u{1813}}]]/v, "\u{1813}", ["\u{1813}"]);
-
-// Test 201
 testRegExp(/[[\u{0250}-\u{3373}a]&&[\q{\u{1813}}]]/v, "\u{3373}", null);
 testRegExp(/[[\u{0250}-\u{3373}a]&&[\q{\u{3373}}]]/v, "a", null);
+
+// Test 211
 testRegExp(/[[\u{0250}-\u{3373}a]&&[\q{\u{3373}}]]/v, "\u{0250}", null);
 testRegExp(/[[\u{0250}-\u{3373}a]&&[\q{\u{3373}}]]/v, "\u{1813}", null);
 testRegExp(/[[\u{0250}-\u{3373}a]&&[\q{\u{3373}}]]/v, "\u{3373}", ["\u{3373}"]);
-
-// Test 206
 testRegExp(/[[]a]/v, "a", ["a"]);

--- a/Source/JavaScriptCore/yarr/YarrParser.h
+++ b/Source/JavaScriptCore/yarr/YarrParser.h
@@ -54,12 +54,13 @@ private:
 
     enum class UnicodeParseContext : uint8_t { PatternCodePoint, GroupName };
 
-    enum class ParseEscapeMode : uint8_t { Normal, CharacterClass, ClassStringDisjunction };
+    enum class ParseEscapeMode : uint8_t { Normal, CharacterClass, ClassSet, ClassStringDisjunction };
 
     enum class TokenType : uint8_t {
         NotAtom = 0,
         Atom = 1,
-        Lookbehind = 2
+        Lookbehind = 2,
+        SetDisjunction
     };
 
     class NamedCaptureGroups {
@@ -298,8 +299,8 @@ private:
     /*
      * ClassSetParserDelegate:
      *
-     * The class ClassSetParserDelegate is used in the parsing of character
-     * classes.  This class handles detection of class set ops and character ranges.
+     * The class ClassSetParserDelegate is used in the parsing of class sets
+     * This class handles detection of class set ops and character ranges.
      * This class implements enough of the delegate interface such that it can be passed to
      * parseEscape() as an EscapeDelegate.  This allows parseEscape() to be reused
      * to perform the parsing of escape characters in character sets.
@@ -362,6 +363,7 @@ private:
             m_inverted = lastState.m_inverted;
 
             m_delegate.atomCharacterClassPopNested();
+            m_state = ClassSetConstructionState::AfterSetOperand;
             return false;
         }
 
@@ -387,7 +389,7 @@ private:
 
         void setSubtractOp()
         {
-            if (m_setOp != CharacterClassSetOp::Default && m_setOp != CharacterClassSetOp::Subtraction) {
+            if (m_state == ClassSetConstructionState::Empty || (m_setOp != CharacterClassSetOp::Default && m_setOp != CharacterClassSetOp::Subtraction)) {
                 m_errorCode = ErrorCode::InvalidClassSetOperation;
                 return;
             }
@@ -400,7 +402,7 @@ private:
 
         void setIntersectionOp()
         {
-            if (m_setOp != CharacterClassSetOp::Default && m_setOp != CharacterClassSetOp::Intersection) {
+            if (m_state == ClassSetConstructionState::Empty || (m_setOp != CharacterClassSetOp::Default && m_setOp != CharacterClassSetOp::Intersection)) {
                 m_errorCode = ErrorCode::InvalidClassSetOperation;
                 return;
             }
@@ -419,18 +421,9 @@ private:
             }
         }
 
-        void afterOperand()
+        void afterSetOperand()
         {
-            if (m_setOp == CharacterClassSetOp::Default || m_setOp == CharacterClassSetOp::Union)
-                return;
-
             flushCachedCharacterIfNeeded();
-
-            if (m_state != ClassSetConstructionState::Empty && m_state != ClassSetConstructionState::AfterCharacterClass) {
-                m_errorCode = ErrorCode::InvalidClassSetOperation;
-                return;
-            }
-
             m_state = ClassSetConstructionState::AfterSetOperand;
         }
 
@@ -480,6 +473,12 @@ private:
             bool processingEscape = m_processingEscape;
             m_processingEscape = false;
 
+            auto processCharacter = [&] () {
+                m_character = ch;
+                m_state = ClassSetConstructionState::CachedCharacter;
+                return;
+            };
+
             switch (m_state) {
             case ClassSetConstructionState::AfterCharacterClass:
                 // Following a built-in character class we need look out for a hyphen.
@@ -510,8 +509,7 @@ private:
                     return;
                 }
 
-                m_character = ch;
-                m_state = ClassSetConstructionState::CachedCharacter;
+                processCharacter();
                 return;
 
             case ClassSetConstructionState::CachedCharacter:
@@ -525,7 +523,7 @@ private:
                 else {
                     m_delegate.atomCharacterClassAtom(m_character);
                     switchFromDefaultOpToUnionOpIfNeeded();
-                    m_character = ch;
+                    processCharacter();
                 }
                 return;
 
@@ -546,9 +544,17 @@ private:
                 m_errorCode = ErrorCode::CharacterClassRangeInvalid;
                 return;
 
-                // The only thing valid at this point is s repeat of the current operator.
             case ClassSetConstructionState::AfterSetOperand:
-                m_errorCode = ErrorCode::InvalidClassSetOperation;
+                if (!unionOpActive)
+                    m_errorCode = ErrorCode::InvalidClassSetOperation;
+
+                if (ch == '-')
+                    m_errorCode = ErrorCode::InvalidClassSetOperation;
+                else {
+                    m_delegate.atomCharacterClassAtom(m_character);
+                    switchFromDefaultOpToUnionOpIfNeeded();
+                    processCharacter();
+                }
                 return;
             }
         }
@@ -561,6 +567,16 @@ private:
         void atomBuiltInCharacterClass(BuiltInCharacterClassID classID, bool invert)
         {
             bool unionOpActive = m_setOp == CharacterClassSetOp::Default || m_setOp == CharacterClassSetOp::Union;
+
+            auto processBuiltInCharacterClass = [&] () {
+                if ((invert || m_inverted) && characterClassMayContainStrings(classID)) {
+                    m_errorCode = ErrorCode::NegatedClassSetMayContainStrings;
+                    return;
+                }
+                m_delegate.atomCharacterClassBuiltIn(classID, invert);
+                m_state = ClassSetConstructionState::AfterCharacterClass;
+                return;
+            };
 
             switch (m_state) {
             case ClassSetConstructionState::CachedCharacter:
@@ -584,12 +600,7 @@ private:
 
             case ClassSetConstructionState::Empty:
             case ClassSetConstructionState::AfterCharacterClass:
-                if ((invert || m_inverted) && characterClassMayContainStrings(classID)) {
-                    m_errorCode = ErrorCode::NegatedClassSetMayContainStrings;
-                    return;
-                }
-                m_delegate.atomCharacterClassBuiltIn(classID, invert);
-                m_state = ClassSetConstructionState::AfterCharacterClass;
+                processBuiltInCharacterClass();
                 return;
 
                 // If we hit either of these cases, we have an invalid range that
@@ -608,9 +619,11 @@ private:
                 m_errorCode = ErrorCode::CharacterClassRangeInvalid;
                 return;
 
-                // The only thing valid at this point is s repeat of the current operator.
             case ClassSetConstructionState::AfterSetOperand:
-                m_errorCode = ErrorCode::InvalidClassSetOperation;
+                if (!unionOpActive)
+                    m_errorCode = ErrorCode::InvalidClassSetOperation;
+
+                processBuiltInCharacterClass();
                 return;
             }
         }
@@ -1042,19 +1055,22 @@ private:
         case 'q': {
             int escapeChar = consume();
 
-            if (!isUnicodeSetsCompilation() || parseEscapeMode == ParseEscapeMode::ClassStringDisjunction) {
-                if (isIdentityEscapeAnError(escapeChar))
-                    break;
-                delegate.atomPatternCharacter(escapeChar);
-                break;
+            if (parseEscapeMode == ParseEscapeMode::ClassSet) {
+                if (!atEndOfPattern() && peek() == '{') {
+                    parseClassStringDisjunction();
+                    return TokenType::SetDisjunction;
+                }
+
+                m_errorCode = ErrorCode::InvalidUnicodePropertyExpression;
             }
 
-            if (!atEndOfPattern() && peek() == '{')
-                parseClassStringDisjunction();
-            else
-                m_errorCode = ErrorCode::InvalidUnicodePropertyExpression;
+            if (isIdentityEscapeAnError(escapeChar))
+                break;
+
+            delegate.atomPatternCharacter(escapeChar);
             break;
         }
+
         // UnicodeEscape
         case 'u': {
             int codePoint = tryConsumeUnicodeEscape<UnicodeParseContext::PatternCodePoint>();
@@ -1150,7 +1166,7 @@ private:
 
     TokenType parseClassSetEscape(ClassSetParserDelegate& delegate)
     {
-        return parseEscape<ParseEscapeMode::CharacterClass>(delegate);
+        return parseEscape<ParseEscapeMode::ClassSet>(delegate);
     }
 
     void parseClassStringDisjunctionEscape(ClassStringDisjunctionParserDelegate& delegate)
@@ -1236,16 +1252,19 @@ private:
                 break;
             }
 
-            case '\\':
+            case '\\': {
                 if (!classSetConstructor.canTakeSetOperand()) {
                     m_errorCode = ErrorCode::InvalidClassSetOperation;
                     return;
                 }
 
                 classSetConstructor.setProcessingEscape();
-                parseClassSetEscape(classSetConstructor);
-                classSetConstructor.afterOperand();
+
+                if (parseClassSetEscape(classSetConstructor) == TokenType::SetDisjunction)
+                    classSetConstructor.afterSetOperand();
+
                 break;
+            }
 
             case '-': {
                 ParseState state = saveState();
@@ -1329,15 +1348,14 @@ private:
                 m_errorCode = ErrorCode::InvalidClassSetCharacter;
                 return;
 
-            default:
-                {
-                    UChar32 ch = consumeAndCheckIfValidClassSetCharacter();
+            default: {
+                UChar32 ch = consumeAndCheckIfValidClassSetCharacter();
 
-                    if (ch == -1)
-                        return;
+                if (ch == -1)
+                    return;
 
-                    stringDisjunctionDelegate.atomPatternCharacter(ch);
-                }
+                stringDisjunctionDelegate.atomPatternCharacter(ch);
+            }
             }
 
             if (hasError(m_errorCode))


### PR DESCRIPTION
#### 06b56b4c9d0015be87161819dd740b686827980e
<pre>
[Yarr] ASSERTION FAILED: m_setOp == CharacterClassSetOp::Default || m_setOp == setOp
<a href="https://bugs.webkit.org/show_bug.cgi?id=256822">https://bugs.webkit.org/show_bug.cgi?id=256822</a>
rdar://108256053

Reviewed by Yusuke Suzuki.

Refactored ClassSetParserDelegate state transitions.  Prior to this refactoring, ClassSetConstructionState::Empty
was used at both the start of a class set and after a class set operation with its left and right operands.
Given that this bug occurred with standalone class set operator, the prior use of ClassSetConstructionState::Empty
didn&apos;t allow for proper detection of the bug case.  Changed the state after the right hand operand of a class set
operator to be ClassSetConstructionState::AfterSetOperand Most of the refactoring occurs in
ClassSetParserDelegate::atomPatternCharacter() and ClassSetParserDelegate::atomBuiltInCharacterClass().

This change necessitated some other changes.  Added a new ClassSet parseEscape() mode to simplify processing of
\q{} class disjunction escapes.  Since class set disjunctions may return strings, a parsed class set disjunction
returns a new TokenType, SetDisjunction, to distinguish it from the other parse escapes results that resolve to
either a single character, via atomPatternCharacter(), or a builtin character class, via atomBuiltInCharacterClass().

Updated regexp-vflag-property-of-strings.js with new test cases.

* JSTests/stress/regexp-vflag-property-of-strings.js:
* Source/JavaScriptCore/yarr/YarrParser.h:
(JSC::Yarr::Parser::ClassSetParserDelegate::nestedClassEnd):
(JSC::Yarr::Parser::ClassSetParserDelegate::setSubtractOp):
(JSC::Yarr::Parser::ClassSetParserDelegate::setIntersectionOp):
(JSC::Yarr::Parser::ClassSetParserDelegate::afterSetOperand):
(JSC::Yarr::Parser::ClassSetParserDelegate::atomPatternCharacter):
(JSC::Yarr::Parser::ClassSetParserDelegate::atomBuiltInCharacterClass):
(JSC::Yarr::Parser::parseEscape):
(JSC::Yarr::Parser::parseClassSetEscape):
(JSC::Yarr::Parser::parseClassSet):
(JSC::Yarr::Parser::parseClassStringDisjunction):
(JSC::Yarr::Parser::ClassSetParserDelegate::afterOperand): Deleted.

Canonical link: <a href="https://commits.webkit.org/264153@main">https://commits.webkit.org/264153@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/fd36a62638f600f8ccf96518b043763d778ccbdb

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/6888 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/7118 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/7301 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/8487 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/7135 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/8360 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/7057 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/10034 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/7010 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/7672 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/6339 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/8587 "Built successfully") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/39/builds/5054 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/6250 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/14042 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/5812 "Built successfully and passed tests") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/6740 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/6337 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/9144 "Passed tests") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/6463 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/6820 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/5585 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/7028 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/6196 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/1645 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/1629 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/10381 "Built successfully") | | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/24/builds/7219 "Built successfully") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/6574 "Built successfully") | | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/3/builds/1781 "Passed tests") | 
<!--EWS-Status-Bubble-End-->