### PR TITLE
[ManagedMSE] onbufferedchange fired too many times if GPU process isn't in use.

### DIFF
--- a/LayoutTests/media/media-source/media-managedmse-bufferedchange-expected.txt
+++ b/LayoutTests/media/media-source/media-managedmse-bufferedchange-expected.txt
@@ -8,11 +8,13 @@ RUN(sourceBuffer.appendBuffer(loader.initSegment()))
 EVENT(update)
 Append a media segment.
 RUN(sourceBuffer.appendBuffer(loader.mediaSegment(0)))
+onbufferedchange called.
 EVENT(bufferedchange)
 EVENT(update)
 EXPECTED (sourceBuffer.buffered.length == '1') OK
 Clean sourcebuffer of all content.
 RUN(sourceBuffer.remove(0, sourceBuffer.buffered.end(0)))
+onbufferedchange called.
 EVENT(bufferedchange)
 EVENT(update)
 EXPECTED (sourceBuffer.buffered.length == '0') OK

--- a/LayoutTests/media/media-source/media-managedmse-bufferedchange.html
+++ b/LayoutTests/media/media-source/media-managedmse-bufferedchange.html
@@ -38,6 +38,10 @@
             testExpected('sourceBuffer.__proto__', ManagedSourceBuffer.prototype);
             testExpected('sourceBuffer.onbufferedchange !== undefined', true);
 
+            sourceBuffer.onbufferedchange = () => {
+                consoleWrite('onbufferedchange called.')
+            };
+
             run('sourceBuffer.appendBuffer(loader.initSegment())');
             await waitFor(sourceBuffer, 'update');
 

--- a/Source/WebCore/Modules/mediasource/SourceBuffer.cpp
+++ b/Source/WebCore/Modules/mediasource/SourceBuffer.cpp
@@ -433,7 +433,7 @@ MediaTime SourceBuffer::highestPresentationTimestamp() const
 void SourceBuffer::readyStateChanged()
 {
     if (!isRemoved())
-        m_private->updateBufferedFromTrackBuffers(m_source->isEnded());
+        m_private->clientReadyStateChanged(m_source->isEnded());
 }
 
 void SourceBuffer::removedFromMediaSource()

--- a/Source/WebCore/platform/graphics/SourceBufferPrivate.cpp
+++ b/Source/WebCore/platform/graphics/SourceBufferPrivate.cpp
@@ -108,23 +108,37 @@ void SourceBufferPrivate::setBufferedRanges(PlatformTimeRanges&& timeRanges, Com
         completionHandler();
 }
 
