### PR TITLE
Do not parse caption-side: left / right as valid CSS

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-tables/parsing/caption-side-invalid-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-tables/parsing/caption-side-invalid-expected.txt
@@ -1,6 +1,6 @@
 
 PASS e.style['caption-side'] = "auto" should not set the property value
-FAIL e.style['caption-side'] = "left" should not set the property value assert_equals: expected "" but got "left"
-FAIL e.style['caption-side'] = "right" should not set the property value assert_equals: expected "" but got "right"
+PASS e.style['caption-side'] = "left" should not set the property value
+PASS e.style['caption-side'] = "right" should not set the property value
 PASS e.style['caption-side'] = "top bottom" should not set the property value
 

--- a/Source/WebCore/css/CSSPrimitiveValueMappings.h
+++ b/Source/WebCore/css/CSSPrimitiveValueMappings.h
@@ -560,7 +560,7 @@ template<> constexpr BoxOrient fromCSSValueID(CSSValueID valueID)
 }
 
 #define TYPE CaptionSide
-#define FOR_EACH(CASE) CASE(Left) CASE(Right) CASE(Top) CASE(Bottom)
+#define FOR_EACH(CASE) CASE(Top) CASE(Bottom)
 DEFINE_TO_FROM_CSS_VALUE_ID_FUNCTIONS
 #undef TYPE
 #undef FOR_EACH

--- a/Source/WebCore/css/CSSProperties.json
+++ b/Source/WebCore/css/CSSProperties.json
@@ -3071,8 +3071,6 @@
         "caption-side": {
             "inherited": true,
             "values": [
-                "left",
-                "right",
                 "top",
                 "bottom",
                 {

--- a/Source/WebCore/rendering/style/RenderStyleConstants.cpp
+++ b/Source/WebCore/rendering/style/RenderStyleConstants.cpp
@@ -224,8 +224,6 @@ TextStream& operator<<(TextStream& ts, CaptionSide side)
     switch (side) {
     case CaptionSide::Top: ts << "top"; break;
     case CaptionSide::Bottom: ts << "bottom"; break;
-    case CaptionSide::Left: ts << "left"; break;
-    case CaptionSide::Right: ts << "right"; break;
     }
     return ts;
 }

--- a/Source/WebCore/rendering/style/RenderStyleConstants.h
+++ b/Source/WebCore/rendering/style/RenderStyleConstants.h
@@ -746,9 +746,7 @@ enum class EmptyCell : bool {
 
 enum class CaptionSide : uint8_t {
     Top,
-    Bottom,
-    Left,
-    Right
+    Bottom
 };
 
 enum class ListStylePosition : bool {


### PR DESCRIPTION
#### 402ed699af6cddc14e0c068446c8e803d3bc9f91
<pre>
Do not parse caption-side: left / right as valid CSS

<a href="https://bugs.webkit.org/show_bug.cgi?id=256040">https://bugs.webkit.org/show_bug.cgi?id=256040</a>
rdar://problem/108892083

Reviewed by Antti Koivisto.

This patch aligns WebKit with Blink / Chromium, Gecko / Firefox and Web-Spec [1]
by removing &apos;left&apos; and &apos;right&apos; parsing support for &apos;caption-side&apos;

[1] <a href="https://drafts.csswg.org/css-tables/#propdef-caption-side">https://drafts.csswg.org/css-tables/#propdef-caption-side</a>

* Source/WebCore/css/CSSProperties.json:
* Source/WebCore/css/CSSPrimitiveValueMappings.h: Remove &apos;left&apos; and &apos;right&apos; case
* Source/WebCore/rendering/style/RenderStyleConstants.cpp: Ditto from caption-side function
* Source/WebCore/rendering/style/RenderStyleConstants.h: Ditto from caption-side enum
* LayoutTests/imported/w3c/web-platform-tests/css/css-tables/parsing/caption-side-invalid-expected.txt: Rebaselined

Canonical link: <a href="https://commits.webkit.org/264262@main">https://commits.webkit.org/264262@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/8ba03c810c52a64a0a4dadc9c203580f014e9fec

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/7182 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/7430 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/7609 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/8799 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/7402 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/7192 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/8756 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/7363 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/10306 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/7309 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/8004 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/6620 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/8906 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/5355 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/6539 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/14279 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/6999 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/6639 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/9523 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/7118 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/5818 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/6478 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/10677 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/838 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/6861 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->