### PR TITLE
Only claim to be eligible for Smart Routing when generating audio

### DIFF
--- a/Source/WebCore/platform/audio/cocoa/AudioSessionCocoa.h
+++ b/Source/WebCore/platform/audio/cocoa/AudioSessionCocoa.h
@@ -39,12 +39,21 @@ class AudioSessionCocoa : public AudioSession {
 public:
     virtual ~AudioSessionCocoa();
 
+    bool isEligibleForSmartRouting() const { return m_isEligibleForSmartRouting; }
+
+    enum class ForceUpdate : bool { No, Yes };
+    void setEligibleForSmartRouting(bool, ForceUpdate = ForceUpdate::No);
+
 protected:
     AudioSessionCocoa();
 
+    void setEligibleForSmartRoutingInternal(bool);
+
     // AudioSession
     bool tryToSetActiveInternal(bool) final;
+    void setCategory(CategoryType, Mode, RouteSharingPolicy) override;
 
+    bool m_isEligibleForSmartRouting { false };
     Ref<WTF::WorkQueue> m_workQueue;
 };
 

--- a/Source/WebCore/platform/audio/ios/AudioSessionIOS.mm
+++ b/Source/WebCore/platform/audio/ios/AudioSessionIOS.mm
@@ -171,6 +171,8 @@ void AudioSessionIOS::setCategory(CategoryType newCategory, Mode newMode, RouteS
 
     LOG(Media, "AudioSession::setCategory() - category = %s mode = %s", convertEnumerationToString(newCategory).ascii().data(), convertEnumerationToString(newMode).ascii().data());
 
+    AudioSessionCocoa::setCategory(newCategory, newMode, policy);
+
     if (categoryOverride() != CategoryType::None && categoryOverride() != newCategory) {
         LOG(Media, "AudioSession::setCategory() - override set, NOT changing");
         return;

--- a/Source/WebCore/platform/audio/mac/AudioSessionMac.mm
+++ b/Source/WebCore/platform/audio/mac/AudioSessionMac.mm
@@ -283,8 +283,10 @@ void AudioSessionMac::setIsPlayingToBluetoothOverride(std::optional<bool> value)
 #endif
 }
 
-void AudioSessionMac::setCategory(CategoryType category, Mode, RouteSharingPolicy policy)
+void AudioSessionMac::setCategory(CategoryType category, Mode mode, RouteSharingPolicy policy)
 {
+    AudioSessionCocoa::setCategory(category, mode, policy);
+
 #if ENABLE(ROUTING_ARBITRATION)
     bool playingToBluetooth = defaultDeviceTransportIsBluetooth();
     if (category == m_category && m_playingToBluetooth && *m_playingToBluetooth == playingToBluetooth)


### PR DESCRIPTION
#### 56f6f91ae9b4074cc5f08c80aab4cbc191d6e00b
<pre>
Only claim to be eligible for Smart Routing when generating audio
<a href="https://bugs.webkit.org/show_bug.cgi?id=257388">https://bugs.webkit.org/show_bug.cgi?id=257388</a>
rdar://109724130

Reviewed by Jer Noble.

Don&apos;t claim to be eligible for Smart Routing if the audio session is inactive
or the audio session category is None.

* Source/WebCore/platform/audio/cocoa/AudioSessionCocoa.h:
(WebCore::AudioSessionCocoa::isEligibleForSmartRouting const):
* Source/WebCore/platform/audio/cocoa/AudioSessionCocoa.mm:
(WebCore::AudioSessionCocoa::setEligibleForSmartRoutingInternal):
(WebCore::AudioSessionCocoa::AudioSessionCocoa):
(WebCore::AudioSessionCocoa::~AudioSessionCocoa):
(WebCore::AudioSessionCocoa::setEligibleForSmartRouting):
(WebCore::AudioSessionCocoa::tryToSetActiveInternal):
(WebCore::AudioSessionCocoa::setCategory):
(WebCore::setEligibleForSmartRouting): Deleted.
* Source/WebCore/platform/audio/ios/AudioSessionIOS.mm:
(WebCore::AudioSessionIOS::setCategory):
* Source/WebCore/platform/audio/mac/AudioSessionMac.mm:
(WebCore::AudioSessionMac::setCategory):

Canonical link: <a href="https://commits.webkit.org/264610@main">https://commits.webkit.org/264610@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/cfacfa3c8337f2a21c67efb24a17b1d39ab9a8bd

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/8075 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/8361 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/8574 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/9728 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/8174 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/8080 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/10346 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/8271 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/11033 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/8219 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/9303 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/7357 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/9849 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/6604 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/7389 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/14966 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/7727 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/7514 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/10871 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/7986 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/6500 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/7297 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/1951 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/11506 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/7727 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->