### PR TITLE
[JSC] Remove ReflectSet PutPropertySlot context

### DIFF
--- a/JSTests/stress/custom-get-set-inline-caching-one-level-up-proto-chain.js
+++ b/JSTests/stress/custom-get-set-inline-caching-one-level-up-proto-chain.js
@@ -27,13 +27,15 @@ function validate(x, valueResult, accessorResult) {
 
     let o = {};
     x.customValue = o;
-    assert(o.result === valueResult);
+    assert(o.result === undefined);
+    assert(x.customValue === o);
 
     o = {};
     x.customAccessor = o;
     assert(o.result === accessorResult);
 
     assert(x.randomProp === 42 || x.randomProp === undefined);
+    x.customValue = valueResult;
 }
 noInline(validate);
 
@@ -53,7 +55,25 @@ for (let i = 0; i < 10000; ++i) {
     }
 }
 
+function validate2(x, valueResult, accessorResult) {
+    assert(x.customValue === valueResult);
+
+    assert(x.customAccessor === accessorResult);
+
+    let o = {};
+    x.customValue = o;
+    assert(o.result === valueResult);
+
+    o = {};
+    x.customAccessor = o;
+    assert(o.result === accessorResult);
+
+    assert(x.randomProp === 42 || x.randomProp === undefined);
+}
+noInline(validate2);
+
 items.forEach((x) => {
+    delete x.customValue;
     Reflect.setPrototypeOf(x, {
         get customValue() { return 42; },
         get customAccessor() { return 22; },
@@ -64,6 +84,6 @@ items.forEach((x) => {
 
 for (let i = 0; i < 10000; ++i) {
     for (let i = 0; i < items.length; ++i) {
-        validate(items[i], 42, 22);
+        validate2(items[i], 42, 22);
     }
 }

--- a/JSTests/stress/custom-get-set-proto-chain-put.js
+++ b/JSTests/stress/custom-get-set-proto-chain-put.js
@@ -67,8 +67,16 @@ function getBases() {
     for (let base of getBases()) {
         for (let i = 0; i < 100; ++i) {
             let value = {};
-            base.customValue = value;
-            assert(value.hasOwnProperty("result"));
+            if (base == null || typeof base !== 'object') {
+                shouldThrow(() => {
+                    base.customValue = value;
+                }, `TypeError: Attempted to assign to readonly property.`);
+            } else {
+                base.customValue = value;
+                assert(!value.hasOwnProperty("result"));
+                assert(base.customValue === value);
+                assert(base.hasOwnProperty('customValue'));
+            }
         }
         assert(Reflect.set(Object(base), "customValue", {}));
     }
@@ -89,9 +97,16 @@ function getBases() {
 // FIXME: Once legacy RegExp features are implemented, there would be no use case for calling CustomValue setter if receiver is altered.
 (() => {
     for (let base of getBases()) {
-        for (let i = 0; i < 100; ++i)
-            base.customValue = 1;
-        assert(!base.hasOwnProperty("customValue"));
+        for (let i = 0; i < 100; ++i) {
+            if (base == null || typeof base !== 'object') {
+                shouldThrow(() => {
+                    base.customValue = 1;
+                }, `TypeError: Attempted to assign to readonly property.`);
+            } else {
+                base.customValue = 1;
+                assert(base.hasOwnProperty("customValue"));
+            }
+        }
         assert(Reflect.set(Object(base), "customValue", 1));
     }
 })();

--- a/JSTests/stress/multiline-error.js
+++ b/JSTests/stress/multiline-error.js
@@ -1,0 +1,14 @@
+function foo() {
+  return RegExp;
+}
+
+class C extends foo {
+  constructor() {
+    super();
+    super.multiline = undefined;
+  }
+}
+
+try {
+    new C();
+} catch { }

--- a/JSTests/stress/poly-proto-custom-value-and-accessor.js
+++ b/JSTests/stress/poly-proto-custom-value-and-accessor.js
@@ -50,13 +50,15 @@ function validate(x, valueResult, accessorResult) {
 
     let o = {};
     x.customValue = o;
-    assert(o.result === valueResult);
+    assert(o.result === undefined);
+    assert(x.customValue === o);
 
     o = {};
     x.customAccessor = o;
     assert(o.result === accessorResult);
 
     assert(x.randomProp === 42 || x.randomProp === undefined);
+    x.customValue = valueResult;
 }
 noInline(validate);
 
@@ -76,7 +78,25 @@ for (let i = 0; i < 10000; ++i) {
     }
 }
 
+function validate2(x, valueResult, accessorResult) {
+    assert(x.customValue === valueResult);
+
+    assert(x.customAccessor === accessorResult);
+
+    let o = {};
+    x.customValue = o;
+    assert(o.result === valueResult);
+
+    o = {};
+    x.customAccessor = o;
+    assert(o.result === accessorResult);
+
+    assert(x.randomProp === 42 || x.randomProp === undefined);
+}
+noInline(validate2);
+
 items.forEach((x) => {
+    delete x.customValue;
     Reflect.setPrototypeOf(x, {
         get customValue() { return 42; },
         get customAccessor() { return 22; },
@@ -87,7 +107,7 @@ items.forEach((x) => {
 
 for (let i = 0; i < 10000; ++i) {
     for (let i = 0; i < items.length; ++i) {
-        validate(items[i], 42, 22);
+        validate2(items[i], 42, 22);
     }
 }
 

--- a/JSTests/stress/put-to-primitive-non-reified-static-custom.js
+++ b/JSTests/stress/put-to-primitive-non-reified-static-custom.js
@@ -33,8 +33,8 @@ const primitives = [true, 1, "", Symbol(), 0n];
         const staticCustomValue = $vm.createStaticCustomValue();
         Object.setPrototypeOf(primitivePrototype, staticCustomValue);
 
-        primitive.testStaticValue = 1;
-        shouldBe(staticCustomValue.testStaticValue, 1);
+        shouldThrow(() => { primitive.testStaticValue = 1; }, "TypeError: Attempted to assign to readonly property.");
+        shouldBe(staticCustomValue.testStaticValue, undefined);
         shouldThrow(() => { primitive.testStaticValue = 1; }, "TypeError: Attempted to assign to readonly property.");
 
         shouldThrow(() => { primitive.testStaticValueNoSetter = 1; }, "TypeError: Attempted to assign to readonly property.");

--- a/JSTests/stress/static-put-in-prototype-chain.js
+++ b/JSTests/stress/static-put-in-prototype-chain.js
@@ -9,6 +9,12 @@ var result = {
     result: undefined
 };
 
+// This does not invoke customValue setter since it is value.
 testObject.customValue = result;
 
-shouldBe(result.result, target);
+shouldBe(result.result, undefined);
+
+// This invokes customAccessor setter since it is an accessor.
+testObject.customAccessor = result;
+
+shouldBe(result.result, testObject);

--- a/Source/JavaScriptCore/runtime/PutPropertySlot.h
+++ b/Source/JavaScriptCore/runtime/PutPropertySlot.h
@@ -39,7 +39,7 @@ using CustomAccessorValueFunc = FunctionPtr<CustomAccessorPtrTag, bool(JSGlobalO
 class PutPropertySlot {
 public:
     enum Type : uint8_t { Uncachable, ExistingProperty, NewProperty, SetterProperty, CustomValue, CustomAccessor };
-    enum Context : uint8_t { UnknownContext, PutById, PutByIdEval, ReflectSet };
+    enum Context : uint8_t { UnknownContext, PutById, PutByIdEval };
 
     PutPropertySlot(JSValue thisValue, bool isStrictMode = false, Context context = UnknownContext, bool isInitialization = false)
         : m_base(nullptr)

--- a/Source/JavaScriptCore/runtime/ReflectObject.cpp
+++ b/Source/JavaScriptCore/runtime/ReflectObject.cpp
@@ -240,7 +240,7 @@ JSC_DEFINE_HOST_FUNCTION(reflectObjectSet, (JSGlobalObject* globalObject, CallFr
 
     // Do not raise any readonly errors that happen in strict mode.
     bool shouldThrowIfCantSet = false;
-    PutPropertySlot slot(receiver, shouldThrowIfCantSet, PutPropertySlot::ReflectSet);
+    PutPropertySlot slot(receiver, shouldThrowIfCantSet);
     RELEASE_AND_RETURN(scope, JSValue::encode(jsBoolean(targetObject->methodTable()->put(targetObject, globalObject, propertyName, callFrame->argument(2), slot))));
 }
 


### PR DESCRIPTION
#### 0bcb041d293c3589cb6096b08e29dd9981e0f0e6
<pre>
[JSC] Remove ReflectSet PutPropertySlot context
<a href="https://bugs.webkit.org/show_bug.cgi?id=257293">https://bugs.webkit.org/show_bug.cgi?id=257293</a>
rdar://108261050

Reviewed by Alexey Shvayka.

ReflectSet Context is almost always wrong. There are ways to alter |this| with receiver (e.g. `super.prop`).
So this patch removes it. We also stop calling CustomValue setter for altered |this|, since it is value, not accessor.

* JSTests/stress/multiline-error.js: Added.
(foo):
(C):
* Source/JavaScriptCore/runtime/JSObject.cpp:
(JSC::JSObject::putInlineSlow):
(JSC::JSObject::putInlineFastReplacingStaticPropertyIfNeeded):
* Source/JavaScriptCore/runtime/PutPropertySlot.h:
* Source/JavaScriptCore/runtime/ReflectObject.cpp:
(JSC::JSC_DEFINE_HOST_FUNCTION):

Canonical link: <a href="https://commits.webkit.org/264520@main">https://commits.webkit.org/264520@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/47450429c0ad1c912e08b4d8e242a973e24ba4aa

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/7857 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/8135 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/8321 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/9506 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/7984 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/10128 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/8052 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/10851 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/7997 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/9100 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/7181 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/9636 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/6405 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/7163 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/14804 "Passed tests") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/6696 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/7530 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/7283 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/10695 "Passed tests") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/7427 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/7776 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/6323 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/8019 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/7094 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/1841 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/11303 "Built successfully") | | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/24/builds/8237 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/941 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/7511 "Built successfully") | | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/3/builds/1989 "Passed tests") | 
<!--EWS-Status-Bubble-End-->