### PR TITLE
InteractionRegions are missing for some `display: table` elements

### DIFF
--- a/LayoutTests/interaction-region/display-table-expected.txt
+++ b/LayoutTests/interaction-region/display-table-expected.txt
@@ -1,0 +1,24 @@
+This
+is a link with display: table.
+(GraphicsLayer
+  (anchor 0.00 0.00)
+  (bounds 800.00 600.00)
+  (children 1
+    (GraphicsLayer
+      (bounds 800.00 600.00)
+      (contentsOpaque 1)
+      (drawsContent 1)
+      (backgroundColor #FFFFFF)
+      (event region
+        (rect (0,0) width=800 height=600)
+
+      (interaction regions [
+        (guard (0,-10) width=29 height=39)
+        (borderRadius 0.00),
+        (interaction (0,0) width=29 height=19)
+        (borderRadius 8.00)])
+      )
+    )
+  )
+)
+

--- a/LayoutTests/interaction-region/display-table.html
+++ b/LayoutTests/interaction-region/display-table.html
@@ -1,0 +1,23 @@
+<!DOCTYPE html>
+<html>
+<style>
+    body { margin: 0; }
+    a {
+        display: table;
+    }
+</style>
+<body>
+<a href="#">This</a> is a link with <em>display: table</em>.
+
+<pre id="results"></pre>
+<script>
+if (window.testRunner)
+    testRunner.dumpAsText();
+
+window.onload = function () {
+    if (window.internals)
+       results.textContent = internals.layerTreeAsText(document, internals.LAYER_TREE_INCLUDES_EVENT_REGION | internals.LAYER_TREE_INCLUDES_ROOT_LAYER_PROPERTIES);
+};
+</script>
+</body>
+</html>

--- a/LayoutTests/interaction-region/layer-tree-expected.txt
+++ b/LayoutTests/interaction-region/layer-tree-expected.txt
@@ -113,97 +113,43 @@
                                               (layer bounds [x: 0 y: 0 width: 800 height: 20])
                                               (layer position [x: 400 y: 400]))))))))))))))))))
             (
-              (layer bounds [x: 0 y: 0 width: 0 height: 0]))
-            (
-              (layer bounds [x: 0 y: 0 width: 0 height: 0])
-              (sublayers
-                (
-                  (layer bounds [x: 0 y: 0 width: 0 height: 0]))))
-            (
-              (layer bounds [x: 0 y: 0 width: 0 height: 0])
-              (sublayers
-                (
-                  (layer bounds [x: 0 y: 0 width: 0 height: 0]))))
-            (
-              (layer bounds [x: 0 y: 0 width: 0 height: 0])
-              (layer opacity 0.32)
-              (sublayers
-                (
-                  (layer bounds [x: 0 y: 0 width: 0 height: 0]))))
-            (
-              (layer bounds [x: 0 y: 0 width: 0 height: 0])
-              (sublayers
-                (
-                  (layer bounds [x: 0 y: 0 width: 2 height: 0])
-                  (layer position [x: 1 y: 1]))
-                (
-                  (layer bounds [x: 0 y: 0 width: 0 height: 0])
-                  (sublayers
-                    (
-                      (layer bounds [x: 0 y: 0 width: 0 height: 0]))))))
-            (
-              (layer bounds [x: 0 y: 0 width: 0 height: 0])
-              (sublayers
-                (
-                  (layer bounds [x: 0 y: 0 width: 0 height: 0])
-                  (sublayers
-                    (
-                      (layer bounds [x: 0 y: 0 width: 0 height: 0]))
-                    (
-                      (layer bounds [x: 0 y: 0 width: 20 height: 20])
-                      (layer position [x: 0 y: 0]))))
-                (
-                  (layer bounds [x: 0 y: 0 width: 0 height: 0])
-                  (sublayers
-                    (
-                      (layer bounds [x: 0 y: 0 width: 0 height: 0]))
-                    (
-                      (layer bounds [x: 0 y: 0 width: 20 height: 20])
-                      (layer position [x: 0 y: 0]))))))
-            (
-              (layer bounds [x: 0 y: 0 width: 0 height: 0])
-              (sublayers
-                (
-                  (layer bounds [x: 0 y: 0 width: 0 height: 0])
-                  (sublayers
-                    (
-                      (layer bounds [x: 0 y: 0 width: 0 height: 0]))))))))
+              (layer bounds [x: 0 y: 0 width: 0 height: 0]))))
         (
           (layer bounds [x: 0 y: 0 width: 0 height: 0])
           (layer anchorPoint [x: 0 y: 0]))
         (
-          (layer bounds [x: 0 y: 0 width: 794 height: 6])
+          (layer bounds [x: 0 y: 0 width: 794 height: 8.16])
           (layer position [x: 400 y: 400])
           (layer opacity 0)
           (sublayers
             (
-              (layer bounds [x: 0 y: 0 width: 794 height: 6])
+              (layer bounds [x: 0 y: 0 width: 794 height: 8.16])
               (layer position [x: 397 y: 397])
               (layer zPosition 1000)
               (sublayers
                 (
-                  (layer bounds [x: 0 y: 0 width: 794 height: 6])
+                  (layer bounds [x: 0 y: 0 width: 794 height: 8.16])
                   (layer position [x: 397 y: 397])
-                  (layer cornerRadius 3.5))))
+                  (layer cornerRadius 4.760000000000001))))
             (
-              (layer bounds [x: 0 y: 0 width: 794 height: 6])
+              (layer bounds [x: 0 y: 0 width: 794 height: 8.16])
               (layer position [x: 397 y: 397])
               (layer opacity 0.005))))
         (
-          (layer bounds [x: 0 y: 0 width: 6 height: 594])
-          (layer position [x: 794 y: 794])
+          (layer bounds [x: 0 y: 0 width: 8.16 height: 594])
+          (layer position [x: 792.9200000000001 y: 792.9200000000001])
           (layer opacity 0)
           (sublayers
             (
-              (layer bounds [x: 0 y: 0 width: 6 height: 594])
-              (layer position [x: 3 y: 3])
+              (layer bounds [x: 0 y: 0 width: 8.16 height: 594])
+              (layer position [x: 4.08 y: 4.08])
               (layer zPosition 1000)
               (sublayers
                 (
-                  (layer bounds [x: 0 y: 0 width: 6 height: 594])
-                  (layer position [x: 3 y: 3])
-                  (layer cornerRadius 3.5))))
+                  (layer bounds [x: 0 y: 0 width: 8.16 height: 594])
+                  (layer position [x: 4.08 y: 4.08])
+                  (layer cornerRadius 4.760000000000001))))
             (
-              (layer bounds [x: 0 y: 0 width: 6 height: 594])
-              (layer position [x: 3 y: 3])
+              (layer bounds [x: 0 y: 0 width: 8.16 height: 594])
+              (layer position [x: 4.08 y: 4.08])
               (layer opacity 0.005))))))))

