### PR TITLE
[GTK] gsk_gl_command_queue_create_render_target: assertion failed (glCheckFramebufferStatus (GL_FRAMEBUFFER) == GL_FRAMEBUFFER_COMPLETE) when opening webkit://gpu

### DIFF
--- a/Source/WebCore/platform/graphics/egl/GLContext.cpp
+++ b/Source/WebCore/platform/graphics/egl/GLContext.cpp
@@ -640,6 +640,25 @@ unsigned GLContext::version()
     return m_version;
 }
 
+GLContext::ScopedGLContext::ScopedGLContext(std::unique_ptr<GLContext>&& context)
+    : m_context(WTFMove(context))
+{
+    m_previous.context = eglGetCurrentContext();
+    if (m_previous.context) {
+        m_previous.display = eglGetCurrentDisplay();
+        m_previous.readSurface = eglGetCurrentSurface(EGL_READ);
+        m_previous.drawSurface = eglGetCurrentSurface(EGL_DRAW);
+    }
+    m_context->makeContextCurrent();
+}
+
+GLContext::ScopedGLContext::~ScopedGLContext()
+{
+    m_context = nullptr;
+    if (m_previous.context)
+        eglMakeCurrent(m_previous.display, m_previous.drawSurface, m_previous.readSurface, m_previous.context);
+}
+
 } // namespace WebCore
 
 #endif // USE(EGL)

--- a/Source/WebCore/platform/graphics/egl/GLContext.h
+++ b/Source/WebCore/platform/graphics/egl/GLContext.h
@@ -131,6 +131,21 @@ public:
     WEBCORE_EXPORT void swapBuffers();
     GCGLContext platformContext() const;
 
+    class ScopedGLContext {
+        WTF_MAKE_NONCOPYABLE(ScopedGLContext);
+    public:
+        explicit ScopedGLContext(std::unique_ptr<GLContext>&&);
+        ~ScopedGLContext();
+    private:
+        struct {
+            EGLDisplay display { nullptr };
+            EGLContext context { nullptr };
+            EGLSurface readSurface { nullptr };
+            EGLSurface drawSurface { nullptr };
+        } m_previous;
+        std::unique_ptr<GLContext> m_context;
+    };
+
 private:
     static EGLContext createContextForEGLVersion(PlatformDisplay&, EGLConfig, EGLContext);
 


### PR DESCRIPTION
#### edc3fa95e5155cd31a53ef133d6018d052754c39
<pre>
[GTK] gsk_gl_command_queue_create_render_target: assertion failed (glCheckFramebufferStatus (GL_FRAMEBUFFER) == GL_FRAMEBUFFER_COMPLETE) when opening webkit://gpu
<a href="https://bugs.webkit.org/show_bug.cgi?id=256873">https://bugs.webkit.org/show_bug.cgi?id=256873</a>

Reviewed by Michael Catanzaro.

Add ScopedGLContext class to create a GLContext that is made current for
the current scope and restores the previous current context on destruction.
In case of GLX being used by the UI process, use a dedicated thread to
create the EGL context and fill the GPU information.

* Source/WebCore/platform/graphics/egl/GLContext.cpp:
(WebCore::GLContext::ScopedGLContext::ScopedGLContext):
(WebCore::GLContext::ScopedGLContext::~ScopedGLContext):
* Source/WebCore/platform/graphics/egl/GLContext.h:
* Source/WebKit/UIProcess/API/glib/WebKitProtocolHandler.cpp:
(WebKit::WebKitProtocolHandler::handleGPU):

Canonical link: <a href="https://commits.webkit.org/264311@main">https://commits.webkit.org/264311@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/263c4a0086d0b92155876c522c1812913e6b9a34

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/7159 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/7407 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/7586 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/8776 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/7379 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/7169 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/8702 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/7340 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/10282 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/7286 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/7963 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/6595 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/8882 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/5314 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/6514 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/14253 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/6965 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/6614 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/9490 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/7095 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/5797 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/6455 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/10654 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/854 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/6838 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->