### PR TITLE
Update layout of child frames before hit testing a document if necessary

### DIFF
--- a/LayoutTests/fast/editing/insert-text-hit-testing-crash-expected.txt
+++ b/LayoutTests/fast/editing/insert-text-hit-testing-crash-expected.txt
@@ -1,0 +1,1 @@
+ This test passes if it does crash

--- a/LayoutTests/fast/editing/insert-text-hit-testing-crash.html
+++ b/LayoutTests/fast/editing/insert-text-hit-testing-crash.html
@@ -1,0 +1,15 @@
+<script>
+    if (window.testRunner)
+      testRunner.dumpAsText();
+
+    function main() {
+        x2.setSelectionRange(1, 0);
+        x1.contentDocument.body.style.setProperty("scale", "1 0.5122158757062186 -1");
+        document.execCommand("insertText");
+    }
+</script>
+
+<body onload=main()>
+<textarea id="x2">crash</textarea>
+This test passes if it does crash
+<iframe id="x1">

--- a/LayoutTests/fast/forms/input-type-radio-form-gc-crash-expected.txt
+++ b/LayoutTests/fast/forms/input-type-radio-form-gc-crash-expected.txt
@@ -1,0 +1,10 @@
+No crash when a form with a input type=radio gets destroyed
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+PASS successfullyParsed is true
+
+TEST COMPLETE
+
+

--- a/LayoutTests/fast/forms/input-type-radio-form-gc-crash.html
+++ b/LayoutTests/fast/forms/input-type-radio-form-gc-crash.html
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<html>
+<body>
+  <script src="../../resources/js-test.js"></script>
+  <script>
+    description("No crash when a form with a input type=radio gets destroyed");
+  </script>
+  <table>
+  <div>
+    <form>
+      <input name="foo" type="radio" required="true">
+    </form>
+  </div>
+</body>

--- a/Source/WebCore/dom/Document.cpp
+++ b/Source/WebCore/dom/Document.cpp
@@ -9308,16 +9308,23 @@ bool Document::hitTest(const HitTestRequest& request, HitTestResult& result)
 bool Document::hitTest(const HitTestRequest& request, const HitTestLocation& location, HitTestResult& result)
 {
     Ref<Document> protectedThis(*this);
-    updateLayout();
+
     if (!renderView())
         return false;
+
+    auto& frameView = renderView()->frameView();
+    Ref<FrameView> protector(frameView);
+
+    // If hit testing can descend into child frames, then we should make sure those frames have an updated layout
+    // before proceeding
+    if (request.allowsAnyFrameContent())
+        frameView.updateLayoutAndStyleIfNeededRecursive();
+    else
+        updateLayout();
 
 #if ASSERT_ENABLED
     SetForScope hitTestRestorer { m_inHitTesting, true };
 #endif
-
-    auto& frameView = renderView()->frameView();
-    Ref<LocalFrameView> protector(frameView);
 
     bool resultLayer = renderView()->layer()->hitTest(request, location, result);
 

--- a/Source/WebCore/html/FormAssociatedCustomElement.cpp
+++ b/Source/WebCore/html/FormAssociatedCustomElement.cpp
@@ -136,13 +136,6 @@ bool FormAssociatedCustomElement::appendFormData(DOMFormData& formData)
     return true;
 }
 
