### PR TITLE
Speedometer 3 hits Webkit's replaceState/pushState limits

### DIFF
--- a/LayoutTests/fast/loader/stateobjects/pushstate-frequency-expected.txt
+++ b/LayoutTests/fast/loader/stateobjects/pushstate-frequency-expected.txt
@@ -99,6 +99,6 @@ Successfully added item: 96
 Successfully added item: 97
 Successfully added item: 98
 Successfully added item: 99
-SecurityError: Attempt to use history.pushState() more than 100 times per 30 seconds
+SecurityError: Attempt to use history.pushState() more than 100 times per 10 seconds
 Test complete
 

--- a/LayoutTests/fast/loader/stateobjects/pushstate-frequency-iframe-expected.txt
+++ b/LayoutTests/fast/loader/stateobjects/pushstate-frequency-iframe-expected.txt
@@ -107,5 +107,5 @@ Successfully added item: 21
 Successfully added item: 22
 Successfully added item: 23
 Successfully added item: 24
-Expected exception: SecurityError: Attempt to use history.pushState() more than 100 times per 30 seconds
+Expected exception: SecurityError: Attempt to use history.pushState() more than 100 times per 10 seconds
 

--- a/LayoutTests/fast/loader/stateobjects/replacestate-frequency-expected.txt
+++ b/LayoutTests/fast/loader/stateobjects/replacestate-frequency-expected.txt
@@ -99,6 +99,6 @@ Successfully added item: 96
 Successfully added item: 97
 Successfully added item: 98
 Successfully added item: 99
-SecurityError: Attempt to use history.replaceState() more than 100 times per 30 seconds
+SecurityError: Attempt to use history.replaceState() more than 100 times per 10 seconds
 Test complete
 

--- a/LayoutTests/fast/loader/stateobjects/replacestate-frequency-iframe-expected.txt
+++ b/LayoutTests/fast/loader/stateobjects/replacestate-frequency-iframe-expected.txt
@@ -106,5 +106,5 @@ Successfully added item: 21
 Successfully added item: 22
 Successfully added item: 23
 Successfully added item: 24
-Expected exception: SecurityError: Attempt to use history.replaceState() more than 100 times per 30 seconds
+Expected exception: SecurityError: Attempt to use history.replaceState() more than 100 times per 10 seconds
 

--- a/Source/WebCore/page/History.cpp
+++ b/Source/WebCore/page/History.cpp
@@ -189,7 +189,7 @@ ExceptionOr<void> History::stateObjectAdded(RefPtr<SerializedScriptValue>&& data
 
     // Each unique main-frame document is only allowed to send 64MB of state object payload to the UI client/process.
     static uint32_t totalStateObjectPayloadLimit = 0x4000000;
-    static Seconds stateObjectTimeSpan { 30_s };
+    static Seconds stateObjectTimeSpan { 10_s };
     static unsigned perStateObjectTimeSpanLimit = 100;
 
     auto* frame = this->frame();


### PR DESCRIPTION
#### 451d10e21bf95fec6dc00ef842ab676a38db4278
<pre>
Speedometer 3 hits Webkit&apos;s replaceState/pushState limits
<a href="https://bugs.webkit.org/show_bug.cgi?id=257269">https://bugs.webkit.org/show_bug.cgi?id=257269</a>

Reviewed by Alex Christensen.

Triple the limit of pushState / replaceState so that the latest version of Speedometer 3 runs in WebKit.

* LayoutTests/fast/loader/stateobjects/pushstate-frequency-expected.txt:
* LayoutTests/fast/loader/stateobjects/pushstate-frequency-iframe-expected.txt:
* LayoutTests/fast/loader/stateobjects/replacestate-frequency-expected.txt:
* LayoutTests/fast/loader/stateobjects/replacestate-frequency-iframe-expected.txt:
* Source/WebCore/page/History.cpp:
(WebCore::History::stateObjectAdded):

Canonical link: <a href="https://commits.webkit.org/264499@main">https://commits.webkit.org/264499@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0ceb4a203c21d7786fb85625d5d376fca85698c1

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/7831 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/8107 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/8292 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/9478 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/7965 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/7835 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/10100 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/8024 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/10833 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/7970 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/9074 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/7166 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/9591 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/6380 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/7138 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/14773 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/7513 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/7257 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/10658 "run-api-tests-without-change (failure)") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/7752 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/6308 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/7072 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/11280 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/936 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/7487 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->