### PR TITLE
Add non-empty spans at the start and end of the shadow tree

### DIFF
--- a/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
+++ b/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
@@ -637,7 +637,7 @@ AsynchronousSpellCheckingEnabled:
 
 AttachmentElementEnabled:
   type: bool
-  status: embedder
+  status: internal
   humanReadableName: "Attachment Element"
   humanReadableDescription: "Allow the insertion of attachment elements"
   webcoreBinding: DeprecatedGlobalSettings
@@ -650,7 +650,7 @@ AttachmentElementEnabled:
 
 AttachmentWideLayoutEnabled:
   type: bool
-  status: embedder
+  status: internal
   humanReadableName: "Attachment wide-layout styling"
   humanReadableDescription: "Use horizontal wide-layout attachment style, requires Attachment Element"
   condition: ENABLE(ATTACHMENT_ELEMENT)

--- a/Source/WebCore/html/HTMLAttachmentElement.cpp
+++ b/Source/WebCore/html/HTMLAttachmentElement.cpp
@@ -42,6 +42,7 @@
 #include "HTMLElementTypeHelpers.h"
 #include "HTMLImageElement.h"
 #include "HTMLNames.h"
+#include "HTMLSpanElement.h"
 #include "HTMLStyleElement.h"
 #include "LocalFrame.h"
 #include "MIMETypeRegistry.h"
@@ -215,9 +216,17 @@ void HTMLAttachmentElement::ensureModernShadowTree(ShadowRoot& root)
     style->setTextContent(String { shadowStyle });
     root.appendChild(WTFMove(style));
 
-    m_containerElement = HTMLDivElement::create(document());
+    auto spanBefore = HTMLSpanElement::create(document());
+    spanBefore->setInnerText("-"_s);
+    root.appendChild(spanBefore);
+
+    m_containerElement = HTMLSpanElement::create(document());
     m_containerElement->setIdAttribute(attachmentContainerIdentifier());
     root.appendChild(*m_containerElement);
+
+    auto spanAfter = HTMLSpanElement::create(document());
+    spanAfter->setInnerText("_"_s);
+    root.appendChild(spanAfter);
 
     auto previewArea = createContainedElement<HTMLDivElement>(*m_containerElement, attachmentPreviewAreaIdentifier());
 

--- a/Source/WebCore/html/shadow/attachmentElementShadow.css
+++ b/Source/WebCore/html/shadow/attachmentElementShadow.css
@@ -40,8 +40,8 @@ div#attachment-container {
     border-radius: 8px;
     font: caption;
     pointer-events: none;
-    user-select: none;
-    -webkit-user-select: none;
+    /* user-select: none; */
+    /* -webkit-user-select: none; */
 }
 
 div#attachment-container::selection {

--- a/Source/WebCore/html/shadow/attachmentElementShadow.css
+++ b/Source/WebCore/html/shadow/attachmentElementShadow.css
@@ -40,8 +40,6 @@ div#attachment-container {
     border-radius: 8px;
     font: caption;
     pointer-events: none;
-    /* user-select: none; */
-    /* -webkit-user-select: none; */
 }
 
 div#attachment-container::selection {
@@ -66,6 +64,8 @@ div#attachment-preview-area {
     gap: 0;
     align-items: center;
     justify-items: center;
+    user-select: none;
+    -webkit-user-select: none;
 }
 
 attachment#attachment-preview {
@@ -126,6 +126,8 @@ div#attachment-information-area {
     display: grid;
     gap: 0;
     align-items: center;
+    user-select: none;
+    -webkit-user-select: none;
 }
 
 div#attachment-information-block {

--- a/Source/WebCore/html/shadow/attachmentElementShadow.css
+++ b/Source/WebCore/html/shadow/attachmentElementShadow.css
@@ -22,7 +22,7 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-div#attachment-container {
+span#attachment-container {
     display: grid;
     gap: 0;
 #if (defined(WTF_PLATFORM_IOS_FAMILY) && WTF_PLATFORM_IOS_FAMILY)
@@ -42,7 +42,7 @@ div#attachment-container {
     pointer-events: none;
 }
 
-div#attachment-container::selection {
+span#attachment-container::selection {
     background-color: -apple-system-selected-content-background;
 }
 

