### PR TITLE
[css-flexbox][baseline-alignment] Do not synthesize first baseline when flex item block axis is parallel to flex cross axis.

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-flexbox/align-items-baseline-column-vert-lr-flexbox-item-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-flexbox/align-items-baseline-column-vert-lr-flexbox-item-expected.txt
@@ -1,8 +1,7 @@
-
-
-
+two
+lines
+hello
 
 PASS #target > div 1
 PASS #target > div 2
-PASS #target > div 3
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-flexbox/align-items-baseline-column-vert-lr-flexbox-item.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-flexbox/align-items-baseline-column-vert-lr-flexbox-item.html
@@ -1,0 +1,42 @@
+<!DOCTYPE html>
+<link rel="help" href="https://drafts.csswg.org/css-align-3/#baseline-rules">
+<link rel="help" href="https://drafts.csswg.org/css-flexbox-1/#cross-alignment">
+<link rel="author" href="mailto:sammy.gill@apple.com" title="Sammy Gill">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/resources/check-layout-th.js"></script>
+<style>
+#target {
+  display: flex;
+  flex-direction: column;
+  width: 200px;
+  align-items: baseline;
+  border: 3px solid black;
+  font-family: monospace;
+  font-size: 10px;
+  line-height: 10px;
+}
+#target > :nth-child(1) {
+  background: hotpink;
+  writing-mode: vertical-lr;
+  padding-left: 30px;
+  margin-left: 10px;
+}
+#target > :nth-child(2) {
+  background: papayawhip;
+  writing-mode: vertical-lr;
+}
+.inner {
+    display: flex;
+    border: 5px solid black;
+    padding: 5px;
+}
+</style>
+<body onload="checkLayout('#target > div')">
+<div id="target">
+  <div class="inner" data-offset-x="21">
+    <div>two<br>lines</div>
+  </div>
+  <div data-offset-x="56">hello</div>
+</div>
+</body>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-flexbox/align-items-baseline-column-vert-lr-grid-item-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-flexbox/align-items-baseline-column-vert-lr-grid-item-expected.txt
@@ -1,8 +1,7 @@
-
-
-
+two
+lines
+hello
 
 PASS #target > div 1
 PASS #target > div 2
-PASS #target > div 3
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-flexbox/align-items-baseline-column-vert-lr-grid-item.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-flexbox/align-items-baseline-column-vert-lr-grid-item.html
@@ -1,0 +1,43 @@
+<!DOCTYPE html>
+<link rel="help" href="https://drafts.csswg.org/css-align-3/#baseline-rules">
+<link rel="help" href="https://drafts.csswg.org/css-flexbox-1/#cross-alignment">
+<link rel="author" href="mailto:sammy.gill@apple.com" title="Sammy Gill">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/resources/check-layout-th.js"></script>
+<style>
+#target {
+  display: flex;
+  flex-direction: column;
+  width: 200px;
+  align-items: baseline;
+  border: 3px solid black;
+  font-family: monospace;
+  font-size: 10px;
+  line-height: 10px;
+}
+#target > :nth-child(1) {
+  background: hotpink;
+  writing-mode: vertical-lr;
+  padding-left: 30px;
+  margin-left: 10px;
+}
+#target > :nth-child(2) {
+  background: papayawhip;
+  writing-mode: vertical-lr;
+}
+.inner {
+    display: grid;
+    grid-template: auto / auto;
+    border: 5px solid black;
+    padding: 5px;
+}
+</style>
+<body onload="checkLayout('#target > div')">
+<div id="target">
+  <div class="inner" data-offset-x="21">
+    <div>two<br>lines</div>
+  </div>
+  <div data-offset-x="56">hello</div>
+</div>
+</body>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-flexbox/align-items-baseline-column-vert-lr-items-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-flexbox/align-items-baseline-column-vert-lr-items-expected.txt
@@ -1,8 +1,7 @@
-
-
-
+two
+lines
+hello
 
 PASS #target > div 1
 PASS #target > div 2
