### PR TITLE
XSLTProcessor fails when xsl calls exsl:node-set() on empty variable

### DIFF
--- a/LayoutTests/fast/xsl/xslt-node-set-empty-expected.txt
+++ b/LayoutTests/fast/xsl/xslt-node-set-empty-expected.txt
@@ -1,0 +1,3 @@
+
+PASS a variable set to node-set of a string should not halt processing
+

--- a/LayoutTests/fast/xsl/xslt-node-set-empty.html
+++ b/LayoutTests/fast/xsl/xslt-node-set-empty.html
@@ -1,0 +1,27 @@
+<!DOCTYPE html>
+<script src="../../resources/testharness.js"></script>
+<script src="../../resources/testharnessreport.js"></script>
+<script>
+test(() => {
+  const xmlSource = '<poke/>';
+  const xslSource = `<xsl:stylesheet version="1.0"
+    xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
+    xmlns:exsl="http://exslt.org/common">
+
+    <xsl:variable name="peek" select="exsl:node-set('')"/>
+
+    <xsl:template match="poke">
+      <xsl:text>PASS</xsl:text>
+    </xsl:template>
+  </xsl:stylesheet>`;
+
+  const parser = new DOMParser();
+  const xsl = parser.parseFromString(xslSource, 'text/xml');
+  const xml = parser.parseFromString(xmlSource, 'text/xml');
+
+  const xslproc = new XSLTProcessor();
+  xslproc.importStylesheet(xsl);
+  const result = xslproc.transformToFragment(xml, document);
+  assert_equals(result.firstChild.textContent, 'PASS');
+}, 'a variable set to node-set of a string should not halt processing');
+</script>

--- a/Source/WebCore/xml/XSLTExtensions.cpp
+++ b/Source/WebCore/xml/XSLTExtensions.cpp
@@ -37,12 +37,14 @@
 
 namespace WebCore {
 
-// FIXME: This code is taken from libexslt 1.1.11; should sync with newer versions.
+// FIXME: This code is taken from libexslt v1.1.35; should sync with newer versions.
 static void exsltNodeSetFunction(xmlXPathParserContextPtr ctxt, int nargs)
 {
+    xmlDocPtr fragment;
+    xsltTransformContextPtr tctxt = xsltXPathGetTransformContext(ctxt);
+    xmlNodePtr txt;
     xmlChar *strval;
-    xmlNodePtr retNode;
-    xmlXPathObjectPtr ret;
+    xmlXPathObjectPtr obj;
 
     if (nargs != 1) {
         xmlXPathSetArityError(ctxt);
@@ -54,19 +56,38 @@ static void exsltNodeSetFunction(xmlXPathParserContextPtr ctxt, int nargs)
         return;
     }
 
-    strval = xmlXPathPopString(ctxt);
-    retNode = xmlNewDocText(NULL, strval);
-    ret = xmlXPathNewValueTree(retNode);
-    
-    // FIXME: It might be helpful to push any errors from xmlXPathNewValueTree
-    // up to the Javascript Console.
-    if (ret != NULL) 
-        ret->type = XPATH_NODESET;
+    /*
+     * SPEC EXSLT:
+     * "You can also use this function to turn a string into a text
+     * node, which is helpful if you want to pass a string to a
+     * function that only accepts a node-set."
+     */
+    fragment = xsltCreateRVT(tctxt);
+    if (!fragment) {
+        xsltTransformError(tctxt, nullptr, tctxt->inst,
+            "WebCore::exsltNodeSetFunction: Failed to create a tree fragment.\n");
+        tctxt->state = XSLT_STATE_STOPPED;
+        return;
+    }
+    xsltRegisterLocalRVT(tctxt, fragment);
 
+    strval = xmlXPathPopString(ctxt);
+
+    txt = xmlNewDocText(fragment, strval);
+    xmlAddChild(reinterpret_cast<xmlNodePtr>(fragment), txt);
+    obj = xmlXPathNewNodeSet(txt);
+
+    // FIXME: It might be helpful to push any errors from xmlXPathNewNodeSet
+    // up to the Javascript Console.
+    if (!obj) {
+        xsltTransformError(tctxt, nullptr, tctxt->inst,
+            "WebCore::exsltNodeSetFunction: Failed to create a node set object.\n");
+        tctxt->state = XSLT_STATE_STOPPED;
+    }
     if (strval != NULL)
         xmlFree(strval);
 
-    valuePush(ctxt, ret);
+    valuePush(ctxt, obj);
 }
 
 void registerXSLTExtensions(xsltTransformContextPtr ctxt)


### PR DESCRIPTION
#### c8222bf810a77760c11df7b83d024fa395e5d4f5
<pre>
XSLTProcessor fails when xsl calls exsl:node-set() on empty variable
<a href="https://bugs.webkit.org/show_bug.cgi?id=253857">https://bugs.webkit.org/show_bug.cgi?id=253857</a>
&lt;rdar://103622929&gt;

Reviewed by Alex Christensen.

Merge fix for Chromium Issue 689977:
<a href="https://chromium.googlesource.com/chromium/src.git/+/99ead7d1564d35a70799b7ee4c3821053fb3985c">https://chromium.googlesource.com/chromium/src.git/+/99ead7d1564d35a70799b7ee4c3821053fb3985c</a>

Tests:
    fast/xsl/exslt-node-set.xml
    fast/xsl/xslt-node-set-empty.html

* LayoutTests/fast/xsl/xslt-node-set-empty-expected.txt: Add.
* LayoutTests/fast/xsl/xslt-node-set-empty.html: Add.
* Source/WebCore/xml/XSLTExtensions.cpp:
(WebCore::exsltNodeSetFunction):
- Update to match logic in libxslt v1.1.35.

Originally-landed-as: 259548.430@safari-7615-branch (06af3d226e2b). &lt;rdar://103622929&gt;
Canonical link: <a href="https://commits.webkit.org/264508@main">https://commits.webkit.org/264508@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/de5b58cd481453e53050519dd31109c247234809

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/7814 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/8089 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/8271 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/9459 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/7954 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/7820 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/10080 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/8006 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/10829 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/7952 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/9058 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/7154 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/9571 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/6366 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/7114 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/14763 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/7503 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/7241 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/10637 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/7736 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/6297 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/7058 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/7026 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/11266 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/938 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/7469 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->