### PR TITLE
Add tool to verify B3 output of testb3 cases

### DIFF
--- a/Tools/Scripts/canonicalize-testb3-ir.py
+++ b/Tools/Scripts/canonicalize-testb3-ir.py
@@ -1,0 +1,484 @@
+#!/usr/bin/env python3
+
+# canonicalize-testb3-ir
+#
+# This is a simple program that will rewrite a B3 IR dump to quotient away
+# some details that don't affect the program behavior.
+#
+# Notably it serves to make the ordering of effect-free instructions irrelevant:
+#
+# E.g. both this program:
+#
+# BB#0:
+#   Int64 b@0 = ArgumentReg(%rdi)
+#   Int64 b@1 = ArgumentReg(%rsi)
+#   Int64 b@2 = Add(b@0, b@1)
+#   Void b@3 = Return(b@2, Terminal)
+#
+# ... and this program ...:
+#
+# BB#0:
+#   Int64 b@0 = ArgumentReg(%rsi)
+#   Int64 b@1 = ArgumentReg(%rdi)
+#   Int64 b@2 = Add(b@1, b@0)
+#   Void b@3 = Return(b@2, Terminal)
+#
+# ... will canonicalize to the same result:
+#
+# BB#0:
+#   Successors: None
+#     Void %0 = Return(Int64(Add(Int64(ArgumentReg(%rdi)), Int64(ArgumentReg(%rsi))), Terminal))
+
+import argparse
+import sys
+import re
+import typing
+import io
+import traceback
+from dataclasses import dataclass
+from pprint import pprint
+
+if __name__ != "__main__":
+    sys.exit(1)
+
+# We have to parse the B3 output back into some semblance of graph structuer
+# for the purposes of analyzing it:
+
+################################################################################
+# Lexing
+
+
+class TestBegin(typing.NamedTuple):
+    name: str
+
+
+class TestEnd(typing.NamedTuple):
+    name: str
+
+
+class BasicBlockBegin(typing.NamedTuple):
+    id: str
+    detail: str
+
+
+class BasicBlockEnd(typing.NamedTuple):
+    detail: str
+
+
+class Type(typing.NamedTuple):
+    name: str
+
+
+class Var(typing.NamedTuple):
+    name: str
+
+
+class PhiVar(typing.NamedTuple):
+    name: str
+
+
+class Operand(typing.NamedTuple):
+    content: str
+
+
+class LeftParen(typing.NamedTuple):
+    pass
+
+
+class RightParen(typing.NamedTuple):
+    pass
+
+
+class Comma(typing.NamedTuple):
+    pass
+
+
+def lex_ssa(line):
+    match = re.match(r'^([^ ]+) b@([0-9]+) = (.*)$', line)
+    if match is None:
+        raise RuntimeError("lex_ssa: expected an SSA assignment here")
+    yield Type(match.group(1))
+    yield Var(match.group(2))
+
+    operands = match.group(3)
+    for tok in re.findall(r'([^,()]+|,|\(|\)| +)', operands):
+        tok = tok.strip()
+        if tok == '':
+            continue
+        match = re.match('b@([0-9]+)', tok)
+        if match is not None:
+            yield Var(match.group(1))
+            continue
+        match = re.match(r'\^([0-9]+)', tok)
+        if match is not None:
+            yield PhiVar(match.group(1))
+            continue
+        match = re.match(r',', tok)
+        if match is not None:
+            yield Comma()
+            continue
+        match = re.match(r'\(', tok)
+        if match is not None:
+            yield LeftParen()
+            continue
+        match = re.match(r'\)', tok)
+        if match is not None:
+            yield RightParen()
+            continue
+        yield Operand(tok)
+
+
+def lex(f):
+    line_num = 0
+    discard = False
+    for line in f.readlines():
+        line_num += 1
+        try:
+            match = re.match(r'^O[0-2]: (.*)\.\.\.$', line)
+            if match is not None:
+                yield TestBegin(match.group(1))
+                discard = False
+                continue
+            match = re.match(r'^O[0-2]: (.*): OK!$', line)
+            if match is not None:
+                yield TestEnd(match.group(1))
+                discard = False
+                continue
+            if discard:
+                continue
+            if "Initial B3" in line:
+                discard = False
+                continue
+            if "Predecessors" in line:
+                continue
+            if "Variables:" in line:
+                discard = True
+                continue
+            if "Stack slots:" in line:
+                discard = True
+                continue
+            if not line.startswith('b3'):
+                continue
+            line = re.sub(r'^b3 *', '', line)
+            match = re.match(r'BB#([0-9]+): (.*)$', line)
+            if match is not None:
+                yield BasicBlockBegin(match.group(1), match.group(2))
+                continue
+            match = re.match(r'^Successors: (.*)$', line)
+            if match is not None:
+                yield BasicBlockEnd(match.group(1))
+                continue
+            yield from lex_ssa(line)
+        except Exception as e:
+            print(f"lexing failed at line {line_num}: {e}\n")
+            raise
+
+
+################################################################################
+# Parsing
+
+# We implement a non-backtracking recursive-descent parser
+
+
+@dataclass
+class Test:
+    """A test is a named collection of basic blocks, corresponding to one or more B3 procedures"""
+    name: str
+    blocks: typing.List['Block']
+
+
+@dataclass
+class Block:
+    """A basic block"""
+    id: str
+    detail: str
+    insns: typing.List['Instr']
+    successor_detail: str
+
+
+@dataclass
+class Instr:
+    """An instruction"""
+    dest: Var
+    typ: Type
+    rhs: list
+
+
+def parse_test_list(suite, toks):
+    while parse_test(suite, toks):
+        pass
+
+
+def parse_test(suite, toks):
+    if len(toks) == 0:
+        return None
+    if isinstance(toks[-1], TestBegin):
+        test = Test(
+            toks[-1].name,
+            []
+        )
+
+        suite.append(test)
+
+        toks.pop()
+        while parse_block(test.blocks, toks):
+            pass
+
+        if isinstance(toks[-1], TestEnd):
+            toks.pop()
+            return True
+
+    return False
+
+
+def parse_block(prgm, toks):
+    if isinstance(toks[-1], BasicBlockBegin):
+        block = Block(
+            toks[-1].id,
+            toks[-1].detail,
+            [],
+            None
+        )
+        prgm.append(block)
+        toks.pop()
+        parse_insn_list(block, toks)
+        if isinstance(toks[-1], BasicBlockEnd):
+            block.successor_detail = toks[-1].detail
+            toks.pop()
+        return True
+    return False
+
+
+def parse_insn_list(block, toks):
+    while parse_insn(block, toks):
+        pass
+
+
+def parse_insn(block, toks):
+    if isinstance(toks[-1], Type) and isinstance(toks[-2], Var):
+        i = Instr(toks[-2], toks[-1], [])
+        block.insns.append(i)
+        toks.pop()
+        toks.pop()
+        parse_expr(i.rhs, toks)
+        i.rhs = i.rhs[0]
+        return True
+
+    return False
+
+
+def parse_expr_list(out, toks):
+    while parse_expr(out, toks):
+        if isinstance(toks[-1], Comma):
+            toks.pop()
+
+
+def parse_expr(out, toks):
+    if isinstance(toks[-1], Operand) and isinstance(toks[-2], LeftParen):
+        e = [toks[-1]]
+        out.append(e)
+        toks.pop()
+        toks.pop()
+        parse_expr_list(e, toks)
+        if isinstance(toks[-1], RightParen):
+            toks.pop()
+            return True
+    elif isinstance(toks[-1], Operand) or isinstance(toks[-1], Var) or isinstance(toks[-1], PhiVar):
+        out.append(toks[-1])
+        toks.pop()
+        return True
+    return False
+
+
+################################################################################
+# Canonicalization
+
+# Canonicalizing the graph is straightforward--consider an instruction in a basic block:
+
+#   Type b@0 = Opcode( ... args .., [maybe effects])
+
+# If no effects appear in an instruction, we omit this line from the output and
+# replace all uses of b@0 in the unit with the RHS (wrapped in a `Type`
+# pseudo-opcode, since sometimes this is necessary to disambiguate), this has
+# the effect of producing an output that does not vary as effect-free
+# instructions are reordered.
+
+# After substituting away tmps that correspond to effect-free instructions, we
+# renumber all remaining tmps to ensure the numbering is also canonical.
+
+
+@dataclass
+class VisitedBlock:
+    id: str
+    insns: list
+    detail: str
+    successor_detail: str
+
+
+@dataclass
+class VisitedInstr:
+    dest: int
+    typ: Type
+    rhs: list
+
+
+def walk_block(e, block):
+    """Canonicalize `block` in the provided renaming environment"""
+    out = []
+    for insn in block.insns:
+        i = walk_instr(e, insn)
+        if i is not None:
+            out.append(i)
+    return VisitedBlock(block.id, out, block.detail, block.successor_detail)
+
+
+def top_expr_has_effects(exp):
+    """Decide if the top-most instruction of the provided tree is effectful"""
+    last_operand = exp[-1]
+
+    # this is over-eager but will catch everything that looks vaguely effect-like
+    if isinstance(last_operand, Operand):
+        if re.match(r'^[A-Za-z:|]+$', last_operand.content):
+            return True
+
+    return False
+
+
+def walk_instr(e, ins):
+    if top_expr_has_effects(ins.rhs):
+        vid = e.get("next_id", 0)
+        e["next_id"] = vid + 1
+        e[ins.dest.name] = vid
+        return VisitedInstr(vid, ins.typ, ins.rhs)
+    else:
+        # we move the type coercion to the rhs so as to not lose it
+        e[ins.dest.name] = [Operand(ins.typ.name), ins.rhs]
+        return None
+
+
+@dataclass
+class ListK:
+    length: int
+
+
+def subst(e, exp):
+    # explicit stacks because we need to substitute large expression trees and
+    # python isn't up to task if we just write the natural (recursive) thing
+    stack_out = []
+    stack_in = [exp]
+
+    while len(stack_in) > 0:
+        exp = stack_in.pop()
+        if isinstance(exp, list):
+            stack_in.append(ListK(len(exp)))
+            stack_in.extend(exp)
+        elif isinstance(exp, Operand):
+            stack_out.append(exp)
+        elif isinstance(exp, Var):
+            stack_in.append(e[exp.name])
+        elif isinstance(exp, PhiVar):
+            stack_in.append(e[exp.name])
+        elif isinstance(exp, int):
+            stack_out.append(exp)
+        elif isinstance(exp, ListK):
+            elems = []
+            for _ in range(exp.length):
+                elems.append(stack_out.pop())
+            stack_out.append(elems)
+        else:
+            raise RuntimeError("subst")
+    result = stack_out.pop()
+    if len(stack_out) != 0:
+        raise RuntimeError("subst: stacks not balanced")
+    return result
+
+
+################################################################################
+# Writing the output report
+
+def dump_test(test):
+    # We need to deal with the tests that emit multiple B3 procedures during
+    # their run. However, these are not delineated by the parser, so, we do it
+    # here--when we encounter a second basic block with index 0, we flush the
+    # renaming context and finish writing out the current procedure before
+    # continuing with the next
+
+    unit_count = 0
+    e = {}
+    walked_blocks = []
+
+    def flush():
+        # Clear the renaming context, `e', and write out all walked blocks
+        nonlocal unit_count
+        nonlocal e
+        nonlocal walked_blocks
+        if len(walked_blocks) == 0:
+            return
+        print(f"*** *** *** *** {test.name} [unit {unit_count}] *** *** *** ***")
+        for block in walked_blocks:
+            dump_block(e, block)
+        e = {}
+        unit_count += 1
+        walked_blocks = []
+        print("")
+
+    for block in test.blocks:
+        if int(block.id) == 0:
+            flush()
+        walked_blocks.append(walk_block(e, block))
+    flush()
+
+
+def dump_block(e, block):
+    print(f"B{block.id}: {block.detail}")
+    print(f"  Successors: {block.successor_detail}")
+    for insn in block.insns:
+        print(f"    {insn.typ.name} %{insn.dest} = {fmt_expr(subst(e, insn.rhs))}")
+
+
+# After canonicalization, each tmp can end up being defined as a whole tree of
+# instructions and operands, we need to walk it to accomulate it into a string
+def fmt_expr(exp):
+    # explicit stack because we need to write out large expression trees and
+    # python isn't up to task if we just write the natural (recursive) thing
+    out = ""
+    stack = [exp]
+    while len(stack) > 0:
+        exp = stack.pop()
+        if isinstance(exp, list):
+            stack.append(")")
+            operands = exp[1:]
+            operands.reverse()
+            for i, e in enumerate(operands):
+                if i != 0:
+                    stack.append(",")
+                stack.append(e)
+
+            stack.append("(")
+            stack.append(exp[0])
+        elif isinstance(exp, Operand):
+            out += exp.content
+        elif isinstance(exp, int):
+            out += f"%{exp}"
+        elif isinstance(exp, str):
+            out += exp
+        else:
+            print(exp)
+            raise RuntimeError("fmt_expr: not an expr")
+    return out
+
+
+stdin_contents = sys.stdin.read()
+try:
+    toks = [tok for tok in lex(io.StringIO(stdin_contents))]
+    toks.reverse()
+    suite = []
+    leftover = parse_test_list(suite, toks)
+    for test in suite:
+        dump_test(test)
+except Exception as e:
+    # If something goes wrong, put the error in the file along with the
+    # original input
+    print(f"couldn't parse b3 IR; error:\n{traceback.format_exc()}\n\n *** *** *** \n stdin:")
+    for idx, line in enumerate(stdin_contents.split("\n")):
+        print(f"{idx + 1:7} | {line}")

