### PR TITLE
Return opaque origin for blob: URL containing inner non-http(s): URL

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/url/a-element-origin-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/url/a-element-origin-expected.txt
@@ -327,13 +327,13 @@ PASS Parsing origin: <blob:http://example.org:88/> against <about:blank>
 PASS Parsing origin: <blob:d3958f5c-0777-0845-9dcf-2cb28783acaf> against <about:blank>
 PASS Parsing origin: <blob:> against <about:blank>
 PASS Parsing origin: <blob:blob:> against <about:blank>
-FAIL Parsing origin: <blob:blob:https://example.org/> against <about:blank> assert_equals: origin expected "null" but got "blob://"
+PASS Parsing origin: <blob:blob:https://example.org/> against <about:blank>
 PASS Parsing origin: <blob:about:blank> against <about:blank>
 FAIL Parsing origin: <blob:file://host/path> against <about:blank> assert_equals: origin expected "null" but got "file://"
-FAIL Parsing origin: <blob:ftp://host/path> against <about:blank> assert_equals: origin expected "null" but got "ftp://host"
-FAIL Parsing origin: <blob:ws://example.org/> against <about:blank> assert_equals: origin expected "null" but got "ws://example.org"
-FAIL Parsing origin: <blob:wss://example.org/> against <about:blank> assert_equals: origin expected "null" but got "wss://example.org"
-FAIL Parsing origin: <blob:http%3a//example.org/> against <about:blank> assert_equals: origin expected "null" but got "http://example.org"
+PASS Parsing origin: <blob:ftp://host/path> against <about:blank>
+PASS Parsing origin: <blob:ws://example.org/> against <about:blank>
+PASS Parsing origin: <blob:wss://example.org/> against <about:blank>
+PASS Parsing origin: <blob:http%3a//example.org/> against <about:blank>
 PASS Parsing origin: <non-special:cannot-be-a-base-url-\0~> against <about:blank>
 PASS Parsing origin: <https://www.example.com/path{path.html?query'=query#fragment<fragment> against <about:blank>
 PASS Parsing origin: <https://user:pass[@foo/bar> against <http://example.org>

--- a/LayoutTests/imported/w3c/web-platform-tests/url/a-element-origin-xhtml-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/url/a-element-origin-xhtml-expected.txt
@@ -327,13 +327,13 @@ PASS Parsing origin: <blob:http://example.org:88/> against <about:blank>
 PASS Parsing origin: <blob:d3958f5c-0777-0845-9dcf-2cb28783acaf> against <about:blank>
 PASS Parsing origin: <blob:> against <about:blank>
 PASS Parsing origin: <blob:blob:> against <about:blank>
-FAIL Parsing origin: <blob:blob:https://example.org/> against <about:blank> assert_equals: origin expected "null" but got "blob://"
+PASS Parsing origin: <blob:blob:https://example.org/> against <about:blank>
 PASS Parsing origin: <blob:about:blank> against <about:blank>
 FAIL Parsing origin: <blob:file://host/path> against <about:blank> assert_equals: origin expected "null" but got "file://"
-FAIL Parsing origin: <blob:ftp://host/path> against <about:blank> assert_equals: origin expected "null" but got "ftp://host"
-FAIL Parsing origin: <blob:ws://example.org/> against <about:blank> assert_equals: origin expected "null" but got "ws://example.org"
-FAIL Parsing origin: <blob:wss://example.org/> against <about:blank> assert_equals: origin expected "null" but got "wss://example.org"
-FAIL Parsing origin: <blob:http%3a//example.org/> against <about:blank> assert_equals: origin expected "null" but got "http://example.org"
+PASS Parsing origin: <blob:ftp://host/path> against <about:blank>
+PASS Parsing origin: <blob:ws://example.org/> against <about:blank>
+PASS Parsing origin: <blob:wss://example.org/> against <about:blank>
+PASS Parsing origin: <blob:http%3a//example.org/> against <about:blank>
 PASS Parsing origin: <non-special:cannot-be-a-base-url-\0~> against <about:blank>
 PASS Parsing origin: <https://www.example.com/path{path.html?query'=query#fragment<fragment> against <about:blank>
 PASS Parsing origin: <https://user:pass[@foo/bar> against <http://example.org>

