### PR TITLE
css/css-fonts/animations/font-stretch-interpolation.html has failures

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-fonts/animations/font-stretch-interpolation-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-fonts/animations/font-stretch-interpolation-expected.txt
@@ -184,5 +184,5 @@ PASS Web Animations: property <font-stretch> from [normal] to [extra-expanded] a
 PASS Web Animations: property <font-stretch> from [normal] to [extra-expanded] at (0.25) should be [112.5%]
 PASS Web Animations: property <font-stretch> from [normal] to [extra-expanded] at (0.5) should be [125%]
 PASS Web Animations: property <font-stretch> from [normal] to [extra-expanded] at (1) should be [150%]
-FAIL An interpolation to inherit updates correctly on a parent style change. assert_equals: expected "75%" but got "150%"
+PASS An interpolation to inherit updates correctly on a parent style change.
 

--- a/Source/WebCore/animation/KeyframeEffect.cpp
+++ b/Source/WebCore/animation/KeyframeEffect.cpp
@@ -1895,21 +1895,8 @@ std::optional<KeyframeEffect::RecomputationReason> KeyframeEffect::recomputeKeyf
         return false;
     };
 
-    auto propertySetToInheritChanged = [&]() {
-        // In the rare case where a non-inherted property was set to "inherit" on a keyframe,
-        // we consider that a property set to "inherit" changed without trying to work out whether
-        // the computed value changed.
-        if (m_hasExplicitlyInheritedKeyframeProperty)
-            return true;
-
-        if (previousUnanimatedStyle) {
-            for (auto property : m_blendingKeyframes.propertiesSetToInherit()) {
-                ASSERT(m_target);
-                if (!CSSPropertyAnimation::propertiesEqual(property, *previousUnanimatedStyle, unanimatedStyle, m_target->document()))
-                    return true;
-            }
-        }
-        return false;
+    auto hasPropertyExplicitlySetToInherit = [&]() {
+        return !m_blendingKeyframes.propertiesSetToInherit().isEmpty();
     };
 
     auto propertySetToCurrentColorChanged = [&]() {
@@ -1943,7 +1930,7 @@ std::optional<KeyframeEffect::RecomputationReason> KeyframeEffect::recomputeKeyf
         return false;
     }();
 
-    if (logicalPropertyChanged || fontSizeChanged() || fontWeightChanged() || cssVariableChanged() || propertySetToInheritChanged() || propertySetToCurrentColorChanged()) {
+    if (logicalPropertyChanged || fontSizeChanged() || fontWeightChanged() || cssVariableChanged() || hasPropertyExplicitlySetToInherit() || propertySetToCurrentColorChanged()) {
         switch (m_animationType) {
         case WebAnimationType::CSSTransition:
             ASSERT_NOT_REACHED();


### PR DESCRIPTION
#### 819f40d37ebc8588a177fc02cada67c118e22c67
<pre>
css/css-fonts/animations/font-stretch-interpolation.html has failures
<a href="https://bugs.webkit.org/show_bug.cgi?id=235791">https://bugs.webkit.org/show_bug.cgi?id=235791</a>

Reviewed by Antti Koivisto.

Always recompute keyframes if any property is set to `inherit` in the animated style, and in the animated style only.
Indeed, `m_hasExplicitlyInheritedKeyframeProperty` is true also if a property is set to `inherit` on the element&apos;s style.

* LayoutTests/imported/w3c/web-platform-tests/css/css-fonts/animations/font-stretch-interpolation-expected.txt:
* Source/WebCore/animation/KeyframeEffect.cpp:
(WebCore::KeyframeEffect::recomputeKeyframesIfNecessary):

Canonical link: <a href="https://commits.webkit.org/264206@main">https://commits.webkit.org/264206@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/572748c4fc040e8fec462430af0f93d7d36c9f5a

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/6998 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/7238 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/7418 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/8610 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/7232 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/7006 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/8501 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/7173 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/10141 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/7123 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/7794 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/6456 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/8713 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/5162 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/6363 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/14138 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/6833 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/6457 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/9303 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/6933 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/5680 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/6302 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/10495 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/818 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/6684 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->