### PR TITLE
Make debug mode in SVGTextLayoutEngine functional again

### DIFF
--- a/Source/WebCore/rendering/svg/SVGTextLayoutEngine.cpp
+++ b/Source/WebCore/rendering/svg/SVGTextLayoutEngine.cpp
@@ -34,7 +34,7 @@
 #include "SVGTextLayoutEngineSpacing.h"
 
 // Set to a value > 0 to dump the text fragments
-#define DUMP_TEXT_FRAGMENTS 0
+#define DUMP_SVG_TEXT_LAYOUT_FRAGMENTS 0
 
 namespace WebCore {
 
@@ -231,26 +231,26 @@ void SVGTextLayoutEngine::layoutInlineTextBox(SVGInlineTextBox& textBox)
     m_lineLayoutBoxes.append(&textBox);
 }
 
-#if DUMP_TEXT_FRAGMENTS > 0
+#if DUMP_SVG_TEXT_LAYOUT_FRAGMENTS > 0
 static inline void dumpTextBoxes(Vector<SVGInlineTextBox*>& boxes)
 {
-    unsigned boxCount = boxes.size();
-    fprintf(stderr, "Dumping all text fragments in text sub tree, %i boxes\n", boxCount);
+    auto boxCount = boxes.size();
+    fprintf(stderr, "Dumping all text fragments in text sub tree, %ld boxes\n", boxCount);
 
     for (unsigned boxPosition = 0; boxPosition < boxCount; ++boxPosition) {
         SVGInlineTextBox* textBox = boxes.at(boxPosition);
         Vector<SVGTextFragment>& fragments = textBox->textFragments();
-        fprintf(stderr, "-> Box %i: Dumping text fragments for SVGInlineTextBox, textBox=%p, textRenderer=%p\n", boxPosition, textBox, textBox->renderer());
-        fprintf(stderr, "        textBox properties, start=%i, len=%i, box direction=%i\n", textBox->start(), textBox->len(), textBox->direction());
-        fprintf(stderr, "   textRenderer properties, textLength=%i\n", textBox->renderer()->textLength());
+        fprintf(stderr, "-> Box %d: Dumping text fragments for SVGInlineTextBox, textBox=%p, textRenderer=%p\n", boxPosition, textBox, &textBox->renderer());
+        fprintf(stderr, "        textBox properties, start=%d, len=%d, box direction=%d\n", textBox->start(), textBox->len(), (int)textBox->direction());
+        fprintf(stderr, "   textRenderer properties, textLength=%d\n", textBox->renderer().text().length());
 
-        const UChar* characters = textBox->renderer()->characters();
+        const auto* characters = textBox->renderer().text().characters<UChar>();
 
         unsigned fragmentCount = fragments.size();
         for (unsigned i = 0; i < fragmentCount; ++i) {
             SVGTextFragment& fragment = fragments.at(i);
             String fragmentString(characters + fragment.characterOffset, fragment.length);
-            fprintf(stderr, "    -> Fragment %i, x=%lf, y=%lf, width=%lf, height=%lf, characterOffset=%i, length=%i, characters='%s'\n"
+            fprintf(stderr, "    -> Fragment %d, x=%.2f, y=%.2f, width=%.2f, height=%.2f, characterOffset=%d, length=%d, characters='%s'\n"
                           , i, fragment.x, fragment.y, fragment.width, fragment.height, fragment.characterOffset, fragment.length, fragmentString.utf8().data());
         }
     }
@@ -284,7 +284,7 @@ void SVGTextLayoutEngine::finishLayout()
 
     // Finalize transform matrices, after the chunk layout corrections have been applied, and all fragment x/y positions are finalized.
     if (!m_lineLayoutBoxes.isEmpty()) {
-#if DUMP_TEXT_FRAGMENTS > 0
+#if DUMP_SVG_TEXT_LAYOUT_FRAGMENTS > 0
         fprintf(stderr, "Line layout: ");
         dumpTextBoxes(m_lineLayoutBoxes);
 #endif
@@ -293,7 +293,7 @@ void SVGTextLayoutEngine::finishLayout()
     }
 
     if (!m_pathLayoutBoxes.isEmpty()) {
-#if DUMP_TEXT_FRAGMENTS > 0
+#if DUMP_SVG_TEXT_LAYOUT_FRAGMENTS > 0
         fprintf(stderr, "Path layout: ");
         dumpTextBoxes(m_pathLayoutBoxes);
 #endif


### PR DESCRIPTION
#### 459f81b38481aff16323a2fa88756fe2cbd28abe
<pre>
Make debug mode in SVGTextLayoutEngine functional again
<a href="https://bugs.webkit.org/show_bug.cgi?id=257155">https://bugs.webkit.org/show_bug.cgi?id=257155</a>

Reviewed by Rob Buis.

Make debug mode &apos;DUMP_TEXT_FRAGMENTS&apos; &gt; 0, work again.
It wasn&apos;t adapted to the changes in the surrounding code since
a few years, since the code isn&apos;t compiled, usually.

Rename to DUMP_SVG_TEXT_LAYOUT_FRAGMENTS for clarity.
No change in functionality, thus no new tests.

* Source/WebCore/rendering/svg/SVGTextLayoutEngine.cpp:
(WebCore::dumpTextBoxes): Fix build issues.

Canonical link: <a href="https://commits.webkit.org/264625@main">https://commits.webkit.org/264625@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/35748119669a906cd9c7658c51c07b813b5d55e2

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/8073 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/8359 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/8572 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/9726 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/8172 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/8078 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/10344 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/8269 "Built successfully") | [⏳ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/WPE-WK2-Tests-EWS "Waiting to run tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/8217 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/9297 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/7355 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/9847 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/6598 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/7386 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/14964 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/7721 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/7511 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/10869 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/7984 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/6496 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/7295 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/1967 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/11504 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/7725 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->