### PR TITLE
Update libwebm up to M115

### DIFF
--- a/Source/ThirdParty/libwebrtc/Source/third_party/libwebm/CMakeLists.txt
+++ b/Source/ThirdParty/libwebrtc/Source/third_party/libwebm/CMakeLists.txt
@@ -25,7 +25,8 @@ option(ENABLE_IWYU "Enables include-what-you-use support." OFF)
 option(ENABLE_WERROR "Enable warnings as errors." OFF)
 option(ENABLE_WEBM_PARSER "Enables new parser API." OFF)
 
-if(WIN32)
+if(WIN32 OR CYGWIN OR MSYS)
+  # Allow use of rand_r() / fdopen() and other POSIX functions.
   require_cxx_flag_nomsvc("-std=gnu++11")
 else()
   require_cxx_flag_nomsvc("-std=c++11")

--- a/Source/ThirdParty/libwebrtc/Source/third_party/libwebm/common/vp9_header_parser.cc
+++ b/Source/ThirdParty/libwebrtc/Source/third_party/libwebm/common/vp9_header_parser.cc
@@ -169,13 +169,16 @@ void Vp9HeaderParser::ParseColorSpace() {
 void Vp9HeaderParser::ParseFrameResolution() {
   width_ = VpxReadLiteral(16) + 1;
   height_ = VpxReadLiteral(16) + 1;
+  if (ReadBit()) {
+    display_width_ = VpxReadLiteral(16) + 1;
+    display_height_ = VpxReadLiteral(16) + 1;
+  } else {
+    display_width_ = width_;
+    display_height_ = height_;
+  }
 }
 
 void Vp9HeaderParser::ParseFrameParallelMode() {
-  if (ReadBit()) {
-    VpxReadLiteral(16);  // display width
-    VpxReadLiteral(16);  // display height
-  }
   if (!error_resilient_mode_) {
     ReadBit();  // Consume refresh frame context
     frame_parallel_mode_ = ReadBit();

--- a/Source/ThirdParty/libwebrtc/Source/third_party/libwebm/common/vp9_header_parser.h
+++ b/Source/ThirdParty/libwebrtc/Source/third_party/libwebm/common/vp9_header_parser.h
@@ -64,15 +64,18 @@ class Vp9HeaderParser {
   int color_space() const { return color_space_; }
   int width() const { return width_; }
   int height() const { return height_; }
+  int display_width() const { return display_width_; }
+  int display_height() const { return display_height_; }
   int refresh_frame_flags() const { return refresh_frame_flags_; }
   int row_tiles() const { return row_tiles_; }
   int column_tiles() const { return column_tiles_; }
   int frame_parallel_mode() const { return frame_parallel_mode_; }
 
-  // WebKit Additions:
+#if defined(WEBRTC_WEBKIT_BUILD)
   int color_range() const { return color_range_; }
   int subsampling_x() const { return subsampling_x_; }
   int subsampling_y() const { return subsampling_y_; }
+#endif
 
  private:
   // Set the compressed VP9 frame.
@@ -120,6 +123,8 @@ class Vp9HeaderParser {
   int refresh_frame_flags_;
   int width_;
   int height_;
+  int display_width_;
+  int display_height_;
   int row_tiles_;
   int column_tiles_;
   int frame_parallel_mode_;

--- a/Source/ThirdParty/libwebrtc/Source/third_party/libwebm/common/vp9_level_stats.h
+++ b/Source/ThirdParty/libwebrtc/Source/third_party/libwebm/common/vp9_level_stats.h
@@ -40,6 +40,10 @@ enum Vp9Level {
 };
 
 struct Vp9LevelRow {
+  Vp9LevelRow() = default;
+  ~Vp9LevelRow() = default;
+  Vp9LevelRow(Vp9LevelRow&& other) = default;
+  Vp9LevelRow(const Vp9LevelRow& other) = default;
   Vp9LevelRow& operator=(Vp9LevelRow&& other) = delete;
   Vp9LevelRow& operator=(const Vp9LevelRow& other) = delete;
 

--- a/Source/ThirdParty/libwebrtc/Source/third_party/libwebm/mkvmuxer/mkvmuxerutil.cc
+++ b/Source/ThirdParty/libwebrtc/Source/third_party/libwebm/mkvmuxer/mkvmuxerutil.cc
@@ -606,8 +606,8 @@ uint64 WriteVoidElement(IMkvWriter* writer, uint64 size) {
 
 void GetVersion(int32* major, int32* minor, int32* build, int32* revision) {
   *major = 0;
-  *minor = 2;
-  *build = 1;
+  *minor = 3;
+  *build = 0;
   *revision = 0;
 }
 

--- a/Source/ThirdParty/libwebrtc/Source/third_party/libwebm/mkvmuxer_sample.cc
+++ b/Source/ThirdParty/libwebrtc/Source/third_party/libwebm/mkvmuxer_sample.cc
@@ -66,7 +66,7 @@ void Usage() {
   printf("                                   1: Equirectangular\n");
   printf("                                   2: Cube map\n");
   printf("                                   3: Mesh\n");
-  printf("  -projection_file <string>      Override projection private data");
+  printf("  -projection_file <string>      Override projection private data\n");
   printf("                                 with contents of this file\n");
   printf("  -projection_pose_yaw <float>   Projection pose yaw\n");
   printf("  -projection_pose_pitch <float> Projection pose pitch\n");

--- a/Source/ThirdParty/libwebrtc/Source/third_party/libwebm/mkvparser/mkvparser.cc
+++ b/Source/ThirdParty/libwebrtc/Source/third_party/libwebm/mkvparser/mkvparser.cc
@@ -54,9 +54,9 @@ Type* SafeArrayAlloc(unsigned long long num_elements,
 
 void GetVersion(int& major, int& minor, int& build, int& revision) {
   major = 1;
-  minor = 0;
+  minor = 1;
   build = 0;
-  revision = 30;
+  revision = 0;
 }
 
 long long ReadUInt(IMkvReader* pReader, long long pos, long& len) {
@@ -1502,8 +1502,8 @@ long SeekHead::Parse() {
 
   // first count the seek head entries
 
-  int entry_count = 0;
-  int void_element_count = 0;
+  long long entry_count = 0;
+  long long void_element_count = 0;
 
   while (pos < stop) {
     long long id, size;
@@ -1513,10 +1513,15 @@ long SeekHead::Parse() {
     if (status < 0)  // error
       return status;
 
-    if (id == libwebm::kMkvSeek)
+    if (id == libwebm::kMkvSeek) {
       ++entry_count;
-    else if (id == libwebm::kMkvVoid)
+      if (entry_count > INT_MAX)
+        return E_PARSE_FAILED;
+    } else if (id == libwebm::kMkvVoid) {
       ++void_element_count;
+      if (void_element_count > INT_MAX)
+        return E_PARSE_FAILED;
+    }
 
     pos += size;  // consume payload
 
@@ -1582,13 +1587,13 @@ long SeekHead::Parse() {
 
   ptrdiff_t count_ = ptrdiff_t(pEntry - m_entries);
   assert(count_ >= 0);
-  assert(count_ <= entry_count);
+  assert(static_cast<long long>(count_) <= entry_count);
 
   m_entry_count = static_cast<int>(count_);
 
   count_ = ptrdiff_t(pVoidElement - m_void_elements);
   assert(count_ >= 0);
-  assert(count_ <= void_element_count);
+  assert(static_cast<long long>(count_) <= void_element_count);
 
   m_void_element_count = static_cast<int>(count_);
 
@@ -2299,7 +2304,7 @@ bool CuePoint::Load(IMkvReader* pReader) {
   long long pos = pos_;
 
   // First count number of track positions
-
+  unsigned long long track_positions_count = 0;
   while (pos < stop) {
     long len;
 
@@ -2323,11 +2328,16 @@ bool CuePoint::Load(IMkvReader* pReader) {
     if (id == libwebm::kMkvCueTime)
       m_timecode = UnserializeUInt(pReader, pos, size);
 
-    else if (id == libwebm::kMkvCueTrackPositions)
-      ++m_track_positions_count;
+    else if (id == libwebm::kMkvCueTrackPositions) {
+      ++track_positions_count;
+      if (track_positions_count > UINT_MAX)
+        return E_PARSE_FAILED;
+    }
 
     pos += size;  // consume payload
   }
+
+  m_track_positions_count = static_cast<size_t>(track_positions_count);
 
   if (m_timecode < 0 || m_track_positions_count <= 0) {
     return false;
@@ -4194,8 +4204,8 @@ long ContentEncoding::ParseContentEncodingEntry(long long start, long long size,
   const long long stop = start + size;
 
   // Count ContentCompression and ContentEncryption elements.
-  int compression_count = 0;
-  int encryption_count = 0;
+  long long compression_count = 0;
+  long long encryption_count = 0;
 
   while (pos < stop) {
     long long id, size;
@@ -4203,11 +4213,17 @@ long ContentEncoding::ParseContentEncodingEntry(long long start, long long size,
     if (status < 0)  // error
       return status;
 
-    if (id == libwebm::kMkvContentCompression)
+    if (id == libwebm::kMkvContentCompression) {
       ++compression_count;
+      if (compression_count > INT_MAX)
+        return E_PARSE_FAILED;
+    }
 
-    if (id == libwebm::kMkvContentEncryption)
+    if (id == libwebm::kMkvContentEncryption) {
       ++encryption_count;
+      if (encryption_count > INT_MAX)
+        return E_PARSE_FAILED;
+    }
 
     pos += size;  // consume payload
     if (pos > stop)
@@ -4918,7 +4934,7 @@ long Track::ParseContentEncodingsEntry(long long start, long long size) {
   const long long stop = start + size;
 
   // Count ContentEncoding elements.
-  int count = 0;
+  long long count = 0;
   while (pos < stop) {
     long long id, size;
     const long status = ParseElementHeader(pReader, pos, stop, id, size);
@@ -4926,8 +4942,11 @@ long Track::ParseContentEncodingsEntry(long long start, long long size) {
       return status;
 
     // pos now designates start of element
-    if (id == libwebm::kMkvContentEncoding)
+    if (id == libwebm::kMkvContentEncoding) {
       ++count;
+      if (count > INT_MAX)
+        return E_PARSE_FAILED;
+    }
 
     pos += size;  // consume payload
     if (pos > stop)
@@ -5653,7 +5672,7 @@ long Tracks::Parse() {
   const long long stop = m_start + m_size;
   IMkvReader* const pReader = m_pSegment->m_pReader;
 
-  int count = 0;
+  long long count = 0;
   long long pos = m_start;
 
   while (pos < stop) {
@@ -5667,8 +5686,11 @@ long Tracks::Parse() {
     if (size == 0)  // weird
       continue;
 
-    if (id == libwebm::kMkvTrackEntry)
+    if (id == libwebm::kMkvTrackEntry) {
       ++count;
+      if (count > INT_MAX)
+        return E_PARSE_FAILED;
+    }
 
     pos += size;  // consume payload
     if (pos > stop)

--- a/Source/ThirdParty/libwebrtc/Source/third_party/libwebm/webm_info.cc
+++ b/Source/ThirdParty/libwebrtc/Source/third_party/libwebm/webm_info.cc
@@ -761,8 +761,15 @@ void PrintVP9Info(const uint8_t* data, int size, FILE* o, int64_t time_ns,
             version, altref_frame, error_resilient_mode, row_tiles,
             column_tiles, frame_parallel_mode);
 
-    if (key && size > 4) {
-      fprintf(o, " cs:%d", parser->color_space());
+    if (key) {
+      if (size > 4) {
+        fprintf(o, " cs:%d", parser->color_space());
+      }
+      if (parser->display_width() != parser->width() ||
+          parser->display_height() != parser->height()) {
+        fprintf(o, " dw:%d dh:%d", parser->display_width(),
+                parser->display_height());
+      }
     }
 
     if (count > 0) {

--- a/Source/ThirdParty/libwebrtc/Source/third_party/libwebm/webm_parser/include/webm/callback.h
+++ b/Source/ThirdParty/libwebrtc/Source/third_party/libwebm/webm_parser/include/webm/callback.h
@@ -335,7 +335,9 @@ class Callback {
    */
   virtual Status OnSegmentEnd(const ElementMetadata& metadata);
 
+#if defined(WEBRTC_WEBKIT_BUILD)
   virtual Status OnElementEnd(const ElementMetadata& metadata);
+#endif
 
  protected:
   /**

--- a/Source/ThirdParty/libwebrtc/Source/third_party/libwebm/webm_parser/src/callback.cc
+++ b/Source/ThirdParty/libwebrtc/Source/third_party/libwebm/webm_parser/src/callback.cc
@@ -135,9 +135,11 @@ Status Callback::OnSegmentEnd(const ElementMetadata& /* metadata */) {
   return Status(Status::kOkCompleted);
 }
 
+#if defined(WEBRTC_WEBKIT_BUILD)
 Status Callback::OnElementEnd(const ElementMetadata& /* metadata */) {
   return Status(Status::kOkCompleted);
 }
+#endif
 
 Status Callback::Skip(Reader* reader, std::uint64_t* bytes_remaining) {
   assert(reader != nullptr);

--- a/Source/ThirdParty/libwebrtc/Source/third_party/libwebm/webm_parser/src/master_parser.cc
+++ b/Source/ThirdParty/libwebrtc/Source/third_party/libwebm/webm_parser/src/master_parser.cc
@@ -247,8 +247,10 @@ Status MasterParser::Feed(Callback* callback, Reader* reader,
           return Status(Status::kElementOverflow);
         } else if (total_bytes_read_ == byte_cap) {
           state_ = State::kEndReached;
+#if defined(WEBRTC_WEBKIT_BUILD)
           callback = original_callback;
           callback->OnElementEnd(child_metadata_);
+#endif
           continue;
         }
 
@@ -259,7 +261,9 @@ Status MasterParser::Feed(Callback* callback, Reader* reader,
         }
         PrepareForNextChild();
         callback = original_callback;
+#if defined(WEBRTC_WEBKIT_BUILD)
         callback->OnElementEnd(child_metadata_);
+#endif
         continue;
       }
 

--- a/Source/ThirdParty/libwebrtc/Source/third_party/libwebm/webm_parser/src/master_parser.h
+++ b/Source/ThirdParty/libwebrtc/Source/third_party/libwebm/webm_parser/src/master_parser.h
@@ -149,11 +149,6 @@ class MasterParser : public ElementParser {
 
   using StdHashId = std::hash<std::underlying_type<Id>::type>;
 
-#if defined(__clang__)
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wdeprecated-declarations"
-#endif
-
   // Hash functor for hashing Id enums for storage in std::unordered_map.
   struct IdHash : StdHashId {
     // Type aliases for conforming to the std::hash interface.
@@ -165,10 +160,6 @@ class MasterParser : public ElementParser {
       return StdHashId::operator()(static_cast<std::uint32_t>(id));
     }
   };
-
-#if defined(__clang__)
-#pragma clang diagnostic pop
-#endif
 
   // The parser for parsing element Ids.
   IdParser id_parser_;

--- a/Source/ThirdParty/libwebrtc/Source/third_party/libwebm/webm_parser/src/webm_parser.cc
+++ b/Source/ThirdParty/libwebrtc/Source/third_party/libwebm/webm_parser/src/webm_parser.cc
@@ -176,7 +176,9 @@ class WebmParser::DocumentParser {
           PrepareForNextChild();
           callback = original_callback;
           child_metadata_.position = reader->Position();
+#if defined(WEBRTC_WEBKIT_BUILD)
           callback->OnElementEnd(child_metadata_);
+#endif
           continue;
         }
 

--- a/Source/WebCore/platform/graphics/cocoa/SourceBufferParserWebM.cpp
+++ b/Source/WebCore/platform/graphics/cocoa/SourceBufferParserWebM.cpp
@@ -32,6 +32,7 @@
 #include "CMUtilities.h"
 #include "ContentType.h"
 #include "InbandTextTrackPrivate.h"
+#include "LibWebRTCMacros.h"
 #include "Logging.h"
 #include "MediaDescription.h"
 #include "MediaSampleAVFObjC.h"

--- a/Source/WebCore/platform/graphics/cocoa/SourceBufferParserWebM.h
+++ b/Source/WebCore/platform/graphics/cocoa/SourceBufferParserWebM.h
@@ -28,6 +28,7 @@
 #if ENABLE(MEDIA_SOURCE)
 
 #include "ExceptionOr.h"
+#include "LibWebRTCMacros.h"
 #include "MediaSample.h"
 #include "SharedBuffer.h"
 #include "SourceBufferParser.h"


### PR DESCRIPTION
#### aceacb11f422e4fe234a2fa362d988e6abe3db4b
<pre>
Update libwebm up to M115
<a href="https://bugs.webkit.org/show_bug.cgi?id=257265">https://bugs.webkit.org/show_bug.cgi?id=257265</a>
rdar://109779378

Reviewed by Eric Carlson.

Resync libwebm from upstream.
Make sure to put all WebKit specific changes in #if defined(WEBRTC_WEBKIT_BUILD).

* Source/ThirdParty/libwebrtc/Source/third_party/libwebm/CMakeLists.txt:
* Source/ThirdParty/libwebrtc/Source/third_party/libwebm/common/vp9_header_parser.cc:
* Source/ThirdParty/libwebrtc/Source/third_party/libwebm/common/vp9_header_parser.h:
(vp9_parser::Vp9HeaderParser::display_width const):
(vp9_parser::Vp9HeaderParser::display_height const):
* Source/ThirdParty/libwebrtc/Source/third_party/libwebm/common/vp9_level_stats.h:
* Source/ThirdParty/libwebrtc/Source/third_party/libwebm/mkvmuxer/mkvmuxer.cc:
* Source/ThirdParty/libwebrtc/Source/third_party/libwebm/mkvmuxer/mkvmuxerutil.cc:
* Source/ThirdParty/libwebrtc/Source/third_party/libwebm/mkvmuxer_sample.cc:
* Source/ThirdParty/libwebrtc/Source/third_party/libwebm/mkvparser/mkvparser.cc:
* Source/ThirdParty/libwebrtc/Source/third_party/libwebm/webm_info.cc:
* Source/ThirdParty/libwebrtc/Source/third_party/libwebm/webm_parser/include/webm/callback.h:
* Source/ThirdParty/libwebrtc/Source/third_party/libwebm/webm_parser/src/callback.cc:
* Source/ThirdParty/libwebrtc/Source/third_party/libwebm/webm_parser/src/master_parser.cc:
* Source/ThirdParty/libwebrtc/Source/third_party/libwebm/webm_parser/src/master_parser.h:
* Source/ThirdParty/libwebrtc/Source/third_party/libwebm/webm_parser/src/webm_parser.cc:
* Source/WebCore/platform/graphics/cocoa/SourceBufferParserWebM.cpp:
* Source/WebCore/platform/graphics/cocoa/SourceBufferParserWebM.h:

Canonical link: <a href="https://commits.webkit.org/264506@main">https://commits.webkit.org/264506@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2b5356343d4e46caf8b41e6f140bbeb028dccfd6

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/7756 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/8028 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/8208 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/9398 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/7911 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/7762 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/10018 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/7949 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/10778 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/7891 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/9004 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/7122 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/9508 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/6312 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/7061 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/14727 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/7463 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/7187 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/10594 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/7680 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/6258 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/7007 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/1872 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/11219 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/7411 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->