### PR TITLE
[WGSL] Pointers in AST nodes should be null initialized

### DIFF
--- a/Source/WebGPU/WGSL/AST/ASTExpression.h
+++ b/Source/WebGPU/WGSL/AST/ASTExpression.h
@@ -54,7 +54,7 @@ protected:
     { }
 
 private:
-    const Type* m_inferredType;
+    const Type* m_inferredType { nullptr };
 };
 
 } // namespace AST

--- a/Source/WebGPU/WGSL/AST/ASTTypeName.h
+++ b/Source/WebGPU/WGSL/AST/ASTTypeName.h
@@ -55,7 +55,7 @@ protected:
     { }
 
 private:
-    const Type* m_resolvedType;
+    const Type* m_resolvedType { nullptr };
 };
 
 class ArrayTypeName : public TypeName {


### PR DESCRIPTION
#### 519777e2e027d508db6f2a2a8f7c72c413745fdc
<pre>
[WGSL] Pointers in AST nodes should be null initialized
<a href="https://bugs.webkit.org/show_bug.cgi?id=257138">https://bugs.webkit.org/show_bug.cgi?id=257138</a>
rdar://109668226

Reviewed by Dan Glastonbury.

`AST::TypeName::m_resolvedType` and `AST::Expression::m_inferredType` need to
be null initialized.

* Source/WebGPU/WGSL/AST/ASTExpression.h:
* Source/WebGPU/WGSL/AST/ASTTypeName.h:

Canonical link: <a href="https://commits.webkit.org/264409@main">https://commits.webkit.org/264409@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d93783e9e51ea2a3679f573a1ef637303dac90b6

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/7541 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/7809 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/7992 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/9181 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/7730 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/9765 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/7733 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/10607 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/7672 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/8787 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/6961 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/9289 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/6094 "Passed tests") | | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/14567 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/7287 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/7000 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/10326 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/7477 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/6107 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/6818 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/1790 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/11026 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/7211 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->