### PR TITLE
Implement scrollbar-width CSS parsing

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-cascade/all-prop-initial-xml-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-cascade/all-prop-initial-xml-expected.txt
@@ -280,6 +280,7 @@ PASS scroll-padding-top
 PASS scroll-snap-align
 PASS scroll-snap-stop
 PASS scroll-snap-type
+PASS scrollbar-width
 PASS shape-image-threshold
 PASS shape-margin
 PASS shape-outside

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-cascade/all-prop-revert-layer-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-cascade/all-prop-revert-layer-expected.txt
@@ -273,6 +273,7 @@ PASS scroll-padding-top
 PASS scroll-snap-align
 PASS scroll-snap-stop
 PASS scroll-snap-type
+PASS scrollbar-width
 PASS shape-image-threshold
 PASS shape-margin
 PASS shape-outside

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-scrollbars/inheritance-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-scrollbars/inheritance-expected.txt
@@ -1,6 +1,6 @@
 
 FAIL Property scrollbar-color has initial value auto assert_true: scrollbar-color doesn't seem to be supported in the computed style expected true got false
 FAIL Property scrollbar-color inherits assert_true: scrollbar-color doesn't seem to be supported in the computed style expected true got false
-FAIL Property scrollbar-width has initial value auto assert_true: scrollbar-width doesn't seem to be supported in the computed style expected true got false
-FAIL Property scrollbar-width does not inherit assert_true: expected true got false
+PASS Property scrollbar-width has initial value auto
+PASS Property scrollbar-width does not inherit
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-scrollbars/scrollbar-width-parsing-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-scrollbars/scrollbar-width-parsing-expected.txt
@@ -1,7 +1,7 @@
 
-FAIL e.style['scrollbar-width'] = "auto" should set the property value assert_not_equals: property should be set got disallowed value ""
-FAIL e.style['scrollbar-width'] = "thin" should set the property value assert_not_equals: property should be set got disallowed value ""
-FAIL e.style['scrollbar-width'] = "none" should set the property value assert_not_equals: property should be set got disallowed value ""
+PASS e.style['scrollbar-width'] = "auto" should set the property value
+PASS e.style['scrollbar-width'] = "thin" should set the property value
+PASS e.style['scrollbar-width'] = "none" should set the property value
 PASS e.style['scrollbar-width'] = "" should not set the property value
 PASS e.style['scrollbar-width'] = "auto none" should not set the property value
 PASS e.style['scrollbar-width'] = "thin auto" should not set the property value

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/scrollbar-width-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/scrollbar-width-expected.txt
@@ -1,12 +1,12 @@
 
-FAIL Can set 'scrollbar-width' to CSS-wide keywords: initial Invalid property scrollbar-width
-FAIL Can set 'scrollbar-width' to CSS-wide keywords: inherit Invalid property scrollbar-width
-FAIL Can set 'scrollbar-width' to CSS-wide keywords: unset Invalid property scrollbar-width
-FAIL Can set 'scrollbar-width' to CSS-wide keywords: revert Invalid property scrollbar-width
-FAIL Can set 'scrollbar-width' to var() references:  var(--A) Invalid property scrollbar-width
-FAIL Can set 'scrollbar-width' to the 'auto' keyword: auto Invalid property scrollbar-width
-FAIL Can set 'scrollbar-width' to the 'thin' keyword: thin Invalid property scrollbar-width
-FAIL Can set 'scrollbar-width' to the 'none' keyword: none Invalid property scrollbar-width
+PASS Can set 'scrollbar-width' to CSS-wide keywords: initial
+PASS Can set 'scrollbar-width' to CSS-wide keywords: inherit
+PASS Can set 'scrollbar-width' to CSS-wide keywords: unset
+PASS Can set 'scrollbar-width' to CSS-wide keywords: revert
+PASS Can set 'scrollbar-width' to var() references:  var(--A)
+PASS Can set 'scrollbar-width' to the 'auto' keyword: auto
+PASS Can set 'scrollbar-width' to the 'thin' keyword: thin
+PASS Can set 'scrollbar-width' to the 'none' keyword: none
 PASS Setting 'scrollbar-width' to a length: 0px throws TypeError
 PASS Setting 'scrollbar-width' to a length: -3.14em throws TypeError
 PASS Setting 'scrollbar-width' to a length: 3.14cm throws TypeError

