### PR TITLE
[image-set] Re-import WPT changes

### DIFF
--- a/LayoutTests/TestExpectations
+++ b/LayoutTests/TestExpectations
@@ -3355,6 +3355,8 @@ imported/w3c/web-platform-tests/html/semantics/embedded-content/the-iframe-eleme
 
 imported/w3c/web-platform-tests/css/css-images/multiple-position-color-stop-conic.html [ ImageOnlyFailure ]
 
+imported/w3c/web-platform-tests/css/css-images/image-set/image-set-type-first-match-rendering.html [ ImageOnlyFailure ]
+
 webkit.org/b/187773 http/tests/webAPIStatistics [ Skip ]
 
 # This is fallout from turning Web Animations on.

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-images/image-set/image-set-negative-resolution-rendering-3-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-images/image-set/image-set-negative-resolution-rendering-3-expected.html
@@ -1,1 +1,3 @@
-<!DOCTYPE html>
+<!doctype html>
+<title>CSS Test Reference</title>
+<!-- Intentionally blank -->

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-images/image-set/image-set-negative-resolution-rendering-3.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-images/image-set/image-set-negative-resolution-rendering-3.html
@@ -1,11 +1,11 @@
 <!DOCTYPE html>
 <title>Image set negative resolution rendering</title>
 <link rel="help" href="https://drafts.csswg.org/css-images-4/#image-set-notation">
-<link rel="match" href="reference/blank-ref.html">
+<link rel="match" href="/css/reference/blank.html">
 <meta name="assert" content="image-set rendering with negative resolution">
 <style>
   #test {
-    background-image: url("/images/green.png");
+    background-image: url("/images/red.png");
     background-image: image-set(url("/images/red.png") calc(-1 * 1x));
     width: 100px;
     height: 100px;

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-images/image-set/image-set-type-first-match-rendering.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-images/image-set/image-set-type-first-match-rendering.html
@@ -8,8 +8,8 @@
 <style>
   #test {
     background-image: image-set(
-      url("/images/green.png") 1x type('image/png'),
-      url("/images/red.png") 1x type('image/png')
+      url("/images/green.png") 0.0001x type('image/png'),
+      url("/images/red.png") 0.0001x type('image/png')
     );
     width: 100px;
     height: 100px;

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-images/image-set/image-set-zero-resolution-rendering-2-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-images/image-set/image-set-zero-resolution-rendering-2-expected.html
@@ -1,1 +1,3 @@
-<!DOCTYPE html>
+<!doctype html>
+<title>CSS Test Reference</title>
+<!-- Intentionally blank -->

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-images/image-set/image-set-zero-resolution-rendering-2.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-images/image-set/image-set-zero-resolution-rendering-2.html
@@ -1,9 +1,10 @@
 <!DOCTYPE html>
-<link rel="match" href="reference/blank-ref.html">
+<link rel="help" href="https://drafts.csswg.org/css-images-4/#image-set-notation">
+<link rel="match" href="/css/reference/blank.html">
 <meta name="assert" content="image-set rendering with zero resolution">
 <style>
 #test {
-    background-image: url("/images/green.png");
+    background-image: url("/images/red.png");
     background-image: image-set(url("/images/red.png") calc(0dppx * -1));
     width: 100px;
     height: 100px;

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-images/image-set/image-set-zero-resolution-rendering-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-images/image-set/image-set-zero-resolution-rendering-expected.html
@@ -1,1 +1,3 @@
-<!DOCTYPE html>
+<!doctype html>
+<title>CSS Test Reference</title>
+<!-- Intentionally blank -->

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-images/image-set/image-set-zero-resolution-rendering.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-images/image-set/image-set-zero-resolution-rendering.html
@@ -1,9 +1,10 @@
 <!DOCTYPE html>
-<link rel="match" href="reference/blank-ref.html">
+<link rel="help" href="https://drafts.csswg.org/css-images-4/#image-set-notation">
+<link rel="match" href="/css/reference/blank.html">
 <meta name="assert" content="image-set rendering with zero resolution">
 <style>
 #test {
