### PR TITLE
[WebGL] Abstract querying of drawing buffer texture target

### DIFF
--- a/Source/WebCore/Modules/webxr/WebXROpaqueFramebuffer.cpp
+++ b/Source/WebCore/Modules/webxr/WebXROpaqueFramebuffer.cpp
@@ -100,8 +100,7 @@ void WebXROpaqueFramebuffer::startFrame(const PlatformXR::Device::FrameData::Lay
     auto bufferHeight = static_cast<uint32_t>(size.height());
 
     auto gCGL = static_cast<GraphicsContextGLCocoa*>(m_context.graphicsContextGL());
-    GCGLenum textureTarget = gCGL->drawingBufferTextureTarget();
-    GCGLenum textureTargetBinding = gCGL->drawingBufferTextureTargetQueryForDrawingTarget(textureTarget);
+    auto [textureTarget, textureTargetBinding] = gl.externalImageTextureBindingPoint();
 #else
     GCGLenum textureTarget = GL::TEXTURE_2D;
     GCGLenum textureTargetBinding = GL::TEXTURE_BINDING_2D;

--- a/Source/WebCore/platform/graphics/GraphicsContextGL.cpp
+++ b/Source/WebCore/platform/graphics/GraphicsContextGL.cpp
@@ -359,6 +359,11 @@ GraphicsContextGL::GraphicsContextGL(GraphicsContextGLAttributes attrs)
 
 GraphicsContextGL::~GraphicsContextGL() = default;
 
+std::tuple<GCGLenum, GCGLenum> GraphicsContextGL::externalImageTextureBindingPoint()
+{
+    return std::make_tuple(GraphicsContextGL::TEXTURE_2D, GraphicsContextGL::TEXTURE_BINDING_2D);
+}
+
 bool GraphicsContextGL::computeFormatAndTypeParameters(GCGLenum format, GCGLenum type, unsigned* componentsPerPixel, unsigned* bytesPerComponent)
 {
     switch (format) {

--- a/Source/WebCore/platform/graphics/GraphicsContextGL.h
+++ b/Source/WebCore/platform/graphics/GraphicsContextGL.h
@@ -1537,6 +1537,8 @@ public:
     GraphicsContextGLAttributes contextAttributes() const { return m_attrs; }
     void setContextAttributes(const GraphicsContextGLAttributes& attrs) { m_attrs = attrs; }
 
+    virtual std::tuple<GCGLenum, GCGLenum> externalImageTextureBindingPoint();
+
     virtual void reshape(int width, int height) = 0;
 
     virtual void setContextVisibility(bool) = 0;

--- a/Source/WebCore/platform/graphics/angle/GraphicsContextGLANGLE.cpp
+++ b/Source/WebCore/platform/graphics/angle/GraphicsContextGLANGLE.cpp
@@ -114,34 +114,13 @@ bool GraphicsContextGLANGLE::platformInitialize()
 
 GCGLenum GraphicsContextGLANGLE::drawingBufferTextureTarget()
 {
-#if !PLATFORM(COCOA)
-    m_drawingBufferTextureTarget = EGL_TEXTURE_2D;
-#else
-    if (m_drawingBufferTextureTarget == -1)
-        EGL_GetConfigAttrib(platformDisplay(), platformConfig(), EGL_BIND_TO_TEXTURE_TARGET_ANGLE, &m_drawingBufferTextureTarget);
-#endif
-
-    switch (m_drawingBufferTextureTarget) {
-    case EGL_TEXTURE_2D:
-        return TEXTURE_2D;
-    case EGL_TEXTURE_RECTANGLE_ANGLE:
-        return TEXTURE_RECTANGLE_ARB;
-
-    }
-    ASSERT_WITH_MESSAGE(false, "Invalid enum returned from EGL_GetConfigAttrib");
-    return 0;
+    auto [textureTarget, _] = externalImageTextureBindingPoint();
+    return textureTarget;
 }
 
-GCGLenum GraphicsContextGLANGLE::drawingBufferTextureTargetQueryForDrawingTarget(GCGLenum drawingTarget)
+std::tuple<GCGLenum, GCGLenum> GraphicsContextGLANGLE::drawingBufferTextureBindingPoint()
 {
-    switch (drawingTarget) {
-    case TEXTURE_2D:
-        return TEXTURE_BINDING_2D;
-    case TEXTURE_RECTANGLE_ARB:
-        return TEXTURE_BINDING_RECTANGLE_ARB;
-    }
-    ASSERT_WITH_MESSAGE(false, "Invalid drawing target");
-    return -1;
+    return externalImageTextureBindingPoint();
 }
 
 GCGLint GraphicsContextGLANGLE::EGLDrawingBufferTextureTargetForDrawingTarget(GCGLenum drawingTarget)

--- a/Source/WebCore/platform/graphics/angle/GraphicsContextGLANGLE.h
+++ b/Source/WebCore/platform/graphics/angle/GraphicsContextGLANGLE.h
@@ -44,8 +44,9 @@ public:
     GCGLDisplay platformDisplay() const;
     GCGLConfig platformConfig() const;
     GCGLenum drawingBufferTextureTarget();
-    static GCGLenum drawingBufferTextureTargetQueryForDrawingTarget(GCGLenum drawingTarget);
+    std::tuple<GCGLenum, GCGLenum> drawingBufferTextureBindingPoint();
     static GCGLint EGLDrawingBufferTextureTargetForDrawingTarget(GCGLenum drawingTarget);
+
     enum class ReleaseThreadResourceBehavior {
         // Releases current context after GraphicsContextGLANGLE calls done in the thread.
         ReleaseCurrentContext,

--- a/Source/WebCore/platform/graphics/cocoa/GraphicsContextGLCocoa.h
+++ b/Source/WebCore/platform/graphics/cocoa/GraphicsContextGLCocoa.h
@@ -60,6 +60,8 @@ public:
     ~GraphicsContextGLCocoa();
     IOSurface* displayBufferSurface();
 
+    std::tuple<GCGLenum, GCGLenum> externalImageTextureBindingPoint() final;
+
     enum class PbufferAttachmentUsage { Read, Write, ReadWrite };
     // Returns a handle which, if non-null, must be released via the
     // detach call below.

--- a/Source/WebCore/platform/graphics/gbm/GraphicsContextGLFallback.cpp
+++ b/Source/WebCore/platform/graphics/gbm/GraphicsContextGLFallback.cpp
@@ -258,9 +258,9 @@ bool GraphicsContextGLFallback::reshapeDrawingBuffer()
     const int width = size.width();
     const int height = size.height();
     GLuint colorFormat = attrs.alpha ? GL_RGBA : GL_RGB;
-    GLenum textureTarget = drawingBufferTextureTarget();
+    auto [textureTarget, textureBinding] =drawingBufferTextureBindingPoint();
     GLuint internalColorFormat = textureTarget == GL_TEXTURE_2D ? colorFormat : m_internalColorFormat;
-    ScopedRestoreTextureBinding restoreBinding(drawingBufferTextureTargetQueryForDrawingTarget(textureTarget), textureTarget, textureTarget != TEXTURE_RECTANGLE_ARB);
+    ScopedRestoreTextureBinding restoreBinding(textureBinding, textureTarget, textureTarget != TEXTURE_RECTANGLE_ARB);
 
     GL_BindTexture(textureTarget, m_texture);
     GL_TexImage2D(textureTarget, 0, internalColorFormat, width, height, 0, colorFormat, GL_UNSIGNED_BYTE, 0);

--- a/Source/WebCore/platform/graphics/gbm/GraphicsContextGLGBM.cpp
+++ b/Source/WebCore/platform/graphics/gbm/GraphicsContextGLGBM.cpp
@@ -295,8 +295,8 @@ bool GraphicsContextGLGBM::reshapeDrawingBuffer()
     allocateDrawBufferObject();
 
     {
-        GLenum textureTarget = drawingBufferTextureTarget();
-        ScopedRestoreTextureBinding restoreBinding(drawingBufferTextureTargetQueryForDrawingTarget(textureTarget), textureTarget, textureTarget != TEXTURE_RECTANGLE_ARB);
+        auto [textureTarget, textureBinding] =drawingBufferTextureBindingPoint();
+        ScopedRestoreTextureBinding restoreBinding(textureBinding, textureTarget, textureTarget != TEXTURE_RECTANGLE_ARB);
 
         GL_BindTexture(textureTarget, m_texture);
         GL_FramebufferTexture2D(GL_FRAMEBUFFER, GL_COLOR_ATTACHMENT0, textureTarget, m_texture, 0);
@@ -319,8 +319,8 @@ void GraphicsContextGLGBM::allocateDrawBufferObject()
             .flags = GBMBufferSwapchain::BufferDescription::NoFlags,
         });
 
-    GLenum textureTarget = drawingBufferTextureTarget();
-    ScopedRestoreTextureBinding restoreBinding(drawingBufferTextureTargetQueryForDrawingTarget(textureTarget), textureTarget, textureTarget != TEXTURE_RECTANGLE_ARB);
+    auto [textureTarget, textureBinding] =drawingBufferTextureBindingPoint();
+    ScopedRestoreTextureBinding restoreBinding(textureBinding, textureTarget, textureTarget != TEXTURE_RECTANGLE_ARB);
 
     auto result = m_swapchain.images.ensure(m_swapchain.drawBO->handle(),
         [&] {

--- a/Source/WebCore/platform/graphics/texmap/GraphicsContextGLTextureMapperANGLE.cpp
+++ b/Source/WebCore/platform/graphics/texmap/GraphicsContextGLTextureMapperANGLE.cpp
@@ -355,9 +355,9 @@ bool GraphicsContextGLTextureMapperANGLE::reshapeDrawingBuffer()
     const int width = size.width();
     const int height = size.height();
     GLuint colorFormat = attrs.alpha ? GL_RGBA : GL_RGB;
-    GLenum textureTarget = drawingBufferTextureTarget();
+    auto [textureTarget, textureBinding] =drawingBufferTextureBindingPoint();
     GLuint internalColorFormat = textureTarget == GL_TEXTURE_2D ? colorFormat : m_internalColorFormat;
-    ScopedRestoreTextureBinding restoreBinding(drawingBufferTextureTargetQueryForDrawingTarget(textureTarget), textureTarget, textureTarget != TEXTURE_RECTANGLE_ARB);
+    ScopedRestoreTextureBinding restoreBinding(textureBinding, textureTarget, textureTarget != TEXTURE_RECTANGLE_ARB);
 
     GL_BindTexture(textureTarget, m_compositorTexture);
     GL_TexImage2D(textureTarget, 0, internalColorFormat, width, height, 0, colorFormat, GL_UNSIGNED_BYTE, 0);

--- a/Source/WebKit/GPUProcess/graphics/RemoteGraphicsContextGLInitializationState.h
+++ b/Source/WebKit/GPUProcess/graphics/RemoteGraphicsContextGLInitializationState.h
@@ -1,0 +1,72 @@
+/*
+ * Copyright (C) 2023 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#if ENABLE(WEBGL)
+
+#include <WebCore/GraphicsTypesGL.h>
+#include <wtf/text/WTFString.h>
+
+namespace WebKit {
+
+class RemoteGraphicsContextGLInitializationState {
+public:
+    String availableExtensions = emptyString();
+    String requestableExtensions = emptyString();
+    GCGLenum externalImageTarget = 0;
+    GCGLenum externalImageBindingQuery = 0;
+
+    template<class Encoder> void encode(Encoder&) const;
+    template<class Decoder> static std::optional<RemoteGraphicsContextGLInitializationState> decode(Decoder&);
+};
+
+template<class Encoder>
+void RemoteGraphicsContextGLInitializationState::encode(Encoder& encoder) const
+{
+    encoder << availableExtensions;
+    encoder << requestableExtensions;
+    encoder << externalImageTarget;
+    encoder << externalImageBindingQuery;
+}
+
+template<class Decoder>
+std::optional<RemoteGraphicsContextGLInitializationState> RemoteGraphicsContextGLInitializationState::decode(Decoder& decoder)
+{
+    RemoteGraphicsContextGLInitializationState initializationState;
+    if (!decoder.decode(initializationState.availableExtensions))
+        return std::nullopt;
+    if (!decoder.decode(initializationState.requestableExtensions))
+        return std::nullopt;
+    if (!decoder.decode(initializationState.externalImageTarget))
+        return std::nullopt;
+    if (!decoder.decode(initializationState.externalImageBindingQuery))
+        return std::nullopt;
+    return initializationState;
+}
+
+} // namespace WebKit
+
+#endif

--- a/Source/WebKit/WebKit.xcodeproj/project.pbxproj
+++ b/Source/WebKit/WebKit.xcodeproj/project.pbxproj
@@ -4434,6 +4434,7 @@
 		3AB0C59229C8162200141B5E /* NetworkQuotaManager.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = NetworkQuotaManager.h; sourceTree = "<group>"; };
 		3AC4C04529D35D1500402716 /* WebSWRegistrationStore.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = WebSWRegistrationStore.h; sourceTree = "<group>"; };
 		3AC4C04629D35D1B00402716 /* ServiceWorker */ = {isa = PBXFileReference; lastKnownFileType = folder; path = ServiceWorker; sourceTree = "<group>"; };
+		3AC6E5242A1C59AE0059F092 /* RemoteGraphicsContextGLInitializationState.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = RemoteGraphicsContextGLInitializationState.h; sourceTree = "<group>"; };
 		3AE104BD29CBC8BA00661165 /* OriginQuotaManager.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = OriginQuotaManager.cpp; sourceTree = "<group>"; };
 		3AE104BE29CBC8BB00661165 /* OriginQuotaManager.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = OriginQuotaManager.h; sourceTree = "<group>"; };
 		3CAECB5E27465AE300AB78D0 /* UnifiedSource113.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = UnifiedSource113.cpp; sourceTree = "<group>"; };
@@ -10954,6 +10955,7 @@
 				7B904168254AFEA7006EEB8C /* RemoteGraphicsContextGL.messages.in */,
 				7BE72668257680EF00E85D98 /* RemoteGraphicsContextGLCocoa.cpp */,
 				7B90416D2550108C006EEB8C /* RemoteGraphicsContextGLFunctionsGenerated.h */,
+				3AC6E5242A1C59AE0059F092 /* RemoteGraphicsContextGLInitializationState.h */,
 				72440D33287CCC0500FADBC4 /* RemoteImageBuffer.cpp */,
 				55AD09422408A02E00DE4D2F /* RemoteImageBuffer.h */,
 				72A87BBB287678A700289098 /* RemoteRenderingBackend.cpp */,

--- a/Source/WebKit/WebProcess/GPU/graphics/RemoteGraphicsContextGLProxy.cpp
+++ b/Source/WebKit/WebProcess/GPU/graphics/RemoteGraphicsContextGLProxy.cpp
@@ -30,6 +30,7 @@
 
 #include "GPUConnectionToWebProcess.h"
 #include "GPUProcessConnection.h"
+#include "RemoteGraphicsContextGLInitializationState.h"
 #include "RemoteGraphicsContextGLMessages.h"
 #include "RemoteGraphicsContextGLProxyMessages.h"
 #include "RemoteRenderingBackendProxy.h"
@@ -170,12 +171,22 @@ bool RemoteGraphicsContextGLProxy::isExtensionEnabled(const String& name)
     return m_availableExtensions.contains(name) || m_enabledExtensions.contains(name);
 }
 
-void RemoteGraphicsContextGLProxy::initialize(const String& availableExtensions, const String& requestableExtensions)
+void RemoteGraphicsContextGLProxy::initialize(const RemoteGraphicsContextGLInitializationState& initializationState)
 {
-    for (auto extension : StringView(availableExtensions).split(' '))
+    for (auto extension : StringView(initializationState.availableExtensions).split(' '))
         m_availableExtensions.add(extension.toString());
-    for (auto extension : StringView(requestableExtensions).split(' '))
+    for (auto extension : StringView(initializationState.requestableExtensions).split(' '))
         m_requestableExtensions.add(extension.toString());
+    m_externalImageTarget = initializationState.externalImageTarget;
+    m_externalImageBindingQuery = initializationState.externalImageBindingQuery;
+}
+
+std::tuple<GCGLenum, GCGLenum> RemoteGraphicsContextGLProxy::externalImageTextureBindingPoint()
+{
+    if (isContextLost())
+        return std::make_tuple(0, 0);
+
+    return std::make_tuple(m_externalImageTarget, m_externalImageBindingQuery);
 }
 
 void RemoteGraphicsContextGLProxy::reshape(int width, int height)
@@ -422,7 +433,7 @@ void RemoteGraphicsContextGLProxy::multiDrawElementsInstancedBaseVertexBaseInsta
     }
 }
 
-void RemoteGraphicsContextGLProxy::wasCreated(bool didSucceed, IPC::Semaphore&& wakeUpSemaphore, IPC::Semaphore&& clientWaitSemaphore, String&& availableExtensions, String&& requestedExtensions)
+void RemoteGraphicsContextGLProxy::wasCreated(bool didSucceed, IPC::Semaphore&& wakeUpSemaphore, IPC::Semaphore&& clientWaitSemaphore, RemoteGraphicsContextGLInitializationState&& initializationState)
 {
     if (isContextLost())
         return;
@@ -433,7 +444,7 @@ void RemoteGraphicsContextGLProxy::wasCreated(bool didSucceed, IPC::Semaphore&& 
     ASSERT(!m_didInitialize);
     m_streamConnection->setSemaphores(WTFMove(wakeUpSemaphore), WTFMove(clientWaitSemaphore));
     m_didInitialize = true;
-    initialize(availableExtensions, requestedExtensions);
+    initialize(initializationState);
 }
 
 void RemoteGraphicsContextGLProxy::wasLost()

--- a/Source/WebKit/WebProcess/GPU/graphics/RemoteGraphicsContextGLProxy.h
+++ b/Source/WebKit/WebProcess/GPU/graphics/RemoteGraphicsContextGLProxy.h
@@ -45,6 +45,7 @@
 
 namespace WebKit {
 
+class RemoteGraphicsContextGLInitializationState;
 #if ENABLE(VIDEO)
 class RemoteVideoFrameObjectHeapProxy;
 #endif
@@ -70,6 +71,7 @@ public:
     void didReceiveInvalidMessage(IPC::Connection&, IPC::MessageName) final { }
 
     // WebCore::GraphicsContextGL overrides.
+    std::tuple<GCGLenum, GCGLenum> externalImageTextureBindingPoint() final;
     void reshape(int width, int height) final;
     void setContextVisibility(bool) final;
     bool isGLES2Compliant() const final;
@@ -395,11 +397,11 @@ private:
 #endif
     void initializeIPC(IPC::StreamServerConnection::Handle&&, RemoteRenderingBackendProxy&);
     // Messages to be received.
-    void wasCreated(bool didSucceed, IPC::Semaphore&&, IPC::Semaphore&&, String&& availableExtensions, String&& requestedExtensions);
+    void wasCreated(bool, IPC::Semaphore&&, IPC::Semaphore&&, RemoteGraphicsContextGLInitializationState&&);
     void wasLost();
     void wasChanged();
 
-    void initialize(const String& availableExtensions, const String& requestableExtensions);
+    void initialize(const RemoteGraphicsContextGLInitializationState&);
     void waitUntilInitialized();
     void disconnectGpuProcessIfNeeded();
     void abandonGpuProcess();
@@ -418,6 +420,8 @@ private:
 #if ENABLE(VIDEO)
     Ref<RemoteVideoFrameObjectHeapProxy> m_videoFrameObjectHeapProxy;
 #endif
+    GCGLenum m_externalImageTarget;
+    GCGLenum m_externalImageBindingQuery;
 };
 
 // The GCGL types map to following WebKit IPC types. The list is used by generate-gpup-webgl script.

--- a/Source/WebKit/WebProcess/GPU/graphics/RemoteGraphicsContextGLProxy.messages.in
+++ b/Source/WebKit/WebProcess/GPU/graphics/RemoteGraphicsContextGLProxy.messages.in
@@ -23,7 +23,7 @@
 #if ENABLE(GPU_PROCESS) && ENABLE(WEBGL)
 
 messages -> RemoteGraphicsContextGLProxy NotRefCounted {
-    void WasCreated(bool didSucceed, IPC::Semaphore streamWakeUpSemaphore, IPC::Semaphore streamClientWaitSemaphore, String availableExtensions, String requestableExtensions)
+    void WasCreated(bool didSucceed, IPC::Semaphore streamWakeUpSemaphore, IPC::Semaphore streamClientWaitSemaphore, WebKit::RemoteGraphicsContextGLInitializationState initializationState)
     void WasLost()
     void WasChanged()
 }


### PR DESCRIPTION
#### 286ba705946be626f41d95de11bf3dd9a61fc291
<pre>
[WebGL] Abstract querying of drawing buffer texture target
<a href="https://bugs.webkit.org/show_bug.cgi?id=256944">https://bugs.webkit.org/show_bug.cgi?id=256944</a>
rdar://problem/109495048

Reviewed by NOBODY (OOPS!).

Move the interface for querying external image texture target and binding point
to GraphicsContextGL so that it can be implemented by
RemoteGraphicsContextGLProxy. Since the texture target and binding point don&apos;t
change, instead of adding a new remote message the remote proxy stores cached
versions sent on creation of the RemoteGraphicsContextGL.

Support work for WebXR with GPUP.

* Source/WebCore/Modules/webxr/WebXROpaqueFramebuffer.cpp:
(WebCore::WebXROpaqueFramebuffer::startFrame):
* Source/WebCore/platform/graphics/GraphicsContextGL.cpp:
(WebCore::GraphicsContextGL::externalImageTextureBindingPoint):
* Source/WebCore/platform/graphics/GraphicsContextGL.h:
* Source/WebCore/platform/graphics/angle/GraphicsContextGLANGLE.cpp:
(WebCore::GraphicsContextGLANGLE::drawingBufferTextureTarget):
(WebCore::GraphicsContextGLANGLE::drawingBufferTextureBindingPoint):
(WebCore::GraphicsContextGLANGLE::drawingBufferTextureTargetQueryForDrawingTarget): Deleted.
* Source/WebCore/platform/graphics/angle/GraphicsContextGLANGLE.h:
* Source/WebCore/platform/graphics/cocoa/GraphicsContextGLCocoa.h:
* Source/WebCore/platform/graphics/cocoa/GraphicsContextGLCocoa.mm:
(WebCore::GraphicsContextGLCocoa::externalImageTextureBindingPoint):
(WebCore::GraphicsContextGLCocoa::bindNextDrawingBuffer):
(WebCore::GraphicsContextGLCocoa::readCompositedResults):
* Source/WebCore/platform/graphics/gbm/GraphicsContextGLFallback.cpp:
(WebCore::GraphicsContextGLFallback::reshapeDrawingBuffer):
* Source/WebCore/platform/graphics/gbm/GraphicsContextGLGBM.cpp:
(WebCore::GraphicsContextGLGBM::reshapeDrawingBuffer):
(WebCore::GraphicsContextGLGBM::allocateDrawBufferObject):
* Source/WebCore/platform/graphics/texmap/GraphicsContextGLTextureMapperANGLE.cpp:
(WebCore::GraphicsContextGLTextureMapperANGLE::reshapeDrawingBuffer):
* Source/WebKit/GPUProcess/graphics/RemoteGraphicsContextGL.cpp:
(WebKit::RemoteGraphicsContextGL::workQueueInitialize):
* Source/WebKit/GPUProcess/graphics/RemoteGraphicsContextGLInitializationState.h: Added.
(WebKit::RemoteGraphicsContextGLInitializationState::encode const):
(WebKit::RemoteGraphicsContextGLInitializationState::decode):
* Source/WebKit/WebKit.xcodeproj/project.pbxproj:
* Source/WebKit/WebProcess/GPU/graphics/RemoteGraphicsContextGLProxy.cpp:
(WebKit::RemoteGraphicsContextGLProxy::initialize):
(WebKit::RemoteGraphicsContextGLProxy::externalImageTextureBindingPoint):
(WebKit::RemoteGraphicsContextGLProxy::wasCreated):
* Source/WebKit/WebProcess/GPU/graphics/RemoteGraphicsContextGLProxy.h:
* Source/WebKit/WebProcess/GPU/graphics/RemoteGraphicsContextGLProxy.messages.in:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/286ba705946be626f41d95de11bf3dd9a61fc291

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/7520 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/7787 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/7970 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/9159 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/7713 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/7531 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/9876 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/7712 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/10591 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/7651 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/8885 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/6954 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/9266 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/6193 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/6845 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/14556 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/7357 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/6966 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/10294 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/7456 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/6094 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/6797 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/11005 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/7190 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->