### PR TITLE
[WGSL] Type checker should use reference type for var references

### DIFF
--- a/Source/WebGPU/WGSL/Constraints.cpp
+++ b/Source/WebGPU/WGSL/Constraints.cpp
@@ -33,8 +33,11 @@ namespace WGSL {
 bool satisfies(const Type* type, Constraint constraint)
 {
     auto* primitive = std::get_if<Types::Primitive>(type);
-    if (!primitive)
+    if (!primitive) {
+        if (auto* reference = std::get_if<Types::Reference>(type))
+            return satisfies(reference->element, constraint);
         return false;
+    }
 
     switch (primitive->kind) {
     case Types::Primitive::AbstractInt:
@@ -62,8 +65,11 @@ bool satisfies(const Type* type, Constraint constraint)
 Type* satisfyOrPromote(Type* type, Constraint constraint, const TypeStore& types)
 {
     auto* primitive = std::get_if<Types::Primitive>(type);
-    if (!primitive)
+    if (!primitive) {
+        if (auto* reference = std::get_if<Types::Reference>(type))
+            return satisfyOrPromote(reference->element, constraint, types);
         return nullptr;
+    }
 
     switch (primitive->kind) {
     case Types::Primitive::AbstractInt:

--- a/Source/WebGPU/WGSL/tests/invalid/for.wgsl
+++ b/Source/WebGPU/WGSL/tests/invalid/for.wgsl
@@ -1,7 +1,7 @@
 // RUN: %not %wgslc | %check
 
 fn testForStatement() {
-  // CHECK-L: for-loop condition must be bool, got <AbstractInt>
+  // CHECK-L: for-loop condition must be bool, got ref<function, <AbstractInt>, read_write>
   for (var i = 0; i;) {
   }
 }

--- a/Source/WebGPU/WGSL/tests/invalid/overload.wgsl
+++ b/Source/WebGPU/WGSL/tests/invalid/overload.wgsl
@@ -10,7 +10,7 @@ struct S {
 };
 
 fn testConstraints() {
-    var x : S;
+    let x = S(0);
 
     // CHECK-L: no matching overload for operator +(S, S)
     let x2 = x + x;

--- a/Source/WebGPU/WGSL/tests/invalid/references.wgsl
+++ b/Source/WebGPU/WGSL/tests/invalid/references.wgsl
@@ -1,0 +1,20 @@
+// RUN: %not %wgslc | %check
+
+@group(0) @binding(0) var<storage, read> x: i32;
+@group(0) @binding(1) var<storage, read_write> y: i32;
+
+fn testReferenceAssignment()
+{
+    // CHECK-L: cannot store into a read-only type 'ref<storage, i32, read>'
+    x = 0;
+
+    // CHECK-L: cannot assign value of type 'u32' to 'i32'
+    y = 0u;
+
+    // CHECK-L: cannot assign to a value of type 'i32'
+    let z: i32 = 0;
+    z = 0;
+
+    // FIXME: we can't test that we don't accept write-only references for reads
+    // since there are no valid ways of declaring a write-only var
+}

--- a/Source/WebGPU/WGSL/tests/valid/references.wgsl
+++ b/Source/WebGPU/WGSL/tests/valid/references.wgsl
@@ -1,0 +1,13 @@
+// RUN: %wgslc
+
+fn testImplicitConversion()
+{
+    // This is a trivial test case, but it exercises every path of the overload
+    // resolution involving refernces:
+    // - Unpacking the reference for validating the argument
+    // - Matching against the previously inferred type (AbstractInt)
+    // - Satisfying a constraint (Number)
+    var x: i32 = 0;
+    _ = 0 + x;
+    _ = x + 0;
+}


### PR DESCRIPTION
#### d9674fd1aa78109239d952c2f20f1c2fc402947a
<pre>
[WGSL] Type checker should use reference type for var references
<a href="https://bugs.webkit.org/show_bug.cgi?id=257272">https://bugs.webkit.org/show_bug.cgi?id=257272</a>
rdar://109787826

Reviewed by Mike Wyrzykowski.

When we have a declaration `var x: T`, any identifier `x` in the program that
refer to this declaration should have type `ref&lt;T&gt;` instead of `T`. To keep
everything working it was necessary to implement field access and index access
over references as well as handle references in the overload resolution.

* Source/WebGPU/WGSL/Constraints.cpp:
(WGSL::satisfies):
(WGSL::satisfyOrPromote):
* Source/WebGPU/WGSL/Overload.cpp:
(WGSL::OverloadResolver::calculateRank):
(WGSL::OverloadResolver::unify):
* Source/WebGPU/WGSL/TypeCheck.cpp:
(WGSL::TypeChecker::check):
(WGSL::TypeChecker::visit):
(WGSL::TypeChecker::visitVariable):
(WGSL::TypeChecker::vectorFieldAccess):
(WGSL::TypeChecker::isBottom const):
* Source/WebGPU/WGSL/Types.cpp:
(WGSL::conversionRank):
* Source/WebGPU/WGSL/tests/invalid/for.wgsl:
* Source/WebGPU/WGSL/tests/invalid/overload.wgsl:
* Source/WebGPU/WGSL/tests/invalid/references.wgsl: Added.
* Source/WebGPU/WGSL/tests/valid/references.wgsl: Added.

Canonical link: <a href="https://commits.webkit.org/264570@main">https://commits.webkit.org/264570@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c4fefc5df98d7f97e15f35635ade0bda83c23f0c

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/8011 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/8296 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/8508 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/9663 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/8115 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/10282 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/8207 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/10978 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/8155 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/9240 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/7318 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/9783 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/6541 "Passed tests") | | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/14909 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [❌ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/7664 "1 api test failed or timed out") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/7452 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/10812 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/7923 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/6443 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/7237 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/1914 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/11445 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/7664 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->