### PR TITLE
Add a giant character to the shadow tree, to act as a selectable overlay

### DIFF
--- a/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
+++ b/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
@@ -637,7 +637,7 @@ AsynchronousSpellCheckingEnabled:
 
 AttachmentElementEnabled:
   type: bool
-  status: embedder
+  status: internal
   humanReadableName: "Attachment Element"
   humanReadableDescription: "Allow the insertion of attachment elements"
   webcoreBinding: DeprecatedGlobalSettings
@@ -650,7 +650,7 @@ AttachmentElementEnabled:
 
 AttachmentWideLayoutEnabled:
   type: bool
-  status: embedder
+  status: internal
   humanReadableName: "Attachment wide-layout styling"
   humanReadableDescription: "Use horizontal wide-layout attachment style, requires Attachment Element"
   condition: ENABLE(ATTACHMENT_ELEMENT)

--- a/Source/WebCore/html/HTMLAttachmentElement.cpp
+++ b/Source/WebCore/html/HTMLAttachmentElement.cpp
@@ -42,6 +42,7 @@
 #include "HTMLElementTypeHelpers.h"
 #include "HTMLImageElement.h"
 #include "HTMLNames.h"
+#include "HTMLSpanElement.h"
 #include "HTMLStyleElement.h"
 #include "LocalFrame.h"
 #include "MIMETypeRegistry.h"
@@ -259,6 +260,11 @@ void HTMLAttachmentElement::ensureModernShadowTree(ShadowRoot& root)
     m_subtitleElement = createContainedElement<HTMLDivElement>(*m_informationBlock, attachmentSubtitleIdentifier(), String { attachmentSubtitleForDisplay() });
 
     updateSaveButton(!attributeWithoutSynchronization(saveAttr).isNull());
+
+    auto selectable = HTMLSpanElement::create(document());
+    selectable->setIdAttribute("attachment-selectable-overlay"_s);
+    selectable->setInnerHTML("&nbsp;"_s);
+    root.appendChild(selectable);
 }
 
 class AttachmentSaveEventListener final : public EventListener {

--- a/Source/WebCore/html/shadow/attachmentElementShadow.css
+++ b/Source/WebCore/html/shadow/attachmentElementShadow.css
@@ -36,7 +36,7 @@ div#attachment-container {
     height: 80px;
     background-color: -apple-system-tertiary-fill;
 #endif
-    margin: 1px;
+    /* margin: 1px; */
     border-radius: 8px;
     font: caption;
     pointer-events: none;
@@ -46,6 +46,20 @@ div#attachment-container {
 
 div#attachment-container::selection {
     background-color: -apple-system-selected-content-background;
+}
+
+span#attachment-selectable-overlay {
+    position: absolute;
+    inset: 0;
+    font-size: 1064px;
+    overflow: hidden;
+#if (defined(WTF_PLATFORM_IOS_FAMILY) && WTF_PLATFORM_IOS_FAMILY)
+    width: 338px;
+    height: 92px;
+#else
+    width: 266px;
+    height: 80px;
+#endif
 }
 
 div#attachment-preview-area {

--- a/Source/WebCore/rendering/RenderTheme.cpp
+++ b/Source/WebCore/rendering/RenderTheme.cpp
@@ -1490,7 +1490,7 @@ bool RenderTheme::paintCapsLockIndicator(const RenderObject&, const PaintInfo&, 
 String RenderTheme::attachmentStyleSheet() const
 {
     ASSERT(DeprecatedGlobalSettings::attachmentElementEnabled());
-    return "attachment { appearance: auto; }"_s;
+    return "attachment { appearance: auto; position: relative; }"_s;
 }
 
 bool RenderTheme::paintAttachment(const RenderObject&, const PaintInfo&, const IntRect&)

--- a/Source/WebCore/rendering/RenderThemeIOS.mm
+++ b/Source/WebCore/rendering/RenderThemeIOS.mm
@@ -1738,7 +1738,7 @@ bool RenderThemeIOS::paintAttachment(const RenderObject& renderer, const PaintIn
 String RenderThemeIOS::attachmentStyleSheet() const
 {
     ASSERT(DeprecatedGlobalSettings::attachmentElementEnabled());
-    return "attachment { appearance: auto; color: -apple-system-blue; }"_s;
+    return "attachment { appearance: auto; position: relative; color: -apple-system-blue; }"_s;
 }
 
 #endif // ENABLE(ATTACHMENT_ELEMENT)


### PR DESCRIPTION
#### 109ba77e2c0770b808c112474a231bb155c00b61
<pre>
Add a giant character to the shadow tree, to act as a selectable overlay
Need the bug URL (OOPS!).
Include a Radar link (OOPS!).

Reviewed by NOBODY (OOPS!).

Explanation of why this fixes the bug (OOPS!).

* Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml:
* Source/WebCore/html/HTMLAttachmentElement.cpp:
(WebCore::HTMLAttachmentElement::ensureModernShadowTree):
* Source/WebCore/html/shadow/attachmentElementShadow.css:
(div#attachment-container):
(span#attachment-selectable-overlay):
* Source/WebCore/rendering/RenderTheme.cpp:
(WebCore::RenderTheme::attachmentStyleSheet const):
* Source/WebCore/rendering/RenderThemeIOS.mm:
(WebCore::RenderThemeIOS::attachmentStyleSheet const):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/109ba77e2c0770b808c112474a231bb155c00b61

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/8017 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/8302 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/8514 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/9669 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/8121 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/8021 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/10288 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/8213 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/10984 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/8161 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/9247 "1 failures") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/7320 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/9789 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/6548 "Passed tests") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/7337 "1 flakes 2 failures") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/14917 "7 flakes 114 failures") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/6835 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/7671 "Passed tests") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/7458 "3 failures") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/10825 "Passed tests") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/7585 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/7929 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/6450 "18 flakes 11 failures") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/8184 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/7243 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/1869 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/11451 "Built successfully") | | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/24/builds/8405 "Built successfully") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/7670 "Built successfully") | | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/3/builds/2018 "Passed tests") | 
<!--EWS-Status-Bubble-End-->