### PR TITLE
Remove StringView::stripWhiteSpace()

### DIFF
--- a/Source/WTF/wtf/Assertions.cpp
+++ b/Source/WTF/wtf/Assertions.cpp
@@ -559,7 +559,7 @@ void WTFInitializeLogChannelStatesFromString(WTFLogChannel* channels[], size_t c
         if (it == componentInfo.end())
             continue;
 
-        auto component = (*it).stripWhiteSpace();
+        auto component = (*it).stripLeadingAndTrailingMatchedCharacters(isUnicodeCompatibleASCIIWhitespace<UChar>);
 
         WTFLogChannelState logChannelState = WTFLogChannelState::On;
         if (component.startsWith('-')) {
@@ -574,7 +574,7 @@ void WTFInitializeLogChannelStatesFromString(WTFLogChannel* channels[], size_t c
 
         WTFLogLevel logChannelLevel = WTFLogLevel::Error;
         if (++it != componentInfo.end()) {
-            auto level = (*it).stripWhiteSpace();
+            auto level = (*it).stripLeadingAndTrailingMatchedCharacters(isUnicodeCompatibleASCIIWhitespace<UChar>);
             if (equalLettersIgnoringASCIICase(level, "error"_s))
                 logChannelLevel = WTFLogLevel::Error;
             else if (equalLettersIgnoringASCIICase(level, "warning"_s))

--- a/Source/WTF/wtf/text/StringView.cpp
+++ b/Source/WTF/wtf/text/StringView.cpp
@@ -366,11 +366,6 @@ bool equalRespectingNullity(StringView a, StringView b)
     return equalCommon(a, b);
 }
 
-StringView StringView::stripWhiteSpace() const
-{
-    return stripLeadingAndTrailingMatchedCharacters(isUnicodeCompatibleASCIIWhitespace<UChar>);
-}
-
 size_t StringView::reverseFind(StringView matchString, unsigned start) const
 {
     if (isNull())

--- a/Source/WTF/wtf/text/StringView.h
+++ b/Source/WTF/wtf/text/StringView.h
@@ -146,7 +146,6 @@ public:
 
     template<typename MatchedCharacterPredicate>
     StringView stripLeadingAndTrailingMatchedCharacters(const MatchedCharacterPredicate&) const;
-    WTF_EXPORT_PRIVATE StringView stripWhiteSpace() const;
 
     class SplitResult;
     SplitResult split(UChar) const;

--- a/Source/WebCore/Modules/applicationmanifest/ApplicationManifestParser.cpp
+++ b/Source/WebCore/Modules/applicationmanifest/ApplicationManifestParser.cpp
@@ -158,7 +158,7 @@ ApplicationManifest::Display ApplicationManifestParser::parseDisplay(const JSON:
     };
     static constexpr SortedArrayMap displayValues { displayValueMappings };
 
-    if (auto* displayValue = displayValues.tryGet(StringView(stringValue).stripWhiteSpace()))
+    if (auto* displayValue = displayValues.tryGet(StringView(stringValue).stripLeadingAndTrailingMatchedCharacters(isUnicodeCompatibleASCIIWhitespace<UChar>)))
         return *displayValue;
 
     logDeveloperWarning(makeString("\""_s, stringValue, "\" is not a valid display mode."_s));
@@ -190,7 +190,7 @@ const std::optional<ScreenOrientationLockType> ApplicationManifestParser::parseO
 
     static SortedArrayMap orientationValues { orientationValueMappings };
 
-    if (auto* orientationValue = orientationValues.tryGet(StringView(stringValue).stripWhiteSpace()))
+    if (auto* orientationValue = orientationValues.tryGet(StringView(stringValue).stripLeadingAndTrailingMatchedCharacters(isUnicodeCompatibleASCIIWhitespace<UChar>)))
         return *orientationValue;
 
     logDeveloperWarning(makeString("\""_s, stringValue, "\" is not a valid orientation."_s));
@@ -267,7 +267,7 @@ Vector<ApplicationManifest::Icon> ApplicationManifestParser::parseIcons(const JS
                 purposes.add(ApplicationManifest::Icon::Purpose::Any);
                 currentIcon.purposes = purposes;
             } else {
-                for (auto keyword : StringView(purposeStringValue).stripWhiteSpace().splitAllowingEmptyEntries(' ')) {
+                for (auto keyword : StringView(purposeStringValue).stripLeadingAndTrailingMatchedCharacters(isUnicodeCompatibleASCIIWhitespace<UChar>).splitAllowingEmptyEntries(' ')) {
                     if (equalLettersIgnoringASCIICase(keyword, "monochrome"_s))
                         purposes.add(ApplicationManifest::Icon::Purpose::Monochrome);
                     else if (equalLettersIgnoringASCIICase(keyword, "maskable"_s))

--- a/Source/WebCore/layout/integration/LayoutIntegrationCoverage.cpp
+++ b/Source/WebCore/layout/integration/LayoutIntegrationCoverage.cpp
@@ -150,7 +150,7 @@ static void printTextForSubtree(const RenderElement& renderer, unsigned& charact
     for (auto& child : childrenOfType<RenderObject>(downcast<RenderElement>(renderer))) {
         if (is<RenderText>(child)) {
             String text = downcast<RenderText>(child).text();
-            auto textView = StringView(text).stripWhiteSpace();
+            auto textView = StringView(text).stripLeadingAndTrailingMatchedCharacters(isUnicodeCompatibleASCIIWhitespace<UChar>);
             auto length = std::min(charactersLeft, textView.length());
             stream << textView.left(length);
             charactersLeft -= length;

--- a/Source/WebCore/page/WindowFeatures.cpp
+++ b/Source/WebCore/page/WindowFeatures.cpp
@@ -120,7 +120,7 @@ OptionSet<DisabledAdaptations> parseDisabledAdaptations(StringView disabledAdapt
 {
     OptionSet<DisabledAdaptations> disabledAdaptations;
     for (auto name : disabledAdaptationsString.split(',')) {
-        auto trimmedName = name.stripWhiteSpace();
+        auto trimmedName = name.stripLeadingAndTrailingMatchedCharacters(isUnicodeCompatibleASCIIWhitespace<UChar>);
         if (equalIgnoringASCIICase(trimmedName, watchAdaptationName()))
             disabledAdaptations.add(DisabledAdaptations::Watch);
     }
@@ -258,12 +258,12 @@ static DialogFeaturesMap parseDialogFeaturesMap(StringView string)
         if (separatorPosition == notFound)
             separatorPosition = colonPosition;
 
-        auto key = featureString.left(separatorPosition).stripWhiteSpace().toString();
+        auto key = featureString.left(separatorPosition).stripLeadingAndTrailingMatchedCharacters(isUnicodeCompatibleASCIIWhitespace<UChar>).toString();
 
         // Null string for value indicates key without value.
         String value;
         if (separatorPosition != notFound) {
-            auto valueView = featureString.substring(separatorPosition + 1).stripWhiteSpace();
+            auto valueView = featureString.substring(separatorPosition + 1).stripLeadingAndTrailingMatchedCharacters(isUnicodeCompatibleASCIIWhitespace<UChar>);
             value = valueView.left(valueView.find(' ')).toString();
         }
 

--- a/Source/WebCore/platform/network/CacheValidation.cpp
+++ b/Source/WebCore/platform/network/CacheValidation.cpp
@@ -378,7 +378,7 @@ static Vector<std::pair<String, String>> collectVaryingRequestHeadersInternal(co
 
     Vector<std::pair<String, String>> headers;
     for (auto varyHeaderName : StringView(varyValue).split(',')) {
-        auto headerName = varyHeaderName.stripWhiteSpace();
+        auto headerName = varyHeaderName.stripLeadingAndTrailingMatchedCharacters(isUnicodeCompatibleASCIIWhitespace<UChar>);
         headers.append(std::pair { headerName.toString(), headerValueForVaryFunction(headerName) });
     }
     return headers;

--- a/Source/WebCore/platform/network/HTTPParsers.cpp
+++ b/Source/WebCore/platform/network/HTTPParsers.cpp
@@ -343,12 +343,12 @@ StringView filenameFromHTTPContentDisposition(StringView value)
         if (valueStartPos == notFound)
             continue;
 
-        auto key = keyValuePair.left(valueStartPos).stripWhiteSpace();
+        auto key = keyValuePair.left(valueStartPos).stripLeadingAndTrailingMatchedCharacters(isUnicodeCompatibleASCIIWhitespace<UChar>);
 
         if (key.isEmpty() || key != "filename"_s)
             continue;
 
-        auto value = keyValuePair.substring(valueStartPos + 1).stripWhiteSpace();
+        auto value = keyValuePair.substring(valueStartPos + 1).stripLeadingAndTrailingMatchedCharacters(isUnicodeCompatibleASCIIWhitespace<UChar>);
 
         // Remove quotes if there are any
         if (value.length() > 1 && value[0] == '\"')
@@ -564,7 +564,7 @@ XFrameOptionsDisposition parseXFrameOptionsHeader(StringView header)
         return result;
 
     for (auto currentHeader : header.splitAllowingEmptyEntries(',')) {
-        currentHeader = currentHeader.stripWhiteSpace();
+        currentHeader = currentHeader.stripLeadingAndTrailingMatchedCharacters(isUnicodeCompatibleASCIIWhitespace<UChar>);
         XFrameOptionsDisposition currentValue = XFrameOptionsDisposition::None;
         if (equalLettersIgnoringASCIICase(currentHeader, "deny"_s))
             currentValue = XFrameOptionsDisposition::Deny;
@@ -839,7 +839,7 @@ bool isForbiddenHeader(const String& name, StringView value)
         return true;
     if (equalLettersIgnoringASCIICase(name, "x-http-method-override"_s) || equalLettersIgnoringASCIICase(name, "x-http-method"_s) || equalLettersIgnoringASCIICase(name, "x-method-override"_s)) {
         for (auto methodValue : StringView(value).split(',')) {
-            auto method = methodValue.stripWhiteSpace();
+            auto method = methodValue.stripLeadingAndTrailingMatchedCharacters(isUnicodeCompatibleASCIIWhitespace<UChar>);
             if (isForbiddenMethod(method))
                 return true;
         }

--- a/Source/WebCore/platform/network/MIMEHeader.cpp
+++ b/Source/WebCore/platform/network/MIMEHeader.cpp
@@ -72,7 +72,7 @@ static KeyValueMap retrieveKeyValuePairs(WebCore::SharedBufferChunkReader& buffe
             // This is not a key value pair, ignore.
             continue;
         }
-        key = StringView(line).left(semicolonIndex).stripWhiteSpace().convertToASCIILowercase();
+        key = StringView(line).left(semicolonIndex).stripLeadingAndTrailingMatchedCharacters(isUnicodeCompatibleASCIIWhitespace<UChar>).convertToASCIILowercase();
         value.append(StringView(line).substring(semicolonIndex + 1));
     }
     // Store the last property if there is one.
@@ -122,7 +122,7 @@ RefPtr<MIMEHeader> MIMEHeader::parseHeader(SharedBufferChunkReader& buffer)
 
 MIMEHeader::Encoding MIMEHeader::parseContentTransferEncoding(StringView text)
 {
-    auto encoding = text.stripWhiteSpace();
+    auto encoding = text.stripLeadingAndTrailingMatchedCharacters(isUnicodeCompatibleASCIIWhitespace<UChar>);
     if (equalLettersIgnoringASCIICase(encoding, "base64"_s))
         return Base64;
     if (equalLettersIgnoringASCIICase(encoding, "quoted-printable"_s))

--- a/Source/WebCore/platform/network/ResourceResponseBase.cpp
+++ b/Source/WebCore/platform/network/ResourceResponseBase.cpp
@@ -814,7 +814,7 @@ bool ResourceResponseBase::isAttachment() const
     lazyInit(AllFields);
 
     auto value = m_httpHeaderFields.get(HTTPHeaderName::ContentDisposition);
-    return equalLettersIgnoringASCIICase(StringView(value).left(value.find(';')).stripWhiteSpace(), "attachment"_s);
+    return equalLettersIgnoringASCIICase(StringView(value).left(value.find(';')).stripLeadingAndTrailingMatchedCharacters(isUnicodeCompatibleASCIIWhitespace<UChar>), "attachment"_s);
 }
 
 bool ResourceResponseBase::isAttachmentWithFilename() const
@@ -826,7 +826,7 @@ bool ResourceResponseBase::isAttachmentWithFilename() const
         return false;
 
     StringView contentDispositionView { contentDisposition };
-    if (!equalLettersIgnoringASCIICase(contentDispositionView.left(contentDispositionView.find(';')).stripWhiteSpace(), "attachment"_s))
+    if (!equalLettersIgnoringASCIICase(contentDispositionView.left(contentDispositionView.find(';')).stripLeadingAndTrailingMatchedCharacters(isUnicodeCompatibleASCIIWhitespace<UChar>), "attachment"_s))
         return false;
 
     return !filenameFromHTTPContentDisposition(contentDispositionView).isNull();

--- a/Source/WebCore/platform/sql/SQLiteDatabase.cpp
+++ b/Source/WebCore/platform/sql/SQLiteDatabase.cpp
@@ -750,7 +750,7 @@ static Expected<sqlite3_stmt*, int> constructAndPrepareStatement(SQLiteDatabase&
 
 Expected<SQLiteStatement, int> SQLiteDatabase::prepareStatementSlow(StringView queryString)
 {
-    CString query = queryString.stripWhiteSpace().utf8();
+    CString query = queryString.stripLeadingAndTrailingMatchedCharacters(isUnicodeCompatibleASCIIWhitespace<UChar>).utf8();
     auto sqlStatement = constructAndPrepareStatement(*this, query.data(), query.length());
     if (!sqlStatement) {
         RELEASE_LOG_ERROR(SQLDatabase, "SQLiteDatabase::prepareStatement: Failed to prepare statement %" PUBLIC_LOG_STRING, query.data());
@@ -771,7 +771,7 @@ Expected<SQLiteStatement, int> SQLiteDatabase::prepareStatement(ASCIILiteral que
 
 Expected<UniqueRef<SQLiteStatement>, int> SQLiteDatabase::prepareHeapStatementSlow(StringView queryString)
 {
-    CString query = queryString.stripWhiteSpace().utf8();
+    CString query = queryString.stripLeadingAndTrailingMatchedCharacters(isUnicodeCompatibleASCIIWhitespace<UChar>).utf8();
     auto sqlStatement = constructAndPrepareStatement(*this, query.data(), query.length());
     if (!sqlStatement) {
         RELEASE_LOG_ERROR(SQLDatabase, "SQLiteDatabase::prepareHeapStatement: Failed to prepare statement %" PUBLIC_LOG_STRING, query.data());

--- a/Source/WebCore/platform/xr/PlatformXR.h
+++ b/Source/WebCore/platform/xr/PlatformXR.h
@@ -121,7 +121,7 @@ inline SessionFeature sessionFeatureFromReferenceSpaceType(ReferenceSpaceType re
 
 inline std::optional<SessionFeature> parseSessionFeatureDescriptor(StringView string)
 {
-    auto feature = string.stripWhiteSpace().convertToASCIILowercase();
+    auto feature = string.stripLeadingAndTrailingMatchedCharacters(isUnicodeCompatibleASCIIWhitespace<UChar>).convertToASCIILowercase();
 
     if (feature == "viewer"_s)
         return SessionFeature::ReferenceSpaceTypeViewer;

--- a/Source/WebCore/svg/SVGAnimationElement.cpp
+++ b/Source/WebCore/svg/SVGAnimationElement.cpp
@@ -65,7 +65,7 @@ static Vector<float> parseKeyTimes(StringView value, bool verifyOrder)
     Vector<float> result;
 
     for (auto keyTime : keyTimes) {
-        keyTime = keyTime.stripWhiteSpace();
+        keyTime = keyTime.stripLeadingAndTrailingMatchedCharacters(isUnicodeCompatibleASCIIWhitespace<UChar>);
 
         bool ok;
         float time = keyTime.toFloat(ok);

--- a/Source/WebCore/svg/animation/SVGSMILElement.cpp
+++ b/Source/WebCore/svg/animation/SVGSMILElement.cpp
@@ -318,7 +318,7 @@ SMILTime SVGSMILElement::parseOffsetValue(StringView data)
 {
     bool ok;
     double result = 0;
-    auto parse = data.stripWhiteSpace();
+    auto parse = data.stripLeadingAndTrailingMatchedCharacters(isUnicodeCompatibleASCIIWhitespace<UChar>);
     if (parse.endsWith('h'))
         result = parse.left(parse.length() - 1).toDouble(ok) * 60 * 60;
     else if (parse.endsWith("min"_s))
@@ -339,7 +339,7 @@ SMILTime SVGSMILElement::parseClockValue(StringView data)
     if (data.isNull())
         return SMILTime::unresolved();
 
-    auto parse = data.stripWhiteSpace();
+    auto parse = data.stripLeadingAndTrailingMatchedCharacters(isUnicodeCompatibleASCIIWhitespace<UChar>);
     if (parse == indefiniteAtom())
         return SMILTime::indefinite();
 
@@ -372,7 +372,7 @@ static void sortTimeList(Vector<SMILTimeWithOrigin>& timeList)
     
 bool SVGSMILElement::parseCondition(StringView value, BeginOrEnd beginOrEnd)
 {
-    auto parseString = value.stripWhiteSpace();
+    auto parseString = value.stripLeadingAndTrailingMatchedCharacters(isUnicodeCompatibleASCIIWhitespace<UChar>);
     
     double sign = 1.;
     size_t pos = parseString.find('+');
@@ -386,8 +386,8 @@ bool SVGSMILElement::parseCondition(StringView value, BeginOrEnd beginOrEnd)
     if (pos == notFound)
         conditionString = parseString;
     else {
-        conditionString = parseString.left(pos).stripWhiteSpace();
-        auto offsetString = parseString.substring(pos + 1).stripWhiteSpace();
+        conditionString = parseString.left(pos).stripLeadingAndTrailingMatchedCharacters(isUnicodeCompatibleASCIIWhitespace<UChar>);
+        auto offsetString = parseString.substring(pos + 1).stripLeadingAndTrailingMatchedCharacters(isUnicodeCompatibleASCIIWhitespace<UChar>);
         offset = parseOffsetValue(offsetString);
         if (offset.isUnresolved())
             return false;


### PR DESCRIPTION
#### a2fbff3888aa2a3cf061b40a84bfc108a89a4c33
<pre>
Remove StringView::stripWhiteSpace()
<a href="https://bugs.webkit.org/show_bug.cgi?id=257086">https://bugs.webkit.org/show_bug.cgi?id=257086</a>
rdar://109608781

Reviewed by Darin Adler.

This makes all callers use stripLeadingAndTrailingMatchedCharacters()
directly with the same argument.

This is an improvement as stripWhiteSpace() doesn&apos;t match
String::stripWhiteSpace() (isUnicodeCompatibleASCIIWhitespace vs
isSpaceOrNewline) and its semantics are likely not what you want: the
web platform primarily uses isASCIIWhitespace.

* Source/WTF/wtf/Assertions.cpp:
* Source/WTF/wtf/text/StringView.cpp:
(WTF::StringView::stripWhiteSpace const): Deleted.
* Source/WTF/wtf/text/StringView.h:
* Source/WebCore/Modules/applicationmanifest/ApplicationManifestParser.cpp:
(WebCore::ApplicationManifestParser::parseDisplay):
(WebCore::ApplicationManifestParser::parseOrientation):
(WebCore::ApplicationManifestParser::parseIcons):
* Source/WebCore/layout/integration/LayoutIntegrationCoverage.cpp:
(WebCore::LayoutIntegration::printTextForSubtree):
* Source/WebCore/page/WindowFeatures.cpp:
(WebCore::parseDisabledAdaptations):
(WebCore::parseDialogFeaturesMap):
* Source/WebCore/platform/network/CacheValidation.cpp:
(WebCore::collectVaryingRequestHeadersInternal):
* Source/WebCore/platform/network/HTTPParsers.cpp:
(WebCore::filenameFromHTTPContentDisposition):
(WebCore::parseXFrameOptionsHeader):
(WebCore::isForbiddenHeader):
* Source/WebCore/platform/network/MIMEHeader.cpp:
(WebCore::retrieveKeyValuePairs):
(WebCore::MIMEHeader::parseContentTransferEncoding):
* Source/WebCore/platform/network/ResourceResponseBase.cpp:
(WebCore::ResourceResponseBase::isAttachment const):
(WebCore::ResourceResponseBase::isAttachmentWithFilename const):
* Source/WebCore/platform/sql/SQLiteDatabase.cpp:
(WebCore::SQLiteDatabase::prepareStatementSlow):
(WebCore::SQLiteDatabase::prepareHeapStatementSlow):
* Source/WebCore/platform/xr/PlatformXR.h:
(PlatformXR::parseSessionFeatureDescriptor):
* Source/WebCore/svg/SVGAnimationElement.cpp:
(WebCore::parseKeyTimes):
* Source/WebCore/svg/animation/SVGSMILElement.cpp:
(WebCore::SVGSMILElement::parseOffsetValue):
(WebCore::SVGSMILElement::parseClockValue):
(WebCore::SVGSMILElement::parseCondition):

Canonical link: <a href="https://commits.webkit.org/264300@main">https://commits.webkit.org/264300@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/3f317b50c5729628b7cbd8bcb84308c3c5b85497

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/7329 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/7585 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/7759 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/8955 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/7534 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/7339 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/9035 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/7511 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/10427 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/7458 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/8234 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/6747 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/9064 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/5570 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/6668 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/14394 "2 flakes 111 failures") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/6225 "Built successfully and passed tests") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/7108 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/6774 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/9811 "Passed tests") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/6915 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/7264 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/5929 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/7474 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/6618 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/1720 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/1723 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/10822 "Built successfully") | | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/24/builds/7678 "Built successfully") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/7002 "Built successfully") | | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/3/builds/1859 "Passed tests") | 
<!--EWS-Status-Bubble-End-->