### PR TITLE
[GTK] Crash in GraphicsContextGLGBM::allocateDrawBufferObject

### DIFF
--- a/Source/WebCore/platform/graphics/gbm/GBMBufferSwapchain.cpp
+++ b/Source/WebCore/platform/graphics/gbm/GBMBufferSwapchain.cpp
@@ -43,17 +43,55 @@ GBMBufferSwapchain::GBMBufferSwapchain(BufferSwapchainSize size)
 
 GBMBufferSwapchain::~GBMBufferSwapchain() = default;
 
+static inline bool isBufferFormatSupported(const DMABufFormat& format)
+{
+    switch (format.fourcc) {
+    case DMABufFormat::FourCC::XRGB8888:
+    case DMABufFormat::FourCC::XBGR8888:
+    case DMABufFormat::FourCC::RGBX8888:
+    case DMABufFormat::FourCC::BGRX8888:
+    case DMABufFormat::FourCC::ARGB8888:
+    case DMABufFormat::FourCC::ABGR8888:
+    case DMABufFormat::FourCC::RGBA8888:
+    case DMABufFormat::FourCC::BGRA8888:
+    case DMABufFormat::FourCC::I420:
+    case DMABufFormat::FourCC::YV12:
+    case DMABufFormat::FourCC::A420:
+    case DMABufFormat::FourCC::NV12:
+    case DMABufFormat::FourCC::NV21:
+    case DMABufFormat::FourCC::YUY2:
+    case DMABufFormat::FourCC::YVYU:
+    case DMABufFormat::FourCC::UYVY:
+    case DMABufFormat::FourCC::VYUY:
+    case DMABufFormat::FourCC::VUYA:
+    case DMABufFormat::FourCC::AYUV:
+    case DMABufFormat::FourCC::Y444:
+    case DMABufFormat::FourCC::Y41B:
+    case DMABufFormat::FourCC::Y42B:
+        return true;
+    default:
+        return false;
+    }
+}
+
 RefPtr<GBMBufferSwapchain::Buffer> GBMBufferSwapchain::getBuffer(const BufferDescription& description)
 {
     auto* device = GBMDevice::singleton().device();
-    if (!device)
+    if (!device) {
+        WTFLogAlways("Failed to get GBM buffer from swap chain: no GBM device found");
         return nullptr;
+    }
 
     // If the description of the requested buffers has changed, update the description to the new one and wreck the existing buffers.
     // This should handle changes in format or dimension of the buffers.
     if (description.format.fourcc != m_array.description.format.fourcc || description.width != m_array.description.width || description.height != m_array.description.height || description.flags != m_array.description.flags) {
         m_array.description = description;
         m_array.object = { };
+    }
+
+    if (!isBufferFormatSupported(description.format)) {
+        WTFLogAlways("Failed to get GBM buffer from swap chain: unsupported format");
+        return nullptr;
     }
 
     // Swapchain was asked to provide a buffer. The buffer array is traversed to find one.
@@ -64,38 +102,11 @@ RefPtr<GBMBufferSwapchain::Buffer> GBMBufferSwapchain::getBuffer(const BufferDes
             m_array.object[i] = buffer.copyRef();
 
             // Fill out the buffer's description and plane information for known and supported formats.
-            switch (description.format.fourcc) {
-            case DMABufFormat::FourCC::XRGB8888:
-            case DMABufFormat::FourCC::XBGR8888:
-            case DMABufFormat::FourCC::RGBX8888:
-            case DMABufFormat::FourCC::BGRX8888:
-            case DMABufFormat::FourCC::ARGB8888:
-            case DMABufFormat::FourCC::ABGR8888:
-            case DMABufFormat::FourCC::RGBA8888:
-            case DMABufFormat::FourCC::BGRA8888:
-            case DMABufFormat::FourCC::I420:
-            case DMABufFormat::FourCC::YV12:
-            case DMABufFormat::FourCC::A420:
-            case DMABufFormat::FourCC::NV12:
-            case DMABufFormat::FourCC::NV21:
-            case DMABufFormat::FourCC::YUY2:
-            case DMABufFormat::FourCC::YVYU:
-            case DMABufFormat::FourCC::UYVY:
-            case DMABufFormat::FourCC::VYUY:
-            case DMABufFormat::FourCC::VUYA:
-            case DMABufFormat::FourCC::AYUV:
-            case DMABufFormat::FourCC::Y444:
-            case DMABufFormat::FourCC::Y41B:
-            case DMABufFormat::FourCC::Y42B:
-                buffer->m_description.format.numPlanes = description.format.numPlanes;
-                for (unsigned i = 0; i < buffer->m_description.format.numPlanes; ++i) {
-                    buffer->m_planes[i].fourcc = description.format.planes[i].fourcc;
-                    buffer->m_planes[i].width = description.format.planeWidth(i, description.width);
-                    buffer->m_planes[i].height = description.format.planeHeight(i, description.height);
-                }
-                break;
-            default:
-                return nullptr;
+            buffer->m_description.format.numPlanes = description.format.numPlanes;
+            for (unsigned i = 0; i < buffer->m_description.format.numPlanes; ++i) {
+                buffer->m_planes[i].fourcc = description.format.planes[i].fourcc;
+                buffer->m_planes[i].width = description.format.planeWidth(i, description.width);
+                buffer->m_planes[i].height = description.format.planeHeight(i, description.height);
             }
 
             uint32_t boFlags = 0;
@@ -141,6 +152,7 @@ RefPtr<GBMBufferSwapchain::Buffer> GBMBufferSwapchain::getBuffer(const BufferDes
         return buffer;
     }
 
+    WTFLogAlways("Failed to get GBM buffer from swap chain: no buffers available");
     return nullptr;
 }
 

--- a/Source/WebCore/platform/graphics/gbm/GraphicsContextGLGBM.cpp
+++ b/Source/WebCore/platform/graphics/gbm/GraphicsContextGLGBM.cpp
@@ -318,6 +318,8 @@ void GraphicsContextGLGBM::allocateDrawBufferObject()
             .height = std::clamp<uint32_t>(size.height(), 0, UINT_MAX),
             .flags = GBMBufferSwapchain::BufferDescription::NoFlags,
         });
