### PR TITLE
[WebXR] Refactor WebXROpaqueFramebuffer::setupFramebuffer

### DIFF
--- a/LayoutTests/platform/wpe/imported/w3c/web-platform-tests/webxr/xrWebGLLayer_framebuffer_draw.https-expected.txt
+++ b/LayoutTests/platform/wpe/imported/w3c/web-platform-tests/webxr/xrWebGLLayer_framebuffer_draw.https-expected.txt
@@ -1,4 +1,4 @@
 
-FAIL Ensure a WebGL layer's framebuffer can only be drawn to inside a XR frame - webgl assert_equals: expected 0 but got 1280
+FAIL Ensure a WebGL layer's framebuffer can only be drawn to inside a XR frame - webgl assert_equals: expected 1286 but got 0
 FAIL Ensure a WebGL layer's framebuffer can only be drawn to inside a XR frame - webgl2 assert_equals: expected 1286 but got 0
 

--- a/LayoutTests/platform/wpe/imported/w3c/web-platform-tests/webxr/xrWebGLLayer_opaque_framebuffer.https-expected.txt
+++ b/LayoutTests/platform/wpe/imported/w3c/web-platform-tests/webxr/xrWebGLLayer_opaque_framebuffer.https-expected.txt
@@ -1,5 +1,21 @@
+CONSOLE MESSAGE: WebGL: INVALID_OPERATION: deleteFramebuffer: An opaque framebuffer's attachments cannot be inspected or changed
+CONSOLE MESSAGE: WebGL: INVALID_OPERATION: getFramebufferAttachmentParameter: An opaque framebuffer's attachments cannot be inspected or changed
+CONSOLE MESSAGE: WebGL: INVALID_OPERATION: getFramebufferAttachmentParameter: An opaque framebuffer's attachments cannot be inspected or changed
+CONSOLE MESSAGE: WebGL: INVALID_OPERATION: getFramebufferAttachmentParameter: An opaque framebuffer's attachments cannot be inspected or changed
+CONSOLE MESSAGE: WebGL: INVALID_OPERATION: getFramebufferAttachmentParameter: An opaque framebuffer's attachments cannot be inspected or changed
+CONSOLE MESSAGE: WebGL: INVALID_OPERATION: getFramebufferAttachmentParameter: An opaque framebuffer's attachments cannot be inspected or changed
+CONSOLE MESSAGE: WebGL: INVALID_OPERATION: getFramebufferAttachmentParameter: An opaque framebuffer's attachments cannot be inspected or changed
+CONSOLE MESSAGE: WebGL: INVALID_OPERATION: getFramebufferAttachmentParameter: An opaque framebuffer's attachments cannot be inspected or changed
+CONSOLE MESSAGE: WebGL: INVALID_OPERATION: getFramebufferAttachmentParameter: An opaque framebuffer's attachments cannot be inspected or changed
+CONSOLE MESSAGE: WebGL: INVALID_OPERATION: getFramebufferAttachmentParameter: An opaque framebuffer's attachments cannot be inspected or changed
+CONSOLE MESSAGE: WebGL: INVALID_OPERATION: getFramebufferAttachmentParameter: An opaque framebuffer's attachments cannot be inspected or changed
+CONSOLE MESSAGE: WebGL: INVALID_OPERATION: getFramebufferAttachmentParameter: An opaque framebuffer's attachments cannot be inspected or changed
+CONSOLE MESSAGE: WebGL: INVALID_OPERATION: getFramebufferAttachmentParameter: An opaque framebuffer's attachments cannot be inspected or changed
+CONSOLE MESSAGE: WebGL: INVALID_OPERATION: framebufferTexture2D: An opaque framebuffer's attachments cannot be inspected or changed
+CONSOLE MESSAGE: WebGL: INVALID_OPERATION: framebufferRenderbuffer: An opaque framebuffer's attachments cannot be inspected or changed
+CONSOLE MESSAGE: WebGL: INVALID_OPERATION: framebufferRenderbuffer: An opaque framebuffer's attachments cannot be inspected or changed
 
-FAIL Ensure that the framebuffer given by the WebGL layer is opaque for immersive - webgl assert_equals: expected 0 but got 1280
+FAIL Ensure that the framebuffer given by the WebGL layer is opaque for immersive - webgl assert_equals: expected 36061 but got 36053
 FAIL Ensure that the framebuffer given by the WebGL layer is opaque for immersive - webgl2 assert_equals: expected 1282 but got 0
 PASS Ensure that the framebuffer given by the WebGL layer is opaque for non-immersive - webgl
 PASS Ensure that the framebuffer given by the WebGL layer is opaque for non-immersive - webgl2

--- a/Source/WebCore/Modules/webxr/WebXROpaqueFramebuffer.h
+++ b/Source/WebCore/Modules/webxr/WebXROpaqueFramebuffer.h
@@ -66,6 +66,11 @@ private:
     WebXROpaqueFramebuffer(PlatformXR::LayerHandle, Ref<WebGLFramebuffer>&&, WebGLRenderingContextBase&, Attributes&&, uint32_t width, uint32_t height);
 
     bool setupFramebuffer();
