### PR TITLE
[css-flexbox][baseline-alignment] Use BaslineContext/BaselineGroup to perform baseline alignment.

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-flexbox/alignment/flex-align-baseline-001-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-flexbox/alignment/flex-align-baseline-001-expected.txt
@@ -13,13 +13,9 @@ line2
 
 FAIL #target > div 1 assert_equals:
 <div data-offset-x="120">line1<br>line2</div>
-offsetLeft expected 120 but got 20
-FAIL #target > div 2 assert_equals:
-<div data-offset-x="105">line1<br>line2</div>
-offsetLeft expected 105 but got 110
-FAIL #target > div 3 assert_equals:
-<div data-offset-x="126">line1<br>line2</div>
-offsetLeft expected 126 but got 131
+offsetLeft expected 120 but got 15
+PASS #target > div 2
+PASS #target > div 3
 PASS #target > div 4
 FAIL #target > div 5 assert_equals:
 <div data-offset-x="35">line1<br>line2</div>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-flexbox/alignment/flex-align-baseline-002-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-flexbox/alignment/flex-align-baseline-002-expected.txt
@@ -13,13 +13,9 @@ line2
 
 FAIL #target > div 1 assert_equals:
 <div data-offset-x="120">line1<br>line2</div>
-offsetLeft expected 120 but got 20
-FAIL #target > div 2 assert_equals:
-<div data-offset-x="105">line1<br>line2</div>
-offsetLeft expected 105 but got 110
-FAIL #target > div 3 assert_equals:
-<div data-offset-x="126">line1<br>line2</div>
-offsetLeft expected 126 but got 131
+offsetLeft expected 120 but got 15
+PASS #target > div 2
+PASS #target > div 3
 PASS #target > div 4
 FAIL #target > div 5 assert_equals:
 <div data-offset-x="35">line1<br>line2</div>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-flexbox/alignment/flex-align-baseline-003-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-flexbox/alignment/flex-align-baseline-003-expected.txt
@@ -20,11 +20,7 @@ FAIL #target > div 3 assert_equals:
 offsetLeft expected 126 but got 21
 FAIL #target > div 4 assert_equals:
 <div data-offset-x="20">line1<br>line2</div>
-offsetLeft expected 20 but got 120
-FAIL #target > div 5 assert_equals:
-<div data-offset-x="35">line1<br>line2</div>
-offsetLeft expected 35 but got 30
-FAIL #target > div 6 assert_equals:
-<div data-offset-x="42">line1<br>line2</div>
-offsetLeft expected 42 but got 37
+offsetLeft expected 20 but got 125
+PASS #target > div 5
+PASS #target > div 6
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-flexbox/alignment/flex-align-baseline-004-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-flexbox/alignment/flex-align-baseline-004-expected.txt
@@ -16,13 +16,11 @@ FAIL #target > div 1 assert_equals:
 offsetLeft expected 15 but got 120
 PASS #target > div 2
 PASS #target > div 3
-FAIL #target > div 4 assert_equals:
-<div data-offset-x="125">line1<br>line2</div>
-offsetLeft expected 125 but got 120
+PASS #target > div 4
 FAIL #target > div 5 assert_equals:
 <div data-offset-x="140">line1<br>line2</div>
-offsetLeft expected 140 but got 30
+offsetLeft expected 140 but got 35
 FAIL #target > div 6 assert_equals:
 <div data-offset-x="147">line1<br>line2</div>
-offsetLeft expected 147 but got 37
+offsetLeft expected 147 but got 42
 

--- a/Source/WebCore/rendering/BaselineAlignment.cpp
+++ b/Source/WebCore/rendering/BaselineAlignment.cpp
@@ -91,6 +91,11 @@ const BaselineGroup& BaselineAlignmentState::sharedGroup(const RenderBox& child,
     return const_cast<BaselineAlignmentState*>(this)->findCompatibleSharedGroup(child, preference);
 }
 
+Vector<BaselineGroup>& BaselineAlignmentState::sharedGroups()
+{
+    return m_sharedGroups;
+}
+
 void BaselineAlignmentState::updateSharedGroup(const RenderBox& child, ItemPosition preference, LayoutUnit ascent)
 {
     ASSERT(isBaselinePosition(preference));

--- a/Source/WebCore/rendering/BaselineAlignment.h
+++ b/Source/WebCore/rendering/BaselineAlignment.h
@@ -54,6 +54,8 @@ public:
     void update(const RenderBox&, LayoutUnit ascent);
     LayoutUnit maxAscent() const { return m_maxAscent; }
     int computeSize() const { return m_items.computeSize(); }
+    auto begin() { return m_items.begin(); }
+    auto end() { return m_items.end(); }
 
 private:
     friend class BaselineAlignmentState;
@@ -74,7 +76,7 @@ private:
     WritingMode m_blockFlow;
     ItemPosition m_preference;
     LayoutUnit m_maxAscent;
-    WeakHashSet<const RenderBox> m_items;
+    WeakHashSet<RenderBox> m_items;
 };
 
 //
@@ -101,6 +103,7 @@ public:
     // We pass the item's baseline-preference to avoid dependencies with the LayoutGrid class, which is the one
     // managing the alignment behavior of the Grid Items.
     void updateSharedGroup(const RenderBox& child, ItemPosition preference, LayoutUnit ascent);
+    Vector<BaselineGroup>& sharedGroups();
 
 private:
     // Returns the baseline-sharing group compatible with an item.

