### PR TITLE
[Cocoa] Add ContextualizedNSString, to allow line breaking to use Core Foundation but also work with prior context

### DIFF
--- a/Source/WTF/WTF.xcodeproj/project.pbxproj
+++ b/Source/WTF/WTF.xcodeproj/project.pbxproj
@@ -56,6 +56,8 @@
 		1C96836726BE754600A2A2F9 /* Logging.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 1C96836526BE754600A2A2F9 /* Logging.cpp */; };
 		1C96836926BE76B600A2A2F9 /* LoggingCocoa.mm in Sources */ = {isa = PBXBuildFile; fileRef = 1C96836826BE76B600A2A2F9 /* LoggingCocoa.mm */; };
 		1C97FF7A297CD119006422AA /* IOSurfaceSPI.h in Headers */ = {isa = PBXBuildFile; fileRef = 1C97FF79297CD110006422AA /* IOSurfaceSPI.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		1CA6FBA92A1D75B9001D4402 /* ContextualizedNSString.mm in Sources */ = {isa = PBXBuildFile; fileRef = 1CA6FBA82A1D75B9001D4402 /* ContextualizedNSString.mm */; };
+		1CA6FBAB2A1D75D8001D4402 /* ContextualizedNSString.h in Headers */ = {isa = PBXBuildFile; fileRef = 1CA6FBAA2A1D75CD001D4402 /* ContextualizedNSString.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		1CA85CA9241B0B260071C2F5 /* RuntimeApplicationChecksCocoa.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 1CA85CA8241B0B260071C2F5 /* RuntimeApplicationChecksCocoa.cpp */; };
 		1CF18F3B26BB579E004B1722 /* LogChannels.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 1CF18F3926BB579E004B1722 /* LogChannels.cpp */; };
 		1CFD5D3D2851AB3E00A0E30B /* EnumeratedArray.h in Headers */ = {isa = PBXBuildFile; fileRef = 1CFD5D3B2851AB3E00A0E30B /* EnumeratedArray.h */; settings = {ATTRIBUTES = (Private, ); }; };
@@ -1082,6 +1084,8 @@
 		1C96836626BE754600A2A2F9 /* Logging.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = Logging.h; sourceTree = "<group>"; };
 		1C96836826BE76B600A2A2F9 /* LoggingCocoa.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = LoggingCocoa.mm; sourceTree = "<group>"; };
 		1C97FF79297CD110006422AA /* IOSurfaceSPI.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = IOSurfaceSPI.h; sourceTree = "<group>"; };
+		1CA6FBA82A1D75B9001D4402 /* ContextualizedNSString.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = ContextualizedNSString.mm; sourceTree = "<group>"; };
+		1CA6FBAA2A1D75CD001D4402 /* ContextualizedNSString.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = ContextualizedNSString.h; sourceTree = "<group>"; };
 		1CA85CA7241B0B110071C2F5 /* RuntimeApplicationChecksCocoa.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = RuntimeApplicationChecksCocoa.h; sourceTree = "<group>"; };
 		1CA85CA8241B0B260071C2F5 /* RuntimeApplicationChecksCocoa.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = RuntimeApplicationChecksCocoa.cpp; sourceTree = "<group>"; };
 		1CCDB1491E566626006C73C0 /* TextBreakIteratorCF.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = TextBreakIteratorCF.h; sourceTree = "<group>"; };
@@ -1912,6 +1916,8 @@
 			isa = PBXGroup;
 			children = (
 				4655743527F5FC4A002D5522 /* ASCIILiteralCocoa.mm */,
+				1CA6FBAA2A1D75CD001D4402 /* ContextualizedNSString.h */,
+				1CA6FBA82A1D75B9001D4402 /* ContextualizedNSString.mm */,
 				A5BA15F2182433A900A82E69 /* StringCocoa.mm */,
 				A5BA15F41824348000A82E69 /* StringImplCocoa.mm */,
 				93934BD218A1E8C300D0D6A1 /* StringViewCocoa.mm */,
@@ -2981,6 +2987,7 @@
 				DD3DC88F27A4BF8E007E5B61 /* ConcurrentVector.h in Headers */,
 				DD3DC8D027A4BF8E007E5B61 /* Condition.h in Headers */,
 				DDF307F527C0870E006A526F /* config.h in Headers */,
