### PR TITLE
Remove unused members of ProvisionalFrameProxy and SubframePageProxy

### DIFF
--- a/Source/WebKit/UIProcess/ProvisionalFrameProxy.cpp
+++ b/Source/WebKit/UIProcess/ProvisionalFrameProxy.cpp
@@ -84,21 +84,4 @@ ProvisionalFrameProxy::~ProvisionalFrameProxy()
     m_process->removeProvisionalFrameProxy(*this);
 }
 
-void ProvisionalFrameProxy::didReceiveMessage(IPC::Connection& connection, IPC::Decoder& decoder)
-{
-    if (auto* page = m_frame->page())
-        page->didReceiveMessage(connection, decoder);
-}
-
-IPC::Connection* ProvisionalFrameProxy::messageSenderConnection() const
-{
-    return m_process->connection();
-}
-
-uint64_t ProvisionalFrameProxy::messageSenderDestinationID() const
-{
-    // FIXME: This identifier was generated in another process and can collide with identifiers in this frame's process.
-    return m_frame->frameID().object().toUInt64();
-}
-
 }

--- a/Source/WebKit/UIProcess/ProvisionalFrameProxy.h
+++ b/Source/WebKit/UIProcess/ProvisionalFrameProxy.h
@@ -25,31 +25,22 @@
 
 #pragma once
 
-#include "MessageReceiver.h"
-#include "MessageSender.h"
-#include "UserData.h"
-#include "VisitedLinkStore.h"
 #include "WebPageProxyIdentifier.h"
