### PR TITLE
Remove WTF::protocolIsInFTPFamily()

### DIFF
--- a/Source/WTF/wtf/URL.cpp
+++ b/Source/WTF/wtf/URL.cpp
@@ -362,11 +362,6 @@ bool URL::protocolIsJavaScript() const
     return WTF::protocolIsJavaScript(string());
 }
 
-bool URL::protocolIsInFTPFamily() const
-{
-    return WTF::protocolIsInFTPFamily(string());
-}
-
 bool URL::protocolIs(StringView protocol) const
 {
     assertProtocolIsGood(protocol);
@@ -907,17 +902,6 @@ String URL::strippedForUseAsReport() const
 bool protocolIsJavaScript(StringView string)
 {
     return protocolIsInternal(string, "javascript"_s);
-}
-
-bool protocolIsInFTPFamily(StringView url)
-{
-    auto length = url.length();
-    // Do the comparison without making a new string object.
-    return length >= 4
-        && isASCIIAlphaCaselessEqual(url[0], 'f')
-        && isASCIIAlphaCaselessEqual(url[1], 't')
-        && isASCIIAlphaCaselessEqual(url[2], 'p')
-        && (url[3] == ':' || (isASCIIAlphaCaselessEqual(url[3], 's') && length >= 5 && url[4] == ':'));
 }
 
 bool protocolIsInHTTPFamily(StringView url)

--- a/Source/WTF/wtf/URL.h
+++ b/Source/WTF/wtf/URL.h
@@ -142,13 +142,13 @@ public:
     // Returns true if the current URL's protocol is the same as the null-
     // terminated ASCII argument. The argument must be lower-case.
     WTF_EXPORT_PRIVATE bool protocolIs(StringView) const;
-    bool protocolIsAbout() const { return protocolIs("about"_s); };
+    bool protocolIsAbout() const { return protocolIs("about"_s); }
     bool protocolIsBlob() const { return protocolIs("blob"_s); }
     bool protocolIsData() const { return protocolIs("data"_s); }
     bool protocolIsFile() const { return protocolIs("file"_s); }
     WTF_EXPORT_PRIVATE bool protocolIsJavaScript() const;
-    WTF_EXPORT_PRIVATE bool protocolIsInFTPFamily() const;
-    bool protocolIsInHTTPFamily() const;
+    bool protocolIsInFTPFamily() const { return protocolIs("ftp"_s) || protocolIs("ftps"_s); }
+    bool protocolIsInHTTPFamily() const { return m_protocolIsInHTTPFamily; }
     bool cannotBeABaseURL() const { return m_cannotBeABaseURL; }
 
     WTF_EXPORT_PRIVATE bool isAboutBlank() const;
@@ -273,7 +273,6 @@ WTF_EXPORT_PRIVATE const URL& aboutSrcDocURL();
 
 WTF_EXPORT_PRIVATE bool protocolIs(StringView url, ASCIILiteral protocol);
 WTF_EXPORT_PRIVATE bool protocolIsJavaScript(StringView url);
-WTF_EXPORT_PRIVATE bool protocolIsInFTPFamily(StringView url);
 WTF_EXPORT_PRIVATE bool protocolIsInHTTPFamily(StringView url);
 
 WTF_EXPORT_PRIVATE std::optional<uint16_t> defaultPortForProtocol(StringView protocol);
@@ -355,11 +354,6 @@ inline bool URL::hasQuery() const
 inline bool URL::hasFragmentIdentifier() const
 {
     return m_isValid && m_string.length() > m_queryEnd;
-}
-
-inline bool URL::protocolIsInHTTPFamily() const
-{
-    return m_protocolIsInHTTPFamily;
 }
 
 inline unsigned URL::pathEnd() const


### PR DESCRIPTION
#### 4965e0e6693413d4942c38b6fae149c0b9d15017
<pre>
Remove WTF::protocolIsInFTPFamily()
<a href="https://bugs.webkit.org/show_bug.cgi?id=257337">https://bugs.webkit.org/show_bug.cgi?id=257337</a>
rdar://109841524

Reviewed by Alex Christensen.

Implement URL::protocolIsInFTPFamily() directly in terms of
URL::protocolIs() instead.

* Source/WTF/wtf/URL.cpp:
(WTF::URL::protocolIsInFTPFamily const): Deleted.
(WTF::protocolIsInFTPFamily): Deleted.
* Source/WTF/wtf/URL.h:
(WTF::URL::protocolIsAbout const):
(WTF::URL::protocolIsInFTPFamily const):
(WTF::URL::protocolIsInHTTPFamily const):

Canonical link: <a href="https://commits.webkit.org/264559@main">https://commits.webkit.org/264559@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ddf20a9590bfd246fd1b8b083569c8df024e99a9

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/7923 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/8201 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/8444 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/9572 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/8045 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/10194 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/8118 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/10911 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/8063 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/9164 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/7286 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/9690 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/6468 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/7287 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/14848 "Passed tests") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/6756 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/7591 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/7410 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/10742 "Passed tests") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/7493 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/7841 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/6379 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/8085 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/7159 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/1849 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/1904 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/11369 "Built successfully") | | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/24/builds/8303 "Built successfully") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/7577 "Built successfully") | | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/3/builds/1997 "Passed tests") | 
<!--EWS-Status-Bubble-End-->