### PR TITLE
Remove dead code in the SVG, SVG Rendering and SVG Animation

### DIFF
--- a/Source/WebCore/rendering/svg/LegacyRenderSVGImage.h
+++ b/Source/WebCore/rendering/svg/LegacyRenderSVGImage.h
@@ -79,7 +79,6 @@ private:
     bool nodeAtFloatPoint(const HitTestRequest&, HitTestResult&, const FloatPoint& pointInParent, HitTestAction) override;
 
     AffineTransform localTransform() const override { return m_localTransform; }
-    void calculateImageViewport();
 
     bool m_needsBoundariesUpdate : 1;
     bool m_needsTransformUpdate : 1;

--- a/Source/WebCore/rendering/svg/LegacyRenderSVGRoot.h
+++ b/Source/WebCore/rendering/svg/LegacyRenderSVGRoot.h
@@ -87,9 +87,6 @@ private:
 
     const AffineTransform& localToParentTransform() const override;
 
-    bool fillContains(const FloatPoint&) const;
-    bool strokeContains(const FloatPoint&) const;
-
     FloatRect objectBoundingBox() const override { return m_objectBoundingBox; }
     FloatRect strokeBoundingBox() const override { return m_strokeBoundingBox; }
     FloatRect repaintRectInLocalCoordinates() const override { return m_repaintBoundingBox; }

--- a/Source/WebCore/rendering/svg/RenderSVGTextPath.cpp
+++ b/Source/WebCore/rendering/svg/RenderSVGTextPath.cpp
@@ -90,14 +90,4 @@ const SVGLengthValue& RenderSVGTextPath::startOffset() const
     return textPathElement().startOffset();
 }
 
-bool RenderSVGTextPath::exactAlignment() const
-{
-    return textPathElement().spacing() == SVGTextPathSpacingExact;
-}
-
-bool RenderSVGTextPath::stretchMethod() const
-{
-    return textPathElement().method() == SVGTextPathMethodStretch;
-}
-
 }

--- a/Source/WebCore/rendering/svg/RenderSVGTextPath.h
+++ b/Source/WebCore/rendering/svg/RenderSVGTextPath.h
@@ -38,8 +38,6 @@ public:
 
     Path layoutPath() const;
     const SVGLengthValue& startOffset() const;
-    bool exactAlignment() const;
-    bool stretchMethod() const;
 
 private:
     void graphicsElement() const = delete;

--- a/Source/WebCore/rendering/svg/SVGInlineTextBox.h
+++ b/Source/WebCore/rendering/svg/SVGInlineTextBox.h
@@ -41,9 +41,6 @@ public:
     float virtualLogicalHeight() const override { return m_logicalHeight; }
     void setLogicalHeight(float height) { m_logicalHeight = height; }
 
-    int selectionTop() { return top(); }
-    int selectionHeight() { return static_cast<int>(ceilf(m_logicalHeight)); }
-
     void paintSelectionBackground(PaintInfo&);
     void paint(PaintInfo&, const LayoutPoint&, LayoutUnit lineTop, LayoutUnit lineBottom) override;
     LayoutRect localSelectionRect(unsigned startPosition, unsigned endPosition) const override;

--- a/Source/WebCore/rendering/svg/SVGTextLayoutEngine.h
+++ b/Source/WebCore/rendering/svg/SVGTextLayoutEngine.h
@@ -48,7 +48,6 @@ public:
     SVGTextLayoutEngine(Vector<SVGTextLayoutAttributes*>&);
 
     Vector<SVGTextLayoutAttributes*>& layoutAttributes() { return m_layoutAttributes; }
-    SVGTextChunkBuilder& chunkLayoutBuilder() { return m_chunkLayoutBuilder; }
 
     void beginTextPathLayout(RenderSVGTextPath&, SVGTextLayoutEngine& lineLayout);
     void endTextPathLayout();

--- a/Source/WebCore/rendering/svg/SVGTextMetrics.h
+++ b/Source/WebCore/rendering/svg/SVGTextMetrics.h
@@ -52,13 +52,6 @@ public:
         {
         }
 
