### PR TITLE
[git-webkit] Don't annotate cherry-picks from non-production branches

### DIFF
--- a/Tools/Scripts/hooks/prepare-commit-msg
+++ b/Tools/Scripts/hooks/prepare-commit-msg
@@ -9,6 +9,9 @@ LOCATION = r'{{ location }}'
 SPACING = 8
 SCRIPTS = os.path.dirname(os.path.dirname(LOCATION))
 CHERRY_PICKING_RE = re.compile(r'^# You are currently cherry-picking commit (?P<hash>[a-f0-9A-F]+)\.$')
+CHERRY_PICK_COMMIT_RE = re.compile(r'^(?P<a>\S+)( \((?P<b>\S+)\))?$')
+REFNAME_RE = re.compile(r'^refs/remotes/(?P<remote>[^/ ]+)/(?P<branch>\S+)$')
+HASH_RE = re.compile(r'^[a-f0-9A-F]+$')
 IDENTIFIER_RE = re.compile(r'(\d+\.)?\d+@\S+')
 PREFER_RADAR = {{ prefer_radar }}
 
@@ -205,11 +208,40 @@ def cherry_pick(content):
             elif from_last_line:
                 cherry_picked = '{} ({})'.format(from_last_line.group(0), cherry_picked)
 
+    production_hash = None
+    match = CHERRY_PICK_COMMIT_RE.match(cherry_picked)
+    for candidate in ([match.group('a'), match.group('b')] if match else []):
+        if not candidate:
+            continue
+        if HASH_RE.match(candidate):
+            production_hash = candidate
+
+    if production_hash:
+        try:
+            subprocess.check_output(
+                ['git', 'merge-base', '--is-ancestor', production_hash, DEFAULT_BRANCH],
+                **ENCODING_KWARGS
+            )
+        except subprocess.CalledProcessError:
+            remotes = set()
+            for line in subprocess.check_output(
+                ['git', 'branch', '--contains', production_hash, '-a', '--format', '%(refname)'],
+                **ENCODING_KWARGS
+            ).splitlines():
+                match = REFNAME_RE.match(line.strip())
+                if not match:
+                    continue
+                remote = match.group('remote')
+                if remote in SOURCE_REMOTES:
+                    remotes.add(match.group('remote'))
+            if not remotes:
+                production_hash = None
+
     is_trunk_bound = DEFAULT_BRANCH in source_branches()
     in_suffix = False
     cherry_pick_metadata = '{}. {}'.format(cherry_picked or '???', bug or '<bug>')
     result = []
-    if not is_trunk_bound:
+    if not is_trunk_bound and production_hash:
         result += ['Cherry-pick {}'.format(cherry_pick_metadata), '']
     for line in content.splitlines():
         line = line.rstrip()
@@ -218,11 +250,11 @@ def cherry_pick(content):
             continue
         if line[0] == '#' and not in_suffix:
             in_suffix = True
-            if is_trunk_bound:
+            if is_trunk_bound and production_hash:
                 while len(result) and not result[-1] or (result[-1].split(':', 1)[0] in TRAILERS_TO_STRIP):
                     del result[-1]
                 result += ['', 'Originally-landed-as: {}'.format(cherry_pick_metadata)]
-        if line[0] != '#' and not is_trunk_bound:
+        if line[0] != '#' and not is_trunk_bound and production_hash:
             result.append(4*' ' + line)
         else:
             result.append(line)


### PR DESCRIPTION
#### 79ba0fe6a750ac2e0caeb5e864b9a8131879ce5e
<pre>
[git-webkit] Don&apos;t annotate cherry-picks from non-production branches
<a href="https://bugs.webkit.org/show_bug.cgi?id=256905">https://bugs.webkit.org/show_bug.cgi?id=256905</a>
rdar://109466659

Reviewed by Elliott Williams.

Check if a cherry-pick is coming from a branch that exists on a source
remote. If so, the original commit is a persisent part of the repository
and we should annotate the commit message of the cherry-pick.

* Tools/Scripts/hooks/prepare-commit-msg:

Canonical link: <a href="https://commits.webkit.org/265920@main">https://commits.webkit.org/265920@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5765ad8d9060e6481ddbfaf5ebb3504eb4e6e15c

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/12086 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/12432 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/12734 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/13832 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/11665 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/12117 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/14848 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/12446 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/14358 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/12250 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/13061 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/10232 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/14247 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/10349 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/10969 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/18095 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/11429 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/11129 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/14306 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/11620 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/9571 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/10833 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/15159 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/1368 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/11471 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->