### PR TITLE
Move CSS text-wrap property to m_inheritedFlags

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-cascade/all-prop-initial-xml-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-cascade/all-prop-initial-xml-expected.txt
@@ -342,6 +342,7 @@ PASS vector-effect
 PASS vertical-align
 PASS visibility
 PASS white-space
+PASS white-space-collapse
 PASS widows
 PASS width
 PASS will-change

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-text/inheritance-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-text/inheritance-expected.txt
@@ -27,6 +27,8 @@ PASS Property text-wrap has initial value wrap
 PASS Property text-wrap inherits
 PASS Property white-space has initial value normal
 PASS Property white-space inherits
+PASS Property white-space-collapse has initial value collapse
+PASS Property white-space-collapse inherits
 PASS Property word-break has initial value normal
 PASS Property word-break inherits
 PASS Property word-spacing has initial value 0px

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-text/inheritance.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-text/inheritance.html
@@ -29,6 +29,7 @@ assert_inherited('text-justify', 'auto', 'inter-character');
 assert_inherited('text-transform', 'none', 'uppercase');
 assert_inherited('text-wrap', 'wrap', 'nowrap');
 assert_inherited('white-space', 'normal', 'pre-wrap');
+assert_inherited('white-space-collapse', 'collapse', 'preserve');
 assert_inherited('word-break', 'normal', 'break-all');
 assert_inherited('word-spacing', '0px', '10px');
 assert_inherited('word-wrap', 'normal', 'break-word');

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-text/parsing/white-space-collapse-computed-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-text/parsing/white-space-collapse-computed-expected.txt
@@ -1,6 +1,6 @@
 
-FAIL Property white-space-collapse value 'collapse' assert_true: white-space-collapse doesn't seem to be supported in the computed style expected true got false
-FAIL Property white-space-collapse value 'preserve' assert_true: white-space-collapse doesn't seem to be supported in the computed style expected true got false
-FAIL Property white-space-collapse value 'preserve-breaks' assert_true: white-space-collapse doesn't seem to be supported in the computed style expected true got false
-FAIL Property white-space-collapse value 'break-spaces' assert_true: white-space-collapse doesn't seem to be supported in the computed style expected true got false
+PASS Property white-space-collapse value 'collapse'
+PASS Property white-space-collapse value 'preserve'
+PASS Property white-space-collapse value 'preserve-breaks'
+PASS Property white-space-collapse value 'break-spaces'
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-text/parsing/white-space-collapse-valid-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-text/parsing/white-space-collapse-valid-expected.txt
@@ -1,11 +1,11 @@
 
-FAIL e.style['white-space-collapse'] = "collapse" should set the property value assert_not_equals: property should be set got disallowed value ""
-FAIL e.style['white-space-collapse'] = "preserve" should set the property value assert_not_equals: property should be set got disallowed value ""
-FAIL e.style['white-space-collapse'] = "preserve-breaks" should set the property value assert_not_equals: property should be set got disallowed value ""
-FAIL e.style['white-space-collapse'] = "break-spaces" should set the property value assert_not_equals: property should be set got disallowed value ""
-FAIL e.style['white-space-collapse'] = "initial" should set the property value assert_not_equals: property should be set got disallowed value ""
-FAIL e.style['white-space-collapse'] = "inherit" should set the property value assert_not_equals: property should be set got disallowed value ""
-FAIL e.style['white-space-collapse'] = "unset" should set the property value assert_not_equals: property should be set got disallowed value ""
-FAIL e.style['white-space-collapse'] = "revert" should set the property value assert_not_equals: property should be set got disallowed value ""
-FAIL e.style['white-space-collapse'] = "revert-layer" should set the property value assert_not_equals: property should be set got disallowed value ""
+PASS e.style['white-space-collapse'] = "collapse" should set the property value
+PASS e.style['white-space-collapse'] = "preserve" should set the property value
+PASS e.style['white-space-collapse'] = "preserve-breaks" should set the property value
+PASS e.style['white-space-collapse'] = "break-spaces" should set the property value
+PASS e.style['white-space-collapse'] = "initial" should set the property value
+PASS e.style['white-space-collapse'] = "inherit" should set the property value
+PASS e.style['white-space-collapse'] = "unset" should set the property value
+PASS e.style['white-space-collapse'] = "revert" should set the property value
+PASS e.style['white-space-collapse'] = "revert-layer" should set the property value
 

--- a/LayoutTests/imported/w3c/web-platform-tests/web-animations/animation-model/animation-types/accumulation-per-property-002-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/web-animations/animation-model/animation-types/accumulation-per-property-002-expected.txt
@@ -296,6 +296,9 @@ PASS visibility: onto "hidden"
 PASS white-space (type: discrete) has testAccumulation function
 PASS white-space: "nowrap" onto "pre"
 PASS white-space: "pre" onto "nowrap"
+PASS white-space-collapse (type: discrete) has testAccumulation function
+PASS white-space-collapse: "preserve" onto "collapse"
+PASS white-space-collapse: "collapse" onto "preserve"
 PASS word-break (type: discrete) has testAccumulation function
 PASS word-break: "break-all" onto "keep-all"
 PASS word-break: "keep-all" onto "break-all"

