### PR TITLE
[WGSL] Implement all logical operators

### DIFF
--- a/Source/WebGPU/WGSL/Metal/MetalFunctionWriter.cpp
+++ b/Source/WebGPU/WGSL/Metal/MetalFunctionWriter.cpp
@@ -590,10 +590,12 @@ void FunctionDefinitionWriter::visit(AST::UnaryExpression& unary)
     case AST::UnaryOperation::Negate:
         m_stringBuilder.append("-");
         break;
+    case AST::UnaryOperation::Not:
+        m_stringBuilder.append("!");
+        break;
 
     case AST::UnaryOperation::AddressOf:
     case AST::UnaryOperation::Dereference:
-    case AST::UnaryOperation::Not:
         // FIXME: Implement these
         RELEASE_ASSERT_NOT_REACHED();
         break;
@@ -670,9 +672,10 @@ void FunctionDefinitionWriter::visit(AST::BinaryExpression& binary)
         break;
 
     case AST::BinaryOperation::ShortCircuitAnd:
+        m_stringBuilder.append(" && ");
+        break;
     case AST::BinaryOperation::ShortCircuitOr:
-        // FIXME: Implement these
-        RELEASE_ASSERT_NOT_REACHED();
+        m_stringBuilder.append(" || ");
         break;
     }
     visit(binary.rightExpression());

--- a/Source/WebGPU/WGSL/TypeDeclarations.rb
+++ b/Source/WebGPU/WGSL/TypeDeclarations.rb
@@ -146,6 +146,31 @@ operator :vec4, {
     end
 end
 
+# 7.6. Logical Expressions (https://gpuweb.github.io/gpuweb/wgsl/#logical-expr)
+
+operator :!, {
+    [].(Bool) => Bool,
+    [N].(Vector[Bool, N]) => Vector[Bool, N],
+}
+
+operator :'||', {
+    [].(Bool, Bool) => Bool,
+}
+
+operator :'&&', {
+    [].(Bool, Bool) => Bool,
+}
+
+operator :'|', {
+    [].(Bool, Bool) => Bool,
+    [N].(Vector[Bool, N], Vector[Bool, N]) => Vector[Bool, N],
+}
+
+operator :'&', {
+    [].(Bool, Bool) => Bool,
+    [N].(Vector[Bool, N], Vector[Bool, N]) => Vector[Bool, N],
+}
+
 # 17.3. Logical Built-in Functions (https://www.w3.org/TR/WGSL/#logical-builtin-functions)
 
 # 17.3.1 & 17.3.2

--- a/Source/WebGPU/WGSL/tests/valid/overload.wgsl
+++ b/Source/WebGPU/WGSL/tests/valid/overload.wgsl
@@ -366,6 +366,88 @@ fn testBitwise()
   }
 }
 
+// 7.6. Logical Expressions (https://gpuweb.github.io/gpuweb/wgsl/#logical-expr)
+
+fn testLogicalNegation()
+{
+    // [].(Bool) => Bool,
+    _ = !true;
+    _ = !false;
+
+    // [N].(Vector[Bool, N]) => Vector[Bool, N],
+    _ = !vec2(true);
+    _ = !vec3(true);
+    _ = !vec4(true);
+    _ = !vec2(false);
+    _ = !vec3(false);
+    _ = !vec4(false);
+}
+
+fn testShortCircuitingOr()
+{
+    // [].(Bool, Bool) => Bool,
+    _ = false || false;
+    _ = true || false;
+    _ = false || true;
+    _ = true || true;
+}
+
+fn testShortCircuitingAnd()
+{
+    // [].(Bool, Bool) => Bool,
+    _ = false && false;
+    _ = true && false;
+    _ = false && true;
+    _ = true && true;
+}
+
+fn testLogicalOr()
+{
+    // [].(Bool, Bool) => Bool,
+    _ = false | false;
+    _ = true | false;
+    _ = false | true;
+    _ = true | true;
+
+    // [N].(Vector[Bool, N], Vector[Bool, N]) => Vector[Bool, N],
+    _ = vec2(false) | vec2(false);
+    _ = vec2( true) | vec2(false);
+    _ = vec2(false) | vec2( true);
+    _ = vec2( true) | vec2( true);
+    _ = vec3(false) | vec3(false);
+    _ = vec3( true) | vec3(false);
+    _ = vec3(false) | vec3( true);
+    _ = vec3( true) | vec3( true);
+    _ = vec4(false) | vec4(false);
+    _ = vec4( true) | vec4(false);
+    _ = vec4(false) | vec4( true);
+    _ = vec4( true) | vec4( true);
+}
+
+fn testLogicalAnd()
+{
+    // [].(Bool, Bool) => Bool,
+    _ = false & false;
+    _ = true & false;
+    _ = false & true;
+    _ = true & true;
+
+    // [N].(Vector[Bool, N], Vector[Bool, N]) => Vector[Bool, N],
+    _ = vec2(false) & vec2(false);
+    _ = vec2( true) & vec2(false);
+    _ = vec2(false) & vec2( true);
+    _ = vec2( true) & vec2( true);
+    _ = vec3(false) & vec3(false);
+    _ = vec3( true) & vec3(false);
+    _ = vec3(false) & vec3( true);
+    _ = vec3( true) & vec3( true);
+    _ = vec4(false) & vec4(false);
+    _ = vec4( true) & vec4(false);
+    _ = vec4(false) & vec4( true);
+    _ = vec4( true) & vec4( true);
+}
+
+
 // 17.3. Logical Built-in Functions (https://www.w3.org/TR/WGSL/#logical-builtin-functions)
 
 // 17.3.1


