### PR TITLE
REGRESSION(264237@main): [GTK] Minibrowser crashes while initializing ThreadedCompositor

### DIFF
--- a/Source/WebKit/Shared/CoordinatedGraphics/threadedcompositor/CompositingRunLoop.h
+++ b/Source/WebKit/Shared/CoordinatedGraphics/threadedcompositor/CompositingRunLoop.h
@@ -60,6 +60,8 @@ public:
 
     void updateCompleted(LockHolder&);
 
+    RunLoop& runLoop() const { return m_runLoop.get(); }
+
 private:
     enum class UpdateState {
         Idle,

--- a/Source/WebKit/Shared/CoordinatedGraphics/threadedcompositor/ThreadedCompositor.h
+++ b/Source/WebKit/Shared/CoordinatedGraphics/threadedcompositor/ThreadedCompositor.h
@@ -80,6 +80,8 @@ public:
     void suspend();
     void resume();
 
+    RunLoop& compositingRunLoop() const { return m_compositingRunLoop->runLoop(); }
+
 private:
     ThreadedCompositor(Client&, ThreadedDisplayRefreshMonitor::Client&, WebCore::PlatformDisplayID, const WebCore::IntSize&, float scaleFactor, WebCore::TextureMapper::PaintFlags);
 

--- a/Source/WebKit/WebProcess/WebPage/AcceleratedSurface.h
+++ b/Source/WebKit/WebProcess/WebPage/AcceleratedSurface.h
@@ -28,6 +28,10 @@
 #include <WebCore/IntSize.h>
 #include <wtf/Noncopyable.h>
 
+namespace WTF {
+class RunLoop;
+}
+
 namespace WebKit {
 
 class WebPage;
@@ -55,6 +59,9 @@ public:
     virtual void finalize() { }
     virtual void willRenderFrame() { }
     virtual void didRenderFrame() { }
+
+    virtual void didCreateCompositingRunLoop(WTF::RunLoop&) { }
+    virtual void willDestroyCompositingRunLoop() { }
 
 protected:
     AcceleratedSurface(WebPage&, Client&);

--- a/Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/LayerTreeHost.cpp
+++ b/Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/LayerTreeHost.cpp
@@ -81,6 +81,7 @@ LayerTreeHost::LayerTreeHost(WebPage& webPage, WebCore::PlatformDisplayID displa
 
     m_compositor = ThreadedCompositor::create(*this, *this, m_displayID, scaledSize, scaleFactor, paintFlags);
     m_layerTreeContext.contextID = m_surface->surfaceID();
+    m_surface->didCreateCompositingRunLoop(m_compositor->compositingRunLoop());
 
     didChangeViewport();
 }
@@ -89,6 +90,7 @@ LayerTreeHost::~LayerTreeHost()
 {
     cancelPendingLayerFlush();
 
+    m_surface->willDestroyCompositingRunLoop();
     m_coordinator.invalidate();
     m_compositor->invalidate();
     m_surface = nullptr;

--- a/Source/WebKit/WebProcess/WebPage/gtk/AcceleratedSurfaceDMABuf.cpp
+++ b/Source/WebKit/WebProcess/WebPage/gtk/AcceleratedSurfaceDMABuf.cpp
@@ -240,18 +240,24 @@ void AcceleratedSurfaceDMABuf::RenderTargetSHMImage::swap()
     RenderTarget::swap();
 }
 
+void AcceleratedSurfaceDMABuf::didCreateCompositingRunLoop(RunLoop& runLoop)
+{
+    WebProcess::singleton().parentProcessConnection()->addMessageReceiver(runLoop, *this, Messages::AcceleratedSurfaceDMABuf::messageReceiverName(), m_webPage.identifier().toUInt64());
+}
+
+void AcceleratedSurfaceDMABuf::willDestroyCompositingRunLoop()
+{
+    WebProcess::singleton().parentProcessConnection()->removeMessageReceiver(Messages::AcceleratedSurfaceDMABuf::messageReceiverName(), m_webPage.identifier().toUInt64());
+}
+
 void AcceleratedSurfaceDMABuf::didCreateGLContext()
 {
-    WebProcess::singleton().parentProcessConnection()->addMessageReceiver(RunLoop::current(), *this, Messages::AcceleratedSurfaceDMABuf::messageReceiverName(), m_webPage.identifier().toUInt64());
-
     glGenFramebuffers(1, &m_fbo);
     glBindFramebuffer(GL_FRAMEBUFFER, m_fbo);
 }
 
 void AcceleratedSurfaceDMABuf::willDestroyGLContext()
 {
-    WebProcess::singleton().parentProcessConnection()->removeMessageReceiver(Messages::AcceleratedSurfaceDMABuf::messageReceiverName(), m_webPage.identifier().toUInt64());
-
     m_target = nullptr;
 
     if (m_fbo) {

--- a/Source/WebKit/WebProcess/WebPage/gtk/AcceleratedSurfaceDMABuf.h
+++ b/Source/WebKit/WebProcess/WebPage/gtk/AcceleratedSurfaceDMABuf.h
@@ -62,6 +62,9 @@ public:
     void willRenderFrame() override;
     void didRenderFrame() override;
 
+    void didCreateCompositingRunLoop(WTF::RunLoop&) override;
+    void willDestroyCompositingRunLoop();
+
 private:
     AcceleratedSurfaceDMABuf(WebPage&, Client&);
 


### PR DESCRIPTION
#### 50514ebd7771378e008d66e009c9d7c274c94b39
<pre>
REGRESSION(264237@main): [GTK] Minibrowser crashes while initializing ThreadedCompositor
<a href="https://bugs.webkit.org/show_bug.cgi?id=257120">https://bugs.webkit.org/show_bug.cgi?id=257120</a>

Reviewed by Alicia Boya Garcia.

AcceleratedSurfaceDMABuf is now a message receiver that is setting the
message receieve dispatcher from the compositing thread. Connection
expects that message receivers are added from the main connection
dispatcher thread, the main thread in this case. This patch adds new
AcceleratedSurface methods didCreateCompositingRunLoop() and
willDestroyCompositingRunLoop() called from the main thread by
LayerTreeHost and used by AcceleratedSurfaceDMABuf to add and remove the
message receiver.

* Source/WebKit/Shared/CoordinatedGraphics/threadedcompositor/CompositingRunLoop.h:
(WebKit::CompositingRunLoop::runLoop const):
* Source/WebKit/Shared/CoordinatedGraphics/threadedcompositor/ThreadedCompositor.h:
(WebKit::ThreadedCompositor::compositingRunLoop const):
* Source/WebKit/WebProcess/WebPage/AcceleratedSurface.h:
(WebKit::AcceleratedSurface::didCreateCompositingRunLoop):
(WebKit::AcceleratedSurface::willDestroyCompositingRunLoop):
* Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/LayerTreeHost.cpp:
(WebKit::LayerTreeHost::LayerTreeHost):
(WebKit::LayerTreeHost::~LayerTreeHost):
* Source/WebKit/WebProcess/WebPage/gtk/AcceleratedSurfaceDMABuf.cpp:
(WebKit::AcceleratedSurfaceDMABuf::didCreateCompositingRunLoop):
(WebKit::AcceleratedSurfaceDMABuf::willDestroyCompositingRunLoop):
(WebKit::AcceleratedSurfaceDMABuf::didCreateGLContext):
(WebKit::AcceleratedSurfaceDMABuf::willDestroyGLContext):
* Source/WebKit/WebProcess/WebPage/gtk/AcceleratedSurfaceDMABuf.h:

Canonical link: <a href="https://commits.webkit.org/264414@main">https://commits.webkit.org/264414@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/6c60cc41d90b7f18090d45105711fbdbaf6d6b62

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/7560 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/7829 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/8012 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/9201 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/7749 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/9785 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/7753 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/10623 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/7692 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/8803 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/6977 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/9309 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/6111 "Passed tests") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/14581 "Passed tests") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/7297 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/7005 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/10364 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/7497 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/6120 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/6837 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/11046 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/912 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/7230 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->