### PR TITLE
Follow-up: Use the same simulated iPhone model for layout tests an API tests

### DIFF
--- a/Tools/Scripts/webkitpy/api_tests/manager.py
+++ b/Tools/Scripts/webkitpy/api_tests/manager.py
@@ -151,10 +151,7 @@ class Manager(object):
                 self._stream.writeln('')
 
     def _initialize_devices(self):
-        # FIXME: Remove the special-case for iOS Simulator once https://bugs.webkit.org/show_bug.cgi?id=256806 is resolved
-        if self._port.port_name in ('iphone-simulator', 'ios-simulator'):
-            SimulatedDeviceManager.initialize_devices(DeviceRequest(DeviceType(hardware_family='iPhone', hardware_type='SE (3rd generation)'), allow_incomplete_match=True), self.host, simulator_ui=False)
-        elif 'simulator' in self._port.port_name:
+        if 'simulator' in self._port.port_name:
             SimulatedDeviceManager.initialize_devices(DeviceRequest(self._port.supported_device_types()[0], allow_incomplete_match=True), self.host, simulator_ui=False)
         elif 'device' in self._port.port_name:
             raise RuntimeError('Running api tests on {} is not supported'.format(self._port.port_name))


### PR DESCRIPTION
#### c0733478cc6a17a1537f7ce7cff31442b47e1b6f
<pre>
Follow-up: Use the same simulated iPhone model for layout tests an API tests
rdar://109372419
<a href="https://bugs.webkit.org/show_bug.cgi?id=256806">https://bugs.webkit.org/show_bug.cgi?id=256806</a>

Reviewed by Jonathan Bedard.

Remove the override that currently sets run-api-tests to use an iPhone SE (3rd Generation) simulator. Set it to run an iPhone 12 instead.

* Tools/Scripts/webkitpy/api_tests/manager.py:
(Manager._initialize_devices):

Canonical link: <a href="https://commits.webkit.org/264487@main">https://commits.webkit.org/264487@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2f04494135163fc1d0adf86799172ff42671e312

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/7786 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/8060 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/8241 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/9428 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/7935 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/7792 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/10050 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/7980 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/10798 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/7923 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/9035 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/7141 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/9540 "Built successfully") | 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/7904 "Passed tests") | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/6343 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/7089 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/14747 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/7490 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/7216 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/10616 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/7709 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/6284 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/7035 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/11245 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/933 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/7441 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->