### PR TITLE
[WGSL] Implement built-in function textureLoad

### DIFF
--- a/Source/WebGPU/WGSL/Constraints.h
+++ b/Source/WebGPU/WGSL/Constraints.h
@@ -57,6 +57,8 @@ constexpr Constraint SignedInteger = I32 | AbstractInt;
 constexpr Constraint Scalar = Bool | Integer | Float;
 constexpr Constraint ConcreteScalar = Bool | ConcreteInteger | ConcreteFloat;
 
+constexpr Constraint Concrete32BitNumber = ConcreteInteger | F32;
+
 constexpr Constraint SignedNumber = Float | SignedInteger;
 constexpr Constraint Number = Float | Integer;
 

--- a/Source/WebGPU/WGSL/Overload.cpp
+++ b/Source/WebGPU/WGSL/Overload.cpp
@@ -167,6 +167,11 @@ Type* OverloadResolver::materialize(const AbstractType& abstractType) const
                 return m_types.matrixType(element, columns, rows);
             }
             return nullptr;
+        },
+        [&](const AbstractTexture& texture) -> Type* {
+            if (auto* element = materialize(texture.element))
+                return m_types.textureType(element, texture.kind);
+            return nullptr;
         });
 }
 
@@ -283,6 +288,11 @@ ConversionRank OverloadResolver::calculateRank(const AbstractType& parameter, Ty
         return calculateRank(matrixParameter->element, matrixArgument.element);
     }
 
+    if (auto* textureParameter = std::get_if<AbstractTexture>(&parameter)) {
+        auto& textureArgument = std::get<Types::Texture>(*argumentType);
+        return calculateRank(textureParameter->element, textureArgument.element);
+    }
+
     auto* parameterType = std::get<Type*>(parameter);
     return conversionRank(argumentType, parameterType);
 }
@@ -366,6 +376,15 @@ bool OverloadResolver::unify(const AbstractType& parameter, Type* argumentType)
         if (!unify(matrixParameter->columns, matrixArgument->columns))
             return false;
         return unify(matrixParameter->rows, matrixArgument->rows);
+    }
+
+    if (auto* textureParameter = std::get_if<AbstractTexture>(&parameter)) {
+        auto* textureArgument = std::get_if<Types::Texture>(argumentType);
+        if (!textureArgument)
+            return false;
+        if (textureParameter->kind != textureArgument->kind)
+            return false;
+        return unify(textureParameter->element, textureArgument->element);
     }
 
     auto* parameterType = std::get<Type*>(parameter);
@@ -492,6 +511,12 @@ void printInternal(PrintStream& out, const WGSL::AbstractType& type)
             out.print(", ");
             printInternal(out, matrix.rows);
             out.print(">");
+        },
+        [&](const WGSL::AbstractTexture& texture) {
+            printInternal(out, texture.kind);
+            out.print("<");
+            printInternal(out, texture.element);
+            out.print(">");
         });
 }
 
@@ -536,5 +561,45 @@ void printInternal(PrintStream& out, const WGSL::OverloadCandidate& candidate)
     out.print(") -> ");
     printInternal(out, candidate.result);
 }
+
+void printInternal(PrintStream& out, WGSL::Types::Texture::Kind textureKind)
+{
+    switch (textureKind) {
+    case WGSL::Types::Texture::Kind::Texture1d:
+        out.print("texture_1d");
+        return;
+    case WGSL::Types::Texture::Kind::Texture2d:
+        out.print("texture_2d");
+        return;
+    case WGSL::Types::Texture::Kind::Texture2dArray:
+        out.print("texture_2d_array");
+        return;
+    case WGSL::Types::Texture::Kind::Texture3d:
+        out.print("texture_3d");
+        return;
+    case WGSL::Types::Texture::Kind::TextureCube:
+        out.print("texture_cube");
+        return;
+    case WGSL::Types::Texture::Kind::TextureCubeArray:
+        out.print("texture_cube_array");
+        return;
+    case WGSL::Types::Texture::Kind::TextureMultisampled2d:
+        out.print("texture_multisampled_2d");
+        return;
+    case WGSL::Types::Texture::Kind::TextureStorage1d:
+        out.print("texture_storage_1d");
+        return;
+    case WGSL::Types::Texture::Kind::TextureStorage2d:
+        out.print("texture_storage_2d");
+        return;
+    case WGSL::Types::Texture::Kind::TextureStorage2dArray:
+        out.print("texture_storage_2d_array");
+        return;
+    case WGSL::Types::Texture::Kind::TextureStorage3d:
+        out.print("texture_storage_3d");
+        return;
+    }
+}
+
 
 } // namespace WTF

