### PR TITLE
[WGSL] Clean up AST nodes created during compilation

### DIFF
--- a/Source/WebGPU/WGSL/AST/ASTBuilder.cpp
+++ b/Source/WebGPU/WGSL/AST/ASTBuilder.cpp
@@ -61,4 +61,31 @@ void Builder::allocateArena()
     ASSERT(arena() == m_arena);
 }
 
+auto Builder::saveCurrentState() -> State
+{
+    State state;
+    state.m_arena = m_arena;
+#if ASSERT_ENABLED
+    state.m_arenaStart = arena();
+    state.m_arenaEnd = m_arenaEnd;
+#endif
+    state.m_numberOfArenas = m_arenas.size();
+    state.m_numberOfNodes = m_nodes.size();
+    allocateArena();
+    return state;
+}
+
+void Builder::restore(State&& state)
+{
+    for (size_t i = state.m_numberOfNodes; i < m_nodes.size(); ++i)
+        m_nodes[i]->~Node();
+    m_arena = state.m_arena;
+    m_arenas.shrink(state.m_numberOfArenas);
+    m_arenaEnd = m_arenas.last().get() + arenaSize;
+#if ASSERT_ENABLED
+    ASSERT(state.m_arenaStart == m_arenas.last().get());
+    ASSERT(state.m_arenaEnd == m_arenaEnd);
+#endif
+}
+
 } // namespace WGSL::AST

--- a/Source/WebGPU/WGSL/AST/ASTBuilder.h
+++ b/Source/WebGPU/WGSL/AST/ASTBuilder.h
@@ -75,6 +75,23 @@ public:
         return *node;
     }
 
+    class State {
+        friend Builder;
+    private:
+        State() = default;
+
+        uint8_t* m_arena;
+#if ASSERT_ENABLED
+        uint8_t* m_arenaStart;
+        uint8_t* m_arenaEnd;
+#endif
+        unsigned m_numberOfArenas;
+        unsigned m_numberOfNodes;
+    };
+
+    State saveCurrentState();
+    void restore(State&&);
+
 private:
     static constexpr size_t alignSize(size_t size)
     {

--- a/Source/WebGPU/WGSL/WGSL.cpp
+++ b/Source/WebGPU/WGSL/WGSL.cpp
@@ -95,6 +95,8 @@ SuccessfulCheck::~SuccessfulCheck() = default;
 
 inline PrepareResult prepareImpl(ShaderModule& ast, const HashMap<String, std::optional<PipelineLayout>>& pipelineLayouts)
 {
+    ShaderModule::Compilation compilation(ast);
+
     PhaseTimes phaseTimes;
     PrepareResult result;
 
@@ -116,7 +118,6 @@ inline PrepareResult prepareImpl(ShaderModule& ast, const HashMap<String, std::o
 
     logPhaseTimes(phaseTimes);
 
-    ast.revertReplacements();
     return result;
 }
 

--- a/Source/WebGPU/WGSL/WGSLShaderModule.h
+++ b/Source/WebGPU/WGSL/WGSLShaderModule.h
@@ -145,6 +145,25 @@ public:
         m_replacements.clear();
     }
 
+    class Compilation {
+    public:
+        Compilation(ShaderModule& shaderModule)
+            : m_shaderModule(shaderModule)
+            , m_builderState(shaderModule.astBuilder().saveCurrentState())
+        {
+        }
+
+        ~Compilation()
+        {
+            m_shaderModule.revertReplacements();
+            m_shaderModule.astBuilder().restore(WTFMove(m_builderState));
+        }
+
+    private:
+        ShaderModule& m_shaderModule;
+        AST::Builder::State m_builderState;
+    };
+
 private:
     String m_source;
     bool m_usesExternalTextures { false };


### PR DESCRIPTION
#### 8f038359050c7ede97ac743ac058b77b64466ada
<pre>
[WGSL] Clean up AST nodes created during compilation
<a href="https://bugs.webkit.org/show_bug.cgi?id=257328">https://bugs.webkit.org/show_bug.cgi?id=257328</a>
rdar://109833858

Reviewed by Mike Wyrzykowski.

We allocate new nodes during compilation, and since we can compile the
same module multiple times, that could lead to unbounded memory growth.
In order to fix that, we save the state of the allocator before we start
a new compilation and erase all objects allocate after that point once
we are done compiling. That is safe since we already revert all AST
modifications in a similar manner.

* Source/WebGPU/WGSL/AST/ASTBuilder.cpp:
(WGSL::AST::Builder::saveCurrentState):
(WGSL::AST::Builder::restore):
* Source/WebGPU/WGSL/AST/ASTBuilder.h:
* Source/WebGPU/WGSL/WGSL.cpp:
(WGSL::prepareImpl):
* Source/WebGPU/WGSL/WGSLShaderModule.h:
(WGSL::ShaderModule::Compilation::Compilation):
(WGSL::ShaderModule::Compilation::~Compilation):

Canonical link: <a href="https://commits.webkit.org/264571@main">https://commits.webkit.org/264571@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/edc32f8fbe1b1ef4349a9543b2306d97efd4a942

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/7909 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/8187 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/8440 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/9558 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/8032 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/10180 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/8104 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/10900 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/8049 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/9150 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/7273 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/9676 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/6454 "Passed tests") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/14839 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/7577 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/7397 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/10734 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/7828 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/6364 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/7146 "Built successfully") | | | 
| [❌ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/1915 "Failed to push commit to Webkit repository") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/11355 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/7563 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->