### PR TITLE
[GTK] Sometimes image documents do not render in a new web view

### DIFF
--- a/Source/WebCore/dom/Document.h
+++ b/Source/WebCore/dom/Document.h
@@ -1772,6 +1772,8 @@ public:
     DOMAudioSessionType audioSessionType() const { return m_audioSessionType; }
 #endif
 
+    virtual void didChangeViewSize() { }
+
 protected:
     enum class ConstructionFlag : uint8_t {
         Synthesized = 1 << 0,

--- a/Source/WebCore/html/ImageDocument.cpp
+++ b/Source/WebCore/html/ImageDocument.cpp
@@ -260,8 +260,6 @@ void ImageDocument::createDocumentStructure()
         processViewport("width=device-width,viewport-fit=cover"_s, ViewportArguments::ImageDocument);
 #else
         auto listener = ImageEventListener::create(*this);
-        if (RefPtr window = this->domWindow())
-            window->addEventListener(eventNames().resizeEvent, listener.copyRef(), false);
         imageElement->addEventListener(eventNames().clickEvent, WTFMove(listener), false);
 #endif
     }
@@ -291,8 +289,8 @@ void ImageDocument::imageUpdated()
         if (page())
             page()->chrome().client().imageOrMediaDocumentSizeChanged(IntSize(imageSize.width(), imageSize.height()));
 #else
-        // Call windowSizeChanged for its side effect of sizing the image.
-        windowSizeChanged();
+        // Call didChangeViewSize for its side effect of sizing the image.
+        didChangeViewSize();
 #endif
     }
 }
@@ -361,8 +359,7 @@ bool ImageDocument::imageFitsInWindow()
     return imageSize.width() <= viewportSize.width() && imageSize.height() <= viewportSize.height();
 }
 
-
-void ImageDocument::windowSizeChanged()
+void ImageDocument::didChangeViewSize()
 {
     if (!m_imageElement || !m_imageSizeIsKnown)
         return;
@@ -403,8 +400,8 @@ void ImageDocument::imageClicked(int x, int y)
     m_shouldShrinkImage = !m_shouldShrinkImage;
 
     if (m_shouldShrinkImage) {
-        // Call windowSizeChanged for its side effect of sizing the image.
-        windowSizeChanged();
+        // Call didChangeViewSize for its side effect of sizing the image.
+        didChangeViewSize();
     } else {
         restoreImageSize();
 
@@ -425,9 +422,7 @@ void ImageDocument::imageClicked(int x, int y)
 
 void ImageEventListener::handleEvent(ScriptExecutionContext&, Event& event)
 {
-    if (event.type() == eventNames().resizeEvent)
-        m_document.windowSizeChanged();
-    else if (event.type() == eventNames().clickEvent && is<MouseEvent>(event)) {
+    if (event.type() == eventNames().clickEvent && is<MouseEvent>(event)) {
         MouseEvent& mouseEvent = downcast<MouseEvent>(event);
         m_document.imageClicked(mouseEvent.offsetX(), mouseEvent.offsetY());
     }

--- a/Source/WebCore/html/ImageDocument.h
+++ b/Source/WebCore/html/ImageDocument.h
@@ -49,7 +49,6 @@ public:
     void disconnectImageElement() { m_imageElement = nullptr; }
 
 #if !PLATFORM(IOS_FAMILY)
-    void windowSizeChanged();
     void imageClicked(int x, int y);
 #endif
 
@@ -66,6 +65,7 @@ private:
     void restoreImageSize();
     bool imageFitsInWindow();
     float scale();
+    void didChangeViewSize() final;
 #endif
 
     void imageUpdated();

--- a/Source/WebCore/page/LocalFrameView.cpp
+++ b/Source/WebCore/page/LocalFrameView.cpp
@@ -486,6 +486,9 @@ void LocalFrameView::setFrameRect(const IntRect& newRect)
     if (m_frame->isMainFrame() && m_frame->page())
         m_frame->page()->pageOverlayController().didChangeViewSize();
 
+    if (auto* document = m_frame->document())
+        document->didChangeViewSize();
+
     viewportContentsChanged();
     setCurrentScrollType(oldScrollType);
 }


### PR DESCRIPTION
#### 1e27b309b70cb8b5e931ac32f297406b55147e86
<pre>
[GTK] Sometimes image documents do not render in a new web view
<a href="https://bugs.webkit.org/show_bug.cgi?id=254919">https://bugs.webkit.org/show_bug.cgi?id=254919</a>

Reviewed by Darin Adler.

This happens because when the ImageDocument is created the main frame
view visible size hasn&apos;t been set yet, so we end up with a 0x0 image.
When the view is resized the ImageDocument is not notified because the
resize event of dom winow is not emitted for the first layout. Instead
of relying on resize event of dom window, we should just notify the
ImageDocument directly when the frame is resized.

* Source/WebCore/dom/Document.h:
(WebCore::Document::didChangeViewSize):
* Source/WebCore/html/ImageDocument.cpp:
(WebCore::ImageDocument::createDocumentStructure):
(WebCore::ImageDocument::imageUpdated):
(WebCore::ImageDocument::didChangeViewSize):
(WebCore::ImageDocument::imageClicked):
(WebCore::ImageEventListener::handleEvent):
(WebCore::ImageDocument::windowSizeChanged): Deleted.
* Source/WebCore/html/ImageDocument.h:
* Source/WebCore/page/LocalFrameView.cpp:
(WebCore::LocalFrameView::setFrameRect):

Canonical link: <a href="https://commits.webkit.org/264576@main">https://commits.webkit.org/264576@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/22a3fa443f40bb7610a225ef00af0659351ff4f7

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/8022 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/8307 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/8519 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/9674 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/8126 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/8026 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/10293 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/8218 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/10991 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/8166 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/9254 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/7325 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/9795 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/6555 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/7342 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/14921 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/7678 "Passed tests") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/7471 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/10826 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/7934 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/6456 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/7248 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/1920 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/11456 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/7675 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->