### PR TITLE
[GTK] Do not make DMA-BUF renderer depend on GBM

### DIFF
--- a/Source/WebKit/PlatformGTK.cmake
+++ b/Source/WebKit/PlatformGTK.cmake
@@ -52,17 +52,15 @@ list(APPEND WebKit_UNIFIED_SOURCE_LIST_FILES
 
 list(APPEND WebKit_MESSAGES_IN_FILES
     UIProcess/ViewGestureController
-    WebProcess/gtk/GtkSettingsManagerProxy
+
+    UIProcess/gtk/AcceleratedBackingStoreDMABuf
+
     WebProcess/WebPage/ViewGestureGeometryCollector
+
+    WebProcess/WebPage/gtk/AcceleratedSurfaceDMABuf
+
+    WebProcess/gtk/GtkSettingsManagerProxy
 )
-
-if (USE_GBM)
-    list(APPEND WebKit_MESSAGES_IN_FILES
-        UIProcess/gtk/AcceleratedBackingStoreDMABuf
-
-        WebProcess/WebPage/gtk/AcceleratedSurfaceDMABuf
-    )
-endif ()
 
 list(APPEND WebKit_DERIVED_SOURCES
     ${WebKitGTK_DERIVED_SOURCES_DIR}/InspectorGResourceBundle.c

--- a/Source/WebKit/UIProcess/glib/WebProcessPoolGLib.cpp
+++ b/Source/WebKit/UIProcess/glib/WebProcessPoolGLib.cpp
@@ -54,9 +54,7 @@
 
 #if PLATFORM(GTK)
 #include "GtkSettingsManager.h"
-#if USE(GBM)
 #include "AcceleratedBackingStoreDMABuf.h"
-#endif
 #endif
 
 
@@ -90,7 +88,7 @@ void WebProcessPool::platformInitializeWebProcess(const WebProcessProxy& process
     parameters.renderDeviceFile = WebCore::PlatformDisplay::sharedDisplay().drmRenderNodeFile();
 #endif
 
-#if PLATFORM(GTK) && USE(GBM)
+#if PLATFORM(GTK)
     parameters.useDMABufSurfaceForCompositing = AcceleratedBackingStoreDMABuf::checkRequirements();
 #endif
 

--- a/Source/WebKit/UIProcess/gtk/AcceleratedBackingStore.cpp
+++ b/Source/WebKit/UIProcess/gtk/AcceleratedBackingStore.cpp
@@ -40,14 +40,14 @@
 #include "AcceleratedBackingStoreX11.h"
 #endif
 
-#if USE(GBM)
+#if PLATFORM(GTK)
 #include "AcceleratedBackingStoreDMABuf.h"
 #endif
 
 namespace WebKit {
 using namespace WebCore;
 
-#if USE(GBM)
+#if PLATFORM(GTK)
 static bool gtkCanUseHardwareAcceleration()
 {
     static bool canUseHardwareAcceleration;
@@ -72,7 +72,7 @@ static bool gtkCanUseHardwareAcceleration()
 
 bool AcceleratedBackingStore::checkRequirements()
 {
-#if USE(GBM)
+#if PLATFORM(GTK)
     if (AcceleratedBackingStoreDMABuf::checkRequirements())
         return gtkCanUseHardwareAcceleration();
 #endif
@@ -93,7 +93,7 @@ std::unique_ptr<AcceleratedBackingStore> AcceleratedBackingStore::create(WebPage
     if (!HardwareAccelerationManager::singleton().canUseHardwareAcceleration())
         return nullptr;
 
-#if USE(GBM)
+#if PLATFORM(GTK)
     if (AcceleratedBackingStoreDMABuf::checkRequirements())
         return AcceleratedBackingStoreDMABuf::create(webPage);
 #endif

--- a/Source/WebKit/UIProcess/gtk/AcceleratedBackingStoreDMABuf.h
+++ b/Source/WebKit/UIProcess/gtk/AcceleratedBackingStoreDMABuf.h
@@ -27,7 +27,6 @@
 
 #include "AcceleratedBackingStore.h"
 
-#if USE(GBM)
 #include "MessageReceiver.h"
 #include <WebCore/IntSize.h>
 #include <WebCore/RefPtrCairo.h>
@@ -37,7 +36,10 @@
 #include <wtf/unix/UnixFileDescriptor.h>
 
 typedef void *EGLImage;
+
+#if USE(GBM)
 struct gbm_bo;
+#endif
 
 namespace WebCore {
 class IntRect;
@@ -130,7 +132,9 @@ private:
 
     class Surface final : public RenderSource {
     public:
+#if USE(GBM)
         Surface(const WTF::UnixFileDescriptor&, const WTF::UnixFileDescriptor&, const WebCore::IntSize&, uint32_t format, uint32_t offset, uint32_t stride, float deviceScaleFactor);
+#endif
         Surface(RefPtr<ShareableBitmap>&, RefPtr<ShareableBitmap>&, float deviceScaleFactor);
         ~Surface();
 
@@ -145,11 +149,15 @@ private:
         void paint(GtkWidget*, cairo_t*, const WebCore::IntRect&) const override;
 #endif
 
+#if USE(GBM)
         RefPtr<cairo_surface_t> map(struct gbm_bo*) const;
+#endif
         RefPtr<cairo_surface_t> map(RefPtr<ShareableBitmap>&) const;
 
+#if USE(GBM)
         struct gbm_bo* m_backBuffer { nullptr };
         struct gbm_bo* m_frontBuffer { nullptr };
+#endif
         RefPtr<ShareableBitmap> m_backBitmap;
         RefPtr<ShareableBitmap> m_frontBitmap;
         RefPtr<cairo_surface_t> m_surface;
@@ -179,5 +187,3 @@ private:
 };
 
 } // namespace WebKit
-
-#endif // USE(GBM)

--- a/Source/WebKit/WebProcess/WebPage/AcceleratedSurface.cpp
+++ b/Source/WebKit/WebProcess/WebPage/AcceleratedSurface.cpp
@@ -37,7 +37,7 @@
 #include "AcceleratedSurfaceLibWPE.h"
 #endif
 
-#if PLATFORM(GTK) && USE(GBM)
+#if PLATFORM(GTK)
 #include "AcceleratedSurfaceDMABuf.h"
 #endif
 
@@ -46,9 +46,12 @@ using namespace WebCore;
 
 std::unique_ptr<AcceleratedSurface> AcceleratedSurface::create(WebPage& webPage, Client& client)
 {
-#if PLATFORM(GTK) && USE(GBM)
-    if (PlatformDisplay::sharedDisplayForCompositing().type() == PlatformDisplay::Type::GBM
-        || PlatformDisplay::sharedDisplayForCompositing().type() == PlatformDisplay::Type::Surfaceless)
+#if PLATFORM(GTK)
+#if USE(GBM)
+    if (PlatformDisplay::sharedDisplayForCompositing().type() == PlatformDisplay::Type::GBM)
+        return AcceleratedSurfaceDMABuf::create(webPage, client);
+#endif
+    if (PlatformDisplay::sharedDisplayForCompositing().type() == PlatformDisplay::Type::Surfaceless)
         return AcceleratedSurfaceDMABuf::create(webPage, client);
 #endif
 #if PLATFORM(WAYLAND)

--- a/Source/WebKit/WebProcess/WebPage/gtk/AcceleratedSurfaceDMABuf.h
+++ b/Source/WebKit/WebProcess/WebPage/gtk/AcceleratedSurfaceDMABuf.h
@@ -27,13 +27,14 @@
 
 #include "AcceleratedSurface.h"
 
-#if USE(GBM)
 #include "MessageReceiver.h"
 #include <WebCore/PageIdentifier.h>
 #include <wtf/unix/UnixFileDescriptor.h>
 
+#if USE(GBM)
 typedef void *EGLImage;
 struct gbm_bo;
+#endif
 
 namespace WebKit {
 
@@ -91,6 +92,7 @@ private:
         unsigned m_depthStencilBuffer { 0 };
     };
 
+#if USE(GBM)
     class RenderTargetEGLImage final : public RenderTarget {
     public:
         static std::unique_ptr<RenderTarget> create(WebCore::PageIdentifier, const WebCore::IntSize&);
@@ -103,6 +105,7 @@ private:
         EGLImage m_backImage { nullptr };
         EGLImage m_frontImage { nullptr };
     };
+#endif
 
     class RenderTargetSHMImage final : public RenderTarget {
     public:
@@ -118,11 +121,8 @@ private:
         Ref<ShareableBitmap> m_frontBitmap;
     };
 
-    bool m_isSoftwareRast { false };
     unsigned m_fbo { 0 };
     std::unique_ptr<RenderTarget> m_target;
 };
 
 } // namespace WebKit
-
-#endif // USE(GBM)

--- a/Source/WebKit/WebProcess/glib/WebProcessGLib.cpp
+++ b/Source/WebKit/WebProcess/glib/WebProcessGLib.cpp
@@ -141,11 +141,16 @@ void WebProcess::platformInitializeWebProcess(WebProcessCreationParameters& para
     WebCore::GBMDevice::singleton().initialize(parameters.renderDeviceFile);
 #endif
 
-#if PLATFORM(GTK) && USE(GBM)
+#if PLATFORM(GTK)
     if (parameters.useDMABufSurfaceForCompositing) {
-        if (auto* device = WebCore::GBMDevice::singleton().device())
-            m_displayForCompositing = WebCore::PlatformDisplayGBM::create(device);
-        else
+#if USE(GBM)
+        const char* disableGBM = getenv("WEBKIT_DMABUF_RENDERER_DISABLE_GBM");
+        if (!disableGBM || !strcmp(disableGBM, "0")) {
+            if (auto* device = WebCore::GBMDevice::singleton().device())
+                m_displayForCompositing = WebCore::PlatformDisplayGBM::create(device);
+        }
+#endif
+        if (!m_displayForCompositing)
             m_displayForCompositing = WebCore::PlatformDisplaySurfaceless::create();
     }
 #endif


### PR DESCRIPTION
#### 81c064ddb4182a34a36def401025d223ca0d31ba
<pre>
[GTK] Do not make DMA-BUF renderer depend on GBM
<a href="https://bugs.webkit.org/show_bug.cgi?id=257372">https://bugs.webkit.org/show_bug.cgi?id=257372</a>

Reviewed by Alejandro G. Castro.

Fallback to use shared memory buffers when GBM is not available. The env
var WEBKIT_DMABUF_RENDERER_DISABLE_GBM can be used for testing the non-GBM
code path without having to rebuild.

* Source/WebKit/PlatformGTK.cmake:
* Source/WebKit/UIProcess/API/glib/WebKitProtocolHandler.cpp:
(WebKit::WebKitProtocolHandler::handleGPU):
* Source/WebKit/UIProcess/glib/WebProcessPoolGLib.cpp:
(WebKit::WebProcessPool::platformInitializeWebProcess):
* Source/WebKit/UIProcess/gtk/AcceleratedBackingStore.cpp:
(WebKit::AcceleratedBackingStore::checkRequirements):
(WebKit::AcceleratedBackingStore::create):
* Source/WebKit/UIProcess/gtk/AcceleratedBackingStoreDMABuf.cpp:
(WebKit::AcceleratedBackingStoreDMABuf::Surface::~Surface):
(WebKit::AcceleratedBackingStoreDMABuf::Surface::swap):
(WebKit::AcceleratedBackingStoreDMABuf::Surface::prepareForRendering):
(WebKit::AcceleratedBackingStoreDMABuf::createSource):
* Source/WebKit/UIProcess/gtk/AcceleratedBackingStoreDMABuf.h:
* Source/WebKit/WebProcess/WebPage/AcceleratedSurface.cpp:
(WebKit::AcceleratedSurface::create):
* Source/WebKit/WebProcess/WebPage/gtk/AcceleratedSurfaceDMABuf.cpp:
(WebKit::AcceleratedSurfaceDMABuf::AcceleratedSurfaceDMABuf):
(WebKit::AcceleratedSurfaceDMABuf::RenderTargetColorBuffer::~RenderTargetColorBuffer):
(WebKit::AcceleratedSurfaceDMABuf::RenderTargetEGLImage::~RenderTargetEGLImage):
(WebKit::AcceleratedSurfaceDMABuf::RenderTargetTexture::create):
(WebKit::AcceleratedSurfaceDMABuf::RenderTargetTexture::RenderTargetTexture):
(WebKit::AcceleratedSurfaceDMABuf::RenderTarget::swap): Deleted.
* Source/WebKit/WebProcess/WebPage/gtk/AcceleratedSurfaceDMABuf.h:
* Source/WebKit/WebProcess/glib/WebProcessGLib.cpp:
(WebKit::WebProcess::platformInitializeWebProcess):

Canonical link: <a href="https://commits.webkit.org/265188@main">https://commits.webkit.org/265188@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f3e431b059d158a35b69de70279dca629ee286d8

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/8327 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/8620 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/8837 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/9995 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/8392 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/10608 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/8531 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/11260 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/8473 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/9529 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/7550 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/10139 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/6827 "Passed tests") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/15178 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/7948 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/7760 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/11105 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/8232 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/6706 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/7521 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/11731 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/1142 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/7975 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->