-    background-image: url("/images/green.png");
+    background-image: url("/images/red.png");
     background-image: image-set(url("/images/red.png") 0x);
     width: 100px;
     height: 100px;

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-images/image-set/w3c-import.log
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-images/image-set/w3c-import.log
@@ -39,6 +39,8 @@ List of files:
 /LayoutTests/imported/w3c/web-platform-tests/css/css-images/image-set/image-set-linear-gradient-rendering.html
 /LayoutTests/imported/w3c/web-platform-tests/css/css-images/image-set/image-set-negative-resolution-rendering-2-expected.html
 /LayoutTests/imported/w3c/web-platform-tests/css/css-images/image-set/image-set-negative-resolution-rendering-2.html
+/LayoutTests/imported/w3c/web-platform-tests/css/css-images/image-set/image-set-negative-resolution-rendering-3-expected.html
+/LayoutTests/imported/w3c/web-platform-tests/css/css-images/image-set/image-set-negative-resolution-rendering-3.html
 /LayoutTests/imported/w3c/web-platform-tests/css/css-images/image-set/image-set-negative-resolution-rendering-expected.html
 /LayoutTests/imported/w3c/web-platform-tests/css/css-images/image-set/image-set-negative-resolution-rendering.html
 /LayoutTests/imported/w3c/web-platform-tests/css/css-images/image-set/image-set-no-res-rendering-2-expected.html
@@ -83,3 +85,7 @@ List of files:
 /LayoutTests/imported/w3c/web-platform-tests/css/css-images/image-set/image-set-type-unsupported-rendering.html
 /LayoutTests/imported/w3c/web-platform-tests/css/css-images/image-set/image-set-unordered-res-rendering-expected.html
 /LayoutTests/imported/w3c/web-platform-tests/css/css-images/image-set/image-set-unordered-res-rendering.html
+/LayoutTests/imported/w3c/web-platform-tests/css/css-images/image-set/image-set-zero-resolution-rendering-2-expected.html
+/LayoutTests/imported/w3c/web-platform-tests/css/css-images/image-set/image-set-zero-resolution-rendering-2.html
+/LayoutTests/imported/w3c/web-platform-tests/css/css-images/image-set/image-set-zero-resolution-rendering-expected.html
+/LayoutTests/imported/w3c/web-platform-tests/css/css-images/image-set/image-set-zero-resolution-rendering.html


### PR DESCRIPTION
#### e31b4971569eed571c0d339f2038432b45a9bed8
<pre>
[image-set] Re-import WPT changes
<a href="https://bugs.webkit.org/show_bug.cgi?id=257128">https://bugs.webkit.org/show_bug.cgi?id=257128</a>
rdar://109664556

Reviewed by Tim Nguyen.

Re-import changes to upstream image-set WPT as of upstream commit
ba004353155163b0c356b753394e50d2dd6f0b87

* LayoutTests/TestExpectations:
* LayoutTests/imported/w3c/web-platform-tests/css/css-images/image-set/image-set-negative-resolution-rendering-3-expected.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-images/image-set/image-set-negative-resolution-rendering-3.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-images/image-set/image-set-type-first-match-rendering.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-images/image-set/image-set-zero-resolution-rendering-2-expected.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-images/image-set/image-set-zero-resolution-rendering-2.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-images/image-set/image-set-zero-resolution-rendering-expected.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-images/image-set/image-set-zero-resolution-rendering.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-images/image-set/w3c-import.log:

Canonical link: <a href="https://commits.webkit.org/264379@main">https://commits.webkit.org/264379@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/8b77d6c50e19a9ea0b0f02ae4b4ba4e8b0a3bc09

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/7444 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/7709 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/7886 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/9080 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/32/builds/7649 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/9645 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/7631 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/10532 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/7575 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/8693 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/6896 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/9208 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/5999 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/6767 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/14515 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/7229 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/6885 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/10220 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/7382 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/6040 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/6728 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/6677 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/1764 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/10939 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/7115 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->