### PR TITLE
Improve isInsideMulticolumnFlow lambda for top-layer elements

### DIFF
--- a/LayoutTests/fast/multicol/crash-when-constructing-nested-columns2-expected.txt
+++ b/LayoutTests/fast/multicol/crash-when-constructing-nested-columns2-expected.txt
@@ -1,0 +1,2 @@
+PASS if no crash.
+

--- a/LayoutTests/fast/multicol/crash-when-constructing-nested-columns2.html
+++ b/LayoutTests/fast/multicol/crash-when-constructing-nested-columns2.html
@@ -1,0 +1,17 @@
+<style>
+dialog { -webkit-mask-box-image-source: url(about:url); }
+div { column-span: all; }
+html { overflow: -webkit-paged-x; -webkit-perspective: 0vw; }
+</style>
+<script>
+if (window.testRunner)
+  testRunner.dumpAsText();
+function runTest() {
+  dialog.appendChild(document.createElement("div"));
+  target.style.setProperty("overflow-wrap", "break-word");
+  target.style.setProperty("-webkit-column-width", "1px");
+}
+</script>
+<body id="target" onload=runTest()>
+  <dialog id="dialog" open="true">PASS if no crash.</dialog>
+</body>

--- a/Source/WebCore/rendering/RenderObject.cpp
+++ b/Source/WebCore/rendering/RenderObject.cpp
@@ -224,7 +224,7 @@ bool RenderObject::isBlockContainer() const
         || display == DisplayType::TableCaption) && !isRenderReplaced();
 }
 
-void RenderObject::setFragmentedFlowStateIncludingDescendants(FragmentedFlowState state, const RenderElement* fragmentedFlowRoot, SkipDescendentFragmentedFlow skipDescendentFragmentedFlow)
+void RenderObject::setFragmentedFlowStateIncludingDescendants(FragmentedFlowState state, SkipDescendentFragmentedFlow skipDescendentFragmentedFlow)
 {
     setFragmentedFlowState(state);
 
@@ -235,7 +235,7 @@ void RenderObject::setFragmentedFlowStateIncludingDescendants(FragmentedFlowStat
         // If the child is a fragmentation context it already updated the descendants flag accordingly.
         if (child.isRenderFragmentedFlow() && skipDescendentFragmentedFlow == SkipDescendentFragmentedFlow::Yes)
             continue;
-        if (fragmentedFlowRoot && child.isOutOfFlowPositioned()) {
+        if (child.isOutOfFlowPositioned()) {
             // Fragmented status propagation stops at out-of-flow boundary.
             auto isInsideMulticolumnFlow = [&] {
                 auto* containingBlock = child.containingBlock();
@@ -243,14 +243,13 @@ void RenderObject::setFragmentedFlowStateIncludingDescendants(FragmentedFlowStat
                     ASSERT_NOT_REACHED();
                     return false;
                 }
-                // It's ok to only check the first level containing block (as opposed to the containing block chain) as setFragmentedFlowStateIncludingDescendants is top to down.
-                return containingBlock->isDescendantOf(fragmentedFlowRoot);
+                return containingBlock->fragmentedFlowState() == InsideInFragmentedFlow;
             };
             if (!isInsideMulticolumnFlow())
                 continue;
         }
         ASSERT(skipDescendentFragmentedFlow == SkipDescendentFragmentedFlow::No || state != child.fragmentedFlowState());
-        child.setFragmentedFlowStateIncludingDescendants(state, fragmentedFlowRoot, skipDescendentFragmentedFlow);
+        child.setFragmentedFlowStateIncludingDescendants(state, skipDescendentFragmentedFlow);
     }
 }
 
@@ -292,8 +291,7 @@ void RenderObject::initializeFragmentedFlowStateOnInsertion()
     if (fragmentedFlowState() == computedState)
         return;
 
-    auto* enclosingFragmentedFlow = locateEnclosingFragmentedFlow();
-    setFragmentedFlowStateIncludingDescendants(computedState, enclosingFragmentedFlow ? enclosingFragmentedFlow->parent() : nullptr, SkipDescendentFragmentedFlow::No);
+    setFragmentedFlowStateIncludingDescendants(computedState, SkipDescendentFragmentedFlow::No);
 }
 
 void RenderObject::resetFragmentedFlowStateOnRemoval()
