### PR TITLE
[webkitcorepy] Fix race condition in FileLock

### DIFF
--- a/Tools/Scripts/libraries/webkitcorepy/setup.py
+++ b/Tools/Scripts/libraries/webkitcorepy/setup.py
@@ -30,7 +30,7 @@ def readme():
 
 setup(
     name='webkitcorepy',
-    version='0.14.3',
+    version='0.14.4',
     description='Library containing various Python support classes and functions.',
     long_description=readme(),
     classifiers=[

--- a/Tools/Scripts/libraries/webkitcorepy/webkitcorepy/__init__.py
+++ b/Tools/Scripts/libraries/webkitcorepy/webkitcorepy/__init__.py
@@ -48,7 +48,7 @@ from webkitcorepy.null_context import NullContext
 from webkitcorepy.filtered_call import filtered_call
 from webkitcorepy.partial_proxy import PartialProxy
 
-version = Version(0, 14, 3)
+version = Version(0, 14, 4)
 
 from webkitcorepy.autoinstall import Package, AutoInstall
 if sys.version_info > (3, 0):

--- a/Tools/Scripts/libraries/webkitcorepy/webkitcorepy/file_lock.py
+++ b/Tools/Scripts/libraries/webkitcorepy/webkitcorepy/file_lock.py
@@ -1,5 +1,5 @@
 # Copyright (C) 2010 Gabor Rapcsanyi (rgabor@inf.u-szeged.hu), University of Szeged
-# Copyright (C) 2021 Apple Inc. All rights reserved.
+# Copyright (C) 2021-2023 Apple Inc. All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -21,17 +21,35 @@
 # (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
 # SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
+import errno
 import os
+import re
 import sys
 import time
 
+from webkitcorepy import string_utils
+from webkitcorepy.timeout import Timeout
+
 if sys.platform.startswith('win'):
     import msvcrt
-else:
-    import fcntl
 
 
 class FileLock(object):
+    INTEGER_RE = re.compile(r'^\d+$')
+    USE_WINDOWS = sys.platform.startswith('win')
+    USE_EXLOCK = not USE_WINDOWS and getattr(os, 'O_EXLOCK', False)
+
+    @classmethod
+    def is_process_running(cls, pid):
+        if cls.USE_WINDOWS:
+            raise RuntimeError('Funciton does not support Windows')
+        try:
+            os.kill(pid, 0)
+            return True
+        except OSError as e:
+            if e.errno == errno.ESRCH:
+                return False
+            raise
 
     def __init__(self, path, timeout=20):
         self.path = path
@@ -44,42 +62,60 @@ class FileLock(object):
 
     def acquire(self):
         if self._descriptor:
+            raise RuntimeError('Cannot re-enter acquired FileLock')
+
+        if not self.USE_EXLOCK and not self.USE_WINDOWS and os.path.exists(self.path):
+            with open(self.path) as file:
+                pid = file.readline().strip()
+            if self.INTEGER_RE.match(pid) and not self.is_process_running(int(pid)):
+                os.unlink(self.path)
+
+        if self.USE_EXLOCK and self.timeout:
+            with Timeout(
+                seconds=self.timeout,
+                handler=OSError(errno.EAGAIN, "Resource temporarily unavailable: '{}'".format(self.path)),
+            ):
+                self._descriptor = os.open(self.path, os.O_CREAT | os.O_WRONLY | os.O_EXLOCK)
             return True
 
-        descriptor = os.open(self.path, os.O_TRUNC | os.O_CREAT)
         start_time = time.time()
         while True:
             try:
-                if sys.platform.startswith('win'):
+                if self.USE_WINDOWS:
+                    self._descriptor = os.open(self.path, os.O_TRUNC | os.O_CREAT)
                     msvcrt.locking(descriptor, msvcrt.LK_NBLCK, 32)
+                elif self.USE_EXLOCK:
+                    self._descriptor = os.open(self.path, os.O_CREAT | os.O_WRONLY | os.O_EXLOCK | os.O_NONBLOCK)
                 else:
-                    fcntl.flock(descriptor, fcntl.LOCK_EX | fcntl.LOCK_NB)
-                self._descriptor = descriptor
+                    self._descriptor = os.open(self.path, os.O_CREAT | os.O_WRONLY | os.O_EXCL)
+                    os.write(self._descriptor, string_utils.encode(str(os.getpid())))
                 return True
 
-            except IOError:
+            except (IOError, OSError):
                 if time.time() - start_time > self.timeout:
-                    os.close(descriptor)
+                    if self._descriptor:
+                        os.close(self._descriptor)
                     self._descriptor = None
-                    return False
+                    raise
                 time.sleep(0.01)
 
     def release(self):
+        if not self._descriptor:
+            raise RuntimeError('Cannot release unclaimed lock')
         try:
-            if self._descriptor:
-                if sys.platform.startswith('win'):
-                    msvcrt.locking(self._descriptor, msvcrt.LK_UNLCK, 32)
-                else:
-                    fcntl.flock(self._descriptor, fcntl.LOCK_UN)
-                os.close(self._descriptor)
-                self._descriptor = None
-            os.unlink(self.path)
-        except (IOError, OSError):
-            pass
+            if self.USE_WINDOWS:
+                msvcrt.locking(self._descriptor, msvcrt.LK_UNLCK, 32)
+            elif not self.USE_EXLOCK:
+                os.unlink(self.path)
+        finally:
+            os.close(self._descriptor)
+            self._descriptor = None
 
     def __enter__(self):
         self.acquire()
         return self
 
     def __exit__(self, *args, **kwargs):
+        if not self._descriptor:
+            return
         self.release()


### PR DESCRIPTION
#### 1c10cac855587753cfb42e0e7f3b62e2480eb62e
<pre>
[webkitcorepy] Fix race condition in FileLock
<a href="https://bugs.webkit.org/show_bug.cgi?id=256931">https://bugs.webkit.org/show_bug.cgi?id=256931</a>
rdar://109487762

Reviewed by Alexey Proskuryakov.

* Tools/Scripts/libraries/webkitcorepy/setup.py: Bump version.
* Tools/Scripts/libraries/webkitcorepy/webkitcorepy/__init__.py: Ditto.
* Tools/Scripts/libraries/webkitcorepy/webkitcorepy/file_lock.py:
(FileLock.is_process_running): Check if a specific PID is running.
(FileLock.acquire): Create and acquire lock in a single operation on Unix systems.
Save the current PID to the file, which allows future processes to ignore this lock
if the PID saved in it is dead. For systems which support it, use O_EXLOCK and interrupts
instead of a spinlock. Raise exceptions when we fail to acquire the lock.
(FileLock.release): Delete the lockfile before releasing it on Unix systems. Systems using
O_EXLOCK simply need to close their file handle.
(FileLock.__exit__): Don&apos;t raise a 2nd exception if __enter__ has raised one.
* Tools/Scripts/libraries/webkitcorepy/webkitcorepy/tests/file_lock_unittest.py:
(action):
(FileLockTestCase.test_locked):
(FileLockTestCase.test_locked_timeout):
(FileLockTestCase.test_double):
(FileLockTestCase.test_race):

Canonical link: <a href="https://commits.webkit.org/264321@main">https://commits.webkit.org/264321@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/6215bffe968c39b07f6d328fafc7c6ad4a8f7ddd

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/7413 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/7674 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/7847 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/9045 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/7618 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/7423 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/9584 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/7597 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/10503 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/7543 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/15/builds/8645 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/6865 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/9154 "Built successfully") | 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/7527 "Passed tests") | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/39/builds/5955 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/10/builds/6744 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/14471 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/7211 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/6858 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/10145 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/7349 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/6008 "Passed tests") | | 
| [✅ 🧪 services](https://ews-build.webkit.org/#/builders/28/builds/7386 "Passed tests") | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/6698 "Built successfully") | | | 
| [  ~~🛠 🧪 merge~~](https://ews-build.webkit.org/#/builders/19/builds/1743 "Build was cancelled. Recent messages:OS: Monterey (12.6.3), Xcode: 13.4.1; Checked out pull request; Reviewed by Alexey Proskuryakov; Compiled WebKit (cancelled)") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/10906 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/858 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/7084 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->