### PR TITLE
Rename stripLeadingAndTrailing[Matched]Characters() to trim()

### DIFF
--- a/Source/JavaScriptCore/runtime/ExceptionHelpers.cpp
+++ b/Source/JavaScriptCore/runtime/ExceptionHelpers.cpp
@@ -208,7 +208,7 @@ static String invalidParameterInSourceAppender(const String& originalMessage, St
         return makeString(originalMessage, " (evaluating '"_s, sourceText, "')"_s);
 
     static constexpr unsigned inLength = 2;
-    StringView rightHandSide = sourceText.substring(inIndex + inLength).stripLeadingAndTrailingMatchedCharacters(deprecatedIsSpaceOrNewline);
+    auto rightHandSide = sourceText.substring(inIndex + inLength).trim(deprecatedIsSpaceOrNewline);
     return makeString(rightHandSide, " is not an Object. (evaluating '"_s, sourceText, "')"_s);
 }
 
@@ -227,7 +227,7 @@ inline String invalidParameterInstanceofSourceAppender(const String& content, co
         return makeString(originalMessage, " (evaluating '"_s, sourceText, "')"_s);
 
     static constexpr unsigned instanceofLength = 10;
-    StringView rightHandSide = sourceText.substring(instanceofIndex + instanceofLength).stripLeadingAndTrailingMatchedCharacters(deprecatedIsSpaceOrNewline);
+    auto rightHandSide = sourceText.substring(instanceofIndex + instanceofLength).trim(deprecatedIsSpaceOrNewline);
     return makeString(rightHandSide, content, ". (evaluating '"_s, sourceText, "')"_s);
 }
 