--- a/Tools/Scripts/dump-testb3-ir
+++ b/Tools/Scripts/dump-testb3-ir
@@ -1,0 +1,148 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+source "$(which env_parallel.bash)"
+
+thisdir="$(realpath "$(dirname "$0")")"
+
+run_slow_tests=0;
+use_canonicalizer=1;
+
+function usage() {
+    echo "usage: dump-testb3-ir [flags] <path to testb3> <output directory>";
+    echo "flags: "
+    echo "  --slow: include slow tests"
+    echo "  --no-canonicalize: don't run canonicalizer"
+    exit 1;
+}
+
+while true; do
+    case "$1" in
+        --slow)
+            run_slow_tests=1;
+            shift 1;
+            ;;
+        --no-canonicalize)
+            use_canonicalizer=0;
+            shift 1;
+            ;;
+        --*)
+            echo "unrecognized flag: $1";
+            usage;
+            exit 1;
+            ;;
+        *)
+            break
+            ;;
+    esac
+done
+
+testb3="$(realpath "$1")"
+out="$(realpath "$2")"
+
+if [ -z "${testb3}" ] || [ -z "${out}" ];
+then
+    usage
+fi;
+
+mkdir -p "${out}"
+
+function drop_ignored_tests() {
+    # we ignore some tests:
+    grep -Ev '(testTwoBitwiseCastOnInt32|testInt32BArgToFloatBitwiseCast|testBitXorArgs(32)?)\(' | \
+        if [ "$run_slow_tests" -eq 0 ]; then
+            grep -Ev 'testSpill(FP|GP)';
+            # these tests take ages to canonicalize--don't run them unless we have to
+        else
+            cat
+        fi
+    # - testTwoBitwiseCastOnInt32
+    #   we change this one because otherwise it's identical to
+    #   testTwoBitwiseCastOnInt64 which seems unintentional
+    #
+    # - testInt32BArgToFloatBitwiseCast
+    #   this is also changed to match the name, otherwise it's very similar to
+    #   TestInt64BArgToDoubleBitwiseCast
+    #
+    # - testBitXorArgs
+    # - testBitXorArgs32
+    #   these upstream tests have indeterminate order of argument values
+}
+
+function winnow_test_list() {
+    # The sed program here does a few things:
+    sed '/^O2:/!d;s/^O2: //;s/^(//;s/\[.*\] *([^)]*) *{ *\([^;]*\); *}/\1/;s/(.*$/(/'
+    #     ^-[0]   ^-[1]     ^-[2]  ^-[3]                                   ^-[4]
+    #
+    # 0. Exclude everything but O2--some tests don't generate code at lower
+    #    optimization levels
+    #
+    # 1. Strip the O2 marker off the front--makes things nicer to read
+    #
+    # 2. If there's a leading paren on the test name, the whole test expression was parenthesized
+    #    in the source code, which will make things annoying for us in step 4, just remove it right away
+    #
+    # 3. If the name is a C++ lambda, carefully tear out the body expression
+    #
+    # 4. Strip everything after the first parenthesis remaining after the above steps.
+    #
+    # Yes, unfortunately, this is all necessary since there are some truly oddball test names
+    # as a result of using preprocessor stringifying to get them from the source code
+    #
+    # We leave the opening paren on the test group name so that e.g. for `testCompare(...)` we don't
+    # inadvertently end up catching `testCompareOneFloatToDouble(...)` along with it
+
+}
+
+function forget_addresses() {
+    # We need to yank out addresses that end up in the output
+    sed 's/generator = 0x[0-9a-f]*,/generator = <redacted>,/g' | \
+        sed 's/[0-9]\{9,14\}[0-9]*/<bigimm>/g' | \
+        sed 's/DataSection at 0x[0-9a-f]*/DataSection at <redacted>/'
+
+    # FIXME(jgriego) this doesn't include immediates that happen to be stack
+    # addresses--there's several of these.
+    #
+    # FIXME(jgriego) we also need to deal with some trivial reorderings
+    # (ArgumentRegValues always end up first after our changes)--Not really sure
+    # how to cope with this, we probably need to write a sort of sophisticated
+    # semantic diff--i don't think it's ideal to handle in this script
+}
+
+function keep_initial_b3() {
+    sed -n '/Initial B3:/,/B3 after/p;/B3 after/d;/Opt Level/d;/^b3/!p'
+}
+
+function remove_misc_noise() {
+    # some tests have additional output that will break the comparison
+    sed '/That took [0-9.]* ms./d'
+}
+
+function prepare_for_summary() {
+    if [ "$use_canonicalizer" -eq 1 ]; then
+        "${thisdir}/canonicalize-testb3-ir.py"
+    else
+        cat
+    fi
+}
+
+function dump_one() {
+    # This gets invoked for every test group after our winnowing
+    case="$1";
+    filename="$(sed 'y/<>(), /______/;s/__*/_/g;s/_$//' <<<"${case}")"
+    "${testb3}" -filter "O2: ${case}" -printir 2>&1 | \
+        grep -v '^Air' | \
+        keep_initial_b3 | \
+        remove_misc_noise | \
+        forget_addresses | \
+        prepare_for_summary \
+            >"${out}/${filename}"
+}
+
+"${testb3}" -list 2>&1 \
+    | winnow_test_list \
+    | drop_ignored_tests \
+    | uniq \
+    | env_parallel --bar dump_one '{}'
+
+


