### PR TITLE
[iOS] Adjust several API tests so that they pass when run against any iOS simulator

### DIFF
--- a/Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/project.pbxproj
+++ b/Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/project.pbxproj
@@ -200,7 +200,6 @@
 		31B76E4523299BDC007FED2C /* system-preview-trigger.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = 31B76E4423299BA3007FED2C /* system-preview-trigger.html */; };
 		31E9BDA1247F4C62002E51A2 /* WebGLPrepareDisplayOnWebThread.mm in Sources */ = {isa = PBXBuildFile; fileRef = 31E9BDA0247F4C62002E51A2 /* WebGLPrepareDisplayOnWebThread.mm */; };
 		31E9BDA3247F5729002E51A2 /* webgl.html in Copy Resources */ = {isa = PBXBuildFile; fileRef = 31E9BDA2247F4DD0002E51A2 /* webgl.html */; };
-		3302A64E2A11B5350093FA2A /* DragAndDropSimulator.mm in Sources */ = {isa = PBXBuildFile; fileRef = 3302A64D2A11B4410093FA2A /* DragAndDropSimulator.mm */; };
 		33976D8324DC479B00812304 /* IndexSparseSet.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 33976D8224DC479B00812304 /* IndexSparseSet.cpp */; };
 		33BE5AF9137B5AAE00705813 /* MouseMoveAfterCrash_Bundle.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 33BE5AF8137B5AAE00705813 /* MouseMoveAfterCrash_Bundle.cpp */; };
 		33C2C9C12651F5B900E407F6 /* SmallSet.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 33C2C9C02651F5B900E407F6 /* SmallSet.cpp */; };
@@ -6331,7 +6330,6 @@
 				7CCE7EED1A411AE600447C4C /* DOMWindowExtensionNoCache.cpp in Sources */,
 				7CCE7EEE1A411AE600447C4C /* DownloadDecideDestinationCrash.cpp in Sources */,
 				5CF540E92257E67C00E6BC0E /* DownloadThread.mm in Sources */,
-				3302A64E2A11B5350093FA2A /* DragAndDropSimulator.mm in Sources */,
 				F4D4F3B61E4E2BCB00BB2767 /* DragAndDropSimulatorIOS.mm in Sources */,
 				F46128B7211C8ED500D9FADB /* DragAndDropSimulatorMac.mm in Sources */,
 				F4D4F3B91E4E36E400BB2767 /* DragAndDropTestsIOS.mm in Sources */,

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/AnimatedResize.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/AnimatedResize.mm
@@ -51,7 +51,7 @@ static bool didLayout;
 static bool didEndAnimatedResize;
 static bool didChangeSafeAreaShouldAffectObscuredInsets;
 
-@interface AnimatedResizeWebView : WKWebView <WKUIDelegate>
+@interface AnimatedResizeWebView : TestWKWebView <WKUIDelegate>
 
 @end
 

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebViewSnapshot.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebViewSnapshot.mm
@@ -29,6 +29,7 @@
 #import "PlatformUtilities.h"
 #import "Test.h"
 #import "TestNavigationDelegate.h"
+#import "TestWKWebView.h"
 #import <WebKit/WKSnapshotConfigurationPrivate.h>
 #import <wtf/BlockPtr.h>
 #import <wtf/RetainPtr.h>
@@ -80,7 +81,7 @@ TEST(WKWebView, SnapshotImageError)
 {
     CGFloat viewWidth = 800;
     CGFloat viewHeight = 600;
-    RetainPtr<WKWebView> webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, viewWidth, viewHeight)]);
+    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, viewWidth, viewHeight)]);
     
     [webView loadHTMLString:@"<body style='background-color: red;'></body>" baseURL:nil];
     [webView _test_waitForDidFinishNavigation];
@@ -105,7 +106,7 @@ TEST(WKWebView, SnapshotImageEmptyRect)
 {
     CGFloat viewWidth = 800;
     CGFloat viewHeight = 600;
-    RetainPtr<WKWebView> webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, viewWidth, viewHeight)]);
+    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, viewWidth, viewHeight)]);
 
     [webView loadHTMLString:@"<body style='background-color: red;'></body>" baseURL:nil];
     [webView _test_waitForDidFinishNavigation];
