### PR TITLE
[root] 615.1.17: CrashTracer: com.apple.WebKit:  WTF::Detail::CallableWrapper<WebKit::NetworkProcessConnection::broadcastConsoleMessage(JSC::MessageSource, JSC::MessageLevel, WTF::String const&)::$_9, void, WebCore::Page&>::call

### DIFF
--- a/Source/JavaScriptCore/assembler/AbortReason.h
+++ b/Source/JavaScriptCore/assembler/AbortReason.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2014-2021 Apple Inc. All rights reserved.
+ * Copyright (C) 2014-2023 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -76,6 +76,8 @@ enum AbortReason {
     TGInvalidPointer                                  = 320,
     TGNotSupported                                    = 330,
     UncheckedOverflow                                 = 335,
+    VMCreationDisallowed                              = 998,
+    VMEntryDisallowed                                 = 999,
 };
 
 // This enum is for CRASH_WITH_SECURITY_IMPLICATION_AND_INFO so we can easily identify which assertion

--- a/Source/JavaScriptCore/interpreter/Interpreter.cpp
+++ b/Source/JavaScriptCore/interpreter/Interpreter.cpp
@@ -347,6 +347,8 @@ Interpreter::Interpreter()
 #if ASSERT_ENABLED
     static std::once_flag assertOnceKey;
     std::call_once(assertOnceKey, [] {
+        if (g_jscConfig.vmEntryDisallowed)
+            return;
         for (unsigned i = 0; i < NUMBER_OF_BYTECODE_IDS; ++i) {
             OpcodeID opcodeID = static_cast<OpcodeID>(i);
             RELEASE_ASSERT(getOpcodeID(getOpcode(opcodeID)) == opcodeID);

--- a/Source/JavaScriptCore/jit/ExecutableAllocator.cpp
+++ b/Source/JavaScriptCore/jit/ExecutableAllocator.cpp
@@ -1327,6 +1327,8 @@ namespace JSC {
 static ExecutableAllocator* globalExecutableAllocatorToWorkAroundLeaks = nullptr;
 void ExecutableAllocator::initialize()
 {
+    if (g_jscConfig.jitDisabled)
+        return;
     g_jscConfig.executableAllocator = new ExecutableAllocator;
     globalExecutableAllocatorToWorkAroundLeaks = g_jscConfig.executableAllocator;
 }

--- a/Source/JavaScriptCore/llint/LLIntData.cpp
+++ b/Source/JavaScriptCore/llint/LLIntData.cpp
@@ -31,6 +31,7 @@
 #include "JSCConfig.h"
 #include "LLIntCLoop.h"
 #include "LLIntPCRanges.h"
+#include "LLIntSlowPaths.h"
 #include "LLIntThunks.h"
 #include "Opcode.h"
 #include "WriteBarrier.h"
@@ -69,6 +70,30 @@ extern "C" void vmEntryToCSSJITAfter(void);
 JSC_ANNOTATE_JIT_OPERATION_RETURN(vmEntryToCSSJITAfter);
 #endif
 
+static void neuterOpcodeMaps()
+{
+#if CPU(ARM64E)
+#define SET_CRASH_TARGET(entry) do { \
+        void* crashTarget = bitwise_cast<void*>(llint_check_vm_entry_permission); \
+        uint64_t address = bitwise_cast<uint64_t>(&entry); \
+        uint64_t newTag = (bitwise_cast<uint64_t>(BytecodePtrTag) << 48) | address; \
+        void* signedTarget = ptrauth_auth_and_resign(crashTarget, ptrauth_key_function_pointer, 0, ptrauth_key_process_dependent_code, newTag); \
+        entry = bitwise_cast<Opcode>(signedTarget); \
+    } while (false)
+#else
+#define SET_CRASH_TARGET(entry) do { \
+        entry = bitwise_cast<Opcode>(llint_check_vm_entry_permission); \
+    } while (false)
+#endif
+    for (unsigned i = 0; i < numOpcodeIDs + numWasmOpcodeIDs; ++i) {
+        SET_CRASH_TARGET(g_opcodeMap[i]);
+        SET_CRASH_TARGET(g_opcodeMapWide16[i]);
+        SET_CRASH_TARGET(g_opcodeMapWide32[i]);
+    }
+#undef SET_CRASH_TARGET
+}
+
+
 void initialize()
 {
 #if ENABLE(C_LOOP)
@@ -76,11 +101,15 @@ void initialize()
 
 #else // !ENABLE(C_LOOP)
 
-    llint_entry(&g_opcodeMap, &g_opcodeMapWide16, &g_opcodeMapWide32);
-
+    if (UNLIKELY(g_jscConfig.vmEntryDisallowed))
+        neuterOpcodeMaps();
+    else {
+        llint_entry(&g_opcodeMap, &g_opcodeMapWide16, &g_opcodeMapWide32);
+    
 #if ENABLE(WEBASSEMBLY)
-    wasm_entry(&g_opcodeMap[numOpcodeIDs], &g_opcodeMapWide16[numOpcodeIDs], &g_opcodeMapWide32[numOpcodeIDs]);
+        wasm_entry(&g_opcodeMap[numOpcodeIDs], &g_opcodeMapWide16[numOpcodeIDs], &g_opcodeMapWide32[numOpcodeIDs]);
 #endif // ENABLE(WEBASSEMBLY)
+    }
 
     static_assert(llint_throw_from_slow_path_trampoline < UINT8_MAX);
     static_assert(wasm_throw_from_slow_path_trampoline < UINT8_MAX);

--- a/Source/JavaScriptCore/llint/LLIntSlowPaths.cpp
+++ b/Source/JavaScriptCore/llint/LLIntSlowPaths.cpp
@@ -72,10 +72,6 @@
 #include <wtf/NeverDestroyed.h>
 #include <wtf/StringPrintStream.h>
 
-#if USE(APPLE_INTERNAL_SDK)
-#include <sys/reason.h>
-#endif
-
 namespace JSC { namespace LLInt {
 
 #define LLINT_BEGIN_NO_SET_PC() \

--- a/Source/JavaScriptCore/runtime/JSCConfig.h
+++ b/Source/JavaScriptCore/runtime/JSCConfig.h
@@ -64,6 +64,8 @@ struct Config {
     bool disabledFreezingForTesting;
     bool restrictedOptionsEnabled;
     bool jitDisabled;
+    bool vmCreationDisallowed;
+    bool vmEntryDisallowed;
 
     bool useFastJITPermissions;
 

--- a/Source/JavaScriptCore/runtime/VM.cpp
+++ b/Source/JavaScriptCore/runtime/VM.cpp
@@ -29,6 +29,7 @@
 #include "config.h"
 #include "VM.h"
 
+#include "AbortReason.h"
 #include "AccessCase.h"
 #include "AggregateError.h"
 #include "ArgList.h"
@@ -218,8 +219,8 @@ VM::VM(VMType vmType, HeapType heapType, WTF::RunLoop* runLoop, bool* success)
     , m_builtinExecutables(makeUnique<BuiltinExecutables>(*this))
     , m_syncWaiter(adoptRef(*new Waiter(this)))
 {
-    if (UNLIKELY(vmCreationShouldCrash))
-        CRASH_WITH_INFO(0x4242424220202020, 0xbadbeef0badbeef, 0x1234123412341234, 0x1337133713371337);
+    if (UNLIKELY(vmCreationShouldCrash || g_jscConfig.vmCreationDisallowed))
+        CRASH_WITH_EXTRA_SECURITY_IMPLICATION_AND_INFO(VMCreationDisallowed, "VM creation disallowed"_s, 0x4242424220202020, 0xbadbeef0badbeef, 0x1234123412341234, 0x1337133713371337);
 
     VMInspector::instance().add(this);
 

--- a/Source/WTF/WTF.xcodeproj/project.pbxproj
+++ b/Source/WTF/WTF.xcodeproj/project.pbxproj
@@ -837,6 +837,7 @@
 		FE1E2C3B2240C06600F6B729 /* PtrTag.cpp in Sources */ = {isa = PBXBuildFile; fileRef = FE1E2C392240C05400F6B729 /* PtrTag.cpp */; };
 		FE1E2C42224187C600F6B729 /* PlatformRegisters.cpp in Sources */ = {isa = PBXBuildFile; fileRef = FE1E2C41224187C600F6B729 /* PlatformRegisters.cpp */; };
 		FE35D09227DC5ECC009DFA5B /* StackCheck.cpp in Sources */ = {isa = PBXBuildFile; fileRef = FE35D09127DC5ECC009DFA5B /* StackCheck.cpp */; };
+		FE6997E129D241630078B9C6 /* AbortWithReasonSPI.h in Headers */ = {isa = PBXBuildFile; fileRef = FE6997E029D241630078B9C6 /* AbortWithReasonSPI.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		FE7ACFEF285DC2F9007FC8E9 /* RawHex.h in Headers */ = {isa = PBXBuildFile; fileRef = FE7ACFEE285DC2F8007FC8E9 /* RawHex.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		FE9B8B1A28B1453D0088C6E1 /* CodePtr.h in Headers */ = {isa = PBXBuildFile; fileRef = FE9B8B1928B1453D0088C6E1 /* CodePtr.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		FE9B8B1E28B1B1C70088C6E1 /* CodePtr.cpp in Sources */ = {isa = PBXBuildFile; fileRef = FE9B8B1D28B1B1C60088C6E1 /* CodePtr.cpp */; };
@@ -1767,6 +1768,7 @@
 		FE1E2C41224187C600F6B729 /* PlatformRegisters.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = PlatformRegisters.cpp; sourceTree = "<group>"; };
 		FE35D09127DC5ECC009DFA5B /* StackCheck.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = StackCheck.cpp; sourceTree = "<group>"; };
 		FE3842342325CC80009DD445 /* ResourceUsage.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ResourceUsage.h; sourceTree = "<group>"; };
+		FE6997E029D241630078B9C6 /* AbortWithReasonSPI.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = AbortWithReasonSPI.h; sourceTree = "<group>"; };
 		FE7497E4208FFCAA0003565B /* PtrTag.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = PtrTag.h; sourceTree = "<group>"; };
 		FE7ACFEE285DC2F8007FC8E9 /* RawHex.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = RawHex.h; sourceTree = "<group>"; };
 		FE8225301B2A1E5B00BA68FD /* NakedPtr.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = NakedPtr.h; sourceTree = "<group>"; };
@@ -2834,6 +2836,7 @@
 		DDF306CF27C08654006A526F /* darwin */ = {
 			isa = PBXGroup;
 			children = (
+				FE6997E029D241630078B9C6 /* AbortWithReasonSPI.h */,
 				DDF306D727C08654006A526F /* CodeSignSPI.h */,
 				DDF306D527C08654006A526F /* DataVaultSPI.h */,
 				DDF306D327C08654006A526F /* DispatchSPI.h */,
@@ -2914,6 +2917,7 @@
 			isa = PBXHeadersBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				FE6997E129D241630078B9C6 /* AbortWithReasonSPI.h in Headers */,
 				E3B8E6032961EA7600A8AEE3 /* AccessibleAddress.h in Headers */,
 				DD3DC8FA27A4BF8E007E5B61 /* AggregateLogger.h in Headers */,
 				DD3DC96027A4BF8E007E5B61 /* Algorithms.h in Headers */,

--- a/Source/WTF/wtf/Assertions.h
+++ b/Source/WTF/wtf/Assertions.h
@@ -47,6 +47,10 @@
 #include <stdlib.h>
 #include <wtf/ExportMacros.h>
 
+#if OS(DARWIN)
+#include <wtf/spi/darwin/AbortWithReasonSPI.h>
+#endif
+
 #if USE(OS_LOG)
 #include <os/log.h>
 #endif
@@ -67,10 +71,6 @@ extern "C" void _ReadWriteBarrier(void);
 #endif
 #include <intrin.h>
 #endif
-#endif
-
-#if USE(APPLE_INTERNAL_SDK)
-#include <sys/reason.h>
 #endif
 
 /* ASSERT_ENABLED is defined in PlatformEnable.h. */
@@ -822,7 +822,7 @@ inline void compilerFenceForCrash()
 
 #endif /* __cplusplus */
 
-#if USE(APPLE_INTERNAL_SDK)
+#if OS(DARWIN)
 #define CRASH_WITH_EXTRA_SECURITY_IMPLICATION_AND_INFO(abortReason, abortMsg, ...) do { \
         if (g_wtfConfig.useSpecialAbortForExtraSecurityImplications) \
             abort_with_reason(OS_REASON_WEBKIT, abortReason, abortMsg, OS_REASON_FLAG_SECURITY_SENSITIVE); \

--- a/Source/WTF/wtf/Assertions.h
+++ b/Source/WTF/wtf/Assertions.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2003-2022 Apple Inc.  All rights reserved.
+ * Copyright (C) 2003-2023 Apple Inc.  All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -67,6 +67,10 @@ extern "C" void _ReadWriteBarrier(void);
 #endif
 #include <intrin.h>
 #endif
+#endif
+
+#if USE(APPLE_INTERNAL_SDK)
+#include <sys/reason.h>
 #endif
 
 /* ASSERT_ENABLED is defined in PlatformEnable.h. */
@@ -817,6 +821,16 @@ inline void compilerFenceForCrash()
 #endif
 
 #endif /* __cplusplus */
+
+#if USE(APPLE_INTERNAL_SDK)
+#define CRASH_WITH_EXTRA_SECURITY_IMPLICATION_AND_INFO(abortReason, abortMsg, ...) do { \
+        if (g_wtfConfig.useSpecialAbortForExtraSecurityImplications) \
+            abort_with_reason(OS_REASON_WEBKIT, abortReason, abortMsg, OS_REASON_FLAG_SECURITY_SENSITIVE); \
+        CRASH_WITH_INFO(__VA_ARGS__); \
+    } while (false)
+#else
+#define CRASH_WITH_EXTRA_SECURITY_IMPLICATION_AND_INFO(abortReason, abortMsg, ...) CRASH_WITH_INFO(__VA_ARGS__)
+#endif
 
 /* UNREACHABLE_FOR_PLATFORM */
 

--- a/Source/WTF/wtf/WTFConfig.h
+++ b/Source/WTF/wtf/WTFConfig.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2021 Apple Inc. All rights reserved.
+ * Copyright (C) 2020-2023 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -73,6 +73,7 @@ struct Config {
     uintptr_t highestAccessibleAddress;
 
     bool isPermanentlyFrozen;
+    bool useSpecialAbortForExtraSecurityImplications;
 #if PLATFORM(COCOA)
     bool disableForwardingVPrintfStdErrToOSLog;
 #endif

--- a/Source/WTF/wtf/spi/darwin/AbortWithReasonSPI.h
+++ b/Source/WTF/wtf/spi/darwin/AbortWithReasonSPI.h
@@ -1,0 +1,57 @@
+/*
+ * Copyright (C) 2023 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#if (PLATFORM(MAC) && __MAC_OS_X_VERSION_MIN_REQUIRED >= 130000) \
+    || ((PLATFORM(IOS) || PLATFORM(MACCATALYST)) && __IPHONE_OS_VERSION_MIN_REQUIRED >= 160000) \
+    || (PLATFORM(WATCHOS) && __WATCH_OS_VERSION_MIN_REQUIRED >= 90000) \
+    || (PLATFORM(APPLETV) && __TV_OS_VERSION_MIN_REQUIRED >= 160000)
+
+#if USE(APPLE_INTERNAL_SDK)
+#include <sys/reason.h>
+#else
+void abort_with_reason(uint32_t reason_namespace, uint64_t reason_code, const char *reason_string, uint64_t reason_flags);
+#endif
+
+#else
+
+#define abort_with_reason(reason_namespace, reason_code, reason_string, reason_flags)  CRASH()
+
+#endif
+
+#ifdef __cplusplus
+}
+#endif
+
+#if !USE(APPLE_INTERNAL_SDK)
+#define OS_REASON_FLAG_NO_CRASH_REPORT     0x1
+#define OS_REASON_FLAG_SECURITY_SENSITIVE  0x1000
+#define OS_REASON_WEBKIT 31
+#endif

--- a/Source/WebKit/WebProcess/Network/NetworkProcessConnection.cpp
+++ b/Source/WebKit/WebProcess/Network/NetworkProcessConnection.cpp
@@ -335,9 +335,10 @@ void NetworkProcessConnection::broadcastConsoleMessage(MessageSource source, Mes
 {
     FAST_RETURN_IF_NO_FRONTENDS(void());
 
-    Page::forEachPage([&] (Page& page) {
-        if (auto* webPage = WebPage::fromCorePage(page))
-            webPage->mainWebFrame().addConsoleMessage(source, level, message);
+    Page::forEachPage([&] (auto& page) {
+        if (auto* localMainFrame = dynamicDowncast<LocalFrame>(page.mainFrame()))
+            if (auto* document = localMainFrame->document())
+                document->addConsoleMessage(source, level, message);
     });
 }
 


### PR DESCRIPTION
#### ec81069dd2e6d97fe79ae294b0232795384aa976
<pre>
[root] 615.1.17: CrashTracer: com.apple.WebKit:  WTF::Detail::CallableWrapper&lt;WebKit::NetworkProcessConnection::broadcastConsoleMessage(JSC::MessageSource, JSC::MessageLevel, WTF::String const&amp;)::$_9, void, WebCore::Page&amp;&gt;::call
rdar://103903569

Reviewed by Alex Christensen.

Not all pages might have a corresponding WebPage.
iTo wrokaround this, we can directly go from Page to main frame document to print console messages.

* Source/WebKit/WebProcess/Network/NetworkProcessConnection.cpp:
(WebKit::NetworkProcessConnection::broadcastConsoleMessage):

Originally-landed-as: 259548.510@safari-7615-branch (e41d370e4050). rdar://109463439
Canonical link: <a href="https://commits.webkit.org/264459@main">https://commits.webkit.org/264459@main</a>
</pre>
----------------------------------------------------------------------
#### 611d8d08a798d5370bd90370176c1d42e02debbc
<pre>
Declare as abort_with_reason as SPI and add support for older builds.
<a href="https://bugs.webkit.org/show_bug.cgi?id=254551">https://bugs.webkit.org/show_bug.cgi?id=254551</a>
&lt;rdar://problem/107277043&gt;

Reviewed by Tim Horton and Justin Michaud.

We only use abort_with_reason() with OS_REASON_FLAG_SECURITY_SENSITIVE, and that flag
is only available on newer OS versions.  Implement a back up implementation for older
OS versions.

* Source/WTF/WTF.xcodeproj/project.pbxproj:
* Source/WTF/wtf/Assertions.h:
* Source/WTF/wtf/spi/darwin/AbortWithReasonSPI.h: Added.

Originally-landed-as: 259548.499@safari-7615-branch (af3f7f9c0743). rdar://107277043
Canonical link: <a href="https://commits.webkit.org/264458@main">https://commits.webkit.org/264458@main</a>
</pre>
----------------------------------------------------------------------
#### 631724be62d95c99e442cfc06c2c7450ddc3a23e
<pre>
Forbid JS execution in the GPU Process.
<a href="https://bugs.webkit.org/show_bug.cgi?id=254101">https://bugs.webkit.org/show_bug.cgi?id=254101</a>
rdar://106869810

Reviewed by Yusuke Suzuki and Justin Michaud.

The GPU Process does not need to execute any JS code.  We should enforce this invariant.

* Source/JavaScriptCore/assembler/AbortReason.h:
* Source/JavaScriptCore/interpreter/Interpreter.cpp
(JSC::Interpreter::Interpreter):
* Source/JavaScriptCore/jit/ExecutableAllocator.cpp:
(JSC::ExecutableAllocator::initialize):
* Source/JavaScriptCore/llint/LLIntData.cpp:
(JSC::LLInt::neuterOpcodeMaps):
(JSC::LLInt::initialize):
* Source/JavaScriptCore/llint/LLIntSlowPaths.cpp:
(JSC::LLInt::llint_check_vm_entry_permission):
* Source/JavaScriptCore/runtime/JSCConfig.h:
* Source/JavaScriptCore/runtime/VM.cpp:
(JSC::VM::VM):
* Source/WTF/wtf/Assertions.h:
* Source/WTF/wtf/WTFConfig.h:
* Source/WebKit/GPUProcess/EntryPoint/Cocoa/XPCService/GPUServiceEntryPoint.mm:
(GPU_SERVICE_INITIALIZER):

Originally-landed-as: 259548.460@safari-7615-branch (2396d8a6e829). rdar://109463439
Canonical link: <a href="https://commits.webkit.org/264457@main">https://commits.webkit.org/264457@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e0b5d8ca1405c27aae94026ae5a243c2966519df

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/7647 "9 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/7916 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/8100 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/9290 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/7827 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/9915 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/7841 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/10705 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/7780 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/8920 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/7044 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/9400 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/6228 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/6966 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/14658 "Passed tests") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/6527 "Built successfully and passed tests") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/7391 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/7089 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/10510 "Passed tests") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/7237 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/7583 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/6186 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/7802 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/6917 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/1785 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/1829 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/11128 "Built successfully") | | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/24/builds/8009 "Built successfully") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/7314 "Built successfully") | | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/3/builds/1929 "Passed tests") | 
<!--EWS-Status-Bubble-End-->