### PR TITLE
DNS lookup should request then wait for IPv4 and IPv6 addresses

### DIFF
--- a/Source/WebCore/platform/network/DNS.cpp
+++ b/Source/WebCore/platform/network/DNS.cpp
@@ -60,6 +60,22 @@ void stopResolveDNS(uint64_t identifier)
     WebCore::DNSResolveQueue::singleton().stopResolve(identifier);
 }
 
+bool IPAddress::isAllZeros() const
+{
+    return std::visit(WTF::makeVisitor([] (const WTF::HashTableEmptyValueType&) {
+        ASSERT_NOT_REACHED();
+        return false;
+    }, [] (const in_addr& address) {
+        return !address.s_addr;
+    }, [] (const in6_addr& address) {
+        for (uint8_t byte : address.s6_addr) {
+            if (byte)
+                return false;
+        }
+        return true;
+    }), m_address);
+}
+
 std::optional<IPAddress> IPAddress::fromString(const String& string)
 {
 #if OS(UNIX)

--- a/Source/WebCore/platform/network/DNS.h
+++ b/Source/WebCore/platform/network/DNS.h
@@ -62,6 +62,7 @@ public:
 
     bool isIPv4() const { return std::holds_alternative<struct in_addr>(m_address); }
     bool isIPv6() const { return std::holds_alternative<struct in6_addr>(m_address); }
+    bool isAllZeros() const;
 
     const struct in_addr& ipv4Address() const { return std::get<struct in_addr>(m_address); }
     const struct in6_addr& ipv6Address() const { return std::get<struct in6_addr>(m_address); }


### PR DESCRIPTION
#### 5aa25a106be747000c280a1e55134b906f9ffc41
<pre>
DNS lookup should request then wait for IPv4 and IPv6 addresses
<a href="https://bugs.webkit.org/show_bug.cgi?id=257404">https://bugs.webkit.org/show_bug.cgi?id=257404</a>
rdar://109911384

Reviewed by Youenn Fablet.

As advised by one who knows DNS better than I do, with the code I wrote earlier today
in <a href="https://github.com/WebKit/WebKit/pull/14326">https://github.com/WebKit/WebKit/pull/14326</a> I am missing some of the IP addresses.

To receive a set of IP addresses equivalent to what CFHost received, I need to add
the kDNSServiceFlagsReturnIntermediates flag.

Also, there are some times when we receive IPv4 addresses then get a callback with
kDNSServiceFlagsMoreComing and then sometime later receive IPv6 addresses, or vice versa.
The addresses from the second set of callbacks were being dropped.  To fix this,
I explicitly add the protocols kDNSServiceProtocol_IPv4 | kDNSServiceProtocol_IPv6
to request callbacks for both protocols.  This makes it so that sometimes I get
callbacks with kDNSServiceErr_NoSuchRecord and callbacks with IP addresses that are all
zeros.  We simiply ignore kDNSServiceErr_NoSuchRecord and filter out all the all-zero
IP addresses.  That way the result of DNSResolveQueueCFNet::performDNSLookup always
contains all the IP addresses.

I manually verified that IP address lists were incomplete sometimes before this change,
and now they are complete all the time.  There are also two unit tests that exercise
this code path, webrtc/datachannel/mdns-ice-candidates.html and TestWebKitAPI.WebKit2.RTCDataChannelPostMessage
and I verified that they both pass.

* Source/WebCore/platform/network/DNS.cpp:
(WebCore::IPAddress::isAllZeros const):
* Source/WebCore/platform/network/DNS.h:
* Source/WebCore/platform/network/cf/DNSResolveQueueCFNet.cpp:
(WebCore::DNSResolveQueueCFNet::CompletionHandlerWrapper::complete):
(WebCore::DNSResolveQueueCFNet::CompletionHandlerWrapper::addIPAddress):
(WebCore::DNSResolveQueueCFNet::CompletionHandlerWrapper::shouldWaitForMoreAddresses const):
(WebCore::DNSResolveQueueCFNet::CompletionHandlerWrapper::filterZeroAddresses):
(WebCore::dnsLookupCallback):
(WebCore::DNSResolveQueueCFNet::performDNSLookup):

Canonical link: <a href="https://commits.webkit.org/264655@main">https://commits.webkit.org/264655@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f4b8be8e79afb77db8242168cb9e328c14ad9eb8

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/8278 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/8570 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/8787 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/9945 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/8342 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/8287 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/10558 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/8481 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/11216 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/8423 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/9483 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/7512 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/10089 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/6782 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/7573 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/15135 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/7905 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/7712 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/11063 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/8182 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/6661 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/7472 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/11681 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/981 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/7925 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->