### PR TITLE
Fix heap use-after-free in Update::addSVGRendererUpdate

### DIFF
--- a/LayoutTests/svg/animations/svg-element-attribute-changed-crash-expected.txt
+++ b/LayoutTests/svg/animations/svg-element-attribute-changed-crash-expected.txt
@@ -1,0 +1,1 @@
+PASS if no crash

--- a/LayoutTests/svg/animations/svg-element-attribute-changed-crash.html
+++ b/LayoutTests/svg/animations/svg-element-attribute-changed-crash.html
@@ -1,0 +1,17 @@
+<script>
+  onload = async () => {
+    if (window.testRunner)
+      testRunner.dumpAsText();
+    let svg0 = document.createElementNS('http://www.w3.org/2000/svg', 'svg');
+    let svgAnimatedLength = svg0.width;
+    let observation = internals.observeGC(svgAnimatedLength)
+    let baseVal = svgAnimatedLength.baseVal;
+    let clipPath0 = document.createElementNS('http://www.w3.org/2000/svg', 'clipPath');
+    svg0.append(clipPath0);
+    clipPath0.append('');
+    await undefined;
+    GCController.collect();
+    baseVal.value = 0;
+    document.body.innerHTML = 'PASS if no crash';
+  };
+</script>

--- a/Source/WebCore/svg/properties/SVGAnimatedProperty.cpp
+++ b/Source/WebCore/svg/properties/SVGAnimatedProperty.cpp
@@ -39,7 +39,8 @@ void SVGAnimatedProperty::commitPropertyChange(SVGProperty*)
 {
     if (!m_contextElement)
         return;
-    m_contextElement->commitPropertyChange(*this);
+    RefPtr protectedContextElement = m_contextElement;
+    protectedContextElement->commitPropertyChange(*this);
 }
 
 }


### PR DESCRIPTION
#### 777fe1501522cc907234a327b306b3cafffb1501
<pre>
Fix heap use-after-free in Update::addSVGRendererUpdate
<a href="https://bugs.webkit.org/show_bug.cgi?id=254281">https://bugs.webkit.org/show_bug.cgi?id=254281</a>
rdar://107052707

Reviewed by Ryosuke Niwa.

Update::addSVGRendererUpdate can end up removing the SVGElement from
m_roots, which can result in SVGElement being deleted when an attribute
change happens. This change prevents that by protecting the SVGElement
using a RefPtr.

* LayoutTests/svg/animations/svg-element-attribute-changed-crash-expected.txt: Added.
* LayoutTests/svg/animations/svg-element-attribute-changed-crash.html: Added.
* Source/WebCore/svg/properties/SVGAnimatedProperty.cpp:
(WebCore::SVGAnimatedProperty::commitPropertyChange):

Originally-landed-as: 259548.475@safari-7615-branch (aaa1c998206d). rdar://107052707
Canonical link: <a href="https://commits.webkit.org/264355@main">https://commits.webkit.org/264355@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/3c4bd4e3efce8a5f3ec0e8912119ce0baf7e64f8

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/7271 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/7522 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/7698 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/8892 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/7478 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/7279 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/8856 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/7449 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/10370 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/7398 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/8093 "2 new passes 10 flakes 1 failures") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/6696 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/9001 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/5436 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/6625 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/14341 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/7062 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/6729 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/9599 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/7203 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/5886 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/6560 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/6536 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/10761 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/884 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/6942 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->