### PR TITLE
imported/w3c/web-platform-tests/background-fetch/abort.https.window.html is flaky.

### DIFF
--- a/Source/WebCore/bindings/js/JSDOMPromiseDeferred.h
+++ b/Source/WebCore/bindings/js/JSDOMPromiseDeferred.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2013-2021 Apple Inc. All rights reserved.
+ * Copyright (C) 2013-2023 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -37,6 +37,14 @@ namespace WebCore {
 class JSLocalDOMWindow;
 enum class RejectAsHandled : bool { No, Yes };
 
+#define DEFERRED_PROMISE_HANDLE_AND_RETURN_IF_EXCEPTION(scope, globalObject) do { \
+        if (UNLIKELY(scope.exception())) { \
+            handleUncaughtException(scope, *jsCast<JSDOMGlobalObject*>(globalObject)); \
+            return; \
+        } \
+    } while (false)
+
+
 class DeferredPromise : public DOMGuarded<JSC::JSPromise> {
 public:
     enum class Mode {
@@ -66,8 +74,13 @@ public:
         ASSERT(deferred());
         ASSERT(globalObject());
         JSC::JSGlobalObject* lexicalGlobalObject = globalObject();
-        JSC::JSLockHolder locker(lexicalGlobalObject);
-        resolve(*lexicalGlobalObject, toJS<IDLType>(*lexicalGlobalObject, *globalObject(), std::forward<typename IDLType::ParameterType>(value)));
+        auto& vm = lexicalGlobalObject->vm();
+        JSC::JSLockHolder locker(vm);
+        auto scope = DECLARE_CATCH_SCOPE(vm);
+        auto jsValue = toJS<IDLType>(*lexicalGlobalObject, *globalObject(), std::forward<typename IDLType::ParameterType>(value));
+        DEFERRED_PROMISE_HANDLE_AND_RETURN_IF_EXCEPTION(scope, lexicalGlobalObject);
+        resolve(*lexicalGlobalObject, jsValue);
+        DEFERRED_PROMISE_HANDLE_AND_RETURN_IF_EXCEPTION(scope, lexicalGlobalObject);
     }
 
     void resolveWithJSValue(JSC::JSValue resolution)
@@ -103,8 +116,12 @@ public:
         ASSERT(deferred());
         ASSERT(globalObject());
         JSC::JSGlobalObject* lexicalGlobalObject = globalObject();
-        JSC::JSLockHolder locker(lexicalGlobalObject);
-        resolve(*lexicalGlobalObject, toJSNewlyCreated<IDLType>(*lexicalGlobalObject, *globalObject(), std::forward<typename IDLType::ParameterType>(value)));
+        auto& vm = lexicalGlobalObject->vm();
+        JSC::JSLockHolder locker(vm);
+        auto scope = DECLARE_CATCH_SCOPE(vm);
+        auto jsValue = toJSNewlyCreated<IDLType>(*lexicalGlobalObject, *globalObject(), std::forward<typename IDLType::ParameterType>(value));
+        DEFERRED_PROMISE_HANDLE_AND_RETURN_IF_EXCEPTION(scope, lexicalGlobalObject);
+        resolve(*lexicalGlobalObject, jsValue);
     }
 
     template<class IDLType>
@@ -116,8 +133,12 @@ public:
         ASSERT(deferred());
         ASSERT(globalObject());
         auto* lexicalGlobalObject = globalObject();
-        JSC::JSLockHolder locker(lexicalGlobalObject);
-        resolve(*lexicalGlobalObject, toJSNewlyCreated<IDLType>(*lexicalGlobalObject, *globalObject(), createValue(*globalObject()->scriptExecutionContext())));
+        auto& vm = lexicalGlobalObject->vm();
+        JSC::JSLockHolder locker(vm);
+        auto scope = DECLARE_CATCH_SCOPE(vm);
+        auto jsValue = toJSNewlyCreated<IDLType>(*lexicalGlobalObject, *globalObject(), createValue(*globalObject()->scriptExecutionContext()));
+        DEFERRED_PROMISE_HANDLE_AND_RETURN_IF_EXCEPTION(scope, lexicalGlobalObject);
+        resolve(*lexicalGlobalObject, jsValue);
     }
 
     template<class IDLType>
@@ -129,8 +150,12 @@ public:
         ASSERT(deferred());
         ASSERT(globalObject());
         JSC::JSGlobalObject* lexicalGlobalObject = globalObject();
