### PR TITLE
Add BufferedChangeEvent object

### DIFF
--- a/LayoutTests/media/media-source/media-managedmse-bufferedchange-expected.txt
+++ b/LayoutTests/media/media-source/media-managedmse-bufferedchange-expected.txt
@@ -9,12 +9,14 @@ EVENT(update)
 Append a media segment.
 RUN(sourceBuffer.appendBuffer(loader.mediaSegment(0)))
 onbufferedchange called.
+EXPECTED (bufferedChangeEvent.__proto__ == '[object BufferedChangeEvent]') OK
 EVENT(bufferedchange)
 EVENT(update)
 EXPECTED (sourceBuffer.buffered.length == '1') OK
 Clean sourcebuffer of all content.
 RUN(sourceBuffer.remove(0, sourceBuffer.buffered.end(0)))
 onbufferedchange called.
+EXPECTED (bufferedChangeEvent.__proto__ == '[object BufferedChangeEvent]') OK
 EVENT(bufferedchange)
 EVENT(update)
 EXPECTED (sourceBuffer.buffered.length == '0') OK

--- a/LayoutTests/media/media-source/media-managedmse-bufferedchange.html
+++ b/LayoutTests/media/media-source/media-managedmse-bufferedchange.html
@@ -8,6 +8,7 @@
     var loader;
     var source;
     var sourceBuffer;