-void FormAssociatedCustomElement::formWillBeDestroyed()
-{
-    m_formWillBeDestroyed = true;
-    ValidatedFormListedElement::formWillBeDestroyed();
-    m_formWillBeDestroyed = false;
-}
-
 bool FormAssociatedCustomElement::isEnumeratable() const
 {
     ASSERT(m_element->isDefinedCustomElement());
@@ -166,7 +159,7 @@ void FormAssociatedCustomElement::didChangeForm()
 {
     ASSERT(m_element->isDefinedCustomElement());
     ValidatedFormListedElement::didChangeForm();
-    if (!m_formWillBeDestroyed)
+    if (!belongsToFormThatIsBeingDestroyed())
         CustomElementReactionQueue::enqueueFormAssociatedCallbackIfNeeded(*m_element, form());
 }
 

--- a/Source/WebCore/html/FormAssociatedCustomElement.h
+++ b/Source/WebCore/html/FormAssociatedCustomElement.h
@@ -59,7 +59,6 @@ public:
     ExceptionOr<void> setValidity(ValidityStateFlags, String&& message, HTMLElement* validationAnchor);
     String validationMessage() const final;
 
-    void formWillBeDestroyed() final;
     void finishParsingChildren();
 
     bool computeValidity() const final;
@@ -97,7 +96,6 @@ private:
 
     WeakPtr<HTMLMaybeFormAssociatedCustomElement, WeakPtrImplWithEventTargetData> m_element;
     ValidityStateFlags m_validityStateFlags;
-    bool m_formWillBeDestroyed : 1 { false };
     WeakPtr<HTMLElement, WeakPtrImplWithEventTargetData> m_validationAnchor { nullptr };
     std::optional<CustomElementFormValue> m_submissionValue;
     std::optional<CustomElementFormValue> m_state;

--- a/Source/WebCore/html/ValidatedFormListedElement.cpp
+++ b/Source/WebCore/html/ValidatedFormListedElement.cpp
@@ -263,11 +263,13 @@ void ValidatedFormListedElement::updateValidity()
 
         if (willValidate) {
             if (!newIsValid) {
-                addInvalidElementToAncestorFromInsertionPoint(element, element.parentNode());
+                if (!belongsToFormThatIsBeingDestroyed())
+                    addInvalidElementToAncestorFromInsertionPoint(element, element.parentNode());
                 if (auto* form = this->form())
                     form->addInvalidFormControl(element);
             } else {
-                removeInvalidElementToAncestorFromInsertionPoint(element, element.parentNode());
+                if (!belongsToFormThatIsBeingDestroyed())
+                    removeInvalidElementToAncestorFromInsertionPoint(element, element.parentNode());
                 if (auto* form = this->form())
                     form->removeInvalidFormControlIfNeeded(element);
             }
@@ -391,6 +393,13 @@ void ValidatedFormListedElement::didChangeForm()
         if (m_willValidateInitialized && m_willValidate && !isValidFormControlElement())
             form->addInvalidFormControl(asHTMLElement());
     }
+}
+
+void ValidatedFormListedElement::formWillBeDestroyed()
+{
+    m_belongsToFormThatIsBeingDestroyed = true;
+    FormListedElement::formWillBeDestroyed();
+    m_belongsToFormThatIsBeingDestroyed = false;
 }
 
 void ValidatedFormListedElement::disabledStateChanged()

--- a/Source/WebCore/html/ValidatedFormListedElement.h
+++ b/Source/WebCore/html/ValidatedFormListedElement.h
@@ -112,6 +112,8 @@ protected:
 
     void willChangeForm() override;
     void didChangeForm() override;
+    void formWillBeDestroyed() final;
+    bool belongsToFormThatIsBeingDestroyed() const { return m_belongsToFormThatIsBeingDestroyed; }
 
     void setDataListAncestorState(TriState);
     void syncWithFieldsetAncestors(ContainerNode* insertionNode);
@@ -142,6 +144,7 @@ private:
 
     bool m_hasReadOnlyAttribute : 1 { false };
     bool m_wasInteractedWithSinceLastFormSubmitEvent : 1 { false };
+    bool m_belongsToFormThatIsBeingDestroyed : 1 { false };
     bool m_isFocusingWithValidationMessage { false };
 
     mutable TriState m_isInsideDataList : 2 { TriState::Indeterminate };

--- a/Source/WebCore/rendering/HitTestRequest.h
+++ b/Source/WebCore/rendering/HitTestRequest.h
@@ -74,6 +74,7 @@ public:
     bool allowsFrameScrollbars() const { return m_type.contains(Type::AllowFrameScrollbars); }
     bool allowsChildFrameContent() const { return m_type.contains(Type::AllowChildFrameContent); }
     bool allowsVisibleChildFrameContent() const { return m_type.contains(Type::AllowVisibleChildFrameContentOnly); }
