### PR TITLE
Remove no-argument simplifyWhiteSpace()

### DIFF
--- a/Source/WTF/wtf/text/StringImpl.cpp
+++ b/Source/WTF/wtf/text/StringImpl.cpp
@@ -781,13 +781,6 @@ template<typename CharacterType, class UCharPredicate> inline Ref<StringImpl> St
     return adopt(WTFMove(data));
 }
 
-Ref<StringImpl> StringImpl::simplifyWhiteSpace()
-{
-    if (is8Bit())
-        return StringImpl::simplifyMatchedCharactersToSpace<LChar>(deprecatedIsSpaceOrNewline);
-    return StringImpl::simplifyMatchedCharactersToSpace<UChar>(deprecatedIsSpaceOrNewline);
-}
-
 Ref<StringImpl> StringImpl::simplifyWhiteSpace(CodeUnitMatchFunction isWhiteSpace)
 {
     if (is8Bit())

--- a/Source/WTF/wtf/text/StringImpl.h
+++ b/Source/WTF/wtf/text/StringImpl.h
@@ -437,8 +437,7 @@ public:
 
     Ref<StringImpl> foldCase();
 
-    WTF_EXPORT_PRIVATE Ref<StringImpl> simplifyWhiteSpace();
-    Ref<StringImpl> simplifyWhiteSpace(CodeUnitMatchFunction);
+    WTF_EXPORT_PRIVATE Ref<StringImpl> simplifyWhiteSpace(CodeUnitMatchFunction);
 
     WTF_EXPORT_PRIVATE Ref<StringImpl> stripLeadingAndTrailingCharacters(CodeUnitMatchFunction);
     template<typename Predicate> Ref<StringImpl> removeCharacters(const Predicate&);

--- a/Source/WTF/wtf/text/WTFString.cpp
+++ b/Source/WTF/wtf/text/WTFString.cpp
@@ -159,16 +159,6 @@ String String::stripLeadingAndTrailingCharacters(CodeUnitMatchFunction predicate
     return m_impl ? m_impl->stripLeadingAndTrailingCharacters(predicate) : String { };
 }
 
-String String::simplifyWhiteSpace() const
-{
-    // FIXME: Should this function, and the many others like it, be inlined?
-    // FIXME: This function needs a new name. For one thing, "whitespace" is a single
-    // word so the "s" should be lowercase. For another, it's not clear from this name
-    // that the function uses the Unicode definition of whitespace. Most WebKit callers
-    // don't want that and eventually we should consider deleting this.
-    return m_impl ? m_impl->simplifyWhiteSpace() : String { };
-}
-
 String String::simplifyWhiteSpace(CodeUnitMatchFunction isWhiteSpace) const
 {
     // FIXME: Should this function, and the many others like it, be inlined?

--- a/Source/WTF/wtf/text/WTFString.h
+++ b/Source/WTF/wtf/text/WTFString.h
@@ -198,7 +198,6 @@ public:
     WTF_EXPORT_PRIVATE String WARN_UNUSED_RETURN convertToLowercaseWithLocale(const AtomString& localeIdentifier) const;
     WTF_EXPORT_PRIVATE String WARN_UNUSED_RETURN convertToUppercaseWithLocale(const AtomString& localeIdentifier) const;
 
-    WTF_EXPORT_PRIVATE String WARN_UNUSED_RETURN simplifyWhiteSpace() const;
     WTF_EXPORT_PRIVATE String WARN_UNUSED_RETURN simplifyWhiteSpace(CodeUnitMatchFunction) const;
 
     WTF_EXPORT_PRIVATE String WARN_UNUSED_RETURN stripLeadingAndTrailingCharacters(CodeUnitMatchFunction) const;

--- a/Source/WebCore/accessibility/AccessibilityNodeObject.cpp
+++ b/Source/WebCore/accessibility/AccessibilityNodeObject.cpp
@@ -2444,7 +2444,7 @@ static String accessibleNameForNode(Node* node, Node* labelledbyNode)
         if (axObject->accessibleNameDerivesFromContent())
             text = axObject->textUnderElement(AccessibilityTextUnderElementMode(AccessibilityTextUnderElementMode::TextUnderElementModeIncludeNameFromContentsChildren, true, labelledbyNode));
     } else
-        text = (element ? element->innerText() : node->textContent()).simplifyWhiteSpace();
+        text = (element ? element->innerText() : node->textContent()).simplifyWhiteSpace(deprecatedIsSpaceOrNewline);
 
     if (!text.isEmpty())
         return text;

--- a/Source/WebCore/html/HTMLMediaElement.cpp
+++ b/Source/WebCore/html/HTMLMediaElement.cpp
@@ -8334,11 +8334,11 @@ String HTMLMediaElement::mediaSessionTitle() const
     if (!document().page() || document().page()->usesEphemeralSession())
         return emptyString();
 
-    auto title = String(attributeWithoutSynchronization(titleAttr)).stripLeadingAndTrailingCharacters(deprecatedIsSpaceOrNewline).simplifyWhiteSpace();
+    auto title = String(attributeWithoutSynchronization(titleAttr)).stripLeadingAndTrailingCharacters(deprecatedIsSpaceOrNewline).simplifyWhiteSpace(deprecatedIsSpaceOrNewline);
     if (!title.isEmpty())
         return title;
 
-    title = document().title().stripLeadingAndTrailingCharacters(deprecatedIsSpaceOrNewline).simplifyWhiteSpace();
+    title = document().title().stripLeadingAndTrailingCharacters(deprecatedIsSpaceOrNewline).simplifyWhiteSpace(deprecatedIsSpaceOrNewline);
     if (!title.isEmpty())
         return title;
 

--- a/Source/WebCore/html/HTMLOptGroupElement.cpp
+++ b/Source/WebCore/html/HTMLOptGroupElement.cpp
@@ -125,7 +125,7 @@ String HTMLOptGroupElement::groupLabelText() const
     // In WinIE, leading and trailing whitespace is ignored in options and optgroups. We match this behavior.
     itemText = itemText.stripLeadingAndTrailingCharacters(deprecatedIsSpaceOrNewline);
     // We want to collapse our whitespace too.  This will match other browsers.
-    itemText = itemText.simplifyWhiteSpace();
+    itemText = itemText.simplifyWhiteSpace(deprecatedIsSpaceOrNewline);
         
     return itemText;
 }

