### PR TITLE
Begin implementing parent frames navigating RemoteFrames

### DIFF
--- a/Source/WebCore/loader/FrameLoadRequest.h
+++ b/Source/WebCore/loader/FrameLoadRequest.h
@@ -51,7 +51,7 @@ public:
 
     bool isEmpty() const { return m_resourceRequest.isEmpty(); }
 
-    Document& requester();
+    WEBCORE_EXPORT Document& requester();
     const SecurityOrigin& requesterSecurityOrigin() const;
 
     ResourceRequest& resourceRequest() { return m_resourceRequest; }

--- a/Source/WebCore/page/Frame.h
+++ b/Source/WebCore/page/Frame.h
@@ -37,6 +37,7 @@ namespace WebCore {
 
 class DOMWindow;
 class FrameView;
+class FrameLoadRequest;
 class HTMLFrameOwnerElement;
 class NavigationScheduler;
 class Page;
@@ -70,6 +71,7 @@ public:
 
     virtual void frameDetached() = 0;
     virtual bool preventsParentFromBeingComplete() const = 0;
+    virtual void changeLocation(FrameLoadRequest&&) = 0;
 
 protected:
     Frame(Page&, FrameIdentifier, FrameType, HTMLFrameOwnerElement*, Frame* parent);

--- a/Source/WebCore/page/LocalFrame.cpp
+++ b/Source/WebCore/page/LocalFrame.cpp
@@ -323,6 +323,11 @@ bool LocalFrame::preventsParentFromBeingComplete() const
     return !m_loader->isComplete() && (!ownerElement() || !ownerElement()->isLazyLoadObserverActive());
 }
 
+void LocalFrame::changeLocation(FrameLoadRequest&& request)
+{
+    loader().changeLocation(WTFMove(request));
+}
+
 void LocalFrame::invalidateContentEventRegionsIfNeeded(InvalidateContentEventRegionsReason reason)
 {
     if (!page() || !m_doc || !m_doc->renderView())

--- a/Source/WebCore/page/LocalFrame.h
+++ b/Source/WebCore/page/LocalFrame.h
@@ -294,6 +294,7 @@ private:
 
     void frameDetached() final;
     bool preventsParentFromBeingComplete() const final;
+    void changeLocation(FrameLoadRequest&&) final;
 
     FrameView* virtualView() const final;
     DOMWindow* virtualWindow() const final;

--- a/Source/WebCore/page/RemoteFrame.cpp
+++ b/Source/WebCore/page/RemoteFrame.cpp
@@ -85,6 +85,11 @@ bool RemoteFrame::preventsParentFromBeingComplete() const
     return m_preventsParentFromBeingComplete;
 }
 
+void RemoteFrame::changeLocation(FrameLoadRequest&& request)
+{
+    m_client->changeLocation(WTFMove(request));
+}
+
 FrameView* RemoteFrame::virtualView() const
 {
     return m_view.get();

--- a/Source/WebCore/page/RemoteFrame.h
+++ b/Source/WebCore/page/RemoteFrame.h
@@ -67,6 +67,7 @@ private:
 
     void frameDetached() final;
     bool preventsParentFromBeingComplete() const final;
+    void changeLocation(FrameLoadRequest&&) final;
 
     FrameView* virtualView() const final;
     DOMWindow* virtualWindow() const final;

--- a/Source/WebCore/page/RemoteFrameClient.h
+++ b/Source/WebCore/page/RemoteFrameClient.h
@@ -39,6 +39,7 @@ public:
     virtual void frameDetached() = 0;
     virtual void sizeDidChange(IntSize) = 0;
     virtual void postMessageToRemote(ProcessIdentifier, FrameIdentifier, std::optional<SecurityOriginData>, const MessageWithMessagePorts&) = 0;
+    virtual void changeLocation(WebCore::FrameLoadRequest&&) = 0;
     virtual ~RemoteFrameClient() { }
 };
 

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebRemoteFrameClient.cpp
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebRemoteFrameClient.cpp
@@ -29,8 +29,9 @@
 #include "MessageSenderInlines.h"
 #include "WebProcess.h"
 #include "WebProcessProxyMessages.h"
-
+#include <WebCore/FrameLoadRequest.h>
 #include <WebCore/FrameTree.h>
+#include <WebCore/PolicyChecker.h>
 #include <WebCore/RemoteFrame.h>
 
 namespace WebKit {
@@ -66,6 +67,22 @@ void WebRemoteFrameClient::sizeDidChange(WebCore::IntSize size)
 void WebRemoteFrameClient::postMessageToRemote(WebCore::ProcessIdentifier processIdentifier, WebCore::FrameIdentifier identifier, std::optional<WebCore::SecurityOriginData> target, const WebCore::MessageWithMessagePorts& message)
 {
     WebProcess::singleton().send(Messages::WebProcessProxy::PostMessageToRemote(processIdentifier, identifier, target, message), 0);
+}
+
+void WebRemoteFrameClient::changeLocation(WebCore::FrameLoadRequest&& request)
+{
+    // FIXME: FrameLoadRequest and NavigationAction can probably be refactored to share more.
+    WebCore::NavigationAction action(request.requester(), request.resourceRequest(), request.initiatedByMainFrame());
+    // FIXME: action.request and request are probably duplicate information.
+    // FIXME: PolicyCheckIdentifier should probably be pushed to another layer.
+    // FIXME: Get more parameters correct and add tests for each one.
+    dispatchDecidePolicyForNavigationAction(action, action.resourceRequest(), WebCore::ResourceResponse(), nullptr, WebCore::PolicyDecisionMode::Asynchronous, WebCore::PolicyCheckIdentifier::generate(), [protectedFrame = Ref { m_frame }, request = WTFMove(request)] (PolicyAction policyAction, PolicyCheckIdentifier responseIdentifier) mutable {
+        // FIXME: Check responseIdentifier.
+        if (policyAction != PolicyAction::Use)
+            return;
+        protectedFrame->transitionToLocal();
+        protectedFrame->coreAbstractFrame()->changeLocation(WTFMove(request));
+    });
 }
 
 }

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebRemoteFrameClient.h
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebRemoteFrameClient.h
@@ -46,6 +46,7 @@ private:
     void frameDetached() final;
     void sizeDidChange(WebCore::IntSize) final;
     void postMessageToRemote(WebCore::ProcessIdentifier, WebCore::FrameIdentifier, std::optional<WebCore::SecurityOriginData>, const WebCore::MessageWithMessagePorts&) final;
