### PR TITLE
BBQJIT should support gc and funcref opcodes

### DIFF
--- a/JSTests/wasm/gc/array_new_fixed.js
+++ b/JSTests/wasm/gc/array_new_fixed.js
@@ -612,6 +612,16 @@ function testMissingArgumentCount() {
     assert.throws(() => new WebAssembly.Instance(module("\x00\x61\x73\x6D\x01\x00\x00\x00\x01\x89\x80\x80\x80\x00\x02\x5E\x7D\x00\x60\x00\x01\x6B\x00\x03\x82\x80\x80\x80\x00\x01\x01\x07\x87\x80\x80\x80\x00\x01\x03\x6E\x65\x77\x00\x00\x0A\x91\x80\x80\x80\x00\x01\x8B\x80\x80\x80\x00\x00\x43\x00\x00\x80\x3F\xFB\x19\x00\x99\x99")), WebAssembly.CompileError, "WebAssembly.Module doesn't parse at byte 11: can't get argument count for array.new_fixed, in function at index 0");
 }
 
+function testTooManyOperands() {
+    let moduleString = `(module
+  (type $vec (array i32))
+
+  (func $new (export "new") (result (ref $vec))
+    (array.new_canon_fixed $vec 10001)
+  ))`;
+
+    assert.throws(() => compile(moduleString), WebAssembly.CompileError, "WebAssembly.Module doesn't validate: array_new_fixed can take at most 10000 operands. Got 10001, in function at index 0");
+}
 
 testArrayNewFixed();
 testArrayNewFixedNested();
@@ -632,3 +642,4 @@ testArrayFuncrefs();
 testArrayExternrefs();
 testArrayRefNull();
 testMissingArgumentCount();
+testTooManyOperands();

--- a/JSTests/wasm/gc/i31.js
+++ b/JSTests/wasm/gc/i31.js
@@ -148,6 +148,32 @@ function testI31Get() {
     assert.eq(m.exports.f(), 0x7fffffff);
   }
 
