### PR TITLE
[Cocoa] Call [AVCaptureDevice ensureServerConnection] when new extensions are made to the GPU Process

### DIFF
--- a/Source/WebKit/GPUProcess/GPUProcess.cpp
+++ b/Source/WebKit/GPUProcess/GPUProcess.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2022 Apple Inc. All rights reserved.
+ * Copyright (C) 2019-2023 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -39,6 +39,7 @@
 #include "GPUProcessProxyMessages.h"
 #include "GPUProcessSessionParameters.h"
 #include "LogInitialization.h"
+#include "Logging.h"
 #include "RemoteMediaPlayerManagerProxy.h"
 #include "SandboxExtension.h"
 #include "WebPageProxyMessages.h"
@@ -381,6 +382,7 @@ GPUConnectionToWebProcess* GPUProcess::webProcessConnection(WebCore::ProcessIden
 
 void GPUProcess::updateSandboxAccess(const Vector<SandboxExtension::Handle>& extensions)
 {
+    RELEASE_LOG(WebRTC, "GPUProcess::updateSandboxAccess: Adding %ld extensions", extensions.size());
     for (auto& extension : extensions)
         SandboxExtension::consumePermanently(extension);
 }
@@ -409,6 +411,8 @@ void GPUProcess::setOrientationForMediaCapture(IntDegrees orientation)
 
 void GPUProcess::updateCaptureAccess(bool allowAudioCapture, bool allowVideoCapture, bool allowDisplayCapture, WebCore::ProcessIdentifier processID, CompletionHandler<void()>&& completionHandler)
 {
+    RELEASE_LOG(WebRTC, "GPUProcess::updateCaptureAccess: Entering (audio=%d, video=%d, display=%d)", allowAudioCapture, allowVideoCapture, allowDisplayCapture);
+
 #if ENABLE(MEDIA_STREAM) && PLATFORM(COCOA)
     ensureAVCaptureServerConnection();
 #endif

--- a/Source/WebKit/GPUProcess/cocoa/GPUProcessCocoa.mm
+++ b/Source/WebKit/GPUProcess/cocoa/GPUProcessCocoa.mm
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2022 Apple Inc. All rights reserved.
+ * Copyright (C) 2021-2023 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -31,6 +31,7 @@
 #if ENABLE(GPU_PROCESS) && PLATFORM(COCOA)
 
 #import "GPUConnectionToWebProcess.h"
+#import "Logging.h"
 #import "RemoteRenderingBackend.h"
 #import <pal/spi/cocoa/AVFoundationSPI.h>
 #import <wtf/RetainPtr.h>
@@ -80,11 +81,11 @@ void GPUProcess::dispatchSimulatedNotificationsForPreferenceChange(const String&
 #if ENABLE(MEDIA_STREAM)
 void GPUProcess::ensureAVCaptureServerConnection()
 {
-    static std::once_flag flag;
-    std::call_once(flag, [] {
-        if ([PAL::getAVCaptureDeviceClass() respondsToSelector:@selector(ensureServerConnection)])
-            [PAL::getAVCaptureDeviceClass() ensureServerConnection];
-    });
+    RELEASE_LOG(WebRTC, "GPUProcess::ensureAVCaptureServerConnection: Entering.");
+    if ([PAL::getAVCaptureDeviceClass() respondsToSelector:@selector(ensureServerConnection)]) {
+        RELEASE_LOG(WebRTC, "GPUProcess::ensureAVCaptureServerConnection: Calling [AVCaptureDevice ensureServerConnection]");
+        [PAL::getAVCaptureDeviceClass() ensureServerConnection];
+    }
 }
 #endif
 


### PR DESCRIPTION
#### fe4af8b17fb6e12697825b46a8c0a542a7a7525a
<pre>
[Cocoa] Call [AVCaptureDevice ensureServerConnection] when new extensions are made to the GPU Process
<a href="https://bugs.webkit.org/show_bug.cgi?id=257241">https://bugs.webkit.org/show_bug.cgi?id=257241</a>
&lt;rdar://109380900&gt;

Reviewed by Eric Carlson.

Our current code only calls [AVCaptureDevice ensureServerConnection] the first time we extend the sandbox.
This can lead to problems if the user visits a site that only needs Microphone access (for example), and
then visits a site that needs Camera access. Because the camera-related extensions are only recognized by
the video capture system when [AVCaptureDevice ensureServiceConnection] is called, the fact that we called
it before the new sandbox extensions were in place mean we never activate the relevant features.

To fix this, we should simply call [AVCaptureDevice ensureServerConnection] any time we extend the sandbox.
I have confirmed with the relevant teams that this call is low-cost (performance wise), and is not harmful
to call repeatedly for things that have already been activated.

This patch also adds new logging to help debug similar problems in the future.

* Source/WebKit/GPUProcess/GPUProcess.cpp:
(WebKit::GPUProcess::updateSandboxAccess): Add logging.
(WebKit::GPUProcess::updateCaptureAccess): Ditto.
* Source/WebKit/GPUProcess/cocoa/GPUProcessCocoa.mm:
(WebKit::GPUProcess::ensureAVCaptureServerConnection): Add new logging, no longer make this a &apos;std::call_once&apos;.

Canonical link: <a href="https://commits.webkit.org/264460@main">https://commits.webkit.org/264460@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f552b6c9257d595fe9bbf9f193e7fdf6cd7a08eb

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/7673 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/7943 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/8125 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/9313 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/7844 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/9936 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/7866 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/10712 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/7807 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/8939 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/7059 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/9423 "Built successfully") | 
| | [💥 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/6247 "An unexpected error occured. Recent messages:OS: Ventura (13.3), Xcode: 14.3; Skipping applying patch since patch_id isn't provided; Checked out pull request") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/14663 "Passed tests") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/7410 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/7108 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/10517 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/7604 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/6202 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/6934 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/1830 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/11145 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/7337 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->