### PR TITLE
Don't fire a mousemove event when a modifier key is pressed

### DIFF
--- a/LayoutTests/fast/events/no-mousemove-on-modifier-key-press-expected.txt
+++ b/LayoutTests/fast/events/no-mousemove-on-modifier-key-press-expected.txt
@@ -1,0 +1,15 @@
+This test verifies that MouseMove events are not fired when modifier keys are pressed.
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+To run this test by hand, press a modifier key.
+
+Dispatched KeyDown event with modifier metaKey
+Dispatched KeyDown event with modifier altKey
+Dispatched KeyDown event with modifier shiftKey
+Dispatched KeyDown event with modifier ctrlKey
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/fast/events/no-mousemove-on-modifier-key-press.html
+++ b/LayoutTests/fast/events/no-mousemove-on-modifier-key-press.html
@@ -1,0 +1,43 @@
+<!DOCTYPE html>
+<html>
+<head>
+<script src="../../resources/js-test.js"></script>
+<script src="../../resources/ui-helper.js"></script>
+<style>
+.hidden {
+    display: none;
+}
+</style>
+</head>
+
+<body>
+<p id="description"></p>
+<p id="manual-instructions" class="hide">To run this test by hand, press a modifier key.</p>
+<div id="console"></div>
+<script>
+window.jsTestIsAsync = true;
+
+async function fireKeyDownEventsWithModifiers() {
+    for (const modifierKey of ['metaKey', 'altKey', 'shiftKey', 'ctrlKey']) {
+        await UIHelper.keyDown("k", [modifierKey]);
+        debug('Dispatched KeyDown event with modifier ' + modifierKey);
+    }
+}
+
+async function runTest()
+{
+    if (!window.testRunner)
+        document.getElementById("manual-instructions").classList.remove("hidden");
+
+    window.addEventListener('mousemove', () => testFailed("MouseMove event detected"));
+
+    if (window.testRunner)
+        await fireKeyDownEventsWithModifiers();
+    finishJSTest();
+}
+
+description("This test verifies that MouseMove events are not fired when modifier keys are pressed.");
+runTest();
+</script>
+</body>
+</html>

--- a/Source/WebCore/page/Chrome.cpp
+++ b/Source/WebCore/page/Chrome.cpp
@@ -340,6 +340,7 @@ void Chrome::setStatusbarText(LocalFrame& frame, const String& status)
     m_client->setStatusbarText(frame.displayStringModifiedByEncoding(status));
 }
 
+// FIXME: Adopt `OptionSet<PlatformEventModifier>` instead of raw integral modifierFlags. https://bugs.webkit.org/show_bug.cgi?id=257175
 void Chrome::mouseDidMoveOverElement(const HitTestResult& result, unsigned modifierFlags)
 {
     auto* localMainFrame = dynamicDowncast<LocalFrame>(m_page.mainFrame());

--- a/Source/WebCore/page/Chrome.h
+++ b/Source/WebCore/page/Chrome.h
@@ -230,10 +230,10 @@ public:
     void registerPopupOpeningObserver(PopupOpeningObserver&);
     void unregisterPopupOpeningObserver(PopupOpeningObserver&);
 
+    WEBCORE_EXPORT void getToolTip(const HitTestResult&, String&, TextDirection&);
+
 private:
     void notifyPopupOpeningObservers() const;
-
-    void getToolTip(const HitTestResult&, String&, TextDirection&);
 
     Page& m_page;
     UniqueRef<ChromeClient> m_client;

--- a/Source/WebCore/page/EventHandler.h
+++ b/Source/WebCore/page/EventHandler.h
@@ -209,6 +209,8 @@ public:
     WEBCORE_EXPORT void lostMouseCapture();
 
     WEBCORE_EXPORT bool handleMousePressEvent(const PlatformMouseEvent&);
+    WEBCORE_EXPORT OptionSet<HitTestRequest::Type> getHitTypeForMouseMoveEvent(const PlatformMouseEvent&, bool onlyUpdateScrollbars = false);
+    WEBCORE_EXPORT HitTestResult getHitTestResultForMouseEvent(const PlatformMouseEvent&);
     bool handleMouseMoveEvent(const PlatformMouseEvent&, HitTestResult* = nullptr, bool onlyUpdateScrollbars = false);
     WEBCORE_EXPORT bool handleMouseReleaseEvent(const PlatformMouseEvent&);
     bool handleMouseForceEvent(const PlatformMouseEvent&);

--- a/Source/WebKit/UIProcess/WebPageProxy.cpp
+++ b/Source/WebKit/UIProcess/WebPageProxy.cpp
@@ -3186,6 +3186,13 @@ void WebPageProxy::handleMouseEvent(const NativeWebMouseEvent& event)
         processNextQueuedMouseEvent();
 }
 
