### PR TITLE
Ensure we don't crash with calc(round())

### DIFF
--- a/LayoutTests/fast/css/calc-parsing-expected.txt
+++ b/LayoutTests/fast/css/calc-parsing-expected.txt
@@ -128,6 +128,21 @@ PASS 100 is 100
 element.style["width"] = "calc(cos(e - e) * 100px)"
 PASS 100 is 100
 
+element.style["width"] = "round(117px, 25px)"
+PASS 125 is 125
+
+element.style["width"] = "round(nearest, 117px, 25px)"
+PASS 125 is 125
+
+element.style["width"] = "round(up, 117px, 25px)"
+PASS 125 is 125
+
+element.style["width"] = "round(down, 117px, 25px)"
+PASS 100 is 100
+
+element.style["width"] = "round(to-zero, 117px, 25px)"
+PASS 100 is 100
+
 element.style["width"] = "calc(100px, 200px)"
 PASS element.style['width'] is "999px"
 PASS getComputedStyle(element).getPropertyValue('width') is "999px"
@@ -264,6 +279,18 @@ element.style["width"] = "calc(sin() * 100px)"
 PASS element.style['width'] is "999px"
 PASS getComputedStyle(element).getPropertyValue('width') is "999px"
 
+element.style["width"] = "round(dummy, 117px, 25px)"
+PASS element.style['width'] is "999px"
+PASS getComputedStyle(element).getPropertyValue('width') is "999px"
+
+element.style["width"] = "round(nearest)"
+PASS element.style['width'] is "999px"
+PASS getComputedStyle(element).getPropertyValue('width') is "999px"
+
+element.style["width"] = "round(1px, 2px, 3px)"
+PASS element.style['width'] is "999px"
+PASS getComputedStyle(element).getPropertyValue('width') is "999px"
+
 element.style["min-width"] = "calc(100px)"
 PASS element.style['min-width'] is "calc(100px)"
 PASS getComputedStyle(element).getPropertyValue('min-width') is "100px"
@@ -386,6 +413,21 @@ element.style["min-width"] = "calc(sin(pi/2) * 100px)"
 PASS 100 is 100
 
 element.style["min-width"] = "calc(cos(e - e) * 100px)"
+PASS 100 is 100
+
+element.style["min-width"] = "round(117px, 25px)"
+PASS 125 is 125
+
+element.style["min-width"] = "round(nearest, 117px, 25px)"
+PASS 125 is 125
+
+element.style["min-width"] = "round(up, 117px, 25px)"
+PASS 125 is 125
+
+element.style["min-width"] = "round(down, 117px, 25px)"
+PASS 100 is 100
+
+element.style["min-width"] = "round(to-zero, 117px, 25px)"
 PASS 100 is 100
 
 element.style["min-width"] = "calc(100px, 200px)"
@@ -521,6 +563,18 @@ PASS element.style['min-width'] is "999px"
 PASS getComputedStyle(element).getPropertyValue('min-width') is "999px"
 
 element.style["min-width"] = "calc(sin() * 100px)"
+PASS element.style['min-width'] is "999px"
+PASS getComputedStyle(element).getPropertyValue('min-width') is "999px"
+
+element.style["min-width"] = "round(dummy, 117px, 25px)"
+PASS element.style['min-width'] is "999px"
+PASS getComputedStyle(element).getPropertyValue('min-width') is "999px"
+
+element.style["min-width"] = "round(nearest)"
+PASS element.style['min-width'] is "999px"
+PASS getComputedStyle(element).getPropertyValue('min-width') is "999px"
+
+element.style["min-width"] = "round(1px, 2px, 3px)"
 PASS element.style['min-width'] is "999px"
 PASS getComputedStyle(element).getPropertyValue('min-width') is "999px"
 PASS successfullyParsed is true

--- a/LayoutTests/fast/css/calc-parsing.html
+++ b/LayoutTests/fast/css/calc-parsing.html
@@ -63,6 +63,11 @@
                 testValue('calc(tan(30deg + 15deg) * 100px)', '100');
                 testValue('calc(sin(pi/2) * 100px)', '100');
                 testValue('calc(cos(e - e) * 100px)', '100');
