### PR TITLE
WebKit doesn't resize SVG element in response to viewBox change (with height specified and width unspecified)

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/svg/coordinate-systems/outer-svg-intrinsic-size-001-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/svg/coordinate-systems/outer-svg-intrinsic-size-001-expected.txt
@@ -13,5 +13,5 @@ PASS adding specified width, in presence of specified viewBox
 PASS modifiying specified viewBox, in presence of specified width
 PASS removing specified width, in presence of specified viewBox
 PASS adding specified height, in presence of specified viewBox
-FAIL modifiying specified viewBox, in presence of specified height assert_equals: checking width. expected 50 but got 80
+PASS modifiying specified viewBox, in presence of specified height
 

--- a/Source/WebCore/rendering/svg/LegacyRenderSVGRoot.cpp
+++ b/Source/WebCore/rendering/svg/LegacyRenderSVGRoot.cpp
@@ -212,6 +212,7 @@ void LegacyRenderSVGRoot::layout()
 
     repainter.repaintAfterLayout();
 
+    setNeedsLayoutIfNeededAfterIntrinsicSizeChange();
     clearNeedsLayout();
 }
 

--- a/Source/WebCore/rendering/svg/RenderSVGRoot.cpp
+++ b/Source/WebCore/rendering/svg/RenderSVGRoot.cpp
@@ -191,6 +191,7 @@ bool RenderSVGRoot::updateLayoutSizeIfNeeded()
     auto previousSize = size();
     updateLogicalWidth();
     updateLogicalHeight();
+    setNeedsLayoutIfNeededAfterIntrinsicSizeChange();
     return selfNeedsLayout() || previousSize != size();
 }
 


### PR DESCRIPTION
<pre>
WebKit doesn't resize SVG element in response to viewBox change (with height specified and width unspecified)
<a href="https://bugs.webkit.org/show_bug.cgi?id=198609">https://bugs.webkit.org/show_bug.cgi?id=198609</a>
rdar://problem/51486522

Reviewed by NOBODY (OOPS!).

This patch aligns WebKit with Gecko / Firefox and Blink / Chromium.

This patch calls for layout if intrinsic change changes as needed for
case of when dynamically changing the viewBox attribute of the <svg> element.

* Source/WebCore/rendering/svg/LegacyRenderSVGRoot.cpp:
(LegacyRenderSVGRoot::layout): Call 'setNeedsLayoutIfNeededAfterIntrinsicSizeChange'
* Source/WebCore/rendering/svg/RenderSVGRoot.cpp:
(RenderSVGRoot::updateLayoutSizeIfNeeded): Call 'setNeedsLayoutIfNeededAfterIntrinsicSizeChange'
* LayoutTests/imported/w3c/web-platform-tests/svg/coordinate-systems/outer-svg-intrinsic-size-001-expected.txt: Rebaselined
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/fd5012a2ee9cf37692d519adcab46eed26513acc

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/7328 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/7584 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/7758 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/8954 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/7533 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/7338 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/9029 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/7510 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/10426 "101 failures") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/7457 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/8230 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/6745 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/9063 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/5564 "Passed tests") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/6666 "2 failures") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/14393 "1 flakes 147 failures") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/7107 "Passed tests") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/6772 "2 failures") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/9795 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/7263 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/5928 "19 flakes 1 failures") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/6617 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/10821 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/7001 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->