### PR TITLE
window.stop() should fire abort events on XMLHttpRequest asynchronously

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/xhr/abort-after-stop.window-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/xhr/abort-after-stop.window-expected.txt
@@ -1,3 +1,3 @@
 
-FAIL XMLHttpRequest: abort event should fire when stop() method is used assert_equals: expected true but got false
+PASS XMLHttpRequest: abort event should fire when stop() method is used
 

--- a/LayoutTests/imported/w3c/web-platform-tests/xhr/open-after-stop.window-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/xhr/open-after-stop.window-expected.txt
@@ -1,3 +1,3 @@
 
-FAIL open() after window.stop() assert_unreached: loadend should not be fired after window.stop() and open() Reached unreachable code
+PASS open() after window.stop()
 

--- a/LayoutTests/imported/w3c/web-platform-tests/xhr/send-authentication-basic-cors-not-enabled-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/xhr/send-authentication-basic-cors-not-enabled-expected.txt
@@ -1,4 +1,3 @@
-Blocked access to external URL http://www1.localhost:8800/xhr/resources/auth10/auth.py
 
 PASS XMLHttpRequest: send() - "Basic" authenticated CORS requests with user name and password passed to open() (asserts failure)
 

--- a/LayoutTests/imported/w3c/web-platform-tests/xhr/send-authentication-basic-cors-not-enabled.htm
+++ b/LayoutTests/imported/w3c/web-platform-tests/xhr/send-authentication-basic-cors-not-enabled.htm
@@ -5,6 +5,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/utils.js"></script>
+    <script src="/common/get-host-info.sub.js"></script>
     <link rel="help" href="https://xhr.spec.whatwg.org/#the-open()-method" data-tested-assertations="following::ol[1]/li[9]/ol[1]/li[1] following::ol[1]/li[9]/ol[1]/li[2]" />
     <link rel="help" href="https://xhr.spec.whatwg.org/#the-send()-method" data-tested-assertations="following::code[contains(@title,'http-authorization')]/.." />
   </head>
