### PR TITLE
`git-webkit` complains about missing `Python.h`

### DIFF
--- a/Tools/glib/dependencies/apt
+++ b/Tools/glib/dependencies/apt
@@ -111,6 +111,9 @@ PACKAGES=(
     git-svn
     subversion
 
+    # These are dependencies necessary for using git-webkit.
+    python3-dev
+
     # These are GStreamer plugins needed to play different media files.
     gstreamer1.0-gl
     gstreamer1.0-libav

--- a/Tools/glib/dependencies/dnf
+++ b/Tools/glib/dependencies/dnf
@@ -104,6 +104,9 @@ PACKAGES=(
     git-svn
     subversion
 
+    # These are dependencies necessary for using git-webkit.
+    python3-devel
+
     # These are GStreamer plugins needed to play different media files.
     gstreamer1-plugins-bad-free
     gstreamer1-plugins-bad-free-extras


### PR DESCRIPTION
#### 08747dc9d22d3afcdc82e5268b89df4a1f9bf8cc
<pre>
`git-webkit` complains about missing `Python.h`
<a href="https://bugs.webkit.org/show_bug.cgi?id=257021">https://bugs.webkit.org/show_bug.cgi?id=257021</a>

Reviewed by Alejandro G. Castro.

`get-webkit` automatically installs `cffi` which requires `Python.h`
and throws scary messages if it&apos;s not found.

* Tools/glib/dependencies/apt:
* Tools/glib/dependencies/dnf:

Canonical link: <a href="https://commits.webkit.org/264259@main">https://commits.webkit.org/264259@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/cbb4aec5039308123078f512c4eed3bf71566214

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/7178 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/7426 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/7605 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/8795 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/7398 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/7188 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/8748 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/7359 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/10300 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/7305 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/15/builds/7996 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/6616 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/8902 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/5346 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/6535 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/14271 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/6992 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/6635 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/9512 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/7114 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/5814 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/6474 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/1701 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/10673 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/6857 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->