### PR TITLE
[GStreamer] Report video decode errors

### DIFF
--- a/LayoutTests/platform/glib/imported/w3c/web-platform-tests/fetch/metadata/generated/element-audio.https.sub-expected.txt
+++ b/LayoutTests/platform/glib/imported/w3c/web-platform-tests/fetch/metadata/generated/element-audio.https.sub-expected.txt
@@ -1,0 +1,23 @@
+
+PASS sec-fetch-site - Same origin, no attributes
+PASS sec-fetch-site - Cross-site, no attributes
+PASS sec-fetch-site - Same site, no attributes
+PASS sec-fetch-site - Same-Origin -> Cross-Site -> Same-Origin redirect, no attributes
+PASS sec-fetch-site - Same-Origin -> Same-Site -> Same-Origin redirect, no attributes
+PASS sec-fetch-site - Cross-Site -> Same Origin, no attributes
+PASS sec-fetch-site - Cross-Site -> Same-Site, no attributes
+PASS sec-fetch-site - Cross-Site -> Cross-Site, no attributes
+PASS sec-fetch-site - Same-Origin -> Same Origin, no attributes
+PASS sec-fetch-site - Same-Origin -> Same-Site, no attributes
+PASS sec-fetch-site - Same-Origin -> Cross-Site, no attributes
+PASS sec-fetch-site - Same-Site -> Same Origin, no attributes
+PASS sec-fetch-site - Same-Site -> Same-Site, no attributes
+PASS sec-fetch-site - Same-Site -> Cross-Site, no attributes
+PASS sec-fetch-site - HTTPS downgrade-upgrade, no attributes
+PASS sec-fetch-mode - no attributes
+PASS sec-fetch-mode - attributes: crossorigin
+PASS sec-fetch-mode - attributes: crossorigin=anonymous
+PASS sec-fetch-mode - attributes: crossorigin=use-credentials
+PASS sec-fetch-dest - no attributes
+PASS sec-fetch-user - no attributes
+

--- a/LayoutTests/platform/glib/imported/w3c/web-platform-tests/fetch/metadata/generated/element-audio.sub-expected.txt
+++ b/LayoutTests/platform/glib/imported/w3c/web-platform-tests/fetch/metadata/generated/element-audio.sub-expected.txt
@@ -1,0 +1,17 @@
+
+PASS sec-fetch-site - Not sent to non-trustworthy same-origin destination, no attributes
+PASS sec-fetch-site - Not sent to non-trustworthy same-site destination, no attributes
+PASS sec-fetch-site - Not sent to non-trustworthy cross-site destination, no attributes
+PASS sec-fetch-mode - Not sent to non-trustworthy same-origin destination, no attributes
+PASS sec-fetch-mode - Not sent to non-trustworthy same-site destination, no attributes
+PASS sec-fetch-mode - Not sent to non-trustworthy cross-site destination, no attributes
+PASS sec-fetch-dest - Not sent to non-trustworthy same-origin destination, no attributes
+PASS sec-fetch-dest - Not sent to non-trustworthy same-site destination, no attributes
+PASS sec-fetch-dest - Not sent to non-trustworthy cross-site destination, no attributes
+PASS sec-fetch-user - Not sent to non-trustworthy same-origin destination, no attributes
+PASS sec-fetch-user - Not sent to non-trustworthy same-site destination, no attributes
+PASS sec-fetch-user - Not sent to non-trustworthy cross-site destination, no attributes
+PASS sec-fetch-site - HTTPS downgrade (header not sent), no attributes
+PASS sec-fetch-site - HTTPS upgrade, no attributes
+PASS sec-fetch-site - HTTPS downgrade-upgrade, no attributes
+

--- a/LayoutTests/platform/glib/imported/w3c/web-platform-tests/fetch/metadata/generated/element-video.https.sub-expected.txt
+++ b/LayoutTests/platform/glib/imported/w3c/web-platform-tests/fetch/metadata/generated/element-video.https.sub-expected.txt
@@ -1,0 +1,23 @@
+
+PASS sec-fetch-site - Same origin, no attributes
+PASS sec-fetch-site - Cross-site, no attributes
+PASS sec-fetch-site - Same site, no attributes
+PASS sec-fetch-site - Same-Origin -> Cross-Site -> Same-Origin redirect, no attributes
+PASS sec-fetch-site - Same-Origin -> Same-Site -> Same-Origin redirect, no attributes
+PASS sec-fetch-site - Cross-Site -> Same Origin, no attributes
+PASS sec-fetch-site - Cross-Site -> Same-Site, no attributes
+PASS sec-fetch-site - Cross-Site -> Cross-Site, no attributes
+PASS sec-fetch-site - Same-Origin -> Same Origin, no attributes
+PASS sec-fetch-site - Same-Origin -> Same-Site, no attributes
+PASS sec-fetch-site - Same-Origin -> Cross-Site, no attributes
+PASS sec-fetch-site - Same-Site -> Same Origin, no attributes
+PASS sec-fetch-site - Same-Site -> Same-Site, no attributes
+PASS sec-fetch-site - Same-Site -> Cross-Site, no attributes
+PASS sec-fetch-site - HTTPS downgrade-upgrade, no attributes
+PASS sec-fetch-mode - no attributes
+PASS sec-fetch-mode - attributes: crossorigin
+PASS sec-fetch-mode - attributes: crossorigin=anonymous
+PASS sec-fetch-mode - attributes: crossorigin=use-credentials
+PASS sec-fetch-dest - no attributes
+PASS sec-fetch-user - no attributes
+

