### PR TITLE
[JSC] Cache softStackLimit in Wasm::Instance

### DIFF
--- a/Source/JavaScriptCore/jit/AssemblyHelpers.cpp
+++ b/Source/JavaScriptCore/jit/AssemblyHelpers.cpp
@@ -1981,24 +1981,21 @@ void AssemblyHelpers::loadTypedArrayLength(GPRReg baseGPR, GPRReg valueGPR, GPRR
 AssemblyHelpers::JumpList AssemblyHelpers::checkWasmStackOverflow(GPRReg instanceGPR, TrustedImm32 checkSize, GPRReg framePointerGPR)
 {
 #if CPU(ARM64)
-    loadPtr(Address(instanceGPR, Wasm::Instance::offsetOfVM()), getCachedDataTempRegisterIDAndInvalidate());
-    loadPtr(Address(dataTempRegister, VM::offsetOfSoftStackLimit()), getCachedMemoryTempRegisterIDAndInvalidate());
+    loadPtr(Address(instanceGPR, Wasm::Instance::offsetOfSoftStackLimit()), getCachedMemoryTempRegisterIDAndInvalidate());
     JumpList overflow;
     // Because address is within 48bit, this addition never causes overflow.
     addPtr(checkSize, memoryTempRegister); // TrustedImm32 would use dataTempRegister. Thus let's have limit in memoryTempRegister.
     overflow.append(branchPtr(Below, framePointerGPR, memoryTempRegister));
     return overflow;
 #elif CPU(X86_64)
-    loadPtr(Address(instanceGPR, Wasm::Instance::offsetOfVM()), scratchRegister());
-    loadPtr(Address(scratchRegister(), VM::offsetOfSoftStackLimit()), scratchRegister());
+    loadPtr(Address(instanceGPR, Wasm::Instance::offsetOfSoftStackLimit()), scratchRegister());
     JumpList overflow;
     // Because address is within 48bit, this addition never causes overflow.
     addPtr(checkSize, scratchRegister());
     overflow.append(branchPtr(Below, framePointerGPR, scratchRegister()));
     return overflow;
 #elif CPU(RISCV64)
-    loadPtr(Address(instanceGPR, Wasm::Instance::offsetOfVM()), dataTempRegister);
-    loadPtr(Address(dataTempRegister, VM::offsetOfSoftStackLimit()), memoryTempRegister);
+    loadPtr(Address(instanceGPR, Wasm::Instance::offsetOfSoftStackLimit()), memoryTempRegister);
     JumpList overflow;
     // Because address is within 48bit, this addition never causes overflow.
     addPtr(checkSize, memoryTempRegister); // TrustedImm32 would use dataTempRegister. Thus let's have limit in memoryTempRegister.

--- a/Source/JavaScriptCore/llint/WebAssembly.asm
+++ b/Source/JavaScriptCore/llint/WebAssembly.asm
@@ -389,8 +389,7 @@ if not JSVALUE64
 end
 
     bpa ws1, cfr, .stackOverflow
-    loadp Wasm::Instance::m_vm[wasmInstance], ws0
-    bpbeq VM::m_softStackLimit[ws0], ws1, .stackHeightOK
+    bpbeq Wasm::Instance::m_softStackLimit[wasmInstance], ws1, .stackHeightOK
 
 .stackOverflow:
     throwException(StackOverflow)
@@ -485,8 +484,7 @@ if not JSVALUE64
 end
 
     bpa ws1, cfr, .stackOverflow
-    loadp Wasm::Instance::m_vm[wasmInstance], ws0
-    bpbeq VM::m_softStackLimit[ws0], ws1, .stackHeightOK
+    bpbeq Wasm::Instance::m_softStackLimit[wasmInstance], ws1, .stackHeightOK
 
 .stackOverflow:
     throwException(StackOverflow)

--- a/Source/JavaScriptCore/runtime/VM.h
+++ b/Source/JavaScriptCore/runtime/VM.h
@@ -70,6 +70,7 @@
 #include <wtf/StackPointer.h>
 #include <wtf/Stopwatch.h>
 #include <wtf/ThreadSafeRefCounted.h>
+#include <wtf/ThreadSafeWeakHashSet.h>
 #include <wtf/UniqueArray.h>
 #include <wtf/text/SymbolImpl.h>
 #include <wtf/text/SymbolRegistry.h>
@@ -161,6 +162,9 @@ class Database;
 }
 namespace DOMJIT {
 class Signature;
+}
+namespace Wasm {
+class Instance;
 }
 
 struct EntryFrame;
@@ -965,6 +969,10 @@ public:
 
     Ref<Waiter> syncWaiter();
 
+#if ENABLE(WEBASSEMBLY)
+    void registerWasmInstance(Wasm::Instance&);
+#endif
+
 private:
     VM(VMType, HeapType, WTF::RunLoop* = nullptr, bool* success = nullptr);
     static VM*& sharedInstanceInternal();
@@ -1086,6 +1094,9 @@ private:
     Ref<Waiter> m_syncWaiter;
 
     Vector<Function<void()>> m_didPopListeners;
+#if ENABLE(WEBASSEMBLY)
+    ThreadSafeWeakHashSet<Wasm::Instance> m_wasmInstances;
+#endif
 
 #if ENABLE(DFG_DOES_GC_VALIDATION)
     DoesGCCheck m_doesGC;

--- a/Source/JavaScriptCore/wasm/WasmInstance.cpp
+++ b/Source/JavaScriptCore/wasm/WasmInstance.cpp
@@ -41,6 +41,7 @@ namespace JSC { namespace Wasm {
 
 Instance::Instance(VM& vm, JSGlobalObject* globalObject, Ref<Module>&& module)
     : m_vm(&vm)
+    , m_softStackLimit(vm.softStackLimit())
     , m_globalObject(globalObject)
     , m_module(WTFMove(module))
     , m_globalsToMark(m_module.get().moduleInformation().globalCount())
@@ -77,6 +78,7 @@ Instance::Instance(VM& vm, JSGlobalObject* globalObject, Ref<Module>&& module)
         if (dataSegment->isPassive())
             m_passiveDataSegments.quickSet(dataSegmentIndex);
     }
+    vm.registerWasmInstance(*this);
 }
 
 Ref<Instance> Instance::create(VM& vm, JSGlobalObject* globalObject, Ref<Module>&& module)

--- a/Source/JavaScriptCore/wasm/WasmInstance.h
+++ b/Source/JavaScriptCore/wasm/WasmInstance.h
@@ -66,7 +66,10 @@ public:
     JSWebAssemblyInstance* owner() const { return m_owner; }
     static ptrdiff_t offsetOfOwner() { return OBJECT_OFFSETOF(Instance, m_owner); }
     static ptrdiff_t offsetOfVM() { return OBJECT_OFFSETOF(Instance, m_vm); }
+    static ptrdiff_t offsetOfSoftStackLimit() { return OBJECT_OFFSETOF(Instance, m_softStackLimit); }
     static ptrdiff_t offsetOfGlobalObject() { return OBJECT_OFFSETOF(Instance, m_globalObject); }
+
+    void updateSoftStackLimit(void* softStackLimit) { m_softStackLimit = softStackLimit; }
 
     size_t extraMemoryAllocated() const;
 
@@ -246,6 +249,7 @@ private:
         return roundUpToMultipleOf<sizeof(Global::Value)>(offsetOfTail() + sizeof(ImportFunctionInfo) * numImportFunctions + sizeof(Table*) * numTables) + sizeof(Global::Value) * numGlobals;
     }
     VM* m_vm;
