### PR TITLE
[WGSL] Expand accepted syntax in for loops

### DIFF
--- a/Source/WebGPU/WGSL/Metal/MetalFunctionWriter.cpp
+++ b/Source/WebGPU/WGSL/Metal/MetalFunctionWriter.cpp
@@ -945,7 +945,15 @@ void FunctionDefinitionWriter::visit(AST::CompoundStatement& statement)
 void FunctionDefinitionWriter::visit(AST::DecrementIncrementStatement& statement)
 {
     visit(statement.expression());
-    m_stringBuilder.append(statement.operation(), ";");
+    switch (statement.operation()) {
+    case AST::DecrementIncrementStatement::Operation::Increment:
+        m_stringBuilder.append("++");
+        break;
+    case AST::DecrementIncrementStatement::Operation::Decrement:
+        m_stringBuilder.append("--");
+        break;
+    }
+    m_stringBuilder.append(";");
 }
 
 void FunctionDefinitionWriter::visit(AST::IfStatement& statement)

--- a/Source/WebGPU/WGSL/ParserPrivate.h
+++ b/Source/WebGPU/WGSL/ParserPrivate.h
@@ -78,6 +78,7 @@ public:
     Result<AST::Statement::Ref> parseIfStatementWithAttributes(AST::Attribute::List&&, SourcePosition _startOfElementPosition);
     Result<AST::Statement::Ref> parseForStatement();
     Result<AST::Statement::Ref> parseReturnStatement();
+    Result<AST::Statement::Ref> parseVariableUpdatingStatement();
     Result<AST::Expression::Ref> parseShortCircuitExpression(AST::Expression::Ref&&, TokenType, AST::BinaryOperation);
     Result<AST::Expression::Ref> parseRelationalExpression();
     Result<AST::Expression::Ref> parseRelationalExpressionPostUnary(AST::Expression::Ref&& lhs);

--- a/Source/WebGPU/WGSL/TypeCheck.cpp
+++ b/Source/WebGPU/WGSL/TypeCheck.cpp
@@ -365,7 +365,7 @@ void TypeChecker::visit(AST::ForStatement& statement)
     if (auto* test = statement.maybeTest()) {
         auto* testType = infer(*test);
         if (!unify(m_types.boolType(), testType))
-            typeError(test->span(), "for-loop condition must be bool, got ", *testType);
+            typeError(InferBottom::No, test->span(), "for-loop condition must be bool, got ", *testType);
     }
 
     if (auto* update = statement.maybeUpdate())

--- a/Source/WebGPU/WGSL/tests/invalid/for.wgsl
+++ b/Source/WebGPU/WGSL/tests/invalid/for.wgsl
@@ -2,6 +2,6 @@
 
 fn testForStatement() {
   // CHECK-L: for-loop condition must be bool, got ref<function, <AbstractInt>, read_write>
-  for (var i = 0; i;) {
+  for (var i = 0; i; i++) {
   }
 }

--- a/Source/WebGPU/WGSL/tests/valid/for.wgsl
+++ b/Source/WebGPU/WGSL/tests/valid/for.wgsl
@@ -1,6 +1,11 @@
 // RUN: %wgslc
 
+@compute
+@workgroup_size(1, 1, 1)
 fn testForStatement() {
-    for (var x = -1; x <= 1;) {
+    for (var i = -1; i <= 1; i++) {
+    }
+
+    for (i++; i <= 0; i--) {
     }
 }


### PR DESCRIPTION
#### 46e1b8e9331986ad0ab166060c88fddbfec1ce1c
<pre>
[WGSL] Expand accepted syntax in for loops
<a href="https://bugs.webkit.org/show_bug.cgi?id=257320">https://bugs.webkit.org/show_bug.cgi?id=257320</a>
rdar://109827463

Reviewed by Mike Wyrzykowski.

Accept a &quot;variable-updating-statement&quot; in for-init and for-update, as per the
reference grammar. After this patch, the last missing piece of syntax for
for-loops is accepting calls in for-init and for-update, but that requires
refactoring how we parse function calls first.

* Source/WebGPU/WGSL/Metal/MetalFunctionWriter.cpp:
(WGSL::Metal::FunctionDefinitionWriter::visit):
* Source/WebGPU/WGSL/Parser.cpp:
(WGSL::Parser&lt;Lexer&gt;::parseStatement):
(WGSL::Parser&lt;Lexer&gt;::parseForStatement):
(WGSL::Parser&lt;Lexer&gt;::parseVariableUpdatingStatement):
* Source/WebGPU/WGSL/ParserPrivate.h:
* Source/WebGPU/WGSL/TypeCheck.cpp:
(WGSL::TypeChecker::visit):
* Source/WebGPU/WGSL/tests/invalid/for.wgsl:
* Source/WebGPU/WGSL/tests/valid/for.wgsl:

Canonical link: <a href="https://commits.webkit.org/264577@main">https://commits.webkit.org/264577@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/3f259e33b374b1fe5c7e9a0bfd6b4446f46afafc

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/8024 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/8309 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/8521 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/9676 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/8128 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/10295 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/8220 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/10992 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/8168 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/9255 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/7327 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/9798 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/6556 "Passed tests") | | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/14925 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/7679 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/7466 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/10830 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/7936 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/6457 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/7250 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/1921 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/11458 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/7677 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->