### PR TITLE
Potential use-after-free in WebAnimation::commitStyles

### DIFF
--- a/Source/WebCore/animation/WebAnimation.cpp
+++ b/Source/WebCore/animation/WebAnimation.cpp
@@ -1531,8 +1531,8 @@ ExceptionOr<void> WebAnimation::commitStyles()
     // https://drafts.csswg.org/web-animations-1/#commit-computed-styles
 
     // 1. Let targets be the set of all effect targets for animation effects associated with animation.
-    auto* effect = dynamicDowncast<KeyframeEffect>(m_effect.get());
-    auto* target = effect ? effect->target() : nullptr;
+    RefPtr effect = dynamicDowncast<KeyframeEffect>(m_effect.get());
+    RefPtr target = effect ? effect->target() : nullptr;
 
     // 2. For each target in targets:
     //


### PR DESCRIPTION
#### 85fd2302d16a09a82d9a6e81eb286babb23c4b3c
<pre>
Potential use-after-free in WebAnimation::commitStyles
<a href="https://bugs.webkit.org/show_bug.cgi?id=254840">https://bugs.webkit.org/show_bug.cgi?id=254840</a>
rdar://107444873

Reviewed by Dean Jackson and Darin Adler.

Ensure that the animation&apos;s effect and target are kept alive for the duration of this method
since it is possible that calling updateStyleIfNeeded() could call into JavaScript and thus
these two pointers could be changed to a null value using the Web Animations API.

* Source/WebCore/animation/WebAnimation.cpp:
(WebCore::WebAnimation::commitStyles):

Originally-landed-as: 259548.532@safari-7615-branch (1d6fe184ea53). rdar://107444873
Canonical link: <a href="https://commits.webkit.org/264363@main">https://commits.webkit.org/264363@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/25f920bd9fb5cf23edfaed9ab2df3724d14ec90a

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/7278 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/7530 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/7705 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/8900 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/7485 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/7286 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/8863 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/7456 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/10380 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/7405 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/8101 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/6691 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/9008 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/5444 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/6620 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/14348 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/7070 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/6723 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/9606 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/7210 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/5891 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/6567 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/10768 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/889 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/6949 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->