### PR TITLE
[WGSL] Add support for increment and decrement statements

### DIFF
--- a/Source/WebGPU/WGSL/AST/ASTDecrementIncrementStatement.cpp
+++ b/Source/WebGPU/WGSL/AST/ASTDecrementIncrementStatement.cpp
@@ -23,38 +23,23 @@
  * THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-#pragma once
+#include "config.h"
+#include "ASTDecrementIncrementStatement.h"
 
-#include "ASTExpression.h"
-#include "ASTStatement.h"
+#include <wtf/PrintStream.h>
 
 namespace WGSL::AST {
 
-class DecrementIncrementStatement final : public Statement {
-    WGSL_AST_BUILDER_NODE(DecrementIncrementStatement);
-public:
-    enum class Operation : uint8_t {
-        Decrement,
-        Increment,
-    };
-
-    NodeKind kind() const override;
-    Expression& expression() { return m_expression; }
-    Operation operation() const { return m_operation; }
-
-private:
-    DecrementIncrementStatement(SourceSpan span, Expression::Ref&& expression, Operation operation)
-        : Statement(span)
-        , m_expression(WTFMove(expression))
-        , m_operation(operation)
-    { }
-
-    Expression::Ref m_expression;
-    Operation m_operation;
-};
-
-void printInternal(PrintStream&, DecrementIncrementStatement::Operation);
+void printInternal(PrintStream& out, DecrementIncrementStatement::Operation operation)
+{
+    switch (operation) {
+    case DecrementIncrementStatement::Operation::Increment:
+        out.print("++");
+        break;
+    case DecrementIncrementStatement::Operation::Decrement:
+        out.print("--");
+        break;
+    }
+}
 
 } // namespace WGSL::AST
-
-SPECIALIZE_TYPE_TRAITS_WGSL_AST(DecrementIncrementStatement)

--- a/Source/WebGPU/WGSL/AST/ASTStringDumper.cpp
+++ b/Source/WebGPU/WGSL/AST/ASTStringDumper.cpp
@@ -326,6 +326,14 @@ void StringDumper::visit(CompoundStatement& block)
     m_out.print("}\n");
 }
 
+void StringDumper::visit(DecrementIncrementStatement& statement)
+{
+    m_out.print(m_indent);
+    visit(statement.expression());
+    m_out.print(statement.operation(), ";");
+}
+
+
 void StringDumper::visit(IfStatement& statement)
 {
     m_out.print(m_indent, "if ");

--- a/Source/WebGPU/WGSL/AST/ASTStringDumper.h
+++ b/Source/WebGPU/WGSL/AST/ASTStringDumper.h
@@ -79,6 +79,7 @@ public:
     void visit(AssignmentStatement&) override;
     void visit(CompoundAssignmentStatement&) override;
     void visit(CompoundStatement&) override;
+    void visit(AST::DecrementIncrementStatement&) override;
     void visit(IfStatement&) override;
     void visit(PhonyAssignmentStatement&) override;
     void visit(ReturnStatement&) override;

--- a/Source/WebGPU/WGSL/Metal/MetalFunctionWriter.cpp
+++ b/Source/WebGPU/WGSL/Metal/MetalFunctionWriter.cpp
@@ -86,6 +86,7 @@ public:
     void visit(AST::Statement&) override;
     void visit(AST::AssignmentStatement&) override;
     void visit(AST::CompoundStatement&) override;
+    void visit(AST::DecrementIncrementStatement&) override;
     void visit(AST::IfStatement&) override;
     void visit(AST::PhonyAssignmentStatement&) override;
     void visit(AST::ReturnStatement&) override;
@@ -939,6 +940,12 @@ void FunctionDefinitionWriter::visit(AST::CompoundStatement& statement)
         }
     }
     m_stringBuilder.append(m_indent, "}\n");
+}
+
+void FunctionDefinitionWriter::visit(AST::DecrementIncrementStatement& statement)
+{
+    visit(statement.expression());
+    m_stringBuilder.append(statement.operation(), ";");
 }
 
 void FunctionDefinitionWriter::visit(AST::IfStatement& statement)

--- a/Source/WebGPU/WGSL/tests/invalid/references.wgsl
+++ b/Source/WebGPU/WGSL/tests/invalid/references.wgsl
@@ -18,3 +18,21 @@ fn testReferenceAssignment()
     // FIXME: we can't test that we don't accept write-only references for reads
     // since there are no valid ways of declaring a write-only var
 }
+
+fn testDecrementIcrement() {
+    {
+        // CHECK-L: cannot modify a value of type 'i32'
+        let x = 0i;
+        x++;
+    }
+    {
+        // CHECK-L: cannot modify read-only type 'ref<storage, i32, read>'
+        x++;
+    }
+    {
+        // CHECK-L: increment can only be applied to integers, found f32
+        var x = 0f;
+        x++;
+    }
+}
+

--- a/Source/WebGPU/WGSL/tests/valid/references.wgsl
+++ b/Source/WebGPU/WGSL/tests/valid/references.wgsl
@@ -11,3 +11,17 @@ fn testImplicitConversion()
     _ = 0 + x;
     _ = x + 0;
 }
+
+fn testDecrementIcrement() {
+    {
+        var x = 0i;
+        x++;
+        x--;
+    }
+
+    {
+        var x = 0;
+        x++;
+        x--;
+    }
+}

