### PR TITLE
[WebGPU] Use UnsignedWithZeroKeyHashTraits in m_cachedBindGroupLayouts instead of adding 1 to the key

### DIFF
--- a/Source/WebGPU/WebGPU/ComputePipeline.h
+++ b/Source/WebGPU/WebGPU/ComputePipeline.h
@@ -28,6 +28,8 @@
 #import "BindGroupLayout.h"
 
 #import <wtf/FastMalloc.h>
+#import <wtf/HashMap.h>
+#import <wtf/HashTraits.h>
 #import <wtf/Ref.h>
 #import <wtf/RefCounted.h>
 
@@ -81,7 +83,7 @@ private:
 #endif
     const PipelineLayout *m_pipelineLayout { nullptr };
     const Ref<Device> m_device;
-    HashMap<uint32_t, Ref<BindGroupLayout>> m_cachedBindGroupLayouts;
+    HashMap<uint32_t, Ref<BindGroupLayout>, WTF::DefaultHash<uint32_t>, WTF::UnsignedWithZeroKeyHashTraits<uint32_t>> m_cachedBindGroupLayouts;
     const MTLSize m_threadsPerThreadgroup;
 };
 

--- a/Source/WebGPU/WebGPU/ComputePipeline.mm
+++ b/Source/WebGPU/WebGPU/ComputePipeline.mm
@@ -138,7 +138,7 @@ RefPtr<BindGroupLayout> ComputePipeline::getBindGroupLayout(uint32_t groupIndex)
     if (m_pipelineLayout)
         return const_cast<BindGroupLayout*>(&m_pipelineLayout->bindGroupLayout(groupIndex));
 
-    auto it = m_cachedBindGroupLayouts.find(groupIndex + 1);
+    auto it = m_cachedBindGroupLayouts.find(groupIndex);
     if (it != m_cachedBindGroupLayouts.end())
         return it->value.ptr();
 
@@ -159,7 +159,7 @@ RefPtr<BindGroupLayout> ComputePipeline::getBindGroupLayout(uint32_t groupIndex)
     bindGroupLayoutDescriptor.entryCount = entries.size();
     bindGroupLayoutDescriptor.entries = entries.size() ? &entries[0] : nullptr;
     auto bindGroupLayout = m_device->createBindGroupLayout(bindGroupLayoutDescriptor);
-    m_cachedBindGroupLayouts.add(groupIndex + 1, bindGroupLayout);
+    m_cachedBindGroupLayouts.add(groupIndex, bindGroupLayout);
 
     return bindGroupLayout.ptr();
 #else

--- a/Source/WebGPU/WebGPU/RenderPipeline.h
+++ b/Source/WebGPU/WebGPU/RenderPipeline.h
@@ -27,6 +27,7 @@
 
 #import <wtf/FastMalloc.h>
 #import <wtf/HashMap.h>
+#import <wtf/HashTraits.h>
 #import <wtf/Ref.h>
 #import <wtf/RefCounted.h>
 
@@ -77,7 +78,7 @@ private:
     const id<MTLRenderPipelineState> m_renderPipelineState { nil };
 
     const Ref<Device> m_device;
-    HashMap<uint32_t, Ref<BindGroupLayout>> m_cachedBindGroupLayouts;
+    HashMap<uint32_t, Ref<BindGroupLayout>, WTF::DefaultHash<uint32_t>, WTF::UnsignedWithZeroKeyHashTraits<uint32_t>> m_cachedBindGroupLayouts;
     MTLPrimitiveType m_primitiveType;
     std::optional<MTLIndexType> m_indexType;
     MTLWinding m_frontFace;

--- a/Source/WebGPU/WebGPU/RenderPipeline.mm
+++ b/Source/WebGPU/WebGPU/RenderPipeline.mm
@@ -526,7 +526,7 @@ RefPtr<BindGroupLayout> RenderPipeline::getBindGroupLayout(uint32_t groupIndex)
     if (m_pipelineLayout)
         return const_cast<BindGroupLayout*>(&m_pipelineLayout->bindGroupLayout(groupIndex));
 
-    auto it = m_cachedBindGroupLayouts.find(groupIndex + 1);
+    auto it = m_cachedBindGroupLayouts.find(groupIndex);
     if (it != m_cachedBindGroupLayouts.end())
         return it->value.ptr();
 
@@ -557,7 +557,7 @@ RefPtr<BindGroupLayout> RenderPipeline::getBindGroupLayout(uint32_t groupIndex)
     bindGroupLayoutDescriptor.entryCount = entries.size();
     bindGroupLayoutDescriptor.entries = entries.size() ? &entries[0] : nullptr;
     auto bindGroupLayout = m_device->createBindGroupLayout(bindGroupLayoutDescriptor);
-    m_cachedBindGroupLayouts.add(groupIndex + 1, bindGroupLayout);
+    m_cachedBindGroupLayouts.add(groupIndex, bindGroupLayout);
 
     return WebGPU::releaseToAPI(WTFMove(bindGroupLayout));
 #else


### PR DESCRIPTION
#### 597aa395dcdcdb2c1c48069f450f7419a30df72d
<pre>
[WebGPU] Use UnsignedWithZeroKeyHashTraits in m_cachedBindGroupLayouts instead of adding 1 to the key
<a href="https://bugs.webkit.org/show_bug.cgi?id=257068">https://bugs.webkit.org/show_bug.cgi?id=257068</a>
&lt;rdar://problem/109590315&gt;

Reviewed by Dan Glastonbury.

This is exactly what UnsignedWithZeroKeyHashTraits is meant for.

* Source/WebGPU/WebGPU/ComputePipeline.h:
* Source/WebGPU/WebGPU/ComputePipeline.mm:
(WebGPU::ComputePipeline::getBindGroupLayout):
* Source/WebGPU/WebGPU/RenderPipeline.h:
* Source/WebGPU/WebGPU/RenderPipeline.mm:
(WebGPU::RenderPipeline::getBindGroupLayout):

Canonical link: <a href="https://commits.webkit.org/264304@main">https://commits.webkit.org/264304@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d759ad8796e1183679acc829961d6d6ae4a0841f

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/7284 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/7537 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/7712 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/8907 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/7491 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/8871 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/7463 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/10388 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/7411 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/8106 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/6702 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/9015 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/5449 "Passed tests") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/14355 "Passed tests") | 
| | [❌ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/7075 "7 api tests failed or timed out") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/6734 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/9613 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/7217 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/5897 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/6573 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/1727 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/10774 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/6955 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->