### PR TITLE
The first RemoteLayerTreeDrawingAreaProxy::commitLayerTree after being idle is always considered 'missed'.

### DIFF
--- a/Source/WebCore/loader/EmptyClients.h
+++ b/Source/WebCore/loader/EmptyClients.h
@@ -170,7 +170,7 @@ class EmptyChromeClient : public ChromeClient {
     void attachRootGraphicsLayer(LocalFrame&, GraphicsLayer*) final { }
     void attachViewOverlayGraphicsLayer(GraphicsLayer*) final { }
     void setNeedsOneShotDrawingSynchronization() final { }
-    void triggerRenderingUpdate() final { }
+    void triggerRenderingUpdate(bool) final { }
 
 #if PLATFORM(WIN)
     void setLastSetCursorToCurrentCursor() final { }

--- a/Source/WebCore/page/ChromeClient.h
+++ b/Source/WebCore/page/ChromeClient.h
@@ -391,7 +391,7 @@ public:
 
     virtual bool shouldTriggerRenderingUpdate(unsigned) const { return true; }
     // Makes a rendering update happen soon, typically in the current runloop.
-    virtual void triggerRenderingUpdate() = 0;
+    virtual void triggerRenderingUpdate(bool forDisplayDidRefresh = false) = 0;
     // Schedule a rendering update that coordinates with display refresh. Returns true if scheduled. (This is only used by SVGImageChromeClient.)
     virtual bool scheduleRenderingUpdate() { return false; }
 

--- a/Source/WebCore/page/RenderingUpdateScheduler.cpp
+++ b/Source/WebCore/page/RenderingUpdateScheduler.cpp
@@ -130,7 +130,7 @@ void RenderingUpdateScheduler::displayRefreshFired()
     clearScheduled();
     
     if (m_page.chrome().client().shouldTriggerRenderingUpdate(m_rescheduledRenderingUpdateCount)) {
-        triggerRenderingUpdate();
+        triggerRenderingUpdate(true);
         m_rescheduledRenderingUpdateCount = 0;
     } else {
         scheduleRenderingUpdate();
@@ -143,9 +143,9 @@ void RenderingUpdateScheduler::triggerRenderingUpdateForTesting()
     triggerRenderingUpdate();
 }
 
-void RenderingUpdateScheduler::triggerRenderingUpdate()
+void RenderingUpdateScheduler::triggerRenderingUpdate(bool forDisplayDidRefresh)
 {
-    m_page.chrome().client().triggerRenderingUpdate();
+    m_page.chrome().client().triggerRenderingUpdate(forDisplayDidRefresh);
 }
 
 }

--- a/Source/WebCore/page/RenderingUpdateScheduler.h
+++ b/Source/WebCore/page/RenderingUpdateScheduler.h
@@ -61,7 +61,7 @@ private:
     void startTimer(Seconds);
     void clearScheduled();
 
-    void triggerRenderingUpdate();
+    void triggerRenderingUpdate(bool forDisplayDidRefresh = false);
 
     Page& m_page;
     std::unique_ptr<Timer> m_refreshTimer;

--- a/Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeDrawingAreaProxy.h
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeDrawingAreaProxy.h
@@ -118,7 +118,7 @@ private:
     // Message handlers
     virtual void setPreferredFramesPerSecond(WebCore::FramesPerSecond) { }
     void willCommitLayerTree(TransactionID);
-    void commitLayerTree(IPC::Connection&, const Vector<std::pair<RemoteLayerTreeTransaction, RemoteScrollingCoordinatorTransaction>>&);
+    void commitLayerTree(IPC::Connection&, const Vector<std::pair<RemoteLayerTreeTransaction, RemoteScrollingCoordinatorTransaction>>&, bool wasTriggeredByDisplayDidRefresh);
     void commitLayerTreeTransaction(IPC::Connection&, const RemoteLayerTreeTransaction&, const RemoteScrollingCoordinatorTransaction&);
     virtual void didCommitLayerTree(IPC::Connection&, const RemoteLayerTreeTransaction&, const RemoteScrollingCoordinatorTransaction&) { }
 

