### PR TITLE
[baseline-alignment]Rename BaselineContext to BaselineAlignmentState.

### DIFF
--- a/Source/WebCore/rendering/BaselineAlignment.cpp
+++ b/Source/WebCore/rendering/BaselineAlignment.cpp
@@ -76,19 +76,19 @@ bool BaselineGroup::isCompatible(WritingMode childBlockFlow, ItemPosition childP
     return ((m_blockFlow == childBlockFlow || isOrthogonalBlockFlow(childBlockFlow)) && m_preference == childPreference) || (isOppositeBlockFlow(childBlockFlow) && m_preference != childPreference);
 }
 
-BaselineContext::BaselineContext(const RenderBox& child, ItemPosition preference, LayoutUnit ascent)
+BaselineAlignmentState::BaselineAlignmentState(const RenderBox& child, ItemPosition preference, LayoutUnit ascent)
 {
     ASSERT(isBaselinePosition(preference));
     updateSharedGroup(child, preference, ascent);
 }
 
-const BaselineGroup& BaselineContext::sharedGroup(const RenderBox& child, ItemPosition preference) const
+const BaselineGroup& BaselineAlignmentState::sharedGroup(const RenderBox& child, ItemPosition preference) const
 {
     ASSERT(isBaselinePosition(preference));
-    return const_cast<BaselineContext*>(this)->findCompatibleSharedGroup(child, preference);
+    return const_cast<BaselineAlignmentState*>(this)->findCompatibleSharedGroup(child, preference);
 }
 
