### PR TITLE
[CSS] Resolve "currentcolor" with style if possible

### DIFF
--- a/LayoutTests/fast/css/color-mix-various-expected.html
+++ b/LayoutTests/fast/css/color-mix-various-expected.html
@@ -1,0 +1,14 @@
+<style>
+body {
+  color: green;
+}
+span {
+  box-shadow: 5px 5px green;
+  text-shadow: 5px 5px green;
+  background: linear-gradient(green, green);
+  filter: drop-shadow(30px 10px 4px green);
+}
+</style>
+
+<span> PASS if no crash and only green</span>
+

--- a/LayoutTests/fast/css/color-mix-various.html
+++ b/LayoutTests/fast/css/color-mix-various.html
@@ -1,0 +1,14 @@
+<style>
+body {
+  color: green;
+}
+span {
+  box-shadow: 5px 5px color-mix(in srgb, green, currentColor);
+  text-shadow: 5px 5px color-mix(in srgb, green, currentColor);
+  background: linear-gradient(green, color-mix(in srgb, green, currentcolor));
+  filter: drop-shadow(30px 10px 4px color-mix(in srgb, green, currentcolor));
+}
+</style>
+
+<span> PASS if no crash and only green</span>
+

--- a/Source/WebCore/style/ColorFromPrimitiveValue.cpp
+++ b/Source/WebCore/style/ColorFromPrimitiveValue.cpp
@@ -65,14 +65,14 @@ StyleColor colorFromPrimitiveValue(const Document& document, RenderStyle& style,
 Color colorFromPrimitiveValueWithResolvedCurrentColor(const Document& document, RenderStyle& style, const CSSPrimitiveValue& value)
 {
     // FIXME: 'currentcolor' should be resolved at use time to make it inherit correctly. https://bugs.webkit.org/show_bug.cgi?id=210005
-    if (StyleColor::isCurrentColor(value)) {
+    if (StyleColor::containsCurrentColor(value)) {
         // Color is an inherited property so depending on it effectively makes the property inherited.
         style.setHasExplicitlyInheritedProperties();
         style.setDisallowsFastPathInheritance();
-        return style.color();
     }
 
-    return colorFromPrimitiveValue(document, style, value, ForVisitedLink::No).absoluteColor();
+    auto color = colorFromPrimitiveValue(document, style, value, ForVisitedLink::No);
+    return style.colorResolvingCurrentColor(color);
 }
 
 } // namespace Style

--- a/Source/WebCore/style/ElementRuleCollector.cpp
+++ b/Source/WebCore/style/ElementRuleCollector.cpp
@@ -684,7 +684,7 @@ void ElementRuleCollector::addMatchedProperties(MatchedProperties&& matchedPrope
 
             // The value currentColor has implicitely the same side effect. It depends on the value of color,
             // which is an inherited value, making the non-inherited property implicitly inherited.
-            if (is<CSSPrimitiveValue>(value) && StyleColor::isCurrentColor(downcast<CSSPrimitiveValue>(value)))
+            if (is<CSSPrimitiveValue>(value) && StyleColor::containsCurrentColor(downcast<CSSPrimitiveValue>(value)))
                 return false;
 
             if (value.hasVariableReferences())


### PR DESCRIPTION
#### 80e4d733b9172fb72755d59424e5195944f1d416
<pre>
[CSS] Resolve &quot;currentcolor&quot; with style if possible
<a href="https://bugs.webkit.org/show_bug.cgi?id=257255">https://bugs.webkit.org/show_bug.cgi?id=257255</a>
rdar://108683501

Reviewed by Tim Nguyen.

Ideally, we should never try to resolve &quot;currentcolor&quot; during
style building.
However, for the rare cases where we do it (gradient, drop-shadow)
it&apos;s better to use the incomplete style than assuming an absolute color.

* LayoutTests/fast/css/color-mix-various-expected.html: Added.
* LayoutTests/fast/css/color-mix-various.html: Added.
* Source/WebCore/style/ColorFromPrimitiveValue.cpp:
(WebCore::Style::colorFromPrimitiveValueWithResolvedCurrentColor):
* Source/WebCore/style/ElementRuleCollector.cpp:
(WebCore::Style::ElementRuleCollector::addMatchedProperties):

Canonical link: <a href="https://commits.webkit.org/264737@main">https://commits.webkit.org/264737@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/705a3e46ba44ac8745d2675021903b867743f1dd

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/8475 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/8768 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/8987 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/10142 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/8521 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/8483 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/10758 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/8715 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/11389 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/8621 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/9663 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/7641 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/10297 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/6961 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/7753 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/15305 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/8082 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/7900 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/11256 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/8374 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/6839 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/7660 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/7664 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/2056 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/11871 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/8119 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->