### PR TITLE
Add crash test for bad update of fixed position scrolling node

### DIFF
--- a/LayoutTests/fast/scrolling/fixed-positioned-element-update-crash-expected.txt
+++ b/LayoutTests/fast/scrolling/fixed-positioned-element-update-crash-expected.txt
@@ -1,0 +1,1 @@
+PASS if no crashes.

--- a/LayoutTests/fast/scrolling/fixed-positioned-element-update-crash.html
+++ b/LayoutTests/fast/scrolling/fixed-positioned-element-update-crash.html
@@ -1,0 +1,42 @@
+<!DOCTYPE html>
+ <style>
+ #container {
+   display: inline-block;
+   height: 100px;
+ }
+ #sticky {
+   position: sticky;
+   writing-mode: tb;
+   overflow-x: overlay;
+ }
+ #fixed {
+   position: fixed;
+   display: inline-block;
+ }
+ </style>
+ <div id="container">
+   <span>
+     <div id="sticky"></div>
+   </span>
+ </div>
+ <div id="fixed"></div>
+ <custom style="transform: scale(2)" id="custom"></foo>
+ <script>
+   if (window.testRunner) {
+     testRunner.waitUntilDone();
+     testRunner.dumpAsText();
+   }
+   onload = () => {
+     requestAnimationFrame(() => {
+       custom.style.setProperty("-webkit-mask-box-image", "url(about:blank)");
+       requestAnimationFrame(() => {
+         custom.style.width = "5px";
+         requestAnimationFrame(() => {
+           document.body.innerHTML = "PASS if no crashes.";
+           if (window.testRunner)
+             testRunner.notifyDone();
+         });
+       });
+     });
+   };
+ </script>


### PR DESCRIPTION
#### 7f75e69d34965ffeb9c91e9dae5f3e79e460eeba
<pre>
Add crash test for bad update of fixed position scrolling node
<a href="https://bugs.webkit.org/show_bug.cgi?id=245389">https://bugs.webkit.org/show_bug.cgi?id=245389</a>
rdar://99637052

Reviewed by Simon Fraser.

This was already fixed with #255114, but add the test for completeness.

* LayoutTests/fast/scrolling/fixed-positioned-element-update-crash-expected.txt: Added.
* LayoutTests/fast/scrolling/fixed-positioned-element-update-crash.html: Added.

Originally-landed-as: 260286.10@webkit-2023.2-embargoed (010528ca060e). <a href="https://bugs.webkit.org/show_bug.cgi?id=245389">https://bugs.webkit.org/show_bug.cgi?id=245389</a>
Canonical link: <a href="https://commits.webkit.org/264349@main">https://commits.webkit.org/264349@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d04b9ecc6972188dfb370af9ea7837d94b5d96e3

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/7235 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/7483 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/7659 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/8855 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/7447 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/8816 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/7413 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/10349 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/7362 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/8064 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/6663 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/8961 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/5408 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/6583 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/14316 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/7042 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/6686 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/9561 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/7167 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/5855 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/6526 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/6492 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/10726 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/878 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/6907 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->