### PR TITLE
Close explicitly the user media capture manager in GPUProcess when its WebProcess connection is closed

### DIFF
--- a/Source/WebKit/GPUProcess/GPUConnectionToWebProcess.cpp
+++ b/Source/WebKit/GPUProcess/GPUConnectionToWebProcess.cpp
@@ -343,6 +343,10 @@ void GPUConnectionToWebProcess::didClose(IPC::Connection& connection)
         m_audioSessionProxy = nullptr;
     }
 #endif
+#if PLATFORM(COCOA) && ENABLE(MEDIA_STREAM)
+    if (auto userMediaCaptureManagerProxy = std::exchange(m_userMediaCaptureManagerProxy, { }))
+        userMediaCaptureManagerProxy->close();
+#endif
 #if ENABLE(VIDEO)
     m_videoFrameObjectHeap->close();
     m_remoteMediaPlayerManagerProxy->clear();

--- a/Source/WebKit/UIProcess/Cocoa/UserMediaCaptureManagerProxy.cpp
+++ b/Source/WebKit/UIProcess/Cocoa/UserMediaCaptureManagerProxy.cpp
@@ -530,6 +530,13 @@ void UserMediaCaptureManagerProxy::clear()
     m_proxies.clear();
 }
 
+void UserMediaCaptureManagerProxy::close()
+{
+    auto proxies = std::exchange(m_proxies, { });
+    for (auto& proxy : proxies.values())
+        proxy->stop();
+}
+
 void UserMediaCaptureManagerProxy::setOrientation(WebCore::IntDegrees orientation)
 {
     m_orientationNotifier.orientationChanged(orientation);

--- a/Source/WebKit/UIProcess/Cocoa/UserMediaCaptureManagerProxy.h
+++ b/Source/WebKit/UIProcess/Cocoa/UserMediaCaptureManagerProxy.h
@@ -72,6 +72,7 @@ public:
     explicit UserMediaCaptureManagerProxy(UniqueRef<ConnectionProxy>&&);
     ~UserMediaCaptureManagerProxy();
 
+    void close();
     void clear();
 
     void setOrientation(WebCore::IntDegrees);


### PR DESCRIPTION
#### 1504515d9a2cfd52f76ff827505d6271484bcde7
<pre>
Close explicitly the user media capture manager in GPUProcess when its WebProcess connection is closed
<a href="https://bugs.webkit.org/show_bug.cgi?id=257203">https://bugs.webkit.org/show_bug.cgi?id=257203</a>
rdar://99093866

Reviewed by Eric Carlson.

UserMediaCaptureManagerProxy keeps sources alive until destroyed.
It is destroyed when its GPUConnectionToWebProcess is destroyed, which can take some time, given it is ref counted.
To be more proactive, we now close the UserMediaCaptureManagerProxy when GPUConnectionToWebProcess loses its IPC connection.
This stops capture sources quickly, we then close the VideoFrame Object heap so that VideoFrames gets disposed quickly.

* Source/WebKit/GPUProcess/GPUConnectionToWebProcess.cpp:
(WebKit::GPUConnectionToWebProcess::didClose):
* Source/WebKit/UIProcess/Cocoa/UserMediaCaptureManagerProxy.cpp:
(WebKit::UserMediaCaptureManagerProxy::close):
* Source/WebKit/UIProcess/Cocoa/UserMediaCaptureManagerProxy.h:

Canonical link: <a href="https://commits.webkit.org/264854@main">https://commits.webkit.org/264854@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e3fc1f2153731b83c8f82d99f2d2b1831b8e27e0

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/7750 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/8022 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/8202 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/9392 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/7905 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/10012 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/7943 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/10775 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/7885 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/9000 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/7115 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/9502 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/6308 "Passed tests") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/14724 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/7459 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/7180 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/10591 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/7674 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/6254 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/7001 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/2150 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/11213 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/7405 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->