### PR TITLE
Unreviewed, reverting 262829@main

### DIFF
--- a/Source/WebCore/Modules/modern-media-controls/controls/time-control.js
+++ b/Source/WebCore/Modules/modern-media-controls/controls/time-control.js
@@ -103,17 +103,20 @@ class TimeControl extends LayoutItem
     get minimumWidth()
     {
         this._performIdealLayout();
-
-        if (this._timeLabelsDisplayOnScrubberSide)
-            return MinimumScrubberWidth + this._scrubberMargin + this._durationOrRemainingTimeLabel().width;
+        if (this._timeLabelsDisplayOnScrubberSide) {
+            const scrubberMargin = this.computedValueForStylePropertyInPx("--scrubber-margin");
+            return MinimumScrubberWidth + scrubberMargin + this._durationOrRemainingTimeLabel().width;
+        }
         return MinimumScrubberWidth;
     }
 
     get idealMinimumWidth()
     {
         this._performIdealLayout();
-        if (this._timeLabelsDisplayOnScrubberSide)
-            return this.elapsedTimeLabel.width + MinimumScrubberWidth + (2 * this._scrubberMargin) + this._durationOrRemainingTimeLabel().width;
+        if (this._timeLabelsDisplayOnScrubberSide) {
+            const scrubberMargin = this.computedValueForStylePropertyInPx("--scrubber-margin");
+            return this.elapsedTimeLabel.width + MinimumScrubberWidth + (2 * scrubberMargin) + this._durationOrRemainingTimeLabel().width;
+        }
         return MinimumScrubberWidth;
     }
 
@@ -141,11 +144,20 @@ class TimeControl extends LayoutItem
         if (this._loading || !this._timeLabelsDisplayOnScrubberSide)
             return;
 
-        // If the scrubber width is larger or equal to the minimal scrubber width, this means we determined during ideal layout
-        // that there is enough space to fit both the elapsed time label and either the duration or remaining time label. Otherwise
-        // it must be hidden.
-        this.elapsedTimeLabel.visible = this.scrubber.width >= MinimumScrubberWidth;
-        this._performLayoutWithRightTimeLabel(this._durationOrRemainingTimeLabel());
+        if (this.scrubber.width >= MinimumScrubberWidth) {
+            this.elapsedTimeLabel.visible = true;
+            return;
+        }
+
+        let durationOrRemainingTimeLabel = this._durationOrRemainingTimeLabel();
+
+        // We drop the elapsed time label if width is constrained and we can't guarantee
+        // the scrubber minimum size otherwise.
+        this.scrubber.x = 0;
+        const scrubberMargin = this.computedValueForStylePropertyInPx("--scrubber-margin");
+        this.scrubber.width = this.width - scrubberMargin - durationOrRemainingTimeLabel.width;
+        durationOrRemainingTimeLabel.x = this.scrubber.x + this.scrubber.width + scrubberMargin;
+        this.elapsedTimeLabel.visible = false;
     }
 
     handleEvent(event)
@@ -170,11 +182,6 @@ class TimeControl extends LayoutItem
 
     // Private
 
