### PR TITLE
Add support for structured cloning of ErrorInstance objects

### DIFF
--- a/LayoutTests/fast/dom/Window/window-postmessage-clone-expected.txt
+++ b/LayoutTests/fast/dom/Window/window-postmessage-clone-expected.txt
@@ -1,7 +1,6 @@
 Tests that we clone object hierarchies
 
 PASS: 'postMessage((function(){}))' threw DataCloneError: The object can not be cloned.
-PASS: 'postMessage(var x = 0; try { eval("badref"); } catch(e) { x = e; } x)' threw DataCloneError: The object can not be cloned.
 PASS: 'postMessage(window)' threw DataCloneError: The object can not be cloned.
 PASS: 'postMessage(({get a() { throw "x" }}))' threw x
 PASS: 'postMessage((function() {return {get a() { throw "accessor-exn"; }};})())' threw accessor-exn
@@ -44,6 +43,7 @@ PASS: eventData is a,a,b,a,b of type object
 PASS: eventData is a,a,b,[object Object] of type object
 PASS: eventData is 1,2,3 of type object
 PASS: eventData is ,,1 of type object
+PASS: eventData is ReferenceError: Can't find variable: badref of type object
 PASS: eventData is 2009-02-13T23:31:30.000Z of type object
 PASS: eventData is [object Object] of type object
 PASS: eventData is true of type object

--- a/LayoutTests/fast/dom/Window/window-postmessage-clone.html
+++ b/LayoutTests/fast/dom/Window/window-postmessage-clone.html
@@ -46,7 +46,7 @@ tryPostMessage('["a", "a", "b", {a:"b", b:"a"}]');
 tryPostMessage('[1,2,3]');
 tryPostMessage('[,,1]');
 tryPostMessage('(function(){})', true, null, DOMException.DATA_CLONE_ERR);
-tryPostMessage('var x = 0; try { eval("badref"); } catch(e) { x = e; } x', true, null, DOMException.DATA_CLONE_ERR);
+tryPostMessage('var x = 0; try { eval("badref"); } catch(e) { x = e; } x');
 tryPostMessage('new Date(1234567890000)');
 tryPostMessage('new ConstructorWithPrototype("foo")', false, '({field:"foo"})');
 tryPostMessage('new Boolean(true)');

--- a/LayoutTests/fast/events/message-port-multi-expected.txt
+++ b/LayoutTests/fast/events/message-port-multi-expected.txt
@@ -18,10 +18,11 @@ PASS event.ports contains two ports when two ports re-sent after error
 PASS Sending host object has thrown DataCloneError: The object can not be cloned.
 PASS Sending host object has thrown DataCloneError: The object can not be cloned.
 PASS Sending Function object has thrown DataCloneError: The object can not be cloned.
-PASS Sending Error object has thrown DataCloneError: The object can not be cloned.
+PASS Sending Error object should not throw
 PASS send-port: transferred one port
 PASS send-port-twice: transferred one port twice
 PASS send-two-ports: transferred two ports
+PASS Managed to send an Error object
 
 TEST COMPLETE
 

