### PR TITLE
[mixed-content] Resync WPT

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/mixed-content/csp.https.window-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/mixed-content/csp.https.window-expected.txt
@@ -1,0 +1,5 @@
+
+FAIL Mixed content checks apply to fetches in sandboxed documents assert_unreached: Should have rejected: mixed content fetch Reached unreachable code
+FAIL Mixed content checks apply to iframes in sandboxed documents promise_test: Unhandled rejection with value: object "ReferenceError: Can't find variable: remoteExecutorUrl"
+FAIL Mixed content checks apply to popups in sandboxed documents promise_test: Unhandled rejection with value: object "ReferenceError: Can't find variable: remoteExecutorUrl"
+

--- a/LayoutTests/imported/w3c/web-platform-tests/mixed-content/csp.https.window.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/mixed-content/csp.https.window.html
@@ -1,0 +1,1 @@
+<!-- This file is required for WebKit test infrastructure to run the templated test -->

--- a/LayoutTests/imported/w3c/web-platform-tests/mixed-content/csp.https.window.js
+++ b/LayoutTests/imported/w3c/web-platform-tests/mixed-content/csp.https.window.js
@@ -1,0 +1,41 @@
+// META: script=/common/dispatcher/dispatcher.js
+// META: script=/common/get-host-info.sub.js
+// META: script=/common/utils.js
+
+promise_test((t) => {
+  const url = `${get_host_info().HTTP_ORIGIN}/common/text-plain.txt`;
+  const promise = fetch(url, { mode: "no-cors" });
+  return promise_rejects_js(t, TypeError, promise, "mixed content fetch");
+}, "Mixed content checks apply to fetches in sandboxed documents");
+
+promise_test(async (t) => {
+  const uuid = token();
+  const context = new RemoteContext(uuid);
+
+  const iframe = document.body.appendChild(document.createElement("iframe"));
+  iframe.src = remoteExecutorUrl(uuid, { protocol: "http:" });
+
+  const result = await Promise.race([
+      context.execute_script(() => "loaded"),
+      new Promise((resolve) => t.step_timeout(() => {
+        resolve("timed out");
+      }, 1000 /* ms */)),
+  ]);
+  assert_equals(result, "timed out");
+}, "Mixed content checks apply to iframes in sandboxed documents");
+
+
+promise_test(async (t) => {
+  const uuid = token();
+
+  const popup = window.open(remoteExecutorUrl(uuid, { protocol: "http:" }));
+
+  const context = new RemoteContext(uuid);
+  const result = await Promise.race([
+      context.execute_script(() => "loaded"),
+      new Promise((resolve) => t.step_timeout(() => {
+        resolve("timed out");
+      }, 1000 /* ms */)),
+  ]);
+  assert_equals(result, "timed out");
+}, "Mixed content checks apply to popups in sandboxed documents");

--- a/LayoutTests/imported/w3c/web-platform-tests/mixed-content/csp.https.window.js.headers
+++ b/LayoutTests/imported/w3c/web-platform-tests/mixed-content/csp.https.window.js.headers
@@ -1,0 +1,1 @@
+Content-Security-Policy: sandbox allow-scripts allow-popups;

--- a/LayoutTests/imported/w3c/web-platform-tests/mixed-content/nested-iframes.window-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/mixed-content/nested-iframes.window-expected.txt
@@ -1,0 +1,4 @@
+
+FAIL HTTP fetch assert_false: success expected false got true
+PASS HTTPS fetch
+

--- a/LayoutTests/imported/w3c/web-platform-tests/mixed-content/nested-iframes.window.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/mixed-content/nested-iframes.window.html
@@ -1,0 +1,1 @@
+<!-- This file is required for WebKit test infrastructure to run the templated test -->

--- a/LayoutTests/imported/w3c/web-platform-tests/mixed-content/nested-iframes.window.js
+++ b/LayoutTests/imported/w3c/web-platform-tests/mixed-content/nested-iframes.window.js
@@ -1,0 +1,25 @@
+// META: script=/common/get-host-info.sub.js
+
+const t1 = async_test("HTTP fetch");
+const t2 = async_test("HTTPS fetch");
+
+onmessage = function(e) {
+  const {protocol, success} = e.data;
+  if (protocol == "http:") {
+    t1.step(() => assert_false(success, "success"));
+    t1.done();
+  } else if (protocol == "https:") {
+    t2.step(() => assert_true(success, "success"));
+    t2.done();
+  } else {
+    [t1, t2].forEach(t => {
+      t.step(() => assert_unreached("Unknown message"));
+      t.done();
+    });
+  }
+};
+
+const httpsFrame = document.createElement("iframe");
+httpsFrame.src = get_host_info().HTTPS_ORIGIN + "/mixed-content/resources/middle-frame.html";
+
+document.body.appendChild(httpsFrame);