--- a/Source/WebGPU/WGSL/Overload.h
+++ b/Source/WebGPU/WGSL/Overload.h
@@ -43,9 +43,11 @@ struct TypeVariable {
 
 struct AbstractVector;
 struct AbstractMatrix;
+struct AbstractTexture;
 using AbstractType = std::variant<
     AbstractVector,
     AbstractMatrix,
+    AbstractTexture,
     TypeVariable,
     Type*
 >;
@@ -64,6 +66,11 @@ struct AbstractMatrix {
     AbstractScalarType element;
     AbstractValue columns;
     AbstractValue rows;
+};
+
+struct AbstractTexture {
+    AbstractScalarType element;
+    Types::Texture::Kind kind;
 };
 
 struct OverloadCandidate {
@@ -89,4 +96,5 @@ void printInternal(PrintStream&, const WGSL::TypeVariable&);
 void printInternal(PrintStream&, const WGSL::AbstractType&);
 void printInternal(PrintStream&, const WGSL::AbstractScalarType&);
 void printInternal(PrintStream&, const WGSL::OverloadCandidate&);
+void printInternal(PrintStream&, WGSL::Types::Texture::Kind);
 } // namespace WTF

--- a/Source/WebGPU/WGSL/TypeDeclarations.rb
+++ b/Source/WebGPU/WGSL/TypeDeclarations.rb
@@ -485,3 +485,19 @@ operator :trunc, {
     [T < Float].(T) => T,
     [T < Float, N].(Vector[T, N]) => Vector[T, N],
 }
+
+# 17.7. Texture Built-in Functions (https://gpuweb.github.io/gpuweb/wgsl/#texture-builtin-functions)
+
+# 17.7.4
+operator :textureLoad, {
+    [T < ConcreteInteger, U < ConcreteInteger, S < Concrete32BitNumber].(Texture[S, Texture1d], T, U) => Vector[S, 4],
+    [T < ConcreteInteger, U < ConcreteInteger, S < Concrete32BitNumber].(Texture[S, Texture2d], Vector[T, 2], U) => Vector[S, 4],
+    [T < ConcreteInteger, V < ConcreteInteger, U < ConcreteInteger, S < Concrete32BitNumber].(Texture[S, Texture2dArray], Vector[T, 2], V, U) => Vector[S, 4],
+    [T < ConcreteInteger, U < ConcreteInteger, S < Concrete32BitNumber].(Texture[S, Texture3d], Vector[T, 3], U) => Vector[S, 4],
+    [T < ConcreteInteger, U < ConcreteInteger, S < Concrete32BitNumber].(Texture[S, TextureMultisampled2d], Vector[T, 2], U) => Vector[S, 4],
+
+    [T < ConcreteInteger].(TextureExternal, Vector[T, 2]) => Vector[F32, 4],
+
+    # FIXME: add overloads for texture_depth
+    # https://bugs.webkit.org/show_bug.cgi?id=254515
+}

--- a/Source/WebGPU/WGSL/generator/main.rb
+++ b/Source/WebGPU/WGSL/generator/main.rb
@@ -98,7 +98,7 @@ class AbstractType
         #    later be promoted to a concrete type once an overload is chosen.
         # 2) A concrete type if it's given a concrete type. Since there are no
         #    variables involved, we can immediately construct a concrete type.
-        if arguments.any? do |arg| arg.is_a? Variable end
+        if arguments.any? do |arg| arg.is_a?(Variable) && !arg.kind.nil? end
             ParameterizedAbstractType.new(self, arguments)
         else
             Constructor.new(@name.downcase)[*arguments]
@@ -263,11 +263,11 @@ module DSL
         Vector = AbstractType.new(:Vector)
         Matrix = AbstractType.new(:Matrix)
         Array = AbstractType.new(:Array)
-
-        Texture = Constructor.new(:texture)
+        Texture = AbstractType.new(:Texture)
 
         Texture1d = Variable.new(:"Types::Texture::Kind::Texture1d", nil)
         Texture2d = Variable.new(:"Types::Texture::Kind::Texture2d", nil)
+        TextureMultisampled2d = Variable.new(:"Types::Texture::Kind::TextureMultisampled2d", nil)
         Texture2dArray = Variable.new(:"Types::Texture::Kind::Texture2dArray", nil)
         Texture3d = Variable.new(:"Types::Texture::Kind::Texture3d", nil)
         TextureCube = Variable.new(:"Types::Texture::Kind::TextureCube", nil)
@@ -285,6 +285,8 @@ module DSL
 
         S = Variable.new(:S, @TypeVariable)
         T = Variable.new(:T, @TypeVariable)
+        U = Variable.new(:U, @TypeVariable)
+        V = Variable.new(:V, @TypeVariable)
         N = Variable.new(:N, @NumericVariable)
         C = Variable.new(:C, @NumericVariable)
         R = Variable.new(:R, @NumericVariable)
@@ -297,6 +299,7 @@ module DSL
         ConcreteInteger = Constraint.new(:ConcreteInteger)
         ConcreteFloat = Constraint.new(:ConcreteFloat)
         ConcreteScalar = Constraint.new(:ConcreteScalar)
+        Concrete32BitNumber = Constraint.new(:Concrete32BitNumber)
         SignedNumber = Constraint.new(:SignedNumber)
         EOS
     end

--- a/Source/WebGPU/WGSL/tests/valid/overload.wgsl
+++ b/Source/WebGPU/WGSL/tests/valid/overload.wgsl
@@ -146,6 +146,127 @@ fn testTextureSample() {
   }
 }
 
