### PR TITLE
Media recorder produces empty chunks

### DIFF
--- a/LayoutTests/http/wpt/mediarecorder/record-context-created-late-expected.txt
+++ b/LayoutTests/http/wpt/mediarecorder/record-context-created-late-expected.txt
@@ -1,0 +1,3 @@
+
+PASS Verify late canvas context creation does not break recording
+

--- a/LayoutTests/http/wpt/mediarecorder/record-context-created-late.html
+++ b/LayoutTests/http/wpt/mediarecorder/record-context-created-late.html
@@ -1,0 +1,32 @@
+<!doctype html>
+<html>
+<head>
+    <title>MediaRecorder context created late</title>
+    <script src="/resources/testharness.js"></script>
+    <script src="/resources/testharnessreport.js"></script>
+</head>
+<body>
+<canvas id="canvas" width="500" height="500"></canvas>
+<script>
+promise_test(async (t) => {
+    const stream = canvas.captureStream(25);
+    const mediaRecorder = new MediaRecorder(stream)
+    mediaRecorder.start(10);
+
+    setTimeout(() => {
+        const ctx = canvas.getContext('2d');
+        ctx.fillStyle = 'green';
+        ctx.fillRect(10, 10, 150, 100);
+    }, 100);
+
+    return new Promise((resolve, reject) => {
+        mediaRecorder.ondataavailable = (event) => {
+            if (event.data.size > 0)
+                resolve();
+        };
+        setTimeout(() => reject("no blob with data"), 5000);
+    });
+}, "Verify late canvas context creation does not break recording");
+</script>
+</body>
+</html>

--- a/LayoutTests/webrtc/routines.js
+++ b/LayoutTests/webrtc/routines.js
@@ -263,7 +263,7 @@ function getReceivedTrackStats(connection)
     return connection.getStats().then((report) => {
         var stats;
         report.forEach((statItem) => {
-            if (statItem.type === "track") {
+            if (statItem.type === "inbound-rtp") {
                 stats = statItem;
             }
         });

--- a/Source/WebCore/Modules/mediastream/CanvasCaptureMediaStreamTrack.cpp
+++ b/Source/WebCore/Modules/mediastream/CanvasCaptureMediaStreamTrack.cpp
@@ -156,7 +156,7 @@ void CanvasCaptureMediaStreamTrack::Source::canvasChanged(CanvasBase& canvas, co
 {
     ASSERT_UNUSED(canvas, m_canvas == &canvas);
 #if ENABLE(WEBGL)
-    if (m_canvas->renderingContext() && m_canvas->renderingContext()->needsPreparationForDisplay())
+    if (m_canvas->renderingContext() && m_canvas->renderingContext()->needsPreparationForDisplay() && m_canvas->hasObserver(m_canvas->document()))
         return;
 #endif
     scheduleCaptureCanvas();

--- a/Source/WebCore/html/CanvasBase.cpp
+++ b/Source/WebCore/html/CanvasBase.cpp
@@ -195,6 +195,11 @@ void CanvasBase::removeObserver(CanvasObserver& observer)
         InspectorInstrumentation::didChangeCSSCanvasClientNodes(*this);
 }
 
+bool CanvasBase::hasObserver(CanvasObserver& observer) const
+{
+    return m_observers.contains(observer);
+}
+
 void CanvasBase::notifyObserversCanvasChanged(const std::optional<FloatRect>& rect)
 {
     for (auto& observer : m_observers)

--- a/Source/WebCore/html/CanvasBase.h
+++ b/Source/WebCore/html/CanvasBase.h
@@ -98,6 +98,7 @@ public:
 
     void addObserver(CanvasObserver&);
     void removeObserver(CanvasObserver&);
+    bool hasObserver(CanvasObserver&) const;
     void notifyObserversCanvasChanged(const std::optional<FloatRect>&);
     void notifyObserversCanvasResized();
     void notifyObserversCanvasDestroyed(); // Must be called in destruction before clearing m_context.


### PR DESCRIPTION
#### 712b8a916d0da3c2661c38f3273bc303f3ea431b
<pre>
Media recorder produces empty chunks
<a href="https://bugs.webkit.org/show_bug.cgi?id=257016">https://bugs.webkit.org/show_bug.cgi?id=257016</a>
rdar://109705910

Reviewed by Eric Carlson.

We were skipping video frame generation when needing preparation for display.
This works fine as long as we receive the canvasDisplayBufferPrepared notification.
This notification only happens if the document is observing canvas changes.
If that is not the case, we schedule a capture canvas, which will trigger a video frame generation and will register the document as a canvas change observer.

Making a side fix in LayoutTests/webrtc/routines.js so that computeFrameRate works fine on browsers without internals.
This is necessary for LayoutTests/fast/mediacapturefromelement/CanvasCaptureMediaStream-capture-out-of-DOM-canvas.html in particular.

* LayoutTests/http/wpt/mediarecorder/record-context-created-late-expected.txt: Added.
* LayoutTests/http/wpt/mediarecorder/record-context-created-late.html: Added.
* LayoutTests/webrtc/routines.js:
* Source/WebCore/Modules/mediastream/CanvasCaptureMediaStreamTrack.cpp:
(WebCore::CanvasCaptureMediaStreamTrack::Source::canvasChanged):
* Source/WebCore/html/CanvasBase.cpp:
(WebCore::CanvasBase::hasObserver const):
* Source/WebCore/html/CanvasBase.h:

Canonical link: <a href="https://commits.webkit.org/264478@main">https://commits.webkit.org/264478@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/01fa006ecd879579c42aa1268595803cb0a1f970

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/7737 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/8008 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/8189 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/9378 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/7892 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/7742 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/9998 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/7929 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/10762 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/7871 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/8996 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/7107 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/9486 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/6297 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/7045 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/14710 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/7448 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/7171 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/10576 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/7660 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/6243 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/6987 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/6955 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/1852 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/11199 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/7392 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->