### PR TITLE
[WGSL] Initial constant resolution implementation

### DIFF
--- a/Source/WebGPU/WGSL/ConstantRewriter.cpp
+++ b/Source/WebGPU/WGSL/ConstantRewriter.cpp
@@ -1,0 +1,288 @@
+/*
+ * Copyright (c) 2023 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "ConstantRewriter.h"
+
+#include "AST.h"
+#include "ASTStringDumper.h"
+#include "ASTVisitor.h"
+#include "ContextProviderInlines.h"
+#include "Types.h"
+#include "WGSLShaderModule.h"
+#include <wtf/DataLog.h>
+
+namespace WGSL {
+
+constexpr bool shouldDumpConstantValues = false;
+
+// A constant value might be:
+// - a scalar
+// - a vector
+// - a matrix
+// - a fixed-size array type
+// - a structure
+using BaseValue = std::variant<double, int64_t, bool>;
+struct ConstantValue : BaseValue {
+    using BaseValue::BaseValue;
+
+    void dump(PrintStream&) const;
+};
+
+void ConstantValue::dump(PrintStream& out) const
+{
+    WTF::switchOn(*this,
+        [&](double d) {
+            out.print(String::number(d));
+        },
+        [&](int64_t i) {
+            out.print(String::number(i));
+        },
+        [&](bool b) {
+            out.print(b ? "true" : "false");
+        });
+}
+
+class ConstantRewriter : public AST::Visitor, public ContextProvider<ConstantValue> {
+public:
+    ConstantRewriter(ShaderModule&);
+
+    std::optional<FailedCheck> rewrite();
+
+    // Declarations
+    void visit(AST::Structure&) override;
+    void visit(AST::Variable&) override;
+
+    // Statements
+    void visit(AST::CompoundStatement&) override;
+
+    // Expressions
+    void visit(AST::IdentifierExpression&) override;
+
+private:
+    template<typename... Arguments>
+    void error(const SourceSpan&, Arguments&&...);
+
+    ConstantValue evaluate(AST::Expression&);
+    ConstantValue evaluate(AST::IdentifierExpression&);
+
+    void materialize(AST::Expression&, ConstantValue);
+
+    ShaderModule& m_shaderModule;
+    Vector<Error> m_errors;
+};
+
+ConstantRewriter::ConstantRewriter(ShaderModule& shaderModule)
+    : m_shaderModule(shaderModule)
+{
+}
+
+std::optional<FailedCheck> ConstantRewriter::rewrite()
+{
+    for (auto& structure : m_shaderModule.structures())
+        visit(structure);
+
+    for (auto& variable : m_shaderModule.variables())
+        visit(variable);
+
+    for (auto& function : m_shaderModule.functions())
+        AST::Visitor::visit(function);
+
+    if (m_errors.isEmpty())
+        return std::nullopt;
+
+    Vector<Warning> warnings { };
+    return FailedCheck { WTFMove(m_errors), WTFMove(warnings) };
+}
+
+// Declarations
+void ConstantRewriter::visit(AST::Structure& structure)
+{
+    // FIXME: implement
+    UNUSED_PARAM(structure);
+}
+
+void ConstantRewriter::visit(AST::Variable& variable)
+{
+    if (variable.flavor() != AST::VariableFlavor::Const) {
+        if (auto* initializer = variable.maybeInitializer())
+            AST::Visitor::visit(*initializer);
+        return;
+    }
+
+    ASSERT(variable.maybeInitializer());
+    introduceVariable(variable.name(), evaluate(*variable.maybeInitializer()));
+}
+
+// Statements
+void ConstantRewriter::visit(AST::CompoundStatement& statement)
+{
+    ContextScope blockScope(this);
+    AST::Visitor::visit(statement);
+}
+
+// Expressions
+void ConstantRewriter::visit(AST::IdentifierExpression& identifier)
+{
+    auto* constant = readVariable(identifier.identifier());
+    if (!constant)
+        return;
+
+    if (shouldDumpConstantValues)
+        dataLogLn("> Replacing identifier '", identifier.identifier(), "' with constant: ", *constant);
+
+    materialize(identifier, *constant);
+}
+
+// Private helpers
+ConstantValue ConstantRewriter::evaluate(AST::Expression& expression)
+{
+    ConstantValue result;
+    switch (expression.kind()) {
+    case AST::NodeKind::AbstractFloatLiteral:
+        result = downcast<AST::AbstractFloatLiteral>(expression).value();
+        break;
+    case AST::NodeKind::AbstractIntegerLiteral:
+        result = downcast<AST::AbstractIntegerLiteral>(expression).value();
+        break;
+    case AST::NodeKind::Float32Literal:
+        result = downcast<AST::Float32Literal>(expression).value();
+        break;
+    case AST::NodeKind::Signed32Literal:
+        result = downcast<AST::Signed32Literal>(expression).value();
+        break;
+    case AST::NodeKind::Unsigned32Literal:
+        result = downcast<AST::Unsigned32Literal>(expression).value();
+        break;
+    case AST::NodeKind::BoolLiteral:
+        result = downcast<AST::BoolLiteral>(expression).value();
+        break;
+
+    case AST::NodeKind::IdentifierExpression:
+        result = evaluate(downcast<AST::IdentifierExpression>(expression));
+        break;
+
+    default:
+        ASSERT_NOT_REACHED("Unhandled Expression");
+    }
+
+    if (shouldDumpConstantValues) {
+        dataLog("> Evaluated expression: ");
+        dumpNode(WTF::dataFile(), expression);
+        dataLog(" = ");
+        dataLogLn(result);
+    }
+
+    return result;
+}
+
+ConstantValue ConstantRewriter::evaluate(AST::IdentifierExpression& identifier)
+{
+    auto* value = readVariable(identifier.identifier());
+    ASSERT(value);
+    return *value;
+}
+
+void ConstantRewriter::materialize(AST::Expression& expression, ConstantValue value)
+{
+    using namespace Types;
+
+    const auto& replace = [&]<typename Node, typename Value>() {
+        m_shaderModule.replace(expression, m_shaderModule.astBuilder().construct<Node>(SourceSpan::empty(), std::get<Value>(value)));
+    };
+
+    return WTF::switchOn(*expression.inferredType(),
+        [&](const Primitive& primitive) {
+            switch (primitive.kind) {
+            case Primitive::AbstractInt:
+                replace.operator()<AST::AbstractIntegerLiteral, int64_t>();
+                break;
+            case Primitive::I32:
+                replace.operator()<AST::Signed32Literal, int64_t>();
+                break;
+            case Primitive::U32:
+                replace.operator()<AST::Unsigned32Literal, int64_t>();
+                break;
+            case Primitive::AbstractFloat:
+                replace.operator()<AST::AbstractFloatLiteral, double>();
+                break;
+            case Primitive::F32:
+                replace.operator()<AST::Float32Literal, double>();
+                break;
+            case Primitive::Bool:
+                replace.operator()<AST::BoolLiteral, bool>();
+                break;
+            case Primitive::Void:
+            case Primitive::Sampler:
+            case Primitive::TextureExternal:
+                RELEASE_ASSERT_NOT_REACHED();
+            }
+        },
+        [&](const Vector& vector) {
+            // FIXME: implement
+            UNUSED_PARAM(vector);
+            RELEASE_ASSERT_NOT_REACHED();
+        },
+        [&](const Matrix& matrix) {
+            // FIXME: implement
+            UNUSED_PARAM(matrix);
+            RELEASE_ASSERT_NOT_REACHED();
+        },
+        [&](const Array& array) {
+            // FIXME: implement
+            UNUSED_PARAM(array);
+            RELEASE_ASSERT_NOT_REACHED();
+        },
+        [&](const Struct& structure) {
+            // FIXME: implement
+            UNUSED_PARAM(structure);
+            RELEASE_ASSERT_NOT_REACHED();
+        },
+        [&](const Reference&) {
+            RELEASE_ASSERT_NOT_REACHED();
+        },
+        [&](const Function&) {
+            RELEASE_ASSERT_NOT_REACHED();
+        },
+        [&](const Texture&) {
+            RELEASE_ASSERT_NOT_REACHED();
+        },
+        [&](const Bottom&) {
+            RELEASE_ASSERT_NOT_REACHED();
+        });
+}
+
+template<typename... Arguments>
+void ConstantRewriter::error(const SourceSpan& span, Arguments&&... arguments)
+{
+    m_errors.append({ makeString(std::forward<Arguments>(arguments)...), span });
+}
+
+std::optional<FailedCheck> rewriteConstants(ShaderModule& shaderModule)
+{
+    return ConstantRewriter(shaderModule).rewrite();
+}
+
+} // namespace WGSL

--- a/Source/WebGPU/WGSL/ConstantRewriter.h
+++ b/Source/WebGPU/WGSL/ConstantRewriter.h
@@ -1,0 +1,36 @@
+/*
+ * Copyright (c) 2023 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include "WGSL.h"
+
+namespace WGSL {
+
+class ShaderModule;
+
+std::optional<FailedCheck> rewriteConstants(ShaderModule&);
+
+} // namespace WGSL

--- a/Source/WebGPU/WGSL/GlobalVariableRewriter.cpp
+++ b/Source/WebGPU/WGSL/GlobalVariableRewriter.cpp
@@ -239,8 +239,7 @@ auto RewriteGlobalVariables::determineUsedGlobals(PipelineLayout& pipelineLayout
             }
             break;
         case AST::VariableFlavor::Const:
-            // Constants must be resolved at an earlier phase
-            RELEASE_ASSERT_NOT_REACHED();
+            continue;
         }
 
         auto group = global.resource->group;

--- a/Source/WebGPU/WGSL/WGSL.cpp
+++ b/Source/WebGPU/WGSL/WGSL.cpp
@@ -27,6 +27,7 @@
 #include "WGSL.h"
 
 #include "CallGraph.h"
+#include "ConstantRewriter.h"
 #include "EntryPointRewriter.h"
 #include "GlobalVariableRewriter.h"
 #include "MangleNames.h"
@@ -76,6 +77,10 @@ std::variant<SuccessfulCheck, FailedCheck> staticCheck(const String& wgsl, const
 
     // FIXME: add more validation
     auto maybeFailure = typeCheck(shaderModule);
+    if (maybeFailure.has_value())
+        return *maybeFailure;
+
+    maybeFailure = rewriteConstants(shaderModule);
     if (maybeFailure.has_value())
         return *maybeFailure;
 

--- a/Source/WebGPU/WGSL/tests/valid/constants.wgsl
+++ b/Source/WebGPU/WGSL/tests/valid/constants.wgsl
@@ -1,0 +1,30 @@
+// RUN: %wgslc
+
+fn testLiteralConstants()
+{
+    {
+        const x = 1;
+        _ = countOneBits(x);
+    }
+
+    {
+        const x = 1i;
+        _ = countOneBits(x);
+    }
+
+    {
+        const x = true;
+        if x {
+        }
+    }
+
+    {
+        const x = 3.0;
+        _ = sqrt(x);
+    }
+
+    {
+        const x = 3f;
+        _ = sqrt(x);
+    }
+}

--- a/Source/WebGPU/WebGPU.xcodeproj/project.pbxproj
+++ b/Source/WebGPU/WebGPU.xcodeproj/project.pbxproj
@@ -150,6 +150,8 @@
 		97C36CFE29F1730100CFB379 /* Constraints.h in Headers */ = {isa = PBXBuildFile; fileRef = 97C36CFC29F1730000CFB379 /* Constraints.h */; };
 		97C36CFF29F1730100CFB379 /* Constraints.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 97C36CFD29F1730000CFB379 /* Constraints.cpp */; };
 		97E21C8B2A1F5DCC009CEB0E /* ASTDecrementIncrementStatement.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 97E21C8A2A1F5DCC009CEB0E /* ASTDecrementIncrementStatement.cpp */; };
