### PR TITLE
Make wide-layout attachment appear like a replaced element

### DIFF
--- a/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
+++ b/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
@@ -637,7 +637,7 @@ AsynchronousSpellCheckingEnabled:
 
 AttachmentElementEnabled:
   type: bool
-  status: embedder
+  status: internal
   humanReadableName: "Attachment Element"
   humanReadableDescription: "Allow the insertion of attachment elements"
   webcoreBinding: DeprecatedGlobalSettings
@@ -650,7 +650,7 @@ AttachmentElementEnabled:
 
 AttachmentWideLayoutEnabled:
   type: bool
-  status: embedder
+  status: internal
   humanReadableName: "Attachment wide-layout styling"
   humanReadableDescription: "Use horizontal wide-layout attachment style, requires Attachment Element"
   condition: ENABLE(ATTACHMENT_ELEMENT)

--- a/Source/WebCore/editing/TextManipulationController.cpp
+++ b/Source/WebCore/editing/TextManipulationController.cpp
@@ -188,7 +188,7 @@ public:
         CurrentContent content = { m_node.copyRef(), m_text ? m_text.value() : Vector<String> { }, !!m_text };
         if (content.node) {
             if (auto* renderer = content.node->renderer()) {
-                if (renderer->isRenderReplaced()) {
+                if (renderer->isRenderReplacedOrAttachment()) {
                     content.isTextContent = false;
                     content.isReplacedContent = true;
                 }

--- a/Source/WebCore/html/HTMLAttachmentElement.cpp
+++ b/Source/WebCore/html/HTMLAttachmentElement.cpp
@@ -358,8 +358,11 @@ DOMRectReadOnly* HTMLAttachmentElement::saveButtonClientRect() const
 
 RenderPtr<RenderElement> HTMLAttachmentElement::createElementRenderer(RenderStyle&& style, const RenderTreePosition& position)
 {
-    if (m_implementation == Implementation::Modern)
-        return HTMLElement::createElementRenderer(WTFMove(style), position);
+    if (m_implementation == Implementation::Modern) {
+        auto renderer = HTMLElement::createElementRenderer(WTFMove(style), position);
+        renderer->setReplacedOrInlineBlock(true);
+        return renderer;
+    }
 
     return createRenderer<RenderAttachment>(*this, WTFMove(style));
 }

--- a/Source/WebCore/layout/integration/LayoutIntegrationBoxTree.cpp
+++ b/Source/WebCore/layout/integration/LayoutIntegrationBoxTree.cpp
@@ -74,6 +74,8 @@ static Layout::Box::ElementAttributes elementAttributes(const RenderElement& ren
             return Layout::Box::NodeType::ListMarker;
         if (is<RenderReplaced>(renderer))
             return is<RenderImage>(renderer) ? Layout::Box::NodeType::Image : Layout::Box::NodeType::ReplacedElement;
+        if (renderer.isAttachment())
+            return Layout::Box::NodeType::ReplacedElement;
         if (is<RenderLineBreak>(renderer))
             return downcast<RenderLineBreak>(renderer).isWBR() ? Layout::Box::NodeType::WordBreakOpportunity : Layout::Box::NodeType::LineBreak;
         return Layout::Box::NodeType::GenericElement;

--- a/Source/WebCore/rendering/RenderBlock.cpp
+++ b/Source/WebCore/rendering/RenderBlock.cpp
@@ -2442,7 +2442,7 @@ void RenderBlock::computeChildPreferredLogicalWidths(RenderObject& child, Layout
         auto& box = downcast<RenderBox>(child);
         if (box.shouldComputeLogicalHeightFromAspectRatio() && box.style().logicalWidth().isFixed()) {
             LayoutUnit logicalWidth = LayoutUnit(box.style().logicalWidth().value());
-            minPreferredLogicalWidth = maxPreferredLogicalWidth = blockSizeFromAspectRatio(box.horizontalBorderAndPaddingExtent(), box.verticalBorderAndPaddingExtent(), LayoutUnit(box.style().logicalAspectRatio()), box.style().boxSizingForAspectRatio(), logicalWidth, style().aspectRatioType(), isRenderReplaced());
+            minPreferredLogicalWidth = maxPreferredLogicalWidth = blockSizeFromAspectRatio(box.horizontalBorderAndPaddingExtent(), box.verticalBorderAndPaddingExtent(), LayoutUnit(box.style().logicalAspectRatio()), box.style().boxSizingForAspectRatio(), logicalWidth, style().aspectRatioType(), isRenderReplacedOrAttachment());
             return;
         }
         minPreferredLogicalWidth = maxPreferredLogicalWidth = box.computeLogicalHeightWithoutLayout();
@@ -3240,7 +3240,7 @@ std::optional<LayoutUnit> RenderBlock::availableLogicalHeightForPercentageComput
         // Only grid is expected to be in a state where it is calculating pref width and having unknown logical width.
         if (isRenderGrid() && preferredLogicalWidthsDirty() && !style().logicalWidth().isSpecified())
             return availableHeight;
-        availableHeight = blockSizeFromAspectRatio(horizontalBorderAndPaddingExtent(), verticalBorderAndPaddingExtent(), LayoutUnit(style().logicalAspectRatio()), style().boxSizingForAspectRatio(), logicalWidth(), style().aspectRatioType(), isRenderReplaced());
+        availableHeight = blockSizeFromAspectRatio(horizontalBorderAndPaddingExtent(), verticalBorderAndPaddingExtent(), LayoutUnit(style().logicalAspectRatio()), style().boxSizingForAspectRatio(), logicalWidth(), style().aspectRatioType(), isRenderReplacedOrAttachment());
     } else if (isOutOfFlowPositionedWithSpecifiedHeight) {
         // Don't allow this to affect the block' size() member variable, since this
         // can get called while the block is still laying out its kids.

--- a/Source/WebCore/rendering/RenderElement.h
+++ b/Source/WebCore/rendering/RenderElement.h
@@ -122,6 +122,7 @@ public:
     bool isRenderBlock() const;
     bool isRenderBlockFlow() const;
     bool isRenderReplaced() const;
+    bool isRenderReplacedOrAttachment() const;
     bool isRenderInline() const;
 
     virtual bool isChildAllowed(const RenderObject&, const RenderStyle&) const { return true; }
@@ -457,6 +458,11 @@ inline bool RenderElement::isRenderReplaced() const
     return m_baseTypeFlags & RenderReplacedFlag;
 }
 
+inline bool RenderElement::isRenderReplacedOrAttachment() const
+{
+    return isRenderReplaced() || isAttachment();
+}
+
 inline bool RenderElement::isRenderInline() const
 {
     return m_baseTypeFlags & RenderInlineFlag;
@@ -495,6 +501,11 @@ inline bool RenderObject::isRenderBlockFlow() const
 inline bool RenderObject::isRenderReplaced() const
 {
     return is<RenderElement>(*this) && downcast<RenderElement>(*this).isRenderReplaced();
+}
+
+inline bool RenderObject::isRenderReplacedOrAttachment() const
+{
+    return is<RenderElement>(*this) && downcast<RenderElement>(*this).isRenderReplacedOrAttachment();
 }
 
 inline bool RenderObject::isRenderInline() const

--- a/Source/WebCore/rendering/RenderFlexibleBox.cpp
+++ b/Source/WebCore/rendering/RenderFlexibleBox.cpp
@@ -590,7 +590,9 @@ LayoutUnit RenderFlexibleBox::cachedChildIntrinsicContentLogicalHeight(const Ren
 {
     if (child.isRenderReplaced())
         return downcast<RenderReplaced>(child).intrinsicLogicalHeight();
-    
+    if (child.isAttachment())
+        return child.intrinsicLogicalHeight();
+
     if (m_intrinsicContentLogicalHeights.contains(&child))
         return m_intrinsicContentLogicalHeights.get(&child);
     
@@ -599,14 +601,14 @@ LayoutUnit RenderFlexibleBox::cachedChildIntrinsicContentLogicalHeight(const Ren
 
 void RenderFlexibleBox::setCachedChildIntrinsicContentLogicalHeight(const RenderBox& child, LayoutUnit height)
 {
-    if (child.isRenderReplaced())
+    if (child.isRenderReplacedOrAttachment())
         return; // Replaced elements know their intrinsic height already, so save space by not caching.
     m_intrinsicContentLogicalHeights.set(&child, height);
 }
 
 void RenderFlexibleBox::clearCachedChildIntrinsicContentLogicalHeight(const RenderBox& child)
 {
-    if (child.isRenderReplaced())
+    if (child.isRenderReplacedOrAttachment())
         return; // Replaced elements know their intrinsic height already, so nothing to do.
     m_intrinsicContentLogicalHeights.remove(&child);
 }
@@ -1554,7 +1556,7 @@ std::pair<LayoutUnit, LayoutUnit> RenderFlexibleBox::computeFlexItemMinMaxSizes(
         LayoutUnit contentSize;
         Length childCrossSizeLength = crossSizeLengthForChild(MainOrPreferredSize, child);
 
-        bool canComputeSizeThroughAspectRatio = child.isRenderReplaced() && childHasComputableAspectRatio(child) && childCrossSizeIsDefinite(child, childCrossSizeLength);
+        bool canComputeSizeThroughAspectRatio = child.isRenderReplacedOrAttachment() && childHasComputableAspectRatio(child) && childCrossSizeIsDefinite(child, childCrossSizeLength);
 
         if (canComputeSizeThroughAspectRatio)
             contentSize = computeMainSizeFromAspectRatioUsing(child, childCrossSizeLength);
@@ -1574,7 +1576,7 @@ std::pair<LayoutUnit, LayoutUnit> RenderFlexibleBox::computeFlexItemMinMaxSizes(
             return { std::min(specifiedSize, contentSize), maxExtent.value_or(LayoutUnit::max()) };
         }
 
-        if (child.isRenderReplaced() && childHasComputableAspectRatioAndCrossSizeIsConsideredDefinite(child)) {
+        if (child.isRenderReplacedOrAttachment() && childHasComputableAspectRatioAndCrossSizeIsConsideredDefinite(child)) {
             LayoutUnit transferredSize = computeMainSizeFromAspectRatioUsing(child, childCrossSizeLength);
             transferredSize = adjustChildSizeForAspectRatioCrossAxisMinAndMax(child, transferredSize);
             return { std::min(transferredSize, contentSize), maxExtent.value_or(LayoutUnit::max()) };
@@ -2068,7 +2070,7 @@ bool RenderFlexibleBox::needToStretchChildLogicalHeight(const RenderBox& child) 
         return false;
 
     // Aspect ratio is properly handled by RenderReplaced during layout.
-    if (child.isRenderReplaced() && childHasAspectRatio(child))
+    if (child.isRenderReplacedOrAttachment() && childHasAspectRatio(child))
         return false;
 
     return child.style().logicalHeight().isAuto();

--- a/Source/WebCore/rendering/RenderGrid.h
+++ b/Source/WebCore/rendering/RenderGrid.h
@@ -135,7 +135,7 @@ private:
     ItemPosition selfAlignmentNormalBehavior(const RenderBox* child = nullptr) const override
     {
         ASSERT(child);
-        return child->isRenderReplaced() ? ItemPosition::Start : ItemPosition::Stretch;
+        return child->isRenderReplacedOrAttachment() ? ItemPosition::Start : ItemPosition::Stretch;
     }
 
     ASCIILiteral renderName() const override;

--- a/Source/WebCore/rendering/RenderLayer.cpp
+++ b/Source/WebCore/rendering/RenderLayer.cpp
@@ -5346,7 +5346,7 @@ bool RenderLayer::isVisuallyNonEmpty(PaintedContentRequest* request) const
     if (!hasVisibleContent() || !renderer().style().opacity())
         return false;
 
-    if (renderer().isRenderReplaced() || (m_scrollableArea && m_scrollableArea->hasOverflowControls())) {
+    if (renderer().isRenderReplacedOrAttachment() || (m_scrollableArea && m_scrollableArea->hasOverflowControls())) {
         if (!request)
             return true;
 

--- a/Source/WebCore/rendering/RenderLayerBacking.cpp
+++ b/Source/WebCore/rendering/RenderLayerBacking.cpp
@@ -2883,7 +2883,7 @@ bool RenderLayerBacking::isSimpleContainerCompositingLayer(PaintedContentsInfo& 
     if (hasBackingSharingLayers())
         return false;
 
-    if (renderer().isRenderReplaced() && !isCompositedPlugin(renderer()))
+    if (renderer().isRenderReplacedOrAttachment() && !isCompositedPlugin(renderer()))
         return false;
 
     if (renderer().isTextControl())

--- a/Source/WebCore/rendering/RenderObject.cpp
+++ b/Source/WebCore/rendering/RenderObject.cpp
@@ -221,7 +221,7 @@ bool RenderObject::isBlockContainer() const
         || display == DisplayType::FlowRoot
         || display == DisplayType::ListItem
         || display == DisplayType::TableCell
-        || display == DisplayType::TableCaption) && !isRenderReplaced();
+        || display == DisplayType::TableCaption) && !isRenderReplacedOrAttachment();
 }
 
 void RenderObject::setFragmentedFlowStateIncludingDescendants(FragmentedFlowState state, SkipDescendentFragmentedFlow skipDescendentFragmentedFlow)

--- a/Source/WebCore/rendering/RenderObject.h
+++ b/Source/WebCore/rendering/RenderObject.h
@@ -201,6 +201,7 @@ public:
 
     bool isRenderElement() const { return !isText(); }
     bool isRenderReplaced() const;
+    bool isRenderReplacedOrAttachment() const;
     bool isBoxModelObject() const;
     bool isRenderBlock() const;
     bool isRenderBlockFlow() const;


### PR DESCRIPTION
#### c1b78eecbe961123c714ab49cf8dbcf246cecf04
<pre>
Make wide-layout attachment appear like a replaced element
Need the bug URL (OOPS!).
Include a Radar link (OOPS!).

Reviewed by NOBODY (OOPS!).

Change most `isReplaced()` calls with added `isReplacedOrAttachment()`.
Also `setReplacedOrInlineBlock()` on the (not-really-replaced) renderer.
And make it layout attribute `Layout::Box::NodeType::ReplacedElement`.

Selection still looks wrong, but when copying the pasteboard contain multiple attachments as expected.

* Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml:
* Source/WebCore/editing/TextManipulationController.cpp:
(WebCore::ParagraphContentIterator::currentContent):
* Source/WebCore/html/HTMLAttachmentElement.cpp:
(WebCore::HTMLAttachmentElement::createElementRenderer):
* Source/WebCore/layout/integration/LayoutIntegrationBoxTree.cpp:
(WebCore::LayoutIntegration::elementAttributes):
* Source/WebCore/rendering/RenderBlock.cpp:
(WebCore::RenderBlock::computeChildPreferredLogicalWidths const):
(WebCore::RenderBlock::availableLogicalHeightForPercentageComputation const):
* Source/WebCore/rendering/RenderBox.cpp:
(WebCore::RenderBox::constrainLogicalHeightByMinMax const):
(WebCore::RenderBox::computeVisibleRectInContainer const):
(WebCore::inlineSizeFromAspectRatio):
(WebCore::RenderBox::computeLogicalHeight const):
(WebCore::RenderBox::availableLogicalHeightUsing const):
(WebCore::RenderBox::computePositionedLogicalHeightUsing const):
(WebCore::RenderBox::computeLogicalWidthFromAspectRatioInternal const):
(WebCore::RenderBox::computeMinMaxLogicalWidthFromAspectRatio const):
(WebCore::RenderBox::computeMinMaxLogicalHeightFromAspectRatio const):
* Source/WebCore/rendering/RenderElement.h:
(WebCore::RenderElement::isRenderReplacedOrAttachment const):
(WebCore::RenderObject::isRenderReplacedOrAttachment const):
* Source/WebCore/rendering/RenderFlexibleBox.cpp:
(WebCore::RenderFlexibleBox::cachedChildIntrinsicContentLogicalHeight const):
(WebCore::RenderFlexibleBox::setCachedChildIntrinsicContentLogicalHeight):
(WebCore::RenderFlexibleBox::clearCachedChildIntrinsicContentLogicalHeight):
(WebCore::RenderFlexibleBox::computeFlexItemMinMaxSizes):
(WebCore::RenderFlexibleBox::needToStretchChildLogicalHeight const):
* Source/WebCore/rendering/RenderGrid.h:
* Source/WebCore/rendering/RenderLayer.cpp:
(WebCore::RenderLayer::calculateClipRects const):
* Source/WebCore/rendering/RenderLayerBacking.cpp:
(WebCore::RenderLayerBacking::isSimpleContainerCompositingLayer const):
* Source/WebCore/rendering/RenderObject.cpp:
(WebCore::RenderObject::isBlockContainer const):
* Source/WebCore/rendering/RenderObject.h:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c1b78eecbe961123c714ab49cf8dbcf246cecf04

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/7556 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/7824 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/8007 "Built successfully") | [❌ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/9196 "Failed to compile WebKit") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/7745 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/7567 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/9885 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/7748 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/5/builds/9196 "Failed to compile WebKit") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/7687 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/8895 "1 failures") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/6974 "Passed tests") | [❌ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/9304 "Failed to compile WebKit") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/6203 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/6878 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/2/builds/9304 "Failed to compile WebKit") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/6448 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/7367 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/6999 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/2/builds/9304 "Failed to compile WebKit") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/7144 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/7492 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/6117 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/7710 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/6833 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/1763 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/11041 "Built successfully") | | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/24/builds/7913 "Built successfully") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/7226 "Built successfully") | | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/3/builds/1905 "Passed tests") | 
<!--EWS-Status-Bubble-End-->