### PR TITLE
Add additional test with `image` tag post 263850@main

### DIFF
--- a/LayoutTests/fast/preloader/image-in-nested-template-01-expected.txt
+++ b/LayoutTests/fast/preloader/image-in-nested-template-01-expected.txt
@@ -1,0 +1,1 @@
+This test requires DumpRenderTree to see the log of what resources are loaded.

--- a/LayoutTests/fast/preloader/image-in-nested-template-01.html
+++ b/LayoutTests/fast/preloader/image-in-nested-template-01.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<body>
+    <script>
+    if (window.testRunner) {
+        testRunner.dumpAsText();
+        testRunner.dumpResourceResponseMIMETypes();
+    }
+    </script>
+    This test requires DumpRenderTree to see the log of what resources are loaded.
+    <template>
+        <template></template>
+        <script src=resources/non-existant.js></script>
+        <script>document.write("<plaintext>");</script>
+        <!-- This test is copy of 'image-in-nested-template' with incorrect <image> tag -->
+        <image src=resources/image1.png>
+    </template>
+</body>

--- a/LayoutTests/fast/preloader/image-with-incorrect-tag-expected.txt
+++ b/LayoutTests/fast/preloader/image-with-incorrect-tag-expected.txt
@@ -1,0 +1,4 @@
+This test requires DumpRenderTree to see the log of what resources are loaded.
+
+    <image src=resources/image1.png>
+

--- a/LayoutTests/fast/preloader/image-with-incorrect-tag.html
+++ b/LayoutTests/fast/preloader/image-with-incorrect-tag.html
@@ -1,0 +1,11 @@
+<body>
+    <script>
+    if (window.testRunner) {
+        testRunner.dumpAsText();
+        testRunner.dumpResourceResponseMIMETypes();
+    }
+    </script>
+    This test requires DumpRenderTree to see the log of what resources are loaded.
+    <script src=resources/non-existant.js></script>
+    <script>document.write("<plaintext>");</script>
+    <image src=resources/image1.png>


### PR DESCRIPTION
#### 31ed359e3324f2f5c4fad10c6bfbad5675e1d577
<pre>
Add additional test with `image` tag post 263850@main

<a href="https://bugs.webkit.org/show_bug.cgi?id=257106">https://bugs.webkit.org/show_bug.cgi?id=257106</a>

Reviewed by Ryosuke Niwa.

This patch adds another test case scenario post 263850@main for incorrect tag
within nested template to ensure it does not preload.
Further, it also add &apos;image&apos; (incorrect) tag test to confirm
that it does not preload as well.

* LayoutTests/fast/preloader/image-in-nested-template-01.html: Add Test Case
* LayoutTests/fast/preloader/image-in-nested-template-01-expected.txt: Add Test Case Expectation
* LayoutTests/fast/preloader/image-with-incorrect-tag.html: Add Test Case
* LayoutTests/fast/preloader/image-with-incorrect-tag-expected.txt: Add Test Case Expectation

Canonical link: <a href="https://commits.webkit.org/264492@main">https://commits.webkit.org/264492@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/080d539b610c8f48a45f782fde63e5837cd47558

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/7657 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/7926 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/8110 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/9300 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/7836 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/9925 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/7851 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/10702 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/7790 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/8926 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/7058 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/9410 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/6234 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/6983 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/14656 "7 flakes 113 failures") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/7397 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/7107 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/10508 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/7593 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/6194 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/6926 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/6894 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/11137 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/935 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/7324 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->