### PR TITLE
[JSC] Optimize ProxyObject's "ownKeys" trap

### DIFF
--- a/JSTests/microbenchmarks/proxy-ownkeys-via-object-assign-miss-handler.js
+++ b/JSTests/microbenchmarks/proxy-ownkeys-via-object-assign-miss-handler.js
@@ -1,0 +1,12 @@
+(function() {
+    var target = {k0: 0, k1: 1, k2: 2, k3: 3, k4: 4, k5: 5, k6: 6, k7: 7, k8: 8, k9: 9};
+    var targetKeys = Object.keys(target);
+    var proxy = new Proxy(target, {});
+
+    var lastObj = {};
+    for (var i = 0; i < 2e5; ++i)
+        lastObj = Object.assign({}, proxy);
+
+    if (Object.keys(lastObj).join() !== targetKeys.join())
+        throw new Error("Bad assertion!");
+})();

--- a/JSTests/microbenchmarks/proxy-ownkeys-via-object-assign.js
+++ b/JSTests/microbenchmarks/proxy-ownkeys-via-object-assign.js
@@ -1,0 +1,16 @@
+(function() {
+    var target = {k0: 0, k1: 1, k2: 2, k3: 3, k4: 4, k5: 5, k6: 6, k7: 7, k8: 8, k9: 9};
+    var targetKeys = Object.keys(target);
+    var proxy = new Proxy(target, {
+        ownKeys() {
+            return targetKeys;
+        },
+    });
+
+    var lastObj = {};
+    for (var i = 0; i < 2e5; ++i)
+        lastObj = Object.assign({}, proxy);
+
+    if (Object.keys(lastObj).join() !== targetKeys.join())
+        throw new Error("Bad assertion!");
+})();

--- a/JSTests/microbenchmarks/proxy-ownkeys-via-object-keys-miss-handler.js
+++ b/JSTests/microbenchmarks/proxy-ownkeys-via-object-keys-miss-handler.js
@@ -1,0 +1,12 @@
+(function() {
+    var target = {k0: 0, k1: 1, k2: 2, k3: 3, k4: 4, k5: 5, k6: 6, k7: 7, k8: 8, k9: 9};
+    var targetKeys = Object.keys(target);
+    var proxy = new Proxy(target, {});
+
+    var proxyKeys;
+    for (var i = 0; i < 2e5; ++i)
+        proxyKeys = Object.keys(proxy);
+
+    if (proxyKeys.join() !== targetKeys.join())
+        throw new Error("Bad assertion!");
+})();

--- a/JSTests/microbenchmarks/proxy-ownkeys-via-object-keys.js
+++ b/JSTests/microbenchmarks/proxy-ownkeys-via-object-keys.js
@@ -1,0 +1,16 @@
+(function() {
+    var target = {k0: 0, k1: 1, k2: 2, k3: 3, k4: 4, k5: 5, k6: 6, k7: 7, k8: 8, k9: 9};
+    var targetKeys = Object.keys(target);
+    var proxy = new Proxy(target, {
+        ownKeys() {
+            return targetKeys;
+        },
+    });
+
+    var proxyKeys;
+    for (var i = 0; i < 2e5; ++i)
+        proxyKeys = Object.keys(proxy);
+
+    if (proxyKeys.join() !== targetKeys.join())
+        throw new Error("Bad assertion!");
+})();

--- a/JSTests/microbenchmarks/proxy-ownkeys-via-reflect-ownkeys-miss-handler.js
+++ b/JSTests/microbenchmarks/proxy-ownkeys-via-reflect-ownkeys-miss-handler.js
@@ -1,0 +1,12 @@
+(function() {
+    var target = {k0: 0, k1: 1, k2: 2, k3: 3, k4: 4, k5: 5, k6: 6, k7: 7, k8: 8, k9: 9};
+    var targetKeys = Reflect.ownKeys(target);
+    var proxy = new Proxy(target, {});
+
+    var proxyKeys;
+    for (var i = 0; i < 2e5; ++i)
+        proxyKeys = Reflect.ownKeys(proxy);
+
+    if (proxyKeys.join() !== targetKeys.join())
+        throw new Error("Bad assertion!");
+})();

