### PR TITLE
Change event isn't firing when the user reverts the value of color/date/time/datetime input after JS changed the value

### DIFF
--- a/LayoutTests/fast/forms/date/date-editable-components/date-multiple-fields-choose-default-value-after-set-value-expected.txt
+++ b/LayoutTests/fast/forms/date/date-editable-components/date-multiple-fields-choose-default-value-after-set-value-expected.txt
@@ -1,0 +1,17 @@
+Test if change event fires when the user selects the default value after the value was changed by JS.
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+PASS input.value is "2001-01-01"
+PASS eventsCounter.input is undefined.
+PASS eventsCounter.change is undefined.
+==> "input" event was dispatched.
+==> "change" event was dispatched.
+PASS input.value is "2000-01-01"
+PASS eventsCounter.input is 1
+PASS eventsCounter.change is 1
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/fast/forms/date/date-editable-components/date-multiple-fields-choose-default-value-after-set-value.html
+++ b/LayoutTests/fast/forms/date/date-editable-components/date-multiple-fields-choose-default-value-after-set-value.html
@@ -1,0 +1,45 @@
+<!DOCTYPE html>
+<html>
+<head>
+<script src="../../../../resources/js-test.js"></script>
+<script src="../../../../resources/ui-helper.js"></script>
+</head>
+<body>
+<p id="description"></p>
+<div id="console"></div>
+<input type="date" id="input" value="2000-01-01">
+<script>
+description('Test if change event fires when the user selects the default value after the value was changed by JS.');
+
+var eventsCounter = {};
+function recordEvent(event) {
+    if (eventsCounter[event.type] === undefined)
+        eventsCounter[event.type] = 0;
+    eventsCounter[event.type]++;
+    debug('==> "' + event.type + '" event was dispatched.');
+}
+
+var input = document.getElementById('input');
+input.addEventListener('input', recordEvent, false);
+input.addEventListener('change', recordEvent, false);
+
+input.value = '2001-01-01';
+
+shouldBeEqualToString('input.value', '2001-01-01');
+shouldBeUndefined('eventsCounter.input');
+shouldBeUndefined('eventsCounter.change');
+
+// We assume the date format is MM/dd/yyyy.
+
+input.focus();
+UIHelper.keyDown('rightArrow');
+UIHelper.keyDown('rightArrow');
+UIHelper.keyDown('downArrow');
+
+shouldBeEqualToString('input.value', '2000-01-01');
+shouldBe('eventsCounter.input', '1');
+shouldBe('eventsCounter.change', '1');
+
+</script>
+</body>
+</html>

--- a/LayoutTests/fast/forms/datetimelocal/datetimelocal-editable-components/datetimelocal-multiple-fields-choose-default-value-after-set-value-expected.txt
+++ b/LayoutTests/fast/forms/datetimelocal/datetimelocal-editable-components/datetimelocal-multiple-fields-choose-default-value-after-set-value-expected.txt
@@ -1,0 +1,17 @@
+Test if change event fires when the user selects the default value after the value was changed by JS.
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+PASS input.value is "2001-01-01T01:01:01"
+PASS eventsCounter.input is undefined.
+PASS eventsCounter.change is undefined.
+==> "input" event was dispatched.
+==> "change" event was dispatched.
+PASS input.value is "2000-01-01T01:01:01"
+PASS eventsCounter.input is 1
+PASS eventsCounter.change is 1
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/fast/forms/datetimelocal/datetimelocal-editable-components/datetimelocal-multiple-fields-choose-default-value-after-set-value.html
+++ b/LayoutTests/fast/forms/datetimelocal/datetimelocal-editable-components/datetimelocal-multiple-fields-choose-default-value-after-set-value.html
@@ -1,0 +1,45 @@
+<!DOCTYPE html>
+<html>
+<head>
+<script src="../../../../resources/js-test.js"></script>
+<script src="../../../../resources/ui-helper.js"></script>
+</head>
+<body>
+<p id="description"></p>
+<div id="console"></div>
+<input type="datetime-local" id="input" value="2000-01-01T01:01:01">
+<script>
+description('Test if change event fires when the user selects the default value after the value was changed by JS.');
+
+var eventsCounter = {};
+function recordEvent(event) {
+    if (eventsCounter[event.type] === undefined)
+        eventsCounter[event.type] = 0;
+    eventsCounter[event.type]++;
+    debug('==> "' + event.type + '" event was dispatched.');
+}
+
+var input = document.getElementById('input');
+input.addEventListener('input', recordEvent, false);
+input.addEventListener('change', recordEvent, false);
+
+input.value = '2001-01-01T01:01:01';
+
+shouldBeEqualToString('input.value', '2001-01-01T01:01:01');
+shouldBeUndefined('eventsCounter.input');
+shouldBeUndefined('eventsCounter.change');
+
+// We assume the date format is MM/dd/yyyy h:m a.
+
+input.focus();
+UIHelper.keyDown('rightArrow');
+UIHelper.keyDown('rightArrow');
+UIHelper.keyDown('downArrow');
+
+shouldBeEqualToString('input.value', '2000-01-01T01:01:01');
+shouldBe('eventsCounter.input', '1');
+shouldBe('eventsCounter.change', '1');
+
+</script>
+</body>
+</html>

