### PR TITLE
[WGSL] Add reference types to the type system

### DIFF
--- a/Source/WebGPU/WGSL/GlobalVariableRewriter.cpp
+++ b/Source/WebGPU/WGSL/GlobalVariableRewriter.cpp
@@ -132,7 +132,8 @@ void RewriteGlobalVariables::visitCallee(const CallGraph::Callee& callee)
                 SourceSpan::empty(),
                 WTFMove(typeName)
             );
-            typeName.get().m_resolvedType = type;
+            // FIXME: use const Type* everywhere
+            typeName.get().m_resolvedType = m_callGraph.ast().types().referenceType(AddressSpace::Function, const_cast<Type*>(type), AccessMode::ReadWrite);
         }
         m_callGraph.ast().append(callee.target->parameters(), m_callGraph.ast().astBuilder().construct<AST::Parameter>(
             SourceSpan::empty(),
@@ -345,8 +346,8 @@ void RewriteGlobalVariables::insertStructs(const UsedResources& usedResources)
             auto* type = memberType.get().resolvedType();
             if (shouldBeReference(type)) {
                 memberType = m_callGraph.ast().astBuilder().construct<AST::ReferenceTypeName>(span, WTFMove(memberType));
-                // FIXME: we need to be able to represent reference types in the type system
-                memberType.get().m_resolvedType = type;
+                // FIXME: use const Type* everywhere
+                memberType.get().m_resolvedType = m_callGraph.ast().types().referenceType(AddressSpace::Uniform, const_cast<Type*>(type), AccessMode::Read);
             }
             structMembers.append(m_callGraph.ast().astBuilder().construct<AST::StructureMember>(
                 span,
@@ -418,7 +419,8 @@ void RewriteGlobalVariables::insertMaterializations(AST::Function& function, con
                     SourceSpan::empty(),
                     WTFMove(typeName)
                 );
-                typeName.get().m_resolvedType = type;
+                // FIXME: use const Type* everywhere
+                typeName.get().m_resolvedType = m_callGraph.ast().types().referenceType(AddressSpace::Uniform, const_cast<Type*>(type), AccessMode::Read);
             }
 
             auto& variable = m_callGraph.ast().astBuilder().construct<AST::VariableStatement>(

--- a/Source/WebGPU/WGSL/TypeStore.cpp
+++ b/Source/WebGPU/WGSL/TypeStore.cpp
@@ -194,6 +194,12 @@ Type* TypeStore::functionType(WTF::Vector<Type*>&& parameters, Type* result)
     return allocateType<Function>(WTFMove(parameters), result);
 }
 
+Type* TypeStore::referenceType(AddressSpace addressSpace, Type* element, AccessMode accessMode)
+{
+    // FIXME: do we need to cache reference types?
+    return allocateType<Reference>(addressSpace, accessMode, element);
+}
+
 template<typename TypeKind, typename... Arguments>
 Type* TypeStore::allocateType(Arguments&&... arguments)
 {

--- a/Source/WebGPU/WGSL/TypeStore.h
+++ b/Source/WebGPU/WGSL/TypeStore.h
@@ -62,6 +62,7 @@ public:
     Type* matrixType(Type*, uint8_t columns, uint8_t rows);
     Type* textureType(Type*, Types::Texture::Kind);
     Type* functionType(Vector<Type*>&&, Type*);
+    Type* referenceType(AddressSpace, Type*, AccessMode);
 
     Type* constructType(AST::ParameterizedTypeName::Base, Type*);
 

--- a/Source/WebGPU/WGSL/Types.cpp
+++ b/Source/WebGPU/WGSL/Types.cpp
@@ -74,11 +74,6 @@ void Type::dump(PrintStream& out) const
             }
             out.print(") -> ", *function.result);
         },
-        [&](const Bottom&) {
-            // Bottom is an implementation detail and should never leak, but we
-            // keep the ability to print it in debug to help when dumping types
-            out.print("⊥");
-        },
         [&](const Texture& texture) {
             switch (texture.kind) {
             case Texture::Kind::Texture1d:
@@ -116,6 +111,14 @@ void Type::dump(PrintStream& out) const
                 break;
             }
             out.print("<", *texture.element, ">");
+        },
+        [&](const Reference& reference) {
+            out.print("ref<", reference.addressSpace, ", ", *reference.element, ", ", reference.accessMode, ">");
+        },
+        [&](const Bottom&) {
+            // Bottom is an implementation detail and should never leak, but we
+            // keep the ability to print it in debug to help when dumping types
+            out.print("⊥");
         });
 }
 
