### PR TITLE
[JSC] Early return in microtask draining when termination happens

### DIFF
--- a/JSTests/stress/exception-check-unhandled-promise-rejection-in-shell.js
+++ b/JSTests/stress/exception-check-unhandled-promise-rejection-in-shell.js
@@ -1,0 +1,9 @@
+//@ runDefault("--watchdog=100", "--watchdog-exception-ok")
+async function foo() {
+  await undefined;
+  throw new Error();
+}
+
+setUnhandledRejectionCallback(foo);
+foo();
+drainMicrotasks();

--- a/Source/JavaScriptCore/runtime/VM.cpp
+++ b/Source/JavaScriptCore/runtime/VM.cpp
@@ -1240,6 +1240,8 @@ void VM::didExhaustMicrotaskQueue()
                 continue;
 
             callPromiseRejectionCallback(promise);
+            if (UNLIKELY(hasPendingTerminationException()))
+                return;
         }
     } while (!m_aboutToBeNotifiedRejectedPromises.isEmpty());
 }
@@ -1258,10 +1260,14 @@ void VM::drainMicrotasks()
             while (!m_microtaskQueue.isEmpty()) {
                 auto task = m_microtaskQueue.dequeue();
                 task.run();
+                if (UNLIKELY(hasPendingTerminationException()))
+                    return;
                 if (m_onEachMicrotaskTick)
                     m_onEachMicrotaskTick(*this);
             }
             didExhaustMicrotaskQueue();
+            if (UNLIKELY(hasPendingTerminationException()))
+                return;
         } while (!m_microtaskQueue.isEmpty());
     }
     finalizeSynchronousJSExecution();


### PR DESCRIPTION
#### 3201e5f5a718fc241b820adb575455d2e3bc9b95
<pre>
[JSC] Early return in microtask draining when termination happens
<a href="https://bugs.webkit.org/show_bug.cgi?id=257163">https://bugs.webkit.org/show_bug.cgi?id=257163</a>
rdar://109401883

Reviewed by Mark Lam.

This is Debug only, JSC shell only issue. Early returning from microtask draining when termination happens.

* JSTests/stress/exception-check-unhandled-promise-rejection-in-shell.js: Added.
(async foo):
* Source/JavaScriptCore/runtime/VM.cpp:
(JSC::VM::didExhaustMicrotaskQueue):
(JSC::VM::drainMicrotasks):

Canonical link: <a href="https://commits.webkit.org/264390@main">https://commits.webkit.org/264390@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/dc0167d10d36ae26625c99183645b843fc15c2a2

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/7489 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/7755 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/7935 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/9125 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/32/builds/7685 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/9700 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/7679 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/10567 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/7620 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/8735 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/6928 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/9233 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/6043 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/6810 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/14534 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/6384 "Built successfully and passed tests") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/7257 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/6930 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/10257 "run-api-tests-without-change (failure)") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/7073 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/7424 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/6071 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/7638 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/6768 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/1752 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/1772 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/10977 "Built successfully") | | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/24/builds/7841 "Built successfully") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/7158 "Built successfully") | | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/3/builds/1892 "Passed tests") | 
<!--EWS-Status-Bubble-End-->