### PR TITLE
[WGSL] Add support for calls with simple built-in types

### DIFF
--- a/Source/WebGPU/WGSL/Metal/MetalFunctionWriter.cpp
+++ b/Source/WebGPU/WGSL/Metal/MetalFunctionWriter.cpp
@@ -623,8 +623,17 @@ void FunctionDefinitionWriter::visit(AST::CallExpression& call)
             return;
         }
 
+        static constexpr std::pair<ComparableASCIILiteral, ASCIILiteral> baseTypesMappings[] {
+            { "f32", "float"_s },
+            { "i32", "int"_s },
+            { "u32", "unsigned"_s }
+        };
+        static constexpr SortedArrayMap baseTypes { baseTypesMappings };
+
         if (AST::ParameterizedTypeName::stringViewToKind(targetName).has_value())
             visit(call.inferredType());
+        else if (auto mappedName = baseTypes.get(targetName))
+            m_stringBuilder.append(mappedName);
         else
             m_stringBuilder.append(targetName);
         visitArguments(this, call);

--- a/Source/WebGPU/WGSL/Parser.cpp
+++ b/Source/WebGPU/WGSL/Parser.cpp
@@ -1198,6 +1198,14 @@ Result<AST::Expression::Ref> Parser<Lexer>::parsePrimaryExpression()
         }
         RETURN_ARENA_NODE(IdentifierExpression, WTFMove(ident));
     }
+    case TokenType::KeywordI32:
+    case TokenType::KeywordU32:
+    case TokenType::KeywordF32:
+    case TokenType::KeywordBool: {
+        PARSE(type, TypeName);
+        PARSE(arguments, ArgumentExpressionList);
+        RETURN_ARENA_NODE(CallExpression, WTFMove(type), WTFMove(arguments));
+    }
     case TokenType::KeywordArray: {
         PARSE(arrayType, ArrayType);
         PARSE(arguments, ArgumentExpressionList);


### PR DESCRIPTION
#### e511c232f3f7a97c1ee7f4c8a0b50d4eb0f03e1a
<pre>
[WGSL] Add support for calls with simple built-in types
<a href="https://bugs.webkit.org/show_bug.cgi?id=257028">https://bugs.webkit.org/show_bug.cgi?id=257028</a>
rdar://109564906

Reviewed by Myles C. Maxfield.

Allow function calls with simple built-in types (i.e. function-style cast) such
as `f32(x)`. The way we currently handle it is not great, since we treat type
names as keywords in the lexer, but all of this will have to be refactored soon
when we update the parser to solve the template ambiguity. For now, this unblocks
a few more CTS tests to pass.

* Source/WebGPU/WGSL/Metal/MetalFunctionWriter.cpp:
(WGSL::Metal::FunctionDefinitionWriter::visit):
* Source/WebGPU/WGSL/Parser.cpp:
(WGSL::Parser&lt;Lexer&gt;::parsePrimaryExpression):

Canonical link: <a href="https://commits.webkit.org/264314@main">https://commits.webkit.org/264314@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/650d0c50cfef1aeaf9606dfcd4675d83ec492f86

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/7175 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/7423 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/7602 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/8792 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/7395 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/8741 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/7356 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/10298 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/7302 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/7990 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/6612 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/8898 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/5341 "Passed tests") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/14267 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/6987 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/6631 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/9508 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/7111 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/5811 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/6471 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/1737 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/10670 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/6854 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->