### PR TITLE
[WGSL] Struct members shouldn't have built-in attributes

### DIFF
--- a/Source/WebGPU/WGSL/Metal/MetalFunctionWriter.cpp
+++ b/Source/WebGPU/WGSL/Metal/MetalFunctionWriter.cpp
@@ -238,6 +238,12 @@ void FunctionDefinitionWriter::visit(AST::Attribute& attribute)
 
 void FunctionDefinitionWriter::visit(AST::BuiltinAttribute& builtin)
 {
+    // Built-in attributes are only valid for parameters. If a struct member originally
+    // had a built-in attribute it must have already been hoisted into a parameter, but
+    // we keep the original struct so we can reconstruct it.
+    if (m_structRole.has_value())
+        return;
+
     // FIXME: we should replace this with something more efficient, like a trie
     static constexpr std::pair<ComparableASCIILiteral, ASCIILiteral> builtinMappings[] {
         { "frag_depth", "depth(any)"_s },


### PR DESCRIPTION
#### d6f9f3ee61b8accacdc7790d72fcb03af4e84811
<pre>
[WGSL] Struct members shouldn&apos;t have built-in attributes
<a href="https://bugs.webkit.org/show_bug.cgi?id=256967">https://bugs.webkit.org/show_bug.cgi?id=256967</a>
rdar://109515831

Reviewed by Mike Wyrzykowski and Dan Glastonbury.

It&apos;s invalid for MSL code to have built-in attributes in struct members, and at
this point of the compilation these inputs were already hoisted into parameters
of the entry point function, so we should just skip the serialization of built-in
attributes if we are serializing a struct.

* Source/WebGPU/WGSL/Metal/MetalFunctionWriter.cpp:
(WGSL::Metal::FunctionDefinitionWriter::visit):

Canonical link: <a href="https://commits.webkit.org/264231@main">https://commits.webkit.org/264231@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/66df76269ddbfe8468697055de68cd7917bc00ef

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/7023 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/7266 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/7445 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/8638 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/7257 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/8528 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/7198 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/10167 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/7150 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/7817 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/6480 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/8741 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/5184 "Passed tests") | | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/14162 "2 flakes 110 failures") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/6848 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/6481 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/9344 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/6961 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/5699 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/6327 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/1681 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/10522 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/6710 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->