### PR TITLE
[GStreamer] SinksWorkarounds leak and version check fix

### DIFF
--- a/Source/WebCore/platform/graphics/gstreamer/GStreamerSinksWorkarounds.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/GStreamerSinksWorkarounds.cpp
@@ -69,7 +69,7 @@ static WorkaroundMode getWorkAroundModeFromEnvironment(const char* environmentVa
 }
 
 // Workaround for: https://gitlab.freedesktop.org/gstreamer/gstreamer/-/merge_requests/3471 basesink: Support position queries after non-resetting flushes.
-// Fix will land in GStreamer 1.24.0.
+// Fix merged in 1.23, will ship in GStreamer 1.24.0.
 
 class BaseSinkPositionFlushWorkaroundProbe {
 public:
@@ -99,7 +99,10 @@ private:
 
     static bool checkIsNeeded()
     {
-        GST_DEBUG("BaseSinkPositionFlushWorkaroundProbe: running GStreamer %s, the bug fix is expected to land in 1.24.0.", gst_version_string());
+#ifndef GST_DISABLE_GST_DEBUG
+        GUniquePtr<char> versionString(gst_version_string());
+        GST_DEBUG("BaseSinkPositionFlushWorkaroundProbe: running GStreamer %s, the bug fix is was merged in 1.23 and is expected to ship in 1.24.0.", versionString.get());
+#endif
         WorkaroundMode mode = getWorkAroundModeFromEnvironment("WEBKIT_GST_WORKAROUND_BASE_SINK_POSITION_FLUSH", WEBKIT_GST_WORKAROUND_BASE_SINK_POSITION_FLUSH_DEFAULT_MODE);
         if (mode == WorkaroundMode::ForceEnable) {
             GST_DEBUG("BaseSinkPositionFlushWorkaroundProbe: forcing workaround to be enabled.");
@@ -110,7 +113,7 @@ private:
             return false;
         }
 
-        return !webkitGstCheckVersion(1, 24, 0);
+        return !webkitGstCheckVersion(1, 23, 0);
     }
 
     static void initializeIsNeeded()


### PR DESCRIPTION
#### 8cb4f84c4e9bdcd9a106133076677ffe90b7f5d3
<pre>
[GStreamer] SinksWorkarounds leak and version check fix
<a href="https://bugs.webkit.org/show_bug.cgi?id=257420">https://bugs.webkit.org/show_bug.cgi?id=257420</a>

Reviewed by Alicia Boya Garcia and Xabier Rodriguez-Calvar.

<a href="https://gitlab.freedesktop.org/gstreamer/gstreamer/-/merge_requests/3471">https://gitlab.freedesktop.org/gstreamer/gstreamer/-/merge_requests/3471</a> was merged in 1.23, so the
version check should account for this. Also drive-by fix leak of gst_version_string().

* Source/WebCore/platform/graphics/gstreamer/GStreamerSinksWorkarounds.cpp:
(WebCore::BaseSinkPositionFlushWorkaroundProbe::checkIsNeeded):

Canonical link: <a href="https://commits.webkit.org/264672@main">https://commits.webkit.org/264672@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/87d738d23e9674577398c22cfbf0a8bb49a17a59

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/8169 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/8460 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/8677 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/9832 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/8242 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/8176 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/10448 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/8371 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/11111 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/8314 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/9380 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/7415 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/9954 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/6680 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/7473 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/15031 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/7803 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/7603 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/10956 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/8075 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/6562 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/7369 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/2001 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/11576 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/7817 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->