### PR TITLE
Web Inspector: XHR request with same URL as main resource should have type XHR

### DIFF
--- a/LayoutTests/http/tests/inspector/network/xhr-request-type-expected.txt
+++ b/LayoutTests/http/tests/inspector/network/xhr-request-type-expected.txt
@@ -1,0 +1,17 @@
+Tests that XHRs requests have type XHR, inlcuding those with the same URL as the main resource.
+
+Bug 68646 Bug 257407
+
+== Running test suite: Resource.Type.XHR
+-- Running test case: Resource.Type.XHR.Same.As.Main.Resource.Url
+PASS: Resource should be XHR type.
+PASS: Resource should be a GET request.
+PASS: Resource should have a 200 response.
+PASS: Resource should receive main resource in response.
+
+-- Running test case: Resource.Type.XHR.Another.Url
+PASS: Resource should be XHR type.
+PASS: Resource should be a GET request.
+PASS: Resource should have a 200 response.
+PASS: Resource should receive json in response.
+

--- a/LayoutTests/http/tests/inspector/network/xhr-request-type.html
+++ b/LayoutTests/http/tests/inspector/network/xhr-request-type.html
@@ -1,0 +1,66 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<script src="../resources/inspector-test.js"></script>
+<script>
+function triggerXHR(path) {
+    const x = new XMLHttpRequest();
+    x.open("GET", path || location.href, false);
+    x.send();
+}
+
+// ----
+
+function test()
+{
+    const suite = InspectorTest.createAsyncSuite("Resource.Type.XHR");
+
+    function addTestCase({name, description, expression, resourceHandler}) {
+        suite.addTestCase({
+            name, description,
+            async test() {
+                const completeEvent = InspectorTest.awaitEvent("Completed");
+                InspectorTest.evaluateInPage(expression);
+                const event = await WI.Frame.awaitEvent(WI.Frame.Event.ResourceWasAdded);
+                const resource = event.data.resource;
+                InspectorTest.expectEqual(resource.type, WI.Resource.Type.XHR, "Resource should be XHR type.");
+                InspectorTest.expectEqual(resource.requestMethod, "GET", "Resource should be a GET request.");
+                await resource.awaitEvent(WI.Resource.Event.LoadingDidFinish);
+                const content = await resource.requestContentFromBackend()
+                resourceHandler(resource, content);
+            }
+        });
+    }
+
+    addTestCase({
+        name: "Resource.Type.XHR.Same.As.Main.Resource.Url",
+        description: "XHR with the same URL as main resource.",
+        expression: "triggerXHR()",
+        resourceHandler(resource, content) {
+            InspectorTest.expectEqual(resource.statusCode, 200, "Resource should have a 200 response.");
+            InspectorTest.expectThat(content.body.includes("Tests that XHRs with the same url as a main resource have correct type"), "Resource should receive main resource in response.");
+        }
+    });
+
+    addTestCase({
+        name: "Resource.Type.XHR.Another.Url",
+        description: "XHR with the same URL as main resource.",
+        expression: "triggerXHR('/inspector/network/resources/data.json')",
+        resourceHandler(resource, content) {
+            InspectorTest.expectEqual(resource.statusCode, 200, "Resource should have a 200 response.");
+            InspectorTest.expectEqual(content.body, `{"json": true, "value": 42}\n`, "Resource should receive json in response.");
+        }
+    });
+
+    suite.runTestCasesAndFinish();
+}
+</script>
+</head>
+<body onload="runTest()">
+<p>Tests that XHRs requests have type XHR, inlcuding those with the same URL as the main resource.</p>
+<a href="https://bugs.webkit.org/show_bug.cgi?id=68646">Bug 68646</a>
+<a href="https://bugs.webkit.org/show_bug.cgi?id=257407">Bug 257407</a>
+<div id="log"></div>
+</body>
+</html>

--- a/LayoutTests/platform/mac-wk1/TestExpectations
+++ b/LayoutTests/platform/mac-wk1/TestExpectations
@@ -1567,6 +1567,9 @@ http/tests/inspector/network/resource-response-inspector-override.html [ Skip ]
 inspector/network/intercept-aborted-request.html [ Skip ]
 inspector/network/interceptContinue.html [ Skip ]
 
+# Resource content retrival times out in WebKit1.
+webkit.org/b/257407 http/tests/inspector/network/xhr-request-type.html [ Skip ]
+
 webkit.org/b/164933 http/tests/misc/link-rel-icon-beforeload.html [ Failure ]
 
 # rdar://92764272 ([ Ventura wk1 ] 18 X fast/html/details (layout-tests) are flaky text failures)


### PR DESCRIPTION
#### 883556d2265f71ae3ff0ba8c595936d7884192e7
<pre>
Web Inspector: XHR request with same URL as main resource should have type XHR
<a href="https://bugs.webkit.org/show_bug.cgi?id=257407">https://bugs.webkit.org/show_bug.cgi?id=257407</a>

Reviewed by Devin Rousso.

Only use cached resource type when couldn&apos;t infer resource type based on the current
ResourceRequest because CachedResource for the same URL may have different type. This
fixes the bug where XHR is sent with the same URL as the main resource and was
wrongly marked as another request with type Document rather than XHR.

* LayoutTests/http/tests/inspector/network/xhr-request-type-expected.txt: Added.
* LayoutTests/http/tests/inspector/network/xhr-request-type.html: Added.
* Source/WebCore/inspector/agents/InspectorNetworkAgent.cpp:
(WebCore::InspectorNetworkAgent::willSendRequest):

* LayoutTests/platform/mac-wk1/TestExpectations: ignore new test in WK1.

Canonical link: <a href="https://commits.webkit.org/264686@main">https://commits.webkit.org/264686@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/da638ad1a717c82e1d62104ce5d4db883ac5f42d

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/8347 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/8640 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/8857 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/10015 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/8412 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/8356 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/10628 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/8551 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/11278 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/8493 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/9547 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/7567 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/10174 "Built successfully") | 
| | [💥 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/6845 "An unexpected error occured. Recent messages:OS: Ventura (13.3), Xcode: 14.3; Skipping applying patch since patch_id isn't provided; Checked out pull request") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/7636 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/15207 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/7966 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/7779 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/11138 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/8252 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/6725 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/7541 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/7548 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/2012 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/11751 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/7995 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->