### PR TITLE
Fix crash when innerTextElement() can be null when designMode="off"

### DIFF
--- a/LayoutTests/fast/rendering/render-text-control-crash-with-designmode-off-expected.txt
+++ b/LayoutTests/fast/rendering/render-text-control-crash-with-designmode-off-expected.txt
@@ -1,0 +1,1 @@
+PASS if no crash.

--- a/LayoutTests/fast/rendering/render-text-control-crash-with-designmode-off.html
+++ b/LayoutTests/fast/rendering/render-text-control-crash-with-designmode-off.html
@@ -1,0 +1,16 @@
+<style>
+  body {
+    container-type: size;
+  }
+</style>
+<script>
+  onload = () => {
+    if (window.testRunner)
+      testRunner.dumpAsText();
+    document.designMode = 'off';
+    i.type = 'radio';
+    document.body.offsetHeight;
+    document.body.innerHTML = 'PASS if no crash.';
+  };
+</script>
+<input id="i">

--- a/Source/WebCore/rendering/RenderTextControl.cpp
+++ b/Source/WebCore/rendering/RenderTextControl.cpp
@@ -91,7 +91,8 @@ int RenderTextControl::textBlockLogicalHeight() const
 int RenderTextControl::textBlockLogicalWidth() const
 {
     auto innerText = innerTextElement();
-    ASSERT(innerText);
+    if (!innerText)
+        return 0;
 
     LayoutUnit unitWidth = logicalWidth() - borderAndPaddingLogicalWidth();
     if (innerText->renderer())
@@ -109,7 +110,9 @@ int RenderTextControl::scrollbarThickness() const
 RenderBox::LogicalExtentComputedValues RenderTextControl::computeLogicalHeight(LayoutUnit logicalHeight, LayoutUnit logicalTop) const
 {
     auto innerText = innerTextElement();
-    ASSERT(innerText);
+    if (!innerText)
+        return RenderBox::computeLogicalHeight(LayoutUnit(), LayoutUnit());
+
     if (RenderBox* innerTextBox = innerText->renderBox()) {
         LayoutUnit nonContentHeight = innerTextBox->verticalBorderAndPaddingExtent() + innerTextBox->verticalMarginExtent();
         logicalHeight = computeControlLogicalHeight(innerTextBox->lineHeight(true, HorizontalLine, PositionOfInteriorLineBoxes), nonContentHeight);
@@ -177,7 +180,7 @@ void RenderTextControl::computeIntrinsicLogicalWidths(LayoutUnit& minLogicalWidt
     }
     // Use average character width. Matches IE.
     maxLogicalWidth = preferredContentLogicalWidth(const_cast<RenderTextControl*>(this)->getAverageCharWidth());
-    if (RenderBox* innerTextRenderBox = innerTextElement()->renderBox())
+    if (RenderBox* innerTextRenderBox = innerTextElement() ? innerTextElement()->renderBox() : nullptr)
         maxLogicalWidth += innerTextRenderBox->paddingStart() + innerTextRenderBox->paddingEnd();
     if (!style().logicalWidth().isPercentOrCalculated())
         minLogicalWidth = maxLogicalWidth;

--- a/Source/WebCore/rendering/RenderTextControlSingleLine.cpp
+++ b/Source/WebCore/rendering/RenderTextControlSingleLine.cpp
@@ -106,7 +106,7 @@ void RenderTextControlSingleLine::layout()
     // and type=search if the text height is taller than the contentHeight()
     // because of compability.
 
-    RenderTextControlInnerBlock* innerTextRenderer = innerTextElement()->renderer();
+    RenderTextControlInnerBlock* innerTextRenderer = innerTextElement() ? innerTextElement()->renderer() : nullptr;
     RenderBox* innerBlockRenderer = innerBlockElement() ? innerBlockElement()->renderBox() : nullptr;
     HTMLElement* container = containerElement();
     RenderBox* containerRenderer = container ? container->renderBox() : nullptr;
@@ -346,8 +346,8 @@ LayoutUnit RenderTextControlSingleLine::preferredContentLogicalWidth(float charW
 
     if (includesDecoration)
         result += inputElement().decorationWidth();
-    
-    if (auto* innerRenderer = innerTextElement()->renderer())
+
+    if (auto* innerRenderer = innerTextElement() ? innerTextElement()->renderer() : nullptr)
         result += innerRenderer->endPaddingWidthForCaret();
 
     return result;


### PR DESCRIPTION
#### f2875a3ad7ac0693e0853f58d7884c85345f89a1
<pre>
Fix crash when innerTextElement() can be null when designMode=&quot;off&quot;
<a href="https://bugs.webkit.org/show_bug.cgi?id=255423">https://bugs.webkit.org/show_bug.cgi?id=255423</a>
rdar://107985448

Reviewed by Antti Koivisto.

This change guards against innerTextElement() being null. The file
already checked for this in some places, but it wasn&apos;t consistent.

* LayoutTests/fast/rendering/render-text-control-crash-with-designmode-off-expected.txt: Added.
* LayoutTests/fast/rendering/render-text-control-crash-with-designmode-off.html: Added.
* Source/WebCore/rendering/RenderTextControl.cpp:
(WebCore::RenderTextControl::textBlockLogicalWidth const):
(WebCore::RenderTextControl::computeLogicalHeight const):
(WebCore::RenderTextControl::computeIntrinsicLogicalWidths const):
* Source/WebCore/rendering/RenderTextControlSingleLine.cpp:
(WebCore::RenderTextControlSingleLine::layout):
(WebCore::RenderTextControlSingleLine::preferredContentLogicalWidth const):

Originally-landed-as: 259548.635@safari-7615-branch (064579d997ae). rdar://107985448
Canonical link: <a href="https://commits.webkit.org/264372@main">https://commits.webkit.org/264372@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9eb397e5c7fa2f3e05273c2c45704102bba6bd4d

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/7290 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/7543 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/7718 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/8913 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/7497 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/7298 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/8878 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/7469 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/10392 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/7417 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/8113 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/6708 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/9021 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/5456 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/6636 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/14362 "1 flakes 108 failures") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/7082 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/6740 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/9620 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/7223 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/5903 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/6579 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/6547 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/10780 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/898 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/6961 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->