@@ -310,8 +308,7 @@ void RenderObject::resetFragmentedFlowStateOnRemoval()
     if (isRenderFragmentedFlow())
         return;
 
-    auto* enclosingFragmentedFlow = this->enclosingFragmentedFlow();
-    setFragmentedFlowStateIncludingDescendants(NotInsideFragmentedFlow, enclosingFragmentedFlow ? enclosingFragmentedFlow->parent() : nullptr);
+    setFragmentedFlowStateIncludingDescendants(NotInsideFragmentedFlow);
 }
 
 void RenderObject::setParent(RenderElement* parent)

--- a/Source/WebCore/rendering/RenderObject.h
+++ b/Source/WebCore/rendering/RenderObject.h
@@ -298,7 +298,7 @@ public:
     };
 
     enum class SkipDescendentFragmentedFlow { No, Yes };
-    void setFragmentedFlowStateIncludingDescendants(FragmentedFlowState, const RenderElement* fragmentedFlowRoot, SkipDescendentFragmentedFlow = SkipDescendentFragmentedFlow::Yes);
+    void setFragmentedFlowStateIncludingDescendants(FragmentedFlowState, SkipDescendentFragmentedFlow = SkipDescendentFragmentedFlow::Yes);
 
     FragmentedFlowState fragmentedFlowState() const { return m_bitfields.fragmentedFlowState(); }
     void setFragmentedFlowState(FragmentedFlowState state) { m_bitfields.setFragmentedFlowState(state); }

--- a/Source/WebCore/rendering/updating/RenderTreeBuilderMultiColumn.cpp
+++ b/Source/WebCore/rendering/updating/RenderTreeBuilderMultiColumn.cpp
@@ -34,6 +34,7 @@
 #include "RenderTreeBuilder.h"
 #include "RenderTreeBuilderBlock.h"
 #include "RenderView.h"
+#include <wtf/SetForScope.h>
 
 namespace WebCore {
 
@@ -178,6 +179,8 @@ void RenderTreeBuilder::MultiColumn::createFragmentedFlow(RenderBlockFlow& flow)
     flow.setMultiColumnFlow(fragmentedFlow);
 }
 
+static bool gRestoringColumnSpannersForContainer = false;
+
 void RenderTreeBuilder::MultiColumn::restoreColumnSpannersForContainer(const RenderElement& container, RenderMultiColumnFlow& multiColumnFlow)
 {
     auto& spanners = multiColumnFlow.spannerMap();
@@ -198,6 +201,7 @@ void RenderTreeBuilder::MultiColumn::restoreColumnSpannersForContainer(const Ren
         auto& spannerOriginalParent = *placeholder->parent();
         // Detaching the spanner takes care of removing the placeholder (and merges the RenderMultiColumnSets).
         auto spannerToReInsert = m_builder.detach(*spanner->parent(), *spanner);
+        auto restoreColumnSpannersScope = SetForScope { gRestoringColumnSpannersForContainer, true };
         m_builder.attach(spannerOriginalParent, WTFMove(spannerToReInsert));
     }
 }
