### PR TITLE
Use the fullscreen preferred size when reporting screen dimensions followup

### DIFF
--- a/Source/WebKit/UIProcess/ios/WebPageProxyIOS.mm
+++ b/Source/WebKit/UIProcess/ios/WebPageProxyIOS.mm
@@ -844,21 +844,30 @@ FloatSize WebPageProxy::screenSize()
     return WebCore::screenSize();
 }
 
+#if HAVE(UIKIT_WEBKIT_INTERNALS)
+static FloatSize fullscreenPreferencesScreenSize(CGFloat preferredWidth)
+{
+    CGFloat preferredHeight = preferredWidth / kTargetFullscreenAspectRatio;
+    return FloatSize(CGSizeMake(preferredWidth, preferredHeight));
+}
+#endif
+
 FloatSize WebPageProxy::availableScreenSize()
 {
+#if HAVE(UIKIT_WEBKIT_INTERNALS)
+    return fullscreenPreferencesScreenSize(m_preferences->mediaPreferredFullscreenWidth());
+#else
     return WebCore::availableScreenSize();
+#endif
 }
 
 FloatSize WebPageProxy::overrideScreenSize()
 {
 #if HAVE(UIKIT_WEBKIT_INTERNALS)
-    // Report screen dimensions based on fullscreen preferences.
-    CGFloat preferredWidth = m_preferences->mediaPreferredFullscreenWidth();
-    CGFloat preferredHeight = preferredWidth / kTargetFullscreenAspectRatio;
-    return FloatSize(CGSizeMake(preferredWidth, preferredHeight));
-#endif
-
+    return fullscreenPreferencesScreenSize(m_preferences->mediaPreferredFullscreenWidth());
+#else
     return WebCore::overrideScreenSize();
+#endif
 }
 
 float WebPageProxy::textAutosizingWidth()


### PR DESCRIPTION
#### e78ba96e4f2e5613a2d3931b2f4e373c5c30ddb1
<pre>
Use the fullscreen preferred size when reporting screen dimensions followup
<a href="https://bugs.webkit.org/show_bug.cgi?id=257390">https://bugs.webkit.org/show_bug.cgi?id=257390</a>
rdar://109289474

Reviewed by Tim Horton.

In the fix for <a href="https://github.com/WebKit/WebKit/commit/da50bb2bfac4cb2530f12086789caf196b3adcb9">https://github.com/WebKit/WebKit/commit/da50bb2bfac4cb2530f12086789caf196b3adcb9</a>
rdar://99403187
we failed to also accout for availableScreenSize. Add the logic to this
function as well.

* Source/WebKit/UIProcess/ios/WebPageProxyIOS.mm:
(WebKit::fullscreenPreferencesScreenSize):
(WebKit::WebPageProxy::availableScreenSize):
(WebKit::WebPageProxy::overrideScreenSize):

Canonical link: <a href="https://commits.webkit.org/264614@main">https://commits.webkit.org/264614@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/87af6fd7df42d1cae7110daa73aa31a33da48b7f

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/8093 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/8380 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/8594 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/9748 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/32/builds/8187 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/10366 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/8291 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/11048 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/8237 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/9319 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/7371 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/9869 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/6620 "Passed tests") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/14981 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/7742 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/7537 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/10887 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/8002 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/6510 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/7311 "Built successfully") | | | 
| [❌ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/1955 "Failed to push commit to Webkit repository") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/11520 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/7745 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->