### PR TITLE
[JSC] ASSERTION FAILED: YarrParser.h:1763 : int JSC::Yarr::Parser<JSC::Yarr::YarrPatternConstructor, unsigned char>::peek()

### DIFF
--- a/JSTests/stress/regexp-vflag-property-of-strings.js
+++ b/JSTests/stress/regexp-vflag-property-of-strings.js
@@ -356,122 +356,136 @@ testRegExpSyntaxError("[\\p{Number}&&&&5]", "v", "SyntaxError: Invalid regular e
 
 // Test 141
 testRegExpSyntaxError("[\\p{Number}&&--5]", "v", "SyntaxError: Invalid regular expression: invalid operation in class set");
+testRegExpSyntaxError("[&", "v", "SyntaxError: Invalid regular expression: missing terminating ] for character class");
+testRegExpSyntaxError("[-", "v", "SyntaxError: Invalid regular expression: missing terminating ] for character class");
+testRegExpSyntaxError("[&&", "v", "SyntaxError: Invalid regular expression: invalid class set character");
+testRegExpSyntaxError("[--", "v", "SyntaxError: Invalid regular expression: invalid class set character");
+
+// Test 146
+testRegExpSyntaxError("[&&&", "v", "SyntaxError: Invalid regular expression: invalid class set character");
+testRegExpSyntaxError("[---", "v", "SyntaxError: Invalid regular expression: invalid class set character");
+testRegExpSyntaxError("[&-", "v", "SyntaxError: Invalid regular expression: missing terminating ] for character class");
+testRegExpSyntaxError("[-&", "v", "SyntaxError: Invalid regular expression: invalid class set character");
+testRegExpSyntaxError("[&&-", "v", "SyntaxError: Invalid regular expression: invalid operation in class set");
+
+// Test 151
+testRegExpSyntaxError("[--&", "v", "SyntaxError: Invalid regular expression: invalid operation in class set");
 testRegExp(/[\p{ASCII}&&\&]/v, "a&b", ["&"]);
 testRegExp(/[\p{ASCII}&&\-]/v, "a-b", ["-"]);
 testRegExp(/[\p{ASCII}--\&]/v, "&b", ["b"]);
 testRegExp(/[\p{ASCII}--&]/v, "&b", ["b"]);
 
-// Test 146
+// Test 156
 testRegExp(/[\p{ASCII}--\-]/v, "-b", ["b"]);
 testRegExp(/[\p{RGI_Emoji_Tag_Sequence}a]/, "a", ["a"]);
 testRegExp(/[\p{RGI_Emoji_Tag_Sequence}a]/v, "a", ["a"]);
 testRegExp(/(?:\u{1f3f4}\u{e0067}\u{e0062}\u{e0065}\u{e006e}\u{e0067}\u{e007F}|\u{1f3f4}\u{e0067}\u{e0062}\u{e0073}\u{e0063}\u{e0074}\u{e007f}|\u{1f3f4}\u{e0067}\u{e0062}\u{e0077}\u{e006C}\u{e0073}\u{e007F}|[a])/v, "\u{1f3f4}\u{e0067}\u{e0062}\u{e0073}\u{e0063}\u{e0074}\u{e007f}", ["\u{1f3f4}\u{e0067}\u{e0062}\u{e0073}\u{e0063}\u{e0074}\u{e007f}"]);
 testRegExp(/[\p{RGI_Emoji_Tag_Sequence}a]/v, "\u{1f3f4}\u{e0067}\u{e0062}\u{e0073}\u{e0063}\u{e0074}\u{e007f}", ["\u{1f3f4}\u{e0067}\u{e0062}\u{e0073}\u{e0063}\u{e0074}\u{e007f}"]);
 
-// Test 151
+// Test 161
 testRegExp(/[a\p{RGI_Emoji_Tag_Sequence}]/v, "a", ["a"]);
 testRegExp(/[\p{RGI_Emoji_Tag_Sequence}\q{\u{1f1fa}\u{1f1f8}}]/v, "\u{1f3f4}\u{e0067}\u{e0062}\u{e0073}\u{e0063}\u{e0074}\u{e007f}", ["\u{1f3f4}\u{e0067}\u{e0062}\u{e0073}\u{e0063}\u{e0074}\u{e007f}"]);
 testRegExp(/[\p{RGI_Emoji_Tag_Sequence}\q{\u{1f1fa}\u{1f1f8}}]/v, "\u{1f1fa}\u{1f1f8}", ["\u{1f1fa}\u{1f1f8}"]);
 testRegExp(/[\p{RGI_Emoji_Tag_Sequence}\q{\u{1f1fa}\u{1f1f8}}]/v, "a", null);
 testRegExp(/[\q{\u{1f1fa}\u{1f1f8}}a]/v, "a", ["a"]);
 
-// Test 156
+// Test 166
 testRegExp(/[\q{\u{1f1fa}\u{1f1f8}}a]/v, "\u{1f1fa}\u{1f1f8}", ["\u{1f1fa}\u{1f1f8}"]);
 testRegExp(/[\q{\u{1f1fa}}\q{\u{1f1fa}\u{1f1f8}}]/v, "\u{1f1fa}\u{1f1f8}", ["\u{1f1fa}\u{1f1f8}"]);
 testRegExp(/[\q{\u{1f3f4}\u{e0067}\u{e0062}\u{e0073}\u{e0063}\u{e0074}}\p{RGI_Emoji_Tag_Sequence}]/v, "\u{1f3f4}\u{e0067}\u{e0062}\u{e0073}\u{e0063}\u{e0074}\u{e007f}", ["\u{1f3f4}\u{e0067}\u{e0062}\u{e0073}\u{e0063}\u{e0074}\u{e007f}"]);
 testRegExp(/[\p{RGI_Emoji_Tag_Sequence}[\q{\u{1f1fa}\u{1f1f8}}a]]/v, "\u{1f1fa}\u{1f1f8}", ["\u{1f1fa}\u{1f1f8}"]);
 testRegExp(/[\p{RGI_Emoji_Tag_Sequence}[\q{\u{1f1fa}\u{1f1f8}}a]]/v, "a", ["a"]);
 
-// Test 161
+// Test 171
 testRegExp(/[b-z[a]]/v, "a", ["a"]);
 testRegExp(/[[a-z]--k]/v, "a", ["a"]);
 testRegExp(/[\p{RGI_Emoji_Tag_Sequence}--\q{\u{1F3f4}\u{e0067}\u{e0062}\u{e0077}\u{e006c}\u{e0073}\u{e007f}}]/v, "\u{1f3f4}\u{e0067}\u{e0062}\u{e0073}\u{e0063}\u{e0074}\u{e007f}", ["\u{1f3f4}\u{e0067}\u{e0062}\u{e0073}\u{e0063}\u{e0074}\u{e007f}"]);
 testRegExp(/[a-z\q{X}]/v, "X", ["X"]);
 testRegExp(/[[a-z]--\q{k}]/v, "a", ["a"]);
 
-// Test 166
+// Test 176
 testRegExp(/[\p{RGI_Emoji_Tag_Sequence}\q{\u{1f1fa}\u{1f1f8}|abc|a|\u{1f1fa}}]/v, "a", ["a"]);
 testRegExp(/[\p{RGI_Emoji_Tag_Sequence}--\q{\u{1f3f4}\u{e0067}\u{e0062}\u{e0073}\u{e0063}\u{e0074}\u{e007f}}]/v, "\u{1f3f4}\u{e0067}\u{e0062}\u{e0073}\u{e0063}\u{e0074}\u{e007f}", null);
 testRegExp(/[\p{RGI_Emoji_Tag_Sequence}--\q{\u{1f3f4}\u{e0067}\u{e0062}\u{e0073}\u{e0063}\u{e0074}\u{e007f}}]/v, "\u{1f3f4}\u{e0067}\u{e0062}\u{e0077}\u{e006c}\u{e0073}\u{e007f}", ["\u{1f3f4}\u{e0067}\u{e0062}\u{e0077}\u{e006c}\u{e0073}\u{e007f}"]);
 testRegExp(/[\p{RGI_Emoji_Tag_Sequence}&&\q{\u{1f3f4}\u{e0067}\u{e0062}\u{e0073}\u{e0063}\u{e0074}\u{e007f}}]/v, "\u{1f3f4}\u{e0067}\u{e0062}\u{e0073}\u{e0063}\u{e0074}\u{e007f}", ["\u{1f3f4}\u{e0067}\u{e0062}\u{e0073}\u{e0063}\u{e0074}\u{e007f}"]);
 testRegExp(/[\p{RGI_Emoji_Tag_Sequence}&&\q{\u{1f3f4}\u{e0067}\u{e0062}\u{e0073}\u{e0063}\u{e0074}\u{e007f}}]/v, "\u{1f3f4}\u{e0067}\u{e0062}\u{e0077}\u{e006c}\u{e0073}\u{e007f}", null);
 
-// Test 171
+// Test 181
 testRegExp(/[[a-z]&&\q{a|e|i|o|u|X|Y|Z}]/v, "a", ["a"]);
 testRegExp(/[\p{White_Space}&&\p{ASCII}]/v, " ", [" "]);
 testRegExp(/[\p{White_Space}&&\p{ASCII}]/v, "\u2028", null);
 testRegExp(/[\p{White_Space}--\p{ASCII}]/v, " ", null);
 testRegExp(/[\p{White_Space}--\p{ASCII}]/v, "\u2028", ["\u2028"]);
 
-// Test 176
+// Test 186
 testRegExp(/^[[0-9]&&\d]+$/v, "0", ["0"]);
 testRegExp(/^[_--[0-9]]+$/v, "_", ["_"]);
 testRegExp(/[[a-z]--[a]]/v, "a", null);
 testRegExp(/^\p{RGI_Emoji_Flag_Sequence}+$/v, "\u{1F1E6}\u{1F1E8}", ["\u{1F1E6}\u{1F1E8}"]);
 testRegExp(/^\p{RGI_Emoji_Flag_Sequence}+$/v, "\u{1F1E6}\u{1F1E8}\u{1f1e7}\u{1f1f1}", ["\u{1f1e6}\u{1f1e8}\u{1f1e7}\u{1f1f1}"]);
 
-// Test 181
+// Test 191
 testRegExp(/^\p{RGI_Emoji_Flag_Sequence}+$/v, "\u{1f1f9}\u{1f1ef}\u{1F1E6}\u{1F1E8}\u{1f1f9}\u{1f1f7}", ["\u{1f1f9}\u{1f1ef}\u{1F1E6}\u{1F1E8}\u{1f1f9}\u{1f1f7}"]);
 testRegExp(/^\p{Emoji_Keycap_Sequence}+$/v, "#\u{fe0f}\u{20e3}", ["#\u{fe0f}\u{20e3}"]);
 testRegExp(/^\p{RGI_Emoji}+$/v, "#\u{fe0f}\u{20e3}", ["#\u{fe0f}\u{20e3}"]);
 testRegExp(/[a\(\)]+/v, "a()", ["a()"]);
 testRegExp(/[a\q{\(\)}]{2}/v, "()a()", ["()a"]);
 
-// Test 186
+// Test 196
 testRegExp(/[a\q{\(\)}]+/v, "()a()", ["()a()"]);
 testRegExp(/[a\q{\=\=}]+/v, "==a==", ["==a=="]);
 testRegExp(/[\q{\u{3373}}\q{\u{1813}}\q{\u{0250}}a]/v, "a", ["a"]);
 testRegExp(/[\q{\u{3373}}\q{\u{1813}}\q{\u{0250}}a]/v, "\u{0250}", ["\u{0250}"]);
 testRegExp(/[\q{\u{3373}}\q{\u{1813}}\q{\u{0250}}a]/v, "\u{1813}", ["\u{1813}"]);
 
-// Test 191
+// Test 201
 testRegExp(/[\q{\u{3373}}\q{\u{1813}}\q{\u{0250}}a]/v, "\u{3373}", ["\u{3373}"]);
 testRegExp(/[[\u{0250}-\u{3373}a]--[\q{\u{3373}}\q{\u{1813}}\q{\u{0250}}]]/v, "a", ["a"]);
 testRegExp(/[[\u{0250}-\u{3373}a]--[\q{\u{3373}}\q{\u{1813}}\q{\u{0250}}]]/v, "\u{0250}", null);
 testRegExp(/[[\u{0250}-\u{3373}a]--[\q{\u{3373}}\q{\u{1813}}\q{\u{0250}}]]/v, "\u{1813}", null);
 testRegExp(/[[\u{0250}-\u{3373}a]--[\q{\u{3373}}\q{\u{1813}}\q{\u{0250}}]]/v, "\u{3373}", null);
 
-// Test 196
+// Test 206
 testRegExp(/[[\u{0250}-\u{3373}a]--[\q{\u{3373}}\q{\u{1813}}a]]/v, "a", null);
 testRegExp(/[[\u{0250}-\u{3373}a]--[\q{\u{3373}}\q{\u{1813}}a]]/v, "\u{0250}", ["\u{0250}"]);
 testRegExp(/[[\u{0250}-\u{3373}a]--[\q{\u{3373}}\q{\u{1813}}a]]/v, "\u{1813}", null);
 testRegExp(/[[\u{0250}-\u{3373}a]--[\q{\u{3373}}\q{\u{1813}}a]]/v, "\u{3373}", null);
 testRegExp(/[[\u{0250}-\u{3373}a]--[\q{\u{3373}}\q{\u{0250}}a]]/v, "a", null);
 
-// Test 201
+// Test 211
 testRegExp(/[[\u{0250}-\u{3373}a]--[\q{\u{3373}}\q{\u{0250}}a]]/v, "\u{0250}", null);
 testRegExp(/[[\u{0250}-\u{3373}a]--[\q{\u{3373}}\q{\u{0250}}a]]/v, "\u{1813}", ["\u{1813}"]);
 testRegExp(/[[\u{0250}-\u{3373}a]--[\q{\u{3373}}\q{\u{0250}}a]]/v, "\u{3373}", null);
 testRegExp(/[[\u{0250}-\u{3373}a]--[\q{\u{1813}}\q{\u{0250}}a]]/v, "a", null);
 testRegExp(/[[\u{0250}-\u{3373}a]--[\q{\u{1813}}\q{\u{0250}}a]]/v, "\u{0250}", null);
 
-// Test 206
+// Test 216
 testRegExp(/[[\u{0250}-\u{3373}a]--[\q{\u{1813}}\q{\u{0250}}a]]/v, "\u{1813}", null);
 testRegExp(/[[\u{0250}-\u{3373}a]--[\q{\u{1813}}\q{\u{0250}}a]]/v, "\u{3373}", ["\u{3373}"]);
 testRegExp(/[[\u{0250}-\u{3373}a]&&[a]]/v, "a", ["a"]);
 testRegExp(/[[\u{0250}-\u{3373}a]&&[a]]/v, "\u{0250}", null);
 testRegExp(/[[\u{0250}-\u{3373}a]&&[a]]/v, "\u{1813}", null);
 
-// Test 211
+// Test 221
 testRegExp(/[[\u{0250}-\u{3373}a]&&[a]]/v, "\u{3373}", null);
 testRegExp(/[[\u{0250}-\u{3373}a]&&[\q{\u{0250}}]]/v, "a", null);
 testRegExp(/[[\u{0250}-\u{3373}a]&&[\q{\u{0250}}]]/v, "\u{0250}", ["\u{0250}"]);
 testRegExp(/[[\u{0250}-\u{3373}a]&&[\q{\u{0250}}]]/v, "\u{1813}", null);
 testRegExp(/[[\u{0250}-\u{3373}a]&&[\q{\u{0250}}]]/v, "\u{3373}", null);
 
-// Test 216
+// Test 226
 testRegExp(/[[\u{0250}-\u{3373}a]&&[\q{\u{1813}}]]/v, "a", null);
 testRegExp(/[[\u{0250}-\u{3373}a]&&[\q{\u{1813}}]]/v, "\u{0250}", null);
 testRegExp(/[[\u{0250}-\u{3373}a]&&[\q{\u{1813}}]]/v, "\u{1813}", ["\u{1813}"]);
 testRegExp(/[[\u{0250}-\u{3373}a]&&[\q{\u{1813}}]]/v, "\u{3373}", null);
 testRegExp(/[[\u{0250}-\u{3373}a]&&[\q{\u{3373}}]]/v, "a", null);
 
-// Test 221
+// Test 231
 testRegExp(/[[\u{0250}-\u{3373}a]&&[\q{\u{3373}}]]/v, "\u{0250}", null);
 testRegExp(/[[\u{0250}-\u{3373}a]&&[\q{\u{3373}}]]/v, "\u{1813}", null);
 testRegExp(/[[\u{0250}-\u{3373}a]&&[\q{\u{3373}}]]/v, "\u{3373}", ["\u{3373}"]);
 testRegExp(/[[]a]/v, "a", ["a"]);
 testRegExp(/[\p{ASCII}--[a-z]][\.!]/v, "TEST!", ["T!"]);
 
-// Test 226
+// Test 236
 testRegExp(/[ab][c--c]/v, "a", null);

--- a/Source/JavaScriptCore/yarr/YarrParser.h
+++ b/Source/JavaScriptCore/yarr/YarrParser.h
@@ -1275,9 +1275,13 @@ private:
             case '-': {
                 ParseState state = saveState();
                 consume();
+                if (atEndOfPattern()) {
+                    m_errorCode = ErrorCode::CharacterClassUnmatched;
+                    return;
+                }
                 if (peek() == '-') {
                     consume();
-                    if (peek() == '-') {
+                    if (atEndOfPattern() || peek() == '-') {
                         m_errorCode = ErrorCode::InvalidClassSetCharacter;
                         return;
                     }
@@ -1292,9 +1296,13 @@ private:
             case '&': {
                 ParseState state = saveState();
                 consume();
+                if (atEndOfPattern()) {
+                    m_errorCode = ErrorCode::CharacterClassUnmatched;
+                    return;
+                }
                 if (peek() == '&') {
                     consume();
-                    if (peek() == '&') {
+                    if (atEndOfPattern() || peek() == '&') {
                         m_errorCode = ErrorCode::InvalidClassSetCharacter;
                         return;
                     }


### PR DESCRIPTION
#### 5f779abc52a092373ac28d70a90b2b2df725d707
<pre>
[JSC] ASSERTION FAILED: YarrParser.h:1763 : int JSC::Yarr::Parser&lt;JSC::Yarr::YarrPatternConstructor, unsigned char&gt;::peek()
<a href="https://bugs.webkit.org/show_bug.cgi?id=257214">https://bugs.webkit.org/show_bug.cgi?id=257214</a>
rdar://109261396

Reviewed by Yusuke Suzuki.

The use of peek() in YarrParser.h needs to be protected by a prior atEndOfPattern() check.
Added those missing checks to parseClassSet() with appropriate errors.

Added new test cases for these cases along with a few others.

* JSTests/stress/regexp-vflag-property-of-strings.js:
* Source/JavaScriptCore/yarr/YarrParser.h:
(JSC::Yarr::Parser::parseClassSet):

Canonical link: <a href="https://commits.webkit.org/264438@main">https://commits.webkit.org/264438@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c4add9087b1e1bd2008fee6c816e43187e49a3aa

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/7610 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/7878 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/8062 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/9253 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/7799 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/9837 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/7805 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/10669 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/7743 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/8854 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/7017 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/9362 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/6163 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/6931 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/14627 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/6498 "Built successfully and passed tests") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/7333 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/7055 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/10458 "Passed tests") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/7201 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/7548 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/6162 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/7765 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/6885 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/1775 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/1813 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/11097 "Built successfully") | | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/24/builds/7970 "Built successfully") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/7279 "Built successfully") | | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/3/builds/1918 "Passed tests") | 
<!--EWS-Status-Bubble-End-->