### PR TITLE
Allow implicit CoreAnimation transactions on the scrolling thread.

### DIFF
--- a/Source/WebCore/PAL/pal/spi/cocoa/QuartzCoreSPI.h
+++ b/Source/WebCore/PAL/pal/spi/cocoa/QuartzCoreSPI.h
@@ -226,6 +226,10 @@ typedef enum {
 #endif
 @end
 
+@interface CATransaction ()
++ (void)setDisableImplicitTransactionMainThreadAssert:(BOOL)flag;
+@end
+
 WTF_EXTERN_C_BEGIN
 
 // FIXME: Declare these functions even when USE(APPLE_INTERNAL_SDK) is true once we can fix <rdar://problem/26584828> in a better way.

--- a/Source/WebKit/UIProcess/RemoteLayerTree/RemoteScrollingTree.cpp
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/RemoteScrollingTree.cpp
@@ -227,7 +227,6 @@ void RemoteScrollingTree::tryToApplyLayerPositions()
     if (m_hasNodesWithSynchronousScrollingReasons)
         return;
 
-    auto transaction = RemoteScrollingTreeTransactionHolder { *this };
     applyLayerPositionsInternal();
 }
 

--- a/Source/WebKit/UIProcess/RemoteLayerTree/RemoteScrollingTree.h
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/RemoteScrollingTree.h
@@ -75,9 +75,6 @@ public:
 
     void tryToApplyLayerPositions();
 
-    virtual void beginTransactionOnScrollingThread() { }
-    virtual void commitTransactionOnScrollingThread() { }
-
 protected:
     explicit RemoteScrollingTree(RemoteScrollingCoordinatorProxy&);
 
