### PR TITLE
[WGSL] EntryPointRewriter is skipping materializations

### DIFF
--- a/Source/WebGPU/WGSL/EntryPointRewriter.cpp
+++ b/Source/WebGPU/WGSL/EntryPointRewriter.cpp
@@ -100,27 +100,23 @@ void EntryPointRewriter::rewrite()
 
     collectParameters();
     checkReturnType();
-
-    // nothing to rewrite
-    if (m_parameters.isEmpty()) {
-        appendBuiltins();
-        return;
-    }
-
-    constructInputStruct();
     appendBuiltins();
 
-    // add parameter to builtins: ${structName} : ${structType}
-    auto& type = m_shaderModule.astBuilder().construct<AST::NamedTypeName>(SourceSpan::empty(), AST::Identifier::make(m_structTypeName));
-    type.m_resolvedType = m_structType;
-    auto& parameter = m_shaderModule.astBuilder().construct<AST::Parameter>(
-        SourceSpan::empty(),
-        AST::Identifier::make(m_structParameterName),
-        type,
-        AST::Attribute::List { },
-        AST::ParameterRole::StageIn
-    );
-    m_shaderModule.append(m_function.parameters(), parameter);
+    if (!m_parameters.isEmpty()) {
+        constructInputStruct();
+
+        // add parameter to builtins: ${structName} : ${structType}
+        auto& type = m_shaderModule.astBuilder().construct<AST::NamedTypeName>(SourceSpan::empty(), AST::Identifier::make(m_structTypeName));
+        type.m_resolvedType = m_structType;
+        auto& parameter = m_shaderModule.astBuilder().construct<AST::Parameter>(
+            SourceSpan::empty(),
+            AST::Identifier::make(m_structParameterName),
+            type,
+            AST::Attribute::List { },
+            AST::ParameterRole::StageIn
+        );
+        m_shaderModule.append(m_function.parameters(), parameter);
+    }
 
     while (m_materializations.size())
         m_shaderModule.insert(m_function.body().statements(), 0, m_materializations.takeLast());


### PR DESCRIPTION
#### 8364b025cf0649b2f3a4eae233a496cac9e0e232
<pre>
[WGSL] EntryPointRewriter is skipping materializations
<a href="https://bugs.webkit.org/show_bug.cgi?id=256966">https://bugs.webkit.org/show_bug.cgi?id=256966</a>
rdar://109515526

Reviewed by Mike Wyrzykowski and Dan Glastonbury.

The EntryPointRewriter would return early when `m_parameters` was empty. `m_parameters`
holds parameters that were moved into the stage_in struct. Before early returning, it
also called `appendBuiltins`, which inserted all the built-in inputs into function&apos;s
parameters, whether those were already parameters to begin with, or were hoisted from
a struct parameter, since Metal doesn&apos;t allow built-ins in structs. However, we were
missing that we could have an empty `m_parameters`, but still have values in `m_materializations`,
which holds the operations we might need to reconstruct struct arguments whose fields
got hoisted into the function&apos;s top-level parameters. To make the code less error-prone,
I removed the early return and instead conditionally apply each of the steps: append the
built-in parameters, construct the stage_in struct and materialize (user-defined) struct
inputs.

* Source/WebGPU/WGSL/EntryPointRewriter.cpp:
(WGSL::EntryPointRewriter::rewrite):

Canonical link: <a href="https://commits.webkit.org/264232@main">https://commits.webkit.org/264232@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a30380f50b702109db424981a7fa385c1e28290b

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/7038 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/7281 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/7460 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/8653 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/7272 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/8543 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/7213 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/10178 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/7165 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/7829 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/6492 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/8756 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/5195 "Passed tests") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/14172 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/6859 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/6521 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/9364 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/6976 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/5712 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/6342 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/1680 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/10537 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/6724 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->