### PR TITLE
[JSC] Extend megamorphic store cache with invalidating replacement watchpoint set

### DIFF
--- a/Source/JavaScriptCore/bytecode/InlineCacheCompiler.cpp
+++ b/Source/JavaScriptCore/bytecode/InlineCacheCompiler.cpp
@@ -2860,6 +2860,12 @@ AccessGenerationResult InlineCacheCompiler::regenerate(const GCSafeConcurrentJSL
                     allAreSimpleReplaceOrTransition = false;
                     break;
                 }
+                if (accessCase->type() == AccessCase::Transition) {
+                    if (accessCase->newStructure()->outOfLineCapacity() != accessCase->structure()->outOfLineCapacity()) {
+                        allAreSimpleReplaceOrTransition = false;
+                        break;
+                    }
+                }
             }
 
             // Currently, we do not apply megamorphic cache for "length" property since Array#length and String#length are too common.
@@ -2897,6 +2903,12 @@ AccessGenerationResult InlineCacheCompiler::regenerate(const GCSafeConcurrentJSL
                 if (!canUseMegamorphicPutFastPath(accessCase->structure())) {
                     allAreSimpleReplaceOrTransition = false;
                     break;
+                }
+                if (accessCase->type() == AccessCase::Transition) {
+                    if (accessCase->newStructure()->outOfLineCapacity() != accessCase->structure()->outOfLineCapacity()) {
+                        allAreSimpleReplaceOrTransition = false;
+                        break;
+                    }
                 }
             }
 

