### PR TITLE
Make URLKeepingBlobAlive a movable only type

### DIFF
--- a/Source/WebCore/fileapi/URLKeepingBlobAlive.cpp
+++ b/Source/WebCore/fileapi/URLKeepingBlobAlive.cpp
@@ -37,13 +37,6 @@ URLKeepingBlobAlive::URLKeepingBlobAlive(const URL& url, const SecurityOriginDat
     registerBlobURLHandleIfNecessary();
 }
 
-URLKeepingBlobAlive::URLKeepingBlobAlive(const URLKeepingBlobAlive& other)
-    : m_url(other.m_url)
-    , m_topOrigin(other.m_topOrigin)
-{
-    registerBlobURLHandleIfNecessary();
-}
-
 URLKeepingBlobAlive::~URLKeepingBlobAlive()
 {
     unregisterBlobURLHandleIfNecessary();
@@ -54,18 +47,6 @@ void URLKeepingBlobAlive::clear()
     unregisterBlobURLHandleIfNecessary();
     m_url = { };
     m_topOrigin = { };
-}
-
-URLKeepingBlobAlive& URLKeepingBlobAlive::operator=(const URLKeepingBlobAlive& other)
-{
-    if (&other == this)
-        return *this;
-
-    unregisterBlobURLHandleIfNecessary();
-    m_url = other.m_url;
-    m_topOrigin = other.m_topOrigin;
-    registerBlobURLHandleIfNecessary();
-    return *this;
 }
 
 URLKeepingBlobAlive& URLKeepingBlobAlive::operator=(URLKeepingBlobAlive&& other)

--- a/Source/WebCore/fileapi/URLKeepingBlobAlive.h
+++ b/Source/WebCore/fileapi/URLKeepingBlobAlive.h
@@ -38,9 +38,10 @@ public:
     WEBCORE_EXPORT ~URLKeepingBlobAlive();
 
     URLKeepingBlobAlive(URLKeepingBlobAlive&&) = default;
-    URLKeepingBlobAlive(const URLKeepingBlobAlive&);
-    URLKeepingBlobAlive& operator=(const URLKeepingBlobAlive&);
     URLKeepingBlobAlive& operator=(URLKeepingBlobAlive&&);
+
+    URLKeepingBlobAlive(const URLKeepingBlobAlive&) = delete;
+    URLKeepingBlobAlive& operator=(const URLKeepingBlobAlive&) = delete;
 
     operator const URL&() const { return m_url; }
     const URL& url() const { return m_url; }


### PR DESCRIPTION
#### e6e4a0f8fc3dc6dfe4adb2a6f8686c767629562b
<pre>
Make URLKeepingBlobAlive a movable only type
<a href="https://bugs.webkit.org/show_bug.cgi?id=257201">https://bugs.webkit.org/show_bug.cgi?id=257201</a>
rdar://109716479

Reviewed by Chris Dumez.

Copying this object will trigger two IPC messages to network process.
It seems best to make it movable only. Copying it is easy anyway with the current constructor.

* Source/WebCore/fileapi/URLKeepingBlobAlive.cpp:
* Source/WebCore/fileapi/URLKeepingBlobAlive.h:

Canonical link: <a href="https://commits.webkit.org/264507@main">https://commits.webkit.org/264507@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/890887224b209c980d11df6b3bae2e5906fb53c8

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/7579 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/7848 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/8032 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/9221 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/7768 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/7592 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/9897 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/7773 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/10644 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/7712 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/8914 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/6993 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/9329 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/6222 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/6902 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/14602 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/7385 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/7025 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/10413 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/7517 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/6138 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/6856 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/1873 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/11066 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/7249 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->