--- a/LayoutTests/imported/w3c/web-platform-tests/mixed-content/resources/middle-frame.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/mixed-content/resources/middle-frame.html
@@ -1,0 +1,39 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <script src="/common/get-host-info.sub.js"></script>
+  </head>
+  <body>
+    <script>
+      onmessage = e => parent.postMessage(e.data, "*");
+
+      const path = "/fetch/api/resources/cors-top.txt";
+      const http_url = get_host_info().HTTP_ORIGIN + path;
+      const https_url = get_host_info().HTTPS_ORIGIN + path;
+
+      const ifr = document.createElement("iframe");
+      ifr.src = `data:text/html,
+        <!DOCTYPE html>
+        <script>
+          async function try_fetch(url) {
+            try {
+              const response = await fetch(url);
+              return response.ok;
+            } catch(e) {
+              return false;
+            }
+          }
+          async function try_fetch_and_report(url) {
+            parent.postMessage({
+              protocol: new URL(url).protocol,
+              success: await try_fetch(url),
+            }, "*");
+          }
+          try_fetch_and_report("${http_url}");
+          try_fetch_and_report("${https_url}");
+        <\/script>
+      `;
+      document.body.appendChild(ifr);
+    </script>
+  </body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/mixed-content/resources/w3c-import.log
+++ b/LayoutTests/imported/w3c/web-platform-tests/mixed-content/resources/w3c-import.log
@@ -15,3 +15,4 @@ None
 ------------------------------------------------------------------------
 List of files:
 /LayoutTests/imported/w3c/web-platform-tests/mixed-content/resources/blob-popup.html
+/LayoutTests/imported/w3c/web-platform-tests/mixed-content/resources/middle-frame.html

--- a/LayoutTests/imported/w3c/web-platform-tests/mixed-content/tentative/autoupgrades/audio-upgrade.https.sub-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/mixed-content/tentative/autoupgrades/audio-upgrade.https.sub-expected.txt
@@ -1,3 +1,4 @@
 
 FAIL Audio autoupgraded assert_unreached: Audio should load successfully from http://localhost:9443/mixed-content/tentative/resources/test.wav Reached unreachable code
+FAIL Audio of other host autoupgraded assert_unreached: Audio of other host should load successfully from http://127.0.0.1:9443/mixed-content/tentative/resources/test.wav Reached unreachable code
 

--- a/LayoutTests/imported/w3c/web-platform-tests/mixed-content/tentative/autoupgrades/audio-upgrade.https.sub.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/mixed-content/tentative/autoupgrades/audio-upgrade.https.sub.html
@@ -4,6 +4,7 @@
 <title>Autoupgrade mixed content: Audio.</title>
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
+<script src="/common/get-host-info.sub.js"></script>
 
 </head>
 <body>
@@ -19,6 +20,20 @@
         });
         i.onerror = test.unreached_func("Audio should load successfully from " + url);
         i.src = url;
+    }
+    // Test the same just with another host
+    async_test(t => assert_other_host_audio_loads(t), "Audio of other host autoupgraded");
+
+    function assert_other_host_audio_loads(test) {
+    // Since autoupgrades don't upgrade custom ports, we use the https port with an HTTP scheme. A successful autoupgrade will result in the right URL loading (and no autoupgrade will result in failure).
+    var otherHost = get_host_info().HTTP_NOTSAMESITE_ORIGIN.slice(0,-4); // cut of http port
+    var url = new URL( otherHost + "{{ports[https][0]}}/mixed-content/tentative/resources/test.wav")
+    var i = document.createElement('audio');
+    i.oncanplaythrough = test.step_func_done(_ => {
+            assert_equals(i.duration, 1, "Length of other host audio is correct");
+    });
+    i.onerror = test.unreached_func("Audio of other host should load successfully from " + url);
+    i.src = url;
     }
 </script>
 </body>

--- a/LayoutTests/imported/w3c/web-platform-tests/mixed-content/tentative/autoupgrades/image-upgrade.https.sub-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/mixed-content/tentative/autoupgrades/image-upgrade.https.sub-expected.txt
@@ -1,3 +1,4 @@
 
 FAIL Image autoupgraded assert_unreached: Image should load successfully from http://localhost:9443/mixed-content/tentative/resources/pass.png Reached unreachable code
