### PR TITLE
Avoid running WheelEventTestMonitor-related test-only code when not testing

### DIFF
--- a/Source/WebKit/UIProcess/RemoteLayerTree/RemoteScrollingTree.cpp
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/RemoteScrollingTree.cpp
@@ -199,7 +199,7 @@ void RemoteScrollingTree::deferWheelEventTestCompletionForReason(ScrollingNodeID
 {
     ASSERT(isMainRunLoop());
 
-    if (!m_scrollingCoordinatorProxy)
+    if (!m_scrollingCoordinatorProxy || !isMonitoringWheelEvents())
         return;
 
     m_scrollingCoordinatorProxy->deferWheelEventTestCompletionForReason(nodeID, reason);
@@ -209,7 +209,7 @@ void RemoteScrollingTree::removeWheelEventTestCompletionDeferralForReason(Scroll
 {
     ASSERT(isMainRunLoop());
 
-    if (!m_scrollingCoordinatorProxy)
+    if (!m_scrollingCoordinatorProxy || !isMonitoringWheelEvents())
         return;
 
     m_scrollingCoordinatorProxy->removeWheelEventTestCompletionDeferralForReason(nodeID, reason);

--- a/Source/WebKit/UIProcess/RemoteLayerTree/mac/RemoteScrollingTreeMac.mm
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/mac/RemoteScrollingTreeMac.mm
@@ -323,6 +323,9 @@ WheelEventHandlingResult RemoteScrollingTreeMac::handleWheelEventAfterDefaultHan
 
 void RemoteScrollingTreeMac::deferWheelEventTestCompletionForReason(ScrollingNodeID nodeID, WheelEventTestMonitor::DeferReason reason)
 {
+    if (!isMonitoringWheelEvents())
+        return;
+
     RunLoop::main().dispatch([strongThis = Ref { *this }, nodeID, reason] {
         if (auto* scrollingCoordinatorProxy = strongThis->scrollingCoordinatorProxy())
             scrollingCoordinatorProxy->deferWheelEventTestCompletionForReason(nodeID, reason);
@@ -331,6 +334,9 @@ void RemoteScrollingTreeMac::deferWheelEventTestCompletionForReason(ScrollingNod
 
 void RemoteScrollingTreeMac::removeWheelEventTestCompletionDeferralForReason(ScrollingNodeID nodeID, WheelEventTestMonitor::DeferReason reason)
 {
+    if (!isMonitoringWheelEvents())
+        return;
+
     RunLoop::main().dispatch([strongThis = Ref { *this }, nodeID, reason] {
         if (auto* scrollingCoordinatorProxy = strongThis->scrollingCoordinatorProxy())
             scrollingCoordinatorProxy->removeWheelEventTestCompletionDeferralForReason(nodeID, reason);


### PR DESCRIPTION
#### ab78a74247b81231d5b746c71e724db5fc8910c2
<pre>
Avoid running WheelEventTestMonitor-related test-only code when not testing
<a href="https://bugs.webkit.org/show_bug.cgi?id=256934">https://bugs.webkit.org/show_bug.cgi?id=256934</a>
rdar://109488666

Reviewed by Wenson Hsieh.

RemoteScrollingTreeMac::deferWheelEventTestCompletionForReason() and RemoteScrollingTreeMac::removeWheelEventTestCompletionDeferralForReason()
would always trigger the hop to main thread, and IPC with the web process. We only need to do that when running layout tests
that use `eventSender.monitorWheelEvents()`, and the RemoteScrollingTree already has a bit for that, so use it.

* Source/WebKit/UIProcess/RemoteLayerTree/RemoteScrollingTree.cpp:
(WebKit::RemoteScrollingTree::deferWheelEventTestCompletionForReason):
(WebKit::RemoteScrollingTree::removeWheelEventTestCompletionDeferralForReason):
* Source/WebKit/UIProcess/RemoteLayerTree/mac/RemoteScrollingTreeMac.mm:
(WebKit::RemoteScrollingTreeMac::deferWheelEventTestCompletionForReason):
(WebKit::RemoteScrollingTreeMac::removeWheelEventTestCompletionDeferralForReason):

Canonical link: <a href="https://commits.webkit.org/264208@main">https://commits.webkit.org/264208@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d686e5d7580552fc5d3d3e2cc314a430386b15a7

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/6957 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/7191 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/7374 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/8565 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/7195 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/8455 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/7129 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/10104 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/7080 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/7750 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/6409 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/8666 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/5133 "Passed tests") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/14102 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/6809 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/6412 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/9239 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/6889 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/5646 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/6262 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/1664 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/10449 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/6644 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->