### PR TITLE
ASAN_BUS | Yarr::Interpreter::matchDisjunction; Yarr::Interpreter::backtrackParentheses; Yarr::Interpreter::matchDisjunction

### DIFF
--- a/JSTests/stress/regexp-lookbehind-greedy-backreference.js
+++ b/JSTests/stress/regexp-lookbehind-greedy-backreference.js
@@ -1,0 +1,83 @@
+let errors = 0;
+
+function arrayToString(arr)
+{
+    let str = '';
+    arr.forEach(function(v, index) {
+        if (typeof v == "string")
+            str += "\"" + v + "\"";
+        else
+            str += v;
+
+        if (index != (arr.length - 1))
+            str += ',';
+      });
+  return str;
+}
+
+function dumpValue(v)
+{
+    if (v === null)
+        return "<null>";
+
+    if (v === undefined)
+        return "<undefined>";
+
+    if (typeof v == "string")
+        return "\"" + v + "\"";
+
+    let str = "";
+
+    if (v.length)
+        str += arrayToString(v);
+
+    return "[ " + str + " ]";
+}
+
+function compareArray(expected, actual)
+{
+    if (expected === null && actual === null)
+        return true;
+
+    if (expected === null) {
+        print("### expected is null, actual is not null");
+        return false;
+    }
+
+    if (actual === null) {
+        print("### expected is not null, actual is null");
+        return false;
+    }
+
+    if (expected.length !== actual.length) {
+        print("### expected.length: " + expected.length + ", actual.length: " + actual.length);
+        return false;
+    }
+
+    for (var i = 0; i < expected.length; i++) {
+        if (expected[i] !== actual[i]) {
+            print("### expected[" + i + "]: \"" + expected[i] + "\" !== actual[" + i + "]: \"" + actual[i] + "\"");
+            return false;
+        }
+    }
+
+    return true;
+}
+
+function testRegExp(re, str, exp)
+{
+    let actual = re.exec(str);
+
+    let result = compareArray(exp, actual);
+
+    if (!result) {
+        print(re.toString() + ".exec(" + dumpValue(str) + "), FAILED: Expected ", dumpValue(exp), " got ", dumpValue(actual));
+        ++errors;
+    }
+}
+
+testRegExp(/((c)(?<!([a]\2?)*|))/, "caf", null);
+testRegExp(/((c)(?<=([a]\2?)*|))/, "caf", ["c", "c", "c", undefined]);
+
+if (errors)
+    throw("Test FAILED.");

--- a/Source/JavaScriptCore/yarr/YarrInterpreter.cpp
+++ b/Source/JavaScriptCore/yarr/YarrInterpreter.cpp
@@ -1024,7 +1024,9 @@ public:
         case QuantifierType::Greedy:
             if (backTrack->matchAmount) {
                 --backTrack->matchAmount;
-                input.rewind(backTrack->backReferenceSize);
+                if (term.matchDirection() == Backward)
+                    return input.checkInput(matchEnd - matchBegin);
+                input.rewind(matchEnd - matchBegin);
                 return true;
             }
             break;


### PR DESCRIPTION
#### c654724c531ef90a5676f0b5dbcfede89ae40189
<pre>
ASAN_BUS | Yarr::Interpreter::matchDisjunction; Yarr::Interpreter::backtrackParentheses; Yarr::Interpreter::matchDisjunction
<a href="https://bugs.webkit.org/show_bug.cgi?id=253466">https://bugs.webkit.org/show_bug.cgi?id=253466</a>
rdar://105669717

Reviewed by Yusuke Suzuki.

When backtracking, i.e. unmatching a greedy backreference in a lookbehind, the unmatch requires moving the input pointer
forward.  THis means we need to do a checkInput() instead of a rewind() in this case.

* JSTests/stress/regexp-lookbehind-greedy-backreference.js: Added.
(arrayToString):
(dumpValue):
(compareArray):
(testRegExp):
* Source/JavaScriptCore/yarr/YarrInterpreter.cpp:
(JSC::Yarr::Interpreter::backtrackBackReference):

Originally-landed-as: 259548.378@safari-7615-branch (3d135908241d). rdar://1056697172
Canonical link: <a href="https://commits.webkit.org/264264@main">https://commits.webkit.org/264264@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/268e04aaa92732357651b8cff779fdc29b8e6037

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/7107 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/7352 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/7530 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/8721 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/7333 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/8613 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/7284 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/10232 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/7234 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/7885 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/6551 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/8826 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/5244 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/6467 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/14218 "2 flakes 117 failures") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/6020 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/6907 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/6565 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/9436 "Passed tests") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/6690 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/7044 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/5764 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/7244 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/6405 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/1679 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/10603 "Built successfully") | | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/24/builds/7444 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/840 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/6788 "Built successfully") | | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/3/builds/1819 "Passed tests") | 
<!--EWS-Status-Bubble-End-->