### PR TITLE
Remove serialization keyword NoForwardDeclaration

### DIFF
--- a/Source/WebKit/Scripts/webkit/tests/GeneratedSerializers.cpp
+++ b/Source/WebKit/Scripts/webkit/tests/GeneratedSerializers.cpp
@@ -25,6 +25,30 @@
 #include "config.h"
 #include "GeneratedSerializers.h"
 
+#include "CommonHeader.h"
+#if ENABLE(TEST_FEATURE)
+#include "CommonHeader.h"
+#endif
+#if ENABLE(TEST_FEATURE)
+#include "FirstMemberType.h"
+#endif
+#include "HeaderWithoutCondition"
+#if ENABLE(TEST_FEATURE)
+#include "SecondMemberType.h"
+#endif
+#if ENABLE(TEST_FEATURE)
+#include "StructHeader.h"
+#endif
+#include <Namespace/EmptyConstructorNullable.h>
+#include <Namespace/EmptyConstructorStruct.h>
+#include <Namespace/ReturnRefClass.h>
+#include <WebCore/FloatBoxExtent.h>
+#include <WebCore/InheritanceGrandchild.h>
+#include <WebCore/InheritsFrom.h>
+#include <WebCore/TimingFunction.h>
+#include <wtf/CreateUsingClass.h>
+#include <wtf/Seconds.h>
+
 template<size_t...> struct MembersInCorrectOrder;
 template<size_t onlyOffset> struct MembersInCorrectOrder<onlyOffset> { static constexpr bool value = true; };
 template<size_t firstOffset, size_t secondOffset, size_t... remainingOffsets> struct MembersInCorrectOrder<firstOffset, secondOffset, remainingOffsets...> {
@@ -63,29 +87,6 @@ template<> struct VirtualTableAndRefCountOverhead<false, false> { };
 #if COMPILER(GCC)
 IGNORE_WARNINGS_BEGIN("invalid-offsetof")
 #endif
-#include "CommonHeader.h"
-#if ENABLE(TEST_FEATURE)
-#include "CommonHeader.h"
-#endif
-#if ENABLE(TEST_FEATURE)
-#include "FirstMemberType.h"
-#endif
-#include "HeaderWithoutCondition"
-#if ENABLE(TEST_FEATURE)
-#include "SecondMemberType.h"
-#endif
-#if ENABLE(TEST_FEATURE)
-#include "StructHeader.h"
-#endif
-#include <Namespace/EmptyConstructorNullable.h>
-#include <Namespace/EmptyConstructorStruct.h>
-#include <Namespace/ReturnRefClass.h>
-#include <WebCore/FloatBoxExtent.h>
-#include <WebCore/InheritanceGrandchild.h>
-#include <WebCore/InheritsFrom.h>
-#include <WebCore/TimingFunction.h>
-#include <wtf/CreateUsingClass.h>
-#include <wtf/Seconds.h>
 
 namespace IPC {
 

--- a/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
+++ b/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
@@ -2450,7 +2450,7 @@ class WebCore::ResourceResponse : WebCore::ResourceResponseBase {
 }
 
 header: <WebCore/ResourceResponseBase.h>
-[CustomHeader, NoForwardDeclaration=<WebCore/ResourceResponseBase.h>] struct WebCore::ResourceResponseBase::CrossThreadData {
+[Nested] struct WebCore::ResourceResponseBase::CrossThreadData {
     URL url;
     String mimeType;
     long long expectedContentLength;


### PR DESCRIPTION
#### 6a75a47bd571b5ae5f0d7dd16527883ed80bb772
<pre>
Remove serialization keyword NoForwardDeclaration
<a href="https://bugs.webkit.org/show_bug.cgi?id=257145">https://bugs.webkit.org/show_bug.cgi?id=257145</a>
rdar://109672374

Reviewed by Sihui Liu.

It&apos;s not needed and slows down the build.
Use [Nested] instead because the one place it is used is for a nested class.

* Source/WebKit/Scripts/generate-serializers.py:
(SerializedType.__init__):
(alias_struct_or_class):
(generate_header):
(generate_impl):
(parse_serialized_types):
(generate_headers_for_header): Deleted.
* Source/WebKit/Scripts/webkit/tests/GeneratedSerializers.cpp:
* Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in:

Canonical link: <a href="https://commits.webkit.org/264398@main">https://commits.webkit.org/264398@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e2c02adb70056a72c403ac110b6dd4200489cc15

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/7518 "1 style error") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/7785 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/7968 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/9157 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/32/builds/7711 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/9740 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/7710 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/10586 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/7649 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/8764 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/6951 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/9264 "Built successfully") | 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/7631 "Passed tests") | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/6071 "Passed tests") | | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/14553 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/7277 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/6977 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/10288 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/7454 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/6093 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/6795 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/11003 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/910 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/7188 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->