### PR TITLE
Pixel pack and unpack state is cached but also asked from the underlying context

### DIFF
--- a/Source/WebCore/html/canvas/WebGL2RenderingContext.h
+++ b/Source/WebCore/html/canvas/WebGL2RenderingContext.h
@@ -266,9 +266,6 @@ public:
 
     GCGLuint maxTransformFeedbackSeparateAttribs() const;
 
-    PixelStoreParams getPackPixelStoreParams() const override;
-    PixelStoreParams getUnpackPixelStoreParams(TexImageDimension) const override;
-
     bool checkAndTranslateAttachments(const char* functionName, GCGLenum, Vector<GCGLenum>&);
 
     void addMembersToOpaqueRoots(JSC::AbstractSlotVisitor&) override;
@@ -282,11 +279,6 @@ private:
     bool isWebGL2() const final { return true; }
 
     void initializeNewContext() final;
-
-    // Set all ES 3.0 unpack parameters to their default value.
-    void resetUnpackParameters() final;
-    // Restore the client's ES 3.0 unpack parameters.
-    void restoreUnpackParameters() final;
 
     RefPtr<ArrayBufferView> arrayBufferViewSliceFactory(const char* const functionName, const ArrayBufferView& data, unsigned startByte, unsigned bytelength);
     RefPtr<ArrayBufferView> sliceArrayBufferView(const char* const functionName, const ArrayBufferView& data, GCGLuint srcOffset, GCGLuint length);
@@ -361,14 +353,6 @@ private:
 
     Vector<RefPtr<WebGLSampler>> m_boundSamplers;
 
-    GCGLint m_packRowLength { 0 };
-    GCGLint m_packSkipPixels { 0 };
-    GCGLint m_packSkipRows { 0 };
-    GCGLint m_unpackSkipPixels { 0 };
-    GCGLint m_unpackSkipRows { 0 };
-    GCGLint m_unpackRowLength { 0 };
-    GCGLint m_unpackImageHeight { 0 };
-    GCGLint m_unpackSkipImages { 0 };
     GCGLint m_uniformBufferOffsetAlignment { 0 };
     GCGLuint m_maxTransformFeedbackSeparateAttribs { 0 };
     GCGLint m_max3DTextureSize { 0 };

--- a/Source/WebCore/html/canvas/WebGLRenderingContextBase.cpp
+++ b/Source/WebCore/html/canvas/WebGLRenderingContextBase.cpp
@@ -284,25 +284,43 @@ static const GCGLenum supportedTypesOESTextureHalfFloat[] = {
     GraphicsContextGL::HALF_FLOAT_OES,
 };
 
