### PR TITLE
Resolve percentage in `use` against the instance's viewport element

### DIFF
--- a/LayoutTests/svg/custom/use-nested-symbol-viewport-expected.html
+++ b/LayoutTests/svg/custom/use-nested-symbol-viewport-expected.html
@@ -1,0 +1,2 @@
+<!DOCTYPE html>
+<div style="width: 100px; height: 100px; background-color: green"></div>

--- a/LayoutTests/svg/custom/use-nested-symbol-viewport.html
+++ b/LayoutTests/svg/custom/use-nested-symbol-viewport.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<svg width="200" height="100">
+  <rect width="100" height="100" fill="red"/>
+  <symbol id="inner">
+    <rect width="100" height="100"/>
+  </symbol>
+  <symbol id="outer">
+    <rect x="50%" width="100" height="100" fill="red"/>
+    <use xlink:href="#inner" x="50%" fill="green"/>
+  </symbol>
+  <use xlink:href="#outer" transform="translate(-100, 0)"/>
+</svg>

--- a/Source/WebCore/rendering/svg/LegacyRenderSVGTransformableContainer.cpp
+++ b/Source/WebCore/rendering/svg/LegacyRenderSVGTransformableContainer.cpp
@@ -1,7 +1,7 @@
 /*
  * Copyright (C) 2004, 2005 Nikolas Zimmermann <zimmermann@kde.org>
  * Copyright (C) 2004, 2005, 2006 Rob Buis <buis@kde.org>
- * Copyright (C) 2009 Google, Inc.
+ * Copyright (C) 2009-2016 Google, Inc.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Library General Public
@@ -58,7 +58,7 @@ bool LegacyRenderSVGTransformableContainer::calculateLocalTransform()
     }
 
     if (useElement) {
-        SVGLengthContext lengthContext(useElement);
+        SVGLengthContext lengthContext(&element);
         FloatSize translation(useElement->x().value(lengthContext), useElement->y().value(lengthContext));
         if (translation != m_lastTranslation)
             m_needsTransformUpdate = true;


### PR DESCRIPTION
#### 590f8fce92dfea7e21fc936798cacf2c5f18a323
<pre>
Resolve percentage in `use` against the instance&apos;s viewport element

<a href="https://bugs.webkit.org/show_bug.cgi?id=256702">https://bugs.webkit.org/show_bug.cgi?id=256702</a>
rdar://problem/109565397

Reviewed by Simon Fraser.

This patch aligns WebKit with Blink / Chromium and Gecko / Firefox.

Merge: <a href="https://chromium.googlesource.com/chromium/src/+/b34ff6fe2d5842a63e2c66f68f050f0cf9163010">https://chromium.googlesource.com/chromium/src/+/b34ff6fe2d5842a63e2c66f68f050f0cf9163010</a>

In RenderSVGTransformableContainer::calculateLocalTransform, &apos;x&apos; and &apos;y&apos;
were resolved against the original (corresponding) element. For a `use`
nested within a `symbol`, this would mean that when were going to look
up the viewport element, we would return the outer `symbol` element and thus
fail to get a viewport.
Use the instance element to setup the SVGLengthContext instead.

* Source/WebCore/rendering/svg/LegacyRenderSVGTransformableContainer.cpp:
(LegacyRenderSVGTransformableContainer::calculateLocalTransform): Use &apos;element&apos; rather than &apos;useElement&apos;
* LayoutTests/svg/custom/use-nested-symbol-viewport.html: Add Test Case
* LayoutTests/svg/custom/use-nested-symbol-viewport-expected.html: Add Test Case Expectation

Canonical link: <a href="https://commits.webkit.org/264596@main">https://commits.webkit.org/264596@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/3b4418b893d5467e5cd03abb53360fab2c499e68

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/7362 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/7619 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/7793 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/8989 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/7567 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/7372 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/9368 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/7544 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/10457 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/7491 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/8473 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/6806 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/9098 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/5795 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/6699 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/14427 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/7234 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/6808 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/10003 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/7298 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/5987 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/6651 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/6610 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/1937 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/10856 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/7035 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->