@@ -13,10 +14,10 @@
     <script>
       test(function() {
         var client = new XMLHttpRequest(),
-          urlstart = 'www1.'+location.host + location.pathname.replace(/\/[^\/]*$/, '/')
+          urlstart = get_host_info().REMOTE_ORIGIN + location.pathname.replace(/\/[^\/]*$/, '/')
         client.withCredentials = true
         user = token()
-        client.open("GET", location.protocol+'//'+urlstart + "resources/auth10/auth.py", false, user, 'pass')
+        client.open("GET", urlstart + "resources/auth10/auth.py", false, user, 'pass')
         client.setRequestHeader("x-user", user)
         assert_throws_dom("NetworkError", function(){ client.send(null) })
         assert_equals(client.responseText, '')

--- a/LayoutTests/imported/w3c/web-platform-tests/xhr/send-authentication-cors-basic-setrequestheader-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/xhr/send-authentication-cors-basic-setrequestheader-expected.txt
@@ -1,4 +1,3 @@
-Blocked access to external URL http://www1.localhost:8800/xhr/resources/auth2/corsenabled.py
 
-FAIL XMLHttpRequest: send() - "Basic" authenticated CORS request using setRequestHeader() (expects to succeed)  A network error occurred.
+PASS XMLHttpRequest: send() - "Basic" authenticated CORS request using setRequestHeader() (expects to succeed)
 

--- a/LayoutTests/imported/w3c/web-platform-tests/xhr/send-authentication-cors-basic-setrequestheader.htm
+++ b/LayoutTests/imported/w3c/web-platform-tests/xhr/send-authentication-cors-basic-setrequestheader.htm
@@ -5,15 +5,16 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/utils.js"></script>
+    <script src="/common/get-host-info.sub.js"></script>
   </head>
   <body>
     <div id="log"></div>
     <script>
       async_test(test => {
         var client = new XMLHttpRequest(),
-            urlstart = location.host + location.pathname.replace(/\/[^\/]*$/, '/'),
+            urlstart = get_host_info().REMOTE_ORIGIN + location.pathname.replace(/\/[^\/]*$/, '/'),
             user = token()
-        client.open("GET", location.protocol+'//www1.'+urlstart + "resources/auth2/corsenabled.py", false)
+        client.open("GET", urlstart + "resources/auth2/corsenabled.py", false)
         client.withCredentials = true
         client.setRequestHeader("x-user", user)
         client.setRequestHeader("x-pass", 'pass')

--- a/LayoutTests/imported/w3c/web-platform-tests/xhr/send-authentication-cors-setrequestheader-no-cred-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/xhr/send-authentication-cors-setrequestheader-no-cred-expected.txt
@@ -1,6 +1,4 @@
-Blocked access to external URL http://www1.localhost:8800/xhr/resources/auth7/corsenabled.py
-Blocked access to external URL http://www1.localhost:8800/xhr/resources/auth8/corsenabled-no-authorize.py
 
-FAIL CORS request with setRequestHeader auth to URL accepting Authorization header assert_true: responseText should contain the right user and password expected true got false
+PASS CORS request with setRequestHeader auth to URL accepting Authorization header
 PASS CORS request with setRequestHeader auth to URL NOT accepting Authorization header
 

--- a/LayoutTests/imported/w3c/web-platform-tests/xhr/send-authentication-cors-setrequestheader-no-cred.htm
+++ b/LayoutTests/imported/w3c/web-platform-tests/xhr/send-authentication-cors-setrequestheader-no-cred.htm
@@ -5,6 +5,7 @@
     <script src="/resources/testharness.js"></script>
     <script src="/resources/testharnessreport.js"></script>
     <script src="/common/utils.js"></script>
+    <script src="/common/get-host-info.sub.js"></script>
     <!-- These spec references do not make much sense simply because the spec doesn't say very much about this.. -->
     <link rel="help" href="https://xhr.spec.whatwg.org/#the-setrequestheader()-method" data-tested-assertations="following::ol[1]/li[6]" />
     <link rel="help" href="https://xhr.spec.whatwg.org/#the-send()-method" data-tested-assertations="following::code[contains(@title,'http-authorization')]/.." />
@@ -16,9 +17,9 @@
       var test = async_test(desc)
       test.step(function() {
         var client = new XMLHttpRequest(),
-            urlstart = location.host + location.pathname.replace(/\/[^\/]*$/, '/'),
+            urlstart = get_host_info().REMOTE_ORIGIN + location.pathname.replace(/\/[^\/]*$/, '/'),
             user = token()
-        client.open("GET", location.protocol + "//www1." + urlstart + "resources/" + pathsuffix, false)
+        client.open("GET", urlstart + "resources/" + pathsuffix, false)
         client.setRequestHeader("x-user", user)
         client.setRequestHeader("x-pass", 'pass')
         client.setRequestHeader("Authorization", "Basic " + btoa(user + ":pass"))

--- a/LayoutTests/imported/w3c/web-platform-tests/xhr/send-network-error-sync-events.sub-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/xhr/send-network-error-sync-events.sub-expected.txt
@@ -1,4 +1,3 @@
-Blocked access to external URL http://nonexistent.localhost:8800/
 
 PASS http URL
 PASS data URL

--- a/LayoutTests/imported/w3c/web-platform-tests/xhr/send-network-error-sync-events.sub.htm
+++ b/LayoutTests/imported/w3c/web-platform-tests/xhr/send-network-error-sync-events.sub.htm
@@ -17,7 +17,7 @@
         {
             var xhr = new XMLHttpRequest();
 
-            xhr.open("POST", "http://nonexistent.{{host}}:{{ports[http][0]}}", false);
+            xhr.open("POST", "http://{{host}}:1", false); // Bad port.
 
             assert_throws_dom("NetworkError", function()
             {

--- a/Source/WebCore/page/LocalDOMWindow.cpp
+++ b/Source/WebCore/page/LocalDOMWindow.cpp
@@ -1149,6 +1149,7 @@ void LocalDOMWindow::stop()
     if (!frame)
         return;
 
+    SetForScope isStopping { m_isStopping, true };
     // We must check whether the load is complete asynchronously, because we might still be parsing
     // the document until the callstack unwinds.
     frame->loader().stopForUserCancel(true);

--- a/Source/WebCore/page/LocalDOMWindow.h
+++ b/Source/WebCore/page/LocalDOMWindow.h
@@ -192,6 +192,7 @@ public:
     void close(Document&);
     void print();
     void stop();
+    bool isStopping() const { return m_isStopping; }
 
     WEBCORE_EXPORT ExceptionOr<RefPtr<WindowProxy>> open(LocalDOMWindow& activeWindow, LocalDOMWindow& firstWindow, const String& urlString, const AtomString& frameName, const String& windowFeaturesString);
 
@@ -489,6 +490,7 @@ private:
 
     bool m_wasWrappedWithoutInitializedSecurityOrigin { false };
     bool m_mayReuseForNavigation { true };
+    bool m_isStopping { false };
 #if ENABLE(USER_MESSAGE_HANDLERS)
     mutable RefPtr<WebKitNamespace> m_webkitNamespace;
 #endif

--- a/Source/WebCore/xml/XMLHttpRequest.h
+++ b/Source/WebCore/xml/XMLHttpRequest.h
@@ -33,6 +33,7 @@
 #include "XMLHttpRequestEventTarget.h"
 #include "XMLHttpRequestProgressEventThrottle.h"
 #include <variant>
+#include <wtf/CancellableTask.h>
 #include <wtf/text/StringBuilder.h>
 
 namespace JSC {
@@ -139,6 +140,7 @@ private:
     explicit XMLHttpRequest(ScriptExecutionContext&);
 
     void updateHasRelevantEventListener();
+    void handleCancellation();
 
     // EventTarget.
     void eventListenersDidChange() final;
@@ -207,7 +209,6 @@ private:
     unsigned m_error : 1;
     unsigned m_uploadListenerFlag : 1;
     unsigned m_uploadComplete : 1;
-    unsigned m_wasAbortedByClient : 1;
     unsigned m_responseCacheIsValid : 1;
     unsigned m_readyState : 3; // State
     unsigned m_responseType : 3; // ResponseType
@@ -254,6 +255,7 @@ private:
     std::optional<ExceptionCode> m_exceptionCode;
     RefPtr<UserGestureToken> m_userGestureToken;
     std::atomic<bool> m_hasRelevantEventListener;
+    TaskCancellationGroup m_abortErrorGroup;
     bool m_wasDidSendDataCalledForTotalBytes { false };
 };
 


### PR DESCRIPTION
#### 02e1d3e39f48975c3a6fcc396ad05574f2191759
<pre>
window.stop() should fire abort events on XMLHttpRequest asynchronously
<a href="https://bugs.webkit.org/show_bug.cgi?id=257397">https://bugs.webkit.org/show_bug.cgi?id=257397</a>

Reviewed by Darin Adler and Youenn Fablet.

window.stop() should fire an abort event on XMLHttpRequest asynchronously, to match
the behavior of Blink and Gecko.

It should schedule a asynchronous task, which should get cancelled if the
JavaScript calls `open()` on the XMLHttpRequest again. This is covered by WPT
tests.

* LayoutTests/imported/w3c/web-platform-tests/xhr/abort-after-stop.window-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/xhr/open-after-stop.window-expected.txt:
Rebaseline tests now that more checks are passing.

* LayoutTests/imported/w3c/web-platform-tests/xhr/send-authentication-basic-cors-not-enabled-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/xhr/send-authentication-basic-cors-not-enabled.htm:
* LayoutTests/imported/w3c/web-platform-tests/xhr/send-authentication-cors-basic-setrequestheader-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/xhr/send-authentication-cors-basic-setrequestheader.htm:
* LayoutTests/imported/w3c/web-platform-tests/xhr/send-authentication-cors-setrequestheader-no-cred-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/xhr/send-authentication-cors-setrequestheader-no-cred.htm:
* LayoutTests/imported/w3c/web-platform-tests/xhr/send-network-error-sync-events.sub-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/xhr/send-network-error-sync-events.sub.htm:
Fix tests to use get_host_info() instead of hardcoding custom domains which don&apos;t work with the
WebKit layout tests infrastructure. This improves test coverage. I&apos;ll upstream those changes.

* Source/WebCore/xml/XMLHttpRequest.cpp:
(WebCore::XMLHttpRequest::XMLHttpRequest):
(WebCore::XMLHttpRequest::open):
(WebCore::XMLHttpRequest::abort):
(WebCore::XMLHttpRequest::internalAbort):
(WebCore::XMLHttpRequest::abortError):
(WebCore::XMLHttpRequest::handleCancellation):
(WebCore::XMLHttpRequest::didFail):
* Source/WebCore/xml/XMLHttpRequest.h:
Align our behavior with Blink and Gecko.

Canonical link: <a href="https://commits.webkit.org/264765@main">https://commits.webkit.org/264765@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c67bf03591216d5a9ece7f0edcb57ca9ec1a34cc

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/8496 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/8789 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/9062 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/10163 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/8541 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/8505 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/10779 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/8740 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/11410 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/8643 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/9684 "3 failures") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/7699 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/10318 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/6982 "Passed tests") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/10/builds/7826 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/15326 "19 flakes 123 failures") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/8103 "Passed tests") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/36/builds/9754 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/11278 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/8395 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/6862 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/7680 "Built successfully") | | | 
| [❌ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/2073 "Failed to push commit to Webkit repository") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/11891 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/8140 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->