+		97E21C8E2A20B2A3009CEB0E /* ConstantRewriter.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 97E21C8C2A20B2A3009CEB0E /* ConstantRewriter.cpp */; };
+		97E21C8F2A20B2A3009CEB0E /* ConstantRewriter.h in Headers */ = {isa = PBXBuildFile; fileRef = 97E21C8D2A20B2A3009CEB0E /* ConstantRewriter.h */; };
 		97F547B8298055D90011D79A /* GlobalVariableRewriter.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 97F547B6298055D90011D79A /* GlobalVariableRewriter.cpp */; };
 		97F547B9298055D90011D79A /* GlobalVariableRewriter.h in Headers */ = {isa = PBXBuildFile; fileRef = 97F547B7298055D90011D79A /* GlobalVariableRewriter.h */; };
 		97FA1A8E29C086230052D650 /* wgslc.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 97FA1A8729C085A60052D650 /* wgslc.cpp */; };
@@ -396,6 +398,8 @@
 		97C36CFC29F1730000CFB379 /* Constraints.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = Constraints.h; sourceTree = "<group>"; };
 		97C36CFD29F1730000CFB379 /* Constraints.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = Constraints.cpp; sourceTree = "<group>"; };
 		97E21C8A2A1F5DCC009CEB0E /* ASTDecrementIncrementStatement.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = ASTDecrementIncrementStatement.cpp; sourceTree = "<group>"; };
+		97E21C8C2A20B2A3009CEB0E /* ConstantRewriter.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = ConstantRewriter.cpp; sourceTree = "<group>"; };
+		97E21C8D2A20B2A3009CEB0E /* ConstantRewriter.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ConstantRewriter.h; sourceTree = "<group>"; };
 		97F547B6298055D90011D79A /* GlobalVariableRewriter.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = GlobalVariableRewriter.cpp; sourceTree = "<group>"; };
 		97F547B7298055D90011D79A /* GlobalVariableRewriter.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GlobalVariableRewriter.h; sourceTree = "<group>"; };
 		97FA1A7F29C085740052D650 /* wgslc */ = {isa = PBXFileReference; explicitFileType = "compiled.mach-o.executable"; includeInIndex = 0; path = wgslc; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -540,6 +544,8 @@
 				33EA186727BC1B1400A1DD52 /* CompilationMessage.cpp */,
 				33EA186527BC1AD500A1DD52 /* CompilationMessage.h */,
 				1CEBD8042716BFAB00A5254D /* config.h */,
+				97E21C8C2A20B2A3009CEB0E /* ConstantRewriter.cpp */,
+				97E21C8D2A20B2A3009CEB0E /* ConstantRewriter.h */,
 				97C36CFD29F1730000CFB379 /* Constraints.cpp */,
 				97C36CFC29F1730000CFB379 /* Constraints.h */,
 				978A9129298AB60200B37E5E /* ContextProvider.h */,
@@ -779,6 +785,7 @@
 				3A12AEC828FCEEC400C1B975 /* ASTWhileStatement.h in Headers */,
 				3A12AEB228FCE94C00C1B975 /* ASTWorkgroupSizeAttribute.h in Headers */,
 				33EA186627BC1AD500A1DD52 /* CompilationMessage.h in Headers */,
+				97E21C8F2A20B2A3009CEB0E /* ConstantRewriter.h in Headers */,
 				97C36CFE29F1730100CFB379 /* Constraints.h in Headers */,
 				978A912A298AB60200B37E5E /* ContextProvider.h in Headers */,
 				978A912C298AB8EE00B37E5E /* ContextProviderInlines.h in Headers */,
@@ -980,6 +987,7 @@
 				3A1337E728FBD56400F29B73 /* ASTVisitor.cpp in Sources */,
 				9789C31A297EA105009E9006 /* CallGraph.cpp in Sources */,
 				339B7B1E27D816270072BF9A /* CompilationMessage.cpp in Sources */,
+				97E21C8E2A20B2A3009CEB0E /* ConstantRewriter.cpp in Sources */,
 				97C36CFF29F1730100CFB379 /* Constraints.cpp in Sources */,
 				979240C929769AC00050EA2C /* EntryPointRewriter.cpp in Sources */,
 				97F547B8298055D90011D79A /* GlobalVariableRewriter.cpp in Sources */,


### PR DESCRIPTION
#### 7ba090e99148d4ffea4f8c4ceb7cbf0dd60a5f37
<pre>
[WGSL] Initial constant resolution implementation
<a href="https://bugs.webkit.org/show_bug.cgi?id=257381">https://bugs.webkit.org/show_bug.cgi?id=257381</a>
rdar://109888410

Reviewed by Mike Wyrzykowski.

Add a simple constant resolution phase. For now, it can only handle literals,
but it will be expanded soon to handle other types of data and expressions.

* Source/WebGPU/WGSL/ConstantRewriter.cpp: Added.
(WGSL::ConstantValue::dump const):
(WGSL::ConstantRewriter::ConstantRewriter):
(WGSL::ConstantRewriter::rewrite):
(WGSL::ConstantRewriter::visit):
(WGSL::ConstantRewriter::evaluate):
(WGSL::ConstantRewriter::materialize):
(WGSL::ConstantRewriter::error):
(WGSL::rewriteConstants):
* Source/WebGPU/WGSL/ConstantRewriter.h: Added.
* Source/WebGPU/WGSL/GlobalVariableRewriter.cpp:
(WGSL::RewriteGlobalVariables::determineUsedGlobals):
* Source/WebGPU/WGSL/WGSL.cpp:
(WGSL::staticCheck):
* Source/WebGPU/WGSL/tests/valid/constants.wgsl: Added.
* Source/WebGPU/WebGPU.xcodeproj/project.pbxproj:

Canonical link: <a href="https://commits.webkit.org/264652@main">https://commits.webkit.org/264652@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b2b2f8e1f3d08f81e2548179c38e71628a773d89

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/8263 "1 style error") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/8555 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/8772 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/9930 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/8327 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/10543 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/8466 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/11201 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/8408 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/9468 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/7496 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/10074 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/6767 "Passed tests") | | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/15119 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/7890 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/7696 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/11048 "run-api-tests-without-change (failure)") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/8167 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/6646 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/7457 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/1986 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/11666 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/7910 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->