### PR TITLE
Add API to EventDispatcher for observing rendering update refreshes.

### DIFF
--- a/Source/WebCore/page/ChromeClient.h
+++ b/Source/WebCore/page/ChromeClient.h
@@ -394,6 +394,7 @@ public:
     virtual void triggerRenderingUpdate() = 0;
     // Schedule a rendering update that coordinates with display refresh. Returns true if scheduled. (This is only used by SVGImageChromeClient.)
     virtual bool scheduleRenderingUpdate() { return false; }
+    virtual void renderingUpdateFrequencyChanged() { }
 
     virtual unsigned remoteImagesCountForTesting() const { return 0; }
 

--- a/Source/WebCore/page/Page.h
+++ b/Source/WebCore/page/Page.h
@@ -510,8 +510,8 @@ public:
         IncludeAnimationsFrameRate  = 1 << 1
     };
     static constexpr OptionSet<PreferredRenderingUpdateOption> allPreferredRenderingUpdateOptions = { PreferredRenderingUpdateOption::IncludeThrottlingReasons, PreferredRenderingUpdateOption::IncludeAnimationsFrameRate };
-    std::optional<FramesPerSecond> preferredRenderingUpdateFramesPerSecond(OptionSet<PreferredRenderingUpdateOption> = allPreferredRenderingUpdateOptions) const;
-    Seconds preferredRenderingUpdateInterval() const;
+    WEBCORE_EXPORT std::optional<FramesPerSecond> preferredRenderingUpdateFramesPerSecond(OptionSet<PreferredRenderingUpdateOption> = allPreferredRenderingUpdateOptions) const;
+    WEBCORE_EXPORT Seconds preferredRenderingUpdateInterval() const;
 
     float topContentInset() const { return m_topContentInset; }
     WEBCORE_EXPORT void setTopContentInset(float);

