### PR TITLE
[Buildstream SDK] May 2023 updates

### DIFF
--- a/LayoutTests/platform/glib/TestExpectations
+++ b/LayoutTests/platform/glib/TestExpectations
@@ -2165,7 +2165,8 @@ webkit.org/b/189343 imported/w3c/web-platform-tests/xhr/sync-no-timeout.any.html
 webkit.org/b/189345 http/tests/media/clearkey/collect-webkit-media-session.html [ Skip ]
 
 media/encrypted-media [ Pass ]
-media/encrypted-media/encrypted-media-append-encrypted-unencrypted.html [ Pass ]
+webkit.org/b/254664 media/encrypted-media/encrypted-media-append-encrypted-unencrypted.html [ Failure ]
+
 
 webkit.org/b/205857 media/encrypted-media/mock-navigator-requestMediaKeySystemAccess.html [ Skip ]
 webkit.org/b/205860 media/encrypted-media/mock-MediaKeySession-remove.html [ Skip ]

--- a/Tools/buildstream/elements/freedesktop-sdk.bst
+++ b/Tools/buildstream/elements/freedesktop-sdk.bst
@@ -3,7 +3,7 @@ sources:
 - kind: git_tag
   url: gitlab_com:freedesktop-sdk/freedesktop-sdk.git
   track: 'release/22.08'
-  ref: freedesktop-sdk-22.08.11-24-g67b3605b402cffed2db0344f1da3a6acb5b6c914
+  ref: freedesktop-sdk-22.08.11-127-g7bed8a0d05bfd13939862b30e7080d1ffd5f635b
 - kind: patch
   path: patches/fdo-0001-pipewire-base-Disable-AEC-module.patch
 - kind: patch
@@ -15,7 +15,7 @@ sources:
 - kind: patch
   path: patches/fdo-0004-gst-plugins-ugly-Enable-x264-encoder.patch
 - kind: patch
-  path: patches/fdo-0005-GStreamer-Bump-to-1.22.2.patch
+  path: patches/fdo-0005-GStreamer-Bump-to-1.22.3.patch
 - kind: patch
   path: patches/fdo-0006-gst-plugins-bad-Enable-soundtouch.patch
 config:

--- a/Tools/buildstream/elements/sdk-platform.bst
+++ b/Tools/buildstream/elements/sdk-platform.bst
@@ -43,6 +43,7 @@ depends:
 - sdk/ruby-webrick.bst
 - sdk/sccache.bst
 - sdk/sparkle-cdm.bst
+- sdk/svt-av1.bst
 - sdk/unifdef.bst
 - sdk/woff2.bst
 - sdk/wpebackend-fdo.bst

--- a/Tools/buildstream/elements/sdk/libwpe.bst
+++ b/Tools/buildstream/elements/sdk/libwpe.bst
@@ -1,8 +1,9 @@
 kind: meson
 sources:
-- kind: tar
-  url: wpe:libwpe-1.13.90.tar.xz
-  ref: 97af9fbea3a70093e5f3979fa89594343e255942645c3b781d4f3517df5388a1
+- kind: git_tag
+  url: github_com:WebPlatformForEmbedded/libwpe
+  track: master
+  ref: 1.15.1-1-gd7c669ca6f5ec0d544c264016d270669b336c931
 build-depends:
 - freedesktop-sdk.bst:public-stacks/buildsystem-meson.bst
 depends:

--- a/Tools/buildstream/elements/sdk/svt-av1.bst
+++ b/Tools/buildstream/elements/sdk/svt-av1.bst
@@ -1,0 +1,26 @@
+kind: cmake
+
+build-depends:
+- freedesktop-sdk.bst:public-stacks/buildsystem-cmake.bst
+- freedesktop-sdk.bst:components/nasm.bst
+
+depends:
+- freedesktop-sdk.bst:bootstrap-import.bst
+
+variables:
+  cmake-local: >-
+    -DREPRODUCIBLE_BUILDS=1
+
+public:
+  bst:
+    split-rules:
+      devel:
+        (>):
+          - "%{libdir}/libSvtAv1Dec.so"
+          - "%{libdir}/libSvtAv1Enc.so"
+
+sources:
+- kind: git_tag
+  url: gitlab_com:AOMediaCodec/SVT-AV1
+  track: v*.*.*
+  ref: v1.5.0-0-gea296ef350714fb6f105b420fb0bc321d9997ffd

--- a/Tools/buildstream/patches/fdo-0005-GStreamer-Bump-to-1.22.3.patch
+++ b/Tools/buildstream/patches/fdo-0005-GStreamer-Bump-to-1.22.3.patch
@@ -49,7 +49,7 @@ index e73a056ab..ee16131c9 100644
    match:
    - 1.*[02468].*
 -  ref: 1.20.6-0-gb7d3037cca2fe72c5b7daab5e0617e61ae013dcc
-+  ref: 1.22.2-0-ga8f569e801491204bcd7f1d050bd40a794507a68
++  ref: 1.22.3-0-gecd471f5ea4645102b206a43d863f0f0fe7d04ec
  - kind: patch_queue
    path: patches/gstreamer
 diff --git a/patches/gstreamer/gst-libav-no-cache-generator.patch b/patches/gstreamer/gst-libav-no-cache-generator.patch


### PR DESCRIPTION
#### d72386bb1e65069cb0b78ffe4bfd6ad0c329dd23
<pre>
[Buildstream SDK] May 2023 updates
<a href="https://bugs.webkit.org/show_bug.cgi?id=257321">https://bugs.webkit.org/show_bug.cgi?id=257321</a>

Reviewed by Michael Catanzaro.

- FDO junction update to latest 22.08 release
- gst 1.22.3
- libwpe git master (useful for pointer lock)
- new recipe: SVT-AV1 encoder (without gst plugin for now)

* LayoutTests/platform/glib/TestExpectations:
* Tools/buildstream/elements/freedesktop-sdk.bst:
* Tools/buildstream/elements/sdk-platform.bst:
* Tools/buildstream/elements/sdk/libwpe.bst:
* Tools/buildstream/elements/sdk/svt-av1.bst: Added.
* Tools/buildstream/patches/fdo-0005-GStreamer-Bump-to-1.22.3.patch: Renamed from Tools/buildstream/patches/fdo-0005-GStreamer-Bump-to-1.22.2.patch.

Canonical link: <a href="https://commits.webkit.org/264514@main">https://commits.webkit.org/264514@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/da7355ec8e38015048d9caf61c38bd6b79f7523a

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/7908 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/8186 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/8372 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/9557 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/8031 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/7913 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/10179 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/8103 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/10898 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/8048 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/9148 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/7222 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/9675 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/6452 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/7213 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/14837 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/7575 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/7335 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/10731 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/7827 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/6363 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/7145 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/11354 "Built successfully") | | | 
| [❌ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/940 "Failed to push commit to Webkit repository") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/7562 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->