### PR TITLE
Move CSS text-wrap property to m_inheritedFlags

### DIFF
--- a/Source/WebCore/rendering/style/RenderStyle.h
+++ b/Source/WebCore/rendering/style/RenderStyle.h
@@ -575,6 +575,7 @@ public:
     inline bool breakWords() const;
 
     WhiteSpaceCollapse whiteSpaceCollapse() const { return static_cast<WhiteSpaceCollapse>(m_inheritedFlags.whiteSpaceCollapse); }
+    TextWrap textWrap() const { return static_cast<TextWrap>(m_inheritedFlags.textWrap); }
 
     inline FillRepeatXY backgroundRepeat() const;
     inline FillAttachment backgroundAttachment() const;
@@ -795,7 +796,6 @@ public:
     WEBCORE_EXPORT UserSelect effectiveUserSelect() const;
     inline UserSelect userSelect() const;
     inline TextOverflow textOverflow() const;
-    inline TextWrap textWrap() const;
     inline WordBreak wordBreak() const;
     inline OverflowWrap overflowWrap() const;
     inline NBSPMode nbspMode() const;
@@ -1223,6 +1223,7 @@ public:
 
     void setWhiteSpace(WhiteSpace v) { m_inheritedFlags.whiteSpace = static_cast<unsigned>(v); }
     void setWhiteSpaceCollapse(WhiteSpaceCollapse v) { m_inheritedFlags.whiteSpaceCollapse = static_cast<unsigned>(v); }
+    void setTextWrap(TextWrap v) { m_inheritedFlags.textWrap = static_cast<unsigned>(v); }
 
     void setWordSpacing(Length&&);
 
@@ -1395,7 +1396,6 @@ public:
     inline void setUserDrag(UserDrag);
     inline void setUserSelect(UserSelect);
     inline void setTextOverflow(TextOverflow);
-    inline void setTextWrap(TextWrap);
     inline void setWordBreak(WordBreak);
     inline void setOverflowWrap(OverflowWrap);
     inline void setNBSPMode(NBSPMode);
@@ -2174,7 +2174,8 @@ private:
         unsigned direction : 1; // TextDirection
         unsigned whiteSpace : 3; // WhiteSpace
         unsigned whiteSpaceCollapse : 3; // WhiteSpaceCollapse
-        // 33 bits
+        unsigned textWrap : 3; // TextWrap
+        // 36 bits
         unsigned borderCollapse : 1; // BorderCollapse
         unsigned boxDirection : 1; // BoxDirection
 
@@ -2184,16 +2185,16 @@ private:
         unsigned pointerEvents : 4; // PointerEvents
         unsigned insideLink : 2; // InsideLink
         unsigned insideDefaultButton : 1;
-        // 44 bits
+        // 47 bits
 
         // CSS Text Layout Module Level 3: Vertical writing support
         unsigned writingMode : 2; // WritingMode
-        // 46 bits
+        // 49 bits
 
 #if ENABLE(TEXT_AUTOSIZING)
         unsigned autosizeStatus : 5;
 #endif
-        // 51 bits
+        // 54 bits
     };
 
     // This constructor is used to implement the replace operation.

