### PR TITLE
OSS: [WebRTC] Heap-buffer-overflow in av1_get_one_pass_rt_params - Heap Buffer Overflow in AV1 Video Encoder

### DIFF
--- a/Source/ThirdParty/libwebrtc/Source/third_party/libaom/source/libaom/av1/encoder/ratectrl.h
+++ b/Source/ThirdParty/libwebrtc/Source/third_party/libaom/source/libaom/av1/encoder/ratectrl.h
@@ -253,6 +253,9 @@ typedef struct {
   int frame_level_fast_extra_bits;
 
   double frame_level_rate_correction_factors[RATE_FACTOR_LEVELS];
+
+  int prev_coded_width;
+  int prev_coded_height;
   /*!\endcond */
 } RATE_CONTROL;
 


### PR DESCRIPTION
#### 1b5e5ce3caa031758574aa68e9c118e269b5a122
<pre>
OSS: [WebRTC] Heap-buffer-overflow in av1_get_one_pass_rt_params - Heap Buffer Overflow in AV1 Video Encoder
rdar://106645234

Reviewed by Eric Carlson.

Cherry-picking of <a href="https://aomedia.googlesource.com/aom/+/bee1caded272127a6d6b70ac79479083d183d5d0%5E%21/#F0.">https://aomedia.googlesource.com/aom/+/bee1caded272127a6d6b70ac79479083d183d5d0%5E%21/#F0.</a>
I had to manually apply the patch since it does not apply cleanly.

* Source/ThirdParty/libwebrtc/Source/third_party/libaom/source/libaom/av1/encoder/ratectrl.c:
(av1_rc_postencode_update):
(av1_rc_postencode_update_drop_frame):
(av1_get_one_pass_rt_params):
* Source/ThirdParty/libwebrtc/Source/third_party/libaom/source/libaom/av1/encoder/ratectrl.h:

Originally-landed-as: 259548.439@safari-7615-branch (4a5ecd489674). rdar://106645234
Canonical link: <a href="https://commits.webkit.org/264347@main">https://commits.webkit.org/264347@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f824bc64e22f1b57cb9b1dbfb274511c60589c83

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/7239 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/7487 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/7663 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/8859 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/7450 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/8820 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/7416 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/10347 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/7366 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/8052 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/6667 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/8964 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/5403 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/6588 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/14317 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/7038 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/6691 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/9562 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/7171 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/5860 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/6529 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/10729 "Built successfully") | | | 
| [❌ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/876 "Failed to push commit to Webkit repository") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/6910 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->