--- a/Source/WebCore/rendering/RenderFlexibleBox.h
+++ b/Source/WebCore/rendering/RenderFlexibleBox.h
@@ -219,8 +219,9 @@ private:
     void layoutAndPlaceChildren(LayoutUnit& crossAxisOffset, Vector<FlexItem>&, LayoutUnit availableFreeSpace, bool relayoutChildren, Vector<LineState>&, LayoutUnit gapBetweenItems);
     void layoutColumnReverse(const Vector<FlexItem>&, LayoutUnit crossAxisOffset, LayoutUnit availableFreeSpace, LayoutUnit gapBetweenItems);
     void alignFlexLines(Vector<LineState>&, LayoutUnit gapBetweenLines);
-    void alignChildren(const Vector<LineState>&);
+    void alignChildren(Vector<LineState>&);
     void applyStretchAlignmentToChild(RenderBox& child, LayoutUnit lineCrossAxisExtent);
+    void performBaselineAlignment(LineState&);
     void flipForRightToLeftColumn(const Vector<LineState>& linesState);
     void flipForWrapReverse(const Vector<LineState>&, LayoutUnit crossAxisStartEdge);
     


### PR DESCRIPTION
#### b7b43b9bf044a2edb16f3fc873f69f1bdf3d8379
<pre>
[css-flexbox][baseline-alignment] Use BaslineContext/BaselineGroup to perform baseline alignment.
<a href="https://bugs.webkit.org/show_bug.cgi?id=256793">https://bugs.webkit.org/show_bug.cgi?id=256793</a>
rdar://109362699

Reviewed by Alan Baradlay.

The BaselineContext and BaselineGroup classes provide us with the ability
to represent baseline alignment contexts and baseline sharing groups
as described in css-align-3. The main purpose of this patch is to replace
the data structures we use in flex layout to hold state for baseline
alignment with these new objects.

Previously, we were storing our baseline alignment state, in particular
the max ascent for baseline and last baseline alignment, for each
flex line inside of LineContext. The maxAscent value was computed
off of all of the items which had baseline alignment specified and
lastBaselineMaxAscent was computed off of all of the items which had
last baseline alignment specified.

This was not quite right since the spec mentions ways in which items
there are baseline and last baseline aligned could get placed in the
same baseline sharing group and should get aligned together. In the
following example the two flex items are placed in the same baseline
sharing group:

&lt;div style=&quot;display: flex; flex-direction: column; align-items: last-baseline; width: 200px;&quot;&gt;
  &lt;div style=&quot;align-self: first baseline; writing-mode: vertical-rl;&quot;&gt;line1&lt;br&gt;line2&lt;/div&gt;
  &lt;div style=&quot;writing-mode: vertical-lr;&quot;&gt;line1&lt;br&gt;line2&lt;/div&gt;
&lt;/div&gt;

With the new addition of the BaselineContext and BaselineGroup objects
we can now place items into the correct baseline sharing group as
described in the spec and the max ascent values are now kept track of
within the baseline sharing group. However, the above example does
still not render correctly because there are still some outstanding
bugs related to baseline alignment, but this serves as a good starting
point for addressing them.

In order to perform baseline alignment with these new classes, a slight
refactoring was needed. Instead of iterating over all of the children
on the flex line we instead iterate over all of the baseline sharing
groups on the line and perform the alignment for each group. We do this
by checking to see if the LineContext has a BaselineContext early in
alignChildren() and for into performBaselineAlignment(). This is a
little more intuitive and will be useful as we address the rest of the
portions of the spec in css-align-3 as it mentions working with baseline
sharing groups as a whole.

Since we have not added any new functionality in regards to baseline
alignment besides just separating items into baseline sharing groups,
we should ideally not be regressing any scenarios in which we perform
baseline and last baseline alignment correctly.

* LayoutTests/imported/w3c/web-platform-tests/css/css-flexbox/alignment/flex-align-baseline-001-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-flexbox/alignment/flex-align-baseline-002-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-flexbox/alignment/flex-align-baseline-003-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-flexbox/alignment/flex-align-baseline-004-expected.txt:
* Source/WebCore/rendering/BaselineAlignment.cpp:
(WebCore::BaselineAlignmentState::sharedGroups):
* Source/WebCore/rendering/BaselineAlignment.h:
(WebCore::BaselineGroup::begin):
(WebCore::BaselineGroup::end):
* Source/WebCore/rendering/RenderFlexibleBox.cpp:
(WebCore::RenderFlexibleBox::LineState::LineState):
(WebCore::alignmentOffset):
(WebCore::RenderFlexibleBox::staticCrossAxisPositionForPositionedChild):
(WebCore::RenderFlexibleBox::layoutAndPlaceChildren):
(WebCore::RenderFlexibleBox::alignChildren):
(WebCore::RenderFlexibleBox::performBaselineAlignment):
* Source/WebCore/rendering/RenderFlexibleBox.h:

Canonical link: <a href="https://commits.webkit.org/266387@main">https://commits.webkit.org/266387@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/944b2f63a881baf5de67d545981a5aceed93a21c

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/13672 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/13986 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/14319 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/15408 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/12983 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/13753 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/16494 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/14067 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/15665 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/13838 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/14462 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/11568 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/16105 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/11751 "Passed tests") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/12326 "2 flakes 5 failures") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/19360 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/12826 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/12491 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/15698 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/13017 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/10897 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/12287 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/3331 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/16618 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/12858 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->