### PR TITLE
Add a helper function to return the effective DocumentLoader for website policies

### DIFF
--- a/Source/WebKit/WebProcess/Network/WebLoaderStrategy.cpp
+++ b/Source/WebKit/WebProcess/Network/WebLoaderStrategy.cpp
@@ -310,13 +310,10 @@ static RefPtr<DocumentLoader> policySourceDocumentLoaderForFrame(const LocalFram
     if (!mainFrame)
         return { };
 
-    RefPtr mainFrameDocumentLoader = mainFrame->loader().policyDocumentLoader();
-    if (!mainFrameDocumentLoader)
-        mainFrameDocumentLoader = mainFrame->loader().provisionalDocumentLoader();
-    if (!mainFrameDocumentLoader || !isMainFrameNavigation)
-        mainFrameDocumentLoader = mainFrame->loader().documentLoader();
+    auto canIncludeCurrentDocumentLoader = isMainFrameNavigation ? WebDocumentLoader::CanIncludeCurrentDocumentLoader::No : WebDocumentLoader::CanIncludeCurrentDocumentLoader::Yes;
+    RefPtr<DocumentLoader> mainFrameDocumentLoader = WebDocumentLoader::loaderForWebsitePolicies(*mainFrame, canIncludeCurrentDocumentLoader);
 
-    RefPtr policySourceDocumentLoader = mainFrameDocumentLoader;
+    auto policySourceDocumentLoader = mainFrameDocumentLoader;
     if (policySourceDocumentLoader && !policySourceDocumentLoader->request().url().hasSpecialScheme() && frame.document()->url().protocolIsInHTTPFamily())
         policySourceDocumentLoader = frame.loader().documentLoader();
 

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebFrameLoaderClient.cpp
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebFrameLoaderClient.cpp
@@ -109,14 +109,11 @@ void WebFrameLoaderClient::dispatchDecidePolicyForNavigationAction(const Navigat
     // FIXME: Move all this DocumentLoader stuff to the caller, pass in the results.
     RefPtr coreFrame = m_frame->coreLocalFrame();
 
-    WebDocumentLoader* documentLoader = coreFrame ? static_cast<WebDocumentLoader*>(coreFrame->loader().policyDocumentLoader()) : nullptr;
-    if (!documentLoader) {
-        // FIXME: When we receive a redirect after the navigation policy has been decided for the initial request,
-        // the provisional load's DocumentLoader needs to receive navigation policy decisions. We need a better model for this state.
-        documentLoader = coreFrame ? static_cast<WebDocumentLoader*>(coreFrame->loader().provisionalDocumentLoader()) : nullptr;
-    }
-    if (!documentLoader)
-        documentLoader = coreFrame ? static_cast<WebDocumentLoader*>(coreFrame->loader().documentLoader()) : nullptr;
+    // FIXME: When we receive a redirect after the navigation policy has been decided for the initial request,
+    // the provisional load's DocumentLoader needs to receive navigation policy decisions. We need a better model for this state.
+    RefPtr<WebDocumentLoader> documentLoader;
+    if (coreFrame)
+        documentLoader = WebDocumentLoader::loaderForWebsitePolicies(*coreFrame);
 
     auto& mouseEventData = navigationAction.mouseEventData();
     NavigationActionData navigationActionData {

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebLocalFrameLoaderClient.cpp
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebLocalFrameLoaderClient.cpp
@@ -973,11 +973,8 @@ void WebLocalFrameLoaderClient::applyToDocumentLoader(WebsitePoliciesData&& webs
     auto* coreFrame = m_frame->coreLocalFrame();
     if (!coreFrame)
         return;
-    WebDocumentLoader* documentLoader = static_cast<WebDocumentLoader*>(coreFrame->loader().policyDocumentLoader());
-    if (!documentLoader)
-        documentLoader = static_cast<WebDocumentLoader*>(coreFrame->loader().provisionalDocumentLoader());
-    if (!documentLoader)
-        documentLoader = static_cast<WebDocumentLoader*>(coreFrame->loader().documentLoader());
+
+    RefPtr documentLoader = WebDocumentLoader::loaderForWebsitePolicies(*coreFrame);
     if (!documentLoader)
         return;
 

--- a/Source/WebKit/WebProcess/WebPage/WebDocumentLoader.cpp
+++ b/Source/WebKit/WebProcess/WebPage/WebDocumentLoader.cpp
@@ -56,4 +56,14 @@ void WebDocumentLoader::setNavigationID(uint64_t navigationID)
     m_navigationID = navigationID;
 }
 
+WebDocumentLoader* WebDocumentLoader::loaderForWebsitePolicies(const LocalFrame& frame, CanIncludeCurrentDocumentLoader canIncludeCurrentDocumentLoader)
+{
+    auto* loader = static_cast<WebDocumentLoader*>(frame.loader().policyDocumentLoader());
+    if (!loader)
+        loader = static_cast<WebDocumentLoader*>(frame.loader().provisionalDocumentLoader());
+    if (!loader && canIncludeCurrentDocumentLoader == CanIncludeCurrentDocumentLoader::Yes)
+        loader = static_cast<WebDocumentLoader*>(frame.loader().documentLoader());
+    return loader;
+}
+
 } // namespace WebKit

--- a/Source/WebKit/WebProcess/WebPage/WebDocumentLoader.h
+++ b/Source/WebKit/WebProcess/WebPage/WebDocumentLoader.h
@@ -40,6 +40,9 @@ public:
     uint64_t navigationID() const { return m_navigationID; }
     void setNavigationID(uint64_t);
 
+    enum class CanIncludeCurrentDocumentLoader : bool { No, Yes };
+    static WebDocumentLoader* loaderForWebsitePolicies(const WebCore::LocalFrame&, CanIncludeCurrentDocumentLoader = CanIncludeCurrentDocumentLoader::Yes);
+
 private:
     WebDocumentLoader(const WebCore::ResourceRequest&, const WebCore::SubstituteData&);
 


### PR DESCRIPTION
#### ddb41c0a2bc1ab838e7adad4bc2ae52cb7dbf12a
<pre>
Add a helper function to return the effective DocumentLoader for website policies
<a href="https://bugs.webkit.org/show_bug.cgi?id=257152">https://bugs.webkit.org/show_bug.cgi?id=257152</a>

Reviewed by Tim Horton.

Avoid some code duplication by merging all the three (nearly) identical implementations of &quot;get the
effective `WebDocumentLoader` for website policies&quot; in WebKit2 into a single helper method. No
change in behavior.

* Source/WebKit/WebProcess/Network/WebLoaderStrategy.cpp:
(WebKit::policySourceDocumentLoaderForFrame):
* Source/WebKit/WebProcess/WebCoreSupport/WebFrameLoaderClient.cpp:
(WebKit::WebFrameLoaderClient::dispatchDecidePolicyForNavigationAction):
* Source/WebKit/WebProcess/WebCoreSupport/WebLocalFrameLoaderClient.cpp:
(WebKit::WebLocalFrameLoaderClient::applyToDocumentLoader):
* Source/WebKit/WebProcess/WebPage/WebDocumentLoader.cpp:
(WebKit::WebDocumentLoader::loaderForWebsitePolicies):
* Source/WebKit/WebProcess/WebPage/WebDocumentLoader.h:

Canonical link: <a href="https://commits.webkit.org/264436@main">https://commits.webkit.org/264436@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/962f244b9e71a7fa0f95a4b04bc49048c7ff6053

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/7474 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/7740 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/7918 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/9108 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/7672 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/9681 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/7662 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/10555 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/7605 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/8720 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/6925 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/9220 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/6029 "Passed tests") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/14523 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/7248 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/6925 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/10234 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/7410 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/6062 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/6755 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/1814 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/10964 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/7143 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->