### PR TITLE
[WebGPU] Give BindGroupLayouts a notion of external textures (like BindGroups have)

### DIFF
--- a/Source/WebCore/Modules/WebGPU/GPUExternalTextureBindingLayout.idl
+++ b/Source/WebCore/Modules/WebGPU/GPUExternalTextureBindingLayout.idl
@@ -23,8 +23,6 @@
  * THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-// https://gpuweb.github.io/gpuweb/#gpupipelinelayout
-
 // https://gpuweb.github.io/gpuweb/#dictdef-gpuexternaltexturebindinglayout
 
 [

--- a/Source/WebCore/html/canvas/GPUCanvasContextCocoa.mm
+++ b/Source/WebCore/html/canvas/GPUCanvasContextCocoa.mm
@@ -183,6 +183,7 @@ void GPUCanvasContextCocoa::configure(GPUCanvasConfiguration&& configuration)
         return;
 
     auto renderBuffers = m_compositorIntegration->recreateRenderBuffers(m_width, m_height);
+    // FIXME: This ASSERT() is wrong. It's totally possible for the IPC to the GPU process to timeout if the GPUP is busy, and return nothing here.
     ASSERT(!renderBuffers.isEmpty());
 
     m_presentationContext->configure(configuration);

--- a/Source/WebGPU/WGSL/WGSL.h
+++ b/Source/WebGPU/WGSL/WGSL.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021-2022 Apple Inc. All rights reserved.
+ * Copyright (c) 2021-2023 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -141,7 +141,8 @@ enum class ShaderStage : uint8_t {
 struct BindGroupLayoutEntry {
     uint32_t binding;
     OptionSet<ShaderStage> visibility;
-    std::variant<BufferBindingLayout, SamplerBindingLayout, TextureBindingLayout, StorageTextureBindingLayout, ExternalTextureBindingLayout> bindingMember;
+    using BindingMember = std::variant<BufferBindingLayout, SamplerBindingLayout, TextureBindingLayout, StorageTextureBindingLayout, ExternalTextureBindingLayout>;
+    BindingMember bindingMember;
 };
 
 struct BindGroupLayout {

--- a/Source/WebGPU/WebGPU/BindGroupLayout.h
+++ b/Source/WebGPU/WebGPU/BindGroupLayout.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021-2022 Apple Inc. All rights reserved.
+ * Copyright (c) 2021-2023 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -48,7 +48,14 @@ class Device;
 class BindGroupLayout : public WGPUBindGroupLayoutImpl, public RefCounted<BindGroupLayout> {
     WTF_MAKE_FAST_ALLOCATED;
 public:
-    static Ref<BindGroupLayout> create(HashMap<uint32_t, WGPUShaderStageFlags>&& stageMapTable, id<MTLArgumentEncoder> vertexArgumentEncoder, id<MTLArgumentEncoder> fragmentArgumentEncoder, id<MTLArgumentEncoder> computeArgumentEncoder, Vector<WGPUBindGroupLayoutEntry>&& entries)
+    struct Entry {
+        uint32_t binding;
+        WGPUShaderStageFlags visibility;
+        using BindingLayout = std::variant<WGPUBufferBindingLayout, WGPUSamplerBindingLayout, WGPUTextureBindingLayout, WGPUStorageTextureBindingLayout, WGPUExternalTextureBindingLayout>;
+        BindingLayout bindingLayout;
+    };
+
+    static Ref<BindGroupLayout> create(HashMap<uint32_t, WGPUShaderStageFlags>&& stageMapTable, id<MTLArgumentEncoder> vertexArgumentEncoder, id<MTLArgumentEncoder> fragmentArgumentEncoder, id<MTLArgumentEncoder> computeArgumentEncoder, Vector<Entry>&& entries)
     {
         return adoptRef(*new BindGroupLayout(WTFMove(stageMapTable), vertexArgumentEncoder, fragmentArgumentEncoder, computeArgumentEncoder, WTFMove(entries)));
     }
@@ -78,12 +85,13 @@ public:
     static bool isPresent(const WGPUSamplerBindingLayout&);
     static bool isPresent(const WGPUTextureBindingLayout&);
     static bool isPresent(const WGPUStorageTextureBindingLayout&);
+    static bool isPresent(const WGPUExternalTextureBindingLayout&);
 
-    const Vector<WGPUBindGroupLayoutEntry>& entries() const;
+    const Vector<Entry>& entries() const { return m_bindGroupLayoutEntries; }
 
 private:
-    BindGroupLayout(HashMap<uint32_t, WGPUShaderStageFlags>&&, id<MTLArgumentEncoder>, id<MTLArgumentEncoder>, id<MTLArgumentEncoder>, Vector<WGPUBindGroupLayoutEntry>&&);
-    BindGroupLayout();
+    BindGroupLayout(HashMap<uint32_t, WGPUShaderStageFlags>&&, id<MTLArgumentEncoder>, id<MTLArgumentEncoder>, id<MTLArgumentEncoder>, Vector<Entry>&&);
+    explicit BindGroupLayout();
 
     const HashMap<uint32_t, WGPUShaderStageFlags> m_shaderStageForBinding;
 
@@ -91,7 +99,7 @@ private:
     const id<MTLArgumentEncoder> m_fragmentArgumentEncoder { nil };
     const id<MTLArgumentEncoder> m_computeArgumentEncoder { nil };
 
-    const Vector<WGPUBindGroupLayoutEntry> m_bindGroupLayoutEntries;
+    const Vector<Entry> m_bindGroupLayoutEntries;
 };
 
 } // namespace WebGPU

--- a/Source/WebGPU/WebGPU/BindGroupLayout.mm
+++ b/Source/WebGPU/WebGPU/BindGroupLayout.mm
@@ -110,7 +110,6 @@ static MTLArgumentDescriptor *createArgumentDescriptor(const WGPUTextureBindingL
     if (texture.nextInChain)
         return nil;
 
-    UNUSED_PARAM(texture);
     auto descriptor = [MTLArgumentDescriptor new];
     descriptor.dataType = MTLDataTypeTexture;
 #if USE(METAL_ARGUMENT_ACCESS_ENUMS)
@@ -133,10 +132,33 @@ static MTLArgumentDescriptor *createArgumentDescriptor(const WGPUStorageTextureB
     if (storageTexture.nextInChain)
         return nil;
 
-    UNUSED_PARAM(storageTexture);
     auto descriptor = [MTLArgumentDescriptor new];
     descriptor.dataType = MTLDataTypeTexture;
     // FIXME: Implement this.
+    return descriptor;
+}
+
+bool BindGroupLayout::isPresent(const WGPUExternalTextureBindingLayout&)
+{
+    return true;
+}
+
+static MTLArgumentDescriptor *createArgumentDescriptor(const WGPUExternalTextureBindingLayout& externalTexture)
+{
+    if (externalTexture.nextInChain)
+        return nil;
+
+    // FIXME: Implement this properly.
+    // External textures have a bunch of information included in them, not just a single texture.
+    auto descriptor = [MTLArgumentDescriptor new];
+    descriptor.dataType = MTLDataTypeTexture;
+#if USE(METAL_ARGUMENT_ACCESS_ENUMS)
+ALLOW_DEPRECATED_DECLARATIONS_BEGIN
+    descriptor.access = MTLArgumentAccessReadOnly;
+ALLOW_DEPRECATED_DECLARATIONS_END
+#else
+    descriptor.access = MTLBindingAccessReadOnly;
+#endif
     return descriptor;
 }
 
@@ -165,24 +187,47 @@ Ref<BindGroupLayout> Device::createBindGroupLayout(const WGPUBindGroupLayoutDesc
     for (size_t i = 0; i < stageCount; ++i)
         arguments[i] = [NSMutableArray arrayWithCapacity:descriptor.entryCount];
 
-    Vector<WGPUBindGroupLayoutEntry> bindGroupLayoutEntries;
-    bindGroupLayoutEntries.resize(descriptor.entryCount);
+    Vector<BindGroupLayout::Entry> bindGroupLayoutEntries;
+    bindGroupLayoutEntries.reserveInitialCapacity(descriptor.entryCount);
     for (uint32_t i = 0; i < descriptor.entryCount; ++i) {
         const WGPUBindGroupLayoutEntry& entry = descriptor.entries[i];
-        if (entry.nextInChain)
-            return BindGroupLayout::createInvalid(*this);
+        if (entry.nextInChain) {
+            if (entry.nextInChain->sType != static_cast<WGPUSType>(WGPUSTypeExtended_BindGroupLayoutEntryExternalTexture))
+                return BindGroupLayout::createInvalid(*this);
+            if (entry.nextInChain->next)
+                return BindGroupLayout::createInvalid(*this);
+        }
 
         shaderStageForBinding.add(entry.binding + 1, entry.visibility);
         MTLArgumentDescriptor *descriptor = nil;
 
-        if (BindGroupLayout::isPresent(entry.buffer))
-            descriptor = createArgumentDescriptor(entry.buffer);
-        else if (BindGroupLayout::isPresent(entry.sampler))
-            descriptor = createArgumentDescriptor(entry.sampler);
-        else if (BindGroupLayout::isPresent(entry.texture))
-            descriptor = createArgumentDescriptor(entry.texture);
-        else if (BindGroupLayout::isPresent(entry.storageTexture))
-            descriptor = createArgumentDescriptor(entry.storageTexture);
+        BindGroupLayout::Entry::BindingLayout bindingLayout;
+        auto processBindingLayout = [&](const auto& type) {
+            if (!BindGroupLayout::isPresent(type))
+                return true;
+            if (descriptor)
+                return false;
+            descriptor = createArgumentDescriptor(type);
+            if (!descriptor)
+                return false;
+            bindingLayout = type;
+            return true;
+        };
+        if (!processBindingLayout(entry.buffer))
+            return BindGroupLayout::createInvalid(*this);
+        if (!processBindingLayout(entry.sampler))
+            return BindGroupLayout::createInvalid(*this);
+        if (!processBindingLayout(entry.texture))
+            return BindGroupLayout::createInvalid(*this);
+        if (!processBindingLayout(entry.storageTexture))
+            return BindGroupLayout::createInvalid(*this);
+        if (entry.nextInChain) {
+            const WGPUExternalTextureBindGroupLayoutEntry& externalTextureEntry = *reinterpret_cast<const WGPUExternalTextureBindGroupLayoutEntry*>(entry.nextInChain);
+            ASSERT(externalTextureEntry.chain.sType == static_cast<WGPUSType>(WGPUSTypeExtended_BindGroupLayoutEntryExternalTexture));
+            processBindingLayout(entry.storageTexture);
+            if (!processBindingLayout(externalTextureEntry.externalTexture))
+                return BindGroupLayout::createInvalid(*this);
+        }
 
         if (!descriptor)
             return BindGroupLayout::createInvalid(*this);
@@ -192,7 +237,11 @@ Ref<BindGroupLayout> Device::createBindGroupLayout(const WGPUBindGroupLayoutDesc
                 addDescriptor(arguments[stage], descriptor);
         }
 
-        bindGroupLayoutEntries[i] = entry;
+        bindGroupLayoutEntries.uncheckedAppend({
+            entry.binding,
+            entry.visibility,
+            WTFMove(bindingLayout),
+        });
     }
 
     auto label = fromAPI(descriptor.label);
@@ -207,7 +256,7 @@ Ref<BindGroupLayout> Device::createBindGroupLayout(const WGPUBindGroupLayoutDesc
     return BindGroupLayout::create(WTFMove(shaderStageForBinding), argumentEncoders[0], argumentEncoders[1], argumentEncoders[2], WTFMove(bindGroupLayoutEntries));
 }
 
-BindGroupLayout::BindGroupLayout(HashMap<uint32_t, WGPUShaderStageFlags>&& shaderStageForBinding, id<MTLArgumentEncoder> vertexArgumentEncoder, id<MTLArgumentEncoder> fragmentArgumentEncoder, id<MTLArgumentEncoder> computeArgumentEncoder, Vector<WGPUBindGroupLayoutEntry>&& bindGroupLayoutEntries)
+BindGroupLayout::BindGroupLayout(HashMap<uint32_t, WGPUShaderStageFlags>&& shaderStageForBinding, id<MTLArgumentEncoder> vertexArgumentEncoder, id<MTLArgumentEncoder> fragmentArgumentEncoder, id<MTLArgumentEncoder> computeArgumentEncoder, Vector<Entry>&& bindGroupLayoutEntries)
     : m_shaderStageForBinding(WTFMove(shaderStageForBinding))
     , m_vertexArgumentEncoder(vertexArgumentEncoder)
     , m_fragmentArgumentEncoder(fragmentArgumentEncoder)
@@ -216,9 +265,7 @@ BindGroupLayout::BindGroupLayout(HashMap<uint32_t, WGPUShaderStageFlags>&& shade
 {
 }
 
-BindGroupLayout::BindGroupLayout()
-{
-}
+BindGroupLayout::BindGroupLayout() = default;
 
 BindGroupLayout::~BindGroupLayout() = default;
 
@@ -279,11 +326,6 @@ WGPUBindGroupLayoutEntry BindGroupLayout::createEntryFromStructMember(MTLStructM
     return entry;
 }
 #endif // HAVE(METAL_BUFFER_BINDING_REFLECTION)
-
-const Vector<WGPUBindGroupLayoutEntry>& BindGroupLayout::entries() const
-{
-    return m_bindGroupLayoutEntries;
-}
 
 } // namespace WebGPU
 

--- a/Source/WebGPU/WebGPU/Instance.h
+++ b/Source/WebGPU/WebGPU/Instance.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021-2022 Apple Inc. All rights reserved.
+ * Copyright (c) 2021-2023 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -64,7 +64,7 @@ public:
 
 private:
     Instance(WGPUScheduleWorkBlock);
-    Instance();
+    explicit Instance();
 
     // This can be called on a background thread.
     void defaultScheduleWork(WGPUWorkItem&&);

--- a/Source/WebGPU/WebGPU/Pipeline.h
+++ b/Source/WebGPU/WebGPU/Pipeline.h
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2023 Apple Inc. All rights reserved.
+ *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
  * are met:

--- a/Source/WebGPU/WebGPU/PresentationContext.h
+++ b/Source/WebGPU/WebGPU/PresentationContext.h
@@ -68,7 +68,7 @@ public:
     virtual bool isPresentationContextCoreAnimation() const { return false; }
 
 protected:
-    PresentationContext();
+    explicit PresentationContext();
 };
 
 } // namespace WebGPU

--- a/Source/WebGPU/WebGPU/ShaderModule.mm
+++ b/Source/WebGPU/WebGPU/ShaderModule.mm
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021-2022 Apple Inc. All rights reserved.
+ * Copyright (c) 2021-2023 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -326,30 +326,32 @@ static auto wgslViewDimension(WGPUTextureViewDimension viewDimension)
     }
 }
 
