### PR TITLE
Implement scrollbar-width CSS property in WebKit Legacy

### DIFF
--- a/LayoutTests/platform/mac-wk1/imported/w3c/web-platform-tests/css/css-scrollbars/scrollbar-width-007-expected.txt
+++ b/LayoutTests/platform/mac-wk1/imported/w3c/web-platform-tests/css/css-scrollbars/scrollbar-width-007-expected.txt
@@ -1,3 +1,0 @@
-
-FAIL viewport does not display a scrollbar assert_equals: viewport does not show a scrollbar expected 800 but got 785
-

--- a/LayoutTests/platform/mac-wk1/imported/w3c/web-platform-tests/css/cssom-view/client-props-root-expected.txt
+++ b/LayoutTests/platform/mac-wk1/imported/w3c/web-platform-tests/css/cssom-view/client-props-root-expected.txt
@@ -1,3 +1,0 @@
-
-FAIL client* properties on the root element assert_equals: Without scrollbars, client width should match viewport width expected 800 but got 785
-

--- a/Source/WebCore/rendering/style/RenderStyle.h
+++ b/Source/WebCore/rendering/style/RenderStyle.h
@@ -968,7 +968,7 @@ public:
     ScrollSnapStop scrollSnapStop() const;
 
     const ScrollbarGutter scrollbarGutter() const;
-    ScrollbarWidth scrollbarWidth() const;
+    WEBCORE_EXPORT ScrollbarWidth scrollbarWidth() const;
 
 #if ENABLE(TOUCH_EVENTS)
     inline StyleColor tapHighlightColor() const;

--- a/Source/WebKitLegacy/mac/WebView/WebDynamicScrollBarsView.mm
+++ b/Source/WebKitLegacy/mac/WebView/WebDynamicScrollBarsView.mm
@@ -362,10 +362,20 @@ static const unsigned cMaxUpdateScrollbarsPass = 2;
         newHasHorizontalScroller = NO;
 
     _private->horizontalScrollingAllowedButScrollerHidden = newHasHorizontalScroller && _private->alwaysHideHorizontalScroller;
+    _private->verticalScrollingAllowedButScrollerHidden = newHasVerticalScroller && _private->alwaysHideVerticalScroller;
+
+    if ([documentView isKindOfClass:[WebHTMLView class]]) {
+        WebHTMLView* htmlView = (WebHTMLView*)documentView;
+        WebCore::ScrollbarWidth scrollbarWidthStyle = [htmlView _scrollbarWidthStyle];
+        if (scrollbarWidthStyle == WebCore::ScrollbarWidth::None) {
+            _private->horizontalScrollingAllowedButScrollerHidden = true;
+            _private->verticalScrollingAllowedButScrollerHidden = true;
+        }
+    }
+
     if (_private->horizontalScrollingAllowedButScrollerHidden)
         newHasHorizontalScroller = NO;
 
-    _private->verticalScrollingAllowedButScrollerHidden = newHasVerticalScroller && _private->alwaysHideVerticalScroller;
     if (_private->verticalScrollingAllowedButScrollerHidden)
         newHasVerticalScroller = NO;
 

--- a/Source/WebKitLegacy/mac/WebView/WebHTMLView.mm
+++ b/Source/WebKitLegacy/mac/WebView/WebHTMLView.mm
@@ -6255,6 +6255,16 @@ ALLOW_DEPRECATED_DECLARATIONS_END
     return _private->pluginController.get();
 }
 
+- (WebCore::ScrollbarWidth)_scrollbarWidthStyle
+{
+    auto* frame = core([self _frame]);
+
+    if (!frame || !frame->document() || !frame->document()->documentElement() || !frame->document()->documentElement()->renderer())
+        return WebCore::ScrollbarWidth::Auto;
+
+    return frame->document()->documentElement()->renderer()->style().scrollbarWidth();
+}
+
 @end
 
 @implementation WebHTMLView (WebNSTextInputSupport)

--- a/Source/WebKitLegacy/mac/WebView/WebHTMLViewInternal.h
+++ b/Source/WebKitLegacy/mac/WebView/WebHTMLViewInternal.h
@@ -102,6 +102,8 @@ namespace WebCore {
 
 - (void)_executeSavedKeypressCommands;
 
+- (WebCore::ScrollbarWidth)_scrollbarWidthStyle;
+
 @end
 
 @interface WebHTMLView (RemovedAppKitSuperclassMethods)


### PR DESCRIPTION
#### e55f3a44ffb20e7d84e5415465ee54436d29559a
<pre>
Implement scrollbar-width CSS property in WebKit Legacy
<a href="https://bugs.webkit.org/show_bug.cgi?id=257056">https://bugs.webkit.org/show_bug.cgi?id=257056</a>

Reviewed by Tim Nguyen.

This change implements the missing code for the scrollbar-width CSS property none value to work inside of WebKit Legacy.

The thin value doesn&apos;t always have an effect in WebKit Legacy but this is spec compliant.

* LayoutTests/platform/mac-wk1/imported/w3c/web-platform-tests/css/css-scrollbars/scrollbar-width-007-expected.txt: Removed.
* LayoutTests/platform/mac-wk1/imported/w3c/web-platform-tests/css/cssom-view/client-props-root-expected.txt: Removed.
* Source/WebCore/rendering/style/RenderStyle.h:
* Source/WebKitLegacy/mac/WebView/WebDynamicScrollBarsView.mm:
(-[WebDynamicScrollBarsView updateScrollers]):
* Source/WebKitLegacy/mac/WebView/WebHTMLView.mm:
(-[WebHTMLView _scrollbarWidthStyle]):
* Source/WebKitLegacy/mac/WebView/WebHTMLViewInternal.h:

Canonical link: <a href="https://commits.webkit.org/264633@main">https://commits.webkit.org/264633@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/7a4fa03d7f25d985a0f9f8b3ef9e0dddf0f5fff0

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/8195 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/8487 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/8704 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/9859 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/8261 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/8203 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/10475 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/8398 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/11138 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/8340 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/9406 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/7432 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/9981 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/6706 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/7498 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/15056 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/7829 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/7627 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/10987 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/8100 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/6583 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/7391 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/1973 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/11598 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/7841 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->