### PR TITLE
Convert the remaining enums in FrameSelection.h to enum classes

### DIFF
--- a/Source/WebCore/editing/EditorCommand.cpp
+++ b/Source/WebCore/editing/EditorCommand.cpp
@@ -655,7 +655,7 @@ static bool executeMovePageDown(LocalFrame& frame, Event*, EditorCommandSource, 
     unsigned distance = verticalScrollDistance(frame);
     if (!distance)
         return false;
-    return frame.selection().modify(FrameSelection::Alteration::Move, distance, FrameSelection::DirectionDown,
+    return frame.selection().modify(FrameSelection::Alteration::Move, distance, FrameSelection::VerticalDirection::Down,
         UserTriggered::Yes, FrameSelection::CursorAlignOnScroll::Always);
 }
 
@@ -664,7 +664,7 @@ static bool executeMovePageDownAndModifySelection(LocalFrame& frame, Event*, Edi
     unsigned distance = verticalScrollDistance(frame);
     if (!distance)
         return false;
-    return frame.selection().modify(FrameSelection::Alteration::Extend, distance, FrameSelection::DirectionDown,
+    return frame.selection().modify(FrameSelection::Alteration::Extend, distance, FrameSelection::VerticalDirection::Down,
         UserTriggered::Yes, FrameSelection::CursorAlignOnScroll::Always);
 }
 
@@ -673,7 +673,7 @@ static bool executeMovePageUp(LocalFrame& frame, Event*, EditorCommandSource, co
     unsigned distance = verticalScrollDistance(frame);
     if (!distance)
         return false;
-    return frame.selection().modify(FrameSelection::Alteration::Move, distance, FrameSelection::DirectionUp,
+    return frame.selection().modify(FrameSelection::Alteration::Move, distance, FrameSelection::VerticalDirection::Up,
         UserTriggered::Yes, FrameSelection::CursorAlignOnScroll::Always);
 }
 
@@ -682,7 +682,7 @@ static bool executeMovePageUpAndModifySelection(LocalFrame& frame, Event*, Edito
     unsigned distance = verticalScrollDistance(frame);
     if (!distance)
         return false;
-    return frame.selection().modify(FrameSelection::Alteration::Extend, distance, FrameSelection::DirectionUp,
+    return frame.selection().modify(FrameSelection::Alteration::Extend, distance, FrameSelection::VerticalDirection::Up,
         UserTriggered::Yes, FrameSelection::CursorAlignOnScroll::Always);
 }
 

--- a/Source/WebCore/editing/FrameSelection.h
+++ b/Source/WebCore/editing/FrameSelection.h
@@ -60,8 +60,8 @@ class CaretBase {
 public:
     WEBCORE_EXPORT static Color computeCaretColor(const RenderStyle& elementStyle, const Node*);
 protected:
-    enum CaretVisibility { Visible, Hidden };
-    explicit CaretBase(CaretVisibility = Hidden);
+    enum class CaretVisibility : bool { Visible, Hidden };
+    explicit CaretBase(CaretVisibility = CaretVisibility::Hidden);
 
     void invalidateCaretRect(Node*, bool caretRectChanged = false, CaretAnimator* = nullptr);
     void clearCaretRect();
@@ -75,7 +75,7 @@ protected:
     void setCaretRectNeedsUpdate() { m_caretRectNeedsUpdate = true; }
 
     void setCaretVisibility(CaretVisibility visibility) { m_caretVisibility = visibility; }
-    bool caretIsVisible() const { return m_caretVisibility == Visible; }
+    bool caretIsVisible() const { return m_caretVisibility == CaretVisibility::Visible; }
     CaretVisibility caretVisibility() const { return m_caretVisibility; }
 
 private:
@@ -164,7 +164,7 @@ public:
     WEBCORE_EXPORT bool contains(const LayoutPoint&) const;
 
     WEBCORE_EXPORT bool modify(Alteration, SelectionDirection, TextGranularity, UserTriggered = UserTriggered::No);
-    enum VerticalDirection { DirectionUp, DirectionDown };
+    enum class VerticalDirection : bool { Up, Down };
     bool modify(Alteration, unsigned verticalDistance, VerticalDirection, UserTriggered = UserTriggered::No, CursorAlignOnScroll = CursorAlignOnScroll::IfNeeded);
 
     TextGranularity granularity() const { return m_granularity; }
@@ -195,7 +195,7 @@ public:
     void nodeWillBeRemoved(Node&);
     void textWasReplaced(CharacterData&, unsigned offset, unsigned oldLength, unsigned newLength);
 
-    void setCaretVisible(bool caretIsVisible) { setCaretVisibility(caretIsVisible ? Visible : Hidden, ShouldUpdateAppearance::Yes); }
+    void setCaretVisible(bool caretIsVisible) { setCaretVisibility(caretIsVisible ? CaretVisibility::Visible : CaretVisibility::Hidden, ShouldUpdateAppearance::Yes); }
     void paintCaret(GraphicsContext&, const LayoutPoint&, const LayoutRect& clipRect);
 
     // Used to suspend caret blinking while the mouse is down.
@@ -248,7 +248,7 @@ public:
     enum class ClipToVisibleContent : bool { No, Yes };
     WEBCORE_EXPORT FloatRect selectionBounds(ClipToVisibleContent = ClipToVisibleContent::Yes);
 
-    enum class TextRectangleHeight { TextHeight, SelectionHeight };
+    enum class TextRectangleHeight : bool { TextHeight, SelectionHeight };
     WEBCORE_EXPORT void getClippedVisibleTextRectangles(Vector<FloatRect>&, TextRectangleHeight = TextRectangleHeight::SelectionHeight) const;
 
     WEBCORE_EXPORT HTMLFormElement* currentForm() const;
@@ -298,7 +298,7 @@ private:
     VisiblePosition modifyMovingLeft(TextGranularity, bool* reachedBoundary = nullptr);
     VisiblePosition modifyMovingBackward(TextGranularity, bool* reachedBoundary = nullptr);
 
-    enum PositionType : uint8_t { Start, End, Extent };
+    enum class PositionType : uint8_t { Start, End, Extent };
     LayoutUnit lineDirectionPointForBlockDirectionNavigation(PositionType);
 
     AXTextStateChangeIntent textSelectionIntent(Alteration, SelectionDirection, TextGranularity);


### PR DESCRIPTION
#### 05b6a82d72138cfb89e758d8c1afd70a88c9c850
<pre>
Convert the remaining enums in FrameSelection.h to enum classes
<a href="https://bugs.webkit.org/show_bug.cgi?id=257061">https://bugs.webkit.org/show_bug.cgi?id=257061</a>

Reviewed by Wenson Hsieh.

* Source/WebCore/editing/EditorCommand.cpp:
(WebCore::executeMovePageDown):
(WebCore::executeMovePageDownAndModifySelection):
(WebCore::executeMovePageUp):
(WebCore::executeMovePageUpAndModifySelection):
* Source/WebCore/editing/FrameSelection.cpp:
(WebCore::DragCaretController::DragCaretController):
(WebCore::FrameSelection::FrameSelection):
(WebCore::FrameSelection::modifyExtendingForward):
(WebCore::FrameSelection::modifyMovingForward):
(WebCore::FrameSelection::modifyExtendingBackward):
(WebCore::FrameSelection::modifyMovingBackward):
(WebCore::FrameSelection::modify):
(WebCore::FrameSelection::lineDirectionPointForBlockDirectionNavigation):
(WebCore::CaretBase::paintCaret const):
(WebCore::FrameSelection::focusedOrActiveStateChanged):
* Source/WebCore/editing/FrameSelection.h:
(WebCore::CaretBase::caretIsVisible const):

Canonical link: <a href="https://commits.webkit.org/264288@main">https://commits.webkit.org/264288@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/be426fb90504e5033e4b6c17184838d744a51637

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/7264 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/7515 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/7691 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/8885 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/7471 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/7272 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/8849 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/7442 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/10365 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/7391 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/8088 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/6693 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/8994 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/5431 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/6622 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/14335 "Passed tests") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/7057 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/6750 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/9592 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/7196 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/5877 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/6553 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/10754 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/848 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/6935 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->