+    PlatformGLObject allocateRenderbufferStorage(GraphicsContextGL&, GCGLsizei, GCGLenum, GCGLsizei, GCGLsizei);
+    PlatformGLObject allocateColorStorage(GraphicsContextGL&, GCGLsizei, GCGLsizei, GCGLsizei);
+    std::tuple<PlatformGLObject, PlatformGLObject> allocateDepthStencilStorage(GraphicsContextGL&, GCGLsizei, GCGLsizei, GCGLsizei);
+    void bindColor(GraphicsContextGL&, PlatformGLObject);
+    void bindDepthStencil(GraphicsContextGL&, PlatformGLObject, PlatformGLObject);
 
     PlatformXR::LayerHandle m_handle;
     Ref<WebGLFramebuffer> m_framebuffer;
@@ -77,7 +82,6 @@ private:
     GCGLOwnedRenderbuffer m_stencilBuffer;
     GCGLOwnedRenderbuffer m_multisampleColorBuffer;
     GCGLOwnedFramebuffer m_resolvedFBO;
-    GCGLint m_sampleCount { 0 };
 #if USE(IOSURFACE_FOR_XR_LAYER_DATA)
     GCGLOwnedTexture m_opaqueTexture;
     void* m_ioSurfaceTextureHandle { nullptr };

--- a/Source/WebCore/platform/graphics/GraphicsContextGL.h
+++ b/Source/WebCore/platform/graphics/GraphicsContextGL.h
@@ -86,6 +86,7 @@ protected:
 
 #define DECLARE_GCGL_OWNED(ClassName) \
 struct GCGLOwned##ClassName : public GCGLOwned { \
+    void adopt(GraphicsContextGL& gl, PlatformGLObject object); \
     void ensure(GraphicsContextGL& gl); \
     void release(GraphicsContextGL& gl); \
 }
@@ -1657,6 +1658,12 @@ inline GCGLOwned::~GCGLOwned()
 }
 
 #define IMPLEMENT_GCGL_OWNED(ClassName) \
+inline void GCGLOwned##ClassName::adopt(GraphicsContextGL& gl, PlatformGLObject object) \
+{ \
+    if (m_object) \
+        gl.delete##ClassName(m_object); \
+    m_object = object; \
+} \
 inline void GCGLOwned##ClassName::ensure(GraphicsContextGL& gl) \
 { \
     if (!m_object) \
@@ -1665,9 +1672,7 @@ inline void GCGLOwned##ClassName::ensure(GraphicsContextGL& gl) \
 \
 inline void GCGLOwned##ClassName::release(GraphicsContextGL& gl) \
 { \
-    if (m_object) \
-        gl.delete##ClassName(m_object); \
-    m_object = 0; \
+    adopt(gl, 0); \
 }
 
 IMPLEMENT_GCGL_OWNED(Framebuffer)


### PR DESCRIPTION
#### 12c38eddb8f19ee73b871eef5946b662a39a3ceb
<pre>
[WebXR] Refactor WebXROpaqueFramebuffer::setupFramebuffer
<a href="https://bugs.webkit.org/show_bug.cgi?id=257117">https://bugs.webkit.org/show_bug.cgi?id=257117</a>
rdar://problem/109647523

Reviewed by Dean Jackson.

Reduce the complicated nesting of if/else statement by extracting common parts
into helper functions.

No features changed.

* LayoutTests/platform/wpe/imported/w3c/web-platform-tests/webxr/xrWebGLLayer_framebuffer_draw.https-expected.txt:
* LayoutTests/platform/wpe/imported/w3c/web-platform-tests/webxr/xrWebGLLayer_opaque_framebuffer.https-expected.txt:
* Source/WebCore/Modules/webxr/WebXROpaqueFramebuffer.cpp:
(WebCore::WebXROpaqueFramebuffer::setupFramebuffer):
(WebCore::WebXROpaqueFramebuffer::allocateRenderbufferStorage):
(WebCore::WebXROpaqueFramebuffer::allocateColorStorage):
(WebCore::WebXROpaqueFramebuffer::allocateDepthStencilStorage):
(WebCore::WebXROpaqueFramebuffer::bindColor):
(WebCore::WebXROpaqueFramebuffer::bindDepthStencil):
* Source/WebCore/Modules/webxr/WebXROpaqueFramebuffer.h:
* Source/WebCore/platform/graphics/GraphicsContextGL.h:

Canonical link: <a href="https://commits.webkit.org/264466@main">https://commits.webkit.org/264466@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/3d87b203bce6784a8c719da1916b724c595f21e9

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [  ~~🧪 style~~](https://ews-build.webkit.org/#/builders/38/builds/7705 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 ios~~](https://ews-build.webkit.org/#/builders/26/builds/7975 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/14/builds/8157 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/9348 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/7865 "Built successfully") 
| [  ~~🧪 bindings~~](https://ews-build.webkit.org/#/builders/9/builds/7711 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/23/builds/9965 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/16/builds/7896 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/10736 "Passed tests") | 
| [  ~~🧪 webkitperl~~](https://ews-build.webkit.org/#/builders/11/builds/7839 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/23/builds/9965 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/14/builds/8157 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/2/builds/9453 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/23/builds/9965 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/14/builds/8157 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/2/builds/9453 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/23/builds/9965 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/14/builds/8157 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/2/builds/9453 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/7/builds/7628 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/16/builds/7896 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/30/builds/6956 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/14/builds/8157 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/1837 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/11166 "Built successfully") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/31/builds/7362 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->