### PR TITLE
[UI-side compositing] Significantly more scrolling sync events

### DIFF
--- a/Source/WebCore/page/scrolling/ScrollingTree.cpp
+++ b/Source/WebCore/page/scrolling/ScrollingTree.cpp
@@ -880,6 +880,11 @@ PlatformDisplayID ScrollingTree::displayID()
     return m_treeState.displayID;
 }
 
+bool ScrollingTree::hasRecentActivity()
+{
+    return hasProcessedWheelEventsRecently() || hasNodeWithActiveScrollAnimations();
+}
+
 bool ScrollingTree::hasProcessedWheelEventsRecently()
 {
     Locker locker { m_lastWheelEventTimeLock };

--- a/Source/WebCore/page/scrolling/ScrollingTree.h
+++ b/Source/WebCore/page/scrolling/ScrollingTree.h
@@ -203,6 +203,8 @@ public:
     void setIsMonitoringWheelEvents(bool b) { m_isMonitoringWheelEvents = b; }
     bool inCommitTreeState() const { return m_inCommitTreeState; }
 
+    WEBCORE_EXPORT bool hasRecentActivity();
+
     void scrollBySimulatingWheelEventForTesting(ScrollingNodeID, FloatSize);
 
     virtual void lockLayersForHitTesting() { }

--- a/Source/WebCore/page/scrolling/ThreadedScrollingTree.cpp
+++ b/Source/WebCore/page/scrolling/ThreadedScrollingTree.cpp
@@ -381,11 +381,6 @@ void ThreadedScrollingTree::unlockLayersForHitTesting()
     m_layerHitTestMutex.unlock();
 }
 
