### PR TITLE
AVVideoCaptureSource intrinsicSize should be set at initialisation time

### DIFF
--- a/Source/WebCore/platform/mediastream/RealtimeMediaSource.cpp
+++ b/Source/WebCore/platform/mediastream/RealtimeMediaSource.cpp
@@ -306,6 +306,7 @@ static RefPtr<VideoFrame> adaptVideoFrame(VideoFrameAdaptor& adaptor, VideoFrame
 
 IntSize RealtimeMediaSource::computeResizedVideoFrameSize(IntSize desiredSize, IntSize actualSize)
 {
+    ASSERT(!actualSize.isEmpty());
     if (desiredSize.width() && !desiredSize.height())
         return { desiredSize.width(), desiredSize.width() * actualSize.height() / actualSize.width() };
     if (desiredSize.height() && !desiredSize.width())

--- a/Source/WebCore/platform/mediastream/mac/AVVideoCaptureSource.mm
+++ b/Source/WebCore/platform/mediastream/mac/AVVideoCaptureSource.mm
@@ -395,6 +395,9 @@ bool AVVideoCaptureSource::prefersPreset(const VideoPreset& preset)
 void AVVideoCaptureSource::setFrameRateAndZoomWithPreset(double requestedFrameRate, double requestedZoom, std::optional<VideoPreset>&& preset)
 {
     m_currentPreset = WTFMove(preset);
+    if (m_currentPreset)
+        setIntrinsicSize({ m_currentPreset->size().width(), m_currentPreset->size().height() });
+
     m_currentFrameRate = requestedFrameRate;
     m_currentZoom = m_zoomScaleFactor * requestedZoom;
 


### PR DESCRIPTION
#### 2b3323161f9a2ea81cf3bad4691ee76bb166f5da
<pre>
AVVideoCaptureSource intrinsicSize should be set at initialisation time
<a href="https://bugs.webkit.org/show_bug.cgi?id=257112">https://bugs.webkit.org/show_bug.cgi?id=257112</a>
rdar://109283915

Reviewed by Eric Carlson.

The source intrinsicSize is used to compute the final video frame size in case constraints are setting only the width or only the height.
Make sure to set the intrisic size whenever the preset is set, which happens when the source gets created, at applying constraints time.
This ensures the intrinsic size is not zero when computing the video size after resizing.

* Source/WebCore/platform/mediastream/RealtimeMediaSource.cpp:
(WebCore::RealtimeMediaSource::computeResizedVideoFrameSize):
* Source/WebCore/platform/mediastream/mac/AVVideoCaptureSource.mm:
(WebCore::AVVideoCaptureSource::setFrameRateAndZoomWithPreset):

Canonical link: <a href="https://commits.webkit.org/264422@main">https://commits.webkit.org/264422@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/af07d62a00aacc899bc6f7b5564b9b269b293c82

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/7573 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/7842 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/8026 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/9215 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/7762 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/7586 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/9799 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/7767 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/10637 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/7706 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/8818 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/6989 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/9323 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/6126 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/6897 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/14594 "Passed tests") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/7310 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/7020 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/10395 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/7511 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/6133 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/6850 "Built successfully") | | | 
| [❌ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/1802 "Failed to push commit to Webkit repository") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/11060 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/7243 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->