### PR TITLE
[Cocoa] Add nextChildIdentifier() to VideoFullscreenModel

### DIFF
--- a/Source/WebCore/platform/cocoa/VideoFullscreenModel.h
+++ b/Source/WebCore/platform/cocoa/VideoFullscreenModel.h
@@ -79,6 +79,7 @@ public:
 
 #if !RELEASE_LOG_DISABLED
     virtual const void* logIdentifier() const { return nullptr; }
+    virtual const void* nextChildIdentifier() const { return logIdentifier(); }
     virtual const Logger* loggerPtr() const { return nullptr; }
 #endif
 };

--- a/Source/WebCore/platform/cocoa/VideoFullscreenModelVideoElement.h
+++ b/Source/WebCore/platform/cocoa/VideoFullscreenModelVideoElement.h
@@ -79,8 +79,9 @@ public:
     WEBCORE_EXPORT void requestRouteSharingPolicyAndContextUID(CompletionHandler<void(RouteSharingPolicy, String)>&&) override;
 
 #if !RELEASE_LOG_DISABLED
-    const Logger* loggerPtr() const override;
-    WEBCORE_EXPORT const void* logIdentifier() const override;
+    const Logger* loggerPtr() const final;
+    WEBCORE_EXPORT const void* logIdentifier() const final;
+    WEBCORE_EXPORT const void* nextChildIdentifier() const final;
     const char* logClassName() const { return "VideoFullscreenModelVideoElement"; }
     WTFLogChannel& logChannel() const;
 #endif
@@ -112,6 +113,10 @@ private:
     Vector<RefPtr<TextTrack>> m_legibleTracksForMenu;
     Vector<RefPtr<AudioTrack>> m_audioTracksForMenu;
     std::optional<MediaPlayerIdentifier> m_playerIdentifier;
+
+#if !RELEASE_LOG_DISABLED
+    mutable uint64_t m_childIdentifierSeed { 0 };
+#endif
 };
 
 }

--- a/Source/WebCore/platform/cocoa/VideoFullscreenModelVideoElement.mm
+++ b/Source/WebCore/platform/cocoa/VideoFullscreenModelVideoElement.mm
@@ -338,6 +338,11 @@ const void* VideoFullscreenModelVideoElement::logIdentifier() const
     return m_videoElement ? m_videoElement->logIdentifier() : nullptr;
 }
 
+const void* VideoFullscreenModelVideoElement::nextChildIdentifier() const
+{
+    return LoggerHelper::childLogIdentifier(logIdentifier(), ++m_childIdentifierSeed);
+}
+
 WTFLogChannel& VideoFullscreenModelVideoElement::logChannel() const
 {
     return LogFullscreen;

--- a/Source/WebCore/platform/cocoa/WebAVPlayerLayer.mm
+++ b/Source/WebCore/platform/cocoa/WebAVPlayerLayer.mm
@@ -83,6 +83,9 @@ private:
     RetainPtr<NSString> _videoGravity;
     RetainPtr<NSString> _previousVideoGravity;
     std::unique_ptr<WebAVPlayerLayerFullscreenModelClient> _fullscreenModelClient;
+#if !RELEASE_LOG_DISABLED
+    const void* _logIdentifier;
+#endif
 }
 
 - (instancetype)init
@@ -127,6 +130,9 @@ private:
         _fullscreenModel->addClient(*_fullscreenModelClient);
 
     self.videoDimensions = _fullscreenModel->videoDimensions();
+#if !RELEASE_LOG_DISABLED
+    _logIdentifier = _fullscreenModel ? _fullscreenModel->nextChildIdentifier() : nullptr;
+#endif
 }
 
 - (AVPlayerController *)playerController