+void WebPageProxy::dispatchMouseDidMoveOverElementAsynchronously(const NativeWebMouseEvent& event)
+{
+    sendWithAsyncReply(Messages::WebPage::PerformHitTestForMouseEvent { event }, [this, protectedThis = Ref { *this }](WebHitTestResultData&& hitTestResult, OptionSet<WebEventModifier> modifiers, UserData&& userData) {
+        this->mouseDidMoveOverElement(WTFMove(hitTestResult), modifiers.toRaw(), WTFMove(userData));
+    });
+}
+
 void WebPageProxy::processNextQueuedMouseEvent()
 {
     if (!hasRunningProcess())
@@ -6938,8 +6945,7 @@ void WebPageProxy::setStatusText(const String& text)
 void WebPageProxy::mouseDidMoveOverElement(WebHitTestResultData&& hitTestResultData, uint32_t opaqueModifiers, UserData&& userData)
 {
     m_lastMouseMoveHitTestResult = API::HitTestResult::create(hitTestResultData);
-    auto modifiers = OptionSet<WebEventModifier>::fromRaw(opaqueModifiers);
-    m_uiClient->mouseDidMoveOverElement(*this, hitTestResultData, modifiers, m_process->transformHandlesToObjects(userData.object()).get());
+    m_uiClient->mouseDidMoveOverElement(*this, hitTestResultData, OptionSet<WebEventModifier>::fromRaw(opaqueModifiers), m_process->transformHandlesToObjects(userData.object()).get());
     setToolTip(hitTestResultData.toolTipText);
 }
 

--- a/Source/WebKit/UIProcess/WebPageProxy.h
+++ b/Source/WebKit/UIProcess/WebPageProxy.h
@@ -1096,6 +1096,7 @@ public:
     bool isProcessingMouseEvents() const;
     void processNextQueuedMouseEvent();
     void handleMouseEvent(const NativeWebMouseEvent&);
+    void dispatchMouseDidMoveOverElementAsynchronously(const NativeWebMouseEvent&);
 
     void doAfterProcessingAllPendingMouseEvents(Function<void()>&&);
     void didFinishProcessingAllPendingMouseEvents();

--- a/Source/WebKit/UIProcess/mac/WebViewImpl.h
+++ b/Source/WebKit/UIProcess/mac/WebViewImpl.h
@@ -735,8 +735,6 @@ private:
     void scheduleSetTopContentInsetDispatch();
     void dispatchSetTopContentInset();
 
-    void postFakeMouseMovedEventForFlagsChangedEvent(NSEvent *);
-
     void sendToolTipMouseExited();
     void sendToolTipMouseEntered();
 
@@ -751,6 +749,8 @@ private:
     void nativeMouseEventHandler(NSEvent *);
     void nativeMouseEventHandlerInternal(NSEvent *);
     
+    void scheduleMouseDidMoveOverElement(NSEvent *);
+
     void mouseMovedInternal(NSEvent *);
     void mouseDownInternal(NSEvent *);
     void mouseUpInternal(NSEvent *);

--- a/Source/WebKit/UIProcess/mac/WebViewImpl.mm
+++ b/Source/WebKit/UIProcess/mac/WebViewImpl.mm
@@ -2181,7 +2181,7 @@ void WebViewImpl::viewDidMoveToWindow()
             WeakPtr weakThis { *this };
             m_flagsChangedEventMonitor = [NSEvent addLocalMonitorForEventsMatchingMask:NSEventMaskFlagsChanged handler:[weakThis] (NSEvent *flagsChangedEvent) {
                 if (weakThis)
-                    weakThis->postFakeMouseMovedEventForFlagsChangedEvent(flagsChangedEvent);
+                    weakThis->scheduleMouseDidMoveOverElement(flagsChangedEvent);
                 return flagsChangedEvent;
             }];
         }