+    void* m_softStackLimit { nullptr };
     JSWebAssemblyInstance* m_owner { nullptr };
     JSGlobalObject* m_globalObject; // This is kept by JSWebAssemblyInstance*.
     CagedPtr<Gigacage::Primitive, void, tagCagedPtr> m_cachedMemory;


### PR DESCRIPTION
#### 5be4a1faae21540b04ba622fbc0f482100903f77
<pre>
[JSC] Cache softStackLimit in Wasm::Instance
<a href="https://bugs.webkit.org/show_bug.cgi?id=257230">https://bugs.webkit.org/show_bug.cgi?id=257230</a>
rdar://109740794

Reviewed by Justin Michaud.

Let&apos;s store m_softStackLimit in Wasm::Instance directly. Wasm::Instance is strictly tied to one VM.
This patch associates Wasm::Instance to VM, and we update this field of Instance when VM&apos;s m_softStackLimit
changes (this is very rare). So we do not need to do double-load to stack overflow check in each prologue
of wasm functions.

* Source/JavaScriptCore/jit/AssemblyHelpers.cpp:
(JSC::AssemblyHelpers::checkWasmStackOverflow):
* Source/JavaScriptCore/llint/WebAssembly.asm:
* Source/JavaScriptCore/runtime/VM.cpp:
(JSC::VM::updateStackLimits):
(JSC::VM::registerWasmInstance):
* Source/JavaScriptCore/runtime/VM.h:
* Source/JavaScriptCore/wasm/WasmBBQJIT.cpp:
(JSC::Wasm::BBQJIT::addTopLevel):
(JSC::Wasm::BBQJIT::addLoopOSREntrypoint):
* Source/JavaScriptCore/wasm/WasmInstance.cpp:
(JSC::Wasm::Instance::Instance):
* Source/JavaScriptCore/wasm/WasmInstance.h:
(JSC::Wasm::Instance::offsetOfSoftStackLimit):
(JSC::Wasm::Instance::updateSoftStackLimit):

Canonical link: <a href="https://commits.webkit.org/264531@main">https://commits.webkit.org/264531@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b6592ad63e76bdaff4644797bbb0b13f83be8765

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/7828 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/8104 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/8289 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/9475 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/7963 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/10097 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/8021 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/10832 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/7967 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/9073 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/7164 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/9588 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/6379 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/7135 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/14772 "Passed tests") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/6675 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/7512 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/7254 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/10657 "Passed tests") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/7402 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/7749 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/6306 "16 flakes 1 failures") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/7992 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/7069 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/1828 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/11277 "Built successfully") | | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/24/builds/8208 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/946 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/7484 "Built successfully") | | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/3/builds/1976 "Passed tests") | 
<!--EWS-Status-Bubble-End-->