@@ -187,6 +190,12 @@ ConversionRank conversionRank(Type* from, Type* to)
         return conversionRank(fromArray->element, toArray->element);
     }
 
+    if (auto* fromReference = std::get_if<Reference>(from)) {
+        if (fromReference->accessMode == AccessMode::Write)
+            return std::nullopt;
+        return conversionRank(fromReference->element, to);
+    }
+
     // FIXME: add the abstract result conversion rules
     return std::nullopt;
 }
@@ -246,10 +255,13 @@ unsigned Type::size() const
         [&](const Function&) -> unsigned {
             RELEASE_ASSERT_NOT_REACHED();
         },
-        [&](const Bottom&) -> unsigned {
+        [&](const Texture&) -> unsigned {
             RELEASE_ASSERT_NOT_REACHED();
         },
-        [&](const Texture&) -> unsigned {
+        [&](const Reference&) -> unsigned {
+            RELEASE_ASSERT_NOT_REACHED();
+        },
+        [&](const Bottom&) -> unsigned {
             RELEASE_ASSERT_NOT_REACHED();
         });
 }
@@ -296,12 +308,69 @@ unsigned Type::alignment() const
         [&](const Function&) -> unsigned {
             RELEASE_ASSERT_NOT_REACHED();
         },
-        [&](const Bottom&) -> unsigned {
+        [&](const Texture&) -> unsigned {
             RELEASE_ASSERT_NOT_REACHED();
         },
-        [&](const Texture&) -> unsigned {
+        [&](const Reference&) -> unsigned {
+            RELEASE_ASSERT_NOT_REACHED();
+        },
+        [&](const Bottom&) -> unsigned {
             RELEASE_ASSERT_NOT_REACHED();
         });
 }
 
+bool isPrimitiveReference(const Type* type, Primitive::Kind kind)
+{
+    auto* reference = std::get_if<Reference>(type);
+    if (!reference)
+        return false;
+    auto* primitive = std::get_if<Primitive>(reference->element);
+    if (!primitive)
+        return false;
+    return primitive->kind == kind;
+}
+
 } // namespace WGSL
+
+namespace WTF {
+
+void printInternal(PrintStream& out, WGSL::AddressSpace addressSpace)
+{
+    switch (addressSpace) {
+    case WGSL::AddressSpace::Function:
+        out.print("function");
+        return;
+    case WGSL::AddressSpace::Private:
+        out.print("private");
+        return;
+    case WGSL::AddressSpace::Workgroup:
+        out.print("workgroup");
+        return;
+    case WGSL::AddressSpace::Uniform:
+        out.print("uniform");
+        return;
+    case WGSL::AddressSpace::Storage:
+        out.print("storage");
+        return;
+    case WGSL::AddressSpace::Handle:
+        out.print("handle");
+        return;
+    }
+}
+
+void printInternal(PrintStream& out, WGSL::AccessMode accessMode)
+{
+    switch (accessMode) {
+    case WGSL::AccessMode::Read:
+        out.print("read");
+        return;
+    case WGSL::AccessMode::Write:
+        out.print("write");
+        return;
+    case WGSL::AccessMode::ReadWrite:
+        out.print("read_write");
+        return;
+    }
+}
+
+} // namespace WTF

