### PR TITLE
[Win] Use Win32Handle for m_fileMapping of WTF::FileSystem::MappedFileData

### DIFF
--- a/Source/WTF/wtf/FileSystem.h
+++ b/Source/WTF/wtf/FileSystem.h
@@ -50,7 +50,7 @@ typedef const struct __CFData* CFDataRef;
 OBJC_CLASS NSString;
 
 #if OS(WINDOWS)
-typedef void *HANDLE;
+#include <wtf/win/Win32Handle.h>
 #endif
 
 
@@ -256,7 +256,7 @@ public:
     void* leakHandle() { return std::exchange(m_fileData, nullptr); }
 #endif
 #if OS(WINDOWS)
-    HANDLE fileMapping() const { return m_fileMapping; }
+    const Win32Handle& fileMapping() const { return m_fileMapping; }
 #endif
 
 private:
@@ -265,7 +265,7 @@ private:
     void* m_fileData { nullptr };
     unsigned m_fileSize { 0 };
 #if OS(WINDOWS)
-    HANDLE m_fileMapping { nullptr };
+    Win32Handle m_fileMapping;
 #endif
 };
 
@@ -283,7 +283,7 @@ inline MappedFileData::MappedFileData(MappedFileData&& other)
     : m_fileData(std::exchange(other.m_fileData, nullptr))
     , m_fileSize(std::exchange(other.m_fileSize, 0))
 #if OS(WINDOWS)
-    , m_fileMapping(std::exchange(other.m_fileMapping, nullptr))
+    , m_fileMapping(WTFMove(other.m_fileMapping))
 #endif
 {
 }
@@ -293,7 +293,7 @@ inline MappedFileData& MappedFileData::operator=(MappedFileData&& other)
     m_fileData = std::exchange(other.m_fileData, nullptr);
     m_fileSize = std::exchange(other.m_fileSize, 0);
 #if OS(WINDOWS)
-    m_fileMapping = std::exchange(other.m_fileMapping, nullptr);
+    m_fileMapping = WTFMove(other.m_fileMapping);
 #endif
     return *this;
 }

--- a/Source/WTF/wtf/win/FileSystemWin.cpp
+++ b/Source/WTF/wtf/win/FileSystemWin.cpp
@@ -371,8 +371,6 @@ MappedFileData::~MappedFileData()
 {
     if (m_fileData)
         UnmapViewOfFile(m_fileData);
-    if (m_fileMapping)
-        CloseHandle(m_fileMapping);
 }
 
 bool MappedFileData::mapFileHandle(PlatformFileHandle handle, FileOpenMode openMode, MappedFileMode)
@@ -406,11 +404,11 @@ bool MappedFileData::mapFileHandle(PlatformFileHandle handle, FileOpenMode openM
         break;
     }
 
-    m_fileMapping = CreateFileMapping(handle, nullptr, pageProtection, 0, 0, nullptr);
+    m_fileMapping = Win32Handle::adopt(CreateFileMapping(handle, nullptr, pageProtection, 0, 0, nullptr));
     if (!m_fileMapping)
         return false;
 
-    m_fileData = MapViewOfFile(m_fileMapping, desiredAccess, 0, 0, *size);
+    m_fileData = MapViewOfFile(m_fileMapping.get(), desiredAccess, 0, 0, *size);
     if (!m_fileData)
         return false;
     m_fileSize = *size;

--- a/Source/WebKit/NetworkProcess/cache/NetworkCacheDataCurl.cpp
+++ b/Source/WebKit/NetworkProcess/cache/NetworkCacheDataCurl.cpp
@@ -113,12 +113,11 @@ RefPtr<SharedMemory> Data::tryCreateSharedMemory() const
     if (isNull() || !isMap())
         return nullptr;
 
-    HANDLE handle = std::get<FileSystem::MappedFileData>(*m_buffer).fileMapping();
-    HANDLE newHandle;
-    if (!DuplicateHandle(GetCurrentProcess(), handle, GetCurrentProcess(), &newHandle, 0, false, DUPLICATE_SAME_ACCESS))
+    auto newHandle = std::get<FileSystem::MappedFileData>(*m_buffer).fileMapping();
+    if (!newHandle)
         return nullptr;
 
-    return SharedMemory::adopt(newHandle, m_size, SharedMemory::Protection::ReadOnly);
+    return SharedMemory::adopt(newHandle.leak(), m_size, SharedMemory::Protection::ReadOnly);
 }
 #endif
 


### PR DESCRIPTION
#### f0c80d6f85768a161b0d767707ca44284373db84
<pre>
[Win] Use Win32Handle for m_fileMapping of WTF::FileSystem::MappedFileData
<a href="https://bugs.webkit.org/show_bug.cgi?id=257296">https://bugs.webkit.org/show_bug.cgi?id=257296</a>

Reviewed by Don Olmstead.

Changed the type of m_fileMapping from HANDLE to Win32Handle.

* Source/WTF/wtf/FileSystem.h:
(WTF::FileSystemImpl::MappedFileData::fileMapping const):
(WTF::FileSystemImpl::MappedFileData::MappedFileData):
(WTF::FileSystemImpl::MappedFileData::operator=):
* Source/WTF/wtf/win/FileSystemWin.cpp:
(WTF::FileSystemImpl::MappedFileData::~MappedFileData):
(WTF::FileSystemImpl::MappedFileData::mapFileHandle):
* Source/WebKit/NetworkProcess/cache/NetworkCacheDataCurl.cpp:
(WebKit::NetworkCache::Data::tryCreateSharedMemory const):

Canonical link: <a href="https://commits.webkit.org/264502@main">https://commits.webkit.org/264502@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f97dc2c298c6b6fce8c0c62576201b1f389b9348

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/7851 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/8129 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/8315 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/9500 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/32/builds/7980 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/10122 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/8046 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/10846 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/7991 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/9096 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/7176 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/9615 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/6401 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/7157 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/14787 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [  ~~🛠 🧪 jsc~~](https://ews-build.webkit.org/#/builders/20/builds/6692 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/7527 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/7277 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/10675 "Passed tests") | 
| [  ~~🛠 🧪 jsc-arm64~~](https://ews-build.webkit.org/#/builders/12/builds/7422 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/7771 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/6319 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/8014 "Built successfully") | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/30/builds/7090 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/1838 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/1868 "Built successfully and passed tests") | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/4/builds/11298 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/24/builds/8232 "Built successfully") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/7506 "Built successfully") | | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/3/builds/1986 "Passed tests") | 
<!--EWS-Status-Bubble-End-->