--- a/Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeDrawingAreaProxy.messages.in
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeDrawingAreaProxy.messages.in
@@ -23,6 +23,6 @@
 messages -> RemoteLayerTreeDrawingAreaProxy : DrawingAreaProxy NotRefCounted {
     void SetPreferredFramesPerSecond(unsigned preferredFramesPerSecond)
     void WillCommitLayerTree(WebKit::TransactionID transactionID)
-    void CommitLayerTree(Vector<std::pair<WebKit::RemoteLayerTreeTransaction, WebKit::RemoteScrollingCoordinatorTransaction>> transactions)
+    void CommitLayerTree(Vector<std::pair<WebKit::RemoteLayerTreeTransaction, WebKit::RemoteScrollingCoordinatorTransaction>> transactions, bool wasTriggeredByDisplayDidRefresh)
     void AsyncSetLayerContents(WebCore::PlatformLayerIdentifier layer, WebKit::ImageBufferBackendHandle handle, WebCore::RenderingResourceIdentifier identifier)
 }

--- a/Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeDrawingAreaProxy.mm
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeDrawingAreaProxy.mm
@@ -152,8 +152,14 @@ void RemoteLayerTreeDrawingAreaProxy::willCommitLayerTree(TransactionID transact
     m_pendingLayerTreeTransactionID = transactionID;
 }
 
-void RemoteLayerTreeDrawingAreaProxy::commitLayerTree(IPC::Connection& connection, const Vector<std::pair<RemoteLayerTreeTransaction, RemoteScrollingCoordinatorTransaction>>& transactions)
+void RemoteLayerTreeDrawingAreaProxy::commitLayerTree(IPC::Connection& connection, const Vector<std::pair<RemoteLayerTreeTransaction, RemoteScrollingCoordinatorTransaction>>& transactions, bool wasTriggeredByDisplayDidRefresh)
 {
+    // If this commit wasn't triggered by displayDidRefresh, then
+    // it can't be considered 'missed', so overwrite a potential
+    // 'MissedCommit' state.
+    if (!wasTriggeredByDisplayDidRefresh)
+        m_didUpdateMessageState = NeedsDidUpdate;
+
     for (auto& transaction : transactions)
         commitLayerTreeTransaction(connection, transaction.first, transaction.second);
 }

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebChromeClient.cpp
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebChromeClient.cpp
@@ -1073,10 +1073,10 @@ bool WebChromeClient::shouldTriggerRenderingUpdate(unsigned rescheduledRendering
     return m_page.shouldTriggerRenderingUpdate(rescheduledRenderingUpdateCount);
 }
 
-void WebChromeClient::triggerRenderingUpdate()
+void WebChromeClient::triggerRenderingUpdate(bool forDisplayDidRefresh)
 {
     if (m_page.drawingArea())
-        m_page.drawingArea()->triggerRenderingUpdate();
+        m_page.drawingArea()->triggerRenderingUpdate(forDisplayDidRefresh);
 }
 
 unsigned WebChromeClient::remoteImagesCountForTesting() const

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebChromeClient.h
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebChromeClient.h
@@ -230,7 +230,7 @@ private:
     void attachViewOverlayGraphicsLayer(WebCore::GraphicsLayer*) final;
     void setNeedsOneShotDrawingSynchronization() final;
     bool shouldTriggerRenderingUpdate(unsigned rescheduledRenderingUpdateCount) const final;
-    void triggerRenderingUpdate() final;
+    void triggerRenderingUpdate(bool) final;
     unsigned remoteImagesCountForTesting() const final; 
 
     void contentRuleListNotification(const URL&, const WebCore::ContentRuleListResults&) final;

--- a/Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/DrawingAreaCoordinatedGraphics.cpp
+++ b/Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/DrawingAreaCoordinatedGraphics.cpp
@@ -355,7 +355,7 @@ void DrawingAreaCoordinatedGraphics::setRootCompositingLayer(WebCore::Frame&, Gr
     enterAcceleratedCompositingMode(graphicsLayer);
 }
 