@@ -279,7 +283,7 @@ static bool gShiftingSpanner = false;
 
 void RenderTreeBuilder::MultiColumn::multiColumnDescendantInserted(RenderMultiColumnFlow& flow, RenderObject& newDescendant)
 {
-    if (gShiftingSpanner || newDescendant.isRenderFragmentedFlow())
+    if (gShiftingSpanner || gRestoringColumnSpannersForContainer || newDescendant.isRenderFragmentedFlow())
         return;
 
     auto* subtreeRoot = &newDescendant;
@@ -342,9 +346,8 @@ RenderObject* RenderTreeBuilder::MultiColumn::processPossibleSpannerDescendant(R
         auto takenDescendant = m_builder.detach(*container, descendant);
 
         // This is a guard to stop an ancestor flow thread from processing the spanner.
-        gShiftingSpanner = true;
+        auto shiftingSpannerScope = SetForScope { gShiftingSpanner, true };
         m_builder.blockBuilder().attach(*multicolContainer, WTFMove(takenDescendant), insertBeforeMulticolChild);
-        gShiftingSpanner = false;
 
         // The spanner has now been moved out from the flow thread, but we don't want to
         // examine its children anyway. They are all part of the spanner and shouldn't trigger


### PR DESCRIPTION
#### 18b93e6b5e09f167e09d9ac7770996e3760e2cb5
<pre>
Improve isInsideMulticolumnFlow lambda for top-layer elements
<a href="https://bugs.webkit.org/show_bug.cgi?id=245374">https://bugs.webkit.org/show_bug.cgi?id=245374</a>
rdar://98438399

Reviewed by Alan Baradlay.

Improve isInsideMulticolumnFlow lambda for top-layer elements.
Top-layer elements can skip many ancestors since the containing
block is the RenderView. So instead of checking the fragmentedFlowRoot
boundary, check the containing block fragmented flow state.

* Source/WebCore/rendering/RenderObject.cpp:
(WebCore::RenderObject::setFragmentedFlowStateIncludingDescendants):
(WebCore::RenderObject::initializeFragmentedFlowStateOnInsertion):
(WebCore::RenderObject::resetFragmentedFlowStateOnRemoval):
* Source/WebCore/rendering/RenderObject.h:

Originally-landed-as: 260286.14@webkit-2023.2-embargoed (0888aabefd69). <a href="https://bugs.webkit.org/show_bug.cgi?id=245374">https://bugs.webkit.org/show_bug.cgi?id=245374</a>
Canonical link: <a href="https://commits.webkit.org/264362@main">https://commits.webkit.org/264362@main</a>
</pre>
----------------------------------------------------------------------
#### c3bc98d2edafe692e7aa90fa8d6c188e4c7b0168
<pre>
Fix spanner reset logic
<a href="https://bugs.webkit.org/show_bug.cgi?id=245374">https://bugs.webkit.org/show_bug.cgi?id=245374</a>
rdar://98438399

Reviewed by Alan Baradlay.

In restoreColumnSpannersForContainer we want to reset the spanners to their original position
and remove the placeholders, however in some cases the attach step will call multiColumnDescendantInserted
and re-insert placeholders. To fix this, prevent calling the spanner processing logic by
multiColumnDescendantInserted by introducing a new flag gRestoringColumnSpannersForContainer.

* LayoutTests/fast/multicol/crash-when-constructing-nested-columns2-expected.txt: Added.
* LayoutTests/fast/multicol/crash-when-constructing-nested-columns2.html: Added.
* Source/WebCore/rendering/updating/RenderTreeBuilderMultiColumn.cpp:
(WebCore::RenderTreeBuilder::MultiColumn::restoreColumnSpannersForContainer):
(WebCore::RenderTreeBuilder::MultiColumn::multiColumnDescendantInserted):
(WebCore::RenderTreeBuilder::MultiColumn::processPossibleSpannerDescendant):

Originally-landed-as: 260286.15@webkit-2023.2-embargoed (028f984310b6). <a href="https://bugs.webkit.org/show_bug.cgi?id=245374">https://bugs.webkit.org/show_bug.cgi?id=245374</a>
Canonical link: <a href="https://commits.webkit.org/264361@main">https://commits.webkit.org/264361@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f699a45fd58dc52f3d1a9f54cdda9bbb03227904

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/7267 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/7518 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/7694 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/8888 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/7474 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/7275 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/8852 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/7445 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/10369 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/7394 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/8092 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/6685 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/8997 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/5435 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/6615 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/14342 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/7061 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/6718 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/9600 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/7199 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/5880 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/6556 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/6525 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/10757 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/888 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/6938 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->