### PR TITLE
Some compositing configurations cause duplicated InteractionRegion layers with an offset

### DIFF
--- a/LayoutTests/interaction-region/position-only-update-expected.txt
+++ b/LayoutTests/interaction-region/position-only-update-expected.txt
@@ -1,0 +1,59 @@
+Sometimes fixed with a link! compositing
+compositing
+(GraphicsLayer
+  (anchor 0.00 0.00)
+  (bounds 800.00 600.00)
+  (children 1
+    (GraphicsLayer
+      (bounds 800.00 600.00)
+      (contentsOpaque 1)
+      (drawsContent 1)
+      (backgroundColor #FFFFFF)
+      (event region
+        (rect (0,0) width=800 height=600)
+
+      (interaction regions [
+        (occlusion (0,0) width=800 height=140)
+        (borderRadius 0.00),
+        (interaction (107,76) width=83 height=27)
+        (borderRadius 8.00)])
+      )
+      (children 2
+        (GraphicsLayer
+          (position 0.00 200.00)
+          (anchor 0.50 0.50)
+          (bounds 79.50 20.00)
+          (drawsContent 1)
+          (transform [1.00 0.00 0.00 0.00] [0.00 1.00 0.00 0.00] [0.00 0.00 1.00 0.00] [500.00 50.00 0.00 1.00])
+          (event region
+            (rect (0,0) width=80 height=20)
+          )
+        )
+        (GraphicsLayer
+          (bounds 800.00 140.00)
+          (event region
+            (rect (0,0) width=800 height=100)
+          )
+          (children 1
+            (GraphicsLayer
+              (bounds 800.00 140.00)
+              (children 1
+                (GraphicsLayer
+                  (position 0.00 240.00)
+                  (anchor 0.50 0.50)
+                  (bounds 79.50 100.00)
+                  (drawsContent 1)
+                  (transform [1.00 0.00 0.00 0.00] [0.00 1.00 0.00 0.00] [0.00 0.00 1.00 0.00] [500.00 50.00 0.00 1.00])
+                  (event region
+                    (rect (0,0) width=80 height=100)
+                  )
+                )
+              )
+            )
+          )
+        )
+      )
+    )
+  )
+)
+

--- a/LayoutTests/interaction-region/position-only-update.html
+++ b/LayoutTests/interaction-region/position-only-update.html
@@ -1,0 +1,84 @@
+<!DOCTYPE html>
+<html>
+<style>
+    body { margin: 0; padding: 0; }
+
+    .header {
+        position: relative;
+        width: 100%;
+        z-index: 1000;
+        overflow: hidden;
+    }
+    .move .header {
+        position: fixed;
+    }
+
+    .menu {
+        height: 40px;
+    }
+    .move .menu {
+        height: 0;
+    }
+
+    .content {
+        position: relative;
+        line-height: 100px;
+    }
+
+    .spacer {
+        position: fixed;
+        height: 140px;
+    }
+    .move .spacer {
+        position: relative;
+    }
+
+    .compositing {
+        position: absolute;
+        top: 200px;
+        left: 0;
+        transform: translate3d(500px, 50px, 0);
+    }
+</style>
+<script src="../resources/ui-helper.js"></script>
+<body>
+<div class="header">
+    <div class="menu">
+    </div>
+    <div class="content">
+        Sometimes fixed
+        <a href="#">with a link!</a>
+        <div class="compositing">
+            compositing
+        </div>
+    </div>
+</div>
+<div class="spacer">
+</div>
+<div class="compositing">
+    compositing
+</div>
+
+<pre id="results"></pre>
+<script>
+    if (window.testRunner) {
+        testRunner.waitUntilDone();
+        testRunner.dumpAsText();
+    }
+
+    (async function () {
+        await UIHelper.renderingUpdate();
+        document.body.classList.add("move");
+        await UIHelper.renderingUpdate();
+        document.body.classList.remove("move");
+        await UIHelper.renderingUpdate();
+
+        if (window.internals)
+            results.textContent = internals.layerTreeAsText(document, internals.LAYER_TREE_INCLUDES_EVENT_REGION | internals.LAYER_TREE_INCLUDES_ROOT_LAYER_PROPERTIES);
+
+        if (window.testRunner)
+            testRunner.notifyDone();
+    })();
+</script>
+</body>
+</html>

--- a/Source/WebCore/rendering/EventRegion.cpp
+++ b/Source/WebCore/rendering/EventRegion.cpp
@@ -540,6 +540,11 @@ void EventRegion::appendInteractionRegions(const Vector<InteractionRegion>& inte
     m_interactionRegions.appendVector(interactionRegions);
 }
 
+void EventRegion::clearInteractionRegions()
+{
+    m_interactionRegions.clear();
+}
+
 #endif
 
 void EventRegion::dump(TextStream& ts) const

--- a/Source/WebCore/rendering/EventRegion.h
+++ b/Source/WebCore/rendering/EventRegion.h
@@ -130,6 +130,7 @@ public:
 #if ENABLE(INTERACTION_REGIONS_IN_EVENT_REGION)
     const Vector<InteractionRegion>& interactionRegions() const { return m_interactionRegions; }
     void appendInteractionRegions(const Vector<InteractionRegion>&);
+    void clearInteractionRegions();
 #endif
 
 private:

--- a/Source/WebCore/rendering/RenderLayerBacking.cpp
+++ b/Source/WebCore/rendering/RenderLayerBacking.cpp
@@ -1829,6 +1829,12 @@ void RenderLayerBacking::updateDrawsContent(PaintedContentsInfo& contentsInfo)
 
     bool hasPaintedContent = containsPaintedContent(contentsInfo);
 
+#if ENABLE(INTERACTION_REGIONS_IN_EVENT_REGION)
+    // We need to clean-up existing Interaction Regions since we won't repaint.
+    if (!hasPaintedContent)
+        clearInteractionRegions();
+#endif
+
     // FIXME: we could refine this to only allocate backing for one of these layers if possible.
     m_graphicsLayer->setDrawsContent(hasPaintedContent);
     if (m_foregroundLayer)
@@ -1960,6 +1966,28 @@ void RenderLayerBacking::updateEventRegion()
     renderer().view().setNeedsEventRegionUpdateForNonCompositedFrame(false);
     
     setNeedsEventRegionUpdate(false);
+}
+#endif
+
+#if ENABLE(INTERACTION_REGIONS_IN_EVENT_REGION)
+void RenderLayerBacking::clearInteractionRegions()
+{
+    auto clearInteractionRegionsForLayer = [&](GraphicsLayer& graphicsLayer) {
+        if (graphicsLayer.eventRegion().isEmpty())
+            return;
+
+        EventRegion eventRegion = graphicsLayer.eventRegion();
+        eventRegion.clearInteractionRegions();
+        graphicsLayer.setEventRegion(WTFMove(eventRegion));
+    };
+
+    clearInteractionRegionsForLayer(*m_graphicsLayer);
+
+    if (m_scrolledContentsLayer)
+        clearInteractionRegionsForLayer(*m_scrolledContentsLayer);
+
+    if (m_foregroundLayer)
+        clearInteractionRegionsForLayer(*m_foregroundLayer);
 }
 #endif
 

