### PR TITLE
av1/encoder/encoder_utils.c & a/av1/common/resize: Stack-buffer-overflow in aom_scaled_2d_ssse3

### DIFF
--- a/Source/ThirdParty/libwebrtc/Source/third_party/libaom/source/libaom/av1/common/resize.c
+++ b/Source/ThirdParty/libwebrtc/Source/third_party/libaom/source/libaom/av1/common/resize.c
@@ -1384,15 +1384,20 @@ YV12_BUFFER_CONFIG *av1_realloc_and_scale_if_required(
       aom_internal_error(cm->error, AOM_CODEC_MEM_ERROR,
                          "Failed to allocate scaled buffer");
 
+    const bool has_optimized_scaler = av1_has_optimized_scaler(
+        unscaled->y_crop_width, unscaled->y_crop_height, scaled_width,
+        scaled_height);
+
 #if CONFIG_AV1_HIGHBITDEPTH
-    if (use_optimized_scaler && cm->seq_params->bit_depth == AOM_BITS_8) {
+    if (use_optimized_scaler && has_optimized_scaler &&
+        cm->seq_params->bit_depth == AOM_BITS_8) {
       av1_resize_and_extend_frame(unscaled, scaled, filter, phase, num_planes);
     } else {
       av1_resize_and_extend_frame_nonnormative(
           unscaled, scaled, (int)cm->seq_params->bit_depth, num_planes);
     }
 #else
-    if (use_optimized_scaler) {
+    if (use_optimized_scaler && has_optimized_scaler) {
       av1_resize_and_extend_frame(unscaled, scaled, filter, phase, num_planes);
     } else {
       av1_resize_and_extend_frame_nonnormative(

--- a/Source/ThirdParty/libwebrtc/Source/third_party/libaom/source/libaom/av1/common/resize.h
+++ b/Source/ThirdParty/libwebrtc/Source/third_party/libaom/source/libaom/av1/common/resize.h
@@ -105,6 +105,24 @@ static INLINE int av1_superres_scaled(const AV1_COMMON *cm) {
   return !(cm->width == cm->superres_upscaled_width);
 }
 
+// There's SIMD optimizations for 1/4, 1/2 and 3/4 downscaling.
+// SSSE3 also has optimizations for 2x upscaling.
+// Use non normative scalers for other scaling ratios.
+static INLINE bool av1_has_optimized_scaler(const int src_width,
+                                            const int src_height,
+                                            const int dst_width,
+                                            const int dst_height) {
+  const bool has_optimized_scaler =
+      (dst_width * 4 == src_width && dst_height * 4 == src_height) ||
+      (dst_width * 2 == src_width && dst_height * 2 == src_height) ||
+      (dst_width * 4 == src_width * 3 && dst_height * 4 == src_height * 3);
+#if HAVE_SSSE3
+  return has_optimized_scaler ||
+         (dst_width == src_width * 2 && dst_height == src_height * 2);
+#endif
+  return has_optimized_scaler;
+}
+
 #define UPSCALE_NORMATIVE_TAPS 8
 extern const int16_t av1_resize_filter_normative[1 << RS_SUBPEL_BITS]
                                                 [UPSCALE_NORMATIVE_TAPS];

--- a/Source/ThirdParty/libwebrtc/Source/third_party/libaom/source/libaom/av1/encoder/encoder_utils.c
+++ b/Source/ThirdParty/libwebrtc/Source/third_party/libaom/source/libaom/av1/encoder/encoder_utils.c
@@ -733,15 +733,19 @@ void av1_scale_references(AV1_COMP *cpi, const InterpFilter filter,
             aom_internal_error(cm->error, AOM_CODEC_MEM_ERROR,
                                "Failed to allocate frame buffer");
           }
+          const bool has_optimized_scaler = av1_has_optimized_scaler(
+              cm->width, cm->height, new_fb->buf.y_crop_width,
+              new_fb->buf.y_crop_height);
 #if CONFIG_AV1_HIGHBITDEPTH
-          if (use_optimized_scaler && cm->seq_params->bit_depth == AOM_BITS_8)
+          if (use_optimized_scaler && has_optimized_scaler &&
+              cm->seq_params->bit_depth == AOM_BITS_8)
             av1_resize_and_extend_frame(ref, &new_fb->buf, filter, phase,
                                         num_planes);
           else
             av1_resize_and_extend_frame_nonnormative(
                 ref, &new_fb->buf, (int)cm->seq_params->bit_depth, num_planes);
 #else
-          if (use_optimized_scaler)
+          if (use_optimized_scaler && has_optimized_scaler)
             av1_resize_and_extend_frame(ref, &new_fb->buf, filter, phase,
                                         num_planes);
           else


### PR DESCRIPTION
#### a6f57c1a1ab98c1ee64db9a32a8d42e78d5d49a4
<pre>
av1/encoder/encoder_utils.c &amp; a/av1/common/resize: Stack-buffer-overflow in aom_scaled_2d_ssse3
<a href="https://bugs.webkit.org/show_bug.cgi?id=253498">https://bugs.webkit.org/show_bug.cgi?id=253498</a>
rdar://106063201

Reviewed by Eric Carlson.

Cherry-pick upstream change from <a href="https://aomedia.googlesource.com/aom/+/6318378f833b2a0d8e67fb3d12bcdc4e1c26b0e6%5E%21/#F2.">https://aomedia.googlesource.com/aom/+/6318378f833b2a0d8e67fb3d12bcdc4e1c26b0e6%5E%21/#F2.</a>

* Source/ThirdParty/libwebrtc/Source/third_party/libaom/source/libaom/av1/common/resize.c:
(av1_realloc_and_scale_if_required):
* Source/ThirdParty/libwebrtc/Source/third_party/libaom/source/libaom/av1/common/resize.h:
* Source/ThirdParty/libwebrtc/Source/third_party/libaom/source/libaom/av1/encoder/encoder_utils.c:
(av1_scale_references):

Originally-landed-as: 259548.381@safari-7615-branch (1de648970cbf). rdar://106063201
Canonical link: <a href="https://commits.webkit.org/264327@main">https://commits.webkit.org/264327@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/aea8731f471d5451f1253ac2e4c59d81a92bb584

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/7205 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/7454 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/7633 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/8823 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/7424 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/8790 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/7387 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/10322 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/7332 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/8028 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/6642 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/8965 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/5379 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/6561 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/14318 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/7020 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/6664 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/9563 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/7141 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/5840 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/6500 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/10700 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/862 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/6883 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->