### PR TITLE
Bail out early if m_element is deleted

### DIFF
--- a/LayoutTests/fullscreen/element-clear-during-fullscreen-crash-expected.txt
+++ b/LayoutTests/fullscreen/element-clear-during-fullscreen-crash-expected.txt
@@ -1,0 +1,1 @@
+PASS if no crash.

--- a/LayoutTests/fullscreen/element-clear-during-fullscreen-crash.html
+++ b/LayoutTests/fullscreen/element-clear-during-fullscreen-crash.html
@@ -1,0 +1,22 @@
+<script>
+  async function test() {
+    if (window.testRunner) {
+      testRunner.dumpAsText();
+      testRunner.waitUntilDone();
+    }
+    internals.withUserGesture(() => {});
+    let form0 = document.createElement('form');
+    document.body.append(form0);
+    form0.submit();
+    let audio0 = document.createElement('audio');
+    document.body.append(audio0);
+    await audio0.requestFullscreen();
+    location.hash = '#x';
+    if (window.testRunner) {
+      document.body.innerHTML = 'PASS if no crash.';
+      testRunner.notifyDone();
+    }
+}
+</script>
+<body onload="test()">
+</body>

--- a/Source/WebKit/WebProcess/FullScreen/WebFullScreenManager.cpp
+++ b/Source/WebKit/WebProcess/FullScreen/WebFullScreenManager.cpp
@@ -238,6 +238,11 @@ void WebFullScreenManager::willEnterFullScreen()
         return;
     }
 
+    if (!m_element) {
+        close();
+        return;
+    }
+
 #if !PLATFORM(IOS_FAMILY)
     m_page->hidePageBanners();
 #endif


### PR DESCRIPTION
#### ed09dda9c3d682c4691967faba0348aada894e59
<pre>
REGRESSION: WebKit provides rectilinear selection rects for rotated text in images
<a href="https://bugs.webkit.org/show_bug.cgi?id=259888">https://bugs.webkit.org/show_bug.cgi?id=259888</a>
rdar://113287677

Reviewed by Wenson Hsieh.

`EditorState::clipOwnedRectExtentsToNumericLimits` was erroneously converting some selection
geometries from quads to rects.

Fix by removing these conversions. Since `FloatQuad`s have no notion of validity, there is no
need to clip them to numeric limits.

* Source/WebKit/Shared/EditorState.cpp:
(WebKit::EditorState::clipOwnedRectExtentsToNumericLimits):

Originally-landed-as: 265870.235@safari-7616-branch (bfc6efd0dc4e). rdar://104290899
</pre>