@@ -104,23 +101,6 @@ public:
     ~RemoteLayerTreeHitTestLocker()
     {
         m_scrollingTree->unlockLayersForHitTesting();
-    }
-
-private:
-    Ref<RemoteScrollingTree> m_scrollingTree;
-};
-
-class RemoteScrollingTreeTransactionHolder {
-public:
-    RemoteScrollingTreeTransactionHolder(RemoteScrollingTree& scrollingTree)
-        : m_scrollingTree(scrollingTree)
-    {
-        m_scrollingTree->beginTransactionOnScrollingThread();
-    }
-
-    ~RemoteScrollingTreeTransactionHolder()
-    {
-        m_scrollingTree->commitTransactionOnScrollingThread();
     }
 
 private:

--- a/Source/WebKit/UIProcess/RemoteLayerTree/mac/RemoteLayerTreeEventDispatcher.cpp
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/mac/RemoteLayerTreeEventDispatcher.cpp
@@ -205,7 +205,6 @@ void RemoteLayerTreeEventDispatcher::scrollingThreadHandleWheelEvent(const WebWh
         return;
 
     auto locker = RemoteLayerTreeHitTestLocker { *scrollingTree };
-    auto transaction = RemoteScrollingTreeTransactionHolder { *scrollingTree };
 
     auto platformWheelEvent = platform(webWheelEvent);
     auto processingSteps = determineWheelEventProcessing(platformWheelEvent, rubberBandableEdges);

--- a/Source/WebKit/UIProcess/RemoteLayerTree/mac/RemoteScrollingTreeMac.h
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/mac/RemoteScrollingTreeMac.h
@@ -80,9 +80,6 @@ private:
     void lockLayersForHitTesting() final WTF_ACQUIRES_LOCK(m_layerHitTestMutex);
     void unlockLayersForHitTesting() final WTF_RELEASES_LOCK(m_layerHitTestMutex);
 
-    void beginTransactionOnScrollingThread() final;
-    void commitTransactionOnScrollingThread() final;
-
     void startPendingScrollAnimations() WTF_REQUIRES_LOCK(m_treeLock);
 
     void scrollingTreeNodeWillStartScroll(WebCore::ScrollingNodeID) override;

--- a/Source/WebKit/UIProcess/RemoteLayerTree/mac/RemoteScrollingTreeMac.mm
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/mac/RemoteScrollingTreeMac.mm
@@ -52,6 +52,11 @@ Ref<RemoteScrollingTree> RemoteScrollingTree::create(RemoteScrollingCoordinatorP
 RemoteScrollingTreeMac::RemoteScrollingTreeMac(RemoteScrollingCoordinatorProxy& scrollingCoordinator)
     : RemoteScrollingTree(scrollingCoordinator)
 {
+    ASSERT(isMainRunLoop());
+    ScrollingThread::dispatch([protectedThis = Ref { *this }]() {
+        if ([CATransaction instancesRespondToSelector:@selector(setDisableImplicitTransactionMainThreadAssert:)])
+            [CATransaction setDisableImplicitTransactionMainThreadAssert:YES];
+    });
 }
 
 RemoteScrollingTreeMac::~RemoteScrollingTreeMac() = default;
@@ -351,19 +356,6 @@ void RemoteScrollingTreeMac::lockLayersForHitTesting()
 void RemoteScrollingTreeMac::unlockLayersForHitTesting()
 {
     m_layerHitTestMutex.unlock();
-}
-
-
-void RemoteScrollingTreeMac::beginTransactionOnScrollingThread()
-{
-    ASSERT(ScrollingThread::isCurrentThread());
-    [CATransaction begin];
-}
-
-void RemoteScrollingTreeMac::commitTransactionOnScrollingThread()
-{
-    ASSERT(ScrollingThread::isCurrentThread());
-    [CATransaction commit];
 }
 
 static ScrollingNodeID scrollingNodeIDForLayer(CALayer *layer)


### PR DESCRIPTION
#### 66deadcc6fb0d4af05de1edc20ebfd6e5f58c697
<pre>
Allow implicit CoreAnimation transactions on the scrolling thread.
<a href="https://bugs.webkit.org/show_bug.cgi?id=256989">https://bugs.webkit.org/show_bug.cgi?id=256989</a>
&lt;rdar://109211223&gt;

Reviewed by Simon Fraser.

* Source/WebCore/PAL/pal/spi/cocoa/QuartzCoreSPI.h:
* Source/WebKit/UIProcess/RemoteLayerTree/RemoteScrollingTree.cpp:
(WebKit::RemoteScrollingTree::tryToApplyLayerPositions):
* Source/WebKit/UIProcess/RemoteLayerTree/RemoteScrollingTree.h:
(WebKit::RemoteScrollingTree::beginTransactionOnScrollingThread): Deleted.
(WebKit::RemoteScrollingTree::commitTransactionOnScrollingThread): Deleted.
(WebKit::RemoteScrollingTreeTransactionHolder::RemoteScrollingTreeTransactionHolder): Deleted.
(WebKit::RemoteScrollingTreeTransactionHolder::~RemoteScrollingTreeTransactionHolder): Deleted.
* Source/WebKit/UIProcess/RemoteLayerTree/mac/RemoteLayerTreeEventDispatcher.cpp:
(WebKit::RemoteLayerTreeEventDispatcher::scrollingThreadHandleWheelEvent):
* Source/WebKit/UIProcess/RemoteLayerTree/mac/RemoteScrollingTreeMac.h:
* Source/WebKit/UIProcess/RemoteLayerTree/mac/RemoteScrollingTreeMac.mm:
(WebKit::RemoteScrollingTreeMac::RemoteScrollingTreeMac):
(WebKit::RemoteScrollingTreeMac::beginTransactionOnScrollingThread): Deleted.
(WebKit::RemoteScrollingTreeMac::commitTransactionOnScrollingThread): Deleted.

Canonical link: <a href="https://commits.webkit.org/264224@main">https://commits.webkit.org/264224@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/28b301a2841c94e45c407320cd4254eb4e5a0c60

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/7076 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/7321 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/7500 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/8693 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/7309 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/7087 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/8583 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/7252 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/10212 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/7203 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/7864 "2 new passes 4 flakes 2 failures") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/6527 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/8797 "Built successfully") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/39/builds/5225 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/6440 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/14200 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/6888 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/6537 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/9416 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/7015 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/5742 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/6380 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/1674 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/10576 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/6763 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->