### PR TITLE
CDMPrivateFairPlayStreaming parsing of WebCore::ISOTrackEncryptionBox can lead to a heap-buffer-overflow.

### DIFF
--- a/LayoutTests/http/tests/media/fairplay/fps-init-data-sinf-oob-crash-expected.txt
+++ b/LayoutTests/http/tests/media/fairplay/fps-init-data-sinf-oob-crash-expected.txt
@@ -1,0 +1,8 @@
+PROMISE: requestMediaKeySystemAccess resolved
+PROMISE: createMediaKeys resolved
+FETCH: server certificate recieved
+PROMISE: arrayBuffer resolved
+PROMISE: setServerCertificate resolved
+PROMISE: session.update() resolved
+END OF TEST
+

--- a/LayoutTests/http/tests/media/fairplay/fps-init-data-sinf-oob-crash.html
+++ b/LayoutTests/http/tests/media/fairplay/fps-init-data-sinf-oob-crash.html
@@ -1,0 +1,50 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <title>fps-init-data-sinf</title>
+    <script src=../../../media-resources/video-test.js></script>
+    <script src=eme2016.js></script>
+    <script src=support.js></script>
+    <script>
+    window.addEventListener('load', async event => {
+        startTest().then(endTest).catch(failTest);
+    });
+
+    async function startTest() {
+        var access = await navigator.requestMediaKeySystemAccess("com.apple.fps", [{
+            initDataTypes: ['sinf'],
+            videoCapabilities: [{ contentType: 'video/mp4', robustness: '' }],
+            distinctiveIdentifier: 'not-allowed',
+            persistentState: 'not-allowed',
+            sessionTypes: ['temporary'],
+        }]);
+
+        consoleWrite('PROMISE: requestMediaKeySystemAccess resolved');
+        var keys = await access.createMediaKeys();
+
+        consoleWrite('PROMISE: createMediaKeys resolved');
+        var certificateResponse = await fetch('resources/cert.der');
+
+        consoleWrite('FETCH: server certificate recieved');
+        var arrayBuffer = await certificateResponse.arrayBuffer();
+
+        consoleWrite('PROMISE: arrayBuffer resolved');
+        await keys.setServerCertificate(arrayBuffer);
+
+        consoleWrite('PROMISE: setServerCertificate resolved');
+        var session = keys.createSession();
+
+	var initData = new TextEncoder().encode(JSON.stringify({
+        sinf: [
+            "AAAAFHNjaG0AAAAAY2JjcwABAAAAAAA5c2NoaQAAADF0ZW5jAAAAAAAAAAA="
+        ]
+    }));
+
+        session.generateRequest('sinf', initData);
+        consoleWrite('PROMISE: session.update() resolved');
+    }
+    </script>
+</head>
+<body>
+</body>
+</html>

--- a/Source/WebCore/platform/graphics/iso/ISOTrackEncryptionBox.cpp
+++ b/Source/WebCore/platform/graphics/iso/ISOTrackEncryptionBox.cpp
@@ -80,6 +80,9 @@ bool ISOTrackEncryptionBox::parsePayload(DataView& view, unsigned& offset)
     offset += 16;
 
     m_defaultKID.resize(16);
+    if (keyIDBuffer->byteLength() < 16)
+        return false;
+
     memcpy(m_defaultKID.data(), keyIDBuffer->data(), 16);
 
     if (m_defaultIsProtected == 1 && !m_defaultPerSampleIVSize) {


### PR DESCRIPTION
#### 5c059ab32c26d642874354e3be0f8802d8e71e1b
<pre>
CDMPrivateFairPlayStreaming parsing of WebCore::ISOTrackEncryptionBox can lead to a heap-buffer-overflow.
<a href="https://bugs.webkit.org/show_bug.cgi?id=254781.">https://bugs.webkit.org/show_bug.cgi?id=254781.</a>
rdar://103849722

Reviewed by Jer Noble.

WebCore::ISOTrackEncryptionBox::parse() is missing basic bounds checking before memcpy. This change add the check.

* LayoutTests/http/tests/media/fairplay/fps-init-data-sinf-oob-crash-expected.txt: Added.
* LayoutTests/http/tests/media/fairplay/fps-init-data-sinf-oob-crash.html: Added.
* Source/WebCore/platform/graphics/iso/ISOTrackEncryptionBox.cpp:
(WebCore::ISOTrackEncryptionBox::parse):

Originally-landed-as: 259548.536@safari-7615-branch (8320a5247c74). rdar://103849722
Canonical link: <a href="https://commits.webkit.org/264364@main">https://commits.webkit.org/264364@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/da4277a63e28d1d66637354dd0c96340953d7c50

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/7280 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/7533 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/7708 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/8903 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/7487 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/7288 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/8867 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/7459 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/10386 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/7407 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/8102 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/6694 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/9011 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/5445 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/6623 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/14351 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/7071 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/6727 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/9609 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/7213 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/5892 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/6569 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/6534 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/10770 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/890 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/6951 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->