+				1CA6FBAB2A1D75D8001D4402 /* ContextualizedNSString.h in Headers */,
 				DDF307C627C086DF006A526F /* ConversionMode.h in Headers */,
 				DD3DC8D127A4BF8E007E5B61 /* CountingLock.h in Headers */,
 				DD3DC92627A4BF8E007E5B61 /* CPUTime.h in Headers */,
@@ -3702,6 +3709,7 @@
 				0F8F2B92172E0103007DBDA5 /* CompilationThread.cpp in Sources */,
 				E3149A3B228BDCAC00BFA6C7 /* ConcurrentBuffer.cpp in Sources */,
 				0F30CB5A1FCDF134004B5323 /* ConcurrentPtrHashSet.cpp in Sources */,
+				1CA6FBA92A1D75B9001D4402 /* ContextualizedNSString.mm in Sources */,
 				0F8E85DB1FD485B000691889 /* CountingLock.cpp in Sources */,
 				E38C41281EB4E0680042957D /* CPUTime.cpp in Sources */,
 				EB2C86D9267B275D0052CB9A /* CPUTimePOSIX.cpp in Sources */,

--- a/Source/WTF/wtf/text/cocoa/ContextualizedNSString.h
+++ b/Source/WTF/wtf/text/cocoa/ContextualizedNSString.h
@@ -1,0 +1,33 @@
+/*
+ * Copyright (C) 2023 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#import <Foundation/Foundation.h>
+#import <wtf/text/StringView.h>
+
+@interface WTFContextualizedNSString : NSString
+- (instancetype)initWithContext:(StringView)context contents:(StringView)contents;
+@end

--- a/Source/WTF/wtf/text/cocoa/ContextualizedNSString.mm
+++ b/Source/WTF/wtf/text/cocoa/ContextualizedNSString.mm
@@ -1,0 +1,71 @@
+/*
+ * Copyright (C) 2023 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#import "config.h"
+#import <wtf/text/cocoa/ContextualizedNSString.h>
+
+#import <algorithm>
+#import <wtf/text/StringView.h>
+
+@implementation WTFContextualizedNSString {
+    StringView context;
+    StringView contents;
+}
+
+- (instancetype)initWithContext:(StringView)context contents:(StringView)contents
+{
+    if (self = [super init]) {
+        self->context = context;
+        self->contents = contents;
+    }
+    return self;
+}
+
+- (NSUInteger)length
+{
+    return context.length() + contents.length();
+}
+
+- (unichar)characterAtIndex:(NSUInteger)index
+{
+    if (index < context.length())
+        return context[index];
+    return contents[index - context.length()];
+}
+
+- (void)getCharacters:(unichar *)buffer range:(NSRange)range
+{
+    auto contextLow = std::clamp(static_cast<unsigned>(range.location), 0U, context.length());
+    auto contextHigh = std::clamp(static_cast<unsigned>(range.location + range.length), 0U, context.length());
+    auto contextSubstring = context.substring(contextLow, contextHigh - contextLow);
+    auto contentsLow = std::clamp(static_cast<unsigned>(range.location), context.length(), context.length() + contents.length());
+    auto contentsHigh = std::clamp(static_cast<unsigned>(range.location + range.length), context.length(), context.length() + contents.length());
+    auto contentsSubstring = contents.substring(contentsLow - context.length(), contentsHigh - contentsLow);
+    static_assert(std::is_same_v<std::make_unsigned_t<unichar>, std::make_unsigned_t<UChar>>);
+    contextSubstring.getCharacters(reinterpret_cast<UChar*>(buffer));
+    contentsSubstring.getCharacters(reinterpret_cast<UChar*>(buffer) + contextSubstring.length());
+}
+
+@end

--- a/Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/project.pbxproj
+++ b/Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/project.pbxproj
@@ -121,6 +121,7 @@
 		1C9C7F512891238500C4649E /* ImmediateFont.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = 1C9C7F4F2891234500C4649E /* ImmediateFont.html */; };
 		1C9DD9232697655B00274DB2 /* SVGImageCasts.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 1C9DD9222697655B00274DB2 /* SVGImageCasts.cpp */; };
 		1C9EB8411E380DA1005C6442 /* ComplexTextController.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 1C9EB8401E380DA1005C6442 /* ComplexTextController.cpp */; };
