### PR TITLE
[image-set] Pick first choice when identical resolutions are found

### DIFF
--- a/LayoutTests/TestExpectations
+++ b/LayoutTests/TestExpectations
@@ -3397,8 +3397,6 @@ imported/w3c/web-platform-tests/html/semantics/embedded-content/the-iframe-eleme
 
 imported/w3c/web-platform-tests/css/css-images/multiple-position-color-stop-conic.html [ ImageOnlyFailure ]
 
-imported/w3c/web-platform-tests/css/css-images/image-set/image-set-type-first-match-rendering.html [ ImageOnlyFailure ]
-
 webkit.org/b/187773 http/tests/webAPIStatistics [ Skip ]
 
 # This is fallout from turning Web Animations on.

--- a/LayoutTests/platform/ios/TestExpectations
+++ b/LayoutTests/platform/ios/TestExpectations
@@ -3600,7 +3600,6 @@ webkit.org/b/237694 [ Debug ] webgl/1.0.3/conformance/uniforms/uniform-samplers-
 
 # image-set failing only on iOS
 webkit.org/b/253095 imported/w3c/web-platform-tests/css/css-images/image-set/image-set-type-rendering-2.html [ ImageOnlyFailure ]
-webkit.org/b/253095 imported/w3c/web-platform-tests/css/css-images/image-set/image-set-type-first-match-rendering.html [ ImageOnlyFailure ]
 
 [ Release ] editing/spelling/toggle-spellchecking.html [ Failure Pass ]
 pointerevents/mouse/pointer-event-basic-properties.html [ Timeout ]

--- a/Source/WebCore/rendering/style/StyleImageSet.cpp
+++ b/Source/WebCore/rendering/style/StyleImageSet.cpp
@@ -90,14 +90,16 @@ ImageWithScale StyleImageSet::bestImageForScaleFactor()
         const auto& image = m_images[index];
         if (!image.mimeType.isNull() && !MIMETypeRegistry::isSupportedImageMIMEType(image.mimeType))
             continue;
-
+        if (!result.image->isInvalidImage() && result.scaleFactor == image.scaleFactor)
+            continue;
         if (image.scaleFactor >= m_deviceScaleFactor)
             return image;
+
         result = image;
     }
 
     ASSERT(result.scaleFactor >= 0);
-    if (!result.image || !result.scaleFactor)
+    if (result.image->isInvalidImage() || !result.scaleFactor)
         result = ImageWithScale { StyleInvalidImage::create(), 1, String() };
 
     return result;


### PR DESCRIPTION
#### 56e5d7cb43e7069afcda466873b4fd9ac13ce646
<pre>
[image-set] Pick first choice when identical resolutions are found
<a href="https://bugs.webkit.org/show_bug.cgi?id=257100">https://bugs.webkit.org/show_bug.cgi?id=257100</a>
rdar://109619779

Reviewed by Tim Nguyen.

Step 2 of the image-set selection algorithm [0] specifies that we should
drop any &lt;image-set-option&gt; whose resolution we have already seen. This
can be acheived by comparing the resolution against the `result` that we
have selected in the loop. This works because the Vector is sorted by
resolution and we bail out of the loop the first time we find an image
whose resolution is greater or equal to device resolution.

While here, also fix up a bug where we were checking if the
ImageWithScale object had a non-null pointer to an image rather than
checking if the pointer was to a StyleInvalidImage object. The
ImageWithScale defaults to having a StyleInvalidImage rather than a null
pointer.

[0] <a href="https://drafts.csswg.org/css-images-4/#image-set-notation">https://drafts.csswg.org/css-images-4/#image-set-notation</a>

* LayoutTests/TestExpectations:
* LayoutTests/platform/ios/TestExpectations:
* Source/WebCore/rendering/style/StyleImageSet.cpp:
(WebCore::StyleImageSet::bestImageForScaleFactor):

Canonical link: <a href="https://commits.webkit.org/264481@main">https://commits.webkit.org/264481@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/6aad1ffdc85374d6adce64a51499f7c89c16a6cd

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/7749 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/8021 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/8201 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/9391 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/7904 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/7755 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/10011 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/7942 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/10774 "58 failures") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/7884 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/8999 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/7117 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/9501 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/6307 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/7056 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/14723 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/7458 "Passed tests") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/7201 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/10590 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/7673 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/6253 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/7000 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/1855 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/11212 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/7404 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->