### PR TITLE
[JSC] add JSFunction::nameWithoutGC

### DIFF
--- a/JSTests/stress/error-bound-function.js
+++ b/JSTests/stress/error-bound-function.js
@@ -1,0 +1,27 @@
+function throwing()
+{
+    throw new Error('ok');
+}
+noInline(throwing);
+
+function test()
+{
+    throwing();
+}
+noInline(test);
+
+function calling()
+{
+    test.bind(null)();
+}
+noInline(calling);
+
+var errors = [];
+for (var i = 0; i < 1000; ++i) {
+    try {
+        calling();
+    } catch(e) {
+        errors.push(e);
+    }
+}
+fullGC();

--- a/Source/JavaScriptCore/runtime/JSBoundFunction.h
+++ b/Source/JavaScriptCore/runtime/JSBoundFunction.h
@@ -73,6 +73,15 @@ public:
         bool allocationAllowed = false;
         return m_nameMayBeNull->tryGetValue(allocationAllowed);
     }
+    String nameStringWithoutGC(VM& vm)
+    {
+        if (m_nameMayBeNull) {
+            ASSERT(!m_nameMayBeNull->isRope());
+            bool allocationAllowed = false;
+            return m_nameMayBeNull->tryGetValue(allocationAllowed);
+        }
+        return nameStringWithoutGCSlow(vm);
+    }
 
     double length(VM& vm)
     {
@@ -131,6 +140,7 @@ private:
     JSString* nameSlow(VM&);
     double lengthSlow(VM&);
     bool canConstructSlow();
+    String nameStringWithoutGCSlow(VM&);
 
     DECLARE_DEFAULT_FINISH_CREATION;
     DECLARE_VISIT_CHILDREN;

--- a/Source/JavaScriptCore/runtime/JSFunction.h
+++ b/Source/JavaScriptCore/runtime/JSFunction.h
@@ -92,6 +92,8 @@ public:
     JS_EXPORT_PRIVATE const String calculatedDisplayName(VM&);
     JS_EXPORT_PRIVATE JSString* toString(JSGlobalObject*);
 
+    String nameWithoutGC(VM&);
+
     JSString* asStringConcurrently() const;
 
     ExecutableBase* executable() const


### PR DESCRIPTION
#### 8661025c07ae37a7fecab656ea5d5fce16c2c293
<pre>
[JSC] add JSFunction::nameWithoutGC
<a href="https://bugs.webkit.org/show_bug.cgi?id=257091">https://bugs.webkit.org/show_bug.cgi?id=257091</a>
rdar://109614514

Reviewed by Keith Miller.

This patch does not change the production behavior, but it adds JSFunction::nameWithoutGC
to make it extra robust against ErrorInstance&apos;s stack cleaning up in GC end phase, which
must not cause any GC activity. Right now, JSBoundFunction::name can cause GC, but JSBoundFunction
was never listed in the error stack (so there is no problem), but let&apos;s make this invariant
clear for ErrorInstance to defend against the future possible extension.

* JSTests/stress/error-bound-function.js: Added.
(throwing):
(test):
(calling):
(i.catch):
* Source/JavaScriptCore/runtime/JSBoundFunction.cpp:
(JSC::JSBoundFunction::nameStringWithoutGCSlow):
* Source/JavaScriptCore/runtime/JSBoundFunction.h:
* Source/JavaScriptCore/runtime/JSFunction.cpp:
(JSC::JSFunction::nameWithoutGC):
(JSC::getCalculatedDisplayName):
* Source/JavaScriptCore/runtime/JSFunction.h:

Canonical link: <a href="https://commits.webkit.org/264299@main">https://commits.webkit.org/264299@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/62e5d737950b86b4c8c9a45c5b9bebd4504dd596

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/7338 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/7595 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/7769 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/8965 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/7543 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/9074 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/7520 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/10436 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/7467 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/8262 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/6764 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/9074 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/5598 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/6679 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/14403 "Passed tests") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/6235 "Built successfully and passed tests") | [⏳ 🧪 api-ios](https://ews-build.webkit.org/#/builders/API-Tests-iOS-Simulator-EWS "Waiting to run tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/6785 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/9850 "Passed tests") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/6925 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/7274 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/5938 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/7483 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/6627 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/1723 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/1722 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/10832 "Built successfully") | | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/24/builds/7687 "Built successfully") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/7011 "Built successfully") | | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/3/builds/1862 "Passed tests") | 
<!--EWS-Status-Bubble-End-->