### PR TITLE
Regression(263830@main) Frequent Jetsams on macOS 13.3+

### DIFF
--- a/Source/WebKit/Scripts/update-info-plist-for-runningboard.sh
+++ b/Source/WebKit/Scripts/update-info-plist-for-runningboard.sh
@@ -1,4 +1,8 @@
-if [[ "${USE_INTERNAL_SDK}" == "YES"  &&  "${WK_PLATFORM_NAME}" == macosx ]] && (( "${TARGET_MAC_OS_X_VERSION_MAJOR}" >= 130300 ))
+VERSION_MAJOR=`echo $MACOSX_DEPLOYMENT_TARGET | cut -d"." -f1`
+VERSION_MINOR=`echo $MACOSX_DEPLOYMENT_TARGET | cut -d"." -f2`
+
+# We only use RunningBoard on macOS >= 13.3
+if [[ "${USE_INTERNAL_SDK}" == "YES"  &&  "${WK_PLATFORM_NAME}" == macosx ]] && (([[ $VERSION_MAJOR -eq 13 ]] && [[ $VERSION_MINOR -ge 3 ]]) || [[ $VERSION_MAJOR -ge 14 ]])
 then
     /usr/libexec/PlistBuddy -c "Add :LSDoNotSetTaskPolicyAutomatically bool YES" "${SCRIPT_INPUT_FILE_0}"
     /usr/libexec/PlistBuddy -c "Add :XPCService:_AdditionalProperties:RunningBoard:Managed bool YES" "${SCRIPT_INPUT_FILE_0}"


### PR DESCRIPTION
#### 7a80dfacdb26f49d6dea6ded444f7b1ffce578b5
<pre>
Regression(263830@main) Frequent Jetsams on macOS 13.3+
<a href="https://bugs.webkit.org/show_bug.cgi?id=257077">https://bugs.webkit.org/show_bug.cgi?id=257077</a>
rdar://109517882

Reviewed by Wenson Hsieh.

In 263830@main, I updated the script to compare TARGET_MAC_OS_X_VERSION_MAJOR
to 130300 instead of 130000, since we only use RunningBoard on macOS 13.3+.
However, TARGET_MAC_OS_X_VERSION_MAJOR only contains the &quot;major&quot; version,
meaning that it is 130000 on all macOS 13.x versions. As a result, the check
now fails on macOS 13.x and we don&apos;t mark our processes as managed by
RunningBoard, even though our code uses RunningBoard on macOS 13.3.

To address the issue, we now rely on the MACOSX_DEPLOYMENT_TARGET variable
instead, which contains both the major and minor version (formatted like
&quot;13.3&quot;).

* Source/WebKit/Scripts/update-info-plist-for-runningboard.sh:

Canonical link: <a href="https://commits.webkit.org/264286@main">https://commits.webkit.org/264286@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e34d3329c5470de2451c82a6359ce8b92f6dc722

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/7307 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/7561 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/7736 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/8931 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/7511 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/8902 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/7487 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/10407 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/7435 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/8133 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/6720 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/9040 "Built successfully") | 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/7418 "Passed tests") | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/5476 "Passed tests") | | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/14376 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/7095 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/6753 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/9666 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/7240 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/5913 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/6596 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/1717 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/10798 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/6978 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->