### PR TITLE
Fix warnings introduced in 264411@main

### DIFF
--- a/Source/WebCore/workers/service/context/SWContextManager.cpp
+++ b/Source/WebCore/workers/service/context/SWContextManager.cpp
@@ -102,7 +102,7 @@ void SWContextManager::fireInstallEvent(ServiceWorkerIdentifier identifier)
 {
     auto* serviceWorker = serviceWorkerThreadProxy(identifier);
     if (!serviceWorker) {
-        RELEASE_LOG_ERROR(ServiceWorker, "SWContextManager::fireInstallEvent but service worker %llu not found", identifier.toUInt64());
+        RELEASE_LOG_ERROR(ServiceWorker, "SWContextManager::fireInstallEvent but service worker %" PRIu64 " not found", identifier.toUInt64());
         return;
     }
 
@@ -113,7 +113,7 @@ void SWContextManager::fireActivateEvent(ServiceWorkerIdentifier identifier)
 {
     auto* serviceWorker = serviceWorkerThreadProxy(identifier);
     if (!serviceWorker) {
-        RELEASE_LOG_ERROR(ServiceWorker, "SWContextManager::fireActivateEvent but service worker %llu not found", identifier.toUInt64());
+        RELEASE_LOG_ERROR(ServiceWorker, "SWContextManager::fireActivateEvent but service worker %" PRIu64 " not found", identifier.toUInt64());
         return;
     }
 
@@ -124,7 +124,7 @@ void SWContextManager::firePushEvent(ServiceWorkerIdentifier identifier, std::op
 {
     auto* serviceWorker = serviceWorkerThreadProxy(identifier);
     if (!serviceWorker) {
-        RELEASE_LOG_ERROR(ServiceWorker, "SWContextManager::firePushEvent but service worker %llu not found", identifier.toUInt64());
+        RELEASE_LOG_ERROR(ServiceWorker, "SWContextManager::firePushEvent but service worker %" PRIu64 " not found", identifier.toUInt64());
         callback(false);
         return;
     }
@@ -136,7 +136,7 @@ void SWContextManager::firePushSubscriptionChangeEvent(ServiceWorkerIdentifier i
 {
     auto* serviceWorker = serviceWorkerThreadProxy(identifier);
     if (!serviceWorker) {
-        RELEASE_LOG_ERROR(ServiceWorker, "SWContextManager::firePushSubscriptionChangeEvent but service worker %llu not found", identifier.toUInt64());
+        RELEASE_LOG_ERROR(ServiceWorker, "SWContextManager::firePushSubscriptionChangeEvent but service worker %" PRIu64 " not found", identifier.toUInt64());
         return;
     }
 
@@ -147,7 +147,7 @@ void SWContextManager::fireNotificationEvent(ServiceWorkerIdentifier identifier,
 {
     auto* serviceWorker = serviceWorkerThreadProxy(identifier);
     if (!serviceWorker) {
-        RELEASE_LOG_ERROR(ServiceWorker, "SWContextManager::fireNotificationEvent but service worker %llu not found", identifier.toUInt64());
+        RELEASE_LOG_ERROR(ServiceWorker, "SWContextManager::fireNotificationEvent but service worker %" PRIu64 " not found", identifier.toUInt64());
         callback(false);
         return;
     }
@@ -159,7 +159,7 @@ void SWContextManager::fireBackgroundFetchEvent(ServiceWorkerIdentifier identifi
 {
     auto* serviceWorker = serviceWorkerThreadProxy(identifier);
     if (!serviceWorker) {
-        RELEASE_LOG_ERROR(ServiceWorker, "SWContextManager::fireBackgroundFetchEvent but service worker %llu not found", identifier.toUInt64());
+        RELEASE_LOG_ERROR(ServiceWorker, "SWContextManager::fireBackgroundFetchEvent but service worker %" PRIu64 " not found", identifier.toUInt64());
         callback(false);
         return;
     }
@@ -171,7 +171,7 @@ void SWContextManager::fireBackgroundFetchClickEvent(ServiceWorkerIdentifier ide
 {
     auto* serviceWorker = serviceWorkerThreadProxy(identifier);
     if (!serviceWorker) {
-        RELEASE_LOG_ERROR(ServiceWorker, "SWContextManager::fireBackgroundFetchClickEvent but service worker %llu not found", identifier.toUInt64());
+        RELEASE_LOG_ERROR(ServiceWorker, "SWContextManager::fireBackgroundFetchClickEvent but service worker %" PRIu64 " not found", identifier.toUInt64());
         callback(false);
         return;
     }
@@ -181,7 +181,7 @@ void SWContextManager::fireBackgroundFetchClickEvent(ServiceWorkerIdentifier ide
 
 void SWContextManager::terminateWorker(ServiceWorkerIdentifier identifier, Seconds timeout, Function<void()>&& completionHandler)
 {
-    RELEASE_LOG(ServiceWorker, "SWContextManager::terminateWorker %llu", identifier.toUInt64());
+    RELEASE_LOG(ServiceWorker, "SWContextManager::terminateWorker %" PRIu64, identifier.toUInt64());
 
     RefPtr<ServiceWorkerThreadProxy> serviceWorker;
     {


### PR DESCRIPTION
#### 91f5e58e538de748c3da83346dc866f25f8146f0
<pre>
Fix warnings introduced in 264411@main
<a href="https://bugs.webkit.org/show_bug.cgi?id=257359">https://bugs.webkit.org/show_bug.cgi?id=257359</a>

Reviewed by Don Olmstead.

Use `PRIu64` when printing out `uint64_t` values.

* Source/WebCore/workers/service/context/SWContextManager.cpp:
(WebCore::SWContextManager::fireInstallEvent):
(WebCore::SWContextManager::fireActivateEvent):
(WebCore::SWContextManager::firePushEvent):
(WebCore::SWContextManager::firePushSubscriptionChangeEvent):
(WebCore::SWContextManager::fireNotificationEvent):
(WebCore::SWContextManager::fireBackgroundFetchEvent):
(WebCore::SWContextManager::fireBackgroundFetchClickEvent):
(WebCore::SWContextManager::terminateWorker):

Canonical link: <a href="https://commits.webkit.org/264764@main">https://commits.webkit.org/264764@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/dfb8478cac9561127b7b85ca3230598b4666933a

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/7974 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/8256 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/8469 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/9624 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/8085 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/7978 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/10243 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/8168 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/10945 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/8117 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/9206 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/7291 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/9743 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/6507 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/7292 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/14881 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/7630 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/7416 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/10778 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/7890 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/6416 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/7205 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/2075 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/11413 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/7628 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->