@@ -133,7 +134,7 @@ TEST(WKWebView, SnapshotImageZeroWidth)
 {
     CGFloat viewWidth = 800;
     CGFloat viewHeight = 600;
-    RetainPtr<WKWebView> webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, viewWidth, viewHeight)]);
+    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, viewWidth, viewHeight)]);
 
     [webView loadHTMLString:@"<body style='background-color: red;'></body>" baseURL:nil];
     [webView _test_waitForDidFinishNavigation];
@@ -159,7 +160,7 @@ TEST(WKWebView, SnapshotImageZeroSizeView)
 {
     CGFloat viewWidth = 0;
     CGFloat viewHeight = 0;
-    RetainPtr<WKWebView> webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, viewWidth, viewHeight)]);
+    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, viewWidth, viewHeight)]);
 
     [webView loadHTMLString:@"<body style='background-color: red;'></body>" baseURL:nil];
     [webView _test_waitForDidFinishNavigation];
@@ -187,7 +188,7 @@ TEST(WKWebView, SnapshotImageZeroSizeViewNoConfiguration)
 {
     CGFloat viewWidth = 0;
     CGFloat viewHeight = 0;
-    RetainPtr<WKWebView> webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, viewWidth, viewHeight)]);
+    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, viewWidth, viewHeight)]);
 
     [webView loadHTMLString:@"<body style='background-color: red;'></body>" baseURL:nil];
     [webView _test_waitForDidFinishNavigation];
@@ -211,7 +212,7 @@ TEST(WKWebView, SnapshotImageEmptyWithOutOfScopeCompletionHandler)
 {
     CGFloat viewWidth = 0;
     CGFloat viewHeight = 0;
-    RetainPtr<WKWebView> webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, viewWidth, viewHeight)]);
+    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, viewWidth, viewHeight)]);
 
     [webView loadHTMLString:@"<body style='background-color: red;'></body>" baseURL:nil];
     [webView _test_waitForDidFinishNavigation];
@@ -244,7 +245,7 @@ TEST(WKWebView, SnapshotImageBaseCase)
 {
     NSInteger viewWidth = 800;
     NSInteger viewHeight = 600;
-    RetainPtr<WKWebView> webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, viewWidth, viewHeight)]);
+    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, viewWidth, viewHeight)]);
 
     RetainPtr<PlatformWindow> window;
     CGFloat backingScaleFactor;
@@ -311,7 +312,7 @@ TEST(WKWebView, SnapshotImageScale)
     CGFloat viewWidth = 800;
     CGFloat viewHeight = 600;
     CGFloat scaleFactor = 2;
-    RetainPtr<WKWebView> webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, viewWidth, viewHeight)]);
+    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, viewWidth, viewHeight)]);
 
     [webView loadHTMLString:@"<body style='background-color: red;'></body>" baseURL:nil];
     [webView _test_waitForDidFinishNavigation];
@@ -337,7 +338,7 @@ TEST(WKWebView, SnapshotImageNilConfiguration)
 {
     CGFloat viewWidth = 800;
     CGFloat viewHeight = 600;
-    RetainPtr<WKWebView> webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, viewWidth, viewHeight)]);
+    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, viewWidth, viewHeight)]);
 
     [webView loadHTMLString:@"<body style='background-color: red;'></body>" baseURL:nil];
     [webView _test_waitForDidFinishNavigation];
@@ -358,7 +359,7 @@ TEST(WKWebView, SnapshotImageUninitializedConfiguration)
 {
     CGFloat viewWidth = 800;
     CGFloat viewHeight = 600;
-    RetainPtr<WKWebView> webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, viewWidth, viewHeight)]);
+    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, viewWidth, viewHeight)]);
 
     [webView loadHTMLString:@"<body style='background-color: red;'></body>" baseURL:nil];
     [webView _test_waitForDidFinishNavigation];
@@ -381,7 +382,7 @@ TEST(WKWebView, SnapshotImageUninitializedSnapshotWidth)
 {
     CGFloat viewWidth = 800;
     CGFloat viewHeight = 600;
-    RetainPtr<WKWebView> webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, viewWidth, viewHeight)]);
+    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, viewWidth, viewHeight)]);
 
     [webView loadHTMLString:@"<body style='background-color: red;'></body>" baseURL:nil];
     [webView _test_waitForDidFinishNavigation];
