### PR TITLE
[JSC] CFA should clear abstract values first before reconstruction

### DIFF
--- a/JSTests/stress/regress-109263765.js
+++ b/JSTests/stress/regress-109263765.js
@@ -1,0 +1,16 @@
+//@requireOptions("--thresholdForFTLOptimizeSoon=0", "--validateAbstractInterpreterState=1")
+function foo() {
+    let a = Object;
+    let b = Object;
+    let c = Array.prototype;
+    for (let i = 0; i < 10; i++) {
+        for (let j = 0; j < 100; j++) {
+            let xs = [0, 1];
+            for (let x in xs) { }
+        }
+    }
+}
+
+for (let i = 0; i < 100; i++) {
+    foo();
+}

--- a/Source/JavaScriptCore/dfg/DFGAbstractInterpreterInlines.h
+++ b/Source/JavaScriptCore/dfg/DFGAbstractInterpreterInlines.h
@@ -4614,6 +4614,7 @@ bool AbstractInterpreter<AbstractStateType>::executeEffects(unsigned clobberLimi
             }
         }
         m_state.setNonCellTypeForTupleNode(node, 0, SpecInt32Only);
+        clearForNode(node);
         break;
     }
 

--- a/Source/JavaScriptCore/dfg/DFGArgumentsEliminationPhase.cpp
+++ b/Source/JavaScriptCore/dfg/DFGArgumentsEliminationPhase.cpp
@@ -501,7 +501,7 @@ private:
     // object's payload. Conservatively this means that the stack region doesn't get stored to.
     void eliminateCandidatesThatInterfere()
     {
-        performLivenessAnalysis(m_graph);
+        performGraphPackingAndLivenessAnalysis(m_graph);
         m_graph.initializeNodeOwners();
         CombinedLiveness combinedLiveness(m_graph);
 

--- a/Source/JavaScriptCore/dfg/DFGCFAPhase.cpp
+++ b/Source/JavaScriptCore/dfg/DFGCFAPhase.cpp
@@ -55,7 +55,7 @@ public:
     {
         ASSERT(m_graph.m_form == ThreadedCPS || m_graph.m_form == SSA);
         ASSERT(m_graph.m_unificationState == GloballyUnified);
-        ASSERT(m_graph.m_refCountState == EverythingIsLive);
+        ASSERT(m_graph.m_refCountState == EverythingIsLive || Options::validateAbstractInterpreterState() && m_graph.m_refCountState == ExactRefCount);
         
         m_count = 0;
 

--- a/Source/JavaScriptCore/dfg/DFGFlowMap.h
+++ b/Source/JavaScriptCore/dfg/DFGFlowMap.h
@@ -106,7 +106,14 @@ public:
     ALWAYS_INLINE const T& at(unsigned nodeIndex, NodeFlowProjection::Kind kind) const { return const_cast<FlowMap*>(this)->at(nodeIndex, kind); }
     ALWAYS_INLINE const T& at(Node* node, NodeFlowProjection::Kind kind) const { return const_cast<FlowMap*>(this)->at(node, kind); }
     ALWAYS_INLINE const T& at(NodeFlowProjection projection) const { return const_cast<FlowMap*>(this)->at(projection); }
-    
+
+    ALWAYS_INLINE void clear()
+    {
+        m_map.clear();
+        m_shadowMap.clear();
+        resize();
+    }
+
 private:
     Graph& m_graph;
     Vector<T, 0, UnsafeVectorOverflow> m_map;

--- a/Source/JavaScriptCore/dfg/DFGGraph.cpp
+++ b/Source/JavaScriptCore/dfg/DFGGraph.cpp
@@ -685,6 +685,11 @@ void Graph::packNodeIndices()
     m_nodes.packIndices();
 }
 
+void Graph::clearAbstractValues()
+{
+    m_abstractValuesCache->clear();
+}
+
 void Graph::dethread()
 {
     if (m_form == LoadStore || m_form == SSA)

--- a/Source/JavaScriptCore/dfg/DFGGraph.h
+++ b/Source/JavaScriptCore/dfg/DFGGraph.h
@@ -237,6 +237,7 @@ public:
     unsigned maxNodeCount() const { return m_nodes.size(); }
     Node* nodeAt(unsigned index) const { return m_nodes[index]; }
     void packNodeIndices();
+    void clearAbstractValues();
 
     void dethread();
     

--- a/Source/JavaScriptCore/dfg/DFGInPlaceAbstractState.h
+++ b/Source/JavaScriptCore/dfg/DFGInPlaceAbstractState.h
@@ -88,7 +88,6 @@ public:
     
     ALWAYS_INLINE void clearForNode(NodeFlowProjection node)
     {
-        ASSERT(!node->isTuple());
         AbstractValue& value = m_abstractValues.at(node);
         value.clear();
         value.m_effectEpoch = m_effectEpoch;

--- a/Source/JavaScriptCore/dfg/DFGLivenessAnalysisPhase.cpp
+++ b/Source/JavaScriptCore/dfg/DFGLivenessAnalysisPhase.cpp
@@ -185,10 +185,12 @@ private:
 
 } // anonymous namespace
 
-bool performLivenessAnalysis(Graph& graph)
+bool performGraphPackingAndLivenessAnalysis(Graph& graph)
 {
     graph.packNodeIndices();
-
+#ifndef NDEBUG
+    graph.clearAbstractValues();
+#endif
     return runPhase<LivenessAnalysisPhase>(graph);
 }
 

--- a/Source/JavaScriptCore/dfg/DFGLivenessAnalysisPhase.h
+++ b/Source/JavaScriptCore/dfg/DFGLivenessAnalysisPhase.h
@@ -34,7 +34,7 @@ class Graph;
 
 // Computes BasicBlock::ssa->liveAtHead/liveAtTail.
 
-bool performLivenessAnalysis(Graph&);
+bool performGraphPackingAndLivenessAnalysis(Graph&);
 
 } } // namespace JSC::DFG
 

