### PR TITLE
[JSC] Do not hoist constant if constant fits in Imm for B3 Add/Sub

### DIFF
--- a/Source/JavaScriptCore/b3/B3MoveConstants.cpp
+++ b/Source/JavaScriptCore/b3/B3MoveConstants.cpp
@@ -215,6 +215,10 @@ private:
                         if (!addend->hasInt() || !filter(addend))
                             break;
                         int64_t addendConst = addend->asInt();
+                        if (Air::Arg::isValidImmForm(addendConst))
+                            break;
+                        if (addendConst != INT64_MIN && Air::Arg::isValidImmForm(-addendConst))
+                            break;
                         Value* bestAddend = findBestConstant(
                             [&] (Value* candidateAddend) -> bool {
                                 if (candidateAddend->type() != addend->type())


### PR DESCRIPTION
#### 0a71587c8602f9a85bda30559009533cc4e5602a
<pre>
[JSC] Do not hoist constant if constant fits in Imm for B3 Add/Sub
<a href="https://bugs.webkit.org/show_bug.cgi?id=257008">https://bugs.webkit.org/show_bug.cgi?id=257008</a>
rdar://109551466

Reviewed by Tadeu Zagallo.

We should just use Imm directly if constant is small enough to be directly represented as Imm.
This reduces register pressure.

* Source/JavaScriptCore/b3/B3MoveConstants.cpp:

Canonical link: <a href="https://commits.webkit.org/264241@main">https://commits.webkit.org/264241@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/40c58f80947ea9f6a2aaf79c8401fac22a0b6ecf

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/7137 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/7384 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/7563 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/8753 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/7359 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/8651 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/7316 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/10259 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/7264 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/7927 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/6574 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/8859 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/5281 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/6493 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/14237 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/6047 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/6941 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/6592 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/9468 "Passed tests") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/6721 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/7073 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/5783 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/7275 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/6433 "Built successfully") | | [❌ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/1686 "Failed to checkout and rebase branch from PR 14059") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/10632 "Built successfully") | | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/24/builds/7477 "Built successfully") | 
| [❌ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/830 "Failed to push commit to Webkit repository") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/6816 "Built successfully") | | [❌ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/3/builds/1826 "Failed to checkout and rebase branch from PR 14059") | 
<!--EWS-Status-Bubble-End-->