--- a/LayoutTests/imported/w3c/web-platform-tests/web-animations/animation-model/animation-types/addition-per-property-002-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/web-animations/animation-model/animation-types/addition-per-property-002-expected.txt
@@ -292,6 +292,9 @@ PASS visibility: onto "hidden"
 PASS white-space (type: discrete) has testAddition function
 PASS white-space: "nowrap" onto "pre"
 PASS white-space: "pre" onto "nowrap"
+PASS white-space-collapse (type: discrete) has testAddition function
+PASS white-space-collapse: "preserve" onto "collapse"
+PASS white-space-collapse: "collapse" onto "preserve"
 PASS word-break (type: discrete) has testAddition function
 PASS word-break: "break-all" onto "keep-all"
 PASS word-break: "keep-all" onto "break-all"

--- a/LayoutTests/imported/w3c/web-platform-tests/web-animations/animation-model/animation-types/interpolation-per-property-002-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/web-animations/animation-model/animation-types/interpolation-per-property-002-expected.txt
@@ -368,6 +368,10 @@ PASS white-space (type: discrete) has testInterpolation function
 PASS white-space uses discrete animation when animating between "pre" and "nowrap" with linear easing
 PASS white-space uses discrete animation when animating between "pre" and "nowrap" with effect easing
 PASS white-space uses discrete animation when animating between "pre" and "nowrap" with keyframe easing
+PASS white-space-collapse (type: discrete) has testInterpolation function
+PASS white-space-collapse uses discrete animation when animating between "collapse" and "preserve" with linear easing
+PASS white-space-collapse uses discrete animation when animating between "collapse" and "preserve" with effect easing
+PASS white-space-collapse uses discrete animation when animating between "collapse" and "preserve" with keyframe easing
 PASS word-break (type: discrete) has testInterpolation function
 PASS word-break uses discrete animation when animating between "keep-all" and "break-all" with linear easing
 PASS word-break uses discrete animation when animating between "keep-all" and "break-all" with effect easing

--- a/LayoutTests/imported/w3c/web-platform-tests/web-animations/animation-model/animation-types/property-list.js
+++ b/LayoutTests/imported/w3c/web-platform-tests/web-animations/animation-model/animation-types/property-list.js
@@ -1429,6 +1429,12 @@ const gCSSProperties2 = {
       { type: 'discrete', options: [ [ 'pre', 'nowrap' ] ] }
     ]
   },