+FAIL Image of other host autoupgraded assert_unreached: image of other host should load successfully from http://127.0.0.1:9443/mixed-content/tentative/resources/pass.png Reached unreachable code
 

--- a/LayoutTests/imported/w3c/web-platform-tests/mixed-content/tentative/autoupgrades/image-upgrade.https.sub.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/mixed-content/tentative/autoupgrades/image-upgrade.https.sub.html
@@ -4,6 +4,7 @@
 <title>Autoupgrade mixed content: Optionally Blockable.</title>
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
+<script src="/common/get-host-info.sub.js"></script>
 
 </head>
 <body>
@@ -19,6 +20,22 @@
             assert_equals(i.naturalWidth, 168, "Width.");
         });
         i.onerror = test.unreached_func("Image should load successfully from " + url);
+        i.src = url;
+    }
+
+     // Test the same just with another host
+     async_test(t => assert_other_host_image_loads(t), "Image of other host autoupgraded");
+
+    function assert_other_host_image_loads(test) {
+        // Since autoupgrades don't upgrade custom ports, we use the https port with an HTTP scheme. A successful autoupgrade will result in the right URL loading (and no autoupgrade will result in failure).
+        var otherHost = get_host_info().HTTP_NOTSAMESITE_ORIGIN.slice(0,-4); // cut of http port
+        var url = new URL( otherHost + "{{ports[https][0]}}/mixed-content/tentative/resources/pass.png")
+        var i = document.createElement('img');
+        i.onload = test.step_func_done(_ => {
+            assert_equals(i.naturalHeight, 64, "Height.");
+            assert_equals(i.naturalWidth, 168, "Width.");
+        });
+        i.onerror = test.unreached_func("image of other host should load successfully from " + url);
         i.src = url;
     }
 </script>

--- a/LayoutTests/imported/w3c/web-platform-tests/mixed-content/tentative/autoupgrades/mixed-content-cors.https.sub-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/mixed-content/tentative/autoupgrades/mixed-content-cors.https.sub-expected.txt
@@ -1,0 +1,5 @@
+
+FAIL Cross-Origin audio should get upgraded even if CORS is set assert_unreached: Audio of other host should load successfully from http://127.0.0.1:9443/mixed-content/tentative/resources/test.wav?pipe=header(Access-Control-Allow-Origin,*) Reached unreachable code
+FAIL Cross-Origin image should get upgraded even if CORS is set assert_unreached: image of other host should load successfully from http://127.0.0.1:9443/mixed-content/tentative/resources/pass.png?pipe=header(Access-Control-Allow-Origin,*) Reached unreachable code
+FAIL Cross-Origin video should get upgraded even if CORS is set assert_unreached: Video of other host should load successfully from http://127.0.0.1:9443/mixed-content/tentative/resources/test.ogv?pipe=header(Access-Control-Allow-Origin,*) Reached unreachable code
+