+		1CA6FBAD2A1D818D001D4402 /* ContextualizedNSString.mm in Sources */ = {isa = PBXBuildFile; fileRef = 1CA6FBAC2A1D818C001D4402 /* ContextualizedNSString.mm */; };
 		1CACADA1230620AE0007D54C /* WKWebViewOpaque.mm in Sources */ = {isa = PBXBuildFile; fileRef = 1CACADA0230620AD0007D54C /* WKWebViewOpaque.mm */; };
 		1CB2F27C24F88379000A5BC1 /* OrthogonalFlowAvailableSize.mm in Sources */ = {isa = PBXBuildFile; fileRef = 1CB2F27B24F88379000A5BC1 /* OrthogonalFlowAvailableSize.mm */; };
 		1CB2F27E24F88A52000A5BC1 /* orthogonal-flow-available-size.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = 1CB2F27D24F883BE000A5BC1 /* orthogonal-flow-available-size.html */; };
@@ -2062,6 +2063,7 @@
 		1C9C7F4F2891234500C4649E /* ImmediateFont.html */ = {isa = PBXFileReference; lastKnownFileType = text.html; path = ImmediateFont.html; sourceTree = "<group>"; };
 		1C9DD9222697655B00274DB2 /* SVGImageCasts.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = SVGImageCasts.cpp; sourceTree = "<group>"; };
 		1C9EB8401E380DA1005C6442 /* ComplexTextController.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = ComplexTextController.cpp; sourceTree = "<group>"; };
+		1CA6FBAC2A1D818C001D4402 /* ContextualizedNSString.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = ContextualizedNSString.mm; sourceTree = "<group>"; };
 		1CAB9B7128F5E08900E6C77E /* WKWebExtensionController.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = WKWebExtensionController.mm; sourceTree = "<group>"; };
 		1CACADA0230620AD0007D54C /* WKWebViewOpaque.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = WKWebViewOpaque.mm; sourceTree = "<group>"; };
 		1CB2F27B24F88379000A5BC1 /* OrthogonalFlowAvailableSize.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = OrthogonalFlowAvailableSize.mm; sourceTree = "<group>"; };
@@ -5692,6 +5694,7 @@
 		E3C21A7821B25C82003B31A3 /* cocoa */ = {
 			isa = PBXGroup;
 			children = (
+				1CA6FBAC2A1D818C001D4402 /* ContextualizedNSString.mm */,
 				1C4616A626BB172F00F8C9F6 /* TextStreamCocoa.cpp */,
 				1C46169E26BA510700F8C9F6 /* TextStreamCocoa.mm */,
 				44CDE4D326EE6E41009F6ACB /* TypeCastsCocoa.mm */,
@@ -6109,6 +6112,7 @@
 				7BB8BDE428F0781A00129836 /* CompletionHandlerTests.cpp in Sources */,
 				0F30CB5C1FCE1796004B5323 /* ConcurrentPtrHashSet.cpp in Sources */,
 				7C83DEC31D0A590C00FEBCF3 /* Condition.cpp in Sources */,
+				1CA6FBAD2A1D818D001D4402 /* ContextualizedNSString.mm in Sources */,
 				7C83DEA61D0A590C00FEBCF3 /* Counters.cpp in Sources */,
 				5C2C01A82734883600F89D37 /* CrossThreadCopierTests.cpp in Sources */,
 				7C83DEA91D0A590C00FEBCF3 /* CString.cpp in Sources */,

--- a/Tools/TestWebKitAPI/Tests/WTF/cocoa/ContextualizedNSString.mm
+++ b/Tools/TestWebKitAPI/Tests/WTF/cocoa/ContextualizedNSString.mm
@@ -1,0 +1,261 @@
+/*
+ * Copyright (C) 2023 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#import "config.h"
+#import <wtf/text/cocoa/ContextualizedNSString.h>
+
+#import <wtf/cocoa/TypeCastsCocoa.h>
+
+TEST(WTF_ContextualizedNSString, Basic)
+{
+    auto context = "abc"_str;
+    auto contents = "def"_str;
+    auto contextualizedString = adoptNS([[WTFContextualizedNSString alloc] initWithContext:context contents:contents]);
+    EXPECT_TRUE([contextualizedString isEqualToString:@"abcdef"]);
+    EXPECT_TRUE([@"abcdef" isEqualToString:contextualizedString.get()]);
+    EXPECT_EQ(contextualizedString.get().length, 6UL);
+    EXPECT_EQ([contextualizedString characterAtIndex:0], 'a');
+    EXPECT_EQ([contextualizedString characterAtIndex:1], 'b');
+    EXPECT_EQ([contextualizedString characterAtIndex:2], 'c');
+    EXPECT_EQ([contextualizedString characterAtIndex:3], 'd');
+    EXPECT_EQ([contextualizedString characterAtIndex:4], 'e');
+    EXPECT_EQ([contextualizedString characterAtIndex:5], 'f');
+}
+
+TEST(WTF_ContextualizedNSString, getCharacters)
+{
+    auto context = "abc"_str;
+    auto contents = "def"_str;
+    auto contextualizedString = adoptNS([[WTFContextualizedNSString alloc] initWithContext:context contents:contents]);
+
+    unichar buffer[7];
+    std::fill(buffer, buffer + std::size(buffer), '\0');
+
+    [contextualizedString getCharacters:buffer range:NSMakeRange(0, 0)];
+    EXPECT_EQ(buffer[0], '\0');
+    std::fill(buffer, buffer + std::size(buffer), '\0');
+
+    [contextualizedString getCharacters:buffer range:NSMakeRange(0, 1)];
+    EXPECT_EQ(buffer[0], 'a');
+    EXPECT_EQ(buffer[1], '\0');
+    std::fill(buffer, buffer + std::size(buffer), '\0');
+
+    [contextualizedString getCharacters:buffer range:NSMakeRange(0, 2)];
+    EXPECT_EQ(buffer[0], 'a');
+    EXPECT_EQ(buffer[1], 'b');
+    EXPECT_EQ(buffer[2], '\0');
+    std::fill(buffer, buffer + std::size(buffer), '\0');
+
+    [contextualizedString getCharacters:buffer range:NSMakeRange(0, 3)];
+    EXPECT_EQ(buffer[0], 'a');
+    EXPECT_EQ(buffer[1], 'b');
+    EXPECT_EQ(buffer[2], 'c');
+    EXPECT_EQ(buffer[3], '\0');
+    std::fill(buffer, buffer + std::size(buffer), '\0');
+
+    [contextualizedString getCharacters:buffer range:NSMakeRange(0, 4)];
+    EXPECT_EQ(buffer[0], 'a');
+    EXPECT_EQ(buffer[1], 'b');
+    EXPECT_EQ(buffer[2], 'c');
+    EXPECT_EQ(buffer[3], 'd');
+    EXPECT_EQ(buffer[4], '\0');
+    std::fill(buffer, buffer + std::size(buffer), '\0');
+
+    [contextualizedString getCharacters:buffer range:NSMakeRange(0, 5)];
+    EXPECT_EQ(buffer[0], 'a');
+    EXPECT_EQ(buffer[1], 'b');
+    EXPECT_EQ(buffer[2], 'c');
+    EXPECT_EQ(buffer[3], 'd');
+    EXPECT_EQ(buffer[4], 'e');
+    EXPECT_EQ(buffer[5], '\0');
+    std::fill(buffer, buffer + std::size(buffer), '\0');
+
+    [contextualizedString getCharacters:buffer range:NSMakeRange(0, 6)];
+    EXPECT_EQ(buffer[0], 'a');
+    EXPECT_EQ(buffer[1], 'b');
+    EXPECT_EQ(buffer[2], 'c');
+    EXPECT_EQ(buffer[3], 'd');
+    EXPECT_EQ(buffer[4], 'e');
+    EXPECT_EQ(buffer[5], 'f');
+    EXPECT_EQ(buffer[6], '\0');
+    std::fill(buffer, buffer + std::size(buffer), '\0');
+
+    [contextualizedString getCharacters:buffer range:NSMakeRange(1, 0)];
+    EXPECT_EQ(buffer[0], '\0');
+    std::fill(buffer, buffer + std::size(buffer), '\0');
+
+    [contextualizedString getCharacters:buffer range:NSMakeRange(1, 1)];
+    EXPECT_EQ(buffer[0], 'b');
+    EXPECT_EQ(buffer[1], '\0');
+    std::fill(buffer, buffer + std::size(buffer), '\0');
+
+    [contextualizedString getCharacters:buffer range:NSMakeRange(1, 2)];
+    EXPECT_EQ(buffer[0], 'b');
+    EXPECT_EQ(buffer[1], 'c');
+    EXPECT_EQ(buffer[2], '\0');
+    std::fill(buffer, buffer + std::size(buffer), '\0');
+
+    [contextualizedString getCharacters:buffer range:NSMakeRange(1, 3)];
+    EXPECT_EQ(buffer[0], 'b');
+    EXPECT_EQ(buffer[1], 'c');
+    EXPECT_EQ(buffer[2], 'd');
+    EXPECT_EQ(buffer[3], '\0');
+    std::fill(buffer, buffer + std::size(buffer), '\0');
+
+    [contextualizedString getCharacters:buffer range:NSMakeRange(1, 4)];
+    EXPECT_EQ(buffer[0], 'b');
+    EXPECT_EQ(buffer[1], 'c');
+    EXPECT_EQ(buffer[2], 'd');
+    EXPECT_EQ(buffer[3], 'e');
+    EXPECT_EQ(buffer[4], '\0');
+    std::fill(buffer, buffer + std::size(buffer), '\0');
+
+    [contextualizedString getCharacters:buffer range:NSMakeRange(1, 5)];
+    EXPECT_EQ(buffer[0], 'b');
+    EXPECT_EQ(buffer[1], 'c');
+    EXPECT_EQ(buffer[2], 'd');
+    EXPECT_EQ(buffer[3], 'e');
+    EXPECT_EQ(buffer[4], 'f');
+    EXPECT_EQ(buffer[5], '\0');
+    std::fill(buffer, buffer + std::size(buffer), '\0');
+
+    [contextualizedString getCharacters:buffer range:NSMakeRange(3, 0)];
+    EXPECT_EQ(buffer[0], '\0');
+    std::fill(buffer, buffer + std::size(buffer), '\0');
+
+    [contextualizedString getCharacters:buffer range:NSMakeRange(3, 1)];
+    EXPECT_EQ(buffer[0], 'd');
+    EXPECT_EQ(buffer[1], '\0');
+    std::fill(buffer, buffer + std::size(buffer), '\0');
+
+    [contextualizedString getCharacters:buffer range:NSMakeRange(3, 2)];
+    EXPECT_EQ(buffer[0], 'd');
+    EXPECT_EQ(buffer[1], 'e');
+    EXPECT_EQ(buffer[2], '\0');
+    std::fill(buffer, buffer + std::size(buffer), '\0');
+
+    [contextualizedString getCharacters:buffer range:NSMakeRange(3, 3)];
+    EXPECT_EQ(buffer[0], 'd');
+    EXPECT_EQ(buffer[1], 'e');
+    EXPECT_EQ(buffer[2], 'f');
+    EXPECT_EQ(buffer[3], '\0');
+    std::fill(buffer, buffer + std::size(buffer), '\0');
+
+    [contextualizedString getCharacters:buffer range:NSMakeRange(4, 0)];
+    EXPECT_EQ(buffer[0], '\0');
+    std::fill(buffer, buffer + std::size(buffer), '\0');
+
+    [contextualizedString getCharacters:buffer range:NSMakeRange(4, 1)];
+    EXPECT_EQ(buffer[0], 'e');
+    EXPECT_EQ(buffer[1], '\0');
+    std::fill(buffer, buffer + std::size(buffer), '\0');
+
+    [contextualizedString getCharacters:buffer range:NSMakeRange(4, 2)];
+    EXPECT_EQ(buffer[0], 'e');
+    EXPECT_EQ(buffer[1], 'f');
+    EXPECT_EQ(buffer[2], '\0');
+    std::fill(buffer, buffer + std::size(buffer), '\0');
+
+    [contextualizedString getCharacters:buffer range:NSMakeRange(6, 0)];
+    EXPECT_EQ(buffer[0], '\0');
+    std::fill(buffer, buffer + std::size(buffer), '\0');
+
+    [contextualizedString getCharacters:buffer range:NSMakeRange(7, 0)];
+    EXPECT_EQ(buffer[0], '\0');
+    std::fill(buffer, buffer + std::size(buffer), '\0');
+}
+
+TEST(WTF_ContextualizedNSString, nonPrimitive)
+{
+    auto context = "abc"_str;
+    auto contents = "def"_str;
+    auto contextualizedString = adoptNS([[WTFContextualizedNSString alloc] initWithContext:context contents:contents]);
+
+    EXPECT_TRUE([contextualizedString hasPrefix:@"ab"]);
+    EXPECT_TRUE([contextualizedString hasPrefix:@"abcd"]);
+    EXPECT_FALSE([contextualizedString hasPrefix:@"b"]);
+    EXPECT_FALSE([contextualizedString hasPrefix:@"bcd"]);
+    EXPECT_TRUE([contextualizedString hasSuffix:@"ef"]);
+    EXPECT_TRUE([contextualizedString hasSuffix:@"cdef"]);
+    EXPECT_FALSE([contextualizedString hasSuffix:@"c"]);
+    EXPECT_FALSE([contextualizedString hasSuffix:@"bcd"]);
+    EXPECT_TRUE([contextualizedString containsString:@"ab"]);
+    EXPECT_TRUE([contextualizedString containsString:@"bcd"]);
+    EXPECT_TRUE([contextualizedString containsString:@"e"]);
+    EXPECT_FALSE([contextualizedString containsString:@"cb"]);
+
+    auto copy = adoptNS([contextualizedString copy]);
+    EXPECT_TRUE([copy isEqualToString:@"abcdef"]);
+
+    auto mutableCopy = adoptNS([contextualizedString mutableCopy]);
+    EXPECT_TRUE([mutableCopy isEqualToString:@"abcdef"]);
+}
+
+TEST(WTF_ContextualizedNSString, cfString)
+{
+    auto context = "abc"_str;
+    auto contents = "def"_str;
+    auto contextualizedString = adoptNS([[WTFContextualizedNSString alloc] initWithContext:context contents:contents]);
+    auto contextualizedCFString = bridge_cast(static_cast<NSString *>(contextualizedString.get()));
+
+    EXPECT_EQ(CFStringGetCharacterAtIndex(contextualizedCFString, 0), 'a');
+    EXPECT_EQ(CFStringGetCharacterAtIndex(contextualizedCFString, 1), 'b');
+    EXPECT_EQ(CFStringGetCharacterAtIndex(contextualizedCFString, 2), 'c');
+    EXPECT_EQ(CFStringGetCharacterAtIndex(contextualizedCFString, 3), 'd');
+    EXPECT_EQ(CFStringGetCharacterAtIndex(contextualizedCFString, 4), 'e');
+    EXPECT_EQ(CFStringGetCharacterAtIndex(contextualizedCFString, 5), 'f');
+
+    EXPECT_NE(CFStringFind(contextualizedCFString, CFSTR("ab"), 0).location, kCFNotFound);
+    EXPECT_NE(CFStringFind(contextualizedCFString, CFSTR("bcd"), 0).location, kCFNotFound);
+    EXPECT_NE(CFStringFind(contextualizedCFString, CFSTR("de"), 0).location, kCFNotFound);
+    EXPECT_EQ(CFStringFind(contextualizedCFString, CFSTR("AB"), 0).location, kCFNotFound);
+    EXPECT_NE(CFStringFind(contextualizedCFString, CFSTR("AB"), kCFCompareCaseInsensitive).location, kCFNotFound);
+
+    EXPECT_EQ(CFStringGetLength(contextualizedCFString), 6);
+}
+
+TEST(WTF_ContextualizedNSString, tokenizer)
+{
+    auto context = "th"_str;
+    auto contents = "is is some text"_str;
+    auto contextualizedString = adoptNS([[WTFContextualizedNSString alloc] initWithContext:context contents:contents]);
+    auto contextualizedCFString = bridge_cast(static_cast<NSString *>(contextualizedString.get()));
+
+    auto locale = adoptCF(CFLocaleCreate(kCFAllocatorDefault, CFSTR("en_US")));
+    auto tokenizer = adoptCF(CFStringTokenizerCreate(kCFAllocatorDefault, contextualizedCFString, CFRangeMake(0, CFStringGetLength(contextualizedCFString)), kCFStringTokenizerUnitWord, locale.get()));
+
+    CFIndex indices[] = { 4, 7, 12, 17 };
+    unsigned index = 0;
+    for (CFIndex i = 0; i < CFStringGetLength(contextualizedCFString); ++index) {
+        CFStringTokenizerGoToTokenAtIndex(tokenizer.get(), i);
+        auto range = CFStringTokenizerGetCurrentTokenRange(tokenizer.get());
+        ASSERT_NE(range.location, kCFNotFound);
+        auto next = range.location + range.length;
+        ASSERT_LT(index, std::size(indices));
+        EXPECT_EQ(next, indices[index]);
+        i = next + 1;
+    }
+    EXPECT_EQ(index, std::size(indices));
+}


### PR DESCRIPTION
#### da000fdb0dc70c5758b808a5bbad99178068bb87
<pre>
[Cocoa] Add ContextualizedNSString, to allow line breaking to use Core Foundation but also work with prior context
<a href="https://bugs.webkit.org/show_bug.cgi?id=257244">https://bugs.webkit.org/show_bug.cgi?id=257244</a>
rdar://109747545

Reviewed by Yusuke Suzuki.

In WebKit, we (may) create a new line breaker for each element on the line. This means that,
in order to perform line breaking correctly, the line breaker needs to know about the last few
characters that came at the end of the previous element - we call this a &quot;prior context.&quot; The
problem here is that this prior context isn&apos;t contiguous in memory with the string being
inspected; it&apos;s part of a different string altogether.

Core Foundation has facilities to perform line breaking. If we want to perform line breaking
using these facilities, it has to be possible to make CFString work with this &quot;prior context.&quot;
CFString either A) copies and owns its character contents, or B) only accepts a single pointer
to string contents, which it doesn&apos;t own. That&apos;s not quite what we want: we want it to take
2 pointers to string contents, and act as if the contents of those 2 strings are concatenated.

The standard way of doing this is to subclass NSString. This sounds scary, but it&apos;s actually a
totally normal thing to do. There&apos;s even a whole section in the docs[1] about how to do it,
for exactly this use case. Because NSStrings are toll-free bridged with CFStrings, the CFString
methods end up calling our overridden Objective C NSString methods. This is how we can make
Core Foundation&apos;s line breaking work with prior context.

This patch adds a new NSString subclass, called ContextualizedNSString, and tests it in TestWTF.
It doesn&apos;t actually start using it in WTF yet. I&apos;ll do that in another patch.

[1] <a href="https://developer.apple.com/documentation/foundation/nsstring?language=objc">https://developer.apple.com/documentation/foundation/nsstring?language=objc</a>

* Source/WTF/WTF.xcodeproj/project.pbxproj:
* Source/WTF/wtf/text/cocoa/ContextualizedNSString.h: Added.
* Source/WTF/wtf/text/cocoa/ContextualizedNSString.mm: Added.
(-[ContextualizedNSString initWithContext:contents:]):
(-[ContextualizedNSString length]):
(-[ContextualizedNSString characterAtIndex:]):
(-[ContextualizedNSString getCharacters:range:]):
* Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/project.pbxproj:
* Tools/TestWebKitAPI/Tests/WTF/cocoa/ContextualizedNSString.mm: Added.
(TEST):

Canonical link: <a href="https://commits.webkit.org/264454@main">https://commits.webkit.org/264454@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5fcf1ef0803cee50b690073c290e92fc7a241035

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/7688 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/7958 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/8140 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/9326 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/32/builds/7852 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/7694 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/9948 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/7878 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/10719 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/7822 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/15/builds/8944 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/7065 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/9435 "Built successfully") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/39/builds/6252 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/6996 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/14670 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [  ~~🛠 🧪 jsc~~](https://ews-build.webkit.org/#/builders/20/builds/6553 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/7415 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/7118 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/10529 "6 api tests failed or timed out") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/7271 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/7612 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/6207 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/7843 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/6942 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/1793 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/1826 "Built successfully and passed tests") | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/4/builds/11153 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/24/builds/8054 "Built successfully") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/7346 "Built successfully") | | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/3/builds/1937 "Passed tests") | 
<!--EWS-Status-Bubble-End-->