-void SourceBufferPrivate::updateBufferedFromTrackBuffers(bool sourceIsEnded)
+Vector<PlatformTimeRanges> SourceBufferPrivate::trackBuffersRanges() const
+{
+    Vector<PlatformTimeRanges> trackBuffers;
+    trackBuffers.reserveInitialCapacity(m_trackBufferMap.size());
+    for (auto&& trackBuffer : m_trackBufferMap.values())
+        trackBuffers.uncheckedAppend(trackBuffer->buffered());
+    return trackBuffers;
+}
+
+void SourceBufferPrivate::clientReadyStateChanged(bool sourceIsEnded)
+{
+    updateBufferedFromTrackBuffers(trackBuffersRanges(), sourceIsEnded);
+}
+
+void SourceBufferPrivate::updateBufferedFromTrackBuffers(const Vector<PlatformTimeRanges>& trackBuffers, bool sourceIsEnded, CompletionHandler<void()>&& completionHandler)
 {
     // 3.1 Attributes, buffered
     // https://rawgit.com/w3c/media-source/45627646344eea0170dd1cbc5a3d508ca751abb8/media-source-respec.html#dom-sourcebuffer-buffered
 
     // 2. Let highest end time be the largest track buffer ranges end time across all the track buffers managed by this SourceBuffer object.
     MediaTime highestEndTime = MediaTime::negativeInfiniteTime();
-    for (auto& trackBuffer : m_trackBufferMap.values()) {
-        if (!trackBuffer->buffered().length())
+    for (auto& trackBuffer : trackBuffers) {
+        if (!trackBuffer.length())
             continue;
-        highestEndTime = std::max(highestEndTime, trackBuffer->maximumBufferedTime());
+        highestEndTime = std::max(highestEndTime, trackBuffer.maximumBufferedTime());
     }
 
     // NOTE: Short circuit the following if none of the TrackBuffers have buffered ranges to avoid generating
     // a single range of {0, 0}.
     if (highestEndTime.isNegativeInfinite()) {
-        setBufferedRanges(PlatformTimeRanges());
+        setBufferedRanges({ }, WTFMove(completionHandler));
         return;
     }
 
@@ -132,12 +146,12 @@ void SourceBufferPrivate::updateBufferedFromTrackBuffers(bool sourceIsEnded)
     PlatformTimeRanges intersectionRanges { MediaTime::zeroTime(), highestEndTime };
 
     // 4. For each audio and video track buffer managed by this SourceBuffer, run the following steps:
-    for (auto& trackBuffer : m_trackBufferMap.values()) {
-        if (!trackBuffer->buffered().length())
+    for (auto& trackBuffer : trackBuffers) {
+        if (!trackBuffer.length())
             continue;
 
         // 4.1 Let track ranges equal the track buffer ranges for the current track buffer.
-        PlatformTimeRanges trackRanges = trackBuffer->buffered();
+        auto trackRanges = trackBuffer;
 
         // 4.2 If readyState is "ended", then set the end time on the last range in track ranges to highest end time.
         if (sourceIsEnded)
@@ -150,7 +164,7 @@ void SourceBufferPrivate::updateBufferedFromTrackBuffers(bool sourceIsEnded)
 
     // 5. If intersection ranges does not contain the exact same range information as the current value of this attribute,
     //    then update the current value of this attribute to intersection ranges.
-    setBufferedRanges(WTFMove(intersectionRanges));
+    setBufferedRanges(WTFMove(intersectionRanges), WTFMove(completionHandler));
 }
 
 void SourceBufferPrivate::advanceOperationState()
@@ -202,9 +216,11 @@ void SourceBufferPrivate::processAppendCompletedOperation(AppendCompletedOperati
 
     // Resolve the changes in TrackBuffers' buffered ranges
     // into the SourceBuffer's buffered ranges
-    updateBufferedFromTrackBuffers(operation.isEnded);
+    auto trackBuffers = trackBuffersRanges();
+    if (isAttached())
+        m_client->sourceBufferPrivateTrackBuffersChanged(trackBuffers);
 
-    m_client->sourceBufferPrivateBufferedChanged(buffered(), [weakSelf = WeakPtr { *this }, this, operation = WTFMove(operation)] () mutable {
+    updateBufferedFromTrackBuffers(trackBuffers, operation.isEnded, [weakSelf = WeakPtr { *this }, this, operation = WTFMove(operation)] () mutable {
         if (!weakSelf || !isAttached())
             return;
 
@@ -260,10 +276,13 @@ void SourceBufferPrivate::clearTrackBuffers(bool shouldReportToClient)
         return;
 
     updateHighestPresentationTimestamp();
-    updateBufferedFromTrackBuffers(true);
 
-    if (isAttached())
+    if (isAttached()) {
+        m_client->sourceBufferPrivateTrackBuffersChanged({ });
         m_client->sourceBufferPrivateReportExtraMemoryCost(totalTrackBufferSizeInBytes());
+    }
+    bool isEnded = true;
+    updateBufferedFromTrackBuffers({ }, isEnded);
 }
 
 void SourceBufferPrivate::bufferedSamplesForTrackId(const AtomString& trackId, CompletionHandler<void(Vector<String>&&)>&& completionHandler)
@@ -462,8 +481,7 @@ void SourceBufferPrivate::removeCodedFrames(const MediaTime& start, const MediaT
         TrackBuffer& trackBuffer = trackBufferKeyValue.value;
         AtomString trackID = trackBufferKeyValue.key;
 
-        if (!trackBuffer.removeCodedFrames(start, end, currentTime))
-            continue;
+        trackBuffer.removeCodedFrames(start, end, currentTime);
 
         // 3.4 If this object is in activeSourceBuffers, the current playback position is greater than or equal to start
         // and less than the remove end timestamp, and HTMLMediaElement.readyState is greater than HAVE_METADATA, then set
@@ -473,8 +491,6 @@ void SourceBufferPrivate::removeCodedFrames(const MediaTime& start, const MediaT
 
     reenqueueMediaIfNeeded(currentTime);
 
-    updateBufferedFromTrackBuffers(isEnded);
-
     // 4. If buffer full flag equals true and this object is ready to accept more bytes, then set the buffer full flag to false.
     // No-op
 
@@ -482,12 +498,13 @@ void SourceBufferPrivate::removeCodedFrames(const MediaTime& start, const MediaT
 
     LOG(Media, "SourceBuffer::removeCodedFrames(%p) - buffered = %s", this, toString(m_buffered).utf8().data());
 
-    if (!isAttached()) {
-        completionHandler();
-        return;
+    auto trackBuffers = trackBuffersRanges();
+    if (isAttached()) {
+        m_client->sourceBufferPrivateTrackBuffersChanged(trackBuffers);
+        m_client->sourceBufferPrivateReportExtraMemoryCost(totalTrackBufferSizeInBytes());
     }
-    m_client->sourceBufferPrivateReportExtraMemoryCost(totalTrackBufferSizeInBytes());
-    m_client->sourceBufferPrivateBufferedChanged(buffered(), WTFMove(completionHandler));
+
+    updateBufferedFromTrackBuffers(trackBuffers, isEnded, WTFMove(completionHandler));
 }
 
 void SourceBufferPrivate::evictCodedFrames(uint64_t newDataSize, uint64_t maximumBufferSize, const MediaTime& currentTime, bool isEnded)

--- a/Source/WebCore/platform/graphics/SourceBufferPrivate.h
+++ b/Source/WebCore/platform/graphics/SourceBufferPrivate.h
@@ -81,6 +81,7 @@ public:
     virtual void removedFromMediaSource() = 0;
     virtual MediaPlayer::ReadyState readyState() const = 0;
     virtual void setReadyState(MediaPlayer::ReadyState) = 0;
+    WEBCORE_EXPORT virtual void clientReadyStateChanged(bool endOfStream);
 
     virtual bool canSwitchToType(const ContentType&) { return false; }
 
@@ -94,7 +95,6 @@ public:
     virtual void setGroupStartTimestamp(const MediaTime& mediaTime) { m_groupStartTimestamp = mediaTime; }
     virtual void setGroupStartTimestampToEndTimestamp() { m_groupStartTimestamp = m_groupEndTimestamp; }
     virtual void setShouldGenerateTimestamps(bool flag) { m_shouldGenerateTimestamps = flag; }
-    WEBCORE_EXPORT virtual void updateBufferedFromTrackBuffers(bool sourceIsEnded);
     WEBCORE_EXPORT virtual void removeCodedFrames(const MediaTime& start, const MediaTime& end, const MediaTime& currentMediaTime, bool isEnded, CompletionHandler<void()>&& = [] { });
     WEBCORE_EXPORT virtual void evictCodedFrames(uint64_t newDataSize, uint64_t maximumBufferSize, const MediaTime& currentTime, bool isEnded);
     WEBCORE_EXPORT virtual uint64_t totalTrackBufferSizeInBytes() const;
@@ -137,6 +137,8 @@ public:
 #endif
 
 protected:
+    WEBCORE_EXPORT void updateBufferedFromTrackBuffers(const Vector<PlatformTimeRanges>&, bool sourceIsEnded, CompletionHandler<void()>&& = [] { });
+
     struct ResetParserOperation { };
     struct ErrorOperation { };
     using AppendBufferOperation = Ref<SharedBuffer>;
@@ -202,6 +204,7 @@ private:
     MediaTime findPreviousSyncSamplePresentationTime(const MediaTime&);
     bool evictFrames(uint64_t newDataSize, uint64_t maximumBufferSize, const MediaTime& currentTime, bool isEnded);
     bool isAttached() const;
+    Vector<PlatformTimeRanges> trackBuffersRanges() const;
 
     bool m_hasAudio { false };
     bool m_hasVideo { false };

--- a/Source/WebCore/platform/graphics/SourceBufferPrivateClient.h
+++ b/Source/WebCore/platform/graphics/SourceBufferPrivateClient.h
@@ -83,6 +83,7 @@ public:
     };
     virtual void sourceBufferPrivateAppendComplete(AppendResult) = 0;
     virtual void sourceBufferPrivateBufferedChanged(const PlatformTimeRanges&, CompletionHandler<void()>&&) = 0;
+    virtual void sourceBufferPrivateTrackBuffersChanged(const Vector<PlatformTimeRanges>&) { };
     virtual void sourceBufferPrivateDurationChanged(const MediaTime&, CompletionHandler<void()>&&) = 0;
     virtual void sourceBufferPrivateHighestPresentationTimestampChanged(const MediaTime&) = 0;
     virtual void sourceBufferPrivateDidParseSample(double frameDuration) = 0;

--- a/Source/WebKit/GPUProcess/media/RemoteSourceBufferProxy.cpp
+++ b/Source/WebKit/GPUProcess/media/RemoteSourceBufferProxy.cpp
@@ -139,6 +139,13 @@ void RemoteSourceBufferProxy::sourceBufferPrivateDurationChanged(const MediaTime
     m_connectionToWebProcess->connection().sendWithAsyncReply(Messages::SourceBufferPrivateRemote::SourceBufferPrivateDurationChanged(duration), WTFMove(completionHandler), m_identifier);
 }
 
+void RemoteSourceBufferProxy::sourceBufferPrivateTrackBuffersChanged(const Vector<WebCore::PlatformTimeRanges>& trackBuffers)
+{
+    if (!m_connectionToWebProcess)
+        return;
+    m_connectionToWebProcess->connection().send(Messages::SourceBufferPrivateRemote::SourceBufferPrivateTrackBuffersChanged(trackBuffers), m_identifier);
+}
+
 void RemoteSourceBufferProxy::sourceBufferPrivateBufferedChanged(const PlatformTimeRanges& buffered, CompletionHandler<void()>&& completionHandler)
 {
     if (!m_connectionToWebProcess) {
@@ -245,11 +252,9 @@ void RemoteSourceBufferProxy::startChangingType()
     m_sourceBufferPrivate->startChangingType();
 }
 
-void RemoteSourceBufferProxy::updateBufferedFromTrackBuffers(bool sourceIsEnded, CompletionHandler<void(WebCore::PlatformTimeRanges&&)>&& completionHandler)
+void RemoteSourceBufferProxy::clientReadyStateChanged(bool sourceIsEnded)
 {
-    m_sourceBufferPrivate->updateBufferedFromTrackBuffers(sourceIsEnded);
-    auto buffered = m_sourceBufferPrivate->buffered();
-    completionHandler(WTFMove(buffered));
+    m_sourceBufferPrivate->clientReadyStateChanged(sourceIsEnded);
 }
 
 void RemoteSourceBufferProxy::removeCodedFrames(const MediaTime& start, const MediaTime& end, const MediaTime& currentTime, bool isEnded, CompletionHandler<void(WebCore::PlatformTimeRanges&&, uint64_t)>&& completionHandler)

--- a/Source/WebKit/GPUProcess/media/RemoteSourceBufferProxy.h
+++ b/Source/WebKit/GPUProcess/media/RemoteSourceBufferProxy.h
@@ -73,13 +73,14 @@ private:
     void sourceBufferPrivateStreamEndedWithDecodeError() final;
     void sourceBufferPrivateAppendComplete(WebCore::SourceBufferPrivateClient::AppendResult) final;
     void sourceBufferPrivateBufferedChanged(const WebCore::PlatformTimeRanges&, CompletionHandler<void()>&&) final;
+    void sourceBufferPrivateTrackBuffersChanged(const Vector<WebCore::PlatformTimeRanges>&) final;
     void sourceBufferPrivateHighestPresentationTimestampChanged(const MediaTime&) final;
     void sourceBufferPrivateDurationChanged(const MediaTime&, CompletionHandler<void()>&&) final;
     void sourceBufferPrivateDidParseSample(double sampleDuration) final;
     void sourceBufferPrivateDidDropSample() final;
     void sourceBufferPrivateDidReceiveRenderingError(int64_t errorCode) final;
     void sourceBufferPrivateReportExtraMemoryCost(uint64_t extraMemory) final;
-    bool isAsync() const { return true; }
+    bool isAsync() const final { return true; }
 
     // IPC::MessageReceiver
     void didReceiveMessage(IPC::Connection&, IPC::Decoder&) final;
@@ -95,7 +96,7 @@ private:
     void setMediaSourceEnded(bool);
     void setReadyState(WebCore::MediaPlayer::ReadyState);
     void startChangingType();
-    void updateBufferedFromTrackBuffers(bool sourceIsEnded, CompletionHandler<void(WebCore::PlatformTimeRanges&&)>&&);
+    void clientReadyStateChanged(bool sourceIsEnded);
     void removeCodedFrames(const MediaTime& start, const MediaTime& end, const MediaTime& currentTime, bool isEnded, CompletionHandler<void(WebCore::PlatformTimeRanges&&, uint64_t)>&&);
     void evictCodedFrames(uint64_t newDataSize, uint64_t maximumBufferSize, const MediaTime& currentTime, bool isEnded, CompletionHandler<void(WebCore::PlatformTimeRanges&&, uint64_t)>&&);
     void addTrackBuffer(TrackPrivateRemoteIdentifier);

--- a/Source/WebKit/GPUProcess/media/RemoteSourceBufferProxy.messages.in
+++ b/Source/WebKit/GPUProcess/media/RemoteSourceBufferProxy.messages.in
@@ -36,7 +36,7 @@ messages -> RemoteSourceBufferProxy NotRefCounted {
     SetMediaSourceEnded(bool isEnded)
     SetReadyState(WebCore::MediaPlayer::ReadyState state)
     StartChangingType()
-    UpdateBufferedFromTrackBuffers(bool sourceIsEnded) -> (WebCore::PlatformTimeRanges buffered) Synchronous
+    ClientReadyStateChanged(bool sourceIsEnded)
     AddTrackBuffer(WebKit::TrackPrivateRemoteIdentifier remoteIdentifier)
     ResetTrackBuffers()
     ClearTrackBuffers()

--- a/Source/WebKit/WebProcess/GPU/media/SourceBufferPrivateRemote.h
+++ b/Source/WebKit/WebProcess/GPU/media/SourceBufferPrivateRemote.h
@@ -92,7 +92,7 @@ private:
     void setGroupStartTimestamp(const MediaTime&) final;
     void setGroupStartTimestampToEndTimestamp() final;
     void setShouldGenerateTimestamps(bool) final;
-    void updateBufferedFromTrackBuffers(bool sourceIsEnded) final;
+    void clientReadyStateChanged(bool) final;
     void removeCodedFrames(const MediaTime& start, const MediaTime& end, const MediaTime& currentMediaTime, bool isEnded, CompletionHandler<void()>&&) final;
     void evictCodedFrames(uint64_t newDataSize, uint64_t maximumBufferSize, const MediaTime& currentTime, bool isEnded) final;
     void resetTimestampOffsetInTrackBuffers() final;
@@ -118,6 +118,7 @@ private:
     void sourceBufferPrivateAppendComplete(WebCore::SourceBufferPrivateClient::AppendResult, uint64_t totalTrackBufferSizeInBytes, const MediaTime& timestampOffset);
     void sourceBufferPrivateHighestPresentationTimestampChanged(const MediaTime&);
     void sourceBufferPrivateBufferedChanged(WebCore::PlatformTimeRanges&&, CompletionHandler<void()>&&);
+    void sourceBufferPrivateTrackBuffersChanged(Vector<WebCore::PlatformTimeRanges>&&);
     void sourceBufferPrivateDurationChanged(const MediaTime&, CompletionHandler<void()>&&);
     void sourceBufferPrivateDidParseSample(double sampleDuration);
     void sourceBufferPrivateDidDropSample();
@@ -133,6 +134,7 @@ private:
 
     HashMap<AtomString, TrackPrivateRemoteIdentifier> m_trackIdentifierMap;
     HashMap<AtomString, TrackPrivateRemoteIdentifier> m_prevTrackIdentifierMap;
+    Vector<WebCore::PlatformTimeRanges> m_trackBufferRanges;
 
     bool m_isActive { false };
     uint64_t m_totalTrackBufferSizeInBytes = { 0 };

--- a/Source/WebKit/WebProcess/GPU/media/SourceBufferPrivateRemote.messages.in
+++ b/Source/WebKit/WebProcess/GPU/media/SourceBufferPrivateRemote.messages.in
@@ -31,6 +31,7 @@ messages -> SourceBufferPrivateRemote NotRefCounted {
     SourceBufferPrivateAppendComplete(WebCore::SourceBufferPrivateClient::AppendResult appendResult, uint64_t totalTrackBufferSizeInBytes, MediaTime timeStampOffset)
     SourceBufferPrivateHighestPresentationTimestampChanged(MediaTime timestamp)
     SourceBufferPrivateBufferedChanged(WebCore::PlatformTimeRanges buffered) -> ()
+    SourceBufferPrivateTrackBuffersChanged(Vector<WebCore::PlatformTimeRanges> trackBuffers)
     SourceBufferPrivateDurationChanged(MediaTime duration) -> ()
     SourceBufferPrivateDidParseSample(double sampleDuration)
     SourceBufferPrivateDidDropSample()


### PR DESCRIPTION
#### dab28312bc80bc475196b7d6221b060347254e33
<pre>
[ManagedMSE] onbufferedchange fired too many times if GPU process isn&apos;t in use.
<a href="https://bugs.webkit.org/show_bug.cgi?id=257057">https://bugs.webkit.org/show_bug.cgi?id=257057</a>
rdar://problem/109586019

Reviewed by Youenn Fablet.

In bug 253560, changes were made so that we correctly re-calculated the
buffered range and notify of the changes back to the SourcebufferPrivateClient.
However it left an issue open: the SourceBufferPrivateClient would be notified
twice whenever the buffered attribute changed.
When running in the GPU process, this wasn&apos;t a problem as the RemoteSourceBufferProxy
would then only send a single message to the content process, and so the
event was only fired once.
But in WK1, both would lead the `bufferedchanged` event to be fired, and
the test in place only ensured that it was fired, not how many times.
We remove the redundant call to `sourceBufferPrivateBufferedChanged`.

Fly-by fix: The SourceBuffer once closed would notify the SourceBufferPrivate
that it should recalculate the buffered range to execute step 6.2.2.4.2
(<a href="https://w3c.github.io/media-source/#htmlmediaelement-extensions-buffered)">https://w3c.github.io/media-source/#htmlmediaelement-extensions-buffered)</a>
which is a synchronous process.
This caused the need for UpdateBufferedFromTrackBuffers IPC message to be
synchronous as well as it required access to the SourceBuffer&apos;s track buffers
living in the GPU process.
To get around this, we add a new IPC method that allows the CP&apos;s SourceBufferPrivateRemote
to cache its own copy of all the track buffers ranges. So that when the SourceBuffer
gets ended, we can immediately locally calculate the new buffered range
without the need to query the GPU process and the sync call can be removed.
The track buffers&apos; ranges are updated in the CP&apos;s SourceBufferPrivateRemote
when:
- during the prepare append algorithm
- after an append operation
- after a remove operation
- if ManagedSourceBuffer, after a memory pressure signal.

There is now only one SourceBufferPrivate synchronous IPC method left: EvictCodedFrames.

* LayoutTests/media/media-source/media-managedmse-bufferedchange-expected.txt:
* LayoutTests/media/media-source/media-managedmse-bufferedchange.html: log whenever
the bufferedchange event is called.
* Source/WebCore/Modules/mediasource/SourceBuffer.cpp:
(WebCore::SourceBuffer::readyStateChanged):
* Source/WebCore/platform/graphics/SourceBufferPrivate.cpp:
(WebCore::SourceBufferPrivate::trackBuffersRanges const):
(WebCore::SourceBufferPrivate::clientReadyStateChanged):
(WebCore::SourceBufferPrivate::updateBufferedFromTrackBuffers):
(WebCore::SourceBufferPrivate::processAppendCompletedOperation):
(WebCore::SourceBufferPrivate::clearTrackBuffers):
(WebCore::SourceBufferPrivate::removeCodedFrames):
* Source/WebCore/platform/graphics/SourceBufferPrivate.h:
(WebCore::SourceBufferPrivate::setShouldGenerateTimestamps):
(WebCore::SourceBufferPrivate::updateBufferedFromTrackBuffers):
* Source/WebCore/platform/graphics/SourceBufferPrivateClient.h:
(WebCore::SourceBufferPrivateClient::sourceBufferPrivateTrackBuffersChanged):
* Source/WebKit/GPUProcess/media/RemoteSourceBufferProxy.cpp:
(WebKit::RemoteSourceBufferProxy::sourceBufferPrivateTrackBuffersChanged):
(WebKit::RemoteSourceBufferProxy::clientReadyStateChanged):
(WebKit::RemoteSourceBufferProxy::updateBufferedFromTrackBuffers): Deleted.
* Source/WebKit/GPUProcess/media/RemoteSourceBufferProxy.h:
* Source/WebKit/GPUProcess/media/RemoteSourceBufferProxy.messages.in:
* Source/WebKit/WebProcess/GPU/media/SourceBufferPrivateRemote.cpp:
(WebKit::SourceBufferPrivateRemote::clientReadyStateChanged):
(WebKit::SourceBufferPrivateRemote::sourceBufferPrivateTrackBuffersChanged):
(WebKit::SourceBufferPrivateRemote::updateBufferedFromTrackBuffers): Deleted.
* Source/WebKit/WebProcess/GPU/media/SourceBufferPrivateRemote.h:
* Source/WebKit/WebProcess/GPU/media/SourceBufferPrivateRemote.messages.in:

Canonical link: <a href="https://commits.webkit.org/264467@main">https://commits.webkit.org/264467@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/fc807f154b6e487794a0f4ce33cfef55e931f2ec

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/7715 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/7985 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/8167 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/9355 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/32/builds/7873 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/7721 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/9975 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/7906 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/10741 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/7849 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/8965 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/7084 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/9463 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/6275 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/7024 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/14687 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/7432 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/7148 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/10553 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/7638 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/6226 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/6966 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/6934 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/1840 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/11176 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/7372 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->