### PR TITLE
[IndexedDB] An array keyPath should yield an array key

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/IndexedDB/idbindex_keyPath.any-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/IndexedDB/idbindex_keyPath.any-expected.txt
@@ -1,3 +1,5 @@
 
 PASS IDBIndex's keyPath attribute returns the same object.
+PASS IDBIndex's keyPath array with a single value
+PASS IDBIndex's keyPath array with multiple values
 

--- a/LayoutTests/imported/w3c/web-platform-tests/IndexedDB/idbindex_keyPath.any.js
+++ b/LayoutTests/imported/w3c/web-platform-tests/IndexedDB/idbindex_keyPath.any.js
@@ -1,4 +1,4 @@
-// META: title=IndexedDB: IDBIndex keyPath attribute - same object
+// META: title=IndexedDB: IDBIndex keyPath attribute
 // META: script=resources/support.js
 
 indexeddb_test(
@@ -7,7 +7,7 @@ indexeddb_test(
     store.createIndex('index', ['a', 'b']);
   },
   (t, db) => {
-    const tx = db.transaction('store');
+    const tx = db.transaction('store', 'readonly', {durability: 'relaxed'});
     const store = tx.objectStore('store');
     const index = store.index('index');
     assert_equals(typeof index.keyPath, 'object', 'keyPath is an object');
@@ -17,7 +17,7 @@ indexeddb_test(
       index.keyPath, index.keyPath,
       'Same object instance is returned each time keyPath is inspected');
 
-    const tx2 = db.transaction('store');
+    const tx2 = db.transaction('store', 'readonly', {durability: 'relaxed'});
     const store2 = tx2.objectStore('store');
     const index2 = store2.index('index');
 
@@ -28,3 +28,47 @@ indexeddb_test(
     t.done();
   },
   `IDBIndex's keyPath attribute returns the same object.`);
+
+  indexeddb_test(
+  (t, db) => {
+    const store = db.createObjectStore('store', {autoIncrement: true});
+    store.createIndex('index', ['a']);
+
+    store.add({a: 1, b: 2, c: 3})
+  },
+  (t, db) => {
+    const tx = db.transaction('store', 'readonly', {durability: 'relaxed'});
+    const store = tx.objectStore('store');
+    const index = store.index('index');
+    const cursorReq = index.openCursor();
+
+    cursorReq.onsuccess = t.step_func_done((e) => {
+      const expectedKeyValue = [1];
+      const actualKeyValue = e.target.result.key;
+
+      assert_array_equals(actualKeyValue, expectedKeyValue, "An array keypath should yield an array key");
+    });
+  },
+  `IDBIndex's keyPath array with a single value`);
+
+  indexeddb_test(
+  (t, db) => {
+    const store = db.createObjectStore('store', {autoIncrement: true});
+    store.createIndex('index', ['a', 'b']);
+
+    store.add({a: 1, b: 2, c: 3})
+  },
+  (t, db) => {
+    const tx = db.transaction('store', 'readonly', {durability: 'relaxed'});
+    const store = tx.objectStore('store');
+    const index = store.index('index');
+    const cursorReq = index.openCursor();
+
+    cursorReq.onsuccess = t.step_func_done((e) => {
+      const expectedKeyValue = [1, 2];
+      const actualKeyValue = e.target.result.key;
+
+      assert_array_equals(actualKeyValue, expectedKeyValue, "An array keypath should yield an array key");
+    });
+  },
+  `IDBIndex's keyPath array with multiple values`);

--- a/LayoutTests/imported/w3c/web-platform-tests/IndexedDB/idbindex_keyPath.any.worker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/IndexedDB/idbindex_keyPath.any.worker-expected.txt
@@ -1,3 +1,5 @@
 
 PASS IDBIndex's keyPath attribute returns the same object.
+PASS IDBIndex's keyPath array with a single value
+PASS IDBIndex's keyPath array with multiple values
 

--- a/Source/WebCore/Modules/indexeddb/shared/IndexKey.h
+++ b/Source/WebCore/Modules/indexeddb/shared/IndexKey.h
@@ -33,8 +33,9 @@ namespace WebCore {
 
 class IndexKey {
 public:
+    using Data = std::variant<std::nullptr_t, IDBKeyData, Vector<IDBKeyData>>;
     IndexKey();
-    IndexKey(Vector<IDBKeyData>&&);
+    IndexKey(Data&&);
 
     IndexKey isolatedCopy() const &;
     IndexKey isolatedCopy() &&;
@@ -42,10 +43,10 @@ public:
     IDBKeyData asOneKey() const;
     Vector<IDBKeyData> multiEntry() const;
 
-    bool isNull() const { return m_keys.isEmpty(); }
+    bool isNull() const { return std::holds_alternative<std::nullptr_t>(m_keys); }
 
 private:
-    Vector<IDBKeyData> m_keys;
+    Data m_keys;
 };
 
 typedef HashMap<uint64_t, IndexKey> IndexIDToIndexKeyMap;

--- a/Source/WebCore/bindings/js/IDBBindingUtilities.cpp
+++ b/Source/WebCore/bindings/js/IDBBindingUtilities.cpp
@@ -436,25 +436,25 @@ JSC::JSValue toJS(JSC::JSGlobalObject* lexicalGlobalObject, JSDOMGlobalObject* g
     return toJS(*lexicalGlobalObject, *globalObject, keyData.maybeCreateIDBKey().get());
 }
 
-static Vector<IDBKeyData> createKeyPathArray(JSGlobalObject& lexicalGlobalObject, JSValue value, const IDBIndexInfo& info, std::optional<IDBKeyPath> objectStoreKeyPath, const IDBKeyData& objectStoreKey)
+static IndexKey::Data createKeyPathArray(JSGlobalObject& lexicalGlobalObject, JSValue value, const IDBIndexInfo& info, std::optional<IDBKeyPath> objectStoreKeyPath, const IDBKeyData& objectStoreKey)
 {
-    auto visitor = WTF::makeVisitor([&](const String& string) -> Vector<IDBKeyData> {
+    auto visitor = WTF::makeVisitor([&](const String& string) -> IndexKey::Data {
         // Value doesn't contain auto-generated key, so we need to manually add key if it is possibly auto-generated.
         if (objectStoreKeyPath && std::holds_alternative<String>(objectStoreKeyPath.value()) && IDBKeyPath(string) == objectStoreKeyPath.value())
-            return { objectStoreKey };
+            return objectStoreKey;
 
         auto idbKey = internalCreateIDBKeyFromScriptValueAndKeyPath(lexicalGlobalObject, value, string);
         if (!idbKey)
-            return { };
+            return nullptr;
 
-        Vector<IDBKeyData> keys;
         if (info.multiEntry() && idbKey->type() == IndexedDB::KeyType::Array) {
+            Vector<IDBKeyData> keys;
             for (auto& key : idbKey->array())
                 keys.append(key.get());
-        } else
-            keys.append(idbKey.get());
-        return keys;
-    }, [&](const Vector<String>& vector) -> Vector<IDBKeyData> {
+            return keys;
+        }
+        return idbKey.get();
+    }, [&](const Vector<String>& vector) -> IndexKey::Data {
         Vector<IDBKeyData> keys;
         for (auto& entry : vector) {
             if (objectStoreKeyPath && std::holds_alternative<String>(objectStoreKeyPath.value()) && IDBKeyPath(entry) == objectStoreKeyPath.value())
@@ -475,7 +475,7 @@ static Vector<IDBKeyData> createKeyPathArray(JSGlobalObject& lexicalGlobalObject
 void generateIndexKeyForValue(JSGlobalObject& lexicalGlobalObject, const IDBIndexInfo& info, JSValue value, IndexKey& outKey, const std::optional<IDBKeyPath>& objectStoreKeyPath, const IDBKeyData& objectStoreKey)
 {
     auto keyDatas = createKeyPathArray(lexicalGlobalObject, value, info, objectStoreKeyPath, objectStoreKey);
-    if (keyDatas.isEmpty())
+    if (std::holds_alternative<nullptr_t>(keyDatas))
         return;
 
     outKey = IndexKey(WTFMove(keyDatas));


### PR DESCRIPTION
#### 54a7b93842dd440a06ca58f89e15c4206c129772
<pre>
[IndexedDB] An array keyPath should yield an array key
<a href="https://bugs.webkit.org/show_bug.cgi?id=257238">https://bugs.webkit.org/show_bug.cgi?id=257238</a>

Reviewed by Sihui Liu.

An array keyPath should yield an array key, to match the behavior of Blink and Gecko.

* LayoutTests/imported/w3c/web-platform-tests/IndexedDB/idbindex_keyPath.any-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/IndexedDB/idbindex_keyPath.any.js:
* LayoutTests/imported/w3c/web-platform-tests/IndexedDB/idbindex_keyPath.any.worker-expected.txt:
Resync WPT test from upstream to get test coverage. Without this change, the
second subtest was failing with WebKit (but passing with Blink &amp; Gecko).

* Source/WebCore/Modules/indexeddb/shared/IndexKey.cpp:
(WebCore::IndexKey::IndexKey):
(WebCore::IndexKey::asOneKey const):
(WebCore::IndexKey::multiEntry const):
* Source/WebCore/Modules/indexeddb/shared/IndexKey.h:
(WebCore::IndexKey::isNull const):
* Source/WebCore/bindings/js/IDBBindingUtilities.cpp:
(WebCore::createKeyPathArray):
(WebCore::generateIndexKeyForValue):
IndexKey was losing was storing the key as a Vector unconditionally and thus
was losing the information about whether or not the key was a vector or not.
To address the issue, we now use a `std::variant&lt;std::nullptr_t, IDBKeyData, Vector&lt;IDBKeyData&gt;&gt;`
with nullptr_t being the null state that this class supports.

Canonical link: <a href="https://commits.webkit.org/264479@main">https://commits.webkit.org/264479@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/983c475d58362ffc2541e273e75fb8f01661d2aa

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/7751 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/8023 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/8203 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/9393 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/7906 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/7757 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/10013 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/7944 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/10780 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/7886 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/9001 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/7116 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/9503 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/6309 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/7055 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/14728 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/7460 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/7181 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/10595 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/7675 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/6255 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/7002 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/1854 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/11214 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/7406 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->