--- a/LayoutTests/imported/w3c/web-platform-tests/mixed-content/tentative/autoupgrades/mixed-content-cors.https.sub.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/mixed-content/tentative/autoupgrades/mixed-content-cors.https.sub.html
@@ -1,0 +1,84 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Test mixed content autoupgrade behavior for CORS request</title>
+    <script src="/resources/testharness.js"></script>
+    <script src="/resources/testharnessreport.js"></script>
+    <script src="/common/get-host-info.sub.js"></script>
+  </head>
+  <body>
+    <script>
+      // Test that request with CORS get upgraded for audio elements
+      async_test(
+        (t) => assert_other_host_audio_loads(t),
+        "Cross-Origin audio should get upgraded even if CORS is set"
+      );
+
+      function assert_other_host_audio_loads(test) {
+        // Since autoupgrades don't upgrade custom ports, we use the https port with an HTTP scheme. A successful autoupgrade will result in the right URL loading (and no autoupgrade will result in failure).
+        var otherHost = get_host_info().HTTP_NOTSAMESITE_ORIGIN.slice(0, -4); // cut of http port
+        var url =
+          otherHost +
+          "{{ports[https][0]}}/mixed-content/tentative/resources/test.wav?pipe=header(Access-Control-Allow-Origin,*)";
+        var i = document.createElement("audio");
+        i.oncanplaythrough = test.step_func_done((_) => {
+          assert_equals(i.duration, 1, "Length of other host audio is correct");
+        });
+        i.onerror = test.unreached_func(
+          "Audio of other host should load successfully from " + url
+        );
+        i.crossOrigin = "anonymous";
+        i.src = url;
+      }
+
+      // Test that request with CORS get upgraded for image elements
+      async_test(
+        (t) => assert_other_host_image_loads(t),
+        "Cross-Origin image should get upgraded even if CORS is set"
+      );
+
+      function assert_other_host_image_loads(test) {
+        // Since autoupgrades don't upgrade custom ports, we use the https port with an HTTP scheme. A successful autoupgrade will result in the right URL loading (and no autoupgrade will result in failure).
+        var otherHost = get_host_info().HTTP_NOTSAMESITE_ORIGIN.slice(0, -4); // cut of http port
+        var url = new URL(
+          otherHost +
+            "{{ports[https][0]}}/mixed-content/tentative/resources/pass.png?pipe=header(Access-Control-Allow-Origin,*)"
+        );
+        var i = document.createElement("img");
+        i.onload = test.step_func_done((_) => {
+          assert_equals(i.naturalHeight, 64, "Height.");
+          assert_equals(i.naturalWidth, 168, "Width.");
+        });
+        i.crossOrigin = "anonymous";
+        i.onerror = test.unreached_func(
+          "image of other host should load successfully from " + url
+        );
+        i.src = url;
+      }
+
+      // Test that request with CORS get upgraded for video elements
+      async_test(
+        (t) => assert_other_host_video_loads(t),
+        "Cross-Origin video should get upgraded even if CORS is set"
+      );
+
+      function assert_other_host_video_loads(test) {
+        // Since autoupgrades don't upgrade custom ports, we use the https port with an HTTP scheme. A successful autoupgrade will result in the right URL loading (and no autoupgrade will result in failure).
+        var otherHost = get_host_info().HTTP_NOTSAMESITE_ORIGIN.slice(0, -4); // cut of http port
+        var url = new URL(
+          otherHost +
+            "{{ports[https][0]}}/mixed-content/tentative/resources/test.ogv?pipe=header(Access-Control-Allow-Origin,*)"
+        );
+        var i = document.createElement("video");
+        i.oncanplaythrough = test.step_func_done((_) => {
+          assert_equals(Math.floor(i.duration), 300, "Length. Other host");
+        });
+        i.crossOrigin = "anonymous";
+        i.onerror = test.unreached_func(
+          "Video of other host should load successfully from " + url
+        );
+        i.src = url;
+      }
+    </script>
+  </body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/mixed-content/tentative/autoupgrades/video-upgrade.https.sub-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/mixed-content/tentative/autoupgrades/video-upgrade.https.sub-expected.txt
@@ -1,3 +1,4 @@
 
 FAIL Video autoupgraded assert_unreached: Video should load successfully from http://localhost:9443/mixed-content/tentative/resources/test.ogv Reached unreachable code
+FAIL Video of other host autoupgraded assert_unreached: Video of other host should load successfully from http://127.0.0.1:9443/mixed-content/tentative/resources/test.ogv Reached unreachable code
 

--- a/LayoutTests/imported/w3c/web-platform-tests/mixed-content/tentative/autoupgrades/video-upgrade.https.sub.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/mixed-content/tentative/autoupgrades/video-upgrade.https.sub.html
@@ -4,6 +4,7 @@
 <title>Autoupgrade mixed content: Video.</title>
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
+<script src="/common/get-host-info.sub.js"></script>
 
 </head>
 <body>
@@ -18,6 +19,21 @@
             assert_equals(Math.floor(i.duration), 300, "Length.");
         });
         i.onerror = test.unreached_func("Video should load successfully from " + url);
+        i.src = url;
+    }
+
+    // Test the same just with another host
+    async_test(t => assert_other_host_video_loads(t), "Video of other host autoupgraded");
+
+    function assert_other_host_video_loads(test) {
+        // Since autoupgrades don't upgrade custom ports, we use the https port with an HTTP scheme. A successful autoupgrade will result in the right URL loading (and no autoupgrade will result in failure).
+        var otherHost = get_host_info().HTTP_NOTSAMESITE_ORIGIN.slice(0,-4); // cut of http port
+        var url = new URL( otherHost + "{{ports[https][0]}}/mixed-content/tentative/resources/test.ogv")
+        var i = document.createElement('video');
+        i.oncanplaythrough = test.step_func_done(_ => {
+            assert_equals(Math.floor(i.duration), 300, "Length. Other host");
+        });
+        i.onerror = test.unreached_func("Video of other host should load successfully from " + url);
         i.src = url;
     }
 </script>

