### PR TITLE
Pull out LazyLineBreakIterator's prior context handling into a separate class

### DIFF
--- a/Source/WebCore/layout/formattingContexts/inline/InlineLineBuilder.cpp
+++ b/Source/WebCore/layout/formattingContexts/inline/InlineLineBuilder.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019 Apple Inc. All rights reserved.
+ * Copyright (C) 2019-2023 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -137,7 +137,7 @@ static inline bool endsWithSoftWrapOpportunity(const InlineTextItem& currentText
     if (lastCharacter == softHyphen && currentTextItem.style().hyphens() == Hyphens::None)
         return false;
     UChar secondToLastCharacter = previousContentLength > 1 ? previousContent[previousContentLength - 2] : 0;
-    lineBreakIterator.setPriorContext(lastCharacter, secondToLastCharacter);
+    lineBreakIterator.priorContext().set({ secondToLastCharacter, lastCharacter });
     // Now check if we can break right at the inline item boundary.
     // With the [ex-ample], findNextBreakablePosition should return the startPosition (0).
     // FIXME: Check if there's a more correct way of finding breaking opportunities.

--- a/Source/WebCore/rendering/BreakLines.h
+++ b/Source/WebCore/rendering/BreakLines.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2005, 2007, 2010, 2013, 2016 Apple Inc. All rights reserved.
+ * Copyright (C) 2005-2023 Apple Inc. All rights reserved.
  * Copyright (C) 2011 Google Inc. All rights reserved.
  *
  * This library is free software; you can redistribute it and/or
@@ -89,9 +89,9 @@ inline unsigned nextBreakablePosition(LazyLineBreakIterator& lazyBreakIterator, 
 {
     std::optional<unsigned> nextBreak;
 
-    CharacterType lastLastCharacter = startPosition > 1 ? string[startPosition - 2] : static_cast<CharacterType>(lazyBreakIterator.secondToLastCharacter());
-    CharacterType lastCharacter = startPosition > 0 ? string[startPosition - 1] : static_cast<CharacterType>(lazyBreakIterator.lastCharacter());
-    unsigned priorContextLength = lazyBreakIterator.priorContextLength();
+    CharacterType lastLastCharacter = startPosition > 1 ? string[startPosition - 2] : static_cast<CharacterType>(lazyBreakIterator.priorContext().secondToLastCharacter());
+    CharacterType lastCharacter = startPosition > 0 ? string[startPosition - 1] : static_cast<CharacterType>(lazyBreakIterator.priorContext().lastCharacter());
+    unsigned priorContextLength = lazyBreakIterator.priorContext().length();
     for (unsigned i = startPosition; i < length; i++) {
         CharacterType character = string[i];
 
@@ -102,7 +102,7 @@ inline unsigned nextBreakablePosition(LazyLineBreakIterator& lazyBreakIterator, 
             if (!nextBreak || nextBreak.value() < i) {
                 // Don't break if positioned at start of primary context and there is no prior context.
                 if (i || priorContextLength) {
-                    UBreakIterator* breakIterator = lazyBreakIterator.get(priorContextLength);
+                    UBreakIterator* breakIterator = lazyBreakIterator.get();
                     if (breakIterator) {
                         int candidate = ubrk_following(breakIterator, i - 1 + priorContextLength);
                         if (candidate == UBRK_DONE)

--- a/Source/WebCore/rendering/LegacyLineLayout.cpp
+++ b/Source/WebCore/rendering/LegacyLineLayout.cpp
@@ -1,6 +1,6 @@
 /*
  * Copyright (C) 2000 Lars Knoll (knoll@kde.org)
- * Copyright (C) 2003-2019 Apple Inc. All right reserved.
+ * Copyright (C) 2003-2023 Apple Inc. All right reserved.
  * Copyright (C) 2010 Google Inc. All rights reserved.
  * Copyright (C) 2013 ChangSeok Oh <shivamidow@gmail.com>
  * Copyright (C) 2013 Adobe Systems Inc. All right reserved.
@@ -1427,7 +1427,7 @@ void LegacyLineLayout::layoutRunsAndFloatsInRange(LineLayoutState& layoutState, 
         WordMeasurements wordMeasurements;
         end = lineBreaker.nextLineBreak(resolver, layoutState.lineInfo(), renderTextInfo, lastFloatFromPreviousLine, consecutiveHyphenatedLines, wordMeasurements);
         m_flow.cachePriorCharactersIfNeeded(renderTextInfo.lineBreakIterator);
-        renderTextInfo.lineBreakIterator.resetPriorContext();
+        renderTextInfo.lineBreakIterator.priorContext().reset();
         if (resolver.position().atEnd()) {
             // FIXME: We shouldn't be creating any runs in nextLineBreak to begin with!
             // Once BidiRunList is separated from BidiResolver this will not be needed.

--- a/Source/WebCore/rendering/RenderRubyBase.cpp
+++ b/Source/WebCore/rendering/RenderRubyBase.cpp
@@ -1,5 +1,6 @@
 /*
  * Copyright (C) 2009 Google Inc. All rights reserved.
+ * Copyright (C) 2023 Apple Inc. All right reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are
@@ -91,7 +92,7 @@ void RenderRubyBase::cachePriorCharactersIfNeeded(const LazyLineBreakIterator& l
 {
     auto* run = rubyRun();
     if (run)
-        run->setCachedPriorCharacters(lineBreakIterator.lastCharacter(), lineBreakIterator.secondToLastCharacter());
+        run->setCachedPriorCharacters(lineBreakIterator.priorContext().lastCharacter(), lineBreakIterator.priorContext().secondToLastCharacter());
 }
 
 bool RenderRubyBase::isEmptyOrHasInFlowContent() const

--- a/Source/WebCore/rendering/RenderRubyRun.cpp
+++ b/Source/WebCore/rendering/RenderRubyRun.cpp
@@ -1,5 +1,6 @@
 /*
  * Copyright (C) 2009 Google Inc. All rights reserved.
+ * Copyright (C) 2023 Apple Inc. All right reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are
@@ -277,7 +278,7 @@ std::pair<float, float> RenderRubyRun::startAndEndOverhang(bool forFirstLine) co
 
 void RenderRubyRun::updatePriorContextFromCachedBreakIterator(LazyLineBreakIterator& iterator) const
 {
-    iterator.setPriorContext(m_lastCharacter, m_secondToLastCharacter);
+    iterator.priorContext().set({ m_secondToLastCharacter, m_lastCharacter });
 }
 
 bool RenderRubyRun::canBreakBefore(const LazyLineBreakIterator& iterator) const

--- a/Source/WebCore/rendering/RenderRubyText.cpp
+++ b/Source/WebCore/rendering/RenderRubyText.cpp
@@ -1,6 +1,6 @@
 /*
  * Copyright (C) 2009 Google Inc. All rights reserved.
- * Copyright (C) 2011 Apple Inc. All rights reserved.
+ * Copyright (C) 2011-2023 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are
@@ -99,9 +99,9 @@ bool RenderRubyText::canBreakBefore(const LazyLineBreakIterator& iterator) const
     // FIXME: It would be nice to improve this so that it isn't just hard-coded, but lookahead in this
     // case is particularly problematic.
 
-    if (!iterator.priorContextLength())
+    if (!iterator.priorContext().length())
         return true;
-    UChar ch = iterator.lastCharacter();
+    UChar ch = iterator.priorContext().lastCharacter();
     ULineBreak lineBreak = (ULineBreak)u_getIntPropertyValue(ch, UCHAR_LINE_BREAK);
     // UNICODE LINE BREAKING ALGORITHM
     // http://www.unicode.org/reports/tr14/

--- a/Source/WebCore/rendering/line/BreakingContext.h
+++ b/Source/WebCore/rendering/line/BreakingContext.h
@@ -1,6 +1,6 @@
 /*
  * Copyright (C) 2000 Lars Knoll (knoll@kde.org)
- * Copyright (C) 2003-2022 Apple Inc. All right reserved.
+ * Copyright (C) 2003-2023 Apple Inc. All right reserved.
  * Copyright (C) 2010-2015 Google Inc. All rights reserved.
  * Copyright (C) 2013 ChangSeok Oh <shivamidow@gmail.com>
  * Copyright (C) 2013 Adobe Systems Inc. All right reserved.
@@ -362,7 +362,7 @@ inline void BreakingContext::handleOutOfFlowPositioned(Vector<RenderBox*>& posit
         m_appliedStartWidth = true;
     }
     // Reset prior line break context characters.
-    m_renderTextInfo.lineBreakIterator.resetPriorContext();
+    m_renderTextInfo.lineBreakIterator.priorContext().reset();
 }
 
 inline void BreakingContext::handleFloat()
@@ -400,7 +400,7 @@ inline void BreakingContext::handleFloat()
     } else
         m_floatsFitOnLine = false;
     // Update prior line break context characters, using U+FFFD (OBJECT REPLACEMENT CHARACTER) for floating element.
-    m_renderTextInfo.lineBreakIterator.updatePriorContext(replacementCharacter);
+    m_renderTextInfo.lineBreakIterator.priorContext().update(replacementCharacter);
 }
 
 // This is currently just used for list markers and inline flows that have line boxes. Neither should
@@ -506,8 +506,8 @@ inline void BreakingContext::handleReplaced()
         downcast<RenderRubyRun>(replacedBox).updatePriorContextFromCachedBreakIterator(m_renderTextInfo.lineBreakIterator);
     } else {
         // Update prior line break context characters, using U+FFFD (OBJECT REPLACEMENT CHARACTER) for replaced element.
-        m_renderTextInfo.lineBreakIterator.updatePriorContext(replacementCharacter);
-    }    
+        m_renderTextInfo.lineBreakIterator.priorContext().update(replacementCharacter);
+    }
 }
 
 inline float firstPositiveWidth(const WordMeasurements& wordMeasurements)
@@ -722,9 +722,9 @@ inline bool BreakingContext::handleText(WordMeasurements& wordMeasurements, bool
     HashSet<const Font*> fallbackFonts;
     m_hasFormerOpportunity = false;
     bool canBreakMidWord = breakWords || breakAll;
-    UChar lastCharacterFromPreviousRenderText = m_renderTextInfo.lineBreakIterator.lastCharacter();
-    UChar lastCharacter = m_renderTextInfo.lineBreakIterator.lastCharacter();
-    UChar secondToLastCharacter = m_renderTextInfo.lineBreakIterator.secondToLastCharacter();
+    UChar lastCharacterFromPreviousRenderText = m_renderTextInfo.lineBreakIterator.priorContext().lastCharacter();
+    UChar lastCharacter = m_renderTextInfo.lineBreakIterator.priorContext().lastCharacter();
+    UChar secondToLastCharacter = m_renderTextInfo.lineBreakIterator.priorContext().secondToLastCharacter();
     // Non-zero only when kerning is enabled and TextLayout isn't used, in which case we measure
     // words with their trailing space, then subtract its width.
     TextLayout* textLayout = m_renderTextInfo.layout.get();
@@ -1025,7 +1025,7 @@ inline bool BreakingContext::handleText(WordMeasurements& wordMeasurements, bool
         nextCharacter(c, lastCharacter, secondToLastCharacter);
     }
 
-    m_renderTextInfo.lineBreakIterator.setPriorContext(lastCharacter, secondToLastCharacter);
+    m_renderTextInfo.lineBreakIterator.priorContext().set({ secondToLastCharacter, lastCharacter });
 
     wordMeasurements.grow(wordMeasurements.size() + 1);
     WordMeasurement& wordMeasurement = wordMeasurements.last();

--- a/Tools/TestWebKitAPI/Tests/WTF/TextBreakIterator.cpp
+++ b/Tools/TestWebKitAPI/Tests/WTF/TextBreakIterator.cpp
@@ -163,4 +163,21 @@ TEST(WTF, TextBreakIteratorBehaviors)
     }
 }
 
+TEST(WTF, LazyLineBreakIteratorPriorContext)
+{
+    LazyLineBreakIterator::PriorContext priorContext;
+    EXPECT_EQ(0U, priorContext.length());
+    priorContext.set({ 'a', 'b' });
+    EXPECT_EQ(2U, priorContext.length());
+    LazyLineBreakIterator::PriorContext priorContext2;
+    EXPECT_FALSE(priorContext == priorContext2);
+    priorContext2.set({ 'a', 'b' });
+    EXPECT_TRUE(priorContext == priorContext2);
+    EXPECT_EQ('a', priorContext.characters()[0]);
+    priorContext.set({ '\0', 'b' });
+    EXPECT_EQ('b', priorContext.characters()[0]);
+    priorContext.reset();
+    EXPECT_EQ(0U, priorContext.length());
+}
+
 } // namespace TestWebKitAPI


### PR DESCRIPTION
#### b5583c5d124d54f19e8e87f3f9daad7450495656
<pre>
Pull out LazyLineBreakIterator&apos;s prior context handling into a separate class
<a href="https://bugs.webkit.org/show_bug.cgi?id=257115">https://bugs.webkit.org/show_bug.cgi?id=257115</a>
rdar://109646131

Reviewed by Yusuke Suzuki.

LazyLineBreakIterator is really a factory, which holds the necessary parameters to
create line break iterators. But, it also has a bunch of handling for a &quot;prior context&quot;
which is conceptually a prefix to the string being broken.

This patch isn&apos;t strictly necessary, but I thought it would be a bit more elegant to
have a class separation between the two pieces of LazyLineBreakIterator.

* Source/WTF/wtf/text/TextBreakIterator.h:
(WTF::LazyLineBreakIterator::PriorContext::PriorContext):
(WTF::LazyLineBreakIterator::PriorContext::lastCharacter const):
(WTF::LazyLineBreakIterator::PriorContext::secondToLastCharacter const):
(WTF::LazyLineBreakIterator::PriorContext::set):
(WTF::LazyLineBreakIterator::PriorContext::update):
(WTF::LazyLineBreakIterator::PriorContext::reset):
(WTF::LazyLineBreakIterator::PriorContext::length const):
(WTF::LazyLineBreakIterator::PriorContext::characters const):
(WTF::LazyLineBreakIterator::LazyLineBreakIterator):
(WTF::LazyLineBreakIterator::get):
(WTF::LazyLineBreakIterator::resetStringAndReleaseIterator):
(WTF::LazyLineBreakIterator::priorContext const):
(WTF::LazyLineBreakIterator::priorContext):
(WTF::TextBreakIteratorCache::TextBreakIteratorCache): Deleted.
(WTF::LazyLineBreakIterator::lastCharacter const): Deleted.
(WTF::LazyLineBreakIterator::secondToLastCharacter const): Deleted.
(WTF::LazyLineBreakIterator::setPriorContext): Deleted.
(WTF::LazyLineBreakIterator::updatePriorContext): Deleted.
(WTF::LazyLineBreakIterator::resetPriorContext): Deleted.
(WTF::LazyLineBreakIterator::priorContextLength const): Deleted.
* Source/WebCore/layout/formattingContexts/inline/InlineLineBuilder.cpp:
(WebCore::Layout::endsWithSoftWrapOpportunity):
* Source/WebCore/rendering/BreakLines.h:
(WebCore::nextBreakablePosition):
* Source/WebCore/rendering/LegacyLineLayout.cpp:
(WebCore::LegacyLineLayout::layoutRunsAndFloatsInRange):
* Source/WebCore/rendering/RenderRubyBase.cpp:
(WebCore::RenderRubyBase::cachePriorCharactersIfNeeded):
* Source/WebCore/rendering/RenderRubyRun.cpp:
(WebCore::RenderRubyRun::updatePriorContextFromCachedBreakIterator const):
* Source/WebCore/rendering/RenderRubyText.cpp:
(WebCore::RenderRubyText::canBreakBefore const):
* Source/WebCore/rendering/line/BreakingContext.h:
(WebCore::BreakingContext::handleOutOfFlowPositioned):
(WebCore::BreakingContext::handleFloat):
(WebCore::BreakingContext::handleReplaced):
(WebCore::BreakingContext::handleText):

Canonical link: <a href="https://commits.webkit.org/264444@main">https://commits.webkit.org/264444@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/cca0ce9a70e6ca458ff5ee768a1e0f10a49da249

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/7561 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/7830 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/8013 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/9202 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/7750 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/7573 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/9888 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/7754 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/10627 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/7693 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/15/builds/8900 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/6979 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/9310 "Built successfully") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/39/builds/6208 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/6885 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/14585 "Passed tests") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/6452 "Built successfully and passed tests") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/7371 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/7007 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/10371 "Passed tests") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/7150 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/7498 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/6122 "1 flakes 1 failures") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/7716 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/6838 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/1764 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/1819 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/11047 "Built successfully") | | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/24/builds/7919 "Built successfully") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/7231 "Built successfully") | | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/3/builds/1906 "Passed tests") | 
<!--EWS-Status-Bubble-End-->