@@ -405,13 +406,14 @@ TEST(WKWebView, SnapshotImageLargeAsyncDecoding)
 {
     NSInteger viewWidth = 800;
     NSInteger viewHeight = 600;
-    RetainPtr<WKWebView> webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, viewWidth, viewHeight)]);
+    // FIXME: This test fails when adopting TestWKWebView; it might be interesting to investigate why.
+    auto webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, viewWidth, viewHeight)]);
 
     NSURL *fileURL = [[NSBundle mainBundle] URLForResource:@"large-red-square-image" withExtension:@"html" subdirectory:@"TestWebKitAPI.resources"];
     [webView loadFileURL:fileURL allowingReadAccessToURL:fileURL];
     [webView _test_waitForDidFinishNavigation];
 
-    RetainPtr<WKSnapshotConfiguration> snapshotConfiguration = adoptNS([[WKSnapshotConfiguration alloc] init]);
+    auto snapshotConfiguration = adoptNS([[WKSnapshotConfiguration alloc] init]);
     [snapshotConfiguration setRect:NSMakeRect(0, 0, viewWidth, viewHeight)];
     [snapshotConfiguration setSnapshotWidth:@(viewWidth)];
 
@@ -421,8 +423,8 @@ TEST(WKWebView, SnapshotImageLargeAsyncDecoding)
 
         EXPECT_EQ(viewWidth, snapshotImage.size.width);
 
-        RetainPtr<CGImageRef> cgImage = convertToCGImage(snapshotImage);
-        RetainPtr<CGColorSpaceRef> colorSpace = adoptCF(CGColorSpaceCreateDeviceRGB());
+        auto cgImage = convertToCGImage(snapshotImage);
+        auto colorSpace = adoptCF(CGColorSpaceCreateDeviceRGB());
 
         uint8_t *rgba = (unsigned char *)calloc(viewWidth * viewHeight * 4, sizeof(unsigned char));
         auto context = adoptCF(CGBitmapContextCreate(rgba, viewWidth, viewHeight, 8, 4 * viewWidth, colorSpace.get(), static_cast<uint32_t>(kCGImageAlphaPremultipliedLast) | static_cast<uint32_t>(kCGBitmapByteOrder32Big)));
@@ -462,7 +464,7 @@ TEST(WKWebView, SnapshotAfterScreenUpdates)
     // pass this test.
     NSInteger viewWidth = 800;
     NSInteger viewHeight = 600;
-    RetainPtr<WKWebView> webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, viewWidth, viewHeight)]);
+    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, viewWidth, viewHeight)]);
     
     RetainPtr<PlatformWindow> window;
     CGFloat backingScaleFactor;
@@ -525,7 +527,7 @@ TEST(WKWebView, SnapshotWithoutAfterScreenUpdates)
     // then we would expect the pixels to be red instead of blue.
     NSInteger viewWidth = 800;
     NSInteger viewHeight = 600;
-    RetainPtr<WKWebView> webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, viewWidth, viewHeight)]);
+    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, viewWidth, viewHeight)]);
     
     RetainPtr<PlatformWindow> window;
     CGFloat backingScaleFactor;
@@ -585,7 +587,7 @@ TEST(WKWebView, SnapshotWebGL)
 {
     NSInteger viewWidth = 800;
     NSInteger viewHeight = 600;
-    RetainPtr<WKWebView> webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, viewWidth, viewHeight)]);
+    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, viewWidth, viewHeight)]);
 
     RetainPtr<PlatformWindow> window;
     CGFloat backingScaleFactor;
@@ -644,7 +646,7 @@ TEST(WKWebView, SnapshotWithoutSelectionHighlighting)
 {
     NSInteger viewWidth = 800;
     NSInteger viewHeight = 600;
-    RetainPtr<WKWebView> webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, viewWidth, viewHeight)]);
+    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, viewWidth, viewHeight)]);
 
     RetainPtr<PlatformWindow> window = adoptNS([[NSWindow alloc] initWithContentRect:[webView frame] styleMask:NSBorderlessWindowMask backing:NSBackingStoreBuffered defer:NO]);
     [[window contentView] addSubview:webView.get()];

--- a/Tools/TestWebKitAPI/Tests/WebKitLegacy/ios/SnapshotViaRenderInContext.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitLegacy/ios/SnapshotViaRenderInContext.mm
@@ -57,6 +57,19 @@ IGNORE_WARNINGS_END
 
 @end
 
