### PR TITLE
[iOS] Adjust the bindings-exposed screen size in headless browser mode

### DIFF
--- a/Source/WebCore/page/ChromeClient.h
+++ b/Source/WebCore/page/ChromeClient.h
@@ -647,6 +647,8 @@ public:
     
     virtual bool isInStableState() const { return true; }
 
+    virtual FloatSize screenSizeForHeadlessMode(const LocalFrame&, FloatSize defaultSize) const { return defaultSize; }
+
     WEBCORE_EXPORT virtual ~ChromeClient();
 
 protected:

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebChromeClient.cpp
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebChromeClient.cpp
@@ -1261,6 +1261,11 @@ FloatSize WebChromeClient::overrideScreenSize() const
 
 #endif
 
+FloatSize WebChromeClient::screenSizeForHeadlessMode(const LocalFrame& frame, FloatSize defaultSize) const
+{
+    return m_page.screenSizeForHeadlessMode(frame, defaultSize);
+}
+
 void WebChromeClient::dispatchDisabledAdaptationsDidChange(const OptionSet<DisabledAdaptations>& disabledAdaptations) const
 {
     m_page.disabledAdaptationsDidChange(disabledAdaptations);

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebChromeClient.h
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebChromeClient.h
@@ -489,6 +489,8 @@ private:
 
     bool isInStableState() const final;
 
+    WebCore::FloatSize screenSizeForHeadlessMode(const WebCore::LocalFrame&, WebCore::FloatSize defaultSize) const final;
+
     mutable bool m_cachedMainFrameHasHorizontalScrollbar { false };
     mutable bool m_cachedMainFrameHasVerticalScrollbar { false };
 

--- a/Source/WebKit/WebProcess/WebPage/WebPage.cpp
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.cpp
@@ -2660,6 +2660,15 @@ void WebPage::viewportPropertiesDidChange(const ViewportArguments& viewportArgum
 #endif
 }
 
+#if !PLATFORM(IOS_FAMILY)
+
+FloatSize WebPage::screenSizeForHeadlessMode(const LocalFrame& frame, FloatSize defaultSize) const
+{
+    return frame.view() ? FloatSize { frame.view()->unobscuredContentRectIncludingScrollbars().size() } : defaultSize;
+}
+
+#endif // !PLATFORM(IOS_FAMILY)
+
 void WebPage::listenForLayoutMilestones(OptionSet<WebCore::LayoutMilestone> milestones)
 {
     if (!m_page)

--- a/Source/WebKit/WebProcess/WebPage/WebPage.h
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.h
@@ -1643,6 +1643,8 @@ public:
     bool isInStableState() const { return m_isInStableState; }
 #endif
 
+    WebCore::FloatSize screenSizeForHeadlessMode(const WebCore::LocalFrame&, WebCore::FloatSize defaultSize) const;
+
     const Logger& logger() const;
     const void* logIdentifier() const;
 

--- a/Source/WebKit/WebProcess/WebPage/ios/WebPageIOS.mm
+++ b/Source/WebKit/WebProcess/WebPage/ios/WebPageIOS.mm
@@ -52,6 +52,7 @@
 #import "TextCheckingControllerProxy.h"
 #import "UIKitSPI.h"
 #import "UserData.h"
+#import "UserInterfaceIdiom.h"
 #import "ViewGestureGeometryCollector.h"
 #import "VisibleContentRectUpdateInfo.h"
 #import "WKAccessibilityWebPageObjectIOS.h"
@@ -5151,6 +5152,25 @@ void WebPage::animationDidFinishForElement(const WebCore::Element& animatedEleme
     RefPtr endContainer = selection.end().containerNode();
     if (startContainer != endContainer)
         scheduleEditorStateUpdateForStartOrEndContainerNodeIfNeeded(endContainer.get());
+}
+
+FloatSize WebPage::screenSizeForHeadlessMode(const LocalFrame&, FloatSize defaultSize) const
+{
+    if (!currentUserInterfaceIdiomIsSmallScreen())
+        return m_viewportConfiguration.minimumLayoutSize();
+
+    static constexpr std::array fixedSizes {
+        FloatSize { 320,  568 },
+        FloatSize { 375,  667 },
+        FloatSize { 414,  736 },
+    };
+
+    for (auto fixedSize : fixedSizes) {
+        if (defaultSize.width() <= fixedSize.width())
+            return fixedSize;
+    }
+
+    return std::get<std::tuple_size_v<decltype(fixedSizes)> - 1>(fixedSizes);
 }
 
 } // namespace WebKit


### PR DESCRIPTION
#### e82dfc6a2175995d6e92081192b7cbd8faaa0ce4
<pre>
[iOS] Adjust the bindings-exposed screen size in headless browser mode
<a href="https://bugs.webkit.org/show_bug.cgi?id=256939">https://bugs.webkit.org/show_bug.cgi?id=256939</a>

Reviewed by Alan Baradlay.

Add different, platform-specific strategies when returning an appropriate screen size for bindings
in headless browsing. See below for more details.

Changes covered by a new API test (and adjustments to some existing tests).

* Source/WebCore/page/ChromeClient.h:
(WebCore::ChromeClient::screenSizeForHeadlessMode const):

Add a chrome client hook to return a screen size specifically for &quot;headless mode&quot;, given the
requesting frame and the actual screen size.

* Source/WebCore/page/LocalFrame.cpp:
(WebCore::LocalFrame::screenSize const):
* Source/WebKit/WebProcess/WebCoreSupport/WebChromeClient.cpp:
(WebKit::WebChromeClient::screenSizeForHeadlessMode const):

Add some plumbing out to `WebPage`.

* Source/WebKit/WebProcess/WebCoreSupport/WebChromeClient.h:
* Source/WebKit/WebProcess/WebPage/WebPage.cpp:
(WebKit::WebPage::screenSizeForHeadlessMode const):

Move the logic currently in `LocalFrame::screenSize` over to this method; additionally, instead of
trying to counterscale the innerWidth/innerHeight, simply return the unobscured content rect; this
does not change with `pageScaleFactor` on macOS, eliminating the need for counterscaling.

* Source/WebKit/WebProcess/WebPage/WebPage.h:
* Source/WebKit/WebProcess/WebPage/ios/WebPageIOS.mm:
(WebKit::WebPage::screenSizeForHeadlessMode const):

Implement an iOS-specific strategy for `screenSizeForHeadlessMode`, returning one of three canned
values on iPhone (based on the current user idiom), and falling back to the initial containing block
(ignoring the current scale factor, by using `ViewportConfiguration::minimumLayoutSize()`) on iPad.

Canonical link: <a href="https://commits.webkit.org/264200@main">https://commits.webkit.org/264200@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c958a4c355041f1a00eebfb38aafc3de2dee4af4

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/6962 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/7197 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/7380 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/8569 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/7199 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/6968 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/8461 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/7135 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/10108 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/7085 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/7757 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/6414 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/8671 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/5139 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/6327 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/14105 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/6815 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/6418 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/9242 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/6893 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/5652 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/6266 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/1661 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/10453 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/6648 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->