### PR TITLE
GraphicsContextGL::computeFormatAndTypeParameters has redundant output parameters

### DIFF
--- a/Source/WebCore/platform/graphics/GraphicsContextGL.cpp
+++ b/Source/WebCore/platform/graphics/GraphicsContextGL.cpp
@@ -364,8 +364,9 @@ std::tuple<GCGLenum, GCGLenum> GraphicsContextGL::externalImageTextureBindingPoi
     return std::make_tuple(GraphicsContextGL::TEXTURE_2D, GraphicsContextGL::TEXTURE_BINDING_2D);
 }
 
-bool GraphicsContextGL::computeFormatAndTypeParameters(GCGLenum format, GCGLenum type, unsigned* componentsPerPixel, unsigned* bytesPerComponent)
+unsigned GraphicsContextGL::computeBytesPerGroup(GCGLenum format, GCGLenum type)
 {
+    unsigned componentsPerGroup = 0;
     switch (format) {
     case GraphicsContextGL::ALPHA:
     case GraphicsContextGL::LUMINANCE:
@@ -373,74 +374,55 @@ bool GraphicsContextGL::computeFormatAndTypeParameters(GCGLenum format, GCGLenum
     case GraphicsContextGL::RED_INTEGER:
     case GraphicsContextGL::DEPTH_COMPONENT:
     case GraphicsContextGL::DEPTH_STENCIL: // Treat it as one component.
-        *componentsPerPixel = 1;
+        componentsPerGroup = 1;
         break;
     case GraphicsContextGL::LUMINANCE_ALPHA:
     case GraphicsContextGL::RG:
     case GraphicsContextGL::RG_INTEGER:
-        *componentsPerPixel = 2;
+        componentsPerGroup = 2;
         break;
     case GraphicsContextGL::RGB:
     case GraphicsContextGL::RGB_INTEGER:
     case GraphicsContextGL::SRGB_EXT:
-        *componentsPerPixel = 3;
+        componentsPerGroup = 3;
         break;
     case GraphicsContextGL::RGBA:
     case GraphicsContextGL::RGBA_INTEGER:
     case GraphicsContextGL::BGRA_EXT: // GL_EXT_texture_format_BGRA8888
     case GraphicsContextGL::SRGB_ALPHA_EXT:
-        *componentsPerPixel = 4;
+        componentsPerGroup = 4;
         break;
     default:
-        return false;
+        return 0;
     }
 
     switch (type) {
-    case GraphicsContextGL::BYTE:
-        *bytesPerComponent = sizeof(GCGLbyte);
-        break;
-    case GraphicsContextGL::UNSIGNED_BYTE:
-        *bytesPerComponent = sizeof(GCGLubyte);
-        break;
-    case GraphicsContextGL::SHORT:
-        *bytesPerComponent = sizeof(GCGLshort);
-        break;
-    case GraphicsContextGL::UNSIGNED_SHORT:
-        *bytesPerComponent = sizeof(GCGLushort);
-        break;
     case GraphicsContextGL::UNSIGNED_SHORT_5_6_5:
     case GraphicsContextGL::UNSIGNED_SHORT_4_4_4_4:
     case GraphicsContextGL::UNSIGNED_SHORT_5_5_5_1:
-        *componentsPerPixel = 1;
-        *bytesPerComponent = sizeof(GCGLushort);
-        break;
-    case GraphicsContextGL::INT:
-        *bytesPerComponent = sizeof(GCGLint);
-        break;
-    case GraphicsContextGL::UNSIGNED_INT:
-        *bytesPerComponent = sizeof(GCGLuint);
-        break;
+        return 2;
     case GraphicsContextGL::UNSIGNED_INT_24_8:
     case GraphicsContextGL::UNSIGNED_INT_10F_11F_11F_REV:
     case GraphicsContextGL::UNSIGNED_INT_5_9_9_9_REV:
     case GraphicsContextGL::UNSIGNED_INT_2_10_10_10_REV:
-        *componentsPerPixel = 1;
-        *bytesPerComponent = sizeof(GCGLuint);
-        break;
-    case GraphicsContextGL::FLOAT: // OES_texture_float
-        *bytesPerComponent = sizeof(GCGLfloat);
-        break;
+        return 4;
+    case GraphicsContextGL::BYTE:
+    case GraphicsContextGL::UNSIGNED_BYTE:
+        return componentsPerGroup;
+    case GraphicsContextGL::SHORT:
+    case GraphicsContextGL::UNSIGNED_SHORT:
     case GraphicsContextGL::HALF_FLOAT:
     case GraphicsContextGL::HALF_FLOAT_OES: // OES_texture_half_float
-        *bytesPerComponent = sizeof(GCGLhalffloat);
-        break;
+        return componentsPerGroup * 2;
+    case GraphicsContextGL::INT:
+    case GraphicsContextGL::UNSIGNED_INT:
+    case GraphicsContextGL::FLOAT: // OES_texture_float
+        return componentsPerGroup * 4;
     case GraphicsContextGL::FLOAT_32_UNSIGNED_INT_24_8_REV:
-        *bytesPerComponent = sizeof(GCGLfloat) + sizeof(GCGLuint);
-        break;
+        return componentsPerGroup * 8;
     default:
-        return false;
+        return 0;
     }
-    return true;
 }
 
 GCGLenum GraphicsContextGL::computeImageSizeInBytes(GCGLenum format, GCGLenum type, GCGLsizei width, GCGLsizei height, GCGLsizei depth, const PixelStoreParams& params, unsigned* imageSizeInBytes, unsigned* paddingInBytes, unsigned* skipSizeInBytes)
@@ -466,10 +448,9 @@ GCGLenum GraphicsContextGL::computeImageSizeInBytes(GCGLenum format, GCGLenum ty
     int rowLength = params.rowLength > 0 ? params.rowLength : width;
     int imageHeight = params.imageHeight > 0 ? params.imageHeight : height;
 
-    unsigned bytesPerComponent, componentsPerPixel;
-    if (!computeFormatAndTypeParameters(format, type, &componentsPerPixel, &bytesPerComponent))
+    unsigned bytesPerGroup = computeBytesPerGroup(format, type);
+    if (!bytesPerGroup)
         return GraphicsContextGL::INVALID_ENUM;
-    unsigned bytesPerGroup = bytesPerComponent * componentsPerPixel;
     CheckedUint32 checkedValue = static_cast<uint32_t>(rowLength);
     checkedValue *= bytesPerGroup;
     if (checkedValue.hasOverflowed())
@@ -589,11 +570,9 @@ bool GraphicsContextGL::extractTextureData(unsigned width, unsigned height, GCGL
     DataFormat sourceDataFormat = getDataFormat(format, type);
     if (sourceDataFormat == GraphicsContextGL::DataFormat::Invalid)
         return false;
-    // Resize the output buffer.
-    unsigned componentsPerPixel, bytesPerComponent;
-    if (!computeFormatAndTypeParameters(format, type, &componentsPerPixel, &bytesPerComponent))
+    unsigned bytesPerPixel = computeBytesPerGroup(format, type);
+    if (!bytesPerPixel)
         return false;
-    unsigned bytesPerPixel = componentsPerPixel * bytesPerComponent;
     data.resize(width * height * bytesPerPixel);
 
     unsigned imageSizeInBytes, skipSizeInBytes;

--- a/Source/WebCore/platform/graphics/GraphicsContextGL.h
+++ b/Source/WebCore/platform/graphics/GraphicsContextGL.h
@@ -1599,10 +1599,9 @@ public:
         GCGLint skipImages { 0 };
     };
 
-    // Computes the components per pixel and bytes per component
-    // for the given format and type combination. Returns false if
-    // either was an invalid enum.
-    static bool computeFormatAndTypeParameters(GCGLenum format, GCGLenum type, unsigned* componentsPerPixel, unsigned* bytesPerComponent);
+    // Computes the bytes per image element for a format and type.
+    // Returns zero if format or type is an invalid enum.
+    static unsigned computeBytesPerGroup(GCGLenum format, GCGLenum type);
 
     // Computes the image size in bytes. If paddingInBytes is not null, padding
     // is also calculated in return. Returns NO_ERROR if succeed, otherwise


### PR DESCRIPTION
#### f68899545f37bf5b76a1c1a5c7db9daa48f65c27
<pre>
GraphicsContextGL::computeFormatAndTypeParameters has redundant output parameters
<a href="https://bugs.webkit.org/show_bug.cgi?id=257259">https://bugs.webkit.org/show_bug.cgi?id=257259</a>
rdar://109772907

Reviewed by Dan Glastonbury.

The callers use the bytes per element value, so return that instead
of bytes per component and components per element.

* Source/WebCore/platform/graphics/GraphicsContextGL.cpp:
(WebCore::GraphicsContextGL::computeBytesPerElement):
(WebCore::GraphicsContextGL::computeImageSizeInBytes):
(WebCore::GraphicsContextGL::extractTextureData):
(WebCore::GraphicsContextGL::computeFormatAndTypeParameters): Deleted.
* Source/WebCore/platform/graphics/GraphicsContextGL.h:

Canonical link: <a href="https://commits.webkit.org/264566@main">https://commits.webkit.org/264566@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a9eaa7db4362b4a23781f82eae7a555e1e232914

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/7881 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/8159 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/8419 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/9530 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/8005 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/7886 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/10152 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/8076 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/10874 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/8021 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/9123 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/7271 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/9648 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/6428 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/7271 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/14817 "3 flakes 113 failures") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/7551 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/7395 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/10709 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/7800 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/6340 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/7118 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/1911 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/11327 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/7535 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->