### PR TITLE
XPath: Fix context node after evaluating an expression in a predicate

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/domxpath/predicates-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/domxpath/predicates-expected.txt
@@ -1,3 +1,3 @@
 
-FAIL An expression in a predicate should not change the context node assert_equals: expected 1 but got 0
+PASS An expression in a predicate should not change the context node
 

--- a/Source/WebCore/xml/XPathPredicate.cpp
+++ b/Source/WebCore/xml/XPathPredicate.cpp
@@ -82,7 +82,7 @@ Value NumericOp::evaluate() const
     double rightVal;
 
     {
-        SetForScope<EvaluationContext> contextForScope(Expression::evaluationContext(), clonedContext);
+        SetForScope contextForScope(Expression::evaluationContext(), clonedContext);
         rightVal = subexpression(1).evaluate().toNumber();
     }
 
@@ -211,7 +211,7 @@ Value EqTestOp::evaluate() const
 
     Value lhs(subexpression(0).evaluate());
     Value rhs = [&] {
-        SetForScope<EvaluationContext> contextForScope(Expression::evaluationContext(), clonedContext);
+        SetForScope contextForScope(Expression::evaluationContext(), clonedContext);
         return subexpression(1).evaluate();
     }();
 
@@ -240,7 +240,7 @@ Value LogicalOp::evaluate() const
     if (lhsBool == shortCircuitOn())
         return lhsBool;
 
-    SetForScope<EvaluationContext> contextForScope(Expression::evaluationContext(), clonedContext);
+    SetForScope contextForScope(Expression::evaluationContext(), clonedContext);
     return subexpression(1).evaluate().toBoolean();
 }
 
@@ -255,7 +255,7 @@ Value Union::evaluate() const
     EvaluationContext clonedContext(Expression::evaluationContext());
     Value lhsResult = subexpression(0).evaluate();
     Value rhsResult = [&] {
-        SetForScope<EvaluationContext> contextForScope(Expression::evaluationContext(), clonedContext);
+        SetForScope contextForScope(Expression::evaluationContext(), clonedContext);
         return subexpression(1).evaluate();
     }();
     Expression::evaluationContext().hadTypeConversionError |= clonedContext.hadTypeConversionError;
@@ -281,7 +281,12 @@ Value Union::evaluate() const
 
 bool evaluatePredicate(const Expression& expression)
 {
-    Value result(expression.evaluate());
+    EvaluationContext clonedContext(Expression::evaluationContext());
+    Value result = [&] {
+        SetForScope contextForScope(Expression::evaluationContext(), clonedContext);
+        return expression.evaluate();
+    }();
+    Expression::evaluationContext().hadTypeConversionError |= clonedContext.hadTypeConversionError;
 
     // foo[3] means foo[position()=3]
     if (result.isNumber())


### PR DESCRIPTION
#### 1ffefa8e2da2aaee749712cd4c4cc96394309003
<pre>
XPath: Fix context node after evaluating an expression in a predicate
<a href="https://bugs.webkit.org/show_bug.cgi?id=256953">https://bugs.webkit.org/show_bug.cgi?id=256953</a>

Reviewed by Darin Adler.

Fix evaluation context for XPath predicate evaluation.

This aligns our behavior with Blink &amp; Gecko.

This is a cherry-pick of Blink&apos;s:
<a href="https://chromium.googlesource.com/chromium/src.git/+/869417867e1da3822a03f8ce1e454d19706c6832">https://chromium.googlesource.com/chromium/src.git/+/869417867e1da3822a03f8ce1e454d19706c6832</a>

* LayoutTests/imported/w3c/web-platform-tests/domxpath/predicates-expected.txt:
* Source/WebCore/xml/XPathPredicate.cpp:
(WebCore::XPath::evaluatePredicate):

Canonical link: <a href="https://commits.webkit.org/264210@main">https://commits.webkit.org/264210@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/194d0e696654bff2785eea48bc879da4063caf32

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/7054 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/7298 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/7477 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/8670 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/7288 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/7064 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/8560 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/7230 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/10192 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/7181 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/7843 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/6506 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/8773 "Built successfully") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/39/builds/5206 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/6415 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/14183 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/6869 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/6510 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/9383 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/6993 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/5724 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/6358 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/1665 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/10554 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/6741 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->