--- a/Source/WTF/wtf/Assertions.cpp
+++ b/Source/WTF/wtf/Assertions.cpp
@@ -559,7 +559,7 @@ void WTFInitializeLogChannelStatesFromString(WTFLogChannel* channels[], size_t c
         if (it == componentInfo.end())
             continue;
 
-        auto component = (*it).stripLeadingAndTrailingMatchedCharacters(isUnicodeCompatibleASCIIWhitespace<UChar>);
+        auto component = (*it).trim(isUnicodeCompatibleASCIIWhitespace<UChar>);
 
         WTFLogChannelState logChannelState = WTFLogChannelState::On;
         if (component.startsWith('-')) {
@@ -574,7 +574,7 @@ void WTFInitializeLogChannelStatesFromString(WTFLogChannel* channels[], size_t c
 
         WTFLogLevel logChannelLevel = WTFLogLevel::Error;
         if (++it != componentInfo.end()) {
-            auto level = (*it).stripLeadingAndTrailingMatchedCharacters(isUnicodeCompatibleASCIIWhitespace<UChar>);
+            auto level = (*it).trim(isUnicodeCompatibleASCIIWhitespace<UChar>);
             if (equalLettersIgnoringASCIICase(level, "error"_s))
                 logChannelLevel = WTFLogLevel::Error;
             else if (equalLettersIgnoringASCIICase(level, "warning"_s))

--- a/Source/WTF/wtf/text/StringImpl.cpp
+++ b/Source/WTF/wtf/text/StringImpl.cpp
@@ -709,7 +709,7 @@ Ref<StringImpl> StringImpl::convertToASCIIUppercase()
     return convertASCIICase<CaseConvertType::Upper>(*this, m_data16, m_length);
 }
 
-template<typename CodeUnitPredicate> inline Ref<StringImpl> StringImpl::stripMatchedCharacters(CodeUnitPredicate predicate)
+template<typename CodeUnitPredicate> inline Ref<StringImpl> StringImpl::trimMatchedCharacters(CodeUnitPredicate predicate)
 {
     if (!m_length)
         return *this;
@@ -736,9 +736,9 @@ template<typename CodeUnitPredicate> inline Ref<StringImpl> StringImpl::stripMat
     return create(m_data16 + start, end + 1 - start);
 }
 
-Ref<StringImpl> StringImpl::stripLeadingAndTrailingCharacters(CodeUnitMatchFunction predicate)
+Ref<StringImpl> StringImpl::trim(CodeUnitMatchFunction predicate)
 {
-    return stripMatchedCharacters(predicate);
+    return trimMatchedCharacters(predicate);
 }
 
 template<typename CharacterType, class UCharPredicate> inline Ref<StringImpl> StringImpl::simplifyMatchedCharactersToSpace(UCharPredicate predicate)

--- a/Source/WTF/wtf/text/StringImpl.h
+++ b/Source/WTF/wtf/text/StringImpl.h
@@ -441,7 +441,7 @@ public:
 
     WTF_EXPORT_PRIVATE Ref<StringImpl> simplifyWhiteSpace(CodeUnitMatchFunction);
 
-    WTF_EXPORT_PRIVATE Ref<StringImpl> stripLeadingAndTrailingCharacters(CodeUnitMatchFunction);
+    WTF_EXPORT_PRIVATE Ref<StringImpl> trim(CodeUnitMatchFunction);
     template<typename Predicate> Ref<StringImpl> removeCharacters(const Predicate&);
 
     bool isAllASCII() const;
@@ -532,7 +532,7 @@ private:
     WTF_EXPORT_PRIVATE static Ref<StringImpl> createWithoutCopyingNonEmpty(const LChar*, unsigned length);
     WTF_EXPORT_PRIVATE static Ref<StringImpl> createWithoutCopyingNonEmpty(const UChar*, unsigned length);
 
-    template<class CodeUnitPredicate> Ref<StringImpl> stripMatchedCharacters(CodeUnitPredicate);
+    template<class CodeUnitPredicate> Ref<StringImpl> trimMatchedCharacters(CodeUnitPredicate);
     template<typename CharacterType, typename Predicate> ALWAYS_INLINE Ref<StringImpl> removeCharactersImpl(const CharacterType* characters, const Predicate&);
     template<typename CharacterType, class CodeUnitPredicate> Ref<StringImpl> simplifyMatchedCharactersToSpace(CodeUnitPredicate);
     template<typename CharacterType> static Ref<StringImpl> constructInternal(StringImpl&, unsigned);

--- a/Source/WTF/wtf/text/StringView.h
+++ b/Source/WTF/wtf/text/StringView.h
@@ -145,7 +145,7 @@ public:
     StringView right(unsigned length) const { return substring(this->length() - length, length); }
 
     template<typename MatchedCharacterPredicate>
-    StringView stripLeadingAndTrailingMatchedCharacters(const MatchedCharacterPredicate&) const;
+    StringView trim(const MatchedCharacterPredicate&) const;
 
     class SplitResult;
     SplitResult split(UChar) const;
@@ -211,7 +211,7 @@ private:
     WTF_EXPORT_PRIVATE size_t reverseFind(const LChar* match, unsigned matchLength, unsigned start) const;
 
     template<typename CharacterType, typename MatchedCharacterPredicate>
-    StringView stripLeadingAndTrailingMatchedCharacters(const CharacterType*, const MatchedCharacterPredicate&) const;
+    StringView trim(const CharacterType*, const MatchedCharacterPredicate&) const;
 
     WTF_EXPORT_PRIVATE bool underlyingStringIsValidImpl() const;
     WTF_EXPORT_PRIVATE void setUnderlyingStringImpl(const StringImpl*);
@@ -1103,7 +1103,7 @@ inline bool StringView::SplitResult::Iterator::operator==(const Iterator& other)
 }
 
 template<typename CharacterType, typename MatchedCharacterPredicate>
-inline StringView StringView::stripLeadingAndTrailingMatchedCharacters(const CharacterType* characters, const MatchedCharacterPredicate& predicate) const
+inline StringView StringView::trim(const CharacterType* characters, const MatchedCharacterPredicate& predicate) const
 {
     if (!m_length)
         return *this;
@@ -1129,11 +1129,11 @@ inline StringView StringView::stripLeadingAndTrailingMatchedCharacters(const Cha
 }
 
 template<typename MatchedCharacterPredicate>
-StringView StringView::stripLeadingAndTrailingMatchedCharacters(const MatchedCharacterPredicate& predicate) const
+StringView StringView::trim(const MatchedCharacterPredicate& predicate) const
 {
     if (is8Bit())
-        return stripLeadingAndTrailingMatchedCharacters<LChar>(characters8(), predicate);
-    return stripLeadingAndTrailingMatchedCharacters<UChar>(characters16(), predicate);
+        return trim<LChar>(characters8(), predicate);
+    return trim<UChar>(characters16(), predicate);
 }
 
 inline bool equalLettersIgnoringASCIICase(StringView string, ASCIILiteral literal)

--- a/Source/WTF/wtf/text/WTFString.cpp
+++ b/Source/WTF/wtf/text/WTFString.cpp
@@ -153,10 +153,10 @@ String String::convertToUppercaseWithLocale(const AtomString& localeIdentifier) 
     return m_impl ? m_impl->convertToUppercaseWithLocale(localeIdentifier) : String { };
 }
 
-String String::stripLeadingAndTrailingCharacters(CodeUnitMatchFunction predicate) const
+String String::trim(CodeUnitMatchFunction predicate) const
 {
     // FIXME: Should this function, and the many others like it, be inlined?
-    return m_impl ? m_impl->stripLeadingAndTrailingCharacters(predicate) : String { };
+    return m_impl ? m_impl->trim(predicate) : String { };
 }
 
 String String::simplifyWhiteSpace(CodeUnitMatchFunction isWhiteSpace) const

--- a/Source/WTF/wtf/text/WTFString.h
+++ b/Source/WTF/wtf/text/WTFString.h
@@ -200,7 +200,7 @@ public:
 
     WTF_EXPORT_PRIVATE String WARN_UNUSED_RETURN simplifyWhiteSpace(CodeUnitMatchFunction) const;
 
-    WTF_EXPORT_PRIVATE String WARN_UNUSED_RETURN stripLeadingAndTrailingCharacters(CodeUnitMatchFunction) const;
+    WTF_EXPORT_PRIVATE String WARN_UNUSED_RETURN trim(CodeUnitMatchFunction) const;
     template<typename Predicate> String WARN_UNUSED_RETURN removeCharacters(const Predicate&) const;
 
     // Returns the string with case folded for case insensitive comparison.

--- a/Source/WebCore/Modules/applicationmanifest/ApplicationManifestParser.cpp
+++ b/Source/WebCore/Modules/applicationmanifest/ApplicationManifestParser.cpp
@@ -158,7 +158,7 @@ ApplicationManifest::Display ApplicationManifestParser::parseDisplay(const JSON:
     };
     static constexpr SortedArrayMap displayValues { displayValueMappings };
 
-    if (auto* displayValue = displayValues.tryGet(StringView(stringValue).stripLeadingAndTrailingMatchedCharacters(isUnicodeCompatibleASCIIWhitespace<UChar>)))
+    if (auto* displayValue = displayValues.tryGet(StringView(stringValue).trim(isUnicodeCompatibleASCIIWhitespace<UChar>)))
         return *displayValue;
 
     logDeveloperWarning(makeString("\""_s, stringValue, "\" is not a valid display mode."_s));
@@ -190,7 +190,7 @@ const std::optional<ScreenOrientationLockType> ApplicationManifestParser::parseO
 
     static SortedArrayMap orientationValues { orientationValueMappings };
 
-    if (auto* orientationValue = orientationValues.tryGet(StringView(stringValue).stripLeadingAndTrailingMatchedCharacters(isUnicodeCompatibleASCIIWhitespace<UChar>)))
+    if (auto* orientationValue = orientationValues.tryGet(StringView(stringValue).trim(isUnicodeCompatibleASCIIWhitespace<UChar>)))
         return *orientationValue;
 
     logDeveloperWarning(makeString("\""_s, stringValue, "\" is not a valid orientation."_s));
@@ -267,7 +267,7 @@ Vector<ApplicationManifest::Icon> ApplicationManifestParser::parseIcons(const JS
                 purposes.add(ApplicationManifest::Icon::Purpose::Any);
                 currentIcon.purposes = purposes;
             } else {
-                for (auto keyword : StringView(purposeStringValue).stripLeadingAndTrailingMatchedCharacters(isUnicodeCompatibleASCIIWhitespace<UChar>).splitAllowingEmptyEntries(' ')) {
+                for (auto keyword : StringView(purposeStringValue).trim(isUnicodeCompatibleASCIIWhitespace<UChar>).splitAllowingEmptyEntries(' ')) {
                     if (equalLettersIgnoringASCIICase(keyword, "monochrome"_s))
                         purposes.add(ApplicationManifest::Icon::Purpose::Monochrome);
                     else if (equalLettersIgnoringASCIICase(keyword, "maskable"_s))
@@ -400,7 +400,7 @@ String ApplicationManifestParser::parseGenericString(const JSON::Object& manifes
         return { };
     }
 
-    return stringValue.stripLeadingAndTrailingCharacters(deprecatedIsSpaceOrNewline);
+    return stringValue.trim(deprecatedIsSpaceOrNewline);
 }
 
 } // namespace WebCore

--- a/Source/WebCore/Modules/fetch/FetchBodyConsumer.cpp
+++ b/Source/WebCore/Modules/fetch/FetchBodyConsumer.cpp
@@ -175,7 +175,7 @@ RefPtr<DOMFormData> FetchBodyConsumer::packageFormData(ScriptExecutionContext* c
             size_t contentTypeBegin = header.find(contentTypeCharacters);
             if (contentTypeBegin != notFound) {
                 size_t contentTypeEnd = header.find("\r\n"_s, contentTypeBegin);
-                contentType = StringView(header).substring(contentTypeBegin + contentTypePrefixLength, contentTypeEnd - contentTypeBegin - contentTypePrefixLength).stripLeadingAndTrailingMatchedCharacters(isHTTPSpace).toString();
+                contentType = StringView(header).substring(contentTypeBegin + contentTypePrefixLength, contentTypeEnd - contentTypeBegin - contentTypePrefixLength).trim(isHTTPSpace).toString();
             }
 
             form.append(name, File::create(context, Blob::create(context, Vector { bodyBegin, bodyLength }, Blob::normalizedContentType(contentType)).get(), filename).get(), filename);

--- a/Source/WebCore/Modules/mediarecorder/MediaRecorderProvider.cpp
+++ b/Source/WebCore/Modules/mediarecorder/MediaRecorderProvider.cpp
@@ -64,7 +64,7 @@ bool MediaRecorderProvider::isSupported(const String& value)
         return false;
 
     for (auto& item : mimeType.codecs()) {
-        auto codec = StringView(item).stripLeadingAndTrailingMatchedCharacters(isASCIIWhitespace<UChar>);
+        auto codec = StringView(item).trim(isASCIIWhitespace<UChar>);
         // FIXME: We should further validate parameters.
         if (!startsWithLettersIgnoringASCIICase(codec, "avc1"_s) && !startsWithLettersIgnoringASCIICase(codec, "mp4a"_s))
             return false;

--- a/Source/WebCore/accessibility/AccessibilityNodeObject.cpp
+++ b/Source/WebCore/accessibility/AccessibilityNodeObject.cpp
@@ -2238,7 +2238,7 @@ String AccessibilityNodeObject::textUnderElement(AccessibilityTextUnderElementMo
             appendNameToStringBuilder(builder, childText);
     }
 
-    return builder.toString().stripLeadingAndTrailingCharacters(deprecatedIsSpaceOrNewline).simplifyWhiteSpace(isHTMLSpaceButNotLineBreak);
+    return builder.toString().trim(deprecatedIsSpaceOrNewline).simplifyWhiteSpace(isHTMLSpaceButNotLineBreak);
 }
 
 String AccessibilityNodeObject::title() const

--- a/Source/WebCore/css/parser/CSSParserImpl.cpp
+++ b/Source/WebCore/css/parser/CSSParserImpl.cpp
@@ -640,7 +640,7 @@ RefPtr<StyleRuleSupports> CSSParserImpl::consumeSupportsRule(CSSParserTokenRange
     if (m_observerWrapper)
         m_observerWrapper->observer().endRuleBody(m_observerWrapper->endOffset(block));
 
-    return StyleRuleSupports::create(prelude.serialize().stripLeadingAndTrailingCharacters(deprecatedIsSpaceOrNewline), supported, WTFMove(rules));
+    return StyleRuleSupports::create(prelude.serialize().trim(deprecatedIsSpaceOrNewline), supported, WTFMove(rules));
 }
 
 RefPtr<StyleRuleFontFace> CSSParserImpl::consumeFontFaceRule(CSSParserTokenRange prelude, CSSParserTokenRange block)

--- a/Source/WebCore/dom/ImageOverlay.cpp
+++ b/Source/WebCore/dom/ImageOverlay.cpp
@@ -346,7 +346,7 @@ static Elements updateSubtree(HTMLElement& element, const TextRecognitionResult&
                     return false;
 
                 for (size_t childIndex = 0; childIndex < childResults.size(); ++childIndex) {
-                    if (childResults[childIndex].text != StringView(childTextElements[childIndex]->textContent()).stripLeadingAndTrailingMatchedCharacters(deprecatedIsSpaceOrNewline))
+                    if (childResults[childIndex].text != StringView(childTextElements[childIndex]->textContent()).trim(deprecatedIsSpaceOrNewline))
                         return false;
                 }
             }
@@ -358,7 +358,7 @@ static Elements updateSubtree(HTMLElement& element, const TextRecognitionResult&
                     if (textContentByLine.size() <= lineIndex)
                         return false;
 
-                    if (StringView(textContentByLine[lineIndex++]).stripLeadingAndTrailingMatchedCharacters(deprecatedIsSpaceOrNewline) != StringView(text.wholeText()).stripLeadingAndTrailingMatchedCharacters(deprecatedIsSpaceOrNewline))
+                    if (StringView(textContentByLine[lineIndex++]).trim(deprecatedIsSpaceOrNewline) != StringView(text.wholeText()).trim(deprecatedIsSpaceOrNewline))
                         return false;
                 }
             }

--- a/Source/WebCore/dom/ScriptElement.cpp
+++ b/Source/WebCore/dom/ScriptElement.cpp
@@ -153,7 +153,7 @@ std::optional<ScriptType> ScriptElement::determineScriptType(LegacyTypeSupport s
     if (type.isEmpty())
         return ScriptType::Classic; // Assume text/javascript.
 
-    if (MIMETypeRegistry::isSupportedJavaScriptMIMEType(type.stripLeadingAndTrailingCharacters(deprecatedIsSpaceOrNewline)))
+    if (MIMETypeRegistry::isSupportedJavaScriptMIMEType(type.trim(deprecatedIsSpaceOrNewline)))
         return ScriptType::Classic;
     if (supportLegacyTypes == AllowLegacyTypeInTypeAttribute && isLegacySupportedJavaScriptLanguage(type))
         return ScriptType::Classic;

--- a/Source/WebCore/editing/TextManipulationController.cpp
+++ b/Source/WebCore/editing/TextManipulationController.cpp
@@ -837,7 +837,7 @@ auto TextManipulationController::replace(const ManipulationItemData& item, const
                 return ManipulationFailure::Type::ContentChanged;
 
             auto& currentToken = item.tokens[currentTokenIndex++];
-            bool isContentUnchanged = StringView(currentToken.content).stripLeadingAndTrailingMatchedCharacters(deprecatedIsSpaceOrNewline) == StringView(token.content).stripLeadingAndTrailingMatchedCharacters(deprecatedIsSpaceOrNewline);
+            bool isContentUnchanged = StringView(currentToken.content).trim(deprecatedIsSpaceOrNewline) == StringView(token.content).trim(deprecatedIsSpaceOrNewline);
             if (!content.isReplacedContent && !isContentUnchanged)
                 return ManipulationFailure::Type::ContentChanged;
 

--- a/Source/WebCore/editing/TypingCommand.cpp
+++ b/Source/WebCore/editing/TypingCommand.cpp
@@ -458,10 +458,10 @@ void TypingCommand::markMisspellingsAfterTyping(Type commandType)
         VisiblePosition p2 = startOfWord(start, LeftWordIfOnBoundary);
         if (p1 != p2) {
             auto range = makeSimpleRange(p1, p2);
-            String strippedPreviousWord;
+            String trimmedPreviousWord;
             if (range && (commandType == TypingCommand::Type::InsertText || commandType == TypingCommand::Type::InsertLineBreak || commandType == TypingCommand::Type::InsertParagraphSeparator || commandType == TypingCommand::Type::InsertParagraphSeparatorInQuotedContent))
-                strippedPreviousWord = plainText(*range).stripLeadingAndTrailingCharacters(deprecatedIsSpaceOrNewline);
-            document().editor().markMisspellingsAfterTypingToWord(p1, endingSelection(), !strippedPreviousWord.isEmpty());
+                trimmedPreviousWord = plainText(*range).trim(deprecatedIsSpaceOrNewline);
+            document().editor().markMisspellingsAfterTypingToWord(p1, endingSelection(), !trimmedPreviousWord.isEmpty());
         } else if (commandType == TypingCommand::Type::InsertText)
             document().editor().startAlternativeTextUITimer();
 #else

--- a/Source/WebCore/html/FeaturePolicy.cpp
+++ b/Source/WebCore/html/FeaturePolicy.cpp
@@ -129,7 +129,7 @@ static inline void processOriginItem(Document& document, FeaturePolicy::AllowRul
     if (rule.type == FeaturePolicy::AllowRule::Type::None)
         return;
 
-    item = item.stripLeadingAndTrailingMatchedCharacters(isASCIIWhitespace<UChar>);
+    item = item.trim(isASCIIWhitespace<UChar>);
     // FIXME: Support 'src'.
     if (item == "'src'"_s)
         return;
@@ -168,7 +168,7 @@ static inline void updateList(Document& document, FeaturePolicy::AllowRule& rule
         }
 
         processOriginItem(document, rule, value.left(position));
-        value = value.substring(position + 1).stripLeadingAndTrailingMatchedCharacters(isASCIIWhitespace<UChar>);
+        value = value.substring(position + 1).trim(isASCIIWhitespace<UChar>);
     }
 }
 
@@ -197,7 +197,7 @@ FeaturePolicy FeaturePolicy::parse(Document& document, const HTMLIFrameElement& 
     bool isXRSpatialTrackingInitialized = false;
 #endif
     for (auto allowItem : allowAttributeValue.split(';')) {
-        auto item = allowItem.stripLeadingAndTrailingMatchedCharacters(isASCIIWhitespace<UChar>);
+        auto item = allowItem.trim(isASCIIWhitespace<UChar>);
         if (item.startsWith("camera"_s)) {
             isCameraInitialized = true;
             updateList(document, policy.m_cameraRule, item.substring(7));

--- a/Source/WebCore/html/HTMLElement.cpp
+++ b/Source/WebCore/html/HTMLElement.cpp
@@ -1037,7 +1037,7 @@ std::optional<SRGBA<uint8_t>> HTMLElement::parseLegacyColorValue(StringView stri
     if (string.isEmpty())
         return std::nullopt;
 
-    string = string.stripLeadingAndTrailingMatchedCharacters(isASCIIWhitespace<UChar>);
+    string = string.trim(isASCIIWhitespace<UChar>);
     if (string.isEmpty())
         return Color::black;
 

--- a/Source/WebCore/html/HTMLImageElement.cpp
+++ b/Source/WebCore/html/HTMLImageElement.cpp
@@ -241,7 +241,7 @@ static String extractMIMETypeFromTypeAttributeForLookup(const String& typeAttrib
     auto semicolonIndex = typeAttribute.find(';');
     if (semicolonIndex == notFound)
         return stripLeadingAndTrailingHTMLSpaces(typeAttribute);
-    return StringView(typeAttribute).left(semicolonIndex).stripLeadingAndTrailingMatchedCharacters(isASCIIWhitespace<UChar>).toStringWithoutCopying();
+    return StringView(typeAttribute).left(semicolonIndex).trim(isASCIIWhitespace<UChar>).toStringWithoutCopying();
 }
 
 ImageCandidate HTMLImageElement::bestFitSourceFromPictureElement()

--- a/Source/WebCore/html/HTMLInputElement.cpp
+++ b/Source/WebCore/html/HTMLInputElement.cpp
@@ -1375,7 +1375,7 @@ static Vector<String> parseAcceptAttribute(StringView acceptString, bool (*predi
         return types;
 
     for (auto splitType : acceptString.split(',')) {
-        auto trimmedType = splitType.stripLeadingAndTrailingMatchedCharacters(isASCIIWhitespace<UChar>);
+        auto trimmedType = splitType.trim(isASCIIWhitespace<UChar>);
         if (trimmedType.isEmpty())
             continue;
         if (!predicate(trimmedType))

--- a/Source/WebCore/html/HTMLMediaElement.cpp
+++ b/Source/WebCore/html/HTMLMediaElement.cpp
@@ -8337,11 +8337,11 @@ String HTMLMediaElement::mediaSessionTitle() const
     if (!document().page() || document().page()->usesEphemeralSession())
         return emptyString();
 
-    auto title = String(attributeWithoutSynchronization(titleAttr)).stripLeadingAndTrailingCharacters(deprecatedIsSpaceOrNewline).simplifyWhiteSpace(deprecatedIsSpaceOrNewline);
+    auto title = String(attributeWithoutSynchronization(titleAttr)).trim(deprecatedIsSpaceOrNewline).simplifyWhiteSpace(deprecatedIsSpaceOrNewline);
     if (!title.isEmpty())
         return title;
 
-    title = document().title().stripLeadingAndTrailingCharacters(deprecatedIsSpaceOrNewline).simplifyWhiteSpace(deprecatedIsSpaceOrNewline);
+    title = document().title().trim(deprecatedIsSpaceOrNewline).simplifyWhiteSpace(deprecatedIsSpaceOrNewline);
     if (!title.isEmpty())
         return title;
 

--- a/Source/WebCore/html/HTMLOptGroupElement.cpp
+++ b/Source/WebCore/html/HTMLOptGroupElement.cpp
@@ -123,7 +123,7 @@ String HTMLOptGroupElement::groupLabelText() const
     String itemText = document().displayStringModifiedByEncoding(attributeWithoutSynchronization(labelAttr));
     
     // In WinIE, leading and trailing whitespace is ignored in options and optgroups. We match this behavior.
-    itemText = itemText.stripLeadingAndTrailingCharacters(deprecatedIsSpaceOrNewline);
+    itemText = itemText.trim(deprecatedIsSpaceOrNewline);
     // We want to collapse our whitespace too.  This will match other browsers.
     itemText = itemText.simplifyWhiteSpace(deprecatedIsSpaceOrNewline);
         

--- a/Source/WebCore/html/ValidatedFormListedElement.cpp
+++ b/Source/WebCore/html/ValidatedFormListedElement.cpp
@@ -102,7 +102,7 @@ void ValidatedFormListedElement::updateVisibleValidationMessage(Ref<HTMLElement>
         return;
     String message;
     if (element.renderer() && willValidate())
-        message = validationMessage().stripLeadingAndTrailingCharacters(deprecatedIsSpaceOrNewline);
+        message = validationMessage().trim(deprecatedIsSpaceOrNewline);
     if (!m_validationMessage)
         m_validationMessage = makeUnique<ValidationMessage>(validationAnchor);
     m_validationMessage->updateValidationMessage(validationAnchor, message);

--- a/Source/WebCore/html/parser/CSSPreloadScanner.cpp
+++ b/Source/WebCore/html/parser/CSSPreloadScanner.cpp
@@ -206,7 +206,7 @@ static bool hasValidImportConditions(StringView conditions)
     if (conditions.isEmpty())
         return true;
 
-    conditions = conditions.stripLeadingAndTrailingMatchedCharacters(isASCIIWhitespace<UChar>);
+    conditions = conditions.trim(isASCIIWhitespace<UChar>);
 
     // FIXME: Support multiple conditions.
     // FIXME: Support media queries.

--- a/Source/WebCore/html/parser/HTMLMetaCharsetParser.cpp
+++ b/Source/WebCore/html/parser/HTMLMetaCharsetParser.cpp
@@ -117,7 +117,7 @@ PAL::TextEncoding HTMLMetaCharsetParser::encodingFromMetaAttributes(std::span<co
     }
 
     if (mode == Charset || (mode == Pragma && gotPragma))
-        return charset.stripLeadingAndTrailingMatchedCharacters(isASCIIWhitespace<UChar>);
+        return charset.trim(isASCIIWhitespace<UChar>);
 
     return PAL::TextEncoding();
 }

--- a/Source/WebCore/html/parser/HTMLPreloadScanner.cpp
+++ b/Source/WebCore/html/parser/HTMLPreloadScanner.cpp
@@ -185,7 +185,7 @@ private:
         if (match(attributeName, srcAttr))
             setURLToLoad(attributeValue);
         else if (match(attributeName, crossoriginAttr))
-            m_crossOriginMode = attributeValue.stripLeadingAndTrailingMatchedCharacters(isASCIIWhitespace<UChar>).toString();
+            m_crossOriginMode = attributeValue.trim(isASCIIWhitespace<UChar>).toString();
         else if (match(attributeName, charsetAttr))
             m_charset = attributeValue.toString();
     }
@@ -280,7 +280,7 @@ private:
             else if (match(attributeName, charsetAttr))
                 m_charset = attributeValue.toString();
             else if (match(attributeName, crossoriginAttr))
-                m_crossOriginMode = attributeValue.stripLeadingAndTrailingMatchedCharacters(isASCIIWhitespace<UChar>).toString();
+                m_crossOriginMode = attributeValue.trim(isASCIIWhitespace<UChar>).toString();
             else if (match(attributeName, nonceAttr))
                 m_nonceAttribute = attributeValue.toString();
             else if (match(attributeName, asAttr))
@@ -331,10 +331,10 @@ private:
 
     void setURLToLoadAllowingReplacement(StringView value)
     {
-        auto strippedURL = value.stripLeadingAndTrailingMatchedCharacters(isASCIIWhitespace<UChar>);
-        if (strippedURL.isEmpty())
+        auto trimmedURL = value.trim(isASCIIWhitespace<UChar>);
+        if (trimmedURL.isEmpty())
             return;
-        m_urlToLoad = strippedURL.toString();
+        m_urlToLoad = trimmedURL.toString();
     }
 
     const String& charset() const

--- a/Source/WebCore/inspector/InspectorStyleSheet.cpp
+++ b/Source/WebCore/inspector/InspectorStyleSheet.cpp
@@ -477,14 +477,14 @@ void StyleSheetHandler::observeProperty(unsigned startOffset, unsigned endOffset
         ++endOffset;
     
     ASSERT(startOffset < endOffset);
-    StringView propertyString = StringView(m_parsedText).substring(startOffset, endOffset - startOffset).stripLeadingAndTrailingMatchedCharacters(deprecatedIsSpaceOrNewline);
+    auto propertyString = StringView(m_parsedText).substring(startOffset, endOffset - startOffset).trim(deprecatedIsSpaceOrNewline);
     if (propertyString.endsWith(';'))
         propertyString = propertyString.left(propertyString.length() - 1);
     size_t colonIndex = propertyString.find(':');
     ASSERT(colonIndex != notFound);
 
-    String name = propertyString.left(colonIndex).stripLeadingAndTrailingMatchedCharacters(deprecatedIsSpaceOrNewline).toString();
-    String value = propertyString.substring(colonIndex + 1, propertyString.length()).stripLeadingAndTrailingMatchedCharacters(deprecatedIsSpaceOrNewline).toString();
+    auto name = propertyString.left(colonIndex).trim(deprecatedIsSpaceOrNewline).toString();
+    auto value = propertyString.substring(colonIndex + 1, propertyString.length()).trim(deprecatedIsSpaceOrNewline).toString();
     
     // FIXME-NEWPARSER: The property range is relative to the declaration start offset, but no
     // good reason for it, and it complicates fixUnparsedProperties.
@@ -509,7 +509,7 @@ void StyleSheetHandler::observeComment(unsigned startOffset, unsigned endOffset)
     // Require well-formed comments.
     if (!commentTextView.endsWith("*/"_s))
         return;
-    commentTextView = commentTextView.left(commentTextView.length() - 2).stripLeadingAndTrailingMatchedCharacters(deprecatedIsSpaceOrNewline);
+    commentTextView = commentTextView.left(commentTextView.length() - 2).trim(deprecatedIsSpaceOrNewline);
     if (commentTextView.isEmpty())
         return;
 
@@ -1319,7 +1319,7 @@ static Ref<JSON::ArrayOf<Protocol::CSS::CSSSelector>> selectorsFromSource(const 
 
         // We don't want to see any comments in the selector components, only the meaningful parts.
         replace(selectorText, comment, String());
-        result->addItem(buildObjectForSelectorHelper(selectorText.stripLeadingAndTrailingCharacters(deprecatedIsSpaceOrNewline), *selectors.at(selectorIndex)));
+        result->addItem(buildObjectForSelectorHelper(selectorText.trim(deprecatedIsSpaceOrNewline), *selectors.at(selectorIndex)));
 
         ++selectorIndex;
     }

--- a/Source/WebCore/layout/integration/LayoutIntegrationCoverage.cpp
+++ b/Source/WebCore/layout/integration/LayoutIntegrationCoverage.cpp
@@ -150,7 +150,7 @@ static void printTextForSubtree(const RenderElement& renderer, unsigned& charact
     for (auto& child : childrenOfType<RenderObject>(downcast<RenderElement>(renderer))) {
         if (is<RenderText>(child)) {
             String text = downcast<RenderText>(child).text();
-            auto textView = StringView(text).stripLeadingAndTrailingMatchedCharacters(isUnicodeCompatibleASCIIWhitespace<UChar>);
+            auto textView = StringView(text).trim(isUnicodeCompatibleASCIIWhitespace<UChar>);
             auto length = std::min(charactersLeft, textView.length());
             stream << textView.left(length);
             charactersLeft -= length;

--- a/Source/WebCore/loader/FrameLoader.cpp
+++ b/Source/WebCore/loader/FrameLoader.cpp
@@ -751,7 +751,7 @@ static AtomString extractContentLanguageFromHeader(const String& header)
     auto commaIndex = header.find(',');
     if (commaIndex == notFound)
         return AtomString { stripLeadingAndTrailingHTMLSpaces(header) };
-    return StringView(header).left(commaIndex).stripLeadingAndTrailingMatchedCharacters(isASCIIWhitespace<UChar>).toAtomString();
+    return StringView(header).left(commaIndex).trim(isASCIIWhitespace<UChar>).toAtomString();
 }
 
 void FrameLoader::didBeginDocument(bool dispatch)

--- a/Source/WebCore/loader/HTTPHeaderField.cpp
+++ b/Source/WebCore/loader/HTTPHeaderField.cpp
@@ -32,13 +32,13 @@ namespace WebCore {
 
 std::optional<HTTPHeaderField> HTTPHeaderField::create(String&& unparsedName, String&& unparsedValue)
 {
-    StringView strippedName = StringView(unparsedName).stripLeadingAndTrailingMatchedCharacters(isTabOrSpace<UChar>);
-    StringView strippedValue = StringView(unparsedValue).stripLeadingAndTrailingMatchedCharacters(isTabOrSpace<UChar>);
-    if (!RFC7230::isValidName(strippedName) || !RFC7230::isValidValue(strippedValue))
+    auto trimmedName = StringView(unparsedName).trim(isTabOrSpace<UChar>);
+    auto trimmedValue = StringView(unparsedValue).trim(isTabOrSpace<UChar>);
+    if (!RFC7230::isValidName(trimmedName) || !RFC7230::isValidValue(trimmedValue))
         return std::nullopt;
 
-    String name = strippedName.length() == unparsedName.length() ? WTFMove(unparsedName) : strippedName.toString();
-    String value = strippedValue.length() == unparsedValue.length() ? WTFMove(unparsedValue) : strippedValue.toString();
+    auto name = trimmedName.length() == unparsedName.length() ? WTFMove(unparsedName) : trimmedName.toString();
+    auto value = trimmedValue.length() == unparsedValue.length() ? WTFMove(unparsedValue) : trimmedValue.toString();
     return {{ WTFMove(name), WTFMove(value) }};
 }
 

--- a/Source/WebCore/page/WindowFeatures.cpp
+++ b/Source/WebCore/page/WindowFeatures.cpp
@@ -120,7 +120,7 @@ OptionSet<DisabledAdaptations> parseDisabledAdaptations(StringView disabledAdapt
 {
     OptionSet<DisabledAdaptations> disabledAdaptations;
     for (auto name : disabledAdaptationsString.split(',')) {
-        auto trimmedName = name.stripLeadingAndTrailingMatchedCharacters(isUnicodeCompatibleASCIIWhitespace<UChar>);
+        auto trimmedName = name.trim(isUnicodeCompatibleASCIIWhitespace<UChar>);
         if (equalIgnoringASCIICase(trimmedName, watchAdaptationName()))
             disabledAdaptations.add(DisabledAdaptations::Watch);
     }
@@ -258,12 +258,12 @@ static DialogFeaturesMap parseDialogFeaturesMap(StringView string)
         if (separatorPosition == notFound)
             separatorPosition = colonPosition;
 
-        auto key = featureString.left(separatorPosition).stripLeadingAndTrailingMatchedCharacters(isUnicodeCompatibleASCIIWhitespace<UChar>).toString();
+        auto key = featureString.left(separatorPosition).trim(isUnicodeCompatibleASCIIWhitespace<UChar>).toString();
 
         // Null string for value indicates key without value.
         String value;
         if (separatorPosition != notFound) {
-            auto valueView = featureString.substring(separatorPosition + 1).stripLeadingAndTrailingMatchedCharacters(isUnicodeCompatibleASCIIWhitespace<UChar>);
+            auto valueView = featureString.substring(separatorPosition + 1).trim(isUnicodeCompatibleASCIIWhitespace<UChar>);
             value = valueView.left(valueView.find(' ')).toString();
         }
 

--- a/Source/WebCore/page/csp/ContentSecurityPolicyDirectiveList.cpp
+++ b/Source/WebCore/page/csp/ContentSecurityPolicyDirectiveList.cpp
@@ -132,7 +132,7 @@ static inline bool checkMediaType(ContentSecurityPolicyMediaListDirective* direc
 {
     if (!directive)
         return true;
-    if (typeAttribute.isEmpty() || StringView(typeAttribute).stripLeadingAndTrailingMatchedCharacters(deprecatedIsSpaceOrNewline) != type)
+    if (typeAttribute.isEmpty() || StringView(typeAttribute).trim(deprecatedIsSpaceOrNewline) != type)
         return false;
     return directive->allows(type);
 }

--- a/Source/WebCore/platform/ContentType.cpp
+++ b/Source/WebCore/platform/ContentType.cpp
@@ -87,7 +87,7 @@ String ContentType::parameter(const String& parameterName) const
         start = equalSignPosition + 1;
         end = m_type.find(';', start);
     }
-    return StringView { m_type }.substring(start, end - start).stripLeadingAndTrailingMatchedCharacters(isASCIIWhitespace<UChar>).toString();
+    return StringView { m_type }.substring(start, end - start).trim(isASCIIWhitespace<UChar>).toString();
 }
 
 String ContentType::containerType() const
@@ -101,7 +101,7 @@ static inline Vector<String> splitParameters(StringView parametersView)
 {
     Vector<String> result;
     for (auto view : parametersView.split(','))
-        result.append(view.stripLeadingAndTrailingMatchedCharacters(isASCIIWhitespace<UChar>).toString());
+        result.append(view.trim(isASCIIWhitespace<UChar>).toString());
     return result;
 }
 

--- a/Source/WebCore/platform/LocalizedStrings.cpp
+++ b/Source/WebCore/platform/LocalizedStrings.cpp
@@ -143,7 +143,7 @@ static String truncatedStringForMenuItem(const String& original)
     // Truncate the string if it's too long. This number is roughly the same as the one used by AppKit.
     unsigned maxNumberOfGraphemeClustersInLookupMenuItem = 24;
 
-    String trimmed = original.stripLeadingAndTrailingCharacters(deprecatedIsSpaceOrNewline);
+    auto trimmed = original.trim(deprecatedIsSpaceOrNewline);
     unsigned numberOfCharacters = numCodeUnitsInGraphemeClusters(trimmed, maxNumberOfGraphemeClustersInLookupMenuItem);
     return numberOfCharacters == trimmed.length() ? trimmed : makeString(trimmed.left(numberOfCharacters), horizontalEllipsis);
 }

--- a/Source/WebCore/platform/graphics/gstreamer/MediaPlayerPrivateGStreamer.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/MediaPlayerPrivateGStreamer.cpp
@@ -2773,7 +2773,7 @@ bool isMediaDiskCacheDisabled()
         if (!s.isEmpty()) {
             // FIXME: should this use StringView and equalLettersIgnoringASCIICase? Or even strcmp?
             // https://github.com/WebKit/WebKit/pull/14233#discussion_r1202410966
-            String value = s.stripLeadingAndTrailingCharacters(deprecatedIsSpaceOrNewline).convertToLowercaseWithoutLocale();
+            auto value = s.trim(deprecatedIsSpaceOrNewline).convertToLowercaseWithoutLocale();
             result = (value == "1"_s || value == "t"_s || value == "true"_s);
         }
     });

--- a/Source/WebCore/platform/graphics/gstreamer/mse/SourceBufferPrivateGStreamer.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/mse/SourceBufferPrivateGStreamer.cpp
@@ -306,8 +306,8 @@ size_t SourceBufferPrivateGStreamer::platformMaximumBufferSize() const
                 Vector<String> keyvalue = entry.split(':');
                 if (keyvalue.size() != 2)
                     continue;
-                String key = keyvalue[0].stripLeadingAndTrailingCharacters(deprecatedIsSpaceOrNewline).convertToLowercaseWithoutLocale();
-                String value = keyvalue[1].stripLeadingAndTrailingCharacters(deprecatedIsSpaceOrNewline).convertToLowercaseWithoutLocale();
+                auto key = keyvalue[0].trim(deprecatedIsSpaceOrNewline).convertToLowercaseWithoutLocale();
+                auto value = keyvalue[1].trim(deprecatedIsSpaceOrNewline).convertToLowercaseWithoutLocale();
                 size_t units = 1;
                 if (value.endsWith('k'))
                     units = 1024;

--- a/Source/WebCore/platform/gtk/SelectionData.cpp
+++ b/Source/WebCore/platform/gtk/SelectionData.cpp
@@ -54,7 +54,7 @@ void SelectionData::setURIList(const String& uriListString)
     // from the URI list.
     bool setURL = hasURL();
     for (auto& line : uriListString.split('\n')) {
-        line = line.stripLeadingAndTrailingCharacters(deprecatedIsSpaceOrNewline);
+        line = line.trim(deprecatedIsSpaceOrNewline);
         if (line.isEmpty())
             continue;
         if (line[0] == '#')

--- a/Source/WebCore/platform/ios/DragImageIOS.mm
+++ b/Source/WebCore/platform/ios/DragImageIOS.mm
@@ -120,8 +120,8 @@ DragImageRef createDragImageForLink(Element& linkElement, URL& url, const String
     static const NeverDestroyed titleFontCascade = cascadeForSystemFont(16);
     static const NeverDestroyed urlFontCascade = cascadeForSystemFont(14);
 
-    String topString(title.stripLeadingAndTrailingCharacters(deprecatedIsSpaceOrNewline));
-    String bottomString([(NSURL *)url absoluteString]);
+    auto topString(title.trim(deprecatedIsSpaceOrNewline));
+    auto bottomString([(NSURL *)url absoluteString]);
     if (topString.isEmpty()) {
         topString = bottomString;
         bottomString = emptyString();

--- a/Source/WebCore/platform/mac/PasteboardMac.mm
+++ b/Source/WebCore/platform/mac/PasteboardMac.mm
@@ -211,7 +211,7 @@ static long writeURLForTypes(const Vector<String>& types, const String& pasteboa
     }
 
     if (types.contains(WebURLsWithTitlesPboardType)) {
-        PasteboardURL url = { pasteboardURL.url, String(title).stripLeadingAndTrailingCharacters(deprecatedIsSpaceOrNewline), emptyString() };
+        PasteboardURL url = { pasteboardURL.url, String(title).trim(deprecatedIsSpaceOrNewline), emptyString() };
         newChangeCount = platformStrategies()->pasteboardStrategy()->setURL(url, pasteboardName, context);
     }
     if (types.contains(String(legacyURLPasteboardType())))
@@ -233,7 +233,7 @@ void Pasteboard::write(const PasteboardURL& pasteboardURL)
 
 void Pasteboard::writeTrustworthyWebURLsPboardType(const PasteboardURL& pasteboardURL)
 {
-    PasteboardURL url = { pasteboardURL.url, pasteboardURL.title.stripLeadingAndTrailingCharacters(deprecatedIsSpaceOrNewline), emptyString() };
+    PasteboardURL url = { pasteboardURL.url, pasteboardURL.title.trim(deprecatedIsSpaceOrNewline), emptyString() };
     m_changeCount = platformStrategies()->pasteboardStrategy()->setURL(url, m_pasteboardName, context());
 }
 

--- a/Source/WebCore/platform/mac/PasteboardWriter.mm
+++ b/Source/WebCore/platform/mac/PasteboardWriter.mm
@@ -82,7 +82,7 @@ ALLOW_DEPRECATED_DECLARATIONS_END
 
         // WebURLsWithTitlesPboardType.
         // FIXME: This could use StringView (the one that creates NSString) to save an allocation
-        auto paths = adoptNS([[NSArray alloc] initWithObjects:@[ @[ cocoaURL.absoluteString ] ], @[ urlData->title.stripLeadingAndTrailingCharacters(deprecatedIsSpaceOrNewline) ], nil]);
+        auto paths = adoptNS([[NSArray alloc] initWithObjects:@[ @[ cocoaURL.absoluteString ] ], @[ urlData->title.trim(deprecatedIsSpaceOrNewline) ], nil]);
         [pasteboardItem setPropertyList:paths.get() forType:toUTI(@"WebURLsWithTitlesPboardType").get()];
 
         // NSURLPboardType.

--- a/Source/WebCore/platform/network/CacheValidation.cpp
+++ b/Source/WebCore/platform/network/CacheValidation.cpp
@@ -378,7 +378,7 @@ static Vector<std::pair<String, String>> collectVaryingRequestHeadersInternal(co
 
     Vector<std::pair<String, String>> headers;
     for (auto varyHeaderName : StringView(varyValue).split(',')) {
-        auto headerName = varyHeaderName.stripLeadingAndTrailingMatchedCharacters(isUnicodeCompatibleASCIIWhitespace<UChar>);
+        auto headerName = varyHeaderName.trim(isUnicodeCompatibleASCIIWhitespace<UChar>);
         headers.append(std::pair { headerName.toString(), headerValueForVaryFunction(headerName) });
     }
     return headers;

--- a/Source/WebCore/platform/network/HTTPParsers.cpp
+++ b/Source/WebCore/platform/network/HTTPParsers.cpp
@@ -343,12 +343,12 @@ StringView filenameFromHTTPContentDisposition(StringView value)
         if (valueStartPos == notFound)
             continue;
 
-        auto key = keyValuePair.left(valueStartPos).stripLeadingAndTrailingMatchedCharacters(isUnicodeCompatibleASCIIWhitespace<UChar>);
+        auto key = keyValuePair.left(valueStartPos).trim(isUnicodeCompatibleASCIIWhitespace<UChar>);
 
         if (key.isEmpty() || key != "filename"_s)
             continue;
 
-        auto value = keyValuePair.substring(valueStartPos + 1).stripLeadingAndTrailingMatchedCharacters(isUnicodeCompatibleASCIIWhitespace<UChar>);
+        auto value = keyValuePair.substring(valueStartPos + 1).trim(isUnicodeCompatibleASCIIWhitespace<UChar>);
 
         // Remove quotes if there are any
         if (value.length() > 1 && value[0] == '\"')
@@ -564,7 +564,7 @@ XFrameOptionsDisposition parseXFrameOptionsHeader(StringView header)
         return result;
 
     for (auto currentHeader : header.splitAllowingEmptyEntries(',')) {
-        currentHeader = currentHeader.stripLeadingAndTrailingMatchedCharacters(isUnicodeCompatibleASCIIWhitespace<UChar>);
+        currentHeader = currentHeader.trim(isUnicodeCompatibleASCIIWhitespace<UChar>);
         XFrameOptionsDisposition currentValue = XFrameOptionsDisposition::None;
         if (equalLettersIgnoringASCIICase(currentHeader, "deny"_s))
             currentValue = XFrameOptionsDisposition::Deny;
@@ -595,7 +595,7 @@ OptionSet<ClearSiteDataValue> parseClearSiteDataHeader(const ResourceResponse& r
         return result;
 
     for (auto value : StringView(headerValue).split(',')) {
-        auto trimmedValue = value.stripLeadingAndTrailingMatchedCharacters(isHTTPSpace);
+        auto trimmedValue = value.trim(isHTTPSpace);
         if (trimmedValue == "\"cache\""_s)
             result.add(ClearSiteDataValue::Cache);
         else if (trimmedValue == "\"cookies\""_s)
@@ -839,7 +839,7 @@ bool isForbiddenHeader(const String& name, StringView value)
         return true;
     if (equalLettersIgnoringASCIICase(name, "x-http-method-override"_s) || equalLettersIgnoringASCIICase(name, "x-http-method"_s) || equalLettersIgnoringASCIICase(name, "x-method-override"_s)) {
         for (auto methodValue : StringView(value).split(',')) {
-            auto method = methodValue.stripLeadingAndTrailingMatchedCharacters(isUnicodeCompatibleASCIIWhitespace<UChar>);
+            auto method = methodValue.trim(isUnicodeCompatibleASCIIWhitespace<UChar>);
             if (isForbiddenMethod(method))
                 return true;
         }

--- a/Source/WebCore/platform/network/HTTPParsers.h
+++ b/Source/WebCore/platform/network/HTTPParsers.h
@@ -131,12 +131,12 @@ inline bool isHTTPSpace(UChar character)
 // Strip leading and trailing whitespace as defined in https://fetch.spec.whatwg.org/#concept-header-value-normalize.
 inline String stripLeadingAndTrailingHTTPSpaces(const String& string)
 {
-    return string.stripLeadingAndTrailingCharacters(isHTTPSpace);
+    return string.trim(isHTTPSpace);
 }
 
 inline StringView stripLeadingAndTrailingHTTPSpaces(StringView string)
 {
-    return string.stripLeadingAndTrailingMatchedCharacters(isHTTPSpace);
+    return string.trim(isHTTPSpace);
 }
 
 template<class HashType>

--- a/Source/WebCore/platform/network/MIMEHeader.cpp
+++ b/Source/WebCore/platform/network/MIMEHeader.cpp
@@ -63,7 +63,7 @@ static KeyValueMap retrieveKeyValuePairs(WebCore::SharedBufferChunkReader& buffe
         if (!key.isEmpty()) {
             if (keyValuePairs.find(key) != keyValuePairs.end())
                 LOG_ERROR("Key duplicate found in MIME header. Key is '%s', previous value replaced.", key.ascii().data());
-            keyValuePairs.add(key, value.toString().stripLeadingAndTrailingCharacters(deprecatedIsSpaceOrNewline));
+            keyValuePairs.add(key, value.toString().trim(deprecatedIsSpaceOrNewline));
             key = String();
             value.clear();
         }
@@ -72,12 +72,12 @@ static KeyValueMap retrieveKeyValuePairs(WebCore::SharedBufferChunkReader& buffe
             // This is not a key value pair, ignore.
             continue;
         }
-        key = StringView(line).left(semicolonIndex).stripLeadingAndTrailingMatchedCharacters(isUnicodeCompatibleASCIIWhitespace<UChar>).convertToASCIILowercase();
+        key = StringView(line).left(semicolonIndex).trim(isUnicodeCompatibleASCIIWhitespace<UChar>).convertToASCIILowercase();
         value.append(StringView(line).substring(semicolonIndex + 1));
     }
     // Store the last property if there is one.
     if (!key.isEmpty())
-        keyValuePairs.set(key, value.toString().stripLeadingAndTrailingCharacters(deprecatedIsSpaceOrNewline));
+        keyValuePairs.set(key, value.toString().trim(deprecatedIsSpaceOrNewline));
     return keyValuePairs;
 }
 
@@ -90,7 +90,7 @@ RefPtr<MIMEHeader> MIMEHeader::parseHeader(SharedBufferChunkReader& buffer)
         String contentType, charset, multipartType, endOfPartBoundary;
         if (auto parsedContentType = ParsedContentType::create(mimeParametersIterator->value)) {
             contentType = parsedContentType->mimeType();
-            charset = parsedContentType->charset().stripLeadingAndTrailingCharacters(deprecatedIsSpaceOrNewline);
+            charset = parsedContentType->charset().trim(deprecatedIsSpaceOrNewline);
             multipartType = parsedContentType->parameterValueForName("type"_s);
             endOfPartBoundary = parsedContentType->parameterValueForName("boundary"_s);
         }
@@ -122,7 +122,7 @@ RefPtr<MIMEHeader> MIMEHeader::parseHeader(SharedBufferChunkReader& buffer)
 
 MIMEHeader::Encoding MIMEHeader::parseContentTransferEncoding(StringView text)
 {
-    auto encoding = text.stripLeadingAndTrailingMatchedCharacters(isUnicodeCompatibleASCIIWhitespace<UChar>);
+    auto encoding = text.trim(isUnicodeCompatibleASCIIWhitespace<UChar>);
     if (equalLettersIgnoringASCIICase(encoding, "base64"_s))
         return Base64;
     if (equalLettersIgnoringASCIICase(encoding, "quoted-printable"_s))

--- a/Source/WebCore/platform/network/ParsedContentType.cpp
+++ b/Source/WebCore/platform/network/ParsedContentType.cpp
@@ -371,7 +371,7 @@ void ParsedContentType::setContentType(String&& contentRange, Mode mode)
     if (mode == Mode::MimeSniff)
         m_mimeType = stripLeadingAndTrailingHTTPSpaces(StringView(m_mimeType)).convertToASCIILowercase();
     else
-        m_mimeType = m_mimeType.stripLeadingAndTrailingCharacters(deprecatedIsSpaceOrNewline);
+        m_mimeType = m_mimeType.trim(deprecatedIsSpaceOrNewline);
 }
 
 static bool containsNonQuoteStringTokenCharacters(const String& input)

--- a/Source/WebCore/platform/network/ResourceResponseBase.cpp
+++ b/Source/WebCore/platform/network/ResourceResponseBase.cpp
@@ -814,7 +814,7 @@ bool ResourceResponseBase::isAttachment() const
     lazyInit(AllFields);
 
     auto value = m_httpHeaderFields.get(HTTPHeaderName::ContentDisposition);
-    return equalLettersIgnoringASCIICase(StringView(value).left(value.find(';')).stripLeadingAndTrailingMatchedCharacters(isUnicodeCompatibleASCIIWhitespace<UChar>), "attachment"_s);
+    return equalLettersIgnoringASCIICase(StringView(value).left(value.find(';')).trim(isUnicodeCompatibleASCIIWhitespace<UChar>), "attachment"_s);
 }
 
 bool ResourceResponseBase::isAttachmentWithFilename() const
@@ -826,7 +826,7 @@ bool ResourceResponseBase::isAttachmentWithFilename() const
         return false;
 
     StringView contentDispositionView { contentDisposition };
-    if (!equalLettersIgnoringASCIICase(contentDispositionView.left(contentDispositionView.find(';')).stripLeadingAndTrailingMatchedCharacters(isUnicodeCompatibleASCIIWhitespace<UChar>), "attachment"_s))
+    if (!equalLettersIgnoringASCIICase(contentDispositionView.left(contentDispositionView.find(';')).trim(isUnicodeCompatibleASCIIWhitespace<UChar>), "attachment"_s))
         return false;
 
     return !filenameFromHTTPContentDisposition(contentDispositionView).isNull();

--- a/Source/WebCore/platform/network/curl/CookieUtil.cpp
+++ b/Source/WebCore/platform/network/curl/CookieUtil.cpp
@@ -97,10 +97,10 @@ static void parseCookieAttributes(const String& attribute, bool& hasMaxAge, Cook
     String attributeValue;
 
     if (assignmentPosition != notFound) {
-        attributeName = attribute.left(assignmentPosition).stripLeadingAndTrailingCharacters(deprecatedIsSpaceOrNewline);
-        attributeValue = attribute.substring(assignmentPosition + 1).stripLeadingAndTrailingCharacters(deprecatedIsSpaceOrNewline);
+        attributeName = attribute.left(assignmentPosition).trim(deprecatedIsSpaceOrNewline);
+        attributeValue = attribute.substring(assignmentPosition + 1).trim(deprecatedIsSpaceOrNewline);
     } else
-        attributeName = attribute.stripLeadingAndTrailingCharacters(deprecatedIsSpaceOrNewline);
+        attributeName = attribute.trim(deprecatedIsSpaceOrNewline);
 
     if (equalLettersIgnoringASCIICase(attributeName, "httponly"_s))
         result.httpOnly = true;
@@ -169,8 +169,8 @@ std::optional<Cookie> parseCookieHeader(const String& cookieLine)
     }
 
     Cookie cookie;
-    cookie.name = cookieName.stripLeadingAndTrailingCharacters(deprecatedIsSpaceOrNewline);
-    cookie.value = cookieValue.stripLeadingAndTrailingCharacters(deprecatedIsSpaceOrNewline);
+    cookie.name = cookieName.trim(deprecatedIsSpaceOrNewline);
+    cookie.value = cookieValue.trim(deprecatedIsSpaceOrNewline);
 
     bool hasMaxAge = false;
     cookie.session = true;

--- a/Source/WebCore/platform/network/curl/CurlMultipartHandle.cpp
+++ b/Source/WebCore/platform/network/curl/CurlMultipartHandle.cpp
@@ -56,11 +56,11 @@ std::optional<String> CurlMultipartHandle::extractBoundary(const CurlResponse& r
         if (splitPosition == notFound)
             continue;
 
-        auto key = header.left(splitPosition).stripLeadingAndTrailingCharacters(deprecatedIsSpaceOrNewline);
+        auto key = header.left(splitPosition).trim(deprecatedIsSpaceOrNewline);
         if (!equalIgnoringASCIICase(key, "Content-Type"_s))
             continue;
 
-        auto contentType = header.substring(splitPosition + 1).stripLeadingAndTrailingCharacters(deprecatedIsSpaceOrNewline);
+        auto contentType = header.substring(splitPosition + 1).trim(deprecatedIsSpaceOrNewline);
         auto mimeType = extractMIMETypeFromMediaType(contentType);
         if (!equalLettersIgnoringASCIICase(mimeType, "multipart/x-mixed-replace"_s))
             continue;

--- a/Source/WebCore/platform/network/curl/CurlRequest.cpp
+++ b/Source/WebCore/platform/network/curl/CurlRequest.cpp
@@ -531,8 +531,8 @@ int CurlRequest::didReceiveDebugInfo(curl_infotype type, char* data, size_t size
         for (auto& header : headerFields) {
             auto pos = header.find(':');
             if (pos != notFound) {
-                auto key = header.left(pos).stripLeadingAndTrailingCharacters(deprecatedIsSpaceOrNewline);
-                auto value = header.substring(pos + 1).stripLeadingAndTrailingCharacters(deprecatedIsSpaceOrNewline);
+                auto key = header.left(pos).trim(deprecatedIsSpaceOrNewline);
+                auto value = header.substring(pos + 1).trim(deprecatedIsSpaceOrNewline);
                 m_requestHeaders.add(key, value);
             }
         }

--- a/Source/WebCore/platform/network/curl/ResourceResponseCurl.cpp
+++ b/Source/WebCore/platform/network/curl/ResourceResponseCurl.cpp
@@ -116,8 +116,8 @@ void ResourceResponse::appendHTTPHeaderField(const String& header)
 {
     auto splitPosition = header.find(':');
     if (splitPosition != notFound) {
-        auto key = header.left(splitPosition).stripLeadingAndTrailingCharacters(deprecatedIsSpaceOrNewline);
-        auto value = header.substring(splitPosition + 1).stripLeadingAndTrailingCharacters(deprecatedIsSpaceOrNewline);
+        auto key = header.left(splitPosition).trim(deprecatedIsSpaceOrNewline);
+        auto value = header.substring(splitPosition + 1).trim(deprecatedIsSpaceOrNewline);
 
         if (isAppendableHeader(key))
             addHTTPHeaderField(key, value);
@@ -131,20 +131,20 @@ void ResourceResponse::appendHTTPHeaderField(const String& header)
 
 void ResourceResponse::setStatusLine(StringView header)
 {
-    auto statusLine = header.stripLeadingAndTrailingMatchedCharacters(deprecatedIsSpaceOrNewline);
+    auto statusLine = header.trim(deprecatedIsSpaceOrNewline);
 
     auto httpVersionEndPosition = statusLine.find(' ');
     auto statusCodeEndPosition = notFound;
 
     // Extract the http version
     if (httpVersionEndPosition != notFound) {
-        statusLine = statusLine.substring(httpVersionEndPosition + 1).stripLeadingAndTrailingMatchedCharacters(deprecatedIsSpaceOrNewline);
+        statusLine = statusLine.substring(httpVersionEndPosition + 1).trim(deprecatedIsSpaceOrNewline);
         statusCodeEndPosition = statusLine.find(' ');
     }
 
     // Extract the http status text
     if (statusCodeEndPosition != notFound) {
-        auto statusText = statusLine.substring(statusCodeEndPosition + 1).stripLeadingAndTrailingMatchedCharacters(deprecatedIsSpaceOrNewline);
+        auto statusText = statusLine.substring(statusCodeEndPosition + 1).trim(deprecatedIsSpaceOrNewline);
         setHTTPStatusText(statusText.toAtomString());
     }
 }

--- a/Source/WebCore/platform/network/soup/ResourceResponseSoup.cpp
+++ b/Source/WebCore/platform/network/soup/ResourceResponseSoup.cpp
@@ -103,8 +103,8 @@ static String sanitizeFilename(const String& filename)
     if (filename.isEmpty())
         return filename;
 
-    // Strip leading/trailing whitespaces, path separators and dots
-    auto result = filename.stripLeadingAndTrailingCharacters([](UChar character) -> bool {
+    // Trim leading/trailing whitespaces, path separators and dots
+    auto result = filename.trim([](UChar character) -> bool {
         return deprecatedIsSpaceOrNewline(character) || character == '/' || character == '\\' || character == '.';
     });
 

--- a/Source/WebCore/platform/sql/SQLiteDatabase.cpp
+++ b/Source/WebCore/platform/sql/SQLiteDatabase.cpp
@@ -750,7 +750,7 @@ static Expected<sqlite3_stmt*, int> constructAndPrepareStatement(SQLiteDatabase&
 
 Expected<SQLiteStatement, int> SQLiteDatabase::prepareStatementSlow(StringView queryString)
 {
-    CString query = queryString.stripLeadingAndTrailingMatchedCharacters(isUnicodeCompatibleASCIIWhitespace<UChar>).utf8();
+    auto query = queryString.trim(isUnicodeCompatibleASCIIWhitespace<UChar>).utf8();
     auto sqlStatement = constructAndPrepareStatement(*this, query.data(), query.length());
     if (!sqlStatement) {
         RELEASE_LOG_ERROR(SQLDatabase, "SQLiteDatabase::prepareStatement: Failed to prepare statement %" PUBLIC_LOG_STRING, query.data());
@@ -771,7 +771,7 @@ Expected<SQLiteStatement, int> SQLiteDatabase::prepareStatement(ASCIILiteral que
 
 Expected<UniqueRef<SQLiteStatement>, int> SQLiteDatabase::prepareHeapStatementSlow(StringView queryString)
 {
-    CString query = queryString.stripLeadingAndTrailingMatchedCharacters(isUnicodeCompatibleASCIIWhitespace<UChar>).utf8();
+    auto query = queryString.trim(isUnicodeCompatibleASCIIWhitespace<UChar>).utf8();
     auto sqlStatement = constructAndPrepareStatement(*this, query.data(), query.length());
     if (!sqlStatement) {
         RELEASE_LOG_ERROR(SQLDatabase, "SQLiteDatabase::prepareHeapStatement: Failed to prepare statement %" PUBLIC_LOG_STRING, query.data());

--- a/Source/WebCore/platform/text/PlatformLocale.cpp
+++ b/Source/WebCore/platform/text/PlatformLocale.cpp
@@ -297,7 +297,7 @@ unsigned Locale::matchedDecimalSymbolIndex(const String& input, unsigned& positi
 String Locale::convertFromLocalizedNumber(const String& localized)
 {
     initializeLocaleData();
-    String input = localized.stripLeadingAndTrailingCharacters(deprecatedIsSpaceOrNewline);
+    auto input = localized.trim(deprecatedIsSpaceOrNewline);
     if (!m_hasLocaleData || input.isEmpty())
         return input;
 

--- a/Source/WebCore/platform/win/ClipboardUtilitiesWin.cpp
+++ b/Source/WebCore/platform/win/ClipboardUtilitiesWin.cpp
@@ -230,7 +230,7 @@ static String extractMarkupFromCFHTML(const String& cfhtml)
     unsigned fragmentStart = cfhtml.find('>', tagStart) + 1;
     unsigned tagEnd = cfhtml.findIgnoringASCIICase("endfragment"_s, fragmentStart);
     unsigned fragmentEnd = cfhtml.reverseFind('<', tagEnd);
-    return cfhtml.substring(fragmentStart, fragmentEnd - fragmentStart).stripLeadingAndTrailingCharacters(deprecatedIsSpaceOrNewline);
+    return cfhtml.substring(fragmentStart, fragmentEnd - fragmentStart).trim(deprecatedIsSpaceOrNewline);
 }
 
 // Documentation for the CF_HTML format is available at http://msdn.microsoft.com/workshop/networking/clipboard/htmlclipboard.asp
@@ -620,7 +620,7 @@ Ref<DocumentFragment> fragmentFromCFHTML(Document* doc, const String& cfhtml)
         unsigned srcStart = lineStart+srcURLStr.length();
         String rawSrcURL = cfhtml.substring(srcStart, srcEnd-srcStart);
         replaceNBSPWithSpace(rawSrcURL);
-        srcURL = rawSrcURL.stripLeadingAndTrailingCharacters(deprecatedIsSpaceOrNewline);
+        srcURL = rawSrcURL.trim(deprecatedIsSpaceOrNewline);
     }
 
     String markup = extractMarkupFromCFHTML(cfhtml);

--- a/Source/WebCore/platform/xr/PlatformXR.h
+++ b/Source/WebCore/platform/xr/PlatformXR.h
@@ -121,7 +121,7 @@ inline SessionFeature sessionFeatureFromReferenceSpaceType(ReferenceSpaceType re
 
 inline std::optional<SessionFeature> parseSessionFeatureDescriptor(StringView string)
 {
-    auto feature = string.stripLeadingAndTrailingMatchedCharacters(isUnicodeCompatibleASCIIWhitespace<UChar>).convertToASCIILowercase();
+    auto feature = string.trim(isUnicodeCompatibleASCIIWhitespace<UChar>).convertToASCIILowercase();
 
     if (feature == "viewer"_s)
         return SessionFeature::ReferenceSpaceTypeViewer;

--- a/Source/WebCore/rendering/RenderMenuList.cpp
+++ b/Source/WebCore/rendering/RenderMenuList.cpp
@@ -272,7 +272,7 @@ void RenderMenuList::setTextFromOption(int optionIndex)
     }
 #endif
 
-    setText(text.stripLeadingAndTrailingCharacters(deprecatedIsSpaceOrNewline));
+    setText(text.trim(deprecatedIsSpaceOrNewline));
     didUpdateActiveOption(optionIndex);
 }
 

--- a/Source/WebCore/svg/SVGAnimationElement.cpp
+++ b/Source/WebCore/svg/SVGAnimationElement.cpp
@@ -65,7 +65,7 @@ static Vector<float> parseKeyTimes(StringView value, bool verifyOrder)
     Vector<float> result;
 
     for (auto keyTime : keyTimes) {
-        keyTime = keyTime.stripLeadingAndTrailingMatchedCharacters(isUnicodeCompatibleASCIIWhitespace<UChar>);
+        keyTime = keyTime.trim(isUnicodeCompatibleASCIIWhitespace<UChar>);
 
         bool ok;
         float time = keyTime.toFloat(ok);
@@ -156,7 +156,7 @@ bool SVGAnimationElement::attributeContainsJavaScriptURL(const Attribute& attrib
 
     if (attribute.name() == SVGNames::valuesAttr) {
         for (auto innerValue : StringView(attribute.value()).split(';')) {
-            if (WTF::protocolIsJavaScript(innerValue.stripLeadingAndTrailingMatchedCharacters(isASCIIWhitespace<UChar>)))
+            if (WTF::protocolIsJavaScript(innerValue.trim(isASCIIWhitespace<UChar>)))
                 return true;
         }
         return false;
@@ -176,7 +176,7 @@ void SVGAnimationElement::attributeChanged(const QualifiedName& name, const Atom
         // http://www.w3.org/TR/SVG11/animate.html#ValuesAttribute
         m_values.clear();
         newValue.string().split(';', [this](StringView innerValue) {
-            m_values.append(innerValue.stripLeadingAndTrailingMatchedCharacters(isASCIIWhitespace<UChar>).toString());
+            m_values.append(innerValue.trim(isASCIIWhitespace<UChar>).toString());
         });
         updateAnimationMode();
         break;

--- a/Source/WebCore/svg/animation/SVGSMILElement.cpp
+++ b/Source/WebCore/svg/animation/SVGSMILElement.cpp
@@ -318,7 +318,7 @@ SMILTime SVGSMILElement::parseOffsetValue(StringView data)
 {
     bool ok;
     double result = 0;
-    auto parse = data.stripLeadingAndTrailingMatchedCharacters(isUnicodeCompatibleASCIIWhitespace<UChar>);
+    auto parse = data.trim(isUnicodeCompatibleASCIIWhitespace<UChar>);
     if (parse.endsWith('h'))
         result = parse.left(parse.length() - 1).toDouble(ok) * 60 * 60;
     else if (parse.endsWith("min"_s))
@@ -339,7 +339,7 @@ SMILTime SVGSMILElement::parseClockValue(StringView data)
     if (data.isNull())
         return SMILTime::unresolved();
 
-    auto parse = data.stripLeadingAndTrailingMatchedCharacters(isUnicodeCompatibleASCIIWhitespace<UChar>);
+    auto parse = data.trim(isUnicodeCompatibleASCIIWhitespace<UChar>);
     if (parse == indefiniteAtom())
         return SMILTime::indefinite();
 
@@ -372,7 +372,7 @@ static void sortTimeList(Vector<SMILTimeWithOrigin>& timeList)
     
 bool SVGSMILElement::parseCondition(StringView value, BeginOrEnd beginOrEnd)
 {
-    auto parseString = value.stripLeadingAndTrailingMatchedCharacters(isUnicodeCompatibleASCIIWhitespace<UChar>);
+    auto parseString = value.trim(isUnicodeCompatibleASCIIWhitespace<UChar>);
     
     double sign = 1.;
     size_t pos = parseString.find('+');
@@ -386,8 +386,8 @@ bool SVGSMILElement::parseCondition(StringView value, BeginOrEnd beginOrEnd)
     if (pos == notFound)
         conditionString = parseString;
     else {
-        conditionString = parseString.left(pos).stripLeadingAndTrailingMatchedCharacters(isUnicodeCompatibleASCIIWhitespace<UChar>);
-        auto offsetString = parseString.substring(pos + 1).stripLeadingAndTrailingMatchedCharacters(isUnicodeCompatibleASCIIWhitespace<UChar>);
+        conditionString = parseString.left(pos).trim(isUnicodeCompatibleASCIIWhitespace<UChar>);
+        auto offsetString = parseString.substring(pos + 1).trim(isUnicodeCompatibleASCIIWhitespace<UChar>);
         offset = parseOffsetValue(offsetString);
         if (offset.isUnresolved())
             return false;

--- a/Source/WebCore/svg/properties/SVGAnimationAdditiveValueFunctionImpl.cpp
+++ b/Source/WebCore/svg/properties/SVGAnimationAdditiveValueFunctionImpl.cpp
@@ -47,8 +47,8 @@ Color SVGAnimationColorFunction::colorFromString(SVGElement& targetElement, cons
 
 std::optional<float> SVGAnimationColorFunction::calculateDistance(SVGElement&, const String& from, const String& to) const
 {
-    auto simpleFrom = CSSParser::parseColorWithoutContext(from.stripLeadingAndTrailingCharacters(deprecatedIsSpaceOrNewline)).toColorTypeLossy<SRGBA<uint8_t>>().resolved();
-    auto simpleTo = CSSParser::parseColorWithoutContext(to.stripLeadingAndTrailingCharacters(deprecatedIsSpaceOrNewline)).toColorTypeLossy<SRGBA<uint8_t>>().resolved();
+    auto simpleFrom = CSSParser::parseColorWithoutContext(from.trim(deprecatedIsSpaceOrNewline)).toColorTypeLossy<SRGBA<uint8_t>>().resolved();
+    auto simpleTo = CSSParser::parseColorWithoutContext(to.trim(deprecatedIsSpaceOrNewline)).toColorTypeLossy<SRGBA<uint8_t>>().resolved();
 
     float red = simpleFrom.red - simpleTo.red;
     float green = simpleFrom.green - simpleTo.green;

--- a/Source/WebCore/svg/properties/SVGPropertyTraits.h
+++ b/Source/WebCore/svg/properties/SVGPropertyTraits.h
@@ -46,10 +46,10 @@ struct SVGPropertyTraits<bool> {
 template<>
 struct SVGPropertyTraits<Color> {
     static Color initialValue() { return Color(); }
-    static Color fromString(const String& string) { return CSSParser::parseColorWithoutContext(string.stripLeadingAndTrailingCharacters(deprecatedIsSpaceOrNewline)); }
+    static Color fromString(const String& string) { return CSSParser::parseColorWithoutContext(string.trim(deprecatedIsSpaceOrNewline)); }
     static std::optional<Color> parse(const QualifiedName&, const String& string)
     {
-        Color color = CSSParser::parseColorWithoutContext(string.stripLeadingAndTrailingCharacters(deprecatedIsSpaceOrNewline));
+        Color color = CSSParser::parseColorWithoutContext(string.trim(deprecatedIsSpaceOrNewline));
         if (!color.isValid())
             return std::nullopt;
         return color;

--- a/Source/WebCore/xml/XPathGrammar.cpp
+++ b/Source/WebCore/xml/XPathGrammar.cpp
@@ -1822,7 +1822,7 @@ yyreduce:
     {
         auto stringImpl = adoptRef((yyvsp[(3) - (4)].string));
         if (stringImpl)
-            stringImpl = stringImpl->stripLeadingAndTrailingCharacters(deprecatedIsSpaceOrNewline);
+            stringImpl = stringImpl->trim(deprecatedIsSpaceOrNewline);
         (yyval.nodeTest) = new WebCore::XPath::Step::NodeTest(WebCore::XPath::Step::NodeTest::ProcessingInstructionNodeTest, stringImpl.get());
     ;}
     break;

--- a/Source/WebCore/xml/XPathGrammar.y
+++ b/Source/WebCore/xml/XPathGrammar.y
@@ -262,7 +262,7 @@ NodeTest:
     {
         auto stringImpl = adoptRef($3);
         if (stringImpl)
-            stringImpl = stringImpl->stripLeadingAndTrailingCharacters(deprecatedIsSpaceOrNewline);
+            stringImpl = stringImpl->trim(deprecatedIsSpaceOrNewline);
         $$ = new WebCore::XPath::Step::NodeTest(WebCore::XPath::Step::NodeTest::ProcessingInstructionNodeTest, stringImpl.get());
     }
     ;

--- a/Source/WebKit/UIProcess/API/glib/WebKitOptionMenuItemPrivate.h
+++ b/Source/WebKit/UIProcess/API/glib/WebKitOptionMenuItemPrivate.h
@@ -27,7 +27,7 @@ struct _WebKitOptionMenuItem {
     _WebKitOptionMenuItem() = default;
 
     _WebKitOptionMenuItem(const WebKit::WebPopupItem& item)
-        : label(item.m_text.stripLeadingAndTrailingCharacters(deprecatedIsSpaceOrNewline).utf8())
+        : label(item.m_text.trim(deprecatedIsSpaceOrNewline).utf8())
         , isGroupLabel(item.m_isLabel)
         , isGroupChild(item.m_text.startsWith("    "_s))
         , isEnabled(item.m_isEnabled)

--- a/Source/WebKit/UIProcess/gtk/WebPopupMenuProxyGtk.cpp
+++ b/Source/WebKit/UIProcess/gtk/WebPopupMenuProxyGtk.cpp
@@ -169,7 +169,7 @@ void WebPopupMenuProxyGtk::createPopupMenu(const Vector<WebPopupItem>& items, in
     for (const auto& item : items) {
         if (item.m_isLabel) {
             gtk_tree_store_insert_with_values(model.get(), &parentIter, nullptr, -1,
-                Columns::Label, item.m_text.stripLeadingAndTrailingCharacters(deprecatedIsSpaceOrNewline).utf8().data(),
+                Columns::Label, item.m_text.trim(deprecatedIsSpaceOrNewline).utf8().data(),
                 Columns::IsGroup, TRUE,
                 Columns::IsEnabled, TRUE,
                 -1);
@@ -179,7 +179,7 @@ void WebPopupMenuProxyGtk::createPopupMenu(const Vector<WebPopupItem>& items, in
             GtkTreeIter iter;
             bool isSelected = selectedIndex && static_cast<unsigned>(selectedIndex) == index;
             gtk_tree_store_insert_with_values(model.get(), &iter, item.m_text.startsWith("    "_s) ? &parentIter : nullptr, -1,
-                Columns::Label, item.m_text.stripLeadingAndTrailingCharacters(deprecatedIsSpaceOrNewline).utf8().data(),
+                Columns::Label, item.m_text.trim(deprecatedIsSpaceOrNewline).utf8().data(),
                 Columns::Tooltip, item.m_toolTip.isEmpty() ? nullptr : item.m_toolTip.utf8().data(),
                 Columns::IsGroup, FALSE,
                 Columns::IsSelected, isSelected,

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebContextMenuClient.cpp
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebContextMenuClient.cpp
@@ -53,7 +53,7 @@ void WebContextMenuClient::searchWithGoogle(const WebCore::LocalFrame* frame)
     if (!page)
         return;
 
-    auto searchString = frame->editor().selectedText().stripLeadingAndTrailingCharacters(deprecatedIsSpaceOrNewline);
+    auto searchString = frame->editor().selectedText().trim(deprecatedIsSpaceOrNewline);
     searchString = makeStringByReplacingAll(encodeWithURLEscapeSequences(searchString), "%20"_s, "+"_s);
     auto searchURL = URL { "https://www.google.com/search?q=" + searchString + "&ie=UTF-8&oe=UTF-8" };
 

--- a/Source/WebKit/WebProcess/WebCoreSupport/mac/WebContextMenuClientMac.mm
+++ b/Source/WebKit/WebProcess/WebCoreSupport/mac/WebContextMenuClientMac.mm
@@ -65,7 +65,7 @@ void WebContextMenuClient::stopSpeaking()
 
 void WebContextMenuClient::searchWithGoogle(const LocalFrame* frame)
 {
-    String searchString = frame->editor().selectedText().stripLeadingAndTrailingCharacters(deprecatedIsSpaceOrNewline);
+    auto searchString = frame->editor().selectedText().trim(deprecatedIsSpaceOrNewline);
     m_page->send(Messages::WebPageProxy::SearchTheWeb(searchString));
 }
 

--- a/Tools/TestWebKitAPI/Tests/WTF/StringView.cpp
+++ b/Tools/TestWebKitAPI/Tests/WTF/StringView.cpp
@@ -954,26 +954,26 @@ TEST(WTF, StringViewReverseFindBasic)
     EXPECT_EQ(reference.reverseFind('c', 4), notFound);
 }
 
-TEST(WTF, StringViewStripLeadingAndTrailingMatchedCharacters)
+TEST(WTF, StringViewTrim)
 {
     auto isA = [] (UChar c) { 
         return c == 'A';
     };
 
-    EXPECT_TRUE(stringViewFromLiteral("AAABBBAAA").stripLeadingAndTrailingMatchedCharacters(isA) == stringViewFromLiteral("BBB"));
-    EXPECT_TRUE(stringViewFromLiteral("AAABBBCCC").stripLeadingAndTrailingMatchedCharacters(isA) == stringViewFromLiteral("BBBCCC"));
-    EXPECT_TRUE(stringViewFromLiteral("CCCBBBAAA").stripLeadingAndTrailingMatchedCharacters(isA) == stringViewFromLiteral("CCCBBB"));
-    EXPECT_TRUE(stringViewFromLiteral("CCCBBBCCC").stripLeadingAndTrailingMatchedCharacters(isA) == stringViewFromLiteral("CCCBBBCCC"));
-    EXPECT_TRUE(stringViewFromLiteral("AAAAAACCC").stripLeadingAndTrailingMatchedCharacters(isA) == stringViewFromLiteral("CCC"));
-    EXPECT_TRUE(stringViewFromLiteral("BBBAAAAAA").stripLeadingAndTrailingMatchedCharacters(isA) == stringViewFromLiteral("BBB"));
-    EXPECT_TRUE(stringViewFromLiteral("CCCAAABBB").stripLeadingAndTrailingMatchedCharacters(isA) == stringViewFromLiteral("CCCAAABBB"));
-    EXPECT_TRUE(stringViewFromLiteral("AAAAAAAAA").stripLeadingAndTrailingMatchedCharacters(isA) == StringView::empty());
+    EXPECT_TRUE(stringViewFromLiteral("AAABBBAAA").trim(isA) == stringViewFromLiteral("BBB"));
+    EXPECT_TRUE(stringViewFromLiteral("AAABBBCCC").trim(isA) == stringViewFromLiteral("BBBCCC"));
+    EXPECT_TRUE(stringViewFromLiteral("CCCBBBAAA").trim(isA) == stringViewFromLiteral("CCCBBB"));
+    EXPECT_TRUE(stringViewFromLiteral("CCCBBBCCC").trim(isA) == stringViewFromLiteral("CCCBBBCCC"));
+    EXPECT_TRUE(stringViewFromLiteral("AAAAAACCC").trim(isA) == stringViewFromLiteral("CCC"));
+    EXPECT_TRUE(stringViewFromLiteral("BBBAAAAAA").trim(isA) == stringViewFromLiteral("BBB"));
+    EXPECT_TRUE(stringViewFromLiteral("CCCAAABBB").trim(isA) == stringViewFromLiteral("CCCAAABBB"));
+    EXPECT_TRUE(stringViewFromLiteral("AAAAAAAAA").trim(isA) == StringView::empty());
 
     StringView emptyView = StringView::empty();
-    EXPECT_TRUE(emptyView.stripLeadingAndTrailingMatchedCharacters(isA) == emptyView);
+    EXPECT_TRUE(emptyView.trim(isA) == emptyView);
 
     StringView nullView;
-    EXPECT_TRUE(nullView.stripLeadingAndTrailingMatchedCharacters(isA) == nullView);
+    EXPECT_TRUE(nullView.trim(isA) == nullView);
 }
 
 TEST(WTF, StringViewIsAllASCII)

--- a/Tools/TestWebKitAPI/Tests/WebCore/DisplayListRecorderTests.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebCore/DisplayListRecorderTests.cpp
@@ -478,8 +478,8 @@ TYPED_TEST_P(DisplayListRecorderResultStateTest, StateThroughDisplayListIsPreser
     auto resultTarget = createReferenceTarget();
     auto& result = resultTarget->context();
 
-    auto description = testedTarget->displayList().asText({ WebCore::DisplayList::AsTextFlag::IncludePlatformOperations }).stripLeadingAndTrailingCharacters(deprecatedIsSpaceOrNewline);
-    auto expectedDescription = this->operationDescription().stripLeadingAndTrailingCharacters(deprecatedIsSpaceOrNewline);
+    auto description = testedTarget->displayList().asText({ WebCore::DisplayList::AsTextFlag::IncludePlatformOperations }).trim(deprecatedIsSpaceOrNewline);
+    auto expectedDescription = this->operationDescription().trim(deprecatedIsSpaceOrNewline);
     EXPECT_EQ(expectedDescription, description);
 
     testedTarget->replayDisplayList(result);

--- a/Tools/TestWebKitAPI/cocoa/TestPDFDocument.mm
+++ b/Tools/TestWebKitAPI/cocoa/TestPDFDocument.mm
@@ -95,7 +95,7 @@ size_t TestPDFPage::characterCount() const
     return text().length();
 }
 
-inline bool shouldStrip(UChar character)
+inline bool shouldTrim(UChar character)
 {
     // This is a list of trailing and leading white space characters we've seen in PDF generation.
     // It can be expanded if we see more popup.
@@ -105,7 +105,7 @@ inline bool shouldStrip(UChar character)
 String TestPDFPage::text() const
 {
     if (!m_textWithoutSurroundingWhitespace)
-        m_textWithoutSurroundingWhitespace = String(m_page.get().string).stripLeadingAndTrailingCharacters(shouldStrip);
+        m_textWithoutSurroundingWhitespace = String(m_page.get().string).trim(shouldTrim);
 
     return *m_textWithoutSurroundingWhitespace;
 }


### PR DESCRIPTION
#### f5ea05710cd6cdfe72f6dedc9624f8e11b5e35f1
<pre>
Rename stripLeadingAndTrailing[Matched]Characters() to trim()
<a href="https://bugs.webkit.org/show_bug.cgi?id=257257">https://bugs.webkit.org/show_bug.cgi?id=257257</a>
rdar://109771825

Reviewed by Chris Dumez.

stripWhiteSpace() (although recently removed) set precedent for this
shorter naming and JavaScript has trim() meaning essentially the same
thing.

* Source/JavaScriptCore/runtime/ExceptionHelpers.cpp:
(JSC::invalidParameterInSourceAppender):
(JSC::invalidParameterInstanceofSourceAppender):
* Source/WTF/wtf/Assertions.cpp:
* Source/WTF/wtf/text/StringImpl.cpp:
(WTF::StringImpl::strip):
(WTF::StringImpl::stripLeadingAndTrailingCharacters): Deleted.
* Source/WTF/wtf/text/StringImpl.h:
* Source/WTF/wtf/text/StringView.h:
(WTF::StringView::strip const):
(WTF::StringView::stripLeadingAndTrailingMatchedCharacters const): Deleted.
* Source/WTF/wtf/text/WTFString.cpp:
(WTF::String::strip const):
(WTF::String::stripLeadingAndTrailingCharacters const): Deleted.
* Source/WTF/wtf/text/WTFString.h:
* Source/WebCore/Modules/applicationmanifest/ApplicationManifestParser.cpp:
(WebCore::ApplicationManifestParser::parseDisplay):
(WebCore::ApplicationManifestParser::parseOrientation):
(WebCore::ApplicationManifestParser::parseIcons):
(WebCore::ApplicationManifestParser::parseGenericString):
* Source/WebCore/Modules/fetch/FetchBodyConsumer.cpp:
(WebCore::FetchBodyConsumer::packageFormData):
* Source/WebCore/Modules/mediarecorder/MediaRecorderProvider.cpp:
(WebCore::MediaRecorderProvider::isSupported):
* Source/WebCore/accessibility/AccessibilityNodeObject.cpp:
(WebCore::AccessibilityNodeObject::textUnderElement const):
* Source/WebCore/css/parser/CSSParserImpl.cpp:
(WebCore::CSSParserImpl::consumeSupportsRule):
* Source/WebCore/dom/ImageOverlay.cpp:
(WebCore::ImageOverlay::updateSubtree):
* Source/WebCore/dom/ScriptElement.cpp:
(WebCore::ScriptElement::determineScriptType const):
* Source/WebCore/editing/TextManipulationController.cpp:
(WebCore::TextManipulationController::replace):
* Source/WebCore/editing/TypingCommand.cpp:
(WebCore::TypingCommand::markMisspellingsAfterTyping):
* Source/WebCore/html/FeaturePolicy.cpp:
(WebCore::processOriginItem):
(WebCore::updateList):
(WebCore::FeaturePolicy::parse):
* Source/WebCore/html/HTMLElement.cpp:
(WebCore::HTMLElement::parseLegacyColorValue):
* Source/WebCore/html/HTMLImageElement.cpp:
(WebCore::extractMIMETypeFromTypeAttributeForLookup):
* Source/WebCore/html/HTMLInputElement.cpp:
(WebCore::parseAcceptAttribute):
* Source/WebCore/html/HTMLMediaElement.cpp:
(WebCore::HTMLMediaElement::mediaSessionTitle const):
* Source/WebCore/html/HTMLOptGroupElement.cpp:
(WebCore::HTMLOptGroupElement::groupLabelText const):
* Source/WebCore/html/ValidatedFormListedElement.cpp:
(WebCore::ValidatedFormListedElement::updateVisibleValidationMessage):
* Source/WebCore/html/parser/CSSPreloadScanner.cpp:
(WebCore::hasValidImportConditions):
* Source/WebCore/html/parser/HTMLMetaCharsetParser.cpp:
(WebCore::HTMLMetaCharsetParser::encodingFromMetaAttributes):
* Source/WebCore/html/parser/HTMLPreloadScanner.cpp:
(WebCore::TokenPreloadScanner::StartTagScanner::processImageAndScriptAttribute):
(WebCore::TokenPreloadScanner::StartTagScanner::processAttribute):
(WebCore::TokenPreloadScanner::StartTagScanner::setURLToLoadAllowingReplacement):
* Source/WebCore/inspector/InspectorStyleSheet.cpp:
(WebCore::StyleSheetHandler::observeProperty):
(WebCore::StyleSheetHandler::observeComment):
(WebCore::selectorsFromSource):
* Source/WebCore/layout/integration/LayoutIntegrationCoverage.cpp:
(WebCore::LayoutIntegration::printTextForSubtree):
* Source/WebCore/loader/FrameLoader.cpp:
(WebCore::extractContentLanguageFromHeader):
* Source/WebCore/loader/HTTPHeaderField.cpp:
(WebCore::HTTPHeaderField::create):
* Source/WebCore/page/WindowFeatures.cpp:
(WebCore::parseDisabledAdaptations):
(WebCore::parseDialogFeaturesMap):
* Source/WebCore/page/csp/ContentSecurityPolicyDirectiveList.cpp:
(WebCore::checkMediaType):
* Source/WebCore/platform/ContentType.cpp:
(WebCore::ContentType::parameter const):
(WebCore::splitParameters):
* Source/WebCore/platform/LocalizedStrings.cpp:
(WebCore::truncatedStringForMenuItem):
* Source/WebCore/platform/graphics/gstreamer/MediaPlayerPrivateGStreamer.cpp:
(WebCore::isMediaDiskCacheDisabled):
* Source/WebCore/platform/graphics/gstreamer/mse/SourceBufferPrivateGStreamer.cpp:
(WebCore::SourceBufferPrivateGStreamer::platformMaximumBufferSize const):
* Source/WebCore/platform/gtk/SelectionData.cpp:
(WebCore::SelectionData::setURIList):
* Source/WebCore/platform/ios/DragImageIOS.mm:
(WebCore::createDragImageForLink):
* Source/WebCore/platform/mac/PasteboardMac.mm:
(WebCore::writeURLForTypes):
(WebCore::Pasteboard::writeTrustworthyWebURLsPboardType):
* Source/WebCore/platform/mac/PasteboardWriter.mm:
(WebCore::createPasteboardWriter):
* Source/WebCore/platform/network/CacheValidation.cpp:
(WebCore::collectVaryingRequestHeadersInternal):
* Source/WebCore/platform/network/HTTPParsers.cpp:
(WebCore::filenameFromHTTPContentDisposition):
(WebCore::parseXFrameOptionsHeader):
(WebCore::parseClearSiteDataHeader):
(WebCore::isForbiddenHeader):
* Source/WebCore/platform/network/HTTPParsers.h:
(WebCore::stripLeadingAndTrailingHTTPSpaces):
* Source/WebCore/platform/network/MIMEHeader.cpp:
(WebCore::retrieveKeyValuePairs):
(WebCore::MIMEHeader::parseHeader):
(WebCore::MIMEHeader::parseContentTransferEncoding):
* Source/WebCore/platform/network/ParsedContentType.cpp:
(WebCore::ParsedContentType::setContentType):
* Source/WebCore/platform/network/ResourceResponseBase.cpp:
(WebCore::ResourceResponseBase::isAttachment const):
(WebCore::ResourceResponseBase::isAttachmentWithFilename const):
* Source/WebCore/platform/network/curl/CookieUtil.cpp:
(WebCore::CookieUtil::parseCookieAttributes):
(WebCore::CookieUtil::parseCookieHeader):
* Source/WebCore/platform/network/curl/CurlMultipartHandle.cpp:
(WebCore::CurlMultipartHandle::extractBoundary):
* Source/WebCore/platform/network/curl/CurlRequest.cpp:
(WebCore::CurlRequest::didReceiveDebugInfo):
* Source/WebCore/platform/network/curl/ResourceResponseCurl.cpp:
(WebCore::ResourceResponse::appendHTTPHeaderField):
(WebCore::ResourceResponse::setStatusLine):
* Source/WebCore/platform/network/soup/ResourceResponseSoup.cpp:
(WebCore::sanitizeFilename):
* Source/WebCore/platform/sql/SQLiteDatabase.cpp:
(WebCore::SQLiteDatabase::prepareStatementSlow):
(WebCore::SQLiteDatabase::prepareHeapStatementSlow):
* Source/WebCore/platform/text/PlatformLocale.cpp:
(WebCore::Locale::convertFromLocalizedNumber):
* Source/WebCore/platform/win/ClipboardUtilitiesWin.cpp:
(WebCore::extractMarkupFromCFHTML):
(WebCore::fragmentFromCFHTML):
* Source/WebCore/platform/xr/PlatformXR.h:
(PlatformXR::parseSessionFeatureDescriptor):
* Source/WebCore/rendering/RenderMenuList.cpp:
(RenderMenuList::setTextFromOption):
* Source/WebCore/svg/SVGAnimationElement.cpp:
(WebCore::parseKeyTimes):
(WebCore::SVGAnimationElement::attributeContainsJavaScriptURL const):
(WebCore::SVGAnimationElement::attributeChanged):
* Source/WebCore/svg/animation/SVGSMILElement.cpp:
(WebCore::SVGSMILElement::parseOffsetValue):
(WebCore::SVGSMILElement::parseClockValue):
(WebCore::SVGSMILElement::parseCondition):
* Source/WebCore/svg/properties/SVGAnimationAdditiveValueFunctionImpl.cpp:
(WebCore::SVGAnimationColorFunction::calculateDistance const):
* Source/WebCore/svg/properties/SVGPropertyTraits.h:
(WebCore::SVGPropertyTraits&lt;Color&gt;::fromString):
(WebCore::SVGPropertyTraits&lt;Color&gt;::parse):
* Source/WebCore/xml/XPathGrammar.cpp:
* Source/WebCore/xml/XPathGrammar.y:
* Source/WebKit/UIProcess/API/glib/WebKitOptionMenuItemPrivate.h:
(_WebKitOptionMenuItem::_WebKitOptionMenuItem):
* Source/WebKit/UIProcess/gtk/WebPopupMenuProxyGtk.cpp:
(WebKit::WebPopupMenuProxyGtk::createPopupMenu):
* Source/WebKit/WebProcess/WebCoreSupport/WebContextMenuClient.cpp:
(WebKit::WebContextMenuClient::searchWithGoogle):
* Source/WebKit/WebProcess/WebCoreSupport/mac/WebContextMenuClientMac.mm:
(WebKit::WebContextMenuClient::searchWithGoogle):
* Tools/TestWebKitAPI/Tests/WTF/StringView.cpp:
(TestWebKitAPI::TEST):
* Tools/TestWebKitAPI/Tests/WebCore/DisplayListRecorderTests.cpp:
* Tools/TestWebKitAPI/cocoa/TestPDFDocument.mm:
(TestWebKitAPI::TestPDFPage::text const):

Canonical link: <a href="https://commits.webkit.org/264597@main">https://commits.webkit.org/264597@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/725ff76907f980eef544369b492861a166f04cdf

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/8047 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/8332 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/8544 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/9699 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/8150 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/8051 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/10318 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/8243 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/11015 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/8191 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/9277 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/7340 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/9823 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/6578 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/7365 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/14952 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/6864 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/7701 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/7489 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/10857 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/7614 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/7959 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/6478 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/8214 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/7272 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/1876 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/1933 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/11480 "Built successfully") | | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/24/builds/8435 "Built successfully") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/7700 "Built successfully") | | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/3/builds/2025 "Passed tests") | 
<!--EWS-Status-Bubble-End-->