### PR TITLE
Web Inspector: Deeply nested async stack traces are not fully truncated

### DIFF
--- a/LayoutTests/inspector/debugger/async-stack-trace-truncate-expected.txt
+++ b/LayoutTests/inspector/debugger/async-stack-trace-truncate-expected.txt
@@ -1,3 +1,4 @@
+CONSOLE MESSAGE: Reached 1 million iterations
 Tests for truncating async stack traces that exceed the maximum async stack trace depth.
 
 
@@ -44,4 +45,9 @@ ASYNC CALL STACK:
 3: [P] Global Code
 PASS: Async stack trace should not be truncated.
 -- Running test teardown.
+
+-- Running test case: AsyncStackTrace.CheckDeeplyNestedDoesNotCrash
+Performing deeply nested microtask.
+Clearing console.
+Running GC.
 

--- a/LayoutTests/inspector/debugger/async-stack-trace-truncate.html
+++ b/LayoutTests/inspector/debugger/async-stack-trace-truncate.html
@@ -20,6 +20,30 @@ function triggerChainedRequestAnimationFrame(count) {
     requestAnimationFrame(handleAnimationFrame);
 }
 
+function triggerDeeplyNestedAsyncMicrotask() {
+    return new Promise((resolve, reject) => {
+        function recursiveMicrotask(iteration = 0) {
+            queueMicrotask(() => {
+                if (iteration !== 0 && (iteration % 1_000_000) == 0) {
+                    try {
+                        // Throwing will log the error to the console.
+                        throw "Reached 1 million iterations";
+                    } catch (error) {
+                        console.error(error);
+                        resolve();
+                    }
+
+                    return;
+                }
+
+                recursiveMicrotask(iteration + 1);
+            });
+        }
+
+        recursiveMicrotask();
+    });
+}
+
 function test()
 {
     let suite = InspectorTest.createAsyncSuite("AsyncStackTrace.Truncate");
@@ -75,6 +99,27 @@ function test()
         pausedHandler(stackTrace) {
             InspectorTest.expectFalse(isTruncated(stackTrace), "Async stack trace should not be truncated.");
         }
+    });
+
+    suite.addTestCase({
+        name: "AsyncStackTrace.CheckDeeplyNestedDoesNotCrash",
+        description: "Ensure that very deeply nested stack traces do not result in a crash.",
+        async test() {
+            InspectorTest.log("Performing deeply nested microtask.")
+            await InspectorTest.evaluateInPage(`triggerDeeplyNestedAsyncMicrotask()`);
+
+            // triggerDeeplyNestedAsyncMicrotask() logged a stack trace to the console that was very deeply nested.
+            // Clear the console to release ownership of the logged stack trace.
+            InspectorTest.log("Clearing console.")
+            let consoleClearedEvent = WI.consoleManager.awaitEvent(WI.ConsoleManager.Event.Cleared);
+            ConsoleAgent.clearMessages();
+            await consoleClearedEvent;
+
+            InspectorTest.log("Running GC.")
+            let garbageCollectedEvent = WI.heapManager.awaitEvent(WI.HeapManager.Event.GarbageCollected);
+            HeapAgent.gc();
+            await garbageCollectedEvent;
+        },
     });
 
     suite.runTestCasesAndFinish();

--- a/Source/JavaScriptCore/inspector/AsyncStackTrace.cpp
+++ b/Source/JavaScriptCore/inspector/AsyncStackTrace.cpp
@@ -207,6 +207,8 @@ void AsyncStackTrace::remove()
     ASSERT(m_parent->m_childCount);
     m_parent->m_childCount--;
     m_parent = nullptr;
+
+    m_callStack->removeParentStackTrace();
 }
 
 } // namespace Inspector

--- a/Source/JavaScriptCore/inspector/ScriptCallStack.cpp
+++ b/Source/JavaScriptCore/inspector/ScriptCallStack.cpp
@@ -89,6 +89,11 @@ void ScriptCallStack::append(const ScriptCallFrame& frame)
     m_frames.append(frame);
 }
 
+void ScriptCallStack::removeParentStackTrace()
+{
+    m_parentStackTrace = nullptr;
+}
+
 bool ScriptCallStack::isEqual(ScriptCallStack* o) const
 {
     if (!o)

--- a/Source/JavaScriptCore/inspector/ScriptCallStack.h
+++ b/Source/JavaScriptCore/inspector/ScriptCallStack.h
@@ -55,6 +55,7 @@ public:
     bool truncated() const { return m_truncated; }
 
     const RefPtr<AsyncStackTrace>& parentStackTrace() const { return m_parentStackTrace; }
+    void removeParentStackTrace();
 
     const ScriptCallFrame* firstNonNativeCallFrame() const;
 


### PR DESCRIPTION
#### 33106442561e29aec6760903d306bb78c3eee2fc
<pre>
Web Inspector: Deeply nested async stack traces are not fully truncated
<a href="https://bugs.webkit.org/show_bug.cgi?id=254244">https://bugs.webkit.org/show_bug.cgi?id=254244</a>
rdar://105900359

Reviewed by Yusuke Suzuki.

As of 252630@main, ScriptCallStack holds a reference to its parent AsyncStackTrace to enable providing async stack
traces in places where previously the async context was being lost. However when this was added, the truncation
functionality used to ensure that AsyncStackTrace did not create an infinitely nested set of objects did not take the
new reference into account. In practice, we should break that relationship any time we are removing the parent of the
AsyncStackTrace. This allows us to correctly release ownership of AsyncStackTraces as we nest deeper, then preventing us
from recursing during their deconstruction later.

* LayoutTests/inspector/debugger/async-stack-trace-truncate-expected.txt:
* LayoutTests/inspector/debugger/async-stack-trace-truncate.html:
- Add test case that creates a nested set of AsyncStackTrace/ScriptCallStack that will exceed the size of the stack if
not correctly truncated.

* Source/JavaScriptCore/inspector/AsyncStackTrace.cpp:
(Inspector::AsyncStackTrace::remove):
Remove the ScriptCallStack&apos;s parent at the same time we remove the AsyncStackTrace&apos;s parent.

* Source/JavaScriptCore/inspector/ScriptCallStack.cpp:
(Inspector::ScriptCallStack::removeParentStackTrace):
* Source/JavaScriptCore/inspector/ScriptCallStack.h:

Originally-landed-as: 259548.467@safari-7615-branch (69eae63cd374). rdar://105900359
Canonical link: <a href="https://commits.webkit.org/264354@main">https://commits.webkit.org/264354@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/56b82a3cbaea7e2aaea72742e032e4dbaff0fad2

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/7270 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/7521 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/7697 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/8891 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/7477 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/8855 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/7448 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/10374 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/7397 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/8095 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/6681 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/9000 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/5438 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/6611 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/14344 "34 flakes 111 failures") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/6166 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/7064 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/6714 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/9602 "8 api tests failed or timed out") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/6853 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/7202 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/5881 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/7411 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/6559 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/6521 "Passed tests") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/1709 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/10760 "Built successfully") | | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/24/builds/7614 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/883 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/6941 "Built successfully") | | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/3/builds/1847 "Passed tests") | 
<!--EWS-Status-Bubble-End-->