--- a/JSTests/microbenchmarks/proxy-ownkeys-via-reflect-ownkeys.js
+++ b/JSTests/microbenchmarks/proxy-ownkeys-via-reflect-ownkeys.js
@@ -1,0 +1,16 @@
+(function() {
+    var target = {k0: 0, k1: 1, k2: 2, k3: 3, k4: 4, k5: 5, k6: 6, k7: 7, k8: 8, k9: 9};
+    var targetKeys = Reflect.ownKeys(target);
+    var proxy = new Proxy(target, {
+        ownKeys() {
+            return targetKeys;
+        },
+    });
+
+    var proxyKeys;
+    for (var i = 0; i < 2e5; ++i)
+        proxyKeys = Reflect.ownKeys(proxy);
+
+    if (proxyKeys.join() !== targetKeys.join())
+        throw new Error("Bad assertion!");
+})();

--- a/Source/JavaScriptCore/runtime/CommonIdentifiers.h
+++ b/Source/JavaScriptCore/runtime/CommonIdentifiers.h
@@ -133,6 +133,7 @@
     macro(from) \
     macro(fromCharCode) \
     macro(get) \
+    macro(getOwnPropertyDescriptor) \
     macro(global) \
     macro(go) \
     macro(granularity) \
@@ -222,6 +223,7 @@
     macro(osrExitSites) \
     macro(osrExits) \
     macro(overflow) \
+    macro(ownKeys) \
     macro(parse) \
     macro(parseInt) \
     macro(parseFloat) \

