### PR TITLE
[iOS] <option> label attribute is not rendered

### DIFF
--- a/LayoutTests/fast/forms/ios/select-option-label-expected.txt
+++ b/LayoutTests/fast/forms/ios/select-option-label-expected.txt
@@ -1,0 +1,12 @@
+This test verifies that an option's label attribute is used as the corresponding menu item's title.
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+PASS select.value is "Option 1 Text"
+PASS areArraysEqual(items, ["Option 1 Text", "Option 2 Label", "Option 3 Label"]) is true
+PASS select.value is "Option 2 Value"
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/fast/forms/ios/select-option-label-quirks-mode-expected.txt
+++ b/LayoutTests/fast/forms/ios/select-option-label-quirks-mode-expected.txt
@@ -1,0 +1,12 @@
+This test verifies that an option's label attribute is not used as the corresponding menu item's title in quirks mode.
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+PASS select.value is "Option 1 Text"
+PASS areArraysEqual(items, ["Option 1 Text", "", "Option 3 Text"]) is true
+PASS select.value is "Option 2 Value"
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/fast/forms/ios/select-option-label-quirks-mode.html
+++ b/LayoutTests/fast/forms/ios/select-option-label-quirks-mode.html
@@ -1,0 +1,33 @@
+<html>
+    <head>
+        <meta name="viewport" content="width=device-width, initial-scale=1, user-scalable=no">
+        <script src="../../../resources/js-test.js"></script>
+        <script src="../../../resources/ui-helper.js"></script>
+    </head>
+<body>
+<select id="select">
+    <option>Option 1 Text</option>
+    <option label="Option 2 Label" value="Option 2 Value"></option>
+    <option label="Option 3 Label">Option 3 Text</option>
+</select>
+</body>
+<script>
+jsTestIsAsync = true;
+
+addEventListener("load", async () => {
+    description("This test verifies that an option's label attribute is not used as the corresponding menu item's title in quirks mode.");
+
+    shouldBeEqualToString("select.value", "Option 1 Text");
+    await UIHelper.activateElement(select);
+
+    items = await UIHelper.selectMenuItems();
+    shouldBeTrue("areArraysEqual(items, " + '["Option 1 Text", "", "Option 3 Text"]' + ")");
+
+    await UIHelper.selectFormAccessoryPickerRow(1);
+    await UIHelper.waitForContextMenuToHide();
+    shouldBeEqualToString("select.value", "Option 2 Value");
+
+    finishJSTest();
+});
+</script>
+</html>

--- a/LayoutTests/fast/forms/ios/select-option-label.html
+++ b/LayoutTests/fast/forms/ios/select-option-label.html
@@ -1,0 +1,34 @@
+<!DOCTYPE html>
+<html>
+    <head>
+        <meta name="viewport" content="width=device-width, initial-scale=1, user-scalable=no">
+        <script src="../../../resources/js-test.js"></script>
+        <script src="../../../resources/ui-helper.js"></script>
+    </head>
+<body>
+<select id="select">
+    <option>Option 1 Text</option>
+    <option label="Option 2 Label" value="Option 2 Value"></option>
+    <option label="Option 3 Label">Option 3 Text</option>
+</select>
+</body>
+<script>
+jsTestIsAsync = true;
+
+addEventListener("load", async () => {
+    description("This test verifies that an option's label attribute is used as the corresponding menu item's title.");
+
+    shouldBeEqualToString("select.value", "Option 1 Text");
+    await UIHelper.activateElement(select);
+
+    items = await UIHelper.selectMenuItems();
+    shouldBeTrue("areArraysEqual(items, " + '["Option 1 Text", "Option 2 Label", "Option 3 Label"]' + ")");
+
+    await UIHelper.selectFormAccessoryPickerRow(1);
+    await UIHelper.waitForContextMenuToHide();
+    shouldBeEqualToString("select.value", "Option 2 Value");
+
+    finishJSTest();
+});
+</script>
+</html>

--- a/LayoutTests/resources/ui-helper.js
+++ b/LayoutTests/resources/ui-helper.js
@@ -1016,6 +1016,18 @@ window.UIHelper = class UIHelper {
         });
     }
 
