### PR TITLE
Add support for printing RenderTree for RemoteFrame(s)

### DIFF
--- a/LayoutTests/TestExpectations
+++ b/LayoutTests/TestExpectations
@@ -6522,3 +6522,5 @@ imported/w3c/web-platform-tests/css/css-overflow/scrollbar-gutter-vertical-rl-00
 imported/w3c/web-platform-tests/css/css-overflow/scrollbar-gutter-002.html [ Skip ]
 
 webkit.org/b/257336 imported/w3c/web-platform-tests/css/css-tables/visibility-collapse-row-003-dynamic.html [ Pass Failure ]
+
+webkit.org/b/257904 http/tests/site-isolation/basic-iframe.html [ Skip ]

--- a/LayoutTests/http/tests/site-isolation/basic-iframe-render-output-expected.txt
+++ b/LayoutTests/http/tests/site-isolation/basic-iframe-render-output-expected.txt
@@ -1,0 +1,13 @@
+layer at (0,0) size 800x600
+  RenderView at (0,0) size 800x600
+layer at (0,0) size 800x600
+  RenderBlock {HTML} at (0,0) size 800x600
+    RenderBody {BODY} at (8,8) size 784x584 [bgcolor=#0000FF]
+      RenderText {#text} at (0,0) size 0x0
+layer at (8,8) size 300x150
+  RenderIFrame {IFRAME} at (0,0) size 300x150
+    layer at (0,0) size 300x150
+      RenderView at (0,0) size 300x150
+    layer at (0,0) size 300x150
+      RenderBlock {HTML} at (0,0) size 300x150
+        RenderBody {BODY} at (8,8) size 284x134 [bgcolor=#008000]

--- a/LayoutTests/http/tests/site-isolation/basic-iframe-render-output.html
+++ b/LayoutTests/http/tests/site-isolation/basic-iframe-render-output.html
@@ -1,0 +1,4 @@
+<!-- webkit-test-runner [ SiteIsolationEnabled=true ] -->
+<body bgcolor=blue>
+<iframe src="http://localhost:8000/site-isolation/resources/green-background.html" frameborder=0></iframe>
+</body>

--- a/LayoutTests/platform/mac-wk1/TestExpectations
+++ b/LayoutTests/platform/mac-wk1/TestExpectations
@@ -2532,7 +2532,9 @@ webkit.org/b/255498 css3/scroll-snap/scroll-snap-discrete-wheel-event-in-mainfra
 # test failing only on mac-wk1 after importing wpt css/css-tables
 imported/w3c/web-platform-tests/css/css-tables/collapsed-border-positioned-tr-td.html [ ImageOnlyFailure ]
 
-
 #rdar://105804155 ([ WK1 ] 2 http/tests/resourceLoadStatistics/* (layout-tests) are constant failures)
 http/tests/resourceLoadStatistics/website-data-removal-for-site-without-user-interaction-js-cookie-checking.html [ Skip ]
 http/tests/resourceLoadStatistics/website-data-removal-for-site-navigated-to-with-link-decoration-js-cookie-checking.html [ Skip ]
+
+# Site-isolation isn't supported in WK1
+http/tests/site-isolation [ Skip ]

--- a/Source/WebCore/accessibility/AccessibilityObject.cpp
+++ b/Source/WebCore/accessibility/AccessibilityObject.cpp
@@ -3049,7 +3049,7 @@ AXCoreObject* AccessibilityObject::elementAccessibilityHitTest(const IntPoint& p
     if (isAttachment()) {
         Widget* widget = widgetForAttachmentView();
         // Normalize the point for the widget's bounds.
-        if (widget && widget->isFrameView()) {
+        if (widget && widget->isLocalFrameView()) {
             if (AXObjectCache* cache = axObjectCache())
                 return cache->getOrCreate(widget)->accessibilityHitTest(IntPoint(point - widget->frameRect().location()));
         }

--- a/Source/WebCore/accessibility/AccessibilityRenderObject.cpp
+++ b/Source/WebCore/accessibility/AccessibilityRenderObject.cpp
@@ -2448,7 +2448,7 @@ void AccessibilityRenderObject::addAttachmentChildren()
 
     // LocalFrameView's need to be inserted into the AX hierarchy when encountered.
     Widget* widget = widgetForAttachmentView();
-    if (!widget || !widget->isFrameView())
+    if (!widget || !widget->isLocalFrameView())
         return;
     
     addChild(axObjectCache()->getOrCreate(widget));

--- a/Source/WebCore/accessibility/mac/AccessibilityObjectMac.mm
+++ b/Source/WebCore/accessibility/mac/AccessibilityObjectMac.mm
@@ -115,7 +115,7 @@ bool AccessibilityObject::accessibilityIgnoreAttachment() const
     // LocalFrameView attachments are now handled by AccessibilityScrollView,
     // so if this is the attachment, it should be ignored.
     Widget* widget = nullptr;
-    if (isAttachment() && (widget = widgetForAttachmentView()) && widget->isFrameView())
+    if (isAttachment() && (widget = widgetForAttachmentView()) && widget->isLocalFrameView())
         return true;
 
 ALLOW_DEPRECATED_DECLARATIONS_BEGIN

--- a/Source/WebCore/editing/FrameSelection.cpp
+++ b/Source/WebCore/editing/FrameSelection.cpp
@@ -2329,7 +2329,7 @@ static bool isFrameElement(const Node* n)
     if (!is<RenderWidget>(renderer))
         return false;
     Widget* widget = downcast<RenderWidget>(*renderer).widget();
-    return widget && widget->isFrameView();
+    return widget && widget->isLocalFrameView();
 }
 
 void FrameSelection::setFocusedElementIfNeeded()

--- a/Source/WebCore/page/FrameView.h
+++ b/Source/WebCore/page/FrameView.h
@@ -29,10 +29,17 @@
 
 namespace WebCore {
 
+enum class RenderAsTextFlag : uint16_t;
+
 class FrameView : public ScrollView {
 public:
     enum class Type : bool { Local, Remote };
     virtual Type viewType() const = 0;
+    virtual void writeRenderTreeAsText(TextStream&, OptionSet<RenderAsTextFlag>) = 0;
 };
 
 }
+
+SPECIALIZE_TYPE_TRAITS_BEGIN(WebCore::FrameView)
+static bool isType(const WebCore::Widget& widget) { return widget.isLocalFrameView() || widget.isRemoteFrameView(); }
+SPECIALIZE_TYPE_TRAITS_END()

--- a/Source/WebCore/page/LocalFrameView.cpp
+++ b/Source/WebCore/page/LocalFrameView.cpp
@@ -96,6 +96,7 @@
 #include "RenderStyleSetters.h"
 #include "RenderText.h"
 #include "RenderTheme.h"
+#include "RenderTreeAsText.h"
 #include "RenderView.h"
 #include "RenderWidget.h"
 #include "ResizeObserver.h"
@@ -6365,6 +6366,14 @@ float LocalFrameView::deviceScaleFactor() const
     if (auto* page = m_frame->page())
         return page->deviceScaleFactor();
     return 1;
+}
+
+void LocalFrameView::writeRenderTreeAsText(TextStream& ts, OptionSet<RenderAsTextFlag> behavior)
+{
+    auto* localFrame = dynamicDowncast<LocalFrame>(frame());
+    if (!localFrame)
+        return;
+    externalRepresentationForLocalFrame(ts, *localFrame, behavior);
 }
 
 } // namespace WebCore

--- a/Source/WebCore/page/LocalFrameView.h
+++ b/Source/WebCore/page/LocalFrameView.h
@@ -107,6 +107,7 @@ public:
     WEBCORE_EXPORT void invalidateRect(const IntRect&) final;
     void setFrameRect(const IntRect&) final;
     Type viewType() const final { return Type::Local; }
+    void writeRenderTreeAsText(TextStream&, OptionSet<RenderAsTextFlag>) override;
 
     // FIXME: This should return Frame. If it were a RemoteFrame, we would have a RemoteFrameView.
     WEBCORE_EXPORT Frame& frame() const;
@@ -736,6 +737,7 @@ public:
 private:
     explicit LocalFrameView(LocalFrame&);
 
+    bool isLocalFrameView() const final { return true; }
     bool scrollContentsFastPath(const IntSize& scrollDelta, const IntRect& rectToScroll, const IntRect& clipRect) final;
     void scrollContentsSlowPath(const IntRect& updateRect) final;
 
@@ -755,8 +757,6 @@ private:
         InViewSizeAdjust,
         InPostLayout
     };
-
-    bool isFrameView() const final { return true; }
 
     friend class RenderWidget;
     bool useSlowRepaints(bool considerOverlap = true) const;
@@ -1078,5 +1078,5 @@ WTF::TextStream& operator<<(WTF::TextStream&, const LocalFrameView&);
 
 SPECIALIZE_TYPE_TRAITS_BEGIN(WebCore::LocalFrameView)
 static bool isType(const WebCore::FrameView& view) { return view.viewType() == WebCore::FrameView::Type::Local; }
-static bool isType(const WebCore::Widget& widget) { return widget.isFrameView(); }
+static bool isType(const WebCore::Widget& widget) { return widget.isLocalFrameView(); }
 SPECIALIZE_TYPE_TRAITS_END()

--- a/Source/WebCore/page/RemoteFrame.cpp
+++ b/Source/WebCore/page/RemoteFrame.cpp
@@ -105,4 +105,9 @@ void RemoteFrame::frameDetached()
     m_client->frameDetached();
 }
 
+String RemoteFrame::renderTreeAsText(size_t baseIndent, OptionSet<RenderAsTextFlag> behavior)
+{
+    return m_client->renderTreeAsText(m_remoteProcessIdentifier, frameID(), baseIndent, behavior);
+}
+
 } // namespace WebCore

