### PR TITLE
Fix and enable v8's multi-value test

### DIFF
--- a/JSTests/wasm/v8/multi-value.js
+++ b/JSTests/wasm/v8/multi-value.js
@@ -1,5 +1,4 @@
-//@ requireOptions("--useBBQJIT=1", "--useWasmLLInt=1", "--wasmLLIntTiersUpToBBQ=1")
-//@ skip
+
 // Failure:
 // Exception: Did not throw exception, expected CompileError
 //
@@ -94,28 +93,6 @@ load("wasm-module-builder.js");
   let module = new WebAssembly.Module(builder.toBuffer());
   let instance = new WebAssembly.Instance(module);
   assertEquals(instance.exports.main(1, 2), 1);
-})();
-
-(function MultiBlockUnreachableTypeErrorTest() {
-  // print(arguments.callee.name);
-  let builder = new WasmModuleBuilder();
-  let sig_il_v = builder.addType(makeSig([], [kWasmI32, kWasmI64]));
-
-  builder.addFunction("main", kSig_i_v)
-    .addBody([
-      kExprBlock, sig_il_v,
-      kExprI32Const, 1,
-      kExprI64Const, 1,
-      kExprBr, 0,
-      kExprI64Const, 1,
-      kExprI32Const, 1,
-      // Wrong order: expect i32, i64.
-      kExprEnd,
-      kExprDrop])
-    .exportAs("main");
-
-  assertThrows(() => new WebAssembly.Module(builder.toBuffer()),
-      WebAssembly.CompileError, /expected type i64, found i32.const/);
 })();
 
 (function MultiLoopResultTest() {
@@ -318,7 +295,7 @@ load("wasm-module-builder.js");
       kExprEnd]);
 
   assertThrows(() => new WebAssembly.Module(builder.toBuffer()),
-      WebAssembly.CompileError, /expected i32, got i64/);
+      WebAssembly.CompileError, /I64 is not a I32/);
 })();
 
 (function MultiResultTest() {
@@ -556,15 +533,15 @@ load("wasm-module-builder.js");
   assertEquals(instance.exports.main(1, 2), [1, 2]);
 
   instance = new WebAssembly.Instance(module, { 'imports' : { 'f' : drop_first } });
-  assertThrows(() => instance.exports.main(1, 2), TypeError, "multi-return length mismatch");
+  assertThrows(() => instance.exports.main(1, 2), TypeError, "Incorrect number of values returned to Wasm from JS");
   instance = new WebAssembly.Instance(module, { 'imports' : { 'f' : repeat } });
-  assertThrows(() => instance.exports.main(1, 2), TypeError, "multi-return length mismatch");
+  assertThrows(() => instance.exports.main(1, 2), TypeError, "Incorrect number of values returned to Wasm from JS");
   instance = new WebAssembly.Instance(module, { 'imports' : { 'f' : proxy_throw } });
   assertThrows(() => instance.exports.main(1, 2), Error, "abc");
   instance = new WebAssembly.Instance(module, { 'imports' : { 'f' : not_receiver } });
-  assertThrows(() => instance.exports.main(1, 2), TypeError, /not iterable/);
+  assertThrows(() => instance.exports.main(1, 2), TypeError, /Type error/);
   instance = new WebAssembly.Instance(module, { 'imports' : { 'f' : not_iterable } });
-  assertThrows(() => instance.exports.main(1, 2), TypeError, /not iterable/);
+  assertThrows(() => instance.exports.main(1, 2), TypeError, /Type error/);
   instance = new WebAssembly.Instance(module, { 'imports' : { 'f' : generator_throw } });
   assertThrows(() => instance.exports.main(1, 2), Error, "def");
 })();


### PR DESCRIPTION
#### 95a170759a008c7875d381ff5fb261ff2b55042f
<pre>
Fix and enable v8&apos;s multi-value test
<a href="https://bugs.webkit.org/show_bug.cgi?id=256980">https://bugs.webkit.org/show_bug.cgi?id=256980</a>

Reviewed by Yusuke Suzuki.

Most tests just needed an error correction. One test incorrectly tested that
the unreachable return values of a function must match the signature&apos;s return type.
This doesn&apos;t seem to match what the spec/interpreter say.

* JSTests/wasm/v8/multi-value.js:
(MultiIfOneArmedNoTypeCheckTest):
(MultiJSToWasmReturnTest):
(MultiBlockUnreachableTypeErrorTest): Deleted.

Canonical link: <a href="https://commits.webkit.org/264250@main">https://commits.webkit.org/264250@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/6e83e6b18a911ca885e03095241b4cef657cc0a3

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/7062 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/7306 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/7485 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/8678 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/7296 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/8568 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/7238 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/10201 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/7189 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/7852 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/6512 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/8813 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/5214 "Passed tests") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/14212 "Passed tests") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/5977 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/6877 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/6517 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/9430 "Passed tests") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/6645 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/7001 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/5729 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/7199 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/6366 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/1671 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/1694 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/10562 "Built successfully") | | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/24/builds/7398 "Built successfully") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/6749 "Built successfully") | | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/3/builds/1811 "Passed tests") | 
<!--EWS-Status-Bubble-End-->