--- a/LayoutTests/imported/w3c/web-platform-tests/mixed-content/tentative/autoupgrades/w3c-import.log
+++ b/LayoutTests/imported/w3c/web-platform-tests/mixed-content/tentative/autoupgrades/w3c-import.log
@@ -16,4 +16,5 @@ None
 List of files:
 /LayoutTests/imported/w3c/web-platform-tests/mixed-content/tentative/autoupgrades/audio-upgrade.https.sub.html
 /LayoutTests/imported/w3c/web-platform-tests/mixed-content/tentative/autoupgrades/image-upgrade.https.sub.html
+/LayoutTests/imported/w3c/web-platform-tests/mixed-content/tentative/autoupgrades/mixed-content-cors.https.sub.html
 /LayoutTests/imported/w3c/web-platform-tests/mixed-content/tentative/autoupgrades/video-upgrade.https.sub.html

--- a/LayoutTests/imported/w3c/web-platform-tests/mixed-content/w3c-import.log
+++ b/LayoutTests/imported/w3c/web-platform-tests/mixed-content/w3c-import.log
@@ -17,5 +17,8 @@ List of files:
 /LayoutTests/imported/w3c/web-platform-tests/mixed-content/META.yml
 /LayoutTests/imported/w3c/web-platform-tests/mixed-content/README.md
 /LayoutTests/imported/w3c/web-platform-tests/mixed-content/blob.https.sub.html
+/LayoutTests/imported/w3c/web-platform-tests/mixed-content/csp.https.window.js
+/LayoutTests/imported/w3c/web-platform-tests/mixed-content/csp.https.window.js.headers
 /LayoutTests/imported/w3c/web-platform-tests/mixed-content/imageset.https.sub.html
+/LayoutTests/imported/w3c/web-platform-tests/mixed-content/nested-iframes.window.js
 /LayoutTests/imported/w3c/web-platform-tests/mixed-content/spec.src.json

--- a/LayoutTests/platform/glib/imported/w3c/web-platform-tests/mixed-content/tentative/autoupgrades/audio-upgrade.https.sub-expected.txt
+++ b/LayoutTests/platform/glib/imported/w3c/web-platform-tests/mixed-content/tentative/autoupgrades/audio-upgrade.https.sub-expected.txt
@@ -1,3 +1,4 @@
 
 FAIL Audio autoupgraded assert_unreached: Audio should load successfully from http://web-platform.test:9443/mixed-content/tentative/resources/test.wav Reached unreachable code
+FAIL Audio of other host autoupgraded assert_unreached: Audio of other host should load successfully from http://not-web-platform.test:9443/mixed-content/tentative/resources/test.wav Reached unreachable code
 

--- a/LayoutTests/platform/glib/imported/w3c/web-platform-tests/mixed-content/tentative/autoupgrades/image-upgrade.https.sub-expected.txt
+++ b/LayoutTests/platform/glib/imported/w3c/web-platform-tests/mixed-content/tentative/autoupgrades/image-upgrade.https.sub-expected.txt
@@ -1,3 +1,4 @@
 
 FAIL Image autoupgraded assert_unreached: Image should load successfully from http://web-platform.test:9443/mixed-content/tentative/resources/pass.png Reached unreachable code
+FAIL Image of other host autoupgraded assert_unreached: image of other host should load successfully from http://not-web-platform.test:9443/mixed-content/tentative/resources/pass.png Reached unreachable code
 

--- a/LayoutTests/platform/glib/imported/w3c/web-platform-tests/mixed-content/tentative/autoupgrades/mixed-content-cors.https.sub-expected.txt
+++ b/LayoutTests/platform/glib/imported/w3c/web-platform-tests/mixed-content/tentative/autoupgrades/mixed-content-cors.https.sub-expected.txt
@@ -1,0 +1,5 @@
+
+FAIL Cross-Origin audio should get upgraded even if CORS is set assert_unreached: Audio of other host should load successfully from http://not-web-platform.test:9443/mixed-content/tentative/resources/test.wav?pipe=header(Access-Control-Allow-Origin,*) Reached unreachable code
+FAIL Cross-Origin image should get upgraded even if CORS is set assert_unreached: image of other host should load successfully from http://not-web-platform.test:9443/mixed-content/tentative/resources/pass.png?pipe=header(Access-Control-Allow-Origin,*) Reached unreachable code
+FAIL Cross-Origin video should get upgraded even if CORS is set assert_unreached: Video of other host should load successfully from http://not-web-platform.test:9443/mixed-content/tentative/resources/test.ogv?pipe=header(Access-Control-Allow-Origin,*) Reached unreachable code
+