--- a/LayoutTests/imported/w3c/web-platform-tests/web-animations/animation-model/animation-types/accumulation-per-property-002-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/web-animations/animation-model/animation-types/accumulation-per-property-002-expected.txt
@@ -148,6 +148,13 @@ PASS resize: "both" onto "horizontal"
 PASS scroll-behavior (type: discrete) has testAccumulation function
 PASS scroll-behavior: "smooth" onto "auto"
 PASS scroll-behavior: "auto" onto "smooth"
+PASS scrollbar-width (type: discrete) has testAccumulation function
+PASS scrollbar-width: "thin" onto "auto"
+PASS scrollbar-width: "auto" onto "thin"
+PASS scrollbar-width: "none" onto "auto"
+PASS scrollbar-width: "auto" onto "none"
+PASS scrollbar-width: "none" onto "thin"
+PASS scrollbar-width: "thin" onto "none"
 PASS shape-outside (type: discrete) has testAccumulation function
 PASS shape-outside: "url("http://localhost/test-2")" onto "url("http://localhost/test-1")"
 PASS shape-outside: "url("http://localhost/test-1")" onto "url("http://localhost/test-2")"

--- a/LayoutTests/imported/w3c/web-platform-tests/web-animations/animation-model/animation-types/addition-per-property-002-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/web-animations/animation-model/animation-types/addition-per-property-002-expected.txt
@@ -148,6 +148,13 @@ PASS resize: "both" onto "horizontal"
 PASS scroll-behavior (type: discrete) has testAddition function
 PASS scroll-behavior: "smooth" onto "auto"
 PASS scroll-behavior: "auto" onto "smooth"
+PASS scrollbar-width (type: discrete) has testAddition function
+PASS scrollbar-width: "thin" onto "auto"
+PASS scrollbar-width: "auto" onto "thin"
+PASS scrollbar-width: "none" onto "auto"
+PASS scrollbar-width: "auto" onto "none"
+PASS scrollbar-width: "none" onto "thin"
+PASS scrollbar-width: "thin" onto "none"
 PASS shape-outside (type: discrete) has testAddition function
 PASS shape-outside: "url("http://localhost/test-2")" onto "url("http://localhost/test-1")"
 PASS shape-outside: "url("http://localhost/test-1")" onto "url("http://localhost/test-2")"

--- a/LayoutTests/imported/w3c/web-platform-tests/web-animations/animation-model/animation-types/interpolation-per-property-002-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/web-animations/animation-model/animation-types/interpolation-per-property-002-expected.txt
@@ -180,6 +180,16 @@ PASS scroll-behavior (type: discrete) has testInterpolation function
 PASS scroll-behavior uses discrete animation when animating between "auto" and "smooth" with linear easing
 PASS scroll-behavior uses discrete animation when animating between "auto" and "smooth" with effect easing
 PASS scroll-behavior uses discrete animation when animating between "auto" and "smooth" with keyframe easing
+PASS scrollbar-width (type: discrete) has testInterpolation function
+PASS scrollbar-width uses discrete animation when animating between "auto" and "thin" with linear easing
+PASS scrollbar-width uses discrete animation when animating between "auto" and "thin" with effect easing
+PASS scrollbar-width uses discrete animation when animating between "auto" and "thin" with keyframe easing
+PASS scrollbar-width uses discrete animation when animating between "auto" and "none" with linear easing
+PASS scrollbar-width uses discrete animation when animating between "auto" and "none" with effect easing
+PASS scrollbar-width uses discrete animation when animating between "auto" and "none" with keyframe easing
+PASS scrollbar-width uses discrete animation when animating between "thin" and "none" with linear easing
+PASS scrollbar-width uses discrete animation when animating between "thin" and "none" with effect easing
+PASS scrollbar-width uses discrete animation when animating between "thin" and "none" with keyframe easing
 PASS shape-outside (type: discrete) has testInterpolation function
 PASS shape-outside uses discrete animation when animating between "url("http://localhost/test-1")" and "url("http://localhost/test-2")" with linear easing
 PASS shape-outside uses discrete animation when animating between "url("http://localhost/test-1")" and "url("http://localhost/test-2")" with effect easing

