### PR TITLE
[JSC] StringConstructor constant function inlining is incorrect in case of [[Construct]]

### DIFF
--- a/JSTests/stress/regress-255512.js
+++ b/JSTests/stress/regress-255512.js
@@ -1,0 +1,27 @@
+//@ requireOptions("--useConcurrentJIT=0", "--jitPolicyScale=0")
+
+function shouldThrow(func, errorMessage) {
+  let errorThrown = false;
+  try {
+    func();
+  } catch (error) {
+    errorThrown = true;
+    if (String(error) !== errorMessage)
+      throw new Error(`Bad error: ${error}`);
+  }
+  if (!errorThrown)
+    throw new Error(`Didn't throw!`);
+}
+
+let keyObj;
+const StringProxy = new Proxy(String, {
+  get(target, key) {
+    keyObj = new String(key);
+    return String;
+  }
+});
+
+shouldThrow(() => { StringProxy.split(StringProxy); }, "TypeError: Cannot convert a symbol to a string");
+
+if (!(keyObj instanceof String))
+  throw new Error("Bad assertion!");

--- a/Source/JavaScriptCore/dfg/DFGByteCodeParser.cpp
+++ b/Source/JavaScriptCore/dfg/DFGByteCodeParser.cpp
@@ -4523,15 +4523,17 @@ bool ByteCodeParser::handleConstantFunction(
     if (function->classInfo() == StringConstructor::info()) {
         insertChecks();
         
-        Node* resultNode;
-        
+        Node* argumentNode;
         if (argumentCountIncludingThis <= 1)
-            resultNode = jsConstant(m_vm->smallStrings.emptyString());
+            argumentNode = jsConstant(m_vm->smallStrings.emptyString());
         else
-            resultNode = addToGraph(CallStringConstructor, get(virtualRegisterForArgumentIncludingThis(1, registerOffset)));
+            argumentNode = get(virtualRegisterForArgumentIncludingThis(1, registerOffset));
         
+        Node* resultNode;
         if (kind == CodeForConstruct)
-            resultNode = addToGraph(NewStringObject, OpInfo(m_graph.registerStructure(function->globalObject()->stringObjectStructure())), resultNode);
+            resultNode = addToGraph(NewStringObject, OpInfo(m_graph.registerStructure(function->globalObject()->stringObjectStructure())), addToGraph(ToString, argumentNode));
+        else
+            resultNode = addToGraph(CallStringConstructor, argumentNode);
         
         set(result, resultNode);
         return true;


### PR DESCRIPTION
#### 4c2728c1626b6d8e7da0e1f6776ea96909088666
<pre>
[JSC] StringConstructor constant function inlining is incorrect in case of [[Construct]]
<a href="https://bugs.webkit.org/show_bug.cgi?id=255512">https://bugs.webkit.org/show_bug.cgi?id=255512</a>
&lt;rdar://problem/108448272&gt;

Reviewed by Yusuke Suzuki.

Before this change, StringConstructor constant function, when invoked via [[Construct]], was inlined to

    NewStringObject(CallStringConstructor(argument1))

which was incorrect given StringConstructor has special-casing for Symbol argument [1] only when invoked
via [[Call]].

This patch replaces CallStringConstructor with ToString which throws for symbols rather then returning
their description string.

[1] <a href="https://tc39.es/ecma262/#sec-string-constructor-string-value">https://tc39.es/ecma262/#sec-string-constructor-string-value</a> (step 2.a)

* JSTests/stress/regress-255512.js: Added.
* Source/JavaScriptCore/dfg/DFGByteCodeParser.cpp:
(JSC::DFG::ByteCodeParser::handleConstantFunction):

Canonical link: <a href="https://commits.webkit.org/264191@main">https://commits.webkit.org/264191@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/509049f5f6b2664fd27223b9703fd609f5b21256

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/6935 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/7168 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/7351 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/8542 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/7176 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/8429 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/7106 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/10084 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/7057 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/7732 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/6389 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/8641 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/5116 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/6301 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/14086 "Passed tests") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/5855 "Built successfully and passed tests") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/6792 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/6391 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/9218 "Passed tests") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/6513 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/6866 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/5629 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/7072 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/6242 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/1654 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/10428 "Built successfully") | | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/24/builds/7268 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/810 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/6625 "Built successfully") | | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/3/builds/1795 "Passed tests") | 
<!--EWS-Status-Bubble-End-->