### PR TITLE
[Cocoa] Allow additional Socket Option powers in Network Process

### DIFF
--- a/Source/WebKit/NetworkProcess/mac/com.apple.WebKit.NetworkProcess.sb.in
+++ b/Source/WebKit/NetworkProcess/mac/com.apple.WebKit.NetworkProcess.sb.in
@@ -80,18 +80,23 @@
         (socket-option-name
             SO_DELEGATED
             SO_DELEGATED_UUID
+            SO_MARK_KNOWN_TRACKER
             SO_NECP_ATTRIBUTES
             SO_NECP_CLIENTUUID
             SO_NECP_LISTENUUID
             SO_NOSIGPIPE
             SO_RCVBUF
             SO_REUSEADDR
-            SO_REUSEPORT)))
+            SO_REUSEPORT
+            SO_SNDLOWAT)))
 
 (allow socket-option-get
     (require-all
         (socket-option-level SOL_SOCKET)
-        (socket-option-name SO_ERROR SO_NREAD)))
+        (socket-option-name
+            SO_ERROR
+            SO_NREAD
+            SO_SNDBUF)))
 
 (allow socket-option-set
     (require-all

--- a/Source/WebKit/Resources/SandboxProfiles/ios/com.apple.WebKit.Networking.sb.in
+++ b/Source/WebKit/Resources/SandboxProfiles/ios/com.apple.WebKit.Networking.sb.in
@@ -57,7 +57,9 @@
 (allow socket-option-get
     (require-all
         (socket-option-level SOL_SOCKET)
-        (socket-option-name SO_NREAD)))
+        (socket-option-name
+            SO_NREAD
+            SO_SNDBUF)))
 
 (allow socket-option-get
     (require-all
@@ -73,6 +75,7 @@
     (require-all
         (socket-option-level SOL_SOCKET)
         (socket-option-name
+            SO_MARK_KNOWN_TRACKER
             SO_NECP_LISTENUUID
             SO_NOSIGPIPE
             SO_RCVBUF


### PR DESCRIPTION
#### 89cc82d5b08e9a51e582e13390667fd022b8c317
<pre>
[Cocoa] Allow additional Socket Option powers in Network Process
<a href="https://bugs.webkit.org/show_bug.cgi?id=256992">https://bugs.webkit.org/show_bug.cgi?id=256992</a>
&lt;rdar://problem/109534729&gt;

Reviewed by Per Arne Vollan.

Update the Network sandboxes to permit socket options that have been hit during telemetry collection:

    allow socket-option-set level:SOL_SOCKET name:SO_MARK_KNOWN_TRACKER
    allow socket-option-get level:SOL_SOCKET name:SO_SNDBUF
    allow socket-option-set level:SOL_SOCKET name:SO_SNDLOWAT

We should add these permissions to avoid generating telemetry and reports for things that are needed
during normal WebKit operations.

* Source/WebKit/NetworkProcess/mac/com.apple.WebKit.NetworkProcess.sb.in:
* Source/WebKit/Resources/SandboxProfiles/ios/com.apple.WebKit.Networking.sb.in:

Canonical link: <a href="https://commits.webkit.org/264275@main">https://commits.webkit.org/264275@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5e7ba059af5e1209e0c62fffcd996e5bc89f16d0

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/7199 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/7448 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/7626 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/8817 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/7419 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/8783 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/7381 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/10318 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/7326 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/8027 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/6634 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/8924 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/5378 "Passed tests") | | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/14291 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/7019 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/6655 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/9533 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/7135 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/5832 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/6494 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/1709 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/10694 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/6878 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->