+    var bufferedChangeEvent;
 
     function loaderPromise(loader) {
         return new Promise((resolve, reject) => {
@@ -38,8 +39,10 @@
             testExpected('sourceBuffer.__proto__', ManagedSourceBuffer.prototype);
             testExpected('sourceBuffer.onbufferedchange !== undefined', true);
 
-            sourceBuffer.onbufferedchange = () => {
+            sourceBuffer.onbufferedchange = (e) => {
                 consoleWrite('onbufferedchange called.')
+                bufferedChangeEvent = e;
+                testExpected('bufferedChangeEvent.__proto__', BufferedChangeEvent.prototype);
             };
 
             run('sourceBuffer.appendBuffer(loader.initSegment())');

--- a/LayoutTests/media/media-source/mock-managedmse-bufferedchange-expected.txt
+++ b/LayoutTests/media/media-source/mock-managedmse-bufferedchange-expected.txt
@@ -1,0 +1,103 @@
+
+EXPECTED (source.readyState == 'closed') OK
+RUN(sourceElement = document.createElement("source"))
+RUN(sourceElement.type = "video/mock; codecs=mock")
+RUN(sourceElement.src = URL.createObjectURL(source))
+RUN(video.appendChild(sourceElement))
+RUN(sourceElement = document.createElement("source"))
+RUN(sourceElement.src = "http://foo.com/playlist.m3u8")
+RUN(sourceElement.type = "application/vnd.apple.mpegurl")
+RUN(video.appendChild(sourceElement))
+EVENT(sourceopen)
+RUN(sourceBuffer = source.addSourceBuffer("video/mock; codecs=mock"))
+RUN(sourceBuffer.appendBuffer(initSegment))
+EVENT(updateend)
+RUN(sourceBuffer.appendBuffer(syncSampleRun(5, 10)))
+onbufferedchange called.
+e.addedRanges = [5, 10)
+e.removedRanges = null
+EVENT(update)
+EXPECTED (sourceBuffer.buffered.length == '1') OK
+RUN(sourceBuffer.appendBuffer(syncSampleRun(0, 5)))
+onbufferedchange called.
+e.addedRanges = [0, 5)
+e.removedRanges = null
+EVENT(update)
+EXPECTED (sourceBuffer.buffered.length == '1') OK
+Clean sourcebuffer of all content.
+RUN(sourceBuffer.remove(0, sourceBuffer.buffered.end(0)))
+onbufferedchange called.
+e.addedRanges = null
+e.removedRanges = [0, 10)
+EVENT(update)
+EXPECTED (sourceBuffer.buffered.length == '0') OK
+RUN(sourceBuffer.appendBuffer(syncSampleRun(0, 3)))
+onbufferedchange called.
+e.addedRanges = [0, 3)
+e.removedRanges = null
+EVENT(update)
+RUN(sourceBuffer.appendBuffer(syncSampleRun(3, 6)))
+onbufferedchange called.
+e.addedRanges = [3, 6)
+e.removedRanges = null
+EVENT(update)
+RUN(sourceBuffer.appendBuffer(syncSampleRun(6, 9)))
+onbufferedchange called.
+e.addedRanges = [6, 9)
+e.removedRanges = null
+EVENT(update)
+Re-adding the same samples does not update the buffer
+RUN(sourceBuffer.appendBuffer(syncSampleRun(0, 3)))
+EVENT(update)
+Removing first sync sample, remove the first 3 seconds block
+RUN(sourceBuffer.remove(0, 1))
+onbufferedchange called.
+e.addedRanges = null
+e.removedRanges = [0, 3)
+EVENT(update)
+Removing from 8 to infinity, remove to the end of existing buffer
+RUN(sourceBuffer.remove(8, Infinity))
+onbufferedchange called.
+e.addedRanges = null
+e.removedRanges = [8, 9)
+EVENT(update)
+Removing from empty range, does not update the buffer
+RUN(sourceBuffer.remove(0, 2))
+EVENT(update)
+Removing from non-sync sample
+RUN(sourceBuffer.remove(4, 5))
+onbufferedchange called.
+e.addedRanges = null
+e.removedRanges = [4, 6)
+EVENT(update)
+Overriding sync sample, remove following block and only update buffer for missing samples
+before: [3, 4)[6, 8)
+RUN(sourceBuffer.appendBuffer(syncSampleRun(5, 7)))
+onbufferedchange called.
+e.addedRanges = [5, 6)
+e.removedRanges = [7, 8)
+EVENT(update)
+after: [3, 4)[5, 7)
+Only report samples added in missing intervals
+RUN(sourceBuffer.appendBuffer(syncSampleRun(0, 10, 2)))
+onbufferedchange called.
+e.addedRanges = [0, 3)[4, 5)[7, 10)
+e.removedRanges = null
+EVENT(update)
+RUN(sourceBuffer.remove(2, 4))
+onbufferedchange called.
+e.addedRanges = null
+e.removedRanges = [2, 4)
+EVENT(update)
+RUN(sourceBuffer.remove(6, 8))
+onbufferedchange called.
+e.addedRanges = null
+e.removedRanges = [6, 8)
+EVENT(update)
+RUN(sourceBuffer.remove(0, 10))
+onbufferedchange called.
+e.addedRanges = null
+e.removedRanges = [0, 2)[4, 6)[8, 10)
+EVENT(update)
+END OF TEST
+

--- a/LayoutTests/media/media-source/mock-managedmse-bufferedchange.html
+++ b/LayoutTests/media/media-source/mock-managedmse-bufferedchange.html
@@ -1,0 +1,117 @@
+<!DOCTYPE html> <!-- webkit-test-runner [ ManagedMediaSourceEnabled=true MediaSourceEnabled=true ] -->
+<html>
+<head>
+    <title>managedmediasource</title>
+    <script src="mock-media-source.js"></script>
+    <script src="../../media/video-test.js"></script>
+    <script src="../../media/utilities.js"></script>
+    <script>
+    var loader;
+    var source;
+    var sourceBuffer;
+    var bufferedChangeEvent;
+    var sourceElement;
+
+    if (window.internals)
+        internals.initializeMockMediaSource();
+
+    function syncSampleRun(start, end, stepSync = 9999999999) {
+        const samples = [];
+        for (let time = start; time < end; time++)
+            samples.push(makeASample(time, time, 1, 1, 1, (time - start) % stepSync == 0 ? SAMPLE_FLAG.SYNC : SAMPLE_FLAG.NONE));
+        return concatenateSamples(samples);
+    }
+
+    window.addEventListener('load', async event => {
+        findMediaElement();
+
+        source = new ManagedMediaSource();
+
+        testExpected('source.readyState', 'closed');
+        run('sourceElement = document.createElement("source")');
+        run('sourceElement.type = "video/mock; codecs=mock"');
+        run('sourceElement.src = URL.createObjectURL(source)');
+        run('video.appendChild(sourceElement)');
+        run('sourceElement = document.createElement("source")');
+        run('sourceElement.src = "http://foo.com/playlist.m3u8"');
+        run('sourceElement.type = "application/vnd.apple.mpegurl"');
+        run('video.appendChild(sourceElement)');
+        await waitFor(source, 'sourceopen');
+
+        run('sourceBuffer = source.addSourceBuffer("video/mock; codecs=mock")');
+        sourceBuffer.onbufferedchange = (e) => {
+            consoleWrite('onbufferedchange called.')
+            consoleWrite(`e.addedRanges = ${ timeRangesToString(e.addedRanges) }`);
+            consoleWrite(`e.removedRanges = ${ timeRangesToString(e.removedRanges) }`);
+        };
+
+        initSegment = makeAInit(10, [makeATrack(1, 'mock', TRACK_KIND.VIDEO)]);
+
+        run('sourceBuffer.appendBuffer(initSegment)');
+        await waitFor(sourceBuffer, 'updateend');
+
+        run('sourceBuffer.appendBuffer(syncSampleRun(5, 10))');
+        await waitFor(sourceBuffer, 'update');
+        testExpected('sourceBuffer.buffered.length', '1');
+
+        run('sourceBuffer.appendBuffer(syncSampleRun(0, 5))');
+        await waitFor(sourceBuffer, 'update');
+        testExpected('sourceBuffer.buffered.length', '1');
+
+        consoleWrite('Clean sourcebuffer of all content.');
+        run('sourceBuffer.remove(0, sourceBuffer.buffered.end(0))');
+        await waitFor(sourceBuffer, 'update');
+        testExpected('sourceBuffer.buffered.length', '0');
+
+        run('sourceBuffer.appendBuffer(syncSampleRun(0, 3))');
+        await waitFor(sourceBuffer, 'update');
+        run('sourceBuffer.appendBuffer(syncSampleRun(3, 6))');
+        await waitFor(sourceBuffer, 'update');
+        run('sourceBuffer.appendBuffer(syncSampleRun(6, 9))');
+        await waitFor(sourceBuffer, 'update');
+
+        consoleWrite('Re-adding the same samples does not update the buffer');
+        run('sourceBuffer.appendBuffer(syncSampleRun(0, 3))');
+        await waitFor(sourceBuffer, 'update');
+
+        consoleWrite('Removing first sync sample, remove the first 3 seconds block');
+        run('sourceBuffer.remove(0, 1)');
+        await waitFor(sourceBuffer, 'update');
+
+        consoleWrite('Removing from 8 to infinity, remove to the end of existing buffer');
+        run('sourceBuffer.remove(8, Infinity)');
+        await waitFor(sourceBuffer, 'update');
+
+        consoleWrite('Removing from empty range, does not update the buffer');
+        run('sourceBuffer.remove(0, 2)');
+        await waitFor(sourceBuffer, 'update');
+
+        consoleWrite('Removing from non-sync sample');
+        run('sourceBuffer.remove(4, 5)');
+        await waitFor(sourceBuffer, 'update');
+
+        consoleWrite('Overriding sync sample, remove following block and only update buffer for missing samples');
+        consoleWrite(`before: ${ timeRangesToString(sourceBuffer.buffered) }`);
+        run('sourceBuffer.appendBuffer(syncSampleRun(5, 7))');
+        await waitFor(sourceBuffer, 'update');
+        consoleWrite(`after: ${ timeRangesToString(sourceBuffer.buffered) }`);
+
+        consoleWrite('Only report samples added in missing intervals');
+        run('sourceBuffer.appendBuffer(syncSampleRun(0, 10, 2))');
+        await waitFor(sourceBuffer, 'update');
+
+        run('sourceBuffer.remove(2, 4)');
+        await waitFor(sourceBuffer, 'update');
+        run('sourceBuffer.remove(6, 8)');
+        await waitFor(sourceBuffer, 'update');
+        run('sourceBuffer.remove(0, 10)');
+        await waitFor(sourceBuffer, 'update');
+
+        endTest();
+    });
+    </script>
+</head>
+<body>
+    <video controls></video>
+</body>
+</html>

--- a/LayoutTests/media/utilities.js
+++ b/LayoutTests/media/utilities.js
@@ -78,3 +78,15 @@ function waitForVideoFrameUntil(video, time, cb) {
         p.then(cb);
     return p;
 }
+
+function timeRangesToString(ranges) {
+    var str = "";
+    if (!!!ranges) {
+        str += "null";
+        return str;
+    }
+    for (var i = 0; i < ranges.length; i++) {
+        str += "[" + ranges.start(i) + ", " + ranges.end(i) + ")";
+    }
+    return str;
+}

--- a/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
+++ b/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
@@ -3911,7 +3911,7 @@ ManagedMediaSourceEnabled:
   category: media
   humanReadableName: "Managed Media Source API"
   humanReadableDescription: "Managed Media Source API"
-  condition: ENABLE(MANAGED_MEDIA_SOURCE) && ENABLE(MEDIA_SOURCE)
+  condition: ENABLE(MANAGED_MEDIA_SOURCE)
   defaultValue:
     WebKitLegacy:
       default: false
@@ -3946,7 +3946,7 @@ ManagedMediaSourceNeedsAirPlay:
   category: media
   humanReadableName: "Managed Media Source Requires AirPlay source"
   humanReadableDescription: "Managed Media Source Requires AirPlay source"
-  condition: ENABLE(MANAGED_MEDIA_SOURCE) && ENABLE(MEDIA_SOURCE) && ENABLE(WIRELESS_PLAYBACK_TARGET)
+  condition: ENABLE(MANAGED_MEDIA_SOURCE) && ENABLE(WIRELESS_PLAYBACK_TARGET)
   defaultValue:
     WebKitLegacy:
       default: false

--- a/Source/WebCore/CMakeLists.txt
+++ b/Source/WebCore/CMakeLists.txt
@@ -407,6 +407,7 @@ set(WebCore_NON_SVG_IDL_FILES
     Modules/mediasession/Navigator+MediaSession.idl
 
     Modules/mediasource/AudioTrack+MediaSource.idl
+    Modules/mediasource/BufferedChangeEvent.idl
     Modules/mediasource/DOMURL+MediaSource.idl
     Modules/mediasource/ManagedMediaSource.idl
     Modules/mediasource/ManagedSourceBuffer.idl

--- a/Source/WebCore/DerivedSources-input.xcfilelist
+++ b/Source/WebCore/DerivedSources-input.xcfilelist
@@ -393,6 +393,7 @@ $(PROJECT_DIR)/Modules/mediasession/MediaSessionPlaylistMixin.idl
 $(PROJECT_DIR)/Modules/mediasession/MediaSessionReadyState.idl
 $(PROJECT_DIR)/Modules/mediasession/Navigator+MediaSession.idl
 $(PROJECT_DIR)/Modules/mediasource/AudioTrack+MediaSource.idl
+$(PROJECT_DIR)/Modules/mediasource/BufferedChangeEvent.idl
 $(PROJECT_DIR)/Modules/mediasource/DOMURL+MediaSource.idl
 $(PROJECT_DIR)/Modules/mediasource/ManagedMediaSource.idl
 $(PROJECT_DIR)/Modules/mediasource/ManagedSourceBuffer.idl

--- a/Source/WebCore/DerivedSources-output.xcfilelist
+++ b/Source/WebCore/DerivedSources-output.xcfilelist
@@ -341,6 +341,8 @@ $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSBlobPropertyBag.cpp
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSBlobPropertyBag.h
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSBroadcastChannel.cpp
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSBroadcastChannel.h
+$(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSBufferedChangeEvent.cpp
+$(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSBufferedChangeEvent.h
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSByteLengthQueuingStrategy.cpp
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSByteLengthQueuingStrategy.h
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSCDATASection.cpp

--- a/Source/WebCore/DerivedSources.make
+++ b/Source/WebCore/DerivedSources.make
@@ -396,6 +396,7 @@ JS_BINDING_IDLS := \
     $(WebCore)/Modules/mediarecorder/MediaRecorder.idl \
     $(WebCore)/Modules/mediarecorder/MediaRecorderErrorEvent.idl \
     $(WebCore)/Modules/mediasource/AudioTrack+MediaSource.idl \
+    $(WebCore)/Modules/mediasource/BufferedChangeEvent.idl \
     $(WebCore)/Modules/mediasource/DOMURL+MediaSource.idl \
     $(WebCore)/Modules/mediasource/ManagedMediaSource.idl \
     $(WebCore)/Modules/mediasource/ManagedSourceBuffer.idl \

--- a/Source/WebCore/Modules/mediasource/BufferedChangeEvent.cpp
+++ b/Source/WebCore/Modules/mediasource/BufferedChangeEvent.cpp
@@ -1,0 +1,63 @@
+/*
+ * Copyright (C) 2023 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+
+#if ENABLE(MANAGED_MEDIA_SOURCE)
+#include "BufferedChangeEvent.h"
+
+#include "Event.h"
+#include "EventNames.h"
+#include "TimeRanges.h"
+#include <wtf/IsoMallocInlines.h>
+
+namespace WebCore {
+
+WTF_MAKE_ISO_ALLOCATED_IMPL(BufferedChangeEvent);
+
+BufferedChangeEvent::BufferedChangeEvent(RefPtr<TimeRanges>&& added, RefPtr<TimeRanges>&& removed)
+    : Event(eventNames().bufferedchangeEvent, CanBubble::No, IsCancelable::No)
+    , m_added(WTFMove(added))
+    , m_removed(WTFMove(removed))
+{
+}
+
+BufferedChangeEvent::BufferedChangeEvent(const AtomString& type, Init&& init)
+    : Event(type, init, IsTrusted::No)
+    , m_added(WTFMove(init.addedRanges))
+    , m_removed(WTFMove(init.removedRanges))
+{
+}
+
+BufferedChangeEvent::~BufferedChangeEvent() = default;
+
+EventInterface BufferedChangeEvent::eventInterface() const
+{
+    return BufferedChangeEventInterfaceType;
+}
+
+} // namespace WebCore
+
+#endif

--- a/Source/WebCore/Modules/mediasource/BufferedChangeEvent.h
+++ b/Source/WebCore/Modules/mediasource/BufferedChangeEvent.h
@@ -1,0 +1,70 @@
+/*
+ * Copyright (C) 2023 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#if ENABLE(MANAGED_MEDIA_SOURCE)
+
+#include "Event.h"
+
+namespace WebCore {
+
+class TimeRanges;
+
+class BufferedChangeEvent final : public Event {
+    WTF_MAKE_ISO_ALLOCATED(BufferedChangeEvent);
+public:
+    ~BufferedChangeEvent();
+
+    struct Init : EventInit {
+        RefPtr<TimeRanges> addedRanges;
+        RefPtr<TimeRanges> removedRanges;
+    };
+
+    static Ref<BufferedChangeEvent> create(RefPtr<TimeRanges>&& added, RefPtr<TimeRanges>&& removed)
+    {
+        return adoptRef(*new BufferedChangeEvent(WTFMove(added), WTFMove(removed)));
+    }
+
+    static Ref<BufferedChangeEvent> create(const AtomString& type, Init&& init)
+    {
+        return adoptRef(*new BufferedChangeEvent(type, WTFMove(init)));
+    }
+
+    RefPtr<TimeRanges> addedRanges() const { return m_added; }
+    RefPtr<TimeRanges> removedRanges() const { return m_removed; }
+
+private:
+    BufferedChangeEvent(RefPtr<TimeRanges>&& added, RefPtr<TimeRanges>&& removed);
+    BufferedChangeEvent(const AtomString& type, Init&&);
+    EventInterface eventInterface() const final;
+
+    RefPtr<TimeRanges> m_added;
+    RefPtr<TimeRanges> m_removed;
+};
+
+} // namespace WebCore
+
+#endif

--- a/Source/WebCore/Modules/mediasource/BufferedChangeEvent.idl
+++ b/Source/WebCore/Modules/mediasource/BufferedChangeEvent.idl
@@ -1,0 +1,44 @@
+/*
+ * Copyright (C) 2023 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+[
+    Conditional=MANAGED_MEDIA_SOURCE,
+    EnabledBySetting=ManagedMediaSourceEnabled
+]
+dictionary BufferedChangeEventInit : EventInit {
+  TimeRanges? addedRanges = null;
+  TimeRanges? removedRanges = null;
+};
+
+[
+    Conditional=MANAGED_MEDIA_SOURCE,
+    EnabledBySetting=ManagedMediaSourceEnabled,
+    Exposed=Window
+]
+interface BufferedChangeEvent : Event {
+  constructor([AtomString] DOMString type, optional BufferedChangeEventInit eventInitDict);
+  [SameObject] readonly attribute TimeRanges? addedRanges;
+  [SameObject] readonly attribute TimeRanges? removedRanges;
+};

--- a/Source/WebCore/Modules/mediasource/ManagedMediaSource.cpp
+++ b/Source/WebCore/Modules/mediasource/ManagedMediaSource.cpp
@@ -26,7 +26,7 @@
 #include "config.h"
 #include "ManagedMediaSource.h"
 
-#if ENABLE(MANAGED_MEDIA_SOURCE) && ENABLE(MEDIA_SOURCE)
+#if ENABLE(MANAGED_MEDIA_SOURCE)
 
 #include "Event.h"
 #include "EventNames.h"

--- a/Source/WebCore/Modules/mediasource/ManagedMediaSource.h
+++ b/Source/WebCore/Modules/mediasource/ManagedMediaSource.h
@@ -25,7 +25,7 @@
 
 #pragma once
 
-#if ENABLE(MANAGED_MEDIA_SOURCE) && ENABLE(MEDIA_SOURCE)
+#if ENABLE(MANAGED_MEDIA_SOURCE)
 
 #include "MediaSource.h"
 #include "Timer.h"

--- a/Source/WebCore/Modules/mediasource/ManagedMediaSource.idl
+++ b/Source/WebCore/Modules/mediasource/ManagedMediaSource.idl
@@ -31,7 +31,7 @@ enum PreferredQuality {
 
 [
     ActiveDOMObject,
-    Conditional=MANAGED_MEDIA_SOURCE&MEDIA_SOURCE,
+    Conditional=MANAGED_MEDIA_SOURCE,
     EnabledBySetting=ManagedMediaSourceEnabled,
     Exposed=Window
 ] interface ManagedMediaSource : MediaSource {

--- a/Source/WebCore/Modules/mediasource/ManagedSourceBuffer.cpp
+++ b/Source/WebCore/Modules/mediasource/ManagedSourceBuffer.cpp
@@ -26,7 +26,7 @@
 #include "config.h"
 #include "ManagedSourceBuffer.h"
 
-#if ENABLE(MANAGED_MEDIA_SOURCE) && ENABLE(MEDIA_SOURCE)
+#if ENABLE(MANAGED_MEDIA_SOURCE)
 
 #include "ManagedMediaSource.h"
 #include <wtf/IsoMallocInlines.h>

--- a/Source/WebCore/Modules/mediasource/ManagedSourceBuffer.h
+++ b/Source/WebCore/Modules/mediasource/ManagedSourceBuffer.h
@@ -25,7 +25,7 @@
 
 #pragma once
 
-#if ENABLE(MANAGED_MEDIA_SOURCE) && ENABLE(MEDIA_SOURCE)
+#if ENABLE(MANAGED_MEDIA_SOURCE)
 
 #include "SourceBuffer.h"
 

--- a/Source/WebCore/Modules/mediasource/ManagedSourceBuffer.idl
+++ b/Source/WebCore/Modules/mediasource/ManagedSourceBuffer.idl
@@ -25,7 +25,7 @@
 
 [
     ActiveDOMObject,
-    Conditional=MANAGED_MEDIA_SOURCE&MEDIA_SOURCE,
+    Conditional=MANAGED_MEDIA_SOURCE,
     EnabledBySetting=ManagedMediaSourceEnabled,
     ExportMacro=WEBCORE_EXPORT,
     GenerateAddOpaqueRoot,

--- a/Source/WebCore/Modules/mediasource/MediaSource.cpp
+++ b/Source/WebCore/Modules/mediasource/MediaSource.cpp
@@ -1237,6 +1237,7 @@ void MediaSource::failedToCreateRenderer(RendererType type)
         context->addConsoleMessage(MessageSource::JS, MessageLevel::Error, makeString("MediaSource ", type == RendererType::Video ? "video" : "audio", " renderer creation failed."));
 }
 
+#if ENABLE(MANAGED_MEDIA_SOURCE)
 void MediaSource::memoryPressure()
 {
     if (!isManaged())
@@ -1244,6 +1245,7 @@ void MediaSource::memoryPressure()
     for (auto& sourceBuffer : *m_sourceBuffers)
         sourceBuffer->memoryPressure();
 }
+#endif
 
 }
 

--- a/Source/WebCore/Modules/mediasource/MediaSource.h
+++ b/Source/WebCore/Modules/mediasource/MediaSource.h
@@ -128,8 +128,10 @@ public:
 
     void failedToCreateRenderer(RendererType) final;
 
+#if ENABLE(MANAGED_MEDIA_SOURCE)
     virtual bool isManaged() const { return false; }
     void memoryPressure();
+#endif
 
 protected:
     explicit MediaSource(ScriptExecutionContext&);

--- a/Source/WebCore/Modules/mediasource/SourceBuffer.cpp
+++ b/Source/WebCore/Modules/mediasource/SourceBuffer.cpp
@@ -38,6 +38,7 @@
 #include "AudioTrackList.h"
 #include "AudioTrackPrivate.h"
 #include "BufferSource.h"
+#include "BufferedChangeEvent.h"
 #include "ContentTypeUtilities.h"
 #include "Event.h"
 #include "EventNames.h"
@@ -120,8 +121,7 @@ ExceptionOr<Ref<TimeRanges>> SourceBuffer::buffered()
         return Exception { InvalidStateError };
 
     // 5. If intersection ranges does not contain the exact same range information as the current value of this attribute, then update the current value of this attribute to intersection ranges.
-    if (m_buffered->ranges() != m_private->buffered())
-        m_buffered = TimeRanges::create(m_private->buffered());
+    // Handled by sourceBufferPrivateBufferedChanged().
 
     // 6. Return the current value of this attribute.
     return Ref { m_buffered };
@@ -1356,11 +1356,25 @@ void SourceBuffer::setShouldGenerateTimestamps(bool flag)
     m_private->setShouldGenerateTimestamps(flag);
 }
 
-void SourceBuffer::sourceBufferPrivateBufferedChanged(const PlatformTimeRanges&, CompletionHandler<void()>&& completionHandler)
+void SourceBuffer::sourceBufferPrivateBufferedChanged(const PlatformTimeRanges& ranges, CompletionHandler<void()>&& completionHandler)
 {
+    ASSERT(ranges != m_buffered->ranges(), "sourceBufferPrivateBufferedChanged should only be called if the ranges did change");
+#if ENABLE(MANAGED_MEDIA_SOURCE)
+    if (isManaged()) {
+        auto addedRanges = ranges;
+        addedRanges -= m_buffered->ranges();
+        auto addedTimeRanges = addedRanges.length() ? RefPtr { TimeRanges::create(WTFMove(addedRanges)) } : nullptr;
+
+        auto removedRanges = m_buffered->ranges();
+        removedRanges -= ranges;
+        auto removedTimeRanges = removedRanges.length() ? RefPtr { TimeRanges::create(WTFMove(removedRanges)) } : nullptr;
+
+        ASSERT(addedTimeRanges || removedTimeRanges, "Can't generate an empty dictionary");
+        queueTaskToDispatchEvent(*this, TaskSource::MediaElement, BufferedChangeEvent::create(WTFMove(addedTimeRanges), WTFMove(removedTimeRanges)));
+    }
+#endif
+    m_buffered = TimeRanges::create(ranges);
     setBufferedDirty(true);
-    if (isManaged())
-        scheduleEvent(eventNames().bufferedchangeEvent);
     completionHandler();
 }
 
@@ -1393,12 +1407,14 @@ WebCoreOpaqueRoot SourceBuffer::opaqueRoot()
     return WebCoreOpaqueRoot { this };
 }
 
+#if ENABLE(MANAGED_MEDIA_SOURCE)
 void SourceBuffer::memoryPressure()
 {
     if (!isManaged())
         return;
     m_private->memoryPressure(maximumBufferSize(), m_source->currentTime(), m_source->isEnded());
 }
+#endif
 
 #if !RELEASE_LOG_DISABLED
 WTFLogChannel& SourceBuffer::logChannel() const

--- a/Source/WebCore/Modules/mediasource/SourceBuffer.h
+++ b/Source/WebCore/Modules/mediasource/SourceBuffer.h
@@ -145,8 +145,10 @@ public:
 
     WebCoreOpaqueRoot opaqueRoot();
 
+#if ENABLE(MANAGED_MEDIA_SOURCE)
     virtual bool isManaged() const { return false; }
     void memoryPressure();
+#endif
 
 protected:
     SourceBuffer(Ref<SourceBufferPrivate>&&, MediaSource&);

--- a/Source/WebCore/Sources.txt
+++ b/Source/WebCore/Sources.txt
@@ -184,6 +184,7 @@ Modules/mediarecorder/BlobEvent.cpp
 Modules/mediarecorder/MediaRecorder.cpp
 Modules/mediarecorder/MediaRecorderErrorEvent.cpp
 Modules/mediarecorder/MediaRecorderProvider.cpp
+Modules/mediasource/BufferedChangeEvent.cpp
 Modules/mediasource/DOMURLMediaSource.cpp
 Modules/mediasource/ManagedMediaSource.cpp
 Modules/mediasource/ManagedSourceBuffer.cpp
@@ -3147,6 +3148,7 @@ JSBlob.cpp
 JSBlobCallback.cpp
 JSBlobEvent.cpp
 JSBlobPropertyBag.cpp
+JSBufferedChangeEvent.cpp
 JSBroadcastChannel.cpp
 JSByteLengthQueuingStrategy.cpp
 JSCDATASection.cpp

--- a/Source/WebCore/bindings/js/WebCoreBuiltinNames.h
+++ b/Source/WebCore/bindings/js/WebCoreBuiltinNames.h
@@ -101,6 +101,7 @@ namespace WebCore {
     macro(BiquadFilterNode) \
     macro(BlobEvent) \
     macro(BroadcastChannel) \
+    macro(BufferedChangeEvent) \
     macro(Cache) \
     macro(CacheStorage) \
     macro(ChannelMergerNode) \

--- a/Source/WebCore/dom/EventNames.in
+++ b/Source/WebCore/dom/EventNames.in
@@ -10,6 +10,7 @@ BackgroundFetchEvent conditional=SERVICE_WORKER
 BackgroundFetchUpdateUIEvent conditional=SERVICE_WORKER
 BeforeLoadEvent interfaceName=Event
 BeforeUnloadEvent
+BufferedChangeEvent conditional=MANAGED_MEDIA_SOURCE
 ClipboardEvent
 CloseEvent
 CompositionEvent

--- a/Source/WebCore/html/HTMLMediaElement.cpp
+++ b/Source/WebCore/html/HTMLMediaElement.cpp
@@ -8701,7 +8701,7 @@ void HTMLMediaElement::setBufferingPolicy(BufferingPolicy policy)
     m_bufferingPolicy = policy;
     if (m_player)
         m_player->setBufferingPolicy(policy);
-#if ENABLE(MEDIA_SOURCE)
+#if ENABLE(MANAGED_MEDIA_SOURCE)
     if (m_mediaSource && policy == BufferingPolicy::PurgeResources)
         m_mediaSource->memoryPressure();
 #endif
@@ -8712,7 +8712,7 @@ void HTMLMediaElement::purgeBufferedDataIfPossible()
     ALWAYS_LOG(LOGIDENTIFIER);
 
     bool isPausedOrMSE = [&] {
-#if ENABLE(MEDIA_SOURCE)
+#if ENABLE(MANAGED_MEDIA_SOURCE)
         if (m_mediaSource)
             return true;
 #endif

--- a/Source/WebCore/platform/graphics/PlatformTimeRanges.cpp
+++ b/Source/WebCore/platform/graphics/PlatformTimeRanges.cpp
@@ -103,6 +103,37 @@ void PlatformTimeRanges::unionWith(const PlatformTimeRanges& other)
     m_ranges.swap(unioned.m_ranges);
 }
 
+PlatformTimeRanges& PlatformTimeRanges::operator+=(const PlatformTimeRanges& other)
+{
+    unionWith(other);
+    return *this;
+}
+
+PlatformTimeRanges& PlatformTimeRanges::operator-=(const PlatformTimeRanges& other)
+{
+    for (const auto& range : other.m_ranges)
+        *this -= range;
+
+    return *this;
+}
+
+PlatformTimeRanges& PlatformTimeRanges::operator-=(const Range& range)
+{
+    if (range.isEmpty() || m_ranges.isEmpty())
+        return *this;
+
+    auto firstEnd = std::max(m_ranges[0].start, range.start);
+    auto secondStart = std::min(m_ranges.last().end, range.end);
+    Vector<Range> ranges { 2 };
+    if (m_ranges[0].start != firstEnd)
+        ranges.append({ m_ranges[0].start, firstEnd });
+    if (secondStart != m_ranges.last().end)
+        ranges.append({ secondStart, m_ranges.last().end });
+    intersectWith(WTFMove(ranges));
+
+    return *this;
+}
+
 MediaTime PlatformTimeRanges::start(unsigned index) const
 {
     bool ignoredValid;

--- a/Source/WebCore/platform/graphics/PlatformTimeRanges.h
+++ b/Source/WebCore/platform/graphics/PlatformTimeRanges.h
@@ -57,6 +57,8 @@ public:
     void invert();
     void intersectWith(const PlatformTimeRanges&);
     void unionWith(const PlatformTimeRanges&);
+    PlatformTimeRanges& operator+=(const PlatformTimeRanges&);
+    PlatformTimeRanges& operator-=(const PlatformTimeRanges&);
 
     unsigned length() const { return m_ranges.size(); }
 
@@ -79,6 +81,11 @@ public:
     struct Range {
         MediaTime start;
         MediaTime end;
+
+        inline bool isEmpty() const
+        {
+            return start == end;
+        }
 
         inline bool isPointInRange(const MediaTime& point) const
         {
@@ -119,6 +126,7 @@ private:
     friend struct IPC::ArgumentCoder<PlatformTimeRanges, void>;
 
     PlatformTimeRanges(Vector<Range>&&);
+    PlatformTimeRanges& operator-=(const Range&);
 
     Vector<Range> m_ranges;
 };


### PR DESCRIPTION
#### 03f910f7ebd4cbeade20a0c7ebee6043979268ec
<pre>
Add BufferedChangeEvent object
<a href="https://bugs.webkit.org/show_bug.cgi?id=256985">https://bugs.webkit.org/show_bug.cgi?id=256985</a>
rdar://109532732

Reviewed by Youenn Fablet.

Pass to `bufferedchange` a dictionary containing the range added and removed
from the last operation on the source buffer.

Fly-by: remove the need for code to be conditional on both ENABLE(MEDIA_SOURCE) and
ENABLE(MANAGED_MEDIA_SOURCE), assume that if the latter is true, then
so is the first, as doing otherwise would be totally nonsensical.

* LayoutTests/media/media-source/media-managedmse-bufferedchange-expected.txt:
* LayoutTests/media/media-source/media-managedmse-bufferedchange.html: Check that object received is of type BufferedChangeEvent
* LayoutTests/media/media-source/mock-managedmse-bufferedchange-expected.txt: Added.
* LayoutTests/media/media-source/mock-managedmse-bufferedchange.html: Added.
* LayoutTests/media/utilities.js:
(timeRangesToString):
* Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml:
* Source/WebCore/CMakeLists.txt:
* Source/WebCore/DerivedSources-input.xcfilelist:
* Source/WebCore/DerivedSources-output.xcfilelist:
* Source/WebCore/DerivedSources.make:
* Source/WebCore/Modules/mediasource/BufferedChangeEvent.cpp: Copied from Source/WebCore/Modules/mediasource/ManagedSourceBuffer.cpp.
(WebCore::BufferedChangeEvent::BufferedChangeEvent):
(WebCore::BufferedChangeEvent::eventInterface const):
* Source/WebCore/Modules/mediasource/BufferedChangeEvent.h: Copied from Source/WebCore/Modules/mediasource/ManagedSourceBuffer.h.
* Source/WebCore/Modules/mediasource/BufferedChangeEvent.idl: Copied from Source/WebCore/Modules/mediasource/ManagedSourceBuffer.idl.
* Source/WebCore/Modules/mediasource/ManagedMediaSource.cpp:
* Source/WebCore/Modules/mediasource/ManagedMediaSource.h:
* Source/WebCore/Modules/mediasource/ManagedMediaSource.idl:
* Source/WebCore/Modules/mediasource/ManagedSourceBuffer.cpp:
* Source/WebCore/Modules/mediasource/ManagedSourceBuffer.h:
* Source/WebCore/Modules/mediasource/ManagedSourceBuffer.idl:
* Source/WebCore/Modules/mediasource/MediaSource.cpp:
* Source/WebCore/Modules/mediasource/MediaSource.h:
* Source/WebCore/Modules/mediasource/SourceBuffer.cpp:
(WebCore::SourceBuffer::buffered):
(WebCore::SourceBuffer::sourceBufferPrivateBufferedChanged):
* Source/WebCore/Modules/mediasource/SourceBuffer.h:
* Source/WebCore/Sources.txt:
* Source/WebCore/WebCore.xcodeproj/project.pbxproj:
* Source/WebCore/bindings/js/WebCoreBuiltinNames.h:
* Source/WebCore/dom/EventNames.in:
* Source/WebCore/html/HTMLMediaElement.cpp:
(WebCore::HTMLMediaElement::setBufferingPolicy): Change to be conditional on MANAGED_MEDIA_SOURCE
(WebCore::HTMLMediaElement::purgeBufferedDataIfPossible): same as above
* Source/WebCore/platform/graphics/PlatformTimeRanges.cpp:
(WebCore::PlatformTimeRanges::operator+=): Add alias to `unionWith` method for naming consistency.
(WebCore::PlatformTimeRanges::operator-=): Add operator to process calculation of range removal.
* Source/WebCore/platform/graphics/PlatformTimeRanges.h:

Canonical link: <a href="https://commits.webkit.org/264472@main">https://commits.webkit.org/264472@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/6327aeade0442937a7f5d5416377daaa3d0f38ce

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/7724 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/7995 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/8176 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/9365 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/7881 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/7730 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/9985 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/7916 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/10755 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/7858 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/8976 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/7093 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/9473 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/6285 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/7032 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/14698 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/6587 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/7438 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/7157 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/10565 "Passed tests") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/7307 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/7647 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/6233 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/7879 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/6975 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/6942 "Passed tests") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/1804 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/1845 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/11186 "Built successfully") | | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/24/builds/8091 "Built successfully") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/7381 "Built successfully") | | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/3/builds/1953 "Passed tests") | 
<!--EWS-Status-Bubble-End-->