### PR TITLE
SVGTextLayoutEngine m_textPathStartOffset is uninitialized

### DIFF
--- a/Source/WebCore/rendering/svg/SVGTextLayoutEngine.cpp
+++ b/Source/WebCore/rendering/svg/SVGTextLayoutEngine.cpp
@@ -40,21 +40,6 @@ namespace WebCore {
 
 SVGTextLayoutEngine::SVGTextLayoutEngine(Vector<SVGTextLayoutAttributes*>& layoutAttributes)
     : m_layoutAttributes(layoutAttributes)
-    , m_layoutAttributesPosition(0)
-    , m_logicalCharacterOffset(0)
-    , m_logicalMetricsListOffset(0)
-    , m_visualCharacterOffset(0)
-    , m_visualMetricsListOffset(0)
-    , m_x(0)
-    , m_y(0)
-    , m_dx(0)
-    , m_dy(0)
-    , m_isVerticalText(false)
-    , m_inPathLayout(false)
-    , m_textPathLength(0)
-    , m_textPathCurrentOffset(0)
-    , m_textPathSpacing(0)
-    , m_textPathScaling(1)
 {
     ASSERT(!m_layoutAttributes.isEmpty());
 }

--- a/Source/WebCore/rendering/svg/SVGTextLayoutEngine.h
+++ b/Source/WebCore/rendering/svg/SVGTextLayoutEngine.h
@@ -81,25 +81,25 @@ private:
     SVGTextChunkBuilder m_chunkLayoutBuilder;
 
     SVGTextFragment m_currentTextFragment;
-    unsigned m_layoutAttributesPosition;
-    unsigned m_logicalCharacterOffset;
-    unsigned m_logicalMetricsListOffset;
-    unsigned m_visualCharacterOffset;
-    unsigned m_visualMetricsListOffset;
-    float m_x;
-    float m_y;
-    float m_dx;
-    float m_dy;
-    bool m_isVerticalText;
-    bool m_inPathLayout;
+    unsigned m_layoutAttributesPosition { 0 };
+    unsigned m_logicalCharacterOffset { 0 };
+    unsigned m_logicalMetricsListOffset { 0 };
+    unsigned m_visualCharacterOffset { 0 };
+    unsigned m_visualMetricsListOffset { 0 };
+    float m_x { 0.0f };
+    float m_y { 0.0f };
+    float m_dx { 0.0f };
+    float m_dy { 0.0f };
+    bool m_isVerticalText { false };
+    bool m_inPathLayout { false };
 
     // Text on path layout
     Path m_textPath;
-    float m_textPathLength;
-    float m_textPathStartOffset;
-    float m_textPathCurrentOffset;
-    float m_textPathSpacing;
-    float m_textPathScaling;
+    float m_textPathLength { 0.0f };
+    float m_textPathStartOffset { 0.0f };
+    float m_textPathCurrentOffset { 0.0f };
+    float m_textPathSpacing { 0.0f };
+    float m_textPathScaling { 1.0f };
 };
 
 } // namespace WebCore


### PR DESCRIPTION
#### 835136aa12f7848edb9abdc3e8d0d11500172ad2
<pre>
SVGTextLayoutEngine m_textPathStartOffset is uninitialized
<a href="https://bugs.webkit.org/show_bug.cgi?id=257156">https://bugs.webkit.org/show_bug.cgi?id=257156</a>

Reviewed by Rob Buis.

Initialize all SVGTextLayoutEngine members using brace initializaation
in the header, to avoid uninitialized variables, like m_textPathStartOffset.

It has no practical consequences, as it&apos;s always set before entering
path-layout mode - however we should clean it up to avoid this in future.

Covered by existing tests.

* Source/WebCore/rendering/svg/SVGTextLayoutEngine.cpp:
(WebCore::SVGTextLayoutEngine::SVGTextLayoutEngine):
* Source/WebCore/rendering/svg/SVGTextLayoutEngine.h:

Canonical link: <a href="https://commits.webkit.org/264580@main">https://commits.webkit.org/264580@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/638ba60844088166fff9bc69d742cc476f4091ac

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/7468 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/7734 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/7912 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/9102 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/7668 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/7479 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/9673 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/7656 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/10557 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/7599 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/8713 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/6916 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/9215 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/6022 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/6793 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/14517 "Passed tests") | 
| | [❌ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/7243 "30 api tests failed or timed out") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/6913 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/10227 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/7404 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/6056 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/6750 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/1923 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/10960 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/7137 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->