### PR TITLE
[WGSL] Move logic to handle global references into serialization

### DIFF
--- a/Source/WebGPU/WGSL/AST/ASTVariable.h
+++ b/Source/WebGPU/WGSL/AST/ASTVariable.h
@@ -33,7 +33,11 @@
 #include "ASTTypeName.h"
 #include "ASTVariableQualifier.h"
 
-namespace WGSL::AST {
+namespace WGSL {
+class TypeChecker;
+struct Type;
+
+namespace AST {
 
 enum class VariableFlavor : uint8_t {
     Const,
@@ -44,6 +48,7 @@ enum class VariableFlavor : uint8_t {
 
 class Variable final : public Declaration {
     WGSL_AST_BUILDER_NODE(Variable);
+    friend TypeChecker;
 public:
     using Ref = std::reference_wrapper<Variable>;
     using List = ReferenceWrapperVector<Variable>;
@@ -55,6 +60,13 @@ public:
     VariableQualifier* maybeQualifier() { return m_qualifier; }
     TypeName* maybeTypeName() { return m_type; }
     Expression* maybeInitializer() { return m_initializer; }
+    TypeName* maybeReferenceType() { return m_referenceType; }
+    const Type* storeType() const
+    {
+        if (m_type)
+            return m_type->resolvedType();
+        return m_initializer->inferredType();
+    }
 
 private:
     Variable(SourceSpan span, VariableFlavor flavor, Identifier&& name, TypeName::Ptr type, Expression::Ptr initializer)
@@ -81,8 +93,10 @@ private:
     TypeName::Ptr m_type;
     Expression::Ptr m_initializer;
     VariableFlavor m_flavor;
+    TypeName::Ptr m_referenceType { nullptr };
 };
 
-} // namespace WGSL::AST
+} // namespace AST
+} // namespace WGSL
 
 SPECIALIZE_TYPE_TRAITS_WGSL_AST(Variable)

--- a/Source/WebGPU/WGSL/TypeCheck.cpp
+++ b/Source/WebGPU/WGSL/TypeCheck.cpp
@@ -224,6 +224,14 @@ void TypeChecker::visitVariable(AST::Variable& variable, VariableKind variableKi
             accessMode = AccessMode::Read;
         }
         result = m_types.referenceType(addressSpace, result, accessMode);
+        if (auto* maybeTypeName = variable.maybeTypeName()) {
+            auto& referenceType = m_shaderModule.astBuilder().construct<AST::ReferenceTypeName>(
+                maybeTypeName->span(),
+                *maybeTypeName
+            );
+            referenceType.m_resolvedType = result;
+            variable.m_referenceType = &referenceType;
+        }
     }
     introduceVariable(variable.name(), result);
 }

--- a/Source/WebGPU/WGSL/Types.cpp
+++ b/Source/WebGPU/WGSL/Types.cpp
@@ -323,15 +323,20 @@ unsigned Type::alignment() const
         });
 }
 
+bool isPrimitive(const Type* type, Primitive::Kind kind)
+{
+    auto* primitive = std::get_if<Primitive>(type);
+    if (!primitive)
+        return false;
+    return primitive->kind == kind;
+}
+
 bool isPrimitiveReference(const Type* type, Primitive::Kind kind)
 {
     auto* reference = std::get_if<Reference>(type);
     if (!reference)
         return false;
-    auto* primitive = std::get_if<Primitive>(reference->element);
-    if (!primitive)
-        return false;
-    return primitive->kind == kind;
+    return isPrimitive(reference->element, kind);
 }
 
 } // namespace WGSL

--- a/Source/WebGPU/WGSL/Types.h
+++ b/Source/WebGPU/WGSL/Types.h
@@ -160,6 +160,7 @@ struct Type : public std::variant<
 using ConversionRank = Markable<unsigned, IntegralMarkableTraits<unsigned, std::numeric_limits<unsigned>::max()>>;
 ConversionRank conversionRank(Type* from, Type* to);
 
+bool isPrimitive(const Type*, Types::Primitive::Kind);
 bool isPrimitiveReference(const Type*, Types::Primitive::Kind);
 
 } // namespace WGSL


### PR DESCRIPTION
#### 5d6541ead5140df5a918ad857033c325ddadbf6a
<pre>
[WGSL] Move logic to handle global references into serialization
<a href="https://bugs.webkit.org/show_bug.cgi?id=257275">https://bugs.webkit.org/show_bug.cgi?id=257275</a>
rdar://109789455

Reviewed by Mike Wyrzykowski.

Instead of trying to decide whether a given global should be a reference by looking
at its type during rewriting, now that we have proper knowledge about address spaces
we can greatly simply this logic by consistently using references for all globals,
which is semantically correct, and handling this in the serializaiton stage.

* Source/WebGPU/WGSL/AST/ASTVariable.h:
* Source/WebGPU/WGSL/GlobalVariableRewriter.cpp:
(WGSL::RewriteGlobalVariables::visitCallee):
(WGSL::RewriteGlobalVariables::usesOverride):
(WGSL::RewriteGlobalVariables::insertStructs):
(WGSL::RewriteGlobalVariables::insertMaterializations):
(WGSL::RewriteGlobalVariables::shouldBeReference const): Deleted.
* Source/WebGPU/WGSL/Metal/MetalFunctionWriter.cpp:
(WGSL::Metal::FunctionDefinitionWriter::serializeVariable):
(WGSL::Metal::FunctionDefinitionWriter::visit):
* Source/WebGPU/WGSL/TypeCheck.cpp:
(WGSL::TypeChecker::visitVariable):
* Source/WebGPU/WGSL/Types.cpp:
(WGSL::isPrimitive):
(WGSL::isPrimitiveReference):
* Source/WebGPU/WGSL/Types.h:

Canonical link: <a href="https://commits.webkit.org/264574@main">https://commits.webkit.org/264574@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2ec3c6243ac95b1a223f03b8b10fc9dea37d9d9a

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/8020 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/8305 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/8517 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/9672 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/32/builds/8124 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/10291 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/8216 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/10989 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/8164 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/9250 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/7323 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/9792 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/6551 "Passed tests") | | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/14920 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/7674 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/7461 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/10823 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/7932 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/6453 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/7246 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/1918 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/11454 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/7673 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->