### PR TITLE
RemoteLayerTreeDisplayRefreshMonitor::requestRefreshCallback doesn't clear scheduled state.

### DIFF
--- a/Source/WebKit/WebProcess/WebPage/RemoteLayerTree/RemoteLayerTreeDisplayRefreshMonitor.mm
+++ b/Source/WebKit/WebProcess/WebPage/RemoteLayerTree/RemoteLayerTreeDisplayRefreshMonitor.mm
@@ -72,13 +72,21 @@ bool RemoteLayerTreeDisplayRefreshMonitor::requestRefreshCallback()
     if (isScheduled())
         return true;
 
+    setIsScheduled(true);
+
+    if (m_drawingArea->displayDidRefreshIsPending())
+        return true;
+
     LOG_WITH_STREAM(DisplayLink, stream << "[Web] RemoteLayerTreeDisplayRefreshMonitor::requestRefreshCallback - triggering update");
     callOnMainRunLoop([self = Ref { *this }, this] () {
+        {
+            Locker locker { lock() };
+            setIsScheduled(false);
+        }
         if (m_drawingArea)
             static_cast<DrawingArea&>(*m_drawingArea.get()).triggerRenderingUpdate();
     });
 
-    setIsScheduled(true);
     return true;
 }
 
@@ -86,6 +94,9 @@ void RemoteLayerTreeDisplayRefreshMonitor::triggerDisplayDidRefresh()
 {
     {
         Locker locker { lock() };
+        if (!isScheduled())
+            return;
+
         setIsScheduled(false);
 
         if (!isPreviousFrameDone())

--- a/Source/WebKit/WebProcess/WebPage/RemoteLayerTree/RemoteLayerTreeDrawingArea.h
+++ b/Source/WebKit/WebProcess/WebPage/RemoteLayerTree/RemoteLayerTreeDrawingArea.h
@@ -58,6 +58,8 @@ public:
     TransactionID nextTransactionID() const { return m_currentTransactionID.next(); }
     TransactionID lastCommittedTransactionID() const { return m_currentTransactionID; }
 
+    bool displayDidRefreshIsPending() const { return m_waitingForBackingStoreSwap; }
+
 protected:
     void updateRendering();
 


### PR DESCRIPTION
#### f0847a50740a2e312af43140a1c7bce1d0b941ff
<pre>
RemoteLayerTreeDisplayRefreshMonitor::requestRefreshCallback doesn&apos;t clear scheduled state.
<a href="https://bugs.webkit.org/show_bug.cgi?id=257004">https://bugs.webkit.org/show_bug.cgi?id=257004</a>
&lt;rdar://107848069&gt;

Reviewed by Simon Fraser.

RemoteLayerTreeDisplayRefreshMonitor::requestRefreshCallback dispatches a task to the main thread and sets scheduled to true.

When that task runs, it triggers the rendering update but doesn&apos;t set scheduled back to false.

Normally, the rendering update results in a commit to the UI process, and then we get a RemoteLayerTreeDrawingArea::displayDidRefresh callback, which sets scheduled to false (but also triggers a second rendering update)

This makes it more clear as to whether we&apos;re dispatching a task, or waiting for a pending displayDidRefresh in order to schedule a refresh callback, and sets the scheduled state correctly.

* Source/WebKit/WebProcess/WebPage/RemoteLayerTree/RemoteLayerTreeDisplayRefreshMonitor.mm:
(WebKit::RemoteLayerTreeDisplayRefreshMonitor::requestRefreshCallback):
(WebKit::RemoteLayerTreeDisplayRefreshMonitor::triggerDisplayDidRefresh):
* Source/WebKit/WebProcess/WebPage/RemoteLayerTree/RemoteLayerTreeDrawingArea.h:
(WebKit::RemoteLayerTreeDrawingArea::displayDidRefreshIsPending const):

Canonical link: <a href="https://commits.webkit.org/264297@main">https://commits.webkit.org/264297@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/68b148a4d03e2ea96f95d45ed8daea32a9946f7d

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/7114 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/7359 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/7538 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/8728 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/7339 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/8620 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/7291 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/10236 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/7241 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/7896 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/6552 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/8833 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/5253 "Passed tests") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/14221 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/6917 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/6566 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/9441 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/7050 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/5768 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/6411 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/1721 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/10609 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/6794 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->