### PR TITLE
FTL missing bound check of for-in loop

### DIFF
--- a/JSTests/stress/ftl-bound-check-for-enumerator-next-update-index-and-mode.js
+++ b/JSTests/stress/ftl-bound-check-for-enumerator-next-update-index-and-mode.js
@@ -1,0 +1,27 @@
+//@ runDefault("--useConcurrentJIT=0", "--jitPolicyScale=0.1")
+
+function shouldBe(actual, expected) {
+    if (actual !== expected)
+        throw new Error('bad value: ' + actual);
+}
+
+function opt(){
+    let A = [];
+
+    for (let i = 0; i < 500; ++i) {
+      A[i]=500
+    }
+    A.shift()
+
+    let count = 0
+    for (let j in A) {
+      A.shift()
+      count++
+    }
+    return count
+}
+for(let ii=0;ii<1000;ii++){
+  opt()
+}
+
+shouldBe(opt(), 250);


### PR DESCRIPTION
#### fb4ca5da0f8e84a9e186efd411a0f14d709de0b4
<pre>
FTL missing bound check of for-in loop
<a href="https://bugs.webkit.org/show_bug.cgi?id=252801">https://bugs.webkit.org/show_bug.cgi?id=252801</a>
rdar://105820083

Reviewed by Michael Saboff.

EnumeratorNextUpdateIndexAndMode for IndexedMode uses HasIndexProperty internally. But
this node does not do bound check when ArrayMode is inBounds in FTL since FTL SSALowering
phase extracts this bound check as a separate CheckInBounds node. But EnumeratorNextUpdateIndexAndMode,
we cannot do that since EnumeratorNextUpdateIndexAndMode&apos;s index is incremented internally. Thus,
we need to do bound check inside EnumeratorNextUpdateIndexAndMode when it is not done in HasIndexProperty&apos;s
code.

* JSTests/stress/ftl-bound-check-for-enumerator-next-update-index-and-mode.js: Added.
(shouldBe):
(opt):
* Source/JavaScriptCore/ftl/FTLLowerDFGToB3.cpp:
(JSC::FTL::DFG::LowerDFGToB3::compileCompareStrictEq):

Originally-landed-as: 259548.377@safari-7615-branch (25a414a61f3e). rdar://105820083
Canonical link: <a href="https://commits.webkit.org/264326@main">https://commits.webkit.org/264326@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ed28af943688260202717cdc759bf52aba72a85c

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/7203 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/7452 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/7631 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/8821 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/7422 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/8788 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/7385 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/10321 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/7330 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/8029 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/6639 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/8928 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/5380 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/6558 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/14308 "Passed tests") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/6112 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/7021 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/6661 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/9551 "8 api tests failed or timed out") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/6789 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/7139 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/5839 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/7343 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/6498 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/1695 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/10698 "Built successfully") | | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/24/builds/7546 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/861 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/6881 "Built successfully") | | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/3/builds/1835 "Passed tests") | 
<!--EWS-Status-Bubble-End-->