+    if (!m_swapchain.drawBO)
+        return;
 
     auto [textureTarget, textureBinding] = drawingBufferTextureBindingPoint();
     ScopedRestoreTextureBinding restoreBinding(textureBinding, textureTarget, textureTarget != TEXTURE_RECTANGLE_ARB);


### PR DESCRIPTION
#### 153153309cef73f2b65f8dfc3991044e705fe5a5
<pre>
[GTK] Crash in GraphicsContextGLGBM::allocateDrawBufferObject
<a href="https://bugs.webkit.org/show_bug.cgi?id=255398">https://bugs.webkit.org/show_bug.cgi?id=255398</a>

Reviewed by Michael Catanzaro.

GBMBufferSwapchain::getBuffer() can return nullptr for several reasons,
so we need to handle that case in
GraphicsContextGLGBM::allocateDrawBufferObject(). This also adds error
messages for the cases where getBuffer() returns nullptr, and returns
earlier without creating any buffer when the given format is
unsupported.

* Source/WebCore/platform/graphics/gbm/GBMBufferSwapchain.cpp:
(WebCore::isBufferFormatSupported):
(WebCore::GBMBufferSwapchain::getBuffer):
* Source/WebCore/platform/graphics/gbm/GraphicsContextGLGBM.cpp:
(WebCore::GraphicsContextGLGBM::allocateDrawBufferObject):

Canonical link: <a href="https://commits.webkit.org/264648@main">https://commits.webkit.org/264648@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f7a6eb2923fff231499c9d1d79ce31988244395b

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/8004 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/8289 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/8501 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/9656 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/8108 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/8008 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/10275 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/8200 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/10974 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/8148 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/9236 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/7313 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/9776 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/6537 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/7325 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/14906 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/7660 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/7446 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/10809 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/7916 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/6439 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/7230 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/11438 "Built successfully") | | | 
| [❌ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/978 "Failed to push commit to Webkit repository") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/7657 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->