### PR TITLE
[WebGPU] [Style] Make lambdas in Modules/WebGPU adhere to the style guide

### DIFF
--- a/Source/WebCore/Modules/WebGPU/GPU.cpp
+++ b/Source/WebCore/Modules/WebGPU/GPU.cpp
@@ -55,7 +55,7 @@ struct GPU::PendingRequestAdapterArguments {
 
 void GPU::requestAdapter(const std::optional<GPURequestAdapterOptions>& options, RequestAdapterPromise&& promise)
 {
-    m_backing->requestAdapter(convertToBacking(options), [promise = WTFMove(promise)] (RefPtr<PAL::WebGPU::Adapter>&& adapter) mutable {
+    m_backing->requestAdapter(convertToBacking(options), [promise = WTFMove(promise)](RefPtr<PAL::WebGPU::Adapter>&& adapter) mutable {
         if (!adapter) {
             promise.resolve(nullptr);
             return;

--- a/Source/WebCore/Modules/WebGPU/GPUAdapter.cpp
+++ b/Source/WebCore/Modules/WebGPU/GPUAdapter.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021 Apple Inc. All rights reserved.
+ * Copyright (C) 2021-2023 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -63,7 +63,7 @@ static PAL::WebGPU::DeviceDescriptor convertToBacking(const std::optional<GPUDev
 
 void GPUAdapter::requestDevice(ScriptExecutionContext&, const std::optional<GPUDeviceDescriptor>& deviceDescriptor, RequestDevicePromise&& promise)
 {
-    m_backing->requestDevice(convertToBacking(deviceDescriptor), [promise = WTFMove(promise)] (RefPtr<PAL::WebGPU::Device>&& device) mutable {
+    m_backing->requestDevice(convertToBacking(deviceDescriptor), [promise = WTFMove(promise)](RefPtr<PAL::WebGPU::Device>&& device) mutable {
         if (!device.get())
             promise.reject(Exception(OperationError));
         else

--- a/Source/WebCore/Modules/WebGPU/GPUBindGroupDescriptor.h
+++ b/Source/WebCore/Modules/WebGPU/GPUBindGroupDescriptor.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021 Apple Inc. All rights reserved.
+ * Copyright (C) 2021-2023 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -40,7 +40,7 @@ struct GPUBindGroupDescriptor : public GPUObjectDescriptorBase {
         return {
             { label },
             layout->backing(),
-            entries.map([] (auto& bindGroupEntry) {
+            entries.map([](auto& bindGroupEntry) {
                 return bindGroupEntry.convertToBacking();
             }),
         };

--- a/Source/WebCore/Modules/WebGPU/GPUBindGroupEntry.h
+++ b/Source/WebCore/Modules/WebGPU/GPUBindGroupEntry.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021 Apple Inc. All rights reserved.
+ * Copyright (C) 2021-2023 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -40,15 +40,15 @@ using GPUBindingResource = std::variant<RefPtr<GPUSampler>, RefPtr<GPUTextureVie
 
 inline PAL::WebGPU::BindingResource convertToBacking(const GPUBindingResource& bindingResource)
 {
-    return WTF::switchOn(bindingResource, [] (const RefPtr<GPUSampler>& sampler) -> PAL::WebGPU::BindingResource {
+    return WTF::switchOn(bindingResource, [](const RefPtr<GPUSampler>& sampler) -> PAL::WebGPU::BindingResource {
         ASSERT(sampler);
         return sampler->backing();
-    }, [] (const RefPtr<GPUTextureView>& textureView) -> PAL::WebGPU::BindingResource {
+    }, [](const RefPtr<GPUTextureView>& textureView) -> PAL::WebGPU::BindingResource {
         ASSERT(textureView);
         return textureView->backing();
-    }, [] (const GPUBufferBinding& bufferBinding) -> PAL::WebGPU::BindingResource {
+    }, [](const GPUBufferBinding& bufferBinding) -> PAL::WebGPU::BindingResource {
         return bufferBinding.convertToBacking();
-    }, [] (const RefPtr<GPUExternalTexture>& externalTexture) -> PAL::WebGPU::BindingResource {
+    }, [](const RefPtr<GPUExternalTexture>& externalTexture) -> PAL::WebGPU::BindingResource {
         ASSERT(externalTexture);
         return externalTexture->backing();
     });

--- a/Source/WebCore/Modules/WebGPU/GPUBindGroupLayoutDescriptor.h
+++ b/Source/WebCore/Modules/WebGPU/GPUBindGroupLayoutDescriptor.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021 Apple Inc. All rights reserved.
+ * Copyright (C) 2021-2023 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -37,7 +37,7 @@ struct GPUBindGroupLayoutDescriptor : public GPUObjectDescriptorBase {
     {
         return {
             { label },
-            entries.map([] (auto& entry) {
+            entries.map([](auto& entry) {
                 return entry.convertToBacking();
             }),
         };

--- a/Source/WebCore/Modules/WebGPU/GPUBuffer.cpp
+++ b/Source/WebCore/Modules/WebGPU/GPUBuffer.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2022 Apple Inc. All rights reserved.
+ * Copyright (C) 2021-2023 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -71,7 +71,8 @@ void GPUBuffer::mapAsync(GPUMapModeFlags mode, std::optional<GPUSize64> offset, 
         m_mapState = GPUBufferMapState::Pending;
 
     m_pendingMapPromise = promise;
-    m_backing->mapAsync(convertMapModeFlagsToBacking(mode), offset.value_or(0), size, [promise = WTFMove(promise), protectedThis = Ref { *this }] (bool success) mutable {
+    // FIXME: Should this capture a weak pointer to |this| instead?
+    m_backing->mapAsync(convertMapModeFlagsToBacking(mode), offset.value_or(0), size, [promise = WTFMove(promise), protectedThis = Ref { *this }](bool success) mutable {
         if (!protectedThis->m_pendingMapPromise)
             return;
 

--- a/Source/WebCore/Modules/WebGPU/GPUCanvasConfiguration.h
+++ b/Source/WebCore/Modules/WebGPU/GPUCanvasConfiguration.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2022 Apple Inc. All rights reserved.
+ * Copyright (C) 2021-2023 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -43,7 +43,7 @@ struct GPUCanvasConfiguration {
             device->backing(),
             WebCore::convertToBacking(format),
             convertTextureUsageFlagsToBacking(usage),
-            viewFormats.map([] (auto& viewFormat) {
+            viewFormats.map([](auto& viewFormat) {
                 return WebCore::convertToBacking(viewFormat);
             }),
             WebCore::convertToBacking(colorSpace),

--- a/Source/WebCore/Modules/WebGPU/GPUColorDict.h
+++ b/Source/WebCore/Modules/WebGPU/GPUColorDict.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021 Apple Inc. All rights reserved.
+ * Copyright (C) 2021-2023 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -53,9 +53,9 @@ using GPUColor = std::variant<Vector<double>, GPUColorDict>;
 
 inline PAL::WebGPU::Color convertToBacking(const GPUColor& color)
 {
-    return WTF::switchOn(color, [] (const Vector<double>& vector) -> PAL::WebGPU::Color {
+    return WTF::switchOn(color, [](const Vector<double>& vector) -> PAL::WebGPU::Color {
         return vector;
-    }, [] (const GPUColorDict& color) -> PAL::WebGPU::Color {
+    }, [](const GPUColorDict& color) -> PAL::WebGPU::Color {
         return color.convertToBacking();
     });
 }

--- a/Source/WebCore/Modules/WebGPU/GPUCompilationInfo.cpp
+++ b/Source/WebCore/Modules/WebGPU/GPUCompilationInfo.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021 Apple Inc. All rights reserved.
+ * Copyright (C) 2021-2023 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -30,7 +30,7 @@ namespace WebCore {
 
 Vector<Ref<GPUCompilationMessage>> GPUCompilationInfo::messages() const
 {
-    return m_backing->messages().map([] (const auto& message) {
+    return m_backing->messages().map([](const auto& message) {
         return GPUCompilationMessage::create(message);
     });
 }

--- a/Source/WebCore/Modules/WebGPU/GPUComputePassTimestampWrite.h
+++ b/Source/WebCore/Modules/WebGPU/GPUComputePassTimestampWrite.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021 Apple Inc. All rights reserved.
+ * Copyright (C) 2021-2023 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -54,7 +54,7 @@ using GPUComputePassTimestampWrites = Vector<GPUComputePassTimestampWrite>;
 
 inline PAL::WebGPU::ComputePassTimestampWrites convertToBacking(const GPUComputePassTimestampWrites& computePassTimestampWrites)
 {
-    return computePassTimestampWrites.map([] (auto& computePassTimestampWrite) {
+    return computePassTimestampWrites.map([](auto& computePassTimestampWrite) {
         return computePassTimestampWrite.convertToBacking();
     });
 }

--- a/Source/WebCore/Modules/WebGPU/GPUDeviceDescriptor.h
+++ b/Source/WebCore/Modules/WebGPU/GPUDeviceDescriptor.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021 Apple Inc. All rights reserved.
+ * Copyright (C) 2021-2023 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -41,7 +41,7 @@ struct GPUDeviceDescriptor : public GPUObjectDescriptorBase {
     {
         return {
             { label },
-            requiredFeatures.map([] (const auto& requiredFeature) {
+            requiredFeatures.map([](const auto& requiredFeature) {
                 return WebCore::convertToBacking(requiredFeature);
             }),
             requiredLimits,

--- a/Source/WebCore/Modules/WebGPU/GPUExtent3DDict.h
+++ b/Source/WebCore/Modules/WebGPU/GPUExtent3DDict.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021 Apple Inc. All rights reserved.
+ * Copyright (C) 2021-2023 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -51,9 +51,9 @@ using GPUExtent3D = std::variant<Vector<GPUIntegerCoordinate>, GPUExtent3DDict>;
 
 inline PAL::WebGPU::Extent3D convertToBacking(const GPUExtent3D& extent3D)
 {
-    return WTF::switchOn(extent3D, [] (const Vector<GPUIntegerCoordinate>& vector) -> PAL::WebGPU::Extent3D {
+    return WTF::switchOn(extent3D, [](const Vector<GPUIntegerCoordinate>& vector) -> PAL::WebGPU::Extent3D {
         return vector;
-    }, [] (const GPUExtent3DDict& extent3D) -> PAL::WebGPU::Extent3D {
+    }, [](const GPUExtent3DDict& extent3D) -> PAL::WebGPU::Extent3D {
         return extent3D.convertToBacking();
     });
 }

--- a/Source/WebCore/Modules/WebGPU/GPUFragmentState.h
+++ b/Source/WebCore/Modules/WebGPU/GPUFragmentState.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2022 Apple Inc. All rights reserved.
+ * Copyright (C) 2021-2023 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -43,7 +43,7 @@ struct GPUFragmentState : public GPUProgrammableStage {
                 entryPoint,
                 constants,
             },
-            targets.map([] (auto& target) -> std::optional<PAL::WebGPU::ColorTargetState> {
+            targets.map([](auto& target) -> std::optional<PAL::WebGPU::ColorTargetState> {
                 if (target)
                     return target->convertToBacking();
                 return std::nullopt;

--- a/Source/WebCore/Modules/WebGPU/GPUOrigin2DDict.h
+++ b/Source/WebCore/Modules/WebGPU/GPUOrigin2DDict.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021 Apple Inc. All rights reserved.
+ * Copyright (C) 2021-2023 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -49,9 +49,9 @@ using GPUOrigin2D = std::variant<Vector<GPUIntegerCoordinate>, GPUOrigin2DDict>;
 
 inline PAL::WebGPU::Origin2D convertToBacking(const GPUOrigin2D& origin2D)
 {
-    return WTF::switchOn(origin2D, [] (const Vector<GPUIntegerCoordinate>& vector) -> PAL::WebGPU::Origin2D {
+    return WTF::switchOn(origin2D, [](const Vector<GPUIntegerCoordinate>& vector) -> PAL::WebGPU::Origin2D {
         return vector;
-    }, [] (const GPUOrigin2DDict& origin2D) -> PAL::WebGPU::Origin2D {
+    }, [](const GPUOrigin2DDict& origin2D) -> PAL::WebGPU::Origin2D {
         return origin2D.convertToBacking();
     });
 }

--- a/Source/WebCore/Modules/WebGPU/GPUOrigin3DDict.h
+++ b/Source/WebCore/Modules/WebGPU/GPUOrigin3DDict.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021 Apple Inc. All rights reserved.
+ * Copyright (C) 2021-2023 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -51,9 +51,9 @@ using GPUOrigin3D = std::variant<Vector<GPUIntegerCoordinate>, GPUOrigin3DDict>;
 
 inline PAL::WebGPU::Origin3D convertToBacking(const GPUOrigin3D& origin3D)
 {
-    return WTF::switchOn(origin3D, [] (const Vector<GPUIntegerCoordinate>& vector) -> PAL::WebGPU::Origin3D {
+    return WTF::switchOn(origin3D, [](const Vector<GPUIntegerCoordinate>& vector) -> PAL::WebGPU::Origin3D {
         return vector;
-    }, [] (const GPUOrigin3DDict& origin3D) -> PAL::WebGPU::Origin3D {
+    }, [](const GPUOrigin3DDict& origin3D) -> PAL::WebGPU::Origin3D {
         return origin3D.convertToBacking();
     });
 }

--- a/Source/WebCore/Modules/WebGPU/GPUPipelineDescriptorBase.h
+++ b/Source/WebCore/Modules/WebGPU/GPUPipelineDescriptorBase.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021 Apple Inc. All rights reserved.
+ * Copyright (C) 2021-2023 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -41,9 +41,9 @@ using GPULayoutMode = std::variant<
 
 static PAL::WebGPU::PipelineLayout& convertPipelineLayoutToBacking(const GPULayoutMode& layout, const Ref<GPUPipelineLayout>& autoLayout)
 {
-    return *WTF::switchOn(layout, [] (auto pipelineLayout) {
+    return *WTF::switchOn(layout, [](auto pipelineLayout) {
         return &pipelineLayout->backing();
-    }, [&autoLayout] (GPUAutoLayoutMode) {
+    }, [&autoLayout](GPUAutoLayoutMode) {
         return &autoLayout->backing();
     });
 }

--- a/Source/WebCore/Modules/WebGPU/GPUPipelineLayoutDescriptor.h
+++ b/Source/WebCore/Modules/WebGPU/GPUPipelineLayoutDescriptor.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021 Apple Inc. All rights reserved.
+ * Copyright (C) 2021-2023 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -37,7 +37,7 @@ struct GPUPipelineLayoutDescriptor : public GPUObjectDescriptorBase {
     {
         return {
             { label },
-            bindGroupLayouts.map([] (const auto& bindGroupLayout) -> std::reference_wrapper<PAL::WebGPU::BindGroupLayout> {
+            bindGroupLayouts.map([](const auto& bindGroupLayout) -> std::reference_wrapper<PAL::WebGPU::BindGroupLayout> {
                 ASSERT(bindGroupLayout);
                 return bindGroupLayout->backing();
             }),

--- a/Source/WebCore/Modules/WebGPU/GPUQueue.cpp
+++ b/Source/WebCore/Modules/WebGPU/GPUQueue.cpp
@@ -62,7 +62,7 @@ void GPUQueue::submit(Vector<RefPtr<GPUCommandBuffer>>&& commandBuffers)
 
 void GPUQueue::onSubmittedWorkDone(OnSubmittedWorkDonePromise&& promise)
 {
-    m_backing->onSubmittedWorkDone([promise = WTFMove(promise)] () mutable {
+    m_backing->onSubmittedWorkDone([promise = WTFMove(promise)]() mutable {
         promise.resolve(nullptr);
     });
 }
@@ -108,13 +108,13 @@ void GPUQueue::writeTexture(
 
 static ImageBuffer* imageBufferForSource(const auto& source)
 {
-    return WTF::switchOn(source, [] (const RefPtr<ImageBitmap>& imageBitmap) {
+    return WTF::switchOn(source, [](const RefPtr<ImageBitmap>& imageBitmap) {
         return imageBitmap->buffer();
-    }, [] (const RefPtr<HTMLCanvasElement>& canvasElement) {
+    }, [](const RefPtr<HTMLCanvasElement>& canvasElement) {
         return canvasElement->buffer();
     }
 #if ENABLE(OFFSCREEN_CANVAS)
-    , [] (const RefPtr<OffscreenCanvas>& offscreenCanvasElement) {
+    , [](const RefPtr<OffscreenCanvas>& offscreenCanvasElement) {
         return offscreenCanvasElement->buffer();
     }
 #endif

--- a/Source/WebCore/Modules/WebGPU/GPUQueue.idl
+++ b/Source/WebCore/Modules/WebGPU/GPUQueue.idl
@@ -45,13 +45,13 @@ interface GPUQueue {
     undefined writeBuffer(
         GPUBuffer buffer,
         GPUSize64 bufferOffset,
-        [AllowShared] (ArrayBufferView or ArrayBuffer) data,
+        [AllowShared](ArrayBufferView or ArrayBuffer) data,
         optional GPUSize64 dataOffset,
         optional GPUSize64 size);
 
     undefined writeTexture(
         GPUImageCopyTexture destination,
-        [AllowShared] (ArrayBufferView or ArrayBuffer) data,
+        [AllowShared](ArrayBufferView or ArrayBuffer) data,
         GPUImageDataLayout dataLayout,
         GPUExtent3D size);
 

--- a/Source/WebCore/Modules/WebGPU/GPURenderBundleEncoderDescriptor.h
+++ b/Source/WebCore/Modules/WebGPU/GPURenderBundleEncoderDescriptor.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2022 Apple Inc. All rights reserved.
+ * Copyright (C) 2021-2023 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -36,7 +36,7 @@ struct GPURenderBundleEncoderDescriptor : public GPURenderPassLayout {
         return {
             {
                 { label },
-                colorFormats.map([] (auto& colorFormat) -> std::optional<PAL::WebGPU::TextureFormat> {
+                colorFormats.map([](auto& colorFormat) -> std::optional<PAL::WebGPU::TextureFormat> {
                     if (colorFormat)
                         return WebCore::convertToBacking(*colorFormat);
                     return std::nullopt;

--- a/Source/WebCore/Modules/WebGPU/GPURenderPassDescriptor.h
+++ b/Source/WebCore/Modules/WebGPU/GPURenderPassDescriptor.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2022 Apple Inc. All rights reserved.
+ * Copyright (C) 2021-2023 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -42,7 +42,7 @@ struct GPURenderPassDescriptor : public GPUObjectDescriptorBase {
     {
         return {
             { label },
-            colorAttachments.map([] (auto& colorAttachment) -> std::optional<PAL::WebGPU::RenderPassColorAttachment> {
+            colorAttachments.map([](auto& colorAttachment) -> std::optional<PAL::WebGPU::RenderPassColorAttachment> {
                 if (colorAttachment)
                     return colorAttachment->convertToBacking();
                 return std::nullopt;

--- a/Source/WebCore/Modules/WebGPU/GPURenderPassLayout.h
+++ b/Source/WebCore/Modules/WebGPU/GPURenderPassLayout.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2022 Apple Inc. All rights reserved.
+ * Copyright (C) 2021-2023 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -39,7 +39,7 @@ struct GPURenderPassLayout : public GPUObjectDescriptorBase {
     {
         return {
             { label },
-            colorFormats.map([] (auto& colorFormat) -> std::optional<PAL::WebGPU::TextureFormat> {
+            colorFormats.map([](auto& colorFormat) -> std::optional<PAL::WebGPU::TextureFormat> {
                 if (colorFormat)
                     return WebCore::convertToBacking(*colorFormat);
                 return std::nullopt;

--- a/Source/WebCore/Modules/WebGPU/GPURenderPassTimestampWrite.h
+++ b/Source/WebCore/Modules/WebGPU/GPURenderPassTimestampWrite.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021 Apple Inc. All rights reserved.
+ * Copyright (C) 2021-2023 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -54,7 +54,7 @@ using GPURenderPassTimestampWrites = Vector<GPURenderPassTimestampWrite>;
 
 inline PAL::WebGPU::RenderPassTimestampWrites convertToBacking(const GPURenderPassTimestampWrites& renderPassTimestampWrites)
 {
-    return renderPassTimestampWrites.map([] (auto& renderPassTimestampWrite) {
+    return renderPassTimestampWrites.map([](auto& renderPassTimestampWrite) {
         return renderPassTimestampWrite.convertToBacking();
     });
 }

--- a/Source/WebCore/Modules/WebGPU/GPUShaderModule.cpp
+++ b/Source/WebCore/Modules/WebGPU/GPUShaderModule.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021 Apple Inc. All rights reserved.
+ * Copyright (C) 2021-2023 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -43,7 +43,7 @@ void GPUShaderModule::setLabel(String&& label)
 
 void GPUShaderModule::compilationInfo(CompilationInfoPromise&& promise)
 {
-    m_backing->compilationInfo([promise = WTFMove(promise)] (Ref<PAL::WebGPU::CompilationInfo>&& compilationInfo) mutable {
+    m_backing->compilationInfo([promise = WTFMove(promise)](Ref<PAL::WebGPU::CompilationInfo>&& compilationInfo) mutable {
         promise.resolve(GPUCompilationInfo::create(WTFMove(compilationInfo)));
     });
 }

--- a/Source/WebCore/Modules/WebGPU/GPUShaderModuleDescriptor.h
+++ b/Source/WebCore/Modules/WebGPU/GPUShaderModuleDescriptor.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2022 Apple Inc. All rights reserved.
+ * Copyright (C) 2021-2023 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -41,7 +41,7 @@ struct GPUShaderModuleDescriptor : public GPUObjectDescriptorBase {
             { label },
             code,
             // FIXME: Handle the sourceMap.
-            hints.map([&autoLayout] (auto& hint) {
+            hints.map([&autoLayout](auto& hint) {
                 return KeyValuePair<String, PAL::WebGPU::ShaderModuleCompilationHint>(hint.key, hint.value.convertToBacking(autoLayout));
             }),
         };

--- a/Source/WebCore/Modules/WebGPU/GPUTextureDescriptor.h
+++ b/Source/WebCore/Modules/WebGPU/GPUTextureDescriptor.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2022 Apple Inc. All rights reserved.
+ * Copyright (C) 2021-2023 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -46,7 +46,7 @@ struct GPUTextureDescriptor : public GPUObjectDescriptorBase {
             WebCore::convertToBacking(dimension),
             WebCore::convertToBacking(format),
             convertTextureUsageFlagsToBacking(usage),
-            viewFormats.map([] (auto viewFormat) {
+            viewFormats.map([](auto viewFormat) {
                 return WebCore::convertToBacking(viewFormat);
             }),
         };

--- a/Source/WebCore/Modules/WebGPU/GPUUncapturedErrorEvent.cpp
+++ b/Source/WebCore/Modules/WebGPU/GPUUncapturedErrorEvent.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021 Apple Inc. All rights reserved.
+ * Copyright (C) 2021-2023 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -37,11 +37,11 @@ GPUError GPUUncapturedErrorEvent::error() const
     if (!m_backing)
         return m_uncapturedErrorEventInit.error;
 
-    return WTF::switchOn(PAL::WebGPU::Error(m_backing->error()), [] (Ref<PAL::WebGPU::OutOfMemoryError>&& outOfMemoryError) -> GPUError {
+    return WTF::switchOn(PAL::WebGPU::Error(m_backing->error()), [](Ref<PAL::WebGPU::OutOfMemoryError>&& outOfMemoryError) -> GPUError {
         return RefPtr<GPUOutOfMemoryError>(GPUOutOfMemoryError::create(WTFMove(outOfMemoryError)));
-    }, [] (Ref<PAL::WebGPU::ValidationError>&& validationError) -> GPUError {
+    }, [](Ref<PAL::WebGPU::ValidationError>&& validationError) -> GPUError {
         return RefPtr<GPUValidationError>(GPUValidationError::create(WTFMove(validationError)));
-    }, [] (Ref<PAL::WebGPU::InternalError>&& internalError) -> GPUError {
+    }, [](Ref<PAL::WebGPU::InternalError>&& internalError) -> GPUError {
         return RefPtr<GPUInternalError>(GPUInternalError::create(WTFMove(internalError)));
     });
 

--- a/Source/WebCore/Modules/WebGPU/GPUVertexBufferLayout.h
+++ b/Source/WebCore/Modules/WebGPU/GPUVertexBufferLayout.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021 Apple Inc. All rights reserved.
+ * Copyright (C) 2021-2023 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -39,7 +39,7 @@ struct GPUVertexBufferLayout {
         return {
             arrayStride,
             WebCore::convertToBacking(stepMode),
-            attributes.map([] (auto& attribute) {
+            attributes.map([](auto& attribute) {
                 return attribute.convertToBacking();
             }),
         };

--- a/Source/WebCore/Modules/WebGPU/GPUVertexState.h
+++ b/Source/WebCore/Modules/WebGPU/GPUVertexState.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021 Apple Inc. All rights reserved.
+ * Copyright (C) 2021-2023 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -43,7 +43,7 @@ struct GPUVertexState : public GPUProgrammableStage {
                 entryPoint,
                 constants,
             },
-            buffers.map([] (auto& buffer) -> std::optional<PAL::WebGPU::VertexBufferLayout> {
+            buffers.map([](auto& buffer) -> std::optional<PAL::WebGPU::VertexBufferLayout> {
                 if (buffer)
                     return buffer->convertToBacking();
                 return std::nullopt;


### PR DESCRIPTION
#### 25578b6a979e8c70360904ef5e1e29d0e2ad4cc5
<pre>
[WebGPU] [Style] Make lambdas in Modules/WebGPU adhere to the style guide
<a href="https://bugs.webkit.org/show_bug.cgi?id=257066">https://bugs.webkit.org/show_bug.cgi?id=257066</a>
rdar://109589999

Reviewed by Dan Glastonbury.

<a href="https://webkit.org/code-style-guidelines/#spacing-lambda-paren">https://webkit.org/code-style-guidelines/#spacing-lambda-paren</a> says that there shouldn&apos;t be a space
between the [] and the () in a lambda.

* Source/WebCore/Modules/WebGPU/GPU.cpp:
(WebCore::GPU::requestAdapter):
* Source/WebCore/Modules/WebGPU/GPUAdapter.cpp:
(WebCore::GPUAdapter::requestDevice):
* Source/WebCore/Modules/WebGPU/GPUBindGroupDescriptor.h:
(WebCore::GPUBindGroupDescriptor::convertToBacking const):
* Source/WebCore/Modules/WebGPU/GPUBindGroupEntry.h:
(WebCore::convertToBacking):
* Source/WebCore/Modules/WebGPU/GPUBindGroupLayoutDescriptor.h:
(WebCore::GPUBindGroupLayoutDescriptor::convertToBacking const):
* Source/WebCore/Modules/WebGPU/GPUBuffer.cpp:
(WebCore::GPUBuffer::mapAsync):
* Source/WebCore/Modules/WebGPU/GPUCanvasConfiguration.h:
(WebCore::GPUCanvasConfiguration::convertToBacking const):
* Source/WebCore/Modules/WebGPU/GPUColorDict.h:
(WebCore::convertToBacking):
* Source/WebCore/Modules/WebGPU/GPUCompilationInfo.cpp:
(WebCore::GPUCompilationInfo::messages const):
* Source/WebCore/Modules/WebGPU/GPUComputePassTimestampWrite.h:
(WebCore::convertToBacking):
* Source/WebCore/Modules/WebGPU/GPUDevice.cpp:
(WebCore::GPUDevice::lost):
(WebCore::GPUDevice::createComputePipelineAsync):
(WebCore::GPUDevice::createRenderPipelineAsync):
(WebCore::GPUDevice::popErrorScope):
* Source/WebCore/Modules/WebGPU/GPUDeviceDescriptor.h:
(WebCore::GPUDeviceDescriptor::convertToBacking const):
* Source/WebCore/Modules/WebGPU/GPUExtent3DDict.h:
(WebCore::convertToBacking):
* Source/WebCore/Modules/WebGPU/GPUFragmentState.h:
(WebCore::GPUFragmentState::convertToBacking const):
* Source/WebCore/Modules/WebGPU/GPUOrigin2DDict.h:
(WebCore::convertToBacking):
* Source/WebCore/Modules/WebGPU/GPUOrigin3DDict.h:
(WebCore::convertToBacking):
* Source/WebCore/Modules/WebGPU/GPUPipelineDescriptorBase.h:
(WebCore::convertPipelineLayoutToBacking):
* Source/WebCore/Modules/WebGPU/GPUPipelineLayoutDescriptor.h:
(WebCore::GPUPipelineLayoutDescriptor::convertToBacking const):
* Source/WebCore/Modules/WebGPU/GPUQueue.cpp:
(WebCore::GPUQueue::onSubmittedWorkDone):
(WebCore::imageBufferForSource):
* Source/WebCore/Modules/WebGPU/GPUQueue.idl:
* Source/WebCore/Modules/WebGPU/GPURenderBundleEncoderDescriptor.h:
(WebCore::GPURenderBundleEncoderDescriptor::convertToBacking const):
* Source/WebCore/Modules/WebGPU/GPURenderPassDescriptor.h:
(WebCore::GPURenderPassDescriptor::convertToBacking const):
* Source/WebCore/Modules/WebGPU/GPURenderPassLayout.h:
(WebCore::GPURenderPassLayout::convertToBacking const):
* Source/WebCore/Modules/WebGPU/GPURenderPassTimestampWrite.h:
(WebCore::convertToBacking):
* Source/WebCore/Modules/WebGPU/GPUShaderModule.cpp:
(WebCore::GPUShaderModule::compilationInfo):
* Source/WebCore/Modules/WebGPU/GPUShaderModuleDescriptor.h:
(WebCore::GPUShaderModuleDescriptor::convertToBacking const):
* Source/WebCore/Modules/WebGPU/GPUTextureDescriptor.h:
(WebCore::GPUTextureDescriptor::convertToBacking const):
* Source/WebCore/Modules/WebGPU/GPUUncapturedErrorEvent.cpp:
(WebCore::GPUUncapturedErrorEvent::error const):
* Source/WebCore/Modules/WebGPU/GPUVertexBufferLayout.h:
(WebCore::GPUVertexBufferLayout::convertToBacking const):
* Source/WebCore/Modules/WebGPU/GPUVertexState.h:
(WebCore::GPUVertexState::convertToBacking const):

Canonical link: <a href="https://commits.webkit.org/264303@main">https://commits.webkit.org/264303@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2dbe2b75acb09e1f96f194e517a2bab56e77d1f8

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/7279 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/7532 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/7707 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/8902 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/7486 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/7287 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/8866 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/7458 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/10385 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/7406 "Passed tests") | [⏳ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/iOS-16-Simulator-WK2-Tests-EWS "Waiting to run tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/6703 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/9010 "Built successfully") | 
| | [⏳ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/iOS-16-Simulator-WPT-WK2-Tests-EWS "Waiting to run tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/6632 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/14354 "Passed tests") | 
| | [⏳ 🧪 api-ios](https://ews-build.webkit.org/#/builders/API-Tests-iOS-Simulator-EWS "Waiting to run tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/6736 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/9612 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/7212 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/5893 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/6568 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/1726 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/10769 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/6950 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->