### PR TITLE
[WebGPU] [Style] Lambdas in PAL/WebGPU capture more than they should and don't have correct whitespacing

### DIFF
--- a/Source/WebCore/PAL/pal/graphics/WebGPU/Impl/WebGPUAdapterImpl.cpp
+++ b/Source/WebCore/PAL/pal/graphics/WebGPU/Impl/WebGPUAdapterImpl.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2022 Apple Inc. All rights reserved.
+ * Copyright (C) 2021-2023 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -198,8 +198,8 @@ void AdapterImpl::requestDevice(const DeviceDescriptor& descriptor, CompletionHa
 {
     auto label = descriptor.label.utf8();
 
-    auto features = descriptor.requiredFeatures.map([this] (auto featureName) {
-        return m_convertToBackingContext->convertToBacking(featureName);
+    auto features = descriptor.requiredFeatures.map([&convertToBackingContext = m_convertToBackingContext.get()](auto featureName) {
+        return convertToBackingContext.convertToBacking(featureName);
     });
 
     auto limits = WGPULimits {

--- a/Source/WebCore/PAL/pal/graphics/WebGPU/Impl/WebGPUCompositorIntegrationImpl.cpp
+++ b/Source/WebCore/PAL/pal/graphics/WebGPU/Impl/WebGPUCompositorIntegrationImpl.cpp
@@ -99,7 +99,7 @@ Vector<MachSendRight> CompositorIntegrationImpl::recreateRenderBuffers(int width
         m_renderBuffersWereRecreatedCallback(static_cast<CFArrayRef>(renderBuffers));
     }
 
-    return m_renderBuffers.map([] (const auto& renderBuffer) {
+    return m_renderBuffers.map([](const auto& renderBuffer) {
         return MachSendRight::adopt(IOSurfaceCreateMachPort(renderBuffer.get()));
     });
 }

--- a/Source/WebCore/PAL/pal/graphics/WebGPU/Impl/WebGPUConvertToBackingContext.cpp
+++ b/Source/WebCore/PAL/pal/graphics/WebGPU/Impl/WebGPUConvertToBackingContext.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2022 Apple Inc. All rights reserved.
+ * Copyright (C) 2021-2023 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -783,14 +783,14 @@ WGPUTextureUsageFlags ConvertToBackingContext::convertTextureUsageFlagsToBacking
 
 WGPUColor ConvertToBackingContext::convertToBacking(const Color& color)
 {
-    return WTF::switchOn(color, [] (const Vector<double>& vector) {
+    return WTF::switchOn(color, [](const Vector<double>& vector) {
         return WGPUColor {
             vector.size() > 0 ? vector[0] : 0,
             vector.size() > 1 ? vector[1] : 0,
             vector.size() > 2 ? vector[2] : 0,
             vector.size() > 3 ? vector[3] : 0,
         };
-    }, [] (const ColorDict& color) {
+    }, [](const ColorDict& color) {
         return WGPUColor {
             color.r,
             color.g,
@@ -802,13 +802,13 @@ WGPUColor ConvertToBackingContext::convertToBacking(const Color& color)
 
 WGPUExtent3D ConvertToBackingContext::convertToBacking(const Extent3D& extent3D)
 {
-    return WTF::switchOn(extent3D, [] (const Vector<IntegerCoordinate>& vector) {
+    return WTF::switchOn(extent3D, [](const Vector<IntegerCoordinate>& vector) {
         return WGPUExtent3D {
             vector.size() > 0 ? vector[0] : 1,
             vector.size() > 1 ? vector[1] : 1,
             vector.size() > 2 ? vector[2] : 1,
         };
-    }, [] (const Extent3DDict& extent) {
+    }, [](const Extent3DDict& extent) {
         return WGPUExtent3D {
             extent.width,
             extent.height,
@@ -819,13 +819,13 @@ WGPUExtent3D ConvertToBackingContext::convertToBacking(const Extent3D& extent3D)
 
 WGPUOrigin3D ConvertToBackingContext::convertToBacking(const Origin2D& origin2D)
 {
-    return WTF::switchOn(origin2D, [] (const Vector<IntegerCoordinate>& vector) {
+    return WTF::switchOn(origin2D, [](const Vector<IntegerCoordinate>& vector) {
         return WGPUOrigin3D {
             vector.size() > 0 ? vector[0] : 0,
             vector.size() > 1 ? vector[1] : 0,
             0,
         };
-    }, [] (const Origin2DDict& origin) {
+    }, [](const Origin2DDict& origin) {
         return WGPUOrigin3D {
             origin.x,
             origin.y,
@@ -836,13 +836,13 @@ WGPUOrigin3D ConvertToBackingContext::convertToBacking(const Origin2D& origin2D)
 
 WGPUOrigin3D ConvertToBackingContext::convertToBacking(const Origin3D& origin3D)
 {
-    return WTF::switchOn(origin3D, [] (const Vector<IntegerCoordinate>& vector) {
+    return WTF::switchOn(origin3D, [](const Vector<IntegerCoordinate>& vector) {
         return WGPUOrigin3D {
             vector.size() > 0 ? vector[0] : 0,
             vector.size() > 1 ? vector[1] : 0,
             vector.size() > 2 ? vector[2] : 0,
         };
-    }, [] (const Origin3DDict& origin) {
+    }, [](const Origin3DDict& origin) {
         return WGPUOrigin3D {
             origin.x,
             origin.y,

--- a/Source/WebCore/PAL/pal/graphics/WebGPU/Impl/WebGPUQueueImpl.cpp
+++ b/Source/WebCore/PAL/pal/graphics/WebGPU/Impl/WebGPUQueueImpl.cpp
@@ -60,8 +60,8 @@ QueueImpl::~QueueImpl()
 
 void QueueImpl::submit(Vector<std::reference_wrapper<CommandBuffer>>&& commandBuffers)
 {
-    auto backingCommandBuffers = commandBuffers.map([this] (auto commandBuffer) {
-        return m_convertToBackingContext->convertToBacking(commandBuffer);
+    auto backingCommandBuffers = commandBuffers.map([&convertToBackingContext = m_convertToBackingContext.get()](auto commandBuffer) {
+        return convertToBackingContext.convertToBacking(commandBuffer);
     });
 
     wgpuQueueSubmit(m_backing, backingCommandBuffers.size(), backingCommandBuffers.data());

--- a/Source/WebCore/PAL/pal/graphics/WebGPU/Impl/WebGPURenderPassEncoderImpl.cpp
+++ b/Source/WebCore/PAL/pal/graphics/WebGPU/Impl/WebGPURenderPassEncoderImpl.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2022 Apple Inc. All rights reserved.
+ * Copyright (C) 2021-2023 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -158,8 +158,8 @@ void RenderPassEncoderImpl::endOcclusionQuery()
 
 void RenderPassEncoderImpl::executeBundles(Vector<std::reference_wrapper<RenderBundle>>&& renderBundles)
 {
-    auto backingBundles = renderBundles.map([this] (auto renderBundle) {
-        return m_convertToBackingContext->convertToBacking(renderBundle.get());
+    auto backingBundles = renderBundles.map([&convertToBackingContext = m_convertToBackingContext.get()](auto renderBundle) {
+        return convertToBackingContext.convertToBacking(renderBundle.get());
     });
 
     wgpuRenderPassEncoderExecuteBundles(m_backing, backingBundles.size(), backingBundles.data());

--- a/Source/WebCore/PAL/pal/graphics/WebGPU/Impl/WebGPUTextureImpl.cpp
+++ b/Source/WebCore/PAL/pal/graphics/WebGPU/Impl/WebGPUTextureImpl.cpp
@@ -69,7 +69,7 @@ Ref<TextureView> TextureImpl::createView(const std::optional<TextureViewDescript
         nullptr,
         label.data(),
         descriptor && descriptor->format ? m_convertToBackingContext->convertToBacking(*descriptor->format) : m_convertToBackingContext->convertToBacking(m_format),
-        ([&] () -> WGPUTextureViewDimension {
+        ([&]() -> WGPUTextureViewDimension {
             if (descriptor && descriptor->dimension)
                 return m_convertToBackingContext->convertToBacking(*descriptor->dimension);
             switch (m_dimension) {


### PR DESCRIPTION
#### bb2ddeb3d448c9b441e27b7e86dafc0657511bb6
<pre>
[WebGPU] [Style] Lambdas in PAL/WebGPU capture more than they should and don&apos;t have correct whitespacing
<a href="https://bugs.webkit.org/show_bug.cgi?id=257064">https://bugs.webkit.org/show_bug.cgi?id=257064</a>
rdar://109589314

Reviewed by Dan Glastonbury.

This patch doesn&apos;t have any behavior change - it&apos;s just about style.

I generally try to avoid capturing &quot;this&quot; in a lambda, as:
1. Lambdas don&apos;t usually need all the member variables inside &quot;this&quot;, and it&apos;s always good to limit
       the scope of what&apos;s available
2. Depending on how the object is owned (RefPtr, unique_ptr, etc.), naively capturing &quot;this&quot; might
       lead to a UAF or a retain cycle, if you do it wrong.

This patch removes most of the uses of capturing &quot;this&quot; inside PAL/WebGPU.

* Source/WebCore/PAL/pal/graphics/WebGPU/Impl/WebGPUAdapterImpl.cpp:
(PAL::WebGPU::AdapterImpl::requestDevice):
* Source/WebCore/PAL/pal/graphics/WebGPU/Impl/WebGPUCompositorIntegrationImpl.cpp:
(PAL::WebGPU::CompositorIntegrationImpl::recreateRenderBuffers):
* Source/WebCore/PAL/pal/graphics/WebGPU/Impl/WebGPUConvertToBackingContext.cpp:
(PAL::WebGPU::ConvertToBackingContext::convertToBacking):
* Source/WebCore/PAL/pal/graphics/WebGPU/Impl/WebGPUDeviceImpl.cpp:
(PAL::WebGPU::DeviceImpl::createTexture):
(PAL::WebGPU::DeviceImpl::createBindGroupLayout):
(PAL::WebGPU::DeviceImpl::createPipelineLayout):
(PAL::WebGPU::DeviceImpl::createBindGroup):
(PAL::WebGPU::DeviceImpl::createShaderModule):
(PAL::WebGPU::convertToBacking):
(PAL::WebGPU::DeviceImpl::createComputePipeline):
(PAL::WebGPU::DeviceImpl::createRenderPipeline):
(PAL::WebGPU::DeviceImpl::createComputePipelineAsync):
(PAL::WebGPU::DeviceImpl::createRenderPipelineAsync):
(PAL::WebGPU::DeviceImpl::createRenderBundleEncoder):
(PAL::WebGPU::DeviceImpl::resolveDeviceLostPromise):
* Source/WebCore/PAL/pal/graphics/WebGPU/Impl/WebGPUQueueImpl.cpp:
(PAL::WebGPU::QueueImpl::submit):
* Source/WebCore/PAL/pal/graphics/WebGPU/Impl/WebGPURenderPassEncoderImpl.cpp:
(PAL::WebGPU::RenderPassEncoderImpl::executeBundles):
* Source/WebCore/PAL/pal/graphics/WebGPU/Impl/WebGPUTextureImpl.cpp:
(PAL::WebGPU::TextureImpl::createView):

Canonical link: <a href="https://commits.webkit.org/264308@main">https://commits.webkit.org/264308@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c972a58bfc74bb0cd945f996bbf188f250d59738

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/7373 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/7631 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/7806 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/9002 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/7578 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/7383 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/9405 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/7556 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/10464 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/7502 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/8504 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/6818 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/9111 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/5822 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/6707 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/14431 "Passed tests") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/7158 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/6817 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/10021 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/7307 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/5972 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/6659 "Built successfully") | | | 
| [❌ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/1728 "Failed to push commit to Webkit repository") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/10865 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/7043 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->