+    static selectMenuItems()
+    {
+        return new Promise(resolve => {
+            testRunner.runUIScript(`
+            (function() {
+                uiController.didShowContextMenuCallback = function() {
+                    uiController.uiScriptComplete(JSON.stringify(uiController.contentsOfUserInterfaceItem('selectMenu')));
+                };
+            })();`, result => resolve(JSON.parse(result).selectMenu));
+        });
+    }
+
     static setSelectedColorForColorPicker(red, green, blue)
     {
         const selectColorScript = `uiController.setSelectedColorForColorPicker(${red}, ${green}, ${blue})`;

--- a/Source/WebCore/html/HTMLOptionElement.h
+++ b/Source/WebCore/html/HTMLOptionElement.h
@@ -55,7 +55,7 @@ public:
     WEBCORE_EXPORT HTMLSelectElement* ownerSelectElement() const;
 
     WEBCORE_EXPORT String label() const;
-    String displayLabel() const;
+    WEBCORE_EXPORT String displayLabel() const;
     WEBCORE_EXPORT void setLabel(const AtomString&);
 
     bool ownElementDisabled() const { return m_disabled; }

--- a/Source/WebKit/UIProcess/ios/WKContentViewInteraction.mm
+++ b/Source/WebKit/UIProcess/ios/WKContentViewInteraction.mm
@@ -11848,7 +11848,13 @@ static BOOL shouldUseMachineReadableCodeMenuFromImageAnalysisResult(CocoaImageAn
             return @{ userInterfaceItem: @[] };
         return @{ userInterfaceItem: [_fileUploadPanel currentAvailableActionTitles] };
     }
-    
+
+    if ([userInterfaceItem isEqualToString:@"selectMenu"]) {
+        if (auto *menuItemTitles = [self.selectControl menuItemTitles])
+            return @{ userInterfaceItem: menuItemTitles };
+        return @{ userInterfaceItem: @[] };
+    }
+
     return nil;
 }
 

--- a/Source/WebKit/UIProcess/ios/forms/WKFormSelectControl.h
+++ b/Source/WebKit/UIProcess/ios/forms/WKFormSelectControl.h
@@ -43,12 +43,15 @@ CGFloat adjustedFontSize(CGFloat textWidth, UIFont *, CGFloat initialFontSize, c
 - (void)selectRow:(NSInteger)rowIndex inComponent:(NSInteger)componentIndex extendingSelection:(BOOL)extendingSelection;
 - (BOOL)selectFormAccessoryHasCheckedItemAtRow:(long)rowIndex;
 @property (nonatomic, readonly) NSString *selectFormPopoverTitle;
+@property (nonatomic, readonly) NSArray<NSString *> *menuItemTitles;
 @end
 
 @protocol WKSelectTesting
 @optional
 - (void)selectRow:(NSInteger)rowIndex inComponent:(NSInteger)componentIndex extendingSelection:(BOOL)extendingSelection;
 - (BOOL)selectFormAccessoryHasCheckedItemAtRow:(long)rowIndex;
+
+- (NSArray<NSString *> *)menuItemTitles;
 @end
 
 #endif // PLATFORM(IOS_FAMILY)

--- a/Source/WebKit/UIProcess/ios/forms/WKFormSelectControl.mm
+++ b/Source/WebKit/UIProcess/ios/forms/WKFormSelectControl.mm
@@ -121,6 +121,13 @@ CGFloat adjustedFontSize(CGFloat textWidth, UIFont *font, CGFloat initialFontSiz
         && [id<WKSelectTesting>(self.control) selectFormAccessoryHasCheckedItemAtRow:rowIndex];
 }
 
+- (NSArray<NSString *> *)menuItemTitles
+{
+    if ([self.control respondsToSelector:@selector(menuItemTitles)])
+        return [id<WKSelectTesting>(self.control) menuItemTitles];
+    return nil;
+}
+
 @end
 
 #endif  // PLATFORM(IOS_FAMILY)

--- a/Source/WebKit/UIProcess/ios/forms/WKFormSelectPicker.mm
+++ b/Source/WebKit/UIProcess/ios/forms/WKFormSelectPicker.mm
@@ -740,6 +740,27 @@ ALLOW_DEPRECATED_DECLARATIONS_END
     return NO;
 }
 