-        JSC::JSLockHolder locker(lexicalGlobalObject);
-        reject(*lexicalGlobalObject, toJS<IDLType>(*lexicalGlobalObject, *globalObject(), std::forward<typename IDLType::ParameterType>(value)), rejectAsHandled);
+        auto& vm = lexicalGlobalObject->vm();
+        JSC::JSLockHolder locker(vm);
+        auto scope = DECLARE_CATCH_SCOPE(vm);
+        auto jsValue = toJS<IDLType>(*lexicalGlobalObject, *globalObject(), std::forward<typename IDLType::ParameterType>(value));
+        DEFERRED_PROMISE_HANDLE_AND_RETURN_IF_EXCEPTION(scope, lexicalGlobalObject);
+        reject(*lexicalGlobalObject, jsValue, rejectAsHandled);
     }
 
     void reject(RejectAsHandled = RejectAsHandled::No);
@@ -148,12 +173,12 @@ public:
         ASSERT(deferred());
         ASSERT(globalObject());
         auto* lexicalGlobalObject = globalObject();
-        JSC::VM& vm = lexicalGlobalObject->vm();
+        auto& vm = lexicalGlobalObject->vm();
         JSC::JSLockHolder locker(vm);
         auto scope = DECLARE_CATCH_SCOPE(vm);
-        resolve(*lexicalGlobalObject, callback(*globalObject()));
-        if (UNLIKELY(scope.exception()))
-            handleUncaughtException(scope, *lexicalGlobalObject);
+        auto jsValue = callback(*globalObject());
+        DEFERRED_PROMISE_HANDLE_AND_RETURN_IF_EXCEPTION(scope, lexicalGlobalObject);
+        resolve(*lexicalGlobalObject, jsValue);
     }
 
     template<typename Callback>
@@ -168,14 +193,15 @@ public:
         JSC::VM& vm = lexicalGlobalObject->vm();
         JSC::JSLockHolder locker(vm);
         auto scope = DECLARE_CATCH_SCOPE(vm);
-        reject(*lexicalGlobalObject, callback(*globalObject()), rejectAsHandled);
-        if (UNLIKELY(scope.exception()))
-            handleUncaughtException(scope, *lexicalGlobalObject);
+        auto jsValue = callback(*globalObject());
+        DEFERRED_PROMISE_HANDLE_AND_RETURN_IF_EXCEPTION(scope, lexicalGlobalObject);
+        reject(*lexicalGlobalObject, jsValue, rejectAsHandled);
     }
 
     JSC::JSValue promise() const;
 
     void whenSettled(Function<void()>&&);
+    bool needsAbort() const { return m_needsAbort; }
 
 private:
     DeferredPromise(JSDOMGlobalObject& globalObject, JSC::JSPromise& deferred, Mode mode)
@@ -198,9 +224,10 @@ private:
     }
 
     bool handleTerminationExceptionIfNeeded(JSC::CatchScope&, JSDOMGlobalObject& lexicalGlobalObject);
-    void handleUncaughtException(JSC::CatchScope&, JSDOMGlobalObject& lexicalGlobalObject);
+    WEBCORE_EXPORT void handleUncaughtException(JSC::CatchScope&, JSDOMGlobalObject& lexicalGlobalObject);
 
     Mode m_mode;