@@ -358,9 +364,7 @@ static bool areFramesEssentiallyEqualWithTolerance(const FloatRect& a, const Flo
 @implementation WebAVPlayerLayer (Logging)
 - (const void*)logIdentifier
 {
-    if (_fullscreenModel)
-        return _fullscreenModel->logIdentifier();
-    return nullptr;
+    return _logIdentifier;
 }
 
 - (const Logger*)loggerPtr

--- a/Source/WebKit/UIProcess/Cocoa/VideoFullscreenManagerProxy.h
+++ b/Source/WebKit/UIProcess/Cocoa/VideoFullscreenManagerProxy.h
@@ -133,8 +133,9 @@ private:
     void fullscreenMayReturnToInline() final;
 
 #if !RELEASE_LOG_DISABLED
-    const void* logIdentifier() const override;
-    const Logger* loggerPtr() const override;
+    const void* logIdentifier() const final;
+    const void* nextChildIdentifier() const final;
+    const Logger* loggerPtr() const final;
 
     const char* logClassName() const { return "VideoFullscreenModelContext"; };
     WTFLogChannel& logChannel() const;
@@ -153,6 +154,10 @@ private:
     HashSet<WebCore::VideoFullscreenModelClient*> m_clients;
     WebCore::FloatSize m_videoDimensions;
     bool m_hasVideo { false };
+
+#if !RELEASE_LOG_DISABLED
+    mutable uint64_t m_childIdentifierSeed { 0 };
+#endif
 };
 
 class VideoFullscreenManagerProxy : public RefCounted<VideoFullscreenManagerProxy>, private IPC::MessageReceiver {

--- a/Source/WebKit/UIProcess/Cocoa/VideoFullscreenManagerProxy.mm
+++ b/Source/WebKit/UIProcess/Cocoa/VideoFullscreenManagerProxy.mm
@@ -381,6 +381,11 @@ const void* VideoFullscreenModelContext::logIdentifier() const
     return m_playbackSessionModel->logIdentifier();
 }
 
+const void* VideoFullscreenModelContext::nextChildIdentifier() const
+{
+    return LoggerHelper::childLogIdentifier(m_playbackSessionModel->logIdentifier(), ++m_childIdentifierSeed);
+}
+
 const Logger* VideoFullscreenModelContext::loggerPtr() const
 {
     return m_playbackSessionModel->loggerPtr();


### PR DESCRIPTION
#### 88af6d51488ae4f6c0d62420e8f1e3c7d839fbcd
<pre>
[Cocoa] Add nextChildIdentifier() to VideoFullscreenModel
<a href="https://bugs.webkit.org/show_bug.cgi?id=257067">https://bugs.webkit.org/show_bug.cgi?id=257067</a>
rdar://109590097

Reviewed by Eric Carlson.

Multiple WebAVPlayerLayers can exist simultaneously, and disambiguating their logs when they coexist
can be difficult. Use LoggerHelper&apos;s concept of a &quot;child identifier&quot;, and expose that child
identifier through VideoFullscreenModel. Each WebAVPlayerLayer will get a unique but related
identifier.

* Source/WebCore/platform/cocoa/VideoFullscreenModel.h:
(WebCore::VideoFullscreenModel::nextChildIdentifier const):
* Source/WebCore/platform/cocoa/VideoFullscreenModelVideoElement.h:
* Source/WebCore/platform/cocoa/VideoFullscreenModelVideoElement.mm:
(WebCore::VideoFullscreenModelVideoElement::nextChildIdentifier const):
* Source/WebCore/platform/cocoa/WebAVPlayerLayer.mm:
(-[WebAVPlayerLayer setFullscreenModel:]):
(-[WebAVPlayerLayer videoRect]):
* Source/WebKit/UIProcess/Cocoa/VideoFullscreenManagerProxy.h:
* Source/WebKit/UIProcess/Cocoa/VideoFullscreenManagerProxy.mm:
(WebKit::VideoFullscreenModelContext::nextChildIdentifier const):

Canonical link: <a href="https://commits.webkit.org/264309@main">https://commits.webkit.org/264309@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1ff2cbc5a3517bc0915aa8734df4b87410f3000e

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/7375 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/7633 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/7808 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/9004 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/7580 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/7385 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/9412 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/7558 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/10467 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/7504 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/8506 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/6819 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/9113 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/5824 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/6709 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/14435 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/7159 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/6824 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/10029 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/7309 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/5974 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/6661 "Built successfully") | | | 
| [❌ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/1731 "Failed to push commit to Webkit repository") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/10867 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/7045 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->