### PR TITLE
Null ptr deref in CSSStyleSheet::replaceSync.

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/cssom/css-stylesheet-replaceSync-null-deref-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/cssom/css-stylesheet-replaceSync-null-deref-expected.txt
@@ -1,0 +1,1 @@
+Pass if no crash.

--- a/LayoutTests/imported/w3c/web-platform-tests/css/cssom/css-stylesheet-replaceSync-null-deref.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/cssom/css-stylesheet-replaceSync-null-deref.html
@@ -1,0 +1,13 @@
+<script>
+function test() {
+    if (window.testRunner)
+        testRunner.dumpAsText();
+    let cssStyleSheet = new CSSStyleSheet();
+    cssStyleSheet.addRule();
+    cssStyleSheet.addRule();
+    cssStyleSheet.rules.item(0);
+    cssStyleSheet.replaceSync('');
+    document.write("Pass if no crash.");
+}
+</script>
+<body onload=test()></body>

--- a/Source/WebCore/css/CSSStyleSheet.cpp
+++ b/Source/WebCore/css/CSSStyleSheet.cpp
@@ -494,7 +494,8 @@ ExceptionOr<void> CSSStyleSheet::replaceSync(String&& text)
     RuleMutationScope mutationScope(this, RuleReplace);
     m_contents->clearRules();
     for (auto& childRuleWrapper : m_childRuleCSSOMWrappers)
-        childRuleWrapper->setParentStyleSheet(nullptr);
+        if (childRuleWrapper)
+            childRuleWrapper->setParentStyleSheet(nullptr);
     m_childRuleCSSOMWrappers.clear();
 
     m_contents->parseString(WTFMove(text));


### PR DESCRIPTION
#### 9565d92681d724cfb509da570d98241ab6263272
<pre>
Null ptr deref in CSSStyleSheet::replaceSync.
<a href="https://bugs.webkit.org/show_bug.cgi?id=254727.">https://bugs.webkit.org/show_bug.cgi?id=254727.</a>
rdar://101629411.

Reviewed by Chris Dumez.

Added a null check in CSSStyleSheet::replaceSync to prevent a null deref.

* LayoutTests/imported/w3c/web-platform-tests/css/cssom/css-stylesheet-replaceSync-null-deref-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/cssom/css-stylesheet-replaceSync-null-deref.html: Added.
* Source/WebCore/css/CSSStyleSheet.cpp:
(WebCore::CSSStyleSheet::replaceSync):

Originally-landed-as: 259548.524@safari-7615-branch (a48f8590fa3e). rdar://101629411
Canonical link: <a href="https://commits.webkit.org/264358@main">https://commits.webkit.org/264358@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/650157fc62c8198d938727e643f7d4c3aabf65db

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/7276 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/7528 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/7703 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/8898 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/7483 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/7284 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/8861 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/7454 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/10377 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/7403 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/8097 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/6692 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/9006 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/5440 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/6621 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/14349 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/7066 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/6724 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/9607 "run-api-tests-without-change (failure)") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/7208 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/5889 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/6565 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/6531 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/10766 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/885 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/6947 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->