--- a/Source/WebCore/rendering/RenderBlock.cpp
+++ b/Source/WebCore/rendering/RenderBlock.cpp
@@ -2240,6 +2240,12 @@ VisiblePosition RenderBlock::positionForPoint(const LayoutPoint& point, const Re
     while (lastCandidateBox && !isChildHitTestCandidate(*lastCandidateBox, fragment, pointInLogicalContents))
         lastCandidateBox = lastCandidateBox->previousSiblingBox();
 
+    if (style().effectiveUserSelect() == UserSelect::All) {
+        FloatSize deltaToTopLeft { pointInLogicalContents.x().toFloat(), pointInLogicalContents.y().toFloat() };
+        FloatSize deltaToBottomRight { (pointInLogicalContents.x() - logicalWidth()).toFloat(), (pointInLogicalContents.y() - logicalHeight()).toFloat() };
+        return { deltaToTopLeft.diagonalLengthSquared() < deltaToBottomRight.diagonalLengthSquared() ? positionBeforeNode(element()) : positionAfterNode(element()) };
+    }
+
     bool blocksAreFlipped = style().isFlippedBlocksWritingMode();
     if (lastCandidateBox) {
         if (pointInLogicalContents.y() > logicalTopForChild(*lastCandidateBox)

--- a/Source/WebCore/rendering/RenderTheme.cpp
+++ b/Source/WebCore/rendering/RenderTheme.cpp
@@ -1490,7 +1490,7 @@ bool RenderTheme::paintCapsLockIndicator(const RenderObject&, const PaintInfo&, 
 String RenderTheme::attachmentStyleSheet() const
 {
     ASSERT(DeprecatedGlobalSettings::attachmentElementEnabled());
-    return "attachment { appearance: auto; }"_s;
+    return "attachment { appearance: auto; -webkit-user-select: all; user-select: all; display: inline-block; }"_s;
 }
 
 bool RenderTheme::paintAttachment(const RenderObject&, const PaintInfo&, const IntRect&)


### PR DESCRIPTION
#### fac0b6418225fafb13d039457ec146ed23d307dd
<pre>
Add non-empty spans at the start and end of the shadow tree
Need the bug URL (OOPS!).
Include a Radar link (OOPS!).

Reviewed by NOBODY (OOPS!).

Explanation of why this fixes the bug (OOPS!).

* Source/WebCore/html/HTMLAttachmentElement.cpp:
(WebCore::HTMLAttachmentElement::ensureModernShadowTree):
* Source/WebCore/html/shadow/attachmentElementShadow.css:
(span#attachment-container):
(span#attachment-container::selection):
(div#attachment-container): Deleted.
(div#attachment-container::selection): Deleted.
</pre>
----------------------------------------------------------------------
#### a9aba798ce9c1424c8dd1e8411fef38e166e9a18
<pre>
Add user-select:none *under* the shadow container.
Need the bug URL (OOPS!).
Include a Radar link (OOPS!).

Reviewed by NOBODY (OOPS!).

To prevent the visible selection of sub-elements inside attachments, make the shadow areas `user-select:none`. (Note that the top shadow container is not modified, so that it *could* be effectively selected (through the top-element&apos;s being all-selected) and the corresponding `div#attachment-container::selection` should then be activated.

* Source/WebCore/html/shadow/attachmentElementShadow.css:
(div#attachment-container):
(div#attachment-preview-area):
(div#attachment-information-area):
</pre>
----------------------------------------------------------------------
#### 7a38f03a0295f1d6f672ad8d01d3f1ca1d5712bb
<pre>
Wide attachment: user-select:all and related tweaks
Need the bug URL (OOPS!).
Include a Radar link (OOPS!).

Reviewed by NOBODY (OOPS!).

Make the top element user-select:all, make RenderBlock::positionForPoint better handle that; Remove user-select:none from shadow container.

* Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml:
* Source/WebCore/html/shadow/attachmentElementShadow.css:
(div#attachment-container):
* Source/WebCore/rendering/RenderBlock.cpp:
(WebCore::RenderBlock::positionForPoint):
* Source/WebCore/rendering/RenderTheme.cpp:
(WebCore::RenderTheme::attachmentStyleSheet const):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/fac0b6418225fafb13d039457ec146ed23d307dd

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/7562 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/7831 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/8014 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/9203 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/7751 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/7574 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/9889 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/7755 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/10628 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/7694 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/8906 "2 new passes 6 flakes 2 failures") | [❌ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/6978 "2 api tests failed or timed out") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/9311 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/6214 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/6884 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/14579 "Passed tests") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/6453 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/7377 "Passed tests") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/7006 "2 failures") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/10362 "Passed tests") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/7151 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/7499 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/6121 "1 failures") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/7717 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/6839 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/1765 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/11048 "Built successfully") | | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/24/builds/7920 "Built successfully") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/7232 "Built successfully") | | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/3/builds/1907 "Passed tests") | 
<!--EWS-Status-Bubble-End-->