-void BaselineContext::updateSharedGroup(const RenderBox& child, ItemPosition preference, LayoutUnit ascent)
+void BaselineAlignmentState::updateSharedGroup(const RenderBox& child, ItemPosition preference, LayoutUnit ascent)
 {
     ASSERT(isBaselinePosition(preference));
     BaselineGroup& group = findCompatibleSharedGroup(child, preference);
@@ -97,7 +97,7 @@ void BaselineContext::updateSharedGroup(const RenderBox& child, ItemPosition pre
 
 // FIXME: Properly implement baseline-group compatibility.
 // See https://github.com/w3c/csswg-drafts/issues/721
-BaselineGroup& BaselineContext::findCompatibleSharedGroup(const RenderBox& child, ItemPosition preference)
+BaselineGroup& BaselineAlignmentState::findCompatibleSharedGroup(const RenderBox& child, ItemPosition preference)
 {
     WritingMode blockDirection = child.style().writingMode();
     for (auto& group : m_sharedGroups) {

--- a/Source/WebCore/rendering/BaselineAlignment.h
+++ b/Source/WebCore/rendering/BaselineAlignment.h
@@ -52,7 +52,7 @@ public:
     int computeSize() const { return m_items.computeSize(); }
 
 private:
-    friend class BaselineContext;
+    friend class BaselineAlignmentState;
     BaselineGroup(WritingMode blockFlow, ItemPosition childPreference);
 
     // Determines whether a baseline-sharing group is compatible with an item, based on its 'block-flow' and
@@ -73,27 +73,24 @@ private:
     WeakHashSet<const RenderBox> m_items;
 };
 
-// https://drafts.csswg.org/css-align-3/#shared-alignment-context
-// Boxes share an alignment context along a particular axis when they are:
 //
-//  * table cells in the same row, along the table's row (inline) axis
-//  * table cells in the same column, along the table's column (block) axis
-//  * grid items in the same row, along the grid's row (inline) axis
-//  * grid items in the same column, along the grid's colum (block) axis
-//  * flex items in the same flex line, along the flex container's main axis
+// BaselineAlignmentState provides an API to interact with baseline sharing groups in various
+// ways such as adding items to appropriate ones and querying the baseline sharing group for
+// an item. A BaselineAlignmentState should be created by a formatting context to use for each
+// of its baseline alignment contexts.
 //
 // https://drafts.csswg.org/css-align-3/#baseline-sharing-group
 // A Baseline alignment-context may handle several baseline-sharing groups. In order to create an instance, we
-// need to pass the required data to define the first baseline-sharing group; a Baseline Context must have at
+// need to pass the required data to define the first baseline-sharing group; a BaselineAlignmentState must have at
 // least one baseline-sharing group.
 //
-// By adding new items to a Baseline Context, the baseline-sharing groups it handles are automatically updated,
+// By adding new items to a BaselineAlignmentState, the baseline-sharing groups it handles are automatically updated,
 // if there is one that is compatible with such item. Otherwise, a new baseline-sharing group is created,
 // compatible with the new item.
-class BaselineContext {
+class BaselineAlignmentState {
     WTF_MAKE_FAST_ALLOCATED;
 public:
-    BaselineContext(const RenderBox& child, ItemPosition preference, LayoutUnit ascent);
+    BaselineAlignmentState(const RenderBox& child, ItemPosition preference, LayoutUnit ascent);
     const BaselineGroup& sharedGroup(const RenderBox& child, ItemPosition preference) const;
 
     // Updates the baseline-sharing group compatible with the item.

--- a/Source/WebCore/rendering/GridBaselineAlignment.cpp
+++ b/Source/WebCore/rendering/GridBaselineAlignment.cpp
@@ -112,10 +112,10 @@ const BaselineGroup& GridBaselineAlignment::baselineGroupForChild(ItemPosition p
 {
     ASSERT(isBaselinePosition(preference));
     bool isRowAxisContext = baselineAxis == GridColumnAxis;
-    auto& contextsMap = isRowAxisContext ? m_rowAxisAlignmentContext : m_colAxisAlignmentContext;
-    auto* context = contextsMap.get(sharedContext);
-    ASSERT(context);
-    return context->sharedGroup(child, preference);
+    auto& baselineAlignmentStateMap = isRowAxisContext ? m_rowAxisBaselineAlignmentStates : m_colAxisBaselineAlignmentStates;
+    auto* baselineAlignmentState = baselineAlignmentStateMap.get(sharedContext);
+    ASSERT(baselineAlignmentState);
+    return baselineAlignmentState->sharedGroup(child, preference);
 }
 
 void GridBaselineAlignment::updateBaselineAlignmentContext(ItemPosition preference, unsigned sharedContext, const RenderBox& child, GridAxis baselineAxis)
@@ -129,12 +129,12 @@ void GridBaselineAlignment::updateBaselineAlignmentContext(ItemPosition preferen
     // Looking up for a shared alignment context perpendicular to the
     // baseline axis.
     bool isRowAxisContext = baselineAxis == GridColumnAxis;
-    auto& contextsMap = isRowAxisContext ? m_rowAxisAlignmentContext : m_colAxisAlignmentContext;
+    auto& baselineAlignmentStateMap = isRowAxisContext ? m_rowAxisBaselineAlignmentStates : m_colAxisBaselineAlignmentStates;
     // Looking for a compatible baseline-sharing group.
-    if (auto* contextSearch = contextsMap.get(sharedContext))
-        contextSearch->updateSharedGroup(child, preference, ascent);
+    if (auto* baselineAlignmentStateSearch = baselineAlignmentStateMap.get(sharedContext))
+        baselineAlignmentStateSearch->updateSharedGroup(child, preference, ascent);
     else
-        contextsMap.add(sharedContext, makeUnique<BaselineContext>(child, preference, ascent));
+        baselineAlignmentStateMap.add(sharedContext, makeUnique<BaselineAlignmentState>(child, preference, ascent));
 }
 
 LayoutUnit GridBaselineAlignment::baselineOffsetForChild(ItemPosition preference, unsigned sharedContext, const RenderBox& child, GridAxis baselineAxis) const
@@ -149,9 +149,9 @@ LayoutUnit GridBaselineAlignment::baselineOffsetForChild(ItemPosition preference
 void GridBaselineAlignment::clear(GridAxis baselineAxis)
 {
     if (baselineAxis == GridColumnAxis)
-        m_rowAxisAlignmentContext.clear();
+        m_rowAxisBaselineAlignmentStates.clear();
     else
-        m_colAxisAlignmentContext.clear();
+        m_colAxisBaselineAlignmentStates.clear();
 }
 
 } // namespace WebCore

--- a/Source/WebCore/rendering/GridBaselineAlignment.h
+++ b/Source/WebCore/rendering/GridBaselineAlignment.h
@@ -34,7 +34,7 @@
 
 namespace WebCore {
 
-// This is the class that implements the Baseline Alignment logic, using internally the BaselineContext and
+// This is the class that implements the Baseline Alignment logic, using internally the BaselineAlignmentState and
 // BaselineGroup classes.
 //
 // The first phase is to collect the items that will participate in baseline alignment together. During this
@@ -74,12 +74,12 @@ private:
     bool isOrthogonalChildForBaseline(const RenderBox&) const;
     bool isParallelToBaselineAxisForChild(const RenderBox&, GridAxis) const;
 
-    typedef HashMap<unsigned, std::unique_ptr<BaselineContext>, DefaultHash<unsigned>, WTF::UnsignedWithZeroKeyHashTraits<unsigned>> BaselineContextsMap;
+    typedef HashMap<unsigned, std::unique_ptr<BaselineAlignmentState>, DefaultHash<unsigned>, WTF::UnsignedWithZeroKeyHashTraits<unsigned>> BaselineAlignmentStateMap;
 
     // Grid Container's WritingMode, used to determine grid item's orthogonality.
     WritingMode m_blockFlow;
-    BaselineContextsMap m_rowAxisAlignmentContext;
-    BaselineContextsMap m_colAxisAlignmentContext;
+    BaselineAlignmentStateMap m_rowAxisBaselineAlignmentStates;
+    BaselineAlignmentStateMap m_colAxisBaselineAlignmentStates;
 };
 
 } // namespace WebCore


### PR DESCRIPTION
#### 48c6a9eda4fdc93834a69222bd4db466c7b94e52
<pre>
[baseline-alignment]Rename BaselineContext to BaselineAlignmentState.
<a href="https://bugs.webkit.org/show_bug.cgi?id=257233">https://bugs.webkit.org/show_bug.cgi?id=257233</a>
rdar://109742609

Reviewed by Alan Baradlay.

This class is used primarily to provide an API for a formatting context
to interact with baseline sharing groups for baseline alignment. Also, a
baseline alignment context refers to a particular aspect of a formatting
context upon which baseline alignment occurs, such as lines in flex
layout.

Instead we can refer to this as BaselineAlignmentState since this is
the type of information we are holding in it.

* Source/WebCore/rendering/BaselineAlignment.cpp:
(WebCore::BaselineAlignmentState::BaselineAlignmentState):
(WebCore::BaselineAlignmentState::sharedGroup const):
(WebCore::BaselineAlignmentState::updateSharedGroup):
(WebCore::BaselineAlignmentState::findCompatibleSharedGroup):
(WebCore::BaselineContext::BaselineContext): Deleted.
(WebCore::BaselineContext::sharedGroup const): Deleted.
(WebCore::BaselineContext::updateSharedGroup): Deleted.
(WebCore::BaselineContext::findCompatibleSharedGroup): Deleted.
* Source/WebCore/rendering/BaselineAlignment.h:
* Source/WebCore/rendering/GridBaselineAlignment.cpp:
(WebCore::GridBaselineAlignment::updateBaselineAlignmentContext):
* Source/WebCore/rendering/GridBaselineAlignment.h:

Canonical link: <a href="https://commits.webkit.org/264484@main">https://commits.webkit.org/264484@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ec13ec0c159ca8262b9715e81fd3fce25b914c6d

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/7766 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/8039 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/8219 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/9408 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/7920 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/7772 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/10029 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/7959 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/10783 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/7902 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/9013 "1 failures") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/7127 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/9519 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/6321 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/7067 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/14735 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/7472 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/7193 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/10603 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/7690 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/6269 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/7017 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/1858 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/11229 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/7421 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->