### PR TITLE
[WGSL] Don't rewrite global variable accesses

### DIFF
--- a/Source/WebGPU/WGSL/AST/ASTIdentifier.h
+++ b/Source/WebGPU/WGSL/AST/ASTIdentifier.h
@@ -35,7 +35,7 @@ namespace WGSL::AST {
 class Identifier : public Node {
     WTF_FORBID_HEAP_ALLOCATION;
 public:
-    static Identifier make(String& id) { return { SourceSpan::empty(), String(id) }; }
+    static Identifier make(const String& id) { return { SourceSpan::empty(), String(id) }; }
     static Identifier make(String&& id) { return { SourceSpan::empty(), WTFMove(id) }; }
     static Identifier makeWithSpan(SourceSpan span, String&& id) { return { WTFMove(span), WTFMove(id) }; }
     static Identifier makeWithSpan(SourceSpan span, StringView id) { return { WTFMove(span), id }; }

--- a/Source/WebGPU/WGSL/Metal/MetalCodeGenerator.cpp
+++ b/Source/WebGPU/WGSL/Metal/MetalCodeGenerator.cpp
@@ -35,7 +35,7 @@ namespace WGSL {
 
 namespace Metal {
 
-static constexpr bool dumpMetalCode = false;
+static constexpr bool dumpMetalCode = true;
 
 static StringView metalCodePrologue()
 {

--- a/Source/WebGPU/WGSL/WGSLShaderModule.h
+++ b/Source/WebGPU/WGSL/WGSLShaderModule.h
@@ -60,6 +60,10 @@ public:
     TypeStore& types() { return m_types; }
     AST::Builder& astBuilder() { return m_astBuilder; }
 
+    bool usesExternalTextures() const { return m_usesExternalTextures; }
+    void setUsesExternalTextures() { m_usesExternalTextures = true; }
+    void clearUsesExternalTextures() { m_usesExternalTextures = false; }
+
     template<typename T>
     std::enable_if_t<std::is_base_of_v<AST::Node, T>, void> replace(T* current, T&& replacement)
     {
@@ -143,6 +147,7 @@ public:
 
 private:
     String m_source;
+    bool m_usesExternalTextures { false };
     Configuration m_configuration;
     AST::Directive::List m_directives;
     AST::Function::List m_functions;


### PR DESCRIPTION
#### 9e532e28386370bd19b8bf5269c6ffec649cc5ed
<pre>
[WGSL] Don&apos;t rewrite global variable accesses
<a href="https://bugs.webkit.org/show_bug.cgi?id=257135">https://bugs.webkit.org/show_bug.cgi?id=257135</a>
rdar://109667180

Reviewed by Myles C. Maxfield.

Global variables get moved into a struct that represents the ArgumentBuffer layout.
Currently, we rewrite the entrypoint to take an additional parameter, and rewrite
all references to the global into a field access into the parameter. e.g.

@group(0) @binding(0) var s: sampler;
@compute main() { f(s); }

gets rewritten into:

struct AB { s: sampler }
@compute main(ab: AB) { f(ab.s); }

The problem with this is when add we another user-defined function called from multiple
entry points. The different entry points may not share the same argument buffer layout,
so we cannot pass the struct directly. There are a few alternative options on how
we can pass such values, but this patch implements this by materializing all the globals
in the entry point, so that we no longer need to to rewrite all access. The same example
will look as follows:

struct AB { s: sampler }
@compute main(ab: AB) { let s = ab.s; f(s); }

We introduce a new variable declaration for each global, bringing it into scope, rather
than rewrite all the references to all globals.

* Source/WebGPU/WGSL/AST/ASTIdentifier.h:
(WGSL::AST::Identifier::make):
* Source/WebGPU/WGSL/GlobalVariableRewriter.cpp:
(WGSL::RewriteGlobalVariables::visit):
(WGSL::RewriteGlobalVariables::visitEntryPoint):
(WGSL::RewriteGlobalVariables::determineUsedGlobals):
(WGSL::RewriteGlobalVariables::insertStructs):
(WGSL::RewriteGlobalVariables::insertMaterializations):
(WGSL::RewriteGlobalVariables::shouldBeReference const):
* Source/WebGPU/WGSL/Metal/MetalCodeGenerator.cpp:
* Source/WebGPU/WGSL/Metal/MetalFunctionWriter.cpp:
(WGSL::Metal::FunctionDefinitionWriter::write):
(WGSL::Metal::FunctionDefinitionWriter::visit):
(WGSL::Metal::FunctionDefinitionWriter::serializeVariable):
* Source/WebGPU/WGSL/WGSLShaderModule.h:
(WGSL::ShaderModule::usesExternalTextures const):
(WGSL::ShaderModule::setUsesExternalTextures):
(WGSL::ShaderModule::clearUsesExternalTextures):

Canonical link: <a href="https://commits.webkit.org/264417@main">https://commits.webkit.org/264417@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d567c628c76d15b258b18a68c55fbdba2647a013

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/7572 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/7841 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/8025 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/9214 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/7761 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/9798 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/7766 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/10634 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/7705 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/8816 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/6986 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/9322 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/6124 "Passed tests") | | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/14591 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/7308 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/7017 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/10388 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/7510 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/6132 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/6849 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/1798 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/11059 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/7242 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->