+- (NSArray<NSString *> *)menuItemTitles
+{
+#if USE(UICONTEXTMENU)
+    NSMutableArray<NSString *> *itemTitles = [NSMutableArray array];
+    for (UIMenuElement *menuElement in [_selectMenu children]) {
+        if (auto *action = dynamic_objc_cast<UIAction>(menuElement)) {
+            [itemTitles addObject:action.title];
+            continue;
+        }
+
+        if (auto *menu = dynamic_objc_cast<UIMenu>(menuElement)) {
+            for (UIMenuElement *groupedMenuElement in [menu children])
+                [itemTitles addObject:groupedMenuElement.title];
+        }
+    }
+    return itemTitles;
+#else
+    return nil;
+#endif
+}
+
 @end
 
 @interface WKSelectPickerGroupHeaderView : UIView

--- a/Source/WebKit/WebProcess/WebPage/ios/WebPageIOS.mm
+++ b/Source/WebKit/WebProcess/WebPage/ios/WebPageIOS.mm
@@ -3624,7 +3624,7 @@ std::optional<FocusedElementInformation> WebPage::focusedElementInformation()
         // If a select does not have groups, all the option elements have group ID 0.
         for (auto& item : element.listItems()) {
             if (auto* optionElement = dynamicDowncast<HTMLOptionElement>(item.get()))
-                information.selectOptions.append(OptionItem(optionElement->text(), false, optionElement->selected(), optionElement->hasAttributeWithoutSynchronization(WebCore::HTMLNames::disabledAttr), parentGroupID));
+                information.selectOptions.append(OptionItem(optionElement->displayLabel(), false, optionElement->selected(), optionElement->hasAttributeWithoutSynchronization(WebCore::HTMLNames::disabledAttr), parentGroupID));
             else if (auto* optGroupElement = dynamicDowncast<HTMLOptGroupElement>(item.get())) {
                 parentGroupID++;
                 information.selectOptions.append(OptionItem(optGroupElement->groupLabelText(), true, false, optGroupElement->hasAttributeWithoutSynchronization(WebCore::HTMLNames::disabledAttr), 0));


### PR DESCRIPTION
#### a232aa69a5c61fab67aa22472c48df37ba6e038b
<pre>
[iOS] &lt;option&gt; label attribute is not rendered
<a href="https://bugs.webkit.org/show_bug.cgi?id=200469">https://bugs.webkit.org/show_bug.cgi?id=200469</a>
rdar://53989128

Reviewed by Wenson Hsieh.

Use `HTMLOptionElement::displayLabel` rather than `::text` to supply the
option&apos;s title to the UI process. This method is spec-compliant, as it uses
the label attribute when available, and uses the element&apos;s text content in
quirks mode.

Add testing hooks to validate the behavior.

* LayoutTests/fast/forms/ios/select-option-label-expected.txt: Added.
* LayoutTests/fast/forms/ios/select-option-label-quirks-mode-expected.txt: Added.
* LayoutTests/fast/forms/ios/select-option-label-quirks-mode.html: Added.
* LayoutTests/fast/forms/ios/select-option-label.html: Added.
* LayoutTests/resources/ui-helper.js:
(window.UIHelper.selectMenuItems):
* Source/WebCore/html/HTMLOptionElement.h:
* Source/WebKit/UIProcess/ios/WKContentViewInteraction.mm:
(-[WKContentView _contentsOfUserInterfaceItem:]):
* Source/WebKit/UIProcess/ios/forms/WKFormSelectControl.h:
* Source/WebKit/UIProcess/ios/forms/WKFormSelectControl.mm:
(-[WKFormSelectControl menuItemTitles]):
* Source/WebKit/UIProcess/ios/forms/WKFormSelectPicker.mm:
(-[WKSelectPicker menuItemTitles]):
* Source/WebKit/WebProcess/WebPage/ios/WebPageIOS.mm:
(WebKit::WebPage::focusedElementInformation):

Canonical link: <a href="https://commits.webkit.org/264229@main">https://commits.webkit.org/264229@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/570dab381a4ce14c9a839471a36fed5c331e253c

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/7109 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/7354 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/7533 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/8723 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/7334 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/7119 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/8615 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/7286 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/10231 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/7236 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/7887 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/6545 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/8828 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/5246 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/6461 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/14219 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/6909 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/6559 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/9438 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/7045 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/5763 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/6406 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/6370 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/1676 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/10604 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/6789 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->