### PR TITLE
[iOS] REGRESSION (264028@main): Memory regression

### DIFF
--- a/Source/WebKit/Resources/SandboxProfiles/ios/com.apple.WebKit.GPU.sb.in
+++ b/Source/WebKit/Resources/SandboxProfiles/ios/com.apple.WebKit.GPU.sb.in
@@ -768,6 +768,8 @@
 
 (when (defined? 'syscall-unix)
     (deny syscall-unix (with telemetry))
+    (deny syscall-unix (with no-report)
+        SYS_faccessat)
     (allow syscall-unix (syscall-number
         SYS___disable_threadsignal
         SYS___mac_syscall
@@ -790,7 +792,6 @@
         SYS_dup
         SYS_dup2
         SYS_exit
-        SYS_faccessat
         SYS_fcntl
         SYS_fcntl_nocancel
         SYS_fileport_makefd


### PR DESCRIPTION
#### 21a4b1c5559f6ddda3f3c4166e5ab33cab2c475d
<pre>
[iOS] REGRESSION (264028@main): Memory regression
<a href="https://bugs.webkit.org/show_bug.cgi?id=257126">https://bugs.webkit.org/show_bug.cgi?id=257126</a>
&lt;rdar://109409569&gt;

Reviewed by Per Arne Vollan.

Relaxing the iOS GPU Process Sandbox in Bug 256728 had the unintended effect of increasing memory use. Since blocking this call didn&apos;t create any functional issues, but regressed memory, we will instead silence the logging to avoid flooding telemetry with irrelevant logging.

* Source/WebKit/Resources/SandboxProfiles/ios/com.apple.WebKit.GPU.sb.in:

Canonical link: <a href="https://commits.webkit.org/264386@main">https://commits.webkit.org/264386@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f54a1dc95f4d590e6cf593037edd174373aadd9e

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/7422 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/7684 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/7856 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/9055 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/7627 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/9616 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/7606 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/10511 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/7553 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/8678 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/6884 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/9164 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/5983 "Passed tests") | | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/14487 "4 flakes 129 failures") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/7217 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/6875 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/10165 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/7359 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/6024 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/6707 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/1769 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/10916 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/7094 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->