### PR TITLE
[WebGL] Add ability to override default priority for WebGL content

### DIFF
--- a/Source/WebCore/PAL/pal/spi/cocoa/MetalSPI.h
+++ b/Source/WebCore/PAL/pal/spi/cocoa/MetalSPI.h
@@ -25,6 +25,7 @@
 
 #if USE(APPLE_INTERNAL_SDK)
 
+#import <Metal/MTLCommandQueue_Private.h>
 #import <Metal/MTLTexture_Private.h>
 #import <Metal/MetalPrivate.h>
 
@@ -54,5 +55,13 @@ typedef struct __IOSurface *IOSurfaceRef;
 - (instancetype)initWithIOSurface:(IOSurfaceRef)ioSurface label:(NSString*)label;
 @end
 #endif
+
+typedef NS_ENUM(NSUInteger, WebKitMTLGPUPriority) {
+    MTLGPUPriorityLow = 2,
+};
+
+@protocol MTLCommandQueueSPI <MTLCommandQueue>
+- (BOOL)setGPUPriority:(WebKitMTLGPUPriority)priority;
+@end
 
 #endif


### PR DESCRIPTION
#### 80be443f3c5a0349d443d755f81e152e4ed52ce4
<pre>
[WebGL] Add ability to override default priority for WebGL content
<a href="https://bugs.webkit.org/show_bug.cgi?id=257282">https://bugs.webkit.org/show_bug.cgi?id=257282</a>
&lt;radar://104710441&gt;

Reviewed by NOBODY (OOPS!).

Add ability to override the priority of the command queues.

Use swizzling so we don&apos;t need to add SPI to Angle.

Also limit the change to running WebKit.WebContent or WebKit.GPU processes,
as many other processes link WebCore and we don&apos;t want to set their queues
to low priority.

* Source/WebCore/PAL/pal/spi/cocoa/MetalSPI.h:
I only reference low priority directly so that is the only value I staged.

* Source/WebCore/platform/graphics/cocoa/GraphicsContextGLCocoa.mm:
(+[_MTLCommandQueue initialize]):
(-[_MTLCommandQueue WebKit_initWithDevice:]):
Use swizzling so we don&apos;t need to add SPI to Angle.
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/80be443f3c5a0349d443d755f81e152e4ed52ce4

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/7884 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/8162 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/8421 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/9533 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/8008 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/7889 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/10155 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/8079 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/10876 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/8024 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/9124 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/7256 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/9651 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/6429 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/7255 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/14842 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/7552 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/7378 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/10707 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/7803 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/6343 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/7121 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/11330 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/7538 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->