### PR TITLE
Implement a reliable way to get the image type from a mime type

### DIFF
--- a/Source/WebCore/platform/MIMETypeRegistry.cpp
+++ b/Source/WebCore/platform/MIMETypeRegistry.cpp
@@ -408,21 +408,12 @@ bool MIMETypeRegistry::isSupportedImageMIMEType(const String& mimeType)
 {
     if (mimeType.isEmpty())
         return false;
-    static constexpr SortedArraySet supportedImageMIMETypeSet { supportedImageMIMETypeArray };
-#if USE(CG) && ASSERT_ENABLED
-    // Ensure supportedImageMIMETypeArray matches defaultSupportedImageTypes().
-    static std::once_flag onceFlag;
-    std::call_once(onceFlag, [] {
-        for (auto& imageType : defaultSupportedImageTypes()) {
-            auto mimeType = MIMETypeForImageType(imageType);
-            ASSERT_IMPLIES(!mimeType.isEmpty(), supportedImageMIMETypeSet.contains(mimeType));
-        }
-    });
-#endif
 
+    static constexpr SortedArraySet supportedImageMIMETypeSet { supportedImageMIMETypeArray };
     String normalizedMIMEType = normalizedImageMIMEType(mimeType);
     if (supportedImageMIMETypeSet.contains(normalizedMIMEType))
         return true;
+
     return additionalSupportedImageMIMETypes().contains(normalizedMIMEType);
 }
 
@@ -454,7 +445,7 @@ std::unique_ptr<MIMETypeRegistryThreadGlobalData> MIMETypeRegistry::createMIMETy
         CFStringRef supportedType = reinterpret_cast<CFStringRef>(CFArrayGetValueAtIndex(supportedTypes.get(), i));
         if (!isSupportedImageType(supportedType))
             continue;
-        String mimeType = MIMETypeForImageType(supportedType);
+        String mimeType = MIMETypeFromUTI(supportedType);
         if (mimeType.isEmpty())
             continue;
         supportedImageMIMETypesForEncoding.add(mimeType);
@@ -827,14 +818,7 @@ Vector<String> MIMETypeRegistry::allowedFileExtensions(const Vector<String>& mim
 
 bool MIMETypeRegistry::isJPEGMIMEType(const String& mimeType)
 {
-#if USE(CG)
-    auto destinationUTI = utiFromImageBufferMIMEType(mimeType);
-    if (!destinationUTI)
-        return false;
-    return CFEqual(destinationUTI.get(), jpegUTI());
-#else
     return mimeType == "image/jpeg"_s || mimeType == "image/jpg"_s;
-#endif
 }
 
 } // namespace WebCore

--- a/Source/WebCore/platform/graphics/cg/ImageBufferUtilitiesCG.h
+++ b/Source/WebCore/platform/graphics/cg/ImageBufferUtilitiesCG.h
@@ -36,8 +36,6 @@ class PixelBuffer;
 
 WEBCORE_EXPORT uint8_t verifyImageBufferIsBigEnough(const void* buffer, size_t bufferSize);
 
-RetainPtr<CFStringRef> utiFromImageBufferMIMEType(const String& mimeType);
-CFStringRef jpegUTI();
 Vector<uint8_t> encodeData(CGImageRef, const String& mimeType, std::optional<double> quality);
 Vector<uint8_t> encodeData(const PixelBuffer&, const String& mimeType, std::optional<double> quality);
 

--- a/Source/WebCore/platform/graphics/cg/UTIRegistry.cpp
+++ b/Source/WebCore/platform/graphics/cg/UTIRegistry.cpp
@@ -31,6 +31,7 @@
 #include "MIMETypeRegistry.h"
 #include "UTIUtilities.h"
 #include <ImageIO/ImageIO.h>
+#include <wtf/FixedVector.h>
 #include <wtf/HashSet.h>
 #include <wtf/NeverDestroyed.h>
 #include <wtf/RetainPtr.h>