--- a/Source/WebCore/page/InteractionRegion.cpp
+++ b/Source/WebCore/page/InteractionRegion.cpp
@@ -258,7 +258,7 @@ std::optional<InteractionRegion> interactionRegionForRenderedRegion(RenderObject
     bool isInlineNonBlock = renderer.isInline() && !renderer.isReplacedOrInlineBlock();
 
     // The parent will get its own InteractionRegion.
-    if (!isOriginalMatch && !isInlineNonBlock)
+    if (!isOriginalMatch && !isInlineNonBlock && !renderer.style().isDisplayTableOrTablePart())
         return std::nullopt;
 
     float borderRadius = 0;


### PR DESCRIPTION
#### fde1853a7a1574c5468741b2022d4d9d6ae1cf24
<pre>
InteractionRegions are missing for some `display: table` elements
<a href="https://bugs.webkit.org/show_bug.cgi?id=257379">https://bugs.webkit.org/show_bug.cgi?id=257379</a>
&lt;rdar://109538261&gt;

Reviewed by Tim Horton.

Don&apos;t skip the child renderer&apos;s InteractionRegion if the link parent is
`display: table`, like we do for inline links.

* Source/WebCore/page/InteractionRegion.cpp:
(WebCore::interactionRegionForRenderedRegion):
Check if the matched renderer `isDisplayTableOrTablePart()` before
bailing out.

* LayoutTests/interaction-region/display-table-expected.txt: Added.
* LayoutTests/interaction-region/display-table.html: Added.
Add a test.

* LayoutTests/interaction-region/layer-tree-expected.txt:
Test update.

Canonical link: <a href="https://commits.webkit.org/264598@main">https://commits.webkit.org/264598@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b04ffac7092f82b1587842cf0e5f5788b6535adb

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/8035 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/8320 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/8532 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/9687 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/8139 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/8039 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/10306 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/8231 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/11004 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/8179 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/9266 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/7332 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/9817 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/6567 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/7352 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/14941 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/7690 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/7476 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/10846 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/7947 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/6468 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/7261 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/7265 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/1938 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/11469 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/7688 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->