+@interface UIWebViewWithoutSafeArea : UIWebView
+
+@end
+
+@implementation UIWebViewWithoutSafeArea : UIWebView
+
+- (UIEdgeInsets)_safeAreaInsetsForFrame:(CGRect)frame inSuperview:(UIView *)view
+{
+    return UIEdgeInsetsZero;
+}
+
+@end
+
 namespace TestWebKitAPI {
 
 static NSInteger getPixelIndex(NSInteger x, NSInteger y, NSInteger width)
@@ -69,8 +82,8 @@ TEST(WebKitLegacy, RenderInContextSnapshot)
     const NSInteger width = 800;
     const NSInteger height = 600;
     
-    RetainPtr<UIWindow> uiWindow = adoptNS([[UIWindow alloc] initWithFrame:NSMakeRect(0, 0, width, height)]);
-    RetainPtr<UIWebView> uiWebView = adoptNS([[UIWebView alloc] initWithFrame:NSMakeRect(0, 0, width, height)]);
+    auto uiWindow = adoptNS([[UIWindow alloc] initWithFrame:NSMakeRect(0, 0, width, height)]);
+    auto uiWebView = adoptNS([[UIWebViewWithoutSafeArea alloc] initWithFrame:NSMakeRect(0, 0, width, height)]);
     [uiWindow addSubview:uiWebView.get()];
     
     RetainPtr<RenderInContextWebViewDelegate> uiDelegate = adoptNS([[RenderInContextWebViewDelegate alloc] init]);

--- a/Tools/TestWebKitAPI/cocoa/TestWKWebView.mm
+++ b/Tools/TestWebKitAPI/cocoa/TestWKWebView.mm
@@ -774,7 +774,7 @@ static UICalloutBar *suppressUICalloutBar()
     _overrideSafeAreaInset = inset;
 }
 
-- (UIEdgeInsets)safeAreaInsets
+- (UIEdgeInsets)_safeAreaInsetsForFrame:(CGRect)frame inSuperview:(UIView *)view
 {
     return _overrideSafeAreaInset;
 }


### PR DESCRIPTION
#### 874dbd53a389b72df8ec35cbe5b478f4d5327da5
<pre>
[iOS] Adjust several API tests so that they pass when run against any iOS simulator
<a href="https://bugs.webkit.org/show_bug.cgi?id=257246">https://bugs.webkit.org/show_bug.cgi?id=257246</a>
rdar://109743641

Reviewed by Aditya Keerthi.

Make some additional adjustments to several API tests, which currently pass in the iPhone SE
simulator but fail when run against other simulator models. These tests are:

• A subset of `WKWebView.SnapshotImage*`
• A subset of `AnimatedResize.*`
• `WebKitLegacy.RenderInContextSnapshot`

* Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/project.pbxproj:

Drive-by fix: address a (benign) build warning following 264080@main, where the definition of
`-runFromElement:toElement` is compiled twice, due to the fact that `DragAndDropSimulator.mm`
appears in _both_ the unified sources list as well as the Xcode project as a compilation target.
Address this by removing it as a compilation target in Xcode.

* Tools/TestWebKitAPI/Tests/WebKitCocoa/AnimatedResize.mm:

Fix these tests by subclassing `TestWKWebView`, which normalizes safe area inset values between
different device models.

* Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebViewSnapshot.mm:

Fix these tests by adopting `TestWKWebView` in place of `WKWebView`.

* Tools/TestWebKitAPI/Tests/WebKitLegacy/ios/SnapshotViaRenderInContext.mm:
(-[UIWebViewWithoutSafeArea _safeAreaInsetsForFrame:inSuperview:]):

Fix this test by creating a `UIWebView` subclass that simulates 0 safe area insets.

* Tools/TestWebKitAPI/cocoa/TestWKWebView.mm:
(-[TestWKWebView _safeAreaInsetsForFrame:inSuperview:]):

Override this private helper method instead of `-safeAreaInsets`, since this is the ultimate source
of truth that determines `-safeAreaInsets`. This is consistent with `WebKitTestRunner`&apos;s
`TestRunnerWKWebView` subclass, which also has a mechanism for overriding safe area insets.

(-[TestWKWebView safeAreaInsets]): Deleted.

Canonical link: <a href="https://commits.webkit.org/264473@main">https://commits.webkit.org/264473@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/3c16e246aa97a1c4744df19338c61de6a1b7c819

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/7689 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/7959 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/8141 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/9327 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/7853 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/7695 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/9949 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/7879 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/10723 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/7823 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/8946 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/7068 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/9436 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/6254 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/7000 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/14672 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/7417 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/7122 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/10533 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/7613 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/6211 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/6943 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/1846 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/11154 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/7347 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->