-static decltype(WGSL::BindGroupLayoutEntry::bindingMember) populateBindingMember(const WGPUBindGroupLayoutEntry& entry)
+static WGSL::BindGroupLayoutEntry::BindingMember convertBindingLayout(const BindGroupLayout::Entry::BindingLayout& bindingLayout)
 {
-    if (BindGroupLayout::isPresent(entry.buffer)) {
+    return WTF::switchOn(bindingLayout, [](const WGPUBufferBindingLayout& bindingLayout) -> WGSL::BindGroupLayoutEntry::BindingMember {
         return WGSL::BufferBindingLayout {
-            .type = wgslBindingType(entry.buffer.type),
-            .hasDynamicOffset = entry.buffer.hasDynamicOffset,
-            .minBindingSize = entry.buffer.minBindingSize
+            .type = wgslBindingType(bindingLayout.type),
+            .hasDynamicOffset = bindingLayout.hasDynamicOffset,
+            .minBindingSize = bindingLayout.minBindingSize
         };
-    } else if (BindGroupLayout::isPresent(entry.sampler)) {
+    }, [](const WGPUSamplerBindingLayout& bindingLayout) -> WGSL::BindGroupLayoutEntry::BindingMember {
         return WGSL::SamplerBindingLayout {
-            .type = wgslSamplerType(entry.sampler.type)
+            .type = wgslSamplerType(bindingLayout.type)
         };
-    } else if (BindGroupLayout::isPresent(entry.texture)) {
+    }, [](const WGPUTextureBindingLayout& bindingLayout) -> WGSL::BindGroupLayoutEntry::BindingMember {
         return WGSL::TextureBindingLayout {
-            .sampleType = wgslSampleType(entry.texture.sampleType),
-            .viewDimension = wgslViewDimension(entry.texture.viewDimension),
-            .multisampled = entry.texture.multisampled
+            .sampleType = wgslSampleType(bindingLayout.sampleType),
+            .viewDimension = wgslViewDimension(bindingLayout.viewDimension),
+            .multisampled = bindingLayout.multisampled
         };
-    } else {
-        ASSERT(BindGroupLayout::isPresent(entry.storageTexture));
+    }, [](const WGPUStorageTextureBindingLayout& bindingLayout) -> WGSL::BindGroupLayoutEntry::BindingMember {
         return WGSL::StorageTextureBindingLayout {
-            .viewDimension = wgslViewDimension(entry.storageTexture.viewDimension)
+            .viewDimension = wgslViewDimension(bindingLayout.viewDimension)
         };
-    }
+    }, [](const WGPUExternalTextureBindingLayout&) -> WGSL::BindGroupLayoutEntry::BindingMember {
+        return WGSL::ExternalTextureBindingLayout {
+        };
+    });
 }
 
 WGSL::PipelineLayout ShaderModule::convertPipelineLayout(const PipelineLayout& pipelineLayout)