+  {
+    let m = instantiate(`
+      (module
+        (func (export "f") (param $arg i32) (result i32)
+          (i31.get_u (i31.new (local.get $arg))))
+      )
+    `);
+    assert.eq(m.exports.f(0x7fffffff), 0x7fffffff);
+    assert.eq(m.exports.f(0x2aaaaaaa), 0x2aaaaaaa);
+    assert.eq(m.exports.f(0x40000000), 0x40000000);
+    assert.eq(m.exports.f(42), 42);
+  }
+
+  {
+    let m = instantiate(`
+      (module
+        (func (export "f") (param $arg i32) (result i32)
+          (i31.get_s (i31.new (local.get $arg))))
+      )
+    `);
+    assert.eq(m.exports.f(0x7fffffff), -1);
+    assert.eq(m.exports.f(0x2aaaaaaa), 0x2aaaaaaa);
+    assert.eq(m.exports.f(0x40000000), -0x40000000);
+    assert.eq(m.exports.f(42), 42);
+  }
+
   assert.throws(
     () => instantiate(`
       (module

--- a/Source/JavaScriptCore/JavaScriptCore.xcodeproj/project.pbxproj
+++ b/Source/JavaScriptCore/JavaScriptCore.xcodeproj/project.pbxproj
@@ -1072,6 +1072,7 @@
 		538F15F0268FBBB600D601C4 /* UnifiedSource149.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 538F15E6268FBBB600D601C4 /* UnifiedSource149.cpp */; };
 		538F15F2268FBC7B00D601C4 /* UnifiedSource146.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 538F15F1268FBC7B00D601C4 /* UnifiedSource146.cpp */; };
 		53917E7B1B7906FA000EBD33 /* JSGenericTypedArrayViewPrototypeFunctions.h in Headers */ = {isa = PBXBuildFile; fileRef = 53917E7A1B7906E4000EBD33 /* JSGenericTypedArrayViewPrototypeFunctions.h */; };
+		539900052A218CC4007F4335 /* JSWebAssemblyArray.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 55F5DFAD28DA9A2000595620 /* JSWebAssemblyArray.cpp */; };
 		539930C822AD3B9A0051CDE2 /* WeakObjectRefConstructor.h in Headers */ = {isa = PBXBuildFile; fileRef = 539930C722AD3B9A0051CDE2 /* WeakObjectRefConstructor.h */; };
 		539BFBAE22AD3C3A0023F4C0 /* WeakObjectRefPrototype.h in Headers */ = {isa = PBXBuildFile; fileRef = 539BFBAD22AD3C3A0023F4C0 /* WeakObjectRefPrototype.h */; };
 		539BFBB022AD3CDC0023F4C0 /* JSWeakObjectRef.h in Headers */ = {isa = PBXBuildFile; fileRef = 539BFBAF22AD3CDC0023F4C0 /* JSWeakObjectRef.h */; };
@@ -12345,6 +12346,7 @@
 				DD28467C291AF1B20009A61D /* JSCBuiltins.cpp in Sources */,
 				DD284679291A29900009A61D /* JSCBytecodeCacheVersion.cpp.in in Sources */,
 				E38E8790254B978400F6F9E4 /* JSDateMath.cpp in Sources */,
+				539900052A218CC4007F4335 /* JSWebAssemblyArray.cpp in Sources */,
 				4BE92D442898522400FA48E1 /* LowLevelInterpreter.asm in Sources */,
 				4BE92D452898522400FA48E1 /* LowLevelInterpreter.cpp in Sources */,
 				4B46940328984FA800512FDF /* MacroAssemblerARM64.cpp in Sources */,

--- a/Source/JavaScriptCore/Sources.txt
+++ b/Source/JavaScriptCore/Sources.txt
@@ -1151,7 +1151,8 @@ wasm/WasmWorklist.cpp
 wasm/js/JSToWasm.cpp
 wasm/js/JSToWasm.h
 wasm/js/JSWebAssembly.cpp
-wasm/js/JSWebAssemblyArray.cpp
+// FIXME: Remove this @no-unify when clang-AS-debug builds stops crashing in register allocation.
+wasm/js/JSWebAssemblyArray.cpp @no-unify
 wasm/js/JSWebAssemblyCompileError.cpp
 wasm/js/JSWebAssemblyException.cpp
 wasm/js/JSWebAssemblyGlobal.cpp

--- a/Source/JavaScriptCore/runtime/Options.cpp
+++ b/Source/JavaScriptCore/runtime/Options.cpp
@@ -670,14 +670,10 @@ void Options::notifyOptionsChanged()
             Options::forceAllFunctionsToUseSIMD() = true;
         }
 
-        if (Options::useWebAssemblyGC()
-            || Options::useWebAssemblyTypedFunctionReferences()
-            || Options::useWebAssemblyTailCalls()) {
+        if (Options::useWebAssemblyTailCalls()) {
             // The single-pass BBQ JIT doesn't support these features currently, so we should use a different
             // BBQ backend if any of them are enabled. We should remove these limitations as support for each
             // is added.
-            // FIXME: Add WASM GC support to single-pass BBQ JIT. https://bugs.webkit.org/show_bug.cgi?id=253188
-            // FIXME: Add WASM typed function references support to single-pass BBQ JIT. https://bugs.webkit.org/show_bug.cgi?id=253191
             // FIXME: Add WASM tail calls support to single-pass BBQ JIT. https://bugs.webkit.org/show_bug.cgi?id=253192
             Options::useSinglePassBBQJIT() = false;
         }

--- a/Source/JavaScriptCore/wasm/WasmBBQJIT.cpp
+++ b/Source/JavaScriptCore/wasm/WasmBBQJIT.cpp
@@ -35,7 +35,9 @@
 #include "CompilerTimingScope.h"
 #include "GPRInfo.h"
 #include "JSCast.h"
+#include "JSWebAssemblyArray.h"
 #include "JSWebAssemblyException.h"
+#include "JSWebAssemblyStruct.h"
 #include "MacroAssembler.h"
 #include "RegisterSet.h"
 #include "WasmB3IRGenerator.h"
@@ -346,6 +348,22 @@ private:
 
     static_assert(sizeof(Location) == 4);
 
+    static bool isValidValueTypeKind(TypeKind kind)
+    {
+        switch (kind) {
+        case TypeKind::I64:
+        case TypeKind::I32:
+        case TypeKind::F64:
+        case TypeKind::F32:
+        case TypeKind::V128:
+            return true;
+        default:
+            return false;
+        }
+    }
+
+    static TypeKind pointerType() { return is64Bit() ? TypeKind::I64 : TypeKind::I32; }
+
     static bool isFloatingPointType(TypeKind type)
     {
         return type == TypeKind::F32 || type == TypeKind::F64 || type == TypeKind::V128;
@@ -383,6 +401,38 @@ public:
             return 0;
         }
         return 0;
+    }
+
+    static TypeKind toValueKind(TypeKind kind)
+    {
+        switch (kind) {
+        case TypeKind::I32:
+        case TypeKind::F32:
+        case TypeKind::I64:
+        case TypeKind::F64:
+        case TypeKind::V128:
+            return kind;
+        case TypeKind::Func:
+        case TypeKind::I31ref:
+        case TypeKind::Funcref:
+        case TypeKind::Ref:
+        case TypeKind::RefNull:
+        case TypeKind::Rec:
+        case TypeKind::Sub:
+        case TypeKind::Struct:
+        case TypeKind::Structref:
+        case TypeKind::Externref:
+        case TypeKind::Array:
+        case TypeKind::Arrayref:
+        case TypeKind::Eqref:
+        case TypeKind::Anyref:
+        case TypeKind::Nullref:
+            return TypeKind::I64;
+        case TypeKind::Void:
+            RELEASE_ASSERT_NOT_REACHED();
+            return kind;
+        }
+        return kind;
     }
 
     class Value {
@@ -521,7 +571,7 @@ public:
         {
             Value val;
             val.m_kind = Const;
-            val.m_type = refType;
+            val.m_type = toValueKind(refType);
             val.m_ref = ref;
             return val;
         }
@@ -530,7 +580,7 @@ public:
         {
             Value val;
             val.m_kind = Temp;
-            val.m_type = type;
+            val.m_type = toValueKind(type);
             val.m_index = temp;
             return val;
         }
@@ -539,7 +589,7 @@ public:
         {
             Value val;
             val.m_kind = Local;
-            val.m_type = type;
+            val.m_type = toValueKind(type);
             val.m_index = local;
             return val;
         }
@@ -548,7 +598,7 @@ public:
         {
             Value val;
             val.m_kind = Pinned;
-            val.m_type = type;
+            val.m_type = toValueKind(type);
             val.m_pinned = location;
             return val;
         }
@@ -569,6 +619,7 @@ public:
 
         ALWAYS_INLINE TypeKind type() const
         {
+            ASSERT(isValidValueTypeKind(m_type));
             return m_type;
         }
 
@@ -1259,7 +1310,7 @@ public:
         : m_jit(jit)
         , m_callee(callee)
         , m_function(function)
-        , m_functionSignature(signature.as<FunctionSignature>())
+        , m_functionSignature(signature.expand().as<FunctionSignature>())
         , m_functionIndex(functionIndex)
         , m_info(info)
         , m_mode(mode)
@@ -1314,7 +1365,7 @@ public:
             m_disassembler->setStartOfCode(m_jit.label());
         }
 
-        CallInformation callInfo = wasmCallingConvention().callInformationFor(signature, CallRole::Callee);
+        CallInformation callInfo = wasmCallingConvention().callInformationFor(signature.expand(), CallRole::Callee);
         ASSERT(callInfo.params.size() == m_functionSignature->argumentCount());
         for (unsigned i = 0; i < m_functionSignature->argumentCount(); i ++) {
             const Type& type = m_functionSignature->argumentType(i);
@@ -1426,7 +1477,8 @@ public:
             Value::fromI32(tableIndex),
             index
         };
-        emitCCall(&operationGetWasmTableElement, arguments, returnType, result);
+        result = topValue(returnType);
+        emitCCall(&operationGetWasmTableElement, arguments, result);
         Location resultLocation = allocate(result);
 
         LOG_INSTRUCTION("TableGet", tableIndex, index, RESULT(result));
@@ -1447,8 +1499,8 @@ public:
             value
         };
 
-        Value shouldThrow;
-        emitCCall(&operationSetWasmTableElement, arguments, TypeKind::I32, shouldThrow);
+        Value shouldThrow = topValue(TypeKind::I32);
+        emitCCall(&operationSetWasmTableElement, arguments, shouldThrow);
         Location shouldThrowLocation = allocate(shouldThrow);
 
         LOG_INSTRUCTION("TableSet", tableIndex, index, value);
@@ -1474,8 +1526,8 @@ public:
             srcOffset,
             length
         };
-        Value shouldThrow;
-        emitCCall(&operationWasmTableInit, arguments, TypeKind::I32, shouldThrow);
+        Value shouldThrow = topValue(TypeKind::I32);
+        emitCCall(&operationWasmTableInit, arguments, shouldThrow);
         Location shouldThrowLocation = allocate(shouldThrow);
 
         LOG_INSTRUCTION("TableInit", tableIndex, dstOffset, srcOffset, length);
@@ -1505,7 +1557,8 @@ public:
             instanceValue(),
             Value::fromI32(tableIndex)
         };
-        emitCCall(&operationGetWasmTableSize, arguments, TypeKind::I32, result);
+        result = topValue(TypeKind::I32);
+        emitCCall(&operationGetWasmTableSize, arguments, result);
 
         LOG_INSTRUCTION("TableSize", tableIndex, RESULT(result));
         return { };
@@ -1520,7 +1573,8 @@ public:
             Value::fromI32(tableIndex),
             fill, delta
         };
-        emitCCall(&operationWasmTableGrow, arguments, TypeKind::I32, result);
+        result = topValue(TypeKind::I32);
+        emitCCall(&operationWasmTableGrow, arguments, result);
 
         LOG_INSTRUCTION("TableGrow", tableIndex, fill, delta, RESULT(result));
         return { };
@@ -1536,8 +1590,8 @@ public:
             Value::fromI32(tableIndex),
             offset, fill, count
         };
-        Value shouldThrow;
-        emitCCall(&operationWasmTableFill, arguments, TypeKind::I32, shouldThrow);
+        Value shouldThrow = topValue(TypeKind::I32);
+        emitCCall(&operationWasmTableFill, arguments, shouldThrow);
         Location shouldThrowLocation = allocate(shouldThrow);
 
         LOG_INSTRUCTION("TableFill", tableIndex, fill, offset, count);
@@ -1561,8 +1615,8 @@ public:
             Value::fromI32(srcTableIndex),
             dstOffset, srcOffset, length
         };
-        Value shouldThrow;
-        emitCCall(&operationWasmTableCopy, arguments, TypeKind::I32, shouldThrow);
+        Value shouldThrow = topValue(TypeKind::I32);
+        emitCCall(&operationWasmTableCopy, arguments, shouldThrow);
         Location shouldThrowLocation = allocate(shouldThrow);
 
         LOG_INSTRUCTION("TableCopy", dstTableIndex, srcTableIndex, dstOffset, srcOffset, length);
@@ -2185,7 +2239,8 @@ public:
     PartialResult WARN_UNUSED_RETURN addGrowMemory(Value delta, Value& result)
     {
         Vector<Value, 8> arguments = { instanceValue(), delta };
-        emitCCall(&operationGrowMemory, arguments, TypeKind::I32, result);
+        result = topValue(TypeKind::I32);
+        emitCCall(&operationGrowMemory, arguments, result);
         restoreWebAssemblyGlobalState();
 
         LOG_INSTRUCTION("GrowMemory", delta, RESULT(result));
@@ -2221,8 +2276,8 @@ public:
             instanceValue(),
             dstAddress, targetValue, count
         };
-        Value shouldThrow;
-        emitCCall(&operationWasmMemoryFill, arguments, TypeKind::I32, shouldThrow);
+        Value shouldThrow = topValue(TypeKind::I32);
+        emitCCall(&operationWasmMemoryFill, arguments, shouldThrow);
         Location shouldThrowLocation = allocate(shouldThrow);
 
         throwExceptionIf(ExceptionType::OutOfBoundsMemoryAccess, m_jit.branchTest32(ResultCondition::Zero, shouldThrowLocation.asGPR()));
@@ -2244,8 +2299,8 @@ public:
             instanceValue(),
             dstAddress, srcAddress, count
         };
-        Value shouldThrow;
-        emitCCall(&operationWasmMemoryCopy, arguments, TypeKind::I32, shouldThrow);
+        Value shouldThrow = topValue(TypeKind::I32);
+        emitCCall(&operationWasmMemoryCopy, arguments, shouldThrow);
         Location shouldThrowLocation = allocate(shouldThrow);
 
         throwExceptionIf(ExceptionType::OutOfBoundsMemoryAccess, m_jit.branchTest32(ResultCondition::Zero, shouldThrowLocation.asGPR()));
@@ -2268,8 +2323,8 @@ public:
             Value::fromI32(dataSegmentIndex),
             dstAddress, srcAddress, length
         };
-        Value shouldThrow;
-        emitCCall(&operationWasmMemoryInit, arguments, TypeKind::I32, shouldThrow);
+        Value shouldThrow = topValue(TypeKind::I32);
+        emitCCall(&operationWasmMemoryInit, arguments, shouldThrow);
         Location shouldThrowLocation = allocate(shouldThrow);
 
         throwExceptionIf(ExceptionType::OutOfBoundsMemoryAccess, m_jit.branchTest32(ResultCondition::Zero, shouldThrowLocation.asGPR()));
@@ -3247,10 +3302,11 @@ public:
             timeout
         };
 
+        result = topValue(TypeKind::I32);
         if (op == ExtAtomicOpType::MemoryAtomicWait32)
-            emitCCall(&operationMemoryAtomicWait32, arguments, TypeKind::I32, result);
+            emitCCall(&operationMemoryAtomicWait32, arguments, result);
         else
-            emitCCall(&operationMemoryAtomicWait64, arguments, TypeKind::I32, result);
+            emitCCall(&operationMemoryAtomicWait64, arguments, result);
         Location resultLocation = allocate(result);
 
         LOG_INSTRUCTION(makeString(op), pointer, value, timeout, uoffset, RESULT(result));
@@ -3267,7 +3323,8 @@ public:
             Value::fromI32(uoffset),
             count
         };
-        emitCCall(&operationMemoryAtomicNotify, arguments, TypeKind::I32, result);
+        result = topValue(TypeKind::I32);
+        emitCCall(&operationMemoryAtomicNotify, arguments, result);
         Location resultLocation = allocate(result);
 
         LOG_INSTRUCTION(makeString(op), pointer, count, uoffset, RESULT(result));
@@ -3587,27 +3644,562 @@ public:
     }
 
     // GC
-    PartialResult WARN_UNUSED_RETURN addI31New(ExpressionType, ExpressionType&) BBQ_STUB
-    PartialResult WARN_UNUSED_RETURN addI31GetS(ExpressionType, ExpressionType&) BBQ_STUB
-    PartialResult WARN_UNUSED_RETURN addI31GetU(ExpressionType, ExpressionType&) BBQ_STUB
-    PartialResult WARN_UNUSED_RETURN addArrayNew(uint32_t, ExpressionType, ExpressionType, ExpressionType&) BBQ_STUB
-    PartialResult WARN_UNUSED_RETURN addArrayNewDefault(uint32_t, ExpressionType, ExpressionType&) BBQ_STUB
-    PartialResult WARN_UNUSED_RETURN addArrayNewData(uint32_t, uint32_t, ExpressionType, ExpressionType, ExpressionType&) BBQ_STUB
-    PartialResult WARN_UNUSED_RETURN addArrayNewElem(uint32_t, uint32_t, ExpressionType, ExpressionType, ExpressionType&) BBQ_STUB
-    PartialResult WARN_UNUSED_RETURN addArrayNewFixed(uint32_t, Vector<ExpressionType>&, ExpressionType&) BBQ_STUB
-    PartialResult WARN_UNUSED_RETURN addArrayGet(ExtGCOpType, uint32_t, ExpressionType, ExpressionType, ExpressionType&) BBQ_STUB
-    PartialResult WARN_UNUSED_RETURN addArraySet(uint32_t, ExpressionType, ExpressionType, ExpressionType) BBQ_STUB
-    PartialResult WARN_UNUSED_RETURN addArrayLen(ExpressionType, ExpressionType&) BBQ_STUB
-    PartialResult WARN_UNUSED_RETURN addStructNewDefault(uint32_t, ExpressionType&) BBQ_STUB
-    PartialResult WARN_UNUSED_RETURN addRefCast(ExpressionType, bool, int32_t, ExpressionType&) BBQ_STUB
-    PartialResult WARN_UNUSED_RETURN addRefTest(ExpressionType, bool, int32_t, ExpressionType&) BBQ_STUB
+    PartialResult WARN_UNUSED_RETURN addI31New(ExpressionType value, ExpressionType& result)
+    {
+        if (value.isConst()) {
+            result = Value::fromI64((value.asI32() & 0x7fffffff) | JSValue::NumberTag);
+            LOG_INSTRUCTION("I31New", value, RESULT(result));
+            return { };
+        }
+
+        Location initialValue = loadIfNecessary(value);
+        consume(value);
+
+        result = topValue(TypeKind::I64);
+        Location resultLocation = allocateWithHint(result, initialValue);
+
+        LOG_INSTRUCTION("I31New", value, RESULT(result));
+
+        m_jit.and32(TrustedImm32(0x7fffffff), initialValue.asGPR(), resultLocation.asGPR());
+        m_jit.or64(TrustedImm64(JSValue::NumberTag), resultLocation.asGPR());
+        return { };
+    }
+
+    PartialResult WARN_UNUSED_RETURN addI31GetS(ExpressionType value, ExpressionType& result)
+    {
+        if (value.isConst()) {
+            if (JSValue::decode(value.asI64()).isNumber())
+                result = Value::fromI32((value.asI64() << 33) >> 33);
+            else {
+                emitThrowException(ExceptionType::NullI31Get);
+                result = Value::fromI32(0);
+            }
+
+            LOG_INSTRUCTION("I31GetS", value, RESULT(result));
+
+            return { };
+        }
+
+
+        Location initialValue = loadIfNecessary(value);
+        consume(value);
+
+        result = topValue(TypeKind::I64);
+        Location resultLocation = allocateWithHint(result, initialValue);
+
+        LOG_INSTRUCTION("I31GetS", value, RESULT(result));
+
+        m_jit.move(initialValue.asGPR(), resultLocation.asGPR());
+        emitThrowOnNullReference(ExceptionType::NullI31Get, resultLocation);
+
+        m_jit.lshift32(TrustedImm32(1), resultLocation.asGPR());
+        m_jit.rshift32(TrustedImm32(1), resultLocation.asGPR());
+        return { };
+    }
+
+    PartialResult WARN_UNUSED_RETURN addI31GetU(ExpressionType value, ExpressionType& result)
+    {
+        if (value.isConst()) {
+            if (JSValue::decode(value.asI64()).isNumber())
+                result = Value::fromI32(value.asI64());
+            else {
+                emitThrowException(ExceptionType::NullI31Get);
+                result = Value::fromI32(0);
+            }
+
+            LOG_INSTRUCTION("I31GetU", value, RESULT(result));
+
+            return { };
+        }
+
+
+        Location initialValue = loadIfNecessary(value);
+        consume(value);
+
+        result = topValue(TypeKind::I64);
+        Location resultLocation = allocateWithHint(result, initialValue);
+
+        LOG_INSTRUCTION("I31GetU", value, RESULT(result));
+
+        m_jit.move(initialValue.asGPR(), resultLocation.asGPR());
+        emitThrowOnNullReference(ExceptionType::NullI31Get, resultLocation);
+
+        return { };
+    }
+
+    const Ref<TypeDefinition> getTypeDefinition(uint32_t typeIndex) { return m_info.typeSignatures[typeIndex]; }
+
+    // Given a type index, verify that it's an array type and return its expansion
+    const ArrayType* getArrayTypeDefinition(uint32_t typeIndex)
+    {
+        Ref<Wasm::TypeDefinition> typeDef = getTypeDefinition(typeIndex);
+        const Wasm::TypeDefinition& arraySignature = typeDef->expand();
+        return arraySignature.as<ArrayType>();
+    }
+
+    // Given a type index for an array signature, look it up, expand it and
+    // return the element type
+    StorageType getArrayElementType(uint32_t typeIndex)
+    {
+        const ArrayType* arrayType = getArrayTypeDefinition(typeIndex);
+        return arrayType->elementType().type;
+    }
+
+    // This will replace the existing value with a new value. Note that if this is an F32 then the top bits may be garbage but that's ok for our current usage.
+    Value marshallToI64(Value value)
+    {
+        ASSERT(!value.isLocal());
+        if (value.type() == TypeKind::F32 || value.type() == TypeKind::F64) {
+            if (value.isConst())
+                return Value::fromI64(value.type() == TypeKind::F32 ? bitwise_cast<uint32_t>(value.asI32()) : bitwise_cast<uint64_t>(value.asF64()));
+            // This is a bit silly. We could just move initValue to the right argument GPR if we know it's in an FPR already.
+            flushValue(value);
+            return Value::fromTemp(TypeKind::I64, value.asTemp());
+        }
+        return value;
+    }
+
+
+    PartialResult WARN_UNUSED_RETURN addArrayNew(uint32_t typeIndex, ExpressionType size, ExpressionType initValue, ExpressionType& result)
+    {
+        initValue = marshallToI64(initValue);
+
+        Vector<Value, 8> arguments = {
+            instanceValue(),
+            Value::fromI32(typeIndex),
+            size,
+            initValue,
+        };
+        result = topValue(TypeKind::Arrayref);
+        emitCCall(operationWasmArrayNew, arguments, result);
+
+        LOG_INSTRUCTION("ArrayNew", typeIndex, size, initValue, RESULT(result));
+        return { };
+    }
+
+    PartialResult WARN_UNUSED_RETURN addArrayNewDefault(uint32_t typeIndex, ExpressionType size, ExpressionType& result)
+    {
+        StorageType arrayElementType = getArrayElementType(typeIndex);
+        Value initValue = Value::fromI64(isRefType(arrayElementType) ? JSValue::encode(jsNull()) : 0);
+
+        Vector<Value, 8> arguments = {
+            instanceValue(),
+            Value::fromI32(typeIndex),
+            size,
+            initValue,
+        };
+        result = topValue(TypeKind::Arrayref);
+        emitCCall(&operationWasmArrayNew, arguments, result);
+
+        LOG_INSTRUCTION("ArrayNewDefault", typeIndex, size, RESULT(result));
+        return { };
+    }
+
+    using arraySegmentOperation = EncodedJSValue (&)(JSC::Wasm::Instance*, uint32_t, uint32_t, uint32_t, uint32_t);
+    void pushArrayNewFromSegment(arraySegmentOperation operation, uint32_t typeIndex, uint32_t segmentIndex, ExpressionType arraySize, ExpressionType offset, ExceptionType exceptionType, ExpressionType& result)
+    {
+        Vector<Value, 8> arguments = {
+            instanceValue(),
+            Value::fromI32(typeIndex),
+            Value::fromI32(segmentIndex),
+            arraySize,
+            offset,
+        };
+        result = topValue(TypeKind::I64);
+        emitCCall(operation, arguments, result);
+        Location resultLocation = allocate(result);
+
+        emitThrowOnNullReference(exceptionType, resultLocation);
+    }
+
+    PartialResult WARN_UNUSED_RETURN addArrayNewData(uint32_t typeIndex, uint32_t dataIndex, ExpressionType arraySize, ExpressionType offset, ExpressionType& result)
+    {
+        pushArrayNewFromSegment(operationWasmArrayNewData, typeIndex, dataIndex, arraySize, offset, ExceptionType::OutOfBoundsDataSegmentAccess, result);
+        LOG_INSTRUCTION("ArrayNewData", typeIndex, dataIndex, arraySize, offset, RESULT(result));
+        return { };
+    }
+
+    PartialResult WARN_UNUSED_RETURN addArrayNewElem(uint32_t typeIndex, uint32_t elemSegmentIndex, ExpressionType arraySize, ExpressionType offset, ExpressionType& result)
+    {
+        pushArrayNewFromSegment(operationWasmArrayNewElem, typeIndex, elemSegmentIndex, arraySize, offset, ExceptionType::OutOfBoundsElementSegmentAccess, result);
+        LOG_INSTRUCTION("ArrayNewElem", typeIndex, elemSegmentIndex, arraySize, offset, RESULT(result));
+        return { };
+    }
+
+    void emitArraySetUnchecked(uint32_t typeIndex, Value arrayref, Value index, Value value)
+    {
+        value = marshallToI64(value);
+
+        Vector<Value, 8> arguments = {
+            instanceValue(),
+            Value::fromI32(typeIndex),
+            arrayref,
+            index,
+            value,
+        };
+        // FIXME: Emit this inline.
+        // https://bugs.webkit.org/show_bug.cgi?id=245405
+        emitCCall(operationWasmArraySet, arguments);
+    }
+
+    PartialResult WARN_UNUSED_RETURN addArrayNewFixed(uint32_t typeIndex, Vector<ExpressionType>& args, ExpressionType& result)
+    {
+        // Allocate an uninitialized array whose length matches the argument count
+        // FIXME: inline the allocation.
+        // https://bugs.webkit.org/show_bug.cgi?id=244388
+        Vector<Value, 8> arguments = {
+            instanceValue(),
+            Value::fromI32(typeIndex),
+            Value::fromI32(args.size()),
+        };
+        Value allocationResult = Value::fromTemp(TypeKind::Arrayref, currentControlData().enclosedHeight() + currentControlData().implicitSlots() + m_parser->expressionStack().size() + args.size());
+        emitCCall(operationWasmArrayNewEmpty, arguments, allocationResult);
+
+        Location allocationResultLocation = allocate(allocationResult);
+        emitThrowOnNullReference(ExceptionType::NullArraySet, allocationResultLocation);
+
+        for (uint32_t i = 0; i < args.size(); ++i) {
+            // Emit the array set code -- note that this omits the bounds check, since
+            // if operationWasmArrayNewEmpty() returned a non-null value, it's an array of the right size
+            allocationResultLocation = loadIfNecessary(allocationResult);
+            Value pinnedResult = Value::pinned(TypeKind::I64, allocationResultLocation);
+            emitArraySetUnchecked(typeIndex, pinnedResult, Value::fromI32(i), args[i]);
+        }
+
+        result = topValue(TypeKind::Arrayref);
+        Location resultLocation = allocate(result);
+        emitMove(allocationResult, resultLocation);
+        // If args.isEmpty() then allocationResult.asTemp() == result.asTemp() so we will consume our result.
+        if (args.size())
+            consume(allocationResult);
+
+        LOG_INSTRUCTION("ArrayNewFixed", typeIndex, args.size(), RESULT(result));
+        return { };
+    }
+
+    PartialResult WARN_UNUSED_RETURN addArrayGet(ExtGCOpType arrayGetKind, uint32_t typeIndex, ExpressionType arrayref, ExpressionType index, ExpressionType& result)
+    {
+        StorageType elementType = getArrayElementType(typeIndex);
+        Type resultType = elementType.unpacked();
+
+        if (arrayref.isConst()) {
+            ASSERT(arrayref.asI64() == JSValue::encode(jsNull()));
+            emitThrowException(ExceptionType::NullArrayGet);
+            result = Value::fromRef(resultType.kind, 0);
+            return { };
+        }
+
+        Location arrayLocation = loadIfNecessary(arrayref);
+        emitThrowOnNullReference(ExceptionType::NullArrayGet, arrayLocation);
+
+        if (index.isConst()) {
+            m_jit.load32(MacroAssembler::Address(arrayLocation.asGPR(), JSWebAssemblyArray::offsetOfSize()), wasmScratchGPR);
+            throwExceptionIf(ExceptionType::OutOfBoundsArrayGet,
+                m_jit.branch32(MacroAssembler::BelowOrEqual, wasmScratchGPR, TrustedImm32(index.asI32())));
+        } else {
+            Location indexLocation = loadIfNecessary(index);
+            throwExceptionIf(ExceptionType::OutOfBoundsArrayGet,
+                m_jit.branch32(MacroAssembler::AboveOrEqual, indexLocation.asGPR(), MacroAssembler::Address(arrayLocation.asGPR(), JSWebAssemblyArray::offsetOfSize())));
+        }
+
+        Vector<Value, 8> arguments = {
+            instanceValue(),
+            Value::fromI32(typeIndex),
+            arrayref,
+            index,
+        };
+
+        Value getResult = topValue(TypeKind::I64);
+        emitCCall(operationWasmArrayGet, arguments, getResult);
+        Location getResultLocation = loadIfNecessary(getResult);
+
+        if (isFloatingPointType(resultType.kind)) {
+            consume(getResult);
+            result = topValue(resultType.kind);
+            Location resultLocation = allocate(result);
+            m_jit.move64ToDouble(getResultLocation.asGPR(), resultLocation.asFPR());
+        } else
+            result = getResult;
+
+        switch (arrayGetKind) {
+        case ExtGCOpType::ArrayGet:
+            LOG_INSTRUCTION("ArrayGet", typeIndex, arrayref, index, RESULT(result));
+            break;
+        case ExtGCOpType::ArrayGetU:
+            ASSERT(resultType.kind == TypeKind::I32);
+
+            LOG_INSTRUCTION("ArrayGetU", typeIndex, arrayref, index, RESULT(result));
+            break;
+        case ExtGCOpType::ArrayGetS: {
+            ASSERT(resultType.kind == TypeKind::I32);
+            size_t elementSize = elementType.as<PackedType>() == PackedType::I8 ? sizeof(uint8_t) : sizeof(uint16_t);
+            uint8_t bitShift = (sizeof(uint32_t) - elementSize) * 8;
+            Location resultLocation = allocate(result);
+
+            m_jit.lshift32(TrustedImm32(bitShift), resultLocation.asGPR());
+            m_jit.rshift32(TrustedImm32(bitShift), resultLocation.asGPR());
+            LOG_INSTRUCTION("ArrayGetS", typeIndex, arrayref, index, RESULT(result));
+            break;
+        }
+        default:
+            RELEASE_ASSERT_NOT_REACHED();
+            return { };
+        }
+        return { };
+    }
+
+    PartialResult WARN_UNUSED_RETURN addArraySet(uint32_t typeIndex, ExpressionType arrayref, ExpressionType index, ExpressionType value)
+    {
+        if (arrayref.isConst()) {
+            ASSERT(arrayref.asI64() == JSValue::encode(jsNull()));
+            emitThrowException(ExceptionType::NullArraySet);
+            return { };
+        }
+
+        Location arrayLocation = loadIfNecessary(arrayref);
+        emitThrowOnNullReference(ExceptionType::NullArraySet, arrayLocation);
+
+        if (index.isConst()) {
+            m_jit.load32(MacroAssembler::Address(arrayLocation.asGPR(), JSWebAssemblyArray::offsetOfSize()), wasmScratchGPR);
+            throwExceptionIf(ExceptionType::OutOfBoundsArraySet,
+                m_jit.branch32(MacroAssembler::BelowOrEqual, wasmScratchGPR, TrustedImm32(index.asI32())));
+        } else {
+            Location indexLocation = loadIfNecessary(index);
+            throwExceptionIf(ExceptionType::OutOfBoundsArraySet,
+                m_jit.branch32(MacroAssembler::AboveOrEqual, indexLocation.asGPR(), MacroAssembler::Address(arrayLocation.asGPR(), JSWebAssemblyArray::offsetOfSize())));
+        }
+
+        emitArraySetUnchecked(typeIndex, arrayref, index, value);
+
+        LOG_INSTRUCTION("ArraySet", typeIndex, arrayref, index, value);
+        return { };
+    }
+
+    PartialResult WARN_UNUSED_RETURN addArrayLen(ExpressionType arrayref, ExpressionType& result)
+    {
+        if (arrayref.isConst()) {
+            ASSERT(arrayref.asI64() == JSValue::encode(jsNull()));
+            emitThrowException(ExceptionType::NullArrayLen);
+            result = Value::fromI32(0);
+            LOG_INSTRUCTION("ArrayLen", arrayref, RESULT(result), "Exception");
+            return { };
+        }
+
+        Location arrayLocation = loadIfNecessary(arrayref);
+        consume(arrayref);
+        emitThrowOnNullReference(ExceptionType::NullArrayLen, arrayLocation);
+
+        result = topValue(TypeKind::I32);
+        Location resultLocation = allocateWithHint(result, arrayLocation);
+        m_jit.load32(MacroAssembler::Address(arrayLocation.asGPR(), JSWebAssemblyArray::offsetOfSize()), resultLocation.asGPR());
+
+        LOG_INSTRUCTION("ArrayLen", arrayref, RESULT(result));
+        return { };
+    }
+
+    void emitStructSet(GPRReg structGPR, const StructType& structType, uint32_t fieldIndex, Value value)
+    {
+        m_jit.loadPtr(MacroAssembler::Address(structGPR, JSWebAssemblyStruct::offsetOfPayload()), wasmScratchGPR);
+        unsigned fieldOffset = *structType.offsetOfField(fieldIndex);
+        RELEASE_ASSERT((std::numeric_limits<int32_t>::max() & fieldOffset) == fieldOffset);
+
+        TypeKind kind = toValueKind(structType.field(fieldIndex).type.as<Type>().kind);
+        if (value.isConst()) {
+            switch (kind) {
+            case TypeKind::I32:
+            case TypeKind::F32:
+                m_jit.store32(MacroAssembler::Imm32(value.asI32()), MacroAssembler::Address(wasmScratchGPR, fieldOffset));
+                break;
+            case TypeKind::I64:
+            case TypeKind::F64:
+                m_jit.store64(MacroAssembler::Imm64(value.asI64()), MacroAssembler::Address(wasmScratchGPR, fieldOffset));
+                break;
+            default:
+                RELEASE_ASSERT_NOT_REACHED();
+                break;
+            }
+            return;
+        }
+
+        Location valueLocation = loadIfNecessary(value);
+        switch (kind) {
+        case TypeKind::I32:
+            m_jit.store32(valueLocation.asGPR(), MacroAssembler::Address(wasmScratchGPR, fieldOffset));
+            break;
+        case TypeKind::I64:
+            m_jit.store64(valueLocation.asGPR(), MacroAssembler::Address(wasmScratchGPR, fieldOffset));
+            break;
+        case TypeKind::F32:
+            m_jit.storeFloat(valueLocation.asFPR(), MacroAssembler::Address(wasmScratchGPR, fieldOffset));
+            break;
+        case TypeKind::F64:
+            m_jit.storeDouble(valueLocation.asFPR(), MacroAssembler::Address(wasmScratchGPR, fieldOffset));
+            break;
+        default:
+            RELEASE_ASSERT_NOT_REACHED();
+            break;
+        }
+        consume(value);
+    }
+
+    PartialResult WARN_UNUSED_RETURN addStructNewDefault(uint32_t typeIndex, ExpressionType& result)
+    {
+
+        Vector<Value, 8> arguments = {
+            instanceValue(),
+            Value::fromI32(typeIndex),
+        };
+        result = topValue(TypeKind::I64);
+        emitCCall(operationWasmStructNewEmpty, arguments, result);
+
+        // FIXME: What about OOM?
+
+        const auto& structType = *m_info.typeSignatures[typeIndex]->expand().template as<StructType>();
+        Location structLocation = allocate(result);
+        for (StructFieldCount i = 0; i < structType.fieldCount(); ++i) {
+            if (Wasm::isRefType(structType.field(i).type))
+                emitStructSet(structLocation.asGPR(), structType, i, Value::fromRef(TypeKind::RefNull, JSValue::encode(jsNull())));
+            else
+                emitStructSet(structLocation.asGPR(), structType, i, Value::fromI64(0));
+        }
+
+        LOG_INSTRUCTION("StructNewDefault", typeIndex, RESULT(result));
+
+        return { };
+    }
+
+    PartialResult WARN_UNUSED_RETURN addStructNew(uint32_t typeIndex, Vector<Value>& args, Value& result)
+    {
+        Vector<Value, 8> arguments = {
+            instanceValue(),
+            Value::fromI32(typeIndex),
+        };
+        // Note: using topValue here would be wrong because args[0] would be clobbered by the result.
+        Value allocationResult = Value::fromTemp(TypeKind::Structref, currentControlData().enclosedHeight() + currentControlData().implicitSlots() + m_parser->expressionStack().size() + args.size());
+        emitCCall(operationWasmStructNewEmpty, arguments, allocationResult);
+
+        const auto& structType = *m_info.typeSignatures[typeIndex]->expand().template as<StructType>();
+        Location allocationLocation = allocate(allocationResult);
+        for (uint32_t i = 0; i < args.size(); ++i)
+            emitStructSet(allocationLocation.asGPR(), structType, i, args[i]);
+
+        result = topValue(TypeKind::Structref);
+        Location resultLocation = allocate(result);
+        emitMove(allocationResult, resultLocation);
+        // If args.isEmpty() then allocationResult.asTemp() == result.asTemp() so we will consume our result.
+        if (args.size())
+            consume(allocationResult);
+
+        LOG_INSTRUCTION("StructNew", typeIndex, args, RESULT(result));
+
+        return { };
+    }
+
+    PartialResult WARN_UNUSED_RETURN addStructGet(Value structValue, const StructType& structType, uint32_t fieldIndex, Value& result)
+    {
+        TypeKind resultKind = structType.field(fieldIndex).type.as<Type>().kind;
+        if (structValue.isConst()) {
+            // This is the only constant struct currently possible.
+            ASSERT(JSValue::decode(structValue.asRef()).isNull());
+            emitThrowException(ExceptionType::NullStructGet);
+            result = Value::fromRef(resultKind, 0);
+            LOG_INSTRUCTION("StructGet", structValue, fieldIndex, "Exception");
+            return { };
+        }
+
+        Location structLocation = allocate(structValue);
+        emitThrowOnNullReference(ExceptionType::NullStructGet, structLocation);
+
+        m_jit.loadPtr(MacroAssembler::Address(structLocation.asGPR(), JSWebAssemblyStruct::offsetOfPayload()), wasmScratchGPR);
+        unsigned fieldOffset = *structType.offsetOfField(fieldIndex);
+        RELEASE_ASSERT((std::numeric_limits<int32_t>::max() & fieldOffset) == fieldOffset);
+
+        consume(structValue);
+        result = topValue(resultKind);
+        Location resultLocation = allocate(result);
+
+        switch (result.type()) {
+        case TypeKind::I32:
+            m_jit.load32(MacroAssembler::Address(wasmScratchGPR, fieldOffset), resultLocation.asGPR());
+            break;
+        case TypeKind::I64:
+            m_jit.load64(MacroAssembler::Address(wasmScratchGPR, fieldOffset), resultLocation.asGPR());
+            break;
+        case TypeKind::F32:
+            m_jit.loadFloat(MacroAssembler::Address(wasmScratchGPR, fieldOffset), resultLocation.asFPR());
+            break;
+        case TypeKind::F64:
+            m_jit.loadDouble(MacroAssembler::Address(wasmScratchGPR, fieldOffset), resultLocation.asFPR());
+            break;
+        default:
+            RELEASE_ASSERT_NOT_REACHED();
+            break;
+        }
+
+        LOG_INSTRUCTION("StructGet", structValue, fieldIndex, RESULT(result));
+        return { };
+    }
+
+    PartialResult WARN_UNUSED_RETURN addStructSet(Value structValue, const StructType& structType, uint32_t fieldIndex, Value value)
+    {
+        if (structValue.isConst()) {
+            // This is the only constant struct currently possible.
+            ASSERT(JSValue::decode(structValue.asRef()).isNull());
+            emitThrowException(ExceptionType::NullStructSet);
+            LOG_INSTRUCTION("StructSet", structValue, fieldIndex, value, "Exception");
+            return { };
+        }
+
+        Location structLocation = allocate(structValue);
+        emitThrowOnNullReference(ExceptionType::NullStructSet, structLocation);
+
+        emitStructSet(structLocation.asGPR(), structType, fieldIndex, value);
+        LOG_INSTRUCTION("StructSet", structValue, fieldIndex, value);
+        return { };
+    }
+
+    PartialResult WARN_UNUSED_RETURN addRefTest(ExpressionType reference, bool allowNull, int32_t heapType, ExpressionType& result)
+    {
+        Vector<Value, 8> arguments = {
+            instanceValue(),
+            reference,
+            Value::fromI32(allowNull),
+            Value::fromI32(heapType),
+        };
+        result = topValue(TypeKind::I32);
+        emitCCall(operationWasmRefTest, arguments, result);
+
+        LOG_INSTRUCTION("RefTest", reference, allowNull, heapType, RESULT(result));
+
+        return { };
+    }
+
+    PartialResult WARN_UNUSED_RETURN addRefCast(ExpressionType reference, bool allowNull, int32_t heapType, ExpressionType& result)
+    {
+        Vector<Value, 8> arguments = {
+            instanceValue(),
+            reference,
+            Value::fromI32(allowNull),
+            Value::fromI32(heapType),
+        };
+        result = topValue(TypeKind::Ref);
+        emitCCall(operationWasmRefCast, arguments, result);
+        Location resultLocation = allocate(result);
+        throwExceptionIf(ExceptionType::CastFailure, m_jit.branchTest64(MacroAssembler::Zero, resultLocation.asGPR()));
+
+        LOG_INSTRUCTION("RefCast", reference, allowNull, heapType, RESULT(result));
+
+        return { };
+    }
+
 
     PartialResult WARN_UNUSED_RETURN addExternInternalize(ExpressionType reference, ExpressionType& result)
     {
         Vector<Value, 8> arguments = {
             reference
         };
-        emitCCall(&operationWasmExternInternalize, arguments, TypeKind::Anyref, result);
+        result = topValue(TypeKind::Anyref);
+        emitCCall(&operationWasmExternInternalize, arguments, result);
         return { };
     }
 
@@ -4047,6 +4639,11 @@ public:
     void throwExceptionIf(ExceptionType type, Jump jump)
     {
         m_exceptions[static_cast<unsigned>(type)].append(jump);
+    }
+
+    void emitThrowOnNullReference(ExceptionType type, Location ref)
+    {
+        throwExceptionIf(type, m_jit.branch64(MacroAssembler::Equal, ref.asGPR(), TrustedImm64(JSValue::encode(jsNull()))));
     }
 
 #if CPU(X86_64)
@@ -5451,8 +6048,18 @@ public:
             BLOCK(
                 if (m_jit.supportsCountPopulation())
                     m_jit.countPopulation32(operandLocation.asGPR(), resultLocation.asGPR());
-                else
-                    emitCCall(&operationPopcount32, Vector<Value> { operand }, TypeKind::I32, result);
+                else {
+                    // The EMIT_UNARY(...) macro will already assign result to the top value on the stack and give it a register,
+                    // so it should be able to be passed in. However, this creates a somewhat nasty tacit dependency - emitCCall
+                    // will bind result to the returnValueGPR, which will error if result is already bound to a different register
+                    // (to avoid mucking with the register allocator state). It shouldn't currently error specifically because we
+                    // only allocate caller-saved registers, which get flushed across the call regardless; however, if we add
+                    // callee-saved register allocation to BBQJIT in the future, we could get very niche errors.
+                    //
+                    // We avoid this by consuming the result before passing it to emitCCall, which also saves us the mov for spilling.
+                    consume(result);
+                    emitCCall(&operationPopcount32, Vector<Value> { operand }, result);
+                }
             )
         )
     }
@@ -5465,8 +6072,18 @@ public:
             BLOCK(
                 if (m_jit.supportsCountPopulation())
                     m_jit.countPopulation64(operandLocation.asGPR(), resultLocation.asGPR());
-                else
-                    emitCCall(&operationPopcount64, Vector<Value> { operand }, TypeKind::I32, result);
+                else {
+                    // The EMIT_UNARY(...) macro will already assign result to the top value on the stack and give it a register,
+                    // so it should be able to be passed in. However, this creates a somewhat nasty tacit dependency - emitCCall
+                    // will bind result to the returnValueGPR, which will error if result is already bound to a different register
+                    // (to avoid mucking with the register allocator state). It shouldn't currently error specifically because we
+                    // only allocate caller-saved registers, which get flushed across the call regardless; however, if we add
+                    // callee-saved register allocation to BBQJIT in the future, we could get very niche errors.
+                    //
+                    // We avoid this by consuming the result before passing it to emitCCall, which also saves us the mov for spilling.
+                    consume(result);
+                    emitCCall(&operationPopcount64, Vector<Value> { operand }, result);
+                }
             )
         )
     }
@@ -6029,7 +6646,8 @@ public:
             instanceValue(),
             Value::fromI32(index)
         };
-        emitCCall(&operationWasmRefFunc, arguments, returnType, result);
+        result = topValue(returnType);
+        emitCCall(&operationWasmRefFunc, arguments, result);
 
         return { };
     }
@@ -6305,7 +6923,7 @@ public:
         case TypeKind::Eqref:
         case TypeKind::Anyref:
         case TypeKind::Nullref:
-            return B3::Type(is32Bit() ? B3::Int32 : B3::Int64);
+            return B3::Type(B3::Int64);
         case TypeKind::F32:
             return B3::Type(B3::Float);
         case TypeKind::F64:
@@ -7170,10 +7788,12 @@ public:
     }
 
     template<typename Func, size_t N>
-    void emitCCall(Func function, const Vector<Value, N>& arguments, TypeKind returnType, Value& result)
+    void emitCCall(Func function, const Vector<Value, N>& arguments, Value& result)
     {
+        ASSERT(result.isTemp());
+
         // Currently, we assume the Wasm calling convention is the same as the C calling convention
-        Vector<Type, 1> resultTypes = { Type { returnType, 0u } };
+        Vector<Type, 1> resultTypes = { Type { result.type(), 0u } };
         Vector<Type> argumentTypes;
         for (const Value& value : arguments)
             argumentTypes.append(Type { value.type(), 0u });
@@ -7194,10 +7814,8 @@ public:
         m_jit.move(TrustedImmPtr(bitwise_cast<uintptr_t>(taggedFunctionPtr)), wasmScratchGPR);
         m_jit.call(wasmScratchGPR, OperationPtrTag);
 
-        // FIXME: Probably we should make CCall more lower level, and we should bind the result to Value separately.
-        result = Value::fromTemp(returnType, currentControlData().enclosedHeight() + currentControlData().implicitSlots() + m_parser->expressionStack().size());
         Location resultLocation;
-        switch (returnType) {
+        switch (result.type()) {
         case TypeKind::I32:
         case TypeKind::I31ref:
         case TypeKind::I64:
@@ -7399,7 +8017,48 @@ public:
         return { };
     }
 
-    PartialResult WARN_UNUSED_RETURN addCallRef(const TypeDefinition&, Vector<Value>&, ResultList&) BBQ_STUB
+    PartialResult WARN_UNUSED_RETURN addCallRef(const TypeDefinition& originalSignature, Vector<Value>& args, ResultList& results)
+    {
+        Value callee = args.takeLast();
+        const TypeDefinition& signature = originalSignature.expand();
+        ASSERT(signature.as<FunctionSignature>()->argumentCount() == args.size());
+
+        CallInformation callInfo = wasmCallingConvention().callInformationFor(signature, CallRole::Caller);
+        Checked<int32_t> calleeStackSize = WTF::roundUpToMultipleOf(stackAlignmentBytes(), callInfo.headerAndArgumentStackSizeInBytes);
+        m_maxCalleeStackSize = std::max<int>(calleeStackSize, m_maxCalleeStackSize);
+
+        GPRReg calleeInstance;
+        GPRReg calleeCode;
+        GPRReg jsCalleeAnchor;
+        {
+            clobber(GPRInfo::nonPreservedNonArgumentGPR1);
+            ScratchScope<0, 0> calleeCodeScratch(*this, Location::fromGPR(GPRInfo::nonPreservedNonArgumentGPR1));
+            calleeCode = GPRInfo::nonPreservedNonArgumentGPR1;
+            ASSERT(calleeCode == GPRInfo::nonPreservedNonArgumentGPR1);
+
+            ScratchScope<2, 0> otherScratches(*this);
+
+            Location calleeLocation;
+            if (callee.isConst()) {
+                ASSERT(callee.asI64() == JSValue::encode(jsNull()));
+                // This is going to throw anyway. It's suboptimial but probably won't happen in practice anyway.
+                emitMoveConst(callee, calleeLocation = Location::fromGPR(otherScratches.gpr(0)));
+            } else
+                calleeLocation = loadIfNecessary(callee);
+            emitThrowOnNullReference(ExceptionType::NullReference, calleeLocation);
+
+            calleeInstance = otherScratches.gpr(0);
+            jsCalleeAnchor = otherScratches.gpr(1);
+
+            m_jit.loadPtr(MacroAssembler::Address(calleeLocation.asGPR(), WebAssemblyFunctionBase::offsetOfInstance()), jsCalleeAnchor);
+            m_jit.loadPtr(MacroAssembler::Address(calleeLocation.asGPR(), WebAssemblyFunctionBase::offsetOfEntrypointLoadLocation()), calleeCode);
+            m_jit.loadPtr(MacroAssembler::Address(jsCalleeAnchor, JSWebAssemblyInstance::offsetOfInstance()), calleeInstance);
+
+        }
+
+        emitIndirectCall("CallRef", callee, calleeInstance, calleeCode, jsCalleeAnchor, signature, args, results, CallType::Call);
+        return { };
+    }
 
     PartialResult WARN_UNUSED_RETURN addUnreachable()
     {
@@ -7407,10 +8066,6 @@ public:
         emitThrowException(ExceptionType::Unreachable);
         return { };
     }
-
-    PartialResult WARN_UNUSED_RETURN addStructNew(uint32_t, Vector<Value>&, Value&) BBQ_STUB
-    PartialResult WARN_UNUSED_RETURN addStructGet(Value, const StructType&, uint32_t, Value&) BBQ_STUB
-    PartialResult WARN_UNUSED_RETURN addStructSet(Value, const StructType&, uint32_t, Value) BBQ_STUB
 
     PartialResult WARN_UNUSED_RETURN addCrash()
     {

--- a/Source/JavaScriptCore/wasm/WasmFunctionParser.h
+++ b/Source/JavaScriptCore/wasm/WasmFunctionParser.h
@@ -1871,6 +1871,8 @@ FOR_EACH_WASM_MEMORY_STORE_OP(CREATE_CASE)
             uint32_t argc;
             WASM_PARSER_FAIL_IF(!parseVarUInt32(argc), "can't get argument count for array.new_fixed");
 
+            WASM_VALIDATOR_FAIL_IF(argc > maxArrayNewFixedArgs, "array_new_fixed can take at most ", maxArrayNewFixedArgs, " operands. Got ", argc);
+
             // If more arguments are expected than the current stack size, that's an error
             WASM_VALIDATOR_FAIL_IF(argc > m_expressionStack.size(), "array_new_fixed: found ", m_expressionStack.size(), " operands on stack; expected ", argc, " operands");
 

--- a/Source/JavaScriptCore/wasm/WasmLimits.h
+++ b/Source/JavaScriptCore/wasm/WasmLimits.h
@@ -45,6 +45,7 @@ constexpr size_t maxExceptions = 100000;
 constexpr size_t maxGlobals = 1000000;
 constexpr size_t maxDataSegments = 100000;
 constexpr size_t maxStructFieldCount = 10000;
+constexpr size_t maxArrayNewFixedArgs = 10000;
 constexpr size_t maxRecursionGroupCount = 10000;
 constexpr size_t maxSubtypeSupertypeCount = 1;
 
@@ -56,6 +57,7 @@ constexpr size_t maxFunctionParams = 1000;
 
 constexpr size_t maxTableEntries = 10000000;
 constexpr unsigned maxTables = 1000000;
+
 
 } } // namespace JSC::Wasm
 

--- a/Source/JavaScriptCore/wasm/WasmOperations.cpp
+++ b/Source/JavaScriptCore/wasm/WasmOperations.cpp
@@ -1096,6 +1096,29 @@ JSC_DEFINE_JIT_OPERATION(operationWasmExternInternalize, EncodedJSValue, (Encode
     return externInternalize(reference);
 }
 
+JSC_DEFINE_JIT_OPERATION(operationWasmRefTest, int32_t, (Instance* instance, EncodedJSValue reference, uint32_t allowNull, int32_t heapType))
+{
+    Wasm::TypeIndex typeIndex;
+    if (Wasm::typeIndexIsType(static_cast<Wasm::TypeIndex>(heapType)))
+        typeIndex = static_cast<Wasm::TypeIndex>(heapType);
+    else
+        typeIndex = instance->module().moduleInformation().typeSignatures[heapType]->index();
+    // Explicitly return 1 or 0 because bool in C++ only reqiures that the bottom bit match the other bits can be anything.
+    return Wasm::refCast(reference, static_cast<bool>(allowNull), typeIndex) ? 1 : 0;
+}
+
+JSC_DEFINE_JIT_OPERATION(operationWasmRefCast, EncodedJSValue, (Instance* instance, EncodedJSValue reference, uint32_t allowNull, int32_t heapType))
+{
+    Wasm::TypeIndex typeIndex;
+    if (Wasm::typeIndexIsType(static_cast<Wasm::TypeIndex>(heapType)))
+        typeIndex = static_cast<Wasm::TypeIndex>(heapType);
+    else
+        typeIndex = instance->module().moduleInformation().typeSignatures[heapType]->index();
+    if (!Wasm::refCast(reference, static_cast<bool>(allowNull), typeIndex))
+        return encodedJSValue();
+    return reference;
+}
+
 } } // namespace JSC::Wasm
 
 IGNORE_WARNINGS_END

--- a/Source/JavaScriptCore/wasm/WasmOperations.h
+++ b/Source/JavaScriptCore/wasm/WasmOperations.h
@@ -114,6 +114,9 @@ JSC_DECLARE_JIT_OPERATION(operationWasmArraySet, void, (Instance* instance, uint
 JSC_DECLARE_JIT_OPERATION(operationWasmIsSubRTT, bool, (Wasm::RTT*, Wasm::RTT*));
 JSC_DECLARE_JIT_OPERATION(operationWasmExternInternalize, EncodedJSValue, (EncodedJSValue));
 
+JSC_DECLARE_JIT_OPERATION(operationWasmRefTest, int32_t, (Instance*, EncodedJSValue, uint32_t, int32_t));
+JSC_DECLARE_JIT_OPERATION(operationWasmRefCast, EncodedJSValue, (Instance*, EncodedJSValue, uint32_t, int32_t));
+
 #if USE(JSVALUE64)
 JSC_DECLARE_JIT_OPERATION(operationWasmRetrieveAndClearExceptionIfCatchable, ThrownExceptionInfo, (Instance*));
 #else


### PR DESCRIPTION
#### 6ef70e7d7c5a168306c05061320d37496bf285e0
<pre>
BBQJIT should support gc and funcref opcodes
<a href="https://bugs.webkit.org/show_bug.cgi?id=256959">https://bugs.webkit.org/show_bug.cgi?id=256959</a>

Reviewed by Yusuke Suzuki.

This patch adds support for the various gc and funcref opcodes to the new BBQ JIT.
Most of the implementations are just translations of what the B3IRGenerator does.
The main difference is that for opcodes which need to make a C call, e.g. for allocation,
they do so by creating a `Value::fromTemp` that does not conflict with any parameter `Value`.
This is needed because otherwise the BBQJIT allocator gets confused between the existing parameters
that were not passed to the C call and the result of the C call. Also, since BBQJIT doesn&apos;t have a
good way to branch over a call both `ref.cast` and `ref.test` just call an operation.

Also, this patch fixes an issue where we weren&apos;t checking for the spec&apos;s limit on array.new_fixed
static argument count.

Lastly, there is a workaround for a clang bug where it crashed when compiling a unified source.
The workaround was to @no-unify one of the files in that bundle.

* JSTests/wasm/gc/array_new_fixed.js:
* JSTests/wasm/gc/i31.js:
(testI31Get):
* Source/JavaScriptCore/JavaScriptCore.xcodeproj/project.pbxproj:
* Source/JavaScriptCore/Sources.txt:
* Source/JavaScriptCore/runtime/Options.cpp:
(JSC::Options::notifyOptionsChanged):
* Source/JavaScriptCore/wasm/WasmBBQJIT.cpp:
(JSC::Wasm::BBQJIT::isValidValueTypeKind):
(JSC::Wasm::BBQJIT::pointerType):
(JSC::Wasm::BBQJIT::toValueKind):
(JSC::Wasm::BBQJIT::Value::fromRef):
(JSC::Wasm::BBQJIT::Value::fromTemp):
(JSC::Wasm::BBQJIT::Value::fromLocal):
(JSC::Wasm::BBQJIT::Value::pinned):
(JSC::Wasm::BBQJIT::Value::type const):
(JSC::Wasm::BBQJIT::BBQJIT):
(JSC::Wasm::BBQJIT::addTableGet):
(JSC::Wasm::BBQJIT::addTableSet):
(JSC::Wasm::BBQJIT::addTableInit):
(JSC::Wasm::BBQJIT::addTableSize):
(JSC::Wasm::BBQJIT::addTableGrow):
(JSC::Wasm::BBQJIT::addTableFill):
(JSC::Wasm::BBQJIT::addTableCopy):
(JSC::Wasm::BBQJIT::addGrowMemory):
(JSC::Wasm::BBQJIT::addMemoryFill):
(JSC::Wasm::BBQJIT::addMemoryCopy):
(JSC::Wasm::BBQJIT::addMemoryInit):
(JSC::Wasm::BBQJIT::atomicWait):
(JSC::Wasm::BBQJIT::atomicNotify):
(JSC::Wasm::BBQJIT::addI31New):
(JSC::Wasm::BBQJIT::addI31GetS):
(JSC::Wasm::BBQJIT::addI31GetU):
(JSC::Wasm::BBQJIT::getTypeDefinition):
(JSC::Wasm::BBQJIT::getArrayTypeDefinition):
(JSC::Wasm::BBQJIT::getArrayElementType):
(JSC::Wasm::BBQJIT::marshallToI64):
(JSC::Wasm::BBQJIT::addArrayNew):
(JSC::Wasm::BBQJIT::addArrayNewDefault):
(JSC::Wasm::BBQJIT::pushArrayNewFromSegment):
(JSC::Wasm::BBQJIT::addArrayNewData):
(JSC::Wasm::BBQJIT::addArrayNewElem):
(JSC::Wasm::BBQJIT::emitArraySetUnchecked):
(JSC::Wasm::BBQJIT::addArrayNewFixed):
(JSC::Wasm::BBQJIT::addArrayGet):
(JSC::Wasm::BBQJIT::addArraySet):
(JSC::Wasm::BBQJIT::addArrayLen):
(JSC::Wasm::BBQJIT::emitStructSet):
(JSC::Wasm::BBQJIT::addStructNewDefault):
(JSC::Wasm::BBQJIT::addStructNew):
(JSC::Wasm::BBQJIT::addStructGet):
(JSC::Wasm::BBQJIT::addStructSet):
(JSC::Wasm::BBQJIT::addRefTest):
(JSC::Wasm::BBQJIT::addRefCast):
(JSC::Wasm::BBQJIT::addExternInternalize):
(JSC::Wasm::BBQJIT::emitThrowOnNullReference):
(JSC::Wasm::BBQJIT::addI32Popcnt):
(JSC::Wasm::BBQJIT::addI64Popcnt):
(JSC::Wasm::BBQJIT::addRefFunc):
(JSC::Wasm::BBQJIT::toB3Type):
(JSC::Wasm::BBQJIT::emitCCall):
(JSC::Wasm::BBQJIT::addCallRef):
* Source/JavaScriptCore/wasm/WasmFunctionParser.h:
(JSC::Wasm::FunctionParser&lt;Context&gt;::parseExpression):
* Source/JavaScriptCore/wasm/WasmLimits.h:
* Source/JavaScriptCore/wasm/WasmOperations.cpp:
(JSC::Wasm::JSC_DEFINE_JIT_OPERATION):
* Source/JavaScriptCore/wasm/WasmOperations.h:

Canonical link: <a href="https://commits.webkit.org/264638@main">https://commits.webkit.org/264638@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/450b85be1377533841691977c54b846572249f1b

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/8185 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/8476 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/8693 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/9848 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/8255 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/10464 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/8387 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/11127 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/8330 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/9395 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/7430 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/9970 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/6695 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/7489 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/15048 "Passed tests") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/6979 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/7818 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/7619 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/10975 "Passed tests") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/7751 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/8091 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/6576 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/8357 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/7383 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/1922 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/1977 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/11590 "Built successfully") | | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/24/builds/8581 "Built successfully") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/7833 "Built successfully") | | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/3/builds/2068 "Passed tests") | 
<!--EWS-Status-Bubble-End-->