-    get _scrubberMargin()
-    {
-        return this.computedValueForStylePropertyInPx("--scrubber-margin");
-    }
-
     get _timeLabelsDisplayOnScrubberSide()
     {
         return this._timeLabelsAttachment == TimeControl.TimeLabelsAttachment.Side;
@@ -192,14 +199,8 @@ class TimeControl extends LayoutItem
 
     _performIdealLayout()
     {
-        // During an ideal layout, we want the elapsed time label to be visible so we only account for _shouldShowDurationTimeLabel
-        // to determine whether to show the duration or remaining time label.
-        const durationOrRemainingTimeLabel = this._shouldShowDurationTimeLabel ? this.durationTimeLabel : this.remainingTimeLabel;
-
-        // We can only show the duration time label if the elapsed time label is visible.
-        // During an ideal layout, we must assume the elapsed time label is visible.
         if (this._loading)
-            durationOrRemainingTimeLabel.setValueWithNumberOfDigits(NaN, 4);
+            this._durationOrRemainingTimeLabel().setValueWithNumberOfDigits(NaN, 4);
         else {
             const shouldShowZeroDurations = isNaN(this._duration) || this._duration === Number.POSITIVE_INFINITY;
 
@@ -213,45 +214,33 @@ class TimeControl extends LayoutItem
             else
                 numberOfDigitsForTimeLabels = 6;
 
-            // Even though we only care about the metrics of durationOrRemainingTimeLabel, we set the values for both
-            // labels here since this is the only place where we set such values.
             this.elapsedTimeLabel.setValueWithNumberOfDigits(shouldShowZeroDurations ? 0 : this._currentTime, numberOfDigitsForTimeLabels);
-            this.remainingTimeLabel.setValueWithNumberOfDigits(shouldShowZeroDurations ? 0 : this._currentTime - this._duration, numberOfDigitsForTimeLabels);
-            if (this.durationTimeLabel)
+            if (this._canShowDurationTimeLabel && this._shouldShowDurationTimeLabel)
                 this.durationTimeLabel.setValueWithNumberOfDigits(shouldShowZeroDurations ? 0 : this._duration, numberOfDigitsForTimeLabels);
+            else
+                this.remainingTimeLabel.setValueWithNumberOfDigits(shouldShowZeroDurations ? 0 : this._currentTime - this._duration, numberOfDigitsForTimeLabels);
         }
 
         if (this._duration)
             this.scrubber.value = this._currentTime / this._duration;
 
-        this._performLayoutWithRightTimeLabel(durationOrRemainingTimeLabel);
-    }
+        let durationOrRemainingTimeLabel = this._durationOrRemainingTimeLabel();
 
-    _performLayoutWithRightTimeLabel(rightTimeLabel)
-    {
-        const scrubberMargin = this._scrubberMargin;
-
-        this.scrubber.x = (() => {
-            if (this._loading)
-                return this.activityIndicator.width + scrubberMargin;
-            if (this._timeLabelsDisplayOnScrubberSide && this.elapsedTimeLabel.visible)
-                return this.elapsedTimeLabel.width + scrubberMargin;
-            return 0;
-        })();
-
+        const scrubberMargin = this.computedValueForStylePropertyInPx("--scrubber-margin");
+        this.scrubber.x = (this._loading ? this.activityIndicator.width : this.elapsedTimeLabel.width) + scrubberMargin;
         this.scrubber.width = (() => {
             if (this._timeLabelsDisplayOnScrubberSide)
-                return this.width - this.scrubber.x - scrubberMargin - rightTimeLabel.width;
+                return this.width - this.scrubber.x - scrubberMargin - durationOrRemainingTimeLabel.width;
             return this.width;
         })();
 
-        rightTimeLabel.x = (() => {
+        durationOrRemainingTimeLabel.x = (() => {
             if (this._timeLabelsDisplayOnScrubberSide)
                 return this.scrubber.x + this.scrubber.width + scrubberMargin;
-            return this.width - rightTimeLabel.width;
-        })()
+            return this.width - durationOrRemainingTimeLabel.width;
+        })();
 
-        this.children = [this._loading ? this.activityIndicator : this.elapsedTimeLabel, this.scrubber, rightTimeLabel];
+        this.children = [this._loading ? this.activityIndicator : this.elapsedTimeLabel, this.scrubber, durationOrRemainingTimeLabel];
     }
 
     updateScrubberLabel()


### PR DESCRIPTION
#### 1be5261428234b2357b74bb5de686c7bce227953
<pre>
Unreviewed, reverting 262829@main
<a href="https://bugs.webkit.org/show_bug.cgi?id=257075">https://bugs.webkit.org/show_bug.cgi?id=257075</a>
rdar://108764454

Reverting 262829@main since it broke the modern media controls scrubber.

Reverted changeset:

&quot;REGRESSION (261912@main): [macOS WK2] imported/w3c/web-platform-tests/css/css-sizing/aspect-ratio/replaced-element-035.html is a flaky failure&quot;
<a href="https://bugs.webkit.org/show_bug.cgi?id=254745">https://bugs.webkit.org/show_bug.cgi?id=254745</a>
<a href="https://commits.webkit.org/262829@main&quot">https://commits.webkit.org/262829@main&quot</a>;

* Source/WebCore/Modules/modern-media-controls/controls/time-control.js:
(TimeControl.prototype.get minimumWidth):
(TimeControl.prototype.get idealMinimumWidth):
(TimeControl.prototype.layout):
(TimeControl.prototype._performIdealLayout):
(TimeControl.prototype.get _scrubberMargin): Deleted.
(TimeControl.prototype._performLayoutWithRightTimeLabel): Deleted.

Canonical link: <a href="https://commits.webkit.org/264301@main">https://commits.webkit.org/264301@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/6a1f93d6c06f3d157c38a0c8e4b5a681d714c4d0

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/7305 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/7559 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/7734 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/8929 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/7510 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/7314 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/8898 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/7485 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/10405 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/7433 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/8129 "2 new passes 9 flakes 1 failures") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/6719 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/9037 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/5472 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/6647 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/14372 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/7093 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/6752 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/9656 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/7238 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/5911 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/6594 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/10796 "Built successfully") | | | 
| [❌ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/853 "Failed to push commit to Webkit repository") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/6976 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->