### PR TITLE
Increase max scrollbar update passes

### DIFF
--- a/LayoutTests/fast/editing/frame-selection-in-child-view-crash-expected.txt
+++ b/LayoutTests/fast/editing/frame-selection-in-child-view-crash-expected.txt
@@ -1,0 +1,1 @@
+This test passes if it does not crash

--- a/LayoutTests/fast/editing/frame-selection-in-child-view-crash.html
+++ b/LayoutTests/fast/editing/frame-selection-in-child-view-crash.html
@@ -1,0 +1,19 @@
+<style>
+    body {
+        width: 0vmin;
+        overflow-y: -webkit-paged-x;
+    }
+</style>
+<script>
+    if (window.testRunner)
+        testRunner.dumpAsText();
+    function main() {
+        x1.src = window.location;
+        x1.height = "10";
+        window.find("crash", false, false);
+    }
+</script>
+
+<body onload=main()>
+    <embed id="x1">This test passes if it does not crash</embed>
+</body>

--- a/Source/WebCore/platform/ScrollView.cpp
+++ b/Source/WebCore/platform/ScrollView.cpp
@@ -721,7 +721,7 @@ void ScrollView::updateScrollbars(const ScrollPosition& desiredPosition)
             }
         }
 
-        const unsigned cMaxUpdateScrollbarsPass = 2;
+        const unsigned cMaxUpdateScrollbarsPass = 3;
         if ((sendContentResizedNotification || needAnotherPass) && m_updateScrollbarsPass < cMaxUpdateScrollbarsPass) {
             m_updateScrollbarsPass++;
             availableContentSizeChanged(AvailableSizeChangeReason::ScrollbarsChanged);

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/CSSViewportUnits.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/CSSViewportUnits.mm
@@ -499,7 +499,7 @@ TEST(CSSViewportUnits, MinimumViewportInsetWithWritingMode)
     EXPECT_FLOAT_EQ(458, viewportUnitLength(webView, @"lvi"));
 
     {
-        double fixedWidth = widthOfElementWithID(webView, @"fixed"); // No vertical overflow.
+        double fixedWidth = widthOfElementWithID(webView, @"fixed") + scrollbarSize;
         double fixedHeight = heightOfElementWithID(webView, @"fixed") + scrollbarSize;
         EXPECT_FLOAT_EQ(fixedWidth, viewportUnitLength(webView, @"dvw"));
         EXPECT_FLOAT_EQ(fixedHeight, viewportUnitLength(webView, @"dvh"));
@@ -576,7 +576,7 @@ TEST(CSSViewportUnits, MaximumViewportInsetWithWritingMode)
     EXPECT_FLOAT_EQ(500, viewportUnitLength(webView, @"lvi"));
 
     {
-        double fixedWidth = widthOfElementWithID(webView, @"fixed"); // No vertical overflow.
+        double fixedWidth = widthOfElementWithID(webView, @"fixed") + scrollbarSize;
         double fixedHeight = heightOfElementWithID(webView, @"fixed") + scrollbarSize;
         EXPECT_FLOAT_EQ(fixedWidth, viewportUnitLength(webView, @"dvw"));
         EXPECT_FLOAT_EQ(fixedHeight, viewportUnitLength(webView, @"dvh"));


### PR DESCRIPTION
#### e4c271f0d9f8b4f3b7ea38335366734a81433920
<pre>
Increase max scrollbar update passes
rdar://104064235

Reviewed by Simon Fraser.

Scrollbars are not fully updated in a single layout which
can lead to an additional layout in the scriptDisallowedScope
in FrameView::scrollRectToVisibleInChildView.

* LayoutTests/fast/editing/frame-selection-in-child-view-crash-expected.txt: Added.
* LayoutTests/fast/editing/frame-selection-in-child-view-crash.html: Added.
* Source/WebCore/platform/ScrollView.cpp:
(WebCore::ScrollView::updateScrollbars):

* Tools/TestWebKitAPI/Tests/WebKitCocoa/CSSViewportUnits.mm:
(TEST):
Add scrollbarSize to width in WritingMode tests because we should
expect vertical overflow in these cases. This test would pass prior
to this patch despite the displayed WebView having both a vertical
and horizontal scroll bar.

Originally-landed-as: 259548.465@safari-7615-branch (cf0b3436ba58). rdar://104064235
Canonical link: <a href="https://commits.webkit.org/264353@main">https://commits.webkit.org/264353@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/8a6e228b514600f798219f6d9f65d3a550c4a5f7

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/7265 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/7516 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/7692 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/8886 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/7472 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/7273 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/8850 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/7443 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/10367 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/7392 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/8089 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/6679 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/8995 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/5432 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/6609 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/14337 "5 flakes 133 failures") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/7058 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/6712 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/9595 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/7197 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/5878 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/6554 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/6519 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/10755 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/882 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/6936 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->