--- a/LayoutTests/imported/w3c/web-platform-tests/url/url-origin.any-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/url/url-origin.any-expected.txt
@@ -326,13 +326,13 @@ PASS Origin parsing: <blob:http://example.org:88/> without base
 PASS Origin parsing: <blob:d3958f5c-0777-0845-9dcf-2cb28783acaf> without base
 PASS Origin parsing: <blob:> without base
 PASS Origin parsing: <blob:blob:> without base
-FAIL Origin parsing: <blob:blob:https://example.org/> without base assert_equals: origin expected "null" but got "blob://"
+PASS Origin parsing: <blob:blob:https://example.org/> without base
 PASS Origin parsing: <blob:about:blank> without base
 FAIL Origin parsing: <blob:file://host/path> without base assert_equals: origin expected "null" but got "file://"
-FAIL Origin parsing: <blob:ftp://host/path> without base assert_equals: origin expected "null" but got "ftp://host"
-FAIL Origin parsing: <blob:ws://example.org/> without base assert_equals: origin expected "null" but got "ws://example.org"
-FAIL Origin parsing: <blob:wss://example.org/> without base assert_equals: origin expected "null" but got "wss://example.org"
-FAIL Origin parsing: <blob:http%3a//example.org/> without base assert_equals: origin expected "null" but got "http://example.org"
+PASS Origin parsing: <blob:ftp://host/path> without base
+PASS Origin parsing: <blob:ws://example.org/> without base
+PASS Origin parsing: <blob:wss://example.org/> without base
+PASS Origin parsing: <blob:http%3a//example.org/> without base
 PASS Origin parsing: <non-special:cannot-be-a-base-url-\0~> without base
 PASS Origin parsing: <https://www.example.com/path{path.html?query'=query#fragment<fragment> without base
 PASS Origin parsing: <https://user:pass[@foo/bar> against <http://example.org>

--- a/LayoutTests/imported/w3c/web-platform-tests/url/url-origin.any.worker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/url/url-origin.any.worker-expected.txt
@@ -326,13 +326,13 @@ PASS Origin parsing: <blob:http://example.org:88/> without base
 PASS Origin parsing: <blob:d3958f5c-0777-0845-9dcf-2cb28783acaf> without base
 PASS Origin parsing: <blob:> without base
 PASS Origin parsing: <blob:blob:> without base
-FAIL Origin parsing: <blob:blob:https://example.org/> without base assert_equals: origin expected "null" but got "blob://"
+PASS Origin parsing: <blob:blob:https://example.org/> without base
 PASS Origin parsing: <blob:about:blank> without base
 FAIL Origin parsing: <blob:file://host/path> without base assert_equals: origin expected "null" but got "file://"
-FAIL Origin parsing: <blob:ftp://host/path> without base assert_equals: origin expected "null" but got "ftp://host"
-FAIL Origin parsing: <blob:ws://example.org/> without base assert_equals: origin expected "null" but got "ws://example.org"
-FAIL Origin parsing: <blob:wss://example.org/> without base assert_equals: origin expected "null" but got "wss://example.org"
-FAIL Origin parsing: <blob:http%3a//example.org/> without base assert_equals: origin expected "null" but got "http://example.org"
+PASS Origin parsing: <blob:ftp://host/path> without base
+PASS Origin parsing: <blob:ws://example.org/> without base
+PASS Origin parsing: <blob:wss://example.org/> without base
+PASS Origin parsing: <blob:http%3a//example.org/> without base
 PASS Origin parsing: <non-special:cannot-be-a-base-url-\0~> without base
 PASS Origin parsing: <https://www.example.com/path{path.html?query'=query#fragment<fragment> without base
 PASS Origin parsing: <https://user:pass[@foo/bar> against <http://example.org>

