### PR TITLE
Password protected PDFs should emit password-related navigation delegate methods

### DIFF
--- a/Source/WebKit/UIProcess/API/ios/WKWebViewIOS.h
+++ b/Source/WebKit/UIProcess/API/ios/WKWebViewIOS.h
@@ -117,6 +117,8 @@ enum class TapHandlingResult : uint8_t;
 
 - (void)_showPasswordViewWithDocumentName:(NSString *)documentName passwordHandler:(void (^)(NSString *))passwordHandler;
 - (void)_hidePasswordView;
+- (void)_didRequestPasswordForDocument;
+- (void)_didStopRequestingPasswordForDocument;
 
 - (void)_addShortcut:(id)sender;
 - (void)_define:(id)sender;

--- a/Source/WebKit/UIProcess/API/ios/WKWebViewIOS.mm
+++ b/Source/WebKit/UIProcess/API/ios/WKWebViewIOS.mm
@@ -2914,6 +2914,8 @@ static WebCore::IntDegrees activeOrientation(WKWebView *webView)
     [_passwordView setUserDidEnterPassword:passwordHandler];
     [_passwordView showInScrollView:_scrollView.get()];
     self._currentContentView.hidden = YES;
+
+    [self _didRequestPasswordForDocument];
 }
 
 - (void)_hidePasswordView
@@ -2925,9 +2927,17 @@ static WebCore::IntDegrees activeOrientation(WKWebView *webView)
     [_passwordView hide];
     _passwordView = nil;
 
-#if USE(QUICK_LOOK)
+    [self _didStopRequestingPasswordForDocument];
+}
+
+- (void)_didRequestPasswordForDocument
+{
+    _navigationState->didRequestPasswordForQuickLookDocument();
+}
+
+- (void)_didStopRequestingPasswordForDocument
+{
     _navigationState->didStopRequestingPasswordForQuickLookDocument();
-#endif
 }
 
 - (WKPasswordView *)_passwordView

--- a/Source/WebKit/UIProcess/Cocoa/NavigationState.h
+++ b/Source/WebKit/UIProcess/Cocoa/NavigationState.h
@@ -77,7 +77,8 @@ public:
     void navigationGestureDidEnd(bool willNavigate, WebBackForwardListItem&);
     void willRecordNavigationSnapshot(WebBackForwardListItem&);
     void navigationGestureSnapshotWasRemoved();
-#if USE(QUICK_LOOK)
+
+#if PLATFORM(IOS_FAMILY)
     void didRequestPasswordForQuickLookDocument();
     void didStopRequestingPasswordForQuickLookDocument();
 #endif
@@ -255,9 +256,9 @@ private:
 #if USE(QUICK_LOOK)
         bool webViewDidStartLoadForQuickLookDocumentInMainFrame : 1;
         bool webViewDidFinishLoadForQuickLookDocumentInMainFrame : 1;
+#endif
         bool webViewDidRequestPasswordForQuickLookDocument : 1;
         bool webViewDidStopRequestingPasswordForQuickLookDocument : 1;
-#endif
 
 #if PLATFORM(MAC)
         bool webViewBackForwardListItemAddedRemoved : 1;

--- a/Source/WebKit/UIProcess/Cocoa/NavigationState.mm
+++ b/Source/WebKit/UIProcess/Cocoa/NavigationState.mm
@@ -199,6 +199,8 @@ void NavigationState::setNavigationDelegate(id <WKNavigationDelegate> delegate)
 #if USE(QUICK_LOOK)
     m_navigationDelegateMethods.webViewDidStartLoadForQuickLookDocumentInMainFrame = [delegate respondsToSelector:@selector(_webView:didStartLoadForQuickLookDocumentInMainFrameWithFileName:uti:)];
     m_navigationDelegateMethods.webViewDidFinishLoadForQuickLookDocumentInMainFrame = [delegate respondsToSelector:@selector(_webView:didFinishLoadForQuickLookDocumentInMainFrame:)];
+#endif
+#if PLATFORM(IOS_FAMILY)
     m_navigationDelegateMethods.webViewDidRequestPasswordForQuickLookDocument = [delegate respondsToSelector:@selector(_webViewDidRequestPasswordForQuickLookDocument:)];
     m_navigationDelegateMethods.webViewDidStopRequestingPasswordForQuickLookDocument = [delegate respondsToSelector:@selector(_webViewDidStopRequestingPasswordForQuickLookDocument:)];
 #endif
@@ -286,7 +288,7 @@ void NavigationState::navigationGestureSnapshotWasRemoved()
     [static_cast<id <WKNavigationDelegatePrivate>>(navigationDelegate) _webViewDidRemoveNavigationGestureSnapshot:m_webView];
 }
 
-#if USE(QUICK_LOOK)
+#if PLATFORM(IOS_FAMILY)
 void NavigationState::didRequestPasswordForQuickLookDocument()
 {
     if (!m_navigationDelegateMethods.webViewDidRequestPasswordForQuickLookDocument)

--- a/Source/WebKit/UIProcess/ios/PageClientImplIOS.mm
+++ b/Source/WebKit/UIProcess/ios/PageClientImplIOS.mm
@@ -971,7 +971,6 @@ void PageClientImpl::requestPasswordForQuickLookDocument(const String& fileName,
     }
 
     [m_webView _showPasswordViewWithDocumentName:fileName passwordHandler:passwordHandler.get()];
-    NavigationState::fromWebPage(*m_webView.get()->_page).didRequestPasswordForQuickLookDocument();
 }
 #endif
 