--- a/LayoutTests/platform/glib/imported/w3c/web-platform-tests/fetch/metadata/generated/element-video.sub-expected.txt
+++ b/LayoutTests/platform/glib/imported/w3c/web-platform-tests/fetch/metadata/generated/element-video.sub-expected.txt
@@ -1,0 +1,17 @@
+
+PASS sec-fetch-site - Not sent to non-trustworthy same-origin destination, no attributes
+PASS sec-fetch-site - Not sent to non-trustworthy same-site destination, no attributes
+PASS sec-fetch-site - Not sent to non-trustworthy cross-site destination, no attributes
+PASS sec-fetch-mode - Not sent to non-trustworthy same-origin destination, no attributes
+PASS sec-fetch-mode - Not sent to non-trustworthy same-site destination, no attributes
+PASS sec-fetch-mode - Not sent to non-trustworthy cross-site destination, no attributes
+PASS sec-fetch-dest - Not sent to non-trustworthy same-origin destination, no attributes
+PASS sec-fetch-dest - Not sent to non-trustworthy same-site destination, no attributes
+PASS sec-fetch-dest - Not sent to non-trustworthy cross-site destination, no attributes
+PASS sec-fetch-user - Not sent to non-trustworthy same-origin destination, no attributes
+PASS sec-fetch-user - Not sent to non-trustworthy same-site destination, no attributes
+PASS sec-fetch-user - Not sent to non-trustworthy cross-site destination, no attributes
+PASS sec-fetch-site - HTTPS downgrade (header not sent), no attributes
+PASS sec-fetch-site - HTTPS upgrade, no attributes
+PASS sec-fetch-site - HTTPS downgrade-upgrade, no attributes
+

--- a/LayoutTests/platform/glib/imported/w3c/web-platform-tests/html/browsers/browsing-the-web/read-media/cross-origin-video-expected.txt
+++ b/LayoutTests/platform/glib/imported/w3c/web-platform-tests/html/browsers/browsing-the-web/read-media/cross-origin-video-expected.txt
@@ -1,6 +1,4 @@
 
 
-Harness Error (TIMEOUT), message = null
-
-TIMEOUT Test cross origin load of media document in parts Test timed out
+FAIL Test cross origin load of media document in parts promise_test: Unhandled rejection with value: object "NotSupportedError: The operation is not supported."
 

--- a/Source/WebCore/platform/graphics/gstreamer/MediaPlayerPrivateGStreamer.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/MediaPlayerPrivateGStreamer.cpp
@@ -1805,10 +1805,10 @@ void MediaPlayerPrivateGStreamer::handleMessage(GstMessage* message)
             || g_error_matches(err.get(), GST_RESOURCE_ERROR, GST_RESOURCE_ERROR_NOT_FOUND))
             error = MediaPlayer::NetworkState::FormatError;
         else if (g_error_matches(err.get(), GST_STREAM_ERROR, GST_STREAM_ERROR_TYPE_NOT_FOUND)) {
-            // Let the mediaPlayerClient handle the stream error, in this case the HTMLMediaElement will emit a stalled event.
             GST_ERROR_OBJECT(pipeline(), "Decode error, let the Media element emit a stalled event.");
             m_loadingStalled = true;
-            break;
+            error = MediaPlayer::NetworkState::DecodeError;
+            attemptNextLocation = true;
         } else if (err->domain == GST_STREAM_ERROR) {
             error = MediaPlayer::NetworkState::DecodeError;
             attemptNextLocation = true;


### PR DESCRIPTION
#### 47683cbce224b66ec4be118dc9279b730d204e8a
<pre>
[GStreamer] Report video decode errors
<a href="https://bugs.webkit.org/show_bug.cgi?id=257195">https://bugs.webkit.org/show_bug.cgi?id=257195</a>

Reviewed by Philippe Normand.

When a GST_STREAM_ERROR or GST_STREAM_ERROR_TYPE_NOT_FOUND occurs, the
player does not set the error to MediaPlayer::NetworkState::DecodeError,
but expects the application to do so if needed via the stalled event.
However the latter is too generic for the application to determine the
actual cause of error and decide whether this is a decode error or some
other deficiency (e.g. temporary bandwidth issues).

Original author: Michael Pantazoglou &lt;michael.pantazoglou@oceanbluesoftware.co.uk&gt;
See: <a href="https://github.com/WebPlatformForEmbedded/WPEWebKit/pull/1072">https://github.com/WebPlatformForEmbedded/WPEWebKit/pull/1072</a>

* Source/WebCore/platform/graphics/gstreamer/MediaPlayerPrivateGStreamer.cpp:
(WebCore::MediaPlayerPrivateGStreamer::handleMessage): set DecodeError

Canonical link: <a href="https://commits.webkit.org/265543@main">https://commits.webkit.org/265543@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/330fff1170e0d5f771816e78398ca571d1b94ceb

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/11196 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/11406 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/11737 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/12847 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/10676 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/11217 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/13785 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/11391 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/13591 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/11357 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/12243 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/9454 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/13252 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/9537 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/10130 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/17331 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/10607 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/10285 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/13503 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/10717 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/8804 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/9887 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/2678 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/14161 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/10570 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->