### PR TITLE
[TextureMapper] Missing implementation of backingStoreMemoryEstimate

### DIFF
--- a/Source/WebCore/page/linux/ResourceUsageThreadLinux.cpp
+++ b/Source/WebCore/page/linux/ResourceUsageThreadLinux.cpp
@@ -45,6 +45,10 @@
 #include <wtf/linux/CurrentProcessMemoryStatus.h>
 #include <wtf/text/StringToIntegerConversion.h>
 
+#if USE(NICOSIA)
+#include "NicosiaBuffer.h"
+#endif
+
 namespace WebCore {
 
 static float cpuPeriod()
@@ -104,6 +108,9 @@ void ResourceUsageThread::platformSaveStateBeforeStarting()
         if (auto* thread = profiler->thread())
             m_samplingProfilerThreadID = thread->id();
     }
+#endif
+#if USE(NICOSIA)
+    Nicosia::Buffer::resetMemoryUsage();
 #endif
 }
 
@@ -319,6 +326,10 @@ void ResourceUsageThread::platformCollectMemoryData(JSC::VM* vm, ResourceUsageDa
         imagesDecodedSize = MemoryCache::singleton().getStatistics().images.decodedSize;
     });
     data.categories[MemoryCategory::Images].dirtySize = imagesDecodedSize;
+
+#if USE(NICOSIA)
+    data.categories[MemoryCategory::Layers].dirtySize = Nicosia::Buffer::getMemoryUsage();
+#endif
 
     size_t categoriesTotalSize = 0;
     for (auto& category : data.categories)

--- a/Source/WebCore/platform/graphics/nicosia/NicosiaBuffer.cpp
+++ b/Source/WebCore/platform/graphics/nicosia/NicosiaBuffer.cpp
@@ -33,6 +33,25 @@
 
 namespace Nicosia {
 
+Lock Buffer::s_layersMemoryUsageLock;
+double Buffer::s_currentLayersMemoryUsage = 0.0;
+double Buffer::s_maxLayersMemoryUsage = 0.0;
+
+void Buffer::resetMemoryUsage()
+{
+    Locker locker { s_layersMemoryUsageLock };
+    s_maxLayersMemoryUsage = s_currentLayersMemoryUsage;
+}
+
+double Buffer::getMemoryUsage()
+{
+    // The memory usage is max of memory usage since last resetMemoryUsage or getMemoryUsage.
+    Locker locker { s_layersMemoryUsageLock };
+    const auto memoryUsage = s_maxLayersMemoryUsage;
+    s_maxLayersMemoryUsage = s_currentLayersMemoryUsage;
+    return memoryUsage;
+}
+
 Ref<Buffer> Buffer::create(const WebCore::IntSize& size, Flags flags)
 {
     return adoptRef(*new Buffer(size, flags));
@@ -42,11 +61,24 @@ Buffer::Buffer(const WebCore::IntSize& size, Flags flags)
     : m_size(size)
     , m_flags(flags)
 {
-    auto checkedArea = size.area() * 4;
+    const auto checkedArea = size.area() * 4;
     m_data = MallocPtr<unsigned char>::tryZeroedMalloc(checkedArea);
+
+    {
+        Locker locker { s_layersMemoryUsageLock };
+        s_currentLayersMemoryUsage += checkedArea;
+        s_maxLayersMemoryUsage = std::max(s_maxLayersMemoryUsage, s_currentLayersMemoryUsage);
+    }
 }
 
-Buffer::~Buffer() = default;
+Buffer::~Buffer()
+{
+    const auto checkedArea = m_size.area().value() * 4;
+    {
+        Locker locker { s_layersMemoryUsageLock };
+        s_currentLayersMemoryUsage -= checkedArea;
+    }
+}
 
 void Buffer::beginPainting()
 {

--- a/Source/WebCore/platform/graphics/nicosia/NicosiaBuffer.h
+++ b/Source/WebCore/platform/graphics/nicosia/NicosiaBuffer.h
@@ -57,6 +57,9 @@ public:
     void completePainting();
     void waitUntilPaintingComplete();
 
+    static void resetMemoryUsage();
+    static double getMemoryUsage();
+
 private:
     Buffer(const WebCore::IntSize&, Flags);
 
@@ -74,6 +77,10 @@ private:
         Condition condition;
         PaintingState state { PaintingState::Complete };
     } m_painting;
+
+    static Lock s_layersMemoryUsageLock;
+    static double s_currentLayersMemoryUsage;
+    static double s_maxLayersMemoryUsage;
 };
 
 } // namespace Nicosia