+  'white-space-collapse': {
+    // https://drafts.csswg.org/css-text-4/#propdef-white-space-collapse
+    types: [
+      { type: 'discrete', options: [ [ 'collapse', 'preserve' ] ] }
+    ]
+  },
   'width': {
     // https://drafts.csswg.org/css21/visudet.html#propdef-width
     types: [

--- a/LayoutTests/platform/gtk/imported/w3c/web-platform-tests/css/css-cascade/all-prop-initial-xml-expected.txt
+++ b/LayoutTests/platform/gtk/imported/w3c/web-platform-tests/css/css-cascade/all-prop-initial-xml-expected.txt
@@ -342,6 +342,7 @@ PASS vector-effect
 PASS vertical-align
 PASS visibility
 PASS white-space
+PASS white-space-collapse
 PASS widows
 PASS width
 PASS will-change

--- a/LayoutTests/platform/ios-wk2/imported/w3c/web-platform-tests/css/css-cascade/all-prop-initial-xml-expected.txt
+++ b/LayoutTests/platform/ios-wk2/imported/w3c/web-platform-tests/css/css-cascade/all-prop-initial-xml-expected.txt
@@ -342,6 +342,7 @@ PASS vector-effect
 PASS vertical-align
 PASS visibility
 PASS white-space
+PASS white-space-collapse
 PASS widows
 PASS width
 PASS will-change

--- a/LayoutTests/platform/ipad/imported/w3c/web-platform-tests/css/css-cascade/all-prop-initial-xml-expected.txt
+++ b/LayoutTests/platform/ipad/imported/w3c/web-platform-tests/css/css-cascade/all-prop-initial-xml-expected.txt
@@ -342,6 +342,7 @@ PASS vector-effect
 PASS vertical-align
 PASS visibility
 PASS white-space
+PASS white-space-collapse
 PASS widows
 PASS width
 PASS will-change

--- a/LayoutTests/platform/mac-wk1/imported/w3c/web-platform-tests/css/css-cascade/all-prop-initial-xml-expected.txt
+++ b/LayoutTests/platform/mac-wk1/imported/w3c/web-platform-tests/css/css-cascade/all-prop-initial-xml-expected.txt
@@ -341,6 +341,7 @@ PASS vector-effect
 PASS vertical-align
 PASS visibility
 PASS white-space
+PASS white-space-collapse
 PASS widows
 PASS width
 PASS will-change

--- a/LayoutTests/platform/mac-wk1/imported/w3c/web-platform-tests/web-animations/animation-model/animation-types/accumulation-per-property-002-expected.txt
+++ b/LayoutTests/platform/mac-wk1/imported/w3c/web-platform-tests/web-animations/animation-model/animation-types/accumulation-per-property-002-expected.txt
@@ -293,6 +293,9 @@ PASS visibility: onto "hidden"
 PASS white-space (type: discrete) has testAccumulation function
 PASS white-space: "nowrap" onto "pre"
 PASS white-space: "pre" onto "nowrap"
+PASS white-space-collapse (type: discrete) has testAccumulation function
+PASS white-space-collapse: "preserve" onto "collapse"
+PASS white-space-collapse: "collapse" onto "preserve"
 PASS word-break (type: discrete) has testAccumulation function
 PASS word-break: "break-all" onto "keep-all"
 PASS word-break: "keep-all" onto "break-all"

--- a/LayoutTests/platform/mac-wk1/imported/w3c/web-platform-tests/web-animations/animation-model/animation-types/addition-per-property-002-expected.txt
+++ b/LayoutTests/platform/mac-wk1/imported/w3c/web-platform-tests/web-animations/animation-model/animation-types/addition-per-property-002-expected.txt
@@ -289,6 +289,9 @@ PASS visibility: onto "hidden"
 PASS white-space (type: discrete) has testAddition function
 PASS white-space: "nowrap" onto "pre"
 PASS white-space: "pre" onto "nowrap"
+PASS white-space-collapse (type: discrete) has testAddition function
+PASS white-space-collapse: "preserve" onto "collapse"
+PASS white-space-collapse: "collapse" onto "preserve"
 PASS word-break (type: discrete) has testAddition function
 PASS word-break: "break-all" onto "keep-all"
 PASS word-break: "keep-all" onto "break-all"

--- a/LayoutTests/platform/mac-wk1/imported/w3c/web-platform-tests/web-animations/animation-model/animation-types/interpolation-per-property-002-expected.txt
+++ b/LayoutTests/platform/mac-wk1/imported/w3c/web-platform-tests/web-animations/animation-model/animation-types/interpolation-per-property-002-expected.txt
@@ -364,6 +364,10 @@ PASS white-space (type: discrete) has testInterpolation function
 PASS white-space uses discrete animation when animating between "pre" and "nowrap" with linear easing
 PASS white-space uses discrete animation when animating between "pre" and "nowrap" with effect easing
 PASS white-space uses discrete animation when animating between "pre" and "nowrap" with keyframe easing
+PASS white-space-collapse (type: discrete) has testInterpolation function
+PASS white-space-collapse uses discrete animation when animating between "collapse" and "preserve" with linear easing
+PASS white-space-collapse uses discrete animation when animating between "collapse" and "preserve" with effect easing
+PASS white-space-collapse uses discrete animation when animating between "collapse" and "preserve" with keyframe easing
 PASS word-break (type: discrete) has testInterpolation function
 PASS word-break uses discrete animation when animating between "keep-all" and "break-all" with linear easing
 PASS word-break uses discrete animation when animating between "keep-all" and "break-all" with effect easing

--- a/LayoutTests/platform/wpe/imported/w3c/web-platform-tests/css/css-cascade/all-prop-initial-xml-expected.txt
+++ b/LayoutTests/platform/wpe/imported/w3c/web-platform-tests/css/css-cascade/all-prop-initial-xml-expected.txt
@@ -342,6 +342,7 @@ PASS vector-effect
 PASS vertical-align
 PASS visibility
 PASS white-space
+PASS white-space-collapse
 PASS widows
 PASS width
 PASS will-change

--- a/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
+++ b/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
@@ -1393,6 +1393,20 @@ CSSTypedOMEnabled:
     WebCore:
       default: true
 
+CSSWhiteSpaceCollapseEnabled:
+  type: bool
+  status: testable
+  category: css
+  humanReadableName: "CSS white-space-collapse property"
+  humanReadableDescription: "Enable white-space-collapse CSS property"
+  defaultValue:
+    WebKitLegacy:
+      default: false
+    WebKit:
+      default: false
+    WebCore:
+      default: false
+
 # FIXME: This is not relevent for WebKitLegacy, so should be excluded from WebKitLegacy entirely (though we should still set the default value to false when initializing settings).
 CacheAPIEnabled:
   type: bool

--- a/Source/WebCore/animation/CSSPropertyAnimation.cpp
+++ b/Source/WebCore/animation/CSSPropertyAnimation.cpp
@@ -3638,6 +3638,7 @@ CSSPropertyAnimationWrapperMap::CSSPropertyAnimationWrapperMap()
         new DiscretePropertyWrapper<TextOverflow>(CSSPropertyTextOverflow, &RenderStyle::textOverflow, &RenderStyle::setTextOverflow),
         new DiscretePropertyWrapper<OptionSet<TouchAction>>(CSSPropertyTouchAction, &RenderStyle::touchActions, &RenderStyle::setTouchActions),
         new DiscretePropertyWrapper<OptionSet<TextTransform>>(CSSPropertyTextTransform, &RenderStyle::textTransform, &RenderStyle::setTextTransform),
+        new DiscretePropertyWrapper<WhiteSpaceCollapse>(CSSPropertyWhiteSpaceCollapse, &RenderStyle::whiteSpaceCollapse, &RenderStyle::setWhiteSpaceCollapse),
         new DiscretePropertyWrapper<TextWrap>(CSSPropertyTextWrap, &RenderStyle::textWrap, &RenderStyle::setTextWrap),
         new DiscretePropertyWrapper<TransformBox>(CSSPropertyTransformBox, &RenderStyle::transformBox, &RenderStyle::setTransformBox),
         new DiscretePropertyWrapper<TransformStyle3D>(CSSPropertyTransformStyle, &RenderStyle::transformStyle3D, &RenderStyle::setTransformStyle3D),

--- a/Source/WebCore/css/CSSPrimitiveValueMappings.h
+++ b/Source/WebCore/css/CSSPrimitiveValueMappings.h
@@ -1389,6 +1389,12 @@ template<> constexpr WhiteSpace fromCSSValueID(CSSValueID valueID)
     return WhiteSpace::Normal;
 }
 
+#define TYPE WhiteSpaceCollapse
+#define FOR_EACH(CASE) CASE(Collapse) CASE(Discard) CASE(Preserve) CASE(PreserveBreaks) CASE(PreserveSpaces) CASE(BreakSpaces)
+DEFINE_TO_FROM_CSS_VALUE_ID_FUNCTIONS
+#undef TYPE
+#undef FOR_EACH
+
 #define TYPE WordBreak
 #define FOR_EACH(CASE) CASE(Normal) CASE(BreakAll) CASE(KeepAll) CASE(BreakWord)
 DEFINE_TO_FROM_CSS_VALUE_ID_FUNCTIONS

--- a/Source/WebCore/css/CSSProperties.json
+++ b/Source/WebCore/css/CSSProperties.json
@@ -6300,6 +6300,25 @@
                 "url": "https://www.w3.org/TR/CSS22/text.html#propdef-white-space"
             }
         },
