### PR TITLE
[WGSL] EntryPointRewriter can't assume that return type is NamedTypeName

### DIFF
--- a/Source/WebGPU/WGSL/EntryPointRewriter.cpp
+++ b/Source/WebGPU/WGSL/EntryPointRewriter.cpp
@@ -157,9 +157,10 @@ void EntryPointRewriter::checkReturnType()
         return;
 
     if (auto* maybeReturnType = m_function.maybeReturnType()) {
-        ASSERT(is<AST::NamedTypeName>(*maybeReturnType));
-        auto& namedTypeName = downcast<AST::NamedTypeName>(*maybeReturnType);
+        if (!is<AST::NamedTypeName>(*maybeReturnType))
+            return;
 
+        auto& namedTypeName = downcast<AST::NamedTypeName>(*maybeReturnType);
         if (auto* structType = std::get_if<Types::Struct>(namedTypeName.resolvedType())) {
             ASSERT(structType->structure.role() == AST::StructureRole::UserDefined);
 


### PR DESCRIPTION
#### 4da294485bf141234315e66fb945e026f0b9c79b
<pre>
[WGSL] EntryPointRewriter can&apos;t assume that return type is NamedTypeName
<a href="https://bugs.webkit.org/show_bug.cgi?id=257139">https://bugs.webkit.org/show_bug.cgi?id=257139</a>
rdar://109668418

Reviewed by Dan Glastonbury.

In 264316@main I introduced an incorrect assertion in `EntryPointRewriter::checkReturnType`.
We can&apos;t assert that the return type is a `NamedTypeName` (i.e. an identifier that refers
to a type). Instead, we return early if the return type is of a different kind.

* Source/WebGPU/WGSL/EntryPointRewriter.cpp:
(WGSL::EntryPointRewriter::checkReturnType):

Canonical link: <a href="https://commits.webkit.org/264408@main">https://commits.webkit.org/264408@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/df6da5793bf13f2f5b572e69647136a2548ce067

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/7540 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/7807 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/7990 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/9179 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/32/builds/7729 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/9763 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/7732 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/10605 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/7671 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/8782 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/6964 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/9287 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/6089 "Passed tests") | | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/14566 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/7285 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/6986 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/10323 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/7476 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/6104 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/6817 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/1789 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/11025 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/7210 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->