### PR TITLE
Make the NotificationData NSDictionary representation property list serializable

### DIFF
--- a/Source/WebCore/Modules/notifications/NotificationDataCocoa.mm
+++ b/Source/WebCore/Modules/notifications/NotificationDataCocoa.mm
@@ -93,7 +93,7 @@ std::optional<NotificationData> NotificationData::fromDictionary(NSDictionary *d
 
 NSDictionary *NotificationData::dictionaryRepresentation() const
 {
-    return @{
+    NSMutableDictionary *result = @{
         WebNotificationTitleKey : (NSString *)title,
         WebNotificationBodyKey : (NSString *)body,
         WebNotificationIconURLKey : (NSString *)iconURL,
@@ -106,8 +106,12 @@ NSDictionary *NotificationData::dictionaryRepresentation() const
         WebNotificationContextUUIDStringKey : (NSString *)contextIdentifier.toString(),
         WebNotificationSessionIDKey : @(sourceSession.toUInt64()),
         WebNotificationDataKey: [NSData dataWithBytes:data.data() length:data.size()],
-        WebNotificationSilentKey: silent == std::nullopt ? [NSNull null] : [NSNumber numberWithBool:*silent]
-    };
+    }.mutableCopy;
+
+    if (silent != std::nullopt)
+        result[WebNotificationSilentKey] = @(*silent);
+
+    return result;
 }
 
 } // namespace WebKit

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/PushAPI.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/PushAPI.mm
@@ -399,7 +399,7 @@ TEST(PushAPI, testSilentFlag)
     EXPECT_TRUE(pushMessageSuccessful);
     EXPECT_TRUE([delegate.get().displayedNotifications.lastObject.title isEqualToString:@"nothing"]);
     EXPECT_EQ(delegate.get().displayedNotifications.lastObject.alert, _WKNotificationAlertDefault);
-    EXPECT_TRUE([delegate.get().displayedNotifications.lastObject.userInfo[@"WebNotificationSilentKey"] isEqual:[NSNull null]]);
+    EXPECT_TRUE(delegate.get().displayedNotifications.lastObject.userInfo[@"WebNotificationSilentKey"] == nil);
 
     done = false;
     pushMessageProcessed = false;


### PR DESCRIPTION
#### b2b22d7e5d2c187d224ca3cfb1c560d83fb2d794
<pre>
Make the NotificationData NSDictionary representation property list serializable
<a href="https://bugs.webkit.org/show_bug.cgi?id=257339">https://bugs.webkit.org/show_bug.cgi?id=257339</a>
rdar://109734742

Reviewed by Tim Horton.

Only put the silent value in the dictionary if it exists.

* Source/WebCore/Modules/notifications/NotificationDataCocoa.mm:
(WebCore::NotificationData::dictionaryRepresentation const):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/PushAPI.mm:

Canonical link: <a href="https://commits.webkit.org/264548@main">https://commits.webkit.org/264548@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/efe3f3313d3e86628b71dc4ede701ef1aa9dea32

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/7963 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/8245 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/8459 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/9613 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/8077 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/7967 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/10233 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/8157 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/10937 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/8106 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/9192 "2 new passes 3 flakes 4 failures") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/7285 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/9732 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/6495 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/7286 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/14874 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/7618 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/7409 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/10776 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/7880 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/6406 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/7197 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/1897 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/11406 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/7618 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->