### PR TITLE
Refactor some enums in EditorState to enum classes

### DIFF
--- a/Source/WebKit/Shared/EditorState.cpp
+++ b/Source/WebKit/Shared/EditorState.cpp
@@ -62,17 +62,17 @@ TextStream& operator<<(TextStream& ts, const EditorState& editorState)
     if (editorState.hasPostLayoutData()) {
         TextStream::GroupScope scope(ts);
         ts << "postLayoutData";
-        if (editorState.postLayoutData->typingAttributes != AttributeNone)
-            ts.dumpProperty("typingAttributes", editorState.postLayoutData->typingAttributes);
+        if (!editorState.postLayoutData->typingAttributes.isEmpty())
+            ts.dumpProperty("typingAttributes", editorState.postLayoutData->typingAttributes.toRaw());
 #if PLATFORM(COCOA)
         if (editorState.postLayoutData->selectedTextLength)
             ts.dumpProperty("selectedTextLength", editorState.postLayoutData->selectedTextLength);
-        if (editorState.postLayoutData->textAlignment != NoAlignment)
-            ts.dumpProperty("textAlignment", editorState.postLayoutData->textAlignment);
+        if (editorState.postLayoutData->textAlignment != TextAlignment::Natural)
+            ts.dumpProperty("textAlignment", enumToUnderlyingType(editorState.postLayoutData->textAlignment));
         if (editorState.postLayoutData->textColor.isValid())
             ts.dumpProperty("textColor", editorState.postLayoutData->textColor);
-        if (editorState.postLayoutData->enclosingListType != NoList)
-            ts.dumpProperty("enclosingListType", editorState.postLayoutData->enclosingListType);
+        if (editorState.postLayoutData->enclosingListType != ListType::None)
+            ts.dumpProperty("enclosingListType", enumToUnderlyingType(editorState.postLayoutData->enclosingListType));
         if (editorState.postLayoutData->baseWritingDirection != WebCore::WritingDirection::Natural)
             ts.dumpProperty("baseWritingDirection", static_cast<uint8_t>(editorState.postLayoutData->baseWritingDirection));
 #endif // PLATFORM(COCOA)

--- a/Source/WebKit/Shared/EditorState.h
+++ b/Source/WebKit/Shared/EditorState.h
@@ -48,24 +48,23 @@ class TextStream;
 
 namespace WebKit {
 
-enum TypingAttributes {
-    AttributeNone = 0,
-    AttributeBold = 1,
-    AttributeItalics = 2,
-    AttributeUnderline = 4,
-    AttributeStrikeThrough = 8
+enum class TypingAttribute : uint8_t {
+    Bold          = 1 << 0,
+    Italics       = 1 << 1,
+    Underline     = 1 << 2,
+    StrikeThrough = 1 << 3,
 };
 
-enum TextAlignment {
-    NoAlignment = 0,
-    LeftAlignment = 1,
-    RightAlignment = 2,
-    CenterAlignment = 3,
-    JustifiedAlignment = 4,
+enum class TextAlignment : uint8_t {
+    Natural,
+    Left,
+    Right,
+    Center,
+    Justified,
 };
 
-enum ListType {
-    NoList = 0,
+enum class ListType : uint8_t {
+    None,
     OrderedList,
     UnorderedList
 };
@@ -88,12 +87,12 @@ struct EditorState {
 #endif
 
     struct PostLayoutData {
-        uint32_t typingAttributes { AttributeNone };
+        OptionSet<TypingAttribute> typingAttributes;
 #if PLATFORM(COCOA)
         uint64_t selectedTextLength { 0 };
-        uint32_t textAlignment { NoAlignment };
+        TextAlignment textAlignment { TextAlignment::Natural };
         WebCore::Color textColor { WebCore::Color::black }; // FIXME: Maybe this should be on VisualData?
-        uint32_t enclosingListType { NoList };
+        ListType enclosingListType { ListType::None };
         WebCore::WritingDirection baseWritingDirection { WebCore::WritingDirection::Natural };
         bool editableRootIsTransparentOrFullyClipped { false };
 #endif

--- a/Source/WebKit/Shared/EditorState.serialization.in
+++ b/Source/WebKit/Shared/EditorState.serialization.in
@@ -20,6 +20,26 @@
 # OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
+enum class WebKit::ListType : uint8_t {
+    None,
+    OrderedList,
+    UnorderedList
+}
+
+enum class WebKit::TextAlignment : uint8_t {
+    Natural,
+    Left,
+    Right,
+    Center,
+    Justified,
+}
+
+[OptionSet] enum class WebKit::TypingAttribute : uint8_t {
+    Bold,
+    Italics,
+    Underline,
+    StrikeThrough
+}
 
 struct WebKit::EditorState {
     WebKit::EditorStateIdentifier identifier;
@@ -42,12 +62,12 @@ struct WebKit::EditorState {
 };
 
 [Nested] struct WebKit::EditorState::PostLayoutData {
-    uint32_t typingAttributes;
+    OptionSet<WebKit::TypingAttribute> typingAttributes;
 #if PLATFORM(COCOA)
     uint64_t selectedTextLength;
-    uint32_t textAlignment;
+    WebKit::TextAlignment textAlignment;
     WebCore::Color textColor;
-    uint32_t enclosingListType;
+    WebKit::ListType enclosingListType;
     WebCore::WritingDirection baseWritingDirection;
     bool editableRootIsTransparentOrFullyClipped;
 #endif

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebView.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebView.mm
@@ -1823,9 +1823,9 @@ static NSDictionary *dictionaryRepresentationForEditorState(const WebKit::Editor
     auto& postLayoutData = *state.postLayoutData;
     return @{
         @"post-layout-data" : @YES,
-        @"bold": postLayoutData.typingAttributes & WebKit::AttributeBold ? @YES : @NO,
-        @"italic": postLayoutData.typingAttributes & WebKit::AttributeItalics ? @YES : @NO,
-        @"underline": postLayoutData.typingAttributes & WebKit::AttributeUnderline ? @YES : @NO,
+        @"bold": postLayoutData.typingAttributes.contains(WebKit::TypingAttribute::Bold) ? @YES : @NO,
+        @"italic": postLayoutData.typingAttributes.contains(WebKit::TypingAttribute::Italics) ? @YES : @NO,
+        @"underline": postLayoutData.typingAttributes.contains(WebKit::TypingAttribute::Underline) ? @YES : @NO,
         @"text-alignment": @(nsTextAlignment(static_cast<WebKit::TextAlignment>(postLayoutData.textAlignment))),
         @"text-color": (NSString *)serializationForCSS(postLayoutData.textColor)
     };
@@ -1834,15 +1834,15 @@ static NSDictionary *dictionaryRepresentationForEditorState(const WebKit::Editor
 static NSTextAlignment nsTextAlignment(WebKit::TextAlignment alignment)
 {
     switch (alignment) {
-    case WebKit::NoAlignment:
+    case WebKit::TextAlignment::Natural:
         return NSTextAlignmentNatural;
-    case WebKit::LeftAlignment:
+    case WebKit::TextAlignment::Left:
         return NSTextAlignmentLeft;
-    case WebKit::RightAlignment:
+    case WebKit::TextAlignment::Right:
         return NSTextAlignmentRight;
-    case WebKit::CenterAlignment:
+    case WebKit::TextAlignment::Center:
         return NSTextAlignmentCenter;
-    case WebKit::JustifiedAlignment:
+    case WebKit::TextAlignment::Justified:
         return NSTextAlignmentJustified;
     }
     ASSERT_NOT_REACHED();

--- a/Source/WebKit/UIProcess/API/glib/WebKitEditorState.cpp
+++ b/Source/WebKit/UIProcess/API/glib/WebKitEditorState.cpp
@@ -123,13 +123,13 @@ void webkitEditorStateChanged(WebKitEditorState* editorState, const EditorState&
 
     unsigned typingAttributes = WEBKIT_EDITOR_TYPING_ATTRIBUTE_NONE;
     const auto& postLayoutData = *newState.postLayoutData;
-    if (postLayoutData.typingAttributes & AttributeBold)
+    if (postLayoutData.typingAttributes.contains(WebKit::TypingAttribute::Bold))
         typingAttributes |= WEBKIT_EDITOR_TYPING_ATTRIBUTE_BOLD;
-    if (postLayoutData.typingAttributes & AttributeItalics)
+    if (postLayoutData.typingAttributes.contains(WebKit::TypingAttribute::Italics))
         typingAttributes |= WEBKIT_EDITOR_TYPING_ATTRIBUTE_ITALIC;
-    if (postLayoutData.typingAttributes & AttributeUnderline)
+    if (postLayoutData.typingAttributes.contains(WebKit::TypingAttribute::Underline))
         typingAttributes |= WEBKIT_EDITOR_TYPING_ATTRIBUTE_UNDERLINE;
-    if (postLayoutData.typingAttributes & AttributeStrikeThrough)
+    if (postLayoutData.typingAttributes.contains(WebKit::TypingAttribute::StrikeThrough))
         typingAttributes |= WEBKIT_EDITOR_TYPING_ATTRIBUTE_STRIKETHROUGH;
 
     webkitEditorStateSetTypingAttributes(editorState, typingAttributes);

--- a/Source/WebKit/UIProcess/ios/WKContentViewInteraction.mm
+++ b/Source/WebKit/UIProcess/ios/WKContentViewInteraction.mm
@@ -3880,9 +3880,9 @@ WEBCORE_COMMAND_FOR_WEBVIEW(pasteAndMatchStyle);
         return nil;
     auto typingAttributes = _page->editorState().postLayoutData->typingAttributes;
     CTFontSymbolicTraits symbolicTraits = 0;
-    if (typingAttributes & WebKit::AttributeBold)
+    if (typingAttributes.contains(WebKit::TypingAttribute::Bold))
         symbolicTraits |= kCTFontBoldTrait;
-    if (typingAttributes & WebKit::AttributeItalics)
+    if (typingAttributes.contains(WebKit::TypingAttribute::Italics))
         symbolicTraits |= kCTFontTraitItalic;
 
     // We chose a random font family and size.
@@ -3896,7 +3896,7 @@ WEBCORE_COMMAND_FOR_WEBVIEW(pasteAndMatchStyle);
     if (font)
         [result setObject:(id)font.get() forKey:NSFontAttributeName];
     
-    if (typingAttributes & WebKit::AttributeUnderline)
+    if (typingAttributes.contains(WebKit::TypingAttribute::Underline))
         [result setObject:@(NSUnderlineStyleSingle) forKey:NSUnderlineStyleAttributeName];
 
     return result;

--- a/Source/WebKit/UIProcess/mac/WebViewImpl.mm
+++ b/Source/WebKit/UIProcess/mac/WebViewImpl.mm
@@ -723,9 +723,9 @@ ALLOW_DEPRECATED_DECLARATIONS_END
         // There is no "remove list" edit command, but InsertOrderedList and InsertUnorderedList both
         // behave as toggles, so we can invoke the appropriate edit command depending on our _currentListType
         // to remove an existing list. We don't have to do anything if _currentListType is NoList.
-        if (_currentListType == WebKit::OrderedList)
+        if (_currentListType == WebKit::ListType::OrderedList)
             _webViewImpl->page().executeEditCommand(@"InsertOrderedList", @"");
-        else if (_currentListType == WebKit::UnorderedList)
+        else if (_currentListType == WebKit::ListType::UnorderedList)
             _webViewImpl->page().executeEditCommand(@"InsertUnorderedList", @"");
         break;
     case unorderedListSegment:
@@ -743,13 +743,13 @@ ALLOW_DEPRECATED_DECLARATIONS_END
 {
     NSSegmentedControl *insertListControl = (NSSegmentedControl *)self.view;
     switch (listType) {
-    case WebKit::NoList:
+    case WebKit::ListType::None:
         [insertListControl setSelected:YES forSegment:noListSegment];
         break;
-    case WebKit::OrderedList:
+    case WebKit::ListType::OrderedList:
         [insertListControl setSelected:YES forSegment:orderedListSegment];
         break;
-    case WebKit::UnorderedList:
+    case WebKit::ListType::UnorderedList:
         [insertListControl setSelected:YES forSegment:unorderedListSegment];
         break;
     }
@@ -5719,15 +5719,15 @@ NSTouchBar *WebViewImpl::textTouchBar() const
 static NSTextAlignment nsTextAlignmentFromTextAlignment(TextAlignment textAlignment)
 {
     switch (textAlignment) {
-    case NoAlignment:
+    case TextAlignment::Natural:
         return NSTextAlignmentNatural;
-    case LeftAlignment:
+    case TextAlignment::Left:
         return NSTextAlignmentLeft;
-    case RightAlignment:
+    case TextAlignment::Right:
         return NSTextAlignmentRight;
-    case CenterAlignment:
+    case TextAlignment::Center:
         return NSTextAlignmentCenter;
-    case JustifiedAlignment:
+    case TextAlignment::Justified:
         return NSTextAlignmentJustified;
     }
     ASSERT_NOT_REACHED();
@@ -5800,9 +5800,9 @@ void WebViewImpl::updateTextTouchBar()
     if (isRichlyEditableForTouchBar()) {
         const EditorState& editorState = m_page->editorState();
         if (editorState.hasPostLayoutData()) {
-            [m_textTouchBarItemController setTextIsBold:(bool)(m_page->editorState().postLayoutData->typingAttributes & AttributeBold)];
-            [m_textTouchBarItemController setTextIsItalic:(bool)(m_page->editorState().postLayoutData->typingAttributes & AttributeItalics)];
-            [m_textTouchBarItemController setTextIsUnderlined:(bool)(m_page->editorState().postLayoutData->typingAttributes & AttributeUnderline)];
+            [m_textTouchBarItemController setTextIsBold:(m_page->editorState().postLayoutData->typingAttributes.contains(TypingAttribute::Bold))];
+            [m_textTouchBarItemController setTextIsItalic:(m_page->editorState().postLayoutData->typingAttributes.contains(TypingAttribute::Italics))];
+            [m_textTouchBarItemController setTextIsUnderlined:(m_page->editorState().postLayoutData->typingAttributes.contains(TypingAttribute::Underline))];
             [m_textTouchBarItemController setTextColor:cocoaColor(editorState.postLayoutData->textColor).get()];
             [[m_textTouchBarItemController textListTouchBarViewController] setCurrentListType:(ListType)m_page->editorState().postLayoutData->enclosingListType];
             [m_textTouchBarItemController setCurrentTextAlignment:nsTextAlignmentFromTextAlignment((TextAlignment)editorState.postLayoutData->textAlignment)];

--- a/Source/WebKit/WebProcess/WebPage/Cocoa/WebPageCocoa.mm
+++ b/Source/WebKit/WebProcess/WebPage/Cocoa/WebPageCocoa.mm
@@ -495,37 +495,37 @@ void WebPage::getPlatformEditorStateCommon(const LocalFrame& frame, EditorState&
     if (result.isContentEditable) {
         if (auto editingStyle = EditingStyle::styleAtSelectionStart(selection)) {
             if (editingStyle->hasStyle(CSSPropertyFontWeight, "bold"_s))
-                postLayoutData.typingAttributes |= AttributeBold;
+                postLayoutData.typingAttributes.add(TypingAttribute::Bold);
 
             if (editingStyle->hasStyle(CSSPropertyFontStyle, "italic"_s) || editingStyle->hasStyle(CSSPropertyFontStyle, "oblique"_s))
-                postLayoutData.typingAttributes |= AttributeItalics;
+                postLayoutData.typingAttributes.add(TypingAttribute::Italics);
 
             if (editingStyle->hasStyle(CSSPropertyWebkitTextDecorationsInEffect, "underline"_s))
-                postLayoutData.typingAttributes |= AttributeUnderline;
+                postLayoutData.typingAttributes.add(TypingAttribute::Underline);
 
             if (auto* styleProperties = editingStyle->style()) {
                 bool isLeftToRight = styleProperties->propertyAsValueID(CSSPropertyDirection) == CSSValueLtr;
                 switch (styleProperties->propertyAsValueID(CSSPropertyTextAlign).value_or(CSSValueInvalid)) {
                 case CSSValueRight:
                 case CSSValueWebkitRight:
-                    postLayoutData.textAlignment = RightAlignment;
+                    postLayoutData.textAlignment = TextAlignment::Right;
                     break;
                 case CSSValueLeft:
                 case CSSValueWebkitLeft:
-                    postLayoutData.textAlignment = LeftAlignment;
+                    postLayoutData.textAlignment = TextAlignment::Left;
                     break;
                 case CSSValueCenter:
                 case CSSValueWebkitCenter:
-                    postLayoutData.textAlignment = CenterAlignment;
+                    postLayoutData.textAlignment = TextAlignment::Center;
                     break;
                 case CSSValueJustify:
-                    postLayoutData.textAlignment = JustifiedAlignment;
+                    postLayoutData.textAlignment = TextAlignment::Justified;
                     break;
                 case CSSValueStart:
-                    postLayoutData.textAlignment = isLeftToRight ? LeftAlignment : RightAlignment;
+                    postLayoutData.textAlignment = isLeftToRight ? TextAlignment::Left : TextAlignment::Right;
                     break;
                 case CSSValueEnd:
-                    postLayoutData.textAlignment = isLeftToRight ? RightAlignment : LeftAlignment;
+                    postLayoutData.textAlignment = isLeftToRight ? TextAlignment::Right : TextAlignment::Left;
                     break;
                 default:
                     break;
@@ -537,9 +537,9 @@ void WebPage::getPlatformEditorStateCommon(const LocalFrame& frame, EditorState&
 
         if (auto* enclosingListElement = enclosingList(selection.start().containerNode())) {
             if (is<HTMLUListElement>(*enclosingListElement))
-                postLayoutData.enclosingListType = UnorderedList;
+                postLayoutData.enclosingListType = ListType::UnorderedList;
             else if (is<HTMLOListElement>(*enclosingListElement))
-                postLayoutData.enclosingListType = OrderedList;
+                postLayoutData.enclosingListType = ListType::OrderedList;
             else
                 ASSERT_NOT_REACHED();
         }

--- a/Source/WebKit/WebProcess/WebPage/glib/WebPageGLib.cpp
+++ b/Source/WebKit/WebProcess/WebPage/glib/WebPageGLib.cpp
@@ -126,22 +126,22 @@ void WebPage::getPlatformEditorState(LocalFrame& frame, EditorState& result) con
     const Editor& editor = frame.editor();
     if (selection.isRange()) {
         if (editor.selectionHasStyle(CSSPropertyFontWeight, "bold"_s) == TriState::True)
-            postLayoutData.typingAttributes |= AttributeBold;
+            postLayoutData.typingAttributes.add(TypingAttribute::Bold);
         if (editor.selectionHasStyle(CSSPropertyFontStyle, "italic"_s) == TriState::True)
-            postLayoutData.typingAttributes |= AttributeItalics;
+            postLayoutData.typingAttributes.add(TypingAttribute::Italics);
         if (editor.selectionHasStyle(CSSPropertyWebkitTextDecorationsInEffect, "underline"_s) == TriState::True)
-            postLayoutData.typingAttributes |= AttributeUnderline;
+            postLayoutData.typingAttributes.add(TypingAttribute::Underline);
         if (editor.selectionHasStyle(CSSPropertyWebkitTextDecorationsInEffect, "line-through"_s) == TriState::True)
-            postLayoutData.typingAttributes |= AttributeStrikeThrough;
+            postLayoutData.typingAttributes.add(TypingAttribute::StrikeThrough);
     } else if (selection.isCaret()) {
         if (editor.selectionStartHasStyle(CSSPropertyFontWeight, "bold"_s))
-            postLayoutData.typingAttributes |= AttributeBold;
+            postLayoutData.typingAttributes.add(TypingAttribute::Bold);
         if (editor.selectionStartHasStyle(CSSPropertyFontStyle, "italic"_s))
-            postLayoutData.typingAttributes |= AttributeItalics;
+            postLayoutData.typingAttributes.add(TypingAttribute::Italics);
         if (editor.selectionStartHasStyle(CSSPropertyWebkitTextDecorationsInEffect, "underline"_s))
-            postLayoutData.typingAttributes |= AttributeUnderline;
+            postLayoutData.typingAttributes.add(TypingAttribute::Underline);
         if (editor.selectionStartHasStyle(CSSPropertyWebkitTextDecorationsInEffect, "line-through"_s))
-            postLayoutData.typingAttributes |= AttributeStrikeThrough;
+            postLayoutData.typingAttributes.add(TypingAttribute::StrikeThrough);
     }
 #endif
 


### PR DESCRIPTION
#### 72fad77b89f09c7567e56e5da0923fc3d4534a2b
<pre>
Refactor some enums in EditorState to enum classes
<a href="https://bugs.webkit.org/show_bug.cgi?id=256930">https://bugs.webkit.org/show_bug.cgi?id=256930</a>
rdar://109487509

Reviewed by Chris Dumez.

Refactored EditorState enums ListType, TextAlignment, and TypingAttributes to enum classes. Changed TypingAttributes to be TypingAttribute.
Changed typingAttributes in PostLayoutData to be an OptionSet.

* Source/WebKit/Shared/EditorState.cpp:
(WebKit::operator&lt;&lt;):
* Source/WebKit/Shared/EditorState.h:
* Source/WebKit/Shared/EditorState.serialization.in:
* Source/WebKit/UIProcess/API/Cocoa/WKWebView.mm:
(dictionaryRepresentationForEditorState):
(nsTextAlignment):
* Source/WebKit/UIProcess/API/glib/WebKitEditorState.cpp:
(webkitEditorStateChanged):
* Source/WebKit/UIProcess/ios/WKContentViewInteraction.mm:
(-[WKContentView textStylingAtPosition:inDirection:]):
* Source/WebKit/UIProcess/mac/WebViewImpl.mm:
(-[WKTextListTouchBarViewController _selectList:]):
(-[WKTextListTouchBarViewController setCurrentListType:]):
(WebKit::nsTextAlignmentFromTextAlignment):
(WebKit::WebViewImpl::updateTextTouchBar):
* Source/WebKit/WebProcess/WebPage/Cocoa/WebPageCocoa.mm:
(WebKit::WebPage::getPlatformEditorStateCommon const):

Canonical link: <a href="https://commits.webkit.org/264439@main">https://commits.webkit.org/264439@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/def5477e80787d5b44d461c86dd70c6783b344ed

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/7598 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/7866 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/8050 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/9241 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/7787 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/9825 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/7793 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/10660 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/7731 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/8845 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/7009 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/9350 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/6154 "Passed tests") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/14620 "Passed tests") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/7327 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/7043 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/10443 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/7536 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/6154 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/6874 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/1815 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/11085 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/7267 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->