### PR TITLE
Update httpHeaderNameString() to return an ASCIILiteral

### DIFF
--- a/Source/WTF/wtf/text/StringHash.h
+++ b/Source/WTF/wtf/text/StringHash.h
@@ -261,6 +261,36 @@ namespace WTF {
         }
     };
 
+    struct HashTranslatorASCIILiteral {
+        static unsigned hash(ASCIILiteral literal)
+        {
+            return StringHasher::computeHashAndMaskTop8Bits(literal.characters(), literal.length());
+        }
+
+        static bool equal(const String& a, ASCIILiteral b)
+        {
+            return a == b;
+        }
+
+        static void translate(String& location, ASCIILiteral literal, unsigned hash)
+        {
+            location = literal;
+            location.impl()->setHash(hash);
+        }
+    };
+
+    struct HashTranslatorASCIILiteralCaseInsensitive {
+        static unsigned hash(ASCIILiteral key)
+        {
+            return ASCIICaseInsensitiveHash::hash(key.characters(), key.length());
+        }
+
+        static bool equal(const String& a, ASCIILiteral b)
+        {
+            return equalIgnoringASCIICase(a, b);
+        }
+    };
+
     template<> struct DefaultHash<StringImpl*> : StringHash { };
     template<> struct DefaultHash<RefPtr<StringImpl>> : StringHash { };
     template<> struct DefaultHash<PackedPtr<StringImpl>> : StringHash { };