--- a/LayoutTests/fast/forms/time/time-editable-components/time-multiple-fields-choose-default-value-after-set-value-expected.txt
+++ b/LayoutTests/fast/forms/time/time-editable-components/time-multiple-fields-choose-default-value-after-set-value-expected.txt
@@ -1,0 +1,18 @@
+Test if change event fires when the user selects the default value after the value was changed by JS.
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+PASS input.value is "02:01:01"
+PASS eventsCounter.input is undefined.
+PASS eventsCounter.change is undefined.
+Digit keys
+==> "input" event was dispatched.
+==> "change" event was dispatched.
+PASS input.value is "01:01:01"
+PASS eventsCounter.input is 1
+PASS eventsCounter.change is 1
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/fast/forms/time/time-editable-components/time-multiple-fields-choose-default-value-after-set-value.html
+++ b/LayoutTests/fast/forms/time/time-editable-components/time-multiple-fields-choose-default-value-after-set-value.html
@@ -1,0 +1,45 @@
+<!DOCTYPE html>
+<html>
+<head>
+<script src="../../../../resources/js-test.js"></script>
+<script src="../../../../resources/ui-helper.js"></script>
+</head>
+<body>
+<p id="description"></p>
+<div id="console"></div>
+<input type="time" id="input" value="01:01:01">
+<script>
+description('Test if change event fires when the user selects the default value after the value was changed by JS.');
+
+var eventsCounter = {};
+function recordEvent(event) {
+    if (eventsCounter[event.type] === undefined)
+        eventsCounter[event.type] = 0;
+    eventsCounter[event.type]++;
+    debug('==> "' + event.type + '" event was dispatched.');
+}
+
+var input = document.getElementById('input');
+input.addEventListener('input', recordEvent, false);
+input.addEventListener('change', recordEvent, false);
+
+input.value = '02:01:01';
+
+shouldBeEqualToString('input.value', '02:01:01');
+shouldBeUndefined('eventsCounter.input');
+shouldBeUndefined('eventsCounter.change');
+
+// We assume the date format is h:m a.
+
+input.focus();
+
+debug("Digit keys");                               // [00]/00/00
+UIHelper.keyDown('downArrow');
+
+shouldBeEqualToString('input.value', '01:01:01');
+shouldBe('eventsCounter.input', '1');
+shouldBe('eventsCounter.change', '1');
+
+</script>
+</body>
+</html>

