### PR TITLE
Web content process crashes when mutating grid-template-columns of subgrid parent grid.

### DIFF
--- a/LayoutTests/fast/css-grid-layout/GridtrackSizing-overflowon-mutating-grid-columns-expected.txt
+++ b/LayoutTests/fast/css-grid-layout/GridtrackSizing-overflowon-mutating-grid-columns-expected.txt
@@ -1,0 +1,2 @@
+Label
+Value

--- a/LayoutTests/fast/css-grid-layout/GridtrackSizing-overflowon-mutating-grid-columns.html
+++ b/LayoutTests/fast/css-grid-layout/GridtrackSizing-overflowon-mutating-grid-columns.html
@@ -1,0 +1,49 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <title>CSS subgrid page crash</title>
+    <style type="text/css">
+
+        div.grid {
+            display: grid;
+            grid-template-columns: 100px 100px;
+        }
+
+        div.subgrid {
+            display: grid;
+            grid-template-columns: subgrid;
+            grid-column-start: 1;
+            grid-column-end: -1; /* -1 seems relevant; it works with `grid-column-end: 3` */
+        }
+
+        div.label {
+            grid-column: 1;
+        }
+
+        div.value {
+            grid-column: 2;
+        }
+
+    </style>
+</head>
+<body>
+    <div class="grid" id="root-div">
+        <div class="subgrid">
+            <div class="label">Label</div>
+            <div class="value">Value</div>
+        </div>
+    </div>
+</body>
+<script>
+onload = () => {
+  setTimeout(test, 1000);
+  if (window.testRunner)
+      testRunner.dumpAsText();
+
+  };
+function test() {
+  const grid = document.getElementById('root-div');
+  grid.style.gridTemplateColumns = '100px';
+}
+</script>
+</html>

--- a/Source/WebCore/rendering/RenderGrid.cpp
+++ b/Source/WebCore/rendering/RenderGrid.cpp
@@ -925,8 +925,14 @@ void RenderGrid::placeItemsOnGrid(std::optional<LayoutUnit> availableLogicalWidt
     unsigned autoRepeatRows = computeAutoRepeatTracksCount(ForRows, availableLogicalHeightForPercentageComputation());
     autoRepeatRows = clampAutoRepeatTracks(ForRows, autoRepeatRows);
     autoRepeatColumns = clampAutoRepeatTracks(ForColumns, autoRepeatColumns);
-
-    if (autoRepeatColumns != currentGrid().autoRepeatTracks(ForColumns) 
+    
+    if (isSubgridInParentDirection(ForColumns) || isSubgridInParentDirection(ForRows)) {
+        auto* parent = dynamicDowncast<RenderGrid>(this->parent());
+        if (parent && parent->currentGrid().needsItemsPlacement())
+            currentGrid().setNeedsItemsPlacement(true);
+    }
+    
+    if (autoRepeatColumns != currentGrid().autoRepeatTracks(ForColumns)
         || autoRepeatRows != currentGrid().autoRepeatTracks(ForRows)
         || isMasonry()) {
         currentGrid().setNeedsItemsPlacement(true);


### PR DESCRIPTION
#### e357a6a2cd384f7aa70e6aa4f2e552829e971b3c
<pre>
Web content process crashes when mutating grid-template-columns of subgrid parent grid.
<a href="https://bugs.webkit.org/show_bug.cgi?id=253916.">https://bugs.webkit.org/show_bug.cgi?id=253916.</a>
rdar://106458581.

Reviewed by Matt Woodrow.

After grid-template-column of the subgrid&apos;s parent grid mutates, needsItemsPlacement flag is not set for the subgrid&apos;s currentgrid. As a result, gridTracks for subgrids-&gt;curretGrid() don&apos;t undergo resizing, resulting in a OOB in copyUsedTrackSizesForSubgrid().This changes sets needsItemPlacement flag as needed.

* LayoutTests/fast/css-grid-layout/GridtrackSizing-overflowon-mutating-grid-columns-expected.txt: Added.
* LayoutTests/fast/css-grid-layout/GridtrackSizing-overflowon-mutating-grid-columns.html: Added.
* Source/WebCore/rendering/RenderGrid.cpp:
(WebCore::RenderGrid::placeItemsOnGrid):

Originally-landed-as: 259548.434@safari-7615-branch (54a21b4db4fa). rdar://106458581
Canonical link: <a href="https://commits.webkit.org/264346@main">https://commits.webkit.org/264346@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/68132b13c23af8c9ad7f450332435b70c7731cbb

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/7234 "2 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/7482 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/7658 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/8854 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/7446 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/7242 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/8815 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/7412 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/10345 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/7361 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/8062 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/6661 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/8960 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/5402 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/6581 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/14315 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/7037 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/6684 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/9560 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/7166 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/5858 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/6525 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/6490 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/10725 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/875 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/6906 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->