--- a/Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedGraphicsLayer.cpp
+++ b/Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedGraphicsLayer.cpp
@@ -1524,6 +1524,11 @@ void CoordinatedGraphicsLayer::dumpAdditionalProperties(TextStream& textStream, 
         dumpInnerLayer(textStream, "backdrop layer"_s, m_backdropLayer.get(), options);
 }
 
+double CoordinatedGraphicsLayer::backingStoreMemoryEstimate() const
+{
+    return 0.0;
+}
+
 } // namespace WebCore
 
 SPECIALIZE_TYPE_TRAITS_ANIMATEDBACKINGSTORECLIENT(WebCore::CoordinatedAnimatedBackingStoreClient, type() == Nicosia::AnimatedBackingStoreClient::Type::Coordinated)

--- a/Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedGraphicsLayer.h
+++ b/Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedGraphicsLayer.h
@@ -167,6 +167,8 @@ public:
 
     void requestBackingStoreUpdate();
 
+    double backingStoreMemoryEstimate() const override;
+
 private:
     enum class FlushNotification {
         Required,


### PR DESCRIPTION
#### 3ed63da0ea8dcf64cb82bd1a61e79c38a2aeaae0
<pre>
[TextureMapper] Missing implementation of backingStoreMemoryEstimate
<a href="https://bugs.webkit.org/show_bug.cgi?id=254910">https://bugs.webkit.org/show_bug.cgi?id=254910</a>

Reviewed by Miguel Gomez.

The backingStores used by the CoordinatedGraphicsLayers are created during a layerFlush,
and they are freed in the next compositor cycle, after their content is uploaded into
a texture. Due to this, the life span of the Nicosia::Buffers is very short. As the
ResourceUsageThread samples the used memory every 500ms, it would be quite common that
the memory usage reported by the timeline would be zero. In order to avoid this,
the maximum memory usage is stored until the ResourceUsageThread is able to read it.
Thanks to this, the timeline is able to show the peak in the memory usage that reflects
the reality. It&apos;s not perfect though, as the peak will be shown in the timeline some ms
after it really happened, but it&apos;s the best approach we can do.

* Source/WebCore/page/linux/ResourceUsageThreadLinux.cpp:
(WebCore::ResourceUsageThread::platformSaveStateBeforeStarting):
(WebCore::ResourceUsageThread::platformCollectMemoryData):
* Source/WebCore/platform/graphics/nicosia/NicosiaBuffer.cpp:
(Nicosia::Buffer::resetMemoryUsage):
(Nicosia::Buffer::getMemoryUsage):
(Nicosia::Buffer::Buffer):
(Nicosia::Buffer::~Buffer):
* Source/WebCore/platform/graphics/nicosia/NicosiaBuffer.h:
* Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedGraphicsLayer.cpp:
(WebCore::CoordinatedGraphicsLayer::backingStoreMemoryEstimate const):
* Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedGraphicsLayer.h:

Canonical link: <a href="https://commits.webkit.org/266424@main">https://commits.webkit.org/266424@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/674c03576275cf3ec33ea23c90091d878e0716f6

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/13829 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/14143 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/14477 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/15565 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/13138 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/13910 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/16651 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/14225 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/15812 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/13996 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/14616 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/11718 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/16269 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/11903 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/12478 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/19516 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/12979 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/12642 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/15857 "1 api test failed or timed out") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/13172 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/11052 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/12443 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/3358 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/16775 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/13015 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->