### PR TITLE
Implement scrollbar-width CSS property in WebKit2

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-scrollbars/scrollbar-width-001-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-scrollbars/scrollbar-width-001-expected.txt
@@ -10,9 +10,9 @@ none
 PASS horizontal-tb, ltr, scrollbar-width auto
 PASS horizontal-tb, ltr, scrollbar-width thin
 PASS horizontal-tb, ltr, scrollbar-width "thin" is same or thinner than "auto"
-FAIL horizontal-tb, ltr, scrollbar-width none assert_equals: ltr none scrollWidth expected 200 but got 185
+PASS horizontal-tb, ltr, scrollbar-width none
 PASS horizontal-tb, rtl, scrollbar-width auto
 PASS horizontal-tb, rtl, scrollbar-width thin
 PASS horizontal-tb, rtl, scrollbar-width "thin" is same or thinner than "auto"
-FAIL horizontal-tb, rtl, scrollbar-width none assert_equals: rtl none scrollWidth expected 200 but got 185
+PASS horizontal-tb, rtl, scrollbar-width none
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-scrollbars/scrollbar-width-002-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-scrollbars/scrollbar-width-002-expected.txt
@@ -10,9 +10,9 @@ none
 PASS vertical-lr, scrollbar-width auto
 PASS vertical-lr, scrollbar-width thin
 PASS vertical-lr, scrollbar-width "thin" is same or thinner than "auto"
-FAIL vertical-lr, scrollbar-width none assert_equals: vertical-lr none scrollHeight expected 200 but got 185
+PASS vertical-lr, scrollbar-width none
 PASS vertical-rl, scrollbar-width auto
 PASS vertical-rl, scrollbar-width thin
 PASS vertical-rl, scrollbar-width "thin" is same or thinner than "auto"
-FAIL vertical-rl, scrollbar-width none assert_equals: vertical-rl none scrollHeight expected 200 but got 185
+PASS vertical-rl, scrollbar-width none
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-scrollbars/scrollbar-width-003-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-scrollbars/scrollbar-width-003-expected.txt
@@ -9,8 +9,8 @@ none
 
 PASS horizontal-tb, ltr, scrollbar-width auto
 PASS horizontal-tb, ltr, scrollbar-width thin
-FAIL horizontal-tb, ltr, scrollbar-width none assert_equals: ltr auto clientWidth expected 200 but got 185
+PASS horizontal-tb, ltr, scrollbar-width none
 PASS horizontal-tb, rtl, scrollbar-width auto
 PASS horizontal-tb, rtl, scrollbar-width thin
-FAIL horizontal-tb, rtl, scrollbar-width none assert_equals: rtl auto clientWidth expected 200 but got 185
+PASS horizontal-tb, rtl, scrollbar-width none
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-scrollbars/scrollbar-width-004-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-scrollbars/scrollbar-width-004-expected.txt
@@ -9,8 +9,8 @@ none
 
 PASS vertical-lr, scrollbar-width auto
 PASS vertical-lr, scrollbar-width thin
-FAIL vertical-lr, scrollbar-width none assert_equals: ltr auto clientWidth expected 200 but got 185
+PASS vertical-lr, scrollbar-width none
 PASS vertical-rl, scrollbar-width auto
 PASS vertical-rl, scrollbar-width thin
-FAIL vertical-rl, scrollbar-width none assert_equals: rtl auto clientWidth expected 200 but got 185
+PASS vertical-rl, scrollbar-width none
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-scrollbars/scrollbar-width-007-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-scrollbars/scrollbar-width-007-expected.txt
@@ -1,3 +1,3 @@
 
-FAIL viewport does not display a scrollbar assert_equals: viewport does not show a scrollbar expected 800 but got 785
+PASS viewport does not display a scrollbar
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-scrollbars/scrollbar-width-keywords-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-scrollbars/scrollbar-width-keywords-expected.txt
@@ -1,5 +1,5 @@
 
 
-FAIL scrollbar-width: none should have no scrollbar assert_equals: expected 100 but got 85
+PASS scrollbar-width: none should have no scrollbar
 PASS scrollbar-width: thin should have scrollbar no wider than auto
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/cssom-view/client-props-root-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/cssom-view/client-props-root-expected.txt
@@ -1,3 +1,3 @@
 
-FAIL client* properties on the root element assert_equals: Without scrollbars, client width should match viewport width expected 800 but got 785
+PASS client* properties on the root element
 

