### PR TITLE
HTMLOptionElement text setter should not have non-conforming observable behavior

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-option-element/option-text-setter-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-option-element/option-text-setter-expected.txt
@@ -1,4 +1,4 @@
 
 
-FAIL Verify that using HTMLOptionElement.text setter does not update the existing text child node. assert_equals: Verify that the text child node does not have an updated value. expected "bar" but got "baz"
+PASS Verify that using HTMLOptionElement.text setter does not update the existing text child node.
 

--- a/Source/WebCore/html/HTMLOptionElement.cpp
+++ b/Source/WebCore/html/HTMLOptionElement.cpp
@@ -4,7 +4,7 @@
  *           (C) 2001 Dirk Mueller (mueller@kde.org)
  *           (C) 2006 Alexey Proskuryakov (ap@nypop.com)
  * Copyright (C) 2004-2020 Apple Inc. All rights reserved.
- * Copyright (C) 2010 Google Inc. All rights reserved.
+ * Copyright (C) 2010-2017 Google Inc. All rights reserved.
  * Copyright (C) 2011 Motorola Mobility, Inc.  All rights reserved.
  *
  * This library is free software; you can redistribute it and/or
@@ -123,14 +123,7 @@ void HTMLOptionElement::setText(String&& text)
     bool selectIsMenuList = select && select->usesMenuList();
     int oldSelectedIndex = selectIsMenuList ? select->selectedIndex() : -1;
 
-    // Handle the common special case where there's exactly 1 child node, and it's a text node.
-    RefPtr child = firstChild();
-    if (is<Text>(child) && !child->nextSibling())
-        downcast<Text>(*child).setData(WTFMove(text));
-    else {
-        removeChildren();
-        appendChild(Text::create(document(), WTFMove(text)));
-    }
+    setTextContent(WTFMove(text));
     
     if (selectIsMenuList && select->selectedIndex() != oldSelectedIndex)
         select->setSelectedIndex(oldSelectedIndex);


### PR DESCRIPTION
#### 8b8e722170c26f24cf420b896cedcbcb979c6a86
<pre>
HTMLOptionElement text setter should not have non-conforming observable behavior

<a href="https://bugs.webkit.org/show_bug.cgi?id=257172">https://bugs.webkit.org/show_bug.cgi?id=257172</a>

Reviewed by Aditya Keerthi.

This patch aligns WebKit with Web-Spec [1] and Blink / Chromium.

Merge: <a href="https://chromium-review.googlesource.com/c/chromium/src/+/721610">https://chromium-review.googlesource.com/c/chromium/src/+/721610</a>

This patch removes non-conforming observable behavior to match the spec regarding using
textContent when setting internally as below:
&quot;The text attribute&apos;s setter must string replace all with the given value within this element.&quot;

[1] <a href="https://html.spec.whatwg.org/#dom-option-text">https://html.spec.whatwg.org/#dom-option-text</a>

* Source/WebCore/html/HTMLOptionElement.cpp:
(HTMLOptionElement::setText): As above
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-option-element/option-text-setter-expected.txt: Rebaselined

Canonical link: <a href="https://commits.webkit.org/264442@main">https://commits.webkit.org/264442@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0519a3a2f637eca8a549f65ca2b8cd0847586948

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/7571 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/7840 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/8024 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/9213 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/7760 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/7584 "Passed tests") | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/23/builds/9895 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/7765 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/10633 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/7704 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/8815 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/6987 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/9321 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/6123 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/6895 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/14592 "Passed tests") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/7307 "Build was cancelled. Recent messages:OS: Ventura (13.3), Xcode: 14.3; Skipping applying patch since patch_id isn't provided; Checked out pull request") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/7018 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/10390 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/7509 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/6131 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/6848 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/11058 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/923 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/7241 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->