### PR DESCRIPTION
#### 05ea9f2199054d060106d936e6144436d01ea956
<pre>
Add tool to verify B3 output of testb3 cases
<a href="https://bugs.webkit.org/show_bug.cgi?id=257283">https://bugs.webkit.org/show_bug.cgi?id=257283</a>

Reviewed by NOBODY (OOPS!).

In preparation for changing testb3 to avoid direct use of ArgumentRegValue, we&apos;d
like to have a way to verify that nothing about the IR being provided as input
to B3 has changed as a result--this adds two scripts that do exactly that:

`dump-testb3-ir` is a script that runs testb3 and dumps the B3 unit(s) for each test
case into a file shared by similarly-named cases (in particular, the arguments
are ignored, so, e.g. `testAddArgImm(0)` and `testAddArgImm(1)` go to the same
file); the output of two runs of testb3 can be directly compared with `diff` or
similar in this way.

In anticipation of the fact that we may introduce some trivial and
inconsequential differences (i.e. changing the ordering of ArgumentRegValue or
other pure arithmetic instructions), we also provide a `canonicalize-testb3-ir`
script designed to make the B3 output insensitive to the ordering of effectful
opcodes; this is easy to do the effectfulness of these instructions is
_explicit_ in the IR dumps. This canonicalizer is run on the B3 dumps by
default; the `--no-canonicalize` option can be passed to `dump-testb3-ir` to run
without it.

* Tools/Scripts/canonicalize-testb3-ir.py: Added.
(TestBegin):
(TestEnd):
(BasicBlockBegin):
(BasicBlockEnd):
(Type):
(Var):
(PhiVar):
(Operand):
(LeftParen):
(RightParen):
(Comma):
(lex_ssa):
(lex):
(Test):
(Block):
(Instr):
(parse_test_list):
(parse_test):
(parse_block):
(parse_insn_list):
(parse_insn):
(parse_expr_list):
(parse_expr):
(dump_test):
(dump_test.flush):
(VisitedBlock):
(VisitedInstr):
(walk_block):
(top_expr_has_effects):
(walk_instr):
(ListK):
(subst):
(dump_block):
(fmt_expr):
* Tools/Scripts/dump-testb3-ir: Added.
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/05ea9f2199054d060106d936e6144436d01ea956

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/7818 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/8093 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/8275 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/9463 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/7955 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/7823 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/10084 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/8010 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/10818 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/7956 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/9061 "1 flakes 2 failures") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/7155 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/9575 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/6369 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/7119 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/14774 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/7504 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/7243 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/10641 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/7739 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/6298 "14 flakes 2 failures") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/7061 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/11269 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/7472 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->