+        "white-space-collapse": {
+            "inherited": true,
+            "values": [
+                "collapse",
+                "discard",
+                "preserve",
+                "preserve-breaks",
+                "preserve-spaces",
+                "break-spaces"
+            ],
+            "codegen-properties": {
+                "settings-flag": "cssWhiteSpaceCollapseEnabled",
+                "parser-grammar": "<<values>>"
+            },
+            "specification": {
+                "category": "css-text",
+                "url": "https://www.w3.org/TR/css-text-4/#white-space-collapsing"
+            }
+        },
         "widows": {
             "inherited": true,
             "codegen-properties": {

--- a/Source/WebCore/css/CSSValueKeywords.in
+++ b/Source/WebCore/css/CSSValueKeywords.in
@@ -865,6 +865,16 @@ break-word
 break-spaces
 
 //
+// CSS_PROP_WHITE_SPACE_COLLAPSE
+//
+// collapse
+// discard
+preserve
+preserve-breaks
+preserve-spaces
+// break-spaces
+
+//
 // CSS_PROP__KHTML_NBSP_MODE
 //
 space

--- a/Source/WebCore/css/ComputedStyleExtractor.cpp
+++ b/Source/WebCore/css/ComputedStyleExtractor.cpp
@@ -3715,6 +3715,8 @@ RefPtr<CSSValue> ComputedStyleExtractor::valueForPropertyInStyle(const RenderSty
         return createConvertingToCSSValueID(style.visibility());
     case CSSPropertyWhiteSpace:
         return createConvertingToCSSValueID(style.whiteSpace());
+    case CSSPropertyWhiteSpaceCollapse:
+        return createConvertingToCSSValueID(style.whiteSpaceCollapse());
     case CSSPropertyWidows:
         if (style.hasAutoWidows())
             return CSSPrimitiveValue::create(CSSValueAuto);

--- a/Source/WebCore/rendering/style/RenderStyle.h
+++ b/Source/WebCore/rendering/style/RenderStyle.h
@@ -575,6 +575,7 @@ public:
     inline bool breakWords() const;
 
     WhiteSpaceCollapse whiteSpaceCollapse() const { return static_cast<WhiteSpaceCollapse>(m_inheritedFlags.whiteSpaceCollapse); }
+    TextWrap textWrap() const { return static_cast<TextWrap>(m_inheritedFlags.textWrap); }
 
     inline FillRepeatXY backgroundRepeat() const;
     inline FillAttachment backgroundAttachment() const;
@@ -795,7 +796,6 @@ public:
     WEBCORE_EXPORT UserSelect effectiveUserSelect() const;
     inline UserSelect userSelect() const;
     inline TextOverflow textOverflow() const;
-    inline TextWrap textWrap() const;
     inline WordBreak wordBreak() const;
     inline OverflowWrap overflowWrap() const;
     inline NBSPMode nbspMode() const;
@@ -1223,6 +1223,7 @@ public:
 
     void setWhiteSpace(WhiteSpace v) { m_inheritedFlags.whiteSpace = static_cast<unsigned>(v); }
     void setWhiteSpaceCollapse(WhiteSpaceCollapse v) { m_inheritedFlags.whiteSpaceCollapse = static_cast<unsigned>(v); }
+    void setTextWrap(TextWrap v) { m_inheritedFlags.textWrap = static_cast<unsigned>(v); }
 
     void setWordSpacing(Length&&);
 
@@ -1395,7 +1396,6 @@ public:
     inline void setUserDrag(UserDrag);
     inline void setUserSelect(UserSelect);
     inline void setTextOverflow(TextOverflow);
-    inline void setTextWrap(TextWrap);
     inline void setWordBreak(WordBreak);
     inline void setOverflowWrap(OverflowWrap);
     inline void setNBSPMode(NBSPMode);
@@ -2174,7 +2174,8 @@ private:
         unsigned direction : 1; // TextDirection
         unsigned whiteSpace : 3; // WhiteSpace
         unsigned whiteSpaceCollapse : 3; // WhiteSpaceCollapse
-        // 33 bits
+        unsigned textWrap : 3; // TextWrap
+        // 36 bits
         unsigned borderCollapse : 1; // BorderCollapse
         unsigned boxDirection : 1; // BoxDirection
 
@@ -2184,16 +2185,16 @@ private:
         unsigned pointerEvents : 4; // PointerEvents
         unsigned insideLink : 2; // InsideLink
         unsigned insideDefaultButton : 1;
-        // 44 bits
+        // 47 bits
 
         // CSS Text Layout Module Level 3: Vertical writing support
         unsigned writingMode : 2; // WritingMode
-        // 46 bits
+        // 49 bits
 
 #if ENABLE(TEXT_AUTOSIZING)
         unsigned autosizeStatus : 5;
 #endif
-        // 51 bits
+        // 54 bits
     };
 
     // This constructor is used to implement the replace operation.

--- a/Source/WebCore/rendering/style/RenderStyle.h
+++ b/Source/WebCore/rendering/style/RenderStyle.h
@@ -222,6 +222,7 @@ enum class UserSelect : uint8_t;
 enum class VerticalAlign : uint8_t;
 enum class Visibility : uint8_t;
 enum class WhiteSpace : uint8_t;
+enum class WhiteSpaceCollapse : uint8_t;
 enum class WordBreak : uint8_t;
 enum class WritingMode : uint8_t;
 
@@ -572,6 +573,8 @@ public:
     inline bool isCollapsibleWhiteSpace(UChar) const;
     inline bool breakOnlyAfterWhiteSpace() const;
     inline bool breakWords() const;
+
+    WhiteSpaceCollapse whiteSpaceCollapse() const { return static_cast<WhiteSpaceCollapse>(m_inheritedFlags.whiteSpaceCollapse); }
 
     inline FillRepeatXY backgroundRepeat() const;
     inline FillAttachment backgroundAttachment() const;
@@ -1219,6 +1222,7 @@ public:
 #endif
 
     void setWhiteSpace(WhiteSpace v) { m_inheritedFlags.whiteSpace = static_cast<unsigned>(v); }
+    void setWhiteSpaceCollapse(WhiteSpaceCollapse v) { m_inheritedFlags.whiteSpaceCollapse = static_cast<unsigned>(v); }
 
     void setWordSpacing(Length&&);
 
@@ -1773,6 +1777,7 @@ public:
     static constexpr OptionSet<TextTransform> initialTextTransform();
     static constexpr Visibility initialVisibility();
     static constexpr WhiteSpace initialWhiteSpace();
+    static constexpr WhiteSpaceCollapse initialWhiteSpaceCollapse();
     static float initialHorizontalBorderSpacing() { return 0; }
     static float initialVerticalBorderSpacing() { return 0; }
     static constexpr CursorType initialCursor();
@@ -2168,7 +2173,8 @@ private:
 #endif
         unsigned direction : 1; // TextDirection
         unsigned whiteSpace : 3; // WhiteSpace
-        // 38 bits
+        unsigned whiteSpaceCollapse : 3; // WhiteSpaceCollapse
+        // 33 bits
         unsigned borderCollapse : 1; // BorderCollapse
         unsigned boxDirection : 1; // BoxDirection
 
@@ -2178,16 +2184,16 @@ private:
         unsigned pointerEvents : 4; // PointerEvents
         unsigned insideLink : 2; // InsideLink
         unsigned insideDefaultButton : 1;
-        // 49 bits
+        // 44 bits
 
         // CSS Text Layout Module Level 3: Vertical writing support
         unsigned writingMode : 2; // WritingMode
-        // 51 bits
+        // 46 bits
 
 #if ENABLE(TEXT_AUTOSIZING)
         unsigned autosizeStatus : 5;
 #endif
-        // 56 bits
+        // 51 bits
     };
 
     // This constructor is used to implement the replace operation.

--- a/Source/WebCore/rendering/style/RenderStyleConstants.cpp
+++ b/Source/WebCore/rendering/style/RenderStyleConstants.cpp
@@ -1318,6 +1318,18 @@ TextStream& operator<<(TextStream& ts, WhiteSpace whiteSpace)
     }
     return ts;
 }
