### PR TITLE
Remove SVGDescElement::description()

### DIFF
--- a/Source/WebCore/svg/SVGDescElement.cpp
+++ b/Source/WebCore/svg/SVGDescElement.cpp
@@ -39,9 +39,4 @@ Ref<SVGDescElement> SVGDescElement::create(const QualifiedName& tagName, Documen
     return adoptRef(*new SVGDescElement(tagName, document));
 }
 
-String SVGDescElement::description() const
-{
-    return textContent().simplifyWhiteSpace();
-}
-
 }

--- a/Source/WebCore/svg/SVGDescElement.h
+++ b/Source/WebCore/svg/SVGDescElement.h
@@ -29,8 +29,6 @@ class SVGDescElement final : public SVGElement {
 public:
     static Ref<SVGDescElement> create(const QualifiedName&, Document&);
 
-    String description() const;
-
 private:
     SVGDescElement(const QualifiedName&, Document&);
 


### PR DESCRIPTION
#### ae737b8a24a23c8c4a9ab0f906005b7d650b0cae
<pre>
Remove SVGDescElement::description()
<a href="https://bugs.webkit.org/show_bug.cgi?id=257130">https://bugs.webkit.org/show_bug.cgi?id=257130</a>
rdar://109664701

Reviewed by NOBODY (OOPS!).

It&apos;s not exposed via IDL and has no callers.

* Source/WebCore/svg/SVGDescElement.cpp:
(WebCore::SVGDescElement::description const): Deleted.
* Source/WebCore/svg/SVGDescElement.h:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ae737b8a24a23c8c4a9ab0f906005b7d650b0cae

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/7427 "Passed style check") | [  ~~🛠 ios~~](https://ews-build.webkit.org/#/builders/26/builds/7689 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/14/builds/7873 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/9060 "Failed to checkout and rebase branch from PR 14186") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/32/builds/7634 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [  ~~🧪 bindings~~](https://ews-build.webkit.org/#/builders/9/builds/7438 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/23/builds/9623 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/16/builds/7611 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/5/builds/9060 "Failed to checkout and rebase branch from PR 14186") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/7558 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/23/builds/9623 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/14/builds/7873 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/9169 "Built successfully") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/23/builds/9623 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/14/builds/7873 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/14485 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/23/builds/9623 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/14/builds/7873 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/10174 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/7364 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/16/builds/7611 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/30/builds/6712 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/14/builds/7873 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/4/builds/10921 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/31/builds/7099 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->