### PR TITLE
[GPUP] Tune minimumRenderingUpdateCountToKeepFontAlive

### DIFF
--- a/Source/WebKit/WebProcess/GPU/graphics/RemoteResourceCacheProxy.cpp
+++ b/Source/WebKit/WebProcess/GPU/graphics/RemoteResourceCacheProxy.cpp
@@ -280,7 +280,7 @@ void RemoteResourceCacheProxy::clearImageBufferBackends()
 
 void RemoteResourceCacheProxy::finalizeRenderingUpdateForFonts()
 {
-    static constexpr unsigned minimumRenderingUpdateCountToKeepFontAlive = 4;
+    static constexpr unsigned minimumRenderingUpdateCountToKeepFontAlive = 41;
 
     unsigned totalFontCount = m_fonts.size();
     RELEASE_ASSERT(m_numberOfFontsUsedInCurrentRenderingUpdate <= totalFontCount);


### PR DESCRIPTION
#### 6406f835389190bc6c5144f5e5ece06214b32d76
<pre>
[GPUP] Tune minimumRenderingUpdateCountToKeepFontAlive
<a href="https://bugs.webkit.org/show_bug.cgi?id=257288">https://bugs.webkit.org/show_bug.cgi?id=257288</a>
rdar://109580010

Reviewed by NOBODY (OOPS!).

Currently, web font objects created in the web process live for the lifetime of the
document. When we need to render glyphs with a font, we send the font to the GPU
process. We don&apos;t want to pay the memory cost of every font twice (once for the web
process, and once for the GPU process), so we instead treat the GPU process as a
cache. Fonts in the GPU process live until they are unused for
minimumRenderingUpdateCountToKeepFontAlive number of rendering updates. At that
point, they are destroyed (and if they are needed again, are resent from the web
process).

If we set this threshold too low, then we end up spending lots of power recreating
lots of fonts for every rendering update. If we set the threshold too high, we
increase memory use for all the duplicated font objects that are alive.

I analyzed our power benchmark, and discovered that, with the current threshold
value, we end up sending 2.15x as many fonts as we need to send. This is showing up
on our power benchmark as a potential optimization opportunity. If we increase the
threshold to 41, we end up sending every font exactly once, which is optimal from
a power perspective.

* Source/WebKit/WebProcess/GPU/graphics/RemoteResourceCacheProxy.cpp:
(WebKit::RemoteResourceCacheProxy::finalizeRenderingUpdateForFonts):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/6406f835389190bc6c5144f5e5ece06214b32d76

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/7824 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/8099 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/8284 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/9470 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/7959 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/10092 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/8017 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/10823 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/7963 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/9068 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/7157 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/9583 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/6374 "Passed tests") | | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/14767 "7 flakes 136 failures") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/7507 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/7247 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/10649 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/7745 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/6300 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/7065 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/11273 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/7480 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->