--- a/Source/WebCore/page/RenderingUpdateScheduler.cpp
+++ b/Source/WebCore/page/RenderingUpdateScheduler.cpp
@@ -53,11 +53,15 @@ bool RenderingUpdateScheduler::scheduleAnimation()
 void RenderingUpdateScheduler::adjustRenderingUpdateFrequency()
 {
     auto renderingUpdateFramesPerSecond = m_page.preferredRenderingUpdateFramesPerSecond();
-    if (renderingUpdateFramesPerSecond) {
-        setPreferredFramesPerSecond(renderingUpdateFramesPerSecond.value());
-        m_useTimer = false;
-    } else
-        m_useTimer = true;
+    std::optional<FramesPerSecond> previousRenderingUpdateFramesPerSecond = m_useTimer ? std::nullopt : std::optional<FramesPerSecond>(preferredFramesPerSecond());
+    if (renderingUpdateFramesPerSecond != previousRenderingUpdateFramesPerSecond) {
+        if (renderingUpdateFramesPerSecond) {
+            setPreferredFramesPerSecond(renderingUpdateFramesPerSecond.value());
+            m_useTimer = false;
+        } else
+            m_useTimer = true;
+        m_page.chrome().client().renderingUpdateFrequencyChanged();
+    }
 
     if (isScheduled()) {
         clearScheduled();

--- a/Source/WebCore/page/WorkerClient.h
+++ b/Source/WebCore/page/WorkerClient.h
@@ -31,11 +31,16 @@
 
 namespace WebCore {
 
+class WorkerAnimationController;
+class WorkerGlobalScope;
+
 class WorkerClient : public GraphicsClient {
     WTF_MAKE_FAST_ALLOCATED;
 public:
 
     virtual std::unique_ptr<WorkerClient> clone(SerialFunctionDispatcher&) = 0;
+
+    virtual RefPtr<WorkerAnimationController> createAnimationController(WorkerGlobalScope&) = 0;
 
     virtual ~WorkerClient() = default;
 };

--- a/Source/WebCore/workers/DedicatedWorkerGlobalScope.cpp
+++ b/Source/WebCore/workers/DedicatedWorkerGlobalScope.cpp
@@ -113,8 +113,12 @@ DedicatedWorkerThread& DedicatedWorkerGlobalScope::thread()
 #if ENABLE(OFFSCREEN_CANVAS_IN_WORKERS)
 CallbackId DedicatedWorkerGlobalScope::requestAnimationFrame(Ref<RequestAnimationFrameCallback>&& callback)
 {
-    if (!m_workerAnimationController)
-        m_workerAnimationController = WorkerAnimationController::create(*this);
+    if (!m_workerAnimationController) {
+        if (workerClient())
+            m_workerAnimationController = workerClient()->createAnimationController(*this);
+        if (!m_workerAnimationController)
+            m_workerAnimationController = TimerWorkerAnimationController::create(*this);
+    }
     return m_workerAnimationController->requestAnimationFrame(WTFMove(callback));
 }
 

--- a/Source/WebKit/Shared/DisplayLinkObserverID.h
+++ b/Source/WebKit/Shared/DisplayLinkObserverID.h
@@ -30,6 +30,6 @@
 namespace WebKit {
 
 struct DisplayLinkObserverIDType;
-using DisplayLinkObserverID = ObjectIdentifier<DisplayLinkObserverIDType>;
+using DisplayLinkObserverID = AtomicObjectIdentifier<DisplayLinkObserverIDType>;
 
 } // namespace WebKit

--- a/Source/WebKit/UIProcess/WebProcessProxy.h
+++ b/Source/WebKit/UIProcess/WebProcessProxy.h
@@ -343,8 +343,8 @@ public:
     DisplayLink::Client& displayLinkClient() { return m_displayLinkClient; }
     std::optional<unsigned> nominalFramesPerSecondForDisplay(WebCore::PlatformDisplayID);
 
-    void startDisplayLink(DisplayLinkObserverID, WebCore::PlatformDisplayID, WebCore::FramesPerSecond);
-    void stopDisplayLink(DisplayLinkObserverID, WebCore::PlatformDisplayID);
+    void startDisplayLink(DisplayLinkObserverID, WebCore::PlatformDisplayID, WebCore::FramesPerSecond, bool sendToEventDispatcher);
+    void stopDisplayLink(DisplayLinkObserverID, WebCore::PlatformDisplayID, bool sendToEventDispatcher);
     void setDisplayLinkPreferredFramesPerSecond(DisplayLinkObserverID, WebCore::PlatformDisplayID, WebCore::FramesPerSecond);
     void setDisplayLinkForDisplayWantsFullSpeedUpdates(WebCore::PlatformDisplayID, bool wantsFullSpeedUpdates);
 #endif
@@ -669,6 +669,7 @@ private:
 
 #if HAVE(CVDISPLAYLINK)
     DisplayLinkProcessProxyClient m_displayLinkClient;
+    uint32_t m_observersWantingSendToEventDispatcher { 0 };
 #endif
 
 #if ENABLE(ROUTING_ARBITRATION)

--- a/Source/WebKit/UIProcess/WebProcessProxy.messages.in
+++ b/Source/WebKit/UIProcess/WebProcessProxy.messages.in
@@ -60,8 +60,8 @@ messages -> WebProcessProxy LegacyReceiver {
 #endif
 
 #if HAVE(CVDISPLAYLINK)
-    StartDisplayLink(WebKit::DisplayLinkObserverID observerID, uint32_t displayID, unsigned preferredFramesPerSecond)
-    StopDisplayLink(WebKit::DisplayLinkObserverID observerID, uint32_t displayID)
+    StartDisplayLink(WebKit::DisplayLinkObserverID observerID, uint32_t displayID, unsigned preferredFramesPerSecond, bool sendToEventDispatcher)
+    StopDisplayLink(WebKit::DisplayLinkObserverID observerID, uint32_t displayID, bool sendToEventDispatcher)
     SetDisplayLinkPreferredFramesPerSecond(WebKit::DisplayLinkObserverID observerID, uint32_t displayID, unsigned preferredFramesPerSecond);
 #endif
 

--- a/Source/WebKit/UIProcess/mac/DisplayLinkProcessProxyClient.cpp
+++ b/Source/WebKit/UIProcess/mac/DisplayLinkProcessProxyClient.cpp
@@ -41,6 +41,11 @@ void DisplayLinkProcessProxyClient::setConnection(RefPtr<IPC::Connection>&& conn
     m_connection = WTFMove(connection);
 }
 
+void DisplayLinkProcessProxyClient::setSendToEventDispatcher(bool sendToEventDispatcher)
+{
+    m_sendToEventDispatcher = sendToEventDispatcher;
+}
+
 // This is called off the main thread.
 void DisplayLinkProcessProxyClient::displayLinkFired(WebCore::PlatformDisplayID displayID, WebCore::DisplayUpdate displayUpdate, bool wantsFullSpeedUpdates, bool anyObserverWantsCallback)
 {
@@ -53,8 +58,8 @@ void DisplayLinkProcessProxyClient::displayLinkFired(WebCore::PlatformDisplayID 
     if (!connection)
         return;
 
-    if (wantsFullSpeedUpdates)
-        connection->send(Messages::EventDispatcher::DisplayDidRefresh(displayID, displayUpdate, anyObserverWantsCallback), 0, { }, Thread::QOS::UserInteractive);
+    if (wantsFullSpeedUpdates || m_sendToEventDispatcher)
+        connection->send(Messages::EventDispatcher::DisplayDidRefresh(displayID, displayUpdate, wantsFullSpeedUpdates, anyObserverWantsCallback), 0, { }, Thread::QOS::UserInteractive);
     else if (anyObserverWantsCallback)
         connection->send(Messages::WebProcess::DisplayDidRefresh(displayID, displayUpdate), 0, { }, Thread::QOS::UserInteractive);
 }

--- a/Source/WebKit/UIProcess/mac/DisplayLinkProcessProxyClient.h
+++ b/Source/WebKit/UIProcess/mac/DisplayLinkProcessProxyClient.h
@@ -43,12 +43,14 @@ public:
     ~DisplayLinkProcessProxyClient() = default;
     
     void setConnection(RefPtr<IPC::Connection>&&);
+    void setSendToEventDispatcher(bool);
 
 private:
     void displayLinkFired(WebCore::PlatformDisplayID, WebCore::DisplayUpdate, bool wantsFullSpeedUpdates, bool anyObserverWantsCallback) override;
 
     Lock m_connectionLock;
     RefPtr<IPC::Connection> m_connection;
+    bool m_sendToEventDispatcher { false };
 };
 
 }

--- a/Source/WebKit/UIProcess/mac/WebProcessProxyMac.mm
+++ b/Source/WebKit/UIProcess/mac/WebProcessProxyMac.mm
@@ -64,15 +64,21 @@ std::optional<unsigned> WebProcessProxy::nominalFramesPerSecondForDisplay(WebCor
     return processPool().displayLinks().nominalFramesPerSecondForDisplay(displayID);
 }
 
-void WebProcessProxy::startDisplayLink(DisplayLinkObserverID observerID, WebCore::PlatformDisplayID displayID, WebCore::FramesPerSecond preferredFramesPerSecond)
+void WebProcessProxy::startDisplayLink(DisplayLinkObserverID observerID, WebCore::PlatformDisplayID displayID, WebCore::FramesPerSecond preferredFramesPerSecond, bool sendToEventDispatcher)
 {
     ASSERT(hasProcessPrivilege(ProcessPrivilege::CanCommunicateWithWindowServer));
     processPool().displayLinks().startDisplayLink(m_displayLinkClient, observerID, displayID, preferredFramesPerSecond);
+    if (sendToEventDispatcher)
+        m_observersWantingSendToEventDispatcher++;
+    m_displayLinkClient.setSendToEventDispatcher(m_observersWantingSendToEventDispatcher > 0);
 }
 
-void WebProcessProxy::stopDisplayLink(DisplayLinkObserverID observerID, WebCore::PlatformDisplayID displayID)
+void WebProcessProxy::stopDisplayLink(DisplayLinkObserverID observerID, WebCore::PlatformDisplayID displayID, bool sendToEventDispatcher)
 {
     processPool().displayLinks().stopDisplayLink(m_displayLinkClient, observerID, displayID);
+    if (sendToEventDispatcher)
+        m_observersWantingSendToEventDispatcher--;
+    m_displayLinkClient.setSendToEventDispatcher(m_observersWantingSendToEventDispatcher > 0);
 }
 
 void WebProcessProxy::setDisplayLinkPreferredFramesPerSecond(DisplayLinkObserverID observerID, WebCore::PlatformDisplayID displayID, WebCore::FramesPerSecond preferredFramesPerSecond)

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebChromeClient.cpp
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebChromeClient.cpp
@@ -1063,6 +1063,11 @@ void WebChromeClient::triggerRenderingUpdate()
         m_page.drawingArea()->triggerRenderingUpdate();
 }
 
+void WebChromeClient::renderingUpdateFrequencyChanged()
+{
+    WebProcess::singleton().eventDispatcher().renderingUpdateFrequencyChanged(m_page.identifier());
+}
+
 unsigned WebChromeClient::remoteImagesCountForTesting() const
 {
     return m_page.remoteImagesCountForTesting();

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebChromeClient.h
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebChromeClient.h
@@ -231,6 +231,7 @@ private:
     void setNeedsOneShotDrawingSynchronization() final;
     bool shouldTriggerRenderingUpdate(unsigned rescheduledRenderingUpdateCount) const final;
     void triggerRenderingUpdate() final;
+    void renderingUpdateFrequencyChanged() final;
     unsigned remoteImagesCountForTesting() const final; 
 
     void contentRuleListNotification(const URL&, const WebCore::ContentRuleListResults&) final;

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebWorkerClient.cpp
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebWorkerClient.cpp
@@ -26,12 +26,14 @@
 #include "config.h"
 #include "WebWorkerClient.h"
 
+#include "EventDispatcher.h"
 #include "ImageBufferShareableBitmapBackend.h"
 #include "RemoteImageBufferProxy.h"
 #include "RemoteRenderingBackendProxy.h"
 #include "WebPage.h"
 #include "WebProcess.h"
 #include <WebCore/Page.h>
+#include <WebCore/WorkerAnimationController.h>
 
 #if ENABLE(WEBGL) && ENABLE(GPU_PROCESS)
 #include "RemoteGraphicsContextGLProxy.h"
@@ -105,6 +107,11 @@ std::unique_ptr<WorkerClient> WebWorkerClient::clone(SerialFunctionDispatcher& d
 #else
     return makeUnique<WebWorkerClient>(dispatcher, m_displayID);
 #endif
+}
+
+RefPtr<WorkerAnimationController> WebWorkerClient::createAnimationController(WorkerGlobalScope& workerGlobalScope)
+{
+    return nullptr;
 }
 
 PlatformDisplayID WebWorkerClient::displayID() const

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebWorkerClient.h
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebWorkerClient.h
@@ -59,6 +59,7 @@ public:
 #endif
 
     std::unique_ptr<WorkerClient> clone(SerialFunctionDispatcher&) final;
+    RefPtr<WebCore::WorkerAnimationController> createAnimationController(WebCore::WorkerGlobalScope&) final;
 
     WebCore::PlatformDisplayID displayID() const final;
 

--- a/Source/WebKit/WebProcess/WebPage/EventDispatcher.messages.in
+++ b/Source/WebKit/WebProcess/WebPage/EventDispatcher.messages.in
@@ -30,7 +30,7 @@ messages -> EventDispatcher NotRefCounted {
     GestureEvent(WebCore::PageIdentifier pageID, WebKit::WebGestureEvent event)
 #endif
 #if HAVE(CVDISPLAYLINK)
-    DisplayDidRefresh(uint32_t displayID, struct WebCore::DisplayUpdate update, bool sendToMainThread)
+    DisplayDidRefresh(uint32_t displayID, struct WebCore::DisplayUpdate update, bool wantsFullSpeedUpdates, bool anyObserverWantsCallback)
 #endif
 
 #if ENABLE(MOMENTUM_EVENT_DISPATCHER)

--- a/Source/WebKit/WebProcess/WebPage/mac/DisplayRefreshMonitorMac.cpp
+++ b/Source/WebKit/WebProcess/WebPage/mac/DisplayRefreshMonitorMac.cpp
@@ -76,7 +76,7 @@ bool DisplayRefreshMonitorMac::startNotificationMechanism()
         return true;
 
     LOG_WITH_STREAM(DisplayLink, stream << "[Web] DisplayRefreshMonitorMac::requestRefreshCallback for display " << displayID() << " - starting");
-    WebProcess::singleton().parentProcessConnection()->send(Messages::WebProcessProxy::StartDisplayLink(m_observerID, displayID(), maxClientPreferredFramesPerSecond().value_or(FullSpeedFramesPerSecond)), 0);
+    WebProcess::singleton().parentProcessConnection()->send(Messages::WebProcessProxy::StartDisplayLink(m_observerID, displayID(), maxClientPreferredFramesPerSecond().value_or(FullSpeedFramesPerSecond), false), 0);
     if (!m_runLoopObserver) {
         // The RunLoopObserver repeats.
         m_runLoopObserver = makeUnique<RunLoopObserver>(kCFRunLoopEntry, [this]() {
@@ -96,7 +96,7 @@ void DisplayRefreshMonitorMac::stopNotificationMechanism()
         return;
 
     LOG_WITH_STREAM(DisplayLink, stream << "[Web] DisplayRefreshMonitorMac::requestRefreshCallback - stopping");
-    WebProcess::singleton().parentProcessConnection()->send(Messages::WebProcessProxy::StopDisplayLink(m_observerID, displayID()), 0);
+    WebProcess::singleton().parentProcessConnection()->send(Messages::WebProcessProxy::StopDisplayLink(m_observerID, displayID(), false), 0);
     m_runLoopObserver->invalidate();
     
     m_displayLinkIsActive = false;


### PR DESCRIPTION
#### 4cf9741321ad98bd56c0a24b6d0313d989fa1027
<pre>
Add API to EventDispatcher for observing rendering update refreshes.
<a href="https://bugs.webkit.org/show_bug.cgi?id=257295">https://bugs.webkit.org/show_bug.cgi?id=257295</a>
&lt;rdar://problem/109804872&gt;

Reviewed by NOBODY (OOPS!).

In order to deliver displayDidRefresh for WorkerThread requestAnimationFrame, we want a version of displayDidRefresh/DisplayRefreshMonitor that allows notifications without blocking on the main thread. We also likely want to match whatever framerate/throttling the underlying WebCore::Page is using, so that we slow down when hidden etc.

DisplayRefreshMonitor is heavily hardcoded towards using the main thread, so this adds an API to EventDispatcher which handles this.

* Source/WebCore/page/ChromeClient.h:
(WebCore::ChromeClient::renderingUpdateFrequencyChanged):
* Source/WebCore/page/Page.h:
* Source/WebCore/page/RenderingUpdateScheduler.cpp:
(WebCore::RenderingUpdateScheduler::adjustRenderingUpdateFrequency):
* Source/WebKit/Shared/DisplayLinkObserverID.h:
* Source/WebKit/WebProcess/WebCoreSupport/WebChromeClient.cpp:
(WebKit::WebChromeClient::renderingUpdateFrequencyChanged):
* Source/WebKit/WebProcess/WebCoreSupport/WebChromeClient.h:
* Source/WebKit/WebProcess/WebPage/EventDispatcher.cpp:
(WebKit::EventDispatcher::displayDidRefresh):
(WebKit::EventDispatcher::pageScreenDidChange):
(WebKit::EventDispatcher::renderingUpdateFrequencyChanged):
(WebKit::EventDispatcher::PageObservers::PageObservers):
(WebKit::EventDispatcher::updateAsyncRenderingRefreshObservers):
(WebKit::EventDispatcher::startTimerForPage):
(WebKit::EventDispatcher::stopTimerForPage):
(WebKit::EventDispatcher::notifyAsyncRenderingRefreshObserversDisplayDidRefresh):
(WebKit::EventDispatcher::notifyPageObserversDisplayDidRefresh):
(WebKit::EventDispatcher::addAsyncRenderingRefreshObserver):
(WebKit::EventDispatcher::removeAsyncRenderingRefreshObserver):
* Source/WebKit/WebProcess/WebPage/EventDispatcher.h:
</pre>
----------------------------------------------------------------------
#### a2375d99791fc4ff8b31885dad23b77fa3654b2d
<pre>
Allow WebKit to override WorkerAnimationController and provide their own implementations
<a href="https://bugs.webkit.org/show_bug.cgi?id=257098">https://bugs.webkit.org/show_bug.cgi?id=257098</a>

Reviewed by NOBODY (OOPS!).

This is a prerequisite to adding a WebKit implementation that uses display link callbacks to
drive the animation frame rate.

* Source/WebCore/page/WorkerClient.h:
* Source/WebCore/workers/DedicatedWorkerGlobalScope.cpp:
(WebCore::DedicatedWorkerGlobalScope::requestAnimationFrame):
* Source/WebCore/workers/WorkerAnimationController.cpp:
(WebCore::WorkerAnimationController::WorkerAnimationController):
(WebCore::WorkerAnimationController::virtualHasPendingActivity const):
(WebCore::WorkerAnimationController::stop):
(WebCore::TimerWorkerAnimationController::TimerWorkerAnimationController):
(WebCore::TimerWorkerAnimationController::~TimerWorkerAnimationController):
(WebCore::TimerWorkerAnimationController::isActive const):
(WebCore::TimerWorkerAnimationController::stopAnimation):
(WebCore::TimerWorkerAnimationController::scheduleAnimation):
(WebCore::TimerWorkerAnimationController::create):
(WebCore::WorkerAnimationController::create): Deleted.
(WebCore::WorkerAnimationController::~WorkerAnimationController): Deleted.
(WebCore::WorkerAnimationController::scheduleAnimation): Deleted.
* Source/WebCore/workers/WorkerAnimationController.h:
* Source/WebKit/WebProcess/WebCoreSupport/WebWorkerClient.cpp:
(WebKit::WebWorkerClient::createAnimationController):
* Source/WebKit/WebProcess/WebCoreSupport/WebWorkerClient.h:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4cf9741321ad98bd56c0a24b6d0313d989fa1027

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/8413 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/8707 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/8925 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/10080 "Built successfully") | [❌ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/8469 "Failed to compile WebKit") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/8422 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/10696 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/8733 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/11330 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/8559 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/9607 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/7612 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/10235 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/6905 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/7700 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/15255 "6 flakes 106 failures") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/8026 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/7869 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/11203 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/8313 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/6856 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/7601 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/11811 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/8058 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->