### PR TITLE
[WGSL] Respect @size and @alignment when serializing structs

### DIFF
--- a/Source/WebGPU/WGSL/GlobalVariableRewriter.cpp
+++ b/Source/WebGPU/WGSL/GlobalVariableRewriter.cpp
@@ -329,8 +329,12 @@ void RewriteGlobalVariables::insertStructs(const UsedGlobals& usedGlobals)
             }
 
             AST::TypeName::Ref memberType = *global->declaration->maybeTypeName();
-            if (shouldBeReference)
+            if (shouldBeReference) {
+                auto* type = memberType.get().resolvedType();
                 memberType = m_callGraph.ast().astBuilder().construct<AST::ReferenceTypeName>(span, WTFMove(memberType));
+                // FIXME: we need to be able to represent reference types in the type system
+                memberType.get().m_resolvedType = type;
+            }
             structMembers.append(m_callGraph.ast().astBuilder().construct<AST::StructureMember>(
                 span,
                 AST::Identifier::make(WTFMove(name)),

--- a/Source/WebGPU/WGSL/Types.h
+++ b/Source/WebGPU/WGSL/Types.h
@@ -129,6 +129,8 @@ struct Type : public std::variant<
         >::variant;
     void dump(PrintStream&) const;
     String toString() const;
+    unsigned size() const;
+    unsigned alignment() const;
 };
 
 using ConversionRank = Markable<unsigned, IntegralMarkableTraits<unsigned, std::numeric_limits<unsigned>::max()>>;


### PR DESCRIPTION
#### b810632939925d5e80263b3991700849b1873cea
<pre>
[WGSL] Respect @size and @alignment when serializing structs
<a href="https://bugs.webkit.org/show_bug.cgi?id=256971">https://bugs.webkit.org/show_bug.cgi?id=256971</a>
rdar://109516591

Reviewed by Dan Glastonbury.

Implement the size and alignment calculation for types according to the spec[1] and
respect both the implicit and explit size and alignments (provided through attributes)
when serializing structs.

[1]: <a href="https://gpuweb.github.io/gpuweb/wgsl/#alignment-and-size">https://gpuweb.github.io/gpuweb/wgsl/#alignment-and-size</a>

* Source/WebGPU/WGSL/GlobalVariableRewriter.cpp:
(WGSL::RewriteGlobalVariables::insertStructs):
* Source/WebGPU/WGSL/Metal/MetalFunctionWriter.cpp:
(WGSL::Metal::FunctionDefinitionWriter::visit):
* Source/WebGPU/WGSL/Types.cpp:
(WGSL::Type::size const):
(WGSL::Type::alignment const):
* Source/WebGPU/WGSL/Types.h:

Canonical link: <a href="https://commits.webkit.org/264243@main">https://commits.webkit.org/264243@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/93b9cc999d265954603e8f20bf3bb72a5b61cd4a

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/7139 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/7386 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/7565 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/8755 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/7360 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/8653 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/7318 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/10261 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/7266 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/7923 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/6573 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/8861 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/5277 "Passed tests") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/14238 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/6938 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/6591 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/9470 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/7075 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/5784 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/6435 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/1689 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/10634 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/6818 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->