### PR TITLE
Correct which element scrollbar-width is resolved from for the viewport

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-scrollbars/scrollbar-width-009-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-scrollbars/scrollbar-width-009-expected.txt
@@ -1,0 +1,3 @@
+
+PASS viewport displays a scrollbar
+

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-scrollbars/scrollbar-width-009.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-scrollbars/scrollbar-width-009.html
@@ -1,0 +1,60 @@
+<meta charset="utf-8">
+<title>CSS Scrollbars: scrollbar-width on the body is not propagated quirks mode</title>
+<link rel="author" title="Luke Warlow" href="mailto:luke@warlow.dev" />
+<link rel="help" href="https://drafts.csswg.org/css-scrollbars-1/" />
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/css/support/parsing-testcommon.js"></script>
+<style>
+  :root {
+    /* CSS scrollbar properties applied to the root element
+       will be propagated to the viewport. */
+    scrollbar-width: thin;
+    overflow: visible;
+  }
+
+  body {
+    /* overflow is propagated as well */
+    overflow: scroll;
+    /* but CSS scrollbar properties applied to the body are not propagated */
+    scrollbar-width: none;
+  }
+
+  :root,
+  body {
+    margin: 0;
+    padding: 0;
+  }
+
+  #content {
+    height: 10vh;
+    width: 100%;
+    background: lightsalmon;
+  }
+
+  #expander {
+    /* force vertical scroll */
+    height: 200vh;
+    width: 300px;
+    background: gray;
+  }
+</style>
+
+<body>
+
+  <div id="content"></div>
+
+  <div id="expander"></div>
+
+  <script>
+    test(function () {
+      let root = document.documentElement;
+      let body = document.body;
+      let content = document.getElementById('content');
+
+      assert_less_than(root.offsetWidth, window.innerWidth, "viewport has a scrollbar");
+      assert_equals(body.offsetWidth, root.offsetWidth, "body matches root");
+      assert_equals(content.offsetWidth, body.offsetWidth, "content matches body");
+    }, "viewport displays a scrollbar");
+  </script>
+</body>

--- a/LayoutTests/platform/ios-wk2/TestExpectations
+++ b/LayoutTests/platform/ios-wk2/TestExpectations
@@ -2414,6 +2414,7 @@ imported/w3c/web-platform-tests/css/css-scrollbars/scrollbar-width-005.html [ Sk
 imported/w3c/web-platform-tests/css/css-scrollbars/scrollbar-width-006.html [ Skip ]
 imported/w3c/web-platform-tests/css/css-scrollbars/scrollbar-width-007.html [ Skip ]
 imported/w3c/web-platform-tests/css/css-scrollbars/scrollbar-width-008.html [ Skip ]
+imported/w3c/web-platform-tests/css/css-scrollbars/scrollbar-width-009.html [ Skip ]
 
 # Trailing space/text alignment iOS-specific WPT failures
 webkit.org/b/257182 imported/w3c/web-platform-tests/css/css-text/white-space/trailing-space-and-text-alignment-001.html [ ImageOnlyFailure ]

--- a/Source/WebCore/page/LocalFrameView.cpp
+++ b/Source/WebCore/page/LocalFrameView.cpp
@@ -6288,7 +6288,7 @@ OverscrollBehavior LocalFrameView::verticalOverscrollBehavior()  const
 ScrollbarWidth LocalFrameView::scrollbarWidthStyle()  const
 {
     auto* document = m_frame->document();
-    auto scrollingObject = document && document->scrollingElement() ? document->scrollingElement()->renderer() : nullptr;
+    auto scrollingObject = document && document->documentElement() ? document->documentElement()->renderer() : nullptr;
     if (scrollingObject && renderView())
         return scrollingObject->style().scrollbarWidth();
     return ScrollbarWidth::Auto;


### PR DESCRIPTION
#### 2f9b54657be4231f239ac8bc8e46394f1848fae4
<pre>
Correct which element scrollbar-width is resolved from for the viewport
<a href="https://bugs.webkit.org/show_bug.cgi?id=257424">https://bugs.webkit.org/show_bug.cgi?id=257424</a>

Reviewed by Tim Nguyen.

A new WPT test has been added which tests to make sure the body style doesn&apos;t propagate (like scrollbar-width-008.html) but runs in quirks mode. That passes inside of
Chrome (with appropriate flags), and Firefox but not WebKit (before this change).

When in quirks mode scrollingElement resolves to body, whereas in standards mode it resolves to documentElement.

I originally had this using documentElement but it was changed during the review process for WebKit 2 implementation. Based on the interop issue caught by the new
test I&apos;ve made I believe I was originally correct and this should be documentElement.

This change addresses that changing scrollingElement back to documentElement.

* LayoutTests/imported/w3c/web-platform-tests/css/css-scrollbars/scrollbar-width-009-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-scrollbars/scrollbar-width-009.html: Added.
* LayoutTests/platform/ios-wk2/TestExpectations:
* Source/WebCore/page/LocalFrameView.cpp:
(WebCore::LocalFrameView::scrollbarWidthStyle const):

Canonical link: <a href="https://commits.webkit.org/264632@main">https://commits.webkit.org/264632@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9df894c37078b560ae02ad694858554b6e1664ad

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/8197 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/8489 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/8706 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/9861 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/32/builds/8263 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/8205 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/10477 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/8400 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/11140 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/8342 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/9408 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/7435 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/9983 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/6708 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/7501 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/15054 "2 flakes 116 failures") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/7831 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/7630 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/10985 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/8102 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/6584 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/7393 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/7413 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/1972 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/11600 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/7843 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->