--- a/Source/JavaScriptCore/jit/AssemblyHelpers.cpp
+++ b/Source/JavaScriptCore/jit/AssemblyHelpers.cpp
@@ -595,13 +595,8 @@ AssemblyHelpers::JumpList AssemblyHelpers::storeMegamorphicProperty(VM& vm, GPRR
 
     // We only support non-allocating transition. This means we do not need to nuke Structure* for transition here.
     store32(scratch4GPR, Address(baseGPR, JSCell::structureIDOffset()));
-    auto store = jump();
 
     replaceCase.link(this);
-    emitNonNullDecodeZeroExtendedStructureID(scratch1GPR, scratch4GPR);
-    slowCases.append(branchTest32(NonZero, Address(scratch4GPR, Structure::bitFieldOffset()), TrustedImm32(Structure::s_isWatchingReplacementBits)));
-
-    store.link(this);
     storeProperty(JSValueRegs { valueGPR }, baseGPR, scratch2GPR, scratch3GPR);
     auto done = jump();
 

--- a/Source/JavaScriptCore/jit/JITOperations.cpp
+++ b/Source/JavaScriptCore/jit/JITOperations.cpp
@@ -858,8 +858,10 @@ ALWAYS_INLINE static void putByIdMegamorphic(JSGlobalObject* globalObject, VM& v
 
     Structure* newStructure = baseObject->structure();
     if (slot.type() == PutPropertySlot::ExistingProperty) {
-        if (LIKELY(oldStructure == newStructure && !oldStructure->isWatchingReplacement() && slot.cachedOffset() <= MegamorphicCache::maxOffset))
+        if (LIKELY(oldStructure == newStructure && slot.cachedOffset() <= MegamorphicCache::maxOffset)) {
+            oldStructure->didCachePropertyReplacement(vm, slot.cachedOffset()); // Ensure invalidating watchpoint set.
             vm.megamorphicCache()->initAsReplace(StructureID::encode(oldStructure), uid, slot.cachedOffset());
+        }
         return;
     }
 
@@ -1521,9 +1523,10 @@ ALWAYS_INLINE static void putByValMegamorphic(JSGlobalObject* globalObject, VM& 
 
     Structure* newStructure = baseObject->structure();
     if (slot.type() == PutPropertySlot::ExistingProperty) {
-        // dataLogLn(MegamorphicCache::storeCachePrimaryMask & MegamorphicCache::storeCachePrimaryHash(StructureID::encode(oldStructure), uid), " ", JSValue(oldStructure));
-        if (LIKELY(oldStructure == newStructure && !oldStructure->isWatchingReplacement() && slot.cachedOffset() <= MegamorphicCache::maxOffset))
+        if (LIKELY(oldStructure == newStructure && slot.cachedOffset() <= MegamorphicCache::maxOffset)) {
+            oldStructure->didCachePropertyReplacement(vm, slot.cachedOffset()); // Ensure invalidating watchpoint set.
             vm.megamorphicCache()->initAsReplace(StructureID::encode(oldStructure), uid, slot.cachedOffset());
+        }
         return;
     }
 

--- a/Source/JavaScriptCore/runtime/Structure.cpp
+++ b/Source/JavaScriptCore/runtime/Structure.cpp
@@ -1039,10 +1039,9 @@ void Structure::startWatchingPropertyForReplacements(VM& vm, PropertyName proper
     startWatchingPropertyForReplacements(vm, get(vm, propertyName));
 }
 
-void Structure::didCachePropertyReplacement(VM& vm, PropertyOffset offset)
+void Structure::didReplacePropertySlow(PropertyOffset offset)
 {
-    RELEASE_ASSERT(isValidOffset(offset));
-    firePropertyReplacementWatchpointSet(vm, offset, "Did cache property replacement");
+    firePropertyReplacementWatchpointSet(vm(), offset, "Property did get replaced");
 }
 
 void Structure::startWatchingInternalProperties(VM& vm)

--- a/Source/JavaScriptCore/runtime/Structure.h
+++ b/Source/JavaScriptCore/runtime/Structure.h
@@ -785,7 +785,7 @@ public:
     }
     void startWatchingPropertyForReplacements(VM&, PropertyName);
     WatchpointSet* propertyReplacementWatchpointSet(PropertyOffset);
-    JS_EXPORT_PRIVATE WatchpointSet* firePropertyReplacementWatchpointSet(VM&, PropertyOffset, const char* reason);
+    WatchpointSet* firePropertyReplacementWatchpointSet(VM&, PropertyOffset, const char* reason);
 
     void didReplaceProperty(PropertyOffset);
     void didCachePropertyReplacement(VM&, PropertyOffset);
@@ -822,6 +822,8 @@ public:
     DECLARE_EXPORT_INFO;
 
 private:
+    JS_EXPORT_PRIVATE void didReplacePropertySlow(PropertyOffset);
+
     typedef enum { 
         NoneDictionaryKind = 0,
         CachedDictionaryKind = 1,

--- a/Source/JavaScriptCore/runtime/StructureInlines.h
+++ b/Source/JavaScriptCore/runtime/StructureInlines.h
@@ -383,7 +383,13 @@ inline void Structure::didReplaceProperty(PropertyOffset offset)
 {
     if (LIKELY(!isWatchingReplacement()))
         return;
-    firePropertyReplacementWatchpointSet(vm(), offset, "Property did get replaced");
+    didReplacePropertySlow(offset);
+}
+
+inline void Structure::didCachePropertyReplacement(VM& vm, PropertyOffset offset)
+{
+    ASSERT(isValidOffset(offset));
+    firePropertyReplacementWatchpointSet(vm, offset, "Did cache property replacement");
 }
 
 inline WatchpointSet* Structure::propertyReplacementWatchpointSet(PropertyOffset offset)


### PR DESCRIPTION
#### b4d99e644e12f78fe4c1e71edea6aab37ead4450
<pre>
[JSC] Extend megamorphic store cache with invalidating replacement watchpoint set
<a href="https://bugs.webkit.org/show_bug.cgi?id=256943">https://bugs.webkit.org/show_bug.cgi?id=256943</a>
rdar://109493502

Reviewed by Justin Michaud.

This patch recovers regression in JetStream2/typescript after introducing megamorphic store cache.
The reason is that the previous cache was a bit too conservative, and we are using slow path for
Structure::isWatchingReplacement case, but JetStream2/typescript includes legit use of this kind of
Structure with megamorphic cache.
This patch allows Structure::isWatchingReplacement case, and invalidate replacement watchpoint when
caching replace structure. This recovers and rather improves JetStream2/typescript.

* Source/JavaScriptCore/bytecode/InlineCacheCompiler.cpp:
(JSC::InlineCacheCompiler::regenerate):
* Source/JavaScriptCore/jit/AssemblyHelpers.cpp:
(JSC::AssemblyHelpers::storeMegamorphicProperty):
* Source/JavaScriptCore/jit/JITOperations.cpp:
(JSC::putByIdMegamorphic):

Canonical link: <a href="https://commits.webkit.org/264212@main">https://commits.webkit.org/264212@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/386f3af7413a91cd5cb96c0e0908d6bbe0c27e14

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/6992 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/7231 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/7412 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/8603 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/7226 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/8494 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/7167 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/10135 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/7117 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/7787 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/6448 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/8705 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/5156 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/6357 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/14132 "1 flakes 118 failures") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/5907 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/6829 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/6450 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/9289 "Passed tests") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/6571 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/6926 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/5675 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/7128 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/6296 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/1666 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/10488 "Built successfully") | | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/24/builds/7328 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/822 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/6678 "Built successfully") | | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/3/builds/1806 "Passed tests") | 
<!--EWS-Status-Bubble-End-->