--- a/LayoutTests/platform/glib/imported/w3c/web-platform-tests/mixed-content/tentative/autoupgrades/video-upgrade.https.sub-expected.txt
+++ b/LayoutTests/platform/glib/imported/w3c/web-platform-tests/mixed-content/tentative/autoupgrades/video-upgrade.https.sub-expected.txt
@@ -1,3 +1,4 @@
 
 FAIL Video autoupgraded assert_unreached: Video should load successfully from http://web-platform.test:9443/mixed-content/tentative/resources/test.ogv Reached unreachable code
+FAIL Video of other host autoupgraded assert_unreached: Video of other host should load successfully from http://not-web-platform.test:9443/mixed-content/tentative/resources/test.ogv Reached unreachable code
 


### PR DESCRIPTION
#### 2f019929ef93eb73df47ac30ee8e53d723a87f6c
<pre>
[mixed-content] Resync WPT
<a href="https://bugs.webkit.org/show_bug.cgi?id=257150">https://bugs.webkit.org/show_bug.cgi?id=257150</a>
rdar://109676140

Reviewed by Tim Nguyen.

Resync mixed-content tests as of upstream commit
a4d663e6e09213bf599fb3a9dc66a52f2549c7fe

* LayoutTests/imported/w3c/web-platform-tests/mixed-content/csp.https.window-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/mixed-content/csp.https.window.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/mixed-content/csp.https.window.js: Added.
(promise_test):
(promise_test.async t):
* LayoutTests/imported/w3c/web-platform-tests/mixed-content/csp.https.window.js.headers: Added.
* LayoutTests/imported/w3c/web-platform-tests/mixed-content/nested-iframes.window-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/mixed-content/nested-iframes.window.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/mixed-content/nested-iframes.window.js: Added.
(onmessage):
* LayoutTests/imported/w3c/web-platform-tests/mixed-content/resources/middle-frame.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/mixed-content/resources/w3c-import.log:
* LayoutTests/imported/w3c/web-platform-tests/mixed-content/tentative/autoupgrades/audio-upgrade.https.sub-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/mixed-content/tentative/autoupgrades/audio-upgrade.https.sub.html:
* LayoutTests/imported/w3c/web-platform-tests/mixed-content/tentative/autoupgrades/image-upgrade.https.sub-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/mixed-content/tentative/autoupgrades/image-upgrade.https.sub.html:
* LayoutTests/imported/w3c/web-platform-tests/mixed-content/tentative/autoupgrades/mixed-content-cors.https.sub-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/mixed-content/tentative/autoupgrades/mixed-content-cors.https.sub.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/mixed-content/tentative/autoupgrades/video-upgrade.https.sub-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/mixed-content/tentative/autoupgrades/video-upgrade.https.sub.html:
* LayoutTests/imported/w3c/web-platform-tests/mixed-content/tentative/autoupgrades/w3c-import.log:
* LayoutTests/imported/w3c/web-platform-tests/mixed-content/w3c-import.log:
* LayoutTests/platform/glib/imported/w3c/web-platform-tests/mixed-content/tentative/autoupgrades/audio-upgrade.https.sub-expected.txt:
* LayoutTests/platform/glib/imported/w3c/web-platform-tests/mixed-content/tentative/autoupgrades/image-upgrade.https.sub-expected.txt:
* LayoutTests/platform/glib/imported/w3c/web-platform-tests/mixed-content/tentative/autoupgrades/mixed-content-cors.https.sub-expected.txt: Added.
* LayoutTests/platform/glib/imported/w3c/web-platform-tests/mixed-content/tentative/autoupgrades/video-upgrade.https.sub-expected.txt:

Canonical link: <a href="https://commits.webkit.org/264495@main">https://commits.webkit.org/264495@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/3d232bb3afb75bb013f5223f2fbabfcb17c60be2

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/7780 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/8054 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/8235 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/9422 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/7930 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/10044 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/7974 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/10793 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/7917 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/9026 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/7135 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/9534 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/6335 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/7080 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/14742 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/7481 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/7208 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/10611 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/7704 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/6278 "16 flakes 3 failures") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/7030 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/6992 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/1866 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/11240 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/7436 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->