### PR TITLE
REGRESSION(252324@main): crash in WebCore::Style::ElementRuleCollector::ruleMatches

### DIFF
--- a/LayoutTests/fast/frames/stylesheet-mutation-focus-crash-expected.txt
+++ b/LayoutTests/fast/frames/stylesheet-mutation-focus-crash-expected.txt
@@ -1,0 +1,1 @@
+  This test passes if it doesn't crash.

--- a/LayoutTests/fast/frames/stylesheet-mutation-focus-crash.html
+++ b/LayoutTests/fast/frames/stylesheet-mutation-focus-crash.html
@@ -1,0 +1,23 @@
+<style>
+  #z, :is(:focus-visible) {
+    width: 0;
+  }
+</style>
+<script>
+  if (window.testRunner)
+    testRunner.dumpAsText();
+
+  document.designMode = "on";
+
+  onload = () => {
+    i0.onblur = () => {
+      document.styleSheets[0].cssRules[0].selectorText = `#w`;
+    };
+    i0.focus();
+    document.body.offsetLeft;
+    i1.focus();
+  };
+</script>
+<iframe id="i0"></iframe>
+<iframe id="i1"></iframe>
+This test passes if it doesn't crash.

--- a/Source/WebCore/css/StyleRule.h
+++ b/Source/WebCore/css/StyleRule.h
@@ -439,8 +439,13 @@ inline void StyleRuleWithNesting::wrapperAdoptOriginalSelectorList(CSSSelectorLi
 
 inline CompiledSelector& StyleRule::compiledSelectorForListIndex(unsigned index) const
 {
-    if (!m_compiledSelectors)
-        m_compiledSelectors = makeUniqueArray<CompiledSelector>(m_selectorList.listSize());
+    ASSERT(index < m_selectorList.listSize());
+
+    if (!m_compiledSelectors) {
+        auto listSize = m_selectorList.listSize();
+        RELEASE_ASSERT_WITH_SECURITY_IMPLICATION(index < listSize);
+        m_compiledSelectors = makeUniqueArray<CompiledSelector>(listSize);
+    }
     return m_compiledSelectors[index];
 }
 

--- a/Source/WebCore/editing/FrameSelection.cpp
+++ b/Source/WebCore/editing/FrameSelection.cpp
@@ -2187,8 +2187,10 @@ void FrameSelection::pageActivationChanged()
 {
     bool isActive = isPageActive(m_document.get());
     RefPtr focusedElement = m_document->focusedElement();
-    auto invalidations = invalidateFocusedElementAndShadowIncludingAncestors(focusedElement.get(), m_focused && isActive);
-    m_isActive = isActive;
+    {
+        auto invalidations = invalidateFocusedElementAndShadowIncludingAncestors(focusedElement.get(), m_focused && isActive);
+        m_isActive = isActive;
+    }
 
     focusedOrActiveStateChanged();
 }
@@ -2200,9 +2202,11 @@ void FrameSelection::setFocused(bool isFocused)
 
     bool isActive = isPageActive(m_document.get());
     RefPtr focusedElement = m_document->focusedElement();
-    auto invalidations = invalidateFocusedElementAndShadowIncludingAncestors(focusedElement.get(), isFocused && isActive);
-    m_focused = isFocused;
-    m_isActive = isActive;
+    {
+        auto invalidations = invalidateFocusedElementAndShadowIncludingAncestors(focusedElement.get(), isFocused && isActive);
+        m_focused = isFocused;
+        m_isActive = isActive;
+    }
 
     focusedOrActiveStateChanged();
 }


### PR DESCRIPTION
#### 8ac402bd38f42315fb8865d301c7afafdf5b5efc
<pre>
REGRESSION(252324@main): crash in WebCore::Style::ElementRuleCollector::ruleMatches
<a href="https://bugs.webkit.org/show_bug.cgi?id=252814">https://bugs.webkit.org/show_bug.cgi?id=252814</a>
rdar://105545642

Reviewed by Ryosuke Niwa and Geoffrey Garen.

* LayoutTests/fast/frames/stylesheet-mutation-focus-crash-expected.txt: Added.
* LayoutTests/fast/frames/stylesheet-mutation-focus-crash.html: Added.
* Source/WebCore/css/StyleRule.h:
(WebCore::StyleRule::compiledSelectorForListIndex const):

Add some asserts.

* Source/WebCore/editing/FrameSelection.cpp:
(WebCore::FrameSelection::pageActivationChanged):
(WebCore::FrameSelection::setFocused):

Scope style invalidation over the state change only. Previously it was scoped over event sending too.

Originally-landed-as: 259548.274@safari-7615-branch (b25aa011e7aa). rdar://105545642
Canonical link: <a href="https://commits.webkit.org/264534@main">https://commits.webkit.org/264534@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/04e4c4f72ab140b36c7695d4da27b0d7ccbf197e

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/7920 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/8198 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/8384 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/9569 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/8042 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/7925 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/10191 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/8115 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/10906 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/8060 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/9157 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/7232 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/9687 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/6461 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/7225 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/14847 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/7584 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/7347 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/10741 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/7838 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/6374 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/7156 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/7136 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/1889 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/11366 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/7574 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->