+fn testTextureLoad()
+{
+    // [T < ConcreteInteger, U < ConcreteInteger, S < Concrete32BitNumber].(Texture[S, Texture1d], T, U) => Vector[S, 4],
+    {
+        {
+            let t: texture_1d<f32>;
+            _ = textureLoad(t, 0, 0);
+            _ = textureLoad(t, 0i, 0u);
+            _ = textureLoad(t, 0u, 0i);
+        }
+        {
+            let t: texture_1d<i32>;
+            _ = textureLoad(t, 0, 0);
+            _ = textureLoad(t, 0i, 0u);
+            _ = textureLoad(t, 0u, 0i);
+        }
+        {
+            let t: texture_1d<u32>;
+            _ = textureLoad(t, 0, 0);
+            _ = textureLoad(t, 0i, 0u);
+            _ = textureLoad(t, 0u, 0i);
+        }
+    }
+
+    // [T < ConcreteInteger, U < ConcreteInteger, S < Concrete32BitNumber].(Texture[S, Texture2d], Vector[T, 2], U) => Vector[S, 4],
+    {
+        {
+            let t: texture_2d<f32>;
+            _ = textureLoad(t, vec2(0), 0);
+            _ = textureLoad(t, vec2(0i), 0u);
+            _ = textureLoad(t, vec2(0u), 0i);
+        }
+        {
+            let t: texture_2d<i32>;
+            _ = textureLoad(t, vec2(0), 0);
+            _ = textureLoad(t, vec2(0i), 0u);
+            _ = textureLoad(t, vec2(0u), 0i);
+        }
+        {
+            let t: texture_2d<u32>;
+            _ = textureLoad(t, vec2(0), 0);
+            _ = textureLoad(t, vec2(0i), 0u);
+            _ = textureLoad(t, vec2(0u), 0i);
+        }
+    }
+
+    // [T < ConcreteInteger, V < ConcreteInteger, U < ConcreteInteger, S < Concrete32BitNumber].(Texture[S, Texture2dArray], Vector[T, 2], V, U) => Vector[S, 4],
+    {
+        {
+            let t: texture_2d_array<f32>;
+            _ = textureLoad(t, vec2(0), 0, 0);
+            _ = textureLoad(t, vec2(0i), 0u, 0i);
+            _ = textureLoad(t, vec2(0u), 0i, 0u);
+        }
+        {
+            let t: texture_2d_array<i32>;
+            _ = textureLoad(t, vec2(0), 0, 0);
+            _ = textureLoad(t, vec2(0i), 0u, 0i);
+            _ = textureLoad(t, vec2(0u), 0i, 0u);
+        }
+        {
+            let t: texture_2d_array<u32>;
+            _ = textureLoad(t, vec2(0), 0, 0);
+            _ = textureLoad(t, vec2(0i), 0u, 0i);
+            _ = textureLoad(t, vec2(0u), 0i, 0u);
+        }
+    }
+
+    // [T < ConcreteInteger, U < ConcreteInteger, S < Concrete32BitNumber].(Texture[S, Texture3d], Vector[T, 3], U) => Vector[S, 4],
+    {
+        {
+            let t: texture_3d<f32>;
+            _ = textureLoad(t, vec3(0), 0);
+            _ = textureLoad(t, vec3(0i), 0u);
+            _ = textureLoad(t, vec3(0u), 0i);
+        }
+        {
+            let t: texture_3d<i32>;
+            _ = textureLoad(t, vec3(0), 0);
+            _ = textureLoad(t, vec3(0i), 0u);
+            _ = textureLoad(t, vec3(0u), 0i);
+        }
+        {
+            let t: texture_3d<u32>;
+            _ = textureLoad(t, vec3(0), 0);
+            _ = textureLoad(t, vec3(0i), 0u);
+            _ = textureLoad(t, vec3(0u), 0i);
+        }
+    }
+
+    // [T < ConcreteInteger, U < ConcreteInteger, S < Concrete32BitNumber].(Texture[S, TextureMultisampled2d], Vector[T, 2], U) => Vector[S, 4],
+    {
+        {
+            let t: texture_multisampled_2d<f32>;
+            _ = textureLoad(t, vec2(0), 0);
+            _ = textureLoad(t, vec2(0i), 0u);
+            _ = textureLoad(t, vec2(0u), 0i);
+        }
+        {
+            let t: texture_multisampled_2d<i32>;
+            _ = textureLoad(t, vec2(0), 0);
+            _ = textureLoad(t, vec2(0i), 0u);
+            _ = textureLoad(t, vec2(0u), 0i);
+        }
+        {
+            let t: texture_multisampled_2d<u32>;
+            _ = textureLoad(t, vec2(0), 0);
+            _ = textureLoad(t, vec2(0i), 0u);
+            _ = textureLoad(t, vec2(0u), 0i);
+        }
+    }
+
+    // [T < ConcreteInteger].(TextureExternal, Vector[T, 2]) => Vector[F32, 4],
+    {
+        let t: texture_external;
+        _ = textureLoad(t, vec2(0));
+        _ = textureLoad(t, vec2(0i));
+        _ = textureLoad(t, vec2(0u));
+    }
+}
+
 fn testVec2() {
   _ = vec2<f32>(0);
   _ = vec2<f32>(0, 0);


### PR DESCRIPTION
#### 2a950b6675bd0730103083de36590141ee0c5540
<pre>
[WGSL] Implement built-in function textureLoad
<a href="https://bugs.webkit.org/show_bug.cgi?id=257256">https://bugs.webkit.org/show_bug.cgi?id=257256</a>
rdar://109769588

Reviewed by Mike Wyrzykowski.

Implement textureLoad according to the spec[1].

[1]: <a href="https://gpuweb.github.io/gpuweb/wgsl/#textureload">https://gpuweb.github.io/gpuweb/wgsl/#textureload</a>

* Source/WebGPU/WGSL/Constraints.h:
* Source/WebGPU/WGSL/Metal/MetalFunctionWriter.cpp:
(WGSL::Metal::FunctionDefinitionWriter::visit):
* Source/WebGPU/WGSL/Overload.cpp:
(WGSL::OverloadResolver::materialize const):
(WGSL::OverloadResolver::calculateRank):
(WGSL::OverloadResolver::unify):
(WTF::printInternal):
* Source/WebGPU/WGSL/Overload.h:
* Source/WebGPU/WGSL/TypeDeclarations.rb:
* Source/WebGPU/WGSL/generator/main.rb:
* Source/WebGPU/WGSL/tests/valid/overload.wgsl:

Canonical link: <a href="https://commits.webkit.org/264564@main">https://commits.webkit.org/264564@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/df06ede078a90ce44e30c548cd4c1395654994cb

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/7906 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/8184 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/8437 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/9555 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/8029 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/10177 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/8101 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/10896 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/8046 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/9145 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/7275 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/9673 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/6449 "Passed tests") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/14833 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/7572 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/7399 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/10726 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/7825 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/6361 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/7143 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/1908 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/11352 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/7560 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->