### PR TITLE
Take legend element into account in propagateRepaintToParentWithOutlineAutoIfNeeded

### DIFF
--- a/LayoutTests/fast/multicol/legend-in-column-outline-auto-crash-expected.txt
+++ b/LayoutTests/fast/multicol/legend-in-column-outline-auto-crash-expected.txt
@@ -1,0 +1,1 @@
+Test passes if there is no crash.

--- a/LayoutTests/fast/multicol/legend-in-column-outline-auto-crash.html
+++ b/LayoutTests/fast/multicol/legend-in-column-outline-auto-crash.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<script>
+if (window.testRunner) {
+    testRunner.dumpAsText();
+    testRunner.waitUntilDone();
+}
+function runTest() {
+  document.defaultView.find("foo");
+  setTimeout(() => { document.write("Test passes if there is no crash."); testRunner.notifyDone(); }, 0);
+}
+</script>
+<body onload=runTest()>
+<div contenteditable="plaintext-only">
+  <fieldset style="column-width: 0px">
+    <legend>foo</legend>
+  </fieldset>
+</div>

--- a/Source/WebCore/rendering/RenderObject.cpp
+++ b/Source/WebCore/rendering/RenderObject.cpp
@@ -918,7 +918,7 @@ void RenderObject::propagateRepaintToParentWithOutlineAutoIfNeeded(const RenderL
     // Issue repaint on the renderer with outline: auto.
     for (const auto* renderer = this; renderer; renderer = renderer->parent()) {
         const auto* originalRenderer = renderer;
-        if (is<RenderMultiColumnSet>(renderer->previousSibling())) {
+        if (is<RenderMultiColumnSet>(renderer->previousSibling()) && !renderer->isLegend()) {
             auto previousMultiColumnSet = downcast<RenderMultiColumnSet>(renderer->previousSibling());
             auto enclosingMultiColumnFlow = previousMultiColumnSet->multiColumnFlow();
             auto& previousMultiColumnSetBox = downcast<RenderBox>(*renderer);


### PR DESCRIPTION
#### 576fb607ea63b0a91732c80950c4170dc34ac639
<pre>
Take legend element into account in propagateRepaintToParentWithOutlineAutoIfNeeded
<a href="https://bugs.webkit.org/show_bug.cgi?id=251381">https://bugs.webkit.org/show_bug.cgi?id=251381</a>
rdar://104813886

Reviewed by Alan Baradlay.

In change r259412 logic was introduced for spanner placeholders and a check was done
to see if the previous sibling renderer is a column set. However legends are kept out of
column flows and thus may also have a column set as previous sibling, in this case we
don&apos;t want to enter the spanner placeholder logic.

* LayoutTests/fast/multicol/legend-in-column-outline-auto-crash-expected.txt: Added.
* LayoutTests/fast/multicol/legend-in-column-outline-auto-crash.html: Added.
* Source/WebCore/rendering/RenderObject.cpp:
(WebCore::RenderObject::propagateRepaintToParentWithOutlineAutoIfNeeded const):

Originally-landed-as: 260286.11@webkit-2023.2-embargoed (e7b0459eaad2). rdar://104813886
Canonical link: <a href="https://commits.webkit.org/264350@main">https://commits.webkit.org/264350@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/592e8df44d81b8f07b846b7247e4b405dd3c49fb

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/7236 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/7484 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/7660 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/8856 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/7448 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/7244 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/8817 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/7414 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/10348 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/7363 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/8063 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/6665 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/8962 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/5404 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/6585 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/14319 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/7039 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/6688 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/9564 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/7168 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/5856 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/6527 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/6494 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/10727 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/879 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/6908 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->