### PR TITLE
Fix that CSSSelectorParser::consumeName doesn't work properly for '|'.

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-conditional/js/CSS-supports-L4-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-conditional/js/CSS-supports-L4-expected.txt
@@ -4,7 +4,7 @@ PASS selector() function doesn't accept a selector list
 PASS selector() function rejects unknown webkit pseudo-elements.
 PASS selector() function accepts known pseudo-elements
 PASS selector() with simple combinators
-FAIL selector() with unknown combinators assert_equals: expected false but got true
+PASS selector() with unknown combinators
 PASS selector() with forgiving :is, 1 arg
 PASS selector() with forgiving :is, multiple args
 PASS selector() with forgiving :where, 1 arg


### PR DESCRIPTION
#### cef7548f63392ca20dc8eec8ba15de3abdc41559
<pre>
Fix that CSSSelectorParser::consumeName doesn&apos;t work properly for &apos;|&apos;.
<a href="https://bugs.webkit.org/show_bug.cgi?id=215635">https://bugs.webkit.org/show_bug.cgi?id=215635</a>

Reviewed by Antti Koivisto.

When css complex selector has an unknown combinator specified as delimiter &apos;|&apos;,
it was addressed as css namespace separator in
CSSSelectorParser::consumeName by consuming it in a wrong manner.

* LayoutTests/imported/w3c/web-platform-tests/css/css-conditional/js/CSS-supports-L4-expected.txt:
* Source/WebCore/css/parser/CSSSelectorParser.cpp:
(WebCore::CSSSelectorParser::supportsComplexSelector):
(WebCore::CSSSelectorParser::consumeName):

Canonical link: <a href="https://commits.webkit.org/264246@main">https://commits.webkit.org/264246@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/7ee07e65072226ba1a306a49634258d7360e12b0

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/6996 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/7236 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/7416 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/8608 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/7230 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/7004 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/8499 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/7171 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/10140 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/7121 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/7793 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/6453 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/8711 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/5161 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/6361 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/14142 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/6832 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/6455 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/9324 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/6931 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/5679 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/6300 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/1692 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/10493 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/6682 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->