@@ -2306,13 +2306,13 @@ NSView *WebViewImpl::hitTest(CGPoint point)
     return hitView;
 }
 
-void WebViewImpl::postFakeMouseMovedEventForFlagsChangedEvent(NSEvent *flagsChangedEvent)
+void WebViewImpl::scheduleMouseDidMoveOverElement(NSEvent *flagsChangedEvent)
 {
     NSEvent *fakeEvent = [NSEvent mouseEventWithType:NSEventTypeMouseMoved location:flagsChangedEvent.window.mouseLocationOutsideOfEventStream
         modifierFlags:flagsChangedEvent.modifierFlags timestamp:flagsChangedEvent.timestamp windowNumber:flagsChangedEvent.windowNumber
         context:nullptr eventNumber:0 clickCount:0 pressure:0];
     NativeWebMouseEvent webEvent(fakeEvent, m_lastPressureEvent.get(), m_view.getAutoreleased());
-    m_page->handleMouseEvent(webEvent);
+    m_page->dispatchMouseDidMoveOverElementAsynchronously(webEvent);
 }
 
 WebCore::DestinationColorSpace WebViewImpl::colorSpace()

--- a/Source/WebKit/WebProcess/WebPage/WebPage.h
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.h
@@ -2038,6 +2038,8 @@ private:
     void handleAcceptedCandidate(WebCore::TextCheckingResult);
 #endif
 
+    void performHitTestForMouseEvent(const WebMouseEvent&, CompletionHandler<void(WebHitTestResultData&&, OptionSet<WebEventModifier>, UserData&&)>&&);
+
 #if PLATFORM(COCOA)
     void requestActiveNowPlayingSessionInfo(CompletionHandler<void(bool, bool, const String&, double, double, uint64_t)>&&);
     RetainPtr<NSData> accessibilityRemoteTokenData() const;

