### PR TITLE
Remove SubframePageProxy and associated processes when no longer used

### DIFF
--- a/Source/WebKit/UIProcess/SubframePageProxy.h
+++ b/Source/WebKit/UIProcess/SubframePageProxy.h
@@ -59,15 +59,16 @@ class WebProcessProxy;
 
 struct FrameInfoData;
 
-class SubframePageProxy : public IPC::MessageReceiver, public IPC::MessageSender {
+class SubframePageProxy : public RefCounted<SubframePageProxy>, public IPC::MessageReceiver, public IPC::MessageSender {
     WTF_MAKE_FAST_ALLOCATED;
 public:
-    SubframePageProxy(WebPageProxy&, WebProcessProxy&);
+    static Ref<SubframePageProxy> create(WebPageProxy& page, WebProcessProxy& process) { return adoptRef(*new SubframePageProxy(page, process)); }
     ~SubframePageProxy();
 
     WebProcessProxy& process() { return m_process.get(); }
 
 private:
+    SubframePageProxy(WebPageProxy&, WebProcessProxy&);
     IPC::Connection* messageSenderConnection() const final;
     uint64_t messageSenderDestinationID() const final;
     void didReceiveMessage(IPC::Connection&, IPC::Decoder&);

--- a/Source/WebKit/UIProcess/WebFrameProxy.h
+++ b/Source/WebKit/UIProcess/WebFrameProxy.h
@@ -55,6 +55,7 @@ namespace WebKit {
 
 class ProvisionalFrameProxy;
 class SafeBrowsingWarning;
+class SubframePageProxy;
 class UserData;
 class WebFramePolicyListenerProxy;
 class WebPageProxy;
@@ -152,6 +153,7 @@ public:
     void swapToProcess(Ref<WebProcessProxy>&&, const WebCore::ResourceRequest&);
 
     void commitProvisionalFrame(WebCore::FrameIdentifier, FrameInfoData&&, WebCore::ResourceRequest&&, uint64_t navigationID, const String& mimeType, bool frameHasCustomContentProvider, WebCore::FrameLoadType, const WebCore::CertificateInfo&, bool usedLegacyTLS, bool privateRelayed, bool containsPluginDocument, WebCore::HasInsecureContent, WebCore::MouseEventPolicy, const UserData&);
+    void setSubframePageProxy(SubframePageProxy&);
 
     void getFrameInfo(CompletionHandler<void(FrameTreeNodeData&&)>&&);
     FrameTreeCreationParameters frameTreeCreationParameters() const;
@@ -180,6 +182,7 @@ private:
     ListHashSet<Ref<WebFrameProxy>> m_childFrames;
     WeakPtr<WebFrameProxy> m_parentFrame;
     std::unique_ptr<ProvisionalFrameProxy> m_provisionalFrame;
+    RefPtr<SubframePageProxy> m_subframePageProxy;
 #if ENABLE(CONTENT_FILTERING)
     WebCore::ContentFilterUnblockHandler m_contentFilterUnblockHandler;
 #endif

--- a/Source/WebKit/UIProcess/WebPageProxy.h
+++ b/Source/WebKit/UIProcess/WebPageProxy.h
@@ -2155,7 +2155,8 @@ public:
 #endif
 
     SubframePageProxy* subpageFrameProxyForRegistrableDomain(WebCore::RegistrableDomain) const;
-    void addSubframePageProxy(WebCore::RegistrableDomain, UniqueRef<SubframePageProxy>&&);
+    void addSubframePageProxy(const WebCore::RegistrableDomain&, Ref<SubframePageProxy>&&);
+    void removeSubpageFrameProxyIfUnused(const WebCore::RegistrableDomain&);
 
     void createRemoteSubframesInOtherProcesses(WebFrameProxy&);
 

--- a/Source/WebKit/UIProcess/WebPageProxyInternals.h
+++ b/Source/WebKit/UIProcess/WebPageProxyInternals.h
@@ -214,7 +214,7 @@ struct WebPageProxy::Internals final : WebPopupMenuProxy::Client
     WindowKind windowKind { WindowKind::Unparented };
     PageAllowedToRunInTheBackgroundCounter::Token pageAllowedToRunInTheBackgroundToken;
 
-    HashMap<WebCore::RegistrableDomain, UniqueRef<SubframePageProxy>> domainToSubframePageProxyMap;
+    HashMap<WebCore::RegistrableDomain, WeakPtr<SubframePageProxy>> domainToSubframePageProxyMap;
 
 #if ENABLE(APPLE_PAY)
     std::unique_ptr<WebPaymentCoordinatorProxy> paymentCoordinator;

--- a/Source/WebKit/UIProcess/WebProcessPool.cpp
+++ b/Source/WebKit/UIProcess/WebProcessPool.cpp
@@ -1857,8 +1857,11 @@ void WebProcessPool::processForNavigation(WebPageProxy& page, WebFrameProxy& fra
 
     if (!frame.isMainFrame() && page.preferences().siteIsolationEnabled()) {
         RegistrableDomain navigationDomain(navigation.currentRequest().url());
-        if (!navigationDomain.isEmpty() && navigationDomain != mainFrameDomain)
-            page.addSubframePageProxy(navigationDomain, makeUniqueRef<SubframePageProxy>(page, process));
+        if (!navigationDomain.isEmpty() && navigationDomain != mainFrameDomain) {
+            auto subframePageProxy = SubframePageProxy::create(page, process);
+            frame.setSubframePageProxy(subframePageProxy.get());
+            page.addSubframePageProxy(navigationDomain, WTFMove(subframePageProxy));
+        }
     }
 
     // We are process-swapping so automatic process prewarming would be beneficial if the client has not explicitly enabled / disabled it.

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/SiteIsolation.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/SiteIsolation.mm
@@ -504,12 +504,7 @@ TEST(SiteIsolation, ParentNavigatingCrossOriginIframeToSameOrigin)
     checkFrameTreesInProcesses(webView.get(), {
         { "https://example.com"_s,
             { { "https://example.com"_s } }
-        },
-        // FIXME: This process should be torn down when the iframe navigates back to example.com.
-        // The count of local frames going to 0 should remove the SubframePageProxy.
-        { RemoteFrame,
-            { { RemoteFrame } }
-        },
+        }
     });
 }
 


### PR DESCRIPTION
#### 9eadb9b6c14f00e9d345a22ea725b74fc36b17a4
<pre>
Remove SubframePageProxy and associated processes when no longer used
<a href="https://bugs.webkit.org/show_bug.cgi?id=257166">https://bugs.webkit.org/show_bug.cgi?id=257166</a>
rdar://105024979

Reviewed by Chris Dumez.

A SubframePageProxy needs to keep track of how many frames are using it,
and when that number hits zero it needs to be deleted.  This sounds a lot
like reference counting.  Make it RefCounted and change its ownership to
the WebFrameProxy.  The WebPageProxy still needs to keep a map of RegistrableDomain
to SubframePageProxy to be able to reuse the same process for multiple iframes,
but this map can keep weak references.

* Source/WebKit/UIProcess/SubframePageProxy.h:
(WebKit::SubframePageProxy::create):
* Source/WebKit/UIProcess/WebFrameProxy.cpp:
(WebKit::WebFrameProxy::commitProvisionalFrame):
(WebKit::WebFrameProxy::setSubframePageProxy):
* Source/WebKit/UIProcess/WebFrameProxy.h:
* Source/WebKit/UIProcess/WebPageProxy.cpp:
(WebKit::WebPageProxy::updateRemoteFrameSize):
(WebKit::WebPageProxy::didFinishLoadForFrame):
(WebKit::WebPageProxy::addSubframePageProxy):
(WebKit::WebPageProxy::removeSubpageFrameProxyIfUnused):
(WebKit::WebPageProxy::subpageFrameProxyForRegistrableDomain const):
* Source/WebKit/UIProcess/WebPageProxy.h:
* Source/WebKit/UIProcess/WebPageProxyInternals.h:
* Source/WebKit/UIProcess/WebProcessPool.cpp:
(WebKit::WebProcessPool::processForNavigation):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/SiteIsolation.mm:
(TestWebKitAPI::TEST):

Canonical link: <a href="https://commits.webkit.org/264401@main">https://commits.webkit.org/264401@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/3d523bfa2d6ed1ac82884f29d4b6a8b6ed82a0cb

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/7492 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/7758 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/7938 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/9128 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/7688 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/7503 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/9705 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/7682 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/10569 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/7623 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/8736 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/6937 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/9236 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/6044 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/6820 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/14536 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/7258 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/6940 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/10254 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/7427 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/6073 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/6771 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/10980 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/911 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/7162 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->