-PASS #target > div 3
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-flexbox/align-items-baseline-column-vert-lr-items.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-flexbox/align-items-baseline-column-vert-lr-items.html
@@ -1,0 +1,35 @@
+<!DOCTYPE html>
+<link rel="help" href="https://drafts.csswg.org/css-align-3/#baseline-rules">
+<link rel="help" href="https://drafts.csswg.org/css-flexbox-1/#cross-alignment">
+<link rel="author" href="mailto:sammy.gill@apple.com" title="Sammy Gill">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/resources/check-layout-th.js"></script>
+<style>
+#target {
+  display: flex;
+  flex-direction: column;
+  width: 200px;
+  align-items: baseline;
+  border: 3px solid black;
+  font-family: monospace;
+  font-size: 10px;
+  line-height: 10px;
+}
+#target > :nth-child(1) {
+  background: hotpink;
+  writing-mode: vertical-lr;
+  padding-left: 30px;
+  margin-left: 10px;
+}
+#target > :nth-child(2) {
+  background: papayawhip;
+  writing-mode: vertical-lr;
+}
+</style>
+<body onload="checkLayout('#target > div')">
+<div id="target">
+  <div data-offset-x="21">two<br>lines</div>
+  <div data-offset-x="51">hello</div>
+</div>
+</body>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-flexbox/align-items-baseline-column-vert-lr-table-item-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-flexbox/align-items-baseline-column-vert-lr-table-item-expected.txt
@@ -1,0 +1,7 @@
+two
+lines
+hello
+
+PASS #target > * 1
+PASS #target > * 2
+

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-flexbox/align-items-baseline-column-vert-lr-table-item.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-flexbox/align-items-baseline-column-vert-lr-table-item.html
@@ -1,0 +1,45 @@
+<!DOCTYPE html>
+<link rel="help" href="https://drafts.csswg.org/css-align-3/#baseline-rules">
+<link rel="help" href="https://drafts.csswg.org/css-flexbox-1/#cross-alignment">
+<link rel="author" href="mailto:sammy.gill@apple.com" title="Sammy Gill">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/resources/check-layout-th.js"></script>
+<style>
+#target {
+  display: flex;
+  flex-direction: column;
+  width: 200px;
+  align-items: baseline;
+  border: 3px solid black;
+  font-family: monospace;
+  font-size: 10px;
+  line-height: 10px;
+}
+#target > :nth-child(1) {
+  background: hotpink;
+  writing-mode: vertical-lr;
+  padding-left: 30px;
+  margin-left: 10px;
+}
+#target > :nth-child(2) {
+  background: papayawhip;
+  writing-mode: vertical-lr;
+}
+.inner {
+    border: 5px solid black;
+    padding: 5px;
+}
+</style>
+<body onload="checkLayout('#target > *')">
+<div id="target">
+  <table class="inner" data-offset-x="21">
+    <tr>
+      <td style="vertical-align: baseline;">
+        <div>two<br>lines</div>
+      </td>
+    </tr>
+  </table>
+  <div data-offset-x="59">hello</div>
+</div>
+</body>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-flexbox/align-items-baseline-column-vert-rl-flexbox-item-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-flexbox/align-items-baseline-column-vert-rl-flexbox-item-expected.txt
@@ -1,0 +1,13 @@
+two
+lines
+hello
+
+FAIL #target > div 1 assert_equals:
+<div class="inner" data-offset-x="146">
+    <div>two<br>lines</div>
+  </div>
+offsetLeft expected 146 but got 21
+FAIL #target > div 2 assert_equals:
+<div data-offset-x="191">hello</div>
+offsetLeft expected 191 but got 66
+

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-flexbox/align-items-baseline-column-vert-rl-flexbox-item.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-flexbox/align-items-baseline-column-vert-rl-flexbox-item.html
@@ -1,0 +1,44 @@
+<!DOCTYPE html>
+<link rel="help" href="https://drafts.csswg.org/css-align-3/#baseline-rules">
+<link rel="help" href="https://drafts.csswg.org/css-flexbox-1/#cross-alignment">
+<link rel="author" href="mailto:sammy.gill@apple.com" title="Sammy Gill">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/resources/check-layout-th.js"></script>
+<style>
+#target {
+  font-size: 16px;
+  line-height: 16px;
+  display: flex;
+  flex-direction: column;
+  width: 200px;
+  align-items: baseline;
+  border: 3px solid black;
+  font-family: monospace;
+  font-size: 10px;
+  line-height: 10px;
+}
+#target > :nth-child(1) {
+  background: hotpink;
+  writing-mode: vertical-rl;
+  padding-left: 30px;
+  margin-left: 10px;
+}
+#target > :nth-child(2) {
+  background: papayawhip;
+  writing-mode: vertical-rl;
+}
+.inner {
+    display: flex;
+    border: 5px solid black;
+    padding: 5px;
+}
+</style>
+<body onload="checkLayout('#target > div')">
+<div id="target">
+  <div class="inner" data-offset-x="146">
+    <div>two<br>lines</div>
+  </div>
+  <div data-offset-x="191">hello</div>
+</div>
+</body>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-flexbox/align-items-baseline-column-vert-rl-grid-item-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-flexbox/align-items-baseline-column-vert-rl-grid-item-expected.txt
@@ -1,0 +1,13 @@
+two
+lines
+hello
+
+FAIL #target > div 1 assert_equals:
+<div class="inner" data-offset-x="146">
+    <div>two<br>lines</div>
+  </div>
+offsetLeft expected 146 but got 21
+FAIL #target > div 2 assert_equals:
+<div data-offset-x="191">hello</div>
+offsetLeft expected 191 but got 66
+

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-flexbox/align-items-baseline-column-vert-rl-grid-item.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-flexbox/align-items-baseline-column-vert-rl-grid-item.html
@@ -1,0 +1,43 @@
+<!DOCTYPE html>
+<link rel="help" href="https://drafts.csswg.org/css-align-3/#baseline-rules">
+<link rel="help" href="https://drafts.csswg.org/css-flexbox-1/#cross-alignment">
+<link rel="author" href="mailto:sammy.gill@apple.com" title="Sammy Gill">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/resources/check-layout-th.js"></script>
+<style>
+#target {
+  display: flex;
+  flex-direction: column;
+  width: 200px;
+  align-items: baseline;
+  border: 3px solid black;
+  font-family: monospace;
+  font-size: 10px;
+  line-height: 10px;
+}
+#target > :nth-child(1) {
+  background: hotpink;
+  writing-mode: vertical-rl;
+  padding-left: 30px;
+  margin-left: 10px;
+}
+#target > :nth-child(2) {
+  background: papayawhip;
+  writing-mode: vertical-rl;
+}
+.inner {
+    display: grid;
+    grid-template: auto / auto;
+    border: 5px solid black;
+    padding: 5px;
+}
+</style>
+<body onload="checkLayout('#target > div')">
+<div id="target">
+  <div class="inner" data-offset-x="146">
+    <div>two<br>lines</div>
+  </div>
+  <div data-offset-x="191">hello</div>
+</div>
+</body>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-flexbox/align-items-baseline-column-vert-rl-items-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-flexbox/align-items-baseline-column-vert-rl-items-expected.txt
@@ -1,0 +1,11 @@
+two
+lines
+hello
+
+FAIL #target > div 1 assert_equals:
+<div data-offset-x="161">two<br>lines</div>
+offsetLeft expected 161 but got 21
+FAIL #target > div 2 assert_equals:
+<div data-offset-x="201">hello</div>
+offsetLeft expected 201 but got 61
+

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-flexbox/align-items-baseline-column-vert-rl-items.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-flexbox/align-items-baseline-column-vert-rl-items.html
@@ -1,0 +1,35 @@
+<!DOCTYPE html>
+<link rel="help" href="https://drafts.csswg.org/css-align-3/#baseline-rules">
+<link rel="help" href="https://drafts.csswg.org/css-flexbox-1/#cross-alignment">
+<link rel="author" href="mailto:sammy.gill@apple.com" title="Sammy Gill">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/resources/check-layout-th.js"></script>
+<style>
+#target {
+  display: flex;
+  flex-direction: column;
+  width: 200px;
+  align-items: baseline;
+  border: 3px solid black;
+  font-family: monospace;
+  font-size: 10px;
+  line-height: 10px;
+}
+#target > :nth-child(1) {
+  background: hotpink;
+  writing-mode: vertical-rl;
+  padding-left: 30px;
+  margin-left: 10px;
+}
+#target > :nth-child(2) {
+  background: papayawhip;
+  writing-mode: vertical-rl;
+}
+</style>
+<body onload="checkLayout('#target > div')">
+<div id="target">
+  <div data-offset-x="161">two<br>lines</div>
+  <div data-offset-x="201">hello</div>
+</div>
+</body>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-flexbox/align-items-baseline-column-vert-rl-table-item-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-flexbox/align-items-baseline-column-vert-rl-table-item-expected.txt
@@ -1,0 +1,17 @@
+two
+lines
+hello
+
+FAIL #target > * 1 assert_equals:
+<table class="inner" data-offset-x="140">
+    <tbody><tr>
+      <td style="vertical-align: baseline;">
+        <div>two<br>lines</div>
+      </td>
+    </tr>
+  </tbody></table>
+offsetLeft expected 140 but got 21
+FAIL #target > * 2 assert_equals:
+<div data-offset-x="188">hello</div>
+offsetLeft expected 188 but got 69
+

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-flexbox/align-items-baseline-column-vert-rl-table-item.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-flexbox/align-items-baseline-column-vert-rl-table-item.html
@@ -1,0 +1,45 @@
+<!DOCTYPE html>
+<link rel="help" href="https://drafts.csswg.org/css-align-3/#baseline-rules">
+<link rel="help" href="https://drafts.csswg.org/css-flexbox-1/#cross-alignment">
+<link rel="author" href="mailto:sammy.gill@apple.com" title="Sammy Gill">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/resources/check-layout-th.js"></script>
+<style>
+#target {
+  display: flex;
+  flex-direction: column;
+  width: 200px;
+  align-items: baseline;
+  border: 3px solid black;
+  font-family: monospace;
+  font-size: 10px;
+  line-height: 10px;
+}
+#target > :nth-child(1) {
+  background: hotpink;
+  writing-mode: vertical-rl;
+  padding-left: 30px;
+  margin-left: 10px;
+}
+#target > :nth-child(2) {
+  background: papayawhip;
+  writing-mode: vertical-rl;
+}
+.inner {
+    border: 5px solid black;
+    padding: 5px;
+}
+</style>
+<body onload="checkLayout('#target > *')">
+<div id="target">
+  <table class="inner" data-offset-x="140">
+    <tr>
+      <td style="vertical-align: baseline;">
+        <div>two<br>lines</div>
+      </td>
+    </tr>
+  </table>
+  <div data-offset-x="188">hello</div>
+</div>
+</body>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-flexbox/align-items-baseline-vert-lr-column-horz-flexbox-item-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-flexbox/align-items-baseline-vert-lr-column-horz-flexbox-item-expected.txt
@@ -1,8 +1,7 @@
-
-
-
+two
+lines
+hello
 
 PASS #target > div 1
 PASS #target > div 2
