### PR TITLE
[UI-side compositing] Mock scrollbars fail to update in many layout tests

### DIFF
--- a/Source/WebCore/platform/Scrollbar.cpp
+++ b/Source/WebCore/platform/Scrollbar.cpp
@@ -443,6 +443,11 @@ bool Scrollbar::isOverlayScrollbar() const
     return theme().usesOverlayScrollbars();
 }
 
+bool Scrollbar::isMockScrollbar() const
+{
+    return theme().isMockTheme();
+}
+
 bool Scrollbar::shouldParticipateInHitTesting()
 {
     // Non-overlay scrollbars should always participate in hit testing.

--- a/Source/WebCore/platform/Scrollbar.h
+++ b/Source/WebCore/platform/Scrollbar.h
@@ -59,6 +59,8 @@ public:
     ScrollableArea& scrollableArea() const { return m_scrollableArea; }
 
     bool isCustomScrollbar() const { return m_isCustomScrollbar; }
+    WEBCORE_EXPORT bool isMockScrollbar() const;
+
     ScrollbarOrientation orientation() const { return m_orientation; }
 
     int value() const { return lroundf(m_currentPos); }

--- a/Source/WebKit/WebProcess/WebPage/RemoteLayerTree/RemoteScrollbarsController.mm
+++ b/Source/WebKit/WebProcess/WebPage/RemoteLayerTree/RemoteScrollbarsController.mm
@@ -91,7 +91,7 @@ bool RemoteScrollbarsController::shouldDrawIntoScrollbarLayer(WebCore::Scrollbar
 {
     // For UI-side compositing we only draw scrollbars in the web process
     // for custom scrollbars
-    return scrollbar.isCustomScrollbar();
+    return scrollbar.isCustomScrollbar() || scrollbar.isMockScrollbar();
 }
 
 }


### PR DESCRIPTION
#### 7c78af270fc7e11ceed2c6e08cc7390b0a99dced
<pre>
[UI-side compositing] Mock scrollbars fail to update in many layout tests
<a href="https://bugs.webkit.org/show_bug.cgi?id=257398">https://bugs.webkit.org/show_bug.cgi?id=257398</a>
rdar://109908570

Reviewed by Tim Nguyen.

After 264094@main we&apos;d fail to issue a repaint in the scrollbar layer in layout tests where
mock scrollers are enabled, so the scrollbar would never update on scrollingcoordinator/mac/multiple-fixed.html
and probably many other tests, with UI-side compositing enabled.

Fix by having RemoteScrollbarsController::shouldDrawIntoScrollbarLayer() ask whether the scrollbar
is a mock scrollbar.

* Source/WebCore/platform/Scrollbar.cpp:
(WebCore::Scrollbar::isMockScrollbar const):
* Source/WebCore/platform/Scrollbar.h:
* Source/WebKit/WebProcess/WebPage/RemoteLayerTree/RemoteScrollbarsController.mm:
(WebKit::RemoteScrollbarsController::shouldDrawIntoScrollbarLayer const):

Canonical link: <a href="https://commits.webkit.org/264615@main">https://commits.webkit.org/264615@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d255b53b37eee4c23a61030b07c949197f235dc9

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/8116 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/8404 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/8620 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/9775 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/8202 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/8122 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/10391 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/8315 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/11069 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/8261 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/9336 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/7383 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/9897 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/6637 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/7430 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/14995 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/7760 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/7555 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/10911 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/8022 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/6522 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/7327 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/1957 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/11535 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/7766 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->