### PR TITLE
REGRESSION (264301@main): _timeLabelsDisplayOnScrubberSide layout is broken (slider is shifted right)

### DIFF
--- a/Source/WebCore/Modules/modern-media-controls/controls/time-control.js
+++ b/Source/WebCore/Modules/modern-media-controls/controls/time-control.js
@@ -227,7 +227,15 @@ class TimeControl extends LayoutItem
         let durationOrRemainingTimeLabel = this._durationOrRemainingTimeLabel();
 
         const scrubberMargin = this.computedValueForStylePropertyInPx("--scrubber-margin");
-        this.scrubber.x = (this._loading ? this.activityIndicator.width : this.elapsedTimeLabel.width) + scrubberMargin;
+
+        this.scrubber.x = (() => {
+            if (this._loading)
+                return this.activityIndicator.width + scrubberMargin;
+            if (this._timeLabelsDisplayOnScrubberSide && this.elapsedTimeLabel.visible)
+                return this.elapsedTimeLabel.width + scrubberMargin;
+            return 0;
+        })();
+
         this.scrubber.width = (() => {
             if (this._timeLabelsDisplayOnScrubberSide)
                 return this.width - this.scrubber.x - scrubberMargin - durationOrRemainingTimeLabel.width;


### PR DESCRIPTION
#### 229381d535516ea27068ee5d16faf05dcf383e3f
<pre>
REGRESSION (264301@main): _timeLabelsDisplayOnScrubberSide layout is broken (slider is shifted right)
<a href="https://bugs.webkit.org/show_bug.cgi?id=257216">https://bugs.webkit.org/show_bug.cgi?id=257216</a>
rdar://109728864

Reviewed by Dean Jackson.

* Source/WebCore/Modules/modern-media-controls/controls/time-control.js:
(TimeControl.prototype._performIdealLayout):
264301@main accidentally entangled some _timeLabelsDisplayOnScrubberSide logic
in its revert, causing the slider&apos;s leading offset to take the labels into account
even when they&apos;re displayed above the slider. Un-revert this part.

Canonical link: <a href="https://commits.webkit.org/264435@main">https://commits.webkit.org/264435@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a13f5e8db695e3d3a7ce0f24f986a6d14f7aa342

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/7612 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/7880 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/8064 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/9255 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/7800 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/7624 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/9839 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/7807 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/10671 "1 flakes 101 failures") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/7745 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/8857 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/7021 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/9364 "Built successfully") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/39/builds/6166 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/10/builds/6935 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/14628 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/7335 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/7059 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/10460 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/7550 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/6164 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/6887 "Built successfully") | | | 
| [  ~~🛠 🧪 merge~~](https://ews-build.webkit.org/#/builders/19/builds/1811 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/11098 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/919 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/7281 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->