### PR TITLE
Fix buffer overflow in FEConvolveMatrixSoftwareApplier

### DIFF
--- a/LayoutTests/svg/filters/feconvolve-matrix-invalid-target-offset-crash-expected.txt
+++ b/LayoutTests/svg/filters/feconvolve-matrix-invalid-target-offset-crash-expected.txt
@@ -1,0 +1,2 @@
+
+PASS if no crash

--- a/LayoutTests/svg/filters/feconvolve-matrix-invalid-target-offset-crash.html
+++ b/LayoutTests/svg/filters/feconvolve-matrix-invalid-target-offset-crash.html
@@ -1,0 +1,18 @@
+<script>
+function test() {
+    if (window.testRunner)
+        testRunner.dumpAsText();
+    matrixID.targetY.baseVal = 7;
+    pID.innerHTML = 'PASS if no crash';
+}
+</script>
+<body onload=test()>
+<video src="x">
+</video>
+<svg filter="url(#filterID)" stroke-linecap="butt">
+<filter id="filterID" font-rendering="optimizeLegibility">
+<feConvolveMatrix id="matrixID" kernelMatrix="3 0 0 0 0 0 0 0 -3"/>
+</filter>
+</svg>
+<p id="pID"></p>
+</body>

--- a/Source/WebCore/platform/graphics/filters/FEConvolveMatrix.cpp
+++ b/Source/WebCore/platform/graphics/filters/FEConvolveMatrix.cpp
@@ -49,6 +49,7 @@ FEConvolveMatrix::FEConvolveMatrix(const IntSize& kernelSize, float divisor, flo
 {
     ASSERT(m_kernelSize.width() > 0);
     ASSERT(m_kernelSize.height() > 0);
+    ASSERT(IntRect(IntPoint::zero(), kernelSize).contains(targetOffset));
 }
 
 bool FEConvolveMatrix::operator==(const FEConvolveMatrix& other) const

--- a/Source/WebCore/platform/graphics/filters/software/FEConvolveMatrixSoftwareApplier.cpp
+++ b/Source/WebCore/platform/graphics/filters/software/FEConvolveMatrixSoftwareApplier.cpp
@@ -90,6 +90,12 @@ namespace WebCore {
    and would make it really hard to understand.
 */
 
+FEConvolveMatrixSoftwareApplier::FEConvolveMatrixSoftwareApplier(const FEConvolveMatrix& effect)
+    : Base(effect)
+{
+    ASSERT(IntRect(IntPoint::zero(), m_effect.kernelSize()).contains(m_effect.targetOffset()));
+}
+
 inline uint8_t FEConvolveMatrixSoftwareApplier::clampRGBAValue(float channel, uint8_t max)
 {
     if (channel <= 0)

--- a/Source/WebCore/platform/graphics/filters/software/FEConvolveMatrixSoftwareApplier.h
+++ b/Source/WebCore/platform/graphics/filters/software/FEConvolveMatrixSoftwareApplier.h
@@ -40,7 +40,7 @@ class FEConvolveMatrixSoftwareApplier final : public FilterEffectConcreteApplier
     using Base = FilterEffectConcreteApplier<FEConvolveMatrix>;
 
 public:
-    using Base::Base;
+    FEConvolveMatrixSoftwareApplier(const FEConvolveMatrix& effect);
 
 private:
     bool apply(const Filter&, const FilterImageVector& inputs, FilterImage& result) const final;

--- a/Source/WebCore/svg/SVGFEConvolveMatrixElement.cpp
+++ b/Source/WebCore/svg/SVGFEConvolveMatrixElement.cpp
@@ -161,8 +161,34 @@ void SVGFEConvolveMatrixElement::setKernelUnitLength(float x, float y)
     updateSVGRendererForElementChange();
 }
 
+bool SVGFEConvolveMatrixElement::isValidTargetXOffset() const
+{
+    auto orderXValue = hasAttribute(SVGNames::orderAttr) ? orderX() : 3;
+    auto targetXValue = hasAttribute(SVGNames::targetXAttr) ? targetX() : static_cast<int>(floorf(orderXValue / 2));
+    return targetXValue >= 0 && targetXValue < orderXValue;
+}
+
+bool SVGFEConvolveMatrixElement::isValidTargetYOffset() const
+{
+    auto orderYValue = hasAttribute(SVGNames::orderAttr) ? orderY() : 3;
+    auto targetYValue = hasAttribute(SVGNames::targetYAttr) ? targetY() : static_cast<int>(floorf(orderYValue / 2));
+    return targetYValue >= 0 && targetYValue < orderYValue;
+}
+
 void SVGFEConvolveMatrixElement::svgAttributeChanged(const QualifiedName& attrName)
 {
+    if ((attrName == SVGNames::targetXAttr || attrName == SVGNames::orderAttr) && !isValidTargetXOffset()) {
+        InstanceInvalidationGuard guard(*this);
+        markFilterEffectForRebuild();
+        return;
+    }
+
+    if ((attrName == SVGNames::targetYAttr || attrName == SVGNames::orderAttr) && !isValidTargetYOffset()) {
+        InstanceInvalidationGuard guard(*this);
+        markFilterEffectForRebuild();
+        return;
+    }
+
     switch (attrName.nodeName()) {
     case AttributeNames::inAttr:
     case AttributeNames::orderAttr:
@@ -206,17 +232,18 @@ RefPtr<FilterEffect> SVGFEConvolveMatrixElement::createFilterEffect(const Filter
     if (orderXValue * orderYValue != kernelMatrixSize)
         return nullptr;
 
-    int targetXValue = targetX();
-    int targetYValue = targetY();
-    if (hasAttribute(SVGNames::targetXAttr) && (targetXValue < 0 || targetXValue >= orderXValue))
+    if (!isValidTargetXOffset())
         return nullptr;
 
+    if (!isValidTargetYOffset())
+        return nullptr;
+
+    int targetXValue = targetX();
     // The spec says the default value is: targetX = floor ( orderX / 2 ))
     if (!hasAttribute(SVGNames::targetXAttr))
         targetXValue = static_cast<int>(floorf(orderXValue / 2));
-    if (hasAttribute(SVGNames::targetYAttr) && (targetYValue < 0 || targetYValue >= orderYValue))
-        return nullptr;
 
+    int targetYValue = targetY();
     // The spec says the default value is: targetY = floor ( orderY / 2 ))
     if (!hasAttribute(SVGNames::targetYAttr))
         targetYValue = static_cast<int>(floorf(orderYValue / 2));

--- a/Source/WebCore/svg/SVGFEConvolveMatrixElement.h
+++ b/Source/WebCore/svg/SVGFEConvolveMatrixElement.h
@@ -102,6 +102,8 @@ private:
     void attributeChanged(const QualifiedName&, const AtomString& oldValue, const AtomString& newValue, AttributeModificationReason) override;
     void svgAttributeChanged(const QualifiedName&) override;
 
+    bool isValidTargetXOffset() const;
+    bool isValidTargetYOffset() const;
     bool setFilterEffectAttribute(FilterEffect&, const QualifiedName&) override;
     Vector<AtomString> filterEffectInputsNames() const override { return { AtomString { in1() } }; }
     RefPtr<FilterEffect> createFilterEffect(const FilterEffectVector&, const GraphicsContext& destinationContext) const override;


### PR DESCRIPTION
#### 3cfb6575ec08a8458894f6323ab09cd03e2475a0
<pre>
Fix buffer overflow in FEConvolveMatrixSoftwareApplier
<a href="https://bugs.webkit.org/show_bug.cgi?id=253721">https://bugs.webkit.org/show_bug.cgi?id=253721</a>
rdar://109800117

Reviewed by Said Abou-Hallawa.

This change fixes a buffer overflow issue in the
FEConvolveMatrixSoftwareApplier code which happens when dealing with the
interior area and setting the destination pixels. This happens because
when the targetX/targetY doesn&apos;t fit in the convolution kernel, we don&apos;t
clip it, and that ends up moving the pixel offset by more than what is
needed. This change fixes that by making sure that when the SVG
attribute changes, we detect the invalid offset and rebuild the filter.

* LayoutTests/svg/filters/feconvolve-matrix-invalid-target-offset-crash-expected.txt: Added.
* LayoutTests/svg/filters/feconvolve-matrix-invalid-target-offset-crash.html: Added.
* Source/WebCore/platform/graphics/filters/FEConvolveMatrix.cpp:
(WebCore::FEConvolveMatrix::FEConvolveMatrix):
* Source/WebCore/platform/graphics/filters/software/FEConvolveMatrixSoftwareApplier.cpp:
(WebCore::FEConvolveMatrixSoftwareApplier::FEConvolveMatrixSoftwareApplier):
* Source/WebCore/platform/graphics/filters/software/FEConvolveMatrixSoftwareApplier.h:
* Source/WebCore/svg/SVGFEConvolveMatrixElement.cpp:
(WebCore::SVGFEConvolveMatrixElement::isValidTargetXOffset const):
(WebCore::SVGFEConvolveMatrixElement::isValidTargetYOffset const):
(WebCore::SVGFEConvolveMatrixElement::svgAttributeChanged):
(WebCore::SVGFEConvolveMatrixElement::createFilterEffect const):
* Source/WebCore/svg/SVGFEConvolveMatrixElement.h:

Originally-landed-as: 259548.425@safari-7615-branch (499c0bf6a8a9). rdar://97909186
Canonical link: <a href="https://commits.webkit.org/264527@main">https://commits.webkit.org/264527@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/93cead87067ba879a7439b792d55943f77ffd5f8

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/7836 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/8112 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/8297 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/9483 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/7968 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/7840 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/10105 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/8029 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/10903 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/7975 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/9077 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/7167 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/9597 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/6382 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/7140 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/14777 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/7515 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/7259 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/10661 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/7757 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/6310 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/7076 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/7052 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/1884 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/11284 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/7492 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->