-#include <WebCore/CertificateInfo.h>
-#include <WebCore/DocumentLoader.h>
-#include <WebCore/FrameIdentifier.h>
-#include <WebCore/FrameLoaderTypes.h>
 #include <WebCore/LayerHostingContextIdentifier.h>
 #include <WebCore/PageIdentifier.h>
 #include <wtf/WeakPtr.h>
 
 namespace WebCore {
 class ResourceRequest;
-class ResourceResponse;
 }
 
 namespace WebKit {
 
+class VisitedLinkStore;
 class WebFrameProxy;
 class WebProcessProxy;
-struct FrameInfoData;
 
-class ProvisionalFrameProxy : public IPC::MessageReceiver, public IPC::MessageSender {
+class ProvisionalFrameProxy : public CanMakeWeakPtr<ProvisionalFrameProxy> {
     WTF_MAKE_FAST_ALLOCATED;
 public:
     ProvisionalFrameProxy(WebFrameProxy&, Ref<WebProcessProxy>&&, const WebCore::ResourceRequest&);
@@ -60,14 +51,6 @@ public:
     WebCore::LayerHostingContextIdentifier layerHostingContextIdentifier() const { return m_layerHostingContextIdentifier; }
 
 private:
-    void didReceiveMessage(IPC::Connection&, IPC::Decoder&) final;
-
-    void decidePolicyForResponse(WebCore::FrameIdentifier, FrameInfoData&&, WebCore::PolicyCheckIdentifier, uint64_t navigationID, const WebCore::ResourceResponse&, const WebCore::ResourceRequest&, bool canShowMIMEType, const String& downloadAttribute, uint64_t listenerID);
-    void didCommitLoadForFrame(WebCore::FrameIdentifier, FrameInfoData&&, WebCore::ResourceRequest&&, uint64_t navigationID, const String& mimeType, bool frameHasCustomContentProvider, WebCore::FrameLoadType, const WebCore::CertificateInfo&, bool usedLegacyTLS, bool privateRelayed, bool containsPluginDocument, WebCore::HasInsecureContent, WebCore::MouseEventPolicy, const UserData&);
-
-    IPC::Connection* messageSenderConnection() const final;
-    uint64_t messageSenderDestinationID() const final;
-
     CheckedRef<WebFrameProxy> m_frame;
     Ref<WebProcessProxy> m_process;
     Ref<VisitedLinkStore> m_visitedLinkStore;

--- a/Source/WebKit/UIProcess/SubframePageProxy.cpp
+++ b/Source/WebKit/UIProcess/SubframePageProxy.cpp
@@ -38,14 +38,12 @@
 
 namespace WebKit {
 
-SubframePageProxy::SubframePageProxy(WebPageProxy& page, WebProcessProxy& process, bool isInSameProcessAsMainFrame)
+SubframePageProxy::SubframePageProxy(WebPageProxy& page, WebProcessProxy& process)
     : m_webPageID(page.webPageID())
     , m_process(process)
     , m_page(page)
-    , m_isInSameProcessAsMainFrame(isInSameProcessAsMainFrame)
 {
-    if (!m_isInSameProcessAsMainFrame)
-        m_process->addMessageReceiver(Messages::WebPageProxy::messageReceiverName(), m_webPageID, *this);
+    m_process->addMessageReceiver(Messages::WebPageProxy::messageReceiverName(), m_webPageID, *this);
 
     auto* drawingArea = page.drawingArea();
     auto parameters = page.creationParameters(m_process, *drawingArea);
@@ -59,8 +57,7 @@ SubframePageProxy::SubframePageProxy(WebPageProxy& page, WebProcessProxy& proces
 
 SubframePageProxy::~SubframePageProxy()
 {
-    if (!m_isInSameProcessAsMainFrame)
-        m_process->removeMessageReceiver(Messages::WebPageProxy::messageReceiverName(), m_webPageID);
+    m_process->removeMessageReceiver(Messages::WebPageProxy::messageReceiverName(), m_webPageID);
 }
 
 IPC::Connection* SubframePageProxy::messageSenderConnection() const

--- a/Source/WebKit/UIProcess/SubframePageProxy.h
+++ b/Source/WebKit/UIProcess/SubframePageProxy.h
@@ -62,7 +62,7 @@ struct FrameInfoData;
 class SubframePageProxy : public IPC::MessageReceiver, public IPC::MessageSender {
     WTF_MAKE_FAST_ALLOCATED;
 public:
-    SubframePageProxy(WebPageProxy&, WebProcessProxy&, bool isInSameProcessAsMainFrame);
+    SubframePageProxy(WebPageProxy&, WebProcessProxy&);
     ~SubframePageProxy();
 
     WebProcessProxy& process() { return m_process.get(); }
@@ -78,9 +78,6 @@ private:
     WebCore::PageIdentifier m_webPageID;
     Ref<WebProcessProxy> m_process;
     WeakPtr<WebPageProxy> m_page;
-
-    // FIXME: We shouldn't make a SubframePageProxy for frames in the same process as the main frame.
-    const bool m_isInSameProcessAsMainFrame { false };
 };
 
 }

--- a/Source/WebKit/UIProcess/WebPageProxy.cpp
+++ b/Source/WebKit/UIProcess/WebPageProxy.cpp
@@ -5586,11 +5586,11 @@ void WebPageProxy::didCommitLoadForFrame(FrameIdentifier frameID, FrameInfoData&
     PageClientProtector protector(pageClient());
 
     RefPtr frame = WebFrameProxy::webFrame(frameID);
+    MESSAGE_CHECK(m_process, frame);
     if (frame->provisionalFrame()) {
         frame->commitProvisionalFrame(frameID, WTFMove(frameInfo), WTFMove(request), navigationID, mimeType, frameHasCustomContentProvider, frameLoadType, certificateInfo, usedLegacyTLS, wasPrivateRelayed, containsPluginDocument, hasInsecureContent, mouseEventPolicy, userData);
         return;
     }
-    MESSAGE_CHECK(m_process, frame);
 
     WEBPAGEPROXY_RELEASE_LOG(Loading, "didCommitLoadForFrame: frameID=%" PRIu64 ", isMainFrame=%d", frameID.object().toUInt64(), frame->isMainFrame());
 

--- a/Source/WebKit/UIProcess/WebProcessPool.cpp
+++ b/Source/WebKit/UIProcess/WebProcessPool.cpp
@@ -1858,7 +1858,7 @@ void WebProcessPool::processForNavigation(WebPageProxy& page, WebFrameProxy& fra
     if (!frame.isMainFrame() && page.preferences().siteIsolationEnabled()) {
         RegistrableDomain navigationDomain(navigation.currentRequest().url());
         if (!navigationDomain.isEmpty() && navigationDomain != mainFrameDomain) {
-            auto subFramePageProxy = makeUniqueRef<SubframePageProxy>(page, process, frame.isMainFrame());
+            auto subFramePageProxy = makeUniqueRef<SubframePageProxy>(page, process);
             page.addSubframePageProxyForFrameID(frame.frameID(), navigationDomain, WTFMove(subFramePageProxy));
         }
     }


### PR DESCRIPTION
#### f4648ebc89fd1597a5b798f7ab8a7feb646c581d
<pre>
Remove unused members of ProvisionalFrameProxy and SubframePageProxy
<a href="https://bugs.webkit.org/show_bug.cgi?id=256984">https://bugs.webkit.org/show_bug.cgi?id=256984</a>
rdar://109532645

Reviewed by J Pascoe.

ProvisionalFrameProxy is no longer a message sender or receiver.  Its messages go through WebPageProxy.
SubframePageProxy is no longer ever created to own the same domain as the WebPageProxy.  We should
rename it to something like RemotePageProxy for its use in window.open.
Also move the MESSAGE_CHECK in WebPageProxy::didCommitLoadForFrame to before we dereference null.

* Source/WebKit/UIProcess/ProvisionalFrameProxy.cpp:
(WebKit::ProvisionalFrameProxy::didReceiveMessage): Deleted.
(WebKit::ProvisionalFrameProxy::messageSenderConnection const): Deleted.
(WebKit::ProvisionalFrameProxy::messageSenderDestinationID const): Deleted.
* Source/WebKit/UIProcess/ProvisionalFrameProxy.h:
* Source/WebKit/UIProcess/SubframePageProxy.cpp:
(WebKit::SubframePageProxy::SubframePageProxy):
(WebKit::SubframePageProxy::~SubframePageProxy):
* Source/WebKit/UIProcess/SubframePageProxy.h:
(): Deleted.
* Source/WebKit/UIProcess/WebProcessPool.cpp:
(WebKit::WebProcessPool::processForNavigation):

Canonical link: <a href="https://commits.webkit.org/264217@main">https://commits.webkit.org/264217@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/75bf6f900257a85874e5ff2a22cfcf493f516322

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/7079 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/7324 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/7503 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/8696 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/32/builds/7312 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/8586 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/7255 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/10214 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/7206 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/15/builds/7870 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/6526 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/8800 "Built successfully") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/39/builds/5231 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/14203 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/6894 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/6536 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/9420 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/7018 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/5743 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/6383 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/10579 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/824 "Built successfully and passed tests") | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/31/builds/6766 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->