### PR TITLE
[Perf dashboard] bundle-v3-scripts.py is broken with python3

### DIFF
--- a/Websites/perf.webkit.org/public/v3/models/manifest.js
+++ b/Websites/perf.webkit.org/public/v3/models/manifest.js
@@ -36,7 +36,7 @@ class Manifest {
             return await RemoteAPI.getJSON('/data/manifest.json');
         } catch(error) {
             if (error != 404)
-                throw `Failed to fetch manifest.json with ${error}`
+                throw `Failed to fetch manifest.json with ${error}`;
             return await RemoteAPI.getJSON('/api/manifest/');
         }
     }

--- a/Websites/perf.webkit.org/tools/bundle-v3-scripts.py
+++ b/Websites/perf.webkit.org/tools/bundle-v3-scripts.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/python3
 # Copyright (C) 2013, 2015, 2016 Apple Inc. All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
@@ -51,15 +51,15 @@ def main(argv):
 
                 bundled_script += script_content
 
-    jsmin = subprocess.Popen(['python', os.path.join(tools_dir, 'jsmin.py')], stdin=subprocess.PIPE, stdout=subprocess.PIPE)
-    minified_script = jsmin.communicate(input=bundled_script)[0]
+    jsmin = subprocess.Popen(['python3', os.path.join(tools_dir, 'jsmin.py')], stdin=subprocess.PIPE, stdout=subprocess.PIPE)
+    minified_script = jsmin.communicate(input=bundled_script.encode())[0]
 
     new_size = float(len(minified_script))
     old_size = float(len(bundled_script))
-    print '%d -> %d (%.1f%%)' % (old_size, new_size, new_size / old_size * 100)
+    print('%d -> %d (%.1f%%)' % (old_size, new_size, new_size / old_size * 100))
 
     with open(os.path.join(public_v3_dir, 'bundled-scripts.js'), 'w') as bundled_file:
-        bundled_file.write(minified_script)
+        bundled_file.write(minified_script.decode())
 
 
 def compress_template(match):


### PR DESCRIPTION
#### 4e9ad0c5934d603812e337239664c066b9852641
<pre>
[Perf dashboard] bundle-v3-scripts.py is broken with python3
<a href="https://bugs.webkit.org/show_bug.cgi?id=256946">https://bugs.webkit.org/show_bug.cgi?id=256946</a>

Reviewed by Dewei Zhu.

Updated the script to make it work under Python3.

* Websites/perf.webkit.org/public/v3/models/manifest.js:
(Manifest.async fetchRawResponse): Added a missing semicolon without which
the bundled script would fail to parse.
* Websites/perf.webkit.org/tools/bundle-v3-scripts.py:
(main):

Canonical link: <a href="https://commits.webkit.org/264192@main">https://commits.webkit.org/264192@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f091a21922586080e6ea9417d075d0b3d73237eb

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/6976 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/7211 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/7394 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/8583 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/7210 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/6982 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/8475 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/7149 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/10118 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/7099 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/7770 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/6428 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/8685 "Built successfully") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/39/builds/5146 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/6340 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/14116 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/6821 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/6432 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/9259 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/6907 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/5660 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/6280 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/10467 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/811 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/6662 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->