### PR TITLE
B3 ArgumentRegValue can encode a register pair on 32-bit

### DIFF
--- a/Source/JavaScriptCore/b3/B3ArgumentRegValue.cpp
+++ b/Source/JavaScriptCore/b3/B3ArgumentRegValue.cpp
@@ -36,7 +36,11 @@ ArgumentRegValue::~ArgumentRegValue()
 
 void ArgumentRegValue::dumpMeta(CommaPrinter& comma, PrintStream& out) const
 {
-    out.print(comma, m_reg);
+    out.print(comma, m_reg[0]);
+    if constexpr (is32Bit()) {
+        if (m_reg[1])
+            out.print(comma, m_reg[1]);
+    }
 }
 
 } } // namespace JSC::B3

--- a/Source/JavaScriptCore/b3/B3ArgumentRegValue.h
+++ b/Source/JavaScriptCore/b3/B3ArgumentRegValue.h
@@ -40,7 +40,16 @@ public:
     
     ~ArgumentRegValue() final;
 
-    Reg argumentReg() const { return m_reg; }
+    Reg argumentReg() const { return m_reg[0]; }
+
+#if CPU(ARM_THUMB2)
+    bool isGPPair() const { return m_reg[1].isSet(); }
+
+    Reg hiReg() const { return m_reg[0]; }
+    Reg loReg() const { return m_reg[1]; }
+#else
+    bool isGPPair() const { return false; }
+#endif
 
     B3_SPECIALIZE_VALUE_FOR_NO_CHILDREN
 
@@ -52,23 +61,39 @@ private:
     
     static Opcode opcodeFromConstructor(Origin, Reg) { return ArgumentReg; }
     static Opcode opcodeFromConstructor(Origin, Reg, VectorTag) { return ArgumentReg; }
+#if CPU(ARM_THUMB2)
+    static Opcode opcodeFromConstructor(Origin, Reg, Reg) { return ArgumentReg; }
+#endif
 
     ArgumentRegValue(Origin origin, Reg reg)
         : Value(CheckedOpcode, ArgumentReg, reg.isGPR() ? pointerType() : Double, Zero, origin)
-        , m_reg(reg)
+        , m_reg { reg }
     {
         ASSERT(reg.isSet());
     }
 
     ArgumentRegValue(Origin origin, Reg reg, VectorTag)
         : Value(CheckedOpcode, ArgumentReg, V128, Zero, origin)
-        , m_reg(reg)
+        , m_reg { reg }
     {
         ASSERT(reg.isSet());
         ASSERT(reg.isFPR());
     }
 
-    Reg m_reg;
+#if CPU(ARM_THUMB2)
+    ArgumentRegValue(Origin origin, Reg hi, Reg lo)
+        : Value(CheckedOpcode, ArgumentReg, Int64, Zero, origin)
+        , m_reg { hi, lo }
+    {
+        ASSERT(m_reg[0].isSet());
+        ASSERT(m_reg[0].isGPR());
+        ASSERT(m_reg[1].isSet());
+        ASSERT(m_reg[1].isGPR());
+    }
+#endif
+
+    static constexpr size_t regCount = isARM_THUMB2() ? 2 : 1;
+    Reg m_reg[regCount];
 };
 
 } } // namespace JSC::B3

--- a/Source/JavaScriptCore/b3/B3Validate.cpp
+++ b/Source/JavaScriptCore/b3/B3Validate.cpp
@@ -203,8 +203,9 @@ public:
                 VALIDATE(!value->kind().hasExtraBits(), ("At ", *value));
                 VALIDATE(!value->numChildren(), ("At ", *value));
                 VALIDATE(
-                    (value->as<ArgumentRegValue>()->argumentReg().isGPR() ? (value->type() == pointerType())
-                        : (value->type() == V128 || value->type() == Double))
+                    value->as<ArgumentRegValue>()->isGPPair() ? (value->type() == Int64) :
+                    value->as<ArgumentRegValue>()->argumentReg().isGPR() ? (value->type() == pointerType()) :
+                    (value->type() == V128 || value->type() == Double)
                     , ("At ", *value));
                 break;
             case Add:


### PR DESCRIPTION
#### f48467a41f62ee02c0b365adb44baa0cd5a89549
<pre>
B3 ArgumentRegValue can encode a register pair on 32-bit
<a href="https://bugs.webkit.org/show_bug.cgi?id=257286">https://bugs.webkit.org/show_bug.cgi?id=257286</a>

Reviewed by NOBODY (OOPS!).

To start to wedge B3 support into the 32-bit port, we need a way to still talk
about the full breadth of B3 values, which includes 64-bit numbers; we need a
way to take these as arguments. Add a constructor for ArgumentRegValue which
denotes a register pair interpreted as a single 64-bit argument.

If we prefer, an alternative would be to add a new Value subclass for this; this
seemed more straightforward.

* Source/JavaScriptCore/b3/B3ArgumentRegValue.cpp:
(JSC::B3::ArgumentRegValue::dumpMeta const):
* Source/JavaScriptCore/b3/B3ArgumentRegValue.h:
* Source/JavaScriptCore/b3/B3Validate.cpp:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f48467a41f62ee02c0b365adb44baa0cd5a89549

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/7823 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/8098 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/8282 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/9469 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/7958 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/10091 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/8016 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/10822 "3 flakes 100 failures") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/7962 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/9067 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/7156 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/9582 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/6373 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/7123 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/14768 "Passed tests") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/6670 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/7506 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/7245 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/10650 "Passed tests") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/7397 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/7744 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/6302 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/7987 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/7064 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/1825 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/11272 "Built successfully") | | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/24/builds/8201 "Built successfully") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/7479 "Built successfully") | | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/3/builds/1973 "Passed tests") | 
<!--EWS-Status-Bubble-End-->