### PR TITLE
Clean up ScrollbarTheme and subclasses

### DIFF
--- a/Source/WebCore/platform/ScrollbarThemeComposite.h
+++ b/Source/WebCore/platform/ScrollbarThemeComposite.h
@@ -27,24 +27,10 @@
 
 #include "ScrollbarTheme.h"
 
-#if PLATFORM(COCOA)
-OBJC_CLASS NSScrollerImp;
-#endif
-
 namespace WebCore {
 
 class ScrollbarThemeComposite : public ScrollbarTheme {
 public:
-    // Implement ScrollbarTheme interface
-    bool paint(Scrollbar&, GraphicsContext&, const IntRect& damageRect) override;
-    ScrollbarPart hitTest(Scrollbar&, const IntPoint&) override;
-    void invalidatePart(Scrollbar&, ScrollbarPart) override;
-    int thumbPosition(Scrollbar&) override;
-    int thumbLength(Scrollbar&) override;
-    int trackPosition(Scrollbar&) override;
-    int trackLength(Scrollbar&) override;
-    void paintOverhangAreas(ScrollView&, GraphicsContext&, const IntRect& horizontalOverhangArea, const IntRect& verticalOverhangArea, const IntRect& dirtyRect) override;
-
     virtual bool hasButtons(Scrollbar&) = 0;
     virtual bool hasThumb(Scrollbar&) = 0;
 
@@ -67,6 +53,17 @@ public:
     virtual void paintThumb(GraphicsContext&, Scrollbar&, const IntRect&) { }
 
     virtual IntRect constrainTrackRectToTrackPieces(Scrollbar&, const IntRect& rect) { return rect; }
+
+protected:
+    // Implement ScrollbarTheme interface
+    bool paint(Scrollbar&, GraphicsContext&, const IntRect& damageRect) override;
+    ScrollbarPart hitTest(Scrollbar&, const IntPoint&) override;
+    void invalidatePart(Scrollbar&, ScrollbarPart) override;
+    int thumbPosition(Scrollbar&) override;
+    int thumbLength(Scrollbar&) override;
+    int trackPosition(Scrollbar&) override;
+    int trackLength(Scrollbar&) override;
+    void paintOverhangAreas(ScrollView&, GraphicsContext&, const IntRect& horizontalOverhangArea, const IntRect& verticalOverhangArea, const IntRect& dirtyRect) override;
 };
 
 }