-void DrawingAreaCoordinatedGraphics::triggerRenderingUpdate()
+void DrawingAreaCoordinatedGraphics::triggerRenderingUpdate(bool)
 {
     if (m_layerTreeStateIsFrozen)
         return;

--- a/Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/DrawingAreaCoordinatedGraphics.h
+++ b/Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/DrawingAreaCoordinatedGraphics.h
@@ -71,7 +71,7 @@ private:
 
     WebCore::GraphicsLayerFactory* graphicsLayerFactory() override;
     void setRootCompositingLayer(WebCore::Frame&, WebCore::GraphicsLayer*) override;
-    void triggerRenderingUpdate() override;
+    void triggerRenderingUpdate(bool forDisplayDidRefresh = false) override;
 
 #if USE(COORDINATED_GRAPHICS) || USE(GRAPHICS_LAYER_TEXTURE_MAPPER)
     void layerHostDidFlushLayers() override;

--- a/Source/WebKit/WebProcess/WebPage/DrawingArea.h
+++ b/Source/WebKit/WebProcess/WebPage/DrawingArea.h
@@ -125,7 +125,7 @@ public:
     virtual void setRootCompositingLayer(WebCore::Frame&, WebCore::GraphicsLayer*) = 0;
     virtual void addRootFrame(WebCore::FrameIdentifier) { }
     // FIXME: Add a corresponding removeRootFrame.
-    virtual void triggerRenderingUpdate() = 0;
+    virtual void triggerRenderingUpdate(bool forDisplayDidRefresh = false) = 0;
 
     virtual void willStartRenderingUpdateDisplay();
     virtual void didCompleteRenderingUpdateDisplay();

--- a/Source/WebKit/WebProcess/WebPage/RemoteLayerTree/RemoteLayerTreeDrawingArea.h
+++ b/Source/WebKit/WebProcess/WebPage/RemoteLayerTree/RemoteLayerTreeDrawingArea.h
@@ -72,7 +72,7 @@ private:
     WebCore::GraphicsLayerFactory* graphicsLayerFactory() override;
     void setRootCompositingLayer(WebCore::Frame&, WebCore::GraphicsLayer*) override;
     void addRootFrame(WebCore::FrameIdentifier) final;
-    void triggerRenderingUpdate() override;
+    void triggerRenderingUpdate(bool forDisplayDidRefresh = false) override;
     void attachViewOverlayGraphicsLayer(WebCore::FrameIdentifier, WebCore::GraphicsLayer*) override;
 
     void dispatchAfterEnsuringDrawing(IPC::AsyncReplyID) final;
@@ -164,6 +164,8 @@ private:
     bool m_isRenderingSuspended { false };
     bool m_hasDeferredRenderingUpdate { false };
     bool m_inUpdateRendering { false };
+    bool m_displayDidRefreshTriggeredRendering { false };
+
 
     bool m_waitingForBackingStoreSwap { false };
     bool m_deferredRenderingUpdateWhileWaitingForBackingStoreSwap { false };

--- a/Source/WebKit/WebProcess/WebPage/mac/TiledCoreAnimationDrawingArea.h
+++ b/Source/WebKit/WebProcess/WebPage/mac/TiledCoreAnimationDrawingArea.h
@@ -65,7 +65,7 @@ private:
     void setLayerTreeStateIsFrozen(bool) override;
     bool layerTreeStateIsFrozen() const override;
     void setRootCompositingLayer(WebCore::Frame&, WebCore::GraphicsLayer*) override;
-    void triggerRenderingUpdate() override;
+    void triggerRenderingUpdate(bool forDisplayDidRefresh = false) override;
 
     void updatePreferences(const WebPreferencesStore&) override;
     void mainFrameContentSizeChanged(WebCore::FrameIdentifier, const WebCore::IntSize&) override;

--- a/Source/WebKit/WebProcess/WebPage/mac/TiledCoreAnimationDrawingArea.mm
+++ b/Source/WebKit/WebProcess/WebPage/mac/TiledCoreAnimationDrawingArea.mm
@@ -223,7 +223,7 @@ bool TiledCoreAnimationDrawingArea::layerTreeStateIsFrozen() const
     return m_layerTreeStateIsFrozen;
 }
 