### PR DESCRIPTION
#### ca8455227212d8b0a160c793fdad2549c07e8124
<pre>
[WGSL] Implement all logical operators
<a href="https://bugs.webkit.org/show_bug.cgi?id=256963">https://bugs.webkit.org/show_bug.cgi?id=256963</a>
rdar://109515188

Reviewed by Dan Glastonbury.

Implement logical operators (or logical expression) according to the spec[1].

[1]: <a href="https://gpuweb.github.io/gpuweb/wgsl/#logical-expr">https://gpuweb.github.io/gpuweb/wgsl/#logical-expr</a>

* Source/WebGPU/WGSL/Metal/MetalFunctionWriter.cpp:
(WGSL::Metal::FunctionDefinitionWriter::visit):
* Source/WebGPU/WGSL/TypeDeclarations.rb:
* Source/WebGPU/WGSL/tests/valid/overload.wgsl:

Canonical link: <a href="https://commits.webkit.org/264236@main">https://commits.webkit.org/264236@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/48bae2502200aa2c160bef9cc231a47401890de6

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [⏳ 🧪 style ](https://ews-build.webkit.org/#/builders/Style-EWS "Waiting in queue, processing has not started yet") | [⏳ 🛠 ios ](https://ews-build.webkit.org/#/builders/iOS-16-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🛠 mac ](https://ews-build.webkit.org/#/builders/macOS-Monterey-Release-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🛠 wpe ](https://ews-build.webkit.org/#/builders/WPE-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🛠 wincairo ](https://ews-build.webkit.org/#/builders/WinCairo-EWS "Waiting in queue, processing has not started yet") 
| [⏳ 🧪 bindings ](https://ews-build.webkit.org/#/builders/Bindings-Tests-EWS "Waiting in queue, processing has not started yet") | [⏳ 🛠 ios-sim ](https://ews-build.webkit.org/#/builders/iOS-16-Simulator-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🛠 mac-AS-debug ](https://ews-build.webkit.org/#/builders/macOS-AppleSilicon-Ventura-Debug-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🧪 wpe-wk2 ](https://ews-build.webkit.org/#/builders/WPE-Build-EWS "Waiting in queue, processing has not started yet") | 
| [⏳ 🧪 webkitperl ](https://ews-build.webkit.org/#/builders/WebKitPerl-Tests-EWS "Waiting in queue, processing has not started yet") | [⏳ 🧪 ios-wk2 ](https://ews-build.webkit.org/#/builders/iOS-16-Simulator-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🧪 api-mac ](https://ews-build.webkit.org/#/builders/macOS-Monterey-Release-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🛠 gtk ](https://ews-build.webkit.org/#/builders/GTK-Build-EWS "Waiting in queue, processing has not started yet") | 
| [⏳ 🧪 webkitpy ](https://ews-build.webkit.org/#/builders/WebKitPy-Tests-EWS "Waiting in queue, processing has not started yet") | [⏳ 🧪 ios-wk2-wpt ](https://ews-build.webkit.org/#/builders/iOS-16-Simulator-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🧪 mac-wk1 ](https://ews-build.webkit.org/#/builders/macOS-Monterey-Release-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🧪 gtk-wk2 ](https://ews-build.webkit.org/#/builders/GTK-Build-EWS "Waiting in queue, processing has not started yet") | 
| [⏳ 🛠 🧪 jsc ](https://ews-build.webkit.org/#/builders/JSC-Tests-EWS "Waiting in queue, processing has not started yet") | [⏳ 🧪 api-ios ](https://ews-build.webkit.org/#/builders/iOS-16-Simulator-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🧪 mac-wk2 ](https://ews-build.webkit.org/#/builders/macOS-Monterey-Release-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🧪 api-gtk ](https://ews-build.webkit.org/#/builders/GTK-Build-EWS "Waiting in queue, processing has not started yet") | 
| [⏳ 🛠 🧪 jsc-arm64 ](https://ews-build.webkit.org/#/builders/JSC-Tests-arm64-EWS "Waiting in queue, processing has not started yet") | [⏳ 🛠 tv ](https://ews-build.webkit.org/#/builders/tvOS-16-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🧪 mac-AS-debug-wk2 ](https://ews-build.webkit.org/#/builders/macOS-AppleSilicon-Ventura-Debug-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🛠 jsc-armv7 ](https://ews-build.webkit.org/#/builders/JSC-ARMv7-32bits-Build-EWS "Waiting in queue, processing has not started yet") | 
| [⏳ 🧪 services ](https://ews-build.webkit.org/#/builders/Services-EWS "Waiting in queue, processing has not started yet") | [⏳ 🛠 tv-sim ](https://ews-build.webkit.org/#/builders/tvOS-16-Simulator-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🧪 mac-wk2-stress ](https://ews-build.webkit.org/#/builders/macOS-Monterey-Release-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🧪 jsc-armv7-tests ](https://ews-build.webkit.org/#/builders/JSC-ARMv7-32bits-Build-EWS "Waiting in queue, processing has not started yet") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/1684 "Built successfully and passed tests") | [⏳ 🛠 watch ](https://ews-build.webkit.org/#/builders/watchOS-9-Build-EWS "Waiting in queue, processing has not started yet") | | [⏳ 🛠 jsc-mips ](https://ews-build.webkit.org/#/builders/JSC-MIPSEL-32bits-Build-EWS "Waiting in queue, processing has not started yet") | 
| | [⏳ 🛠 watch-sim ](https://ews-build.webkit.org/#/builders/watchOS-9-Simulator-Build-EWS "Waiting in queue, processing has not started yet") | | [⏳ 🧪 jsc-mips-tests ](https://ews-build.webkit.org/#/builders/JSC-MIPSEL-32bits-Build-EWS "Waiting in queue, processing has not started yet") | 
<!--EWS-Status-Bubble-End-->