### PR TITLE
[WGSL] Add function types

### DIFF
--- a/Source/WebGPU/WGSL/Metal/MetalFunctionWriter.cpp
+++ b/Source/WebGPU/WGSL/Metal/MetalFunctionWriter.cpp
@@ -481,7 +481,6 @@ void FunctionDefinitionWriter::visit(const Type* type)
             m_stringBuilder.append(structure.structure.name());
         },
         [&](const Function&) {
-            // FIXME: implement this
             RELEASE_ASSERT_NOT_REACHED();
         },
         [&](const Bottom&) {

--- a/Source/WebGPU/WGSL/TypeCheck.cpp
+++ b/Source/WebGPU/WGSL/TypeCheck.cpp
@@ -204,10 +204,16 @@ void TypeChecker::visit(AST::Variable& variable)
 
 void TypeChecker::visit(AST::Function& function)
 {
-    // FIXME: allocate and build function type fromp parameters and return type
+    Vector<Type*> parameters;
+    Type* result;
+    parameters.reserveInitialCapacity(function.parameters().size());
+    for (auto& parameter : function.parameters())
+        parameters.append(resolve(parameter.typeName()));
     if (function.maybeReturnType())
-        resolve(*function.maybeReturnType());
-    Type* functionType = nullptr;
+        result = resolve(*function.maybeReturnType());
+    else
+        result = m_types.voidType();
+    Type* functionType = m_types.functionType(WTFMove(parameters), result);
     introduceVariable(function.name(), functionType);
 }
 

--- a/Source/WebGPU/WGSL/TypeStore.cpp
+++ b/Source/WebGPU/WGSL/TypeStore.cpp
@@ -189,6 +189,11 @@ Type* TypeStore::textureType(Type* elementType, Texture::Kind kind)
     return type;
 }
 
+Type* TypeStore::functionType(WTF::Vector<Type*>&& parameters, Type* result)
+{
+    return allocateType<Function>(WTFMove(parameters), result);
+}
+
 template<typename TypeKind, typename... Arguments>
 Type* TypeStore::allocateType(Arguments&&... arguments)
 {

--- a/Source/WebGPU/WGSL/TypeStore.h
+++ b/Source/WebGPU/WGSL/TypeStore.h
@@ -61,6 +61,7 @@ public:
     Type* vectorType(Type*, uint8_t);
     Type* matrixType(Type*, uint8_t columns, uint8_t rows);
     Type* textureType(Type*, Types::Texture::Kind);
+    Type* functionType(Vector<Type*>&&, Type*);
 
     Type* constructType(AST::ParameterizedTypeName::Base, Type*);
 

--- a/Source/WebGPU/WGSL/Types.cpp
+++ b/Source/WebGPU/WGSL/Types.cpp
@@ -63,9 +63,16 @@ void Type::dump(PrintStream& out) const
         [&](const Struct& structure) {
             out.print(structure.structure.name());
         },
-        [&](const Function&) {
-            // FIXME: implement this
-            ASSERT_NOT_REACHED();
+        [&](const Function& function) {
+            out.print("(");
+            bool first = true;
+            for (auto* parameter : function.parameters) {
+                if (!first)
+                    out.print(", ");
+                first = false;
+                out.print(*parameter);
+            }
+            out.print(") -> ", *function.result);
         },
         [&](const Bottom&) {
             // Bottom is an implementation detail and should never leak, but we

--- a/Source/WebGPU/WGSL/Types.h
+++ b/Source/WebGPU/WGSL/Types.h
@@ -100,6 +100,8 @@ struct Struct {
 };
 
 struct Function {
+    WTF::Vector<Type*> parameters;
+    Type* result;
 };
 
 struct Bottom {


### PR DESCRIPTION
#### 77f0abb8c5ca019311f590e7becc0840d1f7fb4b
<pre>
[WGSL] Add function types
<a href="https://bugs.webkit.org/show_bug.cgi?id=257136">https://bugs.webkit.org/show_bug.cgi?id=257136</a>
rdar://109667649

Reviewed by Dan Glastonbury.

Create types for user-defined functions and introduce them into the typing context.
This is the first step for allowing calls to user-defined functions.

* Source/WebGPU/WGSL/Metal/MetalFunctionWriter.cpp:
(WGSL::Metal::FunctionDefinitionWriter::visit):
* Source/WebGPU/WGSL/TypeCheck.cpp:
(WGSL::TypeChecker::visit):
* Source/WebGPU/WGSL/TypeStore.cpp:
(WGSL::TypeStore::functionType):
* Source/WebGPU/WGSL/TypeStore.h:
* Source/WebGPU/WGSL/Types.cpp:
(WGSL::Type::dump const):
* Source/WebGPU/WGSL/Types.h:

Canonical link: <a href="https://commits.webkit.org/264413@main">https://commits.webkit.org/264413@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/af6e0c0a195dea79b6a5106424cd1dac4267a637

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/7441 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/7706 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/7883 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/9077 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/7646 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/9642 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/7628 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/10535 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/7572 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/8691 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/6897 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/9187 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/5997 "Passed tests") | | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/14498 "7 flakes 101 failures") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/7228 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/6886 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/10186 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/7379 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/6038 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/6725 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/1795 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/10936 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/7112 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->