--- a/Source/WebCore/html/HTMLInputElement.cpp
+++ b/Source/WebCore/html/HTMLInputElement.cpp
@@ -1104,6 +1104,9 @@ ExceptionOr<void> HTMLInputElement::setValue(const String& value, TextFieldEvent
     if (selfOrPrecedingNodesAffectDirAuto())
         updateEffectiveDirectionalityOfDirAuto();
 
+    if (valueChanged && eventBehavior == DispatchNoEvent)
+        setTextAsOfLastFormControlChangeEvent(sanitizedValue);
+
     bool wasModifiedProgrammatically = eventBehavior == DispatchNoEvent;
     if (wasModifiedProgrammatically) {
         resignStrongPasswordAppearance();

--- a/Source/WebCore/html/TextFieldInputType.cpp
+++ b/Source/WebCore/html/TextFieldInputType.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2010 Google Inc. All rights reserved.
+ * Copyright (C) 2010-2013 Google Inc. All rights reserved.
  * Copyright (C) 2011-2020 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -174,8 +174,7 @@ void TextFieldInputType::setValue(const String& sanitizedValue, bool valueChange
         break;
     }
 
-    // FIXME: Why do we do this when eventBehavior == DispatchNoEvent
-    if (!input->focused() || eventBehavior == DispatchNoEvent)
+    if (!input->focused())
         input->setTextAsOfLastFormControlChangeEvent(sanitizedValue);
 
     if (UserTypingGestureIndicator::processingUserTypingGesture())


### PR DESCRIPTION
#### 2434c2b49b9956110d55edfa28a42ceef2776972
<pre>
Change event isn&apos;t firing when the user reverts the value of color/date/time/datetime input after JS changed the value

<a href="https://bugs.webkit.org/show_bug.cgi?id=121590">https://bugs.webkit.org/show_bug.cgi?id=121590</a>

Reviewed by Aditya Keerthi.

Partial Merge: <a href="https://chromium.googlesource.com/chromium/blink/+/3054068c08635caf65eb933794f5ac6bbaf80e23">https://chromium.googlesource.com/chromium/blink/+/3054068c08635caf65eb933794f5ac6bbaf80e23</a>

NOTE: We are not merging &apos;Color&apos; input test due to lack of test infrastructure support.

Setting the value through the value property wasn&apos;t setting the textAsOfLastFormControlChangeEvent.
So change events weren&apos;t firing when the user changes the value
back to the one that was set before JS changed it.

* Source/WebCore/html/HTMLInputElement.cpp:
(HTMLInputElement::setValue) - Add if condition to add &quot;santantizedValue&quot; for setTextAsOfLastFormControlChangeEvent
* Source/WebCore/html/TextFieldInput.cpp:
(TextFieldIputType::setValue) - Remove FIXME and condition of eventBehavior being DispatchNoEvent
* LayoutTests/fast/forms/time/time-editable-components/time-multiple-fields-choose-default-value-after-set-value.html: Add Test Case
* LayoutTests/fast/forms/time/time-editable-components/time-multiple-fields-choose-default-value-after-set-value-expected.txt: Add Test Case Expectation
* LayoutTests/fast/forms/datetimelocal/datetimelocal-editable-components/datetimelocal-multiple-fields-choose-default-value-after-set-value.html: Add Test Case
* LayoutTests/fast/forms/datetimelocal/datetimelocal-editable-components/datetimelocal-multiple-fields-choose-default-value-after-set-value-expected.txt: Add Test Case Expectation
* LayoutTests/fast/forms/date/date-editable-components/date-multiple-fields-choose-default-value-after-set-value.html: Add Test Case
* LayoutTests/fast/forms/date/date-editable-components/date-multiple-fields-choose-default-value-after-set-value-expected.txt: Add Test Case Expectation

Canonical link: <a href="https://commits.webkit.org/264528@main">https://commits.webkit.org/264528@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b73634d875f7a6de742f7342767b87fe79cbc500

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/7485 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/7751 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/7930 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/9120 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/7681 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/7496 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/9696 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/7674 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/10564 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/7616 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/8728 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/6927 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/9229 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/6036 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/6807 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/14532 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/7253 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/6927 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/10248 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/7420 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/6067 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/6764 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/6719 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/1885 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/10973 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/7154 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->