### PR TITLE
[GPUP][CoreIPC] Integer overflow in SharedVideoFrameInfo::storageSize leading to OOB read

### DIFF
--- a/LayoutTests/ipc/shared-video-frame-size-expected.txt
+++ b/LayoutTests/ipc/shared-video-frame-size-expected.txt
@@ -1,0 +1,1 @@
+Test passes if it does not crash.

--- a/LayoutTests/ipc/shared-video-frame-size.html
+++ b/LayoutTests/ipc/shared-video-frame-size.html
@@ -1,0 +1,84 @@
+<!DOCTYPE html><!-- webkit-test-runner [ IPCTestingAPIEnabled=true ] -->
+<head>
+</head>
+<body>
+Test passes if it does not crash.
+<script>
+if (window.testRunner)
+    testRunner.dumpAsText();
+
+if (window.IPC) {
+    function randomID()
+    {
+        return Math.floor(Math.random() * 10000) + 1;
+    }
+
+    let mediaRecorderID = randomID();
+
+    IPC.sendMessage(
+        'GPU',
+        IPC.webPageProxyID,
+        IPC.messages.RemoteMediaRecorderManager_CreateRecorder.name,
+        [
+            {type: 'uint64_t', value: mediaRecorderID},
+            {type: 'uint8_t', value: 1},
+            {type: 'uint8_t', value: 1},
+            {type: 'String', value: 'video/webm'},
+            {type: 'bool', value: 0},
+            {type: 'bool', value: 0},
+            {type: 'bool', value: 0},
+            {type: 'uint64_t', value: 1},
+        ]);
+
+    let sharedMemory = IPC.createSharedMemory(0x1000);
+
+    IPC.sendMessage(
+        'GPU',
+        mediaRecorderID,
+        IPC.messages.RemoteMediaRecorder_SetSharedVideoFrameMemory.name,
+        [
+            {type: 'SharedMemory', value: sharedMemory, dataSize: 0x1000, protection: 'ReadWrite'},
+        ]);
+
+    let ab = new ArrayBuffer(0x1000);
+    let bu = new Uint32Array(ab);
+
+    bu[0] = 0x34323066; // m_bufferType = '420f';
+    bu[1] = 100; // m_width
+    bu[2] = 0x1000; // m_height
+    bu[3] = 0x80000000; // m_bytesPerRow
+    bu[4] = 0; // m_widthPlaneB
+    bu[5] = 0; // m_heightPlaneB
+    bu[6] = 0; // m_bytesPerRowPlaneB
+
+    sharedMemory.writeBytes(new Int8Array(ab));
+
+    IPC.sendMessage(
+        'GPU',
+        mediaRecorderID,
+        IPC.messages.RemoteMediaRecorder_VideoFrameAvailable.name,
+        [
+            {type: 'uint64_t', value: 0},
+            {type: 'uint32_t', value: 0},
+            {type: 'uint8_t', value: 0},
+
+            {type: 'bool', value: 0},
+            {type: 'uint32_t', value: 0},
+
+            {type: 'uint64_t', value: 0},
+            {type: 'uint64_t', value: 0},
+            {type: 'uint64_t', value: 0},
+            {type: 'uint64_t', value: 0},
+        ]);
+
+    IPC.sendMessage(
+        'GPU',
+        IPC.webPageProxyID,
+        IPC.messages.RemoteMediaRecorderManager_ReleaseRecorder.name,
+        [
+            {type: 'uint64_t', value: mediaRecorderID},
+        ]);
+}
+</script>
+</body>
+</html>


### PR DESCRIPTION
#### 46ea28d672831cac886966dd100c4bfe4d9ae418
<pre>
[GPUP][CoreIPC] Integer overflow in SharedVideoFrameInfo::storageSize leading to OOB read
rdar://107023292

Reviewed by Eric Carlson.

Compute with safeMultitply/safeAdd the total size of the frame.
If there is an overflow, we now fail the decoding of SharedVideoFrameInfo.

Covered by provided IPC test.

* LayoutTests/ipc/shared-video-frame-size-expected.txt: Added.
* LayoutTests/ipc/shared-video-frame-size.html: Added.
* Source/WebCore/platform/cocoa/SharedVideoFrameInfo.mm:
(WebCore::SharedVideoFrameInfo::storageSize const):
(WebCore::SharedVideoFrameInfo::decode):

Originally-landed-as: 259548.597@safari-7615-branch (7811f6f9e18f). rdar://107023292
Canonical link: <a href="https://commits.webkit.org/264371@main">https://commits.webkit.org/264371@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/41007fcd6fb031a4e3b4d4f6348e8a9dc9d61878

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/7289 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/7542 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/7717 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/8912 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/7496 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/7297 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/8876 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/7468 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/10393 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/7416 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/8112 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/6707 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/9020 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/5455 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/6635 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/14361 "1 flakes 148 failures") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/7081 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/6739 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/9619 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/7222 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/5902 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/6578 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/6546 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/10779 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/897 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/6960 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->