+    bool m_needsAbort { false };
 };
 
 class DOMPromiseDeferredBase {

--- a/Source/WebCore/bindings/js/JSMicrotaskCallback.h
+++ b/Source/WebCore/bindings/js/JSMicrotaskCallback.h
@@ -1,6 +1,6 @@
 /*
  * Copyright (C) 2018 Yusuke Suzuki <utatane.tea@gmail.com>.
- * Copyright (C) 2021 Apple Inc. All rights reserved.
+ * Copyright (C) 2021-2023 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -43,9 +43,7 @@ public:
         auto protectedThis { Ref { *this } };
         JSC::VM& vm = m_globalObject->vm();
         JSC::JSLockHolder lock(vm);
-        auto scope = DECLARE_CATCH_SCOPE(vm);
         JSExecState::runTask(m_globalObject.get(), m_task);
-        scope.assertNoExceptionExceptTermination();
     }
 
 private:

--- a/Source/WebCore/dom/BroadcastChannel.cpp
+++ b/Source/WebCore/dom/BroadcastChannel.cpp
@@ -248,7 +248,15 @@ void BroadcastChannel::dispatchMessage(Ref<SerializedScriptValue>&& message)
         if (!globalObject)
             return;
 
+        auto& vm = globalObject->vm();
+        auto scope = DECLARE_CATCH_SCOPE(vm);
         auto event = MessageEvent::create(*globalObject, WTFMove(message), scriptExecutionContext()->securityOrigin()->toString());
+        if (UNLIKELY(scope.exception())) {
+            // Currently, we assume that the only way we can get here is if we have a termination.
+            RELEASE_ASSERT(vm.hasPendingTerminationException());
+            return;
+        }
+
         dispatchEvent(event.event);
     });
 }

--- a/Source/WebCore/dom/Microtasks.cpp
+++ b/Source/WebCore/dom/Microtasks.cpp
@@ -1,6 +1,7 @@
 /*
  * Copyright (C) 2014 Yoav Weiss (yoav@yoav.ws)
  * Copyright (C) 2015 Akamai Technologies Inc. All rights reserved.
+ * Copyright (C) 2023 Apple Inc. All rights reserved.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Library General Public
@@ -52,10 +53,12 @@ void MicrotaskQueue::performMicrotaskCheckpoint()
         return;
 
     SetForScope change(m_performingMicrotaskCheckpoint, true);
-    JSC::JSLockHolder locker(vm());
+    VM& vm = this->vm();
+    JSC::JSLockHolder locker(vm);
+    auto catchScope = DECLARE_CATCH_SCOPE(vm);
 
     Vector<std::unique_ptr<EventLoopTask>> toKeep;
-    while (!m_microtaskQueue.isEmpty()) {
+    while (!m_microtaskQueue.isEmpty() && !vm.executionForbidden()) {
         Vector<std::unique_ptr<EventLoopTask>> queue = WTFMove(m_microtaskQueue);
         for (auto& task : queue) {
             auto* group = task->group();
@@ -63,32 +66,45 @@ void MicrotaskQueue::performMicrotaskCheckpoint()
                 continue;
             if (group->isSuspended())
                 toKeep.append(WTFMove(task));
-            else
+            else {
                 task->execute();
+                if (UNLIKELY(!catchScope.clearExceptionExceptTermination()))
+                    break; // Encountered termination.
+            }
         }
     }
 
-    vm().finalizeSynchronousJSExecution();
+    vm.finalizeSynchronousJSExecution();
     m_microtaskQueue = WTFMove(toKeep);
 
-    auto checkpointTasks = std::exchange(m_checkpointTasks, { });
-    for (auto& checkpointTask : checkpointTasks) {
-        auto* group = checkpointTask->group();
-        if (!group || group->isStoppedPermanently())
-            continue;
+    if (!vm.executionForbidden()) {
+        auto checkpointTasks = std::exchange(m_checkpointTasks, { });
+        for (auto& checkpointTask : checkpointTasks) {
+            auto* group = checkpointTask->group();
+            if (!group || group->isStoppedPermanently())
+                continue;
 
-        if (group->isSuspended()) {
-            m_checkpointTasks.append(WTFMove(checkpointTask));
-            continue;
+            if (group->isSuspended()) {
+                m_checkpointTasks.append(WTFMove(checkpointTask));
+                continue;
+            }
+
+            checkpointTask->execute();
+            if (UNLIKELY(!catchScope.clearExceptionExceptTermination()))
+                break; // Encountered termination.
         }
-
-        checkpointTask->execute();
     }
 
     // https://html.spec.whatwg.org/multipage/webappapis.html#perform-a-microtask-checkpoint (step 4).
-    m_eventLoop->forEachAssociatedContext([](auto& context) {
+    auto* vmPtr = &vm;
+    m_eventLoop->forEachAssociatedContext([vmPtr](auto& context) {
+        auto& vm = *vmPtr;
+        if (UNLIKELY(vm.executionForbidden()))
+            return;
+        auto catchScope = DECLARE_CATCH_SCOPE(vm);
         if (auto* tracker = context.rejectedPromiseTracker())
             tracker->processQueueSoon();
+        catchScope.clearExceptionExceptTermination();
     });
 
     // FIXME: We should cleanup Indexed Database transactions as per:

--- a/Source/WebCore/workers/WorkerRunLoop.cpp
+++ b/Source/WebCore/workers/WorkerRunLoop.cpp
@@ -1,6 +1,6 @@
 /*
  * Copyright (C) 2009 Google Inc. All rights reserved.
- * Copyright (C) 2016-2021 Apple Inc.  All rights reserved.
+ * Copyright (C) 2016-2023 Apple Inc.  All rights reserved.
  * 
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are
@@ -32,6 +32,8 @@
 #include "config.h"
 #include "WorkerRunLoop.h"
 
+#include "JSDOMExceptionHandling.h"
+#include "JSDOMGlobalObject.h"
 #include "ScriptExecutionContext.h"
 #include "SharedTimer.h"
 #include "ThreadGlobalData.h"
@@ -40,6 +42,7 @@
 #include "WorkerOrWorkletGlobalScope.h"
 #include "WorkerOrWorkletScriptController.h"
 #include "WorkerThread.h"
+#include <JavaScriptCore/CatchScope.h>
 #include <JavaScriptCore/JSRunLoopTimer.h>
 
 #if USE(GLIB)
@@ -274,8 +277,21 @@ void WorkerRunLoop::postDebuggerTask(ScriptExecutionContext::Task&& task)
 
 void WorkerDedicatedRunLoop::Task::performTask(WorkerOrWorkletGlobalScope* context)
 {
-    if ((!context->isClosing() && context->script() && !context->script()->isTerminatingExecution()) || m_task.isCleanupTask())
+    if (m_task.isCleanupTask())
         m_task.performTask(*context);
+    else if (!context->isClosing() && context->script() && !context->script()->isTerminatingExecution()) {
+        JSC::VM& vm = context->script()->vm();
+        auto scope = DECLARE_CATCH_SCOPE(vm);
+        m_task.performTask(*context);
+        if (UNLIKELY(context->script() && scope.exception())) {
+            if (vm.hasPendingTerminationException()) {
+                context->script()->forbidExecution();
+                return;
+            }
+            Locker<JSC::JSLock> locker(vm.apiLock());
+            reportException(context->script()->globalScopeWrapper(), scope.exception());
+        }
+    }
 }
 
 WorkerDedicatedRunLoop::Task::Task(ScriptExecutionContext::Task&& task, const String& mode)


### PR DESCRIPTION
#### 37cf833410faba85dfccf6bea74aa20292875fff
<pre>
imported/w3c/web-platform-tests/background-fetch/abort.https.window.html is flaky.
<a href="https://bugs.webkit.org/show_bug.cgi?id=253314">https://bugs.webkit.org/show_bug.cgi?id=253314</a>
&lt;rdar://problem/106195333&gt;

Reviewed by Chris Dumez.

The test was flakily crashing in debug bots when trying to resolve the promise of BackgroundFetchRegistration::matchAll.
The issue is that the toJS call can fail due to an exception.  When this happens, it returns an empty value that is
used to resolve the promise.

To prevent this, we add a check in DeferredPromise::callFunction to handle uncaught exceptions.  Also fix all exception
check validation failures under imported/w3c/web-platform-tests/background-fetch.

* Source/WebCore/bindings/js/JSDOMPromiseDeferred.cpp:
(WebCore::DeferredPromise::callFunction):
(WebCore::DeferredPromise::whenSettled):
(WebCore::DeferredPromise::reject):
(WebCore::rejectPromiseWithExceptionIfAny):
(WebCore::DeferredPromise::handleTerminationExceptionIfNeeded):
* Source/WebCore/bindings/js/JSDOMPromiseDeferred.h:
(WebCore::DeferredPromise::resolve):
(WebCore::DeferredPromise::resolveWithNewlyCreated):
(WebCore::DeferredPromise::resolveCallbackValueWithNewlyCreated):
(WebCore::DeferredPromise::reject):
(WebCore::DeferredPromise::resolveWithCallback):
(WebCore::DeferredPromise::rejectWithCallback):
(WebCore::DeferredPromise::needsAbort const):
* Source/WebCore/bindings/js/JSMicrotaskCallback.h:
(WebCore::JSMicrotaskCallback::call):
* Source/WebCore/dom/BroadcastChannel.cpp:
(WebCore::BroadcastChannel::dispatchMessage):
* Source/WebCore/dom/MessagePort.cpp:
(WebCore::MessagePort::dispatchMessages):
* Source/WebCore/dom/Microtasks.cpp:
(WebCore::MicrotaskQueue::performMicrotaskCheckpoint):
* Source/WebCore/page/LocalDOMWindow.cpp:
(WebCore::LocalDOMWindow::processPostMessage):
* Source/WebCore/workers/WorkerMessagingProxy.cpp:
(WebCore::WorkerMessagingProxy::postMessageToWorkerObject):
(WebCore::WorkerMessagingProxy::postMessageToWorkerGlobalScope):
* Source/WebCore/workers/WorkerRunLoop.cpp:
(WebCore::WorkerDedicatedRunLoop::Task::performTask):
* Source/WebCore/workers/service/ServiceWorkerContainer.cpp:
(WebCore::ServiceWorkerContainer::jobResolvedWithRegistration):
(WebCore::ServiceWorkerContainer::postMessage):

Canonical link: <a href="https://commits.webkit.org/264489@main">https://commits.webkit.org/264489@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/02948edecf6f280b99ede2b3217ad75e72244c08

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/7746 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/8018 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/8198 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/9388 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/7901 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/7752 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/10008 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/7939 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/10771 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/7881 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/8997 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/7113 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/9497 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/6305 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/7051 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/14719 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/7456 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/7177 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/10585 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/7670 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/6250 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/6997 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/1861 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/11209 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/7401 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->