### PR TITLE
Stop treating "text/xsl" as a XML MIME type

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/xhr/responsexml-media-type-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/xhr/responsexml-media-type-expected.txt
@@ -9,7 +9,7 @@ PASS XMLHttpRequest: responseXML MIME type tests ('video/x-awesome+xml', should 
 PASS XMLHttpRequest: responseXML MIME type tests ('video/x-awesome', should not parse)
 PASS XMLHttpRequest: responseXML MIME type tests ('text/xml', should  parse)
 PASS XMLHttpRequest: responseXML MIME type tests ('application', should  parse)
-FAIL XMLHttpRequest: responseXML MIME type tests ('text/xsl', should not parse) assert_equals: expected null but got Document node with 1 child
+PASS XMLHttpRequest: responseXML MIME type tests ('text/xsl', should not parse)
 PASS XMLHttpRequest: responseXML MIME type tests ('text/plain', should not parse)
 PASS XMLHttpRequest: responseXML MIME type tests ('application/rdf', should not parse)
 PASS XMLHttpRequest: responseXML MIME type tests ('application/xhtml+xml', should  parse)

--- a/Source/WebCore/loader/TextResourceDecoder.cpp
+++ b/Source/WebCore/loader/TextResourceDecoder.cpp
@@ -289,7 +289,7 @@ TextResourceDecoder::ContentType TextResourceDecoder::determineContentType(const
         return CSS;
     if (equalLettersIgnoringASCIICase(mimeType, "text/html"_s))
         return HTML;
-    if (MIMETypeRegistry::isXMLMIMEType(mimeType))
+    if (MIMETypeRegistry::isXMLMIMEType(mimeType) || mimeType == "text/xsl"_s)
         return XML;
     return PlainText;
 }

--- a/Source/WebCore/platform/MIMETypeRegistry.cpp
+++ b/Source/WebCore/platform/MIMETypeRegistry.cpp
@@ -601,9 +601,10 @@ static inline bool isValidXMLMIMETypeChar(UChar c)
         || c == '-' || c == '.' || c == '^' || c == '_' || c == '`' || c == '{' || c == '|' || c == '}' || c == '~';
 }
 
+// https://mimesniff.spec.whatwg.org/#xml-mime-type
 bool MIMETypeRegistry::isXMLMIMEType(const String& mimeType)
 {
-    if (equalLettersIgnoringASCIICase(mimeType, "text/xml"_s) || equalLettersIgnoringASCIICase(mimeType, "application/xml"_s) || equalLettersIgnoringASCIICase(mimeType, "text/xsl"_s))
+    if (equalLettersIgnoringASCIICase(mimeType, "text/xml"_s) || equalLettersIgnoringASCIICase(mimeType, "application/xml"_s))
         return true;
 
     if (!mimeType.endsWithIgnoringASCIICase("+xml"_s))


### PR DESCRIPTION
#### 7c5509f22cb96221a2a556cedb3f8d0ef9abc7cf
<pre>
Stop treating &quot;text/xsl&quot; as a XML MIME type
<a href="https://bugs.webkit.org/show_bug.cgi?id=257360">https://bugs.webkit.org/show_bug.cgi?id=257360</a>

Reviewed by Youenn Fablet.

Stop treating &quot;text/xsl&quot; as a XML MIME type, as per:
- <a href="https://mimesniff.spec.whatwg.org/#xml-mime-type">https://mimesniff.spec.whatwg.org/#xml-mime-type</a>

Neither Blink nor Gecko treat it as a valid XML MIME type.

* LayoutTests/imported/w3c/web-platform-tests/xhr/responsexml-media-type-expected.txt:
* Source/WebCore/platform/MIMETypeRegistry.cpp:
(WebCore::MIMETypeRegistry::isXMLMIMEType):

Canonical link: <a href="https://commits.webkit.org/264585@main">https://commits.webkit.org/264585@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/3762048974332ede54f3da1eccb775f168575a87

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/8000 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/8285 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/8497 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/9652 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/8105 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/8004 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/10271 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/8196 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/10969 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/8144 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/9232 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/7310 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/9771 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/6533 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/7321 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/14900 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/7656 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/7441 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/10803 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/7912 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/6436 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/7226 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/1931 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/11434 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/7653 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->