### PR TITLE
REGRESSION (264433@main): Drawing small images becomes slower

### DIFF
--- a/LayoutTests/fast/images/async-image-composited-show.html
+++ b/LayoutTests/fast/images/async-image-composited-show.html
@@ -29,15 +29,21 @@
     <script>
         if (window.testRunner) {
             internals.clearMemoryCache();
+            internals.settings.setWebkitImageReadyEventEnabled(true);
             internals.settings.setLargeImageAsyncDecodingEnabled(true);
             testRunner.waitUntilDone();
         }
 
         var image = new Image();
+        document.body.appendChild(image);
+
         image.onload = function() {
-            // Force very long async image decoding for this image.
-            if (window.internals)
-                internals.setImageFrameDecodingDuration(image, 5000);
+            if (window.internals && window.testRunner) {
+                image.addEventListener("webkitImageFrameReady", function() {
+                    image.remove();
+                    testRunner.notifyDone();
+                }, false);
+            }
 
             // Change the background of the element.
             let element = document.querySelector(".composited");
@@ -45,7 +51,6 @@
 
             // Show the body element and end the test.
             document.body.classList.add("background-loaded");
-            testRunner.notifyDone();
         };
         image.src = "resources/green-400x400.png";
     </script>

--- a/LayoutTests/fast/images/async-image-src-change.html
+++ b/LayoutTests/fast/images/async-image-src-change.html
@@ -11,8 +11,7 @@
 
                         // Force layout and display so the image gets drawn.
                         document.body.offsetHeight;
