### PR TITLE
API::PageConfiguration::copy() is error-prone

### DIFF
--- a/Source/WebKit/UIProcess/API/APIPageConfiguration.cpp
+++ b/Source/WebKit/UIProcess/API/APIPageConfiguration.cpp
@@ -53,226 +53,168 @@ Ref<PageConfiguration> PageConfiguration::create()
     return adoptRef(*new PageConfiguration);
 }
 
-PageConfiguration::PageConfiguration()
-{
-}
+PageConfiguration::PageConfiguration() = default;
 
 PageConfiguration::~PageConfiguration() = default;
 
 Ref<PageConfiguration> PageConfiguration::copy() const
 {
     auto copy = create();
-
-    copy->m_processPool = this->m_processPool;
-    copy->m_userContentController = this->m_userContentController;
-#if ENABLE(WK_WEB_EXTENSIONS)
-    copy->m_webExtensionController = this->m_webExtensionController;
-    copy->m_weakWebExtensionController = this->m_weakWebExtensionController;
-#endif
-    copy->m_pageGroup = this->m_pageGroup;
-    copy->m_preferences = this->m_preferences;
-    copy->m_relatedPage = this->m_relatedPage;
-    copy->m_visitedLinkStore = this->m_visitedLinkStore;
-    copy->m_websiteDataStore = this->m_websiteDataStore;
-#if PLATFORM(IOS_FAMILY)
-    copy->m_clientNavigationsRunAtForegroundPriority = this->m_clientNavigationsRunAtForegroundPriority;
-    copy->m_canShowWhileLocked = this->m_canShowWhileLocked;
-    copy->m_clickInteractionDriverForTesting = this->m_clickInteractionDriverForTesting;
-#endif
-    copy->m_initialCapitalizationEnabled = this->m_initialCapitalizationEnabled;
-    copy->m_waitsForPaintAfterViewDidMoveToWindow = this->m_waitsForPaintAfterViewDidMoveToWindow;
-    copy->m_drawsBackground = this->m_drawsBackground;
-    copy->m_controlledByAutomation = this->m_controlledByAutomation;
-    copy->m_delaysWebProcessLaunchUntilFirstLoad = this->m_delaysWebProcessLaunchUntilFirstLoad;
-    copy->m_cpuLimit = this->m_cpuLimit;
-    copy->m_overrideContentSecurityPolicy = this->m_overrideContentSecurityPolicy;
-#if ENABLE(APPLICATION_MANIFEST)
-    copy->m_applicationManifest = this->m_applicationManifest;
-#endif
-    copy->m_shouldRelaxThirdPartyCookieBlocking = this->m_shouldRelaxThirdPartyCookieBlocking;
-    copy->m_attributedBundleIdentifier = this->m_attributedBundleIdentifier;
-    for (auto& pair : this->m_urlSchemeHandlers)
-        copy->m_urlSchemeHandlers.set(pair.key, pair.value.copyRef());
-    copy->m_corsDisablingPatterns = this->m_corsDisablingPatterns;
-    copy->m_maskedURLSchemes = this->m_maskedURLSchemes;
-    copy->m_crossOriginAccessControlCheckEnabled = this->m_crossOriginAccessControlCheckEnabled;
-    copy->m_userScriptsShouldWaitUntilNotification = this->m_userScriptsShouldWaitUntilNotification;
-
-    copy->m_processDisplayName = this->m_processDisplayName;
-    copy->m_loadsSubresources = this->m_loadsSubresources;
-    copy->m_allowedNetworkHosts = this->m_allowedNetworkHosts;
-#if ENABLE(APP_BOUND_DOMAINS)
-    copy->m_ignoresAppBoundDomains = this->m_ignoresAppBoundDomains;
-    copy->m_limitsNavigationsToAppBoundDomains = this->m_limitsNavigationsToAppBoundDomains;
-#endif
-
-    copy->m_mediaCaptureEnabled = this->m_mediaCaptureEnabled;
-    copy->m_httpsUpgradeEnabled = this->m_httpsUpgradeEnabled;
-#if PLATFORM(IOS_FAMILY)
-    copy->m_appInitiatedOverrideValueForTesting = this->m_appInitiatedOverrideValueForTesting;
-#endif
-#if HAVE(TOUCH_BAR)
-    copy->m_requiresUserActionForEditingControlsManager = this->m_requiresUserActionForEditingControlsManager;
-#endif
-    
-    copy->m_allowTestOnlyIPC = this->m_allowTestOnlyIPC;
-
-    copy->m_contentSecurityPolicyModeForExtension = this->m_contentSecurityPolicyModeForExtension;
-
+    copy->m_data = m_data;
     return copy;
 }
 
 
 WebProcessPool* PageConfiguration::processPool()
 {
-    return m_processPool.get();
+    return m_data.processPool.get();
 }
 
 void PageConfiguration::setProcessPool(WebProcessPool* processPool)
 {
-    m_processPool = processPool;
+    m_data.processPool = processPool;
 }
 
 WebUserContentControllerProxy* PageConfiguration::userContentController()
 {
-    return m_userContentController.get();
+    return m_data.userContentController.get();
 }
 
 void PageConfiguration::setUserContentController(WebUserContentControllerProxy* userContentController)
 {
-    m_userContentController = userContentController;
+    m_data.userContentController = userContentController;
 }
 
 #if ENABLE(WK_WEB_EXTENSIONS)
 WebExtensionController* PageConfiguration::webExtensionController()
 {
-    return m_webExtensionController.get();
+    return m_data.webExtensionController.get();
 }
 
 void PageConfiguration::setWebExtensionController(WebExtensionController* webExtensionController)
 {
-    m_webExtensionController = webExtensionController;
+    m_data.webExtensionController = webExtensionController;
 }
 
 WebExtensionController* PageConfiguration::weakWebExtensionController()
 {
-    return m_weakWebExtensionController.get();
+    return m_data.weakWebExtensionController.get();
 }
 
 void PageConfiguration::setWeakWebExtensionController(WebExtensionController* webExtensionController)
 {
-    m_weakWebExtensionController = webExtensionController;
+    m_data.weakWebExtensionController = webExtensionController;
 }
 #endif // ENABLE(WK_WEB_EXTENSIONS)
 
 WebPageGroup* PageConfiguration::pageGroup()
 {
-    return m_pageGroup.get();
+    return m_data.pageGroup.get();
 }
 
 void PageConfiguration::setPageGroup(WebPageGroup* pageGroup)
 {
-    m_pageGroup = pageGroup;
+    m_data.pageGroup = pageGroup;
 }
 
 WebPreferences* PageConfiguration::preferences()
 {
-    return m_preferences.get();
+    return m_data.preferences.get();
 }
 
 void PageConfiguration::setPreferences(WebPreferences* preferences)
 {
-    m_preferences = preferences;
+    m_data.preferences = preferences;
 }
 
 WebPageProxy* PageConfiguration::relatedPage() const
 {
-    return m_relatedPage.get();
+    return m_data.relatedPage.get();
 }
 
 void PageConfiguration::setRelatedPage(WebPageProxy* relatedPage)
 {
-    m_relatedPage = relatedPage;
+    m_data.relatedPage = relatedPage;
 }
 
 WebKit::WebPageProxy* PageConfiguration::pageToCloneSessionStorageFrom() const
 {
-    return m_pageToCloneSessionStorageFrom.get();
+    return m_data.pageToCloneSessionStorageFrom.get();
 }
 
 void PageConfiguration::setPageToCloneSessionStorageFrom(WebKit::WebPageProxy* pageToCloneSessionStorageFrom)
 {
-    m_pageToCloneSessionStorageFrom = pageToCloneSessionStorageFrom;
+    m_data.pageToCloneSessionStorageFrom = pageToCloneSessionStorageFrom;
 }
 
 WebKit::VisitedLinkStore* PageConfiguration::visitedLinkStore()
 {
-    return m_visitedLinkStore.get();
+    return m_data.visitedLinkStore.get();
 }
 
 void PageConfiguration::setVisitedLinkStore(WebKit::VisitedLinkStore* visitedLinkStore)
 {
-    m_visitedLinkStore = visitedLinkStore;
+    m_data.visitedLinkStore = visitedLinkStore;
 }
 
 WebKit::WebsiteDataStore* PageConfiguration::websiteDataStore()
 {
-    return m_websiteDataStore.get();
+    return m_data.websiteDataStore.get();
 }
 
 void PageConfiguration::setWebsiteDataStore(WebKit::WebsiteDataStore* websiteDataStore)
 {
-    m_websiteDataStore = websiteDataStore;
+    m_data.websiteDataStore = websiteDataStore;
 }
 
 WebsitePolicies* PageConfiguration::defaultWebsitePolicies() const
 {
-    return m_defaultWebsitePolicies.get();
+    return m_data.defaultWebsitePolicies.get();
 }
 
 void PageConfiguration::setDefaultWebsitePolicies(WebsitePolicies* policies)
 {
-    m_defaultWebsitePolicies = policies;
+    m_data.defaultWebsitePolicies = policies;
 }
 
 RefPtr<WebKit::WebURLSchemeHandler> PageConfiguration::urlSchemeHandlerForURLScheme(const WTF::String& scheme)
 {
-    return m_urlSchemeHandlers.get(scheme);
+    return m_data.urlSchemeHandlers.get(scheme);
 }
 
 void PageConfiguration::setURLSchemeHandlerForURLScheme(Ref<WebKit::WebURLSchemeHandler>&& handler, const WTF::String& scheme)
 {
-    m_urlSchemeHandlers.set(scheme, WTFMove(handler));
+    m_data.urlSchemeHandlers.set(scheme, WTFMove(handler));
 }
 
 bool PageConfiguration::lockdownModeEnabled() const
 {
-    if (m_defaultWebsitePolicies)
-        return m_defaultWebsitePolicies->lockdownModeEnabled();
+    if (m_data.defaultWebsitePolicies)
+        return m_data.defaultWebsitePolicies->lockdownModeEnabled();
     return lockdownModeEnabledBySystem();
 }
 
 void PageConfiguration::setDelaysWebProcessLaunchUntilFirstLoad(bool delaysWebProcessLaunchUntilFirstLoad)
 {
     RELEASE_LOG(Process, "%p - PageConfiguration::setDelaysWebProcessLaunchUntilFirstLoad(%d)", this, delaysWebProcessLaunchUntilFirstLoad);
-    m_delaysWebProcessLaunchUntilFirstLoad = delaysWebProcessLaunchUntilFirstLoad;
+    m_data.delaysWebProcessLaunchUntilFirstLoad = delaysWebProcessLaunchUntilFirstLoad;
 }
 
 bool PageConfiguration::delaysWebProcessLaunchUntilFirstLoad() const
 {
-    if (m_processPool && isInspectorProcessPool(*m_processPool)) {
+    if (m_data.processPool && isInspectorProcessPool(*m_data.processPool)) {
         // Never delay process launch for inspector pages as inspector pages do not know how to transition from a terminated process.
         RELEASE_LOG(Process, "%p - PageConfiguration::delaysWebProcessLaunchUntilFirstLoad() -> false because of WebInspector pool", this);
         return false;
     }
-    if (m_delaysWebProcessLaunchUntilFirstLoad) {
-        RELEASE_LOG(Process, "%p - PageConfiguration::delaysWebProcessLaunchUntilFirstLoad() -> %{public}s because of explicit client value", this, *m_delaysWebProcessLaunchUntilFirstLoad ? "true" : "false");
+    if (m_data.delaysWebProcessLaunchUntilFirstLoad) {
+        RELEASE_LOG(Process, "%p - PageConfiguration::delaysWebProcessLaunchUntilFirstLoad() -> %{public}s because of explicit client value", this, *m_data.delaysWebProcessLaunchUntilFirstLoad ? "true" : "false");
         // If the client explicitly enabled / disabled the feature, then obey their directives.
-        return *m_delaysWebProcessLaunchUntilFirstLoad;
+        return *m_data.delaysWebProcessLaunchUntilFirstLoad;
     }
-    if (m_processPool) {
-        RELEASE_LOG(Process, "%p - PageConfiguration::delaysWebProcessLaunchUntilFirstLoad() -> %{public}s because of associated processPool value", this, m_processPool->delaysWebProcessLaunchDefaultValue() ? "true" : "false");
-        return m_processPool->delaysWebProcessLaunchDefaultValue();
+    if (m_data.processPool) {
+        RELEASE_LOG(Process, "%p - PageConfiguration::delaysWebProcessLaunchUntilFirstLoad() -> %{public}s because of associated processPool value", this, m_data.processPool->delaysWebProcessLaunchDefaultValue() ? "true" : "false");
+        return m_data.processPool->delaysWebProcessLaunchDefaultValue();
     }
     RELEASE_LOG(Process, "%p - PageConfiguration::delaysWebProcessLaunchUntilFirstLoad() -> %{public}s because of global default value", this, WebProcessPool::globalDelaysWebProcessLaunchDefaultValue() ? "true" : "false");
     return WebProcessPool::globalDelaysWebProcessLaunchDefaultValue();
@@ -280,18 +222,18 @@ bool PageConfiguration::delaysWebProcessLaunchUntilFirstLoad() const
 
 bool PageConfiguration::isLockdownModeExplicitlySet() const
 {
-    return m_defaultWebsitePolicies && m_defaultWebsitePolicies->isLockdownModeExplicitlySet();
+    return m_data.defaultWebsitePolicies && m_data.defaultWebsitePolicies->isLockdownModeExplicitlySet();
 }
 
 #if ENABLE(APPLICATION_MANIFEST)
 ApplicationManifest* PageConfiguration::applicationManifest() const
 {
-    return m_applicationManifest.get();
+    return m_data.applicationManifest.get();
 }
 
 void PageConfiguration::setApplicationManifest(ApplicationManifest* applicationManifest)
 {
-    m_applicationManifest = applicationManifest;
+    m_data.applicationManifest = applicationManifest;
 }
 #endif
 

--- a/Source/WebKit/UIProcess/API/APIPageConfiguration.h
+++ b/Source/WebKit/UIProcess/API/APIPageConfiguration.h
@@ -116,36 +116,36 @@ public:
     void setDefaultWebsitePolicies(WebsitePolicies*);
 
 #if PLATFORM(IOS_FAMILY)
-    bool clientNavigationsRunAtForegroundPriority() const { return m_clientNavigationsRunAtForegroundPriority; }
-    void setClientNavigationsRunAtForegroundPriority(bool value) { m_clientNavigationsRunAtForegroundPriority = value; }
+    bool clientNavigationsRunAtForegroundPriority() const { return m_data.clientNavigationsRunAtForegroundPriority; }
+    void setClientNavigationsRunAtForegroundPriority(bool value) { m_data.clientNavigationsRunAtForegroundPriority = value; }
 
-    bool canShowWhileLocked() const { return m_canShowWhileLocked; }
-    void setCanShowWhileLocked(bool canShowWhileLocked) { m_canShowWhileLocked = canShowWhileLocked; }
+    bool canShowWhileLocked() const { return m_data.canShowWhileLocked; }
+    void setCanShowWhileLocked(bool canShowWhileLocked) { m_data.canShowWhileLocked = canShowWhileLocked; }
 
-    const RetainPtr<_UIClickInteractionDriving>& clickInteractionDriverForTesting() const { return m_clickInteractionDriverForTesting; }
-    void setClickInteractionDriverForTesting(RetainPtr<_UIClickInteractionDriving>&& driver) { m_clickInteractionDriverForTesting = WTFMove(driver); }
+    const RetainPtr<_UIClickInteractionDriving>& clickInteractionDriverForTesting() const { return m_data.clickInteractionDriverForTesting; }
+    void setClickInteractionDriverForTesting(RetainPtr<_UIClickInteractionDriving>&& driver) { m_data.clickInteractionDriverForTesting = WTFMove(driver); }
 #endif
-    bool initialCapitalizationEnabled() { return m_initialCapitalizationEnabled; }
-    void setInitialCapitalizationEnabled(bool initialCapitalizationEnabled) { m_initialCapitalizationEnabled = initialCapitalizationEnabled; }
+    bool initialCapitalizationEnabled() { return m_data.initialCapitalizationEnabled; }
+    void setInitialCapitalizationEnabled(bool initialCapitalizationEnabled) { m_data.initialCapitalizationEnabled = initialCapitalizationEnabled; }
 
-    std::optional<double> cpuLimit() const { return m_cpuLimit; }
-    void setCPULimit(double cpuLimit) { m_cpuLimit = cpuLimit; }
+    std::optional<double> cpuLimit() const { return m_data.cpuLimit; }
+    void setCPULimit(double cpuLimit) { m_data.cpuLimit = cpuLimit; }
 
-    bool waitsForPaintAfterViewDidMoveToWindow() const { return m_waitsForPaintAfterViewDidMoveToWindow; }
-    void setWaitsForPaintAfterViewDidMoveToWindow(bool shouldSynchronize) { m_waitsForPaintAfterViewDidMoveToWindow = shouldSynchronize; }
+    bool waitsForPaintAfterViewDidMoveToWindow() const { return m_data.waitsForPaintAfterViewDidMoveToWindow; }
+    void setWaitsForPaintAfterViewDidMoveToWindow(bool shouldSynchronize) { m_data.waitsForPaintAfterViewDidMoveToWindow = shouldSynchronize; }
 
-    bool drawsBackground() const { return m_drawsBackground; }
-    void setDrawsBackground(bool drawsBackground) { m_drawsBackground = drawsBackground; }
+    bool drawsBackground() const { return m_data.drawsBackground; }
+    void setDrawsBackground(bool drawsBackground) { m_data.drawsBackground = drawsBackground; }
 
-    bool isControlledByAutomation() const { return m_controlledByAutomation; }
-    void setControlledByAutomation(bool controlledByAutomation) { m_controlledByAutomation = controlledByAutomation; }
+    bool isControlledByAutomation() const { return m_data.controlledByAutomation; }
+    void setControlledByAutomation(bool controlledByAutomation) { m_data.controlledByAutomation = controlledByAutomation; }
 
-    const WTF::String& overrideContentSecurityPolicy() const { return m_overrideContentSecurityPolicy; }
-    void setOverrideContentSecurityPolicy(const WTF::String& overrideContentSecurityPolicy) { m_overrideContentSecurityPolicy = overrideContentSecurityPolicy; }
+    const WTF::String& overrideContentSecurityPolicy() const { return m_data.overrideContentSecurityPolicy; }
+    void setOverrideContentSecurityPolicy(const WTF::String& overrideContentSecurityPolicy) { m_data.overrideContentSecurityPolicy = overrideContentSecurityPolicy; }
 
 #if PLATFORM(COCOA)
-    const WTF::Vector<WTF::String>& additionalSupportedImageTypes() const { return m_additionalSupportedImageTypes; }
-    void setAdditionalSupportedImageTypes(WTF::Vector<WTF::String>&& additionalSupportedImageTypes) { m_additionalSupportedImageTypes = WTFMove(additionalSupportedImageTypes); }
+    const WTF::Vector<WTF::String>& additionalSupportedImageTypes() const { return m_data.additionalSupportedImageTypes; }
+    void setAdditionalSupportedImageTypes(WTF::Vector<WTF::String>&& additionalSupportedImageTypes) { m_data.additionalSupportedImageTypes = WTFMove(additionalSupportedImageTypes); }
 #endif
 
 #if ENABLE(APPLICATION_MANIFEST)
@@ -155,140 +155,141 @@ public:
 
     RefPtr<WebKit::WebURLSchemeHandler> urlSchemeHandlerForURLScheme(const WTF::String&);
     void setURLSchemeHandlerForURLScheme(Ref<WebKit::WebURLSchemeHandler>&&, const WTF::String&);
-    const HashMap<WTF::String, Ref<WebKit::WebURLSchemeHandler>>& urlSchemeHandlers() { return m_urlSchemeHandlers; }
+    const HashMap<WTF::String, Ref<WebKit::WebURLSchemeHandler>>& urlSchemeHandlers() { return m_data.urlSchemeHandlers; }
 
-    const Vector<WTF::String>& corsDisablingPatterns() const { return m_corsDisablingPatterns; }
-    void setCORSDisablingPatterns(Vector<WTF::String>&& patterns) { m_corsDisablingPatterns = WTFMove(patterns); }
+    const Vector<WTF::String>& corsDisablingPatterns() const { return m_data.corsDisablingPatterns; }
+    void setCORSDisablingPatterns(Vector<WTF::String>&& patterns) { m_data.corsDisablingPatterns = WTFMove(patterns); }
 
-    const HashSet<WTF::String>& maskedURLSchemes() const { return m_maskedURLSchemes; }
-    void setMaskedURLSchemes(HashSet<WTF::String>&& schemes) { m_maskedURLSchemes = WTFMove(schemes); }
+    const HashSet<WTF::String>& maskedURLSchemes() const { return m_data.maskedURLSchemes; }
+    void setMaskedURLSchemes(HashSet<WTF::String>&& schemes) { m_data.maskedURLSchemes = WTFMove(schemes); }
 
-    bool userScriptsShouldWaitUntilNotification() const { return m_userScriptsShouldWaitUntilNotification; }
-    void setUserScriptsShouldWaitUntilNotification(bool value) { m_userScriptsShouldWaitUntilNotification = value; }
+    bool userScriptsShouldWaitUntilNotification() const { return m_data.userScriptsShouldWaitUntilNotification; }
+    void setUserScriptsShouldWaitUntilNotification(bool value) { m_data.userScriptsShouldWaitUntilNotification = value; }
 
-    bool crossOriginAccessControlCheckEnabled() const { return m_crossOriginAccessControlCheckEnabled; }
-    void setCrossOriginAccessControlCheckEnabled(bool enabled) { m_crossOriginAccessControlCheckEnabled = enabled; }
+    bool crossOriginAccessControlCheckEnabled() const { return m_data.crossOriginAccessControlCheckEnabled; }
+    void setCrossOriginAccessControlCheckEnabled(bool enabled) { m_data.crossOriginAccessControlCheckEnabled = enabled; }
 
-    const WTF::String& processDisplayName() const { return m_processDisplayName; }
-    void setProcessDisplayName(const WTF::String& name) { m_processDisplayName = name; }
+    const WTF::String& processDisplayName() const { return m_data.processDisplayName; }
+    void setProcessDisplayName(const WTF::String& name) { m_data.processDisplayName = name; }
 
-    bool loadsSubresources() const { return m_loadsSubresources; }
-    void setLoadsSubresources(bool loads) { m_loadsSubresources = loads; }
+    bool loadsSubresources() const { return m_data.loadsSubresources; }
+    void setLoadsSubresources(bool loads) { m_data.loadsSubresources = loads; }
 
-    const std::optional<MemoryCompactLookupOnlyRobinHoodHashSet<WTF::String>>& allowedNetworkHosts() const { return m_allowedNetworkHosts; }
-    void setAllowedNetworkHosts(std::optional<MemoryCompactLookupOnlyRobinHoodHashSet<WTF::String>>&& hosts) { m_allowedNetworkHosts = WTFMove(hosts); }
+    const std::optional<MemoryCompactLookupOnlyRobinHoodHashSet<WTF::String>>& allowedNetworkHosts() const { return m_data.allowedNetworkHosts; }
+    void setAllowedNetworkHosts(std::optional<MemoryCompactLookupOnlyRobinHoodHashSet<WTF::String>>&& hosts) { m_data.allowedNetworkHosts = WTFMove(hosts); }
 
 #if ENABLE(APP_BOUND_DOMAINS)
-    bool ignoresAppBoundDomains() const { return m_ignoresAppBoundDomains; }
-    void setIgnoresAppBoundDomains(bool shouldIgnore) { m_ignoresAppBoundDomains = shouldIgnore; }
+    bool ignoresAppBoundDomains() const { return m_data.ignoresAppBoundDomains; }
+    void setIgnoresAppBoundDomains(bool shouldIgnore) { m_data.ignoresAppBoundDomains = shouldIgnore; }
     
-    bool limitsNavigationsToAppBoundDomains() const { return m_limitsNavigationsToAppBoundDomains; }
-    void setLimitsNavigationsToAppBoundDomains(bool limits) { m_limitsNavigationsToAppBoundDomains = limits; }
+    bool limitsNavigationsToAppBoundDomains() const { return m_data.limitsNavigationsToAppBoundDomains; }
+    void setLimitsNavigationsToAppBoundDomains(bool limits) { m_data.limitsNavigationsToAppBoundDomains = limits; }
 #endif
 
-    void setMediaCaptureEnabled(bool value) { m_mediaCaptureEnabled = value; }
-    bool mediaCaptureEnabled() const { return m_mediaCaptureEnabled; }
+    void setMediaCaptureEnabled(bool value) { m_data.mediaCaptureEnabled = value; }
+    bool mediaCaptureEnabled() const { return m_data.mediaCaptureEnabled; }
 
-    void setHTTPSUpgradeEnabled(bool enabled) { m_httpsUpgradeEnabled = enabled; }
-    bool httpsUpgradeEnabled() const { return m_httpsUpgradeEnabled; }
+    void setHTTPSUpgradeEnabled(bool enabled) { m_data.httpsUpgradeEnabled = enabled; }
+    bool httpsUpgradeEnabled() const { return m_data.httpsUpgradeEnabled; }
 
-    void setShouldRelaxThirdPartyCookieBlocking(WebCore::ShouldRelaxThirdPartyCookieBlocking value) { m_shouldRelaxThirdPartyCookieBlocking = value; }
-    WebCore::ShouldRelaxThirdPartyCookieBlocking shouldRelaxThirdPartyCookieBlocking() const { return m_shouldRelaxThirdPartyCookieBlocking; }
+    void setShouldRelaxThirdPartyCookieBlocking(WebCore::ShouldRelaxThirdPartyCookieBlocking value) { m_data.shouldRelaxThirdPartyCookieBlocking = value; }
+    WebCore::ShouldRelaxThirdPartyCookieBlocking shouldRelaxThirdPartyCookieBlocking() const { return m_data.shouldRelaxThirdPartyCookieBlocking; }
 
-    void setAttributedBundleIdentifier(WTF::String&& identifier) { m_attributedBundleIdentifier = WTFMove(identifier); }
-    const WTF::String& attributedBundleIdentifier() const { return m_attributedBundleIdentifier; }
+    void setAttributedBundleIdentifier(WTF::String&& identifier) { m_data.attributedBundleIdentifier = WTFMove(identifier); }
+    const WTF::String& attributedBundleIdentifier() const { return m_data.attributedBundleIdentifier; }
 
 #if PLATFORM(IOS_FAMILY)
-    WebKit::AttributionOverrideTesting appInitiatedOverrideValueForTesting() const { return m_appInitiatedOverrideValueForTesting; }
-    void setAppInitiatedOverrideValueForTesting(WebKit::AttributionOverrideTesting appInitiatedOverrideValueForTesting) { m_appInitiatedOverrideValueForTesting = appInitiatedOverrideValueForTesting; }
+    WebKit::AttributionOverrideTesting appInitiatedOverrideValueForTesting() const { return m_data.appInitiatedOverrideValueForTesting; }
+    void setAppInitiatedOverrideValueForTesting(WebKit::AttributionOverrideTesting appInitiatedOverrideValueForTesting) { m_data.appInitiatedOverrideValueForTesting = appInitiatedOverrideValueForTesting; }
 #endif
 
 #if HAVE(TOUCH_BAR)
-    bool requiresUserActionForEditingControlsManager() const { return m_requiresUserActionForEditingControlsManager; }
-    void setRequiresUserActionForEditingControlsManager(bool value) { m_requiresUserActionForEditingControlsManager = value; }
+    bool requiresUserActionForEditingControlsManager() const { return m_data.requiresUserActionForEditingControlsManager; }
+    void setRequiresUserActionForEditingControlsManager(bool value) { m_data.requiresUserActionForEditingControlsManager = value; }
 #endif
 
     bool isLockdownModeExplicitlySet() const;
     bool lockdownModeEnabled() const;
     
-    void setAllowTestOnlyIPC(bool enabled) { m_allowTestOnlyIPC = enabled; }
-    bool allowTestOnlyIPC() const { return m_allowTestOnlyIPC; }
+    void setAllowTestOnlyIPC(bool enabled) { m_data.allowTestOnlyIPC = enabled; }
+    bool allowTestOnlyIPC() const { return m_data.allowTestOnlyIPC; }
 
     void setDelaysWebProcessLaunchUntilFirstLoad(bool);
     bool delaysWebProcessLaunchUntilFirstLoad() const;
 
-    void setContentSecurityPolicyModeForExtension(WebCore::ContentSecurityPolicyModeForExtension mode) { m_contentSecurityPolicyModeForExtension = mode; }
-    WebCore::ContentSecurityPolicyModeForExtension contentSecurityPolicyModeForExtension() const { return m_contentSecurityPolicyModeForExtension; }
+    void setContentSecurityPolicyModeForExtension(WebCore::ContentSecurityPolicyModeForExtension mode) { m_data.contentSecurityPolicyModeForExtension = mode; }
+    WebCore::ContentSecurityPolicyModeForExtension contentSecurityPolicyModeForExtension() const { return m_data.contentSecurityPolicyModeForExtension; }
 
 private:
-
-    RefPtr<WebKit::WebProcessPool> m_processPool;
-    RefPtr<WebKit::WebUserContentControllerProxy> m_userContentController;
+    struct Data {
+        RefPtr<WebKit::WebProcessPool> processPool;
+        RefPtr<WebKit::WebUserContentControllerProxy> userContentController;
 #if ENABLE(WK_WEB_EXTENSIONS)
-    RefPtr<WebKit::WebExtensionController> m_webExtensionController;
-    WeakPtr<WebKit::WebExtensionController> m_weakWebExtensionController;
+        RefPtr<WebKit::WebExtensionController> webExtensionController;
+        WeakPtr<WebKit::WebExtensionController> weakWebExtensionController;
 #endif
-    RefPtr<WebKit::WebPageGroup> m_pageGroup;
-    RefPtr<WebKit::WebPreferences> m_preferences;
-    RefPtr<WebKit::WebPageProxy> m_relatedPage;
-    WeakPtr<WebKit::WebPageProxy> m_pageToCloneSessionStorageFrom;
-    RefPtr<WebKit::VisitedLinkStore> m_visitedLinkStore;
+        RefPtr<WebKit::WebPageGroup> pageGroup;
+        RefPtr<WebKit::WebPreferences> preferences;
+        RefPtr<WebKit::WebPageProxy> relatedPage;
+        WeakPtr<WebKit::WebPageProxy> pageToCloneSessionStorageFrom;
+        RefPtr<WebKit::VisitedLinkStore> visitedLinkStore;
 
-    RefPtr<WebKit::WebsiteDataStore> m_websiteDataStore;
-    RefPtr<WebsitePolicies> m_defaultWebsitePolicies;
+        RefPtr<WebKit::WebsiteDataStore> websiteDataStore;
+        RefPtr<WebsitePolicies> defaultWebsitePolicies;
 
 #if PLATFORM(IOS_FAMILY)
-    bool m_clientNavigationsRunAtForegroundPriority { true };
-    bool m_canShowWhileLocked { false };
-    RetainPtr<_UIClickInteractionDriving> m_clickInteractionDriverForTesting;
+        bool clientNavigationsRunAtForegroundPriority { true };
+        bool canShowWhileLocked { false };
+        WebKit::AttributionOverrideTesting appInitiatedOverrideValueForTesting { WebKit::AttributionOverrideTesting::NoOverride };
+        RetainPtr<_UIClickInteractionDriving> clickInteractionDriverForTesting;
 #endif
-    bool m_initialCapitalizationEnabled { true };
-    bool m_waitsForPaintAfterViewDidMoveToWindow { true };
-    bool m_drawsBackground { true };
-    bool m_controlledByAutomation { false };
-    bool m_allowTestOnlyIPC { false };
-    std::optional<bool> m_delaysWebProcessLaunchUntilFirstLoad;
-    std::optional<double> m_cpuLimit;
+        bool initialCapitalizationEnabled { true };
+        bool waitsForPaintAfterViewDidMoveToWindow { true };
+        bool drawsBackground { true };
+        bool controlledByAutomation { false };
+        bool allowTestOnlyIPC { false };
+        std::optional<bool> delaysWebProcessLaunchUntilFirstLoad;
+        std::optional<double> cpuLimit;
 
-    WTF::String m_overrideContentSecurityPolicy;
+        WTF::String overrideContentSecurityPolicy;
 
 #if PLATFORM(COCOA)
-    WTF::Vector<WTF::String> m_additionalSupportedImageTypes;
+        WTF::Vector<WTF::String> additionalSupportedImageTypes;
 #endif
 
 #if ENABLE(APPLICATION_MANIFEST)
-    RefPtr<ApplicationManifest> m_applicationManifest;
+        RefPtr<ApplicationManifest> applicationManifest;
 #endif
 
-    HashMap<WTF::String, Ref<WebKit::WebURLSchemeHandler>> m_urlSchemeHandlers;
-    Vector<WTF::String> m_corsDisablingPatterns;
-    HashSet<WTF::String> m_maskedURLSchemes;
-    bool m_userScriptsShouldWaitUntilNotification { true };
-    bool m_crossOriginAccessControlCheckEnabled { true };
-    WTF::String m_processDisplayName;
-    bool m_loadsSubresources { true };
-    std::optional<MemoryCompactLookupOnlyRobinHoodHashSet<WTF::String>> m_allowedNetworkHosts;
-    
+        HashMap<WTF::String, Ref<WebKit::WebURLSchemeHandler>> urlSchemeHandlers;
+        Vector<WTF::String> corsDisablingPatterns;
+        HashSet<WTF::String> maskedURLSchemes;
+        bool userScriptsShouldWaitUntilNotification { true };
+        bool crossOriginAccessControlCheckEnabled { true };
+        WTF::String processDisplayName;
+        bool loadsSubresources { true };
+        std::optional<MemoryCompactLookupOnlyRobinHoodHashSet<WTF::String>> allowedNetworkHosts;
+
 #if ENABLE(APP_BOUND_DOMAINS)
-    bool m_ignoresAppBoundDomains { false };
-    bool m_limitsNavigationsToAppBoundDomains { false };
+        bool ignoresAppBoundDomains { false };
+        bool limitsNavigationsToAppBoundDomains { false };
 #endif
 
-    bool m_mediaCaptureEnabled { false };
-    bool m_httpsUpgradeEnabled { true };
+        bool mediaCaptureEnabled { false };
+        bool httpsUpgradeEnabled { true };
 
-    WebCore::ShouldRelaxThirdPartyCookieBlocking m_shouldRelaxThirdPartyCookieBlocking { WebCore::ShouldRelaxThirdPartyCookieBlocking::No };
-    WTF::String m_attributedBundleIdentifier;
-
-#if PLATFORM(IOS_FAMILY)
-    WebKit::AttributionOverrideTesting m_appInitiatedOverrideValueForTesting { WebKit::AttributionOverrideTesting::NoOverride };
-#endif
+        WebCore::ShouldRelaxThirdPartyCookieBlocking shouldRelaxThirdPartyCookieBlocking { WebCore::ShouldRelaxThirdPartyCookieBlocking::No };
+        WTF::String attributedBundleIdentifier;
 
 #if HAVE(TOUCH_BAR)
-    bool m_requiresUserActionForEditingControlsManager { false };
+        bool requiresUserActionForEditingControlsManager { false };
 #endif
 
-    WebCore::ContentSecurityPolicyModeForExtension m_contentSecurityPolicyModeForExtension { WebCore::ContentSecurityPolicyModeForExtension::None };
+        WebCore::ContentSecurityPolicyModeForExtension contentSecurityPolicyModeForExtension { WebCore::ContentSecurityPolicyModeForExtension::None };
+    };
+
+    // All data members should be added to the Data structure to avoid breaking PageConfiguration::copy().
+    Data m_data;
 };
 
 } // namespace API


### PR DESCRIPTION
#### ecce6504d149b63d13a78cda3b352b240d2569c4
<pre>
API::PageConfiguration::copy() is error-prone
<a href="https://bugs.webkit.org/show_bug.cgi?id=257402">https://bugs.webkit.org/show_bug.cgi?id=257402</a>

Reviewed by Sihui Liu.

API::PageConfiguration::copy() is error-prone as it is too easy to add a data
member and forget to copy it in this function (Like in 264609@main).

Refactor the class so that API::PageConfiguration::copy() no longer needs
updating when adding new data members.

* Source/WebKit/UIProcess/API/APIPageConfiguration.cpp:
(API::PageConfiguration::copy const):
(API::PageConfiguration::processPool):
(API::PageConfiguration::setProcessPool):
(API::PageConfiguration::userContentController):
(API::PageConfiguration::setUserContentController):
(API::PageConfiguration::webExtensionController):
(API::PageConfiguration::setWebExtensionController):
(API::PageConfiguration::weakWebExtensionController):
(API::PageConfiguration::setWeakWebExtensionController):
(API::PageConfiguration::pageGroup):
(API::PageConfiguration::setPageGroup):
(API::PageConfiguration::preferences):
(API::PageConfiguration::setPreferences):
(API::PageConfiguration::relatedPage const):
(API::PageConfiguration::setRelatedPage):
(API::PageConfiguration::pageToCloneSessionStorageFrom const):
(API::PageConfiguration::setPageToCloneSessionStorageFrom):
(API::PageConfiguration::visitedLinkStore):
(API::PageConfiguration::setVisitedLinkStore):
(API::PageConfiguration::websiteDataStore):
(API::PageConfiguration::setWebsiteDataStore):
(API::PageConfiguration::defaultWebsitePolicies const):
(API::PageConfiguration::setDefaultWebsitePolicies):
(API::PageConfiguration::urlSchemeHandlerForURLScheme):
(API::PageConfiguration::setURLSchemeHandlerForURLScheme):
(API::PageConfiguration::lockdownModeEnabled const):
(API::PageConfiguration::setDelaysWebProcessLaunchUntilFirstLoad):
(API::PageConfiguration::delaysWebProcessLaunchUntilFirstLoad const):
(API::PageConfiguration::isLockdownModeExplicitlySet const):
(API::PageConfiguration::applicationManifest const):
(API::PageConfiguration::setApplicationManifest):
(API::PageConfiguration::PageConfiguration): Deleted.
* Source/WebKit/UIProcess/API/APIPageConfiguration.h:
(API::PageConfiguration::clientNavigationsRunAtForegroundPriority const):
(API::PageConfiguration::setClientNavigationsRunAtForegroundPriority):
(API::PageConfiguration::canShowWhileLocked const):
(API::PageConfiguration::setCanShowWhileLocked):
(API::PageConfiguration::clickInteractionDriverForTesting const):
(API::PageConfiguration::setClickInteractionDriverForTesting):
(API::PageConfiguration::initialCapitalizationEnabled):
(API::PageConfiguration::setInitialCapitalizationEnabled):
(API::PageConfiguration::cpuLimit const):
(API::PageConfiguration::setCPULimit):
(API::PageConfiguration::waitsForPaintAfterViewDidMoveToWindow const):
(API::PageConfiguration::setWaitsForPaintAfterViewDidMoveToWindow):
(API::PageConfiguration::drawsBackground const):
(API::PageConfiguration::setDrawsBackground):
(API::PageConfiguration::isControlledByAutomation const):
(API::PageConfiguration::setControlledByAutomation):
(API::PageConfiguration::overrideContentSecurityPolicy const):
(API::PageConfiguration::setOverrideContentSecurityPolicy):
(API::PageConfiguration::additionalSupportedImageTypes const):
(API::PageConfiguration::setAdditionalSupportedImageTypes):
(API::PageConfiguration::urlSchemeHandlers):
(API::PageConfiguration::corsDisablingPatterns const):
(API::PageConfiguration::setCORSDisablingPatterns):
(API::PageConfiguration::maskedURLSchemes const):
(API::PageConfiguration::setMaskedURLSchemes):
(API::PageConfiguration::userScriptsShouldWaitUntilNotification const):
(API::PageConfiguration::setUserScriptsShouldWaitUntilNotification):
(API::PageConfiguration::crossOriginAccessControlCheckEnabled const):
(API::PageConfiguration::setCrossOriginAccessControlCheckEnabled):
(API::PageConfiguration::processDisplayName const):
(API::PageConfiguration::setProcessDisplayName):
(API::PageConfiguration::loadsSubresources const):
(API::PageConfiguration::setLoadsSubresources):
(API::PageConfiguration::allowedNetworkHosts const):
(API::PageConfiguration::setAllowedNetworkHosts):
(API::PageConfiguration::ignoresAppBoundDomains const):
(API::PageConfiguration::setIgnoresAppBoundDomains):
(API::PageConfiguration::limitsNavigationsToAppBoundDomains const):
(API::PageConfiguration::setLimitsNavigationsToAppBoundDomains):
(API::PageConfiguration::setMediaCaptureEnabled):
(API::PageConfiguration::mediaCaptureEnabled const):
(API::PageConfiguration::setHTTPSUpgradeEnabled):
(API::PageConfiguration::httpsUpgradeEnabled const):
(API::PageConfiguration::setShouldRelaxThirdPartyCookieBlocking):
(API::PageConfiguration::shouldRelaxThirdPartyCookieBlocking const):
(API::PageConfiguration::setAttributedBundleIdentifier):
(API::PageConfiguration::attributedBundleIdentifier const):
(API::PageConfiguration::appInitiatedOverrideValueForTesting const):
(API::PageConfiguration::setAppInitiatedOverrideValueForTesting):
(API::PageConfiguration::requiresUserActionForEditingControlsManager const):
(API::PageConfiguration::setRequiresUserActionForEditingControlsManager):
(API::PageConfiguration::setAllowTestOnlyIPC):
(API::PageConfiguration::allowTestOnlyIPC const):
(API::PageConfiguration::setContentSecurityPolicyModeForExtension):
(API::PageConfiguration::contentSecurityPolicyModeForExtension const):

Canonical link: <a href="https://commits.webkit.org/264689@main">https://commits.webkit.org/264689@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/de96704f8180b9f0ca57e6e8bc0f3faf00850b3a

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/8346 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/8639 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/8856 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/10014 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/8411 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/10627 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/8550 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/11277 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/8492 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/9548 "1 flakes 3 failures") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/7568 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/10160 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/6846 "Passed tests") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/15199 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/7967 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/7780 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/11128 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/8251 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/6726 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/7540 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/2015 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/11750 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/7994 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->