-class ScopedUnpackParametersResetRestore {
+// Set UNPACK_ALIGNMENT to 1, all other parameters to 0.
+class ScopedTightUnpackParameters {
 public:
-    explicit ScopedUnpackParametersResetRestore(WebGLRenderingContextBase* context, bool enabled = true)
-        : m_context(context)
-        , m_enabled(enabled)
+    explicit ScopedTightUnpackParameters(WebGLRenderingContextBase& context, bool enabled = true)
+        : m_context(enabled ? &context : nullptr)
     {
-        if (m_enabled)
-            m_context->resetUnpackParameters();
+        if (!m_context)
+            return;
+        set(m_context->unpackPixelStoreParameters(), tightUnpack);
     }
 
-    ~ScopedUnpackParametersResetRestore()
+    ~ScopedTightUnpackParameters()
     {
-        if (m_enabled)
-            m_context->restoreUnpackParameters();
+        if (!m_context)
+            return;
+        set(tightUnpack, m_context->unpackPixelStoreParameters());
     }
-
 private:
-    WebGLRenderingContextBase* m_context;
-    bool m_enabled;
+    using PixelStoreParameters =  WebGLRenderingContextBase::PixelStoreParameters;
+    static constexpr PixelStoreParameters tightUnpack { 1, 0, 0, 0, 0 };
+    void set(const PixelStoreParameters& oldValues, const PixelStoreParameters& newValues)
+    {
+        auto* context = m_context->graphicsContextGL();
+        if (oldValues.alignment != newValues.alignment)
+            context->pixelStorei(GraphicsContextGL::UNPACK_ALIGNMENT, newValues.alignment);
+        if (oldValues.rowLength != newValues.rowLength)
+            context->pixelStorei(GraphicsContextGL::UNPACK_ROW_LENGTH, newValues.rowLength);
+        if (oldValues.imageHeight != newValues.imageHeight)
+            context->pixelStorei(GraphicsContextGL::UNPACK_IMAGE_HEIGHT, newValues.imageHeight);
+        if (oldValues.skipPixels != newValues.skipPixels)
+            context->pixelStorei(GraphicsContextGL::UNPACK_SKIP_PIXELS, newValues.skipPixels);
+        if (oldValues.skipRows != newValues.skipRows)
+            context->pixelStorei(GraphicsContextGL::UNPACK_SKIP_ROWS, newValues.skipRows);
+        if (oldValues.skipImages != newValues.skipImages)
+            context->pixelStorei(GraphicsContextGL::UNPACK_SKIP_IMAGES, newValues.skipImages);
+    }
+    WebGLRenderingContextBase* const m_context;
 };
 
 class ScopedDisableRasterizerDiscard {
@@ -713,8 +731,8 @@ void WebGLRenderingContextBase::initializeNewContext()
     m_needsUpdate = true;
     m_markedCanvasDirty = false;
     m_activeTextureUnit = 0;
-    m_packAlignment = 4;
-    m_unpackAlignment = 4;
+    m_packParameters = { };
+    m_unpackParameters = { };
     m_unpackFlipY = false;
     m_unpackPremultiplyAlpha = false;
     m_unpackColorspaceConversion = GraphicsContextGL::BROWSER_DEFAULT_WEBGL;
@@ -827,18 +845,6 @@ void WebGLRenderingContextBase::addCompressedTextureFormat(GCGLenum format)
 {
     if (!m_compressedTextureFormats.contains(format))
         m_compressedTextureFormats.append(format);
-}
-
-void WebGLRenderingContextBase::resetUnpackParameters()
-{
-    if (m_unpackAlignment != 1)
-        m_context->pixelStorei(GraphicsContextGL::UNPACK_ALIGNMENT, 1);
-}
-
-void WebGLRenderingContextBase::restoreUnpackParameters()
-{
-    if (m_unpackAlignment != 1)
-        m_context->pixelStorei(GraphicsContextGL::UNPACK_ALIGNMENT, m_unpackAlignment);
 }
 
 void WebGLRenderingContextBase::addActivityStateChangeObserverIfNecessary()
@@ -2443,7 +2449,7 @@ WebGLAny WebGLRenderingContextBase::getParameter(GCGLenum pname)
     case GraphicsContextGL::TEXTURE_BINDING_CUBE_MAP:
         return m_textureUnits[m_activeTextureUnit].textureCubeMapBinding;
     case GraphicsContextGL::UNPACK_ALIGNMENT:
-        return getIntParameter(pname);
+        return m_unpackParameters.alignment;
     case GraphicsContextGL::UNPACK_FLIP_Y_WEBGL:
         return m_unpackFlipY;
     case GraphicsContextGL::UNPACK_PREMULTIPLY_ALPHA_WEBGL:
@@ -3305,9 +3311,9 @@ void WebGLRenderingContextBase::pixelStorei(GCGLenum pname, GCGLint param)
     case GraphicsContextGL::UNPACK_ALIGNMENT:
         if (param == 1 || param == 2 || param == 4 || param == 8) {
             if (pname == GraphicsContextGL::PACK_ALIGNMENT)
-                m_packAlignment = param;
+                m_packParameters.alignment = param;
             else // GraphicsContextGL::UNPACK_ALIGNMENT:
-                m_unpackAlignment = param;
+                m_unpackParameters.alignment = param;
             m_context->pixelStorei(pname, param);
         } else {
             synthesizeGLError(GraphicsContextGL::INVALID_VALUE, "pixelStorei", "invalid parameter for alignment");
@@ -3659,7 +3665,7 @@ ExceptionOr<void> WebGLRenderingContextBase::texImageSource(TexImageFunctionID f
         }
         imageData = std::span<const uint8_t> { data.data(), data.size() };
     }
-    ScopedUnpackParametersResetRestore temporaryResetUnpack(this);
+    ScopedTightUnpackParameters temporaryResetUnpack(*this);
     if (functionID == TexImageFunctionID::TexImage2D) {
         texImage2DBase(target, level, internalformat,
             adjustedSourceImageRect.width(), adjustedSourceImageRect.height(), 0,
@@ -3877,7 +3883,7 @@ void WebGLRenderingContextBase::texImageArrayBufferViewHelper(TexImageFunctionID
         ASSERT(sourceType == TexImageDimension::Tex2D);
         // Only enter here if width or height is non-zero. Otherwise, call to the
         // underlying driver to generate appropriate GL errors if needed.
-        PixelStoreParams unpackParams = getUnpackPixelStoreParams(TexImageDimension::Tex2D);
+        PixelStoreParameters unpackParams = computeUnpackPixelStoreParameters(TexImageDimension::Tex2D);
         GCGLint dataStoreWidth = unpackParams.rowLength ? unpackParams.rowLength : width;
         if (unpackParams.skipPixels + width > dataStoreWidth) {
             synthesizeGLError(GraphicsContextGL::INVALID_OPERATION, functionName, "Invalid unpack params combination.");
@@ -3898,7 +3904,7 @@ void WebGLRenderingContextBase::texImageArrayBufferViewHelper(TexImageFunctionID
         m_context->texSubImage3D(target, level, xoffset, yoffset, zoffset, width, height, depth, format, type, data.value());
         return;
     }
-    ScopedUnpackParametersResetRestore temporaryResetUnpack(this, changeUnpackParams);
+    ScopedTightUnpackParameters temporaryResetUnpack(*this, changeUnpackParams);
     if (functionID == TexImageFunctionID::TexImage2D)
         texImage2DBase(target, level, internalformat, width, height, border, format, type, data.value());
     else {
@@ -3964,7 +3970,7 @@ void WebGLRenderingContextBase::texImageImpl(TexImageFunctionID functionID, GCGL
         pixels = std::span<const uint8_t> { data.data(), data.size() };
     }
 
-    ScopedUnpackParametersResetRestore temporaryResetUnpack(this, true);
+    ScopedTightUnpackParameters temporaryResetUnpack(*this);
     if (functionID == TexImageFunctionID::TexImage2D) {
         texImage2DBase(target, level, internalformat,
             adjustedSourceImageRect.width(), adjustedSourceImageRect.height(), 0,
@@ -4230,7 +4236,7 @@ std::optional<std::span<const uint8_t>> WebGLRenderingContextBase::validateTexFu
         return std::nullopt;
 
     unsigned totalBytesRequired, skipBytes;
-    GCGLenum error = m_context->computeImageSizeInBytes(format, type, width, height, depth, getUnpackPixelStoreParams(texDimension), &totalBytesRequired, nullptr, &skipBytes);
+    GCGLenum error = m_context->computeImageSizeInBytes(format, type, width, height, depth, computeUnpackPixelStoreParameters(texDimension), &totalBytesRequired, nullptr, &skipBytes);
     if (error != GraphicsContextGL::NO_ERROR) {
         synthesizeGLError(error, functionName, "invalid texture dimensions");
         return std::nullopt;
@@ -5169,19 +5175,14 @@ RefPtr<Int32Array> WebGLRenderingContextBase::getWebGLIntArrayParameter(GCGLenum
     return Int32Array::tryCreate(value, length);
 }
 
-WebGLRenderingContextBase::PixelStoreParams WebGLRenderingContextBase::getPackPixelStoreParams() const
+WebGLRenderingContextBase::PixelStoreParameters WebGLRenderingContextBase::computeUnpackPixelStoreParameters(TexImageDimension dimension) const
 {
-    PixelStoreParams params;
-    params.alignment = m_packAlignment;
-    return params;
-}
-
-WebGLRenderingContextBase::PixelStoreParams WebGLRenderingContextBase::getUnpackPixelStoreParams(TexImageDimension dimension) const
-{
-    UNUSED_PARAM(dimension);
-    PixelStoreParams params;
-    params.alignment = m_unpackAlignment;
-    return params;
+    PixelStoreParameters parameters = unpackPixelStoreParameters();
+    if (dimension != TexImageDimension::Tex3D) {
+        parameters.imageHeight = 0;
+        parameters.skipImages = 0;
+    }
+    return parameters;
 }
 
 RefPtr<WebGLTexture> WebGLRenderingContextBase::validateTextureBinding(const char* functionName, GCGLenum target)

--- a/Source/WebCore/html/canvas/WebGLRenderingContextBase.h
+++ b/Source/WebCore/html/canvas/WebGLRenderingContextBase.h
@@ -482,6 +482,11 @@ public:
 
     // Returns the ordinal number of when the context was last active (drew, read pixels).
     uint64_t activeOrdinal() const { return m_activeOrdinal; }
+
+    using PixelStoreParameters = GraphicsContextGL::PixelStoreParameters;
+    const PixelStoreParameters& pixelStorePackParameters() const { return m_packParameters; }
+    const PixelStoreParameters& unpackPixelStoreParameters() const { return m_unpackParameters; };
+
 protected:
     WebGLRenderingContextBase(CanvasBase&, WebGLContextAttributes);
     WebGLRenderingContextBase(CanvasBase&, Ref<GraphicsContextGL>&&, WebGLContextAttributes);
@@ -514,7 +519,6 @@ protected:
 
     // Implementation helpers.
     friend class InspectorScopedShaderProgramHighlight;
-    friend class ScopedUnpackParametersResetRestore;
 
     virtual void initializeNewContext();
     virtual void initializeVertexArrayObjects() = 0;
@@ -571,11 +575,6 @@ protected:
 
     // Adds a compressed texture format.
     void addCompressedTextureFormat(GCGLenum);
-
-    // Set UNPACK_ALIGNMENT to 1, all other parameters to 0.
-    virtual void resetUnpackParameters();
-    // Restore the client unpack parameters.
-    virtual void restoreUnpackParameters();
 
     RefPtr<Image> drawImageIntoBuffer(Image&, int width, int height, int deviceScaleFactor, const char* functionName);
 
@@ -692,8 +691,8 @@ protected:
     bool m_drawBuffersWebGLRequirementsChecked;
     bool m_drawBuffersSupported;
 
-    GCGLint m_packAlignment;
-    GCGLint m_unpackAlignment;
+    PixelStoreParameters m_packParameters;
+    PixelStoreParameters m_unpackParameters;
     bool m_unpackFlipY;
     bool m_unpackPremultiplyAlpha;
     GCGLenum m_unpackColorspaceConversion;
@@ -865,9 +864,7 @@ protected:
     static const char* texImageFunctionName(TexImageFunctionID);
     static TexImageFunctionType texImageFunctionType(TexImageFunctionID);
 
-    using PixelStoreParams = GraphicsContextGL::PixelStoreParams;
-    virtual PixelStoreParams getPackPixelStoreParams() const;
-    virtual PixelStoreParams getUnpackPixelStoreParams(TexImageDimension) const;
+    PixelStoreParameters computeUnpackPixelStoreParameters(TexImageDimension) const;
 
     // Helper function to verify limits on the length of uniform and attribute locations.
     bool validateLocationLength(const char* functionName, const String&);

--- a/Source/WebCore/platform/graphics/GraphicsContextGL.cpp
+++ b/Source/WebCore/platform/graphics/GraphicsContextGL.cpp
@@ -425,7 +425,7 @@ unsigned GraphicsContextGL::computeBytesPerGroup(GCGLenum format, GCGLenum type)
     }
 }
 
-GCGLenum GraphicsContextGL::computeImageSizeInBytes(GCGLenum format, GCGLenum type, GCGLsizei width, GCGLsizei height, GCGLsizei depth, const PixelStoreParams& params, unsigned* imageSizeInBytes, unsigned* paddingInBytes, unsigned* skipSizeInBytes)
+GCGLenum GraphicsContextGL::computeImageSizeInBytes(GCGLenum format, GCGLenum type, GCGLsizei width, GCGLsizei height, GCGLsizei depth, const PixelStoreParameters& params, unsigned* imageSizeInBytes, unsigned* paddingInBytes, unsigned* skipSizeInBytes)
 {
     ASSERT(imageSizeInBytes);
     ASSERT(params.alignment == 1 || params.alignment == 2 || params.alignment == 4 || params.alignment == 8);
@@ -532,7 +532,7 @@ bool GraphicsContextGL::packImageData(Image* image, const void* pixels, GCGLenum
 
     unsigned packedSize;
     // Output data is tightly packed (alignment == 1).
-    PixelStoreParams params;
+    PixelStoreParameters params;
     params.alignment = 1;
     if (computeImageSizeInBytes(format, type, sourceImageSubRectangle.width(), sourceImageSubRectangle.height(), depth, params, &packedSize, nullptr, nullptr) != GraphicsContextGL::NO_ERROR)
         return false;
@@ -552,7 +552,7 @@ bool GraphicsContextGL::extractPixelBuffer(const PixelBuffer& pixelBuffer, DataF
 
     unsigned packedSize;
     // Output data is tightly packed (alignment == 1).
-    PixelStoreParams params;
+    PixelStoreParameters params;
     params.alignment = 1;
     if (computeImageSizeInBytes(format, type, sourceImageSubRectangle.width(), sourceImageSubRectangle.height(), depth, params, &packedSize, nullptr, nullptr) != GraphicsContextGL::NO_ERROR)
         return false;
@@ -564,7 +564,7 @@ bool GraphicsContextGL::extractPixelBuffer(const PixelBuffer& pixelBuffer, DataF
     return true;
 }
 
-bool GraphicsContextGL::extractTextureData(unsigned width, unsigned height, GCGLenum format, GCGLenum type, const PixelStoreParams& unpackParams, bool flipY, bool premultiplyAlpha, std::span<const uint8_t> pixels, Vector<uint8_t>& data)
+bool GraphicsContextGL::extractTextureData(unsigned width, unsigned height, GCGLenum format, GCGLenum type, const PixelStoreParameters& unpackParams, bool flipY, bool premultiplyAlpha, std::span<const uint8_t> pixels, Vector<uint8_t>& data)
 {
     // Assumes format, type, etc. have already been validated.
     DataFormat sourceDataFormat = getDataFormat(format, type);

--- a/Source/WebCore/platform/graphics/GraphicsContextGL.h
+++ b/Source/WebCore/platform/graphics/GraphicsContextGL.h
@@ -1590,7 +1590,7 @@ public:
 
     IntSize getInternalFramebufferSize() const { return IntSize(m_currentWidth, m_currentHeight); }
 
-    struct PixelStoreParams final {
+    struct PixelStoreParameters final {
         GCGLint alignment { 4 };
         GCGLint rowLength { 0 };
         GCGLint imageHeight { 0 };
@@ -1608,7 +1608,7 @@ public:
     // return the suggested GL error indicating the cause of the failure:
     //   INVALID_VALUE if width/height is negative or overflow happens.
     //   INVALID_ENUM if format/type is illegal.
-    static GCGLenum computeImageSizeInBytes(GCGLenum format, GCGLenum type, GCGLsizei width, GCGLsizei height, GCGLsizei depth, const PixelStoreParams&, unsigned* imageSizeInBytes, unsigned* paddingInBytes, unsigned* skipSizeInBytes);
+    static GCGLenum computeImageSizeInBytes(GCGLenum format, GCGLenum type, GCGLsizei width, GCGLsizei height, GCGLsizei depth, const PixelStoreParameters&, unsigned* imageSizeInBytes, unsigned* paddingInBytes, unsigned* skipSizeInBytes);
 
     // Extracts the contents of the given PixelBuffer into the passed Vector,
     // packing the pixel data according to the given format and type,
@@ -1621,7 +1621,7 @@ public:
     // If the data is not tightly packed according to the passed
     // unpackParams, the output data will be tightly packed.
     // Returns true if successful, false if any error occurred.
-    static bool extractTextureData(unsigned width, unsigned height, GCGLenum format, GCGLenum type, const PixelStoreParams& unpackParams, bool flipY, bool premultiplyAlpha, std::span<const uint8_t> pixels, Vector<uint8_t>& data);
+    static bool extractTextureData(unsigned width, unsigned height, GCGLenum format, GCGLenum type, const PixelStoreParameters& unpackParams, bool flipY, bool premultiplyAlpha, std::span<const uint8_t> pixels, Vector<uint8_t>& data);
 
     // Packs the contents of the given Image which is passed in |pixels| into the passed Vector
     // according to the given format and type, and obeying the flipY and AlphaOp flags.


### PR DESCRIPTION
#### cd21603ce53071ee1f26c8bf86fe4761316d41cc
<pre>
Pixel pack and unpack state is cached but also asked from the underlying context
<a href="https://bugs.webkit.org/show_bug.cgi?id=257314">https://bugs.webkit.org/show_bug.cgi?id=257314</a>
rdar://109821711

Reviewed by Dan Glastonbury.

WebGLRenderingContextBase, WebGL2RenderingContext caches the
PACK_*, UNPACK_* state. When the WebGL client asks for the state,
the context will ask the underlying GraphicsContextGL for the state,
even though it is available as cached.

Return the cached state directly.
Use WebKit style for the functions and types related to this: use
full names and avoid using get prefix for accesors.

This is work towards being able to not send the state to the underlying
context. Remote variant should always readPixels with ignoring the client
packing in order to minimize transfers. This will be implemented in
subsequent patches. This means the underlying pack state and WebGL
pack state are going to be different, and thus asking the pack state
from the underlying context would need redundant mutation of the
state.

* Source/WebCore/html/canvas/WebGL2RenderingContext.cpp:
(WebCore::WebGL2RenderingContext::initializeNewContext):
(WebCore::WebGL2RenderingContext::getTextureSourceSubRectangle):
(WebCore::WebGL2RenderingContext::pixelStorei):
(WebCore::WebGL2RenderingContext::texImage3D):
(WebCore::WebGL2RenderingContext::texSubImage3D):
(WebCore::WebGL2RenderingContext::getParameter):
(WebCore::WebGL2RenderingContext::resetUnpackParameters): Deleted.
(WebCore::WebGL2RenderingContext::restoreUnpackParameters): Deleted.
(WebCore::WebGL2RenderingContext::getPackPixelStoreParams const): Deleted.
(WebCore::WebGL2RenderingContext::getUnpackPixelStoreParams const): Deleted.
* Source/WebCore/html/canvas/WebGL2RenderingContext.h:
* Source/WebCore/html/canvas/WebGLRenderingContextBase.cpp:
(WebCore::ScopedTightUnpackParameters::ScopedTightUnpackParameters):
(WebCore::ScopedTightUnpackParameters::~ScopedTightUnpackParameters):
(WebCore::ScopedTightUnpackParameters::set):
(WebCore::WebGLRenderingContextBase::initializeNewContext):
(WebCore::WebGLRenderingContextBase::getParameter):
(WebCore::WebGLRenderingContextBase::pixelStorei):
(WebCore::WebGLRenderingContextBase::texImageSource):
(WebCore::WebGLRenderingContextBase::texImageArrayBufferViewHelper):
(WebCore::WebGLRenderingContextBase::texImageImpl):
(WebCore::WebGLRenderingContextBase::validateTexFuncData):
(WebCore::WebGLRenderingContextBase::unpackPixelStoreParameters const):
(WebCore::ScopedUnpackParametersResetRestore::ScopedUnpackParametersResetRestore): Deleted.
(WebCore::ScopedUnpackParametersResetRestore::~ScopedUnpackParametersResetRestore): Deleted.
(WebCore::WebGLRenderingContextBase::resetUnpackParameters): Deleted.
(WebCore::WebGLRenderingContextBase::restoreUnpackParameters): Deleted.
(WebCore::WebGLRenderingContextBase::getPackPixelStoreParams const): Deleted.
(WebCore::WebGLRenderingContextBase::getUnpackPixelStoreParams const): Deleted.
* Source/WebCore/html/canvas/WebGLRenderingContextBase.h:
(WebCore::WebGLRenderingContextBase::pixelStorePackParameters const):
(WebCore::WebGLRenderingContextBase::unpackPixelStoreParameters const):
* Source/WebCore/platform/graphics/GraphicsContextGL.cpp:
(WebCore::GraphicsContextGL::computeImageSizeInBytes):
(WebCore::GraphicsContextGL::packImageData):
(WebCore::GraphicsContextGL::extractPixelBuffer):
(WebCore::GraphicsContextGL::extractTextureData):
* Source/WebCore/platform/graphics/GraphicsContextGL.h:

Canonical link: <a href="https://commits.webkit.org/264567@main">https://commits.webkit.org/264567@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/6f8698de2b21a65ba72d3528d4e566e8c7dc82fe

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/8010 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/8295 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/8507 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/9662 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/32/builds/8114 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/8014 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/10281 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/8206 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/10981 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/8154 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/9242 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/7317 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/9782 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/6543 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/7330 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/14908 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/7666 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/7451 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/10811 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/7922 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/6445 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/7236 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/1910 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/11444 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/7663 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->