--- a/Source/JavaScriptCore/runtime/ObjectConstructor.cpp
+++ b/Source/JavaScriptCore/runtime/ObjectConstructor.cpp
@@ -1044,6 +1044,12 @@ JSArray* ownPropertyKeys(JSGlobalObject* globalObject, JSObject* object, Propert
 
     auto kind = inferCachedPropertyNamesKind(propertyNameMode, dontEnumPropertiesMode);
 
+    if (object->inherits<ProxyObject>()) {
+        ProxyObject* proxy = jsCast<ProxyObject*>(object);
+        if (proxy->forwardsGetOwnPropertyNamesToTarget(dontEnumPropertiesMode))
+            object = proxy->target();
+    }
+
     // We attempt to look up own property keys cache in Object.keys / Object.getOwnPropertyNames cases.
     if (LIKELY(!globalObject->isHavingABadTime())) {
         if (auto* immutableButterfly = object->structure()->cachedPropertyNames(kind)) {


### PR DESCRIPTION
#### ef0e6f6c2894bccf259ee6fc8a782425568980cb
<pre>
[JSC] Optimize ProxyObject&apos;s &quot;ownKeys&quot; trap
<a href="https://bugs.webkit.org/show_bug.cgi?id=257346">https://bugs.webkit.org/show_bug.cgi?id=257346</a>
&lt;rdar://problem/109850846&gt;

Reviewed by Yusuke Suzuki.

It is a common JS pattern to mass-assign properties and clone / merge objects via Object.assign(),
and since in Vue.js v3 front-end developers mostly operate on reactive objects (that are wrapped
in a ProxyObject), optimizing its &quot;ownKeys&quot; trap and related operations is crucial.

This change:

  1. Enables [[ProxyHandler]] trap caching for &quot;ownKeys&quot; and &quot;getOwnPropertyDescriptor&quot; traps.

  2. Introduces forwardsGetOwnPropertyNamesToTarget() fast path that expands existing property
     names caching (based on StructureRareData) to handle ProxyObjects which are missing
     &quot;ownKeys&quot; and &quot;getOwnPropertyDescriptor&quot; traps.

     This was made possible by [[ProxyHandler]] trap caching added in <a href="https://webkit.org/b/256554.">https://webkit.org/b/256554.</a>

  3. Leveraging Structure flags introduced in <a href="https://webkit.org/b/255661">https://webkit.org/b/255661</a>, skips &quot;ownKeys&quot; trap
     result validation in the common case of [[ProxyTarget]] being an ordinary extensible object
     without non-configurable properties.

     This results in nice speed-up given the spec requires [1] to enumerate all [[ProxyTarget]]
     properties and ensure that all non-configurable ones are listed by the userland trap code.

[1]: <a href="https://tc39.es/ecma262/#sec-proxy-object-internal-methods-and-internal-slots-ownpropertykeys">https://tc39.es/ecma262/#sec-proxy-object-internal-methods-and-internal-slots-ownpropertykeys</a> (step 16)

                                                          ToT                      patch

proxy-ownkeys-via-reflect-ownkeys                   81.7443+-0.7848     ^     46.7884+-0.4395        ^ definitely 1.7471x faster
proxy-ownkeys-via-reflect-ownkeys-miss-handler      31.4378+-0.4010     ^      2.2589+-0.0293        ^ definitely 13.9172x faster
proxy-ownkeys-via-object-keys                      215.2480+-1.1130     ^     95.5261+-0.7659        ^ definitely 2.2533x faster
proxy-ownkeys-via-object-keys-miss-handler         168.9327+-0.7422     ^      2.2765+-0.0276        ^ definitely 74.2064x faster
proxy-ownkeys-via-object-assign                    233.9777+-2.1404     ^    112.9695+-0.8461        ^ definitely 2.0712x faster
proxy-ownkeys-via-object-assign-miss-handler       187.8766+-1.0055     ^     93.1520+-0.1716        ^ definitely 2.0169x faster

&lt;geometric&gt;                                        125.4813+-0.2685     ^     24.8795+-0.1193        ^ definitely 5.0436x faster

* JSTests/microbenchmarks/proxy-ownkeys-via-object-assign-miss-handler.js: Added.
* JSTests/microbenchmarks/proxy-ownkeys-via-object-assign.js: Added.
* JSTests/microbenchmarks/proxy-ownkeys-via-object-keys-miss-handler.js: Added.
* JSTests/microbenchmarks/proxy-ownkeys-via-object-keys.js: Added.
* JSTests/microbenchmarks/proxy-ownkeys-via-reflect-ownkeys-miss-handler.js: Added.
* JSTests/microbenchmarks/proxy-ownkeys-via-reflect-ownkeys.js: Added.
* Source/JavaScriptCore/runtime/CommonIdentifiers.h:
* Source/JavaScriptCore/runtime/ObjectConstructor.cpp:
(JSC::ownPropertyKeys):
* Source/JavaScriptCore/runtime/ProxyObject.cpp:
(JSC::ProxyObject::getHandlerTrap):
(JSC::ProxyObject::performInternalMethodGetOwnProperty):
(JSC::ProxyObject::forwardsGetOwnPropertyNamesToTarget):
(JSC::ProxyObject::performGetOwnPropertyNames):
* Source/JavaScriptCore/runtime/ProxyObject.h:
(JSC::ProxyObject::isHandlerTrapsCacheValid):

Canonical link: <a href="https://commits.webkit.org/265218@main">https://commits.webkit.org/265218@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e8b4df697870c11d66e0856edd5ae082e536cd2a

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/8117 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/8405 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/8621 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/9776 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/8203 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/10392 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/8316 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/11074 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/8262 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/9338 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/7384 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/9898 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/6639 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/7432 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/14996 "Passed tests") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/6920 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/7762 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/7557 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/10913 "Passed tests") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/7679 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/8023 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/6523 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/8288 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/7328 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/1892 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/2465 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/11536 "Built successfully") | | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/24/builds/8511 "Built successfully") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/7767 "Built successfully") | | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/3/builds/2042 "Passed tests") | 
<!--EWS-Status-Bubble-End-->