-PASS #target > div 3
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-flexbox/align-items-baseline-vert-lr-column-horz-flexbox-item.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-flexbox/align-items-baseline-vert-lr-column-horz-flexbox-item.html
@@ -1,0 +1,42 @@
+<!DOCTYPE html>
+<link rel="help" href="https://drafts.csswg.org/css-align-3/#baseline-rules">
+<link rel="help" href="https://drafts.csswg.org/css-flexbox-1/#cross-alignment">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/resources/check-layout-th.js"></script>
+<link rel="author" href="mailto:sammy.gill@apple.com" title="Sammy Gill">
+<style>
+#target {
+  display: flex;
+  flex-direction: column;
+  writing-mode: vertical-lr;
+  align-items: baseline;
+  border: 3px solid black;
+  font-family: monospace;
+  font-size: 10px;
+  line-height: 10px;
+}
+#target > :nth-child(1) {
+  background: hotpink;
+  writing-mode: horizontal-tb;
+  padding-left: 30px;
+  margin-left: 10px;
+}
+#target > :nth-child(2) {
+  background: papayawhip;
+  writing-mode: horizontal-tb;
+}
+.inner {
+    display: flex;
+    border: 5px solid black;
+    padding: 5px;
+}
+</style>
+<body onload="checkLayout('#target > div')">
+<div id="target">
+  <div class="inner" data-offset-y="11">
+    <div>two<br>lines</div>
+  </div>
+  <div data-offset-y="21">hello</div>
+</div>
+</body>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-flexbox/align-items-baseline-vert-lr-column-horz-grid-item-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-flexbox/align-items-baseline-vert-lr-column-horz-grid-item-expected.txt
@@ -1,8 +1,7 @@
-
-
-
+two
+lines
+hello
 
 PASS #target > div 1
 PASS #target > div 2