--- a/Source/WebKit/WebProcess/WebPage/WebPage.messages.in
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.messages.in
@@ -573,6 +573,8 @@ GenerateSyntheticEditingCommand(enum:uint8_t WebKit::SyntheticEditingCommandType
     DidEndMagnificationGesture()
 #endif
 
+    PerformHitTestForMouseEvent(WebKit::WebMouseEvent event) -> (struct WebKit::WebHitTestResultData hitTestResult, OptionSet<WebKit::WebEventModifier> modifiers, WebKit::UserData messageBody)
+
     EffectiveAppearanceDidChange(bool useDarkAppearance, bool useElevatedUserInterfaceLevel)
 
 #if HAVE(APP_ACCENT_COLORS)


### PR DESCRIPTION
#### f84b2332af6e577f2e2e3abcf8bc9768410c1f52
<pre>
Don&apos;t fire a mousemove event when a modifier key is pressed
<a href="https://bugs.webkit.org/show_bug.cgi?id=16271">https://bugs.webkit.org/show_bug.cgi?id=16271</a>
rdar://81287778

Reviewed by Wenson Hsieh.

Previously, we dispatched mousemove events whenever a modifier key was
pressed. This was used to call the UIClient delegate callback
mouseDidMoveOverElement, which downstream clients could use to modify
various behaviors based on whether or not modifier keys were pressed.

Unfortunately, the act of dispatching a mousemove event meant that
pressing modifier keys could cause unexpected mouse behavior. One notable
example is Slack. When using Slack through Minibrowser, it is possible
to experience spontaneous mouse selection when a cursor was originally
placed behind a completion list, since our hover state gets constantly
re-evaluated.

In this patch, we introduce a mechanism to avoid the need to fire a
mousemove event when modifier keys are pressed. This is achieved by
adding a new message from the UI process to the web process where we
request that a given mouse event&apos;s hit test be performed. With the hit
test result and user data associated with said mouse event, we can
simply call into the UIClient delegate callback mouseDidMoveOverElement,
avoiding the regular mouse event dispatch dance altogether.

* LayoutTests/fast/events/no-mousemove-on-modifier-key-press-expected.txt: Added.
* LayoutTests/fast/events/no-mousemove-on-modifier-key-press.html: Added.

Layout test that verifies pressing the modifier keys does not fire a
MouseMove event.

* Source/WebCore/page/Chrome.h:

Export (and make public) Chrome::getToolTip to access from the web
process.

* Source/WebCore/page/EventHandler.cpp:
(WebCore::EventHandler::getHitTypeForMouseMoveEvent):
(WebCore::EventHandler::getHitTestResultForMouseEvent):
(WebCore::EventHandler::handleMouseMoveEvent):

Introduce two functions getHitTypeForMouseMoveEvent and
getHitTestResultForMouseEvent. The latter strips out some common code
from handleMouseMoveEvent so that it can be called independently to
identify a hitType, whereas the former is a handy way to produce a
hitTestResult without bringing the MouseEventWithHitTestResults type
into web process land.

* Source/WebCore/page/EventHandler.h:
* Source/WebKit/UIProcess/WebPageProxy.cpp:
(WebKit::WebPageProxy::dispatchMouseDidMoveOverElementAsynchronously):

Introduce a method that communicates the need for user data and a hit
test on a mouse event without actually dispatching said mouse event to
the web process. Once we round trip from the web process, it feeds the
returned data to the client delegate callback mouseDidMoveOverElement.

* Source/WebKit/UIProcess/WebPageProxy.h:
* Source/WebKit/UIProcess/mac/WebViewImpl.h:
* Source/WebKit/UIProcess/mac/WebViewImpl.mm:
(WebKit::WebViewImpl::viewDidMoveToWindow):
(WebKit::WebViewImpl::fireMouseDidMoveOverElement):
(WebKit::WebViewImpl::postFakeMouseMovedEventForFlagsChangedEvent): Deleted.

Rename postFakeMouseMovedEventForFlagsChangedEvent to
fireMouseDidMoveOverElement to better represent our signaling intent.

fireMouseDidMoveOverElement then communicates with the web page to
receive user data and hit test results before passing that over to the
client delegate callback.

* Source/WebKit/WebProcess/WebPage/WebPage.cpp:
(WebKit::WebPage::performHitTestAndGetUserData):
* Source/WebKit/WebProcess/WebPage/WebPage.h:
* Source/WebKit/WebProcess/WebPage/WebPage.messages.in:

Introduce a new message that receives a mouse event from the UI process
and calls into the page&apos;s event handler and chrome clients to perform a
hit test on the received mouse event. This allows us to circumvent the
usual dance with a dispatched mouse event while returning the user data
and hit test result associated with a mouse event.

Canonical link: <a href="https://commits.webkit.org/264455@main">https://commits.webkit.org/264455@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1fd5225ad49f0d449066611540d674c7621100e3

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/7652 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/7921 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/8105 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/9295 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/7832 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/7664 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/9920 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/7846 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/10704 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/7785 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/8927 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/7048 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/9437 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/6235 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/6971 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/14674 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/7398 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/7094 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/10540 "5 api tests failed or timed out") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/7588 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/6191 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/6922 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/6882 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/1827 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/11133 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/7319 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->