### PR TITLE
WebFrame::didCommitLoadInAnotherProcess should work with frames that don't have an owner element or parent in the same process

### DIFF
--- a/Source/WebKit/WebProcess/WebCoreSupport/WebRemoteFrameClient.cpp
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebRemoteFrameClient.cpp
@@ -78,10 +78,7 @@ void WebRemoteFrameClient::changeLocation(WebCore::FrameLoadRequest&& request)
     // FIXME: Get more parameters correct and add tests for each one.
     dispatchDecidePolicyForNavigationAction(action, action.resourceRequest(), WebCore::ResourceResponse(), nullptr, WebCore::PolicyDecisionMode::Asynchronous, WebCore::PolicyCheckIdentifier::generate(), [protectedFrame = Ref { m_frame }, request = WTFMove(request)] (PolicyAction policyAction, PolicyCheckIdentifier responseIdentifier) mutable {
         // FIXME: Check responseIdentifier.
-        if (policyAction != PolicyAction::Use)
-            return;
-        protectedFrame->transitionToLocal();
-        protectedFrame->coreFrame()->changeLocation(WTFMove(request));
+        // WebPage::transitionFrameToLocalAndLoadRequest will make this load happen if needed.
     });
 }
 

--- a/Source/WebKit/WebProcess/WebPage/WebFrame.cpp
+++ b/Source/WebKit/WebProcess/WebPage/WebFrame.cpp
@@ -343,10 +343,6 @@ void WebFrame::didCommitLoadInAnotherProcess(WebCore::LayerHostingContextIdentif
     }
 
     RefPtr parent = coreFrame->tree().parent();
-    if (!parent) {
-        // FIXME: This shouldn't be hit but currently is in a SiteIsolation API test. Investigate and fix.
-        return;
-    }
 
     auto* localFrame = dynamicDowncast<WebCore::LocalFrame>(coreFrame.get());
     if (!localFrame) {
@@ -361,19 +357,22 @@ void WebFrame::didCommitLoadInAnotherProcess(WebCore::LayerHostingContextIdentif
     }
 
     RefPtr ownerElement = coreFrame->ownerElement();
-    if (!ownerElement) {
-        // FIXME: This shouldn't be reached but is after finishing a SiteIsolation API test. Investigate and fix.
-        return;
-    }
 
     auto invalidator = frameLoaderClient->takeFrameInvalidator();
     auto* ownerRenderer = localFrame->ownerRenderer();
     localFrame->setView(nullptr);
 
-    parent->tree().removeChild(*coreFrame);
-    coreFrame->disconnectOwnerElement();
+    if (parent)
+        parent->tree().removeChild(*coreFrame);
+    if (ownerElement)
+        coreFrame->disconnectOwnerElement();
     auto client = makeUniqueRef<WebRemoteFrameClient>(*this, WTFMove(invalidator));
-    auto newFrame = WebCore::RemoteFrame::createSubframeWithContentsInAnotherProcess(*corePage, WTFMove(client), m_frameID, *ownerElement, layerHostingContextIdentifier, remoteProcessIdentifier);
+    auto newFrame = ownerElement
+        ? WebCore::RemoteFrame::createSubframeWithContentsInAnotherProcess(*corePage, WTFMove(client), m_frameID, *ownerElement, layerHostingContextIdentifier, remoteProcessIdentifier)
+        : parent
+            ? WebCore::RemoteFrame::createSubframe(*corePage, WTFMove(client), m_frameID, *parent, remoteProcessIdentifier)
+            : WebCore::RemoteFrame::createMainFrame(*corePage, WTFMove(client), m_frameID, remoteProcessIdentifier);
+
     auto remoteFrameView = WebCore::RemoteFrameView::create(newFrame);
     // FIXME: We need a corresponding setView(nullptr) during teardown to break the ref cycle.
     newFrame->setView(remoteFrameView.ptr());
@@ -383,9 +382,10 @@ void WebFrame::didCommitLoadInAnotherProcess(WebCore::LayerHostingContextIdentif
     m_coreFrame = newFrame.get();
 
     // FIXME: This is also done in the WebCore::Frame constructor. Move one to make this more symmetric.
-    ownerElement->setContentFrame(*m_coreFrame);
-
-    ownerElement->scheduleInvalidateStyleAndLayerComposition();
+    if (ownerElement) {
+        ownerElement->setContentFrame(*m_coreFrame);
+        ownerElement->scheduleInvalidateStyleAndLayerComposition();
+    }
 }
 
 void WebFrame::transitionToLocal(std::optional<WebCore::LayerHostingContextIdentifier> layerHostingContextIdentifier)

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/SiteIsolation.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/SiteIsolation.mm
@@ -506,9 +506,9 @@ TEST(SiteIsolation, ParentNavigatingCrossOriginIframeToSameOrigin)
             { { "https://example.com"_s } }
         },
         // FIXME: This process should be torn down when the iframe navigates back to example.com.
-        // Its iframe should be transitioned to remote, and the count of local frames going to 0 should remove the SubframePageProxy.
+        // The count of local frames going to 0 should remove the SubframePageProxy.
         { RemoteFrame,
-            { { "https://webkit.org"_s } }
+            { { RemoteFrame } }
         },
     });
 }


### PR DESCRIPTION
#### d2f3048d0225e4f7ebf5d30f65d2d3f49fb67f50
<pre>
WebFrame::didCommitLoadInAnotherProcess should work with frames that don&apos;t have an owner element or parent in the same process
<a href="https://bugs.webkit.org/show_bug.cgi?id=257125">https://bugs.webkit.org/show_bug.cgi?id=257125</a>
rdar://109663423

Reviewed by Chris Dumez.

It can happen without an owner element in the same process when a site isolated iframe navigates to a new domain,
such as in the ParentNavigatingCrossOriginIframeToSameOrigin API test.

It can happen without a parent when window.open is used to make a popup that is site isolated, which hasn&apos;t landed
yet but will soon.  So this does some of the same things as <a href="https://github.com/WebKit/WebKit/pull/10169">https://github.com/WebKit/WebKit/pull/10169</a>

I also noticed that the code in the completion lambda of WebRemoteFrameClient::changeLocation wasn&apos;t called so I removed
it and replaced it with a comment explaining what is actually happening.

* Source/WebKit/WebProcess/WebCoreSupport/WebRemoteFrameClient.cpp:
(WebKit::WebRemoteFrameClient::changeLocation):
* Source/WebKit/WebProcess/WebPage/WebFrame.cpp:
(WebKit::WebFrame::didCommitLoadInAnotherProcess):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/SiteIsolation.mm:
(TestWebKitAPI::TEST):

Canonical link: <a href="https://commits.webkit.org/264329@main">https://commits.webkit.org/264329@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d71b5673ef57e5a8bc98f09af102ea97bcd5947a

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/7426 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/7688 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/7860 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/9059 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/32/builds/7633 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/7437 "Passed tests") | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/23/builds/9629 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/7610 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/10514 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/7557 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/23/builds/9629 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/6888 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/9168 "Built successfully") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/23/builds/9629 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/10/builds/6757 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/14489 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/23/builds/9629 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/6872 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/10169 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/7363 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/6025 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/6711 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/10920 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/865 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/7098 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->