### PR TITLE
[:has() pseudo-class] Support invalidation for :defined pseudo class

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/selectors/invalidation/defined-in-has-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/selectors/invalidation/defined-in-has-expected.txt
@@ -1,0 +1,4 @@
+Test :defined pseudo-class invalidation with :has()
+
+PASS Test :has() invalidation with :defined pseudo-class
+

--- a/LayoutTests/imported/w3c/web-platform-tests/css/selectors/invalidation/defined-in-has.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/selectors/invalidation/defined-in-has.html
@@ -1,0 +1,37 @@
+<!DOCTYPE html>
+<title>:has() invalidation with :defined pseudo-class</title>
+<link rel="author" title="Tim Nguyen" href="https://github.com/nt1m">
+<link rel="help" href="https://drafts.csswg.org/selectors/#relational">
+<link rel="help" href="https://html.spec.whatwg.org/multipage/semantics-other.html#selector-defined">
+<style>
+  #subject {
+    background-color: red;
+    width: 100px;
+    height: 100px;
+  }
+  #subject:has(:defined) {
+    background-color: green;
+  }
+</style>
+<body>
+  Test :defined pseudo-class invalidation with :has()
+  <div id="subject">
+    <my-element></my-element>
+  </div>
+  <script src="/resources/testharness.js"></script>
+  <script src="/resources/testharnessreport.js"></script>
+  <script>
+    const GREEN = "rgb(0, 128, 0)";
+    const RED = "rgb(255, 0, 0)";
+
+    function assert_matches_defined(defined) {
+      assert_equals(getComputedStyle(subject).backgroundColor, defined ? GREEN : RED);
+    }
+
+    test(() => {
+      assert_matches_defined(false);
+      customElements.define("my-element", class MyElement extends HTMLElement { });
+      assert_matches_defined(true);
+    }, "Test :has() invalidation with :defined pseudo-class");
+  </script>
+</body>

--- a/Source/WebCore/dom/Element.cpp
+++ b/Source/WebCore/dom/Element.cpp
@@ -2961,6 +2961,11 @@ ShadowRoot& Element::createUserAgentShadowRoot()
 
 inline void Node::setCustomElementState(CustomElementState state)
 {
+    RELEASE_ASSERT(is<Element>(this));
+    Style::PseudoClassChangeInvalidation styleInvalidation(downcast<Element>(*this),
+        CSSSelector::PseudoClassDefined,
+        state == CustomElementState::Custom || state == CustomElementState::Uncustomized
+    );
     auto bitfields = rareDataBitfields();
     bitfields.customElementState = static_cast<uint16_t>(state);
     setRareDataBitfields(bitfields);
@@ -2972,7 +2977,6 @@ void Element::setIsDefinedCustomElement(JSCustomElementInterface& elementInterfa
     auto& data = ensureElementRareData();
     if (!data.customElementReactionQueue())
         data.setCustomElementReactionQueue(makeUnique<CustomElementReactionQueue>(elementInterface));
-    invalidateStyleForSubtree();
     InspectorInstrumentation::didChangeCustomElementState(*this);
 }
 


### PR DESCRIPTION
#### e721d57b1ff83bb33a587aafc023aa2588f80fe2
<pre>
[:has() pseudo-class] Support invalidation for :defined pseudo class
<a href="https://bugs.webkit.org/show_bug.cgi?id=257385">https://bugs.webkit.org/show_bug.cgi?id=257385</a>
rdar://109896689

Reviewed by Ryosuke Niwa.

Use PseudoClassChangeInvalidation instead of manually invalidating the subtree, which does not take in account :has().

* LayoutTests/imported/w3c/web-platform-tests/css/selectors/invalidation/defined-in-has-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/selectors/invalidation/defined-in-has.html: Added.
* Source/WebCore/dom/Element.cpp:
(WebCore::Node::setCustomElementState):
(WebCore::Element::setIsDefinedCustomElement):

Canonical link: <a href="https://commits.webkit.org/264602@main">https://commits.webkit.org/264602@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2b0bf99982353d9116dd8098676b179336bb57c3

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/8069 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/8354 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/8567 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/9721 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/32/builds/8168 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/8073 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/10340 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/8265 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/11030 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/8213 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/9296 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/7351 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/9843 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/6597 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/7381 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/14963 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/7720 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/7506 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/10868 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/7980 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/6495 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/7291 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/7294 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/1946 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/11500 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/7721 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->