### PR TITLE
Document::m_nodeIterators should be WeakHashSet

### DIFF
--- a/Source/WebCore/dom/Document.h
+++ b/Source/WebCore/dom/Document.h
@@ -894,11 +894,7 @@ public:
 
     void attachNodeIterator(NodeIterator&);
     void detachNodeIterator(NodeIterator&);
-    void moveNodeIteratorsToNewDocument(Node& node, Document& newDocument)
-    {
-        if (!m_nodeIterators.isEmpty())
-            moveNodeIteratorsToNewDocumentSlowCase(node, newDocument);
-    }
+    void moveNodeIteratorsToNewDocument(Node&, Document&);
 
     void attachRange(Range&);
     void detachRange(Range&);
@@ -1842,8 +1838,6 @@ private:
     void invalidateAccessKeyCacheSlowCase();
     void buildAccessKeyCache();
 
-    void moveNodeIteratorsToNewDocumentSlowCase(Node&, Document&);
-
     void intersectionObserversInitialUpdateTimerFired();
 
     void loadEventDelayTimerFired();
@@ -1961,7 +1955,7 @@ private:
 
     mutable String m_uniqueIdentifier;
 
-    HashSet<NodeIterator*> m_nodeIterators;
+    WeakHashSet<NodeIterator> m_nodeIterators;
     WeakHashSet<Range> m_ranges;
 
     std::unique_ptr<Style::Scope> m_styleScope;

--- a/Source/WebCore/dom/NodeIterator.h
+++ b/Source/WebCore/dom/NodeIterator.h
@@ -32,7 +32,7 @@
 
 namespace WebCore {
 
-class NodeIterator final : public ScriptWrappable, public RefCounted<NodeIterator>, public NodeIteratorBase {
+class NodeIterator final : public ScriptWrappable, public RefCounted<NodeIterator>, public CanMakeWeakPtr<NodeIterator>, public NodeIteratorBase {
     WTF_MAKE_ISO_ALLOCATED_EXPORT(NodeIterator, WEBCORE_EXPORT);
 public:
     static Ref<NodeIterator> create(Node&, unsigned whatToShow, RefPtr<NodeFilter>&&);


### PR DESCRIPTION
#### d9ba14bdee8bc50f19a82610165fa3e720884afa
<pre>
Document::m_nodeIterators should be WeakHashSet
<a href="https://bugs.webkit.org/show_bug.cgi?id=257079">https://bugs.webkit.org/show_bug.cgi?id=257079</a>

Reviewed by Chris Dumez.

Make NodeIterator compatible with WeakPtr and use WeakHashSet for m_nodeIterators in Document.

* Source/WebCore/dom/Document.cpp:
(WebCore::Document::attachNodeIterator):
(WebCore::Document::detachNodeIterator):
(WebCore::Document::moveNodeIteratorsToNewDocument): Renamed from moveNodeIteratorsToNewDocumentSlowCase.
(WebCore::Document::nodeChildrenWillBeRemoved):
(WebCore::Document::nodeWillBeRemoved):
* Source/WebCore/dom/Document.h:
(WebCore::Document::moveNodeIteratorsToNewDocument): Deleted.
* Source/WebCore/dom/NodeIterator.h:

Canonical link: <a href="https://commits.webkit.org/264334@main">https://commits.webkit.org/264334@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/902e225b423ad994d0798d5a1a089e00502f9b2a

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/7314 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/7568 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/7743 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/8938 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/7518 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/7323 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/8916 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/7494 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/10409 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/7442 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/8141 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/6724 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/9047 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/5484 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/6652 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/14379 "150 failures") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/7097 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/6757 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/9686 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/7247 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/5915 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/6603 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/10805 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/869 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/6985 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->