### PR TITLE
REGRESSION(2.41): [GTK] Contents not rendered in new web view when realized after configure and frame

### DIFF
--- a/Source/WebKit/UIProcess/gtk/AcceleratedBackingStoreDMABuf.h
+++ b/Source/WebKit/UIProcess/gtk/AcceleratedBackingStoreDMABuf.h
@@ -85,7 +85,8 @@ private:
         WTF_MAKE_FAST_ALLOCATED;
     public:
         virtual ~RenderSource() = default;
-        virtual bool swap() = 0;
+        virtual void swap() = 0;
+        virtual bool prepareForRendering() = 0;
 #if USE(GTK4)
         virtual void snapshot(GtkSnapshot*) const = 0;
 #else
@@ -109,7 +110,8 @@ private:
         unsigned texture() const { return m_textureID; }
 
     private:
-        bool swap() override;
+        void swap() override;
+        bool prepareForRendering() override;
 #if USE(GTK4)
         void snapshot(GtkSnapshot*) const override;
 #else
@@ -135,7 +137,8 @@ private:
         cairo_surface_t* surface() const { return m_surface.get(); }
 
     private:
-        bool swap() override;
+        void swap() override;
+        bool prepareForRendering() override;
 #if USE(GTK4)
         void snapshot(GtkSnapshot*) const override;
 #else


### PR DESCRIPTION
#### c60b4c7731a11cedf8448eaf758229fd391be42b
<pre>
REGRESSION(2.41): [GTK] Contents not rendered in new web view when realized after configure and frame
<a href="https://bugs.webkit.org/show_bug.cgi?id=257324">https://bugs.webkit.org/show_bug.cgi?id=257324</a>

Reviewed by Michael Catanzaro.

In case of realize happening after the configure and frame, we create a
committed source, but it&apos;s not ready for rendering. This patch splits
the swap method into swap and prepareForRendering. When a new frame is
available we always do swap, to be in sync with the web process, but only
prepareForRendering when view is realized. When realize happens after the
configure and frame we only need to call prepareForRendering().

* Source/WebKit/UIProcess/gtk/AcceleratedBackingStoreDMABuf.cpp:
(WebKit::AcceleratedBackingStoreDMABuf::Texture::~Texture):
(WebKit::AcceleratedBackingStoreDMABuf::Texture::swap):
(WebKit::AcceleratedBackingStoreDMABuf::Surface::map const):
(WebKit::AcceleratedBackingStoreDMABuf::Surface::swap):
(WebKit::AcceleratedBackingStoreDMABuf::Surface::prepareForRendering):
(WebKit::AcceleratedBackingStoreDMABuf::frame):
(WebKit::AcceleratedBackingStoreDMABuf::realize):
* Source/WebKit/UIProcess/gtk/AcceleratedBackingStoreDMABuf.h:

Canonical link: <a href="https://commits.webkit.org/264558@main">https://commits.webkit.org/264558@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/8f6c227c45856595d711aca1bdfa1718e24c7b3d

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/7905 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/8183 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/8435 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/9554 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/8028 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/10176 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/8100 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/10895 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/8045 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/9147 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/7268 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/9672 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/6451 "Passed tests") | | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/14834 "3 flakes 135 failures") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/7574 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/7392 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/10729 "run-api-tests-without-change (failure)") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/7824 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/6360 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/7142 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/11351 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/959 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/7559 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->