+    bool allowsAnyFrameContent() const { return allowsChildFrameContent() ||  allowsVisibleChildFrameContent(); }
     bool isChildFrameHitTest() const { return m_type.contains(Type::ChildFrameHitTest); }
     bool resultIsElementList() const { return m_type.contains(Type::CollectMultipleElements); }
     bool includesAllElementsUnderPoint() const { return m_type.contains(Type::IncludeAllElementsUnderPoint); }


### PR DESCRIPTION
#### 23ef02b6528e0113ebb5a13bb0b18eef750b7a7c
<pre>
Update layout of child frames before hit testing a document if necessary
<a href="https://bugs.webkit.org/show_bug.cgi?id=253615">https://bugs.webkit.org/show_bug.cgi?id=253615</a>
rdar://107375598

Reviewed by Alan Baradlay.

If hit testing can recurse into a child frame, we should make sure that
layout and style are updated for all children before proceeding with
hit testing.

* LayoutTests/fast/editing/insert-text-hit-testing-crash-expected.txt: Added.
* LayoutTests/fast/editing/insert-text-hit-testing-crash.html: Added.
* Source/WebCore/dom/Document.cpp:
(WebCore::Document::hitTest):

Originally-landed-as: 259548.535@safari-7615-branch (3bc53a0a2ccf). rdar://107375598
Canonical link: <a href="https://commits.webkit.org/264497@main">https://commits.webkit.org/264497@main</a>
</pre>
----------------------------------------------------------------------
#### 2ecaa0ec8a3a99ad250305824746deffb2217acb
<pre>
&lt;input type=radio&gt; crashes in removeInvalidElementToAncestorFromInsertionPoint() during GC
<a href="https://bugs.webkit.org/show_bug.cgi?id=253860">https://bugs.webkit.org/show_bug.cgi?id=253860</a>
&lt;rdar://105086386&gt;

Reviewed by Ryosuke Niwa.

When a &lt;form&gt; gets destroyed, it calls into formWillBeDestroyed() callback of &lt;input type=radio&gt;
which, when removing radio buttons themselves, calls into updateValidity() and then into
removeInvalidElementToAncestorFromInsertionPoint() with partially-deleted ContainerNode as an
argument, causing a crash.

This change guards removeInvalidElementToAncestorFromInsertionPoint() and its counterpart
from being called during form destruction.

* LayoutTests/fast/forms/input-type-radio-form-gc-crash-expected.txt: Added.
* LayoutTests/fast/forms/input-type-radio-form-gc-crash.html: Added.
* Source/WebCore/html/FormAssociatedCustomElement.cpp:
(WebCore::FormAssociatedCustomElement::didChangeForm):
(WebCore::FormAssociatedCustomElement::formWillBeDestroyed): Deleted.
* Source/WebCore/html/FormAssociatedCustomElement.h:
* Source/WebCore/html/ValidatedFormListedElement.cpp:
(WebCore::ValidatedFormListedElement::updateValidity):
(WebCore::ValidatedFormListedElement::formWillBeDestroyed):
* Source/WebCore/html/ValidatedFormListedElement.h:
(WebCore::ValidatedFormListedElement::belongsToFormThatIsBeingDestroyed const):

Originally-landed-as: 259548.534@safari-7615-branch (f5dc82736e2c). rdar://105086386
Canonical link: <a href="https://commits.webkit.org/264496@main">https://commits.webkit.org/264496@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e2b4dff5a08773c2165e9fe4ae02d8e0f34a9a86

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/7779 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/8053 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/8234 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/9421 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/7929 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/7785 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/10043 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/7973 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/10799 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/7916 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/9027 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/7136 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/9533 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/6336 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/7082 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/14745 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/7483 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/7210 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/10614 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/7703 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/6277 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/7029 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/6994 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/1867 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/11239 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/7435 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->