### PR TITLE
Silence sysctl read of LDM state in sandbox

### DIFF
--- a/Source/WebKit/Resources/SandboxProfiles/ios/com.apple.WebKit.WebContent.sb.in
+++ b/Source/WebKit/Resources/SandboxProfiles/ios/com.apple.WebKit.WebContent.sb.in
@@ -664,7 +664,7 @@
 (with-filter (system-attribute apple-internal)
     (mobile-preferences-read "com.apple.CFNetwork"))
 
-(deny sysctl*)
+(deny sysctl-read (with no-report) (with telemetry))
 (allow sysctl-read
     (sysctl-name
         "hw.activecpu" ;; Needed by JSC engine.
@@ -716,15 +716,14 @@
     (sysctl-name-prefix "hw.perflevel") ;; <rdar://problem/76782530>
 )
 
-(deny sysctl-read (with no-report)
-    (sysctl-name "vm.task_no_footprint_for_debug"))
-
 #if HAVE(SANDBOX_STATE_FLAGS)
 (with-filter (require-not (state-flag "WebContentProcessLaunched"))
     (allow sysctl-read (sysctl-name "vm.malloc_ranges"))) ;; <rdar://problem/105161083>
 #else
 (allow sysctl-read (sysctl-name "vm.malloc_ranges")) ;; <rdar://problem/105161083>
 #endif
+
+(deny sysctl-write (with no-report) (with telemetry))
 
 (allow iokit-get-properties
     (iokit-property "AAPL,DisplayPipe")

--- a/Source/WebKit/WebProcess/com.apple.WebProcess.sb.in
+++ b/Source/WebKit/WebProcess/com.apple.WebProcess.sb.in
@@ -605,7 +605,7 @@
 (allow process-codesigning-status*)
 #endif
 
-(deny sysctl*)
+(deny sysctl-read (with no-report) (with telemetry))
 (allow sysctl-read
     (sysctl-name
         "hw.activecpu" ;; <rdar://problem/56795575>
@@ -663,9 +663,6 @@
     (sysctl-name-prefix "hw.perflevel") ;; <rdar://problem/76783596>
 )
 
-(deny sysctl-read (with no-report)
-    (sysctl-name "vm.task_no_footprint_for_debug"))
-
 #if HAVE(SANDBOX_STATE_FLAGS)
 (with-filter (require-not (state-flag "WebContentProcessLaunched"))
     (allow sysctl-read (sysctl-name "vm.malloc_ranges"))) ;; <rdar://problem/105161083>
@@ -673,6 +670,7 @@
 (allow sysctl-read (sysctl-name "vm.malloc_ranges")) ;; <rdar://problem/105161083>
 #endif
 
+(deny sysctl-write (with no-report) (with telemetry))
 (allow sysctl-write
     (sysctl-name
         "kern.tcsm_enable"))


### PR DESCRIPTION
#### 4a7e72df8752c9c45c36de66a55519936da6482a
<pre>
Silence sysctl read of LDM state in sandbox
<a href="https://bugs.webkit.org/show_bug.cgi?id=257263">https://bugs.webkit.org/show_bug.cgi?id=257263</a>
rdar://109737984

Reviewed by Brent Fulgham.

Silence sysctl read of LDM state in the WebContent process sandbox.

* Source/WebKit/Resources/SandboxProfiles/ios/com.apple.WebKit.WebContent.sb.in:
* Source/WebKit/WebProcess/com.apple.WebProcess.sb.in:

Canonical link: <a href="https://commits.webkit.org/264490@main">https://commits.webkit.org/264490@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/15a4ea023f3fe686a341de87e37b72ba5e39c899

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/7804 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/8079 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/8261 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/9448 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/7946 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/10070 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/7996 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/10809 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/7942 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/9048 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/7151 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/9560 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/6357 "Passed tests") | | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/14758 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/7497 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/7237 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/10631 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/7726 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/6293 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/7048 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/1860 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/11258 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/7459 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->