@@ -361,9 +363,9 @@ WGSL::PipelineLayout ShaderModule::convertPipelineLayout(const PipelineLayout& p
         WGSL::BindGroupLayout wgslBindGroupLayout;
         for (auto& entry : bindGroupLayout.entries()) {
             WGSL::BindGroupLayoutEntry wgslEntry;
-            wgslEntry.visibility.fromRaw(entry.visibility);
             wgslEntry.binding = entry.binding;
-            wgslEntry.bindingMember = populateBindingMember(entry);
+            wgslEntry.visibility.fromRaw(entry.visibility);
+            wgslEntry.bindingMember = convertBindingLayout(entry.bindingLayout);
             wgslBindGroupLayout.entries.append(wgslEntry);
         }
 

--- a/Source/WebGPU/WebGPU/WebGPUExt.h
+++ b/Source/WebGPU/WebGPU/WebGPUExt.h
@@ -62,6 +62,7 @@ typedef enum WGPUSTypeExtended {
     WGPUSTypeExtended_InstanceCocoaDescriptor = 0x151BBC00, // Random
     WGPUSTypeExtended_SurfaceDescriptorCocoaSurfaceBacking = 0x017E9710, // Random
     WGPUSTypeExtended_BindGroupEntryExternalTexture = 0xF7A6EBF9, // Random
+    WGPUSTypeExtended_BindGroupLayoutEntryExternalTexture = 0x645C3DAA, // Random
     WGPUSTypeExtended_Force32 = 0x7FFFFFFF
 } WGPUSTypeExtended;
 
@@ -84,6 +85,15 @@ typedef struct WGPUSurfaceDescriptorCocoaCustomSurface {
     WGPUChainedStruct chain;
     WGPUCompositorIntegrationRegisterBlockCallback compositorIntegrationRegister;
 } WGPUSurfaceDescriptorCocoaCustomSurface;
+
+typedef struct WGPUExternalTextureBindingLayout {
+    WGPUChainedStruct const * nextInChain;
+} WGPUExternalTextureBindingLayout;
+
+typedef struct WGPUExternalTextureBindGroupLayoutEntry {
+    WGPUChainedStruct chain;
+    WGPUExternalTextureBindingLayout externalTexture;
+} WGPUExternalTextureBindGroupLayoutEntry;
 
 typedef struct WGPUBindGroupExternalTextureEntry {
     WGPUChainedStruct chain;


### PR DESCRIPTION
#### 936c42734f58a0b09f482a6ba86ba339cfa71164
<pre>
[WebGPU] Give BindGroupLayouts a notion of external textures (like BindGroups have)
<a href="https://bugs.webkit.org/show_bug.cgi?id=257055">https://bugs.webkit.org/show_bug.cgi?id=257055</a>
rdar://109585492

Reviewed by Mike Wyrzykowski.

Just like we added WGPUBindGroupExternalTextureEntry to let bind groups be able to hold
external textures, this patch adds the corresponding WGPUExternalTextureBindGroupLayoutEntry
to bind group layouts.

Note that the external texture handling added by this patch doesn&apos;t actually hook up all
the necessary pieces to the MTLArgumetnDescriptors. This patch instead just creates the
concept of a BGL&apos;s external texture, and the details can be filled in in a subsequent patch.

I&apos;ve also included a few drive-by style improvements, too.

* Source/WebCore/Modules/WebGPU/GPUExternalTextureBindingLayout.idl:
* Source/WebCore/PAL/pal/graphics/WebGPU/Impl/WebGPUDeviceImpl.cpp:
(PAL::WebGPU::DeviceImpl::createBindGroupLayout):
* Source/WebCore/html/canvas/GPUCanvasContextCocoa.mm:
(WebCore::GPUCanvasContextCocoa::configure):
* Source/WebGPU/WGSL/WGSL.h:
* Source/WebGPU/WebGPU/BindGroup.mm:
(WebGPU::Device::createBindGroup):
* Source/WebGPU/WebGPU/BindGroupLayout.h:
(WebGPU::BindGroupLayout::create):
(WebGPU::BindGroupLayout::entries const):
* Source/WebGPU/WebGPU/BindGroupLayout.mm:
(WebGPU::createArgumentDescriptor):
(WebGPU::BindGroupLayout::isPresent):
(WebGPU::Device::createBindGroupLayout):
(WebGPU::BindGroupLayout::BindGroupLayout):
(WebGPU::BindGroupLayout::entries const): Deleted.
* Source/WebGPU/WebGPU/Instance.h:
* Source/WebGPU/WebGPU/Pipeline.h:
* Source/WebGPU/WebGPU/PresentationContext.h:
* Source/WebGPU/WebGPU/RenderPipeline.mm:
(WebGPU::Device::createRenderPipeline):
(WebGPU::RenderPipeline::getBindGroupLayout):
* Source/WebGPU/WebGPU/ShaderModule.mm:
(WebGPU::convertBindingLayout):
(WebGPU::ShaderModule::convertPipelineLayout):
(WebGPU::populateBindingMember): Deleted.
* Source/WebGPU/WebGPU/WebGPUExt.h:

Canonical link: <a href="https://commits.webkit.org/264437@main">https://commits.webkit.org/264437@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/111e626cf1d323d1852c25bd94f43e01aef0222e

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/7553 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/7821 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/8004 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/9193 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/7742 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/7564 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/9777 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/7745 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/10618 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/7684 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/8795 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/6971 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/9301 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/6103 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/6874 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/14574 "Passed tests") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/7292 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/6995 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/10347 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/7489 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/6114 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/6830 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/1812 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/11038 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/7223 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->