### PR TITLE
[WGSL] Validate swizzle beyond vector size

### DIFF
--- a/Source/WebGPU/WGSL/TypeCheck.cpp
+++ b/Source/WebGPU/WGSL/TypeCheck.cpp
@@ -593,11 +593,36 @@ void TypeChecker::vectorFieldAccess(const Types::Vector& vector, AST::FieldAcces
     const auto& fieldName = access.fieldName().id();
     auto length = fieldName.length();
 
+    bool isValid = true;
     const auto& isXYZW = [&](char c) {
-        return c == 'x' || c == 'y' || c == 'z' || c == 'w';
+        switch (c) {
+        case 'x':
+        case 'y':
+            return true;
+        case 'z':
+            isValid &= length >= 3;
+            return true;
+        case 'w':
+            isValid &= length == 4;
+            return true;
+        default:
+            return false;
+        }
     };
     const auto& isRGBA = [&](char c) {
-        return c == 'r' || c == 'g' || c == 'b' || c == 'a';
+        switch (c) {
+        case 'r':
+        case 'g':
+            return true;
+        case 'b':
+            isValid &= length >= 3;
+            return true;
+        case 'a':
+            isValid &= length == 4;
+            return true;
+        default:
+            return false;
+        }
     };
 
     bool hasXYZW = false;
@@ -614,7 +639,7 @@ void TypeChecker::vectorFieldAccess(const Types::Vector& vector, AST::FieldAcces
         }
     }
 
-    if (hasXYZW && hasRGBA) {
+    if (!isValid || (hasRGBA && hasXYZW)) {
         typeError(access.span(), "invalid vector swizzle member");
         return;
     }

--- a/Source/WebGPU/WGSL/tests/invalid/vector.wgsl
+++ b/Source/WebGPU/WGSL/tests/invalid/vector.wgsl
@@ -2,5 +2,19 @@
 
 fn testIndexAccess() {
   // CHECK-L: index must be of type 'i32' or 'u32', found: 'f32'
-  let x1 = vec2(0)[1f];
+  _ = vec2(0)[1f];
+
+  // CHECK-L: invalid vector swizzle member
+  _ = vec2(0).z;
+  // CHECK-L: invalid vector swizzle member
+  _ = vec2(0).w;
+  // CHECK-L: invalid vector swizzle member
+  _ = vec2(0).b;
+  // CHECK-L: invalid vector swizzle member
+  _ = vec2(0).a;
+
+  // CHECK-L: invalid vector swizzle member
+  _ = vec3(0).w;
+  // CHECK-L: invalid vector swizzle member
+  _ = vec3(0).a;
 }


### PR DESCRIPTION
#### 2a1f4cd6305a6108332ec18bd8353c673af195dd
<pre>
[WGSL] Validate swizzle beyond vector size
<a href="https://bugs.webkit.org/show_bug.cgi?id=257311">https://bugs.webkit.org/show_bug.cgi?id=257311</a>
rdar://109819140

Reviewed by Mike Wyrzykowski.

We should validate that the vector swizzle member is within bounds, i.e. it&apos;s
invalid to use vec2.(z|w|b|a) and vec3.(w|a)

* Source/WebGPU/WGSL/TypeCheck.cpp:
(WGSL::TypeChecker::vectorFieldAccess):
* Source/WebGPU/WGSL/tests/invalid/vector.wgsl:

Canonical link: <a href="https://commits.webkit.org/264563@main">https://commits.webkit.org/264563@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4c7fa537a265eb9bd464c46a7c88ab5d7d4d1db9

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/7885 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/8163 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/8423 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/9534 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/8009 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/10156 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/8080 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/10875 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/8025 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/9126 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/7270 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/9652 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/6431 "Passed tests") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/14816 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/7554 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/7394 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/10708 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/7804 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/6344 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/7122 "Built successfully") | | | 
| [❌ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/1906 "Failed to push commit to Webkit repository") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/11331 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/7539 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->