### PR TITLE
[buildbot] Install markupsafe

### DIFF
--- a/Tools/Scripts/webkitpy/autoinstalled/buildbot.py
+++ b/Tools/Scripts/webkitpy/autoinstalled/buildbot.py
@@ -21,8 +21,9 @@
 # SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 import sys
+import webkitscmpy
 
-from webkitscmpy import AutoInstall, Package, Version
+from webkitcorepy import AutoInstall, Package, Version
 from webkitpy.autoinstalled import twisted
 
 AutoInstall.install(Package('attrs', Version(21, 4, 0)))
@@ -34,6 +35,8 @@ AutoInstall.install(Package('pbr', Version(5, 9, 0)))
 AutoInstall.install(Package('PyJWT', Version(1, 7, 1), pypi_name='PyJWT', aliases=['jwt']))
 AutoInstall.install(Package('pyyaml', Version(5, 3, 1), pypi_name='PyYAML'))
 AutoInstall.install(Package('Tempita', Version(0, 4, 0)))
+
+AutoInstall.install('markupsafe')
 
 if sys.version_info >= (3, 0):
     AutoInstall.install(Package('autobahn', Version(20, 7, 1)))


### PR DESCRIPTION
#### 8bef1d982bc6e74688a6d487352a5c81e5eeec89
<pre>
[buildbot] Install markupsafe
<a href="https://bugs.webkit.org/show_bug.cgi?id=257224">https://bugs.webkit.org/show_bug.cgi?id=257224</a>
rdar://109737468

Reviewed by Aakash Jain.

* Tools/Scripts/webkitpy/autoinstalled/buildbot.py: Install markupsafe.

Canonical link: <a href="https://commits.webkit.org/264440@main">https://commits.webkit.org/264440@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0b520fd4c35a2d030c32098db67d02cf46d50b4c

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/7642 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/7911 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/8095 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/9285 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/32/builds/7822 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [  ~~🧪 bindings~~](https://ews-build.webkit.org/#/builders/9/builds/7654 "Build was cancelled. Recent messages:OS: Unknown (10.15.7), Xcode: 11.7; Skipping applying patch since patch_id isn't provided; Checked out pull request; bindings-tests (cancelled)") | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/23/builds/9869 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/16/builds/7836 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/10691 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/7775 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/23/builds/9869 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/7036 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/2/builds/9395 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | 
| [  ~~🧪 webkitpy~~](https://ews-build.webkit.org/#/builders/6/builds/7758 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/23/builds/9869 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/10/builds/6956 "Build was cancelled. Recent messages:OS: Monterey (12.6.3), Xcode: 14.0; Skipping applying patch since patch_id isn't provided; Checked out pull request; Skipped layout-tests; layout-tests (exception)") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/2/builds/9395 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/23/builds/9869 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/7079 "Build was cancelled. Recent messages:OS: Monterey (12.6.3), Xcode: 14.0; Skipping applying patch since patch_id isn't provided; Checked out pull request; Skipped layout-tests; layout-tests (exception)") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/2/builds/9395 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/7/builds/7578 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/16/builds/7836 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/30/builds/6912 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/4/builds/11123 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/921 "Built successfully and passed tests") | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/31/builds/7309 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->