### PR TITLE
Implement scrollbar-gutter CSS parsing

### DIFF
--- a/LayoutTests/TestExpectations
+++ b/LayoutTests/TestExpectations
@@ -6507,8 +6507,6 @@ imported/w3c/web-platform-tests/css/css-overflow/scrollbar-gutter-vertical-lr-00
 imported/w3c/web-platform-tests/css/css-overflow/scrollbar-gutter-vertical-lr-002.html [ Skip ]
 imported/w3c/web-platform-tests/css/css-overflow/scrollbar-gutter-vertical-rl-001.html [ Skip ]
 imported/w3c/web-platform-tests/css/css-overflow/scrollbar-gutter-vertical-rl-002.html [ Skip ]
-imported/w3c/web-platform-tests/css/css-overflow/parsing/scrollbar-gutter-invalid.html [ Skip ]
-imported/w3c/web-platform-tests/css/css-overflow/parsing/scrollbar-gutter-valid.html [ Skip ]
 imported/w3c/web-platform-tests/css/css-overflow/scrollbar-gutter-001.html [ Skip ]
 imported/w3c/web-platform-tests/css/css-overflow/scrollbar-gutter-002.html [ Skip ]
 imported/w3c/web-platform-tests/css/css-overflow/scrollbar-gutter-propagation-001.html [ Skip ]

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-cascade/all-prop-initial-xml-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-cascade/all-prop-initial-xml-expected.txt
@@ -280,6 +280,7 @@ PASS scroll-padding-top
 PASS scroll-snap-align
 PASS scroll-snap-stop
 PASS scroll-snap-type
+PASS scrollbar-gutter
 PASS scrollbar-width
 PASS shape-image-threshold
 PASS shape-margin

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-cascade/all-prop-revert-layer-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-cascade/all-prop-revert-layer-expected.txt
@@ -273,6 +273,7 @@ PASS scroll-padding-top
 PASS scroll-snap-align
 PASS scroll-snap-stop
 PASS scroll-snap-type
+PASS scrollbar-gutter
 PASS scrollbar-width
 PASS shape-image-threshold
 PASS shape-margin

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-overflow/inheritance-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-overflow/inheritance-expected.txt
@@ -15,4 +15,6 @@ PASS Property overflow-y has initial value visible
 PASS Property overflow-y does not inherit
 PASS Property text-overflow has initial value clip
 PASS Property text-overflow does not inherit
+PASS Property scrollbar-gutter has initial value auto
+PASS Property scrollbar-gutter does not inherit
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-overflow/inheritance.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-overflow/inheritance.html
@@ -23,6 +23,7 @@ assert_not_inherited('overflow-inline', 'visible', 'scroll');
 assert_not_inherited('overflow-x', 'visible', 'scroll');
 assert_not_inherited('overflow-y', 'visible', 'scroll');
 assert_not_inherited('text-overflow', 'clip', 'ellipsis');
+assert_not_inherited('scrollbar-gutter', 'auto', 'stable');
 </script>
 </body>
 </html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-overflow/parsing/scrollbar-gutter-invalid-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-overflow/parsing/scrollbar-gutter-invalid-expected.txt
@@ -13,4 +13,16 @@ PASS e.style['scrollbar-gutter'] = "3em" should not set the property value
 PASS e.style['scrollbar-gutter'] = "1 2 3" should not set the property value
 PASS e.style['scrollbar-gutter'] = "none" should not set the property value
 PASS e.style['scrollbar-gutter'] = "red" should not set the property value
+PASS e.style['scrollbar-gutter'] = "stable both" should not set the property value
+PASS e.style['scrollbar-gutter'] = "stable force" should not set the property value
+PASS e.style['scrollbar-gutter'] = "stable both force" should not set the property value
+PASS e.style['scrollbar-gutter'] = "always" should not set the property value
+PASS e.style['scrollbar-gutter'] = "always both" should not set the property value
+PASS e.style['scrollbar-gutter'] = "always force" should not set the property value
+PASS e.style['scrollbar-gutter'] = "always both force" should not set the property value
+PASS e.style['scrollbar-gutter'] = "auto stable" should not set the property value
+PASS e.style['scrollbar-gutter'] = "auto both-edges" should not set the property value
+PASS e.style['scrollbar-gutter'] = "both-edges" should not set the property value
+PASS e.style['scrollbar-gutter'] = "both-edges auto" should not set the property value
+PASS e.style['scrollbar-gutter'] = "stable auto" should not set the property value
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-overflow/parsing/scrollbar-gutter-invalid.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-overflow/parsing/scrollbar-gutter-invalid.html
@@ -34,4 +34,10 @@
     test_invalid_value("scrollbar-gutter", "always force");
     test_invalid_value("scrollbar-gutter", "always both force");
 
+    test_invalid_value("scrollbar-gutter", "auto stable");
+    test_invalid_value("scrollbar-gutter", "auto both-edges");
+    test_invalid_value("scrollbar-gutter", "both-edges");
+    test_invalid_value("scrollbar-gutter", "both-edges auto");
+    test_invalid_value("scrollbar-gutter", "stable auto");
+
 </script>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-overflow/parsing/scrollbar-gutter-valid-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-overflow/parsing/scrollbar-gutter-valid-expected.txt
@@ -1,13 +1,6 @@
 