@@ -42,27 +43,27 @@
 
 namespace WebCore {
 
-const MemoryCompactLookupOnlyRobinHoodHashSet<String>& defaultSupportedImageTypes()
+static const HashMap<String, HashSet<String>>& defaultSupportedImageFormats()
 {
-    static NeverDestroyed defaultSupportedImageTypes = [] {
-        static constexpr std::array defaultSupportedImageTypes = {
-            "com.compuserve.gif"_s,
-            "com.microsoft.bmp"_s,
-            "com.microsoft.cur"_s,
-            "com.microsoft.ico"_s,
-            "public.jpeg"_s,
-            "public.png"_s,
-            "public.tiff"_s,
-            "public.jpeg-2000"_s,
-            "public.mpo-image"_s,
+    static NeverDestroyed defaultSupportedImageFormats = [] {
+        HashMap<String, HashSet<String>> defaultSupportedImageFormats = {
+            { "com.compuserve.gif"_s,   { "image/gif"_s } },
+            { "com.microsoft.bmp"_s,    { "image/bmp"_s } },
+            { "com.microsoft.cur"_s,    { } },
+            { "com.microsoft.ico"_s,    { "image/vnd.microsoft.icon"_s } },
+            { "public.jpeg"_s,          { "image/jpeg"_s, "image/jpg"_s } },
+            { "public.png"_s,           { "image/png"_s, "image/apng"_s } },
+            { "public.tiff"_s,          { "image/tiff"_s } },
+            { "public.jpeg-2000"_s,     { "image/jp2"_s } },
+            { "public.mpo-image"_s,     { } },
 #if HAVE(WEBP)
-            "public.webp"_s,
-            "com.google.webp"_s,
-            "org.webmproject.webp"_s,
+            { "public.webp"_s,          { "image/webp"_s } },
+            { "com.google.webp"_s,      { "image/webp"_s } },
+            { "org.webmproject.webp"_s, { "image/webp"_s } },
 #endif
 #if HAVE(AVIF)
-            "public.avif"_s,
-            "public.avis"_s,
+            { "public.avif"_s,          { "image/avif"_s } },
+            { "public.avis"_s,          { "image/avif"_s } },
 #endif
         };
 
@@ -75,36 +76,53 @@ const MemoryCompactLookupOnlyRobinHoodHashSet<String>& defaultSupportedImageType
             static_cast<HashSet<String>*>(context)->add(imageType);
         }, &systemSupportedImageTypes);
 
-        MemoryCompactLookupOnlyRobinHoodHashSet<String> filtered;
-        for (auto& imageType : defaultSupportedImageTypes) {
-            if (systemSupportedImageTypes.contains(imageType))
-                filtered.add(imageType);
+        HashMap<String, HashSet<String>> filtered;
+        for (auto& imageFormat : defaultSupportedImageFormats) {
+            if (systemSupportedImageTypes.contains(imageFormat.key))
+                filtered.add(imageFormat.key, imageFormat.value);
         }
+
         // rdar://104940377 Workaround for CGImageSourceCopyTypeIdentifiers not returning AVIF for iOS simulator
 #if HAVE(CG_IMAGE_SOURCE_AVIF_IMAGE_TYPES_BUG)
-        filtered.add("public.avif"_s);
-        filtered.add("public.avis"_s);
+        filtered.add("public.avif"_s, HashSet<String> { "image/avif"_s });
+        filtered.add("public.avis"_s, HashSet<String> { "image/avif"_s });
 #endif
         return filtered;
     }();
 
-    return defaultSupportedImageTypes;
+#if ASSERT_ENABLED
+    // Ensure MIMETypeRegistry::supportedImageMIMETypes() matches defaultSupportedImageTypes.
+    static std::once_flag onceFlag;
+    std::call_once(onceFlag, [] {
+        for (auto& imageFormat : defaultSupportedImageFormats.get()) {
+            for (auto& mimeType : imageFormat.value) {
+                if (mimeType.isEmpty())
+                    continue;
+                ASSERT(MIMETypeRegistry::supportedImageMIMETypes().contains(mimeType));
+            }
+        }
+    });
+#endif
+
+    return defaultSupportedImageFormats;
 }
 
-MemoryCompactRobinHoodHashSet<String>& additionalSupportedImageTypes()
+static HashMap<String, HashSet<String>>& additionalSupportedImageFormats()
 {
-    static NeverDestroyed<MemoryCompactRobinHoodHashSet<String>> additionalSupportedImageTypes;
-    return additionalSupportedImageTypes;
+    static NeverDestroyed<HashMap<String, HashSet<String>>> additionalSupportedImageFormats;
+    return additionalSupportedImageFormats;
 }
 
 void setAdditionalSupportedImageTypes(const Vector<String>& imageTypes)
 {
     MIMETypeRegistry::additionalSupportedImageMIMETypes().clear();
     for (const auto& imageType : imageTypes) {
-        additionalSupportedImageTypes().add(imageType);
-        auto mimeType = MIMETypeForImageType(imageType);
-        if (!mimeType.isEmpty())
+        auto mimeType = MIMETypeFromUTI(imageType);
+        if (!mimeType.isEmpty()) {
             MIMETypeRegistry::additionalSupportedImageMIMETypes().add(mimeType);
+            additionalSupportedImageFormats().add(imageType, HashSet<String> { mimeType });
+        } else
+            additionalSupportedImageFormats().add(imageType, HashSet<String> { });
     }
 }
 
@@ -117,7 +135,7 @@ bool isSupportedImageType(const String& imageType)
 {
     if (imageType.isEmpty())
         return false;
-    return defaultSupportedImageTypes().contains(imageType) || additionalSupportedImageTypes().contains(imageType);
+    return defaultSupportedImageFormats().contains(imageType) || additionalSupportedImageFormats().contains(imageType);
 }
 
 bool isGIFImageType(StringView imageType)
@@ -125,9 +143,21 @@ bool isGIFImageType(StringView imageType)
     return imageType == "com.compuserve.gif"_s;
 }
 
-String MIMETypeForImageType(const String& uti)
+String imageTypeForMIMEType(const String& mimeType)
 {
-    return MIMETypeFromUTI(uti);
+    auto imageTypeForMIMEType = [](auto& imageFormats, auto& mimeType) -> String {
+        for (auto& imageFormat : imageFormats) {
+            if (imageFormat.value.contains(mimeType))
+                return imageFormat.key;
+        }
+        return { };
+    };
+
+    auto imageType = imageTypeForMIMEType(defaultSupportedImageFormats(), mimeType);
+    if (!imageType.isEmpty())
+        return imageType;
+
+    return imageTypeForMIMEType(additionalSupportedImageFormats(), mimeType);
 }
 
 String preferredExtensionForImageType(const String& uti)
@@ -137,6 +167,6 @@ ALLOW_DEPRECATED_DECLARATIONS_BEGIN
 ALLOW_DEPRECATED_DECLARATIONS_END
 }
 
