### PR TITLE
[GTK] The stutters are back

### DIFF
--- a/Source/WebKit/PlatformGTK.cmake
+++ b/Source/WebKit/PlatformGTK.cmake
@@ -59,6 +59,8 @@ list(APPEND WebKit_MESSAGES_IN_FILES
 if (USE_GBM)
     list(APPEND WebKit_MESSAGES_IN_FILES
         UIProcess/gtk/AcceleratedBackingStoreDMABuf
+
+        WebProcess/WebPage/gtk/AcceleratedSurfaceDMABuf
     )
 endif ()
 

--- a/Source/WebKit/UIProcess/gtk/AcceleratedBackingStoreDMABuf.h
+++ b/Source/WebKit/UIProcess/gtk/AcceleratedBackingStoreDMABuf.h
@@ -67,7 +67,8 @@ private:
 
     void configure(WTF::UnixFileDescriptor&&, WTF::UnixFileDescriptor&&, const WebCore::IntSize&, uint32_t format, uint32_t offset, uint32_t stride, uint64_t modifier);
     void configureSHM(ShareableBitmapHandle&&, ShareableBitmapHandle&&);
-    void frame(CompletionHandler<void()>&&);
+    void frame();
+    void frameDone();
     void ensureGLContext();
 
 #if USE(GTK4)

--- a/Source/WebKit/WebProcess/WebPage/gtk/AcceleratedSurfaceDMABuf.h
+++ b/Source/WebKit/WebProcess/WebPage/gtk/AcceleratedSurfaceDMABuf.h
@@ -28,8 +28,8 @@
 #include "AcceleratedSurface.h"
 
 #if USE(GBM)
+#include "MessageReceiver.h"
 #include <WebCore/PageIdentifier.h>
-#include <wtf/WeakPtr.h>
 #include <wtf/unix/UnixFileDescriptor.h>
 
 typedef void *EGLImage;
@@ -41,7 +41,7 @@ class ShareableBitmap;
 class ShareableBitmapHandle;
 class WebPage;
 
-class AcceleratedSurfaceDMABuf final : public AcceleratedSurface, public CanMakeWeakPtr<AcceleratedSurfaceDMABuf, WeakPtrFactoryInitialization::Eager> {
+class AcceleratedSurfaceDMABuf final : public AcceleratedSurface, public IPC::MessageReceiver {
 public:
     static std::unique_ptr<AcceleratedSurfaceDMABuf> create(WebPage&, Client&);
     ~AcceleratedSurfaceDMABuf();
@@ -64,6 +64,11 @@ public:
 
 private:
     AcceleratedSurfaceDMABuf(WebPage&, Client&);
+
+    // IPC::MessageReceiver.
+    void didReceiveMessage(IPC::Connection&, IPC::Decoder&) override;
+
+    void frameDone();
 
     class RenderTarget {
         WTF_MAKE_FAST_ALLOCATED;

--- a/Source/WebKit/WebProcess/WebPage/gtk/AcceleratedSurfaceDMABuf.messages.in
+++ b/Source/WebKit/WebProcess/WebPage/gtk/AcceleratedSurfaceDMABuf.messages.in
@@ -20,8 +20,6 @@
 # OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-messages -> AcceleratedBackingStoreDMABuf NotRefCounted {
-    Configure(UnixFileDescriptor backFD, UnixFileDescriptor frontFD, WebCore::IntSize size, uint32_t format, uint32_t offset, uint32_t stride, uint64_t modifier)
-    ConfigureSHM(WebKit::ShareableBitmap::Handle backBufferHandle, WebKit::ShareableBitmap::Handle frontBufferHandle)
-    Frame()
+messages -> AcceleratedSurfaceDMABuf NotRefCounted {
+    FrameDone()
 }


### PR DESCRIPTION
#### f8e938785f3cf4d8135f7d8082e632f5090efd43
<pre>
[GTK] The stutters are back
<a href="https://bugs.webkit.org/show_bug.cgi?id=256756">https://bugs.webkit.org/show_bug.cgi?id=256756</a>

Reviewed by Michael Catanzaro.

Use a explicit FrameDone message instead of using async reply for Frame
message. This allows to make AcceleratedSurfaceDMABuf a message receiver
and use the compositing run loop as receiver queue. This way we avoid
using the main thread to handle frame done notifications.

* Source/WebKit/PlatformGTK.cmake:
* Source/WebKit/UIProcess/gtk/AcceleratedBackingStoreDMABuf.cpp:
(WebKit::AcceleratedBackingStoreDMABuf::frame):
(WebKit::AcceleratedBackingStoreDMABuf::frameDone):
(WebKit::AcceleratedBackingStoreDMABuf::update):
(WebKit::AcceleratedBackingStoreDMABuf::snapshot):
(WebKit::AcceleratedBackingStoreDMABuf::paint):
* Source/WebKit/UIProcess/gtk/AcceleratedBackingStoreDMABuf.h:
* Source/WebKit/UIProcess/gtk/AcceleratedBackingStoreDMABuf.messages.in:
* Source/WebKit/WebProcess/WebPage/gtk/AcceleratedSurfaceDMABuf.cpp:
(WebKit::AcceleratedSurfaceDMABuf::didCreateGLContext):
(WebKit::AcceleratedSurfaceDMABuf::willDestroyGLContext):
(WebKit::AcceleratedSurfaceDMABuf::didRenderFrame):
(WebKit::AcceleratedSurfaceDMABuf::frameDone):
* Source/WebKit/WebProcess/WebPage/gtk/AcceleratedSurfaceDMABuf.h:
* Source/WebKit/WebProcess/WebPage/gtk/AcceleratedSurfaceDMABuf.messages.in: Copied from Source/WebKit/UIProcess/gtk/AcceleratedBackingStoreDMABuf.messages.in.

Canonical link: <a href="https://commits.webkit.org/264237@main">https://commits.webkit.org/264237@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/81b7b1a3efc361cfd4f12c3404efba1f5b2f1d75

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/6999 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/7239 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/7419 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/8611 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/7233 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/8502 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/7174 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/10143 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/7124 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/7795 "1 failures") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/6457 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/8714 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/5163 "Passed tests") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/14141 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/6834 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/6472 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/9307 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/6934 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/5682 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/6303 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/10496 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/828 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/6685 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->