### PR TITLE
[WGSL] Global variables don't need to be mangled

### DIFF
--- a/Source/WebGPU/WGSL/MangleNames.cpp
+++ b/Source/WebGPU/WGSL/MangleNames.cpp
@@ -40,7 +40,6 @@ struct MangledName {
     enum Kind : uint8_t {
         Type,
         Local,
-        Global,
         Parameter,
         Function,
         Field,
@@ -56,7 +55,6 @@ struct MangledName {
         static const ASCIILiteral prefixes[] = {
             "type"_s,
             "local"_s,
-            "global"_s,
             "parameter"_s,
             "function"_s,
             "field"_s,
@@ -138,7 +136,11 @@ void NameManglerVisitor::visitFunctionBody(AST::Function& function)
         introduceVariable(parameter.name(), MangledName::Parameter);
     }
 
+    // It's important that we call the base visitor here directly, otherwise
+    // our overwritten visitor will introduce a new ContextScope for the compound
+    // statement, which would allow shadowing the function's parameters
     AST::Visitor::visit(function.body());
+
     if (function.maybeReturnType())
         AST::Visitor::visit(*function.maybeReturnType());
 }
@@ -179,8 +181,6 @@ void NameManglerVisitor::visit(AST::Variable& variable)
             break;
         }
     }
-
-    visitVariableDeclaration(variable, MangledName::Global);
 
     const String& mangledName = variable.name();
 


### PR DESCRIPTION
#### 4d5fe1667498ade1a7ad5edf54d4542e852f6f15
<pre>
[WGSL] Global variables don&apos;t need to be mangled
<a href="https://bugs.webkit.org/show_bug.cgi?id=257025">https://bugs.webkit.org/show_bug.cgi?id=257025</a>
rdar://109564753

Reviewed by Myles C. Maxfield.

The final program does not contain any global variables,
so we don&apos;t need to mangle them

* Source/WebGPU/WGSL/MangleNames.cpp:
(WGSL::MangledName::toString const):
(WGSL::NameManglerVisitor::visitFunctionBody):
(WGSL::NameManglerVisitor::visit):

Canonical link: <a href="https://commits.webkit.org/264313@main">https://commits.webkit.org/264313@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/fcfef48096a3f67ab222da8914ebe6f284afbfbd

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/7174 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/7422 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/7601 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/8791 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/7394 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/8739 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/7355 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/10297 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/7301 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/8000 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/6610 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/8897 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/5339 "Passed tests") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/14269 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/6986 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/6629 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/9510 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/7110 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/5810 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/6470 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/1736 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/10669 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/6853 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->