### PR TITLE
Remove String::stripWhiteSpace()

### DIFF
--- a/Source/WTF/wtf/text/StringImpl.cpp
+++ b/Source/WTF/wtf/text/StringImpl.cpp
@@ -740,11 +740,6 @@ template<typename CodeUnitPredicate> inline Ref<StringImpl> StringImpl::stripMat
     return create(m_data16 + start, end + 1 - start);
 }
 
-Ref<StringImpl> StringImpl::stripWhiteSpace()
-{
-    return stripMatchedCharacters(deprecatedIsSpaceOrNewline);
-}
-
 Ref<StringImpl> StringImpl::stripLeadingAndTrailingCharacters(CodeUnitMatchFunction predicate)
 {
     return stripMatchedCharacters(predicate);

--- a/Source/WTF/wtf/text/WTFString.cpp
+++ b/Source/WTF/wtf/text/WTFString.cpp
@@ -153,16 +153,6 @@ String String::convertToUppercaseWithLocale(const AtomString& localeIdentifier) 
     return m_impl ? m_impl->convertToUppercaseWithLocale(localeIdentifier) : String { };
 }
 
-String String::stripWhiteSpace() const
-{
-    // FIXME: Should this function, and the many others like it, be inlined?
-    // FIXME: This function needs a new name. For one thing, "whitespace" is a single
-    // word so the "s" should be lowercase. For another, it's not clear from this name
-    // that the function uses the Unicode definition of whitespace. Most WebKit callers
-    // don't want that and eventually we should consider deleting this.
-    return m_impl ? m_impl->stripWhiteSpace() : String { };
-}
-
 String String::stripLeadingAndTrailingCharacters(CodeUnitMatchFunction predicate) const
 {
     // FIXME: Should this function, and the many others like it, be inlined?

--- a/Source/WTF/wtf/text/WTFString.h
+++ b/Source/WTF/wtf/text/WTFString.h
@@ -198,7 +198,6 @@ public:
     WTF_EXPORT_PRIVATE String WARN_UNUSED_RETURN convertToLowercaseWithLocale(const AtomString& localeIdentifier) const;
     WTF_EXPORT_PRIVATE String WARN_UNUSED_RETURN convertToUppercaseWithLocale(const AtomString& localeIdentifier) const;
 
-    WTF_EXPORT_PRIVATE String WARN_UNUSED_RETURN stripWhiteSpace() const;
     WTF_EXPORT_PRIVATE String WARN_UNUSED_RETURN simplifyWhiteSpace() const;
     WTF_EXPORT_PRIVATE String WARN_UNUSED_RETURN simplifyWhiteSpace(CodeUnitMatchFunction) const;
 

--- a/Source/WebCore/Modules/applicationmanifest/ApplicationManifestParser.cpp
+++ b/Source/WebCore/Modules/applicationmanifest/ApplicationManifestParser.cpp
@@ -400,7 +400,7 @@ String ApplicationManifestParser::parseGenericString(const JSON::Object& manifes
         return { };
     }
 
-    return stringValue.stripWhiteSpace();
+    return stringValue.stripLeadingAndTrailingCharacters(deprecatedIsSpaceOrNewline);
 }
 
 } // namespace WebCore

--- a/Source/WebCore/accessibility/AccessibilityNodeObject.cpp
+++ b/Source/WebCore/accessibility/AccessibilityNodeObject.cpp
@@ -580,8 +580,7 @@ bool AccessibilityNodeObject::computeAccessibilityIsIgnored() const
             return true;
 
         // Whitespace only text elements should be ignored when they have no renderer.
-        String string = stringValue().stripWhiteSpace().simplifyWhiteSpace();
-        if (!string.length())
+        if (stringValue().isAllSpecialCharacters<deprecatedIsSpaceOrNewline>())
             return true;
     }
 
@@ -2239,7 +2238,7 @@ String AccessibilityNodeObject::textUnderElement(AccessibilityTextUnderElementMo
             appendNameToStringBuilder(builder, childText);
     }
 
-    return builder.toString().stripWhiteSpace().simplifyWhiteSpace(isHTMLSpaceButNotLineBreak);
+    return builder.toString().stripLeadingAndTrailingCharacters(deprecatedIsSpaceOrNewline).simplifyWhiteSpace(isHTMLSpaceButNotLineBreak);
 }
 
 String AccessibilityNodeObject::title() const

--- a/Source/WebCore/css/parser/CSSParserImpl.cpp
+++ b/Source/WebCore/css/parser/CSSParserImpl.cpp
@@ -640,7 +640,7 @@ RefPtr<StyleRuleSupports> CSSParserImpl::consumeSupportsRule(CSSParserTokenRange
     if (m_observerWrapper)
         m_observerWrapper->observer().endRuleBody(m_observerWrapper->endOffset(block));
 
-    return StyleRuleSupports::create(prelude.serialize().stripWhiteSpace(), supported, WTFMove(rules));
+    return StyleRuleSupports::create(prelude.serialize().stripLeadingAndTrailingCharacters(deprecatedIsSpaceOrNewline), supported, WTFMove(rules));
 }
 
 RefPtr<StyleRuleFontFace> CSSParserImpl::consumeFontFaceRule(CSSParserTokenRange prelude, CSSParserTokenRange block)

--- a/Source/WebCore/dom/ImageOverlay.cpp
+++ b/Source/WebCore/dom/ImageOverlay.cpp
@@ -346,7 +346,7 @@ static Elements updateSubtree(HTMLElement& element, const TextRecognitionResult&
                     return false;
 
                 for (size_t childIndex = 0; childIndex < childResults.size(); ++childIndex) {
-                    if (childResults[childIndex].text != childTextElements[childIndex]->textContent().stripWhiteSpace())
+                    if (childResults[childIndex].text != StringView(childTextElements[childIndex]->textContent()).stripLeadingAndTrailingMatchedCharacters(deprecatedIsSpaceOrNewline))
                         return false;
                 }
             }
