### PR TITLE
[ iOS ] 30 API Tests Failures on EWS Results.

### DIFF
--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/IDBCheckpointWAL.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/IDBCheckpointWAL.mm
@@ -73,7 +73,12 @@ long long fileSizeAtPath(NSString *path)
     return [attrs[NSFileSize] longLongValue];
 }
 
+// FIXME when rdar://109725221 is resolved
+#if PLATFORM(IOS)
+TEST(IndexedDB, DISABLED_CheckpointsWALAutomatically)
+#else
 TEST(IndexedDB, CheckpointsWALAutomatically)
+#endif
 {
     auto handler = adoptNS([[IDBCheckpointWALMessageHandler alloc] init]);
     auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/IDBIndexUpgradeToV2.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/IDBIndexUpgradeToV2.mm
@@ -51,7 +51,12 @@
 
 @end
 
+// FIXME when rdar://109725221 is resolved
+#if PLATFORM(IOS)
+TEST(IndexedDB, DISABLED_IndexUpgradeToV2)
+#else
 TEST(IndexedDB, IndexUpgradeToV2)
+#endif
 {
     RetainPtr<IDBIndexUpgradeToV2MessageHandler> handler = adoptNS([[IDBIndexUpgradeToV2MessageHandler alloc] init]);
     RetainPtr<WKWebViewConfiguration> configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
@@ -112,12 +117,22 @@ static void runMultipleIndicesTestWithDatabase(NSString* databaseName)
     EXPECT_WK_STREQ(@"Get object: {\"name\":\"apple\",\"color\":\"red\"}", [lastScriptMessage body]);
 }
 
+// FIXME when rdar://109725221 is resolved
+#if PLATFORM(IOS)
+TEST(IndexedDB, DISABLED_IndexUpgradeToV2WithMultipleIndices)
+#else
 TEST(IndexedDB, IndexUpgradeToV2WithMultipleIndices)
+#endif
 {
     runMultipleIndicesTestWithDatabase(@"IndexUpgradeWithMultipleIndices");
 }
 
+// FIXME when rdar://109725221 is resolved
+#if PLATFORM(IOS)
+TEST(IndexedDB, DISABLED_IndexUpgradeToV2WithMultipleIndicesHaveSameID)
+#else
 TEST(IndexedDB, IndexUpgradeToV2WithMultipleIndicesHaveSameID)
+#endif
 {
     runMultipleIndicesTestWithDatabase(@"IndexUpgradeWithMultipleIndicesHaveSameID");
 }

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/IndexedDBInPageCache.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/IndexedDBInPageCache.mm
@@ -51,7 +51,12 @@
 
 @end
 
+// FIXME when rdar://109725221 is resolved
+#if PLATFORM(IOS)
+TEST(IndexedDB, DISABLED_IndexedDBInPageCache)
+#else
 TEST(IndexedDB, IndexedDBInPageCache)
+#endif
 {
     auto handler = adoptNS([[IndexedDBInPageCacheMessageHandler alloc] init]);
     auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/IndexedDBMultiProcess.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/IndexedDBMultiProcess.mm
@@ -52,7 +52,12 @@
 
 @end
 
+// FIXME when rdar://109725221 is resolved
+#if PLATFORM(IOS)
+TEST(IndexedDB, DISABLED_IndexedDBMultiProcess)
+#else
 TEST(IndexedDB, IndexedDBMultiProcess)
+#endif
 {
     RetainPtr<IndexedDBMPMessageHandler> handler = adoptNS([[IndexedDBMPMessageHandler alloc] init]);
     RetainPtr<WKWebViewConfiguration> configuration = adoptNS([[WKWebViewConfiguration alloc] init]);

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/IndexedDBPersistence.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/IndexedDBPersistence.mm
@@ -56,7 +56,12 @@
 
 @end
 
+// FIXME when rdar://109725221 is resolved
+#if PLATFORM(IOS)
+TEST(IndexedDB, DISABLED_IndexedDBPersistence)
+#else
 TEST(IndexedDB, IndexedDBPersistence)
+#endif
 {
     RetainPtr<IndexedDBMessageHandler> handler = adoptNS([[IndexedDBMessageHandler alloc] init]);
     RetainPtr<WKWebViewConfiguration> configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
@@ -247,7 +252,12 @@ static void loadThirdPartyPageInWebView(WKWebView *webView, NSString *expectedRe
     EXPECT_WK_STREQ(expectedResult, (NSString *)[getNextMessage() body]);
 }
 
+// FIXME when rdar://109725221 is resolved
+#if PLATFORM(IOS)
+TEST(IndexedDB, DISABLED_IndexedDBThirdPartyFrameHasAccess)
+#else
 TEST(IndexedDB, IndexedDBThirdPartyFrameHasAccess)
+#endif
 {
     auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
     auto handler = adoptNS([[IndexedDBMessageHandler alloc] init]);
@@ -276,7 +286,12 @@ TEST(IndexedDB, IndexedDBThirdPartyFrameHasAccess)
     loadThirdPartyPageInWebView(thirdWebView.get(), @"database is created - put item success");
 }
 
+// FIXME when rdar://109725221 is resolved
+#if PLATFORM(IOS)
+TEST(IndexedDB, DISABLED_IndexedDBThirdPartyDataRemoval)
+#else
 TEST(IndexedDB, IndexedDBThirdPartyDataRemoval)
+#endif
 {
     auto websiteDataTypes = adoptNS([[NSSet alloc] initWithArray:@[WKWebsiteDataTypeIndexedDBDatabases]]);
     readyToContinue = false;
@@ -326,7 +341,12 @@ TEST(IndexedDB, IndexedDBThirdPartyDataRemoval)
     loadThirdPartyPageInWebView(thirdWebView.get(), @"database is created - put item success");
 }
 
+// FIXME when rdar://109725221 is resolved
+#if PLATFORM(IOS)
+TEST(IndexedDB, DISABLED_IndexedDBThirdPartyStorageLayout)
+#else
 TEST(IndexedDB, IndexedDBThirdPartyStorageLayout)
+#endif
 {
     auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
     NSString *databaseHash = WebCore::SQLiteFileSystem::computeHashForFileName("IndexedDBThirdPartyFrameHasAccess"_s);
@@ -475,7 +495,12 @@ static const char* workerFrameBytes = R"TESTRESOURCE(
 </script>
 )TESTRESOURCE";
 
+// FIXME when rdar://109725221 is resolved
+#if PLATFORM(IOS)
+TEST(IndexedDB, DISABLED_IndexedDBThirdPartyWorkerHasAccess)
+#else
 TEST(IndexedDB, IndexedDBThirdPartyWorkerHasAccess)
+#endif
 {
     auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
     auto handler = adoptNS([[IndexedDBMessageHandler alloc] init]);
@@ -553,7 +578,12 @@ indexedDB.databases().then(postDatabases);
 </script>
 )TESTRESOURCE";
 
+// FIXME when rdar://109725221 is resolved
+#if PLATFORM(IOS)
+TEST(IndexedDB, DISABLED_IndexedDBGetDatabases)
+#else
 TEST(IndexedDB, IndexedDBGetDatabases)
+#endif
 {
     readyToContinue = false;
     [[WKWebsiteDataStore defaultDataStore] removeDataOfTypes:[NSSet setWithObjects:WKWebsiteDataTypeIndexedDBDatabases, nil] modifiedSince:[NSDate distantPast] completionHandler:^() {

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/IndexedDBSuspendImminently.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/IndexedDBSuspendImminently.mm
@@ -71,7 +71,12 @@ static void keepNetworkProcessActive()
     }];
 }
 
+// FIXME when rdar://109725221 is resolved
+#if PLATFORM(IOS)
+TEST(IndexedDB, DISABLED_IndexedDBSuspendImminently)
+#else
 TEST(IndexedDB, IndexedDBSuspendImminently)
+#endif
 {
     readyToContinue = false;
     [[WKWebsiteDataStore defaultDataStore] removeDataOfTypes:[WKWebsiteDataStore allWebsiteDataTypes] modifiedSince:[NSDate distantPast] completionHandler:^() {
@@ -139,7 +144,12 @@ try {
 </script>
 )TESTRESOURCE";
 
+// FIXME when rdar://109725221 is resolved
+#if PLATFORM(IOS)
+TEST(IndexedDB, DISABLED_SuspendImminentlyForThirdPartyDatabases)
+#else
 TEST(IndexedDB, SuspendImminentlyForThirdPartyDatabases)
+#endif
 {
     auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
     auto handler = adoptNS([[IndexedDBSuspendImminentlyMessageHandler alloc] init]);

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/IndexedDBTempFileSize.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/IndexedDBTempFileSize.mm
@@ -53,7 +53,12 @@
 
 @end
 
+// FIXME when rdar://109725221 is resolved
+#if PLATFORM(IOS)
+TEST(IndexedDB, DISABLED_IndexedDBTempFileSize)
+#else
 TEST(IndexedDB, IndexedDBTempFileSize)
+#endif
 {
     auto handler = adoptNS([[IndexedDBFileSizeMessageHandler alloc] init]);
     auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/IndexedDBUserDelete.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/IndexedDBUserDelete.mm
@@ -51,7 +51,12 @@
 
 @end
 
+// FIXME when rdar://109725221 is resolved
+#if PLATFORM(IOS)
+TEST(IndexedDB, DISABLED_IndexedDBUserDelete)
+#else
 TEST(IndexedDB, IndexedDBUserDelete)
+#endif
 {
     auto handler = adoptNS([[IndexedDBUserDeleteMessageHandler alloc] init]);
     auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/LocalStoragePersistence.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/LocalStoragePersistence.mm
@@ -89,7 +89,12 @@ static RetainPtr<WKWebView> createdWebView;
 
 @end
 
+// FIXME when rdar://109725221 is resolved
+#if PLATFORM(IOS)
+TEST(WKWebView, DISABLED_LocalStorageProcessCrashes)
+#else
 TEST(WKWebView, LocalStorageProcessCrashes)
+#endif
 {
     readyToContinue = false;
     [[WKWebsiteDataStore defaultDataStore] removeDataOfTypes:[WKWebsiteDataStore allWebsiteDataTypes] modifiedSince:[NSDate distantPast] completionHandler:^() {

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/PushAPI.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/PushAPI.mm
@@ -518,7 +518,12 @@ static void terminateNetworkProcessWhileRegistrationIsStored(WKWebViewConfigurat
     [configuration.websiteDataStore _terminateNetworkProcess];
 }
 
+// FIXME when rdar://109725221 is resolved
+#if PLATFORM(IOS)
+TEST(PushAPI, DISABLED_firePushEventWithNoPagesSuccessful)
+#else
 TEST(PushAPI, firePushEventWithNoPagesSuccessful)
+#endif
 {
     TestWebKitAPI::HTTPServer server({
         { "/"_s, { mainBytes } },
@@ -566,7 +571,12 @@ TEST(PushAPI, firePushEventWithNoPagesSuccessful)
     clearWebsiteDataStore([configuration websiteDataStore]);
 }
 
+// FIXME when rdar://109725221 is resolved
+#if PLATFORM(IOS)
+TEST(PushAPI, DISABLED_firePushEventWithNoPagesFail)
+#else
 TEST(PushAPI, firePushEventWithNoPagesFail)
+#endif
 {
     TestWebKitAPI::HTTPServer server({
         { "/"_s, { mainBytes } },

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/ServiceWorkerBasic.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/ServiceWorkerBasic.mm
@@ -2296,7 +2296,12 @@ static void runTest(ResponseType responseType)
     EXPECT_TRUE(isTestServerTrust(webView.get().serverTrust));
 }
 
+// FIXME when rdar://109725221 is resolved
+#if PLATFORM(IOS)
+TEST(ServiceWorkers, DISABLED_ServerTrust)
+#else
 TEST(ServiceWorkers, ServerTrust)
+#endif
 {
     runTest(ResponseType::Synthetic);
     runTest(ResponseType::Cached);
@@ -2376,7 +2381,12 @@ TEST(ServiceWorkers, ChangeOfServerCertificate)
     }
 }
 
+// FIXME when rdar://109725221 is resolved
+#if PLATFORM(IOS)
+TEST(ServiceWorkers, DISABLED_ClearDOMCacheAlsoIncludesServiceWorkerRegistrations)
+#else
 TEST(ServiceWorkers, ClearDOMCacheAlsoIncludesServiceWorkerRegistrations)
+#endif
 {
     [WKWebsiteDataStore _allowWebsiteDataRecordsForAllOrigins];
 

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/StoreBlobThenDelete.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/StoreBlobThenDelete.mm
@@ -51,7 +51,12 @@
 
 @end
 
+// FIXME when rdar://109725221 is resolved
+#if PLATFORM(IOS)
+TEST(IndexedDB, DISABLED_StoreBlobThenRemoveData)
+#else
 TEST(IndexedDB, StoreBlobThenRemoveData)
+#endif
 {
     auto handler = adoptNS([[StoreBlobMessageHandler alloc] init]);
     auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
@@ -131,7 +136,12 @@ TEST(IndexedDB, StoreBlobThenRemoveData)
     TestWebKitAPI::Util::run(&readyToContinue);
 }
 
+// FIXME when rdar://109725221 is resolved
+#if PLATFORM(IOS)
+TEST(IndexedDB, DISABLED_StoreBlobThenDeleteDatabase)
+#else
 TEST(IndexedDB, StoreBlobThenDeleteDatabase)
+#endif
 {
     auto handler = adoptNS([[StoreBlobMessageHandler alloc] init]);
     auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebsiteDatastore.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebsiteDatastore.mm
@@ -639,7 +639,12 @@ TEST(WKWebsiteDataStore, ListIdentifiers)
     TestWebKitAPI::Util::run(&done);
 }
 
+// FIXME when rdar://109725221 is resolved
+#if PLATFORM(IOS)
+TEST(WKWebsiteDataStorePrivate, DISABLED_FetchWithSize)
+#else
 TEST(WKWebsiteDataStorePrivate, FetchWithSize)
+#endif
 {
     readyToContinue = false;
     [[WKWebsiteDataStore defaultDataStore] removeDataOfTypes:[WKWebsiteDataStore allWebsiteDataTypes] modifiedSince:[NSDate distantPast] completionHandler:^{

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/WebCryptoMasterKey.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/WebCryptoMasterKey.mm
@@ -56,7 +56,12 @@ static bool masterKeyCalled = false;
 
 namespace TestWebKitAPI {
 
+// FIXME when rdar://109725221 is resolved
+#if PLATFORM(IOS)
+TEST(WebKit, DISABLED_WebCryptoNilMasterKey)
+#else
 TEST(WebKit, WebCryptoNilMasterKey)
+#endif
 {
     RetainPtr<NSURL> testURL = [[NSBundle mainBundle] URLForResource:@"navigation-client-default-crypto" withExtension:@"html" subdirectory:@"TestWebKitAPI.resources"];
 

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/WebProcessKillIDBCleanup.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/WebProcessKillIDBCleanup.mm
@@ -51,7 +51,12 @@
 
 @end
 
+// FIXME when rdar://109725221 is resolved
+#if PLATFORM(IOS)
+TEST(IndexedDB, DISABLED_WebProcessKillIDBCleanup)
+#else
 TEST(IndexedDB, WebProcessKillIDBCleanup)
+#endif
 {
     RetainPtr<IndexedDBWebProcessKillMessageHandler> handler = adoptNS([[IndexedDBWebProcessKillMessageHandler alloc] init]);
     RetainPtr<WKWebViewConfiguration> configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
@@ -88,7 +93,12 @@ TEST(IndexedDB, WebProcessKillIDBCleanup)
     EXPECT_WK_STREQ(@"Second WebView Transaction Started", string6.get());
 }
 
+// FIXME when rdar://109725221 is resolved
+#if PLATFORM(IOS)
+TEST(IndexedDB, DISABLED_KillWebProcessWithOpenConnection)
+#else
 TEST(IndexedDB, KillWebProcessWithOpenConnection)
+#endif
 {
     auto handler = adoptNS([[IndexedDBWebProcessKillMessageHandler alloc] init]);
     auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/WebsiteDataStoreCustomPaths.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/WebsiteDataStoreCustomPaths.mm
@@ -267,12 +267,22 @@ static void runWebsiteDataStoreCustomPaths(ShouldEnableProcessPrewarming shouldE
     EXPECT_FALSE([WKWebsiteDataStore _defaultDataStoreExists]);
 }
 
+// FIXME when rdar://109725221 is resolved
+#if PLATFORM(IOS)
+TEST(WebKit, DISABLED_WebsiteDataStoreCustomPathsWithoutPrewarming)
+#else
 TEST(WebKit, WebsiteDataStoreCustomPathsWithoutPrewarming)
+#endif
 {
     runWebsiteDataStoreCustomPaths(ShouldEnableProcessPrewarming::No);
 }
 
+// FIXME when rdar://109725221 is resolved
+#if PLATFORM(IOS)
+TEST(WebKit, DISABLED_WebsiteDataStoreCustomPathsWithPrewarming)
+#else
 TEST(WebKit, WebsiteDataStoreCustomPathsWithPrewarming)
+#endif
 {
     runWebsiteDataStoreCustomPaths(ShouldEnableProcessPrewarming::Yes);
 }
@@ -486,7 +496,12 @@ TEST(WebKit, WebsiteDataStoreIfExists)
     EXPECT_TRUE(dataStore._configuration.persistent);
 }
 
+// FIXME when rdar://109725221 is resolved
+#if PLATFORM(IOS)
+TEST(WebKit, DISABLED_WebsiteDataStoreRenameOriginForIndexedDatabase)
+#else
 TEST(WebKit, WebsiteDataStoreRenameOriginForIndexedDatabase)
+#endif
 {
     // Reset defaultDataStore before test.
     __block bool done = false;


### PR DESCRIPTION
#### 25bd1ac74905d6876f30460f6af9db2807a39695
<pre>
[ iOS ] 30 API Tests Failures on EWS Results.
rdar://109725221
<a href="https://bugs.webkit.org/show_bug.cgi?id=257212">https://bugs.webkit.org/show_bug.cgi?id=257212</a>

Unreviewed test gardening.

Disabling API tests while investigated.

* Tools/TestWebKitAPI/Tests/WebKitCocoa/IDBCheckpointWAL.mm:
(TEST):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/IDBIndexUpgradeToV2.mm:
(TEST):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/IndexedDBInPageCache.mm:
(TEST):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/IndexedDBMultiProcess.mm:
(TEST):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/IndexedDBPersistence.mm:
(TEST):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/IndexedDBSuspendImminently.mm:
(TEST):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/IndexedDBTempFileSize.mm:
(TEST):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/IndexedDBUserDelete.mm:
(TEST):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/LocalStoragePersistence.mm:
(TEST):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/PushAPI.mm:
* Tools/TestWebKitAPI/Tests/WebKitCocoa/ServiceWorkerBasic.mm:
* Tools/TestWebKitAPI/Tests/WebKitCocoa/StoreBlobThenDelete.mm:
(TEST):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebsiteDatastore.mm:
(TestWebKitAPI::TEST):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/WebCryptoMasterKey.mm:
(TestWebKitAPI::TEST):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/WebProcessKillIDBCleanup.mm:
(TEST):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/WebsiteDataStoreCustomPaths.mm:
(TEST):

Canonical link: <a href="https://commits.webkit.org/264431@main">https://commits.webkit.org/264431@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/8b7a5ee11657084d2e20a1a74384bbb74d204e57

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/7608 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/7876 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/8060 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/9251 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/32/builds/7797 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/7620 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/9835 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/7803 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/10667 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/7741 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/15/builds/8852 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/7014 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/9360 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/6161 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/6926 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/14626 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/7331 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/7050 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/10455 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/7546 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/6159 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/6883 "Built successfully") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/4/builds/11095 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/916 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/7277 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->