### PR TITLE
v2: CrashTracer: com.apple.WebKit.Networking at JavaScriptCore: WTF::StringImpl::hashSlowCase const

### DIFF
--- a/Source/WebKit/NetworkProcess/storage/CacheStorageDiskStore.cpp
+++ b/Source/WebKit/NetworkProcess/storage/CacheStorageDiskStore.cpp
@@ -337,23 +337,11 @@ std::optional<CacheStorageRecord> CacheStorageDiskStore::readRecordFromFileData(
     return CacheStorageRecord { storedInfo->info, storedInfo->header.requestHeadersGuard, storedInfo->header.request, storedInfo->header.options, storedInfo->header.referrer, storedInfo->header.responseHeadersGuard, WTFMove(storedInfo->header.responseData), storedInfo->header.responseBodySize, WTFMove(*responseBody) };
 }
 
-void CacheStorageDiskStore::readAllRecordInfos(ReadAllRecordInfosCallback&& callback)
+void CacheStorageDiskStore::readAllRecordInfosInternal(CompletionHandler<void(FileDatas&&)>&& callback)
 {
-    auto didReadRecordFiles = [this, protectedThis = Ref { *this }, callback = WTFMove(callback)](auto fileDatas) mutable {
-        Vector<CacheStorageRecordInformation> result;
-        result.reserveInitialCapacity(fileDatas.size());
-        for (auto& fileData : fileDatas) {
-            if (auto storedInfo = readRecordInfoFromFileData(m_salt, fileData))
-                result.uncheckedAppend(WTFMove(storedInfo->info));
-            else
-                RELEASE_LOG(CacheStorage, "%p - CacheStorageDiskStore::readAllRecordInfos fails to decode record from file", this);
-        }
-        callback(WTFMove(result));
-    };
-
-    m_ioQueue->dispatch([this, protectedThis = Ref { *this }, recordsDirectory = recordsDirectoryPath().isolatedCopy(), cacheName = m_cacheName.isolatedCopy(), didReadRecordFiles = WTFMove(didReadRecordFiles)]() mutable {
-        Vector<Vector<uint8_t>> fileDatas;
-        Vector<Vector<uint8_t>> blobDatas;
+    m_ioQueue->dispatch([this, protectedThis = Ref { *this }, recordsDirectory = recordsDirectoryPath().isolatedCopy(), cacheName = m_cacheName.isolatedCopy(), callback = WTFMove(callback)]() mutable {
+        FileDatas fileDatas;
+        FileDatas blobDatas;
         auto partitionNames = FileSystem::listDirectory(recordsDirectory);
         for (auto& partitionName : partitionNames) {
             auto partitionDirectoryPath = FileSystem::pathByAppendingComponent(recordsDirectory, partitionName);
@@ -369,8 +357,41 @@ void CacheStorageDiskStore::readAllRecordInfos(ReadAllRecordInfosCallback&& call
             }
         }
 
-        m_callbackQueue->dispatch([protectedThis = WTFMove(protectedThis), fileDatas = crossThreadCopy(WTFMove(fileDatas)), didReadRecordFiles = WTFMove(didReadRecordFiles)]() mutable {
-            didReadRecordFiles(WTFMove(fileDatas));
+        m_callbackQueue->dispatch([protectedThis = WTFMove(protectedThis), fileDatas = crossThreadCopy(WTFMove(fileDatas)), callback = WTFMove(callback)]() mutable {
+            callback(WTFMove(fileDatas));
+        });
+    });
+}
+
+void CacheStorageDiskStore::readAllRecordInfos(ReadAllRecordInfosCallback&& callback)
+{
+    readAllRecordInfosInternal([this, protectedThis = Ref { *this }, callback = WTFMove(callback)](auto fileDatas) mutable {
+        Vector<CacheStorageRecordInformation> result;
+        result.reserveInitialCapacity(fileDatas.size());
+        for (auto& fileData : fileDatas) {
+            if (auto storedInfo = readRecordInfoFromFileData(m_salt, fileData))
+                result.uncheckedAppend(WTFMove(storedInfo->info));
+            else
+                RELEASE_LOG(CacheStorage, "%p - CacheStorageDiskStore::readAllRecordInfos fails to decode record from file", this);
+        }
+        callback(WTFMove(result));
+    });
+}
+
+void CacheStorageDiskStore::readRecordsInternal(Vector<String>&& recordFiles, CompletionHandler<void(FileDatas&&, FileDatas&&)>&& callback)
+{
+    m_ioQueue->dispatch([this, protectedThis = Ref { *this }, recordFiles = crossThreadCopy(WTFMove(recordFiles)), callback = WTFMove(callback)]() mutable {
+        FileDatas fileDatas;
+        FileDatas blobDatas;
+        for (auto& recordFile : recordFiles) {
+            auto fileData = valueOrDefault(FileSystem::readEntireFile(recordFile));
+            auto blobData = fileData.isEmpty()? Vector<uint8_t> { } : valueOrDefault(FileSystem::readEntireFile(recordBlobFilePath(recordFile)));
+            fileDatas.append(WTFMove(fileData));
+            blobDatas.append(WTFMove(blobData));
+        }
+
+        m_callbackQueue->dispatch([protectedThis = WTFMove(protectedThis), fileDatas = crossThreadCopy(WTFMove(fileDatas)), blobDatas = crossThreadCopy(WTFMove(blobDatas)), callback = WTFMove(callback)]() mutable {
+            callback(WTFMove(fileDatas), WTFMove(blobDatas));
         });
     });
 }
@@ -381,7 +402,7 @@ void CacheStorageDiskStore::readRecords(const Vector<CacheStorageRecordInformati
         return recordFilePath(recordInfo.key);
     });
 
-    auto didReadRecordFiles = [this, protectedThis = Ref { *this }, recordInfos, callback = WTFMove(callback)](auto fileDatas, auto blobDatas) mutable {
+    readRecordsInternal(WTFMove(recordFiles), [this, protectedThis = Ref { *this }, recordInfos, callback = WTFMove(callback)](auto fileDatas, auto blobDatas) mutable {
         ASSERT(recordInfos.size() == fileDatas.size());
         ASSERT(recordInfos.size() == blobDatas.size());
 
@@ -404,21 +425,6 @@ void CacheStorageDiskStore::readRecords(const Vector<CacheStorageRecordInformati
             result.append(WTFMove(record));
         }
         callback(WTFMove(result));
-    };
-
-    m_ioQueue->dispatch([this, protectedThis = Ref { *this }, recordFiles = crossThreadCopy(WTFMove(recordFiles)), didReadRecordFiles = WTFMove(didReadRecordFiles)]() mutable {
-        Vector<Vector<uint8_t>> fileDatas;
-        Vector<Vector<uint8_t>> blobDatas;
-        for (auto& recordFile : recordFiles) {
-            auto fileData = valueOrDefault(FileSystem::readEntireFile(recordFile));
-            auto blobData = fileData.isEmpty()? Vector<uint8_t> { } : valueOrDefault(FileSystem::readEntireFile(recordBlobFilePath(recordFile)));
-            fileDatas.append(WTFMove(fileData));
-            blobDatas.append(WTFMove(blobData));
-        }
-
-        m_callbackQueue->dispatch([protectedThis = WTFMove(protectedThis), fileDatas = crossThreadCopy(WTFMove(fileDatas)), blobDatas = crossThreadCopy(WTFMove(blobDatas)), didReadRecordFiles = WTFMove(didReadRecordFiles)]() mutable {
-            didReadRecordFiles(WTFMove(fileDatas), WTFMove(blobDatas));
-        });
     });
 }
 

--- a/Source/WebKit/NetworkProcess/storage/CacheStorageDiskStore.h
+++ b/Source/WebKit/NetworkProcess/storage/CacheStorageDiskStore.h
@@ -53,6 +53,9 @@ private:
     String blobsDirectoryPath() const;
     String blobFilePath(const String&) const;
     std::optional<CacheStorageRecord> readRecordFromFileData(const Vector<uint8_t>&, const Vector<uint8_t>&);
+    using FileDatas = Vector<Vector<uint8_t>>;
+    void readAllRecordInfosInternal(CompletionHandler<void(FileDatas&&)>&&);
+    void readRecordsInternal(Vector<String>&&, CompletionHandler<void(FileDatas&&, FileDatas&&)>&&);
 
     String m_cacheName;
     String m_path;


### PR DESCRIPTION
#### faae309df854b228ebf98ab1f9593b1c98d9eaab
<pre>
v2: CrashTracer: com.apple.WebKit.Networking at JavaScriptCore: WTF::StringImpl::hashSlowCase const
rdar://106965632

Reviewed by Youenn Fablet and Ryosuke Niwa.

Moving a lambda might involve copying its captured variables. According to crash trace, recordInfos
(Vector&lt;CacheStorageRecordInformation&gt;) captured by didReadRecordFiles is copied when running on the WorkQueue of
CacheStorageDiskStore (com.apple.WebKit.CacheStorageCache). This is an issue as CacheStorageRecordInformation is not
thread-safe. To avoid this, we now replace the lambda with CompletionHandler, which has a more definitive move behavior
that does not involves copy.

* Source/WebKit/NetworkProcess/storage/CacheStorageDiskStore.cpp:
(WebKit::CacheStorageDiskStore::readAllRecordInfosInternal):
(WebKit::CacheStorageDiskStore::readAllRecordInfos):
(WebKit::CacheStorageDiskStore::readRecordsInternal):
(WebKit::CacheStorageDiskStore::readRecords):
* Source/WebKit/NetworkProcess/storage/CacheStorageDiskStore.h:

Originally-landed-as: 259548.577@safari-7615-branch (3679790c14ce). rdar://106965632
Canonical link: <a href="https://commits.webkit.org/264368@main">https://commits.webkit.org/264368@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5645aee41730854b319f2b77f043c2fb181ecb6c

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/7286 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/7539 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/7714 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/8909 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/7493 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/8873 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/7465 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/10390 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/7413 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/8109 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/6704 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/9017 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/5452 "Passed tests") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/14358 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/7078 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/6735 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/9616 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/7219 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/5900 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/6575 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/10776 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/894 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/6957 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->