### PR TITLE
Fix crash in WebCore::ManagedMediaSource::isOpen()

### DIFF
--- a/LayoutTests/fast/media/managed-media-source-open-crash-expected.txt
+++ b/LayoutTests/fast/media/managed-media-source-open-crash-expected.txt
@@ -1,0 +1,2 @@
+CONSOLE MESSAGE: Unhandled Promise Rejection: InvalidStateError: The object is in an invalid state.
+PASS if no crash.

--- a/LayoutTests/fast/media/managed-media-source-open-crash.html
+++ b/LayoutTests/fast/media/managed-media-source-open-crash.html
@@ -1,0 +1,14 @@
+<script>
+  onload = async () => {
+    if (window.testRunner)
+      testRunner.dumpAsText();
+    let video0 = document.createElement('video');
+    let managedMediaSource = new ManagedMediaSource();
+    video0.srcObject = managedMediaSource;
+    await navigator.locks.query();
+    video0.src = 'data:';
+    managedMediaSource.duration = 0;
+    document.body.offsetHeight;
+  };
+</script>
+<body>PASS if no crash.</body>

--- a/Source/WebCore/Modules/mediasource/ManagedMediaSource.cpp
+++ b/Source/WebCore/Modules/mediasource/ManagedMediaSource.cpp
@@ -124,6 +124,7 @@ void ManagedMediaSource::ensurePrefsRead()
 {
     if (m_lowThreshold && m_highThreshold)
         return;
+    ASSERT(mediaElement());
     m_lowThreshold = mediaElement()->document().settings().managedMediaSourceLowThreshold();
     m_highThreshold = mediaElement()->document().settings().managedMediaSourceHighThreshold();
 }
@@ -173,9 +174,9 @@ bool ManagedMediaSource::isOpen() const
     return MediaSource::isOpen();
 #else
     return MediaSource::isOpen()
-        && (!mediaElement()->document().settings().managedMediaSourceNeedsAirPlay()
+        && (mediaElement() && (!mediaElement()->document().settings().managedMediaSourceNeedsAirPlay()
             || mediaElement()->isWirelessPlaybackTargetDisabled()
-            || mediaElement()->hasWirelessPlaybackTargetAlternative());
+            || mediaElement()->hasWirelessPlaybackTargetAlternative()));
 #endif
 }
 


### PR DESCRIPTION
#### ad0f3bf368a6e3a0a20eb9ec7f94da2fdf343d49
<pre>
Fix crash in WebCore::ManagedMediaSource::isOpen()
<a href="https://bugs.webkit.org/show_bug.cgi?id=257345">https://bugs.webkit.org/show_bug.cgi?id=257345</a>
rdar://109827653

Reviewed by Jer Noble.

mediaElement() might have gone away when we&apos;re checking for
ManagedMediaSource::isOpen(), which can cause a crash. This change fixes
that.

* Source/WebCore/Modules/mediasource/ManagedMediaSource.cpp:
(WebCore::ManagedMediaSource::ensurePrefsRead):
(WebCore::ManagedMediaSource::isOpen const):
* LayoutTests/fast/media/managed-media-source-open-crash-expected.txt: Added.
* LayoutTests/fast/media/managed-media-source-open-crash.html: Added.

Canonical link: <a href="https://commits.webkit.org/264554@main">https://commits.webkit.org/264554@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5ee9ad7a089fe1222f42f300e4afaac257b9e505

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/7938 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/8217 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/8403 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/9588 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/8059 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/7943 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/10210 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/8133 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/10921 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/8079 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/9177 "Passed tests") | [⏳ 🧪 api-mac](https://ews-build.webkit.org/#/builders/API-Tests-macOS-EWS "Waiting to run tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/9705 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/6481 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/7241 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/14857 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/7604 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/7364 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/10751 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/7856 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/6389 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/7174 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/7152 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/1901 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/11384 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/7592 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->