--- a/Source/WebCore/fileapi/BlobURL.cpp
+++ b/Source/WebCore/fileapi/BlobURL.cpp
@@ -41,8 +41,6 @@
 
 namespace WebCore {
 
-static constexpr auto kBlobProtocol = "blob"_s;
-
 URL BlobURL::createPublicURL(SecurityOrigin* securityOrigin)
 {
     ASSERT(securityOrigin);
@@ -68,25 +66,21 @@ static const Document* blobOwner(const SecurityOrigin& blobOrigin)
 
 URL BlobURL::getOriginURL(const URL& url)
 {
-    ASSERT_UNUSED(kBlobProtocol, url.protocolIs(kBlobProtocol));
+    ASSERT(url.protocolIsBlob());
 
-    if (auto blobOrigin = ThreadableBlobRegistry::getCachedOrigin(url)) {
-        if (auto* document = blobOwner(*blobOrigin))
-            return document->url();
-    }
-    return SecurityOrigin::extractInnerURL(url);
+    return URL(SecurityOrigin::createForBlobURL(url)->toString());
 }
 
 bool BlobURL::isSecureBlobURL(const URL& url)
 {
-    ASSERT_UNUSED(kBlobProtocol, url.protocolIs(kBlobProtocol));
+    ASSERT(url.protocolIsBlob());
 
     // As per https://github.com/w3c/webappsec-mixed-content/issues/41, Blob URL is secure if the document that created it is secure.
     if (auto origin = ThreadableBlobRegistry::getCachedOrigin(url)) {
         if (auto* document = blobOwner(*origin))
             return document->isSecureContext();
     }
-    return SecurityOrigin::isSecure(url);
+    return SecurityOrigin::isSecure(getOriginURL(url));
 }
 
 URL BlobURL::createBlobURL(StringView originString)

--- a/Source/WebCore/fileapi/ThreadableBlobRegistry.cpp
+++ b/Source/WebCore/fileapi/ThreadableBlobRegistry.cpp
@@ -226,6 +226,7 @@ void ThreadableBlobRegistry::unregisterBlobURLHandle(const URL& url, const std::
 
 RefPtr<SecurityOrigin> ThreadableBlobRegistry::getCachedOrigin(const URL& url)
 {
+    ASSERT(url.protocolIsBlob());
     RefPtr<SecurityOrigin> cachedOrigin;
 
     bool wasOnMainThread = isMainThread();
@@ -236,7 +237,7 @@ RefPtr<SecurityOrigin> ThreadableBlobRegistry::getCachedOrigin(const URL& url)
     if (cachedOrigin)
         return cachedOrigin;
 
-    if (!url.protocolIsBlob() || !isBlobURLContainsNullOrigin(url))
+    if (!isBlobURLContainsNullOrigin(url))
         return nullptr;
 
     // If we do not have a cached origin for null blob URLs, we use an opaque origin.

--- a/Source/WebCore/page/SecurityOrigin.h
+++ b/Source/WebCore/page/SecurityOrigin.h
@@ -47,7 +47,9 @@ public:
         Ask
     };
 
+    // https://url.spec.whatwg.org/#concept-url-origin
     WEBCORE_EXPORT static Ref<SecurityOrigin> create(const URL&);
+    WEBCORE_EXPORT static Ref<SecurityOrigin> createForBlobURL(const URL&);
     WEBCORE_EXPORT static Ref<SecurityOrigin> createOpaque();
 
     WEBCORE_EXPORT static Ref<SecurityOrigin> createFromString(const String&);
@@ -60,19 +62,6 @@ public:
     // navigations. This lets those documents specify the file path that should be allowed to be
     // displayed from their non-local origin.
     static Ref<SecurityOrigin> createNonLocalWithAllowedFilePath(const URL&, const String& filePath);
-
-    // Some URL schemes use nested URLs for their security context. For example,
-    // filesystem URLs look like the following:
-    //
-    //   filesystem:http://example.com/temporary/path/to/file.png
-    //
-    // We're supposed to use "http://example.com" as the origin.
-    //
-    // Generally, we add URL schemes to this list when WebKit support them. For
-    // example, we don't include the "jar" scheme, even though Firefox
-    // understands that "jar" uses an inner URL for it's security origin.
-    static bool shouldUseInnerURL(const URL&);
-    static URL extractInnerURL(const URL&);
 
     // Create a deep copy of this SecurityOrigin. This method is useful
     // when marshalling a SecurityOrigin to another thread.
@@ -92,8 +81,7 @@ public:
     static bool shouldIgnoreHost(const URL&);
 
     // Returns true if a given URL is secure, based either directly on its
-    // own protocol, or, when relevant, on the protocol of its "inner URL"
-    // Protocols like blob: and filesystem: fall into this latter category.
+    // own protocol, or, for blob:, on the protocol of its "inner URL"
     WEBCORE_EXPORT static bool isSecure(const URL&);
 
     // This method implements the "same origin-domain" algorithm from the HTML Standard:


### PR DESCRIPTION
#### b1a659b38f09d05fd3e7b3b112066894ab099b8c
<pre>
Return opaque origin for blob: URL containing inner non-http(s): URL
<a href="https://bugs.webkit.org/show_bug.cgi?id=257262">https://bugs.webkit.org/show_bug.cgi?id=257262</a>
rdar://109781193

Reviewed by Alex Christensen and Darin Adler.

Refactor SecurityOrigin so it is more clear blob: URLs are the sole
special case. And change how we derive the blob: URL origin to align
with the URL standard:

* No longer perform percent-decoding (matches other browsers).
* Restrict non-opaque origins to HTTP(S) URLs (will soon match other
  browsers). However:

  * Still give blob: URLs derived from file: origins an origin for now
    as removing that ability needs a bit more care. This currently goes
    against the URL standard, but that might change.
  * Also give registered schemes a pass to allow embedders to continue
    to use blob: URLs as they see fit.

Also change BlobURL to rely more directly on SecurityOrigin.

* LayoutTests/imported/w3c/web-platform-tests/url/a-element-origin-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/url/a-element-origin-xhtml-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/url/url-origin.any-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/url/url-origin.any.worker-expected.txt:
* Source/WebCore/fileapi/BlobURL.cpp:
(WebCore::BlobURL::getOriginURL):
(WebCore::BlobURL::isSecureBlobURL):
* Source/WebCore/fileapi/ThreadableBlobRegistry.cpp:
(WebCore::ThreadableBlobRegistry::getCachedOrigin):
* Source/WebCore/page/SecurityOrigin.cpp:
(WebCore::SecurityOrigin::create):
(WebCore::SecurityOrigin::forBlobURL):
(WebCore::SecurityOrigin::isSecure):
(WebCore::SecurityOrigin::shouldUseInnerURL): Deleted.
(WebCore::SecurityOrigin::extractInnerURL): Deleted.
* Source/WebCore/page/SecurityOrigin.h:
* Source/WebCore/page/SecurityOriginData.cpp:
(WebCore::SecurityOriginData::shouldTreatAsOpaqueOrigin):

Canonical link: <a href="https://commits.webkit.org/266247@main">https://commits.webkit.org/266247@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/85470d2b0398da0cf676aeb8b3d62191b5e2e363

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/13310 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/13623 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/13956 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/15047 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/12671 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/13389 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/16131 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/13650 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/15353 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/13477 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/14133 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/11252 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/15676 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/11421 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/12007 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/19060 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/12496 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/12174 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/15386 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/12677 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/10536 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/11948 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/3249 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/16270 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/12519 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->