--- a/LayoutTests/imported/w3c/web-platform-tests/web-animations/animation-model/animation-types/property-list.js
+++ b/LayoutTests/imported/w3c/web-platform-tests/web-animations/animation-model/animation-types/property-list.js
@@ -1172,6 +1172,12 @@ const gCSSProperties2 = {
       { type: 'discrete', options: [ [ 'auto', 'smooth' ] ] }
     ]
   },
+  'scrollbar-width': {
+    // https://drafts.csswg.org/css-scrollbars/#propdef-scrollbar-width
+    types: [
+      { type: 'discrete', options: [ [ 'auto', 'thin' ], [ 'auto', 'none' ], [ 'thin', 'none' ] ] }
+    ]
+  },
   'shape-outside': {
     // http://dev.w3.org/csswg/css-shapes/#propdef-shape-outside
     types: [

--- a/LayoutTests/platform/gtk/imported/w3c/web-platform-tests/css/css-cascade/all-prop-initial-xml-expected.txt
+++ b/LayoutTests/platform/gtk/imported/w3c/web-platform-tests/css/css-cascade/all-prop-initial-xml-expected.txt
@@ -280,6 +280,7 @@ PASS scroll-padding-top
 PASS scroll-snap-align
 PASS scroll-snap-stop
 PASS scroll-snap-type
+PASS scrollbar-width
 PASS shape-image-threshold
 PASS shape-margin
 PASS shape-outside

--- a/LayoutTests/platform/ios-wk2/imported/w3c/web-platform-tests/css/css-cascade/all-prop-initial-xml-expected.txt
+++ b/LayoutTests/platform/ios-wk2/imported/w3c/web-platform-tests/css/css-cascade/all-prop-initial-xml-expected.txt
@@ -280,6 +280,7 @@ PASS scroll-padding-top
 PASS scroll-snap-align
 PASS scroll-snap-stop
 PASS scroll-snap-type
+PASS scrollbar-width
 PASS shape-image-threshold
 PASS shape-margin
 PASS shape-outside

--- a/LayoutTests/platform/ipad/imported/w3c/web-platform-tests/css/css-cascade/all-prop-initial-xml-expected.txt
+++ b/LayoutTests/platform/ipad/imported/w3c/web-platform-tests/css/css-cascade/all-prop-initial-xml-expected.txt
@@ -280,6 +280,7 @@ PASS scroll-padding-top
 PASS scroll-snap-align
 PASS scroll-snap-stop
 PASS scroll-snap-type
+PASS scrollbar-width
 PASS shape-image-threshold
 PASS shape-margin
 PASS shape-outside

--- a/LayoutTests/platform/mac-wk1/imported/w3c/web-platform-tests/css/css-cascade/all-prop-initial-xml-expected.txt
+++ b/LayoutTests/platform/mac-wk1/imported/w3c/web-platform-tests/css/css-cascade/all-prop-initial-xml-expected.txt
@@ -279,6 +279,7 @@ PASS scroll-padding-top
 PASS scroll-snap-align
 PASS scroll-snap-stop
 PASS scroll-snap-type
+PASS scrollbar-width
 PASS shape-image-threshold
 PASS shape-margin
 PASS shape-outside

--- a/LayoutTests/platform/mac-wk1/imported/w3c/web-platform-tests/css/css-cascade/all-prop-revert-layer-expected.txt
+++ b/LayoutTests/platform/mac-wk1/imported/w3c/web-platform-tests/css/css-cascade/all-prop-revert-layer-expected.txt
@@ -272,6 +272,7 @@ PASS scroll-padding-top
 PASS scroll-snap-align
 PASS scroll-snap-stop
 PASS scroll-snap-type
+PASS scrollbar-width
 PASS shape-image-threshold
 PASS shape-margin
 PASS shape-outside

--- a/LayoutTests/platform/mac-wk1/imported/w3c/web-platform-tests/web-animations/animation-model/animation-types/accumulation-per-property-002-expected.txt
+++ b/LayoutTests/platform/mac-wk1/imported/w3c/web-platform-tests/web-animations/animation-model/animation-types/accumulation-per-property-002-expected.txt
@@ -145,6 +145,13 @@ PASS quotes: ""“" "”" "‘" "’"" onto ""‘" "’" "“" "”""
 PASS resize (type: discrete) has testAccumulation function
 PASS resize: "horizontal" onto "both"
 PASS resize: "both" onto "horizontal"
+PASS scrollbar-width (type: discrete) has testAccumulation function
+PASS scrollbar-width: "thin" onto "auto"
+PASS scrollbar-width: "auto" onto "thin"
+PASS scrollbar-width: "none" onto "auto"
+PASS scrollbar-width: "auto" onto "none"
+PASS scrollbar-width: "none" onto "thin"
+PASS scrollbar-width: "thin" onto "none"
 PASS shape-outside (type: discrete) has testAccumulation function
 PASS shape-outside: "url("http://localhost/test-2")" onto "url("http://localhost/test-1")"
 PASS shape-outside: "url("http://localhost/test-1")" onto "url("http://localhost/test-2")"

--- a/LayoutTests/platform/mac-wk1/imported/w3c/web-platform-tests/web-animations/animation-model/animation-types/addition-per-property-002-expected.txt
+++ b/LayoutTests/platform/mac-wk1/imported/w3c/web-platform-tests/web-animations/animation-model/animation-types/addition-per-property-002-expected.txt
@@ -145,6 +145,13 @@ PASS quotes: ""“" "”" "‘" "’"" onto ""‘" "’" "“" "”""
 PASS resize (type: discrete) has testAddition function
 PASS resize: "horizontal" onto "both"
 PASS resize: "both" onto "horizontal"
+PASS scrollbar-width (type: discrete) has testAddition function
+PASS scrollbar-width: "thin" onto "auto"
+PASS scrollbar-width: "auto" onto "thin"
+PASS scrollbar-width: "none" onto "auto"
+PASS scrollbar-width: "auto" onto "none"
+PASS scrollbar-width: "none" onto "thin"
+PASS scrollbar-width: "thin" onto "none"
 PASS shape-outside (type: discrete) has testAddition function
 PASS shape-outside: "url("http://localhost/test-2")" onto "url("http://localhost/test-1")"
 PASS shape-outside: "url("http://localhost/test-1")" onto "url("http://localhost/test-2")"

--- a/LayoutTests/platform/mac-wk1/imported/w3c/web-platform-tests/web-animations/animation-model/animation-types/interpolation-per-property-002-expected.txt
+++ b/LayoutTests/platform/mac-wk1/imported/w3c/web-platform-tests/web-animations/animation-model/animation-types/interpolation-per-property-002-expected.txt
@@ -176,6 +176,16 @@ PASS resize (type: discrete) has testInterpolation function
 PASS resize uses discrete animation when animating between "both" and "horizontal" with linear easing
 PASS resize uses discrete animation when animating between "both" and "horizontal" with effect easing
 PASS resize uses discrete animation when animating between "both" and "horizontal" with keyframe easing
+PASS scrollbar-width (type: discrete) has testInterpolation function
+PASS scrollbar-width uses discrete animation when animating between "auto" and "thin" with linear easing
+PASS scrollbar-width uses discrete animation when animating between "auto" and "thin" with effect easing
+PASS scrollbar-width uses discrete animation when animating between "auto" and "thin" with keyframe easing
+PASS scrollbar-width uses discrete animation when animating between "auto" and "none" with linear easing
+PASS scrollbar-width uses discrete animation when animating between "auto" and "none" with effect easing
+PASS scrollbar-width uses discrete animation when animating between "auto" and "none" with keyframe easing
+PASS scrollbar-width uses discrete animation when animating between "thin" and "none" with linear easing
+PASS scrollbar-width uses discrete animation when animating between "thin" and "none" with effect easing
+PASS scrollbar-width uses discrete animation when animating between "thin" and "none" with keyframe easing
 PASS shape-outside (type: discrete) has testInterpolation function
 PASS shape-outside uses discrete animation when animating between "url("http://localhost/test-1")" and "url("http://localhost/test-2")" with linear easing
 PASS shape-outside uses discrete animation when animating between "url("http://localhost/test-1")" and "url("http://localhost/test-2")" with effect easing

--- a/LayoutTests/platform/wpe/imported/w3c/web-platform-tests/css/css-cascade/all-prop-initial-xml-expected.txt
+++ b/LayoutTests/platform/wpe/imported/w3c/web-platform-tests/css/css-cascade/all-prop-initial-xml-expected.txt
@@ -280,6 +280,7 @@ PASS scroll-padding-top
 PASS scroll-snap-align
 PASS scroll-snap-stop
 PASS scroll-snap-type
+PASS scrollbar-width
 PASS shape-image-threshold
 PASS shape-margin
 PASS shape-outside

--- a/Source/WebCore/animation/CSSPropertyAnimation.cpp
+++ b/Source/WebCore/animation/CSSPropertyAnimation.cpp
@@ -3698,7 +3698,8 @@ CSSPropertyAnimationWrapperMap::CSSPropertyAnimationWrapperMap()
         new DiscreteSVGPropertyWrapper<ShapeRendering>(CSSPropertyShapeRendering, &SVGRenderStyle::shapeRendering, &SVGRenderStyle::setShapeRendering),
         new DiscreteSVGPropertyWrapper<const String&>(CSSPropertyMarkerEnd, &SVGRenderStyle::markerEndResource, &SVGRenderStyle::setMarkerEndResource),
         new DiscreteSVGPropertyWrapper<const String&>(CSSPropertyMarkerMid, &SVGRenderStyle::markerMidResource, &SVGRenderStyle::setMarkerMidResource),
-        new DiscreteSVGPropertyWrapper<const String&>(CSSPropertyMarkerStart, &SVGRenderStyle::markerStartResource, &SVGRenderStyle::setMarkerStartResource)
+        new DiscreteSVGPropertyWrapper<const String&>(CSSPropertyMarkerStart, &SVGRenderStyle::markerStartResource, &SVGRenderStyle::setMarkerStartResource),
+        new DiscretePropertyWrapper<ScrollbarWidth>(CSSPropertyScrollbarWidth, &RenderStyle::scrollbarWidth, &RenderStyle::setScrollbarWidth)
     };
     const unsigned animatableLonghandPropertiesCount = std::size(animatableLonghandPropertyWrappers);
 

--- a/Source/WebCore/css/CSSPrimitiveValueMappings.h
+++ b/Source/WebCore/css/CSSPrimitiveValueMappings.h
@@ -2242,6 +2242,12 @@ DEFINE_TO_FROM_CSS_VALUE_ID_FUNCTIONS
 #undef TYPE
 #undef FOR_EACH
 
+#define TYPE ScrollbarWidth
+#define FOR_EACH(CASE) CASE(Auto) CASE(Thin) CASE(None)
+DEFINE_TO_FROM_CSS_VALUE_ID_FUNCTIONS
+#undef TYPE
+#undef FOR_EACH
+
 constexpr CSSValueID toCSSValueID(TextBoxEdgeType textBoxEdgeType)
 {
     switch (textBoxEdgeType) {

--- a/Source/WebCore/css/CSSProperties.json
+++ b/Source/WebCore/css/CSSProperties.json
@@ -9289,6 +9289,16 @@
                 "url": "https://drafts.csswg.org/css-scroll-snap-1/#propdef-scroll-snap-stop"
             }
         },
+        "scrollbar-width": {
+            "codegen-properties": {
+                "parser-grammar": "auto | thin | none",
+                "settings-flag": "cssScrollbarWidthEnabled"
+            },
+            "specification": {
+                "category": "css-scrollbars",
+                "url": "https://drafts.csswg.org/css-scrollbars/#scrollbar-width"
+            }
+        },
         "shape-outside": {
             "codegen-properties": {
                 "aliases": [
@@ -10207,6 +10217,11 @@
             "shortname": "CSS Scroll Snap",
             "longname": "CSS Scroll Snap Module",
             "url": "https://www.w3.org/TR/css-scroll-snap-1/"
+        },
+        "css-scrollbars": {
+            "shortname": "CSS Scrollbars",
+            "longname": "CSS Scrollbars Styling Module",
+            "url": "https://www.w3.org/TR/css-scrollbars-1/"
         },
         "css-shapes": {
             "shortname": "CSS Shapes",

--- a/Source/WebCore/css/ComputedStyleExtractor.cpp
+++ b/Source/WebCore/css/ComputedStyleExtractor.cpp
@@ -4182,6 +4182,8 @@ RefPtr<CSSValue> ComputedStyleExtractor::valueForPropertyInStyle(const RenderSty
         return createConvertingToCSSValueID(style.scrollSnapStop());
     case CSSPropertyScrollSnapType:
         return valueForScrollSnapType(style.scrollSnapType());
+    case CSSPropertyScrollbarWidth:
+        return createConvertingToCSSValueID(style.scrollbarWidth());
     case CSSPropertyOverflowAnchor:
         return createConvertingToCSSValueID(style.overflowAnchor());
     case CSSPropertyTextBoxEdge:

--- a/Source/WebCore/css/parser/CSSPropertyParser.cpp
+++ b/Source/WebCore/css/parser/CSSPropertyParser.cpp
@@ -928,6 +928,7 @@ static constexpr InitialValue initialValueForLonghand(CSSPropertyID longhand)
     case CSSPropertyScrollPaddingLeft:
     case CSSPropertyScrollPaddingRight:
     case CSSPropertyScrollPaddingTop:
+    case CSSPropertyScrollbarWidth:
     case CSSPropertySize:
     case CSSPropertyTableLayout:
     case CSSPropertyTextAlignLast:

--- a/Source/WebCore/rendering/style/RenderStyle.cpp
+++ b/Source/WebCore/rendering/style/RenderStyle.cpp
@@ -2872,6 +2872,11 @@ ScrollSnapStop RenderStyle::initialScrollSnapStop()
     return ScrollSnapStop::Normal;
 }
 
+ScrollbarWidth RenderStyle::initialScrollbarWidth()
+{
+    return ScrollbarWidth::Auto;
+}
+
 const ScrollSnapType RenderStyle::scrollSnapType() const
 {
     return m_nonInheritedData->rareData->scrollSnapType;
@@ -2887,6 +2892,11 @@ ScrollSnapStop RenderStyle::scrollSnapStop() const
     return m_nonInheritedData->rareData->scrollSnapStop;
 }
 
+ScrollbarWidth RenderStyle::scrollbarWidth() const
+{
+    return m_nonInheritedData->rareData->scrollbarWidth;
+}
+
 void RenderStyle::setScrollSnapType(const ScrollSnapType type)
 {
     SET_NESTED_VAR(m_nonInheritedData, rareData, scrollSnapType, type);
@@ -2900,6 +2910,11 @@ void RenderStyle::setScrollSnapAlign(const ScrollSnapAlign& alignment)
 void RenderStyle::setScrollSnapStop(const ScrollSnapStop stop)
 {
     SET_NESTED_VAR(m_nonInheritedData, rareData, scrollSnapStop, stop);
+}
+
+void RenderStyle::setScrollbarWidth(const ScrollbarWidth width)
+{
+    SET_NESTED_VAR(m_nonInheritedData, rareData, scrollbarWidth, width);
 }
 
 bool RenderStyle::hasSnapPosition() const

--- a/Source/WebCore/rendering/style/RenderStyle.h
+++ b/Source/WebCore/rendering/style/RenderStyle.h
@@ -182,6 +182,7 @@ enum class Resize : uint8_t;
 enum class RubyPosition : uint8_t;
 enum class SVGPaintType : uint8_t;
 enum class ScrollSnapStop : bool;
+enum class ScrollbarWidth : uint8_t;
 enum class SpeakAs : uint8_t;
 enum class StyleAppearance : uint8_t;
 enum class StyleDifference : uint8_t;
@@ -962,6 +963,8 @@ public:
     const ScrollSnapAlign& scrollSnapAlign() const;
     ScrollSnapStop scrollSnapStop() const;
 
+    ScrollbarWidth scrollbarWidth() const;
+
 #if ENABLE(TOUCH_EVENTS)
     inline StyleColor tapHighlightColor() const;
 #endif
@@ -1506,6 +1509,8 @@ public:
     void setScrollSnapAlign(const ScrollSnapAlign&);
     void setScrollSnapStop(ScrollSnapStop);
 
+    void setScrollbarWidth(ScrollbarWidth);
+
 #if ENABLE(TOUCH_EVENTS)
     inline void setTapHighlightColor(const StyleColor&);
 #endif
@@ -1935,6 +1940,8 @@ public:
     static ScrollSnapType initialScrollSnapType();
     static ScrollSnapAlign initialScrollSnapAlign();
     static ScrollSnapStop initialScrollSnapStop();
+
+    static ScrollbarWidth initialScrollbarWidth();
 
 #if ENABLE(APPLE_PAY)
     static constexpr ApplePayButtonStyle initialApplePayButtonStyle();

--- a/Source/WebCore/rendering/style/RenderStyleConstants.cpp
+++ b/Source/WebCore/rendering/style/RenderStyleConstants.cpp
@@ -946,6 +946,16 @@ TextStream& operator<<(TextStream& ts, ScrollSnapStop stop)
     return ts;
 }
 
+TextStream& operator<<(TextStream& ts, ScrollbarWidth width)
+{
+    switch (width) {
+    case ScrollbarWidth::Auto: ts << "auto"; break;
+    case ScrollbarWidth::Thin: ts << "thin"; break;
+    case ScrollbarWidth::None: ts << "none"; break;
+    }
+    return ts;
+}
+
 TextStream& operator<<(TextStream& ts, SpeakAs speakAs)
 {
     switch (speakAs) {

--- a/Source/WebCore/rendering/style/RenderStyleConstants.h
+++ b/Source/WebCore/rendering/style/RenderStyleConstants.h
@@ -1094,6 +1094,12 @@ enum class ScrollSnapStop : bool {
     Always,
 };
 
+enum class ScrollbarWidth : uint8_t {
+    Auto,
+    Thin,
+    None
+};
+
 // These are all minimized combinations of paint-order.
 enum class PaintOrder : uint8_t {
     Normal,
@@ -1245,6 +1251,7 @@ WTF::TextStream& operator<<(WTF::TextStream&, ScrollSnapAxis);
 WTF::TextStream& operator<<(WTF::TextStream&, ScrollSnapAxisAlignType);
 WTF::TextStream& operator<<(WTF::TextStream&, ScrollSnapStop);
 WTF::TextStream& operator<<(WTF::TextStream&, ScrollSnapStrictness);
+WTF::TextStream& operator<<(WTF::TextStream&, ScrollbarWidth);
 WTF::TextStream& operator<<(WTF::TextStream&, SpeakAs);
 WTF::TextStream& operator<<(WTF::TextStream&, StyleDifference);
 WTF::TextStream& operator<<(WTF::TextStream&, TableLayoutType);

--- a/Source/WebCore/rendering/style/StyleRareNonInheritedData.cpp
+++ b/Source/WebCore/rendering/style/StyleRareNonInheritedData.cpp
@@ -82,6 +82,7 @@ StyleRareNonInheritedData::StyleRareNonInheritedData()
     // scrollSnapType
     // scrollSnapAlign
     // scrollSnapStop
+    , scrollbarWidth(RenderStyle::initialScrollbarWidth())
     , zoom(RenderStyle::initialZoom())
     , blockStepSize(RenderStyle::initialBlockStepSize())
     , blockStepInsert(static_cast<unsigned>(RenderStyle::initialBlockStepInsert()))
@@ -164,6 +165,7 @@ inline StyleRareNonInheritedData::StyleRareNonInheritedData(const StyleRareNonIn
     , scrollSnapType(o.scrollSnapType)
     , scrollSnapAlign(o.scrollSnapAlign)
     , scrollSnapStop(o.scrollSnapStop)
+    , scrollbarWidth(o.scrollbarWidth)
     , zoom(o.zoom)
     , blockStepSize(o.blockStepSize)
     , blockStepInsert(o.blockStepInsert)
@@ -253,6 +255,7 @@ bool StyleRareNonInheritedData::operator==(const StyleRareNonInheritedData& o) c
         && scrollSnapType == o.scrollSnapType
         && scrollSnapAlign == o.scrollSnapAlign
         && scrollSnapStop == o.scrollSnapStop
+        && scrollbarWidth == o.scrollbarWidth
         && zoom == o.zoom
         && blockStepSize == o.blockStepSize
         && blockStepInsert == o.blockStepInsert

--- a/Source/WebCore/rendering/style/StyleRareNonInheritedData.h
+++ b/Source/WebCore/rendering/style/StyleRareNonInheritedData.h
@@ -170,6 +170,8 @@ public:
     ScrollSnapAlign scrollSnapAlign;
     ScrollSnapStop scrollSnapStop { ScrollSnapStop::Normal };
 
+    ScrollbarWidth scrollbarWidth { ScrollbarWidth::Auto };
+
     float zoom;
 
     std::optional<Length> blockStepSize;


### PR DESCRIPTION
#### 98d2001782e57b75e18d1cccb1beb4a8db83b242
<pre>
Implement scrollbar-width CSS parsing
<a href="https://bugs.webkit.org/show_bug.cgi?id=256796">https://bugs.webkit.org/show_bug.cgi?id=256796</a>

Reviewed by Tim Nguyen.

Spec: <a href="https://drafts.csswg.org/css-scrollbars/#scrollbar-width">https://drafts.csswg.org/css-scrollbars/#scrollbar-width</a>

Grammar for property: auto | thin | none

This adds the property to the CSS parser behind the flag, and updates the relevant expectation files

* LayoutTests/imported/w3c/web-platform-tests/css/css-cascade/all-prop-initial-xml-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-cascade/all-prop-revert-layer-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-scrollbars/inheritance-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-scrollbars/scrollbar-width-parsing-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/scrollbar-width-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/web-animations/animation-model/animation-types/accumulation-per-property-002-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/web-animations/animation-model/animation-types/addition-per-property-002-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/web-animations/animation-model/animation-types/interpolation-per-property-002-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/web-animations/animation-model/animation-types/property-list.js:
* LayoutTests/platform/gtk/imported/w3c/web-platform-tests/css/css-cascade/all-prop-initial-xml-expected.txt:
* LayoutTests/platform/ios-wk2/imported/w3c/web-platform-tests/css/css-cascade/all-prop-initial-xml-expected.txt:
* LayoutTests/platform/ipad/imported/w3c/web-platform-tests/css/css-cascade/all-prop-initial-xml-expected.txt:
* LayoutTests/platform/mac-wk1/imported/w3c/web-platform-tests/css/css-cascade/all-prop-initial-xml-expected.txt:
* LayoutTests/platform/mac-wk1/imported/w3c/web-platform-tests/css/css-cascade/all-prop-revert-layer-expected.txt:
* LayoutTests/platform/mac-wk1/imported/w3c/web-platform-tests/web-animations/animation-model/animation-types/accumulation-per-property-002-expected.txt:
* LayoutTests/platform/mac-wk1/imported/w3c/web-platform-tests/web-animations/animation-model/animation-types/addition-per-property-002-expected.txt:
* LayoutTests/platform/mac-wk1/imported/w3c/web-platform-tests/web-animations/animation-model/animation-types/interpolation-per-property-002-expected.txt:
* LayoutTests/platform/wpe/imported/w3c/web-platform-tests/css/css-cascade/all-prop-initial-xml-expected.txt:
* Source/WebCore/animation/CSSPropertyAnimation.cpp:
(WebCore::CSSPropertyAnimationWrapperMap::CSSPropertyAnimationWrapperMap):
* Source/WebCore/css/CSSPrimitiveValueMappings.h:
* Source/WebCore/css/CSSProperties.json:
* Source/WebCore/css/ComputedStyleExtractor.cpp:
(WebCore::ComputedStyleExtractor::valueForPropertyInStyle):
* Source/WebCore/css/parser/CSSPropertyParser.cpp:
(WebCore::initialValueForLonghand):
* Source/WebCore/rendering/style/RenderStyle.cpp:
(WebCore::RenderStyle::initialScrollbarWidth):
(WebCore::RenderStyle::scrollbarWidth const):
(WebCore::RenderStyle::setScrollbarWidth):
* Source/WebCore/rendering/style/RenderStyle.h:
* Source/WebCore/rendering/style/RenderStyleConstants.cpp:
(WebCore::operator&lt;&lt;):
* Source/WebCore/rendering/style/RenderStyleConstants.h:
* Source/WebCore/rendering/style/StyleRareNonInheritedData.cpp:
(WebCore::StyleRareNonInheritedData::StyleRareNonInheritedData):
(WebCore::StyleRareNonInheritedData::operator== const):
* Source/WebCore/rendering/style/StyleRareNonInheritedData.h:

Canonical link: <a href="https://commits.webkit.org/264214@main">https://commits.webkit.org/264214@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e1411c8b6cf71854061155200d776cbf2004db4c

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/7002 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/7242 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/7422 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/8614 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/7236 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/7010 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/8505 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/7177 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/10150 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/7127 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/7798 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/6461 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/8717 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/5166 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/6369 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/14149 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/6835 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/6463 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/9320 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/6937 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/5685 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/6306 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/1666 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/10499 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/6688 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->