### PR TITLE
Clear UserActionElement state for the node when it is moved from the Document to a different one

### DIFF
--- a/LayoutTests/fast/html/element-moving-to-new-document-crash-expected.txt
+++ b/LayoutTests/fast/html/element-moving-to-new-document-crash-expected.txt
@@ -1,0 +1,1 @@
+PASS if no crash.

--- a/LayoutTests/fast/html/element-moving-to-new-document-crash.html
+++ b/LayoutTests/fast/html/element-moving-to-new-document-crash.html
@@ -1,0 +1,20 @@
+<script>
+function test() {
+    if (window.testRunner)
+        testRunner.dumpAsText();
+    textAreaID.selectionStart = 1;
+    detailsID.open = false;
+    detailsID.textContent = "1";
+    detailsID.open = true;
+    iframeID.contentDocument.body.append(divID);
+    document.body.innerHTML = 'PASS if no crash.'; 
+}
+</script>
+
+<body onload=test()>
+    <div id="divID">
+    <details id="detailsID" open="true">
+        <textarea id="textAreaID" bordercolor="black"></textarea>
+    </details>
+    </div>
+<iframe id="iframeID"></iframe>

--- a/Source/WebCore/dom/Element.cpp
+++ b/Source/WebCore/dom/Element.cpp
@@ -2778,6 +2778,8 @@ void Element::removedFromAncestor(RemovalType removalType, ContainerNode& oldPar
 
     if (UNLIKELY(isInTopLayer()))
         removeFromTopLayer();
+
+    document().userActionElements().clearAllForElement(*this);
 }
 
 PopoverData* Element::popoverData() const

--- a/Source/WebCore/dom/UserActionElementSet.cpp
+++ b/Source/WebCore/dom/UserActionElementSet.cpp
@@ -34,6 +34,8 @@ namespace WebCore {
 
 void UserActionElementSet::clear()
 {
+    for (auto iterator = m_elements.begin(); iterator != m_elements.end(); ++iterator)
+        iterator->key->setUserActionElement(false);
     m_elements.clear();
 }
 

--- a/Source/WebCore/dom/UserActionElementSet.h
+++ b/Source/WebCore/dom/UserActionElementSet.h
@@ -55,6 +55,7 @@ public:
     void setHasFocusWithin(Element& element, bool enable) { setFlags(element, enable, Flag::HasFocusWithin); }
 
     void clearActiveAndHovered(Element& element) { clearFlags(element, { Flag::IsActive, Flag::InActiveChain, Flag::IsHovered }); }
+    void clearAllForElement(Element& element) { clearFlags(element, { Flag::IsActive, Flag::InActiveChain, Flag::IsHovered, Flag::IsFocused, Flag::IsBeingDragged, Flag::HasFocusVisible, Flag::HasFocusWithin }); }
 
     void clear();
 


### PR DESCRIPTION
#### 272d45367b3566bd8836ec791248c6916710fc04
<pre>
Clear UserActionElement state for the node when it is moved from the Document to a different one
<a href="https://bugs.webkit.org/show_bug.cgi?id=253012">https://bugs.webkit.org/show_bug.cgi?id=253012</a>
rdar://105876245

Reviewed by Ryosuke Niwa.

Before this change, when an element was moved from oldDocument to
newDocument, and we had UserActionElementSet state for it, we never
cleared that. This meant that the element was still marked to have this
state, which the newDocument doesn&apos;t know about. This change fixes
that.

* LayoutTests/fast/html/element-moving-to-new-document-crash-expected.txt: Added.
* LayoutTests/fast/html/element-moving-to-new-document-crash.html: Added.
* Source/WebCore/dom/Element.cpp:
(WebCore::Element::removedFromAncestor):
* Source/WebCore/dom/UserActionElementSet.cpp:
(WebCore::UserActionElementSet::clear):
* Source/WebCore/dom/UserActionElementSet.h:
(WebCore::UserActionElementSet::clearAllForElement):

Originally-landed-as: 259548.353@safari-7615-branch (b82284c1f8c5). rdar://105876245
Canonical link: <a href="https://commits.webkit.org/264272@main">https://commits.webkit.org/264272@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/3f94ce28f45f54f4b94eb657018348add282e41b

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/7097 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/7342 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/7520 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/8711 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/7327 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/7108 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/8604 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/7274 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/10228 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/7224 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/7881 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/6540 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/8816 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/5241 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/6454 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/14216 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/6904 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/6551 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/9434 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/7035 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/5757 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/6495 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/6363 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/10594 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/844 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/6781 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->