@@ -271,5 +301,7 @@ namespace WTF {
 using WTF::ASCIICaseInsensitiveHash;
 using WTF::ASCIICaseInsensitiveStringViewHashTranslator;
 using WTF::AlreadyHashed;
+using WTF::HashTranslatorASCIILiteral;
+using WTF::HashTranslatorASCIILiteralCaseInsensitive;
 using WTF::StringHash;
 using WTF::StringViewHashTranslator;

--- a/Source/WTF/wtf/text/WTFString.h
+++ b/Source/WTF/wtf/text/WTFString.h
@@ -561,24 +561,6 @@ inline bool startsWithLettersIgnoringASCIICase(const String& string, ASCIILitera
     return startsWithLettersIgnoringASCIICase(string.impl(), literal);
 }
 
-struct HashTranslatorASCIILiteral {
-    static unsigned hash(ASCIILiteral literal)
-    {
-        return StringHasher::computeHashAndMaskTop8Bits(literal.characters(), literal.length());
-    }
-
-    static bool equal(const String& a, ASCIILiteral b)
-    {
-        return a == b;
-    }
-
-    static void translate(String& location, ASCIILiteral literal, unsigned hash)
-    {
-        location = literal;
-        location.impl()->setHash(hash);
-    }
-};
-
 inline namespace StringLiterals {
 
 inline String operator"" _str(const char* characters, size_t)
@@ -595,7 +577,6 @@ inline String operator"" _str(const UChar* characters, size_t length)
 
 } // namespace WTF
 
-using WTF::HashTranslatorASCIILiteral;
 using WTF::KeepTrailingZeros;
 using WTF::String;
 using WTF::charactersToDouble;

--- a/Source/WebCore/platform/graphics/gstreamer/MediaPlayerPrivateGStreamer.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/MediaPlayerPrivateGStreamer.cpp
@@ -1947,13 +1947,13 @@ void MediaPlayerPrivateGStreamer::handleMessage(GstMessage* message)
 
             GUniqueOutPtr<GstStructure> responseHeaders;
             if (gst_structure_get(structure, "response-headers", GST_TYPE_STRUCTURE, &responseHeaders.outPtr(), nullptr)) {
-                CString contentLengthHeaderName = httpHeaderNameString(HTTPHeaderName::ContentLength).utf8();
+                auto contentLengthHeaderName = httpHeaderNameString(HTTPHeaderName::ContentLength);
                 uint64_t contentLength = 0;
-                if (!gst_structure_get_uint64(responseHeaders.get(), contentLengthHeaderName.data(), &contentLength)) {
+                if (!gst_structure_get_uint64(responseHeaders.get(), contentLengthHeaderName.characters(), &contentLength)) {
                     // souphttpsrc sets a string for Content-Length, so
                     // handle it here, until we remove the webkit+ protocol
                     // prefix from webkitwebsrc.
-                    if (const char* contentLengthAsString = gst_structure_get_string(responseHeaders.get(), contentLengthHeaderName.data())) {
+                    if (const char* contentLengthAsString = gst_structure_get_string(responseHeaders.get(), contentLengthHeaderName.characters())) {
                         contentLength = g_ascii_strtoull(contentLengthAsString, nullptr, 10);
                         if (contentLength == G_MAXUINT64)
                             contentLength = 0;

--- a/Source/WebCore/platform/network/HTTPHeaderMap.h
+++ b/Source/WebCore/platform/network/HTTPHeaderMap.h
@@ -106,7 +106,7 @@ public:
         {
             if (it == m_table.commonHeaders().end())
                 return false;
-            m_keyValue.key = httpHeaderNameString(it->key).toStringWithoutCopying();
+            m_keyValue.key = httpHeaderNameString(it->key);
             m_keyValue.keyAsHTTPHeaderName = it->key;
             m_keyValue.value = it->value;
             return true;

--- a/Source/WebCore/platform/network/HTTPParsers.cpp
+++ b/Source/WebCore/platform/network/HTTPParsers.cpp
@@ -909,7 +909,7 @@ bool isCrossOriginSafeHeader(HTTPHeaderName name, const HTTPHeaderSet& accessCon
     default:
         break;
     }
-    return accessControlExposeHeaderSet.contains<ASCIICaseInsensitiveStringViewHashTranslator>(httpHeaderNameString(name));
+    return accessControlExposeHeaderSet.contains<HashTranslatorASCIILiteralCaseInsensitive>(httpHeaderNameString(name));
 }
 
 bool isCrossOriginSafeHeader(const String& name, const HTTPHeaderSet& accessControlExposeHeaderSet)

--- a/Source/WebCore/platform/network/RFC8941.h
+++ b/Source/WebCore/platform/network/RFC8941.h
@@ -27,6 +27,7 @@
 
 #include <wtf/Forward.h>
 #include <wtf/HashMap.h>
+#include <wtf/text/StringHash.h>
 #include <wtf/text/WTFString.h>
 
 namespace RFC8941 {

--- a/Source/WebCore/platform/network/ResourceResponseBase.cpp
+++ b/Source/WebCore/platform/network/ResourceResponseBase.cpp
@@ -496,7 +496,7 @@ void ResourceResponseBase::sanitizeHTTPHeaderFieldsAccordingToTainting()
             return;
 
         m_httpHeaderFields.commonHeaders().removeAllMatching([&corsSafeHeaderSet](auto& header) {
-            return !isSafeCrossOriginResponseHeader(header.key) && !corsSafeHeaderSet.contains<ASCIICaseInsensitiveStringViewHashTranslator>(httpHeaderNameString(header.key));
+            return !isSafeCrossOriginResponseHeader(header.key) && !corsSafeHeaderSet.contains<HashTranslatorASCIILiteralCaseInsensitive>(httpHeaderNameString(header.key));
         });
         m_httpHeaderFields.uncommonHeaders().removeAllMatching([&corsSafeHeaderSet](auto& header) { return !corsSafeHeaderSet.contains(header.key); });
         break;

--- a/Source/WebCore/platform/network/create-http-header-name-table
+++ b/Source/WebCore/platform/network/create-http-header-name-table
@@ -97,14 +97,11 @@ IGNORE_WARNINGS_BEGIN("implicit-fallthrough")
 
 namespace WebCore {
 
-static const struct HeaderNameString {
-    const char* const name;
-    unsigned length;
-} headerNameStrings[] = {
+static const ASCIILiteral headerNameStrings[] = {
 ''')
 
 for http_header_name in http_header_names:
-    gperf_file.write('    { "%s", %u },\n' % (http_header_name, len(http_header_name)))
+    gperf_file.write('    "%s"_s,\n' % (http_header_name,))
 
 gperf_file.write('};\n\n')
 
@@ -163,13 +160,11 @@ bool findHTTPHeaderName(StringView stringView, HTTPHeaderName& headerName)
     return false;
 }
 
-StringView httpHeaderNameString(HTTPHeaderName headerName)
+ASCIILiteral httpHeaderNameString(HTTPHeaderName headerName)
 {
     ASSERT(static_cast<unsigned>(headerName) < numHTTPHeaderNames);
     
-    const auto& name = headerNameStrings[static_cast<unsigned>(headerName)];
-    
-    return StringView { reinterpret_cast<const LChar*>(name.name), static_cast<unsigned>(name.length) };
+    return headerNameStrings[static_cast<unsigned>(headerName)];
 }
 
 } // namespace WebCore
@@ -229,7 +224,7 @@ header_file.write('const size_t minHTTPHeaderNameLength = %u;\n' % len(min(http_
 header_file.write('const size_t maxHTTPHeaderNameLength = %u;\n' % len(max(http_header_names, key=len)));
 header_file.write('''
 bool findHTTPHeaderName(StringView, HTTPHeaderName&);
-WEBCORE_EXPORT StringView httpHeaderNameString(HTTPHeaderName);
+WEBCORE_EXPORT ASCIILiteral httpHeaderNameString(HTTPHeaderName);
 
 } // namespace WebCore
 


### PR DESCRIPTION
#### fa601944b216c57b9231f38ffe5db33047a5411d
<pre>
Update httpHeaderNameString() to return an ASCIILiteral
<a href="https://bugs.webkit.org/show_bug.cgi?id=257343">https://bugs.webkit.org/show_bug.cgi?id=257343</a>

Reviewed by Youenn Fablet.

Update httpHeaderNameString() to return an ASCIILiteral instead of a StringView.
It makes it clearer that it only returns ASCII characters and that they are
&quot;immortal&quot;.

* Source/WTF/wtf/text/StringHash.h:
(WTF::HashTranslatorASCIILiteral::hash):
(WTF::HashTranslatorASCIILiteral::equal):
(WTF::HashTranslatorASCIILiteral::translate):
(WTF::HashTranslatorASCIILiteralCaseInsensitive::hash):
(WTF::HashTranslatorASCIILiteralCaseInsensitive::equal):
* Source/WTF/wtf/text/WTFString.h:
(WTF::HashTranslatorASCIILiteral::hash): Deleted.
(WTF::HashTranslatorASCIILiteral::equal): Deleted.
(WTF::HashTranslatorASCIILiteral::translate): Deleted.
* Source/WebCore/platform/graphics/gstreamer/MediaPlayerPrivateGStreamer.cpp:
(WebCore::MediaPlayerPrivateGStreamer::handleMessage):
* Source/WebCore/platform/network/HTTPHeaderMap.h:
(WebCore::HTTPHeaderMap::HTTPHeaderMapConstIterator::updateKeyValue):
* Source/WebCore/platform/network/HTTPParsers.cpp:
(WebCore::isCrossOriginSafeHeader):
* Source/WebCore/platform/network/ResourceResponseBase.cpp:
(WebCore::ResourceResponseBase::sanitizeHTTPHeaderFieldsAccordingToTainting):
* Source/WebCore/platform/network/create-http-header-name-table:

Canonical link: <a href="https://commits.webkit.org/264587@main">https://commits.webkit.org/264587@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a1e3bc62b47b028bec5cce5de1ff41a6f188bfd8

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/7966 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/8248 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/8462 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/9616 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/8080 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/7970 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/10236 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/8160 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/10940 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/8109 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/9201 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/7292 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/9735 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/6503 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/7296 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/14877 "22 flakes 94 failures") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/6792 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/7626 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/7419 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/10771 "Passed tests") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/7534 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/7883 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/6411 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/8130 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/7200 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/1857 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/1930 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/11409 "Built successfully") | | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/24/builds/8350 "Built successfully") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/7621 "Built successfully") | | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/3/builds/2004 "Passed tests") | 
<!--EWS-Status-Bubble-End-->