### PR TITLE
Add BBQ and OMG allow lists to JSC options

### DIFF
--- a/Source/JavaScriptCore/runtime/OptionsList.h
+++ b/Source/JavaScriptCore/runtime/OptionsList.h
@@ -147,6 +147,8 @@ bool canUseWebAssemblyFastMemory();
     v(OptionString, jitAllowlist, nullptr, Normal, "file with newline separated list of function signatures to allow compilation on or, if no such file exists, the function signature to allow") \
     v(OptionString, dfgAllowlist, nullptr, Normal, "file with newline separated list of function signatures to allow DFG compilation on or, if no such file exists, the function signature to allow") \
     v(OptionString, ftlAllowlist, nullptr, Normal, "file with newline separated list of function signatures to allow FTL compilation on or, if no such file exists, the function signature to allow") \
+    v(OptionString, bbqAllowlist, nullptr, Normal, "file with newline separated list of function indices to allow BBQ compilation on or, if no such file exists, the function index to allow") \
+    v(OptionString, omgAllowlist, nullptr, Normal, "file with newline separated list of function indices to allow OMG compilation on or, if no such file exists, the function index to allow") \
     v(Bool, dumpSourceAtDFGTime, false, Normal, "dumps source code of JS function being DFG compiled") \
     v(Bool, dumpBytecodeAtDFGTime, false, Normal, "dumps bytecode of JS function being DFG compiled") \
     v(Bool, dumpGraphAfterParsing, false, Normal, nullptr) \

