### PR TITLE
ASSERTION FAILED: m_setOp == CharacterClassSetOp::Default || m_setOp == setOp

### DIFF
--- a/JSTests/stress/regexp-vflag-property-of-strings.js
+++ b/JSTests/stress/regexp-vflag-property-of-strings.js
@@ -471,3 +471,7 @@ testRegExp(/[[\u{0250}-\u{3373}a]&&[\q{\u{3373}}]]/v, "\u{0250}", null);
 testRegExp(/[[\u{0250}-\u{3373}a]&&[\q{\u{3373}}]]/v, "\u{1813}", null);
 testRegExp(/[[\u{0250}-\u{3373}a]&&[\q{\u{3373}}]]/v, "\u{3373}", ["\u{3373}"]);
 testRegExp(/[[]a]/v, "a", ["a"]);
+testRegExp(/[\p{ASCII}--[a-z]][\.!]/v, "TEST!", ["T!"]);
+
+// Test 226
+testRegExp(/[ab][c--c]/v, "a", null);

--- a/Source/JavaScriptCore/yarr/YarrPattern.cpp
+++ b/Source/JavaScriptCore/yarr/YarrPattern.cpp
@@ -1239,6 +1239,7 @@ public:
         }
 
         auto newCharacterClass = m_currentCharacterClassConstructor->charClass();
+        m_currentCharacterClassConstructor->reset();
         auto hasStrings = newCharacterClass->hasStrings();
 
         if (!m_invertCharacterClass && newCharacterClass.get()->m_anyCharacter) {


### PR DESCRIPTION
#### b33b49a0599257b96cb7f9436fc4c488a6f3ee31
<pre>
ASSERTION FAILED: m_setOp == CharacterClassSetOp::Default || m_setOp == setOp
<a href="https://bugs.webkit.org/show_bug.cgi?id=256750">https://bugs.webkit.org/show_bug.cgi?id=256750</a>
&lt;rdar://problem/108256053&gt;

Reviewed by Yusuke Suzuki.

When we end a character class in YarrPatternConstructor, we need to reset the associated
character class constructor for a possible follow on character class.

Added two new test cases.

* JSTests/stress/regexp-vflag-property-of-strings.js:
* Source/JavaScriptCore/yarr/YarrPattern.cpp:
(JSC::Yarr::YarrPatternConstructor::atomCharacterClassEnd):

Canonical link: <a href="https://commits.webkit.org/264207@main">https://commits.webkit.org/264207@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/62566f6809677ae31c12891ad883c539bdb75008

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/7021 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/7264 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/7443 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/8636 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/7255 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/8526 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/7196 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/10168 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/7148 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/7815 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/6479 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/8739 "Built successfully") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/39/builds/5182 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/6385 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/14164 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/5938 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/6846 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/6480 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/9348 "Passed tests") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/6603 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/6959 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/5701 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/7158 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/6325 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/1669 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/1663 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/10520 "Built successfully") | | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/24/builds/7357 "Built successfully") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/6708 "Built successfully") | | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/3/builds/1809 "Passed tests") | 
<!--EWS-Status-Bubble-End-->