### PR TITLE
[WGSL] Incorrect swizzle validation

### DIFF
--- a/Source/WebGPU/WGSL/TypeCheck.cpp
+++ b/Source/WebGPU/WGSL/TypeCheck.cpp
@@ -689,6 +689,7 @@ Type* TypeChecker::vectorFieldAccess(const Types::Vector& vector, AST::FieldAcce
 {
     const auto& fieldName = access.fieldName().id();
     auto length = fieldName.length();
+    auto vectorSize = vector.size;
 
     bool isValid = true;
     const auto& isXYZW = [&](char c) {
@@ -697,10 +698,10 @@ Type* TypeChecker::vectorFieldAccess(const Types::Vector& vector, AST::FieldAcce
         case 'y':
             return true;
         case 'z':
-            isValid &= length >= 3;
+            isValid &= vectorSize >= 3;
             return true;
         case 'w':
-            isValid &= length == 4;
+            isValid &= vectorSize == 4;
             return true;
         default:
             return false;
@@ -712,10 +713,10 @@ Type* TypeChecker::vectorFieldAccess(const Types::Vector& vector, AST::FieldAcce
         case 'g':
             return true;
         case 'b':
-            isValid &= length >= 3;
+            isValid &= vectorSize >= 3;
             return true;
         case 'a':
-            isValid &= length == 4;
+            isValid &= vectorSize == 4;
             return true;
         default:
             return false;

--- a/Source/WebGPU/WGSL/tests/invalid/vector.wgsl
+++ b/Source/WebGPU/WGSL/tests/invalid/vector.wgsl
@@ -17,4 +17,10 @@ fn testIndexAccess() {
   _ = vec3(0).w;
   // CHECK-L: invalid vector swizzle member
   _ = vec3(0).a;
+
+  // CHECK-L: invalid vector swizzle member
+  _ = vec2(0).rx;
+
+  // CHECK-L: invalid vector swizzle character
+  _ = vec2(0).v;
 }

--- a/Source/WebGPU/WGSL/tests/valid/swizzle.wgsl
+++ b/Source/WebGPU/WGSL/tests/valid/swizzle.wgsl
@@ -1,0 +1,133 @@
+// RUN: %wgslc
+
+fn testi32(x: i32)
+{
+    _ = x;
+}
+
+fn testVec2(x: vec2<i32>)
+{
+    _ = x;
+}
+
+fn testVec3(x: vec3<i32>)
+{
+    _ = x;
+}
+
+fn testVec4(x: vec4<i32>)
+{
+    _ = x;
+}
+
+fn testSwizzleVec2()
+{
+    let v = vec2(0i);
+    _ = v.x;
+    _ = v.xx;
+    _ = v.xxx;
+    _ = v.xxxx;
+
+    _ = v.y;
+    _ = v.yy;
+    _ = v.yyy;
+    _ = v.yyyy;
+
+    _ = v.xy;
+
+    _ = v.r;
+    _ = v.rr;
+    _ = v.rrr;
+    _ = v.rrrr;
+
+    _ = v.g;
+    _ = v.gg;
+    _ = v.ggg;
+    _ = v.gggg;
+
+    _ = v.rg;
+}
+
+fn testSwizzleVec3() {
+    let v = vec3(0);
+    _ = v.x;
+    _ = v.xx;
+    _ = v.xxx;
+    _ = v.xxxx;
+
+    _ = v.y;
+    _ = v.yy;
+    _ = v.yyy;
+    _ = v.yyyy;
+
+    _ = v.z;
+    _ = v.zz;
+    _ = v.zzz;
+    _ = v.zzzz;
+
+    _ = v.xyz;
+
+    _ = v.r;
+    _ = v.rr;
+    _ = v.rrr;
+    _ = v.rrrr;
+
+    _ = v.g;
+    _ = v.gg;
+    _ = v.ggg;
+    _ = v.gggg;
+
+    _ = v.b;
+    _ = v.bb;
+    _ = v.bbb;
+    _ = v.bbbb;
+
+    _ = v.rgb;
+}
+
+fn testSwizzleVec4() {
+    let v = vec4(0);
+    _ = v.x;
+    _ = v.xx;
+    _ = v.xxx;
+    _ = v.xxxx;
+
+    _ = v.y;
+    _ = v.yy;
+    _ = v.yyy;
+    _ = v.yyyy;
+
+    _ = v.z;
+    _ = v.zz;
+    _ = v.zzz;
+    _ = v.zzzz;
+
+    _ = v.w;
+    _ = v.ww;
+    _ = v.www;
+    _ = v.wwww;
+
+    _ = v.xyzw;
+
+    _ = v.r;
+    _ = v.rr;
+    _ = v.rrr;
+    _ = v.rrrr;
+
+    _ = v.g;
+    _ = v.gg;
+    _ = v.ggg;
+    _ = v.gggg;
+
+    _ = v.b;
+    _ = v.bb;
+    _ = v.bbb;
+    _ = v.bbbb;
+
+    _ = v.a;
+    _ = v.aa;
+    _ = v.aaa;
+    _ = v.aaaa;
+
+    _ = v.rgba;
+}


### PR DESCRIPTION
#### cfcd3f2f153c669fa78dd6d679c001b82b66996e
<pre>
[WGSL] Incorrect swizzle validation
<a href="https://bugs.webkit.org/show_bug.cgi?id=257378">https://bugs.webkit.org/show_bug.cgi?id=257378</a>
rdar://109886275

Reviewed by Mike Wyrzykowski.

Swizzle characters need to be checked for bounds, e.g. we can&apos;t access vec2.z,
but the original patch was incorrectly checking the offset of the swizzle against
the size of the resulting vector, not the vector we are loading from.

* Source/WebGPU/WGSL/TypeCheck.cpp:
(WGSL::TypeChecker::vectorFieldAccess):
* Source/WebGPU/WGSL/tests/invalid/vector.wgsl:
* Source/WebGPU/WGSL/tests/valid/swizzle.wgsl: Added.

Canonical link: <a href="https://commits.webkit.org/264650@main">https://commits.webkit.org/264650@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/35dd68b5c8de603838169ea299cca1744f0522bf

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/8031 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/8316 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/8528 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/9683 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/8135 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/10302 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/8227 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/11000 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/8175 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/9262 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/7331 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/9806 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/6563 "Passed tests") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/14932 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/7686 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/7474 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/10837 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/7943 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/6464 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/7257 "Built successfully") | | | 
| [❌ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/1982 "Failed to push commit to Webkit repository") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/11465 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/7684 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->