+    void changeLocation(WebCore::FrameLoadRequest&&) final;
 
     ScopeExit<Function<void()>> m_frameInvalidator;
 };

--- a/Source/WebKit/WebProcess/WebPage/WebFrame.cpp
+++ b/Source/WebKit/WebProcess/WebPage/WebFrame.cpp
@@ -389,7 +389,7 @@ void WebFrame::didCommitLoadInAnotherProcess(WebCore::LayerHostingContextIdentif
     ownerElement->scheduleInvalidateStyleAndLayerComposition();
 }
 
-void WebFrame::transitionToLocal(WebCore::LayerHostingContextIdentifier layerHostingContextIdentifier)
+void WebFrame::transitionToLocal(std::optional<WebCore::LayerHostingContextIdentifier> layerHostingContextIdentifier)
 {
     RefPtr remoteFrame = coreRemoteFrame();
     if (!remoteFrame) {
@@ -417,7 +417,8 @@ void WebFrame::transitionToLocal(WebCore::LayerHostingContextIdentifier layerHos
     m_coreFrame = localFrame.ptr();
     localFrame->init();
 
-    setLayerHostingContextIdentifier(layerHostingContextIdentifier);
+    if (layerHostingContextIdentifier)
+        setLayerHostingContextIdentifier(*layerHostingContextIdentifier);
     if (localFrame->isRootFrame())
         corePage->addRootFrame(localFrame.get());
 

--- a/Source/WebKit/WebProcess/WebPage/WebFrame.h
+++ b/Source/WebKit/WebProcess/WebPage/WebFrame.h
@@ -95,7 +95,7 @@ public:
     WebCore::RemoteFrame* coreRemoteFrame() const;
     WebCore::Frame* coreAbstractFrame() const;
 
-    void transitionToLocal(WebCore::LayerHostingContextIdentifier);
+    void transitionToLocal(std::optional<WebCore::LayerHostingContextIdentifier> = std::nullopt);
 
     FrameInfoData info() const;
     FrameTreeNodeData frameTreeData() const;


### PR DESCRIPTION
#### 7c15d1c8d8906a1951d3d3d313dd5e1d757dcc48
<pre>
Begin implementing parent frames navigating RemoteFrames
<a href="https://bugs.webkit.org/show_bug.cgi?id=256949">https://bugs.webkit.org/show_bug.cgi?id=256949</a>
rdar://109497339

Reviewed by Chris Dumez.

The interesting part of this is in WebRemoteFrameClient::changeLocation,
where we call dispatchDecidePolicyForNavigationAction which I&apos;ve made able
to handle a RemoteFrame, and if the result is PolicyAction::Use then we
call transitionToLocal then changeLocation which begins the provisional
load in this process.  A lot of things aren&apos;t quite hooked up completely
yet, but the progress is testable.

* Source/WebCore/loader/FrameLoadRequest.h:
* Source/WebCore/loader/NavigationScheduler.cpp:
(WebCore::ScheduledNavigation::shouldStartTimer):
(WebCore::ScheduledNavigation::didStartTimer):
(WebCore::ScheduledNavigation::didStopTimer):
(WebCore::NavigationScheduler::timerFired):
(WebCore::NavigationScheduler::startTimer):
(WebCore::NavigationScheduler::cancel):
* Source/WebCore/page/Frame.h:
* Source/WebCore/page/LocalFrame.cpp:
(WebCore::LocalFrame::changeLocation):
* Source/WebCore/page/LocalFrame.h:
* Source/WebCore/page/RemoteFrame.cpp:
(WebCore::RemoteFrame::changeLocation):
* Source/WebCore/page/RemoteFrame.h:
* Source/WebCore/page/RemoteFrameClient.h:
* Source/WebKit/WebProcess/WebCoreSupport/WebFrameLoaderClient.cpp:
(WebKit::WebFrameLoaderClient::dispatchDecidePolicyForNavigationAction):
* Source/WebKit/WebProcess/WebCoreSupport/WebRemoteFrameClient.cpp:
(WebKit::WebRemoteFrameClient::changeLocation):
* Source/WebKit/WebProcess/WebCoreSupport/WebRemoteFrameClient.h:
* Source/WebKit/WebProcess/WebPage/WebFrame.cpp:
(WebKit::WebFrame::transitionToLocal):
* Source/WebKit/WebProcess/WebPage/WebFrame.h:
* Tools/TestWebKitAPI/Tests/WebKitCocoa/SiteIsolation.mm:
(TestWebKitAPI::TEST):

Canonical link: <a href="https://commits.webkit.org/264204@main">https://commits.webkit.org/264204@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/51e16c85c82a2773ee9995794d4ee3f34edbc1f2

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/6979 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/7215 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/7398 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/8587 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/7213 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/6986 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/8478 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/7153 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/10120 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/7103 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/7772 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/6430 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/8689 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/5147 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/6341 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/14119 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/6822 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/6433 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/9266 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/6911 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/5662 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/6283 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/10471 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/817 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/6665 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->