### PR TITLE
Take overflow: clip into account when computing table overflow

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-overflow/overflow-clip-rounded-table-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-overflow/overflow-clip-rounded-table-expected.html
@@ -1,0 +1,24 @@
+<!DOCTYPE html>
+<html><head><meta charset="utf-8">
+<title>Verifies overflow-clip on table with rounded border renders correctly</title>
+<link rel="help" href="https://www.w3.org/TR/css-overflow-3/#valdef-overflow-clip">
+<style>
+table {
+    border-radius: 10px;
+    border-collapse: collapse;
+    overflow: hidden;
+}
+thead {
+    background: green;
+}
+</style>
+</head><body><p>You should see a green table with rounded corners</p>
+<table>
+ <thead>
+    <tr>
+      <th>One</th>
+      <th>Two</th>
+    </tr>
+  </thead>
+</table>
+</body></html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-overflow/overflow-clip-rounded-table.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-overflow/overflow-clip-rounded-table.html
@@ -1,0 +1,25 @@
+<!DOCTYPE html>
+<html><head><meta charset="utf-8">
+<title>Verifies overflow-clip on table with rounded border renders correctly</title>
+<link rel="help" href="https://www.w3.org/TR/css-overflow-3/#valdef-overflow-clip">
+<link rel="match" href="overflow-clip-rounded-table-ref.html">
+<style>
+table {
+    border-radius: 10px;
+    border-collapse: collapse;
+    overflow: clip;
+}
+thead {
+    background: green;
+}
+</style>
+</head><body><p>You should see a green table with rounded corners</p>
+<table>
+ <thead>
+    <tr>
+      <th>One</th>
+      <th>Two</th>
+    </tr>
+  </thead>
+</table>
+</body></html>

--- a/Source/WebCore/style/StyleAdjuster.cpp
+++ b/Source/WebCore/style/StyleAdjuster.cpp
@@ -485,9 +485,9 @@ void Adjuster::adjust(RenderStyle& style, const RenderStyle* userAgentAppearance
     // FIXME: Eventually table sections will support auto and scroll.
     if (style.display() == DisplayType::Table || style.display() == DisplayType::InlineTable
         || style.display() == DisplayType::TableRowGroup || style.display() == DisplayType::TableRow) {
-        if (style.overflowX() != Overflow::Visible && style.overflowX() != Overflow::Hidden)
+        if (style.overflowX() != Overflow::Visible && style.overflowX() != Overflow::Hidden && style.overflowX() != Overflow::Clip)
             style.setOverflowX(Overflow::Visible);
-        if (style.overflowY() != Overflow::Visible && style.overflowY() != Overflow::Hidden)
+        if (style.overflowY() != Overflow::Visible && style.overflowY() != Overflow::Hidden && style.overflowY() != Overflow::Clip)
             style.setOverflowY(Overflow::Visible);
     }
 


### PR DESCRIPTION
#### 0e5a15b8412272786492e4c16b82b3cee54aee26
<pre>
Take overflow: clip into account when computing table overflow
<a href="https://bugs.webkit.org/show_bug.cgi?id=251909">https://bugs.webkit.org/show_bug.cgi?id=251909</a>

Reviewed by Alan Baradlay.

When computing table overflow overflow: clip should be treated like overflow: hidden:
<a href="https://github.com/w3c/csswg-drafts/pull/7492/files">https://github.com/w3c/csswg-drafts/pull/7492/files</a>

* LayoutTests/imported/w3c/web-platform-tests/css/css-overflow/overflow-clip-rounded-table-expected.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-overflow/overflow-clip-rounded-table.html: Added.
* Source/WebCore/style/StyleAdjuster.cpp:
(WebCore::Style::Adjuster::adjust const):

Canonical link: <a href="https://commits.webkit.org/264849@main">https://commits.webkit.org/264849@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/3cd2edf00002cfcb307d9c3868aaa1ac052eed58

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/7200 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/7449 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/7627 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/8818 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/7420 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/7210 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/8784 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/7382 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/10752 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/7327 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/8026 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/6637 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/8925 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/5377 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/6556 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/14289 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/7018 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/6659 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/9531 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/7136 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/5835 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/6496 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/6465 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/2144 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/10695 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/6879 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->