-PASS #target > div 3
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-flexbox/align-items-baseline-vert-lr-column-horz-grid-item.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-flexbox/align-items-baseline-vert-lr-column-horz-grid-item.html
@@ -1,0 +1,43 @@
+<!DOCTYPE html>
+<link rel="help" href="https://drafts.csswg.org/css-align-3/#baseline-rules">
+<link rel="help" href="https://drafts.csswg.org/css-flexbox-1/#cross-alignment">
+<link rel="author" href="mailto:sammy.gill@apple.com" title="Sammy Gill">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/resources/check-layout-th.js"></script>
+<style>
+#target {
+  display: flex;
+  flex-direction: column;
+  writing-mode: vertical-lr;
+  align-items: baseline;
+  border: 3px solid black;
+  font-family: monospace;
+  font-size: 10px;
+  line-height: 10px;
+}
+#target > :nth-child(1) {
+  background: hotpink;
+  writing-mode: horizontal-tb;
+  padding-left: 30px;
+  margin-left: 10px;
+}
+#target > :nth-child(2) {
+  background: papayawhip;
+  writing-mode: horizontal-tb;
+}
+.inner {
+    display: grid;
+    grid-template: auto / auto;
+    border: 5px solid black;
+    padding: 5px;
+}
+</style>
+<body onload="checkLayout('#target > div')">
+<div id="target">
+  <div class="inner" data-offset-y="11">
+    <div>two<br>lines</div>
+  </div>
+  <div data-offset-y="21">hello</div>
+</div>
+</body>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-flexbox/align-items-baseline-vert-lr-column-horz-items-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-flexbox/align-items-baseline-vert-lr-column-horz-items-expected.txt
@@ -1,8 +1,7 @@
-
-
-
+two
+lines
+hello
 
 PASS #target > div 1
 PASS #target > div 2
-PASS #target > div 3
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-flexbox/align-items-baseline-vert-lr-column-horz-items.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-flexbox/align-items-baseline-vert-lr-column-horz-items.html
@@ -1,0 +1,35 @@
+<!DOCTYPE html>
+<link rel="help" href="https://drafts.csswg.org/css-align-3/#baseline-rules">
+<link rel="help" href="https://drafts.csswg.org/css-flexbox-1/#cross-alignment">
+<link rel="author" href="mailto:sammy.gill@apple.com" title="Sammy Gill">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/resources/check-layout-th.js"></script>
+<style>
+#target {
+  display: flex;
+  flex-direction: column;
+  writing-mode: vertical-lr;
+  align-items: baseline;
+  border: 3px solid black;
+  font-family: monospace;
+  font-size: 10px;
+  line-height: 10px;
+}
+#target > :nth-child(1) {
+  background: hotpink;
+  writing-mode: horizontal-tb;
+  padding-left: 30px;
+  margin-left: 10px;
+}
+#target > :nth-child(2) {
+  background: papayawhip;
+  writing-mode: horizontal-tb;
+}
+</style>
+<body onload="checkLayout('#target > div')">
+<div id="target">
+  <div data-offset-y="11">two<br>lines</div>
+  <div data-offset-y="11">hello</div>
+</div>
+</body>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-flexbox/align-items-baseline-vert-lr-column-horz-table-item-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-flexbox/align-items-baseline-vert-lr-column-horz-table-item-expected.txt
@@ -1,0 +1,6 @@
+two
+lines
+hello
+
+PASS #target > div 1
+

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-flexbox/align-items-baseline-vert-lr-column-horz-table-item.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-flexbox/align-items-baseline-vert-lr-column-horz-table-item.html
@@ -1,0 +1,45 @@
+<!DOCTYPE html>
+<link rel="help" href="https://drafts.csswg.org/css-align-3/#baseline-rules">
+<link rel="help" href="https://drafts.csswg.org/css-flexbox-1/#cross-alignment">
+<link rel="author" href="mailto:sammy.gill@apple.com" title="Sammy Gill">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/resources/check-layout-th.js"></script>
+<style>
+#target {
+  display: flex;
+  flex-direction: column;
+  writing-mode: vertical-lr;
+  align-items: baseline;
+  border: 3px solid black;
+  font-family: monospace;
+  font-size: 10px;
+  line-height: 10px;
+}
+#target > :nth-child(1) {
+  background: hotpink;
+  writing-mode: horizontal-tb;
+  padding-left: 30px;
+  margin-left: 10px;
+}
+#target > :nth-child(2) {
+  background: papayawhip;
+  writing-mode: horizontal-tb;
+}
+.inner {
+    border: 5px solid black;
+    padding: 5px;
+}
+</style>
+<body onload="checkLayout('#target > div')">
+<div id="target">
+  <table class="inner" data-offset-y="130">
+    <tr>
+      <td style="vertical-align: baseline;">
+        <div>two<br>lines</div>
+      </td>
+    </tr>
+  </table>
+  <div data-offset-y="24">hello</div>
+</div>
+</body>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-flexbox/align-items-baseline-vert-rl-column-horz-flexbox-item-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-flexbox/align-items-baseline-vert-rl-column-horz-flexbox-item-expected.txt
@@ -1,8 +1,7 @@
-
-
-
+two
+lines
+hello
 
 PASS #target > div 1
 PASS #target > div 2