--- a/LayoutTests/platform/mac-wk1/imported/w3c/web-platform-tests/css/css-scrollbars/scrollbar-width-007-expected.txt
+++ b/LayoutTests/platform/mac-wk1/imported/w3c/web-platform-tests/css/css-scrollbars/scrollbar-width-007-expected.txt
@@ -1,0 +1,3 @@
+
+FAIL viewport does not display a scrollbar assert_equals: viewport does not show a scrollbar expected 800 but got 785
+

--- a/LayoutTests/platform/mac-wk1/imported/w3c/web-platform-tests/css/cssom-view/client-props-root-expected.txt
+++ b/LayoutTests/platform/mac-wk1/imported/w3c/web-platform-tests/css/cssom-view/client-props-root-expected.txt
@@ -1,0 +1,3 @@
+
+FAIL client* properties on the root element assert_equals: Without scrollbars, client width should match viewport width expected 800 but got 785
+

--- a/Source/WebCore/page/LocalFrameView.cpp
+++ b/Source/WebCore/page/LocalFrameView.cpp
@@ -541,8 +541,12 @@ Ref<Scrollbar> LocalFrameView::createScrollbar(ScrollbarOrientation orientation)
     if (frameRenderer && frameRenderer->style().hasPseudoStyle(PseudoId::Scrollbar))
         return RenderScrollbar::createCustomScrollbar(*this, orientation, nullptr, m_frame.ptr());
 
+    auto scrollbarSize = scrollbarWidthStyle() == ScrollbarWidth::Thin
+        ? ScrollbarControlSize::Small
+        : ScrollbarControlSize::Regular;
+
     // Nobody set a custom style, so we just use a native scrollbar.
-    return ScrollView::createScrollbar(orientation);
+    return Scrollbar::createNativeScrollbar(*this, orientation, scrollbarSize);
 }
 
 void LocalFrameView::didRestoreFromBackForwardCache()
@@ -6279,6 +6283,15 @@ OverscrollBehavior LocalFrameView::verticalOverscrollBehavior()  const
     if (scrollingObject && renderView())
         return scrollingObject->style().overscrollBehaviorY();
     return OverscrollBehavior::Auto;
+}
+
+ScrollbarWidth LocalFrameView::scrollbarWidthStyle()  const
+{
+    auto* document = m_frame->document();
+    auto scrollingObject = document && document->scrollingElement() ? document->scrollingElement()->renderer() : nullptr;
+    if (scrollingObject && renderView())
+        return scrollingObject->style().scrollbarWidth();
+    return ScrollbarWidth::Auto;
 }
 
 bool LocalFrameView::isVisibleToHitTesting() const

--- a/Source/WebCore/page/LocalFrameView.h
+++ b/Source/WebCore/page/LocalFrameView.h
@@ -731,6 +731,8 @@ public:
     OverscrollBehavior horizontalOverscrollBehavior() const final;
     OverscrollBehavior verticalOverscrollBehavior() const final;
 
+    ScrollbarWidth scrollbarWidthStyle() const final;
+
 private:
     explicit LocalFrameView(LocalFrame&);
 

--- a/Source/WebCore/platform/ScrollableArea.h
+++ b/Source/WebCore/platform/ScrollableArea.h
@@ -141,6 +141,8 @@ public:
     virtual OverscrollBehavior horizontalOverscrollBehavior() const { return OverscrollBehavior::Auto; }
     virtual OverscrollBehavior verticalOverscrollBehavior() const { return OverscrollBehavior::Auto; }
 
+    virtual ScrollbarWidth scrollbarWidthStyle() const { return ScrollbarWidth::Auto; }
+
     bool allowsHorizontalScrolling() const;
     bool allowsVerticalScrolling() const;
 