--- a/Source/JavaScriptCore/tools/FunctionAllowlist.cpp
+++ b/Source/JavaScriptCore/tools/FunctionAllowlist.cpp
@@ -100,6 +100,14 @@ bool FunctionAllowlist::shouldDumpWasmFunction(uint32_t index) const
 {
     if (!m_hasActiveAllowlist)
         return false;
+    return containsWasmFunction(index);
+}
+
+bool FunctionAllowlist::containsWasmFunction(uint32_t index) const
+{
+    if (!m_hasActiveAllowlist)
+        return true;
+
     if (m_entries.isEmpty())
         return false;
     return m_entries.contains(String::number(index));

--- a/Source/JavaScriptCore/tools/FunctionAllowlist.h
+++ b/Source/JavaScriptCore/tools/FunctionAllowlist.h
@@ -38,6 +38,7 @@ public:
 
     bool contains(CodeBlock*) const;
     bool shouldDumpWasmFunction(uint32_t) const;
+    bool containsWasmFunction(uint32_t) const;
 
 private:
     HashSet<String> m_entries;

--- a/Source/JavaScriptCore/wasm/WasmBBQPlan.cpp
+++ b/Source/JavaScriptCore/wasm/WasmBBQPlan.cpp
@@ -61,6 +61,17 @@ BBQPlan::BBQPlan(VM& vm, Ref<ModuleInformation> moduleInformation, uint32_t func
     dataLogLnIf(WasmBBQPlanInternal::verbose, "Starting BBQ plan for ", functionIndex);
 }
 
+FunctionAllowlist& BBQPlan::ensureGlobalBBQAllowlist()
+{
+    static LazyNeverDestroyed<FunctionAllowlist> bbqAllowlist;
+    static std::once_flag initializeAllowlistFlag;
+    std::call_once(initializeAllowlistFlag, [] {
+        const char* functionAllowlistFile = Options::bbqAllowlist();
+        bbqAllowlist.construct(functionAllowlistFile);
+    });
+    return bbqAllowlist;
+}
+
 bool BBQPlan::planGeneratesLoopOSREntrypoints(const ModuleInformation& moduleInformation)
 {
     if constexpr (is32Bit())

--- a/Source/JavaScriptCore/wasm/WasmBBQPlan.h
+++ b/Source/JavaScriptCore/wasm/WasmBBQPlan.h
@@ -32,6 +32,7 @@
 #include "WasmEntryPlan.h"
 #include "WasmModuleInformation.h"
 #include "WasmTierUpCount.h"
+#include "tools/FunctionAllowlist.h"
 #include <wtf/Bag.h>
 #include <wtf/Function.h>
 #include <wtf/SharedTask.h>
@@ -75,6 +76,7 @@ public:
         return Base::parseAndValidateModule(m_source.data(), m_source.size());
     }
 
+    static FunctionAllowlist& ensureGlobalBBQAllowlist();
     static bool planGeneratesLoopOSREntrypoints(const ModuleInformation&);
 
 private:

--- a/Source/JavaScriptCore/wasm/WasmOMGPlan.cpp
+++ b/Source/JavaScriptCore/wasm/WasmOMGPlan.cpp
@@ -60,6 +60,17 @@ OMGPlan::OMGPlan(VM& vm, Ref<Module>&& module, uint32_t functionIndex, std::opti
     dataLogLnIf(WasmOMGPlanInternal::verbose, "Starting OMG plan for ", functionIndex, " of module: ", RawPointer(&m_module.get()));
 }
 
+FunctionAllowlist& OMGPlan::ensureGlobalOMGAllowlist()
+{
+    static LazyNeverDestroyed<FunctionAllowlist> omgAllowlist;
+    static std::once_flag initializeAllowlistFlag;
+    std::call_once(initializeAllowlistFlag, [] {
+        const char* functionAllowlistFile = Options::omgAllowlist();
+        omgAllowlist.construct(functionAllowlistFile);
+    });
+    return omgAllowlist;
+}
+
 void OMGPlan::dumpDisassembly(CompilationContext& context, LinkBuffer& linkBuffer, unsigned functionIndex, const TypeDefinition& signature, unsigned functionIndexSpace)
 {
     dataLogLnIf(context.procedure->shouldDumpIR() || shouldDumpDisassemblyFor(CompilationMode::OMGMode), "Generated OMG code for WebAssembly OMG function[", functionIndex, "] ", signature.toString().ascii().data(), " name ", makeString(IndexOrName(functionIndexSpace, m_moduleInformation->nameSection->get(functionIndexSpace))).ascii().data());

--- a/Source/JavaScriptCore/wasm/WasmOMGPlan.h
+++ b/Source/JavaScriptCore/wasm/WasmOMGPlan.h
@@ -30,6 +30,7 @@
 #include "WasmContext.h"
 #include "WasmModule.h"
 #include "WasmPlan.h"
+#include "tools/FunctionAllowlist.h"
 
 namespace JSC {
 
@@ -44,6 +45,7 @@ public:
     bool hasWork() const final { return !m_completed; }
     void work(CompilationEffort) final;
     bool multiThreaded() const final { return false; }
+    static FunctionAllowlist& ensureGlobalOMGAllowlist();
 
     // Note: CompletionTask should not hold a reference to the Plan otherwise there will be a reference cycle.
     OMGPlan(VM&, Ref<Module>&&, uint32_t functionIndex, std::optional<bool> hasExceptionHandlers, MemoryMode, CompletionTask&&);

--- a/Source/JavaScriptCore/wasm/WasmOperations.cpp
+++ b/Source/JavaScriptCore/wasm/WasmOperations.cpp
@@ -263,7 +263,7 @@ static void doOSREntry(Instance* instance, Probe::Context& context, BBQCallee& c
 
 inline bool shouldJIT(unsigned functionIndex)
 {
-    if (!Options::useOMGJIT())
+    if (!Options::useOMGJIT() || !OMGPlan::ensureGlobalOMGAllowlist().containsWasmFunction(functionIndex))
         return false;
     if (!Options::wasmFunctionIndexRangeToCompile().isInRange(functionIndex))
         return false;


### PR DESCRIPTION
#### 8b1424b44716f59295d952310e1a5ac509640611
<pre>
Add BBQ and OMG allow lists to JSC options
<a href="https://bugs.webkit.org/show_bug.cgi?id=256914">https://bugs.webkit.org/show_bug.cgi?id=256914</a>
rdar://109474140

Reviewed by Justin Michaud.

Adds --bbqAllowlist and --omgAllowlist options to the JSC command line.
Like existing allowlist options, these take either the single function
to allow compilation of, or a path to a file containing one allowed
function per line. Since WASM doesn&apos;t necessarily keep names in source,
and we don&apos;t currently employ the same function hashing technique we do
in JS, allowed functions are currently specified by function index.

* Source/JavaScriptCore/runtime/OptionsList.h:
* Source/JavaScriptCore/tools/FunctionAllowlist.cpp:
(JSC::FunctionAllowlist::FunctionAllowlist):
(JSC::FunctionAllowlist::shouldDumpWasmFunction const):
(JSC::FunctionAllowlist::containsWasmFunction const):
* Source/JavaScriptCore/tools/FunctionAllowlist.h:
* Source/JavaScriptCore/wasm/WasmBBQPlan.cpp:
(JSC::Wasm::BBQPlan::ensureGlobalBBQAllowlist):
* Source/JavaScriptCore/wasm/WasmBBQPlan.h:
* Source/JavaScriptCore/wasm/WasmOMGPlan.cpp:
(JSC::Wasm::OMGPlan::ensureGlobalOMGAllowlist):
* Source/JavaScriptCore/wasm/WasmOMGPlan.h:
* Source/JavaScriptCore/wasm/WasmOperations.cpp:
(JSC::Wasm::shouldJIT):
* Source/JavaScriptCore/wasm/WasmSlowPaths.cpp:
(JSC::LLInt::shouldJIT):
(JSC::LLInt::jitCompileAndSetHeuristics):

Canonical link: <a href="https://commits.webkit.org/264184@main">https://commits.webkit.org/264184@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a9d6bb272a249def946aed66961b53341ce31fcf

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/6923 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/7153 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/7336 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/8528 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/7168 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/6928 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/8412 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/7092 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/10080 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/7045 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/7718 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/6377 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/8627 "Built successfully") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/39/builds/5108 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/6288 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/14077 "2 flakes 114 failures") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/5846 "Built successfully and passed tests") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/6784 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/6379 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/9207 "Passed tests") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/6500 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/6855 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/5621 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/7063 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/6231 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/1651 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/1652 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/10417 "Built successfully") | | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/24/builds/7254 "Built successfully") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/6613 "Built successfully") | | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/3/builds/1788 "Passed tests") | 
<!--EWS-Status-Bubble-End-->