### PR TITLE
Replace URL::isLocalFile() with URL::protocolIsFile()

### DIFF
--- a/Source/JavaScriptCore/API/JSScript.mm
+++ b/Source/JavaScriptCore/API/JSScript.mm
@@ -73,7 +73,7 @@ static bool validateBytecodeCachePath(NSURL* cachePath, NSError** error)
         return true;
 
     URL cachePathURL([cachePath absoluteURL]);
-    if (!cachePathURL.isLocalFile()) {
+    if (!cachePathURL.protocolIsFile()) {
         createError([NSString stringWithFormat:@"Cache path `%@` is not a local file", static_cast<NSURL *>(cachePathURL)], error);
         return false;
     }
@@ -129,7 +129,7 @@ static bool validateBytecodeCachePath(NSURL* cachePath, NSError** error)
         return nil;
 
     URL filePathURL([filePath absoluteURL]);
-    if (!filePathURL.isLocalFile())
+    if (!filePathURL.protocolIsFile())
         return createError([NSString stringWithFormat:@"File path %@ is not a local file", static_cast<NSURL *>(filePathURL)], error);
 
     bool success = false;

--- a/Source/JavaScriptCore/jsc.cpp
+++ b/Source/JavaScriptCore/jsc.cpp
@@ -918,7 +918,7 @@ JSInternalPromise* GlobalObject::moduleLoaderImportModule(JSGlobalObject* global
     auto specifier = moduleNameValue->value(globalObject);
     RETURN_IF_EXCEPTION(scope, promise->rejectWithCaughtException(globalObject, scope));
 
-    if (!referrer.isLocalFile())
+    if (!referrer.protocolIsFile())
         RELEASE_AND_RETURN(scope, rejectWithError(createError(globalObject, makeString("Could not resolve the referrer's path '"_s, referrer.string(), "', while trying to resolve module '"_s, specifier, "'."_s))));
 
     auto assertions = JSC::retrieveAssertionsFromDynamicImportOptions(globalObject, parameters, { vm.propertyNames->type.impl() });
@@ -957,7 +957,7 @@ Identifier GlobalObject::moduleLoaderResolve(JSGlobalObject* globalObject, JSMod
             return { };
         }
 
-        if (!directoryURL.isLocalFile()) {
+        if (!directoryURL.protocolIsFile()) {
             throwException(globalObject, scope, createError(globalObject, makeString("Could not resolve the referrer's path: "_s, directoryURL.string())));
             return { };
         }
@@ -967,7 +967,7 @@ Identifier GlobalObject::moduleLoaderResolve(JSGlobalObject* globalObject, JSMod
             throwException(globalObject, scope, createError(globalObject, makeString("Resolved module url is not valid: "_s, resolvedURL.string())));
             return { };
         }
-        ASSERT(resolvedURL.isLocalFile());
+        ASSERT(resolvedURL.protocolIsFile());
 
         return Identifier::fromString(vm, resolvedURL.string());
     };
@@ -983,7 +983,7 @@ Identifier GlobalObject::moduleLoaderResolve(JSGlobalObject* globalObject, JSMod
 
     // If the referrer exists, we assume that the referrer is the correct file url.
     URL url = URL({ }, referrer.impl());
-    ASSERT(url.isLocalFile());
+    ASSERT(url.protocolIsFile());
     return resolvePath(url);
 }
 
@@ -1269,7 +1269,7 @@ JSInternalPromise* GlobalObject::moduleLoaderFetch(JSGlobalObject* globalObject,
     RETURN_IF_EXCEPTION(scope, promise->rejectWithCaughtException(globalObject, scope));
 
     URL moduleURL({ }, moduleKey);
-    ASSERT(moduleURL.isLocalFile());
+    ASSERT(moduleURL.protocolIsFile());
     // Strip the URI from our key so Errors print canonical system paths.
     moduleKey = moduleURL.fileSystemPath();
 
@@ -1721,7 +1721,7 @@ static URL computeFilePath(VM& vm, JSGlobalObject* globalObject, CallFrame* call
     URL path;
     if (callerRelative) {
         path = URL(callFrame->callerSourceOrigin(vm).url(), fileName);
-        if (!path.isLocalFile()) {
+        if (!path.protocolIsFile()) {
             throwException(globalObject, scope, createURIError(globalObject, makeString("caller relative URL path is not a local file: "_s, path.string())));
             return URL();
         }

--- a/Source/WTF/wtf/URL.h
+++ b/Source/WTF/wtf/URL.h
@@ -142,13 +142,13 @@ public:
     // Returns true if the current URL's protocol is the same as the null-
     // terminated ASCII argument. The argument must be lower-case.
     WTF_EXPORT_PRIVATE bool protocolIs(StringView) const;
+    bool protocolIsAbout() const { return protocolIs("about"_s); };
     bool protocolIsBlob() const { return protocolIs("blob"_s); }
     bool protocolIsData() const { return protocolIs("data"_s); }
-    WTF_EXPORT_PRIVATE bool protocolIsAbout() const;
+    bool protocolIsFile() const { return protocolIs("file"_s); }
     WTF_EXPORT_PRIVATE bool protocolIsJavaScript() const;
     WTF_EXPORT_PRIVATE bool protocolIsInFTPFamily() const;
     bool protocolIsInHTTPFamily() const;
-    WTF_EXPORT_PRIVATE bool isLocalFile() const;
     bool cannotBeABaseURL() const { return m_cannotBeABaseURL; }
 
     WTF_EXPORT_PRIVATE bool isAboutBlank() const;

--- a/Source/WTF/wtf/URLParser.cpp
+++ b/Source/WTF/wtf/URLParser.cpp
@@ -433,7 +433,7 @@ void URLParser::appendWindowsDriveLetter(CodePointIterator<CharacterType>& itera
 
 bool URLParser::copyBaseWindowsDriveLetter(const URL& base)
 {
-    if (base.protocolIs("file"_s)) {
+    if (base.protocolIsFile()) {
         RELEASE_ASSERT(base.m_hostEnd + base.m_portLength < base.m_string.length());
         if (base.m_string.is8Bit()) {
             const LChar* begin = base.m_string.characters8();
@@ -1100,7 +1100,7 @@ URLParser::URLParser(String&& input, const URL& base, const URLTextEncoding* non
     ASSERT(!m_url.m_isValid
         || m_didSeeSyntaxViolation == (m_url.string() != m_inputString)
         || (m_inputString.isAllSpecialCharacters<isC0ControlOrSpace>() && m_url.m_string == base.m_string.left(base.m_queryEnd))
-        || (base.isValid() && base.protocolIs("file"_s)));
+        || (base.isValid() && base.protocolIsFile()));
     ASSERT(internalValuesConsistent(m_url));
 #if ASSERT_ENABLED
     if (!m_didSeeSyntaxViolation) {
@@ -1290,7 +1290,7 @@ void URLParser::parse(const CharacterType* input, const unsigned length, const U
                 ++c;
                 break;
             }
-            if (!base.protocolIs("file"_s)) {
+            if (!base.protocolIsFile()) {
                 state = State::Relative;
                 break;
             }
@@ -1512,7 +1512,7 @@ void URLParser::parse(const CharacterType* input, const unsigned length, const U
                 break;
             case '?':
                 syntaxViolation(c);
-                if (base.isValid() && base.protocolIs("file"_s)) {
+                if (base.isValid() && base.protocolIsFile()) {
                     copyURLPartsUntil(base, URLPart::PathEnd, c, nonUTF8QueryEncoding);
                     appendToASCIIBuffer('?');
                     ++c;
@@ -1535,7 +1535,7 @@ void URLParser::parse(const CharacterType* input, const unsigned length, const U
                 break;
             case '#':
                 syntaxViolation(c);
-                if (base.isValid() && base.protocolIs("file"_s)) {
+                if (base.isValid() && base.protocolIsFile()) {
                     copyURLPartsUntil(base, URLPart::QueryEnd, c, nonUTF8QueryEncoding);
                     appendToASCIIBuffer('#');
                 } else {
@@ -1554,11 +1554,11 @@ void URLParser::parse(const CharacterType* input, const unsigned length, const U
                 break;
             default:
                 syntaxViolation(c);
-                if (base.isValid() && base.protocolIs("file"_s) && shouldCopyFileURL(c))
+                if (base.isValid() && base.protocolIsFile() && shouldCopyFileURL(c))
                     copyURLPartsUntil(base, URLPart::PathAfterLastSlash, c, nonUTF8QueryEncoding);
                 else {
                     bool copiedHost = false;
-                    if (base.isValid() && base.protocolIs("file"_s)) {
+                    if (base.isValid() && base.protocolIsFile()) {
                         if (base.host().isEmpty()) {
                             copyURLPartsUntil(base, URLPart::SchemeEnd, c, nonUTF8QueryEncoding);
                             appendToASCIIBuffer(":///", 4);
@@ -1589,7 +1589,7 @@ void URLParser::parse(const CharacterType* input, const unsigned length, const U
             if (LIKELY(*c == '/' || *c == '\\')) {
                 if (UNLIKELY(*c == '\\'))
                     syntaxViolation(c);
-                if (base.isValid() && base.protocolIs("file"_s)) {
+                if (base.isValid() && base.protocolIsFile()) {
                     copyURLPartsUntil(base, URLPart::SchemeEnd, c, nonUTF8QueryEncoding);
                     appendToASCIIBuffer(":/", 2);
                 }
@@ -1606,7 +1606,7 @@ void URLParser::parse(const CharacterType* input, const unsigned length, const U
             }
             {
                 bool copiedHost = false;
-                if (base.isValid() && base.protocolIs("file"_s)) {
+                if (base.isValid() && base.protocolIsFile()) {
                     if (base.host().isEmpty()) {
                         copyURLPartsUntil(base, URLPart::SchemeEnd, c, nonUTF8QueryEncoding);
                         appendToASCIIBuffer(":///", 4);
@@ -1900,7 +1900,7 @@ void URLParser::parse(const CharacterType* input, const unsigned length, const U
         break;
     case State::File:
         LOG_FINAL_STATE("File");
-        if (base.isValid() && base.protocolIs("file"_s)) {
+        if (base.isValid() && base.protocolIsFile()) {
             copyURLPartsUntil(base, URLPart::QueryEnd, c, nonUTF8QueryEncoding);
             break;
         }
@@ -1920,7 +1920,7 @@ void URLParser::parse(const CharacterType* input, const unsigned length, const U
         syntaxViolation(c);
         {
             bool copiedHost = false;
-            if (base.isValid() && base.protocolIs("file"_s)) {
+            if (base.isValid() && base.protocolIsFile()) {
                 if (base.host().isEmpty()) {
                     copyURLPartsUntil(base, URLPart::SchemeEnd, c, nonUTF8QueryEncoding);
                     appendToASCIIBuffer(":/", 2);

--- a/Source/WebCore/Modules/model-element/scenekit/SceneKitModelLoader.mm
+++ b/Source/WebCore/Modules/model-element/scenekit/SceneKitModelLoader.mm
@@ -72,7 +72,7 @@ namespace WebCore {
 
 static String mimeTypeUtilizingFileExtensionOverridingForLocalFiles(const Model& modelSource)
 {
-    if (modelSource.url().isLocalFile() && (modelSource.mimeType().isEmpty() || modelSource.mimeType() == WebCore::defaultMIMEType())) {
+    if (modelSource.url().protocolIsFile() && (modelSource.mimeType().isEmpty() || modelSource.mimeType() == WebCore::defaultMIMEType())) {
         // FIXME: Getting the file extension from a URL seems like it should be in shared code.
         auto lastPathComponent = modelSource.url().lastPathComponent();
         auto position = lastPathComponent.reverseFind('.');

--- a/Source/WebCore/dom/Document.cpp
+++ b/Source/WebCore/dom/Document.cpp
@@ -5575,7 +5575,7 @@ bool Document::isCookieAverse() const
 
     // This is not part of the specification but we have historically allowed cookies over file protocol
     // and some developers rely on this for testing.
-    if (cookieURL.isLocalFile())
+    if (cookieURL.protocolIsFile())
         return false;
 
     // A Document whose URL's scheme is not a network scheme is cookie-averse (https://fetch.spec.whatwg.org/#network-scheme).

--- a/Source/WebCore/dom/Element.cpp
+++ b/Source/WebCore/dom/Element.cpp
@@ -5054,7 +5054,7 @@ String Element::resolveURLStringIfNeeded(const String& urlString, ResolveURLs re
     case ResolveURLs::YesExcludingURLsForPrivacy: {
         if (document().shouldMaskURLForBindings(completeURL))
             return maskedURLStringForBindings.get();
-        if (!document().url().isLocalFile())
+        if (!document().url().protocolIsFile())
             return completeURL.string();
         break;
     }

--- a/Source/WebCore/editing/cocoa/WebContentReaderCocoa.mm
+++ b/Source/WebCore/editing/cocoa/WebContentReaderCocoa.mm
@@ -587,7 +587,7 @@ bool WebContentReader::readHTML(const String& string)
     if (DeprecatedGlobalSettings::customPasteboardDataEnabled() && shouldSanitize()) {
         markup = sanitizeMarkup(stringOmittingMicrosoftPrefix, msoListQuirksForMarkup(), WTF::Function<void (DocumentFragment&)> { [] (DocumentFragment& fragment) {
             removeSubresourceURLAttributes(fragment, [](auto& url) {
-                return url.isLocalFile();
+                return url.protocolIsFile();
             });
         } });
     } else
@@ -606,7 +606,7 @@ bool WebContentMarkupReader::readHTML(const String& string)
     if (shouldSanitize()) {
         markup = sanitizeMarkup(rawHTML, msoListQuirksForMarkup(), WTF::Function<void (DocumentFragment&)> { [] (DocumentFragment& fragment) {
             removeSubresourceURLAttributes(fragment, [](auto& url) {
-                return url.isLocalFile();
+                return url.protocolIsFile();
             });
         } });
     } else

--- a/Source/WebCore/editing/ios/EditorIOS.mm
+++ b/Source/WebCore/editing/ios/EditorIOS.mm
@@ -186,7 +186,7 @@ void Editor::writeImageToPasteboard(Pasteboard& pasteboard, Element& imageElemen
     auto imageSourceURL = imageElement.document().completeURL(stripLeadingAndTrailingHTMLSpaces(imageElement.imageSourceURL()));
 
     auto pasteboardImageURL = url.isEmpty() ? imageSourceURL : url;
-    if (!pasteboardImageURL.isLocalFile()) {
+    if (!pasteboardImageURL.protocolIsFile()) {
         pasteboardImage.url.url = pasteboardImageURL;
         pasteboardImage.url.title = title;
     }

--- a/Source/WebCore/html/HTMLMediaElement.cpp
+++ b/Source/WebCore/html/HTMLMediaElement.cpp
@@ -1547,7 +1547,7 @@ void HTMLMediaElement::loadResource(const URL& initialURL, ContentType& contentT
 
     URL url = initialURL;
 #if PLATFORM(COCOA)
-    if (url.isLocalFile() && !frame->loader().willLoadMediaElementURL(url, *this)) {
+    if (url.protocolIsFile() && !frame->loader().willLoadMediaElementURL(url, *this)) {
         mediaLoadingFailed(MediaPlayer::NetworkState::FormatError);
         return;
     }

--- a/Source/WebCore/html/URLDecomposition.cpp
+++ b/Source/WebCore/html/URLDecomposition.cpp
@@ -59,7 +59,7 @@ String URLDecomposition::username() const
 void URLDecomposition::setUsername(StringView user)
 {
     auto fullURL = this->fullURL();
-    if (fullURL.host().isEmpty() || fullURL.cannotBeABaseURL() || fullURL.protocolIs("file"_s))
+    if (fullURL.host().isEmpty() || fullURL.cannotBeABaseURL() || fullURL.protocolIsFile())
         return;
     fullURL.setUser(user);
     setFullURL(fullURL);
@@ -73,7 +73,7 @@ String URLDecomposition::password() const
 void URLDecomposition::setPassword(StringView password)
 {
     auto fullURL = this->fullURL();
-    if (fullURL.host().isEmpty() || fullURL.cannotBeABaseURL() || fullURL.protocolIs("file"_s))
+    if (fullURL.host().isEmpty() || fullURL.cannotBeABaseURL() || fullURL.protocolIsFile())
         return;
     fullURL.setPassword(password);
     setFullURL(fullURL);
@@ -97,7 +97,7 @@ static unsigned countASCIIDigits(StringView string)
 void URLDecomposition::setHost(StringView value)
 {
     auto fullURL = this->fullURL();
-    if (value.isEmpty() && !fullURL.protocolIs("file"_s) && fullURL.hasSpecialScheme())
+    if (value.isEmpty() && !fullURL.protocolIsFile() && fullURL.hasSpecialScheme())
         return;
 
     size_t separator = value.reverseFind(':');
@@ -138,7 +138,7 @@ String URLDecomposition::hostname() const
 void URLDecomposition::setHostname(StringView host)
 {
     auto fullURL = this->fullURL();
-    if (host.isEmpty() && !fullURL.protocolIs("file"_s) && fullURL.hasSpecialScheme())
+    if (host.isEmpty() && !fullURL.protocolIsFile() && fullURL.hasSpecialScheme())
         return;
     if (fullURL.cannotBeABaseURL() || !fullURL.canSetHostOrPort())
         return;
@@ -185,7 +185,7 @@ static std::optional<std::optional<uint16_t>> parsePort(StringView string, Strin
 void URLDecomposition::setPort(StringView value)
 {
     auto fullURL = this->fullURL();
-    if (fullURL.host().isEmpty() || fullURL.cannotBeABaseURL() || fullURL.protocolIs("file"_s) || !fullURL.canSetHostOrPort())
+    if (fullURL.host().isEmpty() || fullURL.cannotBeABaseURL() || fullURL.protocolIsFile() || !fullURL.canSetHostOrPort())
         return;
     auto port = parsePort(value, fullURL.protocol());
     if (!port)

--- a/Source/WebCore/loader/DocumentThreadableLoader.cpp
+++ b/Source/WebCore/loader/DocumentThreadableLoader.cpp
@@ -628,7 +628,7 @@ void DocumentThreadableLoader::loadRequest(ResourceRequest&& request, SecurityCh
     loadTiming.markEndTime();
 
     if (!error.isNull() && response.httpStatusCode() <= 0) {
-        if (requestURL.isLocalFile()) {
+        if (requestURL.protocolIsFile()) {
             // We don't want XMLHttpRequest to raise an exception for file:// resources, see <rdar://problem/4962298>.
             // FIXME: XMLHttpRequest quirks should be in XMLHttpRequest code, not in DocumentThreadableLoader.cpp.
             didReceiveResponse(identifier, response);

--- a/Source/WebCore/page/ContextMenuController.cpp
+++ b/Source/WebCore/page/ContextMenuController.cpp
@@ -1074,7 +1074,7 @@ void ContextMenuController::populate()
             appendItem(DownloadImageItem, m_contextMenu.get());
 
             auto image = m_context.hitTestResult().image();
-            if (imageURL.isLocalFile() || image) {
+            if (imageURL.protocolIsFile() || image) {
                 appendItem(CopyImageItem, m_contextMenu.get());
 
                 if (image && !image->isAnimated()) {
@@ -1628,7 +1628,7 @@ void ContextMenuController::checkOrEnableIfNeeded(ContextMenuItem& item) const
             break;
         case ContextMenuItemTagDownloadImageToDisk:
 #if PLATFORM(MAC)
-            if (m_context.hitTestResult().absoluteImageURL().protocolIs("file"_s))
+            if (m_context.hitTestResult().absoluteImageURL().protocolIsFile())
                 shouldEnable = false;
 #endif
             break;
@@ -1643,7 +1643,7 @@ void ContextMenuController::checkOrEnableIfNeeded(ContextMenuItem& item) const
                 item.setTitle(contextMenuItemTagDownloadVideoToDisk());
             else
                 item.setTitle(contextMenuItemTagDownloadAudioToDisk());
-            if (m_context.hitTestResult().absoluteImageURL().protocolIs("file"_s))
+            if (m_context.hitTestResult().absoluteImageURL().protocolIsFile())
                 shouldEnable = false;
             break;
         case ContextMenuItemTagCopyMediaLinkToClipboard:

--- a/Source/WebCore/page/History.cpp
+++ b/Source/WebCore/page/History.cpp
@@ -209,7 +209,7 @@ ExceptionOr<void> History::stateObjectAdded(RefPtr<SerializedScriptValue>&& data
     if (!protocolHostAndPortAreEqual(fullURL, documentURL) || fullURL.user() != documentURL.user() || fullURL.password() != documentURL.password())
         return createBlockedURLSecurityErrorWithMessageSuffix("Protocols, domains, ports, usernames, and passwords must match.");
 
-    if (fullURL.isLocalFile()
+    if (fullURL.protocolIsFile()
 #if PLATFORM(COCOA)
         && linkedOnOrAfterSDKWithBehavior(SDKAlignedBehavior::PushStateFilePathRestriction)
 #endif

--- a/Source/WebCore/page/Page.cpp
+++ b/Source/WebCore/page/Page.cpp
@@ -3818,7 +3818,7 @@ bool Page::allowsLoadFromURL(const URL& url, MainFrameMainResource mainFrameMain
 
 bool Page::hasLocalDataForURL(const URL& url)
 {
-    if (url.isLocalFile())
+    if (url.protocolIsFile())
         return true;
 
     auto* localMainFrame = dynamicDowncast<LocalFrame>(mainFrame());

--- a/Source/WebCore/page/SecurityOrigin.cpp
+++ b/Source/WebCore/page/SecurityOrigin.cpp
@@ -54,7 +54,7 @@ constexpr unsigned maximumURLSize = 0x04000000;
 
 bool SecurityOrigin::shouldIgnoreHost(const URL& url)
 {
-    return url.protocolIsData() || url.protocolIsAbout() || url.protocolIsJavaScript() || url.protocolIs("file"_s);
+    return url.protocolIsData() || url.protocolIsAbout() || url.protocolIsJavaScript() || url.protocolIsFile();
 }
 
 bool SecurityOrigin::shouldUseInnerURL(const URL& url)
@@ -200,7 +200,7 @@ Ref<SecurityOrigin> SecurityOrigin::createOpaque()
 
 Ref<SecurityOrigin> SecurityOrigin::createNonLocalWithAllowedFilePath(const URL& url, const String& filePath)
 {
-    ASSERT(!url.isLocalFile());
+    ASSERT(!url.protocolIsFile());
     auto securityOrigin = SecurityOrigin::create(url);
     securityOrigin->m_filePath = filePath;
     return securityOrigin;
@@ -355,7 +355,7 @@ bool SecurityOrigin::canDisplay(const URL& url, const OriginAccessPatterns& patt
         return false;
     
 #if !PLATFORM(IOS_FAMILY) && !ENABLE(BUBBLEWRAP_SANDBOX)
-    if (m_data.protocol() == "file"_s && url.isLocalFile() && !FileSystem::filesHaveSameVolume(m_filePath, url.fileSystemPath()))
+    if (m_data.protocol() == "file"_s && url.protocolIsFile() && !FileSystem::filesHaveSameVolume(m_filePath, url.fileSystemPath()))
         return false;
 #endif
 
@@ -373,7 +373,7 @@ bool SecurityOrigin::canDisplay(const URL& url, const OriginAccessPatterns& patt
     if (!SecurityPolicy::restrictAccessToLocal())
         return true;
 
-    if (url.isLocalFile() && url.fileSystemPath() == m_filePath)
+    if (url.protocolIsFile() && url.fileSystemPath() == m_filePath)
         return true;
 
     if (LegacySchemeRegistry::shouldTreatURLSchemeAsLocal(protocol))

--- a/Source/WebCore/page/csp/ContentSecurityPolicy.cpp
+++ b/Source/WebCore/page/csp/ContentSecurityPolicy.cpp
@@ -754,7 +754,7 @@ bool ContentSecurityPolicy::allowBaseURI(const URL& url, bool overrideContentSec
 
 static bool shouldReportProtocolOnly(const URL& url)
 {
-    return !url.isHierarchical() || url.protocolIs("file"_s);
+    return !url.isHierarchical() || url.protocolIsFile();
 }
 
 String ContentSecurityPolicy::createURLForReporting(const URL& url, const String& violatedDirective, bool usesReportingAPI) const

--- a/Source/WebCore/platform/graphics/avfoundation/MediaPlayerPrivateAVFoundation.cpp
+++ b/Source/WebCore/platform/graphics/avfoundation/MediaPlayerPrivateAVFoundation.cpp
@@ -1047,7 +1047,7 @@ bool MediaPlayerPrivateAVFoundation::canSaveMediaData() const
 {
     URL url = resolvedURL();
 
-    if (url.isLocalFile())
+    if (url.protocolIsFile())
         return true;
 
     if (!url.protocolIsInHTTPFamily())

--- a/Source/WebCore/platform/graphics/gstreamer/MediaPlayerPrivateGStreamer.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/MediaPlayerPrivateGStreamer.cpp
@@ -949,7 +949,7 @@ void MediaPlayerPrivateGStreamer::setPlaybinURL(const URL& url)
 {
     // Clean out everything after file:// url path.
     String cleanURLString(url.string());
-    if (url.isLocalFile())
+    if (url.protocolIsFile())
         cleanURLString = cleanURLString.left(url.pathEnd());
 
     m_url = URL { cleanURLString };
@@ -3106,7 +3106,7 @@ bool MediaPlayerPrivateGStreamer::canSaveMediaData() const
     if (m_isLiveStream.value_or(false))
         return false;
 
-    if (m_url.isLocalFile())
+    if (m_url.protocolIsFile())
         return true;
 
     if (m_url.protocolIsInHTTPFamily())

--- a/Source/WebCore/platform/gtk/DragDataGtk.cpp
+++ b/Source/WebCore/platform/gtk/DragDataGtk.cpp
@@ -80,7 +80,7 @@ String DragData::asURL(FilenameConversionPolicy filenamePolicy, String* title) c
     if (!m_platformDragData->hasURL())
         return String();
     if (filenamePolicy != ConvertFilenames) {
-        if (m_platformDragData->url().isLocalFile())
+        if (m_platformDragData->url().protocolIsFile())
             return { };
     }
 

--- a/Source/WebCore/platform/network/ResourceHandle.cpp
+++ b/Source/WebCore/platform/network/ResourceHandle.cpp
@@ -282,7 +282,7 @@ bool ResourceHandle::shouldContentSniffURL(const URL& url)
         return true;
 #endif
     // We shouldn't content sniff file URLs as their MIME type should be established via their extension.
-    return !url.protocolIs("file"_s);
+    return !url.protocolIsFile();
 }
 
 void ResourceHandle::forceContentSniffing()

--- a/Source/WebCore/platform/network/cocoa/ResourceRequestCocoa.mm
+++ b/Source/WebCore/platform/network/cocoa/ResourceRequestCocoa.mm
@@ -321,7 +321,7 @@ void ResourceRequest::doUpdatePlatformRequest()
     }
 
 #if PLATFORM(MAC)
-    if (m_requestData.m_url.isLocalFile()) {
+    if (m_requestData.m_url.protocolIsFile()) {
         auto filePath = m_requestData.m_url.fileSystemPath();
         if (!filePath.isNull()) {
             auto fileDevice = FileSystem::getFileDeviceId(filePath);

--- a/Source/WebCore/platform/network/curl/CurlContext.cpp
+++ b/Source/WebCore/platform/network/curl/CurlContext.cpp
@@ -404,7 +404,7 @@ void CurlHandle::setUrl(const URL& url)
     curlUrl.removeFragmentIdentifier();
 
     // Remove any query part sent to a local file.
-    if (curlUrl.isLocalFile()) {
+    if (curlUrl.protocolIsFile()) {
         // By setting the query to a null string it'll be removed.
         if (!curlUrl.query().isEmpty())
             curlUrl.setQuery(String());

--- a/Source/WebCore/platform/network/curl/CurlRequest.cpp
+++ b/Source/WebCore/platform/network/curl/CurlRequest.cpp
@@ -118,7 +118,7 @@ void CurlRequest::start()
         break;
     }
 
-    if (m_request.url().isLocalFile())
+    if (m_request.url().protocolIsFile())
         invokeDidReceiveResponseForFile(m_request.url());
     else
         startWithJobManager();
@@ -599,7 +599,7 @@ void CurlRequest::invokeDidReceiveResponseForFile(const URL& url)
     // Run the code here for local files to resolve the issue.
 
     ASSERT(isMainThread());
-    ASSERT(url.isLocalFile());
+    ASSERT(url.protocolIsFile());
 
     // Determine the MIME type based on the path.
     auto mimeType = MIMETypeRegistry::mimeTypeForPath(url.path().toString());

--- a/Source/WebCore/platform/win/PasteboardWin.cpp
+++ b/Source/WebCore/platform/win/PasteboardWin.cpp
@@ -618,7 +618,7 @@ static String fileSystemPathFromURLOrTitle(const String& urlString, const String
         // we just use the entire url.
         DWORD len = fsPathMaxLengthExcludingExtension;
         auto lastComponent = url.lastPathComponent();
-        if (url.isLocalFile() || (!isLink && !lastComponent.isEmpty())) {
+        if (url.protocolIsFile() || (!isLink && !lastComponent.isEmpty())) {
             len = std::min<DWORD>(fsPathMaxLengthExcludingExtension, lastComponent.length());
             lastComponent.left(len).getCharacters(fsPathBuffer);
         } else {
@@ -992,7 +992,7 @@ static HGLOBAL createGlobalHDropContent(const URL& url, String& fileName, Fragme
 
     WCHAR filePath[MAX_PATH];
 
-    if (url.isLocalFile()) {
+    if (url.protocolIsFile()) {
         String localPath = PAL::decodeURLEscapeSequences(url.path());
         // windows does not enjoy a leading slash on paths
         if (localPath[0] == '/')

--- a/Source/WebCore/testing/Internals.cpp
+++ b/Source/WebCore/testing/Internals.cpp
@@ -5099,7 +5099,7 @@ RefPtr<File> Internals::createFile(const String& path)
         return nullptr;
 
     URL url = document->completeURL(path);
-    if (!url.isLocalFile())
+    if (!url.protocolIsFile())
         return nullptr;
 
     return File::create(document, url.fileSystemPath());

--- a/Source/WebCore/workers/Worker.cpp
+++ b/Source/WebCore/workers/Worker.cpp
@@ -189,7 +189,7 @@ bool Worker::virtualHasPendingActivity() const
 void Worker::didReceiveResponse(ResourceLoaderIdentifier identifier, const ResourceResponse& response)
 {
     const URL& responseURL = response.url();
-    if (!responseURL.protocolIsBlob() && !responseURL.protocolIs("file"_s) && !SecurityOrigin::create(responseURL)->isOpaque())
+    if (!responseURL.protocolIsBlob() && !responseURL.protocolIsFile() && !SecurityOrigin::create(responseURL)->isOpaque())
         m_contentSecurityPolicyResponseHeaders = ContentSecurityPolicyResponseHeaders(response);
     InspectorInstrumentation::didReceiveScriptResponse(scriptExecutionContext(), identifier);
 }

--- a/Source/WebKit/NetworkProcess/NetworkResourceLoadParameters.cpp
+++ b/Source/WebKit/NetworkProcess/NetworkResourceLoadParameters.cpp
@@ -121,7 +121,7 @@ NetworkResourceLoadParameters::NetworkResourceLoadParameters(
         }
     }
     
-    if (request.url().isLocalFile()) {
+    if (request.url().protocolIsFile()) {
         if (!sandboxExtensionIflocalFile)
             RELEASE_ASSERT_NOT_REACHED_WITH_MESSAGE("NetworkResourceLoadParameters which specify a URL of a local file should have sandboxExtensionIflocalFile");
         resourceSandboxExtension = SandboxExtension::create(WTFMove(*sandboxExtensionIflocalFile));
@@ -154,7 +154,7 @@ std::optional<Vector<SandboxExtension::Handle>> NetworkResourceLoadParameters::s
 
 std::optional<SandboxExtension::Handle> NetworkResourceLoadParameters::sandboxExtensionIflocalFile() const
 {
-    if (!request.url().isLocalFile())
+    if (!request.url().protocolIsFile())
         return std::nullopt;
     
     SandboxExtension::Handle requestSandboxExtension;

--- a/Source/WebKit/NetworkProcess/cocoa/NetworkDataTaskCocoa.mm
+++ b/Source/WebKit/NetworkProcess/cocoa/NetworkDataTaskCocoa.mm
@@ -425,7 +425,7 @@ NetworkDataTaskCocoa::NetworkDataTaskCocoa(NetworkSession& session, NetworkDataT
     m_session->appPrivacyReportTestingData().didLoadAppInitiatedRequest(nsRequest.get().attribution == NSURLRequestAttributionDeveloper);
 #endif
 
-    applySniffingPoliciesAndBindRequestToInferfaceIfNeeded(nsRequest, parameters.contentSniffingPolicy == WebCore::ContentSniffingPolicy::SniffContent && !url.isLocalFile(), parameters.contentEncodingSniffingPolicy);
+    applySniffingPoliciesAndBindRequestToInferfaceIfNeeded(nsRequest, parameters.contentSniffingPolicy == WebCore::ContentSniffingPolicy::SniffContent && !url.protocolIsFile(), parameters.contentEncodingSniffingPolicy);
 
     m_task = [m_sessionWrapper->session dataTaskWithRequest:nsRequest.get()];
 

--- a/Source/WebKit/NetworkProcess/soup/NetworkDataTaskSoup.cpp
+++ b/Source/WebKit/NetworkProcess/soup/NetworkDataTaskSoup.cpp
@@ -142,7 +142,7 @@ void NetworkDataTaskSoup::setPendingDownloadLocation(const String& filename, San
 void NetworkDataTaskSoup::createRequest(ResourceRequest&& request, WasBlockingCookies wasBlockingCookies)
 {
     m_currentRequest = WTFMove(request);
-    if (m_currentRequest.url().isLocalFile()) {
+    if (m_currentRequest.url().protocolIsFile()) {
         m_file = adoptGRef(g_file_new_for_path(m_currentRequest.url().fileSystemPath().utf8().data()));
         return;
     }

--- a/Source/WebKit/UIProcess/WebProcessProxy.cpp
+++ b/Source/WebKit/UIProcess/WebProcessProxy.cpp
@@ -845,7 +845,7 @@ void WebProcessProxy::didDestroyWebUserContentControllerProxy(WebUserContentCont
 void WebProcessProxy::assumeReadAccessToBaseURL(WebPageProxy& page, const String& urlString)
 {
     URL url { urlString };
-    if (!url.isLocalFile())
+    if (!url.protocolIsFile())
         return;
 
     // There's a chance that urlString does not point to a directory.
@@ -862,7 +862,7 @@ void WebProcessProxy::assumeReadAccessToBaseURL(WebPageProxy& page, const String
 
 bool WebProcessProxy::hasAssumedReadAccessToURL(const URL& url) const
 {
-    if (!url.isLocalFile())
+    if (!url.protocolIsFile())
         return false;
 
     String path = url.fileSystemPath();
@@ -893,7 +893,7 @@ bool WebProcessProxy::checkURLReceivedFromWebProcess(const URL& url, CheckBackFo
     // FIXME: Consider checking that the URL is valid. Currently, WebProcess sends invalid URLs in many cases, but it probably doesn't have good reasons to do that.
 
     // Any other non-file URL is OK.
-    if (!url.isLocalFile())
+    if (!url.protocolIsFile())
         return true;
 
     // Any file URL is also OK if we've loaded a file URL through API before, granting universal read access.
@@ -910,10 +910,10 @@ bool WebProcessProxy::checkURLReceivedFromWebProcess(const URL& url, CheckBackFo
         String path = url.fileSystemPath();
         for (auto& item : WebBackForwardListItem::allItems().values()) {
             URL itemURL { item->url() };
-            if (itemURL.isLocalFile() && itemURL.fileSystemPath() == path)
+            if (itemURL.protocolIsFile() && itemURL.fileSystemPath() == path)
                 return true;
             URL itemOriginalURL { item->originalURL() };
-            if (itemOriginalURL.isLocalFile() && itemOriginalURL.fileSystemPath() == path)
+            if (itemOriginalURL.protocolIsFile() && itemOriginalURL.fileSystemPath() == path)
                 return true;
         }
     }
@@ -1282,7 +1282,7 @@ auto WebProcessProxy::visiblePageToken() const -> VisibleWebPageToken
 
 void WebProcessProxy::addPreviouslyApprovedFileURL(const URL& url)
 {
-    ASSERT(url.isLocalFile());
+    ASSERT(url.protocolIsFile());
     auto fileSystemPath = url.fileSystemPath();
     if (!fileSystemPath.isEmpty())
         m_previouslyApprovedFilePaths.add(fileSystemPath);
@@ -1290,7 +1290,7 @@ void WebProcessProxy::addPreviouslyApprovedFileURL(const URL& url)
 
 bool WebProcessProxy::wasPreviouslyApprovedFileURL(const URL& url) const
 {
-    ASSERT(url.isLocalFile());
+    ASSERT(url.protocolIsFile());
     auto fileSystemPath = url.fileSystemPath();
     if (fileSystemPath.isEmpty())
         return false;

--- a/Source/WebKit/WebProcess/GPU/media/MediaPlayerPrivateRemote.cpp
+++ b/Source/WebKit/WebProcess/GPU/media/MediaPlayerPrivateRemote.cpp
@@ -160,7 +160,7 @@ void MediaPlayerPrivateRemote::prepareForPlayback(bool privateMode, MediaPlayer:
 void MediaPlayerPrivateRemote::load(const URL& url, const ContentType& contentType, const String& keySystem)
 {
     std::optional<SandboxExtension::Handle> sandboxExtensionHandle;
-    if (url.isLocalFile()) {
+    if (url.protocolIsFile()) {
         SandboxExtension::Handle handle;
         auto fileSystemPath = url.fileSystemPath();
 

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebResourceLoadObserver.cpp
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebResourceLoadObserver.cpp
@@ -349,7 +349,7 @@ void WebResourceLoadObserver::logWebSocketLoading(const URL& targetURL, const UR
 void WebResourceLoadObserver::logUserInteractionWithReducedTimeResolution(const Document& document)
 {
     auto& url = document.url();
-    if (url.protocolIsAbout() || url.isLocalFile() || url.isEmpty())
+    if (url.protocolIsAbout() || url.protocolIsFile() || url.isEmpty())
         return;
 
     RegistrableDomain topFrameDomain { url };

--- a/Source/WebKit/WebProcess/WebPage/WebPage.cpp
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.cpp
@@ -2290,7 +2290,7 @@ static void dumpHistoryItem(HistoryItem& item, size_t indent, bool isCurrentItem
     }
 
     auto url = item.url();
-    if (url.protocolIs("file"_s)) {
+    if (url.protocolIsFile()) {
         size_t start = url.string().find(directoryName);
         if (start == WTF::notFound)
             start = 0;
@@ -5831,7 +5831,7 @@ bool WebPage::SandboxExtensionTracker::shouldReuseCommittedSandboxExtension(WebF
     if (!documentLoader || !provisionalDocumentLoader)
         return false;
 
-    if (documentLoader->url().isLocalFile() && provisionalDocumentLoader->url().isLocalFile())
+    if (documentLoader->url().protocolIsFile() && provisionalDocumentLoader->url().protocolIsFile())
         return true;
 
     return false;
@@ -8874,7 +8874,7 @@ bool WebPage::shouldSkipDecidePolicyForResponse(const WebCore::ResourceResponse&
     if (!equalIgnoringASCIICase(response.mimeType(), "text/html"_s))
         return false;
 
-    if (response.url().isLocalFile())
+    if (response.url().protocolIsFile())
         return false;
 
     if (auto components = response.httpHeaderField(HTTPHeaderName::ContentDisposition).split(';'); !components.isEmpty() && equalIgnoringASCIICase(stripLeadingAndTrailingHTTPSpaces(components[0]), "attachment"_s))

--- a/Tools/WebKitTestRunner/InjectedBundle/atspi/AccessibilityUIElementAtspi.cpp
+++ b/Tools/WebKitTestRunner/InjectedBundle/atspi/AccessibilityUIElementAtspi.cpp
@@ -1530,7 +1530,7 @@ JSRetainPtr<JSStringRef> AccessibilityUIElement::url()
         return JSStringCreateWithUTF8CString("AXURL: (null)");
 
     auto stringURL = axURL.string();
-    if (axURL.isLocalFile()) {
+    if (axURL.protocolIsFile()) {
         // Do not expose absolute paths.
         auto index = stringURL.find("LayoutTests"_s);
         if (index != notFound)


### PR DESCRIPTION
#### 7d98f2cb5754ff4e12eb2ae74eff12f1ccf3665b
<pre>
Replace URL::isLocalFile() with URL::protocolIsFile()
<a href="https://bugs.webkit.org/show_bug.cgi?id=257316">https://bugs.webkit.org/show_bug.cgi?id=257316</a>
rdar://109824173

Reviewed by Michael Catanzaro.

This makes it consistent with URL::protocolIsBlob().

* Source/JavaScriptCore/API/JSScript.mm:
(validateBytecodeCachePath):
(+[JSScript scriptOfType:memoryMappedFromASCIIFile:withSourceURL:andBytecodeCache:inVirtualMachine:error:]):
* Source/JavaScriptCore/jsc.cpp:
(GlobalObject::moduleLoaderImportModule):
(GlobalObject::moduleLoaderResolve):
(GlobalObject::moduleLoaderFetch):
(computeFilePath):
* Source/WTF/wtf/URL.cpp:
(WTF::URL::hasSpecialScheme const):
(WTF::URL::hasLocalScheme const):
(WTF::URL::fileSystemPath const):
(WTF::URL::setProtocol):
(WTF::URL::setPath):
(WTF::portAllowed):
(WTF::URL::isLocalFile const): Deleted.
(WTF::URL::protocolIsAbout const): Deleted.
* Source/WTF/wtf/URL.h:
(WTF::URL::protocolIsAbout const):
(WTF::URL::protocolIsFile const):
* Source/WTF/wtf/URLParser.cpp:
(WTF::URLParser::copyBaseWindowsDriveLetter):
(WTF::URLParser::URLParser):
(WTF::URLParser::parse):
* Source/WebCore/Modules/model-element/scenekit/SceneKitModelLoader.mm:
(WebCore::mimeTypeUtilizingFileExtensionOverridingForLocalFiles):
* Source/WebCore/dom/Document.cpp:
(WebCore::Document::isCookieAverse const):
* Source/WebCore/dom/Element.cpp:
(WebCore::Element::resolveURLStringIfNeeded const):
* Source/WebCore/editing/cocoa/WebContentReaderCocoa.mm:
(WebCore::WebContentReader::readHTML):
(WebCore::WebContentMarkupReader::readHTML):
* Source/WebCore/editing/ios/EditorIOS.mm:
(WebCore::Editor::writeImageToPasteboard):
* Source/WebCore/html/HTMLMediaElement.cpp:
(WebCore::HTMLMediaElement::loadResource):
* Source/WebCore/html/URLDecomposition.cpp:
(WebCore::URLDecomposition::setUsername):
(WebCore::URLDecomposition::setPassword):
(WebCore::URLDecomposition::setHost):
(WebCore::URLDecomposition::setHostname):
(WebCore::URLDecomposition::setPort):
* Source/WebCore/loader/DocumentThreadableLoader.cpp:
(WebCore::DocumentThreadableLoader::loadRequest):
* Source/WebCore/page/ContextMenuController.cpp:
(WebCore::ContextMenuController::populate):
(WebCore::ContextMenuController::checkOrEnableIfNeeded const):
* Source/WebCore/page/History.cpp:
(WebCore::History::stateObjectAdded):
* Source/WebCore/page/Page.cpp:
(WebCore::Page::hasLocalDataForURL):
* Source/WebCore/page/SecurityOrigin.cpp:
(WebCore::SecurityOrigin::shouldIgnoreHost):
(WebCore::SecurityOrigin::createNonLocalWithAllowedFilePath):
(WebCore::SecurityOrigin::canDisplay const):
* Source/WebCore/page/csp/ContentSecurityPolicy.cpp:
(WebCore::shouldReportProtocolOnly):
* Source/WebCore/platform/graphics/avfoundation/MediaPlayerPrivateAVFoundation.cpp:
(WebCore::MediaPlayerPrivateAVFoundation::canSaveMediaData const):
* Source/WebCore/platform/graphics/gstreamer/MediaPlayerPrivateGStreamer.cpp:
(WebCore::MediaPlayerPrivateGStreamer::setPlaybinURL):
(WebCore::MediaPlayerPrivateGStreamer::canSaveMediaData const):
* Source/WebCore/platform/gtk/DragDataGtk.cpp:
(WebCore::DragData::asURL const):
* Source/WebCore/platform/network/ResourceHandle.cpp:
(WebCore::ResourceHandle::shouldContentSniffURL):
* Source/WebCore/platform/network/cocoa/ResourceRequestCocoa.mm:
(WebCore::ResourceRequest::doUpdatePlatformRequest):
* Source/WebCore/platform/network/curl/CurlContext.cpp:
(WebCore::CurlHandle::setUrl):
* Source/WebCore/platform/network/curl/CurlRequest.cpp:
(WebCore::CurlRequest::start):
(WebCore::CurlRequest::invokeDidReceiveResponseForFile):
* Source/WebCore/platform/win/PasteboardWin.cpp:
(WebCore::fileSystemPathFromURLOrTitle):
(WebCore::createGlobalHDropContent):
* Source/WebCore/testing/Internals.cpp:
(WebCore::Internals::createFile):
* Source/WebCore/workers/Worker.cpp:
(WebCore::Worker::didReceiveResponse):
* Source/WebKit/NetworkProcess/NetworkResourceLoadParameters.cpp:
(WebKit::NetworkResourceLoadParameters::NetworkResourceLoadParameters):
(WebKit::NetworkResourceLoadParameters::sandboxExtensionIflocalFile const):
* Source/WebKit/NetworkProcess/cocoa/NetworkDataTaskCocoa.mm:
(WebKit::NetworkDataTaskCocoa::NetworkDataTaskCocoa):
* Source/WebKit/NetworkProcess/soup/NetworkDataTaskSoup.cpp:
(WebKit::NetworkDataTaskSoup::createRequest):
* Source/WebKit/UIProcess/WebPageProxy.cpp:
(WebKit::WebPageProxy::maybeInitializeSandboxExtensionHandle):
(WebKit::WebPageProxy::loadRequestWithNavigationShared):
(WebKit::WebPageProxy::loadFile):
(WebKit::WebPageProxy::loadAlternateHTML):
(WebKit::shouldTreatURLProtocolAsAppBound):
(WebKit::WebPageProxy::receivedNavigationPolicyDecision):
(WebKit::WebPageProxy::continueNavigationInNewProcess):
(WebKit::WebPageProxy::decidePolicyForNavigationActionAsyncShared):
(WebKit::WebPageProxy::backForwardAddItemShared):
(WebKit::WebPageProxy::checkURLReceivedFromCurrentOrPreviousWebProcess):
* Source/WebKit/UIProcess/WebProcessProxy.cpp:
(WebKit::WebProcessProxy::assumeReadAccessToBaseURL):
(WebKit::WebProcessProxy::hasAssumedReadAccessToURL const):
(WebKit::WebProcessProxy::checkURLReceivedFromWebProcess):
(WebKit::WebProcessProxy::addPreviouslyApprovedFileURL):
(WebKit::WebProcessProxy::wasPreviouslyApprovedFileURL const):
* Source/WebKit/WebProcess/GPU/media/MediaPlayerPrivateRemote.cpp:
(WebKit::MediaPlayerPrivateRemote::load):
* Source/WebKit/WebProcess/WebCoreSupport/WebResourceLoadObserver.cpp:
(WebKit::WebResourceLoadObserver::logUserInteractionWithReducedTimeResolution):
* Source/WebKit/WebProcess/WebPage/WebPage.cpp:
(WebKit::dumpHistoryItem):
(WebKit::WebPage::SandboxExtensionTracker::shouldReuseCommittedSandboxExtension):
(WebKit::WebPage::shouldSkipDecidePolicyForResponse const):
* Tools/WebKitTestRunner/InjectedBundle/atspi/AccessibilityUIElementAtspi.cpp:
(WTR::AccessibilityUIElement::url):

Canonical link: <a href="https://commits.webkit.org/264513@main">https://commits.webkit.org/264513@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/185a456792cacd9bfdb5a4b04f9426cba4edac00

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/7900 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/8178 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/8364 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/9549 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/8023 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/7905 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/10171 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/8095 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/10889 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/8040 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/9141 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/7215 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/9667 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/6445 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/7206 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/14832 "Passed tests") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/6733 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/7568 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/7327 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/10725 "Passed tests") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/7470 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/7819 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/6355 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/8062 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/7137 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/1846 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/1878 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/11346 "Built successfully") | | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/24/builds/8280 "Built successfully") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/7554 "Built successfully") | | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/3/builds/1994 "Passed tests") | 
<!--EWS-Status-Bubble-End-->