--- a/Source/JavaScriptCore/dfg/DFGObjectAllocationSinkingPhase.cpp
+++ b/Source/JavaScriptCore/dfg/DFGObjectAllocationSinkingPhase.cpp
@@ -817,7 +817,7 @@ private:
         m_graph.computeRefCounts();
         m_graph.initializeNodeOwners();
         m_graph.ensureSSADominators();
-        performLivenessAnalysis(m_graph);
+        performGraphPackingAndLivenessAnalysis(m_graph);
         performOSRAvailabilityAnalysis(m_graph);
         m_combinedLiveness = CombinedLiveness(m_graph);
 

--- a/Source/JavaScriptCore/dfg/DFGPlan.cpp
+++ b/Source/JavaScriptCore/dfg/DFGPlan.cpp
@@ -375,7 +375,7 @@ Plan::CompilationPath Plan::compileInThreadImpl()
         
         RUN_PHASE(performConstantHoisting);
         RUN_PHASE(performGlobalCSE);
-        RUN_PHASE(performLivenessAnalysis);
+        RUN_PHASE(performGraphPackingAndLivenessAnalysis);
         RUN_PHASE(performCFA);
         RUN_PHASE(performConstantFolding);
         RUN_PHASE(performCFGSimplification);
@@ -391,7 +391,7 @@ Plan::CompilationPath Plan::compileInThreadImpl()
         if (changed) {
             // State-at-tail and state-at-head will be invalid if we did strength reduction since
             // it might increase live ranges.
-            RUN_PHASE(performLivenessAnalysis);
+            RUN_PHASE(performGraphPackingAndLivenessAnalysis);
             RUN_PHASE(performCFA);
             RUN_PHASE(performConstantFolding);
             RUN_PHASE(performCFGSimplification);
@@ -402,7 +402,7 @@ Plan::CompilationPath Plan::compileInThreadImpl()
         // wrong with running LICM earlier, if we wanted to put other CFG transforms above this point.
         // Alternatively, we could run loop pre-header creation after SSA conversion - but if we did that
         // then we'd need to do some simple SSA fix-up.
-        RUN_PHASE(performLivenessAnalysis);
+        RUN_PHASE(performGraphPackingAndLivenessAnalysis);
         RUN_PHASE(performCFA);
         RUN_PHASE(performLICM);
 
@@ -413,7 +413,7 @@ Plan::CompilationPath Plan::compileInThreadImpl()
         // by IntegerRangeOptimization.
         //
         // Ideally, the dependencies should be explicit. See https://bugs.webkit.org/show_bug.cgi?id=157534.
-        RUN_PHASE(performLivenessAnalysis);
+        RUN_PHASE(performGraphPackingAndLivenessAnalysis);
         RUN_PHASE(performIntegerRangeOptimization);
         
         RUN_PHASE(performCleanUp);
@@ -424,14 +424,14 @@ Plan::CompilationPath Plan::compileInThreadImpl()
         // about code motion assumes that it's OK to insert GC points in random places.
         dfg.m_fixpointState = FixpointConverged;
 
-        RUN_PHASE(performLivenessAnalysis);
+        RUN_PHASE(performGraphPackingAndLivenessAnalysis);
         RUN_PHASE(performCFA);
         RUN_PHASE(performGlobalStoreBarrierInsertion);
         RUN_PHASE(performStoreBarrierClustering);
         RUN_PHASE(performCleanUp);
         RUN_PHASE(performDCE); // We rely on this to kill dead code that won't be recognized as dead by B3.
         RUN_PHASE(performStackLayout);
-        RUN_PHASE(performLivenessAnalysis);
+        RUN_PHASE(performGraphPackingAndLivenessAnalysis);
         RUN_PHASE(performOSRAvailabilityAnalysis);
         
         if (FTL::canCompile(dfg) == FTL::CannotCompile) {


### PR DESCRIPTION
#### 3af657fdb0401840e45d495b73ecf570f4c93401
<pre>
[JSC] CFA should clear abstract values first before reconstruction
<a href="https://bugs.webkit.org/show_bug.cgi?id=257044">https://bugs.webkit.org/show_bug.cgi?id=257044</a>
rdar://109576467

Reviewed by Yusuke Suzuki.

Graph::packNodeIndices updates DFG nodes&apos; indexes after packing,
which is usually performed in LivenessAnalysis phase. Since node
index is used for associating its abstract value, we usually need
to perform CFA subsequently to reconstruct abstract values for DFG graph.

However, the current implementation for CFA to reconstruct abstract
values is to reset their content according the new speculation without
cleaning first. This will bring us a problem that for some DFG nodes
e.g., EnumeratorNextUpdateIndexAndMode which shouldn&apos;t have speculation
type but might be updated with new node indexes after Graph::packNodeIndices.
With those updated node indexes, those DFG nodes might associate to typed
abstract values which is wrong. In this case, even CFA is performed subsequently,
those abstract values are still typed.

This patch fixes this issue by:
1. Clear abstract values after packing graph in debug build.
2. Do perform CFA in AI validation.
3. Clear abstract value for EnumeratorNextUpdateIndexAndMode in AI.

* JSTests/stress/regress-109263765.js: Added.
(foo):
* Source/JavaScriptCore/dfg/DFGAbstractInterpreterInlines.h:
(JSC::DFG::AbstractInterpreter&lt;AbstractStateType&gt;::executeEffects):
* Source/JavaScriptCore/dfg/DFGArgumentsEliminationPhase.cpp:
* Source/JavaScriptCore/dfg/DFGAtTailAbstractState.cpp:
(JSC::DFG::AtTailAbstractState::createOrClearValueForNode):
(JSC::DFG::AtTailAbstractState::createValueForNode): Deleted.
* Source/JavaScriptCore/dfg/DFGAtTailAbstractState.h:
* Source/JavaScriptCore/dfg/DFGCFAPhase.cpp:
(JSC::DFG::CFAPhase::run):
* Source/JavaScriptCore/dfg/DFGInPlaceAbstractState.h:
(JSC::DFG::InPlaceAbstractState::createOrClearValueForNode):
(JSC::DFG::InPlaceAbstractState::createValueForNode): Deleted.
* Source/JavaScriptCore/dfg/DFGLivenessAnalysisPhase.cpp:
(JSC::DFG::performGraphPackingAndLivenessAnalysis):
(JSC::DFG::performLivenessAnalysis): Deleted.
* Source/JavaScriptCore/dfg/DFGLivenessAnalysisPhase.h:
* Source/JavaScriptCore/dfg/DFGObjectAllocationSinkingPhase.cpp:
* Source/JavaScriptCore/dfg/DFGPlan.cpp:
(JSC::DFG::Plan::compileInThreadImpl):
* Source/JavaScriptCore/ftl/FTLLowerDFGToB3.cpp:
(JSC::FTL::DFG::LowerDFGToB3::LowerDFGToB3):
(JSC::FTL::DFG::LowerDFGToB3::compileNode):

Canonical link: <a href="https://commits.webkit.org/264281@main">https://commits.webkit.org/264281@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0a3f845fb314de3f53e95aeeb5fdb04435918431

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/7268 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/7519 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/7695 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/8889 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/32/builds/7475 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/8853 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/7446 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/10371 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/7395 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/8090 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/6684 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/8998 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/5433 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/6614 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/14340 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/6164 "Built successfully and passed tests") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/7059 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/6717 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/9598 "Passed tests") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/6851 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/7200 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/5888 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/7409 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/6557 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/1708 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/1715 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/10758 "Built successfully") | | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/24/builds/7612 "Built successfully") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/6939 "Built successfully") | | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/3/builds/1848 "Passed tests") | 
<!--EWS-Status-Bubble-End-->