### PR TITLE
ServiceWorker downloads fail when chunks are sent via postMessage

### DIFF
--- a/Source/WebCore/fileapi/URLKeepingBlobAlive.cpp
+++ b/Source/WebCore/fileapi/URLKeepingBlobAlive.cpp
@@ -91,13 +91,9 @@ void URLKeepingBlobAlive::unregisterBlobURLHandleIfNecessary()
         ThreadableBlobRegistry::unregisterBlobURLHandle(m_url);
 }
 
-URLKeepingBlobAlive URLKeepingBlobAlive::isolatedCopy() const &
+URLKeepingBlobAlive URLKeepingBlobAlive::isolatedCopy() const
 {
     return { m_url.isolatedCopy(), m_topOrigin.isolatedCopy() };
 }
 
-URLKeepingBlobAlive URLKeepingBlobAlive::isolatedCopy() &&
-{
-    return { WTFMove(m_url).isolatedCopy(), WTFMove(m_topOrigin).isolatedCopy() };
-}
 } // namespace WebCore

--- a/Source/WebCore/fileapi/URLKeepingBlobAlive.h
+++ b/Source/WebCore/fileapi/URLKeepingBlobAlive.h
@@ -49,8 +49,8 @@ public:
 
     void clear();
 
-    URLKeepingBlobAlive WARN_UNUSED_RETURN isolatedCopy() const &;
-    URLKeepingBlobAlive WARN_UNUSED_RETURN isolatedCopy() &&;
+    // We do not introduce a && version since it might break the register/unregister balance.
+    WEBCORE_EXPORT URLKeepingBlobAlive WARN_UNUSED_RETURN isolatedCopy() const;
 
 private:
     void registerBlobURLHandleIfNecessary();


### PR DESCRIPTION
#### fb9630a9c9fc9d67def1d952fca7ba825a7c82ac
<pre>
ServiceWorker downloads fail when chunks are sent via postMessage
<a href="https://bugs.webkit.org/show_bug.cgi?id=256698">https://bugs.webkit.org/show_bug.cgi?id=256698</a>
rdar://problem/109561888

Reviewed by Chris Dumez.

When isolatedCopying() &amp;&amp; a URLKeepingBlobAlive, we would register the blob URL handle for the new URLKeepingBlobAlive,
but the moved URLKeepingBlobAlive would no longer unregister itself if its url is empty.
To prevent this, we remove the isolatedCopy() &amp;&amp; version.
We could make URLKeepingBlobAlive to a move only type in a follow-up.

* Source/WebCore/fileapi/URLKeepingBlobAlive.cpp:
(WebCore::URLKeepingBlobAlive::isolatedCopy const):
(WebCore::URLKeepingBlobAlive::isolatedCopy): Deleted.
* Source/WebCore/fileapi/URLKeepingBlobAlive.h:

Canonical link: <a href="https://commits.webkit.org/264412@main">https://commits.webkit.org/264412@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/cca853a8c002f347309ede30e6bde7e19d7932e3

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/7424 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/7686 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/7872 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/9057 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/7631 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/7435 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/9620 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/7608 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/10525 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/7555 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/8679 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/6892 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/9166 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/5984 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/6763 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/14495 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/7218 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/6881 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/10179 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/7361 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/6028 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/6709 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/1794 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/10918 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/7096 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->