### PR TITLE
Add test for display contents on focus change

### DIFF
--- a/LayoutTests/fast/css/content/display-contents-on-focus-crash-expected.txt
+++ b/LayoutTests/fast/css/content/display-contents-on-focus-crash-expected.txt
@@ -1,0 +1,2 @@
+
+This test passes if it doesn't crash.

--- a/LayoutTests/fast/css/content/display-contents-on-focus-crash.html
+++ b/LayoutTests/fast/css/content/display-contents-on-focus-crash.html
@@ -1,0 +1,24 @@
+<style>
+dfn:focus-within { display: contents }
+html { mask-image: url(about:)}
+</style>
+
+<script>
+if (window.testRunner)
+  testRunner.dumpAsText();
+
+function main() {
+  input.setCustomValidity("foo");
+  input.reportValidity();
+}
+</script>
+
+</style>
+<body onload="main()">
+  <dfn>
+    <textarea autofocus>
+    </textarea>
+  </dfn>
+  <input id="input">
+  <p>This test passes if it doesn't crash.</p>
+</body>


### PR DESCRIPTION
#### 3c98a1beca342adf46e228d27278c9102d08e580
<pre>
Add test for display contents on focus change
<a href="https://bugs.webkit.org/show_bug.cgi?id=251380">https://bugs.webkit.org/show_bug.cgi?id=251380</a>
rdar://104813991

Reviewed by Antti Koivisto.

Already fixed by #248776, but add this test for
completeness.

* LayoutTests/fast/css/content/display-contents-on-focus-crash-expected.txt: Added.
* LayoutTests/fast/css/content/display-contents-on-focus-crash.html: Added.

Originally-landed-as: 260286.12@webkit-2023.2-embargoed (042db6f5677e). <a href="https://bugs.webkit.org/show_bug.cgi?id=251380">https://bugs.webkit.org/show_bug.cgi?id=251380</a>
Canonical link: <a href="https://commits.webkit.org/264351@main">https://commits.webkit.org/264351@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/923353c3d1b42cf3b2c8e63bccce9d8cf157ce29

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/7237 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/7485 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/7661 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/8857 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/7449 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/8818 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/7415 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/10346 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/7364 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/8066 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/6664 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/8963 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/5410 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/6584 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/14324 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/7045 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/6687 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/9573 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/7169 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/5859 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/6528 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/6493 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/10728 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/880 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/6909 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->