### PR TITLE
[WGSL] Report the correct workgroup size in EntryPointInformation

### DIFF
--- a/Source/WebGPU/WGSL/AST/ASTVisitor.cpp
+++ b/Source/WebGPU/WGSL/AST/ASTVisitor.cpp
@@ -527,4 +527,19 @@ void Visitor::visit(VariableQualifier&)
 {
 }
 
+std::optional<unsigned> extractInteger(const AST::Expression& expression)
+{
+    switch (expression.kind()) {
+    case AST::NodeKind::AbstractIntegerLiteral:
+        return { static_cast<unsigned>(downcast<AST::AbstractIntegerLiteral>(expression).value()) };
+    case AST::NodeKind::Unsigned32Literal:
+        return { static_cast<unsigned>(downcast<AST::Unsigned32Literal>(expression).value()) };
+    case AST::NodeKind::Signed32Literal:
+        return { static_cast<unsigned>(downcast<AST::Signed32Literal>(expression).value()) };
+    default:
+        // FIXME: handle constants and overrides
+        return std::nullopt;
+    }
+}
+
 } // namespace WGSL::AST

--- a/Source/WebGPU/WGSL/AST/ASTVisitor.h
+++ b/Source/WebGPU/WGSL/AST/ASTVisitor.h
@@ -140,5 +140,7 @@ private:
     Result<void> m_expectedError;
 };
 
+std::optional<unsigned> extractInteger(const AST::Expression&);
+
 } // namespace AST
 } // namespace WGSL

--- a/Source/WebGPU/WGSL/AST/ASTWorkgroupSizeAttribute.h
+++ b/Source/WebGPU/WGSL/AST/ASTWorkgroupSizeAttribute.h
@@ -37,6 +37,10 @@ public:
     Expression* maybeY() { return m_y; }
     Expression* maybeZ() { return m_z; }
 
+    const Expression& x() const { return m_x.get(); }
+    const Expression* maybeY() const { return m_y; }
+    const Expression* maybeZ() const { return m_z; }
+
 private:
     WorkgroupSizeAttribute(SourceSpan span, Expression::Ref&& x, Expression::Ptr maybeY, Expression::Ptr maybeZ)
         : Attribute(span)

--- a/Source/WebGPU/WGSL/EntryPointRewriter.cpp
+++ b/Source/WebGPU/WGSL/EntryPointRewriter.cpp
@@ -81,9 +81,24 @@ EntryPointRewriter::EntryPointRewriter(ShaderModule& shaderModule, const AST::Fu
     , m_function(function)
 {
     switch (m_stage) {
-    case AST::StageAttribute::Stage::Compute:
-        m_information.typedEntryPoint = Reflection::Compute { 1, 1, 1 };
+    case AST::StageAttribute::Stage::Compute: {
+        unsigned x = 0;
+        unsigned y = 1;
+        unsigned z = 1;
+        for (auto& attribute : function.attributes()) {
+            if (!is<AST::WorkgroupSizeAttribute>(attribute))
+                continue;
+            auto& workgroupSize = downcast<AST::WorkgroupSizeAttribute>(attribute);
+            x = *AST::extractInteger(workgroupSize.x());
+            if (auto* maybeY = workgroupSize.maybeY())
+                y = *AST::extractInteger(*maybeY);
+            if (auto* maybeZ = workgroupSize.maybeZ())
+                z = *AST::extractInteger(*maybeZ);
+        }
+        ASSERT(x);
+        m_information.typedEntryPoint = Reflection::Compute { x, y, z };
         break;
+    }
     case AST::StageAttribute::Stage::Vertex:
         m_information.typedEntryPoint = Reflection::Vertex { false };
         break;

--- a/Source/WebGPU/WGSL/TypeCheck.cpp
+++ b/Source/WebGPU/WGSL/TypeCheck.cpp
@@ -102,7 +102,6 @@ private:
     void inferred(Type*);
     bool unify(Type*, Type*) WARN_UNUSED_RETURN;
     bool isBottom(Type*) const;
-    std::optional<unsigned> extractInteger(AST::Expression&);
 
     template<typename CallArguments>
     Type* chooseOverload(const char*, const SourceSpan&, const String&, CallArguments&& valueArguments, const Vector<Type*>& typeArguments);
@@ -583,21 +582,6 @@ void TypeChecker::visit(AST::ReferenceTypeName&)
 }
 
 // Private helpers
-std::optional<unsigned> TypeChecker::extractInteger(AST::Expression& expression)
-{
-    switch (expression.kind()) {
-    case AST::NodeKind::AbstractIntegerLiteral:
-        return { static_cast<unsigned>(downcast<AST::AbstractIntegerLiteral>(expression).value()) };
-    case AST::NodeKind::Unsigned32Literal:
-        return { static_cast<unsigned>(downcast<AST::Unsigned32Literal>(expression).value()) };
-    case AST::NodeKind::Signed32Literal:
-        return { static_cast<unsigned>(downcast<AST::Signed32Literal>(expression).value()) };
-    default:
-        // FIXME: handle constants and overrides
-        return std::nullopt;
-    }
-}
-
 void TypeChecker::vectorFieldAccess(const Types::Vector& vector, AST::FieldAccessExpression& access)
 {
     const auto& fieldName = access.fieldName().id();


### PR DESCRIPTION
#### dfe31a43c822ff776a5303f79119741966f815ff
<pre>
[WGSL] Report the correct workgroup size in EntryPointInformation
<a href="https://bugs.webkit.org/show_bug.cgi?id=256969">https://bugs.webkit.org/show_bug.cgi?id=256969</a>
rdar://109516093

Reviewed by Mike Wyrzykowski.

Previously, we were always reporting the workgroup size to be `1, 1, 1` to
the API. Instead, extract and use actual values from the AST. This code still
doesn&apos;t handle constants, but that will be done later in a separate pass.

* Source/WebGPU/WGSL/AST/ASTVisitor.cpp:
(WGSL::AST::extractInteger):
* Source/WebGPU/WGSL/AST/ASTVisitor.h:
* Source/WebGPU/WGSL/AST/ASTWorkgroupSizeAttribute.h:
* Source/WebGPU/WGSL/EntryPointRewriter.cpp:
(WGSL::EntryPointRewriter::EntryPointRewriter):
* Source/WebGPU/WGSL/TypeCheck.cpp:
(WGSL::TypeChecker::extractInteger): Deleted.

Canonical link: <a href="https://commits.webkit.org/264234@main">https://commits.webkit.org/264234@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/36ebb4aab007a4ed76b62de6c8a2cb901de42e52

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/7024 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/7267 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/7446 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/8639 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/7258 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/8529 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/7199 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/10165 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/7151 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/7820 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/6481 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/8742 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/5187 "Passed tests") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/14161 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/6851 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/6482 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/9343 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/6962 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/5702 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/6328 "Built successfully") | | | 
| [❌ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/1682 "Failed to push commit to Webkit repository") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/10523 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/6711 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->