### PR TITLE
[WebIDL] document.body.onerror setter should setup a five-parameter listener

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/html/webappapis/scripting/events/event-handler-processing-algorithm-error/body-element-synthetic-errorevent-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/webappapis/scripting/events/event-handler-processing-algorithm-error/body-element-synthetic-errorevent-expected.txt
@@ -1,4 +1,4 @@
 
-FAIL error event is weird (return true cancels; many args) on Window, with a synthetic ErrorEvent assert_greater_than: expected a number greater than 1 but got 1
-FAIL error event has the right 5 args on Window, with a synthetic ErrorEvent assert_equals: There must be exactly 5 arguments expected 5 but got 1
+PASS error event is weird (return true cancels; many args) on Window, with a synthetic ErrorEvent
+PASS error event has the right 5 args on Window, with a synthetic ErrorEvent
 

--- a/LayoutTests/imported/w3c/web-platform-tests/html/webappapis/scripting/events/event-handler-processing-algorithm-error/frameset-element-synthetic-errorevent-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/webappapis/scripting/events/event-handler-processing-algorithm-error/frameset-element-synthetic-errorevent-expected.txt
@@ -1,5 +1,5 @@
 
 
-FAIL error event is weird (return true cancels; many args) on Window, with a synthetic ErrorEvent assert_greater_than: expected a number greater than 1 but got 1
-FAIL error event has the right 5 args on Window, with a synthetic ErrorEvent assert_equals: There must be exactly 5 arguments expected 5 but got 1
+PASS error event is weird (return true cancels; many args) on Window, with a synthetic ErrorEvent
+PASS error event has the right 5 args on Window, with a synthetic ErrorEvent
 

--- a/Source/WebCore/bindings/scripts/CodeGenerator.pm
+++ b/Source/WebCore/bindings/scripts/CodeGenerator.pm
@@ -906,6 +906,15 @@ sub IsConstructorType
     return $type->name =~ /Constructor$/;
 }
 
