### PR TITLE
REGRESSION(262981@main): [iOS] WebKit never activates its AVAudioSession

### DIFF
--- a/Source/WebCore/platform/audio/ios/AudioSessionIOS.h
+++ b/Source/WebCore/platform/audio/ios/AudioSessionIOS.h
@@ -27,7 +27,7 @@
 
 #if USE(AUDIO_SESSION) && PLATFORM(IOS_FAMILY)
 
-#include "AudioSession.h"
+#include "AudioSessionCocoa.h"
 
 OBJC_CLASS WebInterruptionObserverHelper;
 
@@ -37,7 +37,7 @@ class WorkQueue;
 
 namespace WebCore {
 
-class AudioSessionIOS final : public AudioSession {
+class AudioSessionIOS final : public AudioSessionCocoa {
 public:
     AudioSessionIOS();
     virtual ~AudioSessionIOS();


### PR DESCRIPTION
#### 5f43fea0e5c1c638c3dbbdafb73298c5066f0fde
<pre>
REGRESSION(262981@main): [iOS] WebKit never activates its AVAudioSession
<a href="https://bugs.webkit.org/show_bug.cgi?id=257309">https://bugs.webkit.org/show_bug.cgi?id=257309</a>
rdar://109817291

Reviewed by Eric Carlson and Youenn Fablet.

In 262981@main, the contents of AudioSessionIOS::tryToSetActiveInternal() were moved into
a new common base class of AudioSessionIOS and AudioSessionMac: AudioSessionCocoa.

However, that patch neglected to make AudioSessionCocoa a base class of AudioSessionIOS.
This had the effect of removing audio session activation entirely from the iOS port of
WebKit.

* Source/WebCore/platform/audio/ios/AudioSessionIOS.h:

Canonical link: <a href="https://commits.webkit.org/264599@main">https://commits.webkit.org/264599@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/83952f1bbffb39ab9fa02c53969235237934a7e7

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/7883 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/8161 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/8420 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/9532 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/8007 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/7888 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/10154 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/8078 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/10873 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/8023 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/9122 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/7255 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/9650 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/6427 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/7254 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/14814 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/7550 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/7377 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/10706 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/7802 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/6341 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/7120 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/1940 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/11329 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/7537 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->