### PR TITLE
Dynamically added custom scrollbar styles don't apply

### DIFF
--- a/LayoutTests/fast/css/scrollbar-custom-dynamic-change-expected.html
+++ b/LayoutTests/fast/css/scrollbar-custom-dynamic-change-expected.html
@@ -1,0 +1,34 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <style>
+        .scroll {
+            margin: 10px;
+            width: 200px;
+            height: 200px;
+            overflow: scroll;
+            border: 1px solid black;
+        }
+
+        .custom::-webkit-scrollbar {
+            width: 16px
+        }
+
+        .custom::-webkit-scrollbar-track {
+            background-color: silver;
+            border-radius: 8px;
+        }
+
+        .custom::-webkit-scrollbar-thumb {
+            background-color: blue;
+            border-radius: 8px;
+        }
+    </style>
+</head>
+<body>
+    <div class="custom scroll">
+    <p>Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
+    <p>Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>        
+    </div>
+</body>
+</html>

--- a/LayoutTests/fast/css/scrollbar-custom-dynamic-change.html
+++ b/LayoutTests/fast/css/scrollbar-custom-dynamic-change.html
@@ -1,0 +1,41 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <style>
+        .scroll {
+            margin: 10px;
+            width: 200px;
+            height: 200px;
+            overflow: scroll;
+            border: 1px solid black;
+        }
+
+        .custom::-webkit-scrollbar {
+            width: 16px
+        }
+
+        .custom::-webkit-scrollbar-track {
+            background-color: silver;
+            border-radius: 8px;
+        }
+
+        .custom::-webkit-scrollbar-thumb {
+            background-color: blue;
+            border-radius: 8px;
+        }
+    </style>
+    <script>
+        window.onload = () => {
+            let testDiv = document.getElementById('test');
+            testDiv.classList.add('custom');
+        }
+    </script>
+</head>
+<body>
+    <div id="test" class="scroll">
+    <p>Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
+    <p>Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>        
+    </div>
+    
+</body>
+</html>


### PR DESCRIPTION
#### 1ac712cb8d9ba46db5be7a0e9e33511155df750e
<pre>
Dynamically added custom scrollbar styles don&apos;t apply
<a href="https://bugs.webkit.org/show_bug.cgi?id=211219">https://bugs.webkit.org/show_bug.cgi?id=211219</a>

Reviewed by Antti Koivisto.

`::-webkit-scrollbar` pseudo-element should be resolved eagerly during
style resolution, similar to `::first-line` and `::first-letter`.

* LayoutTests/fast/css/scrollbar-custom-dynamic-change-expected.html: Added.
* LayoutTests/fast/css/scrollbar-custom-dynamic-change.html: Added.
* Source/WebCore/style/StyleTreeResolver.cpp:
(WebCore::Style::TreeResolver::resolveElement):

Canonical link: <a href="https://commits.webkit.org/265015@main">https://commits.webkit.org/265015@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a3595f584343e567f6d5aef368f7ac2aa3a041e1

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/9362 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/9638 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/9868 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/11022 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/9236 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/9371 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/11624 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/9600 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/12121 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/9511 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/10430 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/8060 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/11179 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/7727 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/8541 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/15980 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/8824 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/8691 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/12026 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/9185 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/7480 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/8398 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/8446 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/2286 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/12622 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/8947 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->