--- a/Source/WebGPU/WebGPU.xcodeproj/project.pbxproj
+++ b/Source/WebGPU/WebGPU.xcodeproj/project.pbxproj
@@ -149,6 +149,7 @@
 		97BCD6AE29D7422B00A82577 /* JavaScriptCore.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 1CBAB0912718CCA0006080BB /* JavaScriptCore.framework */; };
 		97C36CFE29F1730100CFB379 /* Constraints.h in Headers */ = {isa = PBXBuildFile; fileRef = 97C36CFC29F1730000CFB379 /* Constraints.h */; };
 		97C36CFF29F1730100CFB379 /* Constraints.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 97C36CFD29F1730000CFB379 /* Constraints.cpp */; };
+		97E21C8B2A1F5DCC009CEB0E /* ASTDecrementIncrementStatement.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 97E21C8A2A1F5DCC009CEB0E /* ASTDecrementIncrementStatement.cpp */; };
 		97F547B8298055D90011D79A /* GlobalVariableRewriter.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 97F547B6298055D90011D79A /* GlobalVariableRewriter.cpp */; };
 		97F547B9298055D90011D79A /* GlobalVariableRewriter.h in Headers */ = {isa = PBXBuildFile; fileRef = 97F547B7298055D90011D79A /* GlobalVariableRewriter.h */; };
 		97FA1A8E29C086230052D650 /* wgslc.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 97FA1A8729C085A60052D650 /* wgslc.cpp */; };
@@ -394,6 +395,7 @@
 		979240C729769AC00050EA2C /* EntryPointRewriter.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = EntryPointRewriter.cpp; sourceTree = "<group>"; };
 		97C36CFC29F1730000CFB379 /* Constraints.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = Constraints.h; sourceTree = "<group>"; };
 		97C36CFD29F1730000CFB379 /* Constraints.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = Constraints.cpp; sourceTree = "<group>"; };
+		97E21C8A2A1F5DCC009CEB0E /* ASTDecrementIncrementStatement.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = ASTDecrementIncrementStatement.cpp; sourceTree = "<group>"; };
 		97F547B6298055D90011D79A /* GlobalVariableRewriter.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = GlobalVariableRewriter.cpp; sourceTree = "<group>"; };
 		97F547B7298055D90011D79A /* GlobalVariableRewriter.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GlobalVariableRewriter.h; sourceTree = "<group>"; };
 		97FA1A7F29C085740052D650 /* wgslc */ = {isa = PBXFileReference; explicitFileType = "compiled.mach-o.executable"; includeInIndex = 0; path = wgslc; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -625,6 +627,7 @@
 				3A12AE9E28FCE94B00C1B975 /* ASTConstAttribute.h */,
 				3A12AEA228FCE94C00C1B975 /* ASTContinueStatement.h */,
 				3AD0D2302988D3C10080D728 /* ASTDeclaration.h */,
+				97E21C8A2A1F5DCC009CEB0E /* ASTDecrementIncrementStatement.cpp */,
 				3A12AEA428FCE94C00C1B975 /* ASTDecrementIncrementStatement.h */,
 				33EA185F27BC198100A1DD52 /* ASTDirective.h */,
 				3A12AEA828FCE94C00C1B975 /* ASTDiscardStatement.h */,
@@ -971,6 +974,7 @@
 			files = (
 				3AD0D23E2988F3AB0080D728 /* ASTBinaryExpression.cpp in Sources */,
 				97835C9529F7D85A00939EBA /* ASTBuilder.cpp in Sources */,
+				97E21C8B2A1F5DCC009CEB0E /* ASTDecrementIncrementStatement.cpp in Sources */,
 				3A9D02A4298390CF00888A75 /* ASTStringDumper.cpp in Sources */,
 				3AD0D23B2988ED8F0080D728 /* ASTUnaryExpression.cpp in Sources */,
 				3A1337E728FBD56400F29B73 /* ASTVisitor.cpp in Sources */,


### PR DESCRIPTION
#### dd1161055f1ccb14b69ccf0d940ca3dc10d5818b
<pre>
[WGSL] Add support for increment and decrement statements
<a href="https://bugs.webkit.org/show_bug.cgi?id=257315">https://bugs.webkit.org/show_bug.cgi?id=257315</a>
rdar://109823828

Reviewed by Mike Wyrzykowski.

Add support for `x++` and `x--` statements

* Source/WebGPU/WGSL/AST/ASTDecrementIncrementStatement.cpp: Copied from Source/WebGPU/WGSL/AST/ASTDecrementIncrementStatement.h.
(WGSL::AST::printInternal):
* Source/WebGPU/WGSL/AST/ASTDecrementIncrementStatement.h:
* Source/WebGPU/WGSL/AST/ASTStringDumper.cpp:
(WGSL::AST::StringDumper::visit):
* Source/WebGPU/WGSL/AST/ASTStringDumper.h:
* Source/WebGPU/WGSL/Metal/MetalFunctionWriter.cpp:
(WGSL::Metal::FunctionDefinitionWriter::visit):
* Source/WebGPU/WGSL/Parser.cpp:
(WGSL::Parser&lt;Lexer&gt;::parseStatement):
* Source/WebGPU/WGSL/TypeCheck.cpp:
(WGSL::TypeChecker::visit):
* Source/WebGPU/WGSL/tests/invalid/references.wgsl:
* Source/WebGPU/WGSL/tests/valid/references.wgsl:
* Source/WebGPU/WebGPU.xcodeproj/project.pbxproj:

Canonical link: <a href="https://commits.webkit.org/264575@main">https://commits.webkit.org/264575@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f8edc9b63f71f814b47c5541540b153563f39c76

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/8019 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/8304 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/8516 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/9671 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/32/builds/8123 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/10290 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/8215 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/10988 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/8163 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/9251 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/7322 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/9791 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/6552 "Passed tests") | | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/14919 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/7675 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/7460 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/10822 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/7931 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/6452 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/7245 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/1917 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/11453 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/7672 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->