### PR TITLE
[ iOS ] imported/w3c/web-platform-tests/screen-orientation/fullscreen-interactions.html is a flaky failure

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/screen-orientation/fullscreen-interactions-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/screen-orientation/fullscreen-interactions-expected.txt
@@ -1,5 +1,4 @@
 
-
-FAIL Fully unlocking the screen orientation causes a pending lock to be aborted promise_rejects_dom: function "function () { throw e }" threw object "NotSupportedError: Screen orientation locking is not supported" that is not a DOMException AbortError: property "code" is equal to 9, expected 20
-FAIL Fully unlocking the screen orientation causes a pending lock in a nested browsing context to be aborted promise_rejects_dom: function "function () { throw e }" threw object "SecurityError: Locking the screen orientation is only allowed when in fullscreen" that is not a DOMException AbortError: property "code" is equal to 18, expected 20
+FAIL fullscreen and orientation support promise_test: Unhandled rejection with value: object "NotSupportedError: Screen orientation locking is not supported"
+PASS Iframe can't itself know if it's parent is fullscreen when changing orientation
 

--- a/LayoutTests/imported/w3c/web-platform-tests/screen-orientation/fullscreen-interactions.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/screen-orientation/fullscreen-interactions.html
@@ -5,29 +5,41 @@
 <script src="/resources/testharnessreport.js"></script>
 <script src="/resources/testdriver.js"></script>
 <script src="/resources/testdriver-vendor.js"></script>
+<body></body>
 <script type="module">
   import {
     getOppositeOrientation,
     attachIframe,
+    makeCleanup,
   } from "./resources/orientation-utils.js";
 
   promise_test(async (t) => {
+    t.add_cleanup(makeCleanup());
     await test_driver.bless("request full screen");
     await document.documentElement.requestFullscreen();
-    const lockPromise = screen.orientation.lock(getOppositeOrientation());
-    await document.exitFullscreen();
-    await promise_rejects_dom(t, "AbortError", lockPromise);
-  }, "Fully unlocking the screen orientation causes a pending lock to be aborted");
+    const currentOrientation = screen.orientation.type;
+    await screen.orientation.lock(
+      getOppositeOrientation()
+    );
+  }, "fullscreen and orientation support");
 
   promise_test(async (t) => {
     const iframe = await attachIframe();
+    t.add_cleanup(makeCleanup(iframe));
+    const iframeWindow = iframe.contentWindow;
     await test_driver.bless("request full screen");
     await document.documentElement.requestFullscreen();
-    const lockPromise = iframe.contentWindow.screen.orientation.lock(
+    const currentOrientation = window.screen.orientation.type;
+    const lockPromise = iframeWindow.screen.orientation.lock(
       getOppositeOrientation()
     );
-    await document.exitFullscreen();
-    const frameDOMException = iframe.contentWindow.DOMException;
-    await promise_rejects_dom(t, "AbortError", frameDOMException, lockPromise);
-  }, "Fully unlocking the screen orientation causes a pending lock in a nested browsing context to be aborted");
+    const fsExitPromise = document.exitFullscreen();
+    await promise_rejects_dom(
+      t,
+      "SecurityError",
+      iframeWindow.DOMException,
+      lockPromise
+    );
+    await fsExitPromise;
+  }, "Iframe can't itself know if it's parent is fullscreen when changing orientation");
 </script>

--- a/LayoutTests/imported/w3c/web-platform-tests/screen-orientation/resources/orientation-utils.js
+++ b/LayoutTests/imported/w3c/web-platform-tests/screen-orientation/resources/orientation-utils.js
@@ -17,9 +17,9 @@ export async function attachIframe(options = {}) {
     ...options,
   };
   const iframe = context.document.createElement("iframe");