-                        if (window.testRunner)
-                            testRunner.display();
+                        testRunner.display();
 
                         image.addEventListener("webkitImageFrameReady", function() {
                             internals.setLargeImageAsyncDecodingEnabledForTesting(image, false);

--- a/LayoutTests/fast/images/decode-decoding-change-image-src.html
+++ b/LayoutTests/fast/images/decode-decoding-change-image-src.html
@@ -4,16 +4,22 @@
     <script>
         if (window.internals && window.testRunner) {
             internals.clearMemoryCache();
+            internals.settings.setWebkitImageReadyEventEnabled(true);
+            internals.settings.setLargeImageAsyncDecodingEnabled(true);
             testRunner.waitUntilDone();
         }
 
         function setImageSrc() {
             var image = document.getElementById("image");
             image.onload = (() => {
+                if (window.internals && window.testRunner) {
+                    image.addEventListener("webkitImageFrameReady", function() {
+                        testRunner.notifyDone();
+                    }, false);
+                }
+
                 // Force layout and display so the image frame starts decoding.
                 document.body.offsetHeight;
-                if (window.testRunner)
-                    testRunner.notifyDone();
             });
             image.src = "resources/green-400x400.png";
         }

--- a/LayoutTests/platform/mac-wk1/TestExpectations
+++ b/LayoutTests/platform/mac-wk1/TestExpectations
@@ -1352,6 +1352,9 @@ http/tests/inspector/network/fetch-response-body-304.html [ Skip ]
 # Async image decoding is WK2 only
 fast/images/async-image-background-change.html
 fast/images/async-image-src-change.html
+fast/images/async-image-composited-show.html
+fast/images/decode-decoding-change-image-src.html
+http/tests/images/render-partial-image-load.html
 http/tests/multipart/multipart-async-image.html
 
 css3/masking/mask-repeat-space-padding.html [ ImageOnlyFailure ]

--- a/Source/WebCore/dom/Node.cpp
+++ b/Source/WebCore/dom/Node.cpp
@@ -1273,6 +1273,16 @@ void Node::setManuallyAssignedSlot(HTMLSlotElement* slotElement)
     ensureRareData().setManuallyAssignedSlot(slotElement);
 }
 
+bool Node::hasEverPaintedImages() const
+{
+    return hasRareData() && rareData()->hasEverPaintedImages();
+}
+
+void Node::setHasEverPaintedImages(bool hasEverPaintedImages)
+{
+    ensureRareData().setHasEverPaintedImages(hasEverPaintedImages);
+}
+
 ContainerNode* Node::parentInComposedTree() const
 {
     ASSERT(isMainThreadOrGCThread());

--- a/Source/WebCore/dom/Node.h
+++ b/Source/WebCore/dom/Node.h
@@ -250,6 +250,9 @@ public:
     HTMLSlotElement* manuallyAssignedSlot() const;
     void setManuallyAssignedSlot(HTMLSlotElement*);
 
+    bool hasEverPaintedImages() const;
+    void setHasEverPaintedImages(bool);
+
     bool isUncustomizedCustomElement() const { return customElementState() == CustomElementState::Uncustomized; }
     bool isCustomElementUpgradeCandidate() const { return customElementState() == CustomElementState::Undefined; }
     bool isDefinedCustomElement() const { return customElementState() == CustomElementState::Custom; }

--- a/Source/WebCore/dom/NodeRareData.h
+++ b/Source/WebCore/dom/NodeRareData.h
@@ -286,6 +286,9 @@ public:
     HTMLSlotElement* manuallyAssignedSlot() { return m_manuallyAssignedSlot.get(); }
     void setManuallyAssignedSlot(HTMLSlotElement* slot) { m_manuallyAssignedSlot = slot; }
 
+    bool hasEverPaintedImages() const { return m_hasEverPaintedImages; }
+    void setHasEverPaintedImages(bool hasEverPaintedImages) { m_hasEverPaintedImages = hasEverPaintedImages; }
+
 #if DUMP_NODE_STATISTICS
     OptionSet<UseType> useTypes() const
     {
@@ -309,6 +312,7 @@ private:
     std::unique_ptr<NodeMutationObserverData> m_mutationObserverData;
     WeakPtr<HTMLSlotElement, WeakPtrImplWithEventTargetData> m_manuallyAssignedSlot;
     bool m_isElementRareData; // Keep last for better bit packing with ElementRareData.
+    bool m_hasEverPaintedImages { false }; // Keep last for better bit packing with ElementRareData.
 };
 
 template<> struct NodeListTypeIdentifier<NameNodeList> {

--- a/Source/WebCore/rendering/BackgroundPainter.cpp
+++ b/Source/WebCore/rendering/BackgroundPainter.cpp
@@ -416,6 +416,9 @@ void BackgroundPainter::paintFillLayer(const Color& color, const FillLayer& bgLa
                 ASSERT(bgImage->hasCachedImage());
                 bgImage->cachedImage()->addClientWaitingForAsyncDecoding(m_renderer);
             }
+
+            if (m_renderer.element() && !context.paintingDisabled())
+                m_renderer.element()->setHasEverPaintedImages(true);
         }
     }
 

--- a/Source/WebCore/rendering/RenderBoxModelObject.cpp
+++ b/Source/WebCore/rendering/RenderBoxModelObject.cpp
@@ -322,37 +322,39 @@ DecodingMode RenderBoxModelObject::decodingModeForImageDraw(const Image& image, 
     // A PaintBehavior may force synchronous decoding.
     if (paintInfo.paintBehavior.contains(PaintBehavior::Snapshotting))
         return DecodingMode::Synchronous;
-    if (paintInfo.paintBehavior.contains(PaintBehavior::ForceSynchronousImageDecode))
-        return DecodingMode::Synchronous;
 
-    // <img decoding="sync"> forces synchronous decoding.
+    auto isFlickeringPossible = [&]() -> bool {
+        // Not first paint, so we have to avoid flickering anyway.
+        if (!(element() && element()->hasEverPaintedImages()))
+            return false;
+
+        // FIXME: isVisibleInViewport() is not cheap. Find a way to make this statement faster.
+        return isVisibleInViewport();
+    };
+
     if (is<HTMLImageElement>(element())) {
+        // <img decoding="sync"> forces synchronous decoding.
         if (downcast<HTMLImageElement>(*element()).decodingMode() == DecodingMode::Synchronous)
             return DecodingMode::Synchronous;
+
+        // <img decoding="async"> forces asynchronous decoding but make sure either
+        // the element has not been painted yet or it is outside the viewport.
+        if (downcast<HTMLImageElement>(*element()).decodingMode() == DecodingMode::Asynchronous)
+            return isFlickeringPossible() ? DecodingMode::Synchronous : DecodingMode::Asynchronous;
     }
 
-    // Layout tests may force asynchronous decoding.
-    if (bitmapImage.isLargeImageAsyncDecodingEnabledForTesting())
-        return DecodingMode::Asynchronous;
+    if (!bitmapImage.canUseAsyncDecodingForLargeImages())
+        return DecodingMode::Synchronous;
+
+    // The preference largeImageAsyncDecodingEnabled or WKR may force asynchronous decoding.
+    if (!(settings().largeImageAsyncDecodingEnabled() || bitmapImage.isLargeImageAsyncDecodingEnabledForTesting()))
+        return DecodingMode::Synchronous;
 
     // Not first paint, so we have to avoid flickering anyway.
-    if (!paintInfo.paintBehavior.contains(PaintBehavior::DefaultAsynchronousImageDecode)) {
-        // FIXME: isVisibleInViewport() is not cheap. Find a way to make this condition faster.
-        if (isVisibleInViewport())
-            return DecodingMode::Synchronous;
-    }
+    if (isFlickeringPossible())
+        return DecodingMode::Synchronous;
 
-    // <img decoding="async"> forces asynchronous decoding.
-    if (is<HTMLImageElement>(element())) {
-        if (downcast<HTMLImageElement>(*element()).decodingMode() == DecodingMode::Asynchronous)
-            return DecodingMode::Asynchronous;
-    }
-
-    // Resepect the web preferences key: largeImageAsyncDecodingEnabled.
-    if (settings().largeImageAsyncDecodingEnabled() && bitmapImage.canUseAsyncDecodingForLargeImages())
-        return DecodingMode::Asynchronous;
-
-    return DecodingMode::Synchronous;
+    return DecodingMode::Asynchronous;
 }
 
 LayoutSize RenderBoxModelObject::relativePositionOffset() const

--- a/Source/WebCore/rendering/RenderImage.cpp
+++ b/Source/WebCore/rendering/RenderImage.cpp
@@ -733,6 +733,9 @@ ImageDrawResult RenderImage::paintIntoRect(PaintInfo& paintInfo, const FloatRect
         theme().paintSystemPreviewBadge(*img, paintInfo, rect);
 #endif
 
+    if (element() && !paintInfo.context().paintingDisabled())
+        element()->setHasEverPaintedImages(true);
+
     return drawResult;
 }
 

--- a/Source/WebCore/rendering/RenderObject.h
+++ b/Source/WebCore/rendering/RenderObject.h
@@ -963,8 +963,8 @@ private:
 
     private:
         unsigned m_positionedState : 2; // PositionedState
-        unsigned m_selectionState : 3; // SelectionState
-        unsigned m_fragmentedFlowState : 2; // FragmentedFlowState
+        unsigned m_selectionState : 3; // HighlightState
+        unsigned m_fragmentedFlowState : 1; // FragmentedFlowState
         unsigned m_boxDecorationState : 2; // BoxDecorationState
 
     public:


### PR DESCRIPTION
#### efb71a57dadd74e59047c8eee2ad280b0812a16a
<pre>
REGRESSION (264433@main): Drawing small images becomes slower
<a href="https://bugs.webkit.org/show_bug.cgi?id=257358">https://bugs.webkit.org/show_bug.cgi?id=257358</a>
rdar://109810640

Reviewed by Simon Fraser.

Rearrange the logic of RenderBoxModelObject::decodingModeForImageDraw() such that
we call isVisibleInViewport() at the end of this function. But there is only one
exception to this. If the image has the attribute decoding=&quot;async&quot; specified, then
we have to make sure the image will not flicker. And to check that we have to call
isVisibleInViewport().

Also to fix a subtle one-time-flickering we should not rely on the layer repaint
count because new layers can be created when pinch zoom the image. We can rely
on a new flag called hasEverPaintedImages which is stored on the NodeRareData.
It is initialized to false and it is set to true when an image is drawn on its
RenderObject.

* LayoutTests/fast/images/async-image-composited-show.html:
* LayoutTests/fast/images/async-image-src-change.html:
* LayoutTests/fast/images/decode-decoding-change-image-src.html:
* LayoutTests/platform/mac-wk1/TestExpectations:
* Source/WebCore/dom/Node.cpp:
(WebCore::Node::hasEverPaintedImages const):
(WebCore::Node::setHasEverPaintedImages):
* Source/WebCore/dom/Node.h:
* Source/WebCore/dom/NodeRareData.h:
(WebCore::NodeRareData::hasEverPaintedImages const):
(WebCore::NodeRareData::setHasEverPaintedImages):
* Source/WebCore/rendering/BackgroundPainter.cpp:
(WebCore::BackgroundPainter::paintFillLayer):
* Source/WebCore/rendering/RenderBoxModelObject.cpp:
(WebCore::RenderBoxModelObject::decodingModeForImageDraw const):
* Source/WebCore/rendering/RenderImage.cpp:
(WebCore::RenderImage::paintIntoRect):
* Source/WebCore/rendering/RenderObject.h:

Canonical link: <a href="https://commits.webkit.org/264679@main">https://commits.webkit.org/264679@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c1c4a00916f08b473f769884a219e1948c2b265e

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/8217 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/8509 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/8726 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/9884 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/8283 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/8226 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/10497 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/8420 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/11161 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/8362 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/9429 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/7453 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/10029 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/6729 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/7518 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/15153 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/7852 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/7648 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/11009 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/8122 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/6602 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/7412 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/7430 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/2006 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/11620 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/7863 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->