### PR TITLE
Allow WebKit to override WorkerAnimationController and provide their own implementations

### DIFF
--- a/Source/WebCore/page/WorkerClient.h
+++ b/Source/WebCore/page/WorkerClient.h
@@ -31,11 +31,16 @@
 
 namespace WebCore {
 
+class WorkerAnimationController;
+class WorkerGlobalScope;
+
 class WorkerClient : public GraphicsClient {
     WTF_MAKE_FAST_ALLOCATED;
 public:
 
     virtual std::unique_ptr<WorkerClient> clone(SerialFunctionDispatcher&) = 0;
+
+    virtual RefPtr<WorkerAnimationController> createAnimationController(WorkerGlobalScope&) = 0;
 
     virtual ~WorkerClient() = default;
 };

--- a/Source/WebCore/workers/DedicatedWorkerGlobalScope.cpp
+++ b/Source/WebCore/workers/DedicatedWorkerGlobalScope.cpp
@@ -113,8 +113,12 @@ DedicatedWorkerThread& DedicatedWorkerGlobalScope::thread()
 #if ENABLE(OFFSCREEN_CANVAS_IN_WORKERS)
 CallbackId DedicatedWorkerGlobalScope::requestAnimationFrame(Ref<RequestAnimationFrameCallback>&& callback)
 {
-    if (!m_workerAnimationController)
-        m_workerAnimationController = WorkerAnimationController::create(*this);
+    if (!m_workerAnimationController) {
+        if (workerClient())
+            m_workerAnimationController = workerClient()->createAnimationController(*this);
+        if (!m_workerAnimationController)
+            m_workerAnimationController = TimerWorkerAnimationController::create(*this);
+    }
     return m_workerAnimationController->requestAnimationFrame(WTFMove(callback));
 }
 

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebWorkerClient.cpp
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebWorkerClient.cpp
@@ -26,12 +26,14 @@
 #include "config.h"
 #include "WebWorkerClient.h"
 
+#include "EventDispatcher.h"
 #include "ImageBufferShareableBitmapBackend.h"
 #include "RemoteImageBufferProxy.h"
 #include "RemoteRenderingBackendProxy.h"
 #include "WebPage.h"
 #include "WebProcess.h"
 #include <WebCore/Page.h>
+#include <WebCore/WorkerAnimationController.h>
 
 #if ENABLE(WEBGL) && ENABLE(GPU_PROCESS)
 #include "RemoteGraphicsContextGLProxy.h"
@@ -105,6 +107,11 @@ std::unique_ptr<WorkerClient> WebWorkerClient::clone(SerialFunctionDispatcher& d
 #else
     return makeUnique<WebWorkerClient>(dispatcher, m_displayID);
 #endif
+}
+
+RefPtr<WorkerAnimationController> WebWorkerClient::createAnimationController(WorkerGlobalScope& workerGlobalScope)
+{
+    return nullptr;
 }
 
 PlatformDisplayID WebWorkerClient::displayID() const

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebWorkerClient.h
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebWorkerClient.h
@@ -59,6 +59,7 @@ public:
 #endif
 
     std::unique_ptr<WorkerClient> clone(SerialFunctionDispatcher&) final;
+    RefPtr<WebCore::WorkerAnimationController> createAnimationController(WebCore::WorkerGlobalScope&) final;
 
     WebCore::PlatformDisplayID displayID() const final;
 


### PR DESCRIPTION
#### a2375d99791fc4ff8b31885dad23b77fa3654b2d
<pre>
Allow WebKit to override WorkerAnimationController and provide their own implementations
<a href="https://bugs.webkit.org/show_bug.cgi?id=257098">https://bugs.webkit.org/show_bug.cgi?id=257098</a>

Reviewed by NOBODY (OOPS!).

This is a prerequisite to adding a WebKit implementation that uses display link callbacks to
drive the animation frame rate.

* Source/WebCore/page/WorkerClient.h:
* Source/WebCore/workers/DedicatedWorkerGlobalScope.cpp:
(WebCore::DedicatedWorkerGlobalScope::requestAnimationFrame):
* Source/WebCore/workers/WorkerAnimationController.cpp:
(WebCore::WorkerAnimationController::WorkerAnimationController):
(WebCore::WorkerAnimationController::virtualHasPendingActivity const):
(WebCore::WorkerAnimationController::stop):
(WebCore::TimerWorkerAnimationController::TimerWorkerAnimationController):
(WebCore::TimerWorkerAnimationController::~TimerWorkerAnimationController):
(WebCore::TimerWorkerAnimationController::isActive const):
(WebCore::TimerWorkerAnimationController::stopAnimation):
(WebCore::TimerWorkerAnimationController::scheduleAnimation):
(WebCore::TimerWorkerAnimationController::create):
(WebCore::WorkerAnimationController::create): Deleted.
(WebCore::WorkerAnimationController::~WorkerAnimationController): Deleted.
(WebCore::WorkerAnimationController::scheduleAnimation): Deleted.
* Source/WebCore/workers/WorkerAnimationController.h:
* Source/WebKit/WebProcess/WebCoreSupport/WebWorkerClient.cpp:
(WebKit::WebWorkerClient::createAnimationController):
* Source/WebKit/WebProcess/WebCoreSupport/WebWorkerClient.h:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a2375d99791fc4ff8b31885dad23b77fa3654b2d

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/8412 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/8706 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/8923 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/10079 "Built successfully") | [❌ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/8468 "Failed to compile WebKit") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/8421 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/10694 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/8827 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/11327 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/8558 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/9602 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/7609 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/10234 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/6900 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/7695 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/15252 "115 failures") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/8021 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/7839 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/11190 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/8312 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/6911 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/7600 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/11810 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/8057 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->