### PR TITLE
Adapt OOF with specified height case in availableLogicalHeightForPercentageComputation

### DIFF
--- a/LayoutTests/fast/css-grid-layout/positioned-grid-with-large-inset-and-scrollbar-expected.txt
+++ b/LayoutTests/fast/css-grid-layout/positioned-grid-with-large-inset-and-scrollbar-expected.txt
@@ -1,0 +1,1 @@
+PASS if no crash.

--- a/LayoutTests/fast/css-grid-layout/positioned-grid-with-large-inset-and-scrollbar.html
+++ b/LayoutTests/fast/css-grid-layout/positioned-grid-with-large-inset-and-scrollbar.html
@@ -1,0 +1,16 @@
+<style>
+div {
+  top: 2000px;
+  bottom: 0px;
+  display: grid;
+  position: absolute;
+  overflow: scroll;
+  grid: repeat(auto-fill, 15px) / auto;
+}
+</style>
+<div></div>
+<script>
+  if (window.testRunner)
+    testRunner.dumpAsText();
+</script>
+PASS if no crash.

--- a/Source/WebCore/rendering/RenderBlock.cpp
+++ b/Source/WebCore/rendering/RenderBlock.cpp
@@ -3245,7 +3245,7 @@ std::optional<LayoutUnit> RenderBlock::availableLogicalHeightForPercentageComput
         // Don't allow this to affect the block' size() member variable, since this
         // can get called while the block is still laying out its kids.
         LogicalExtentComputedValues computedValues = computeLogicalHeight(logicalHeight(), 0_lu);
-        availableHeight = computedValues.m_extent - borderAndPaddingLogicalHeight() - scrollbarLogicalHeight();
+        availableHeight = std::max(0_lu, computedValues.m_extent - borderAndPaddingLogicalHeight() - scrollbarLogicalHeight());
     } else if (styleToUse.logicalHeight().isPercentOrCalculated()) {
         std::optional<LayoutUnit> heightWithScrollbar = computePercentageLogicalHeight(styleToUse.logicalHeight());
         if (heightWithScrollbar) {


### PR DESCRIPTION
#### 89b88fd5da18c2017a4261858c4750c6487c4926
<pre>
Adapt OOF with specified height case in availableLogicalHeightForPercentageComputation
<a href="https://bugs.webkit.org/show_bug.cgi?id=253037">https://bugs.webkit.org/show_bug.cgi?id=253037</a>
rdar://105938634

Reviewed by Alan Baradlay.

The computed height for OOF can result in being zero for certain insets (but never negative).
In that case subtracting scrollbar sizes could result in negative values like in the test case, so
clamp to zero.

* LayoutTests/fast/css-grid-layout/positioned-grid-with-large-inset-and-scrollbar-expected.txt: Added.
* LayoutTests/fast/css-grid-layout/positioned-grid-with-large-inset-and-scrollbar.html: Added.
* Source/WebCore/rendering/RenderBlock.cpp:
(WebCore::RenderBlock::availableLogicalHeightForPercentageComputation const):

Originally-landed-as: 260286.13@webkit-2023.2-embargoed (0a7c35b68439). <a href="https://bugs.webkit.org/show_bug.cgi?id=253037">https://bugs.webkit.org/show_bug.cgi?id=253037</a>
Canonical link: <a href="https://commits.webkit.org/264352@main">https://commits.webkit.org/264352@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/dfd4a6a9c6b6433ac0df080c136058374e449ae8

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/7245 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/7493 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/7669 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/8865 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/7455 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/7253 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/8826 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/7422 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/10352 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/7372 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/8065 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/6666 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/8971 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/5409 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/6586 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/14322 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/7043 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/6689 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/9568 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/7177 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/5864 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/6535 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/6495 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/10735 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/881 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/6915 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->