### PR TITLE
Changing the dir attribute of documentElement doesn't update a child element matching :dir pseudo class

### DIFF
--- a/LayoutTests/fast/css/dir-pseudo-update-document-element-expected.html
+++ b/LayoutTests/fast/css/dir-pseudo-update-document-element-expected.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<html>
+<head>
+<style>
+
+div {
+    width: 100px;
+    height: 100px;
+    float: left;
+    background-color: green;
+}
+
+</style>
+</head>
+<body>
+<div></div>
+</body>
+</html>

--- a/LayoutTests/fast/css/dir-pseudo-update-document-element.html
+++ b/LayoutTests/fast/css/dir-pseudo-update-document-element.html
@@ -1,0 +1,26 @@
+<!DOCTYPE html>
+<html dir="ltr">
+<head>
+<script>
+document.documentElement.setAttribute('dir', 'rtl');
+</script>
+<style>
+div {
+    width: 100px;
+    height: 100px;
+    float: left;
+}
+
+div:dir(rtl) {
+    background-color: green;
+}
+
+div:dir(ltr) {
+    background-color: red;
+}
+</style>
+</head>
+<body>
+<div></div>
+</body>
+</html>

--- a/Source/WebCore/html/HTMLElement.cpp
+++ b/Source/WebCore/html/HTMLElement.cpp
@@ -433,7 +433,7 @@ Node::InsertedIntoAncestorResult HTMLElement::insertedIntoAncestor(InsertionType
     auto result = StyledElement::insertedIntoAncestor(insertionType, parentOfInsertedTree);
     hideNonce();
 
-    if (RefPtr parent = parentOrShadowHostElement(); parent && parent != document().documentElement() && UNLIKELY(parent->usesEffectiveTextDirection())) {
+    if (RefPtr parent = parentOrShadowHostElement(); parent && UNLIKELY(parent->usesEffectiveTextDirection())) {
         if (!elementAffectsDirectionality(*this) && !(is<HTMLInputElement>(*this) && downcast<HTMLInputElement>(*this).isTelephoneField())) {
             setUsesEffectiveTextDirection(true);
             setEffectiveTextDirection(parent->effectiveTextDirection());


### PR DESCRIPTION
#### 62b42f584e0a6eeb8adffe59e1ab343e591b090e
<pre>
Changing the dir attribute of documentElement doesn&apos;t update a child element matching :dir pseudo class
<a href="https://bugs.webkit.org/show_bug.cgi?id=257133">https://bugs.webkit.org/show_bug.cgi?id=257133</a>

Reviewed by Antti Koivisto.

The bug was caused by the superfluous condition to not update the effective directionality when
the parent element is the document element. Removed this check to fix the bug.

* LayoutTests/fast/css/dir-pseudo-update-document-element-expected.html: Added.
* LayoutTests/fast/css/dir-pseudo-update-document-element.html: Added.
* Source/WebCore/html/HTMLElement.cpp:
(WebCore::HTMLElement::insertedIntoAncestor):

Canonical link: <a href="https://commits.webkit.org/265332@main">https://commits.webkit.org/265332@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0ba867f42860e73da197694bf79273b1ae7d7219

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/8007 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/8292 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/8504 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/9659 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/8111 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/8011 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/10278 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/8203 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/10980 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/8151 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/9239 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/7316 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/9779 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/6540 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/7328 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/14911 "19 flakes 92 failures") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/7663 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/7462 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/10814 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/7919 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/6442 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/7233 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/7241 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/11441 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/1189 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/7660 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->