### PR TITLE
CompletionHandler assertions fire when navigating away from a QuickLook password field

### DIFF
--- a/Source/WebCore/loader/ios/LegacyPreviewLoader.h
+++ b/Source/WebCore/loader/ios/LegacyPreviewLoader.h
@@ -65,7 +65,7 @@ private:
 
     // PreviewConverterProvider
     void provideMainResourceForPreviewConverter(PreviewConverter&, CompletionHandler<void(Ref<FragmentedSharedBuffer>&&)>&&) final;
-    void providePasswordForPreviewConverter(PreviewConverter&, CompletionHandler<void(const String&)>&&) final;
+    void providePasswordForPreviewConverter(PreviewConverter&, Function<void(const String&)>&&) final;
 
     RefPtr<PreviewConverter> m_converter;
     Ref<LegacyPreviewLoaderClient> m_client;

--- a/Source/WebCore/loader/ios/LegacyPreviewLoader.mm
+++ b/Source/WebCore/loader/ios/LegacyPreviewLoader.mm
@@ -200,7 +200,7 @@ void LegacyPreviewLoader::previewConverterDidFailConverting(PreviewConverter& co
     resourceLoader->didFail(converter.previewError());
 }
 
-void LegacyPreviewLoader::providePasswordForPreviewConverter(PreviewConverter& converter, CompletionHandler<void(const String&)>&& completionHandler)
+void LegacyPreviewLoader::providePasswordForPreviewConverter(PreviewConverter& converter, Function<void(const String&)>&& completionHandler)
 {
     ASSERT_UNUSED(converter, &converter == m_converter);
 

--- a/Source/WebCore/platform/PreviewConverterProvider.h
+++ b/Source/WebCore/platform/PreviewConverterProvider.h
@@ -33,7 +33,7 @@ struct PreviewConverterProvider : CanMakeWeakPtr<PreviewConverterProvider> {
     virtual ~PreviewConverterProvider() = default;
 
     virtual void provideMainResourceForPreviewConverter(PreviewConverter&, CompletionHandler<void(Ref<FragmentedSharedBuffer>&&)>&&) = 0;
-    virtual void providePasswordForPreviewConverter(PreviewConverter&, CompletionHandler<void(const String&)>&&) = 0;
+    virtual void providePasswordForPreviewConverter(PreviewConverter&, Function<void(const String&)>&&) = 0;
 };
 
 } // namespace WebCore


### PR DESCRIPTION
#### 50a6489ac823965b7f7aa40c32b3ed0b39a1168c
<pre>
CompletionHandler assertions fire when navigating away from a QuickLook password field
<a href="https://bugs.webkit.org/show_bug.cgi?id=257342">https://bugs.webkit.org/show_bug.cgi?id=257342</a>
rdar://109847525

Reviewed by Wenson Hsieh.

* Source/WebCore/loader/ios/LegacyPreviewLoader.h:
* Source/WebCore/loader/ios/LegacyPreviewLoader.mm:
(WebCore::LegacyPreviewLoader::providePasswordForPreviewConverter):
* Source/WebCore/platform/PreviewConverterProvider.h:
Convert the argument to `providePasswordForPreviewConverter`
from a CompletionHandler to a plain old function, because it doesn&apos;t fulfull
any of the CompletionHandler invariants:

- it can be never called, if you navigate away without entering a password
- it can be called multiple times, if you get the password wrong and try again

Canonical link: <a href="https://commits.webkit.org/264537@main">https://commits.webkit.org/264537@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/3a68ccf511022ac97616e2e5a2bf065fb2285efb

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/7932 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/8210 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/8396 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/9581 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/8054 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/7937 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/10203 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/8127 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/10917 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/8072 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/9171 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/7240 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/9699 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/6475 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/7237 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/14854 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/7598 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/7360 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/10748 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/7850 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/6387 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/7168 "Built successfully") | | | 
| [❌ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/1890 "Failed to push commit to Webkit repository") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/11378 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/7586 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->