-bool ThreadedScrollingTree::scrollingThreadIsActive()
-{
-    return hasProcessedWheelEventsRecently() || hasNodeWithActiveScrollAnimations();
-}
-
 void ThreadedScrollingTree::didScheduleRenderingUpdate()
 {
     m_renderingUpdateWasScheduled = true;
@@ -397,7 +392,7 @@ void ThreadedScrollingTree::willStartRenderingUpdate()
 
     m_renderingUpdateWasScheduled = false;
 
-    if (!scrollingThreadIsActive())
+    if (!hasRecentActivity())
         return;
 
     tracePoint(ScrollingThreadRenderUpdateSyncStart);
@@ -536,7 +531,7 @@ void ThreadedScrollingTree::displayDidRefreshOnScrollingThread()
 
 void ThreadedScrollingTree::displayDidRefresh(PlatformDisplayID displayID)
 {
-    bool scrollingThreadIsActive = this->scrollingThreadIsActive();
+    bool scrollingThreadIsActive = hasRecentActivity();
 
     // We're on the EventDispatcher thread or in the ThreadedCompositor thread here.
     tracePoint(ScrollingTreeDisplayDidRefresh, displayID, scrollingThreadIsActive);

--- a/Source/WebCore/page/scrolling/ThreadedScrollingTree.h
+++ b/Source/WebCore/page/scrolling/ThreadedScrollingTree.h
@@ -115,8 +115,6 @@ private:
     
     bool isScrollingSynchronizedWithMainThread() final WTF_REQUIRES_LOCK(m_treeLock);
 
-    bool scrollingThreadIsActive();
-
     void receivedWheelEventWithPhases(PlatformWheelEventPhase, PlatformWheelEventPhase) final;
     void deferWheelEventTestCompletionForReason(ScrollingNodeID, WheelEventTestMonitor::DeferReason) final;
     void removeWheelEventTestCompletionDeferralForReason(ScrollingNodeID, WheelEventTestMonitor::DeferReason) final;

--- a/Source/WebKit/UIProcess/RemoteLayerTree/mac/RemoteLayerTreeEventDispatcher.h
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/mac/RemoteLayerTreeEventDispatcher.h
@@ -110,6 +110,8 @@ private:
     void scheduleDelayedRenderingUpdateDetectionTimer(Seconds delay);
     void delayedRenderingUpdateDetectionTimerFired();
 
+    bool scrollingTreeWasRecentlyActive();
+
     void waitForRenderingUpdateCompletionOrTimeout() WTF_REQUIRES_LOCK(m_scrollingTreeLock);
 
 #if ENABLE(MOMENTUM_EVENT_DISPATCHER)

--- a/Source/WebKit/UIProcess/RemoteLayerTree/mac/RemoteScrollingTreeMac.mm
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/mac/RemoteScrollingTreeMac.mm
@@ -128,6 +128,11 @@ Ref<ScrollingTreeNode> RemoteScrollingTreeMac::createScrollingTreeNode(Scrolling
 void RemoteScrollingTreeMac::didCommitTree()
 {
     ASSERT(isMainRunLoop());
+    ASSERT(m_treeLock.isLocked());
+
+    if (m_nodesWithPendingScrollAnimations.isEmpty())
+        return;
+
     ScrollingThread::dispatch([protectedThis = Ref { *this }]() {
         Locker treeLocker { protectedThis->m_treeLock };
         protectedThis->startPendingScrollAnimations();


### PR DESCRIPTION
#### c6eb7d8ac9ade01b20d66470208c430ecac17be0
<pre>
[UI-side compositing] Significantly more scrolling sync events
<a href="https://bugs.webkit.org/show_bug.cgi?id=257001">https://bugs.webkit.org/show_bug.cgi?id=257001</a>
rdar://109535555

Reviewed by Matt Woodrow.

In the web process scrolling model, we avoid doing some work when
ThreadedScrollingTree::scrollingThreadIsActive() returns false, which means
there are no scrolling animations running, and we haven&apos;t received a wheel event in the
last 50ms.

We need to replicate this for UI-process scrolling to optimize power. First, move
scrollingThreadIsActive() to be ScrollingTree::hasRecentActivity().

Second, avoid sending `didRefreshDisplay()` to the scrolling thread if there&apos;s not
recent activity.

Third, return early from `RemoteLayerTreeEventDispatcher::mainThreadDisplayDidRefresh()`
if there&apos;s no recent activity, avoiding a scrolling thread dispatch.

Finally, return early from `RemoteScrollingTreeMac::didCommitTree()` if there are no
scroll animations to start, avoiding another scrolling thread dispatch.

* Source/WebCore/page/scrolling/ScrollingTree.cpp:
(WebCore::ScrollingTree::hasRecentActivity):
* Source/WebCore/page/scrolling/ScrollingTree.h:
* Source/WebCore/page/scrolling/ThreadedScrollingTree.cpp:
(WebCore::ThreadedScrollingTree::willStartRenderingUpdate):
(WebCore::ThreadedScrollingTree::displayDidRefresh):
(WebCore::ThreadedScrollingTree::scrollingThreadIsActive): Deleted.
* Source/WebCore/page/scrolling/ThreadedScrollingTree.h:
* Source/WebKit/UIProcess/RemoteLayerTree/mac/RemoteLayerTreeEventDispatcher.cpp:
(WebKit::RemoteLayerTreeEventDispatcher::scrollingTreeWasRecentlyActive):
(WebKit::RemoteLayerTreeEventDispatcher::mainThreadDisplayDidRefresh):
* Source/WebKit/UIProcess/RemoteLayerTree/mac/RemoteLayerTreeEventDispatcher.h:
* Source/WebKit/UIProcess/RemoteLayerTree/mac/RemoteScrollingTreeMac.mm:
(WebKit::RemoteScrollingTreeMac::didCommitTree):

Canonical link: <a href="https://commits.webkit.org/264230@main">https://commits.webkit.org/264230@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/7b498cccf1afeccd3b4f4618e220a75432f81e5e

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/7127 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/7372 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/7551 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/8741 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/32/builds/7351 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/7137 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/8634 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/7304 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/10246 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/7254 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/7909 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/6563 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/8847 "Built successfully") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/39/builds/5264 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/6481 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/14229 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/6927 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/6580 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/9454 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/7063 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/5776 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/30/builds/6423 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/1677 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/10622 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/6806 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->