### PR TITLE
Network connection integrity policies are missing when connecting via <link rel=preconnect>

### DIFF
--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebViewPrivateForTesting.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebViewPrivateForTesting.h
@@ -95,6 +95,8 @@ struct WKAppPrivacyReportTestingData {
 @property (nonatomic, setter=_setScrollingUpdatesDisabledForTesting:) BOOL _scrollingUpdatesDisabledForTesting;
 @property (nonatomic, readonly) NSString *_scrollingTreeAsText;
 
+@property (nonatomic, readonly) pid_t _networkProcessIdentifier;
+
 @property (nonatomic, readonly) unsigned long _countOfUpdatesWithLayerChanges;
 
 - (void)_processWillSuspendForTesting:(void (^)(void))completionHandler;

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebViewTesting.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebViewTesting.mm
@@ -29,6 +29,7 @@
 #import "AudioSessionRoutingArbitratorProxy.h"
 #import "GPUProcessProxy.h"
 #import "MediaSessionCoordinatorProxyPrivate.h"
+#import "NetworkProcessProxy.h"
 #import "PlaybackSessionManagerProxy.h"
 #import "PrintInfo.h"
 #import "RemoteLayerTreeDrawingAreaProxy.h"
@@ -40,6 +41,7 @@
 #import "WebProcessPool.h"
 #import "WebProcessProxy.h"
 #import "WebViewImpl.h"
+#import "WebsiteDataStore.h"
 #import "_WKFrameHandleInternal.h"
 #import "_WKInspectorInternal.h"
 #import <WebCore/RuntimeApplicationChecks.h>
@@ -211,6 +213,13 @@ static void dumpCALayer(TextStream& ts, CALayer *layer, bool traverse)
         return @"";
 
     return coordinator->scrollingTreeAsText();
+}
+
+- (pid_t)_networkProcessIdentifier
+{
+    auto* networkProcess = _page->websiteDataStore().networkProcessIfExists();
+    RELEASE_ASSERT(networkProcess);
+    return networkProcess->processIdentifier();
 }
 
 - (void)_setScrollingUpdatesDisabledForTesting:(BOOL)disabled

--- a/Tools/TestWebKitAPI/cocoa/HTTPServer.h
+++ b/Tools/TestWebKitAPI/cocoa/HTTPServer.h
@@ -96,6 +96,7 @@ public:
     NSURLRequest *request(StringView path = "/"_s) const;
     NSURLRequest *requestWithLocalhost(StringView path = "/"_s) const;
     WKWebViewConfiguration *httpsProxyConfiguration() const;
+    size_t totalConnections() const;
     size_t totalRequests() const;
     void cancel();
     void terminateAllConnections(CompletionHandler<void()>&&);

--- a/Tools/TestWebKitAPI/cocoa/HTTPServer.mm
+++ b/Tools/TestWebKitAPI/cocoa/HTTPServer.mm
@@ -291,6 +291,11 @@ void HTTPServer::respondWithOK(Connection connection)
     });
 }
 
+size_t HTTPServer::totalConnections() const
+{
+    return m_requestData->connections.size();
+}
+
 size_t HTTPServer::totalRequests() const
 {
     return m_requestData->requestCount;


### PR DESCRIPTION
#### c2ec9c11767361af98d651ab55ba2028b3d1ff4b
<pre>
Network connection integrity policies are missing when connecting via &lt;link rel=preconnect&gt;
<a href="https://bugs.webkit.org/show_bug.cgi?id=257096">https://bugs.webkit.org/show_bug.cgi?id=257096</a>
rdar://107356544

Reviewed by Tim Horton.

Add logic to set network connection integrity policy flags when sending a network request triggered
by a link element with `rel=preconnect`. See below for more details.

* Source/WebKit/UIProcess/API/Cocoa/WKWebViewPrivateForTesting.h:
* Source/WebKit/UIProcess/API/Cocoa/WKWebViewTesting.mm:
(-[WKWebView _networkProcessIdentifier]):

Add a testing hook that returns the network process PID, for use in a new (internal) API test.

* Source/WebKit/WebProcess/Network/WebLoaderStrategy.cpp:
(WebKit::policySourceDocumentLoaderForFrame):

Pull existing logic for grabbing a suitable `DocumentLoader` for a given frame out of
`addParametersShared` and into a separate helper function, so that we can use it in multiple places.

(WebKit::addParametersShared):
(WebKit::WebLoaderStrategy::preconnectTo):

Use the new helper function above to populate network connection integrity flags on the outbound
resource load when handling preconnect.

* Tools/TestWebKitAPI/cocoa/HTTPServer.h:
* Tools/TestWebKitAPI/cocoa/HTTPServer.mm:
(TestWebKitAPI::HTTPServer::totalConnections const):

Add a helper method on the mock HTTP server to return the total connection count.

Canonical link: <a href="https://commits.webkit.org/264382@main">https://commits.webkit.org/264382@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c87ad2ab9be86e63b36c51adf0cb6832645cc8bd

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/7351 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/7608 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/7782 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/8978 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/7556 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/7361 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/9152 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/7533 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/10447 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/7480 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/8325 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/6780 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/9087 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/5657 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/6689 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/14414 "1 flakes 113 failures") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/7120 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/6796 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/9899 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/7287 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/5950 "13 flakes 3 failures") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/6640 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/1765 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/10845 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/7024 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->