-  if (sandbox !== null) iframe.sandbox = sandbox;
   iframe.allowFullscreen = allowFullscreen;
   await new Promise((resolve) => {
+    if (sandbox != null) iframe.sandbox = sandbox;
     iframe.onload = resolve;
     iframe.src = src;
     context.document.body.appendChild(iframe);
@@ -33,11 +33,16 @@ export function getOppositeOrientation() {
     : "portrait";
 }
 
-export function makeCleanup() {
+/**
+ * Exits full screen, and removes the iframe.
+ * @param {HTMLIFrameElement} iframe same-origin iframe.
+ * @returns {() => Promise<void>} The cleanup function.
+ */
+export function makeCleanup(iframe = null) {
+  const context = iframe?.contentWindow ?? window;
+  const doc = iframe?.contentDocument ?? context.document;
   return async () => {
-    screen.orientation.unlock();
-    if (document.fullscreenElement) {
-      await document.fullscreenElement.ownerDocument.exitFullscreen();
-    }
+    await doc.fullscreenElement?.ownerDocument.exitFullscreen();
+    iframe?.remove();
   };
 }

--- a/LayoutTests/platform/ios-wk2/TestExpectations
+++ b/LayoutTests/platform/ios-wk2/TestExpectations
@@ -2401,8 +2401,6 @@ fast/forms/date/date-validity-badinput.html [ Skip ]
 fast/forms/datetimelocal/datetimelocal-validity-badinput.html [ Skip ]
 fast/forms/time/time-validity-badinput.html [ Skip ]
 
-webkit.org/b/256613 imported/w3c/web-platform-tests/screen-orientation/fullscreen-interactions.html [ DumpJSConsoleLogInStdErr ]
-
 # Skipping scrollbar-width tests that don't work with overlay scrollbars
 imported/w3c/web-platform-tests/css/css-scrollbars/scrollbar-width-001.html [ Skip ]
 imported/w3c/web-platform-tests/css/css-scrollbars/scrollbar-width-002.html [ Skip ]

--- a/LayoutTests/platform/ios/imported/w3c/web-platform-tests/screen-orientation/fullscreen-interactions-expected.txt
+++ b/LayoutTests/platform/ios/imported/w3c/web-platform-tests/screen-orientation/fullscreen-interactions-expected.txt
@@ -1,5 +1,4 @@
 
-
-FAIL Fully unlocking the screen orientation causes a pending lock to be aborted assert_unreached: Should have rejected: undefined Reached unreachable code
-FAIL Fully unlocking the screen orientation causes a pending lock in a nested browsing context to be aborted promise_rejects_dom: function "function () { throw e }" threw object "SecurityError: Locking the screen orientation is only allowed when in fullscreen" that is not a DOMException AbortError: property "code" is equal to 18, expected 20
+PASS fullscreen and orientation support
+PASS Iframe can't itself know if it's parent is fullscreen when changing orientation
 

--- a/LayoutTests/platform/mac-wk2/TestExpectations
+++ b/LayoutTests/platform/mac-wk2/TestExpectations
@@ -1792,6 +1792,4 @@ webkit.org/b/256189 [ Debug ] ipc/wait-for-video-output-will-change.html [ Pass 
 
 webkit.org/b/256217 [ Debug ] imported/w3c/web-platform-tests/background-fetch/port-blocking.https.window.html [ Pass Crash ]
 
-webkit.org/b/256613 imported/w3c/web-platform-tests/screen-orientation/fullscreen-interactions.html [ DumpJSConsoleLogInStdErr ]
-
 webkit.org/b/238749 imported/w3c/web-platform-tests/html/semantics/interactive-elements/the-dialog-element/focus-after-close.html [ Pass Failure ]


### PR DESCRIPTION
#### 81ceb06a3201a978675437250f8b2c9e38b64c15
<pre>
[ iOS ] imported/w3c/web-platform-tests/screen-orientation/fullscreen-interactions.html is a flaky failure
<a href="https://bugs.webkit.org/show_bug.cgi?id=256671">https://bugs.webkit.org/show_bug.cgi?id=256671</a>
rdar://109537056

Reviewed by Chris Dumez.

Refactored the test so to make it less flaky. Tested it a few thousand times locally.

* LayoutTests/imported/w3c/web-platform-tests/screen-orientation/fullscreen-interactions-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/screen-orientation/fullscreen-interactions.html:
* LayoutTests/imported/w3c/web-platform-tests/screen-orientation/resources/orientation-utils.js:
(export.async attachIframe):
* LayoutTests/platform/ios-wk2/TestExpectations:
* LayoutTests/platform/ios/imported/w3c/web-platform-tests/screen-orientation/fullscreen-interactions-expected.txt:
* LayoutTests/platform/mac-wk2/TestExpectations:

Canonical link: <a href="https://commits.webkit.org/264830@main">https://commits.webkit.org/264830@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2e922cfb9cf7f043d5db9517578c0285d2f735bd

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/8732 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/9020 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/9237 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/10385 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/8720 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/11007 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/8990 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/11587 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/8878 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/9885 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/7772 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/10549 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/7182 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/7981 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/15497 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/8292 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/8129 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/11475 "8 api tests failed or timed out") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/8612 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/7017 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/7873 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/7889 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/2125 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/12086 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/8359 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->