--- a/Source/WebGPU/WGSL/Types.h
+++ b/Source/WebGPU/WGSL/Types.h
@@ -35,6 +35,21 @@ namespace WGSL {
 
 struct Type;
 
+enum class AddressSpace : uint8_t {
+    Function,
+    Private,
+    Workgroup,
+    Uniform,
+    Storage,
+    Handle,
+};
+
+enum class AccessMode : uint8_t {
+    Read,
+    Write,
+    ReadWrite,
+};
+
 namespace Types {
 
 #define FOR_EACH_PRIMITIVE_TYPE(f) \
@@ -90,7 +105,6 @@ struct Matrix {
 
 struct Array {
     Type* element;
-
     std::optional<unsigned> size;
 };
 
@@ -102,6 +116,12 @@ struct Struct {
 struct Function {
     WTF::Vector<Type*> parameters;
     Type* result;
+};
+
+struct Reference {
+    AddressSpace addressSpace;
+    AccessMode accessMode;
+    Type* element;
 };
 
 struct Bottom {
@@ -116,8 +136,9 @@ struct Type : public std::variant<
     Types::Array,
     Types::Struct,
     Types::Function,
-    Types::Bottom,
-    Types::Texture
+    Types::Texture,
+    Types::Reference,
+    Types::Bottom
 > {
     using std::variant<
         Types::Primitive,
@@ -126,8 +147,9 @@ struct Type : public std::variant<
         Types::Array,
         Types::Struct,
         Types::Function,
-        Types::Bottom,
-        Types::Texture
+        Types::Texture,
+        Types::Reference,
+        Types::Bottom
         >::variant;
     void dump(PrintStream&) const;
     String toString() const;
@@ -137,6 +159,8 @@ struct Type : public std::variant<
 
 using ConversionRank = Markable<unsigned, IntegralMarkableTraits<unsigned, std::numeric_limits<unsigned>::max()>>;
 ConversionRank conversionRank(Type* from, Type* to);
+
+bool isPrimitiveReference(const Type*, Types::Primitive::Kind);
 
 } // namespace WGSL
 
@@ -149,4 +173,9 @@ public:
     { }
 };
 
+} // namespace WTF
+
+namespace WTF {
+void printInternal(PrintStream&, WGSL::AddressSpace);
+void printInternal(PrintStream&, WGSL::AccessMode);
 } // namespace WTF


### PR DESCRIPTION
#### 45a538c6c5eb61cd66820a9027fe2e837bfff21e
<pre>
[WGSL] Add reference types to the type system
<a href="https://bugs.webkit.org/show_bug.cgi?id=257220">https://bugs.webkit.org/show_bug.cgi?id=257220</a>
rdar://109731695

Reviewed by Myles C. Maxfield.

Represent reference types in the type system and use it in the places we
currently instantiate `AST::ReferenceTypeName`.

* Source/WebGPU/WGSL/GlobalVariableRewriter.cpp:
(WGSL::RewriteGlobalVariables::visitCallee):
(WGSL::RewriteGlobalVariables::insertStructs):
(WGSL::RewriteGlobalVariables::insertMaterializations):
* Source/WebGPU/WGSL/Metal/MetalFunctionWriter.cpp:
(WGSL::Metal::FunctionDefinitionWriter::visit):
* Source/WebGPU/WGSL/TypeStore.cpp:
(WGSL::TypeStore::referenceType):
* Source/WebGPU/WGSL/TypeStore.h:
* Source/WebGPU/WGSL/Types.cpp:
(WGSL::Type::dump const):
(WGSL::conversionRank):
(WGSL::Type::size const):
(WGSL::Type::alignment const):
(WTF::printInternal):
* Source/WebGPU/WGSL/Types.h:

Canonical link: <a href="https://commits.webkit.org/264474@main">https://commits.webkit.org/264474@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e9f855b2a444a2c5328850f170f848e8a0c84e8f

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/7734 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/8005 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/8186 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/9375 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/7889 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/7739 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/9995 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/7926 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/10760 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/7868 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/8985 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/7104 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/9491 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/6294 "Passed tests") | | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/14721 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/7445 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/7168 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/10587 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/7317 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/7657 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/6242 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/7889 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/6984 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/1807 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/1847 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/11196 "Built successfully") | | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/24/builds/8101 "Built successfully") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/7389 "Built successfully") | | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/3/builds/1956 "Passed tests") | 
<!--EWS-Status-Bubble-End-->