### PR TITLE
'textLength' support for 'tspan' elements is incomplete

### DIFF
--- a/LayoutTests/svg/text/textLength-tspan-1-expected.html
+++ b/LayoutTests/svg/text/textLength-tspan-1-expected.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html>
+<body>
+<h1>All lines should have the same length</h1>
+<svg style="display: block; width: 100%; height: 600px;" viewBox="0 0 100 100">
+<text><tspan textLength="80" x="0" dy="1em">SHORT</tspan><tspan textLength="80" x="0" dy="1em">SHORT</tspan><tspan textLength="80" x="0" dy="1em">SHORT</tspan></text>
+<line x1="0" x2="100" y1="1.1em" y2="1.1em" stroke="blue"/>  <!-- Indicates the width of the viewport -->
+<line x1="0" x2="80"  y1="1.1em" y2="1.1em" stroke="green"/> <!-- Indicates the specified text length -->
+</svg>
+</body>
+</html>

--- a/LayoutTests/svg/text/textLength-tspan-1.html
+++ b/LayoutTests/svg/text/textLength-tspan-1.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html>
+<body>
+<h1>All lines should have the same length</h1>
+<svg style="display: block; width: 100%; height: 600px;" viewBox="0 0 100 100">
+<!-- Note: The extra space between the second and third <tspan> lead to broken textLength adjustments. -->
+<text><tspan textLength="80" x="0" dy="1em">SHORT</tspan><tspan textLength="80" x="0" dy="1em">SHORT</tspan> <tspan textLength="80" x="0" dy="1em">SHORT</tspan></text>
+<line x1="0" x2="100" y1="1.1em" y2="1.1em" stroke="blue"/>  <!-- Indicates the width of the viewport -->
+<line x1="0" x2="80"  y1="1.1em" y2="1.1em" stroke="green"/> <!-- Indicates the specified text length -->
+</svg>
+</body>
+</html>

--- a/LayoutTests/svg/text/textLength-tspan-2-expected.html
+++ b/LayoutTests/svg/text/textLength-tspan-2-expected.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html>
+<body>
+<h1>All lines should have the same length</h1>
+<svg style="display: block; width: 100%; height: 600px;" viewBox="0 0 100 100">
+<text><tspan textLength="80" x="0" dy="1em">SHORT</tspan><tspan textLength="80" x="0" dy="1em">SHORT</tspan><tspan textLength="80" x="0" dy="1em">SHORT</tspan></text>
+<line x1="0" x2="100" y1="1.1em" y2="1.1em" stroke="blue"/>  <!-- Indicates the width of the viewport -->
+<line x1="0" x2="80"  y1="1.1em" y2="1.1em" stroke="green"/> <!-- Indicates the specified text length -->
+</svg>
+</body>
+</html>

--- a/LayoutTests/svg/text/textLength-tspan-2.html
+++ b/LayoutTests/svg/text/textLength-tspan-2.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html>
+<body>
+<h1>All lines should have the same length</h1>
+<svg style="display: block; width: 100%; height: 600px;" viewBox="0 0 100 100">
+<text>
+  <tspan textLength="80" x="0" dy="1em">SHORT</tspan>   
+  
+  
+     <tspan textLength="80" x="0" dy="1em">SHORT</tspan>   <tspan textLength="80" x="0" dy="1em">SHORT</tspan>
+
+</text>
+<line x1="0" x2="100" y1="1.1em" y2="1.1em" stroke="blue"/>  <!-- Indicates the width of the viewport -->
+<line x1="0" x2="80"  y1="1.1em" y2="1.1em" stroke="green"/> <!-- Indicates the specified text length -->
+</svg>
+</body>
+</html>

--- a/Source/WebCore/rendering/svg/SVGTextLayoutEngine.h
+++ b/Source/WebCore/rendering/svg/SVGTextLayoutEngine.h
@@ -90,6 +90,9 @@ private:
     float m_y { 0.0f };
     float m_dx { 0.0f };
     float m_dy { 0.0f };
+    float m_lastChunkStartPosition { 0.0f };
+    bool m_lastChunkHasTextLength { false };
+    bool m_lastChunkIsVerticalText { false };
     bool m_isVerticalText { false };
     bool m_inPathLayout { false };
 


### PR DESCRIPTION
#### a9ba148c1a1793210f451e03e94ee71a359c94b0
<pre>
&apos;textLength&apos; support for &apos;tspan&apos; elements is incomplete
<a href="https://bugs.webkit.org/show_bug.cgi?id=257160">https://bugs.webkit.org/show_bug.cgi?id=257160</a>

Reviewed by Rob Buis.

WebKit issue #171805 contained an imported fix from Chromium
to properly compute the inter-character spacing (off-by-one).

Continue the work to make textLength fully functional on &lt;tspan&gt;
elements, in a few edge cases related to whitespace/text chunk handling.

Prior to this patch, non-collapsed whitespace remnants between
flow boxes ended up contributing to the size of a text chunk -- this
goes unnoticed as long as textLength support isn&apos;t used. If textLength
is used on &lt;tspan&gt; elements, the extra characters, lead to wrong
inter-character space computation (as the number of characters is
larger than expected).

Add new reftests to cover the new logic - see LayoutTests/svg/text/textLength-tspan-{1|2}.html.

* LayoutTests/svg/text/textLength-tspan-1-expected.html: Added.
* LayoutTests/svg/text/textLength-tspan-1.html: Added.
* LayoutTests/svg/text/textLength-tspan-2-expected.html: Added.
* LayoutTests/svg/text/textLength-tspan-2.html: Added.
* Source/WebCore/rendering/svg/SVGTextLayoutEngine.cpp:
(WebCore::SVGTextLayoutEngine::layoutTextOnLineOrPath):
* Source/WebCore/rendering/svg/SVGTextLayoutEngine.h:

Canonical link: <a href="https://commits.webkit.org/264666@main">https://commits.webkit.org/264666@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/18c453c11b34861b7d287dab10219981d9b1de56

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/8310 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/8603 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/8820 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/9978 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/8375 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/8319 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/10591 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/8514 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/11243 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/8456 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/9516 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/7538 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/10122 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/6815 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/7604 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/15164 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/7936 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/7745 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/11091 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/8215 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/6692 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/7504 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/7516 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/1996 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/11714 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/7958 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->