### PR TITLE
Teach TextBreakIterator about strict and loose line breaking behaviors

### DIFF
--- a/Source/WTF/wtf/text/WTFString.h
+++ b/Source/WTF/wtf/text/WTFString.h
@@ -1,6 +1,6 @@
 /*
  * (C) 1999 Lars Knoll (knoll@kde.org)
- * Copyright (C) 2004-2022 Apple Inc. All rights reserved.
+ * Copyright (C) 2004-2023 Apple Inc. All rights reserved.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Library General Public
@@ -564,6 +564,11 @@ inline namespace StringLiterals {
 inline String operator"" _str(const char* characters, size_t)
 {
     return ASCIILiteral::fromLiteralUnsafe(characters);
+}
+
+inline String operator"" _str(const UChar* characters, size_t length)
+{
+    return String(characters, length);
 }
 
 } // inline StringLiterals

--- a/Source/WebCore/platform/graphics/ComplexTextController.cpp
+++ b/Source/WebCore/platform/graphics/ComplexTextController.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2007-2022 Apple Inc. All rights reserved.
+ * Copyright (C) 2007-2023 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -211,7 +211,7 @@ unsigned ComplexTextController::offsetForPosition(float h, bool includePartialGl
                 }
 
                 unsigned stringLength = complexTextRun.stringLength();
-                CachedTextBreakIterator cursorPositionIterator(StringView(complexTextRun.characters(), stringLength), TextBreakIterator::Mode::Caret, nullAtom());
+                CachedTextBreakIterator cursorPositionIterator(StringView(complexTextRun.characters(), stringLength), TextBreakIterator::CaretMode { }, nullAtom());
                 unsigned clusterStart;
                 if (cursorPositionIterator.isBoundary(hitIndex))
                     clusterStart = hitIndex;
@@ -354,7 +354,7 @@ void ComplexTextController::collectComplexTextRuns()
     const Font* synthesizedFont = nullptr;
     const Font* smallSynthesizedFont = nullptr;
 
-    CachedTextBreakIterator graphemeClusterIterator(m_run.text(), TextBreakIterator::Mode::Character, m_font.fontDescription().computedLocale());
+    CachedTextBreakIterator graphemeClusterIterator(m_run.text(), TextBreakIterator::CharacterMode { }, m_font.fontDescription().computedLocale());
 
     unsigned markCount;
     UChar32 baseCharacter;

--- a/Source/WebCore/platform/graphics/ComposedCharacterClusterTextIterator.h
+++ b/Source/WebCore/platform/graphics/ComposedCharacterClusterTextIterator.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021 Apple Inc. All rights reserved.
+ * Copyright (C) 2021-2023 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -35,7 +35,7 @@ public:
     // The passed in UChar pointer starts at 'currentIndex'. The iterator operates on the range [currentIndex, lastIndex].
     // 'endIndex' denotes the maximum length of the UChar array, which might exceed 'lastIndex'.
     ComposedCharacterClusterTextIterator(const UChar* characters, unsigned currentIndex, unsigned lastIndex, unsigned endIndex)
-        : m_iterator(StringView(characters, endIndex - currentIndex), TextBreakIterator::Mode::Caret, nullAtom())
+        : m_iterator(StringView(characters, endIndex - currentIndex), TextBreakIterator::CaretMode { }, nullAtom())
         , m_characters(characters)
         , m_originalIndex(currentIndex)
         , m_currentIndex(currentIndex)

--- a/Source/WebCore/rendering/RenderText.cpp
+++ b/Source/WebCore/rendering/RenderText.cpp
@@ -1,7 +1,7 @@
 /*
  * (C) 1999 Lars Knoll (knoll@kde.org)
  * (C) 2000 Dirk Mueller (mueller@kde.org)
- * Copyright (C) 2004-2022 Apple Inc. All rights reserved.
+ * Copyright (C) 2004-2023 Apple Inc. All rights reserved.
  * Copyright (C) 2015 Google Inc. All rights reserved.
  * Copyright (C) 2006 Andrew Wellington (proton@wiretapped.net)
  * Copyright (C) 2006 Graham Dennis (graham.dennis@gmail.com)
@@ -1930,13 +1930,13 @@ int RenderText::previousOffset(int current) const
     if (m_isAllASCII || text().is8Bit())
         return current - 1;
 
-    CachedTextBreakIterator iterator(text(), TextBreakIterator::Mode::Caret, nullAtom());
+    CachedTextBreakIterator iterator(text(), TextBreakIterator::CaretMode { }, nullAtom());
     return iterator.preceding(current).value_or(current - 1);
 }
 
 int RenderText::previousOffsetForBackwardDeletion(int current) const
 {
-    CachedTextBreakIterator iterator(text(), TextBreakIterator::Mode::Delete, nullAtom());
+    CachedTextBreakIterator iterator(text(), TextBreakIterator::DeleteMode { }, nullAtom());
     return iterator.preceding(current).value_or(0);
 }
 
@@ -1945,7 +1945,7 @@ int RenderText::nextOffset(int current) const
     if (m_isAllASCII || text().is8Bit())
         return current + 1;
 
-    CachedTextBreakIterator iterator(text(), TextBreakIterator::Mode::Caret, nullAtom());
+    CachedTextBreakIterator iterator(text(), TextBreakIterator::CaretMode { }, nullAtom());
     return iterator.following(current).value_or(current + 1);
 }
 

--- a/Tools/TestWebKitAPI/Tests/WTF/TextBreakIterator.cpp
+++ b/Tools/TestWebKitAPI/Tests/WTF/TextBreakIterator.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016 Apple Inc. All rights reserved.
+ * Copyright (C) 2016-2023 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -141,6 +141,26 @@ TEST(WTF, TextBreakIteratorNumCodeUnitsInGraphemeClusters)
     EXPECT_EQ(4U, numCodeUnitsInGraphemeClusters(makeUTF16({ 'g', 0x308, 'b', 'c' }), 3));
     EXPECT_EQ(4U, numCodeUnitsInGraphemeClusters(makeUTF16({ 'g', 0x308, 'b', 'c' }), 4));
     EXPECT_EQ(4U, numCodeUnitsInGraphemeClusters(makeUTF16({ 'g', 0x308, 'b', 'c' }), 5));
+}
+
+TEST(WTF, TextBreakIteratorBehaviors)
+{
+    {
+        auto string = u"ぁぁ"_str;
+        auto locale = AtomString("ja"_str);
+        CachedTextBreakIterator strictIterator({ string }, TextBreakIterator::LineMode { TextBreakIterator::LineMode::Behavior::Strict }, locale);
+        EXPECT_EQ(strictIterator.following(0), 2);
+        CachedTextBreakIterator looseIterator({ string }, TextBreakIterator::LineMode { TextBreakIterator::LineMode::Behavior::Loose }, locale);
+        EXPECT_EQ(looseIterator.following(0), 1);
+    }
+    {
+        auto string = u"中〜"_str;
+        auto locale = AtomString("zh-Hans"_str);
+        CachedTextBreakIterator strictIterator({ string }, TextBreakIterator::LineMode { TextBreakIterator::LineMode::Behavior::Strict }, locale);
+        EXPECT_EQ(strictIterator.following(0), 2);
+        CachedTextBreakIterator looseIterator({ string }, TextBreakIterator::LineMode { TextBreakIterator::LineMode::Behavior::Loose }, locale);
+        EXPECT_EQ(looseIterator.following(0), 1);
+    }
 }
 
 } // namespace TestWebKitAPI


### PR DESCRIPTION
#### 99eac467073eccfa5ff272ce4c8212273b2c1040
<pre>
Teach TextBreakIterator about strict and loose line breaking behaviors
<a href="https://bugs.webkit.org/show_bug.cgi?id=257108">https://bugs.webkit.org/show_bug.cgi?id=257108</a>
rdar://109634206

Reviewed by Cameron McCormack.

This is the first part of our line breaker refactoring. We currently have 2 totally separate classes,
both of which can perform line breaking: TextBreakIterator and LazyLineBreakIterator.

TextBreakIterator has multiple backends - it can be backed by either ICU or Core Foundation. It also
supports all kinds of text segmentation: caret positions, grapheme cluster segmentation, etc.

LazyLineBreakIterator only works with ICU, and can only do line breaking. However, it supports loose
and strict line breaking modes, and supports a &quot;prior context.&quot;

It&apos;s kind of a shame that we have 2 classes which both do similar things, so I&apos;m going to try to
unify them into a single class which can do everything. I&apos;d like to improve TextBreakIterator to be
able to do everything that LazyLineBreakIterator can do, and then delete LazyLineBreakIterator,
because I think that&apos;s going to be the most straightforward way of doing it.

This patch teaches TextBreakIterator about the different line breaking behaviors, by turning the
&quot;mode&quot; enum into a variant, and giving the Line struct a behavior enum.

* Source/WTF/wtf/text/TextBreakIterator.cpp:
(WTF::mapModeToBackingIterator):
* Source/WTF/wtf/text/TextBreakIterator.h:
(WTF::TextBreakIterator::LineMode::operator== const):
(WTF::TextBreakIterator::CaretMode::operator== const):
(WTF::TextBreakIterator::DeleteMode::operator== const):
(WTF::TextBreakIterator::CharacterMode::operator== const):
(WTF::LazyLineBreakIterator::get):
(WTF::TextBreakIteratorCache::TextBreakIteratorCache): Deleted.
* Source/WTF/wtf/text/WTFString.h:
(WTF::StringLiterals::operator _str):
* Source/WTF/wtf/text/cocoa/TextBreakIteratorInternalICUCocoa.cpp:
(WTF::mapModeToBackingIterator):
* Source/WTF/wtf/text/icu/TextBreakIteratorICU.h:
(WTF::TextBreakIteratorICU::TextBreakIteratorICU):
(WTF::TextBreakIteratorICU::makeLocaleWithBreakKeyword):
* Source/WebCore/platform/graphics/ComplexTextController.cpp:
(WebCore::ComplexTextController::offsetForPosition):
(WebCore::ComplexTextController::collectComplexTextRuns):
* Source/WebCore/platform/graphics/ComposedCharacterClusterTextIterator.h:
(WebCore::ComposedCharacterClusterTextIterator::ComposedCharacterClusterTextIterator):
* Source/WebCore/rendering/RenderText.cpp:
(WebCore::RenderText::previousOffset const):
(WebCore::RenderText::previousOffsetForBackwardDeletion const):
(WebCore::RenderText::nextOffset const):
* Tools/TestWebKitAPI/Tests/WTF/TextBreakIterator.cpp:
(TestWebKitAPI::TEST):

Canonical link: <a href="https://commits.webkit.org/264376@main">https://commits.webkit.org/264376@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1d817999d9c216739503150f32dd7dafceaf79e4

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/7451 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/7716 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/7893 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/9087 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/32/builds/7654 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/7462 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/9653 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/7638 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/10541 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/7582 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/8699 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/6903 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/9197 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/6006 "Passed tests") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/10/builds/6776 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/14509 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/6349 "Built successfully and passed tests") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/7232 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/6894 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/10206 "Passed tests") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/7035 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/7389 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/6047 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/7597 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/6735 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/1745 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/1760 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/10946 "Built successfully") | | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/24/builds/7800 "Built successfully") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/7122 "Built successfully") | | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/3/builds/1885 "Passed tests") | 
<!--EWS-Status-Bubble-End-->