-FAIL e.style['scrollbar-gutter'] = "auto" should set the property value assert_not_equals: property should be set got disallowed value ""
-FAIL e.style['scrollbar-gutter'] = "stable" should set the property value assert_not_equals: property should be set got disallowed value ""
-FAIL e.style['scrollbar-gutter'] = "stable both" should set the property value assert_not_equals: property should be set got disallowed value ""
-FAIL e.style['scrollbar-gutter'] = "stable force" should set the property value assert_not_equals: property should be set got disallowed value ""
-FAIL e.style['scrollbar-gutter'] = "stable both force" should set the property value assert_not_equals: property should be set got disallowed value ""
-FAIL e.style['scrollbar-gutter'] = "always" should set the property value assert_not_equals: property should be set got disallowed value ""
-FAIL e.style['scrollbar-gutter'] = "always both" should set the property value assert_not_equals: property should be set got disallowed value ""
-FAIL e.style['scrollbar-gutter'] = "always force" should set the property value assert_not_equals: property should be set got disallowed value ""
-FAIL e.style['scrollbar-gutter'] = "always both force" should set the property value assert_not_equals: property should be set got disallowed value ""
-FAIL e.style['scrollbar-gutter'] = "force both stable" should set the property value assert_not_equals: property should be set got disallowed value ""
-FAIL e.style['scrollbar-gutter'] = "force always both" should set the property value assert_not_equals: property should be set got disallowed value ""
+PASS e.style['scrollbar-gutter'] = "auto" should set the property value
+PASS e.style['scrollbar-gutter'] = "stable" should set the property value
+PASS e.style['scrollbar-gutter'] = "stable both-edges" should set the property value
+PASS e.style['scrollbar-gutter'] = "both-edges stable" should set the property value
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/scrollbar-gutter-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/scrollbar-gutter-expected.txt
@@ -1,11 +1,11 @@
 
-FAIL Can set 'scrollbar-gutter' to CSS-wide keywords: initial Invalid property scrollbar-gutter
-FAIL Can set 'scrollbar-gutter' to CSS-wide keywords: inherit Invalid property scrollbar-gutter
-FAIL Can set 'scrollbar-gutter' to CSS-wide keywords: unset Invalid property scrollbar-gutter
-FAIL Can set 'scrollbar-gutter' to CSS-wide keywords: revert Invalid property scrollbar-gutter
-FAIL Can set 'scrollbar-gutter' to var() references:  var(--A) Invalid property scrollbar-gutter
-FAIL Can set 'scrollbar-gutter' to the 'auto' keyword: auto Invalid property scrollbar-gutter
-FAIL Can set 'scrollbar-gutter' to the 'stable' keyword: stable Invalid property scrollbar-gutter
+PASS Can set 'scrollbar-gutter' to CSS-wide keywords: initial
+PASS Can set 'scrollbar-gutter' to CSS-wide keywords: inherit
+PASS Can set 'scrollbar-gutter' to CSS-wide keywords: unset
+PASS Can set 'scrollbar-gutter' to CSS-wide keywords: revert
+PASS Can set 'scrollbar-gutter' to var() references:  var(--A)
+PASS Can set 'scrollbar-gutter' to the 'auto' keyword: auto
+PASS Can set 'scrollbar-gutter' to the 'stable' keyword: stable
 PASS Setting 'scrollbar-gutter' to a length: 0px throws TypeError
 PASS Setting 'scrollbar-gutter' to a length: -3.14em throws TypeError
 PASS Setting 'scrollbar-gutter' to a length: 3.14cm throws TypeError
@@ -32,5 +32,5 @@ PASS Setting 'scrollbar-gutter' to a number: calc(2 + 3) throws TypeError
 PASS Setting 'scrollbar-gutter' to a transform: translate(50%, 50%) throws TypeError
 PASS Setting 'scrollbar-gutter' to a transform: perspective(10em) throws TypeError
 PASS Setting 'scrollbar-gutter' to a transform: translate3d(0px, 1px, 2px) translate(0px, 1px) rotate3d(1, 2, 3, 45deg) rotate(45deg) scale3d(1, 2, 3) scale(1, 2) skew(1deg, 1deg) skewX(1deg) skewY(45deg) perspective(1px) matrix3d(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16) matrix(1, 2, 3, 4, 5, 6) throws TypeError
-FAIL 'scrollbar-gutter' does not support 'stable both-edges' Invalid property scrollbar-gutter
+PASS 'scrollbar-gutter' does not support 'stable both-edges'
 

--- a/LayoutTests/imported/w3c/web-platform-tests/web-animations/animation-model/animation-types/accumulation-per-property-002-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/web-animations/animation-model/animation-types/accumulation-per-property-002-expected.txt
@@ -148,6 +148,13 @@ PASS resize: "both" onto "horizontal"
 PASS scroll-behavior (type: discrete) has testAccumulation function
 PASS scroll-behavior: "smooth" onto "auto"
 PASS scroll-behavior: "auto" onto "smooth"
+PASS scrollbar-gutter (type: discrete) has testAccumulation function
+PASS scrollbar-gutter: "stable" onto "auto"
+PASS scrollbar-gutter: "auto" onto "stable"
+PASS scrollbar-gutter: "stable both-edges" onto "auto"
+PASS scrollbar-gutter: "auto" onto "stable both-edges"
+PASS scrollbar-gutter: "stable both-edges" onto "stable"
+PASS scrollbar-gutter: "stable" onto "stable both-edges"
 PASS scrollbar-width (type: discrete) has testAccumulation function
 PASS scrollbar-width: "thin" onto "auto"
 PASS scrollbar-width: "auto" onto "thin"

--- a/LayoutTests/imported/w3c/web-platform-tests/web-animations/animation-model/animation-types/addition-per-property-002-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/web-animations/animation-model/animation-types/addition-per-property-002-expected.txt
@@ -148,6 +148,13 @@ PASS resize: "both" onto "horizontal"
 PASS scroll-behavior (type: discrete) has testAddition function
 PASS scroll-behavior: "smooth" onto "auto"
 PASS scroll-behavior: "auto" onto "smooth"
