### PR TITLE
[ManagedMSE] JS ManagedSourceBuffer object doesn't present any of its attributes

### DIFF
--- a/LayoutTests/media/media-source/media-managedmse-bufferedchange-expected.txt
+++ b/LayoutTests/media/media-source/media-managedmse-bufferedchange-expected.txt
@@ -2,6 +2,8 @@
 RUN(video.src = URL.createObjectURL(source))
 EVENT(sourceopen)
 RUN(sourceBuffer = source.addSourceBuffer(loader.type()))
+EXPECTED (sourceBuffer.__proto__ == '[object ManagedSourceBuffer]') OK
+EXPECTED (sourceBuffer.onbufferedchange !== undefined == 'true') OK
 RUN(sourceBuffer.appendBuffer(loader.initSegment()))
 EVENT(update)
 Append a media segment.

--- a/LayoutTests/media/media-source/media-managedmse-bufferedchange.html
+++ b/LayoutTests/media/media-source/media-managedmse-bufferedchange.html
@@ -35,6 +35,9 @@
             waitFor(video, 'error').then(failTest);
 
             run('sourceBuffer = source.addSourceBuffer(loader.type())');
+            testExpected('sourceBuffer.__proto__', ManagedSourceBuffer.prototype);
+            testExpected('sourceBuffer.onbufferedchange !== undefined', true);
+
             run('sourceBuffer.appendBuffer(loader.initSegment())');
             await waitFor(sourceBuffer, 'update');
 