--- a/Source/WebCore/rendering/RenderLayerBacking.h
+++ b/Source/WebCore/rendering/RenderLayerBacking.h
@@ -212,6 +212,10 @@ public:
     void setNeedsEventRegionUpdate(bool needsUpdate = true) { m_needsEventRegionUpdate = needsUpdate; }
 #endif
 
+#if ENABLE(INTERACTION_REGIONS_IN_EVENT_REGION)
+    void clearInteractionRegions();
+#endif
+
     void updateAfterWidgetResize();
     void positionOverflowControlsLayers();
     


### PR DESCRIPTION
#### 4cd43d6a32eaf36096893b3260ed15ff208bddc5
<pre>
Some compositing configurations cause duplicated InteractionRegion layers with an offset
<a href="https://bugs.webkit.org/show_bug.cgi?id=257317">https://bugs.webkit.org/show_bug.cgi?id=257317</a>
&lt;rdar://109589854&gt;

Reviewed by Tim Horton and Simon Fraser.

When a compositing layer becomes a simple container, clear any existing
interaction region. Otherwise we might keep duplicates around since the
layer won&apos;t repaint.

* Source/WebCore/rendering/EventRegion.h:
* Source/WebCore/rendering/EventRegion.cpp:
(WebCore::EventRegion::clearInteractionRegions):
* Source/WebCore/rendering/RenderLayerBacking.h:
* Source/WebCore/rendering/RenderLayerBacking.cpp:
(WebCore::RenderLayerBacking::clearInteractionRegions):
New method to clear InteractionRegions from an EventRegion.
(WebCore::RenderLayerBacking::updateDrawsContent):
Clear the interaction regions if the layer has no painted content.

* LayoutTests/interaction-region/position-only-update-expected.txt: Added.
* LayoutTests/interaction-region/position-only-update.html: Added.
New test capturing the *very specific* configuration causing the issue.

Canonical link: <a href="https://commits.webkit.org/264622@main">https://commits.webkit.org/264622@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/46571e05c078d242ef8ab2ade2509b94a08e2c0b

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/8074 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/8360 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/8573 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/9727 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/8173 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/8079 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/10345 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/8270 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/11032 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/8218 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/9300 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/7356 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/9848 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/6601 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/7387 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/14965 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/7724 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/7512 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/10870 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/7985 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/6497 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/7296 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/7300 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/1964 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/11505 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/7726 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->