+TextStream& operator<<(TextStream& ts, WhiteSpaceCollapse whiteSpaceCollapse)
+{
+    switch (whiteSpaceCollapse) {
+    case WhiteSpaceCollapse::Collapse: ts << "collapse"; break;
+    case WhiteSpaceCollapse::Discard: ts << "discard"; break;
+    case WhiteSpaceCollapse::Preserve: ts << "preserve"; break;
+    case WhiteSpaceCollapse::PreserveBreaks: ts << "preserve-breaks"; break;
+    case WhiteSpaceCollapse::PreserveSpaces: ts << "preserve-spaces"; break;
+    case WhiteSpaceCollapse::BreakSpaces: ts << "break-spaces"; break;
+    }
+    return ts;
+}
 
 TextStream& operator<<(TextStream& ts, WordBreak wordBreak)
 {

--- a/Source/WebCore/rendering/style/RenderStyleConstants.h
+++ b/Source/WebCore/rendering/style/RenderStyleConstants.h
@@ -596,6 +596,15 @@ enum class WhiteSpace : uint8_t {
     BreakSpaces
 };
 
+enum class WhiteSpaceCollapse : uint8_t {
+    Collapse,
+    Discard,
+    Preserve,
+    PreserveBreaks,
+    PreserveSpaces,
+    BreakSpaces
+};
+
 enum class ReflectionDirection : uint8_t {
     Below,
     Above,
@@ -1281,6 +1290,7 @@ WTF::TextStream& operator<<(WTF::TextStream&, UserSelect);
 WTF::TextStream& operator<<(WTF::TextStream&, VerticalAlign);
 WTF::TextStream& operator<<(WTF::TextStream&, Visibility);
 WTF::TextStream& operator<<(WTF::TextStream&, WhiteSpace);
+WTF::TextStream& operator<<(WTF::TextStream&, WhiteSpaceCollapse);
 WTF::TextStream& operator<<(WTF::TextStream&, WordBreak);
 WTF::TextStream& operator<<(WTF::TextStream&, MathStyle);
 WTF::TextStream& operator<<(WTF::TextStream&, ContainIntrinsicSizeType);

--- a/Source/WebCore/rendering/style/RenderStyleInlines.h
+++ b/Source/WebCore/rendering/style/RenderStyleInlines.h
@@ -672,7 +672,6 @@ inline float RenderStyle::textStrokeWidth() const { return m_rareInheritedData->
 inline OptionSet<TextTransform> RenderStyle::textTransform() const { return OptionSet<TextTransform>::fromRaw(m_inheritedFlags.textTransform); }
 inline TextUnderlineOffset RenderStyle::textUnderlineOffset() const { return m_rareInheritedData->textUnderlineOffset; }
 inline TextUnderlinePosition RenderStyle::textUnderlinePosition() const { return static_cast<TextUnderlinePosition>(m_rareInheritedData->textUnderlinePosition); }
-inline TextWrap RenderStyle::textWrap() const { return static_cast<TextWrap>(m_rareInheritedData->textWrap); }
 inline TextZoom RenderStyle::textZoom() const { return static_cast<TextZoom>(m_rareInheritedData->textZoom); }
 inline const Length& RenderStyle::top() const { return m_nonInheritedData->surroundData->offset.top(); }
 inline OptionSet<TouchAction> RenderStyle::touchActions() const { return m_nonInheritedData->rareData->touchActions; }
@@ -792,6 +791,7 @@ inline bool RenderStyle::InheritedFlags::operator==(const InheritedFlags& other)
         && direction == other.direction
         && whiteSpace == other.whiteSpace
         && whiteSpaceCollapse == other.whiteSpaceCollapse
+        && textWrap == other.textWrap
         && borderCollapse == other.borderCollapse
         && boxDirection == other.boxDirection
         && rtlOrdering == other.rtlOrdering

--- a/Source/WebCore/rendering/style/RenderStyleInlines.h
+++ b/Source/WebCore/rendering/style/RenderStyleInlines.h
@@ -488,6 +488,7 @@ constexpr UserSelect RenderStyle::initialUserSelect() { return UserSelect::Text;
 constexpr VerticalAlign RenderStyle::initialVerticalAlign() { return VerticalAlign::Baseline; }
 constexpr Visibility RenderStyle::initialVisibility() { return Visibility::Visible; }
 constexpr WhiteSpace RenderStyle::initialWhiteSpace() { return WhiteSpace::Normal; }
+constexpr WhiteSpaceCollapse RenderStyle::initialWhiteSpaceCollapse() { return WhiteSpaceCollapse::Collapse; }
 constexpr WordBreak RenderStyle::initialWordBreak() { return WordBreak::Normal; }
 inline Length RenderStyle::initialWordSpacing() { return zeroLength(); }
 constexpr WritingMode RenderStyle::initialWritingMode() { return WritingMode::TopToBottom; }
@@ -790,6 +791,7 @@ inline bool RenderStyle::InheritedFlags::operator==(const InheritedFlags& other)
 #endif
         && direction == other.direction
         && whiteSpace == other.whiteSpace
+        && whiteSpaceCollapse == other.whiteSpaceCollapse
         && borderCollapse == other.borderCollapse
         && boxDirection == other.boxDirection
         && rtlOrdering == other.rtlOrdering

--- a/Source/WebCore/rendering/style/RenderStyleSetters.h
+++ b/Source/WebCore/rendering/style/RenderStyleSetters.h
@@ -309,7 +309,6 @@ inline void RenderStyle::setTextStrokeWidth(float value) { SET(m_rareInheritedDa
 inline void RenderStyle::setTextTransform(OptionSet<TextTransform> value) { m_inheritedFlags.textTransform = value.toRaw(); }
 inline void RenderStyle::setTextUnderlineOffset(TextUnderlineOffset textUnderlineOffset) { SET(m_rareInheritedData, textUnderlineOffset, textUnderlineOffset); }
 inline void RenderStyle::setTextUnderlinePosition(TextUnderlinePosition position) { SET(m_rareInheritedData, textUnderlinePosition, static_cast<unsigned>(position)); }
-inline void RenderStyle::setTextWrap(TextWrap wrap) { SET(m_rareInheritedData, textWrap, static_cast<unsigned>(wrap)); }
 inline void RenderStyle::setTextZoom(TextZoom zoom) { SET(m_rareInheritedData, textZoom, static_cast<unsigned>(zoom)); }
 inline void RenderStyle::setTop(Length&& length) { SET_NESTED(m_nonInheritedData, surroundData, offset.top(), WTFMove(length)); }
 inline void RenderStyle::setTouchActions(OptionSet<TouchAction> actions) { SET_NESTED(m_nonInheritedData, rareData, touchActions, actions); }

--- a/Source/WebCore/rendering/style/StyleRareInheritedData.cpp
+++ b/Source/WebCore/rendering/style/StyleRareInheritedData.cpp
@@ -129,7 +129,6 @@ StyleRareInheritedData::StyleRareInheritedData()
     , textJustify(static_cast<unsigned>(RenderStyle::initialTextJustify()))
     , textDecorationSkipInk(static_cast<unsigned>(RenderStyle::initialTextDecorationSkipInk()))
     , textUnderlinePosition(static_cast<unsigned>(RenderStyle::initialTextUnderlinePosition()))
-    , textWrap(static_cast<unsigned>(RenderStyle::initialTextWrap()))
     , rubyPosition(static_cast<unsigned>(RenderStyle::initialRubyPosition()))
     , textZoom(static_cast<unsigned>(RenderStyle::initialTextZoom()))
 #if PLATFORM(IOS_FAMILY)
@@ -229,7 +228,6 @@ inline StyleRareInheritedData::StyleRareInheritedData(const StyleRareInheritedDa
     , textJustify(o.textJustify)
     , textDecorationSkipInk(o.textDecorationSkipInk)
     , textUnderlinePosition(o.textUnderlinePosition)
-    , textWrap(o.textWrap)
     , rubyPosition(o.rubyPosition)
     , textZoom(o.textZoom)
 #if PLATFORM(IOS_FAMILY)
@@ -362,7 +360,6 @@ bool StyleRareInheritedData::operator==(const StyleRareInheritedData& o) const
         && textJustify == o.textJustify
         && textDecorationSkipInk == o.textDecorationSkipInk
         && textUnderlinePosition == o.textUnderlinePosition
-        && textWrap == o.textWrap
         && rubyPosition == o.rubyPosition
         && textZoom == o.textZoom
         && lineSnap == o.lineSnap

--- a/Source/WebCore/rendering/style/StyleRareInheritedData.h
+++ b/Source/WebCore/rendering/style/StyleRareInheritedData.h
@@ -142,7 +142,6 @@ public:
     unsigned textJustify : 2; // TextJustify
     unsigned textDecorationSkipInk : 2; // TextDecorationSkipInk
     unsigned textUnderlinePosition : 3; // TextUnderlinePosition
-    unsigned textWrap : 3; // TextWrap
     unsigned rubyPosition : 2; // RubyPosition
     unsigned textZoom: 1; // TextZoom
 


### PR DESCRIPTION
#### 853f439d8d5569d9beaa491c3b884683e8a2935f
<pre>
Move CSS text-wrap property to m_inheritedFlags
<a href="https://bugs.webkit.org/show_bug.cgi?id=257237">https://bugs.webkit.org/show_bug.cgi?id=257237</a>
rdar://109743940

Reviewed by NOBODY (OOPS!).

CSS text-wrap is placed inside m_rareInheritedData. Since text-wrap
is a longhand property of white-space, which is frequently set, the
text-wrap property should really reside in either m_inheritedData or
m_inheritedFlags. Given that the possible range of values of text-wrap
can be encoded in 3 bits, m_inheritedFlags is preferable to
m_inheritedData.

* Source/WebCore/rendering/style/RenderStyle.h:
(WebCore::RenderStyle::textWrap const):
(WebCore::RenderStyle::setTextWrap):
* Source/WebCore/rendering/style/RenderStyleInlines.h:
(WebCore::RenderStyle::textUnderlinePosition const):
(WebCore::RenderStyle::InheritedFlags::operator== const):
(WebCore::RenderStyle::textWrap const): Deleted.
* Source/WebCore/rendering/style/RenderStyleSetters.h:
(WebCore::RenderStyle::setTextUnderlinePosition):
(WebCore::RenderStyle::setTextWrap): Deleted.
* Source/WebCore/rendering/style/StyleRareInheritedData.cpp:
(WebCore::StyleRareInheritedData::StyleRareInheritedData):
(WebCore::StyleRareInheritedData::operator== const):
* Source/WebCore/rendering/style/StyleRareInheritedData.h:
</pre>
----------------------------------------------------------------------
#### afa079bda408849dcfd79ade026a2c17e4114ba6
<pre>
Add white-space-collapse parsing support

<a href="https://bugs.webkit.org/show_bug.cgi?id=256924">https://bugs.webkit.org/show_bug.cgi?id=256924</a>
rdar://109486162

Reviewed by NOBODY (OOPS!).

Added parsing support for new CSS longhand white-space-collapse
under a testable feature flag. Placed white-space-collapse property
under m_inheritedFlags.

* LayoutTests/imported/w3c/web-platform-tests/css/css-cascade/all-prop-initial-xml-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-text/inheritance-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-text/inheritance.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-text/parsing/white-space-collapse-computed-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-text/parsing/white-space-collapse-valid-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/web-animations/animation-model/animation-types/accumulation-per-property-002-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/web-animations/animation-model/animation-types/addition-per-property-002-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/web-animations/animation-model/animation-types/interpolation-per-property-002-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/web-animations/animation-model/animation-types/property-list.js:
* LayoutTests/platform/gtk/imported/w3c/web-platform-tests/css/css-cascade/all-prop-initial-xml-expected.txt:
* LayoutTests/platform/ios-wk2/imported/w3c/web-platform-tests/css/css-cascade/all-prop-initial-xml-expected.txt:
* LayoutTests/platform/ipad/imported/w3c/web-platform-tests/css/css-cascade/all-prop-initial-xml-expected.txt:
* LayoutTests/platform/mac-wk1/imported/w3c/web-platform-tests/css/css-cascade/all-prop-initial-xml-expected.txt:
* LayoutTests/platform/mac-wk1/imported/w3c/web-platform-tests/web-animations/animation-model/animation-types/accumulation-per-property-002-expected.txt:
* LayoutTests/platform/mac-wk1/imported/w3c/web-platform-tests/web-animations/animation-model/animation-types/addition-per-property-002-expected.txt:
* LayoutTests/platform/mac-wk1/imported/w3c/web-platform-tests/web-animations/animation-model/animation-types/interpolation-per-property-002-expected.txt:
* LayoutTests/platform/wpe/imported/w3c/web-platform-tests/css/css-cascade/all-prop-initial-xml-expected.txt:
* Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml:
* Source/WebCore/animation/CSSPropertyAnimation.cpp:
(WebCore::CSSPropertyAnimationWrapperMap::CSSPropertyAnimationWrapperMap):
* Source/WebCore/css/CSSPrimitiveValueMappings.h:
* Source/WebCore/css/CSSProperties.json:
* Source/WebCore/css/CSSValueKeywords.in:
* Source/WebCore/css/ComputedStyleExtractor.cpp:
(WebCore::ComputedStyleExtractor::valueForPropertyInStyle):
* Source/WebCore/rendering/style/RenderStyle.h:
(WebCore::RenderStyle::whiteSpaceCollapse const):
(WebCore::RenderStyle::setWhiteSpaceCollapse):
* Source/WebCore/rendering/style/RenderStyleConstants.cpp:
(WebCore::operator&lt;&lt;):
* Source/WebCore/rendering/style/RenderStyleConstants.h:
* Source/WebCore/rendering/style/RenderStyleInlines.h:
(WebCore::RenderStyle::initialWhiteSpaceCollapse):
(WebCore::RenderStyle::InheritedFlags::operator== const):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/853f439d8d5569d9beaa491c3b884683e8a2935f

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/7860 "Failed to checkout and rebase branch from PR 14322") | [❌ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/8138 "Failed to checkout and rebase branch from PR 14322") | [❌ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/8324 "Failed to checkout and rebase branch from PR 14322") | [❌ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/9509 "Failed to checkout and rebase branch from PR 14322") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/32/builds/7987 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [❌ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/7865 "Failed to checkout and rebase branch from PR 14322") | [❌ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/10131 "Failed to checkout and rebase branch from PR 14322") | [❌ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/8055 "Failed to checkout and rebase branch from PR 14322") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/5/builds/9509 "Failed to checkout and rebase branch from PR 14322") | 
| [❌ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/8000 "Failed to checkout and rebase branch from PR 14322") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/23/builds/10131 "Failed to checkout and rebase branch from PR 14322") | [❌ 🧪 api-mac](https://ews-build.webkit.org/#/builders/14/builds/8324 "Failed to checkout and rebase branch from PR 14322") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/2/builds/9626 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/23/builds/10131 "Failed to checkout and rebase branch from PR 14322") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/14/builds/8324 "Failed to checkout and rebase branch from PR 14322") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/2/builds/9626 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [  ~~🛠 🧪 jsc~~](https://ews-build.webkit.org/#/builders/20/builds/6699 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🧪 api-ios](https://ews-build.webkit.org/#/builders/23/builds/10131 "Failed to checkout and rebase branch from PR 14322") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/14/builds/8324 "Failed to checkout and rebase branch from PR 14322") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/2/builds/9626 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [  ~~🛠 🧪 jsc-arm64~~](https://ews-build.webkit.org/#/builders/12/builds/7430 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/7/builds/7779 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/16/builds/8055 "Failed to checkout and rebase branch from PR 14322") | [❌ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/8022 "Failed to checkout and rebase branch from PR 14322") | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/30/builds/7097 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/14/builds/8324 "Failed to checkout and rebase branch from PR 14322") | [❌ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/35/builds/8022 "Failed to checkout and rebase branch from PR 14322") | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/4/builds/11306 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [❌ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/24/builds/8240 "Failed to checkout and rebase branch from PR 14322") | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/31/builds/7514 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [❌ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/24/builds/8240 "Failed to checkout and rebase branch from PR 14322") | 
<!--EWS-Status-Bubble-End-->