### PR TITLE
InteractionRegions: refine the visual edge detection

### DIFF
--- a/LayoutTests/interaction-region/consolidated-nested-regions.html
+++ b/LayoutTests/interaction-region/consolidated-nested-regions.html
@@ -13,6 +13,7 @@
         top: 0;
         right: 0;
         border-radius: 5px;
+        background: blue;
     }
 </style>
 <body>

--- a/LayoutTests/interaction-region/inline-link-expected.txt
+++ b/LayoutTests/interaction-region/inline-link-expected.txt
@@ -1,4 +1,4 @@
-This is a link.
+This is a link. This is a wiki-style link. This is a link with visible edges.
 (GraphicsLayer
   (anchor 0.00 0.00)
   (bounds 800.00 600.00)
@@ -13,7 +13,13 @@ This is a link.
 
       (interaction regions [
         (interaction (-4,-4) width=37 height=27)
-        (borderRadius 8.00)])
+        (borderRadius 8.00),
+        (interaction (87,-4) width=37 height=27)
+        (borderRadius 8.00),
+        (guard (250,-10) width=29 height=39)
+        (borderRadius 0.00),
+        (interaction (250,0) width=29 height=19)
+        (borderRadius 0.00)])
       )
     )
   )

--- a/LayoutTests/interaction-region/inline-link.html
+++ b/LayoutTests/interaction-region/inline-link.html
@@ -5,6 +5,8 @@
 </style>
 <body>
 <a href="#">This</a> is a link.
+<a href="#" style="border: 0; background: none;">This</a> is a wiki-style link.
+<a href="#" style="background: green;">This</a> is a link with visible edges.
 
 <pre id="results"></pre>
 <script>

--- a/Source/WebCore/page/InteractionRegion.cpp
+++ b/Source/WebCore/page/InteractionRegion.cpp
@@ -236,9 +236,9 @@ std::optional<InteractionRegion> interactionRegionForRenderedRegion(RenderObject
     bool detectedHoverRules = false;
     if (!hasPointer) {
         // The hover check can be expensive (it may end up doing selector matching), so we only run it on some elements.
-        bool hasVisualEdges = !renderer.style().borderAndBackgroundEqual(RenderStyle::defaultStyle());
+        bool hasVisibleBoxDecorations = renderer.hasVisibleBoxDecorations();
         bool nonScrollable = !renderer.hasPotentiallyScrollableOverflow();
-        if (hasVisualEdges && nonScrollable)
+        if (hasVisibleBoxDecorations && nonScrollable)
             detectedHoverRules = elementMatchesHoverRules(*matchedElement);
     }
 
@@ -294,12 +294,12 @@ std::optional<InteractionRegion> interactionRegionForRenderedRegion(RenderObject
         }
     }
 
-    bool hasNoVisualEdges = regionRenderer.style().borderAndBackgroundEqual(RenderStyle::defaultStyle());
-    if (isInlineNonBlock && hasNoVisualEdges)
-        bounds.inflate(regionRenderer.document().settings().interactionRegionInlinePadding());
-
-    if (hasNoVisualEdges)
+    if (!regionRenderer.hasVisibleBoxDecorations() && !renderer.hasVisibleBoxDecorations()) {
+        // We can safely tweak the bounds and radius without causing visual mismatch.
         borderRadius = std::max<float>(borderRadius, regionRenderer.document().settings().interactionRegionMinimumCornerRadius());
+        if (isInlineNonBlock)
+            bounds.inflate(regionRenderer.document().settings().interactionRegionInlinePadding());
+    }
 
     return { {
         InteractionRegion::Type::Interaction,

--- a/Source/WebCore/rendering/EventRegion.cpp
+++ b/Source/WebCore/rendering/EventRegion.cpp
@@ -175,7 +175,7 @@ void EventRegionContext::uniteInteractionRegions(const Region& region, RenderObj
 
 bool EventRegionContext::shouldConsolidateInteractionRegion(IntRect bounds, RenderObject& renderer)
 {
-    if (!renderer.style().borderAndBackgroundEqual(RenderStyle::defaultStyle()))
+    if (renderer.hasVisibleBoxDecorations())
         return false;
 
     for (auto& ancestor : ancestorsOfType<RenderElement>(renderer)) {
@@ -206,7 +206,7 @@ bool EventRegionContext::shouldConsolidateInteractionRegion(IntRect bounds, Rend
         }
 
         // If we find a border / background, stop the search.
-        if (!ancestor.style().borderAndBackgroundEqual(RenderStyle::defaultStyle()))
+        if (ancestor.hasVisibleBoxDecorations())
             return false;
     }
 


### PR DESCRIPTION
#### 622bd3bfe173b244d3cc68f2cb14ebbf987e14dd
<pre>
InteractionRegions: refine the visual edge detection
<a href="https://bugs.webkit.org/show_bug.cgi?id=256894">https://bugs.webkit.org/show_bug.cgi?id=256894</a>
&lt;rdar://109412803&gt;

Reviewed by Tim Horton.

Use the more complete `hasVisibleBoxDecorations()` when checking if a
renderer has any visual edge.
This fixes an issue where `border: 0` elements were still considered as
having visual edges.

* Source/WebCore/page/InteractionRegion.cpp:
(WebCore::interactionRegionForRenderedRegion):
Use the `hasVisibleBoxDecorations()` to detect a visual edge.
Expand and clarify the conditions under which we can tweak the region
without causing visual mismatch.
* Source/WebCore/rendering/EventRegion.cpp:
(WebCore::EventRegionContext::shouldConsolidateInteractionRegion):
Use the `hasVisibleBoxDecorations()` to detect a visual edge.

* LayoutTests/interaction-region/consolidated-nested-regions.html:
Add a background to the nested link so that it continues being seen as
having a visual edge (no expectation diff).
* LayoutTests/interaction-region/inline-link-expected.txt:
* LayoutTests/interaction-region/inline-link.html:
Cover the change with new inline link test cases.

Canonical link: <a href="https://commits.webkit.org/264194@main">https://commits.webkit.org/264194@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4b14cfea44dc8c43cd1d7cf8171adc79790e4f78

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/6891 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/7121 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/7304 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/8490 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/7138 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/6896 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/8364 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/7060 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/10036 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/7013 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/7674 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/6344 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/8590 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/5056 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/6254 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/14043 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/6742 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/6341 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/9147 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/6823 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/5588 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/6199 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/6168 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/1656 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/10384 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/6577 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->