+PASS scrollbar-gutter (type: discrete) has testAddition function
+PASS scrollbar-gutter: "stable" onto "auto"
+PASS scrollbar-gutter: "auto" onto "stable"
+PASS scrollbar-gutter: "stable both-edges" onto "auto"
+PASS scrollbar-gutter: "auto" onto "stable both-edges"
+PASS scrollbar-gutter: "stable both-edges" onto "stable"
+PASS scrollbar-gutter: "stable" onto "stable both-edges"
 PASS scrollbar-width (type: discrete) has testAddition function
 PASS scrollbar-width: "thin" onto "auto"
 PASS scrollbar-width: "auto" onto "thin"

--- a/LayoutTests/imported/w3c/web-platform-tests/web-animations/animation-model/animation-types/interpolation-per-property-002-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/web-animations/animation-model/animation-types/interpolation-per-property-002-expected.txt
@@ -180,6 +180,16 @@ PASS scroll-behavior (type: discrete) has testInterpolation function
 PASS scroll-behavior uses discrete animation when animating between "auto" and "smooth" with linear easing
 PASS scroll-behavior uses discrete animation when animating between "auto" and "smooth" with effect easing
 PASS scroll-behavior uses discrete animation when animating between "auto" and "smooth" with keyframe easing
+PASS scrollbar-gutter (type: discrete) has testInterpolation function
+PASS scrollbar-gutter uses discrete animation when animating between "auto" and "stable" with linear easing
+PASS scrollbar-gutter uses discrete animation when animating between "auto" and "stable" with effect easing
+PASS scrollbar-gutter uses discrete animation when animating between "auto" and "stable" with keyframe easing
+PASS scrollbar-gutter uses discrete animation when animating between "auto" and "stable both-edges" with linear easing
+PASS scrollbar-gutter uses discrete animation when animating between "auto" and "stable both-edges" with effect easing
+PASS scrollbar-gutter uses discrete animation when animating between "auto" and "stable both-edges" with keyframe easing
+PASS scrollbar-gutter uses discrete animation when animating between "stable" and "stable both-edges" with linear easing
+PASS scrollbar-gutter uses discrete animation when animating between "stable" and "stable both-edges" with effect easing
+PASS scrollbar-gutter uses discrete animation when animating between "stable" and "stable both-edges" with keyframe easing
 PASS scrollbar-width (type: discrete) has testInterpolation function
 PASS scrollbar-width uses discrete animation when animating between "auto" and "thin" with linear easing
 PASS scrollbar-width uses discrete animation when animating between "auto" and "thin" with effect easing

--- a/LayoutTests/imported/w3c/web-platform-tests/web-animations/animation-model/animation-types/property-list.js
+++ b/LayoutTests/imported/w3c/web-platform-tests/web-animations/animation-model/animation-types/property-list.js
@@ -1172,6 +1172,12 @@ const gCSSProperties2 = {
       { type: 'discrete', options: [ [ 'auto', 'smooth' ] ] }
     ]
   },