--- a/Source/WebCore/platform/ios/ScrollbarThemeIOS.h
+++ b/Source/WebCore/platform/ios/ScrollbarThemeIOS.h
@@ -31,11 +31,14 @@
 
 namespace WebCore {
 
-class ScrollbarThemeIOS : public ScrollbarThemeComposite {
+class ScrollbarThemeIOS final : public ScrollbarThemeComposite {
 public:
     ScrollbarThemeIOS();
     virtual ~ScrollbarThemeIOS();
 
+    void preferencesChanged();
+
+private:
     bool paint(Scrollbar&, GraphicsContext&, const IntRect& damageRect) override;
 
     int scrollbarThickness(ScrollbarControlSize = ScrollbarControlSize::Regular, ScrollbarWidth = ScrollbarWidth::Auto, ScrollbarExpansionState = ScrollbarExpansionState::Expanded) override;
@@ -50,7 +53,6 @@ public:
     void registerScrollbar(Scrollbar&) override;
     void unregisterScrollbar(Scrollbar&) override;
 
-protected:
     bool hasButtons(Scrollbar&) override;
     bool hasThumb(Scrollbar&) override;
 
@@ -59,9 +61,6 @@ protected:
     IntRect trackRect(Scrollbar&, bool painting = false) override;
 
     int minimumThumbLength(Scrollbar&) override;
-
-public:
-    void preferencesChanged();
 };
 
 }

--- a/Source/WebCore/platform/mac/ScrollbarThemeMac.h
+++ b/Source/WebCore/platform/mac/ScrollbarThemeMac.h
@@ -30,35 +30,16 @@
 #if PLATFORM(MAC)
 
 OBJC_CLASS CALayer;
+OBJC_CLASS NSScrollerImp;
 
 namespace WebCore {
 
-class ScrollbarThemeMac : public ScrollbarThemeComposite {
+class ScrollbarThemeMac final : public ScrollbarThemeComposite {
 public:
     ScrollbarThemeMac();
     virtual ~ScrollbarThemeMac();
 
     WEBCORE_EXPORT void preferencesChanged();
-
-    void updateEnabledState(Scrollbar&) override;
-
-    bool paint(Scrollbar&, GraphicsContext&, const IntRect& damageRect) override;
-    void paintScrollCorner(ScrollableArea&, GraphicsContext&, const IntRect& cornerRect) override;
-
-    int scrollbarThickness(ScrollbarControlSize = ScrollbarControlSize::Regular, ScrollbarWidth = ScrollbarWidth::Auto, ScrollbarExpansionState = ScrollbarExpansionState::Expanded) override;
-    
-    bool supportsControlTints() const override { return true; }
-    bool usesOverlayScrollbars() const  override;
-    void usesOverlayScrollbarsChanged() override;
-    void updateScrollbarOverlayStyle(Scrollbar&)  override;
-
-    Seconds initialAutoscrollTimerDelay() override { return 500_ms; }
-    Seconds autoscrollTimerDelay() override { return 50_ms; }
-
-    ScrollbarButtonsPlacement buttonsPlacement() const override;
-
-    void registerScrollbar(Scrollbar&) override;
-    void unregisterScrollbar(Scrollbar&) override;
 
     void setNewPainterForScrollbar(Scrollbar&, RetainPtr<NSScrollerImp>&&);
     static NSScrollerImp *painterForScrollbar(Scrollbar&);
@@ -79,7 +60,27 @@ public:
     WEBCORE_EXPORT static void removeOverhangAreaShadow(CALayer *);
 #endif
 
-protected:
+    void usesOverlayScrollbarsChanged() override;
+    int scrollbarThickness(ScrollbarControlSize = ScrollbarControlSize::Regular, ScrollbarWidth = ScrollbarWidth::Auto, ScrollbarExpansionState = ScrollbarExpansionState::Expanded) override;
+
+private:
+    void updateEnabledState(Scrollbar&) override;
+
+    bool paint(Scrollbar&, GraphicsContext&, const IntRect& damageRect) override;
+    void paintScrollCorner(ScrollableArea&, GraphicsContext&, const IntRect& cornerRect) override;
+
+    bool supportsControlTints() const override { return true; }
+    bool usesOverlayScrollbars() const  override;
+    void updateScrollbarOverlayStyle(Scrollbar&)  override;
+
+    Seconds initialAutoscrollTimerDelay() override { return 500_ms; }
+    Seconds autoscrollTimerDelay() override { return 50_ms; }
+
+    ScrollbarButtonsPlacement buttonsPlacement() const override;
+
+    void registerScrollbar(Scrollbar&) override;
+    void unregisterScrollbar(Scrollbar&) override;
+
     bool hasButtons(Scrollbar&) override;
     bool hasThumb(Scrollbar&) override;
 

--- a/Source/WebCore/platform/mock/ScrollbarThemeMock.h
+++ b/Source/WebCore/platform/mock/ScrollbarThemeMock.h
@@ -23,19 +23,19 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE. 
  */
 
-#ifndef ScrollbarThemeMock_h
-#define ScrollbarThemeMock_h
+#pragma once
 
 #include "ScrollbarThemeComposite.h"
 
 namespace WebCore {
 
 // Scrollbar theme used in image snapshots, to eliminate appearance differences between platforms.
-class ScrollbarThemeMock : public ScrollbarThemeComposite {
-public:
+class ScrollbarThemeMock final : public ScrollbarThemeComposite {
+private:
     int scrollbarThickness(ScrollbarControlSize = ScrollbarControlSize::Regular, ScrollbarWidth = ScrollbarWidth::Auto, ScrollbarExpansionState = ScrollbarExpansionState::Expanded) override;
 
-protected:
+    bool isMockTheme() const override { return true; }
+
     bool hasButtons(Scrollbar&) override { return false; }
     bool hasThumb(Scrollbar&) override  { return true; }
 
@@ -48,9 +48,6 @@ protected:
     int maxOverlapBetweenPages() override { return 40; }
 
     bool usesOverlayScrollbars() const override;
-private:
-    bool isMockTheme() const override { return true; }
 };
 
 }
-#endif // ScrollbarThemeMock_h

--- a/Source/WebCore/platform/win/ScrollbarThemeWin.h
+++ b/Source/WebCore/platform/win/ScrollbarThemeWin.h
@@ -30,7 +30,7 @@
 
 namespace WebCore {
 
-class ScrollbarThemeWin : public ScrollbarThemeComposite {
+class ScrollbarThemeWin final : public ScrollbarThemeComposite {
 public:
     ScrollbarThemeWin();
     virtual ~ScrollbarThemeWin();


### PR DESCRIPTION
#### 7c208491c013ea9c9a7dfcd6bedafdf1440cd556
<pre>
Clean up ScrollbarTheme and subclasses
<a href="https://bugs.webkit.org/show_bug.cgi?id=257403">https://bugs.webkit.org/show_bug.cgi?id=257403</a>
rdar://109911267

Reviewed by NOBODY (OOPS!).

Use `final` for derived classes. Make member functions protected or private.
Use a `#pragma once`.

* Source/WebCore/platform/ScrollbarThemeComposite.h:
* Source/WebCore/platform/ios/ScrollbarThemeIOS.h:
* Source/WebCore/platform/mac/ScrollbarThemeMac.h:
* Source/WebCore/platform/mock/ScrollbarThemeMock.h:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/7c208491c013ea9c9a7dfcd6bedafdf1440cd556

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/8146 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/8436 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/8653 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/9808 "Built successfully") | [❌ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/8220 "Failed to compile WebKit") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/8153 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/10424 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/8347 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/11092 "3 flakes 100 failures") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/8291 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/9356 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/7397 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/9930 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/6656 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/7453 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/15009 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/7779 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/7585 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/10933 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/8052 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/6539 "18 flakes 2 failures") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/7346 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/11553 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/7794 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->