@@ -358,7 +358,7 @@ static Elements updateSubtree(HTMLElement& element, const TextRecognitionResult&
                     if (textContentByLine.size() <= lineIndex)
                         return false;
 
-                    if (textContentByLine[lineIndex++].stripWhiteSpace() != text.wholeText().stripWhiteSpace())
+                    if (StringView(textContentByLine[lineIndex++]).stripLeadingAndTrailingMatchedCharacters(deprecatedIsSpaceOrNewline) != StringView(text.wholeText()).stripLeadingAndTrailingMatchedCharacters(deprecatedIsSpaceOrNewline))
                         return false;
                 }
             }

--- a/Source/WebCore/dom/ScriptElement.cpp
+++ b/Source/WebCore/dom/ScriptElement.cpp
@@ -153,7 +153,7 @@ std::optional<ScriptType> ScriptElement::determineScriptType(LegacyTypeSupport s
     if (type.isEmpty())
         return ScriptType::Classic; // Assume text/javascript.
 
-    if (MIMETypeRegistry::isSupportedJavaScriptMIMEType(type.stripWhiteSpace()))
+    if (MIMETypeRegistry::isSupportedJavaScriptMIMEType(type.stripLeadingAndTrailingCharacters(deprecatedIsSpaceOrNewline)))
         return ScriptType::Classic;
     if (supportLegacyTypes == AllowLegacyTypeInTypeAttribute && isLegacySupportedJavaScriptLanguage(type))
         return ScriptType::Classic;

--- a/Source/WebCore/editing/TextManipulationController.cpp
+++ b/Source/WebCore/editing/TextManipulationController.cpp
@@ -287,11 +287,6 @@ static bool canPerformTextManipulationByReplacingEntireTextContent(const Element
     return element.hasTagName(HTMLNames::titleTag) || element.hasTagName(HTMLNames::optionTag);
 }
 
-static bool areEqualIgnoringLeadingAndTrailingWhitespaces(const String& content, const String& originalContent)
-{
-    return content.stripWhiteSpace() == originalContent.stripWhiteSpace();
-}
-
 static std::optional<TextManipulationTokenInfo> tokenInfo(Node* node)
 {
     if (!node)
@@ -842,7 +837,7 @@ auto TextManipulationController::replace(const ManipulationItemData& item, const
                 return ManipulationFailure::Type::ContentChanged;
 
             auto& currentToken = item.tokens[currentTokenIndex++];
-            bool isContentUnchanged = areEqualIgnoringLeadingAndTrailingWhitespaces(currentToken.content, token.content);
+            bool isContentUnchanged = StringView(currentToken.content).stripLeadingAndTrailingMatchedCharacters(deprecatedIsSpaceOrNewline) == StringView(token.content).stripLeadingAndTrailingMatchedCharacters(deprecatedIsSpaceOrNewline);
             if (!content.isReplacedContent && !isContentUnchanged)
                 return ManipulationFailure::Type::ContentChanged;
 

--- a/Source/WebCore/editing/TypingCommand.cpp
+++ b/Source/WebCore/editing/TypingCommand.cpp
@@ -459,7 +459,7 @@ void TypingCommand::markMisspellingsAfterTyping(ETypingCommand commandType)
             auto range = makeSimpleRange(p1, p2);
             String strippedPreviousWord;
             if (range && (commandType == TypingCommand::InsertText || commandType == TypingCommand::InsertLineBreak || commandType == TypingCommand::InsertParagraphSeparator || commandType == TypingCommand::InsertParagraphSeparatorInQuotedContent))
-                strippedPreviousWord = plainText(*range).stripWhiteSpace();
+                strippedPreviousWord = plainText(*range).stripLeadingAndTrailingCharacters(deprecatedIsSpaceOrNewline);
             document().editor().markMisspellingsAfterTypingToWord(p1, endingSelection(), !strippedPreviousWord.isEmpty());
         } else if (commandType == TypingCommand::InsertText)
             document().editor().startAlternativeTextUITimer();

--- a/Source/WebCore/html/HTMLMediaElement.cpp
+++ b/Source/WebCore/html/HTMLMediaElement.cpp
@@ -8334,11 +8334,11 @@ String HTMLMediaElement::mediaSessionTitle() const
     if (!document().page() || document().page()->usesEphemeralSession())
         return emptyString();
 
-    auto title = String(attributeWithoutSynchronization(titleAttr)).stripWhiteSpace().simplifyWhiteSpace();
+    auto title = String(attributeWithoutSynchronization(titleAttr)).stripLeadingAndTrailingCharacters(deprecatedIsSpaceOrNewline).simplifyWhiteSpace();
     if (!title.isEmpty())
         return title;
 
-    title = document().title().stripWhiteSpace().simplifyWhiteSpace();
+    title = document().title().stripLeadingAndTrailingCharacters(deprecatedIsSpaceOrNewline).simplifyWhiteSpace();
     if (!title.isEmpty())
         return title;
 

--- a/Source/WebCore/html/HTMLOptGroupElement.cpp
+++ b/Source/WebCore/html/HTMLOptGroupElement.cpp
@@ -123,7 +123,7 @@ String HTMLOptGroupElement::groupLabelText() const
     String itemText = document().displayStringModifiedByEncoding(attributeWithoutSynchronization(labelAttr));
     
     // In WinIE, leading and trailing whitespace is ignored in options and optgroups. We match this behavior.
-    itemText = itemText.stripWhiteSpace();
+    itemText = itemText.stripLeadingAndTrailingCharacters(deprecatedIsSpaceOrNewline);
     // We want to collapse our whitespace too.  This will match other browsers.
     itemText = itemText.simplifyWhiteSpace();
         

--- a/Source/WebCore/html/ValidatedFormListedElement.cpp
+++ b/Source/WebCore/html/ValidatedFormListedElement.cpp
@@ -102,7 +102,7 @@ void ValidatedFormListedElement::updateVisibleValidationMessage(Ref<HTMLElement>
         return;
     String message;
     if (element.renderer() && willValidate())
-        message = validationMessage().stripWhiteSpace();
+        message = validationMessage().stripLeadingAndTrailingCharacters(deprecatedIsSpaceOrNewline);
     if (!m_validationMessage)
         m_validationMessage = makeUnique<ValidationMessage>(validationAnchor);
     m_validationMessage->updateValidationMessage(validationAnchor, message);

--- a/Source/WebCore/inspector/InspectorStyleSheet.cpp
+++ b/Source/WebCore/inspector/InspectorStyleSheet.cpp
@@ -1319,7 +1319,7 @@ static Ref<JSON::ArrayOf<Protocol::CSS::CSSSelector>> selectorsFromSource(const 
 
         // We don't want to see any comments in the selector components, only the meaningful parts.
         replace(selectorText, comment, String());
-        result->addItem(buildObjectForSelectorHelper(selectorText.stripWhiteSpace(), *selectors.at(selectorIndex)));
+        result->addItem(buildObjectForSelectorHelper(selectorText.stripLeadingAndTrailingCharacters(deprecatedIsSpaceOrNewline), *selectors.at(selectorIndex)));
 
         ++selectorIndex;
     }

--- a/Source/WebCore/page/csp/ContentSecurityPolicyDirectiveList.cpp
+++ b/Source/WebCore/page/csp/ContentSecurityPolicyDirectiveList.cpp
@@ -132,7 +132,7 @@ static inline bool checkMediaType(ContentSecurityPolicyMediaListDirective* direc
 {
     if (!directive)
         return true;
-    if (typeAttribute.isEmpty() || typeAttribute.stripWhiteSpace() != type)
+    if (typeAttribute.isEmpty() || StringView(typeAttribute).stripLeadingAndTrailingMatchedCharacters(deprecatedIsSpaceOrNewline) != type)
         return false;
     return directive->allows(type);
 }
@@ -401,6 +401,7 @@ const ContentSecurityPolicyDirective* ContentSecurityPolicyDirectiveList::violat
     return operativeDirective;
 }
 
+// FIXME: typeAttribute should be a StringView throughout
 const ContentSecurityPolicyDirective* ContentSecurityPolicyDirectiveList::violatedDirectiveForPluginType(const String& type, const String& typeAttribute) const
 {
     if (checkMediaType(m_pluginTypes.get(), type, typeAttribute))

--- a/Source/WebCore/platform/LocalizedStrings.cpp
+++ b/Source/WebCore/platform/LocalizedStrings.cpp
@@ -143,7 +143,7 @@ static String truncatedStringForMenuItem(const String& original)
     // Truncate the string if it's too long. This number is roughly the same as the one used by AppKit.
     unsigned maxNumberOfGraphemeClustersInLookupMenuItem = 24;
 
-    String trimmed = original.stripWhiteSpace();
+    String trimmed = original.stripLeadingAndTrailingCharacters(deprecatedIsSpaceOrNewline);
     unsigned numberOfCharacters = numCodeUnitsInGraphemeClusters(trimmed, maxNumberOfGraphemeClustersInLookupMenuItem);
     return numberOfCharacters == trimmed.length() ? trimmed : makeString(trimmed.left(numberOfCharacters), horizontalEllipsis);
 }

--- a/Source/WebCore/platform/graphics/gstreamer/MediaPlayerPrivateGStreamer.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/MediaPlayerPrivateGStreamer.cpp
@@ -2786,7 +2786,9 @@ bool isMediaDiskCacheDisabled()
     std::call_once(once, []() {
         auto s = String::fromLatin1(std::getenv("WPE_SHELL_DISABLE_MEDIA_DISK_CACHE"));
         if (!s.isEmpty()) {
-            String value = s.stripWhiteSpace().convertToLowercaseWithoutLocale();
+            // FIXME: should this use StringView and equalLettersIgnoringASCIICase? Or even strcmp?
+            // https://github.com/WebKit/WebKit/pull/14233#discussion_r1202410966
+            String value = s.stripLeadingAndTrailingCharacters(deprecatedIsSpaceOrNewline).convertToLowercaseWithoutLocale();
             result = (value == "1"_s || value == "t"_s || value == "true"_s);
         }
     });

--- a/Source/WebCore/platform/graphics/gstreamer/mse/SourceBufferPrivateGStreamer.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/mse/SourceBufferPrivateGStreamer.cpp
@@ -306,8 +306,8 @@ size_t SourceBufferPrivateGStreamer::platformMaximumBufferSize() const
                 Vector<String> keyvalue = entry.split(':');
                 if (keyvalue.size() != 2)
                     continue;
-                String key = keyvalue[0].stripWhiteSpace().convertToLowercaseWithoutLocale();
-                String value = keyvalue[1].stripWhiteSpace().convertToLowercaseWithoutLocale();
+                String key = keyvalue[0].stripLeadingAndTrailingCharacters(deprecatedIsSpaceOrNewline).convertToLowercaseWithoutLocale();
+                String value = keyvalue[1].stripLeadingAndTrailingCharacters(deprecatedIsSpaceOrNewline).convertToLowercaseWithoutLocale();
                 size_t units = 1;
                 if (value.endsWith('k'))
                     units = 1024;

--- a/Source/WebCore/platform/gtk/SelectionData.cpp
+++ b/Source/WebCore/platform/gtk/SelectionData.cpp
@@ -54,7 +54,7 @@ void SelectionData::setURIList(const String& uriListString)
     // from the URI list.
     bool setURL = hasURL();
     for (auto& line : uriListString.split('\n')) {
-        line = line.stripWhiteSpace();
+        line = line.stripLeadingAndTrailingCharacters(deprecatedIsSpaceOrNewline);
         if (line.isEmpty())
             continue;
         if (line[0] == '#')

--- a/Source/WebCore/platform/ios/DragImageIOS.mm
+++ b/Source/WebCore/platform/ios/DragImageIOS.mm
@@ -120,7 +120,7 @@ DragImageRef createDragImageForLink(Element& linkElement, URL& url, const String
     static const NeverDestroyed titleFontCascade = cascadeForSystemFont(16);
     static const NeverDestroyed urlFontCascade = cascadeForSystemFont(14);
 
-    String topString(title.stripWhiteSpace());
+    String topString(title.stripLeadingAndTrailingCharacters(deprecatedIsSpaceOrNewline));
     String bottomString([(NSURL *)url absoluteString]);
     if (topString.isEmpty()) {
         topString = bottomString;

--- a/Source/WebCore/platform/mac/PasteboardMac.mm
+++ b/Source/WebCore/platform/mac/PasteboardMac.mm
@@ -211,7 +211,7 @@ static long writeURLForTypes(const Vector<String>& types, const String& pasteboa
     }
 
     if (types.contains(WebURLsWithTitlesPboardType)) {
-        PasteboardURL url = { pasteboardURL.url, String(title).stripWhiteSpace(), emptyString() };
+        PasteboardURL url = { pasteboardURL.url, String(title).stripLeadingAndTrailingCharacters(deprecatedIsSpaceOrNewline), emptyString() };
         newChangeCount = platformStrategies()->pasteboardStrategy()->setURL(url, pasteboardName, context);
     }
     if (types.contains(String(legacyURLPasteboardType())))
@@ -233,7 +233,7 @@ void Pasteboard::write(const PasteboardURL& pasteboardURL)
 
 void Pasteboard::writeTrustworthyWebURLsPboardType(const PasteboardURL& pasteboardURL)
 {
-    PasteboardURL url = { pasteboardURL.url, pasteboardURL.title.stripWhiteSpace(), emptyString() };
+    PasteboardURL url = { pasteboardURL.url, pasteboardURL.title.stripLeadingAndTrailingCharacters(deprecatedIsSpaceOrNewline), emptyString() };
     m_changeCount = platformStrategies()->pasteboardStrategy()->setURL(url, m_pasteboardName, context());
 }
 

--- a/Source/WebCore/platform/mac/PasteboardWriter.mm
+++ b/Source/WebCore/platform/mac/PasteboardWriter.mm
@@ -81,7 +81,8 @@ ALLOW_DEPRECATED_DECLARATIONS_END
         }
 
         // WebURLsWithTitlesPboardType.
-        auto paths = adoptNS([[NSArray alloc] initWithObjects:@[ @[ cocoaURL.absoluteString ] ], @[ urlData->title.stripWhiteSpace() ], nil]);
+        // FIXME: This could use StringView (the one that creates NSString) to save an allocation
+        auto paths = adoptNS([[NSArray alloc] initWithObjects:@[ @[ cocoaURL.absoluteString ] ], @[ urlData->title.stripLeadingAndTrailingCharacters(deprecatedIsSpaceOrNewline) ], nil]);
         [pasteboardItem setPropertyList:paths.get() forType:toUTI(@"WebURLsWithTitlesPboardType").get()];
 
         // NSURLPboardType.

--- a/Source/WebCore/platform/network/MIMEHeader.cpp
+++ b/Source/WebCore/platform/network/MIMEHeader.cpp
@@ -63,7 +63,7 @@ static KeyValueMap retrieveKeyValuePairs(WebCore::SharedBufferChunkReader& buffe
         if (!key.isEmpty()) {
             if (keyValuePairs.find(key) != keyValuePairs.end())
                 LOG_ERROR("Key duplicate found in MIME header. Key is '%s', previous value replaced.", key.ascii().data());
-            keyValuePairs.add(key, value.toString().stripWhiteSpace());
+            keyValuePairs.add(key, value.toString().stripLeadingAndTrailingCharacters(deprecatedIsSpaceOrNewline));
             key = String();
             value.clear();
         }
@@ -77,7 +77,7 @@ static KeyValueMap retrieveKeyValuePairs(WebCore::SharedBufferChunkReader& buffe
     }
     // Store the last property if there is one.
     if (!key.isEmpty())
-        keyValuePairs.set(key, value.toString().stripWhiteSpace());
+        keyValuePairs.set(key, value.toString().stripLeadingAndTrailingCharacters(deprecatedIsSpaceOrNewline));
     return keyValuePairs;
 }
 
@@ -90,7 +90,7 @@ RefPtr<MIMEHeader> MIMEHeader::parseHeader(SharedBufferChunkReader& buffer)
         String contentType, charset, multipartType, endOfPartBoundary;
         if (auto parsedContentType = ParsedContentType::create(mimeParametersIterator->value)) {
             contentType = parsedContentType->mimeType();
-            charset = parsedContentType->charset().stripWhiteSpace();
+            charset = parsedContentType->charset().stripLeadingAndTrailingCharacters(deprecatedIsSpaceOrNewline);
             multipartType = parsedContentType->parameterValueForName("type"_s);
             endOfPartBoundary = parsedContentType->parameterValueForName("boundary"_s);
         }

--- a/Source/WebCore/platform/network/ParsedContentType.cpp
+++ b/Source/WebCore/platform/network/ParsedContentType.cpp
@@ -371,7 +371,7 @@ void ParsedContentType::setContentType(String&& contentRange, Mode mode)
     if (mode == Mode::MimeSniff)
         m_mimeType = stripLeadingAndTrailingHTTPSpaces(StringView(m_mimeType)).convertToASCIILowercase();
     else
-        m_mimeType = m_mimeType.stripWhiteSpace();
+        m_mimeType = m_mimeType.stripLeadingAndTrailingCharacters(deprecatedIsSpaceOrNewline);
 }
 
 static bool containsNonQuoteStringTokenCharacters(const String& input)

--- a/Source/WebCore/platform/network/curl/CookieUtil.cpp
+++ b/Source/WebCore/platform/network/curl/CookieUtil.cpp
@@ -97,10 +97,10 @@ static void parseCookieAttributes(const String& attribute, bool& hasMaxAge, Cook
     String attributeValue;
 
     if (assignmentPosition != notFound) {
-        attributeName = attribute.left(assignmentPosition).stripWhiteSpace();
-        attributeValue = attribute.substring(assignmentPosition + 1).stripWhiteSpace();
+        attributeName = attribute.left(assignmentPosition).stripLeadingAndTrailingCharacters(deprecatedIsSpaceOrNewline);
+        attributeValue = attribute.substring(assignmentPosition + 1).stripLeadingAndTrailingCharacters(deprecatedIsSpaceOrNewline);
     } else
-        attributeName = attribute.stripWhiteSpace();
+        attributeName = attribute.stripLeadingAndTrailingCharacters(deprecatedIsSpaceOrNewline);
 
     if (equalLettersIgnoringASCIICase(attributeName, "httponly"_s))
         result.httpOnly = true;
@@ -169,8 +169,8 @@ std::optional<Cookie> parseCookieHeader(const String& cookieLine)
     }
 
     Cookie cookie;
-    cookie.name = cookieName.stripWhiteSpace();
-    cookie.value = cookieValue.stripWhiteSpace();
+    cookie.name = cookieName.stripLeadingAndTrailingCharacters(deprecatedIsSpaceOrNewline);
+    cookie.value = cookieValue.stripLeadingAndTrailingCharacters(deprecatedIsSpaceOrNewline);
 
     bool hasMaxAge = false;
     cookie.session = true;

--- a/Source/WebCore/platform/network/curl/CurlMultipartHandle.cpp
+++ b/Source/WebCore/platform/network/curl/CurlMultipartHandle.cpp
@@ -56,11 +56,11 @@ std::optional<String> CurlMultipartHandle::extractBoundary(const CurlResponse& r
         if (splitPosition == notFound)
             continue;
 
-        auto key = header.left(splitPosition).stripWhiteSpace();
+        auto key = header.left(splitPosition).stripLeadingAndTrailingCharacters(deprecatedIsSpaceOrNewline);
         if (!equalIgnoringASCIICase(key, "Content-Type"_s))
             continue;
 
-        auto contentType = header.substring(splitPosition + 1).stripWhiteSpace();
+        auto contentType = header.substring(splitPosition + 1).stripLeadingAndTrailingCharacters(deprecatedIsSpaceOrNewline);
         auto mimeType = extractMIMETypeFromMediaType(contentType);
         if (!equalLettersIgnoringASCIICase(mimeType, "multipart/x-mixed-replace"_s))
             continue;

--- a/Source/WebCore/platform/network/curl/CurlRequest.cpp
+++ b/Source/WebCore/platform/network/curl/CurlRequest.cpp
@@ -531,8 +531,8 @@ int CurlRequest::didReceiveDebugInfo(curl_infotype type, char* data, size_t size
         for (auto& header : headerFields) {
             auto pos = header.find(':');
             if (pos != notFound) {
-                auto key = header.left(pos).stripWhiteSpace();
-                auto value = header.substring(pos + 1).stripWhiteSpace();
+                auto key = header.left(pos).stripLeadingAndTrailingCharacters(deprecatedIsSpaceOrNewline);
+                auto value = header.substring(pos + 1).stripLeadingAndTrailingCharacters(deprecatedIsSpaceOrNewline);
                 m_requestHeaders.add(key, value);
             }
         }

--- a/Source/WebCore/platform/network/curl/ResourceResponseCurl.cpp
+++ b/Source/WebCore/platform/network/curl/ResourceResponseCurl.cpp
@@ -116,8 +116,8 @@ void ResourceResponse::appendHTTPHeaderField(const String& header)
 {
     auto splitPosition = header.find(':');
     if (splitPosition != notFound) {
-        auto key = header.left(splitPosition).stripWhiteSpace();
-        auto value = header.substring(splitPosition + 1).stripWhiteSpace();
+        auto key = header.left(splitPosition).stripLeadingAndTrailingCharacters(deprecatedIsSpaceOrNewline);
+        auto value = header.substring(splitPosition + 1).stripLeadingAndTrailingCharacters(deprecatedIsSpaceOrNewline);
 
         if (isAppendableHeader(key))
             addHTTPHeaderField(key, value);

--- a/Source/WebCore/platform/text/PlatformLocale.cpp
+++ b/Source/WebCore/platform/text/PlatformLocale.cpp
@@ -297,7 +297,7 @@ unsigned Locale::matchedDecimalSymbolIndex(const String& input, unsigned& positi
 String Locale::convertFromLocalizedNumber(const String& localized)
 {
     initializeLocaleData();
-    String input = localized.stripWhiteSpace();
+    String input = localized.stripLeadingAndTrailingCharacters(deprecatedIsSpaceOrNewline);
     if (!m_hasLocaleData || input.isEmpty())
         return input;
 

--- a/Source/WebCore/platform/win/ClipboardUtilitiesWin.cpp
+++ b/Source/WebCore/platform/win/ClipboardUtilitiesWin.cpp
@@ -230,7 +230,7 @@ static String extractMarkupFromCFHTML(const String& cfhtml)
     unsigned fragmentStart = cfhtml.find('>', tagStart) + 1;
     unsigned tagEnd = cfhtml.findIgnoringASCIICase("endfragment"_s, fragmentStart);
     unsigned fragmentEnd = cfhtml.reverseFind('<', tagEnd);
-    return cfhtml.substring(fragmentStart, fragmentEnd - fragmentStart).stripWhiteSpace();
+    return cfhtml.substring(fragmentStart, fragmentEnd - fragmentStart).stripLeadingAndTrailingCharacters(deprecatedIsSpaceOrNewline);
 }
 
 // Documentation for the CF_HTML format is available at http://msdn.microsoft.com/workshop/networking/clipboard/htmlclipboard.asp
@@ -620,7 +620,7 @@ Ref<DocumentFragment> fragmentFromCFHTML(Document* doc, const String& cfhtml)
         unsigned srcStart = lineStart+srcURLStr.length();
         String rawSrcURL = cfhtml.substring(srcStart, srcEnd-srcStart);
         replaceNBSPWithSpace(rawSrcURL);
-        srcURL = rawSrcURL.stripWhiteSpace();
+        srcURL = rawSrcURL.stripLeadingAndTrailingCharacters(deprecatedIsSpaceOrNewline);
     }
 
     String markup = extractMarkupFromCFHTML(cfhtml);

--- a/Source/WebCore/rendering/RenderMenuList.cpp
+++ b/Source/WebCore/rendering/RenderMenuList.cpp
@@ -272,7 +272,7 @@ void RenderMenuList::setTextFromOption(int optionIndex)
     }
 #endif
 
-    setText(text.stripWhiteSpace());
+    setText(text.stripLeadingAndTrailingCharacters(deprecatedIsSpaceOrNewline));
     didUpdateActiveOption(optionIndex);
 }
 

--- a/Source/WebCore/svg/properties/SVGAnimationAdditiveValueFunctionImpl.cpp
+++ b/Source/WebCore/svg/properties/SVGAnimationAdditiveValueFunctionImpl.cpp
@@ -47,8 +47,8 @@ Color SVGAnimationColorFunction::colorFromString(SVGElement& targetElement, cons
 
 std::optional<float> SVGAnimationColorFunction::calculateDistance(SVGElement&, const String& from, const String& to) const
 {
-    auto simpleFrom = CSSParser::parseColorWithoutContext(from.stripWhiteSpace()).toColorTypeLossy<SRGBA<uint8_t>>().resolved();
-    auto simpleTo = CSSParser::parseColorWithoutContext(to.stripWhiteSpace()).toColorTypeLossy<SRGBA<uint8_t>>().resolved();
+    auto simpleFrom = CSSParser::parseColorWithoutContext(from.stripLeadingAndTrailingCharacters(deprecatedIsSpaceOrNewline)).toColorTypeLossy<SRGBA<uint8_t>>().resolved();
+    auto simpleTo = CSSParser::parseColorWithoutContext(to.stripLeadingAndTrailingCharacters(deprecatedIsSpaceOrNewline)).toColorTypeLossy<SRGBA<uint8_t>>().resolved();
 
     float red = simpleFrom.red - simpleTo.red;
     float green = simpleFrom.green - simpleTo.green;

--- a/Source/WebCore/svg/properties/SVGPropertyTraits.h
+++ b/Source/WebCore/svg/properties/SVGPropertyTraits.h
@@ -46,10 +46,10 @@ struct SVGPropertyTraits<bool> {
 template<>
 struct SVGPropertyTraits<Color> {
     static Color initialValue() { return Color(); }
-    static Color fromString(const String& string) { return CSSParser::parseColorWithoutContext(string.stripWhiteSpace()); }
+    static Color fromString(const String& string) { return CSSParser::parseColorWithoutContext(string.stripLeadingAndTrailingCharacters(deprecatedIsSpaceOrNewline)); }
     static std::optional<Color> parse(const QualifiedName&, const String& string)
     {
-        Color color = CSSParser::parseColorWithoutContext(string.stripWhiteSpace());
+        Color color = CSSParser::parseColorWithoutContext(string.stripLeadingAndTrailingCharacters(deprecatedIsSpaceOrNewline));
         if (!color.isValid())
             return std::nullopt;
         return color;

--- a/Source/WebCore/xml/XPathGrammar.cpp
+++ b/Source/WebCore/xml/XPathGrammar.cpp
@@ -1822,7 +1822,7 @@ yyreduce:
     {
         auto stringImpl = adoptRef((yyvsp[(3) - (4)].string));
         if (stringImpl)
-            stringImpl = stringImpl->stripWhiteSpace();
+            stringImpl = stringImpl->stripLeadingAndTrailingCharacters(deprecatedIsSpaceOrNewline);
         (yyval.nodeTest) = new WebCore::XPath::Step::NodeTest(WebCore::XPath::Step::NodeTest::ProcessingInstructionNodeTest, stringImpl.get());
     ;}
     break;

--- a/Source/WebCore/xml/XPathGrammar.y
+++ b/Source/WebCore/xml/XPathGrammar.y
@@ -183,8 +183,8 @@ Step:
         String nametest = adoptRef($1);
         std::unique_ptr<Vector<std::unique_ptr<WebCore::XPath::Expression>>> predicateList($2);
 
-        String localName;
-        String namespaceURI;
+        AtomString localName;
+        AtomString namespaceURI;
         if (!parser.expandQualifiedName(nametest, localName, namespaceURI)) {
             $$ = nullptr;
             YYABORT;
@@ -212,8 +212,8 @@ Step:
         String nametest = adoptRef($2);
         std::unique_ptr<Vector<std::unique_ptr<WebCore::XPath::Expression>>> predicateList($3);
 
-        String localName;
-        String namespaceURI;
+        AtomString localName;
+        AtomString namespaceURI;
         if (!parser.expandQualifiedName(nametest, localName, namespaceURI)) {
             $$ = nullptr;
             YYABORT;
@@ -260,8 +260,10 @@ NodeTest:
     |
     PI '(' LITERAL ')'
     {
-        String literal = adoptRef($3);
-        $$ = new WebCore::XPath::Step::NodeTest(WebCore::XPath::Step::NodeTest::ProcessingInstructionNodeTest, literal.stripWhiteSpace());
+        auto stringImpl = adoptRef($3);
+        if (stringImpl)
+            stringImpl = stringImpl->stripLeadingAndTrailingCharacters(deprecatedIsSpaceOrNewline);
+        $$ = new WebCore::XPath::Step::NodeTest(WebCore::XPath::Step::NodeTest::ProcessingInstructionNodeTest, stringImpl.get());
     }
     ;
 

--- a/Source/WebKit/UIProcess/API/glib/WebKitOptionMenuItemPrivate.h
+++ b/Source/WebKit/UIProcess/API/glib/WebKitOptionMenuItemPrivate.h
@@ -27,7 +27,7 @@ struct _WebKitOptionMenuItem {
     _WebKitOptionMenuItem() = default;
 
     _WebKitOptionMenuItem(const WebKit::WebPopupItem& item)
-        : label(item.m_text.stripWhiteSpace().utf8())
+        : label(item.m_text.stripLeadingAndTrailingCharacters(deprecatedIsSpaceOrNewline).utf8())
         , isGroupLabel(item.m_isLabel)
         , isGroupChild(item.m_text.startsWith("    "_s))
         , isEnabled(item.m_isEnabled)

--- a/Source/WebKit/UIProcess/gtk/WebPopupMenuProxyGtk.cpp
+++ b/Source/WebKit/UIProcess/gtk/WebPopupMenuProxyGtk.cpp
@@ -169,7 +169,7 @@ void WebPopupMenuProxyGtk::createPopupMenu(const Vector<WebPopupItem>& items, in
     for (const auto& item : items) {
         if (item.m_isLabel) {
             gtk_tree_store_insert_with_values(model.get(), &parentIter, nullptr, -1,
-                Columns::Label, item.m_text.stripWhiteSpace().utf8().data(),
+                Columns::Label, item.m_text.stripLeadingAndTrailingCharacters(deprecatedIsSpaceOrNewline).utf8().data(),
                 Columns::IsGroup, TRUE,
                 Columns::IsEnabled, TRUE,
                 -1);
@@ -179,7 +179,7 @@ void WebPopupMenuProxyGtk::createPopupMenu(const Vector<WebPopupItem>& items, in
             GtkTreeIter iter;
             bool isSelected = selectedIndex && static_cast<unsigned>(selectedIndex) == index;
             gtk_tree_store_insert_with_values(model.get(), &iter, item.m_text.startsWith("    "_s) ? &parentIter : nullptr, -1,
-                Columns::Label, item.m_text.stripWhiteSpace().utf8().data(),
+                Columns::Label, item.m_text.stripLeadingAndTrailingCharacters(deprecatedIsSpaceOrNewline).utf8().data(),
                 Columns::Tooltip, item.m_toolTip.isEmpty() ? nullptr : item.m_toolTip.utf8().data(),
                 Columns::IsGroup, FALSE,
                 Columns::IsSelected, isSelected,

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebContextMenuClient.cpp
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebContextMenuClient.cpp
@@ -53,7 +53,7 @@ void WebContextMenuClient::searchWithGoogle(const WebCore::LocalFrame* frame)
     if (!page)
         return;
 
-    auto searchString = frame->editor().selectedText().stripWhiteSpace();
+    auto searchString = frame->editor().selectedText().stripLeadingAndTrailingCharacters(deprecatedIsSpaceOrNewline);
     searchString = makeStringByReplacingAll(encodeWithURLEscapeSequences(searchString), "%20"_s, "+"_s);
     auto searchURL = URL { "https://www.google.com/search?q=" + searchString + "&ie=UTF-8&oe=UTF-8" };
 

--- a/Source/WebKit/WebProcess/WebCoreSupport/mac/WebContextMenuClientMac.mm
+++ b/Source/WebKit/WebProcess/WebCoreSupport/mac/WebContextMenuClientMac.mm
@@ -65,7 +65,7 @@ void WebContextMenuClient::stopSpeaking()
 
 void WebContextMenuClient::searchWithGoogle(const LocalFrame* frame)
 {
-    String searchString = frame->editor().selectedText().stripWhiteSpace();
+    String searchString = frame->editor().selectedText().stripLeadingAndTrailingCharacters(deprecatedIsSpaceOrNewline);
     m_page->send(Messages::WebPageProxy::SearchTheWeb(searchString));
 }
 

--- a/Tools/TestWebKitAPI/Tests/WebCore/DisplayListRecorderTests.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebCore/DisplayListRecorderTests.cpp
@@ -478,8 +478,8 @@ TYPED_TEST_P(DisplayListRecorderResultStateTest, StateThroughDisplayListIsPreser
     auto resultTarget = createReferenceTarget();
     auto& result = resultTarget->context();
 
-    auto description = testedTarget->displayList().asText({ WebCore::DisplayList::AsTextFlag::IncludePlatformOperations }).stripWhiteSpace();
-    auto expectedDescription = this->operationDescription().stripWhiteSpace();
+    auto description = testedTarget->displayList().asText({ WebCore::DisplayList::AsTextFlag::IncludePlatformOperations }).stripLeadingAndTrailingCharacters(deprecatedIsSpaceOrNewline);
+    auto expectedDescription = this->operationDescription().stripLeadingAndTrailingCharacters(deprecatedIsSpaceOrNewline);
     EXPECT_EQ(expectedDescription, description);
 
     testedTarget->replayDisplayList(result);


### PR DESCRIPTION
#### 4b6eaec45e978ed59f9161c88f8e978ad7fba925
<pre>
Remove String::stripWhiteSpace()
<a href="https://bugs.webkit.org/show_bug.cgi?id=257191">https://bugs.webkit.org/show_bug.cgi?id=257191</a>
rdar://109703510

Reviewed by Darin Adler.

The name is too generic as there are many flavors of whitespace and it
used a deprecated whitespace variant to boot.

This changes deprecatedIsSpaceOrNewline, its inverse, and
isUnicodeWhitespace to use UChar. This is more compatible with the
various templates and White_Space does not go beyond U+3000 (and if it
ever did go beyond UChar we&apos;d have to change the callers somehow anyway
to account for that).

This change exports StringImpl::stripLeadingAndTrailingCharacters() so
it can be used by XPathGrammar.cpp.

This change updates XPathGrammar.y with some changes that were made to
XPathGrammar.cpp directly. Unfortunately I was not able to backport all
changes. <a href="https://bugs.webkit.org/show_bug.cgi?id=257189">https://bugs.webkit.org/show_bug.cgi?id=257189</a> tracks
completing that work.

* Source/WTF/wtf/text/StringImpl.cpp:
(WTF::StringImpl::stripWhiteSpace): Deleted.
* Source/WTF/wtf/text/StringImpl.h:
(WTF::deprecatedIsSpaceOrNewline):
(WTF::isUnicodeWhitespace):
(WTF::deprecatedIsNotSpaceOrNewline):

Make it more clear that isUnicodeWhitespace is not deprecated by
separating it out.

* Source/WTF/wtf/text/WTFString.cpp:
(WTF::String::stripWhiteSpace const): Deleted.
* Source/WTF/wtf/text/WTFString.h:
* Source/WebCore/Modules/applicationmanifest/ApplicationManifestParser.cpp:
(WebCore::ApplicationManifestParser::parseGenericString):
* Source/WebCore/accessibility/AccessibilityNodeObject.cpp:
(WebCore::AccessibilityNodeObject::computeAccessibilityIsIgnored const):
(WebCore::AccessibilityNodeObject::textUnderElement const):

Use isAllSpecialCharacters instead as that&apos;s more efficient.

* Source/WebCore/css/parser/CSSParserImpl.cpp:
(WebCore::CSSParserImpl::consumeSupportsRule):
* Source/WebCore/dom/ImageOverlay.cpp:
(WebCore::ImageOverlay::updateSubtree):

Use StringViews for efficiency.

* Source/WebCore/dom/ScriptElement.cpp:
(WebCore::ScriptElement::determineScriptType const):
* Source/WebCore/editing/TextManipulationController.cpp:
(WebCore::areEqualIgnoringLeadingAndTrailingWhitespaces):

Inline this comparison for now as there&apos;s only one and use StringView
for efficiency.

* Source/WebCore/editing/TypingCommand.cpp:
(WebCore::TypingCommand::markMisspellingsAfterTyping):
* Source/WebCore/html/HTMLMediaElement.cpp:
(WebCore::HTMLMediaElement::mediaSessionTitle const):
* Source/WebCore/html/HTMLOptGroupElement.cpp:
(WebCore::HTMLOptGroupElement::groupLabelText const):
* Source/WebCore/html/ValidatedFormListedElement.cpp:
(WebCore::ValidatedFormListedElement::updateVisibleValidationMessage):
* Source/WebCore/inspector/InspectorStyleSheet.cpp:
(WebCore::selectorsFromSource):
* Source/WebCore/page/csp/ContentSecurityPolicyDirectiveList.cpp:
(WebCore::checkMediaType):

Use StringView for efficiency and add a FIXME for additional possible
cleanup.

* Source/WebCore/platform/LocalizedStrings.cpp:
(WebCore::truncatedStringForMenuItem):
* Source/WebCore/platform/graphics/gstreamer/MediaPlayerPrivateGStreamer.cpp:
(WebCore::isMediaDiskCacheDisabled):

Add a FIXME to indicate this could probably be improved.

* Source/WebCore/platform/graphics/gstreamer/mse/SourceBufferPrivateGStreamer.cpp:
(WebCore::SourceBufferPrivateGStreamer::platformMaximumBufferSize const):
* Source/WebCore/platform/gtk/SelectionData.cpp:
(WebCore::SelectionData::setURIList):
* Source/WebCore/platform/ios/DragImageIOS.mm:
(WebCore::createDragImageForLink):
* Source/WebCore/platform/mac/PasteboardMac.mm:
(WebCore::writeURLForTypes):
(WebCore::Pasteboard::writeTrustworthyWebURLsPboardType):
* Source/WebCore/platform/mac/PasteboardWriter.mm:
(WebCore::createPasteboardWriter):

Add a FIXME to indicate this could probably be improved.

* Source/WebCore/platform/network/MIMEHeader.cpp:
(WebCore::retrieveKeyValuePairs):
(WebCore::MIMEHeader::parseHeader):
* Source/WebCore/platform/network/ParsedContentType.cpp:
(WebCore::ParsedContentType::setContentType):
* Source/WebCore/platform/network/curl/CookieUtil.cpp:
(WebCore::CookieUtil::parseCookieAttributes):
(WebCore::CookieUtil::parseCookieHeader):
* Source/WebCore/platform/network/curl/CurlMultipartHandle.cpp:
(WebCore::CurlMultipartHandle::extractBoundary):
* Source/WebCore/platform/network/curl/CurlRequest.cpp:
(WebCore::CurlRequest::didReceiveDebugInfo):
* Source/WebCore/platform/network/curl/ResourceResponseCurl.cpp:
(WebCore::ResourceResponse::appendHTTPHeaderField):
* Source/WebCore/platform/text/PlatformLocale.cpp:
(WebCore::Locale::convertFromLocalizedNumber):
* Source/WebCore/platform/win/ClipboardUtilitiesWin.cpp:
(WebCore::extractMarkupFromCFHTML):
(WebCore::fragmentFromCFHTML):
* Source/WebCore/rendering/RenderMenuList.cpp:
(RenderMenuList::setTextFromOption):
* Source/WebCore/svg/properties/SVGAnimationAdditiveValueFunctionImpl.cpp:
(WebCore::SVGAnimationColorFunction::calculateDistance const):
* Source/WebCore/svg/properties/SVGPropertyTraits.h:
(WebCore::SVGPropertyTraits&lt;Color&gt;::fromString):
(WebCore::SVGPropertyTraits&lt;Color&gt;::parse):
* Source/WebCore/xml/XPathGrammar.cpp:
* Source/WebCore/xml/XPathGrammar.y:
* Source/WebKit/UIProcess/API/glib/WebKitOptionMenuItemPrivate.h:
(_WebKitOptionMenuItem::_WebKitOptionMenuItem):
* Source/WebKit/UIProcess/gtk/WebPopupMenuProxyGtk.cpp:
(WebKit::WebPopupMenuProxyGtk::createPopupMenu):
* Source/WebKit/WebProcess/WebCoreSupport/WebContextMenuClient.cpp:
(WebKit::WebContextMenuClient::searchWithGoogle):
* Source/WebKit/WebProcess/WebCoreSupport/mac/WebContextMenuClientMac.mm:
(WebKit::WebContextMenuClient::searchWithGoogle):
* Tools/TestWebKitAPI/Tests/WebCore/DisplayListRecorderTests.cpp:

Canonical link: <a href="https://commits.webkit.org/264468@main">https://commits.webkit.org/264468@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/99d836d98180d8fe9347a5a5ad731f9a56ee26ec

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/7717 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/7988 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/8169 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/9358 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/7874 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/7723 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/9978 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/7909 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/10745 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/7851 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/8967 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/7086 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/9466 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/6277 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/7026 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/14692 "Passed tests") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/6580 "Built successfully and passed tests") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/7433 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/7150 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/10558 "Passed tests") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/7300 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/7640 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/6228 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/7872 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/6968 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/1803 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/1841 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/11179 "Built successfully") | | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/24/builds/8084 "Built successfully") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/7374 "Built successfully") | | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/3/builds/1952 "Passed tests") | 
<!--EWS-Status-Bubble-End-->