+  'scrollbar-gutter': {
+    // https://drafts.csswg.org/css-overflow/#propdef-scrollbar-gutter
+    types: [
+      { type: 'discrete', options: [ [ 'auto', 'stable' ], [ 'auto', 'stable both-edges' ], [ 'stable', 'stable both-edges' ] ] }
+    ]
+  },
   'scrollbar-width': {
     // https://drafts.csswg.org/css-scrollbars/#propdef-scrollbar-width
     types: [

--- a/LayoutTests/platform/gtk/imported/w3c/web-platform-tests/css/css-cascade/all-prop-initial-xml-expected.txt
+++ b/LayoutTests/platform/gtk/imported/w3c/web-platform-tests/css/css-cascade/all-prop-initial-xml-expected.txt
@@ -280,6 +280,7 @@ PASS scroll-padding-top
 PASS scroll-snap-align
 PASS scroll-snap-stop
 PASS scroll-snap-type
+PASS scrollbar-gutter
 PASS scrollbar-width
 PASS shape-image-threshold
 PASS shape-margin

--- a/LayoutTests/platform/ios-wk2/imported/w3c/web-platform-tests/css/css-cascade/all-prop-initial-xml-expected.txt
+++ b/LayoutTests/platform/ios-wk2/imported/w3c/web-platform-tests/css/css-cascade/all-prop-initial-xml-expected.txt
@@ -280,6 +280,7 @@ PASS scroll-padding-top
 PASS scroll-snap-align
 PASS scroll-snap-stop
 PASS scroll-snap-type
+PASS scrollbar-gutter
 PASS scrollbar-width
 PASS shape-image-threshold
 PASS shape-margin

--- a/LayoutTests/platform/ipad/imported/w3c/web-platform-tests/css/css-cascade/all-prop-initial-xml-expected.txt
+++ b/LayoutTests/platform/ipad/imported/w3c/web-platform-tests/css/css-cascade/all-prop-initial-xml-expected.txt
@@ -280,6 +280,7 @@ PASS scroll-padding-top
 PASS scroll-snap-align
 PASS scroll-snap-stop
 PASS scroll-snap-type
+PASS scrollbar-gutter
 PASS scrollbar-width
 PASS shape-image-threshold
 PASS shape-margin

--- a/LayoutTests/platform/mac-wk1/imported/w3c/web-platform-tests/css/css-cascade/all-prop-initial-xml-expected.txt
+++ b/LayoutTests/platform/mac-wk1/imported/w3c/web-platform-tests/css/css-cascade/all-prop-initial-xml-expected.txt
@@ -279,6 +279,7 @@ PASS scroll-padding-top
 PASS scroll-snap-align
 PASS scroll-snap-stop
 PASS scroll-snap-type
+PASS scrollbar-gutter
 PASS scrollbar-width
 PASS shape-image-threshold
 PASS shape-margin

--- a/LayoutTests/platform/mac-wk1/imported/w3c/web-platform-tests/css/css-cascade/all-prop-revert-layer-expected.txt
+++ b/LayoutTests/platform/mac-wk1/imported/w3c/web-platform-tests/css/css-cascade/all-prop-revert-layer-expected.txt
@@ -272,6 +272,7 @@ PASS scroll-padding-top
 PASS scroll-snap-align
 PASS scroll-snap-stop
 PASS scroll-snap-type
+PASS scrollbar-gutter
 PASS scrollbar-width
 PASS shape-image-threshold
 PASS shape-margin

--- a/LayoutTests/platform/mac-wk1/imported/w3c/web-platform-tests/web-animations/animation-model/animation-types/accumulation-per-property-002-expected.txt
+++ b/LayoutTests/platform/mac-wk1/imported/w3c/web-platform-tests/web-animations/animation-model/animation-types/accumulation-per-property-002-expected.txt
@@ -145,6 +145,13 @@ PASS quotes: ""“" "”" "‘" "’"" onto ""‘" "’" "“" "”""
 PASS resize (type: discrete) has testAccumulation function
 PASS resize: "horizontal" onto "both"
 PASS resize: "both" onto "horizontal"
+PASS scrollbar-gutter (type: discrete) has testAccumulation function
+PASS scrollbar-gutter: "stable" onto "auto"
+PASS scrollbar-gutter: "auto" onto "stable"
+PASS scrollbar-gutter: "stable both-edges" onto "auto"
+PASS scrollbar-gutter: "auto" onto "stable both-edges"
+PASS scrollbar-gutter: "stable both-edges" onto "stable"
+PASS scrollbar-gutter: "stable" onto "stable both-edges"
 PASS scrollbar-width (type: discrete) has testAccumulation function
 PASS scrollbar-width: "thin" onto "auto"
 PASS scrollbar-width: "auto" onto "thin"

--- a/LayoutTests/platform/mac-wk1/imported/w3c/web-platform-tests/web-animations/animation-model/animation-types/addition-per-property-002-expected.txt
+++ b/LayoutTests/platform/mac-wk1/imported/w3c/web-platform-tests/web-animations/animation-model/animation-types/addition-per-property-002-expected.txt
@@ -145,6 +145,13 @@ PASS quotes: ""“" "”" "‘" "’"" onto ""‘" "’" "“" "”""
 PASS resize (type: discrete) has testAddition function
 PASS resize: "horizontal" onto "both"
 PASS resize: "both" onto "horizontal"
+PASS scrollbar-gutter (type: discrete) has testAddition function
+PASS scrollbar-gutter: "stable" onto "auto"
+PASS scrollbar-gutter: "auto" onto "stable"
+PASS scrollbar-gutter: "stable both-edges" onto "auto"
+PASS scrollbar-gutter: "auto" onto "stable both-edges"
+PASS scrollbar-gutter: "stable both-edges" onto "stable"
+PASS scrollbar-gutter: "stable" onto "stable both-edges"
 PASS scrollbar-width (type: discrete) has testAddition function
 PASS scrollbar-width: "thin" onto "auto"
 PASS scrollbar-width: "auto" onto "thin"

--- a/LayoutTests/platform/mac-wk1/imported/w3c/web-platform-tests/web-animations/animation-model/animation-types/interpolation-per-property-002-expected.txt
+++ b/LayoutTests/platform/mac-wk1/imported/w3c/web-platform-tests/web-animations/animation-model/animation-types/interpolation-per-property-002-expected.txt
@@ -176,6 +176,16 @@ PASS resize (type: discrete) has testInterpolation function
 PASS resize uses discrete animation when animating between "both" and "horizontal" with linear easing
 PASS resize uses discrete animation when animating between "both" and "horizontal" with effect easing
 PASS resize uses discrete animation when animating between "both" and "horizontal" with keyframe easing
+PASS scrollbar-gutter (type: discrete) has testInterpolation function
+PASS scrollbar-gutter uses discrete animation when animating between "auto" and "stable" with linear easing
+PASS scrollbar-gutter uses discrete animation when animating between "auto" and "stable" with effect easing
+PASS scrollbar-gutter uses discrete animation when animating between "auto" and "stable" with keyframe easing
+PASS scrollbar-gutter uses discrete animation when animating between "auto" and "stable both-edges" with linear easing
+PASS scrollbar-gutter uses discrete animation when animating between "auto" and "stable both-edges" with effect easing
+PASS scrollbar-gutter uses discrete animation when animating between "auto" and "stable both-edges" with keyframe easing
+PASS scrollbar-gutter uses discrete animation when animating between "stable" and "stable both-edges" with linear easing
+PASS scrollbar-gutter uses discrete animation when animating between "stable" and "stable both-edges" with effect easing
+PASS scrollbar-gutter uses discrete animation when animating between "stable" and "stable both-edges" with keyframe easing
 PASS scrollbar-width (type: discrete) has testInterpolation function
 PASS scrollbar-width uses discrete animation when animating between "auto" and "thin" with linear easing
 PASS scrollbar-width uses discrete animation when animating between "auto" and "thin" with effect easing

--- a/LayoutTests/platform/wpe/imported/w3c/web-platform-tests/css/css-cascade/all-prop-initial-xml-expected.txt
+++ b/LayoutTests/platform/wpe/imported/w3c/web-platform-tests/css/css-cascade/all-prop-initial-xml-expected.txt
@@ -280,6 +280,7 @@ PASS scroll-padding-top
 PASS scroll-snap-align
 PASS scroll-snap-stop
 PASS scroll-snap-type
+PASS scrollbar-gutter
 PASS scrollbar-width
 PASS shape-image-threshold
 PASS shape-margin

--- a/Source/WebCore/Headers.cmake
+++ b/Source/WebCore/Headers.cmake
@@ -2174,6 +2174,7 @@ set(WebCore_PRIVATE_FRAMEWORK_HEADERS
     rendering/style/RenderStyleConstants.h
     rendering/style/RenderStyleInlines.h
     rendering/style/RenderStyleSetters.h
+    rendering/style/ScrollbarGutter.h
     rendering/style/SVGRenderStyle.h
     rendering/style/SVGRenderStyleDefs.h
     rendering/style/ShadowData.h

--- a/Source/WebCore/Sources.txt
+++ b/Source/WebCore/Sources.txt
@@ -2653,6 +2653,7 @@ rendering/style/StyleNonInheritedData.cpp
 rendering/style/StylePaintImage.cpp
 rendering/style/StyleRareInheritedData.cpp
 rendering/style/StyleRareNonInheritedData.cpp
+rendering/style/ScrollbarGutter.cpp
 rendering/style/StyleSelfAlignmentData.cpp
 rendering/style/StyleSurroundData.cpp
 rendering/style/StyleTransformData.cpp

--- a/Source/WebCore/animation/CSSPropertyAnimation.cpp
+++ b/Source/WebCore/animation/CSSPropertyAnimation.cpp
@@ -57,6 +57,7 @@
 #include "RenderBox.h"
 #include "RenderStyleSetters.h"
 #include "SVGRenderStyle.h"
+#include "ScrollbarGutter.h"
 #include "Settings.h"
 #include "StyleCachedImage.h"
 #include "StyleCrossfadeImage.h"
@@ -3700,6 +3701,7 @@ CSSPropertyAnimationWrapperMap::CSSPropertyAnimationWrapperMap()
         new DiscreteSVGPropertyWrapper<const String&>(CSSPropertyMarkerEnd, &SVGRenderStyle::markerEndResource, &SVGRenderStyle::setMarkerEndResource),
         new DiscreteSVGPropertyWrapper<const String&>(CSSPropertyMarkerMid, &SVGRenderStyle::markerMidResource, &SVGRenderStyle::setMarkerMidResource),
         new DiscreteSVGPropertyWrapper<const String&>(CSSPropertyMarkerStart, &SVGRenderStyle::markerStartResource, &SVGRenderStyle::setMarkerStartResource),
+        new DiscretePropertyWrapper<const ScrollbarGutter>(CSSPropertyScrollbarGutter, &RenderStyle::scrollbarGutter, &RenderStyle::setScrollbarGutter),
         new DiscretePropertyWrapper<ScrollbarWidth>(CSSPropertyScrollbarWidth, &RenderStyle::scrollbarWidth, &RenderStyle::setScrollbarWidth)
     };
     const unsigned animatableLonghandPropertiesCount = std::size(animatableLonghandPropertyWrappers);

--- a/Source/WebCore/css/CSSProperties.json
+++ b/Source/WebCore/css/CSSProperties.json
@@ -9306,6 +9306,19 @@
                 "url": "https://drafts.csswg.org/css-scroll-snap-1/#propdef-scroll-snap-stop"
             }
         },
