### PR TITLE
Include referrer URL with LSAppLink attempts

### DIFF
--- a/Source/WebCore/PAL/pal/spi/cocoa/LaunchServicesSPI.h
+++ b/Source/WebCore/PAL/pal/spi/cocoa/LaunchServicesSPI.h
@@ -69,6 +69,13 @@ const uint8_t kLSOpenRunningInstanceBehaviorUseRunningProcess = 1;
 @interface LSAppLink : NSObject <NSSecureCoding>
 @end
 
+@interface _LSOpenConfiguration : NSObject <NSCopying, NSSecureCoding>
+@property (readwrite) BOOL sensitive;
+@property (readwrite) BOOL allowURLOverrides;
+@property (readwrite, copy) NSDictionary<NSString *, id> *frontBoardOptions;
+@property (readwrite, copy, nonatomic) NSURL *referrerURL;
+@end
+
 @interface LSAppLink ()
 #if HAVE(APP_LINKS_WITH_ISENABLED)
 + (NSArray<LSAppLink *> *)appLinksWithURL:(NSURL *)aURL limit:(NSUInteger)limit error:(NSError **)outError;
@@ -77,11 +84,12 @@ const uint8_t kLSOpenRunningInstanceBehaviorUseRunningProcess = 1;
 #else
 + (void)getAppLinkWithURL:(NSURL *)aURL completionHandler:(LSAppLinkCompletionHandler)completionHandler;
 - (void)openInWebBrowser:(BOOL)inWebBrowser setAppropriateOpenStrategyAndWebBrowserState:(NSDictionary<NSString *, id> *)state completionHandler:(LSAppLinkOpenCompletionHandler)completionHandler;
-#endif
+#endif // HAVE(APP_LINKS_WITH_ISENABLED)
 + (void)openWithURL:(NSURL *)aURL completionHandler:(LSAppLinkOpenCompletionHandler)completionHandler;
++ (void)openWithURL:(NSURL *)aURL configuration:(_LSOpenConfiguration *)configuration completionHandler:(LSAppLinkOpenCompletionHandler)completionHandler;
 @property (readonly, strong) LSApplicationProxy *targetApplicationProxy;
 @end
-#endif
+#endif // HAVE(APP_LINKS)
 
 @interface NSURL ()
 - (NSURL *)iTunesStoreURL;

--- a/Source/WebKit/webpushd/LaunchServicesSPI.h
+++ b/Source/WebKit/webpushd/LaunchServicesSPI.h
@@ -24,6 +24,9 @@
  */
 
 #if PLATFORM(IOS)
+
+#import <pal/spi/cocoa/LaunchServicesSPI.h>
+
 #if USE(APPLE_INTERNAL_SDK)
 
 // This space intentionally left blank
@@ -59,12 +62,6 @@ typedef NS_OPTIONS(uint64_t, LSApplicationEnumerationOptions) {
 
 @interface LSApplicationRecord (Enumeration)
 + (LSEnumerator<LSApplicationRecord *> *)enumeratorWithOptions:(LSApplicationEnumerationOptions)options;
-@end
-
-@interface _LSOpenConfiguration : NSObject <NSCopying, NSSecureCoding>
-@property (readwrite) BOOL sensitive;
-@property (readwrite) BOOL allowURLOverrides;
-@property (readwrite, copy, nullable) NSDictionary<NSString *, id> *frontBoardOptions;
 @end
 
 @interface LSApplicationWorkspace : NSObject

--- a/Source/WebKitLegacy/mac/WebCoreSupport/WebFrameLoaderClient.h
+++ b/Source/WebKitLegacy/mac/WebCoreSupport/WebFrameLoaderClient.h
@@ -224,7 +224,7 @@ private:
     void setAXIsolatedTreeRoot(WebCore::AXCoreObject*) final { }
 #endif
 
-    RetainPtr<WebFramePolicyListener> setUpPolicyListener(WebCore::PolicyCheckIdentifier, WebCore::FramePolicyFunction&&, WebCore::PolicyAction defaultPolicy, NSURL *appLinkURL = nil);
+    RetainPtr<WebFramePolicyListener> setUpPolicyListener(WebCore::PolicyCheckIdentifier, WebCore::FramePolicyFunction&&, WebCore::PolicyAction defaultPolicy, NSURL *appLinkURL, NSURL* referrerURL);
 
     NSDictionary *actionDictionary(const WebCore::NavigationAction&, WebCore::FormState*) const;
     


### PR DESCRIPTION
#### 76418fb29804a661dcf3a2846bc0fbabf6b18a72
<pre>
Include referrer URL with LSAppLink attempts
<a href="https://bugs.webkit.org/show_bug.cgi?id=257396">https://bugs.webkit.org/show_bug.cgi?id=257396</a>
rdar://106221653

Reviewed by David Kilzer.

* Source/WebCore/PAL/pal/spi/cocoa/LaunchServicesSPI.h:

* Source/WebKit/UIProcess/Cocoa/NavigationState.mm:
(WebKit::tryInterceptNavigation):

* Source/WebKitLegacy/mac/WebCoreSupport/WebFrameLoaderClient.h:
* Source/WebKitLegacy/mac/WebCoreSupport/WebFrameLoaderClient.mm:
(WebFrameLoaderClient::dispatchDecidePolicyForResponse):
(WebFrameLoaderClient::dispatchDecidePolicyForNewWindowAction):
(WebFrameLoaderClient::dispatchDecidePolicyForNavigationAction):
(WebFrameLoaderClient::dispatchWillSubmitForm):
(WebFrameLoaderClient::setUpPolicyListener):
(-[WebFramePolicyListener initWithFrame:identifier:policyFunction:defaultPolicy:appLinkURL:referrerURL:]):
(-[WebFramePolicyListener initWithFrame:identifier:policyFunction:defaultPolicy:appLinkURL:]): Deleted.

Canonical link: <a href="https://commits.webkit.org/264634@main">https://commits.webkit.org/264634@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1e271f6aa5c9ab45f1cb57f24b73b3462f8e841d

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/8138 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/8427 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/8643 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/9798 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/8215 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/8146 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/10414 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/8338 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/11088 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/8283 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/9345 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/7392 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/9920 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/6646 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/7443 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/15037 "1 flakes 149 failures") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/7769 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/7568 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/10929 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/8044 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/6533 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/7340 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/1975 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/11548 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/7787 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->