### PR TITLE
Fix syntax error in merchant-validation.php on webkit.org

### DIFF
--- a/Websites/webkit.org/demos/payment-request/merchant-validation.php
+++ b/Websites/webkit.org/demos/payment-request/merchant-validation.php
@@ -91,7 +91,7 @@ $curlOptions = array(
 $curlConnection = curl_init();
 curl_setopt_array($curlConnection, $curlOptions);
 if (!$result = curl_exec($curlConnection))
-    die('An error occurred when connecting to the validation URL.'));
+    die('An error occurred when connecting to the validation URL.');
 
 curl_close($curlConnection);
 


### PR DESCRIPTION
#### 365d91ad2c52506f5ad014bf54777becf6bd5875
<pre>
Fix syntax error in merchant-validation.php on webkit.org
<a href="https://bugs.webkit.org/show_bug.cgi?id=256998">https://bugs.webkit.org/show_bug.cgi?id=256998</a>

Reviewed by Alexey Proskuryakov.

This fixes a syntax error present in the merchant-validation.php backend.

* Websites/webkit.org/demos/payment-request/merchant-validation.php:
Fix a syntax error around error handling in a curl request.

Canonical link: <a href="https://commits.webkit.org/264378@main">https://commits.webkit.org/264378@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/7b1d43da6b507497e62d2f4a4ec35ff31534cfdf

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/7189 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/7437 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/7616 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/8806 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/7409 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/8767 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/7370 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/10311 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/7316 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/8011 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/6625 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/8913 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/5363 "Passed tests") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/14285 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/7007 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/6645 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/9527 "7 api tests failed or timed out") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/7125 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/5827 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/6485 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/10684 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/901 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/6869 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->