### PR TITLE
Ignore snap offsets with an identifier of zero

### DIFF
--- a/LayoutTests/fast/scrolling/scroll-snap-crash-expected.txt
+++ b/LayoutTests/fast/scrolling/scroll-snap-crash-expected.txt
@@ -1,0 +1,1 @@
+This test passes if it does not crash

--- a/LayoutTests/fast/scrolling/scroll-snap-crash.html
+++ b/LayoutTests/fast/scrolling/scroll-snap-crash.html
@@ -1,0 +1,21 @@
+<style>
+html {
+    padding: 100%;
+    scroll-snap-type: x;
+}
+::-webkit-scrollbar {
+    background: #000;
+}
+::-webkit-scrollbar-button {
+    scroll-snap-align: center;
+}
+</style>
+<script>
+if (window.testRunner)
+    testRunner.dumpAsText();
+onload = () => {
+    document.body.offsetTop;
+    document.body.dir = 'rtl';
+};
+</script>
+<p>This test passes if it does not crash</p>

--- a/Source/WebCore/platform/ScrollSnapAnimatorState.cpp
+++ b/Source/WebCore/platform/ScrollSnapAnimatorState.cpp
@@ -128,12 +128,16 @@ HashSet<ElementIdentifier> ScrollSnapAnimatorState::currentlySnappedBoxes(const 
     HashSet<ElementIdentifier> snappedBoxIDs;
         
     for (auto offset : horizontalOffsets) {
+        if (!offset.snapTargetID)
+            continue;
         snappedBoxIDs.add(offset.snapTargetID);
         for (auto i : offset.snapAreaIndices)
             snappedBoxIDs.add(m_snapOffsetsInfo.snapAreasIDs[i]);
     }
     
     for (auto offset : verticalOffsets) {
+        if (!offset.snapTargetID)
+            continue;
         snappedBoxIDs.add(offset.snapTargetID);
         for (auto i : offset.snapAreaIndices)
             snappedBoxIDs.add(m_snapOffsetsInfo.snapAreasIDs[i]);


### PR DESCRIPTION
#### 439b3f7091afcdcb29c02821fd8ead3b24d90d60
<pre>
Ignore snap offsets with an identifier of zero
<a href="https://bugs.webkit.org/show_bug.cgi?id=254383">https://bugs.webkit.org/show_bug.cgi?id=254383</a>
rdar://107130316

Reviewed by Simon Fraser.

When updating snap offsets, if there is no element for a RenderBox,
then a snap offset with an identifier of 0 is created. This can lead
to issues when we add that offset identifier to a HashSet so we should
ignore them in ScrollSnapAnimatorState::currentlySnappedBoxes().

* LayoutTests/fast/animation/scroll-snap-crash-expected.txt: Added.
* LayoutTests/fast/animation/scroll-snap-crash.html: Added.
* Source/WebCore/platform/ScrollSnapAnimatorState.cpp:
(WebCore::ScrollSnapAnimatorState::currentlySnappedBoxes const):

Originally-landed-as: 259548.525@safari-7615-branch (3d4fc69bfad2). rdar://107130316
Canonical link: <a href="https://commits.webkit.org/264359@main">https://commits.webkit.org/264359@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/69591387f0b2d2c4f374b0e7963b06416681dc8a

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/7277 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/7529 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/7704 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/8899 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/7484 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/7285 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/8862 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/7455 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/10379 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/7404 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/8100 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/6695 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/9007 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/5443 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/6624 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/14350 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/7069 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/6728 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/9608 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/7209 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/5890 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/6566 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/6535 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/10767 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/886 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/6948 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->