-void TiledCoreAnimationDrawingArea::triggerRenderingUpdate()
+void TiledCoreAnimationDrawingArea::triggerRenderingUpdate(bool)
 {
     if (m_layerTreeStateIsFrozen)
         return;

--- a/Source/WebKit/WebProcess/WebPage/wc/DrawingAreaWC.cpp
+++ b/Source/WebKit/WebProcess/WebPage/wc/DrawingAreaWC.cpp
@@ -182,7 +182,7 @@ void DrawingAreaWC::forceRepaintAsync(WebPage&, CompletionHandler<void()>&& comp
     setNeedsDisplay();
 }
 
-void DrawingAreaWC::triggerRenderingUpdate()
+void DrawingAreaWC::triggerRenderingUpdate(bool)
 {
     if (m_isRenderingSuspended || m_waitDidUpdate) {
         m_hasDeferredRenderingUpdate = true;

--- a/Source/WebKit/WebProcess/WebPage/wc/DrawingAreaWC.h
+++ b/Source/WebKit/WebProcess/WebPage/wc/DrawingAreaWC.h
@@ -50,7 +50,7 @@ private:
     void setNeedsDisplayInRect(const WebCore::IntRect&) override;
     void scroll(const WebCore::IntRect& scrollRect, const WebCore::IntSize& scrollDelta) override;
     void forceRepaintAsync(WebPage&, CompletionHandler<void()>&&) override;
-    void triggerRenderingUpdate() override;
+    void triggerRenderingUpdate(bool forDisplayDidRefresh = false) override;
     void didChangeViewportAttributes(WebCore::ViewportAttributes&&) override { }
     void deviceOrPageScaleFactorChanged() override { }
     void setLayerTreeStateIsFrozen(bool) override;

--- a/Source/WebKitLegacy/mac/WebCoreSupport/WebChromeClient.h
+++ b/Source/WebKitLegacy/mac/WebCoreSupport/WebChromeClient.h
@@ -184,7 +184,7 @@ private:
     void attachRootGraphicsLayer(WebCore::LocalFrame&, WebCore::GraphicsLayer*) override;
     void attachViewOverlayGraphicsLayer(WebCore::GraphicsLayer*) final;
     void setNeedsOneShotDrawingSynchronization() final;
-    void triggerRenderingUpdate() final;
+    void triggerRenderingUpdate(bool forDisplayDidRefresh) final;
 
     CompositingTriggerFlags allowedCompositingTriggers() const final
     {

--- a/Source/WebKitLegacy/mac/WebCoreSupport/WebChromeClient.mm
+++ b/Source/WebKitLegacy/mac/WebCoreSupport/WebChromeClient.mm
@@ -933,7 +933,7 @@ void WebChromeClient::setNeedsOneShotDrawingSynchronization()
     END_BLOCK_OBJC_EXCEPTIONS
 }
 
-void WebChromeClient::triggerRenderingUpdate()
+void WebChromeClient::triggerRenderingUpdate(bool)
 {
     BEGIN_BLOCK_OBJC_EXCEPTIONS
     [m_webView _scheduleUpdateRendering];


### PR DESCRIPTION
#### 402d91a76b68196f4b382d5144549778812a78c8
<pre>
The first RemoteLayerTreeDrawingAreaProxy::commitLayerTree after being idle is always considered &apos;missed&apos;.
<a href="https://bugs.webkit.org/show_bug.cgi?id=257005">https://bugs.webkit.org/show_bug.cgi?id=257005</a>
&lt;rdar://problem/109543927&gt;

Reviewed by NOBODY (OOPS!).

Each RemoteLayerTreeDrawingAreaProxy::commitLayerTree IPC messages results in a reply displayDidRefresh message being sent back to the WebProcess (once the display link fires) to trigger the next rendering update.

If the next commitLayerTree isn&apos;t received before the following display link callback, it goes into a &apos;missed commit&apos; state, assuming the rendering update took more than one interval to render. In missed commit state, when the commitLayerTree eventually arrives, the displayDidRefresh reply is sent immediately, rather than waiting for the next display link callback.

This can&apos;t differentiate between a slow rendering update, and an idle WebContent process that decided it didn&apos;t need to do a rendering update at all. When we do resume from idle, we&apos;ll always be in missed commit state, and do a second rendering update (attempt) immediately, for no real benefit.

This patch adds a flag to differentiate between a commit that was triggered from displayDidRefresh (and thus can be considered missed if it came in late) and a commit that was triggered from idle.

* Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeDrawingAreaProxy.h:
* Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeDrawingAreaProxy.messages.in:
* Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeDrawingAreaProxy.mm:
(WebKit::RemoteLayerTreeDrawingAreaProxy::commitLayerTree):
* Source/WebKit/WebProcess/WebPage/RemoteLayerTree/RemoteLayerTreeDrawingArea.h:
* Source/WebKit/WebProcess/WebPage/RemoteLayerTree/RemoteLayerTreeDrawingArea.mm:
(WebKit::RemoteLayerTreeDrawingArea::triggerRenderingUpdate):
(WebKit::RemoteLayerTreeDrawingArea::updateRendering):
(WebKit::RemoteLayerTreeDrawingArea::displayDidRefresh):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/402d91a76b68196f4b382d5144549778812a78c8

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/7130 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/7376 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/7555 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/8745 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/7354 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/7140 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/8640 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/7308 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/10252 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/7257 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/7914 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/6569 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/8851 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/5269 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/6488 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/14234 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/6930 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/6587 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/9462 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/7066 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/5779 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/6426 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/10625 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/6809 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->