--- a/Source/WebCore/page/RemoteFrame.h
+++ b/Source/WebCore/page/RemoteFrame.h
@@ -38,6 +38,8 @@ class RemoteFrameClient;
 class RemoteFrameView;
 class WeakPtrImplWithEventTargetData;
 
+enum class RenderAsTextFlag : uint16_t;
+
 class RemoteFrame final : public Frame {
 public:
     WEBCORE_EXPORT static Ref<RemoteFrame> createMainFrame(Page&, UniqueRef<RemoteFrameClient>&&, FrameIdentifier, ProcessIdentifier);
@@ -61,6 +63,7 @@ public:
     Markable<LayerHostingContextIdentifier> layerHostingContextIdentifier() const { return m_layerHostingContextIdentifier; }
 
     ProcessIdentifier remoteProcessIdentifier() const { return m_remoteProcessIdentifier; }
+    String renderTreeAsText(size_t baseIndent, OptionSet<RenderAsTextFlag>);
 
 private:
     WEBCORE_EXPORT explicit RemoteFrame(Page&, UniqueRef<RemoteFrameClient>&&, FrameIdentifier, HTMLFrameOwnerElement*, Frame*, Markable<LayerHostingContextIdentifier>, ProcessIdentifier);

--- a/Source/WebCore/page/RemoteFrameClient.h
+++ b/Source/WebCore/page/RemoteFrameClient.h
@@ -32,6 +32,9 @@ namespace WebCore {
 class FrameLoadRequest;
 class IntSize;
 class SecurityOriginData;
+
+enum class RenderAsTextFlag : uint16_t;
+
 struct MessageWithMessagePorts;
 
 class RemoteFrameClient {
@@ -41,6 +44,7 @@ public:
     virtual void sizeDidChange(IntSize) = 0;
     virtual void postMessageToRemote(ProcessIdentifier, FrameIdentifier, std::optional<SecurityOriginData>, const MessageWithMessagePorts&) = 0;
     virtual void changeLocation(FrameLoadRequest&&) = 0;
+    virtual String renderTreeAsText(ProcessIdentifier, FrameIdentifier, size_t baseIndent, OptionSet<RenderAsTextFlag>) = 0;
     virtual ~RemoteFrameClient() { }
 };
 

--- a/Source/WebCore/page/RemoteFrameView.cpp
+++ b/Source/WebCore/page/RemoteFrameView.cpp
@@ -155,4 +155,10 @@ void RemoteFrameView::updateCompositingLayersAfterScrolling()
 {
 }
 
+void RemoteFrameView::writeRenderTreeAsText(TextStream& ts, OptionSet<RenderAsTextFlag> behavior)
+{
+    auto& remoteFrame = frame();
+    ts << remoteFrame.renderTreeAsText(ts.indent(), behavior);
+}
+
 } // namespace WebCore

--- a/Source/WebCore/page/RemoteFrameView.h
+++ b/Source/WebCore/page/RemoteFrameView.h
@@ -36,11 +36,14 @@ public:
     static Ref<RemoteFrameView> create(RemoteFrame& frame) { return adoptRef(*new RemoteFrameView(frame)); }
 
     Type viewType() const final { return Type::Remote; }
+    void writeRenderTreeAsText(TextStream&, OptionSet<RenderAsTextFlag>) override;
+    const RemoteFrame& frame() const { return m_frame.get(); }
+    RemoteFrame& frame() { return m_frame.get(); }
+
 private:
     WEBCORE_EXPORT RemoteFrameView(RemoteFrame&);
 
     bool isRemoteFrameView() const final { return true; }
-
     void invalidateRect(const IntRect&) final;
     bool isActive() const final;
     bool forceUpdateScrollbarsOnMainThreadForPerformanceTesting() const final;

--- a/Source/WebCore/page/ios/EventHandlerIOS.mm
+++ b/Source/WebCore/page/ios/EventHandlerIOS.mm
@@ -402,7 +402,7 @@ bool EventHandler::passSubframeEventToSubframe(MouseEventWithHitTestResults& eve
         if (!is<RenderWidget>(renderer))
             return false;
         auto* widget = downcast<RenderWidget>(*renderer).widget();
-        if (!widget || !widget->isFrameView())
+        if (!widget || !widget->isLocalFrameView())
             return false;
         if (!passWidgetMouseDownEventToWidget(downcast<RenderWidget>(renderer)))
             return false;

--- a/Source/WebCore/page/mac/EventHandlerMac.mm
+++ b/Source/WebCore/page/mac/EventHandlerMac.mm
@@ -420,7 +420,7 @@ bool EventHandler::passSubframeEventToSubframe(MouseEventWithHitTestResults& eve
         if (!is<RenderWidget>(renderer))
             return false;
         Widget* widget = downcast<RenderWidget>(*renderer).widget();
-        if (!widget || !widget->isFrameView())
+        if (!widget || !widget->isLocalFrameView())
             return false;
         if (!passWidgetMouseDownEventToWidget(downcast<RenderWidget>(renderer)))
             return false;
@@ -969,7 +969,7 @@ void EventHandler::wheelEventWasProcessedByMainThread(const PlatformWheelEvent& 
 bool EventHandler::platformCompletePlatformWidgetWheelEvent(const PlatformWheelEvent& wheelEvent, const Widget& widget, const WeakPtr<ScrollableArea>& scrollableArea)
 {
     // WebKit1: Prevent multiple copies of the scrollWheel event from being sent to the NSScrollView widget.
-    if (frameHasPlatformWidget(m_frame) && widget.isFrameView())
+    if (frameHasPlatformWidget(m_frame) && widget.isLocalFrameView())
         return true;
 
     if (!m_frame.page())

--- a/Source/WebCore/platform/Widget.h
+++ b/Source/WebCore/platform/Widget.h
@@ -128,7 +128,7 @@ public:
 
     void setIsSelected(bool);
 
-    virtual bool isFrameView() const { return false; }
+    virtual bool isLocalFrameView() const { return false; }
     virtual bool isRemoteFrameView() const { return false; }
     virtual bool isPluginViewBase() const { return false; }
     virtual bool isScrollbar() const { return false; }

--- a/Source/WebCore/rendering/RenderTreeAsText.h
+++ b/Source/WebCore/rendering/RenderTreeAsText.h
@@ -38,8 +38,7 @@ class Element;
 class LocalFrame;
 class RenderObject;
 
-enum class RenderAsTextFlag {
-    BehaviorNormal          = 0,
+enum class RenderAsTextFlag : uint16_t {
     ShowAllLayers           = 1 << 0, // Dump all layers, not just those that would paint.
     ShowLayerNesting        = 1 << 1, // Annotate the layer lists.
     ShowCompositedLayers    = 1 << 2, // Show which layers are composited.
@@ -54,8 +53,10 @@ enum class RenderAsTextFlag {
 };
 
 // You don't need pageWidthInPixels if you don't specify RenderAsTextInPrintingMode.
+WEBCORE_EXPORT TextStream createTextStream(const RenderView&);
 WEBCORE_EXPORT String externalRepresentation(LocalFrame*, OptionSet<RenderAsTextFlag> = { });
 WEBCORE_EXPORT String externalRepresentation(Element*, OptionSet<RenderAsTextFlag> = { });
+WEBCORE_EXPORT void externalRepresentationForLocalFrame(TextStream&, LocalFrame&, OptionSet<RenderAsTextFlag> = { });
 void write(WTF::TextStream&, const RenderObject&, OptionSet<RenderAsTextFlag> = { });
 void writeDebugInfo(WTF::TextStream&, const RenderObject&, OptionSet<RenderAsTextFlag> = { });
 

--- a/Source/WebCore/rendering/RenderWidget.cpp
+++ b/Source/WebCore/rendering/RenderWidget.cpp
@@ -169,7 +169,7 @@ bool RenderWidget::updateWidgetGeometry()
 
     LayoutRect contentBox = contentBoxRect();
     LayoutRect absoluteContentBox(localToAbsoluteQuad(FloatQuad(contentBox)).boundingBox());
-    if (m_widget->isFrameView()) {
+    if (m_widget->isLocalFrameView()) {
         contentBox.setLocation(absoluteContentBox.location());
         return setWidgetGeometry(contentBox);
     }

--- a/Source/WebKit/Scripts/webkit/messages.py
+++ b/Source/WebKit/Scripts/webkit/messages.py
@@ -797,6 +797,7 @@ def headers_for_type(type):
         'WebCore::ReasonForDismissingAlternativeText': ['<WebCore/AlternativeTextClient.h>'],
         'WebCore::RecentSearch': ['<WebCore/SearchPopupMenu.h>'],
         'WebCore::ReloadOption': ['<WebCore/FrameLoaderTypes.h>'],
+        'WebCore::RenderAsTextFlag': ['<WebCore/RenderTreeAsText.h>'],
         'WebCore::RenderingPurpose': ['<WebCore/RenderingMode.h>'],
         'WebCore::RequestStorageAccessResult': ['<WebCore/DocumentStorageAccess.h>'],
         'WebCore::RouteSharingPolicy': ['<WebCore/AudioSession.h>'],

--- a/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
+++ b/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
@@ -5173,3 +5173,18 @@ header: <WebCore/LandmarkTypeInterface.h>
     Nose,
 };
 #endif // GPU_PROCESS
+
+header: <WebCore/RenderTreeAsText.h>
+[OptionSet] enum class WebCore::RenderAsTextFlag : uint16_t {
+    ShowAllLayers,
+    ShowLayerNesting,
+    ShowCompositedLayers,
+    ShowOverflow,
+    ShowSVGGeometry,
+    ShowLayerFragments,
+    ShowAddresses,
+    ShowIDAndClass,
+    PrintingMode,
+    DontUpdateLayout,
+    ShowLayoutState
+};

--- a/Source/WebKit/UIProcess/WebProcessProxy.cpp
+++ b/Source/WebKit/UIProcess/WebProcessProxy.cpp
@@ -1359,6 +1359,20 @@ void WebProcessProxy::postMessageToRemote(WebCore::ProcessIdentifier destination
         webProcessProxy->send(Messages::WebProcess::RemotePostMessage(identifier, target, message), 0);
 }
 
+void WebProcessProxy::renderTreeAsText(WebCore::ProcessIdentifier destinationProcessIdentifier, WebCore::FrameIdentifier frameIdentifier, size_t baseIndent, OptionSet<WebCore::RenderAsTextFlag> behavior, CompletionHandler<void(String)>&& completionHandler)
+{
+    auto webProcessProxy = processForIdentifier(destinationProcessIdentifier);
+    if (!webProcessProxy)
+        return completionHandler({ });
+
+    auto reply = webProcessProxy->sendSync(Messages::WebProcess::RenderTreeAsText(frameIdentifier, baseIndent, behavior), 0);
+    if (!reply)
+        return completionHandler({ });
+
+    auto [result] = reply.takeReply();
+    completionHandler(result);
+}
+
 bool WebProcessProxy::canBeAddedToWebProcessCache() const
 {
     if (isRunningServiceWorkers()) {

--- a/Source/WebKit/UIProcess/WebProcessProxy.h
+++ b/Source/WebKit/UIProcess/WebProcessProxy.h
@@ -81,6 +81,7 @@ struct PluginInfo;
 struct PrewarmInformation;
 class SecurityOriginData;
 enum class PermissionName : uint8_t;
+enum class RenderAsTextFlag : uint16_t;
 enum class ThirdPartyCookieBlockingMode : uint8_t;
 using FramesPerSecond = unsigned;
 using PlatformDisplayID = uint32_t;
@@ -539,6 +540,7 @@ private:
     void didDestroyFrame(WebCore::FrameIdentifier, WebPageProxyIdentifier);
     void didDestroyUserGestureToken(uint64_t);
     void postMessageToRemote(WebCore::ProcessIdentifier, WebCore::FrameIdentifier, std::optional<WebCore::SecurityOriginData>, const WebCore::MessageWithMessagePorts&);
+    void renderTreeAsText(WebCore::ProcessIdentifier, WebCore::FrameIdentifier, size_t baseIndent, OptionSet<WebCore::RenderAsTextFlag>, CompletionHandler<void(String)>&&);
 
     bool canBeAddedToWebProcessCache() const;
     void shouldTerminate(CompletionHandler<void(bool)>&&);

--- a/Source/WebKit/UIProcess/WebProcessProxy.messages.in
+++ b/Source/WebKit/UIProcess/WebProcessProxy.messages.in
@@ -89,4 +89,6 @@ messages -> WebProcessProxy LegacyReceiver {
     SetClientBadge(WebKit::WebPageProxyIdentifier pageIdentifier, WebCore::SecurityOriginData origin, std::optional<uint64_t> badge)
 
     PostMessageToRemote(WebCore::ProcessIdentifier processIdentifier, struct WebCore::FrameIdentifier identifier, std::optional<WebCore::SecurityOriginData> target, struct WebCore::MessageWithMessagePorts message)
+
+    RenderTreeAsText(WebCore::ProcessIdentifier processIdentifier, struct WebCore::FrameIdentifier identifier, size_t baseIndent, OptionSet<WebCore::RenderAsTextFlag> behavior) -> (String renderTreeDump) Synchronous
 }

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebRemoteFrameClient.cpp
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebRemoteFrameClient.cpp
@@ -82,4 +82,14 @@ void WebRemoteFrameClient::changeLocation(WebCore::FrameLoadRequest&& request)
     });
 }
 
+String WebRemoteFrameClient::renderTreeAsText(WebCore::ProcessIdentifier processIdentifier, WebCore::FrameIdentifier frameIdentifier, size_t baseIndent, OptionSet<WebCore::RenderAsTextFlag> behavior)
+{
+    auto reply = WebProcess::singleton().parentProcessConnection()->sendSync(Messages::WebProcessProxy::RenderTreeAsText(processIdentifier, frameIdentifier, baseIndent, behavior), 0);
+    if (!reply)
+        return { };
+
+    auto [result] = reply.takeReply();
+    return result;
+}
+
 }

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebRemoteFrameClient.h
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebRemoteFrameClient.h
@@ -47,6 +47,7 @@ private:
     void sizeDidChange(WebCore::IntSize) final;
     void postMessageToRemote(WebCore::ProcessIdentifier, WebCore::FrameIdentifier, std::optional<WebCore::SecurityOriginData>, const WebCore::MessageWithMessagePorts&) final;
     void changeLocation(WebCore::FrameLoadRequest&&) final;
+    String renderTreeAsText(WebCore::ProcessIdentifier, WebCore::FrameIdentifier, size_t baseIndent, OptionSet<WebCore::RenderAsTextFlag>) final;
 
     ScopeExit<Function<void()>> m_frameInvalidator;
 };

--- a/Source/WebKit/WebProcess/WebProcess.h
+++ b/Source/WebKit/WebProcess/WebProcess.h
@@ -100,6 +100,7 @@ class ResourceRequest;
 class UserGestureToken;
 
 enum class EventMakesGamepadsVisible : bool;
+enum class RenderAsTextFlag : uint16_t;
 
 struct ClientOrigin;
 struct DisplayUpdate;
@@ -467,6 +468,8 @@ private:
     void setEnhancedAccessibility(bool);
     void remotePostMessage(WebCore::FrameIdentifier, std::optional<WebCore::SecurityOriginData>, const WebCore::MessageWithMessagePorts&);
 
+    void renderTreeAsText(WebCore::FrameIdentifier, size_t baseIndent, OptionSet<WebCore::RenderAsTextFlag>, CompletionHandler<void(String)>&&);
+
     void startMemorySampler(SandboxExtension::Handle&&, const String&, const double);
     void stopMemorySampler();
     
@@ -563,6 +566,7 @@ private:
     void didClose(IPC::Connection&) final;
 
     // Implemented in generated WebProcessMessageReceiver.cpp
+    bool didReceiveSyncWebProcessMessage(IPC::Connection&, IPC::Decoder&, UniqueRef<IPC::Encoder>&);
     void didReceiveWebProcessMessage(IPC::Connection&, IPC::Decoder&);
 
 #if PLATFORM(MAC)

--- a/Source/WebKit/WebProcess/WebProcess.messages.in
+++ b/Source/WebKit/WebProcess/WebProcess.messages.in
@@ -217,4 +217,6 @@ messages -> WebProcess LegacyReceiver NotRefCounted {
     ReleaseMemory() -> ()
 
     RemotePostMessage(struct WebCore::FrameIdentifier frameIdentifier, std::optional<WebCore::SecurityOriginData> target, struct WebCore::MessageWithMessagePorts message)
+
+    RenderTreeAsText(struct WebCore::FrameIdentifier frameIdentifier, size_t baseIndent, OptionSet<WebCore::RenderAsTextFlag> behavior) -> (String renderTreeDump) Synchronous
 }


### PR DESCRIPTION
#### 7ce8aed08237330dbdb86c0c944e2b4ff538fb57
<pre>
Add support for printing RenderTree for RemoteFrame(s)
<a href="https://bugs.webkit.org/show_bug.cgi?id=256972">https://bugs.webkit.org/show_bug.cgi?id=256972</a>
rdar://105023551

Reviewed by Alex Christensen.

This change adds infrastructure so that we can get RenderTree dumps for
RemoteFrame&apos;s which are not hosted in the process which gets the request
to print the RenderTreeAsText

* LayoutTests/http/tests/site-isolation/basic-iframe-render-output-expected.txt: Added.
* LayoutTests/http/tests/site-isolation/basic-iframe-render-output.html: Added.
* Source/WebCore/accessibility/AccessibilityObject.cpp:
(WebCore::AccessibilityObject::elementAccessibilityHitTest const):
* Source/WebCore/accessibility/AccessibilityRenderObject.cpp:
(WebCore::AccessibilityRenderObject::addAttachmentChildren):
* Source/WebCore/accessibility/mac/AccessibilityObjectMac.mm:
(WebCore::AccessibilityObject::accessibilityIgnoreAttachment const):
* Source/WebCore/editing/FrameSelection.cpp:
(WebCore::isFrameElement):
* Source/WebCore/page/FrameView.h:
(isType):
* Source/WebCore/page/LocalFrameView.cpp:
(WebCore::LocalFrameView::writeRenderTreeAsText):
* Source/WebCore/page/LocalFrameView.h:
(isType):
* Source/WebCore/page/RemoteFrame.cpp:
(WebCore::RemoteFrame::renderTreeAsText):
* Source/WebCore/page/RemoteFrame.h:
* Source/WebCore/page/RemoteFrameClient.h:
* Source/WebCore/page/RemoteFrameView.cpp:
(WebCore::RemoteFrameView::writeRenderTreeAsText):
* Source/WebCore/page/RemoteFrameView.h:
* Source/WebCore/page/ios/EventHandlerIOS.mm:
(WebCore::EventHandler::passSubframeEventToSubframe):
* Source/WebCore/page/mac/EventHandlerMac.mm:
(WebCore::EventHandler::passSubframeEventToSubframe):
(WebCore::EventHandler::platformCompletePlatformWidgetWheelEvent):
* Source/WebCore/platform/Widget.h:
(WebCore::Widget::isLocalFrameView const):
(WebCore::Widget::isFrameView const): Deleted.
* Source/WebCore/rendering/RenderTreeAsText.cpp:
(WebCore::write):
(WebCore::externalRepresentationForLocalFrame):
* Source/WebCore/rendering/RenderTreeAsText.h:
(WebCore::externalRepresentationForLocalFrame):
* Source/WebCore/rendering/RenderWidget.cpp:
(WebCore::RenderWidget::updateWidgetGeometry):
* Source/WebKit/Scripts/webkit/messages.py:
(headers_for_type):
* Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in:
* Source/WebKit/UIProcess/WebProcessProxy.cpp:
(WebKit::WebProcessProxy::renderTreeAsText):
* Source/WebKit/UIProcess/WebProcessProxy.h:
* Source/WebKit/UIProcess/WebProcessProxy.messages.in:
* Source/WebKit/WebProcess/WebCoreSupport/WebRemoteFrameClient.cpp:
(WebKit::WebRemoteFrameClient::renderTreeAsText):
* Source/WebKit/WebProcess/WebCoreSupport/WebRemoteFrameClient.h:
* Source/WebKit/WebProcess/WebProcess.cpp:
(WebKit::WebProcess::didReceiveSyncMessage):
(WebKit::WebProcess::renderTreeAsText):
* Source/WebKit/WebProcess/WebProcess.h:
* Source/WebKit/WebProcess/WebProcess.messages.in:

Canonical link: <a href="https://commits.webkit.org/265046@main">https://commits.webkit.org/265046@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f16517f73ff18e0fbca5d5edd7e18cf174b4d778

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/9568 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/9828 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/10069 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/11229 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/9373 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/9579 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/11807 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/9784 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/12284 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/9720 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/10585 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/8163 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/11388 "Built successfully") | 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/9683 "Passed tests") | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/7880 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/8701 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/16119 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/8975 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/8851 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/12213 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/9344 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/7596 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/8543 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/8607 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/12765 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/1104 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/9115 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->