### PR TITLE
[WGSL] Don't modify the user-defined vertex output struct

### DIFF
--- a/Source/WebGPU/WGSL/EntryPointRewriter.cpp
+++ b/Source/WebGPU/WGSL/EntryPointRewriter.cpp
@@ -156,11 +156,30 @@ void EntryPointRewriter::checkReturnType()
     if (m_stage != AST::StageAttribute::Stage::Vertex)
         return;
 
-    // FIXME: we might have to duplicate this struct if it has other uses
     if (auto* maybeReturnType = m_function.maybeReturnType()) {
-        if (auto* structType = std::get_if<Types::Struct>(maybeReturnType->resolvedType())) {
+        ASSERT(is<AST::NamedTypeName>(*maybeReturnType));
+        auto& namedTypeName = downcast<AST::NamedTypeName>(*maybeReturnType);
+
+        if (auto* structType = std::get_if<Types::Struct>(namedTypeName.resolvedType())) {
             ASSERT(structType->structure.role() == AST::StructureRole::UserDefined);
-            m_shaderModule.replace(&structType->structure.role(), AST::StructureRole::VertexOutput);
+
+            String returnStructName = makeString("__", structType->structure.name(), "_VertexOutput");
+            auto& returnStruct = m_shaderModule.astBuilder().construct<AST::Structure>(
+                SourceSpan::empty(),
+                AST::Identifier::make(returnStructName),
+                AST::StructureMember::List(structType->structure.members()),
+                AST::Attribute::List { },
+                AST::StructureRole::VertexOutput
+
+            );
+            m_shaderModule.append(m_shaderModule.structures(), returnStruct);
+
+            auto& returnType = m_shaderModule.astBuilder().construct<AST::NamedTypeName>(
+                SourceSpan::empty(),
+                AST::Identifier::make(returnStructName)
+            );
+            returnType.m_resolvedType = m_shaderModule.types().structType(returnStruct);
+            m_shaderModule.replace(namedTypeName, returnType);
         }
     }
 }

--- a/Source/WebGPU/WGSL/Metal/MetalFunctionWriter.cpp
+++ b/Source/WebGPU/WGSL/Metal/MetalFunctionWriter.cpp
@@ -227,6 +227,22 @@ void FunctionDefinitionWriter::visit(AST::Structure& structDecl)
         auto finalSize = WTF::roundUpToMultipleOf(alignment, size);
         if (finalSize != size)
             addPadding(finalSize - size);
+
+        if (structDecl.role() == AST::StructureRole::VertexOutput) {
+            m_stringBuilder.append("\n");
+            m_stringBuilder.append(m_indent, "template<typename T>\n");
+            m_stringBuilder.append(m_indent, structDecl.name(), "(const thread T& other)\n");
+            {
+                IndentationScope scope(m_indent);
+                char prefix = ':';
+                for (auto& member : structDecl.members()) {
+                    auto& name = member.name();
+                    m_stringBuilder.append(m_indent, prefix, " ", name, "(other.", name, ")\n");
+                    prefix = ',';
+                }
+            }
+            m_stringBuilder.append(m_indent, "{ }\n");
+        }
     }
     m_stringBuilder.append(m_indent, "};\n\n");
     m_structRole = std::nullopt;


### PR DESCRIPTION
#### 49647f66ed78c1542903200be12d1e213e7bbaab
<pre>
[WGSL] Don&apos;t modify the user-defined vertex output struct
<a href="https://bugs.webkit.org/show_bug.cgi?id=257032">https://bugs.webkit.org/show_bug.cgi?id=257032</a>
rdar://109565231

Reviewed by Myles C. Maxfield.

The user-defined struct can be used for other purposes, and it&apos;s not safe to modify it.

* Source/WebGPU/WGSL/EntryPointRewriter.cpp:
(WGSL::EntryPointRewriter::checkReturnType):
* Source/WebGPU/WGSL/Metal/MetalFunctionWriter.cpp:
(WGSL::Metal::FunctionDefinitionWriter::visit):
* Source/WebGPU/WGSL/WGSLShaderModule.h:
(WGSL::ShaderModule::replace):
(WGSL::ShaderModule::std::enable_if_t&lt;sizeof):

Canonical link: <a href="https://commits.webkit.org/264316@main">https://commits.webkit.org/264316@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/bdf0a2c2c92cb79c4ac6a8b2cdedc0a832a95804

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/7176 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/7424 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/7603 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/8793 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/7396 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/8744 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/7357 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/10299 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/7303 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/7992 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/6613 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/8899 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/5343 "Passed tests") | | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/14268 "17 flakes 130 failures") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/6989 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/6632 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/9509 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/7112 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/5812 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/6472 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/1738 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/10671 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/6855 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->