+        "scrollbar-gutter": {
+            "codegen-properties": {
+                "converter": "ScrollbarGutter",
+                "parser-function": "consumeScrollbarGutter",
+                "parser-grammar-unused": "auto | [ stable && both-edges? ]",
+                "parser-grammar-unused-reason": "Needs support for '&&' groups and optionals.",
+                "settings-flag": "cssScrollbarGutterEnabled"
+            },
+            "specification": {
+                "category": "css-overflow",
+                "url": "https://drafts.csswg.org/css-overflow/#scrollbar-gutter-property"
+            }
+        },
         "scrollbar-width": {
             "codegen-properties": {
                 "parser-grammar": "auto | thin | none",

--- a/Source/WebCore/css/CSSValueKeywords.in
+++ b/Source/WebCore/css/CSSValueKeywords.in
@@ -1715,3 +1715,8 @@ false
 space-all
 // text-autospace
 no-autospace
+
+// scrollbar-gutter
+// auto
+// stable
+both-edges

--- a/Source/WebCore/css/ComputedStyleExtractor.cpp
+++ b/Source/WebCore/css/ComputedStyleExtractor.cpp
@@ -1214,6 +1214,13 @@ static Ref<CSSValueList> valueForScrollSnapAlignment(const ScrollSnapAlign& alig
         createConvertingToCSSValueID(alignment.inlineAlign));
 }
 
+static Ref<CSSValue> valueForScrollbarGutter(const ScrollbarGutter& gutter)
+{
+    if (!gutter.bothEdges)
+        return CSSPrimitiveValue::create(gutter.isAuto ? CSSValueAuto : CSSValueStable);
+    return CSSValuePair::create(CSSPrimitiveValue::create(CSSValueStable), CSSPrimitiveValue::create(CSSValueBothEdges));
+}
+
 static Ref<CSSValueList> valueForTextBoxEdge(const TextBoxEdge& textBoxEdge)
 {
     return CSSValueList::createSpaceSeparated(createConvertingToCSSValueID(textBoxEdge.over),
@@ -4184,6 +4191,8 @@ RefPtr<CSSValue> ComputedStyleExtractor::valueForPropertyInStyle(const RenderSty
         return createConvertingToCSSValueID(style.scrollSnapStop());
     case CSSPropertyScrollSnapType:
         return valueForScrollSnapType(style.scrollSnapType());
+    case CSSPropertyScrollbarGutter:
+        return valueForScrollbarGutter(style.scrollbarGutter());
     case CSSPropertyScrollbarWidth:
         return createConvertingToCSSValueID(style.scrollbarWidth());
     case CSSPropertyOverflowAnchor:

--- a/Source/WebCore/css/parser/CSSPropertyParser.cpp
+++ b/Source/WebCore/css/parser/CSSPropertyParser.cpp
@@ -928,6 +928,7 @@ static constexpr InitialValue initialValueForLonghand(CSSPropertyID longhand)
     case CSSPropertyScrollPaddingLeft:
     case CSSPropertyScrollPaddingRight:
     case CSSPropertyScrollPaddingTop:
+    case CSSPropertyScrollbarGutter:
     case CSSPropertyScrollbarWidth:
     case CSSPropertySize:
     case CSSPropertyTableLayout:

--- a/Source/WebCore/css/parser/CSSPropertyParserHelpers.cpp
+++ b/Source/WebCore/css/parser/CSSPropertyParserHelpers.cpp
@@ -6669,6 +6669,26 @@ RefPtr<CSSValue> consumeScrollSnapType(CSSParserTokenRange& range)
     return CSSValueList::createSpaceSeparated(firstValue.releaseNonNull());
 }
 
+RefPtr<CSSValue> consumeScrollbarGutter(CSSParserTokenRange& range)
+{
+    if (auto ident = consumeIdent<CSSValueAuto>(range))
+        return CSSPrimitiveValue::create(CSSValueAuto);
+
+    if (auto first = consumeIdent<CSSValueStable>(range)) {
+        if (auto second = consumeIdent<CSSValueBothEdges>(range))
+            return CSSValuePair::create(first.releaseNonNull(), second.releaseNonNull());
+        return first;
+    }
+
+    if (auto first = consumeIdent<CSSValueBothEdges>(range)) {
+        if (auto second = consumeIdent<CSSValueStable>(range))
+            return CSSValuePair::create(second.releaseNonNull(), first.releaseNonNull());
+        return nullptr;
+    }
+
+    return nullptr;
+}
+
 RefPtr<CSSValue> consumeTextBoxEdge(CSSParserTokenRange& range)
 {
     if (range.peek().id() == CSSValueLeading)

--- a/Source/WebCore/css/parser/CSSPropertyParserHelpers.h
+++ b/Source/WebCore/css/parser/CSSPropertyParserHelpers.h
@@ -266,6 +266,7 @@ RefPtr<CSSValue> consumeAttr(CSSParserTokenRange args, const CSSParserContext&);
 RefPtr<CSSValue> consumeContent(CSSParserTokenRange&, const CSSParserContext&);
 RefPtr<CSSValue> consumeScrollSnapAlign(CSSParserTokenRange&);
 RefPtr<CSSValue> consumeScrollSnapType(CSSParserTokenRange&);
+RefPtr<CSSValue> consumeScrollbarGutter(CSSParserTokenRange&);
 RefPtr<CSSValue> consumeTextBoxEdge(CSSParserTokenRange&);
 RefPtr<CSSValue> consumeBorderRadiusCorner(CSSParserTokenRange&, CSSParserMode);
 bool consumeRadii(std::array<RefPtr<CSSValue>, 4>& horizontalRadii, std::array<RefPtr<CSSValue>, 4>& verticalRadii, CSSParserTokenRange&, CSSParserMode, bool useLegacyParsing);

--- a/Source/WebCore/rendering/style/RenderStyle.cpp
+++ b/Source/WebCore/rendering/style/RenderStyle.cpp
@@ -44,6 +44,7 @@
 #include "RenderStyleSetters.h"
 #include "RenderTheme.h"
 #include "ScaleTransformOperation.h"
+#include "ScrollbarGutter.h"
 #include "ShadowData.h"
 #include "StyleBuilderConverter.h"
 #include "StyleImage.h"
@@ -2872,6 +2873,11 @@ ScrollSnapStop RenderStyle::initialScrollSnapStop()
     return ScrollSnapStop::Normal;
 }
 
+ScrollbarGutter RenderStyle::initialScrollbarGutter()
+{
+    return { };
+}
+
 ScrollbarWidth RenderStyle::initialScrollbarWidth()
 {
     return ScrollbarWidth::Auto;
@@ -2892,6 +2898,11 @@ ScrollSnapStop RenderStyle::scrollSnapStop() const
     return m_nonInheritedData->rareData->scrollSnapStop;
 }
 
+const ScrollbarGutter RenderStyle::scrollbarGutter() const
+{
+    return m_nonInheritedData->rareData->scrollbarGutter;
+}
+
 ScrollbarWidth RenderStyle::scrollbarWidth() const
 {
     return m_nonInheritedData->rareData->scrollbarWidth;
@@ -2910,6 +2921,11 @@ void RenderStyle::setScrollSnapAlign(const ScrollSnapAlign& alignment)
 void RenderStyle::setScrollSnapStop(const ScrollSnapStop stop)
 {
     SET_NESTED_VAR(m_nonInheritedData, rareData, scrollSnapStop, stop);
+}
+
+void RenderStyle::setScrollbarGutter(const ScrollbarGutter gutter)
+{
+    SET_NESTED_VAR(m_nonInheritedData, rareData, scrollbarGutter, gutter);
 }
 
 void RenderStyle::setScrollbarWidth(const ScrollbarWidth width)

--- a/Source/WebCore/rendering/style/RenderStyle.h
+++ b/Source/WebCore/rendering/style/RenderStyle.h
@@ -243,6 +243,7 @@ struct NamedGridLinesMap;
 struct OrderedNamedGridLinesMap;
 struct ScrollSnapAlign;
 struct ScrollSnapType;
+struct ScrollbarGutter;
 
 struct TabSize;
 struct TextAutospace;
@@ -966,6 +967,7 @@ public:
     const ScrollSnapAlign& scrollSnapAlign() const;
     ScrollSnapStop scrollSnapStop() const;
 
+    const ScrollbarGutter scrollbarGutter() const;
     ScrollbarWidth scrollbarWidth() const;
 
 #if ENABLE(TOUCH_EVENTS)
@@ -1513,6 +1515,7 @@ public:
     void setScrollSnapAlign(const ScrollSnapAlign&);
     void setScrollSnapStop(ScrollSnapStop);
 
+    void setScrollbarGutter(ScrollbarGutter);
     void setScrollbarWidth(ScrollbarWidth);
 
 #if ENABLE(TOUCH_EVENTS)
@@ -1946,6 +1949,7 @@ public:
     static ScrollSnapAlign initialScrollSnapAlign();
     static ScrollSnapStop initialScrollSnapStop();
 
+    static ScrollbarGutter initialScrollbarGutter();
     static ScrollbarWidth initialScrollbarWidth();
 
 #if ENABLE(APPLE_PAY)

--- a/Source/WebCore/rendering/style/ScrollbarGutter.cpp
+++ b/Source/WebCore/rendering/style/ScrollbarGutter.cpp
@@ -1,0 +1,45 @@
+/*
+ * Copyright (C) 2023 Apple Inc.  All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "ScrollbarGutter.h"
+
+#include <wtf/text/TextStream.h>
+
+namespace WebCore {
+
+TextStream& operator<<(TextStream& ts, ScrollbarGutter scrollbarGutter)
+{
+    if (scrollbarGutter.isAuto)
+        ts << "auto";
+    else if (scrollbarGutter.bothEdges)
+        ts << "stable both-edges";
+    else
+        ts << "stable";
+    return ts;
+}
+
+} // namespace WebCore
+

--- a/Source/WebCore/rendering/style/ScrollbarGutter.h
+++ b/Source/WebCore/rendering/style/ScrollbarGutter.h
@@ -1,0 +1,47 @@
+/*
+ * Copyright (C) 2023 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include <optional>
+#include <wtf/Forward.h>
+#include <wtf/RefCounted.h>
+#include <wtf/Vector.h>
+
+namespace WebCore {
+
+struct ScrollbarGutter {
+    bool isAuto { true };
+    bool bothEdges { false };
+};
+
+inline bool operator==(const ScrollbarGutter& a, const ScrollbarGutter& b)
+{
+    return a.isAuto == b.isAuto && a.bothEdges == b.bothEdges;
+}
+
+WTF::TextStream& operator<<(WTF::TextStream&, ScrollbarGutter);
+
+} // namespace WebCore

--- a/Source/WebCore/rendering/style/StyleRareNonInheritedData.cpp
+++ b/Source/WebCore/rendering/style/StyleRareNonInheritedData.cpp
@@ -82,6 +82,7 @@ StyleRareNonInheritedData::StyleRareNonInheritedData()
     // scrollSnapType
     // scrollSnapAlign
     // scrollSnapStop
+    // scrollbarGutter
     , scrollbarWidth(RenderStyle::initialScrollbarWidth())
     , zoom(RenderStyle::initialZoom())
     , blockStepSize(RenderStyle::initialBlockStepSize())
@@ -165,6 +166,7 @@ inline StyleRareNonInheritedData::StyleRareNonInheritedData(const StyleRareNonIn
     , scrollSnapType(o.scrollSnapType)
     , scrollSnapAlign(o.scrollSnapAlign)
     , scrollSnapStop(o.scrollSnapStop)
+    , scrollbarGutter(o.scrollbarGutter)
     , scrollbarWidth(o.scrollbarWidth)
     , zoom(o.zoom)
     , blockStepSize(o.blockStepSize)
@@ -255,6 +257,7 @@ bool StyleRareNonInheritedData::operator==(const StyleRareNonInheritedData& o) c
         && scrollSnapType == o.scrollSnapType
         && scrollSnapAlign == o.scrollSnapAlign
         && scrollSnapStop == o.scrollSnapStop
+        && scrollbarGutter == o.scrollbarGutter
         && scrollbarWidth == o.scrollbarWidth
         && zoom == o.zoom
         && blockStepSize == o.blockStepSize

--- a/Source/WebCore/rendering/style/StyleRareNonInheritedData.h
+++ b/Source/WebCore/rendering/style/StyleRareNonInheritedData.h
@@ -35,6 +35,7 @@
 #include "PathOperation.h"
 #include "RotateTransformOperation.h"
 #include "ScaleTransformOperation.h"
+#include "ScrollbarGutter.h"
 #include "ShapeValue.h"
 #include "StyleColor.h"
 #include "StyleContentAlignmentData.h"
@@ -170,6 +171,7 @@ public:
     ScrollSnapAlign scrollSnapAlign;
     ScrollSnapStop scrollSnapStop { ScrollSnapStop::Normal };
 
+    ScrollbarGutter scrollbarGutter;
     ScrollbarWidth scrollbarWidth { ScrollbarWidth::Auto };
 
     float zoom;

--- a/Source/WebCore/style/StyleBuilderConverter.h
+++ b/Source/WebCore/style/StyleBuilderConverter.h
@@ -63,6 +63,7 @@
 #include "SVGPathElement.h"
 #include "SVGRenderStyle.h"
 #include "SVGURIReference.h"
+#include "ScrollbarGutter.h"
 #include "Settings.h"
 #include "StyleBuilderState.h"
 #include "StyleFontSizeFunctions.h"
@@ -132,6 +133,7 @@ public:
     static ScrollSnapType convertScrollSnapType(BuilderState&, const CSSValue&);
     static ScrollSnapAlign convertScrollSnapAlign(BuilderState&, const CSSValue&);
     static ScrollSnapStop convertScrollSnapStop(BuilderState&, const CSSValue&);
+    static ScrollbarGutter convertScrollbarGutter(BuilderState&, const CSSValue&);
     static GridTrackSize convertGridTrackSize(BuilderState&, const CSSValue&);
     static Vector<GridTrackSize> convertGridTrackSizeList(BuilderState&, const CSSValue&);
     static std::optional<GridPosition> convertGridPosition(BuilderState&, const CSSValue&);
@@ -1046,6 +1048,24 @@ inline ScrollSnapAlign BuilderConverter::convertScrollSnapAlign(BuilderState&, c
 inline ScrollSnapStop BuilderConverter::convertScrollSnapStop(BuilderState&, const CSSValue& value)
 {
     return fromCSSValue<ScrollSnapStop>(value);
+}
+
+inline ScrollbarGutter BuilderConverter::convertScrollbarGutter(BuilderState&, const CSSValue& value)
+{
+    ScrollbarGutter gutter;
+    if (is<CSSPrimitiveValue>(value)) {
+        auto& primitiveValue = downcast<CSSPrimitiveValue>(value);
+        if (primitiveValue.valueID() == CSSValueStable)
+            gutter.isAuto = false;
+        return gutter;
+    }
+
+    ASSERT(value.isPair());
+
+    gutter.isAuto = false;
+    gutter.bothEdges = true;
+
+    return gutter;
 }
 
 inline GridLength BuilderConverter::createGridTrackBreadth(const CSSPrimitiveValue& primitiveValue, BuilderState& builderState)


### PR DESCRIPTION
#### 1232ab0a27b75a8941b0e19276d03c4a67748a64
<pre>
Implement scrollbar-gutter CSS parsing
<a href="https://bugs.webkit.org/show_bug.cgi?id=256892">https://bugs.webkit.org/show_bug.cgi?id=256892</a>

Reviewed by Tim Nguyen.

Spec: <a href="https://drafts.csswg.org/css-overflow/#scrollbar-gutter-property">https://drafts.csswg.org/css-overflow/#scrollbar-gutter-property</a>

Grammar for property: auto | stable &amp;&amp; both-edges?

This adds the property to the CSS parser behind the flag, and updates the
relevant expectation files.

It also updates existing tests for scrollbar-gutter to be a bit more
exhaustive.

* LayoutTests/TestExpectations:
* LayoutTests/imported/w3c/web-platform-tests/css/css-cascade/all-prop-initial-xml-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-cascade/all-prop-revert-layer-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-overflow/inheritance-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-overflow/inheritance.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-overflow/parsing/scrollbar-gutter-invalid-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-overflow/parsing/scrollbar-gutter-invalid.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-overflow/parsing/scrollbar-gutter-valid-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/scrollbar-gutter-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/web-animations/animation-model/animation-types/accumulation-per-property-002-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/web-animations/animation-model/animation-types/addition-per-property-002-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/web-animations/animation-model/animation-types/interpolation-per-property-002-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/web-animations/animation-model/animation-types/property-list.js:
* LayoutTests/platform/gtk/imported/w3c/web-platform-tests/css/css-cascade/all-prop-initial-xml-expected.txt:
* LayoutTests/platform/ios-wk2/imported/w3c/web-platform-tests/css/css-cascade/all-prop-initial-xml-expected.txt:
* LayoutTests/platform/ipad/imported/w3c/web-platform-tests/css/css-cascade/all-prop-initial-xml-expected.txt:
* LayoutTests/platform/mac-wk1/imported/w3c/web-platform-tests/css/css-cascade/all-prop-initial-xml-expected.txt:
* LayoutTests/platform/mac-wk1/imported/w3c/web-platform-tests/css/css-cascade/all-prop-revert-layer-expected.txt:
* LayoutTests/platform/mac-wk1/imported/w3c/web-platform-tests/web-animations/animation-model/animation-types/accumulation-per-property-002-expected.txt:
* LayoutTests/platform/mac-wk1/imported/w3c/web-platform-tests/web-animations/animation-model/animation-types/addition-per-property-002-expected.txt:
* LayoutTests/platform/mac-wk1/imported/w3c/web-platform-tests/web-animations/animation-model/animation-types/interpolation-per-property-002-expected.txt:
* LayoutTests/platform/wpe/imported/w3c/web-platform-tests/css/css-cascade/all-prop-initial-xml-expected.txt:
* Source/WebCore/Headers.cmake:
* Source/WebCore/Sources.txt:
* Source/WebCore/WebCore.xcodeproj/project.pbxproj:
* Source/WebCore/animation/CSSPropertyAnimation.cpp:
(WebCore::CSSPropertyAnimationWrapperMap::CSSPropertyAnimationWrapperMap):
* Source/WebCore/css/CSSProperties.json:
* Source/WebCore/css/CSSValueKeywords.in:
* Source/WebCore/css/ComputedStyleExtractor.cpp:
(WebCore::valueForScrollbarGutter):
(WebCore::ComputedStyleExtractor::valueForPropertyInStyle):
* Source/WebCore/css/parser/CSSPropertyParser.cpp:
(WebCore::initialValueForLonghand):
* Source/WebCore/css/parser/CSSPropertyParserHelpers.cpp:
(WebCore::CSSPropertyParserHelpers::consumeScrollbarGutter):
* Source/WebCore/css/parser/CSSPropertyParserHelpers.h:
* Source/WebCore/rendering/style/RenderStyle.cpp:
(WebCore::RenderStyle::initialScrollbarGutter):
(WebCore::RenderStyle::scrollbarGutter const):
(WebCore::RenderStyle::setScrollbarGutter):
* Source/WebCore/rendering/style/RenderStyle.h:
* Source/WebCore/rendering/style/ScrollbarGutter.cpp: Added.
(WebCore::operator&lt;&lt;):
* Source/WebCore/rendering/style/ScrollbarGutter.h: Added.
(WebCore::operator==):
* Source/WebCore/rendering/style/StyleRareNonInheritedData.cpp:
(WebCore::StyleRareNonInheritedData::StyleRareNonInheritedData):
(WebCore::StyleRareNonInheritedData::operator== const):
* Source/WebCore/rendering/style/StyleRareNonInheritedData.h:
* Source/WebCore/style/StyleBuilderConverter.h:
(WebCore::Style::BuilderConverter::convertScrollbarGutter):

Canonical link: <a href="https://commits.webkit.org/264568@main">https://commits.webkit.org/264568@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/cf9ab87a65ec810035eac50d97acdd345fb5fad1

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/7984 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/8267 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/8480 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/9635 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/8091 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/7988 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/10254 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/8179 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/10958 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/8127 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/9215 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/7303 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/9754 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/6516 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/7311 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/14890 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/7639 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/7432 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/10791 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/7896 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/6422 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/7211 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/7224 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/1912 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/11419 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/7637 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->