+sub IsEventHandlerType
+{
+    my ($object, $type) = @_;
+
+    assert("Not a type") if ref($type) ne "IDLType";
+
+    return $type->name =~ /EventHandler$/;
+}
+
 sub IsSequenceType
 {
     my ($object, $type) = @_;
@@ -1254,7 +1263,7 @@ sub IsJSONType
 
     if ($object->IsInterfaceType($type)) {
         # Special case EventHandler, since there is no real IDL for it.
-        return 0 if $type->name eq "EventHandler";
+        return 0 if $object->IsEventHandlerType($type);
 
         my $interface = $object->GetInterfaceForType($interface, $type);
         if ($object->InterfaceHasRegularToJSONOperation($interface)) {

--- a/Source/WebCore/dom/GlobalEventHandlers.idl
+++ b/Source/WebCore/dom/GlobalEventHandlers.idl
@@ -56,8 +56,7 @@ interface mixin GlobalEventHandlers {
     attribute EventHandler ondurationchange;
     attribute EventHandler onemptied;
     attribute EventHandler onended;
-    // FIXME: The spec 'onerror' should be of type 'OnErrorEventHandler'.
-    attribute EventHandler onerror;
+    attribute OnErrorEventHandler onerror;
     attribute EventHandler onfocus;
     attribute EventHandler onformdata;
     attribute EventHandler oninput;

--- a/Source/WebCore/html/HTMLBodyElement.idl
+++ b/Source/WebCore/html/HTMLBodyElement.idl
@@ -30,7 +30,7 @@
     [CEReactions=NotNeeded, Reflect] attribute [LegacyNullToEmptyString] DOMString vLink;
 
     [WindowEventHandler] attribute EventHandler onblur;
-    [WindowEventHandler] attribute EventHandler onerror;
+    [WindowEventHandler] attribute OnErrorEventHandler onerror;
     [WindowEventHandler] attribute EventHandler onfocus;
     [WindowEventHandler] attribute EventHandler onload;
     [WindowEventHandler] attribute EventHandler onresize;

--- a/Source/WebCore/html/HTMLFrameSetElement.idl
+++ b/Source/WebCore/html/HTMLFrameSetElement.idl
@@ -25,7 +25,7 @@
     [CEReactions=NotNeeded, Reflect] attribute DOMString rows;
 
     [WindowEventHandler] attribute EventHandler onblur;
-    [WindowEventHandler] attribute EventHandler onerror;
+    [WindowEventHandler] attribute OnErrorEventHandler onerror;
     [WindowEventHandler] attribute EventHandler onfocus;
     [WindowEventHandler] attribute EventHandler onload;
     [WindowEventHandler] attribute EventHandler onresize;

--- a/Source/WebCore/page/WindowEventHandlers.idl
+++ b/Source/WebCore/page/WindowEventHandlers.idl
@@ -28,8 +28,7 @@
 interface mixin WindowEventHandlers {
     [WindowEventHandler] attribute EventHandler onafterprint;
     [WindowEventHandler] attribute EventHandler onbeforeprint;
-    // FIXME: The spec says that onbeforeunload should be of type OnBeforeUnloadEventHandler, not EventHandler.
-    [WindowEventHandler] attribute EventHandler onbeforeunload;
+    [WindowEventHandler] attribute OnBeforeUnloadEventHandler onbeforeunload; // OnBeforeUnloadEventHandler semantics is implemented in JSEventListener::handleEvent()
     [WindowEventHandler] attribute EventHandler onhashchange;
     [WindowEventHandler] attribute EventHandler onlanguagechange;
     [WindowEventHandler] attribute EventHandler onmessage;

--- a/Source/WebCore/workers/WorkerGlobalScope.idl
+++ b/Source/WebCore/workers/WorkerGlobalScope.idl
@@ -35,8 +35,7 @@
     readonly attribute WorkerNavigator navigator;
     undefined importScripts(USVString... urls);
 
-    // FIXME: The spec 'onerror' should be of type 'OnErrorEventHandler'.
-    attribute EventHandler onerror;
+    attribute OnErrorEventHandler onerror;
     // FIXME: Implement 'onlanguagechange'.
     // attribute EventHandler onlanguagechange;
     attribute EventHandler onoffline;


### PR DESCRIPTION
#### cf847edd8255f9707e64f91b93ab91b4a5f4eeb8
<pre>
[WebIDL] document.body.onerror setter should setup a five-parameter listener
<a href="https://bugs.webkit.org/show_bug.cgi?id=234568">https://bugs.webkit.org/show_bug.cgi?id=234568</a>
&lt;rdar://problem/86959987&gt;

Reviewed by Darin Adler.

According to the spec [1], &quot;onerror&quot; IDL attributes on &lt;body&gt; / &lt;frameset&gt; elements reflect event
handlers to Window (implemented by [WindowEventHandler] IDL attribute), which fall under
&quot;special error handling&quot; case [2] and are invoked with 5 arguments while cancelling the event if
`true` is returned (implemented in JSErrorHandler).

This patch:

  1. Fixes &quot;onerror&quot; IDL attribute on &lt;body&gt; / &lt;frameset&gt; elements to set up JSErrorHandler handler
     directly on Window.

  2. Resolves FIXME on hardcoding &quot;onerror&quot; by introducing IsEventHandlerType helper and aligning
     &quot;onerror&quot; / &quot;onbeforeunload&quot; IDL types with the specs, resolving a few more FIXMEs.
     This change is safe and forward-compatible given OnErrorEventHandler type is considered legacy
     and won&apos;t be introduced for new global objects.

[1] <a href="https://html.spec.whatwg.org/multipage/webappapis.html#window-reflecting-body-element-event-handler-set">https://html.spec.whatwg.org/multipage/webappapis.html#window-reflecting-body-element-event-handler-set</a>
[2] <a href="https://html.spec.whatwg.org/multipage/webappapis.html#the-event-handler-processing-algorithm">https://html.spec.whatwg.org/multipage/webappapis.html#the-event-handler-processing-algorithm</a> (step 4)

Tests: imported/w3c/web-platform-tests/html/webappapis/scripting/events/event-handler-processing-algorithm-error/body-element-synthetic-errorevent.html
       imported/w3c/web-platform-tests/html/webappapis/scripting/events/event-handler-processing-algorithm-error/frameset-element-synthetic-errorevent.html

* LayoutTests/imported/w3c/web-platform-tests/html/webappapis/scripting/events/event-handler-processing-algorithm-error/body-element-synthetic-errorevent-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/html/webappapis/scripting/events/event-handler-processing-algorithm-error/frameset-element-synthetic-errorevent-expected.txt:
* Source/WebCore/bindings/scripts/CodeGenerator.pm:
(IsEventHandlerType):
(IsJSONType):
* Source/WebCore/bindings/scripts/CodeGeneratorJS.pm:
(GenerateForEachEventHandlerContentAttribute):
(GenerateAttributeGetterBodyDefinition):
(GenerateAttributeSetterBodyDefinition):
* Source/WebCore/dom/GlobalEventHandlers.idl:
* Source/WebCore/html/HTMLBodyElement.idl:
* Source/WebCore/html/HTMLFrameSetElement.idl:
* Source/WebCore/page/WindowEventHandlers.idl:
* Source/WebCore/workers/WorkerGlobalScope.idl:

Canonical link: <a href="https://commits.webkit.org/264190@main">https://commits.webkit.org/264190@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f93d9d4e594c9a2b5f685007a536bd0896ca4daf

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/6927 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/7158 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/7341 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/8532 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/7172 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/6933 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/8416 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/7096 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/10073 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/7049 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/7717 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/6380 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/8647 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/5107 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/6291 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/14089 "10 flakes 128 failures") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/6783 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/6382 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/9221 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/6859 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/5626 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/6235 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/10421 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/809 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/6617 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->