### PR TITLE
[WebAuthn] Clean up observers in CcidService

### DIFF
--- a/Source/WebKit/UIProcess/WebAuthentication/Cocoa/CcidService.h
+++ b/Source/WebKit/UIProcess/WebAuthentication/Cocoa/CcidService.h
@@ -34,6 +34,8 @@
 OBJC_CLASS NSArray;
 OBJC_CLASS TKSmartCardSlot;
 OBJC_CLASS TKSmartCard;
+OBJC_CLASS _WKSmartCardSlotObserver;
+OBJC_CLASS _WKSmartCardSlotStateObserver;
 
 namespace WebKit {
 
@@ -55,11 +57,14 @@ private:
     void startDiscoveryInternal() final;
     void restartDiscoveryInternal() final;
 
+    void removeObservers();
+
     virtual void platformStartDiscovery();
 
     RunLoop::Timer m_restartTimer;
     RefPtr<CcidConnection> m_connection;
-    HashSet<String> m_slotNames;
+    RetainPtr<_WKSmartCardSlotObserver> m_slotsObserver;
+    HashMap<String, RetainPtr<_WKSmartCardSlotStateObserver>> m_slotObservers;
 };
 
 } // namespace WebKit


### PR DESCRIPTION
#### 52e6f05d3e91cf65392e590172ecd444c3fe9eda
<pre>
[WebAuthn] Clean up observers in CcidService
<a href="https://bugs.webkit.org/show_bug.cgi?id=257240">https://bugs.webkit.org/show_bug.cgi?id=257240</a>
rdar://109060751

Reviewed by Brent Fulgham.

This change ensures removeObserver:forKeyPath: is called for each observer we
add via addObserver in CcidService.

* Source/WebKit/UIProcess/WebAuthentication/Cocoa/CcidService.h:
* Source/WebKit/UIProcess/WebAuthentication/Cocoa/CcidService.mm:
(WebKit::CcidService::~CcidService):
(WebKit::CcidService::removeObservers):
(WebKit::CcidService::platformStartDiscovery):
(WebKit::CcidService::updateSlots):
(-[_WKSmartCardSlotStateObserver observeValueForKeyPath:ofObject:change:context:]):
(-[_WKSmartCardSlotStateObserver removeObserver]):

Canonical link: <a href="https://commits.webkit.org/264485@main">https://commits.webkit.org/264485@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/68967386f2adb8aec2a032a7402081fd9a85e950

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/7677 "2 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/7947 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/8128 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/9315 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/7846 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/9938 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/7868 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/10715 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/7811 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/8934 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/7061 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/9425 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/6242 "Passed tests") | | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/14666 "1 flakes 113 failures") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/7405 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/7111 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/10520 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/7606 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/6203 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/6936 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/1856 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/11147 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/7339 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->