--- a/Source/WebKit/UIProcess/ios/WKPDFView.mm
+++ b/Source/WebKit/UIProcess/ios/WKPDFView.mm
@@ -135,6 +135,7 @@
     WeakObjCPtr<WKWebView> _webView;
     RetainPtr<WKKeyboardScrollViewAnimator> _keyboardScrollingAnimator;
     RetainPtr<WKShareSheet> _shareSheet;
+    BOOL _isShowingPasswordView;
 #if HAVE(UIFINDINTERACTION)
     RetainPtr<id<UITextSearchAggregator>> _searchAggregator;
     RetainPtr<NSString> _searchString;
@@ -191,14 +192,25 @@
     if (!(self = [super initWithFrame:frame webView:webView]))
         return nil;
 
-    UIColor *backgroundColor = PDFHostViewController.backgroundColor;
-    self.backgroundColor = backgroundColor;
-    [webView._wkScrollView _setBackgroundColorInternal:backgroundColor];
-
     _keyboardScrollingAnimator = adoptNS([[WKKeyboardScrollViewAnimator alloc] initWithScrollView:webView.scrollView]);
-
     _webView = webView;
+
+    [self updateBackgroundColor];
+
     return self;
+}
+
+- (void)updateBackgroundColor
+{
+    UIColor *backgroundColor = PDFHostViewController.backgroundColor;
+
+#if HAVE(UIKIT_WEBKIT_INTERNALS)
+    if (_isShowingPasswordView)
+        backgroundColor = UIColor.clearColor;
+#endif
+
+    self.backgroundColor = backgroundColor;
+    [[_webView _wkScrollView] _setBackgroundColorInternal:backgroundColor];
 }
 
 - (void)web_setContentProviderData:(NSData *)data suggestedFilename:(NSString *)filename
@@ -492,7 +504,6 @@ static NSStringCompareOptions stringCompareOptions(_WKFindOptions findOptions)
     return self.isBackground;
 }
 
-
 #pragma mark PDFHostViewControllerDelegate
 
 - (void)pdfHostViewController:(PDFHostViewController *)controller updatePageCount:(NSInteger)pageCount
@@ -500,9 +511,21 @@ static NSStringCompareOptions stringCompareOptions(_WKFindOptions findOptions)
     [self _scrollToURLFragment:[_webView URL].fragment];
 }
 
+- (void)pdfHostViewControllerDocumentDidRequestPassword:(PDFHostViewController *)controller
+{
+    [_webView _didRequestPasswordForDocument];
+
+    _isShowingPasswordView = YES;
+    [self updateBackgroundColor];
+}
+
 - (void)pdfHostViewController:(PDFHostViewController *)controller documentDidUnlockWithPassword:(NSString *)password
 {
     _passwordForPrinting = [password UTF8String];
+    [_webView _didStopRequestingPasswordForDocument];
+
+    _isShowingPasswordView = NO;
+    [self updateBackgroundColor];
 }
 
 - (void)pdfHostViewController:(PDFHostViewController *)controller findStringUpdate:(NSUInteger)numFound done:(BOOL)done


### PR DESCRIPTION
#### 3fec0ecd58593da08f46f9e3da99739da19e0618
<pre>
Password protected PDFs should emit password-related navigation delegate methods
<a href="https://bugs.webkit.org/show_bug.cgi?id=257364">https://bugs.webkit.org/show_bug.cgi?id=257364</a>
rdar://109858534

Reviewed by Megan Gardner, Wenson Hsieh and Aditya Keerthi.

* Source/WebKit/UIProcess/API/ios/WKWebViewIOS.h:
* Source/WebKit/UIProcess/API/ios/WKWebViewIOS.mm:
(-[WKWebView _showPasswordViewWithDocumentName:passwordHandler:]):
(-[WKWebView _hidePasswordView]):
(-[WKWebView _didRequestPasswordForDocument]):
(-[WKWebView _didStopRequestingPasswordForDocument]):
* Source/WebKit/UIProcess/Cocoa/NavigationState.h:
* Source/WebKit/UIProcess/Cocoa/NavigationState.mm:
(WebKit::NavigationState::setNavigationDelegate):
* Source/WebKit/UIProcess/ios/PageClientImplIOS.mm:
(WebKit::PageClientImpl::requestPasswordForQuickLookDocument):
Make the password-related navigation delegates exist on all IOS_FAMILY, not just
where USE(QUICKLOOK) is true, and adopt them for WKPDFView as well. Despite
the names being QuickLook-specific, clients generally want to do the same things
when a password field is up regardless of whether it&apos;s up for PDF or QuickLook
reasons.

* Source/WebKit/UIProcess/ios/WKPDFView.mm:
(-[WKPDFView web_initWithFrame:webView:mimeType:]):
(-[WKPDFView updateBackgroundColor]):
Drive-by; update the background color when entering and exiting the password view.

(-[WKPDFView pdfHostViewControllerDocumentDidRequestPassword:]):
(-[WKPDFView pdfHostViewController:documentDidUnlockWithPassword:]):
Call the navigation delegate.

Canonical link: <a href="https://commits.webkit.org/264600@main">https://commits.webkit.org/264600@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/8bc0b789efd2807d9d2a8d1cb4f4844f6d131024

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/8059 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/8344 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/8557 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/9711 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/32/builds/8160 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/10330 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/8255 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/11022 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/8203 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/9290 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/7345 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/9835 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/6591 "Passed tests") | | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/14956 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/7714 "Passed tests") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/7497 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/10861 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/7970 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/6485 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/7283 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/1939 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/11492 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/7711 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->