### PR TITLE
Ignore bidi control characters while collecting fallback fonts

### DIFF
--- a/LayoutTests/platform/glib/TestExpectations
+++ b/LayoutTests/platform/glib/TestExpectations
@@ -3270,7 +3270,6 @@ webkit.org/b/237108 http/tests/websocket/tests/hybi/imported/blink/permessage-de
 webkit.org/b/237108 http/tests/websocket/tests/hybi/simple-wss.html [ Failure ]
 
 webkit.org/b/236298 fast/text/combining-character-sequence-vertical.html [ ImageOnlyFailure ]
-webkit.org/b/236298 fast/text/fallback-font-and-zero-width-glyph.html [ ImageOnlyFailure ]
 webkit.org/b/236298 fast/text/simple-line-layout-with-justified-punctuation.html [ ImageOnlyFailure ]
 webkit.org/b/236298 fast/text/simple-lines-text-transform.html [ ImageOnlyFailure ]
 webkit.org/b/236298 fast/text/strikethrough-int.html [ ImageOnlyFailure ]

--- a/LayoutTests/platform/glib/fast/text/international/bidi-LDB-2-formatting-characters-expected.txt
+++ b/LayoutTests/platform/glib/fast/text/international/bidi-LDB-2-formatting-characters-expected.txt
@@ -86,7 +86,7 @@ layer at (0,0) size 785x654
               text run at (64,1) width 29 RTL: "\x{202E}IHG"
         RenderText {#text} at (107,83) size 5x17
           text run at (107,83) width 5: " "
-        RenderBlock {DIV} at (115,52) size 35x82 [border: (1px solid #008000)]
+        RenderBlock {DIV} at (115,53) size 35x80 [border: (1px solid #008000)]
           RenderTable {TABLE} at (4,4) size 27x18
             RenderTableSection {TBODY} at (0,0) size 27x18
               RenderTableRow {TR} at (0,0) size 27x18
@@ -102,13 +102,13 @@ layer at (0,0) size 785x654
           RenderBlock {P} at (4,22) size 27x18
             RenderText {#text} at (0,0) size 27x17
               text run at (0,0) width 27 RTL: "\x{5D0}\x{5D1}\x{5D2}"
-          RenderBlock {P} at (4,40) size 27x19
-            RenderText {#text} at (0,1) size 27x17
-              text run at (0,1) width 27 RTL: "\x{202A}\x{5D0}\x{5D1}\x{5D2}"
-              text run at (27,1) width 0: "\x{202C}"
-          RenderBlock {P} at (4,59) size 27x19
-            RenderText {#text} at (0,1) size 27x17
-              text run at (0,1) width 27: "\x{202D}\x{5D2}\x{5D1}\x{5D0}\x{202C}"
+          RenderBlock {P} at (4,40) size 27x18
+            RenderText {#text} at (0,0) size 27x17
+              text run at (0,0) width 27 RTL: "\x{202A}\x{5D0}\x{5D1}\x{5D2}"
+              text run at (27,0) width 0: "\x{202C}"
+          RenderBlock {P} at (4,58) size 27x18
+            RenderText {#text} at (0,0) size 27x17
+              text run at (0,0) width 27: "\x{202D}\x{5D2}\x{5D1}\x{5D0}\x{202C}"
         RenderText {#text} at (153,83) size 5x17
           text run at (153,83) width 5: " "
         RenderBlock {DIV} at (161,60) size 101x65 [border: (1px solid #008000)]

--- a/LayoutTests/platform/glib/fast/text/unicode-variation-selector-expected.txt
+++ b/LayoutTests/platform/glib/fast/text/unicode-variation-selector-expected.txt
@@ -17,10 +17,10 @@ layer at (0,0) size 800x600
           RenderText {#text} at (289,0) size 16x15
             text run at (289,0) width 16: "\x{845B}"
         RenderText {#text} at (0,0) size 0x0
-      RenderBlock {DIV} at (0,88) size 784x19
-        RenderText {#text} at (0,1) size 269x17
-          text run at (0,1) width 269: "Glyph for code point U+845B with UVS: "
+      RenderBlock {DIV} at (0,88) size 784x18
+        RenderText {#text} at (0,0) size 269x17
+          text run at (0,0) width 269: "Glyph for code point U+845B with UVS: "
         RenderInline {SPAN} at (0,0) size 16x15
-          RenderText {#text} at (269,1) size 16x15
-            text run at (269,1) width 16: "\x{845B}\x{DB40}\x{DD00}"
+          RenderText {#text} at (269,0) size 16x15
+            text run at (269,0) width 16: "\x{845B}\x{DB40}\x{DD00}"
         RenderText {#text} at (0,0) size 0x0

--- a/Source/WebCore/layout/formattingContexts/inline/text/TextUtil.cpp
+++ b/Source/WebCore/layout/formattingContexts/inline/text/TextUtil.cpp
@@ -136,9 +136,15 @@ static void fallbackFontsForRunWithIterator(HashSet<const Font*>& fallbackFonts,
             auto glyphData = fontCascade.glyphDataForCharacter(character, isRTL);
             if (glyphData.glyph && glyphData.font && glyphData.font != &primaryFont) {
                 auto isNonSpacingMark = U_MASK(u_charType(character)) & U_GC_MN_MASK;
+
+                // https://drafts.csswg.org/css-text-3/#white-space-processing
+                // "Unsupported Default_ignorable characters must be ignored for text rendering."
+                auto isIgnored = isDefaultIgnorableCodePoint(character);
+
                 // If we include the synthetic bold expansion, then even zero-width glyphs will have their fonts added.
                 if (isNonSpacingMark || glyphData.font->widthForGlyph(glyphData.glyph, Font::SyntheticBoldInclusion::Exclude))
-                    fallbackFonts.add(glyphData.font);
+                    if (!isIgnored)
+                        fallbackFonts.add(glyphData.font);
             }
         };
         addFallbackFontForCharacterIfApplicable(currentCharacter);


### PR DESCRIPTION
#### 07b1f5f81cef6ffba197c22cc94d52526da87709
<pre>
Ignore bidi control characters while collecting fallback fonts
<a href="https://bugs.webkit.org/show_bug.cgi?id=257200">https://bugs.webkit.org/show_bug.cgi?id=257200</a>

Reviewed by Myles C. Maxfield.

<a href="https://drafts.csswg.org/css-text-3/#white-space-processing">https://drafts.csswg.org/css-text-3/#white-space-processing</a>
&quot;Unsupported Default_ignorable characters must be ignored for text rendering.&quot;

Fixes test fast/text/fallback-font-and-zero-width-glyph.html; ignores
bidi control characters while collecting fallback fonts.

Per 245154@main, taking zero width glyphs (e.g. control chars) into
consideration while collecting fallback font information may result in
incorrect line height and baseline positioning; an alternative
mentioned there was to check against unicode ranges to omit
certain glyphs.

246121@main replaced our previous hardcoded list of Default_ignorable
characters with the helper function,FontCascade::isCharacterWhoseGlyphsShouldBeDeletedForTextRendering
(also refactored in 260081@main).

That helper function covers the use case &apos;rightToLeftOverride&apos; which the
test `LayoutTests/fast/text/fallback-font-and-zero-width-glyph.html`
relies on. Test now passing.

* Source/WebCore/layout/formattingContexts/inline/text/TextUtil.cpp:
(WebCore::Layout::fallbackFontsForRunWithIterator):
Use FontCascade::isCharacterWhoseGlyphsShouldBeDeletedForTextRendering
to ignore default ignorable characters when collecting fallback fonts.

* LayoutTests/platform/glib/TestExpectations:
Update, as fast/text/fallback-font-and-zero-width-glyph.html now passing.

* LayoutTests/platform/glib/fast/text/international/bidi-LDB-2-formatting-characters-expected.txt:
Update expectations for formatting characters; see ranges at <a href="https://www.compart.com/en/unicode/category/Cf.">https://www.compart.com/en/unicode/category/Cf.</a>

* LayoutTests/platform/glib/fast/text/unicode-variation-selector-expected.txt:
Update expectations; Variation selectors default ignorable code points
were updated in 246121@main, see
&apos;LayoutTests/imported/w3c/web-platform-tests/css/css-text/white-space/default-ignorable-complex.html`

Canonical link: <a href="https://commits.webkit.org/264509@main">https://commits.webkit.org/264509@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/3610e0134b47106bb41a078d8e600bd5316768e4

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/7794 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/8068 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/8249 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/9436 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/7942 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/7800 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/10058 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/7988 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/10804 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/7931 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/9039 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/7146 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/9548 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/6347 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/7096 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/14751 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/7493 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/7224 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/10620 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/7717 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/6289 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/7043 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/1875 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/11253 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/7449 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->