### PR TITLE
[iOS] Tapping "Done" sometimes fails to dismiss the software keyboard after dismissing AutoFill UI

### DIFF
--- a/Source/WebKit/UIProcess/API/ios/WKWebViewIOS.h
+++ b/Source/WebKit/UIProcess/API/ios/WKWebViewIOS.h
@@ -144,7 +144,7 @@ enum class TapHandlingResult : uint8_t;
 
 - (void)_incrementFocusPreservationCount;
 - (void)_decrementFocusPreservationCount;
-- (void)_resetFocusPreservationCount;
+- (NSUInteger)_resetFocusPreservationCount;
 
 - (void)_setOpaqueInternal:(BOOL)opaque;
 - (NSString *)_contentSizeCategory;

--- a/Source/WebKit/UIProcess/API/ios/WKWebViewIOS.mm
+++ b/Source/WebKit/UIProcess/API/ios/WKWebViewIOS.mm
@@ -257,9 +257,9 @@ static WebCore::IntDegrees deviceOrientationForUIInterfaceOrientation(UIInterfac
         --_focusPreservationCount;
 }
 
-- (void)_resetFocusPreservationCount
+- (NSUInteger)_resetFocusPreservationCount
 {
-    _focusPreservationCount = 0;
+    return std::exchange(_focusPreservationCount, 0);
 }
 
 - (BOOL)_isRetainingActiveFocusedState

--- a/Source/WebKit/UIProcess/ios/WKContentViewInteraction.mm
+++ b/Source/WebKit/UIProcess/ios/WKContentViewInteraction.mm
@@ -5371,6 +5371,9 @@ static void logTextInteractionAssistantSelectionChange(const char* methodName, U
 
 - (void)accessoryDone
 {
+    if ([_webView _resetFocusPreservationCount])
+        RELEASE_LOG_ERROR(ViewState, "Keyboard dismissed with nonzero focus preservation count; check for unbalanced calls to -_incrementFocusPreservationCount");
+
     [self stopRelinquishingFirstResponderToFocusedElement];
     [self endEditingAndUpdateFocusAppearanceWithReason:EndEditingReasonAccessoryDone];
     _page->setIsShowingInputViewForFocusedElement(false);
@@ -7204,6 +7207,8 @@ static RetainPtr<NSObject <WKFormPeripheral>> createInputPeripheralWithView(WebK
 - (void)_elementDidBlur
 {
     SetForScope isBlurringFocusedElementForScope { _isBlurringFocusedElement, YES };
+
+    [_webView _resetFocusPreservationCount];
 
     [self _endEditing];
 

--- a/Tools/TestWebKitAPI/Tests/ios/FocusPreservationTests.mm
+++ b/Tools/TestWebKitAPI/Tests/ios/FocusPreservationTests.mm
@@ -74,6 +74,24 @@ TEST(FocusPreservationTests, PreserveAndRestoreFocus)
     EXPECT_TRUE([webView becomeFirstResponder]);
 }
 
+TEST(FocusPreservationTests, UserCanDismissInputViewRegardlessOfFocusPreservationCount)
+{
+    bool inputFocused = false;
+    auto [webView, delegate] = webViewForTestingFocusPreservation([&inputFocused] (id<_WKFocusedElementInfo>) {
+        inputFocused = true;
+    });
+
+    [webView evaluateJavaScript:@"document.querySelector('input').focus()" completionHandler:nil];
+    Util::run(&inputFocused);
+
+    [[webView textInputContentView] _preserveFocusWithToken:NSUUID.UUID destructively:YES];
+    // Simulates a user tapping on the Done button above the keyboard.
+    [webView dismissFormAccessoryView];
+    [webView waitForNextPresentationUpdate];
+
+    EXPECT_FALSE([[webView objectByEvaluatingJavaScript:@"document.activeElement == document.querySelector('input')"] boolValue]);
+}
+
 // FIXME: Re-enable this test once rdar://60644908 is resolved
 TEST(FocusPreservationTests, DISABLED_ChangingFocusedNodeResetsFocusPreservationState)
 {


### PR DESCRIPTION
#### 3315d8e5237e64de3178a0d200631deb98022c3c
<pre>
[iOS] Tapping &quot;Done&quot; sometimes fails to dismiss the software keyboard after dismissing AutoFill UI
<a href="https://bugs.webkit.org/show_bug.cgi?id=256997">https://bugs.webkit.org/show_bug.cgi?id=256997</a>
rdar://109413302

Reviewed by Aditya Keerthi.

Make it harder for WebKit SPI clients to accidentally leave the keyboard in a broken state, where
tapping the Done button fails to dismiss the keyboard. This is currently possible in the case where
`-_preserveFocusWithToken:destructively:` is invoked without a balanced call to
`-_restoreFocusWithToken:`, since we&apos;ll continue to maintain the `_focusPreservationCount` until
a new element is focused (which resets this count back to 0).

Instead, if the user taps the Done button (which is surfaced to WebKit as a call to
`-accessoryDone`), we should always allow the user to dismiss the keyboard; to ensure this, we add a
call to `-_resetFocusPreservationCount` before attempting to blur the focused element.

Test: FocusPreservationTests.UserCanDismissInputViewRegardlessOfFocusPreservationCount

* Source/WebKit/UIProcess/API/ios/WKWebViewIOS.h:
* Source/WebKit/UIProcess/API/ios/WKWebViewIOS.mm:
(-[WKWebView _resetFocusPreservationCount]):
* Source/WebKit/UIProcess/ios/WKContentViewInteraction.mm:
(-[WKContentView accessoryDone]):
(-[WKContentView _elementDidBlur]):
* Tools/TestWebKitAPI/Tests/ios/FocusPreservationTests.mm:

Canonical link: <a href="https://commits.webkit.org/264235@main">https://commits.webkit.org/264235@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/358bba190bd8098f0a5ff20b3aace5eb74f11bf7

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/7116 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/7361 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/7540 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/8730 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/7341 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/7126 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/8622 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/7293 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/10237 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/7243 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/7894 "2 new passes 7 flakes 1 failures") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/6554 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/8835 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/5251 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/6470 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/14222 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/6915 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/6568 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/9442 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/7052 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/5769 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/6413 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/1683 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/10611 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/6796 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->