--- a/Source/WebCore/Modules/mediasource/MediaSource.idl
+++ b/Source/WebCore/Modules/mediasource/MediaSource.idl
@@ -40,7 +40,8 @@ enum ReadyState {
 };
 
 [
-    SkipVTableValidation,
+    CustomToJSObject,
+    JSGenerateToNativeObject,
     ActiveDOMObject,
     Conditional=MEDIA_SOURCE,
     EnabledBySetting=MediaSourceEnabled,

--- a/Source/WebCore/Modules/mediasource/SourceBuffer.idl
+++ b/Source/WebCore/Modules/mediasource/SourceBuffer.idl
@@ -34,7 +34,8 @@
 };
 
 [
-    SkipVTableValidation,
+    CustomToJSObject,
+    JSGenerateToNativeObject,
     ActiveDOMObject,
     Conditional=MEDIA_SOURCE,
     EnabledBySetting=MediaSourceEnabled,

--- a/Source/WebCore/Sources.txt
+++ b/Source/WebCore/Sources.txt
@@ -610,6 +610,7 @@ bindings/js/JSLazyEventListener.cpp
 bindings/js/JSLocalDOMWindowCustom.cpp
 bindings/js/JSLocationCustom.cpp
 bindings/js/JSMediaSessionCustom.cpp
+bindings/js/JSMediaSourceCustom.cpp
 bindings/js/JSMediaStreamTrackCustom.cpp
 bindings/js/JSMessageChannelCustom.cpp
 bindings/js/JSMessageEventCustom.cpp
@@ -644,6 +645,7 @@ bindings/js/JSSVGViewSpecCustom.cpp
 bindings/js/JSServiceWorkerClientCustom.cpp
 bindings/js/JSServiceWorkerGlobalScopeCustom.cpp
 bindings/js/JSShadowRootCustom.cpp
+bindings/js/JSSourceBufferCustom.cpp
 bindings/js/JSStaticRangeCustom.cpp
 bindings/js/JSStyleSheetCustom.cpp
 bindings/js/JSTextCustom.cpp

--- a/Source/WebCore/bindings/js/JSMediaSourceCustom.cpp
+++ b/Source/WebCore/bindings/js/JSMediaSourceCustom.cpp
@@ -1,0 +1,54 @@
+/*
+ * Copyright (C) 2023 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+
+#if ENABLE(MEDIA_SOURCE)
+#include "JSMediaSource.h"
+
+#if ENABLE(MANAGED_MEDIA_SOURCE)
+#include "JSManagedMediaSource.h"
+#endif
+
+namespace WebCore {
+using namespace JSC;
+
+JSValue toJSNewlyCreated(JSGlobalObject*, JSDOMGlobalObject* globalObject, Ref<MediaSource>&& source)
+{
+#if ENABLE(MANAGED_MEDIA_SOURCE)
+    if (source->isManaged())
+        return createWrapper<ManagedMediaSource>(globalObject, WTFMove(source));
+#endif
+    return createWrapper<MediaSource>(globalObject, WTFMove(source));
+}
+
+JSValue toJS(JSGlobalObject* lexicalGlobalObject, JSDOMGlobalObject* globalObject, MediaSource& source)
+{
+    return wrap(lexicalGlobalObject, globalObject, source);
+}
+
+} // namespace WebCore
+
+#endif

--- a/Source/WebCore/bindings/js/JSSourceBufferCustom.cpp
+++ b/Source/WebCore/bindings/js/JSSourceBufferCustom.cpp
@@ -1,0 +1,54 @@
+/*
+ * Copyright (C) 2023 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+
+#if ENABLE(MEDIA_SOURCE)
+#include "JSSourceBuffer.h"
+
+#if ENABLE(MANAGED_MEDIA_SOURCE)
+#include "JSManagedSourceBuffer.h"
+#endif
+
+namespace WebCore {
+using namespace JSC;
+
+JSValue toJSNewlyCreated(JSGlobalObject*, JSDOMGlobalObject* globalObject, Ref<SourceBuffer>&& buffer)
+{
+#if ENABLE(MANAGED_MEDIA_SOURCE)
+    if (buffer->isManaged())
+        return createWrapper<ManagedSourceBuffer>(globalObject, WTFMove(buffer));
+#endif
+    return createWrapper<SourceBuffer>(globalObject, WTFMove(buffer));
+}
+
+JSValue toJS(JSGlobalObject* lexicalGlobalObject, JSDOMGlobalObject* globalObject, SourceBuffer& buffer)
+{
+    return wrap(lexicalGlobalObject, globalObject, buffer);
+}
+
+} // namespace WebCore
+
+#endif


### PR DESCRIPTION
#### 202d7e72c2c6566cff1ed27fa4d010820598c51d
<pre>
[ManagedMSE] JS ManagedSourceBuffer object doesn&apos;t present any of its attributes
<a href="https://bugs.webkit.org/show_bug.cgi?id=257037">https://bugs.webkit.org/show_bug.cgi?id=257037</a>
rdar://109569570

Reviewed by Chris Dumez.

Add missing custom toJS for MediaSource and SourceBuffer.

* LayoutTests/media/media-source/media-managedmse-bufferedchange-expected.txt:
* LayoutTests/media/media-source/media-managedmse-bufferedchange.html:
* Source/WebCore/Modules/mediasource/MediaSource.idl:
* Source/WebCore/Modules/mediasource/SourceBuffer.idl:
* Source/WebCore/Sources.txt:
* Source/WebCore/WebCore.xcodeproj/project.pbxproj:
* Source/WebCore/bindings/js/JSMediaSourceCustom.cpp: Added.
(WebCore::toJSNewlyCreated):
(WebCore::toJS):
* Source/WebCore/bindings/js/JSSourceBufferCustom.cpp: Added.
(WebCore::toJSNewlyCreated):
(WebCore::toJS):

Canonical link: <a href="https://commits.webkit.org/264284@main">https://commits.webkit.org/264284@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f2252eac6adb781b627d240bc21e78e0de0d3b43

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/7253 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/7503 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/7679 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/8874 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/7461 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/7261 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/8836 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/7431 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/10356 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/7380 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/8074 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/6670 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/8982 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/5417 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/6597 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/14330 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/7047 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/6700 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/9588 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/7185 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/5868 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/6542 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/6507 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/1716 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/10743 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/6923 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->