-        bool operator==(const Glyph& other)
-        {
-            return isValid == other.isValid
-                && name == other.name
-                && unicodeString == other.unicodeString;
-        }
-
         bool isValid;
         String name;
         String unicodeString;

--- a/Source/WebCore/svg/SVGAnimationElement.h
+++ b/Source/WebCore/svg/SVGAnimationElement.h
@@ -95,8 +95,6 @@ protected:
     String byValue() const;
     String fromValue() const;
 
-    String targetAttributeBaseValue();
-
     // from SVGSMILElement
     void startedActiveInterval() override;
     void updateAnimation(float percent, unsigned repeat) override;

--- a/Source/WebCore/svg/animation/SVGSMILElement.cpp
+++ b/Source/WebCore/svg/animation/SVGSMILElement.cpp
@@ -663,11 +663,6 @@ SMILTime SVGSMILElement::elapsed() const
     return m_timeContainer ? m_timeContainer->elapsed() : 0;
 }
 
-bool SVGSMILElement::isInactive() const
-{
-     return m_activeState == Inactive;
-}
-
 bool SVGSMILElement::isFrozen() const
 {
     return m_activeState == Frozen;

--- a/Source/WebCore/svg/animation/SVGSMILElement.h
+++ b/Source/WebCore/svg/animation/SVGSMILElement.h
@@ -78,7 +78,6 @@ public:
     SMILTime elapsed() const; 
 
     SMILTime intervalBegin() const { return m_intervalBegin; }
-    SMILTime intervalEnd() const { return m_intervalEnd; }
     SMILTime previousIntervalBegin() const { return m_previousIntervalBegin; }
     SMILTime simpleDuration() const;
 
@@ -92,7 +91,6 @@ public:
     static SMILTime parseOffsetValue(StringView);
 
     bool isContributing(SMILTime elapsed) const;
-    bool isInactive() const;
     bool isFrozen() const;
 
     unsigned documentOrderIndex() const { return m_documentOrderIndex; }


### PR DESCRIPTION
#### 6eb6516133eaa356c2ec72519e6efa667903110d
<pre>
Remove dead code in the SVG, SVG Rendering and SVG Animation

<a href="https://bugs.webkit.org/show_bug.cgi?id=256650">https://bugs.webkit.org/show_bug.cgi?id=256650</a>
rdar://problem/109519169

Reviewed by Simon Fraser.

This patch just removes dead code from SVG related code.

Selective Merge: <a href="https://src.chromium.org/viewvc/blink?revision=163910&amp">https://src.chromium.org/viewvc/blink?revision=163910&amp</a>;view=revision &amp;
<a href="https://src.chromium.org/viewvc/blink?view=revision&amp">https://src.chromium.org/viewvc/blink?view=revision&amp</a>;revision=163974

* Source/WebCore/rendering/svg/LegacyRenderSVGImage.h:
* Source/WebCore/rendering/svg/LegacyRenderSVGRoot.h:
* Source/WebCore/rendering/svg/RenderSVGTextPath.cpp:
* Source/WebCore/rendering/svg/RenderSVGTextPath.h:
* Source/WebCore/rendering/svg/SVGInlineTextBox.h:
* Source/WebCore/rendering/svg/SVGTextLayoutEngine.h:
* Source/WebCore/rendering/svg/SVGTextMetrics.h:
* Source/WebCore/svg/animation/SVGSMILElement.cpp:
* Source/WebCore/svg/animation/SVGSMILElement.h:
* Source/WebCore/svg/SVGAnimationElement.h:

Canonical link: <a href="https://commits.webkit.org/264223@main">https://commits.webkit.org/264223@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/23edcb81efd29fe6df5954130fc529638d6d52f5

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/7096 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/7341 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/7519 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/8710 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/32/builds/7326 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/7107 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/8603 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/7273 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/10225 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/7223 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/15/builds/7878 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/6537 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/8815 "Built successfully") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/39/builds/5238 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/10/builds/6451 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/14213 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/6901 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/6548 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/9431 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/7/builds/7034 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/5755 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/30/builds/6397 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/4/builds/10593 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/827 "Built successfully and passed tests") | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/31/builds/6780 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->