--- a/Source/WebCore/platform/Scrollbar.cpp
+++ b/Source/WebCore/platform/Scrollbar.cpp
@@ -87,7 +87,7 @@ Scrollbar::Scrollbar(ScrollableArea& scrollableArea, ScrollbarOrientation orient
     // FIXME: This is ugly and would not be necessary if we fix cross-platform code to actually query for
     // scrollbar thickness and use it when sizing scrollbars (rather than leaving one dimension of the scrollbar
     // alone when sizing).
-    int thickness = theme().scrollbarThickness(controlSize);
+    int thickness = theme().scrollbarThickness(controlSize, m_scrollableArea.scrollbarWidthStyle());
     Widget::setFrameRect(IntRect(0, 0, thickness, thickness));
 
     m_currentPos = static_cast<float>(offsetForOrientation(m_scrollableArea.scrollOffset(), m_orientation));
@@ -504,6 +504,11 @@ NativeScrollbarVisibility Scrollbar::nativeScrollbarVisibility(const Scrollbar* 
     if (DeprecatedGlobalSettings::mockScrollbarsEnabled() || (scrollbar && scrollbar->isCustomScrollbar()))
         return NativeScrollbarVisibility::ReplacedByCustomScrollbar;
     return NativeScrollbarVisibility::Visible;
+}
+
+bool Scrollbar::isHiddenByStyle() const
+{
+    return m_scrollableArea.scrollbarWidthStyle() == ScrollbarWidth::None;
 }
 
 float Scrollbar::deviceScaleFactor() const

--- a/Source/WebCore/platform/Scrollbar.h
+++ b/Source/WebCore/platform/Scrollbar.h
@@ -92,7 +92,7 @@ public:
 
     virtual bool isOverlayScrollbar() const;
     bool shouldParticipateInHitTesting();
-    virtual bool isHiddenByStyle() const { return false; }
+    virtual bool isHiddenByStyle() const;
 
     bool isWindowActive() const;
 

--- a/Source/WebCore/platform/ScrollbarTheme.h
+++ b/Source/WebCore/platform/ScrollbarTheme.h
@@ -27,6 +27,7 @@
 
 #include "GraphicsContext.h"
 #include "IntRect.h"
+#include "RenderStyleConstants.h"
 #include "ScrollTypes.h"
 
 namespace WebCore {
@@ -51,7 +52,7 @@ public:
     virtual bool paint(Scrollbar&, GraphicsContext&, const IntRect& /*damageRect*/) { return false; }
     virtual ScrollbarPart hitTest(Scrollbar&, const IntPoint&) { return NoPart; }
     
-    virtual int scrollbarThickness(ScrollbarControlSize = ScrollbarControlSize::Regular, ScrollbarExpansionState = ScrollbarExpansionState::Expanded) { return 0; }
+    virtual int scrollbarThickness(ScrollbarControlSize = ScrollbarControlSize::Regular, ScrollbarWidth = ScrollbarWidth::Auto, ScrollbarExpansionState = ScrollbarExpansionState::Expanded) { return 0; }
 
     virtual ScrollbarButtonsPlacement buttonsPlacement() const { return ScrollbarButtonsSingle; }
 

--- a/Source/WebCore/platform/ScrollbarThemeComposite.cpp
+++ b/Source/WebCore/platform/ScrollbarThemeComposite.cpp
@@ -245,7 +245,7 @@ int ScrollbarThemeComposite::thumbLength(Scrollbar& scrollbar)
 
 int ScrollbarThemeComposite::minimumThumbLength(Scrollbar& scrollbar)
 {
-    return scrollbarThickness(scrollbar.controlSize());
+    return scrollbarThickness(scrollbar.controlSize(), scrollbar.scrollableArea().scrollbarWidthStyle());
 }
 
 int ScrollbarThemeComposite::trackPosition(Scrollbar& scrollbar)

--- a/Source/WebCore/platform/adwaita/ScrollbarThemeAdwaita.cpp
+++ b/Source/WebCore/platform/adwaita/ScrollbarThemeAdwaita.cpp
@@ -84,8 +84,10 @@ bool ScrollbarThemeAdwaita::usesOverlayScrollbars() const
 #endif
 }
 
-int ScrollbarThemeAdwaita::scrollbarThickness(ScrollbarControlSize, ScrollbarExpansionState)
+int ScrollbarThemeAdwaita::scrollbarThickness(ScrollbarControlSize, ScrollbarWidth scrollbarWidth, ScrollbarExpansionState)
 {
+    if (scrollbarWidth == ScrollbarWidth::None)
+        return 0;
     return scrollbarSize;
 }
 

--- a/Source/WebCore/platform/adwaita/ScrollbarThemeAdwaita.h
+++ b/Source/WebCore/platform/adwaita/ScrollbarThemeAdwaita.h
@@ -46,7 +46,7 @@ protected:
     void paintScrollCorner(ScrollableArea&, GraphicsContext&, const IntRect&) override;
     ScrollbarButtonPressAction handleMousePressEvent(Scrollbar&, const PlatformMouseEvent&, ScrollbarPart) override;
 
-    int scrollbarThickness(ScrollbarControlSize, ScrollbarExpansionState) override;
+    int scrollbarThickness(ScrollbarControlSize, ScrollbarWidth, ScrollbarExpansionState) override;
     int minimumThumbLength(Scrollbar&) override;
 
     bool hasButtons(Scrollbar&) override;

--- a/Source/WebCore/platform/gtk/ScrollbarThemeGtk.cpp
+++ b/Source/WebCore/platform/gtk/ScrollbarThemeGtk.cpp
@@ -523,10 +523,13 @@ ScrollbarButtonPressAction ScrollbarThemeGtk::handleMousePressEvent(Scrollbar&, 
     return ScrollbarButtonPressAction::None;
 }
 
-int ScrollbarThemeGtk::scrollbarThickness(ScrollbarControlSize controlSize, ScrollbarExpansionState expansionState)
+int ScrollbarThemeGtk::scrollbarThickness(ScrollbarControlSize controlSize, ScrollbarWidth scrollbarWidth, ScrollbarExpansionState expansionState)
 {
     if (!m_useSystemAppearance)
-        return ScrollbarThemeAdwaita::scrollbarThickness(controlSize, expansionState);
+        return ScrollbarThemeAdwaita::scrollbarThickness(controlSize, scrollbarWidth, expansionState);
+
+    if (scrollbarWidth == ScrollbarWidth::None)
+        return 0;
 
     auto& scrollbarWidget = static_cast<RenderThemeScrollbar&>(RenderThemeScrollbar::getOrCreate(RenderThemeScrollbar::Type::VerticalScrollbarRight));
     scrollbarWidget.scrollbar().setState(GTK_STATE_FLAG_PRELIGHT);

--- a/Source/WebCore/platform/gtk/ScrollbarThemeGtk.h
+++ b/Source/WebCore/platform/gtk/ScrollbarThemeGtk.h
@@ -46,7 +46,7 @@ private:
 
     bool paint(Scrollbar&, GraphicsContext&, const IntRect& damageRect) override;
     ScrollbarButtonPressAction handleMousePressEvent(Scrollbar&, const PlatformMouseEvent&, ScrollbarPart) override;
-    int scrollbarThickness(ScrollbarControlSize, ScrollbarExpansionState = ScrollbarExpansionState::Expanded) override;
+    int scrollbarThickness(ScrollbarControlSize, ScrollbarWidth = ScrollbarWidth::Auto, ScrollbarExpansionState = ScrollbarExpansionState::Expanded) override;
     int minimumThumbLength(Scrollbar&) override;
 
     void themeChanged() override;

--- a/Source/WebCore/platform/ios/ScrollbarThemeIOS.h
+++ b/Source/WebCore/platform/ios/ScrollbarThemeIOS.h
@@ -38,7 +38,7 @@ public:
 
     bool paint(Scrollbar&, GraphicsContext&, const IntRect& damageRect) override;
 
-    int scrollbarThickness(ScrollbarControlSize = ScrollbarControlSize::Regular, ScrollbarExpansionState = ScrollbarExpansionState::Expanded) override;
+    int scrollbarThickness(ScrollbarControlSize = ScrollbarControlSize::Regular, ScrollbarWidth = ScrollbarWidth::Auto, ScrollbarExpansionState = ScrollbarExpansionState::Expanded) override;
     
     bool supportsControlTints() const override { return true; }
 

--- a/Source/WebCore/platform/ios/ScrollbarThemeIOS.mm
+++ b/Source/WebCore/platform/ios/ScrollbarThemeIOS.mm
@@ -63,7 +63,7 @@ void ScrollbarThemeIOS::preferencesChanged()
 {
 }
 
-int ScrollbarThemeIOS::scrollbarThickness(ScrollbarControlSize, ScrollbarExpansionState)
+int ScrollbarThemeIOS::scrollbarThickness(ScrollbarControlSize, ScrollbarWidth, ScrollbarExpansionState)
 {
     return 0;
 }

--- a/Source/WebCore/platform/mac/ScrollbarThemeMac.h
+++ b/Source/WebCore/platform/mac/ScrollbarThemeMac.h
@@ -45,7 +45,7 @@ public:
     bool paint(Scrollbar&, GraphicsContext&, const IntRect& damageRect) override;
     void paintScrollCorner(ScrollableArea&, GraphicsContext&, const IntRect& cornerRect) override;
 
-    int scrollbarThickness(ScrollbarControlSize = ScrollbarControlSize::Regular, ScrollbarExpansionState = ScrollbarExpansionState::Expanded) override;
+    int scrollbarThickness(ScrollbarControlSize = ScrollbarControlSize::Regular, ScrollbarWidth = ScrollbarWidth::Auto, ScrollbarExpansionState = ScrollbarExpansionState::Expanded) override;
     
     bool supportsControlTints() const override { return true; }
     bool usesOverlayScrollbars() const  override;

--- a/Source/WebCore/platform/mac/ScrollbarThemeMac.mm
+++ b/Source/WebCore/platform/mac/ScrollbarThemeMac.mm
@@ -243,9 +243,11 @@ void ScrollbarThemeMac::preferencesChanged()
     usesOverlayScrollbarsChanged();
 }
 
-int ScrollbarThemeMac::scrollbarThickness(ScrollbarControlSize controlSize, ScrollbarExpansionState expansionState)
+int ScrollbarThemeMac::scrollbarThickness(ScrollbarControlSize controlSize, ScrollbarWidth scrollbarWidth, ScrollbarExpansionState expansionState)
 {
     BEGIN_BLOCK_OBJC_EXCEPTIONS
+    if (scrollbarWidth == ScrollbarWidth::None)
+        return 0;
     NSScrollerImp *scrollerImp = [NSScrollerImp scrollerImpWithStyle:ScrollerStyle::recommendedScrollerStyle() controlSize:scrollbarControlSizeToNSControlSize(controlSize) horizontal:NO replacingScrollerImp:nil];
     [scrollerImp setExpanded:(expansionState == ScrollbarExpansionState::Expanded)];
     return [scrollerImp trackBoxWidth];
@@ -342,7 +344,7 @@ IntRect ScrollbarThemeMac::backButtonRect(Scrollbar& scrollbar, ScrollbarPart pa
     if (part == BackButtonEndPart && (buttonsPlacement() == ScrollbarButtonsNone || buttonsPlacement() == ScrollbarButtonsDoubleStart || buttonsPlacement() == ScrollbarButtonsSingle))
         return result;
         
-    int thickness = scrollbarThickness(scrollbar.controlSize());
+    int thickness = scrollbarThickness(scrollbar.controlSize(), scrollbar.scrollableArea().scrollbarWidthStyle());
     bool outerButton = part == BackButtonStartPart && (buttonsPlacement() == ScrollbarButtonsDoubleStart || buttonsPlacement() == ScrollbarButtonsDoubleBoth);
     if (outerButton) {
         if (scrollbar.orientation() == ScrollbarOrientation::Horizontal)
@@ -376,7 +378,7 @@ IntRect ScrollbarThemeMac::forwardButtonRect(Scrollbar& scrollbar, ScrollbarPart
     if (part == ForwardButtonStartPart && (buttonsPlacement() == ScrollbarButtonsNone || buttonsPlacement() == ScrollbarButtonsDoubleEnd || buttonsPlacement() == ScrollbarButtonsSingle))
         return result;
         
-    int thickness = scrollbarThickness(scrollbar.controlSize());
+    int thickness = scrollbarThickness(scrollbar.controlSize(), scrollbar.scrollableArea().scrollbarWidthStyle());
     int outerButtonLength = cOuterButtonLength[scrollbarSizeToIndex(scrollbar.controlSize())];
     int buttonLength = cButtonLength[scrollbarSizeToIndex(scrollbar.controlSize())];
     
@@ -412,7 +414,7 @@ IntRect ScrollbarThemeMac::trackRect(Scrollbar& scrollbar, bool painting)
         return scrollbar.frameRect();
     
     IntRect result;
-    int thickness = scrollbarThickness(scrollbar.controlSize());
+    int thickness = scrollbarThickness(scrollbar.controlSize(), scrollbar.scrollableArea().scrollbarWidthStyle());
     int startWidth = 0;
     int endWidth = 0;
     int outerButtonLength = cOuterButtonLength[scrollbarSizeToIndex(scrollbar.controlSize())];

--- a/Source/WebCore/platform/mac/ScrollbarsControllerMac.mm
+++ b/Source/WebCore/platform/mac/ScrollbarsControllerMac.mm
@@ -963,7 +963,7 @@ void ScrollbarsControllerMac::updateScrollerStyle()
         // The different scrollbar styles have different thicknesses, so we must re-set the
         // frameRect to the new thickness, and the re-layout below will ensure the position
         // and length are properly updated.
-        int thickness = macTheme->scrollbarThickness(verticalScrollbar->controlSize());
+        int thickness = macTheme->scrollbarThickness(verticalScrollbar->controlSize(), verticalScrollbar->scrollableArea().scrollbarWidthStyle());
         verticalScrollbar->setFrameRect(IntRect(0, 0, thickness, thickness));
     }
 
@@ -981,7 +981,7 @@ void ScrollbarsControllerMac::updateScrollerStyle()
         // The different scrollbar styles have different thicknesses, so we must re-set the
         // frameRect to the new thickness, and the re-layout below will ensure the position
         // and length are properly updated.
-        int thickness = macTheme->scrollbarThickness(horizontalScrollbar->controlSize());
+        int thickness = macTheme->scrollbarThickness(horizontalScrollbar->controlSize(), horizontalScrollbar->scrollableArea().scrollbarWidthStyle());
         horizontalScrollbar->setFrameRect(IntRect(0, 0, thickness, thickness));
     }
 

--- a/Source/WebCore/platform/mock/ScrollbarThemeMock.cpp
+++ b/Source/WebCore/platform/mock/ScrollbarThemeMock.cpp
@@ -39,8 +39,10 @@ IntRect ScrollbarThemeMock::trackRect(Scrollbar& scrollbar, bool)
     return scrollbar.frameRect();
 }
 
-int ScrollbarThemeMock::scrollbarThickness(ScrollbarControlSize controlSize, ScrollbarExpansionState)
+int ScrollbarThemeMock::scrollbarThickness(ScrollbarControlSize controlSize, ScrollbarWidth scrollbarWidth, ScrollbarExpansionState)
 {
+    if (scrollbarWidth == ScrollbarWidth::None)
+        return 0;
     return cScrollbarThickness[static_cast<uint8_t>(controlSize)];
 }
 

--- a/Source/WebCore/platform/mock/ScrollbarThemeMock.h
+++ b/Source/WebCore/platform/mock/ScrollbarThemeMock.h
@@ -33,7 +33,7 @@ namespace WebCore {
 // Scrollbar theme used in image snapshots, to eliminate appearance differences between platforms.
 class ScrollbarThemeMock : public ScrollbarThemeComposite {
 public:
-    int scrollbarThickness(ScrollbarControlSize = ScrollbarControlSize::Regular, ScrollbarExpansionState = ScrollbarExpansionState::Expanded) override;
+    int scrollbarThickness(ScrollbarControlSize = ScrollbarControlSize::Regular, ScrollbarWidth = ScrollbarWidth::Auto, ScrollbarExpansionState = ScrollbarExpansionState::Expanded) override;
 
 protected:
     bool hasButtons(Scrollbar&) override { return false; }

--- a/Source/WebCore/platform/playstation/ScrollbarThemePlayStation.cpp
+++ b/Source/WebCore/platform/playstation/ScrollbarThemePlayStation.cpp
@@ -39,8 +39,10 @@ ScrollbarTheme& ScrollbarTheme::nativeTheme()
     return theme;
 }
 
-int ScrollbarThemePlayStation::scrollbarThickness(ScrollbarControlSize, ScrollbarExpansionState)
+int ScrollbarThemePlayStation::scrollbarThickness(ScrollbarControlSize, ScrollbarWidth scrollbarWidth, ScrollbarExpansionState)
 {
+    if (scrollbarWidth == ScrollbarWidth::None)
+        return 0;
     return 7;
 }
 

--- a/Source/WebCore/platform/playstation/ScrollbarThemePlayStation.h
+++ b/Source/WebCore/platform/playstation/ScrollbarThemePlayStation.h
@@ -34,7 +34,7 @@ public:
     ScrollbarThemePlayStation() = default;
     virtual ~ScrollbarThemePlayStation() = default;
 
-    int scrollbarThickness(ScrollbarControlSize = ScrollbarControlSize::Regular, ScrollbarExpansionState = ScrollbarExpansionState::Expanded) override;
+    int scrollbarThickness(ScrollbarControlSize = ScrollbarControlSize::Regular, ScrollbarWidth = ScrollbarWidth::Auto, ScrollbarExpansionState = ScrollbarExpansionState::Expanded) override;
 
     bool hasButtons(Scrollbar&) override;
     bool hasThumb(Scrollbar&) override;

--- a/Source/WebCore/platform/win/ScrollbarThemeWin.cpp
+++ b/Source/WebCore/platform/win/ScrollbarThemeWin.cpp
@@ -112,8 +112,10 @@ static int scrollbarThicknessInPixels()
     return thickness;
 }
 
-int ScrollbarThemeWin::scrollbarThickness(ScrollbarControlSize, ScrollbarExpansionState)
+int ScrollbarThemeWin::scrollbarThickness(ScrollbarControlSize, ScrollbarWidth scrollbarWidth, ScrollbarExpansionState)
 {
+    if (scrollbarWidth == ScrollbarWidth::None)
+        return 0;
     float inverseScaleFactor = 1.0f / deviceScaleFactorForWindow(0);
     return clampTo<int>(inverseScaleFactor * scrollbarThicknessInPixels());
 }

--- a/Source/WebCore/platform/win/ScrollbarThemeWin.h
+++ b/Source/WebCore/platform/win/ScrollbarThemeWin.h
@@ -35,7 +35,7 @@ public:
     ScrollbarThemeWin();
     virtual ~ScrollbarThemeWin();
 
-    int scrollbarThickness(ScrollbarControlSize = ScrollbarControlSize::Regular, ScrollbarExpansionState = ScrollbarExpansionState::Expanded) override;
+    int scrollbarThickness(ScrollbarControlSize = ScrollbarControlSize::Regular, ScrollbarWidth = ScrollbarWidth::Auto, ScrollbarExpansionState = ScrollbarExpansionState::Expanded) override;
 
     void themeChanged() override;
     

--- a/Source/WebCore/rendering/RenderLayerScrollableArea.cpp
+++ b/Source/WebCore/rendering/RenderLayerScrollableArea.cpp
@@ -867,7 +867,10 @@ Ref<Scrollbar> RenderLayerScrollableArea::createScrollbar(ScrollbarOrientation o
     if (hasCustomScrollbarStyle && element)
         widget = RenderScrollbar::createCustomScrollbar(*this, orientation, element);
     else {
-        widget = Scrollbar::createNativeScrollbar(*this, orientation, ScrollbarControlSize::Regular);
+        auto scrollbarSize = scrollbarWidthStyle() == ScrollbarWidth::Thin
+            ? ScrollbarControlSize::Small
+            : ScrollbarControlSize::Regular;
+        widget = Scrollbar::createNativeScrollbar(*this, orientation, scrollbarSize);
         
         if (auto scrollbarController = m_layer.page().chrome().client().createScrollbarsController(m_layer.page(), *this))
             setScrollbarsController(WTFMove(scrollbarController));
@@ -1002,6 +1005,13 @@ OverscrollBehavior RenderLayerScrollableArea::verticalOverscrollBehavior() const
     if (m_layer.renderBox())
         return m_layer.renderer().style().overscrollBehaviorY();
     return OverscrollBehavior::Auto;
+}
+
+ScrollbarWidth RenderLayerScrollableArea::scrollbarWidthStyle()  const
+{
+    if (m_layer.renderBox())
+        return m_layer.renderer().style().scrollbarWidth();
+    return ScrollbarWidth::Auto;
 }
 
 bool RenderLayerScrollableArea::hasOverflowControls() const

--- a/Source/WebCore/rendering/RenderLayerScrollableArea.h
+++ b/Source/WebCore/rendering/RenderLayerScrollableArea.h
@@ -109,6 +109,8 @@ public:
     OverscrollBehavior horizontalOverscrollBehavior() const final;
     OverscrollBehavior verticalOverscrollBehavior() const final;
 
+    ScrollbarWidth scrollbarWidthStyle() const final;
+
     bool requiresScrollPositionReconciliation() const { return m_requiresScrollPositionReconciliation; }
     void setRequiresScrollPositionReconciliation(bool requiresReconciliation = true) { m_requiresScrollPositionReconciliation = requiresReconciliation; }
 

--- a/Source/WebCore/rendering/RenderScrollbar.h
+++ b/Source/WebCore/rendering/RenderScrollbar.h
@@ -56,7 +56,7 @@ public:
 
     float opacity() const;
     
-    bool isHiddenByStyle() const final;
+    bool isHiddenByStyle() const override;
 
     std::unique_ptr<RenderStyle> getScrollbarPseudoStyle(ScrollbarPart, PseudoId) const;
 

--- a/Source/WebCore/rendering/RenderScrollbarTheme.h
+++ b/Source/WebCore/rendering/RenderScrollbarTheme.h
@@ -37,7 +37,7 @@ class RenderScrollbarTheme final : public ScrollbarThemeComposite {
 public:
     virtual ~RenderScrollbarTheme() = default;
     
-    int scrollbarThickness(ScrollbarControlSize controlSize, ScrollbarExpansionState expansionState = ScrollbarExpansionState::Expanded) override { return ScrollbarTheme::theme().scrollbarThickness(controlSize, expansionState); }
+    int scrollbarThickness(ScrollbarControlSize controlSize, ScrollbarWidth scrollbarWidth = ScrollbarWidth::Auto, ScrollbarExpansionState expansionState = ScrollbarExpansionState::Expanded) override { return ScrollbarTheme::theme().scrollbarThickness(controlSize, scrollbarWidth, expansionState); }
 
     ScrollbarButtonsPlacement buttonsPlacement() const override { return ScrollbarTheme::theme().buttonsPlacement(); }
 


### PR DESCRIPTION
#### 7a7bb7a3e5e23541e6ca556920b8359cf9c7b785
<pre>
Implement scrollbar-width CSS property in WebKit2
<a href="https://bugs.webkit.org/show_bug.cgi?id=256999">https://bugs.webkit.org/show_bug.cgi?id=256999</a>

Reviewed by Simon Fraser.

This change implements the basics of the scrollbar-width CSS property.

* LayoutTests/imported/w3c/web-platform-tests/css/css-scrollbars/scrollbar-width-001-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-scrollbars/scrollbar-width-002-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-scrollbars/scrollbar-width-003-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-scrollbars/scrollbar-width-004-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-scrollbars/scrollbar-width-007-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-scrollbars/scrollbar-width-keywords-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/cssom-view/client-props-root-expected.txt:
* LayoutTests/platform/mac-wk1/imported/w3c/web-platform-tests/css/css-scrollbars/scrollbar-width-007-expected.txt: Copied from LayoutTests/imported/w3c/web-platform-tests/css/css-scrollbars/scrollbar-width-007-expected.txt.
* LayoutTests/platform/mac-wk1/imported/w3c/web-platform-tests/css/cssom-view/client-props-root-expected.txt: Copied from LayoutTests/imported/w3c/web-platform-tests/css/cssom-view/client-props-root-expected.txt.
* Source/WebCore/page/LocalFrameView.cpp:
(WebCore::LocalFrameView::createScrollbar):
(WebCore::LocalFrameView::scrollbarWidthStyle const):
* Source/WebCore/page/LocalFrameView.h:
* Source/WebCore/platform/ScrollableArea.h:
(WebCore::ScrollableArea::scrollbarWidthStyle const):
* Source/WebCore/platform/Scrollbar.cpp:
(WebCore::Scrollbar::Scrollbar):
(WebCore::Scrollbar::isHiddenByStyle const):
* Source/WebCore/platform/Scrollbar.h:
(WebCore::Scrollbar::isHiddenByStyle const): Deleted.
* Source/WebCore/platform/ScrollbarTheme.h:
(WebCore::ScrollbarTheme::scrollbarThickness):
* Source/WebCore/platform/ScrollbarThemeComposite.cpp:
(WebCore::ScrollbarThemeComposite::minimumThumbLength):
* Source/WebCore/platform/adwaita/ScrollbarThemeAdwaita.cpp:
(WebCore::ScrollbarThemeAdwaita::scrollbarThickness):
* Source/WebCore/platform/adwaita/ScrollbarThemeAdwaita.h:
* Source/WebCore/platform/gtk/ScrollbarThemeGtk.cpp:
(WebCore::ScrollbarThemeGtk::scrollbarThickness):
* Source/WebCore/platform/gtk/ScrollbarThemeGtk.h:
* Source/WebCore/platform/ios/ScrollbarThemeIOS.h:
* Source/WebCore/platform/ios/ScrollbarThemeIOS.mm:
(WebCore::ScrollbarThemeIOS::scrollbarThickness):
* Source/WebCore/platform/mac/ScrollbarThemeMac.h:
* Source/WebCore/platform/mac/ScrollbarThemeMac.mm:
(WebCore::ScrollbarThemeMac::scrollbarThickness):
(WebCore::ScrollbarThemeMac::backButtonRect):
(WebCore::ScrollbarThemeMac::forwardButtonRect):
(WebCore::ScrollbarThemeMac::trackRect):
* Source/WebCore/platform/mac/ScrollbarsControllerMac.mm:
(WebCore::ScrollbarsControllerMac::updateScrollerStyle):
* Source/WebCore/platform/mock/ScrollbarThemeMock.cpp:
(WebCore::ScrollbarThemeMock::scrollbarThickness):
* Source/WebCore/platform/mock/ScrollbarThemeMock.h:
* Source/WebCore/platform/playstation/ScrollbarThemePlayStation.cpp:
(WebCore::ScrollbarThemePlayStation::scrollbarThickness):
* Source/WebCore/platform/playstation/ScrollbarThemePlayStation.h:
* Source/WebCore/platform/win/ScrollbarThemeWin.cpp:
(WebCore::ScrollbarThemeWin::scrollbarThickness):
* Source/WebCore/platform/win/ScrollbarThemeWin.h:
* Source/WebCore/rendering/RenderLayerScrollableArea.cpp:
(WebCore::RenderLayerScrollableArea::createScrollbar):
(WebCore::RenderLayerScrollableArea::scrollbarWidthStyle const):
* Source/WebCore/rendering/RenderLayerScrollableArea.h:
* Source/WebCore/rendering/RenderScrollbar.h:
* Source/WebCore/rendering/RenderScrollbarTheme.h:

Canonical link: <a href="https://commits.webkit.org/264593@main">https://commits.webkit.org/264593@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2334d700df4cf0ecc424da09649af633a41e1355

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/8018 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/8303 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/8515 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/9670 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/8122 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/8022 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/10289 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/8214 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/10987 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/8162 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/9249 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/7321 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/9790 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/6550 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/7338 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/14918 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/7673 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/7459 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/10821 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/7930 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/6451 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/7244 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/1935 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/11452 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/7671 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->