-PASS #target > div 3
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-flexbox/align-items-baseline-vert-rl-column-horz-flexbox-item.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-flexbox/align-items-baseline-vert-rl-column-horz-flexbox-item.html
@@ -1,0 +1,42 @@
+<!DOCTYPE html>
+<link rel="help" href="https://drafts.csswg.org/css-align-3/#baseline-rules">
+<link rel="help" href="https://drafts.csswg.org/css-flexbox-1/#cross-alignment">
+<link rel="author" href="mailto:sammy.gill@apple.com" title="Sammy Gill">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/resources/check-layout-th.js"></script>
+<style>
+#target {
+  display: flex;
+  flex-direction: column;
+  writing-mode: vertical-rl;
+  align-items: baseline;
+  border: 3px solid black;
+  font-family: monospace;
+  font-size: 10px;
+  line-height: 10px;
+}
+#target > :nth-child(1) {
+  background: hotpink;
+  writing-mode: horizontal-tb;
+  padding-left: 30px;
+  margin-left: 10px;
+}
+#target > :nth-child(2) {
+  background: papayawhip;
+  writing-mode: horizontal-tb;
+}
+.inner {
+    display: flex;
+    border: 5px solid black;
+    padding: 5px;
+}
+</style>
+<body onload="checkLayout('#target > div')">
+<div id="target">
+  <div class="inner" data-offset-y="11">
+    <div>two<br>lines</div>
+  </div>
+  <div data-offset-y="21">hello</div>
+</div>
+</body>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-flexbox/align-items-baseline-vert-rl-column-horz-grid-item-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-flexbox/align-items-baseline-vert-rl-column-horz-grid-item-expected.txt
@@ -1,8 +1,7 @@
-
-
-
+two
+lines
+hello
 
 PASS #target > div 1
 PASS #target > div 2
-PASS #target > div 3
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-flexbox/align-items-baseline-vert-rl-column-horz-grid-item.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-flexbox/align-items-baseline-vert-rl-column-horz-grid-item.html
@@ -1,0 +1,43 @@
+<!DOCTYPE html>
+<link rel="help" href="https://drafts.csswg.org/css-align-3/#baseline-rules">
+<link rel="help" href="https://drafts.csswg.org/css-flexbox-1/#cross-alignment">
+<link rel="author" href="mailto:sammy.gill@apple.com" title="Sammy Gill">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/resources/check-layout-th.js"></script>
+<style>
+#target {
+  display: flex;
+  flex-direction: column;
+  writing-mode: vertical-rl;
+  align-items: baseline;
+  border: 3px solid black;
+  font-family: monospace;
+  font-size: 10px;
+  line-height: 10px;
+}
+#target > :nth-child(1) {
+  background: hotpink;
+  writing-mode: horizontal-tb;
+  padding-left: 30px;
+  margin-left: 10px;
+}
+#target > :nth-child(2) {
+  background: papayawhip;
+  writing-mode: horizontal-tb;
+}
+.inner {
+    display: grid;
+    grid-template: auto / auto;
+    border: 5px solid black;
+    padding: 5px;
+}
+</style>
+<body onload="checkLayout('#target > div')">
+<div id="target">
+  <div class="inner" data-offset-y="11">
+    <div>two<br>lines</div>
+  </div>
+  <div data-offset-y="21">hello</div>
+</div>
+</body>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-flexbox/align-items-baseline-vert-rl-column-horz-items-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-flexbox/align-items-baseline-vert-rl-column-horz-items-expected.txt
@@ -1,8 +1,7 @@
-
-
-
+two
+lines
+hello
 
 PASS #target > div 1
 PASS #target > div 2
