### PR TITLE
[JSC] Disable fp-contract explicitly for Date math

### DIFF
--- a/JSTests/test262/config.yaml
+++ b/JSTests/test262/config.yaml
@@ -961,6 +961,3 @@ skip:
 
     # Skip while https://bugs.webkit.org/show_bug.cgi?id=249330 is being investigated
     - test/built-ins/RegExp/named-groups/lookbehind.js 
-
-    # Skip while https://bugs.webkit.org/show_bug.cgi?id=255296 is being investigated
-    - test/built-ins/Date/UTC/fp-evaluation-order.js

--- a/Source/JavaScriptCore/runtime/DateConstructor.cpp
+++ b/Source/JavaScriptCore/runtime/DateConstructor.cpp
@@ -66,41 +66,49 @@ void DateConstructor::finishCreation(VM& vm, DatePrototype* datePrototype)
     putDirectWithoutTransition(vm, vm.propertyNames->prototype, datePrototype, PropertyAttribute::DontEnum | PropertyAttribute::DontDelete | PropertyAttribute::ReadOnly);
 }
 
+static inline double toIntegerOrInfinity(double d)
+{
+    return trunc(std::isnan(d) ? 0.0 : d + 0.0);
+}
+
+// https://tc39.es/ecma262/#sec-makedate
+static inline double makeDate(double day, double time)
+{
+#if COMPILER(CLANG)
+    #pragma STDC FP_CONTRACT OFF
+#endif
+    return (day * msPerDay) + time;
+}
+
+// https://tc39.es/ecma262/#sec-maketime
+static inline double makeTime(double hour, double min, double sec, double ms)
+{
+#if COMPILER(CLANG)
+    #pragma STDC FP_CONTRACT OFF
+#endif
+    return (((hour * msPerHour) + min * msPerMinute) + sec * msPerSecond) + ms;
+}
+
+// https://tc39.es/ecma262/#sec-makeday
+static inline double makeDay(double year, double month, double date)
+{
+    double additionalYears = std::floor(month / 12);
+    double ym = year + additionalYears;
+    if (!std::isfinite(ym))
+        return PNaN;
+    double mm = month - additionalYears * 12;
+    int32_t yearInt32 = toInt32(ym);
+    int32_t monthInt32 = toInt32(mm);
+    if (yearInt32 != ym || monthInt32 != mm)
+        return PNaN;
+    double days = dateToDaysFrom1970(yearInt32, monthInt32, 1);
+    return days + date - 1;
+}
+
 static double millisecondsFromComponents(JSGlobalObject* globalObject, const ArgList& args, WTF::TimeType timeType)
 {
     VM& vm = globalObject->vm();
     auto scope = DECLARE_THROW_SCOPE(vm);
-
-    auto toIntegerOrInfinity = [](double d) {
-        return trunc(std::isnan(d) ? 0.0 : d + 0.0);
-    };
-
-    // https://tc39.es/ecma262/#sec-maketime
-    auto makeTime = [](double hour, double min, double sec, double ms) {
-        return ((hour * msPerHour + min * msPerMinute) + sec * msPerSecond) + ms;
-    };
-
-    // https://tc39.es/ecma262/#sec-makeday
-    auto makeDay = [](double year, double month, double date) {
-        double additionalYears = std::floor(month / 12);
-        double ym = year + additionalYears;
-        if (!std::isfinite(ym))
-            return PNaN;
-        double mm = month - additionalYears * 12;
-        int32_t yearInt32 = toInt32(ym);
-        int32_t monthInt32 = toInt32(mm);
-        if (yearInt32 != ym || monthInt32 != mm)
-            return PNaN;
-        double days = dateToDaysFrom1970(yearInt32, monthInt32, 1);
-        return days + date - 1;
-    };
-
-    // https://tc39.es/ecma262/#sec-makedate
-    auto makeDate = [](double day, double time) {
-        if (!std::isfinite(day) || !std::isfinite(time))
-            return PNaN;
-        return day * msPerDay + time;
-    };
 
     // Initialize doubleArguments with default values.
     double doubleArguments[7] {


### PR DESCRIPTION
#### c0dd96832e9fe3af82713082a391feabd26003dc
<pre>
[JSC] Disable fp-contract explicitly for Date math
<a href="https://bugs.webkit.org/show_bug.cgi?id=255296">https://bugs.webkit.org/show_bug.cgi?id=255296</a>
rdar://107895685

Reviewed by Justin Michaud.

Clang-14 enabled fp-contract=on by default. This means that fused-multiply-add (FMA)
can be automatically applied at C++ code! The problem is that FMA changes precision of FP,
causing FP precision problem in places where the precision is important.
This patch applies pragma to disable this behavior.

* JSTests/test262/config.yaml:
* Source/JavaScriptCore/runtime/DateConstructor.cpp:
(JSC::toIntegerOrInfinity):
(JSC::makeDate):
(JSC::makeTime):
(JSC::makeDay):
(JSC::millisecondsFromComponents):

Canonical link: <a href="https://commits.webkit.org/264453@main">https://commits.webkit.org/264453@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b2fa38910dcfcd09b166bd1e92867d18cc70cdaf

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/7692 "2 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/7962 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/8144 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/9330 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/32/builds/7855 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/9952 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/7882 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/10724 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/7826 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/15/builds/8947 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/7070 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/9440 "Built successfully") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/39/builds/6255 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/7003 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/14673 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [  ~~🛠 🧪 jsc~~](https://ews-build.webkit.org/#/builders/20/builds/6556 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/7418 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/7125 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/10534 "Passed tests") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/7275 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/7616 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/6214 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/7847 "Built successfully") | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/30/builds/6945 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/1795 "Passed tests") | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/4/builds/11156 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/24/builds/8058 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/926 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/7350 "Built successfully") | | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/3/builds/1939 "Passed tests") | 
<!--EWS-Status-Bubble-End-->