+                testValue('round(117px, 25px)', '125')
+                testValue('round(nearest, 117px, 25px)', '125')
+                testValue('round(up, 117px, 25px)', '125')
+                testValue('round(down, 117px, 25px)', '100')
+                testValue('round(to-zero, 117px, 25px)', '100')
 
                 // Non-parsing expressions.
                 testExpression('calc(100px, 200px)', '999px', '999px');
@@ -99,6 +104,9 @@
                 testExpression('calc(sin(piiii/4) * 100px)', '999px', '999px');
                 testExpression('calc(sin(e e/4) * 100px)', '999px', '999px');
                 testExpression('calc(sin() * 100px)', '999px', '999px');
+                testExpression('round(dummy, 117px, 25px)', '999px', '999px');
+                testExpression('round(nearest)', '999px', '999px');
+                testExpression('round(1px, 2px, 3px)', '999px', '999px');
             }
 
             testProperty("width");

--- a/LayoutTests/fast/css/calc-with-round-crash-expected.txt
+++ b/LayoutTests/fast/css/calc-with-round-crash-expected.txt
@@ -1,0 +1,1 @@
+PASS if no crash

--- a/LayoutTests/fast/css/calc-with-round-crash.html
+++ b/LayoutTests/fast/css/calc-with-round-crash.html
@@ -1,0 +1,10 @@
+<script>
+onload = () => {
+  if(window.testRunner)
+    testRunner.dumpAsText();
+  document.execCommand('SelectAll');
+  document.body.innerHTML = 'PASS if no crash';
+};
+</script>
+<body style="-webkit-user-modify: read-write; max-height: calc(1px + 0% + round(0cqmin, 0px));">
+</body>

--- a/Source/WebCore/css/calc/CSSCalcValue.cpp
+++ b/Source/WebCore/css/calc/CSSCalcValue.cpp
@@ -238,16 +238,14 @@ static RefPtr<CSSCalcExpressionNode> createCSS(const CalcExpressionNode& node, c
         }
         case CalcOperator::Mod:
         case CalcOperator::Rem:
-        case CalcOperator::Round: {
-            auto children = createCSS(operationChildren, style);
-            if (children.size() != 2)
-                return nullptr;
-            return CSSCalcOperationNode::createStep(op, WTFMove(children));
-        }
+        case CalcOperator::Round:
         case CalcOperator::Nearest:
         case CalcOperator::ToZero:
         case CalcOperator::Up:
         case CalcOperator::Down: {
+            auto children = createCSS(operationChildren, style);
+            if (children.size() == 2)
+                return CSSCalcOperationNode::createStep(op, WTFMove(children));
             return CSSCalcOperationNode::createRoundConstant(op);
         }
         }


### PR DESCRIPTION
#### 569bdcf08cfad1bb375fb6a15a4304b3ea3a4166
<pre>
Ensure we don&apos;t crash with calc(round())
<a href="https://bugs.webkit.org/show_bug.cgi?id=257157">https://bugs.webkit.org/show_bug.cgi?id=257157</a>
rdar://109503971

Reviewed by Darin Adler.

This change fixes the crash which happens due to us discarding the
children in case of a round to nearest operation.

* LayoutTests/fast/css/calc-parsing-expected.txt:
* LayoutTests/fast/css/calc-parsing.html:
* LayoutTests/fast/css/calc-with-round-crash-expected.txt: Added.
* LayoutTests/fast/css/calc-with-round-crash.html: Added.
* Source/WebCore/css/calc/CSSCalcValue.cpp:
(WebCore::createCSS):

Canonical link: <a href="https://commits.webkit.org/264863@main">https://commits.webkit.org/264863@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9211843f6a3ec5d02d65b0f3c121bb80c74ee73c

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/7958 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/8240 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/8454 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/9608 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/8072 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/7962 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/10228 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/8152 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/10935 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/8101 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/9188 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/7283 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/9727 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/6492 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/7284 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/14873 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/7615 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/7407 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/10767 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/7875 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/6403 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/7192 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/7194 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/2162 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/11401 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/7613 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->