--- a/LayoutTests/fast/events/resources/message-port-multi.js
+++ b/LayoutTests/fast/events/resources/message-port-multi.js
@@ -75,12 +75,9 @@ function testTransfers() {
     try {
         var err = new Error();
         channel0.port1.postMessage({id:"error-object", error:err, port:c4.port1}, [c4.port1]);
-        testFailed("Sending Error object should throw");
+        testPassed("Sending Error object should not throw");
     } catch(e) {
-        if (e.code == DOMException.DATA_CLONE_ERR)
-          testPassed("Sending Error object has thrown " + e);
-        else
-          testPassed("Sending Error object should throw a DataCloneError, got: " + e);
+          testFailed("Sending Error object has thrown " + e);
     }
     c4.port1.postMessage("Should succeed");
     channel0.port1.postMessage({id:"done"});
@@ -91,6 +88,8 @@ function testTransfers() {
                 testPassed("send-port: transferred one port");
             else 
                 testFailed("send-port: port transfer failed");
+        } else if (event.data.id == "error-object") {
+            testPassed("Managed to send an Error object");
         } else if (event.data.id == "send-port-twice") {
             if (event.ports && event.ports.length == 1 && 
                   event.ports[0] === event.data.port0 && event.ports[0] === event.data.port1) 

--- a/LayoutTests/fast/storage/serialized-script-value.html
+++ b/LayoutTests/fast/storage/serialized-script-value.html
@@ -6,7 +6,7 @@
     <body>
         <script>
 
-const currentVersion = 0x0c;
+const currentVersion = 0x0d;
 
 // Here's a little Q&D helper for future adventurers needing to rebaseline this.
 

--- a/LayoutTests/imported/w3c/web-platform-tests/IndexedDB/structured-clone.any.worker_81-100-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/IndexedDB/structured-clone.any.worker_81-100-expected.txt
@@ -9,14 +9,14 @@ PASS Float32Array: -Infinity,-1.5,-1,-0.5,0,0.5,1,1.5,Infinity,NaN
 PASS Float64Array: -Infinity,-1.7976931348623157e+308,-5e-324,0,5e-324,1.7976931348623157e+308,Infinity,NaN
 PASS Map: [object Map]
 PASS Set: [object Set]
-FAIL Error: Error promise_test: Unhandled rejection with value: object "DataCloneError: The object can not be cloned."
-FAIL Error: Error: abc promise_test: Unhandled rejection with value: object "DataCloneError: The object can not be cloned."
-FAIL EvalError: EvalError promise_test: Unhandled rejection with value: object "DataCloneError: The object can not be cloned."
-FAIL EvalError: EvalError: ghi promise_test: Unhandled rejection with value: object "DataCloneError: The object can not be cloned."
-FAIL RangeError: RangeError promise_test: Unhandled rejection with value: object "DataCloneError: The object can not be cloned."
-FAIL RangeError: RangeError: ghi promise_test: Unhandled rejection with value: object "DataCloneError: The object can not be cloned."
-FAIL ReferenceError: ReferenceError promise_test: Unhandled rejection with value: object "DataCloneError: The object can not be cloned."
-FAIL ReferenceError: ReferenceError: ghi promise_test: Unhandled rejection with value: object "DataCloneError: The object can not be cloned."
-FAIL SyntaxError: SyntaxError promise_test: Unhandled rejection with value: object "DataCloneError: The object can not be cloned."
-FAIL SyntaxError: SyntaxError: ghi promise_test: Unhandled rejection with value: object "DataCloneError: The object can not be cloned."
+PASS Error: Error
+PASS Error: Error: abc
+PASS EvalError: EvalError
+PASS EvalError: EvalError: ghi
+PASS RangeError: RangeError
+PASS RangeError: RangeError: ghi
+PASS ReferenceError: ReferenceError
+PASS ReferenceError: ReferenceError: ghi
+PASS SyntaxError: SyntaxError
+PASS SyntaxError: SyntaxError: ghi
 

--- a/LayoutTests/imported/w3c/web-platform-tests/IndexedDB/structured-clone.any_81-100-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/IndexedDB/structured-clone.any_81-100-expected.txt
@@ -9,14 +9,14 @@ PASS Float32Array: -Infinity,-1.5,-1,-0.5,0,0.5,1,1.5,Infinity,NaN
 PASS Float64Array: -Infinity,-1.7976931348623157e+308,-5e-324,0,5e-324,1.7976931348623157e+308,Infinity,NaN
 PASS Map: [object Map]
 PASS Set: [object Set]
-FAIL Error: Error promise_test: Unhandled rejection with value: object "DataCloneError: The object can not be cloned."
-FAIL Error: Error: abc promise_test: Unhandled rejection with value: object "DataCloneError: The object can not be cloned."
-FAIL EvalError: EvalError promise_test: Unhandled rejection with value: object "DataCloneError: The object can not be cloned."
-FAIL EvalError: EvalError: ghi promise_test: Unhandled rejection with value: object "DataCloneError: The object can not be cloned."
-FAIL RangeError: RangeError promise_test: Unhandled rejection with value: object "DataCloneError: The object can not be cloned."
-FAIL RangeError: RangeError: ghi promise_test: Unhandled rejection with value: object "DataCloneError: The object can not be cloned."
-FAIL ReferenceError: ReferenceError promise_test: Unhandled rejection with value: object "DataCloneError: The object can not be cloned."
-FAIL ReferenceError: ReferenceError: ghi promise_test: Unhandled rejection with value: object "DataCloneError: The object can not be cloned."
-FAIL SyntaxError: SyntaxError promise_test: Unhandled rejection with value: object "DataCloneError: The object can not be cloned."
-FAIL SyntaxError: SyntaxError: ghi promise_test: Unhandled rejection with value: object "DataCloneError: The object can not be cloned."
+PASS Error: Error
+PASS Error: Error: abc
+PASS EvalError: EvalError
+PASS EvalError: EvalError: ghi
+PASS RangeError: RangeError
+PASS RangeError: RangeError: ghi
+PASS ReferenceError: ReferenceError
+PASS ReferenceError: ReferenceError: ghi
+PASS SyntaxError: SyntaxError
+PASS SyntaxError: SyntaxError: ghi
 

--- a/LayoutTests/imported/w3c/web-platform-tests/html/infrastructure/safe-passing-of-structured-data/messagechannel.any-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/infrastructure/safe-passing-of-structured-data/messagechannel.any-expected.txt
@@ -72,14 +72,14 @@ PASS Object RegExp object, RegExp unicode flag
 PASS Object RegExp object, RegExp empty
 PASS Object RegExp object, RegExp slash
 PASS Object RegExp object, RegExp new line
-FAIL Empty Error object promise_test: Unhandled rejection with value: object "DataCloneError: The object can not be cloned."
-FAIL Error object promise_test: Unhandled rejection with value: object "DataCloneError: The object can not be cloned."
-FAIL EvalError object promise_test: Unhandled rejection with value: object "DataCloneError: The object can not be cloned."
-FAIL RangeError object promise_test: Unhandled rejection with value: object "DataCloneError: The object can not be cloned."
-FAIL ReferenceError object promise_test: Unhandled rejection with value: object "DataCloneError: The object can not be cloned."
-FAIL SyntaxError object promise_test: Unhandled rejection with value: object "DataCloneError: The object can not be cloned."
-FAIL TypeError object promise_test: Unhandled rejection with value: object "DataCloneError: The object can not be cloned."
-FAIL URIError object promise_test: Unhandled rejection with value: object "DataCloneError: The object can not be cloned."
+PASS Empty Error object
+PASS Error object
+PASS EvalError object
+PASS RangeError object
+PASS ReferenceError object
+PASS SyntaxError object
+PASS TypeError object
+PASS URIError object
 PASS Blob basic
 PASS Blob unpaired high surrogate (invalid utf-8)
 PASS Blob unpaired low surrogate (invalid utf-8)

--- a/LayoutTests/imported/w3c/web-platform-tests/html/infrastructure/safe-passing-of-structured-data/messagechannel.any.serviceworker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/infrastructure/safe-passing-of-structured-data/messagechannel.any.serviceworker-expected.txt
@@ -72,14 +72,14 @@ PASS Object RegExp object, RegExp unicode flag
 PASS Object RegExp object, RegExp empty
 PASS Object RegExp object, RegExp slash
 PASS Object RegExp object, RegExp new line
-FAIL Empty Error object promise_test: Unhandled rejection with value: object "DataCloneError: The object can not be cloned."
-FAIL Error object promise_test: Unhandled rejection with value: object "DataCloneError: The object can not be cloned."
-FAIL EvalError object promise_test: Unhandled rejection with value: object "DataCloneError: The object can not be cloned."
-FAIL RangeError object promise_test: Unhandled rejection with value: object "DataCloneError: The object can not be cloned."
-FAIL ReferenceError object promise_test: Unhandled rejection with value: object "DataCloneError: The object can not be cloned."
-FAIL SyntaxError object promise_test: Unhandled rejection with value: object "DataCloneError: The object can not be cloned."
-FAIL TypeError object promise_test: Unhandled rejection with value: object "DataCloneError: The object can not be cloned."
-FAIL URIError object promise_test: Unhandled rejection with value: object "DataCloneError: The object can not be cloned."
+PASS Empty Error object
+PASS Error object
+PASS EvalError object
+PASS RangeError object
+PASS ReferenceError object
+PASS SyntaxError object
+PASS TypeError object
+PASS URIError object
 PASS Blob basic
 PASS Blob unpaired high surrogate (invalid utf-8)
 PASS Blob unpaired low surrogate (invalid utf-8)

--- a/LayoutTests/imported/w3c/web-platform-tests/html/infrastructure/safe-passing-of-structured-data/messagechannel.any.sharedworker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/infrastructure/safe-passing-of-structured-data/messagechannel.any.sharedworker-expected.txt
@@ -72,14 +72,14 @@ PASS Object RegExp object, RegExp unicode flag
 PASS Object RegExp object, RegExp empty
 PASS Object RegExp object, RegExp slash
 PASS Object RegExp object, RegExp new line
-FAIL Empty Error object promise_test: Unhandled rejection with value: object "DataCloneError: The object can not be cloned."
-FAIL Error object promise_test: Unhandled rejection with value: object "DataCloneError: The object can not be cloned."
-FAIL EvalError object promise_test: Unhandled rejection with value: object "DataCloneError: The object can not be cloned."
-FAIL RangeError object promise_test: Unhandled rejection with value: object "DataCloneError: The object can not be cloned."
-FAIL ReferenceError object promise_test: Unhandled rejection with value: object "DataCloneError: The object can not be cloned."
-FAIL SyntaxError object promise_test: Unhandled rejection with value: object "DataCloneError: The object can not be cloned."
-FAIL TypeError object promise_test: Unhandled rejection with value: object "DataCloneError: The object can not be cloned."
-FAIL URIError object promise_test: Unhandled rejection with value: object "DataCloneError: The object can not be cloned."
+PASS Empty Error object
+PASS Error object
+PASS EvalError object
+PASS RangeError object
+PASS ReferenceError object
+PASS SyntaxError object
+PASS TypeError object
+PASS URIError object
 PASS Blob basic
 PASS Blob unpaired high surrogate (invalid utf-8)
 PASS Blob unpaired low surrogate (invalid utf-8)

--- a/LayoutTests/imported/w3c/web-platform-tests/html/infrastructure/safe-passing-of-structured-data/messagechannel.any.worker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/infrastructure/safe-passing-of-structured-data/messagechannel.any.worker-expected.txt
@@ -72,14 +72,14 @@ PASS Object RegExp object, RegExp unicode flag
 PASS Object RegExp object, RegExp empty
 PASS Object RegExp object, RegExp slash
 PASS Object RegExp object, RegExp new line
-FAIL Empty Error object promise_test: Unhandled rejection with value: object "DataCloneError: The object can not be cloned."
-FAIL Error object promise_test: Unhandled rejection with value: object "DataCloneError: The object can not be cloned."
-FAIL EvalError object promise_test: Unhandled rejection with value: object "DataCloneError: The object can not be cloned."
-FAIL RangeError object promise_test: Unhandled rejection with value: object "DataCloneError: The object can not be cloned."
-FAIL ReferenceError object promise_test: Unhandled rejection with value: object "DataCloneError: The object can not be cloned."
-FAIL SyntaxError object promise_test: Unhandled rejection with value: object "DataCloneError: The object can not be cloned."
-FAIL TypeError object promise_test: Unhandled rejection with value: object "DataCloneError: The object can not be cloned."
-FAIL URIError object promise_test: Unhandled rejection with value: object "DataCloneError: The object can not be cloned."
+PASS Empty Error object
+PASS Error object
+PASS EvalError object
+PASS RangeError object
+PASS ReferenceError object
+PASS SyntaxError object
+PASS TypeError object
+PASS URIError object
 PASS Blob basic
 PASS Blob unpaired high surrogate (invalid utf-8)
 PASS Blob unpaired low surrogate (invalid utf-8)

--- a/LayoutTests/imported/w3c/web-platform-tests/html/infrastructure/safe-passing-of-structured-data/structured-cloning-error-stack-optional.sub.window-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/infrastructure/safe-passing-of-structured-data/structured-cloning-error-stack-optional.sub.window-expected.txt
@@ -1,20 +1,20 @@
 
-FAIL page-created Error (structuredClone()) The object can not be cloned.
-FAIL page-created Error (worker) The object can not be cloned.
-FAIL page-created Error (cross-site iframe) The object can not be cloned.
-FAIL page-created Error (same-origin iframe) The object can not be cloned.
+PASS page-created Error (structuredClone())
+PASS page-created Error (worker)
+PASS page-created Error (cross-site iframe)
+PASS page-created Error (same-origin iframe)
 PASS page-created DOMException (structuredClone())
 PASS page-created DOMException (worker)
 PASS page-created DOMException (cross-site iframe)
 PASS page-created DOMException (same-origin iframe)
-FAIL JS-engine-created TypeError (structuredClone()) The object can not be cloned.
-FAIL JS-engine-created TypeError (worker) The object can not be cloned.
-FAIL JS-engine-created TypeError (cross-site iframe) The object can not be cloned.
-FAIL JS-engine-created TypeError (same-origin iframe) The object can not be cloned.
-FAIL web API-created TypeError (structuredClone()) The object can not be cloned.
-FAIL web API-created TypeError (worker) The object can not be cloned.
-FAIL web API-created TypeError (cross-site iframe) The object can not be cloned.
-FAIL web API-created TypeError (same-origin iframe) The object can not be cloned.
+PASS JS-engine-created TypeError (structuredClone())
+PASS JS-engine-created TypeError (worker)
+PASS JS-engine-created TypeError (cross-site iframe)
+PASS JS-engine-created TypeError (same-origin iframe)
+PASS web API-created TypeError (structuredClone())
+PASS web API-created TypeError (worker)
+PASS web API-created TypeError (cross-site iframe)
+PASS web API-created TypeError (same-origin iframe)
 FAIL web API-created DOMException (structuredClone()) assert_equals: expected (string) "createElement@[native code]\n@http://localhost:8800/html/infrastructure/safe-passing-of-structured-data/structured-cloning-error-stack-optional.sub.window.js:33:27\n@http://localhost:8800/html/infrastructure/safe-passing-of-structured-data/structured-cloning-error-stack-optional.sub.window.js:41:31\n@http://localhost:8800/resources/testharness.js:2591:30\ntest@http://localhost:8800/resources/testharness.js:628:34\nstackTests@http://localhost:8800/html/infrastructure/safe-passing-of-structured-data/structured-cloning-error-stack-optional.sub.window.js:40:7\nglobal code@http://localhost:8800/html/infrastructure/safe-passing-of-structured-data/structured-cloning-error-stack-optional.sub.window.js:31:11" but got (undefined) undefined
 FAIL web API-created DOMException (worker) assert_equals: expected (string) "createElement@[native code]\n@http://localhost:8800/html/infrastructure/safe-passing-of-structured-data/structured-cloning-error-stack-optional.sub.window.js:33:27\n@http://localhost:8800/html/infrastructure/safe-passing-of-structured-data/structured-cloning-error-stack-optional.sub.window.js:53:31\n@http://localhost:8800/resources/testharness.js:2591:30\nasync_test@http://localhost:8800/resources/testharness.js:676:38\nstackTests@http://localhost:8800/html/infrastructure/safe-passing-of-structured-data/structured-cloning-error-stack-optional.sub.window.js:52:13\nglobal code@http://localhost:8800/html/infrastructure/safe-passing-of-structured-data/structured-cloning-error-stack-optional.sub.window.js:31:11" but got (undefined) undefined
 FAIL web API-created DOMException (cross-site iframe) assert_equals: expected (string) "createElement@[native code]\n@http://localhost:8800/html/infrastructure/safe-passing-of-structured-data/structured-cloning-error-stack-optional.sub.window.js:33:27\niframeTest@http://localhost:8800/html/infrastructure/safe-passing-of-structured-data/structured-cloning-error-stack-optional.sub.window.js:72:31\n@http://localhost:8800/html/infrastructure/safe-passing-of-structured-data/structured-cloning-error-stack-optional.sub.window.js:99:15\n@http://localhost:8800/resources/testharness.js:2591:30\nasync_test@http://localhost:8800/resources/testharness.js:676:38\nstackTests@http://localhost:8800/html/infrastructure/safe-passing-of-structured-data/structured-cloning-error-stack-optional.sub.window.js:96:13\nglobal code@http://localhost:8800/html/infrastructure/safe-passing-of-structured-data/structured-cloning-error-stack-optional.sub.window.js:31:11" but got (undefined) undefined

--- a/LayoutTests/imported/w3c/web-platform-tests/html/infrastructure/safe-passing-of-structured-data/structuredclone_0-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/infrastructure/safe-passing-of-structured-data/structuredclone_0-expected.txt
@@ -26,18 +26,18 @@ PASS ImageData object can be cloned
 PASS ImageData expandos are not cloned
 PASS Window objects cannot be cloned
 PASS Document objects cannot be cloned
-FAIL Empty Error objects can be cloned The object can not be cloned.
-FAIL Error objects can be cloned The object can not be cloned.
-FAIL EvalError objects can be cloned The object can not be cloned.
-FAIL RangeError objects can be cloned The object can not be cloned.
-FAIL ReferenceError objects can be cloned The object can not be cloned.
-FAIL SyntaxError objects can be cloned The object can not be cloned.
-FAIL TypeError objects can be cloned The object can not be cloned.
-FAIL URIError objects can be cloned The object can not be cloned.
-FAIL URIError objects from other realms are treated as URIError The object can not be cloned.
-FAIL Cloning a modified Error The object can not be cloned.
-FAIL Error.message: getter is ignored when cloning The object can not be cloned.
-FAIL Error.message: undefined property is stringified The object can not be cloned.
+PASS Empty Error objects can be cloned
+PASS Error objects can be cloned
+PASS EvalError objects can be cloned
+PASS RangeError objects can be cloned
+PASS ReferenceError objects can be cloned
+PASS SyntaxError objects can be cloned
+PASS TypeError objects can be cloned
+PASS URIError objects can be cloned
+PASS URIError objects from other realms are treated as URIError
+PASS Cloning a modified Error
+PASS Error.message: getter is ignored when cloning
+PASS Error.message: undefined property is stringified
 PASS DOMException objects can be cloned
 PASS DOMException objects created by the UA can be cloned
 

--- a/LayoutTests/imported/w3c/web-platform-tests/html/infrastructure/safe-passing-of-structured-data/window-postmessage.window-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/infrastructure/safe-passing-of-structured-data/window-postmessage.window-expected.txt
@@ -72,14 +72,14 @@ PASS Object RegExp object, RegExp unicode flag
 PASS Object RegExp object, RegExp empty
 PASS Object RegExp object, RegExp slash
 PASS Object RegExp object, RegExp new line
-FAIL Empty Error object promise_test: Unhandled rejection with value: object "DataCloneError: The object can not be cloned."
-FAIL Error object promise_test: Unhandled rejection with value: object "DataCloneError: The object can not be cloned."
-FAIL EvalError object promise_test: Unhandled rejection with value: object "DataCloneError: The object can not be cloned."
-FAIL RangeError object promise_test: Unhandled rejection with value: object "DataCloneError: The object can not be cloned."
-FAIL ReferenceError object promise_test: Unhandled rejection with value: object "DataCloneError: The object can not be cloned."
-FAIL SyntaxError object promise_test: Unhandled rejection with value: object "DataCloneError: The object can not be cloned."
-FAIL TypeError object promise_test: Unhandled rejection with value: object "DataCloneError: The object can not be cloned."
-FAIL URIError object promise_test: Unhandled rejection with value: object "DataCloneError: The object can not be cloned."
+PASS Empty Error object
+PASS Error object
+PASS EvalError object
+PASS RangeError object
+PASS ReferenceError object
+PASS SyntaxError object
+PASS TypeError object
+PASS URIError object
 PASS Blob basic
 PASS Blob unpaired high surrogate (invalid utf-8)
 PASS Blob unpaired low surrogate (invalid utf-8)

--- a/LayoutTests/imported/w3c/web-platform-tests/html/webappapis/structured-clone/structured-clone.any-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/webappapis/structured-clone/structured-clone.any-expected.txt
@@ -72,14 +72,14 @@ PASS Object RegExp object, RegExp unicode flag
 PASS Object RegExp object, RegExp empty
 PASS Object RegExp object, RegExp slash
 PASS Object RegExp object, RegExp new line
-FAIL Empty Error object promise_test: Unhandled rejection with value: object "DataCloneError: The object can not be cloned."
-FAIL Error object promise_test: Unhandled rejection with value: object "DataCloneError: The object can not be cloned."
-FAIL EvalError object promise_test: Unhandled rejection with value: object "DataCloneError: The object can not be cloned."
-FAIL RangeError object promise_test: Unhandled rejection with value: object "DataCloneError: The object can not be cloned."
-FAIL ReferenceError object promise_test: Unhandled rejection with value: object "DataCloneError: The object can not be cloned."
-FAIL SyntaxError object promise_test: Unhandled rejection with value: object "DataCloneError: The object can not be cloned."
-FAIL TypeError object promise_test: Unhandled rejection with value: object "DataCloneError: The object can not be cloned."
-FAIL URIError object promise_test: Unhandled rejection with value: object "DataCloneError: The object can not be cloned."
+PASS Empty Error object
+PASS Error object
+PASS EvalError object
+PASS RangeError object
+PASS ReferenceError object
+PASS SyntaxError object
+PASS TypeError object
+PASS URIError object
 PASS Blob basic
 PASS Blob unpaired high surrogate (invalid utf-8)
 PASS Blob unpaired low surrogate (invalid utf-8)

--- a/LayoutTests/imported/w3c/web-platform-tests/html/webappapis/structured-clone/structured-clone.any.worker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/webappapis/structured-clone/structured-clone.any.worker-expected.txt
@@ -72,14 +72,14 @@ PASS Object RegExp object, RegExp unicode flag
 PASS Object RegExp object, RegExp empty
 PASS Object RegExp object, RegExp slash
 PASS Object RegExp object, RegExp new line
-FAIL Empty Error object promise_test: Unhandled rejection with value: object "DataCloneError: The object can not be cloned."
-FAIL Error object promise_test: Unhandled rejection with value: object "DataCloneError: The object can not be cloned."
-FAIL EvalError object promise_test: Unhandled rejection with value: object "DataCloneError: The object can not be cloned."
-FAIL RangeError object promise_test: Unhandled rejection with value: object "DataCloneError: The object can not be cloned."
-FAIL ReferenceError object promise_test: Unhandled rejection with value: object "DataCloneError: The object can not be cloned."
-FAIL SyntaxError object promise_test: Unhandled rejection with value: object "DataCloneError: The object can not be cloned."
-FAIL TypeError object promise_test: Unhandled rejection with value: object "DataCloneError: The object can not be cloned."
-FAIL URIError object promise_test: Unhandled rejection with value: object "DataCloneError: The object can not be cloned."
+PASS Empty Error object
+PASS Error object
+PASS EvalError object
+PASS RangeError object
+PASS ReferenceError object
+PASS SyntaxError object
+PASS TypeError object
+PASS URIError object
 PASS Blob basic
 PASS Blob unpaired high surrogate (invalid utf-8)
 PASS Blob unpaired low surrogate (invalid utf-8)

--- a/LayoutTests/imported/w3c/web-platform-tests/workers/semantics/structured-clone/dedicated-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/workers/semantics/structured-clone/dedicated-expected.txt
@@ -72,14 +72,14 @@ PASS Object RegExp object, RegExp unicode flag
 PASS Object RegExp object, RegExp empty
 PASS Object RegExp object, RegExp slash
 PASS Object RegExp object, RegExp new line
-FAIL Empty Error object promise_test: Unhandled rejection with value: object "DataCloneError: The object can not be cloned."
-FAIL Error object promise_test: Unhandled rejection with value: object "DataCloneError: The object can not be cloned."
-FAIL EvalError object promise_test: Unhandled rejection with value: object "DataCloneError: The object can not be cloned."
-FAIL RangeError object promise_test: Unhandled rejection with value: object "DataCloneError: The object can not be cloned."
-FAIL ReferenceError object promise_test: Unhandled rejection with value: object "DataCloneError: The object can not be cloned."
-FAIL SyntaxError object promise_test: Unhandled rejection with value: object "DataCloneError: The object can not be cloned."
-FAIL TypeError object promise_test: Unhandled rejection with value: object "DataCloneError: The object can not be cloned."
-FAIL URIError object promise_test: Unhandled rejection with value: object "DataCloneError: The object can not be cloned."
+PASS Empty Error object
+PASS Error object
+PASS EvalError object
+PASS RangeError object
+PASS ReferenceError object
+PASS SyntaxError object
+PASS TypeError object
+PASS URIError object
 PASS Blob basic
 PASS Blob unpaired high surrogate (invalid utf-8)
 PASS Blob unpaired low surrogate (invalid utf-8)

--- a/LayoutTests/imported/w3c/web-platform-tests/workers/semantics/structured-clone/shared-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/workers/semantics/structured-clone/shared-expected.txt
@@ -72,14 +72,14 @@ PASS Object RegExp object, RegExp unicode flag
 PASS Object RegExp object, RegExp empty
 PASS Object RegExp object, RegExp slash
 PASS Object RegExp object, RegExp new line
-FAIL Empty Error object promise_test: Unhandled rejection with value: object "DataCloneError: The object can not be cloned."
-FAIL Error object promise_test: Unhandled rejection with value: object "DataCloneError: The object can not be cloned."
-FAIL EvalError object promise_test: Unhandled rejection with value: object "DataCloneError: The object can not be cloned."
-FAIL RangeError object promise_test: Unhandled rejection with value: object "DataCloneError: The object can not be cloned."
-FAIL ReferenceError object promise_test: Unhandled rejection with value: object "DataCloneError: The object can not be cloned."
-FAIL SyntaxError object promise_test: Unhandled rejection with value: object "DataCloneError: The object can not be cloned."
-FAIL TypeError object promise_test: Unhandled rejection with value: object "DataCloneError: The object can not be cloned."
-FAIL URIError object promise_test: Unhandled rejection with value: object "DataCloneError: The object can not be cloned."
+PASS Empty Error object
+PASS Error object
+PASS EvalError object
+PASS RangeError object
+PASS ReferenceError object
+PASS SyntaxError object
+PASS TypeError object
+PASS URIError object
 PASS Blob basic
 PASS Blob unpaired high surrogate (invalid utf-8)
 PASS Blob unpaired low surrogate (invalid utf-8)

--- a/LayoutTests/platform/glib/imported/w3c/web-platform-tests/html/infrastructure/safe-passing-of-structured-data/structured-cloning-error-stack-optional.sub.window-expected.txt
+++ b/LayoutTests/platform/glib/imported/w3c/web-platform-tests/html/infrastructure/safe-passing-of-structured-data/structured-cloning-error-stack-optional.sub.window-expected.txt
@@ -1,20 +1,20 @@
 
-FAIL page-created Error (structuredClone()) The object can not be cloned.
-FAIL page-created Error (worker) The object can not be cloned.
-FAIL page-created Error (cross-site iframe) The object can not be cloned.
-FAIL page-created Error (same-origin iframe) The object can not be cloned.
+PASS page-created Error (structuredClone())
+PASS page-created Error (worker)
+PASS page-created Error (cross-site iframe)
+PASS page-created Error (same-origin iframe)
 PASS page-created DOMException (structuredClone())
 PASS page-created DOMException (worker)
 PASS page-created DOMException (cross-site iframe)
 PASS page-created DOMException (same-origin iframe)
-FAIL JS-engine-created TypeError (structuredClone()) The object can not be cloned.
-FAIL JS-engine-created TypeError (worker) The object can not be cloned.
-FAIL JS-engine-created TypeError (cross-site iframe) The object can not be cloned.
-FAIL JS-engine-created TypeError (same-origin iframe) The object can not be cloned.
-FAIL web API-created TypeError (structuredClone()) The object can not be cloned.
-FAIL web API-created TypeError (worker) The object can not be cloned.
-FAIL web API-created TypeError (cross-site iframe) The object can not be cloned.
-FAIL web API-created TypeError (same-origin iframe) The object can not be cloned.
+PASS JS-engine-created TypeError (structuredClone())
+PASS JS-engine-created TypeError (worker)
+PASS JS-engine-created TypeError (cross-site iframe)
+PASS JS-engine-created TypeError (same-origin iframe)
+PASS web API-created TypeError (structuredClone())
+PASS web API-created TypeError (worker)
+PASS web API-created TypeError (cross-site iframe)
+PASS web API-created TypeError (same-origin iframe)
 FAIL web API-created DOMException (structuredClone()) assert_equals: expected (string) "createElement@[native code]\n@http://web-platform.test:8800/html/infrastructure/safe-passing-of-structured-data/structured-cloning-error-stack-optional.sub.window.js:33:27\n@http://web-platform.test:8800/html/infrastructure/safe-passing-of-structured-data/structured-cloning-error-stack-optional.sub.window.js:41:31\n@http://web-platform.test:8800/resources/testharness.js:2591:30\ntest@http://web-platform.test:8800/resources/testharness.js:628:34\nstackTests@http://web-platform.test:8800/html/infrastructure/safe-passing-of-structured-data/structured-cloning-error-stack-optional.sub.window.js:40:7\nglobal code@http://web-platform.test:8800/html/infrastructure/safe-passing-of-structured-data/structured-cloning-error-stack-optional.sub.window.js:31:11" but got (undefined) undefined
 FAIL web API-created DOMException (worker) assert_equals: expected (string) "createElement@[native code]\n@http://web-platform.test:8800/html/infrastructure/safe-passing-of-structured-data/structured-cloning-error-stack-optional.sub.window.js:33:27\n@http://web-platform.test:8800/html/infrastructure/safe-passing-of-structured-data/structured-cloning-error-stack-optional.sub.window.js:53:31\n@http://web-platform.test:8800/resources/testharness.js:2591:30\nasync_test@http://web-platform.test:8800/resources/testharness.js:676:38\nstackTests@http://web-platform.test:8800/html/infrastructure/safe-passing-of-structured-data/structured-cloning-error-stack-optional.sub.window.js:52:13\nglobal code@http://web-platform.test:8800/html/infrastructure/safe-passing-of-structured-data/structured-cloning-error-stack-optional.sub.window.js:31:11" but got (undefined) undefined
 FAIL web API-created DOMException (cross-site iframe) assert_equals: expected (string) "createElement@[native code]\n@http://web-platform.test:8800/html/infrastructure/safe-passing-of-structured-data/structured-cloning-error-stack-optional.sub.window.js:33:27\niframeTest@http://web-platform.test:8800/html/infrastructure/safe-passing-of-structured-data/structured-cloning-error-stack-optional.sub.window.js:72:31\n@http://web-platform.test:8800/html/infrastructure/safe-passing-of-structured-data/structured-cloning-error-stack-optional.sub.window.js:99:15\n@http://web-platform.test:8800/resources/testharness.js:2591:30\nasync_test@http://web-platform.test:8800/resources/testharness.js:676:38\nstackTests@http://web-platform.test:8800/html/infrastructure/safe-passing-of-structured-data/structured-cloning-error-stack-optional.sub.window.js:96:13\nglobal code@http://web-platform.test:8800/html/infrastructure/safe-passing-of-structured-data/structured-cloning-error-stack-optional.sub.window.js:31:11" but got (undefined) undefined

--- a/LayoutTests/storage/indexeddb/resources/structured-clone.js
+++ b/LayoutTests/storage/indexeddb/resources/structured-clone.js
@@ -658,8 +658,6 @@ function testBadTypes()
     transaction.onabort = unexpectedAbortCallback;
     transaction.oncomplete = finishJSTest;
 
-    debug("Testing Error");
-    evalAndExpectException("store.put(new Error, 'key')", "DOMException.DATA_CLONE_ERR");
     debug("Testing Function");
     evalAndExpectException("store.put(new Function, 'key')", "DOMException.DATA_CLONE_ERR");
 

--- a/LayoutTests/storage/indexeddb/structured-clone-expected.txt
+++ b/LayoutTests/storage/indexeddb/structured-clone-expected.txt
@@ -1010,11 +1010,6 @@ PASS result.toString() is test_data.toString()
 Test types that can't be cloned:
 transaction = db.transaction('storeName', 'readwrite')
 store = transaction.objectStore('storeName')
-Testing Error
-Expecting exception from store.put(new Error, 'key')
-PASS Exception was thrown.
-PASS code is DOMException.DATA_CLONE_ERR
-Exception message: The object can not be cloned.
 Testing Function
 Expecting exception from store.put(new Function, 'key')
 PASS Exception was thrown.

--- a/LayoutTests/userscripts/window-onerror-for-isolated-world-1-expected.txt
+++ b/LayoutTests/userscripts/window-onerror-for-isolated-world-1-expected.txt
@@ -2,13 +2,13 @@ Test that window.onerror and "error" event listeners from main world are invoked
 
 Main world window.onerror: Error: Error in main world inline script. at window-onerror-for-isolated-world-1.html:55:68 Error: Error in main world inline script.
 Main world error event listener: Error: Error in main world inline script. at window-onerror-for-isolated-world-1.html:55:68 Error: Error in main world inline script.
-Main world window.onerror: Error: Error in user script inline script. at undefined:12:20 null
-Main world error event listener: Error: Error in user script inline script. at undefined:12:20 null
+Main world window.onerror: Error: Error in user script inline script. at undefined:12:20 Error: Error in user script inline script.
+Main world error event listener: Error: Error in user script inline script. at undefined:12:20 Error: Error in user script inline script.
 Main world window.onerror: Error: Error in main world load handler. at window-onerror-for-isolated-world-1.html:51:72 Error: Error in main world load handler.
 Main world error event listener: Error: Error in main world load handler. at window-onerror-for-isolated-world-1.html:51:72 Error: Error in main world load handler.
-Main world window.onerror: Error: Error in user script load handler. at undefined:8:24 null
-Main world error event listener: Error: Error in user script load handler. at undefined:8:24 null
+Main world window.onerror: Error: Error in user script load handler. at undefined:8:24 Error: Error in user script load handler.
+Main world error event listener: Error: Error in user script load handler. at undefined:8:24 Error: Error in user script load handler.
 Main world window.onerror: Error: Error in main world setTimeout callback. at window-onerror-for-isolated-world-1.html:49:83 Error: Error in main world setTimeout callback.
 Main world error event listener: Error: Error in main world setTimeout callback. at window-onerror-for-isolated-world-1.html:49:83 Error: Error in main world setTimeout callback.
-Main world window.onerror: Error: Error in user script setTimeout callback. at undefined:6:28 null
-Main world error event listener: Error: Error in user script setTimeout callback. at undefined:6:28 null
+Main world window.onerror: Error: Error in user script setTimeout callback. at undefined:6:28 Error: Error in user script setTimeout callback.
+Main world error event listener: Error: Error in user script setTimeout callback. at undefined:6:28 Error: Error in user script setTimeout callback.

--- a/LayoutTests/userscripts/window-onerror-for-isolated-world-2-expected.txt
+++ b/LayoutTests/userscripts/window-onerror-for-isolated-world-2-expected.txt
@@ -3,11 +3,11 @@ Test that window.onerror and "error" event listeners from isolated world are inv
 
 user script window.onerror: Error: Error in user script inline script. at undefined:33:20 Error: Error in user script inline script.
 user script error event listener: Error: Error in user script inline script. at undefined:33:20 Error: Error in user script inline script.
-user script window.onerror: Error: Error in main world load handler. at window-onerror-for-isolated-world-2.html:27:72 null
-user script error event listener: Error: Error in main world load handler. at window-onerror-for-isolated-world-2.html:27:72 null
+user script window.onerror: Error: Error in main world load handler. at window-onerror-for-isolated-world-2.html:27:72 Error: Error in main world load handler.
+user script error event listener: Error: Error in main world load handler. at window-onerror-for-isolated-world-2.html:27:72 Error: Error in main world load handler.
 user script window.onerror: Error: Error in user script load handler. at undefined:30:24 Error: Error in user script load handler.
 user script error event listener: Error: Error in user script load handler. at undefined:30:24 Error: Error in user script load handler.
-user script window.onerror: Error: Error in main world setTimeout callback. at window-onerror-for-isolated-world-2.html:25:83 null
-user script error event listener: Error: Error in main world setTimeout callback. at window-onerror-for-isolated-world-2.html:25:83 null
+user script window.onerror: Error: Error in main world setTimeout callback. at window-onerror-for-isolated-world-2.html:25:83 Error: Error in main world setTimeout callback.
+user script error event listener: Error: Error in main world setTimeout callback. at window-onerror-for-isolated-world-2.html:25:83 Error: Error in main world setTimeout callback.
 user script window.onerror: Error: Error in user script setTimeout callback. at undefined:28:28 Error: Error in user script setTimeout callback.
 user script error event listener: Error: Error in user script setTimeout callback. at undefined:28:28 Error: Error in user script setTimeout callback.

--- a/Source/JavaScriptCore/runtime/ErrorInstance.cpp
+++ b/Source/JavaScriptCore/runtime/ErrorInstance.cpp
@@ -46,6 +46,15 @@ ErrorInstance::ErrorInstance(VM& vm, Structure* structure, ErrorType errorType)
 {
 }
 
+ErrorInstance* ErrorInstance::create(JSGlobalObject* globalObject, String&& message, ErrorType errorType, unsigned line, unsigned column, String&& sourceURL, String&& stackString)
+{
+    VM& vm = globalObject->vm();
+    Structure* structure = globalObject->errorStructure(errorType);
+    ErrorInstance* instance = new (NotNull, allocateCell<ErrorInstance>(vm)) ErrorInstance(vm, structure, errorType);
+    instance->finishCreation(vm, WTFMove(message), line, column, WTFMove(sourceURL), WTFMove(stackString));
+    return instance;
+}
+
 ErrorInstance* ErrorInstance::create(JSGlobalObject* globalObject, Structure* structure, JSValue message, JSValue options, SourceAppender appender, RuntimeType type, ErrorType errorType, bool useCurrentFrame)
 {
     VM& vm = globalObject->vm();
@@ -136,6 +145,19 @@ void ErrorInstance::finishCreation(VM& vm, JSGlobalObject* globalObject, const S
 
     if (!cause.isEmpty())
         putDirect(vm, vm.propertyNames->cause, cause, static_cast<unsigned>(PropertyAttribute::DontEnum));
+}
+
+void ErrorInstance::finishCreation(VM& vm, String&& message, unsigned line, unsigned column, String&& sourceURL, String&& stackString)
+{
+    Base::finishCreation(vm);
+    ASSERT(inherits(info()));
+
+    m_line = line;
+    m_column = column;
+    m_sourceURL = WTFMove(sourceURL);
+    m_stackString = WTFMove(stackString);
+    if (!message.isNull())
+        putDirect(vm, vm.propertyNames->message, jsString(vm, WTFMove(message)), static_cast<unsigned>(PropertyAttribute::DontEnum));
 }
 
 // Based on ErrorPrototype's errorProtoFuncToString(), but is modified to

--- a/Source/JavaScriptCore/runtime/ErrorInstance.h
+++ b/Source/JavaScriptCore/runtime/ErrorInstance.h
@@ -62,6 +62,7 @@ public:
         return instance;
     }
 
+    JS_EXPORT_PRIVATE static ErrorInstance* create(JSGlobalObject*, String&& message, ErrorType, unsigned line, unsigned column, String&& sourceURL, String&& stackString);
     static ErrorInstance* create(JSGlobalObject*, Structure*, JSValue message, JSValue options, SourceAppender = nullptr, RuntimeType = TypeNothing, ErrorType = ErrorType::Error, bool useCurrentFrame = true);
 
     bool hasSourceAppender() const { return !!m_sourceAppender; }
@@ -101,6 +102,7 @@ protected:
     explicit ErrorInstance(VM&, Structure*, ErrorType);
 
     void finishCreation(VM&, JSGlobalObject*, const String& message, JSValue cause, SourceAppender = nullptr, RuntimeType = TypeNothing, bool useCurrentFrame = true);
+    void finishCreation(VM&, String&& message, unsigned line, unsigned column, String&& sourceURL, String&& stackString);
 
     static bool getOwnPropertySlot(JSObject*, JSGlobalObject*, PropertyName, PropertySlot&);
     static void getOwnSpecialPropertyNames(JSObject*, JSGlobalObject*, PropertyNameArray&, DontEnumPropertiesMode);


### PR DESCRIPTION
#### 7bd6b875a6f7276468c9d900282028fc92f38d59
<pre>
Add support for structured cloning of ErrorInstance objects
<a href="https://bugs.webkit.org/show_bug.cgi?id=257268">https://bugs.webkit.org/show_bug.cgi?id=257268</a>

Reviewed by Yusuke Suzuki and Ryosuke Niwa.

Add support for structured cloning of ErrorInstance objects, per:
- <a href="https://html.spec.whatwg.org/multipage/structured-data.html#structuredserializeinternal">https://html.spec.whatwg.org/multipage/structured-data.html#structuredserializeinternal</a>

This aligns our behavior with Blink and Gecko.

* LayoutTests/fast/dom/Window/window-postmessage-clone-expected.txt:
* LayoutTests/fast/dom/Window/window-postmessage-clone.html:
* LayoutTests/fast/events/message-port-multi-expected.txt:
* LayoutTests/fast/events/resources/message-port-multi.js:
* LayoutTests/fast/storage/serialized-script-value.html:
* LayoutTests/imported/w3c/web-platform-tests/IndexedDB/structured-clone.any.worker_81-100-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/IndexedDB/structured-clone.any_81-100-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/html/infrastructure/safe-passing-of-structured-data/messagechannel.any-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/html/infrastructure/safe-passing-of-structured-data/messagechannel.any.serviceworker-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/html/infrastructure/safe-passing-of-structured-data/messagechannel.any.sharedworker-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/html/infrastructure/safe-passing-of-structured-data/messagechannel.any.worker-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/html/infrastructure/safe-passing-of-structured-data/structured-cloning-error-stack-optional.sub.window-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/html/infrastructure/safe-passing-of-structured-data/structuredclone_0-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/html/infrastructure/safe-passing-of-structured-data/window-postmessage.window-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/workers/semantics/structured-clone/dedicated-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/workers/semantics/structured-clone/shared-expected.txt:
* LayoutTests/storage/indexeddb/resources/structured-clone.js:
* LayoutTests/storage/indexeddb/structured-clone-expected.txt:
* LayoutTests/userscripts/window-onerror-for-isolated-world-1-expected.txt:
* LayoutTests/userscripts/window-onerror-for-isolated-world-2-expected.txt:
* Source/JavaScriptCore/runtime/ErrorInstance.cpp:
(JSC::ErrorInstance::finishCreation):
* Source/JavaScriptCore/runtime/ErrorInstance.h:
(JSC::ErrorInstance::createWithoutStackTrace):
* Source/WebCore/bindings/js/SerializedScriptValue.cpp:
(WebCore::CloneSerializer::dumpIfTerminal):
(WebCore::CloneDeserializer::readTerminal):

Canonical link: <a href="https://commits.webkit.org/264552@main">https://commits.webkit.org/264552@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/cbf266e2b5f92061901d65ced24e607e119ac1cb

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/7962 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/8244 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/8458 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/9612 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/8076 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/7966 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/10232 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/8156 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/10941 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/8105 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/9197 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/7287 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/9731 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/6499 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/7288 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/14876 "Passed tests") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/6788 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/7622 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/7412 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/10770 "Passed tests") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/7530 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/7879 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/6409 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/8126 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/7196 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/7198 "Passed tests") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/1856 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/1899 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/11405 "Built successfully") | | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/24/builds/8346 "Built successfully") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/7617 "Built successfully") | | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/3/builds/2005 "Passed tests") | 
<!--EWS-Status-Bubble-End-->