--- a/Source/WebCore/rendering/style/RenderStyleInlines.h
+++ b/Source/WebCore/rendering/style/RenderStyleInlines.h
@@ -672,7 +672,6 @@ inline float RenderStyle::textStrokeWidth() const { return m_rareInheritedData->
 inline OptionSet<TextTransform> RenderStyle::textTransform() const { return OptionSet<TextTransform>::fromRaw(m_inheritedFlags.textTransform); }
 inline TextUnderlineOffset RenderStyle::textUnderlineOffset() const { return m_rareInheritedData->textUnderlineOffset; }
 inline TextUnderlinePosition RenderStyle::textUnderlinePosition() const { return static_cast<TextUnderlinePosition>(m_rareInheritedData->textUnderlinePosition); }
-inline TextWrap RenderStyle::textWrap() const { return static_cast<TextWrap>(m_rareInheritedData->textWrap); }
 inline TextZoom RenderStyle::textZoom() const { return static_cast<TextZoom>(m_rareInheritedData->textZoom); }
 inline const Length& RenderStyle::top() const { return m_nonInheritedData->surroundData->offset.top(); }
 inline OptionSet<TouchAction> RenderStyle::touchActions() const { return m_nonInheritedData->rareData->touchActions; }
@@ -792,6 +791,7 @@ inline bool RenderStyle::InheritedFlags::operator==(const InheritedFlags& other)
         && direction == other.direction
         && whiteSpace == other.whiteSpace
         && whiteSpaceCollapse == other.whiteSpaceCollapse
+        && textWrap == other.textWrap
         && borderCollapse == other.borderCollapse
         && boxDirection == other.boxDirection
         && rtlOrdering == other.rtlOrdering

--- a/Source/WebCore/rendering/style/RenderStyleSetters.h
+++ b/Source/WebCore/rendering/style/RenderStyleSetters.h
@@ -309,7 +309,6 @@ inline void RenderStyle::setTextStrokeWidth(float value) { SET(m_rareInheritedDa
 inline void RenderStyle::setTextTransform(OptionSet<TextTransform> value) { m_inheritedFlags.textTransform = value.toRaw(); }
 inline void RenderStyle::setTextUnderlineOffset(TextUnderlineOffset textUnderlineOffset) { SET(m_rareInheritedData, textUnderlineOffset, textUnderlineOffset); }
 inline void RenderStyle::setTextUnderlinePosition(TextUnderlinePosition position) { SET(m_rareInheritedData, textUnderlinePosition, static_cast<unsigned>(position)); }
-inline void RenderStyle::setTextWrap(TextWrap wrap) { SET(m_rareInheritedData, textWrap, static_cast<unsigned>(wrap)); }
 inline void RenderStyle::setTextZoom(TextZoom zoom) { SET(m_rareInheritedData, textZoom, static_cast<unsigned>(zoom)); }
 inline void RenderStyle::setTop(Length&& length) { SET_NESTED(m_nonInheritedData, surroundData, offset.top(), WTFMove(length)); }
 inline void RenderStyle::setTouchActions(OptionSet<TouchAction> actions) { SET_NESTED(m_nonInheritedData, rareData, touchActions, actions); }

--- a/Source/WebCore/rendering/style/StyleRareInheritedData.cpp
+++ b/Source/WebCore/rendering/style/StyleRareInheritedData.cpp
@@ -129,7 +129,6 @@ StyleRareInheritedData::StyleRareInheritedData()
     , textJustify(static_cast<unsigned>(RenderStyle::initialTextJustify()))
     , textDecorationSkipInk(static_cast<unsigned>(RenderStyle::initialTextDecorationSkipInk()))
     , textUnderlinePosition(static_cast<unsigned>(RenderStyle::initialTextUnderlinePosition()))
-    , textWrap(static_cast<unsigned>(RenderStyle::initialTextWrap()))
     , rubyPosition(static_cast<unsigned>(RenderStyle::initialRubyPosition()))
     , textZoom(static_cast<unsigned>(RenderStyle::initialTextZoom()))
 #if PLATFORM(IOS_FAMILY)
@@ -229,7 +228,6 @@ inline StyleRareInheritedData::StyleRareInheritedData(const StyleRareInheritedDa
     , textJustify(o.textJustify)
     , textDecorationSkipInk(o.textDecorationSkipInk)
     , textUnderlinePosition(o.textUnderlinePosition)
-    , textWrap(o.textWrap)
     , rubyPosition(o.rubyPosition)
     , textZoom(o.textZoom)
 #if PLATFORM(IOS_FAMILY)
@@ -362,7 +360,6 @@ bool StyleRareInheritedData::operator==(const StyleRareInheritedData& o) const
         && textJustify == o.textJustify
         && textDecorationSkipInk == o.textDecorationSkipInk
         && textUnderlinePosition == o.textUnderlinePosition
-        && textWrap == o.textWrap
         && rubyPosition == o.rubyPosition
         && textZoom == o.textZoom
         && lineSnap == o.lineSnap

--- a/Source/WebCore/rendering/style/StyleRareInheritedData.h
+++ b/Source/WebCore/rendering/style/StyleRareInheritedData.h
@@ -142,7 +142,6 @@ public:
     unsigned textJustify : 2; // TextJustify
     unsigned textDecorationSkipInk : 2; // TextDecorationSkipInk
     unsigned textUnderlinePosition : 3; // TextUnderlinePosition
-    unsigned textWrap : 3; // TextWrap
     unsigned rubyPosition : 2; // RubyPosition
     unsigned textZoom: 1; // TextZoom
 


### PR DESCRIPTION
#### c51eba8aa0097aea61324b0f927871669e306484
<pre>
Move CSS text-wrap property to m_inheritedFlags
<a href="https://bugs.webkit.org/show_bug.cgi?id=257237">https://bugs.webkit.org/show_bug.cgi?id=257237</a>
rdar://109743940

Reviewed by Tim Nguyen.

CSS text-wrap is placed inside m_rareInheritedData. Since text-wrap
is a longhand property of white-space, which is frequently set, the
text-wrap property should really reside in either m_inheritedData or
m_inheritedFlags. Given that the possible range of values of text-wrap
can be encoded in 3 bits, m_inheritedFlags is preferable to
m_inheritedData.

* Source/WebCore/rendering/style/RenderStyle.h:
(WebCore::RenderStyle::textWrap const):
(WebCore::RenderStyle::setTextWrap):
* Source/WebCore/rendering/style/RenderStyleInlines.h:
(WebCore::RenderStyle::textUnderlinePosition const):
(WebCore::RenderStyle::InheritedFlags::operator== const):
(WebCore::RenderStyle::textWrap const): Deleted.
* Source/WebCore/rendering/style/RenderStyleSetters.h:
(WebCore::RenderStyle::setTextUnderlinePosition):
(WebCore::RenderStyle::setTextWrap): Deleted.
* Source/WebCore/rendering/style/StyleRareInheritedData.cpp:
(WebCore::StyleRareInheritedData::StyleRareInheritedData):
(WebCore::StyleRareInheritedData::operator== const):
* Source/WebCore/rendering/style/StyleRareInheritedData.h:

Canonical link: <a href="https://commits.webkit.org/264523@main">https://commits.webkit.org/264523@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/6dfd0e21a8b035b2249492c5b9a9eac93da0e1f2

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/7861 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/8139 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/8325 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/9510 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/7988 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/7866 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/10132 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/8056 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/10853 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/8001 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/9103 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/7184 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/9627 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/6408 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/7166 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/14794 "2 flakes 148 failures") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/7533 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/7286 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/10684 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/7780 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/6326 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/7098 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/1881 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/11307 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/7515 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->