-PASS #target > div 3
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-flexbox/align-items-baseline-vert-rl-column-horz-items.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-flexbox/align-items-baseline-vert-rl-column-horz-items.html
@@ -1,0 +1,36 @@
+<!DOCTYPE html>
+<link rel="help" href="https://drafts.csswg.org/css-align-3/#baseline-rules">
+<link rel="help" href="https://drafts.csswg.org/css-flexbox-1/#cross-alignment">
+<link rel="author" href="mailto:sammy.gill@apple.com" title="Sammy Gill">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/resources/check-layout-th.js"></script>
+<style>
+#target {
+  display: flex;
+  flex-direction: column;
+  width: 200px;
+  writing-mode: vertical-rl;
+  align-items: baseline;
+  border: 3px solid black;
+  font-family: monospace;
+  font-size: 10px;
+  line-height: 10px;
+}
+#target > :nth-child(1) {
+  background: hotpink;
+  writing-mode: horizontal-tb;
+  padding-left: 30px;
+  margin-left: 10px;
+}
+#target > :nth-child(2) {
+  background: papayawhip;
+  writing-mode: horizontal-tb;
+}
+</style>
+<body onload="checkLayout('#target > div')">
+<div id="target">
+  <div data-offset-y="11">two<br>lines</div>
+  <div data-offset-y="11">hello</div>
+</div>
+</body>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-flexbox/align-items-baseline-vert-rl-column-horz-table-item-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-flexbox/align-items-baseline-vert-rl-column-horz-table-item-expected.txt
@@ -1,0 +1,6 @@
+two
+lines
+hello
+
+PASS #target > div 1
+

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-flexbox/align-items-baseline-vert-rl-column-horz-table-item.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-flexbox/align-items-baseline-vert-rl-column-horz-table-item.html
@@ -1,0 +1,45 @@
+<!DOCTYPE html>
+<link rel="help" href="https://drafts.csswg.org/css-align-3/#baseline-rules">
+<link rel="help" href="https://drafts.csswg.org/css-flexbox-1/#cross-alignment">
+<link rel="author" href="mailto:sammy.gill@apple.com" title="Sammy Gill">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/resources/check-layout-th.js"></script>
+<style>
+#target {
+  display: flex;
+  flex-direction: column;
+  writing-mode: vertical-rl;
+  align-items: baseline;
+  border: 3px solid black;
+  font-family: monospace;
+  font-size: 10px;
+  line-height: 10px;
+}
+#target > :nth-child(1) {
+  background: hotpink;
+  writing-mode: horizontal-tb;
+  padding-left: 30px;
+  margin-left: 10px;
+}
+#target > :nth-child(2) {
+  background: papayawhip;
+  writing-mode: horizontal-tb;
+}
+.inner {
+    border: 5px solid black;
+    padding: 5px;
+}
+</style>
+<body onload="checkLayout('#target > div')">
+<div id="target">
+  <table class="inner" data-offset-y="130">
+    <tr>
+      <td style="vertical-align: baseline;">
+        <div>two<br>lines</div>
+      </td>
+    </tr>
+  </table>
+  <div data-offset-y="24">hello</div>
+</div>
+</body>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-flexbox/alignment/flex-align-baseline-001-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-flexbox/alignment/flex-align-baseline-001-expected.txt
@@ -16,15 +16,15 @@ FAIL #target > div 1 assert_equals:
 offsetLeft expected 120 but got 20
 FAIL #target > div 2 assert_equals:
 <div data-offset-x="105">line1<br>line2</div>
-offsetLeft expected 105 but got 140
+offsetLeft expected 105 but got 110
 FAIL #target > div 3 assert_equals:
 <div data-offset-x="126">line1<br>line2</div>
-offsetLeft expected 126 but got 168
+offsetLeft expected 126 but got 131
 PASS #target > div 4
 FAIL #target > div 5 assert_equals:
 <div data-offset-x="35">line1<br>line2</div>
 offsetLeft expected 35 but got 140
 FAIL #target > div 6 assert_equals:
 <div data-offset-x="42">line1<br>line2</div>
-offsetLeft expected 42 but got 168
+offsetLeft expected 42 but got 147
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-flexbox/alignment/flex-align-baseline-002-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-flexbox/alignment/flex-align-baseline-002-expected.txt
@@ -16,15 +16,15 @@ FAIL #target > div 1 assert_equals:
 offsetLeft expected 120 but got 20
 FAIL #target > div 2 assert_equals:
 <div data-offset-x="105">line1<br>line2</div>
-offsetLeft expected 105 but got 125
+offsetLeft expected 105 but got 110
 FAIL #target > div 3 assert_equals:
 <div data-offset-x="126">line1<br>line2</div>
-offsetLeft expected 126 but got 146
+offsetLeft expected 126 but got 131
 PASS #target > div 4
 FAIL #target > div 5 assert_equals:
 <div data-offset-x="35">line1<br>line2</div>
 offsetLeft expected 35 but got 140
 FAIL #target > div 6 assert_equals:
 <div data-offset-x="42">line1<br>line2</div>
-offsetLeft expected 42 but got 154
+offsetLeft expected 42 but got 147
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-flexbox/alignment/flex-align-baseline-003-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-flexbox/alignment/flex-align-baseline-003-expected.txt
@@ -17,14 +17,14 @@ FAIL #target > div 2 assert_equals:
 offsetLeft expected 105 but got 0
 FAIL #target > div 3 assert_equals:
 <div data-offset-x="126">line1<br>line2</div>
-offsetLeft expected 126 but got 14
+offsetLeft expected 126 but got 21
 FAIL #target > div 4 assert_equals:
 <div data-offset-x="20">line1<br>line2</div>
 offsetLeft expected 20 but got 120
 FAIL #target > div 5 assert_equals:
 <div data-offset-x="35">line1<br>line2</div>
-offsetLeft expected 35 but got 15
+offsetLeft expected 35 but got 30
 FAIL #target > div 6 assert_equals:
 <div data-offset-x="42">line1<br>line2</div>
