### PR TITLE
Potential OOB Read in ISOProtectionSystemSpecificHeaderBox::parse(...).

### DIFF
--- a/Source/WebCore/platform/graphics/iso/ISOProtectionSystemSpecificHeaderBox.cpp
+++ b/Source/WebCore/platform/graphics/iso/ISOProtectionSystemSpecificHeaderBox.cpp
@@ -58,6 +58,9 @@ bool ISOProtectionSystemSpecificHeaderBox::parse(DataView& view, unsigned& offse
     offset += 16;
 
     m_systemID.resize(16);
+    if (systemID->byteLength() < 16)
+        return false;
+
     memcpy(m_systemID.data(), systemID->data(), 16);
 
     if (m_version) {
@@ -72,6 +75,8 @@ bool ISOProtectionSystemSpecificHeaderBox::parse(DataView& view, unsigned& offse
             currentKeyID.resize(16);
             auto parsedKeyID = buffer->slice(offset, offset + 16);
             offset += 16;
+            if (parsedKeyID->byteLength() < 16)
+                continue;
             memcpy(currentKeyID.data(), parsedKeyID->data(), 16);
         }
     }
@@ -85,6 +90,9 @@ bool ISOProtectionSystemSpecificHeaderBox::parse(DataView& view, unsigned& offse
     offset += dataSize;
 
     m_data.resize(dataSize);
+    if (parsedData->byteLength() < dataSize)
+        return false;
+
     memcpy(m_data.data(), parsedData->data(), dataSize);
 
     return true;


### PR DESCRIPTION
#### c31488496881035b30feee2217f4640a6c71e18b
<pre>
Potential OOB Read in ISOProtectionSystemSpecificHeaderBox::parse(...).
<a href="https://bugs.webkit.org/show_bug.cgi?id=254931.">https://bugs.webkit.org/show_bug.cgi?id=254931.</a>
rdar://107441432

Reviewed by Jer Noble.

There is a potential OOB access in ISOProtectionSystemSpecificHeaderBox::parse when we do memcpy without a bounds check. This adds a bounds check to prevent such access.

* Source/WebCore/platform/graphics/iso/ISOProtectionSystemSpecificHeaderBox.cpp:
(WebCore::ISOProtectionSystemSpecificHeaderBox::parse):

Originally-landed-as: 259548.574@safari-7615-branch (0c76eb21f2d8). rdar://107441432
Canonical link: <a href="https://commits.webkit.org/264367@main">https://commits.webkit.org/264367@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/fbc8353a93857e42f947bbdeb72dd5bc8b4cd981

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/7285 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/7538 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/7713 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/8908 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/7492 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/7293 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/8872 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/7464 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/10387 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/7412 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/8107 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/6699 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/9016 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/5450 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/6628 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/14357 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/7076 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/6732 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/9615 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/7218 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/5898 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/6574 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/10775 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/893 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/6956 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->