### PR TITLE
Return vertical writing mode aware intrinsic information for SVG

### DIFF
--- a/LayoutTests/svg/in-html/svg-inline-vertical-expected.txt
+++ b/LayoutTests/svg/in-html/svg-inline-vertical-expected.txt
@@ -1,0 +1,4 @@
+
+PASS Test size calculation in vertical writing mode (1)
+PASS Test size calculation in vertical writing mode (2)
+

--- a/LayoutTests/svg/in-html/svg-inline-vertical.html
+++ b/LayoutTests/svg/in-html/svg-inline-vertical.html
@@ -1,0 +1,31 @@
+<!doctype html>
+<title>Test SVG sizing in vertical writing mode</title>
+<script src="../../resources/testharness.js"></script>
+<script src="../../resources/testharnessreport.js"></script>
+<style>
+  div {
+      -webkit-writing-mode: vertical-rl;
+      writing-mode: vertical-rl;
+      height: 200px;
+  }
+</style>
+<div>
+  <!-- All SVGs expected size is 100x200 -->
+  <svg width="100" height="200">
+    <rect x="0" y="0" width="100" height="200" fill="lime" stroke="black" stroke-width="10"/>
+  </svg>
+  <svg style="width: auto !important; height: auto !important" width="100" height="200">
+    <rect x="0" y="0" width="100" height="200" fill="lime" stroke="black" stroke-width="10"/>
+  </svg>
+</div>
+<script>
+  var svgs = document.querySelectorAll('svg');
+  [].forEach.call(svgs, function (svg, index) {
+      test(function() {
+          var bounds = svg.getBoundingClientRect();
+          assert_equals(bounds.height, 200, "Height");
+          assert_equals(bounds.width, 100, "Width");
+
+      }, "Test size calculation in vertical writing mode (" + (index + 1) + ")");
+  });
+</script>

--- a/Source/WebCore/rendering/svg/LegacyRenderSVGRoot.cpp
+++ b/Source/WebCore/rendering/svg/LegacyRenderSVGRoot.cpp
@@ -2,7 +2,7 @@
  * Copyright (C) 2004, 2005, 2007 Nikolas Zimmermann <zimmermann@kde.org>
  * Copyright (C) 2004, 2005, 2007, 2008, 2009 Rob Buis <buis@kde.org>
  * Copyright (C) 2007 Eric Seidel <eric@webkit.org>
- * Copyright (C) 2009 Google, Inc.
+ * Copyright (C) 2009-2015 Google, Inc.
  * Copyright (C) Research In Motion Limited 2011. All rights reserved.
  *
  * This library is free software; you can redistribute it and/or
@@ -93,6 +93,9 @@ void LegacyRenderSVGRoot::computeIntrinsicRatioInformation(FloatSize& intrinsicS
     intrinsicSize.setWidth(floatValueForLength(svgSVGElement().intrinsicWidth(), 0));
     intrinsicSize.setHeight(floatValueForLength(svgSVGElement().intrinsicHeight(), 0));
 
+    if (!isHorizontalWritingMode())
+        intrinsicSize = intrinsicSize.transposedSize();
+
     if (style().aspectRatioType() == AspectRatioType::Ratio) {
         intrinsicRatio = FloatSize::narrowPrecision(style().aspectRatioLogicalWidth(), style().aspectRatioLogicalHeight()); 
         return;
@@ -110,6 +113,8 @@ void LegacyRenderSVGRoot::computeIntrinsicRatioInformation(FloatSize& intrinsicS
         if (!viewBoxSize.isEmpty()) {
             // The viewBox can only yield an intrinsic ratio, not an intrinsic size.
             intrinsicRatioValue = { viewBoxSize.width(), viewBoxSize.height() };
+            if (!isHorizontalWritingMode())
+                intrinsicRatioValue = 1 / intrinsicRatio;
         }
     }
 


### PR DESCRIPTION
<pre>
Return vertical writing mode aware intrinsic information for SVG
<a href="https://bugs.webkit.org/show_bug.cgi?id=248769">https://bugs.webkit.org/show_bug.cgi?id=248769</a>
rdar://problem/103262534

Reviewed by NOBODY (OOPS!).

This patch is to align Webkit with Gecko / Firefox and Blink / Chromium.

Merge (only passing test) - <a href="https://chromium.googlesource.com/chromium/blink/+/60af46f13e39be1daacbcdab27c4e7212ae27886">https://chromium.googlesource.com/chromium/blink/+/60af46f13e39be1daacbcdab27c4e7212ae27886</a>

This patch is to make computeIntrinsicRatioInformation function aware of
writing mode by taking the logical values returned into consideration.

This is limited to Legacy SVG and not for LBSE.

* Source/WebCore/rendering/svg/LegacyRenderSVGRoot.cpp:
(LegacyRenderSVGRoot::computeIntrinsicRatioInformation): Add logic to consider "HorizontalWritingMode"
* LayoutTests/svg/in-html/sizing/svg-inline-vertical.html: Add Test Case
* LayoutTests/svg/in-html/sizing/svg-inline-vertical-expected.txt: Add Test Case Expectation
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/7b213016208014f3afca16c6938dd43a26f18a4c

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/7017 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/7260 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/7439 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/8632 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/7251 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/7027 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/8522 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/7192 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/10158 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/7144 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/7810 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/6473 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/8735 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/5177 "Passed tests") | [💥 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/11523 "An unexpected error occured. Recent messages:OS: Monterey (12.6.7), Xcode: 14.0; Skipping applying patch since patch_id isn't provided; Checked out pull request") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/14155 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/6842 "Passed tests") | [💥 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/11691 "An unexpected error occured. Recent messages:OS: Monterey (12.6.7), Xcode: 14.0; Skipping applying patch since patch_id isn't provided; Checked out pull request") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/9335 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/6955 "Built successfully") | [💥 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/10063 "An unexpected error occured. Recent messages:OS: Ventura (13.4.1), Xcode: 14.3; Skipping applying patch since patch_id isn't provided; Checked out pull request") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/6321 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/6289 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/10516 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/6704 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->