-offsetLeft expected 42 but got 22
+offsetLeft expected 42 but got 37
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-flexbox/alignment/flex-align-baseline-004-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-flexbox/alignment/flex-align-baseline-004-expected.txt
@@ -15,16 +15,14 @@ FAIL #target > div 1 assert_equals:
 <div data-offset-x="15">line1<br>line2</div>
 offsetLeft expected 15 but got 120
 PASS #target > div 2
-FAIL #target > div 3 assert_equals:
-<div data-offset-x="21">line1<br>line2</div>
-offsetLeft expected 21 but got 28
+PASS #target > div 3
 FAIL #target > div 4 assert_equals:
 <div data-offset-x="125">line1<br>line2</div>
 offsetLeft expected 125 but got 120
 FAIL #target > div 5 assert_equals:
 <div data-offset-x="140">line1<br>line2</div>
-offsetLeft expected 140 but got 0
+offsetLeft expected 140 but got 30
 FAIL #target > div 6 assert_equals:
 <div data-offset-x="147">line1<br>line2</div>
-offsetLeft expected 147 but got 28
+offsetLeft expected 147 but got 37
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-flexbox/alignment/flex-align-baseline-007-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-flexbox/alignment/flex-align-baseline-007-expected.txt
@@ -3,10 +3,6 @@
 
 
 PASS #target > div 1
-FAIL #target > div 2 assert_equals:
-<div data-offset-y="0"><span></span><br><span></span></div>
-offsetTop expected 0 but got 20
-FAIL #target > div 3 assert_equals:
-<div data-offset-y="55"><span></span><br><span></span></div>
-offsetTop expected 55 but got 35
+PASS #target > div 2
+PASS #target > div 3
 

--- a/Source/WebCore/rendering/RenderBlock.cpp
+++ b/Source/WebCore/rendering/RenderBlock.cpp
@@ -2562,7 +2562,7 @@ std::optional<LayoutUnit> RenderBlock::firstLineBaseline() const
     if (shouldApplyLayoutContainment())
         return std::nullopt;
 