-}
+} // namespace WebCore
 
-#endif
+#endif // USE(CG)

--- a/Source/WebCore/platform/graphics/cg/UTIRegistry.h
+++ b/Source/WebCore/platform/graphics/cg/UTIRegistry.h
@@ -25,18 +25,21 @@
 
 #pragma once
 
-#include <wtf/RobinHoodHashSet.h>
+#if USE(CG)
+
 #include <wtf/text/WTFString.h>
 
 namespace WebCore {
 
-const MemoryCompactLookupOnlyRobinHoodHashSet<String>& defaultSupportedImageTypes();
-MemoryCompactRobinHoodHashSet<String>& additionalSupportedImageTypes();
 WEBCORE_EXPORT void setAdditionalSupportedImageTypes(const Vector<String>&);
 WEBCORE_EXPORT void setAdditionalSupportedImageTypesForTesting(const String&);
+
 WEBCORE_EXPORT bool isSupportedImageType(const String&);
 bool isGIFImageType(StringView);
-String preferredExtensionForImageType(const String& type);
-String MIMETypeForImageType(const String& type);
 
-}
+String imageTypeForMIMEType(const String& mimeType);
+String preferredExtensionForImageType(const String&);
+
+} // namespace WebCore
+
+#endif // USE(CG)


### PR DESCRIPTION
#### c6c92ff59c2daf22ef2ec2ca4532733085644831
<pre>
Implement a reliable way to get the image type from a mime type
<a href="https://bugs.webkit.org/show_bug.cgi?id=257110">https://bugs.webkit.org/show_bug.cgi?id=257110</a>
rdar://107625991

Reviewed by NOBODY (OOPS!).

Make defaultSupportedImageFormats() maps every image type to a set of mime types.
Make it verify all the WebKit supported image mime types are supported by the
system as well.

Implement imageTypeForMIMEType() which searches the values of HashMaps:
defaultSupportedImageFormats() and additionalSupportedImageFormats() for a match
mime type. If it finds a match it returns the key which is the image type.

Also simplify MIMETypeRegistry::isJPEGMIMEType(). We do not need to go from the
mime type to the image type. And then compare the image type with the predefined
image type of jpeg. We can just compare the mime type with two predefined mime
types of jpeg.

* Source/WebCore/platform/MIMETypeRegistry.cpp:
(WebCore::MIMETypeRegistry::isSupportedImageMIMEType):
(WebCore::MIMETypeRegistry::createMIMETypeRegistryThreadGlobalData):
(WebCore::MIMETypeRegistry::isJPEGMIMEType):
* Source/WebCore/platform/graphics/cg/ImageBufferUtilitiesCG.cpp:
(WebCore::encode):
(WebCore::jpegUTI): Deleted.
(WebCore::utiFromImageBufferMIMEType): Deleted.
* Source/WebCore/platform/graphics/cg/ImageBufferUtilitiesCG.h:
* Source/WebCore/platform/graphics/cg/UTIRegistry.cpp:
(WebCore::defaultSupportedImageFormats):
(WebCore::additionalSupportedImageFormats):
(WebCore::setAdditionalSupportedImageTypes):
(WebCore::isSupportedImageType):
(WebCore::imageTypeForMIMEType):
(WebCore::defaultSupportedImageTypes): Deleted.
(WebCore::additionalSupportedImageTypes): Deleted.
(WebCore::MIMETypeForImageType): Deleted.
* Source/WebCore/platform/graphics/cg/UTIRegistry.h:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c6c92ff59c2daf22ef2ec2ca4532733085644831

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/7503 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/7769 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/7951 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/9140 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/7698 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/7514 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/9870 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/7694 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/10575 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/7634 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/8883 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/6945 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/9248 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/6191 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/6833 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/14543 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/7355 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/6953 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/10264 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/7438 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/6083 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/6781 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/10990 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/7173 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->