--- a/Source/WebCore/page/DragController.cpp
+++ b/Source/WebCore/page/DragController.cpp
@@ -971,7 +971,7 @@ void DragController::prepareForDragStart(LocalFrame& source, OptionSet<DragSourc
 
     auto linkURL = hitTestResult->absoluteLinkURL();
     if (actionMask.contains(DragSourceAction::Link) && !linkURL.isEmpty() && source.document()->securityOrigin().canDisplay(linkURL, OriginAccessPatternsForWebProcess::singleton()))
-        editor.copyURL(linkURL, hitTestResult->textContent().simplifyWhiteSpace(), pasteboard);
+        editor.copyURL(linkURL, hitTestResult->textContent().simplifyWhiteSpace(deprecatedIsSpaceOrNewline), pasteboard);
 #else
     // FIXME: Make this work on Windows by implementing Editor::writeSelectionToPasteboard and Editor::writeImageToPasteboard.
     UNUSED_PARAM(source);
@@ -1169,7 +1169,7 @@ bool DragController::startDrag(LocalFrame& src, const DragState& state, OptionSe
     if (!linkURL.isEmpty() && m_dragSourceAction.contains(DragSourceAction::Link)) {
         PasteboardWriterData pasteboardWriterData;
 
-        String textContentWithSimplifiedWhiteSpace = hitTestResult->textContent().simplifyWhiteSpace();
+        String textContentWithSimplifiedWhiteSpace = hitTestResult->textContent().simplifyWhiteSpace(deprecatedIsSpaceOrNewline);
 
         if (hasData == HasNonDefaultPasteboardData::No) {
             // Simplify whitespace so the title put on the dataTransfer resembles what the user sees

--- a/Source/WebCore/platform/Length.cpp
+++ b/Source/WebCore/platform/Length.cpp
@@ -90,7 +90,7 @@ static unsigned countCharacter(StringImpl& string, UChar character)
 
 UniqueArray<Length> newLengthArray(const String& string, int& len)
 {
-    RefPtr<StringImpl> str = string.impl()->simplifyWhiteSpace();
+    RefPtr<StringImpl> str = string.impl()->simplifyWhiteSpace(deprecatedIsSpaceOrNewline);
     if (!str->length()) {
         len = 1;
         return nullptr;

--- a/Source/WebCore/svg/SVGDescElement.cpp
+++ b/Source/WebCore/svg/SVGDescElement.cpp
@@ -41,7 +41,7 @@ Ref<SVGDescElement> SVGDescElement::create(const QualifiedName& tagName, Documen
 
 String SVGDescElement::description() const
 {
-    return textContent().simplifyWhiteSpace();
+    return textContent().simplifyWhiteSpace(deprecatedIsSpaceOrNewline);
 }
 
 }

--- a/Source/WebCore/xml/XPathValue.cpp
+++ b/Source/WebCore/xml/XPathValue.cpp
@@ -87,7 +87,7 @@ double Value::toNumber() const
         case NumberValue:
             return m_number;
         case StringValue: {
-            const String& str = m_data->string.simplifyWhiteSpace();
+            const String& str = m_data->string.simplifyWhiteSpace(deprecatedIsSpaceOrNewline);
 
             // String::toDouble() supports exponential notation, which is not allowed in XPath.
             unsigned len = str.length();


### PR DESCRIPTION
#### cb0b8f5fb7c37ef6ef0883ad83ec2d79b6947616
<pre>
Remove no-argument simplifyWhiteSpace()
<a href="https://bugs.webkit.org/show_bug.cgi?id=257084">https://bugs.webkit.org/show_bug.cgi?id=257084</a>
rdar://109770814

Reviewed by Darin Adler.

Make callers responsible for the type of whitespace they want replaced
with a space as the current default is deprecated.

* Source/WTF/wtf/text/StringImpl.cpp:
* Source/WTF/wtf/text/StringImpl.h:
* Source/WTF/wtf/text/WTFString.cpp:
(WTF::String::stripLeadingAndTrailingCharacters const):
* Source/WTF/wtf/text/WTFString.h:
* Source/WebCore/accessibility/AccessibilityNodeObject.cpp:
(WebCore::accessibleNameForNode):
* Source/WebCore/html/HTMLMediaElement.cpp:
(WebCore::HTMLMediaElement::mediaSessionTitle const):
* Source/WebCore/html/HTMLOptGroupElement.cpp:
(WebCore::HTMLOptGroupElement::groupLabelText const):
* Source/WebCore/page/DragController.cpp:
(WebCore::DragController::prepareForDragStart const):
(WebCore::DragController::startDrag):
* Source/WebCore/platform/Length.cpp:
(WebCore::newLengthArray):
* Source/WebCore/svg/SVGDescElement.cpp:
(WebCore::SVGDescElement::description const):
* Source/WebCore/xml/XPathValue.cpp:
(WebCore::XPath::Value::toNumber const):

Canonical link: <a href="https://commits.webkit.org/264480@main">https://commits.webkit.org/264480@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/7c05706d347d40b2129ccf36edbdd78584895927

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/7760 "Passed style check") | [  ~~🛠 ios~~](https://ews-build.webkit.org/#/builders/26/builds/8032 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/14/builds/8212 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/9402 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/32/builds/7915 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [  ~~🧪 bindings~~](https://ews-build.webkit.org/#/builders/9/builds/7766 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/23/builds/10022 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/7953 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/9402 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | 
| [  ~~🧪 webkitperl~~](https://ews-build.webkit.org/#/builders/11/builds/7895 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/23/builds/10022 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/14/builds/8212 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/2/builds/9512 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/23/builds/10022 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/14/builds/8212 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/2/builds/9512 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | 
| [  ~~🛠 🧪 jsc~~](https://ews-build.webkit.org/#/builders/20/builds/6620 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/23/builds/10022 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/14/builds/8212 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/2/builds/9512 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/7343 "Built successfully and passed tests") | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/7/builds/7684 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/6263 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/7916 "Built successfully") | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/30/builds/7011 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/14/builds/8212 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 jsc-armv7-tests~~](https://ews-build.webkit.org/#/builders/25/builds/1811 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/4/builds/11223 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | | [  ~~🛠 jsc-mips~~](https://ews-build.webkit.org/#/builders/24/builds/8128 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | 
| [  ~~🛠 🧪 unsafe-merge~~](https://ews-build.webkit.org/#/builders/22/builds/930 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/7415 "Built successfully") | | [  ~~🧪 jsc-mips-tests~~](https://ews-build.webkit.org/#/builders/24/builds/8128 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | 
<!--EWS-Status-Bubble-End-->