-    if (isWritingModeRoot() && !isRubyRun())
+    if (isWritingModeRoot() && !isRubyRun() && !isFlexItem())
         return std::optional<LayoutUnit>();
 
     for (RenderBox* child = firstInFlowChildBox(); child; child = child->nextInFlowSiblingBox()) {

--- a/Source/WebCore/rendering/RenderBlockFlow.cpp
+++ b/Source/WebCore/rendering/RenderBlockFlow.cpp
@@ -3420,7 +3420,7 @@ void RenderBlockFlow::markLinesDirtyInBlockRange(LayoutUnit logicalTop, LayoutUn
 
 std::optional<LayoutUnit> RenderBlockFlow::firstLineBaseline() const
 {
-    if (isWritingModeRoot() && !isRubyRun() && !isGridItem())
+    if (isWritingModeRoot() && !isRubyRun() && !isGridItem() && !isFlexItem())
         return std::nullopt;
 
     if (shouldApplyLayoutContainment())
@@ -3443,7 +3443,7 @@ std::optional<LayoutUnit> RenderBlockFlow::firstLineBaseline() const
 
 std::optional<LayoutUnit> RenderBlockFlow::lastLineBaseline() const
 {
-    if (isWritingModeRoot() && !isRubyRun() && !isGridItem())
+    if (isWritingModeRoot() && !isRubyRun() && !isGridItem() && !isFlexItem())
         return std::nullopt;
 
     if (shouldApplyLayoutContainment())

--- a/Source/WebCore/rendering/RenderGrid.cpp
+++ b/Source/WebCore/rendering/RenderGrid.cpp
@@ -1760,7 +1760,7 @@ LayoutUnit RenderGrid::baselinePosition(FontBaseline, bool, LineDirectionMode di
 
 std::optional<LayoutUnit> RenderGrid::firstLineBaseline() const
 {
-    if (isWritingModeRoot() || !currentGrid().hasGridItems() || shouldApplyLayoutContainment())
+    if ((isWritingModeRoot() && !isFlexItem()) || !currentGrid().hasGridItems() || shouldApplyLayoutContainment())
         return std::nullopt;
 
     // Finding the first grid item in grid order.

--- a/Source/WebCore/rendering/RenderTable.cpp
+++ b/Source/WebCore/rendering/RenderTable.cpp
@@ -1543,7 +1543,7 @@ std::optional<LayoutUnit> RenderTable::firstLineBaseline() const
     // doesn't define the baseline of a 'table' only an 'inline-table').
     // This is also needed to properly determine the baseline of a cell if it has a table child.
 
-    if (isWritingModeRoot() || shouldApplyLayoutContainment())
+    if ((isWritingModeRoot() && !isFlexItem()) || shouldApplyLayoutContainment())
         return std::optional<LayoutUnit>();
 
     recalcSectionsIfNeeded();


### PR DESCRIPTION
#### 2c62617577b66ac454176fbe5f4cf85f998272c3
<pre>
[css-flexbox][baseline-alignment] Do not synthesize first baseline when flex item block axis is parallel to flex cross axis.
<a href="https://bugs.webkit.org/show_bug.cgi?id=256937">https://bugs.webkit.org/show_bug.cgi?id=256937</a>
rdar://109489182

Reviewed by Alan Baradlay.

This patches focuses on applying the described changes to flex items
that are block/grid/flex containers or tables.

If a flex item has a writing-mode that is different from the flex
container, that does not necessarily mean it cannot provide an ascent
value to use for baseline alignment within the flexbox. The
firstLineBaseline implementation within RenderBlockFlow/Grid/FlexibleBox/Table
each had a check for isWritingModeRoot() that would return std::nullopt
if the writing mode of the item was different from the flex container.
This would result in the flex container synthesizing a baseline for
the item which is not correct in all cases. This should only be done
if the block axis is *not* parallel to the flex container&apos;s cross axis.

In the following example we cannot get the baseline of the item so we
should synthesize it:
&lt;div style=&quot;display: flex;&quot;&gt;
  &lt;div style=&quot;writing-mode: vertical-lr&quot;&gt; no valid baseline &lt;/div&gt;
&lt;/div&gt;

However, in the example below we can get the baseline so we should
*not* try to synthesize one:
&lt;div style=&quot;display: flex; flex-direction: column;&quot;&gt;
  &lt;div style=&quot;writing-mode: vertical-lr&quot;&gt; Can get baseline &lt;/div&gt;
&lt;/div&gt;

We can resolve this issue by doing two things:
1.) Append an extra constraint against the isWritingModeRoot() check to
make sure this logic isn&apos;t applied on flex items
2.) Make RenderFlexibleBox check the block axis of the flex item with
its cross axis

We may also need to perform a translation on the ascent value that is
applied to the flex item since it may have been computed in a coordinate
space that is different from the flex container&apos;s (e.g. vertical-lr
flex container with vertical-rl item).

* LayoutTests/imported/w3c/web-platform-tests/css/css-flexbox/align-items-baseline-column-vert-lr-flexbox-item-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-flexbox/align-items-baseline-column-vert-lr-flexbox-item.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-flexbox/align-items-baseline-column-vert-lr-grid-item-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-flexbox/align-items-baseline-column-vert-lr-grid-item.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-flexbox/align-items-baseline-column-vert-lr-items-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-flexbox/align-items-baseline-column-vert-lr-items.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-flexbox/align-items-baseline-column-vert-lr-table-item-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-flexbox/align-items-baseline-column-vert-lr-table-item.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-flexbox/align-items-baseline-column-vert-rl-flexbox-item-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-flexbox/align-items-baseline-column-vert-rl-flexbox-item.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-flexbox/align-items-baseline-column-vert-rl-grid-item-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-flexbox/align-items-baseline-column-vert-rl-grid-item.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-flexbox/align-items-baseline-column-vert-rl-items-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-flexbox/align-items-baseline-column-vert-rl-items.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-flexbox/align-items-baseline-column-vert-rl-table-item-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-flexbox/align-items-baseline-column-vert-rl-table-item.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-flexbox/align-items-baseline-vert-lr-column-horz-flexbox-item-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-flexbox/align-items-baseline-vert-lr-column-horz-flexbox-item.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-flexbox/align-items-baseline-vert-lr-column-horz-grid-item-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-flexbox/align-items-baseline-vert-lr-column-horz-grid-item.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-flexbox/align-items-baseline-vert-lr-column-horz-items-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-flexbox/align-items-baseline-vert-lr-column-horz-items.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-flexbox/align-items-baseline-vert-lr-column-horz-table-item-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-flexbox/align-items-baseline-vert-lr-column-horz-table-item.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-flexbox/align-items-baseline-vert-rl-column-horz-flexbox-item-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-flexbox/align-items-baseline-vert-rl-column-horz-flexbox-item.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-flexbox/align-items-baseline-vert-rl-column-horz-grid-item-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-flexbox/align-items-baseline-vert-rl-column-horz-grid-item.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-flexbox/align-items-baseline-vert-rl-column-horz-items-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-flexbox/align-items-baseline-vert-rl-column-horz-items.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-flexbox/align-items-baseline-vert-rl-column-horz-table-item-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-flexbox/align-items-baseline-vert-rl-column-horz-table-item.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-flexbox/alignment/flex-align-baseline-001-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-flexbox/alignment/flex-align-baseline-002-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-flexbox/alignment/flex-align-baseline-003-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-flexbox/alignment/flex-align-baseline-004-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-flexbox/alignment/flex-align-baseline-006-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-flexbox/alignment/flex-align-baseline-007-expected.txt:
* Source/WebCore/rendering/RenderBlock.cpp:
(WebCore::RenderBlock::firstLineBaseline const):
* Source/WebCore/rendering/RenderBlockFlow.cpp:
(WebCore::RenderBlockFlow::firstLineBaseline const):
(WebCore::RenderBlockFlow::lastLineBaseline const):
* Source/WebCore/rendering/RenderFlexibleBox.cpp:
(WebCore::RenderFlexibleBox::firstLineBaseline const):
(WebCore::RenderFlexibleBox::marginBoxAscentForChild):
* Source/WebCore/rendering/RenderGrid.cpp:
(WebCore::RenderGrid::firstLineBaseline const):
* Source/WebCore/rendering/RenderTable.cpp:
(WebCore::RenderTable::firstLineBaseline const):

Canonical link: <a href="https://commits.webkit.org/264423@main">https://commits.webkit.org/264423@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d64d41855b2b4331beb7ede7eeca75e8e8c0533c

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/7592 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/7860 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/8044 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/9235 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/7781 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/7604 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/9819 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/7787 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/10654 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/7725 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/8837 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/7000 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/9344 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/6145 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/6909 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/14613 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/7320 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/7032 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/10431 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/7530 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/6148 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/6868 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/6820 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/1803 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/11079 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/7261 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->