### PR TITLE
Disable scavenger mini mode in all WebKit service processes

### DIFF
--- a/Source/bmalloc/bmalloc/ProcessCheck.mm
+++ b/Source/bmalloc/bmalloc/ProcessCheck.mm
@@ -59,16 +59,16 @@ bool shouldAllowMiniMode()
 {
     // Mini mode is mainly meant for constraining memory usage in bursty daemons that use JavaScriptCore.
     // It's also contributed to power regressions when enabled for large application processes and in the
-    // WebKit GPU process. So we disable mini mode for those processes.
+    // WebKit XPC services. So we disable mini mode for those processes.
     bool isApplication = false;
-    bool isGPUProcess = false;
+    bool isWebKitProcess = false;
     if (const char* serviceName = getenv("XPC_SERVICE_NAME")) {
         static constexpr char appPrefix[] = "application.";
-        static constexpr char gpuProcessPrefix[] = "com.apple.WebKit.GPU";
+        static constexpr char webKitPrefix[] = "com.apple.WebKit.";
         isApplication = !strncmp(serviceName, appPrefix, sizeof(appPrefix) - 1);
-        isGPUProcess = !strncmp(serviceName, gpuProcessPrefix, sizeof(gpuProcessPrefix) - 1);
+        isWebKitProcess = !strncmp(serviceName, webKitPrefix, sizeof(webKitPrefix) - 1);
     }
-    return !isApplication && !isGPUProcess;
+    return !isApplication && !isWebKitProcess;
 }
 
 #if BPLATFORM(IOS_FAMILY)


### PR DESCRIPTION
#### 35b9897fe3d79051a45b69d5a1d9239be1499e5e
<pre>
Disable scavenger mini mode in all WebKit service processes
<a href="https://bugs.webkit.org/show_bug.cgi?id=257292">https://bugs.webkit.org/show_bug.cgi?id=257292</a>
rdar://109801111

Reviewed by Geoffrey Garen.

The scavenger wakes up every ~5 ms in NetworkProcess. This seems too aggressive. Let&apos;s try lowering
the frequency by disabling mini mode as we do in other service processes.

* Source/bmalloc/bmalloc/ProcessCheck.mm:
(bmalloc::shouldAllowMiniMode):

Canonical link: <a href="https://commits.webkit.org/264533@main">https://commits.webkit.org/264533@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/644885be88d3367a7f81694b3010115c44eaf084

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/7853 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/8131 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/8317 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/9502 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/7981 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/10124 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/8048 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/10848 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/7993 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/9099 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/7178 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/9617 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/6404 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/7159 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/14789 "1 flakes 113 failures") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/6693 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/7529 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/7279 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/10679 "7 api tests failed or timed out") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/7424 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/7773 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/6320 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/8016 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/7091 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/1840 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/1888 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/11300 "Built successfully") | | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/24/builds/8234 "Built successfully") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/7508 "Built successfully") | | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/3/builds/1988 "Passed tests") | 
<!--EWS-Status-Bubble-End-->