### PR TITLE
[results.webkit.org] Display elapsed hours for long runs

### DIFF
--- a/Tools/Scripts/libraries/resultsdbpy/resultsdbpy/view/static/js/common.js
+++ b/Tools/Scripts/libraries/resultsdbpy/resultsdbpy/view/static/js/common.js
@@ -204,11 +204,17 @@ function percentage(value, max)
 
 function elapsedTime(startTimestamp, endTimestamp)
 {
-    const time = new Date((endTimestamp - startTimestamp) * 1000);
-    let result = '';
-    if (time.getMinutes())
-        result += `${time.getMinutes()} minute${time.getMinutes() == 1 ? '' : 's'} and `;
-    result += `${time.getSeconds()} second${time.getSeconds() == 1 ? '' : 's'} to run`;
+    const elapsed = Math.round(endTimestamp - startTimestamp);
+    const seconds = elapsed % 60;
+    const minutes = Math.floor(elapsed / 60) % 60;
+    const hours = Math.floor(elapsed / 3600);
+
+    let result = `${seconds} second${seconds == 1 ? '' : 's'} to run`;
+    if (minutes)
+        result = `${minutes} minute${minutes == 1 ? '' : 's'} and ${result}`;
+    if (hours)
+        result = `${hours} hour${hours == 1 ? '' : 's'}${minutes ? ', ' : ' and '}${result}`;
+
     return result;
 }
 


### PR DESCRIPTION
#### 413f41780160e570f29d88b1d02e51a6e8b5f9cb
<pre>
[results.webkit.org] Display elapsed hours for long runs
<a href="https://bugs.webkit.org/show_bug.cgi?id=257344">https://bugs.webkit.org/show_bug.cgi?id=257344</a>
rdar://109849743

Reviewed by Aakash Jain.

* Tools/Scripts/libraries/resultsdbpy/resultsdbpy/view/static/js/common.js: Convert
elapsed seconds to a human-readable time without using the Date class.

Canonical link: <a href="https://commits.webkit.org/264589@main">https://commits.webkit.org/264589@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b367e724ee631e8691066e49a31463075602079f

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/7934 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/8212 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/8398 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/9583 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/8055 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/7939 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/10205 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/8129 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/10919 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/8074 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/15/builds/9173 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/7241 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/9701 "Built successfully") | 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/8059 "Passed tests") | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/6477 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/7238 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/14865 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/7600 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/7361 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/10759 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/7852 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/6388 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | | 
| [✅ 🧪 services](https://ews-build.webkit.org/#/builders/28/builds/7895 "Passed tests") | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/7170 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/11380 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/963 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/7588 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->