### PR TITLE
[WGSL] Fill callee map in CallGraph

### DIFF
--- a/Source/WebGPU/WGSL/CallGraph.cpp
+++ b/Source/WebGPU/WGSL/CallGraph.cpp
@@ -29,6 +29,7 @@
 #include "AST.h"
 #include "ASTVisitor.h"
 #include "WGSLShaderModule.h"
+#include <wtf/Deque.h>
 
 namespace WGSL {
 
@@ -47,15 +48,16 @@ public:
 
     CallGraph build();
 
-    // FIXME: we also need to visit function calls when we add support for them
     void visit(AST::Function&) override;
+    void visit(AST::CallExpression&) override;
 
 private:
     void initializeMappings();
 
     CallGraph m_callGraph;
-    AST::Function* m_currentFunction;
     const HashMap<String, std::optional<PipelineLayout>>& m_pipelineLayouts;
+    HashMap<AST::Function*, Vector<AST::CallExpression*>> m_calleeBuildingMap;
+    Deque<AST::Function*> m_queue;
 };
 
 CallGraph CallGraphBuilder::build()
@@ -66,36 +68,56 @@ CallGraph CallGraphBuilder::build()
 
 void CallGraphBuilder::initializeMappings()
 {
-    for (auto& functionDecl : m_callGraph.m_ast.functions()) {
-        const auto& name = functionDecl.name();
+    for (auto& function : m_callGraph.m_ast.functions()) {
+        const auto& name = function.name();
         {
-            auto result = m_callGraph.m_functionsByName.add(name, &functionDecl);
-            ASSERT_UNUSED(result, result.isNewEntry);
-        }
-
-        {
-            auto result = m_callGraph.m_callees.add(&functionDecl, Vector<CallGraph::Callee>());
+            auto result = m_callGraph.m_functionsByName.add(name, &function);
             ASSERT_UNUSED(result, result.isNewEntry);
         }
 
         if (!m_pipelineLayouts.contains(name))
             continue;
 
-        for (auto& attribute : functionDecl.attributes()) {
+        for (auto& attribute : function.attributes()) {
             if (is<AST::StageAttribute>(attribute)) {
                 auto stage = downcast<AST::StageAttribute>(attribute).stage();
-                m_callGraph.m_entrypoints.append({ functionDecl, stage });
+                m_callGraph.m_entrypoints.append({ function, stage });
+                m_queue.append(&function);
                 break;
             }
         }
     }
+
+    while (!m_queue.isEmpty())
+        visit(*m_queue.takeFirst());
 }
 
-void CallGraphBuilder::visit(AST::Function& functionDecl)
+void CallGraphBuilder::visit(AST::Function& function)
 {
-    m_currentFunction = &functionDecl;
-    checkErrorAndVisit(functionDecl.body());
-    m_currentFunction = nullptr;
+    auto result = m_callGraph.m_calleeMap.add(&function, Vector<CallGraph::Callee>());
+    if (!result.isNewEntry)
+        return;
+
+    AST::Visitor::visit(function);
+    auto& callees = result.iterator->value;
+    for (auto& [target, callSites] : m_calleeBuildingMap)
+        callees.append(CallGraph::Callee { target, WTFMove(callSites) });
+    m_calleeBuildingMap.clear();
+}
+
+void CallGraphBuilder::visit(AST::CallExpression& call)
+{
+    if (!is<AST::NamedTypeName>(call.target()))
+        return;
+
+    auto& target = downcast<AST::NamedTypeName>(call.target());
+    auto it = m_callGraph.m_functionsByName.find(target.name());
+    if (it == m_callGraph.m_functionsByName.end())
+        return;
+
+    m_queue.append(it->value);
+    auto result = m_calleeBuildingMap.add(it->value, Vector<AST::CallExpression*>());
+    result.iterator->value.append(&call);
 }
 
 CallGraph buildCallGraph(ShaderModule& shaderModule, const HashMap<String, std::optional<PipelineLayout>>& pipelineLayouts)

--- a/Source/WebGPU/WGSL/CallGraph.h
+++ b/Source/WebGPU/WGSL/CallGraph.h
@@ -52,6 +52,7 @@ public:
 
     ShaderModule& ast() const { return m_ast; }
     const Vector<EntryPoint>& entrypoints() const { return m_entrypoints; }
+    const Vector<Callee>& callees(AST::Function& function) const { return m_calleeMap.find(&function)->value; }
 
 private:
     CallGraph(ShaderModule&);
@@ -59,7 +60,7 @@ private:
     ShaderModule& m_ast;
     Vector<EntryPoint> m_entrypoints;
     HashMap<String, AST::Function*> m_functionsByName;
-    HashMap<AST::Function*, Vector<Callee>> m_callees;
+    HashMap<AST::Function*, Vector<Callee>> m_calleeMap;
 };
 
 CallGraph buildCallGraph(ShaderModule&, const HashMap<String, std::optional<PipelineLayout>>& pipelineLayouts);

--- a/Source/WebGPU/WGSL/Metal/MetalFunctionWriter.cpp
+++ b/Source/WebGPU/WGSL/Metal/MetalFunctionWriter.cpp
@@ -125,6 +125,9 @@ void FunctionDefinitionWriter::write()
 
 void FunctionDefinitionWriter::visit(AST::Function& functionDefinition)
 {
+    for (auto& callee : m_callGraph.callees(functionDefinition))
+        visit(*callee.target);
+
     // FIXME: visit return attributes
     for (auto& attribute : functionDefinition.attributes()) {
         checkErrorAndVisit(attribute);


### PR DESCRIPTION
#### 3c5f1d037db65f8c010e200b0591a2c52ef8ad79
<pre>
[WGSL] Fill callee map in CallGraph
<a href="https://bugs.webkit.org/show_bug.cgi?id=257137">https://bugs.webkit.org/show_bug.cgi?id=257137</a>
rdar://109667946

Reviewed by Dan Glastonbury.

So far, the CallGraph has only been used as a list of entry points in addition
to the ShaderModule. This patch actually builds the map from any reachable
function to all its callees. For each callee we also list all the call sites,
which will be helpful in a follow-up patch when we write each call site to
pass the globals around.

* Source/WebGPU/WGSL/CallGraph.cpp:
(WGSL::CallGraphBuilder::initializeMappings):
(WGSL::CallGraphBuilder::visit):
* Source/WebGPU/WGSL/CallGraph.h:
(WGSL::CallGraph::callees const):
* Source/WebGPU/WGSL/Metal/MetalFunctionWriter.cpp:
(WGSL::Metal::FunctionDefinitionWriter::visit):

Canonical link: <a href="https://commits.webkit.org/264407@main">https://commits.webkit.org/264407@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/587fbe68d4f1cffc1fbfdac129d722a859e22126

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [⏳ 🧪 style ](https://ews-build.webkit.org/#/builders/Style-EWS "Waiting in queue, processing has not started yet") | [⏳ 🛠 ios ](https://ews-build.webkit.org/#/builders/iOS-16-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🛠 mac ](https://ews-build.webkit.org/#/builders/macOS-Monterey-Release-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🛠 wpe ](https://ews-build.webkit.org/#/builders/WPE-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🛠 wincairo ](https://ews-build.webkit.org/#/builders/WinCairo-EWS "Waiting in queue, processing has not started yet") 
| [⏳ 🧪 bindings ](https://ews-build.webkit.org/#/builders/Bindings-Tests-EWS "Waiting in queue, processing has not started yet") | [⏳ 🛠 ios-sim ](https://ews-build.webkit.org/#/builders/iOS-16-Simulator-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🛠 mac-AS-debug ](https://ews-build.webkit.org/#/builders/macOS-AppleSilicon-Ventura-Debug-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🧪 wpe-wk2 ](https://ews-build.webkit.org/#/builders/WPE-Build-EWS "Waiting in queue, processing has not started yet") | 
| [⏳ 🧪 webkitperl ](https://ews-build.webkit.org/#/builders/WebKitPerl-Tests-EWS "Waiting in queue, processing has not started yet") | [⏳ 🧪 ios-wk2 ](https://ews-build.webkit.org/#/builders/iOS-16-Simulator-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🧪 api-mac ](https://ews-build.webkit.org/#/builders/macOS-Monterey-Release-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🛠 gtk ](https://ews-build.webkit.org/#/builders/GTK-Build-EWS "Waiting in queue, processing has not started yet") | 
| [⏳ 🧪 webkitpy ](https://ews-build.webkit.org/#/builders/WebKitPy-Tests-EWS "Waiting in queue, processing has not started yet") | [⏳ 🧪 ios-wk2-wpt ](https://ews-build.webkit.org/#/builders/iOS-16-Simulator-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🧪 mac-wk1 ](https://ews-build.webkit.org/#/builders/macOS-Monterey-Release-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🧪 gtk-wk2 ](https://ews-build.webkit.org/#/builders/GTK-Build-EWS "Waiting in queue, processing has not started yet") | 
| [⏳ 🛠 🧪 jsc ](https://ews-build.webkit.org/#/builders/JSC-Tests-EWS "Waiting in queue, processing has not started yet") | [⏳ 🧪 api-ios ](https://ews-build.webkit.org/#/builders/iOS-16-Simulator-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🧪 mac-wk2 ](https://ews-build.webkit.org/#/builders/macOS-Monterey-Release-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🧪 api-gtk ](https://ews-build.webkit.org/#/builders/GTK-Build-EWS "Waiting in queue, processing has not started yet") | 
| [⏳ 🛠 🧪 jsc-arm64 ](https://ews-build.webkit.org/#/builders/JSC-Tests-arm64-EWS "Waiting in queue, processing has not started yet") | [⏳ 🛠 tv ](https://ews-build.webkit.org/#/builders/tvOS-16-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🧪 mac-AS-debug-wk2 ](https://ews-build.webkit.org/#/builders/macOS-AppleSilicon-Ventura-Debug-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🛠 jsc-armv7 ](https://ews-build.webkit.org/#/builders/JSC-ARMv7-32bits-Build-EWS "Waiting in queue, processing has not started yet") | 
| [⏳ 🧪 services ](https://ews-build.webkit.org/#/builders/Services-EWS "Waiting in queue, processing has not started yet") | [⏳ 🛠 tv-sim ](https://ews-build.webkit.org/#/builders/tvOS-16-Simulator-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🧪 mac-wk2-stress ](https://ews-build.webkit.org/#/builders/macOS-Monterey-Release-Build-EWS "Waiting in queue, processing has not started yet") | [⏳ 🧪 jsc-armv7-tests ](https://ews-build.webkit.org/#/builders/JSC-ARMv7-32bits-Build-EWS "Waiting in queue, processing has not started yet") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/1786 "Built successfully and passed tests") | [⏳ 🛠 watch ](https://ews-build.webkit.org/#/builders/watchOS-9-Build-EWS "Waiting in queue, processing has not started yet") | | [⏳ 🛠 jsc-mips ](https://ews-build.webkit.org/#/builders/JSC-MIPSEL-32bits-Build-EWS "Waiting in queue, processing has not started yet") | 
| | [⏳ 🛠 watch-sim ](https://ews-build.webkit.org/#/builders/watchOS-9-Simulator-Build-EWS "Waiting in queue, processing has not started yet") | | [⏳ 🧪 jsc-mips-tests ](https://ews-build.webkit.org/#/builders/JSC-MIPSEL-32bits-Build-EWS "Waiting in queue, processing has not started yet") | 
<!--EWS-Status-Bubble-End-->