### PR TITLE
Replace usages of ScrollbarControlSize with ScrollbarWidth

### DIFF
--- a/Source/WebCore/page/LocalFrameView.cpp
+++ b/Source/WebCore/page/LocalFrameView.cpp
@@ -541,12 +541,8 @@ Ref<Scrollbar> LocalFrameView::createScrollbar(ScrollbarOrientation orientation)
     if (frameRenderer && frameRenderer->style().hasPseudoStyle(PseudoId::Scrollbar))
         return RenderScrollbar::createCustomScrollbar(*this, orientation, nullptr, m_frame.ptr());
 
-    auto scrollbarSize = scrollbarWidthStyle() == ScrollbarWidth::Thin
-        ? ScrollbarControlSize::Small
-        : ScrollbarControlSize::Regular;
-
     // Nobody set a custom style, so we just use a native scrollbar.
-    return Scrollbar::createNativeScrollbar(*this, orientation, scrollbarSize);
+    return Scrollbar::createNativeScrollbar(*this, orientation, scrollbarWidthStyle());
 }
 
 void LocalFrameView::didRestoreFromBackForwardCache()

--- a/Source/WebCore/platform/PopupMenuClient.h
+++ b/Source/WebCore/platform/PopupMenuClient.h
@@ -74,7 +74,7 @@ public:
     virtual FontSelector* fontSelector() const = 0;
     virtual HostWindow* hostWindow() const = 0;
 
-    virtual Ref<Scrollbar> createScrollbar(ScrollableArea&, ScrollbarOrientation, ScrollbarControlSize) = 0;
+    virtual Ref<Scrollbar> createScrollbar(ScrollableArea&, ScrollbarOrientation, ScrollbarWidth) = 0;
 };
 
 }

--- a/Source/WebCore/platform/ScrollTypes.cpp
+++ b/Source/WebCore/platform/ScrollTypes.cpp
@@ -155,4 +155,21 @@ TextStream& operator<<(TextStream& ts, ScrollGranularity granularity)
     return ts;
 }
 
+TextStream& operator<<(TextStream& ts, ScrollbarWidth width)
+{
+    switch (width) {
+    case ScrollbarWidth::Auto:
+        ts << "auto";
+        break;
+    case ScrollbarWidth::Thin:
+        ts << "thin";
+        break;
+    case ScrollbarWidth::None:
+        ts << "none";
+        break;
+    }
+    return ts;
+}
+
+
 } // namespace WebCore

--- a/Source/WebCore/platform/ScrollTypes.h
+++ b/Source/WebCore/platform/ScrollTypes.h
@@ -169,6 +169,12 @@ enum class ScrollbarExpansionState : uint8_t {
     Expanded
 };
 
+enum class ScrollbarWidth : uint8_t {
+    Auto,
+    Thin,
+    None
+};
+
 enum class NativeScrollbarVisibility : uint8_t {
     Visible,
     HiddenByStyle,
@@ -353,6 +359,7 @@ WEBCORE_EXPORT WTF::TextStream& operator<<(WTF::TextStream&, OverflowAnchor);
 WEBCORE_EXPORT WTF::TextStream& operator<<(WTF::TextStream&, ScrollDirection);
 WEBCORE_EXPORT WTF::TextStream& operator<<(WTF::TextStream&, ScrollGranularity);
 WEBCORE_EXPORT WTF::TextStream& operator<<(WTF::TextStream&, NativeScrollbarVisibility);
+WTF::TextStream& operator<<(WTF::TextStream&, ScrollbarWidth);
 
 struct ScrollPositionChangeOptions {
     ScrollType type;

--- a/Source/WebCore/platform/ScrollView.cpp
+++ b/Source/WebCore/platform/ScrollView.cpp
@@ -104,7 +104,7 @@ bool ScrollView::setHasScrollbarInternal(RefPtr<Scrollbar>& scrollbar, Scrollbar
 
 Ref<Scrollbar> ScrollView::createScrollbar(ScrollbarOrientation orientation)
 {
-    return Scrollbar::createNativeScrollbar(*this, orientation, ScrollbarControlSize::Regular);
+    return Scrollbar::createNativeScrollbar(*this, orientation, ScrollbarWidth::Auto);
 }
 
 void ScrollView::setScrollbarModes(ScrollbarMode horizontalMode, ScrollbarMode verticalMode,

--- a/Source/WebCore/platform/Scrollbar.cpp
+++ b/Source/WebCore/platform/Scrollbar.cpp
@@ -45,9 +45,9 @@
 
 namespace WebCore {
 
-Ref<Scrollbar> Scrollbar::createNativeScrollbar(ScrollableArea& scrollableArea, ScrollbarOrientation orientation, ScrollbarControlSize size)
+Ref<Scrollbar> Scrollbar::createNativeScrollbar(ScrollableArea& scrollableArea, ScrollbarOrientation orientation, ScrollbarWidth width)
 {
-    return adoptRef(*new Scrollbar(scrollableArea, orientation, size));
+    return adoptRef(*new Scrollbar(scrollableArea, orientation, width));
 }
 
 static bool s_shouldUseFixedPixelsPerLineStepForTesting;
@@ -74,10 +74,10 @@ int Scrollbar::maxOverlapBetweenPages()
     return maxOverlapBetweenPages;
 }
 
-Scrollbar::Scrollbar(ScrollableArea& scrollableArea, ScrollbarOrientation orientation, ScrollbarControlSize controlSize, ScrollbarTheme* customTheme, bool isCustomScrollbar)
+Scrollbar::Scrollbar(ScrollableArea& scrollableArea, ScrollbarOrientation orientation, ScrollbarWidth widthStyle, ScrollbarTheme* customTheme, bool isCustomScrollbar)
     : m_scrollableArea(scrollableArea)
     , m_orientation(orientation)
-    , m_controlSize(controlSize)
+    , m_widthStyle(widthStyle)
     , m_theme(customTheme ? *customTheme : ScrollbarTheme::theme())
     , m_isCustomScrollbar(isCustomScrollbar)
     , m_scrollTimer(*this, &Scrollbar::autoscrollTimerFired)
@@ -87,7 +87,7 @@ Scrollbar::Scrollbar(ScrollableArea& scrollableArea, ScrollbarOrientation orient
     // FIXME: This is ugly and would not be necessary if we fix cross-platform code to actually query for
     // scrollbar thickness and use it when sizing scrollbars (rather than leaving one dimension of the scrollbar
     // alone when sizing).
-    int thickness = theme().scrollbarThickness(controlSize, m_scrollableArea.scrollbarWidthStyle());
+    int thickness = theme().scrollbarThickness(widthStyle);
     Widget::setFrameRect(IntRect(0, 0, thickness, thickness));
 
     m_currentPos = static_cast<float>(offsetForOrientation(m_scrollableArea.scrollOffset(), m_orientation));
@@ -513,7 +513,7 @@ NativeScrollbarVisibility Scrollbar::nativeScrollbarVisibility(const Scrollbar* 
 
 bool Scrollbar::isHiddenByStyle() const
 {
-    return m_scrollableArea.scrollbarWidthStyle() == ScrollbarWidth::None;
+    return m_widthStyle == ScrollbarWidth::None;
 }
 
 float Scrollbar::deviceScaleFactor() const

--- a/Source/WebCore/platform/Scrollbar.h
+++ b/Source/WebCore/platform/Scrollbar.h
@@ -40,7 +40,7 @@ class ScrollbarTheme;
 class Scrollbar : public Widget {
 public:
     // Must be implemented by platforms that can't simply use the Scrollbar base class.  Right now the only platform that is not using the base class is GTK.
-    WEBCORE_EXPORT static Ref<Scrollbar> createNativeScrollbar(ScrollableArea&, ScrollbarOrientation, ScrollbarControlSize);
+    WEBCORE_EXPORT static Ref<Scrollbar> createNativeScrollbar(ScrollableArea&, ScrollbarOrientation, ScrollbarWidth);
 
     virtual ~Scrollbar();
 
@@ -69,7 +69,7 @@ public:
     int visibleSize() const { return m_visibleSize; }
     int totalSize() const { return m_totalSize; }
     int maximum() const { return m_totalSize - m_visibleSize; }
-    ScrollbarControlSize controlSize() const { return m_controlSize; }
+    ScrollbarWidth widthStyle() const { return m_widthStyle; }
     
     int occupiedWidth() const;
     int occupiedHeight() const;
@@ -140,7 +140,7 @@ public:
     float deviceScaleFactor() const;
 
 protected:
-    Scrollbar(ScrollableArea&, ScrollbarOrientation, ScrollbarControlSize, ScrollbarTheme* = nullptr, bool isCustomScrollbar = false);
+    Scrollbar(ScrollableArea&, ScrollbarOrientation, ScrollbarWidth, ScrollbarTheme* = nullptr, bool isCustomScrollbar = false);
 
     void updateThumb();
     virtual void updateThumbPosition();
@@ -155,7 +155,7 @@ protected:
 
     ScrollableArea& m_scrollableArea;
     ScrollbarOrientation m_orientation;
-    ScrollbarControlSize m_controlSize;
+    ScrollbarWidth m_widthStyle;
     ScrollbarTheme& m_theme;
 
     int m_visibleSize { 0 };

--- a/Source/WebCore/platform/ScrollbarTheme.h
+++ b/Source/WebCore/platform/ScrollbarTheme.h
@@ -27,7 +27,6 @@
 
 #include "GraphicsContext.h"
 #include "IntRect.h"
-#include "RenderStyleConstants.h"
 #include "ScrollTypes.h"
 
 namespace WebCore {
@@ -52,7 +51,7 @@ public:
     virtual bool paint(Scrollbar&, GraphicsContext&, const IntRect& /*damageRect*/) { return false; }
     virtual ScrollbarPart hitTest(Scrollbar&, const IntPoint&) { return NoPart; }
     
-    virtual int scrollbarThickness(ScrollbarControlSize = ScrollbarControlSize::Regular, ScrollbarWidth = ScrollbarWidth::Auto, ScrollbarExpansionState = ScrollbarExpansionState::Expanded) { return 0; }
+    virtual int scrollbarThickness(ScrollbarWidth = ScrollbarWidth::Auto, ScrollbarExpansionState = ScrollbarExpansionState::Expanded) { return 0; }
 
     virtual ScrollbarButtonsPlacement buttonsPlacement() const { return ScrollbarButtonsSingle; }
 

--- a/Source/WebCore/platform/ScrollbarThemeComposite.cpp
+++ b/Source/WebCore/platform/ScrollbarThemeComposite.cpp
@@ -245,7 +245,7 @@ int ScrollbarThemeComposite::thumbLength(Scrollbar& scrollbar)
 
 int ScrollbarThemeComposite::minimumThumbLength(Scrollbar& scrollbar)
 {
-    return scrollbarThickness(scrollbar.controlSize(), scrollbar.scrollableArea().scrollbarWidthStyle());
+    return scrollbarThickness(scrollbar.widthStyle());
 }
 
 int ScrollbarThemeComposite::trackPosition(Scrollbar& scrollbar)

--- a/Source/WebCore/platform/adwaita/ScrollbarThemeAdwaita.cpp
+++ b/Source/WebCore/platform/adwaita/ScrollbarThemeAdwaita.cpp
@@ -84,7 +84,7 @@ bool ScrollbarThemeAdwaita::usesOverlayScrollbars() const
 #endif
 }
 
-int ScrollbarThemeAdwaita::scrollbarThickness(ScrollbarControlSize, ScrollbarWidth scrollbarWidth, ScrollbarExpansionState)
+int ScrollbarThemeAdwaita::scrollbarThickness(ScrollbarWidth scrollbarWidth, ScrollbarExpansionState)
 {
     if (scrollbarWidth == ScrollbarWidth::None)
         return 0;

--- a/Source/WebCore/platform/adwaita/ScrollbarThemeAdwaita.h
+++ b/Source/WebCore/platform/adwaita/ScrollbarThemeAdwaita.h
@@ -46,7 +46,7 @@ protected:
     void paintScrollCorner(ScrollableArea&, GraphicsContext&, const IntRect&) override;
     ScrollbarButtonPressAction handleMousePressEvent(Scrollbar&, const PlatformMouseEvent&, ScrollbarPart) override;
 
-    int scrollbarThickness(ScrollbarControlSize, ScrollbarWidth, ScrollbarExpansionState) override;
+    int scrollbarThickness(ScrollbarWidth, ScrollbarExpansionState) override;
     int minimumThumbLength(Scrollbar&) override;
 
     bool hasButtons(Scrollbar&) override;

--- a/Source/WebCore/platform/gtk/ScrollbarThemeGtk.cpp
+++ b/Source/WebCore/platform/gtk/ScrollbarThemeGtk.cpp
@@ -523,10 +523,10 @@ ScrollbarButtonPressAction ScrollbarThemeGtk::handleMousePressEvent(Scrollbar&, 
     return ScrollbarButtonPressAction::None;
 }
 
-int ScrollbarThemeGtk::scrollbarThickness(ScrollbarControlSize controlSize, ScrollbarWidth scrollbarWidth, ScrollbarExpansionState expansionState)
+int ScrollbarThemeGtk::scrollbarThickness(ScrollbarWidth scrollbarWidth, ScrollbarExpansionState expansionState)
 {
     if (!m_useSystemAppearance)
-        return ScrollbarThemeAdwaita::scrollbarThickness(controlSize, scrollbarWidth, expansionState);
+        return ScrollbarThemeAdwaita::scrollbarThickness(scrollbarWidth, expansionState);
 
     if (scrollbarWidth == ScrollbarWidth::None)
         return 0;

--- a/Source/WebCore/platform/gtk/ScrollbarThemeGtk.h
+++ b/Source/WebCore/platform/gtk/ScrollbarThemeGtk.h
@@ -46,7 +46,7 @@ private:
 
     bool paint(Scrollbar&, GraphicsContext&, const IntRect& damageRect) override;
     ScrollbarButtonPressAction handleMousePressEvent(Scrollbar&, const PlatformMouseEvent&, ScrollbarPart) override;
-    int scrollbarThickness(ScrollbarControlSize, ScrollbarWidth = ScrollbarWidth::Auto, ScrollbarExpansionState = ScrollbarExpansionState::Expanded) override;
+    int scrollbarThickness(ScrollbarWidth = ScrollbarWidth::Auto, ScrollbarExpansionState = ScrollbarExpansionState::Expanded) override;
     int minimumThumbLength(Scrollbar&) override;
 
     void themeChanged() override;

--- a/Source/WebCore/platform/ios/ScrollbarThemeIOS.h
+++ b/Source/WebCore/platform/ios/ScrollbarThemeIOS.h
@@ -38,7 +38,7 @@ public:
 
     bool paint(Scrollbar&, GraphicsContext&, const IntRect& damageRect) override;
 
-    int scrollbarThickness(ScrollbarControlSize = ScrollbarControlSize::Regular, ScrollbarWidth = ScrollbarWidth::Auto, ScrollbarExpansionState = ScrollbarExpansionState::Expanded) override;
+    int scrollbarThickness(ScrollbarWidth = ScrollbarWidth::Auto, ScrollbarExpansionState = ScrollbarExpansionState::Expanded) override;
     
     bool supportsControlTints() const override { return true; }
 

--- a/Source/WebCore/platform/ios/ScrollbarThemeIOS.mm
+++ b/Source/WebCore/platform/ios/ScrollbarThemeIOS.mm
@@ -63,7 +63,7 @@ void ScrollbarThemeIOS::preferencesChanged()
 {
 }
 
-int ScrollbarThemeIOS::scrollbarThickness(ScrollbarControlSize, ScrollbarWidth, ScrollbarExpansionState)
+int ScrollbarThemeIOS::scrollbarThickness(ScrollbarWidth, ScrollbarExpansionState)
 {
     return 0;
 }

--- a/Source/WebCore/platform/mac/ScrollbarThemeMac.h
+++ b/Source/WebCore/platform/mac/ScrollbarThemeMac.h
@@ -45,7 +45,7 @@ public:
     bool paint(Scrollbar&, GraphicsContext&, const IntRect& damageRect) override;
     void paintScrollCorner(ScrollableArea&, GraphicsContext&, const IntRect& cornerRect) override;
 
-    int scrollbarThickness(ScrollbarControlSize = ScrollbarControlSize::Regular, ScrollbarWidth = ScrollbarWidth::Auto, ScrollbarExpansionState = ScrollbarExpansionState::Expanded) override;
+    int scrollbarThickness(ScrollbarWidth = ScrollbarWidth::Auto, ScrollbarExpansionState = ScrollbarExpansionState::Expanded) override;
     
     bool supportsControlTints() const override { return true; }
     bool usesOverlayScrollbars() const  override;

--- a/Source/WebCore/platform/mac/ScrollbarsControllerMac.mm
+++ b/Source/WebCore/platform/mac/ScrollbarsControllerMac.mm
@@ -954,7 +954,7 @@ void ScrollbarsControllerMac::updateScrollerStyle()
         verticalScrollbar->invalidate();
 
         NSScrollerImp *oldVerticalPainter = [m_scrollerImpPair verticalScrollerImp];
-        auto newVerticalPainter = retainPtr([NSScrollerImp scrollerImpWithStyle:newStyle controlSize:(NSControlSize)verticalScrollbar->controlSize() horizontal:NO replacingScrollerImp:oldVerticalPainter]);
+        auto newVerticalPainter = retainPtr([NSScrollerImp scrollerImpWithStyle:newStyle controlSize:(NSControlSize)verticalScrollbar->widthStyle() horizontal:NO replacingScrollerImp:oldVerticalPainter]);
 
         [m_scrollerImpPair setVerticalScrollerImp:newVerticalPainter.get()];
         macTheme->setNewPainterForScrollbar(*verticalScrollbar, WTFMove(newVerticalPainter));
@@ -963,7 +963,7 @@ void ScrollbarsControllerMac::updateScrollerStyle()
         // The different scrollbar styles have different thicknesses, so we must re-set the
         // frameRect to the new thickness, and the re-layout below will ensure the position
         // and length are properly updated.
-        int thickness = macTheme->scrollbarThickness(verticalScrollbar->controlSize(), verticalScrollbar->scrollableArea().scrollbarWidthStyle());
+        int thickness = macTheme->scrollbarThickness(verticalScrollbar->widthStyle());
         verticalScrollbar->setFrameRect(IntRect(0, 0, thickness, thickness));
     }
 
@@ -972,7 +972,7 @@ void ScrollbarsControllerMac::updateScrollerStyle()
         horizontalScrollbar->invalidate();
 
         NSScrollerImp *oldHorizontalPainter = [m_scrollerImpPair horizontalScrollerImp];
-        auto newHorizontalPainter = retainPtr([NSScrollerImp scrollerImpWithStyle:newStyle controlSize:(NSControlSize)horizontalScrollbar->controlSize() horizontal:YES replacingScrollerImp:oldHorizontalPainter]);
+        auto newHorizontalPainter = retainPtr([NSScrollerImp scrollerImpWithStyle:newStyle controlSize:(NSControlSize)horizontalScrollbar->widthStyle() horizontal:YES replacingScrollerImp:oldHorizontalPainter]);
 
         [m_scrollerImpPair setHorizontalScrollerImp:newHorizontalPainter.get()];
         macTheme->setNewPainterForScrollbar(*horizontalScrollbar, WTFMove(newHorizontalPainter));
@@ -981,7 +981,7 @@ void ScrollbarsControllerMac::updateScrollerStyle()
         // The different scrollbar styles have different thicknesses, so we must re-set the
         // frameRect to the new thickness, and the re-layout below will ensure the position
         // and length are properly updated.
-        int thickness = macTheme->scrollbarThickness(horizontalScrollbar->controlSize(), horizontalScrollbar->scrollableArea().scrollbarWidthStyle());
+        int thickness = macTheme->scrollbarThickness(horizontalScrollbar->widthStyle());
         horizontalScrollbar->setFrameRect(IntRect(0, 0, thickness, thickness));
     }
 

--- a/Source/WebCore/platform/mock/ScrollbarThemeMock.cpp
+++ b/Source/WebCore/platform/mock/ScrollbarThemeMock.cpp
@@ -32,18 +32,23 @@
 
 namespace WebCore {
 
-static const int cScrollbarThickness[] = { 15, 11 };
-
 IntRect ScrollbarThemeMock::trackRect(Scrollbar& scrollbar, bool)
 {
     return scrollbar.frameRect();
 }
 
-int ScrollbarThemeMock::scrollbarThickness(ScrollbarControlSize controlSize, ScrollbarWidth scrollbarWidth, ScrollbarExpansionState)
+int ScrollbarThemeMock::scrollbarThickness(ScrollbarWidth scrollbarWidth, ScrollbarExpansionState)
 {
-    if (scrollbarWidth == ScrollbarWidth::None)
+    switch (scrollbarWidth) {
+    case ScrollbarWidth::Auto:
+        return 15;
+    case ScrollbarWidth::Thin:
+        return 11;
+    case ScrollbarWidth::None:
         return 0;
-    return cScrollbarThickness[static_cast<uint8_t>(controlSize)];
+    }
+    ASSERT_NOT_REACHED();
+    return 15;
 }
 
 void ScrollbarThemeMock::paintTrackBackground(GraphicsContext& context, Scrollbar& scrollbar, const IntRect& trackRect)

--- a/Source/WebCore/platform/mock/ScrollbarThemeMock.h
+++ b/Source/WebCore/platform/mock/ScrollbarThemeMock.h
@@ -33,7 +33,7 @@ namespace WebCore {
 // Scrollbar theme used in image snapshots, to eliminate appearance differences between platforms.
 class ScrollbarThemeMock : public ScrollbarThemeComposite {
 public:
-    int scrollbarThickness(ScrollbarControlSize = ScrollbarControlSize::Regular, ScrollbarWidth = ScrollbarWidth::Auto, ScrollbarExpansionState = ScrollbarExpansionState::Expanded) override;
+    int scrollbarThickness(ScrollbarWidth = ScrollbarWidth::Auto, ScrollbarExpansionState = ScrollbarExpansionState::Expanded) override;
 
 protected:
     bool hasButtons(Scrollbar&) override { return false; }

--- a/Source/WebCore/platform/playstation/ScrollbarThemePlayStation.cpp
+++ b/Source/WebCore/platform/playstation/ScrollbarThemePlayStation.cpp
@@ -39,7 +39,7 @@ ScrollbarTheme& ScrollbarTheme::nativeTheme()
     return theme;
 }
 
-int ScrollbarThemePlayStation::scrollbarThickness(ScrollbarControlSize, ScrollbarWidth scrollbarWidth, ScrollbarExpansionState)
+int ScrollbarThemePlayStation::scrollbarThickness(ScrollbarWidth scrollbarWidth, ScrollbarExpansionState)
 {
     if (scrollbarWidth == ScrollbarWidth::None)
         return 0;

--- a/Source/WebCore/platform/playstation/ScrollbarThemePlayStation.h
+++ b/Source/WebCore/platform/playstation/ScrollbarThemePlayStation.h
@@ -34,7 +34,7 @@ public:
     ScrollbarThemePlayStation() = default;
     virtual ~ScrollbarThemePlayStation() = default;
 
-    int scrollbarThickness(ScrollbarControlSize = ScrollbarControlSize::Regular, ScrollbarWidth = ScrollbarWidth::Auto, ScrollbarExpansionState = ScrollbarExpansionState::Expanded) override;
+    int scrollbarThickness(ScrollbarWidth = ScrollbarWidth::Auto, ScrollbarExpansionState = ScrollbarExpansionState::Expanded) override;
 
     bool hasButtons(Scrollbar&) override;
     bool hasThumb(Scrollbar&) override;

--- a/Source/WebCore/platform/win/PopupMenuWin.cpp
+++ b/Source/WebCore/platform/win/PopupMenuWin.cpp
@@ -141,7 +141,7 @@ void PopupMenuWin::show(const IntRect& r, LocalFrameView* view, int index)
 
     if (!m_scrollbar && visibleItems() < client()->listSize()) {
         // We need a scroll bar
-        m_scrollbar = client()->createScrollbar(*this, ScrollbarOrientation::Vertical, ScrollbarControlSize::Small);
+        m_scrollbar = client()->createScrollbar(*this, ScrollbarOrientation::Vertical, ScrollbarWidth::Thin);
         m_scrollbar->styleChanged();
     }
 
@@ -356,7 +356,7 @@ void PopupMenuWin::calculatePositionAndSize(const IntRect& r, LocalFrameView* v)
 
     if (naturalHeight > maxPopupHeight)
         // We need room for a scrollbar
-        popupWidth += ScrollbarTheme::theme().scrollbarThickness(ScrollbarControlSize::Small);
+        popupWidth += ScrollbarTheme::theme().scrollbarThickness(ScrollbarWidth::Thin);
 
     // Add padding to align the popup text with the <select> text
     popupWidth += std::max<int>(0, client()->clientPaddingRight() - client()->clientInsetRight()) + std::max<int>(0, client()->clientPaddingLeft() - client()->clientInsetLeft());

--- a/Source/WebCore/platform/win/ScrollbarThemeWin.cpp
+++ b/Source/WebCore/platform/win/ScrollbarThemeWin.cpp
@@ -112,7 +112,7 @@ static int scrollbarThicknessInPixels()
     return thickness;
 }
 
-int ScrollbarThemeWin::scrollbarThickness(ScrollbarControlSize, ScrollbarWidth scrollbarWidth, ScrollbarExpansionState)
+int ScrollbarThemeWin::scrollbarThickness(ScrollbarWidth scrollbarWidth, ScrollbarExpansionState)
 {
     if (scrollbarWidth == ScrollbarWidth::None)
         return 0;

--- a/Source/WebCore/platform/win/ScrollbarThemeWin.h
+++ b/Source/WebCore/platform/win/ScrollbarThemeWin.h
@@ -35,7 +35,7 @@ public:
     ScrollbarThemeWin();
     virtual ~ScrollbarThemeWin();
 
-    int scrollbarThickness(ScrollbarControlSize = ScrollbarControlSize::Regular, ScrollbarWidth = ScrollbarWidth::Auto, ScrollbarExpansionState = ScrollbarExpansionState::Expanded) override;
+    int scrollbarThickness(ScrollbarWidth = ScrollbarWidth::Auto, ScrollbarExpansionState = ScrollbarExpansionState::Expanded) override;
 
     void themeChanged() override;
     

--- a/Source/WebCore/rendering/RenderLayerScrollableArea.cpp
+++ b/Source/WebCore/rendering/RenderLayerScrollableArea.cpp
@@ -867,10 +867,7 @@ Ref<Scrollbar> RenderLayerScrollableArea::createScrollbar(ScrollbarOrientation o
     if (hasCustomScrollbarStyle && element)
         widget = RenderScrollbar::createCustomScrollbar(*this, orientation, element);
     else {
-        auto scrollbarSize = scrollbarWidthStyle() == ScrollbarWidth::Thin
-            ? ScrollbarControlSize::Small
-            : ScrollbarControlSize::Regular;
-        widget = Scrollbar::createNativeScrollbar(*this, orientation, scrollbarSize);
+        widget = Scrollbar::createNativeScrollbar(*this, orientation, scrollbarWidthStyle());
         
         if (auto scrollbarController = m_layer.page().chrome().client().createScrollbarsController(m_layer.page(), *this))
             setScrollbarsController(WTFMove(scrollbarController));

--- a/Source/WebCore/rendering/RenderListBox.cpp
+++ b/Source/WebCore/rendering/RenderListBox.cpp
@@ -979,7 +979,7 @@ Ref<Scrollbar> RenderListBox::createScrollbar()
     if (hasCustomScrollbarStyle)
         widget = RenderScrollbar::createCustomScrollbar(*this, ScrollbarOrientation::Vertical, &selectElement());
     else {
-        widget = Scrollbar::createNativeScrollbar(*this, ScrollbarOrientation::Vertical, theme().scrollbarControlSizeForPart(StyleAppearance::Listbox));
+        widget = Scrollbar::createNativeScrollbar(*this, ScrollbarOrientation::Vertical, theme().scrollbarWidthStyleForPart(StyleAppearance::Listbox));
         didAddScrollbar(widget.get(), ScrollbarOrientation::Vertical);
         if (page().isMonitoringWheelEvents())
             scrollAnimator().setWheelEventTestMonitor(page().wheelEventTestMonitor());

--- a/Source/WebCore/rendering/RenderMenuList.cpp
+++ b/Source/WebCore/rendering/RenderMenuList.cpp
@@ -560,12 +560,12 @@ HostWindow* RenderMenuList::hostWindow() const
     return RenderFlexibleBox::hostWindow();
 }
 
-Ref<Scrollbar> RenderMenuList::createScrollbar(ScrollableArea& scrollableArea, ScrollbarOrientation orientation, ScrollbarControlSize controlSize)
+Ref<Scrollbar> RenderMenuList::createScrollbar(ScrollableArea& scrollableArea, ScrollbarOrientation orientation, ScrollbarWidth widthStyle)
 {
     bool hasCustomScrollbarStyle = style().hasPseudoStyle(PseudoId::Scrollbar);
     if (hasCustomScrollbarStyle)
         return RenderScrollbar::createCustomScrollbar(scrollableArea, orientation, &selectElement());
-    return Scrollbar::createNativeScrollbar(scrollableArea, orientation, controlSize);
+    return Scrollbar::createNativeScrollbar(scrollableArea, orientation, widthStyle);
 }
 
 int RenderMenuList::clientInsetLeft() const

--- a/Source/WebCore/rendering/RenderMenuList.h
+++ b/Source/WebCore/rendering/RenderMenuList.h
@@ -119,7 +119,7 @@ private:
     bool multiple() const override;
     FontSelector* fontSelector() const override;
     HostWindow* hostWindow() const override;
-    Ref<Scrollbar> createScrollbar(ScrollableArea&, ScrollbarOrientation, ScrollbarControlSize) override;
+    Ref<Scrollbar> createScrollbar(ScrollableArea&, ScrollbarOrientation, ScrollbarWidth) override;
 
     bool hasLineIfEmpty() const override { return true; }
 

--- a/Source/WebCore/rendering/RenderScrollbar.cpp
+++ b/Source/WebCore/rendering/RenderScrollbar.cpp
@@ -43,7 +43,7 @@ Ref<Scrollbar> RenderScrollbar::createCustomScrollbar(ScrollableArea& scrollable
 }
 
 RenderScrollbar::RenderScrollbar(ScrollableArea& scrollableArea, ScrollbarOrientation orientation, Element* ownerElement, LocalFrame* owningFrame)
-    : Scrollbar(scrollableArea, orientation, ScrollbarControlSize::Regular, RenderScrollbarTheme::renderScrollbarTheme(), true)
+    : Scrollbar(scrollableArea, orientation, ScrollbarWidth::Auto, RenderScrollbarTheme::renderScrollbarTheme(), true)
     , m_ownerElement(ownerElement)
     , m_owningFrame(owningFrame)
 {

--- a/Source/WebCore/rendering/RenderScrollbarTheme.h
+++ b/Source/WebCore/rendering/RenderScrollbarTheme.h
@@ -37,7 +37,7 @@ class RenderScrollbarTheme final : public ScrollbarThemeComposite {
 public:
     virtual ~RenderScrollbarTheme() = default;
     
-    int scrollbarThickness(ScrollbarControlSize controlSize, ScrollbarWidth scrollbarWidth = ScrollbarWidth::Auto, ScrollbarExpansionState expansionState = ScrollbarExpansionState::Expanded) override { return ScrollbarTheme::theme().scrollbarThickness(controlSize, scrollbarWidth, expansionState); }
+    int scrollbarThickness(ScrollbarWidth scrollbarWidth = ScrollbarWidth::Auto, ScrollbarExpansionState expansionState = ScrollbarExpansionState::Expanded) override { return ScrollbarTheme::theme().scrollbarThickness(scrollbarWidth, expansionState); }
 
     ScrollbarButtonsPlacement buttonsPlacement() const override { return ScrollbarTheme::theme().buttonsPlacement(); }
 

--- a/Source/WebCore/rendering/RenderSearchField.cpp
+++ b/Source/WebCore/rendering/RenderSearchField.cpp
@@ -372,12 +372,12 @@ HostWindow* RenderSearchField::hostWindow() const
     return RenderTextControlSingleLine::hostWindow();
 }
 
-Ref<Scrollbar> RenderSearchField::createScrollbar(ScrollableArea& scrollableArea, ScrollbarOrientation orientation, ScrollbarControlSize controlSize)
+Ref<Scrollbar> RenderSearchField::createScrollbar(ScrollableArea& scrollableArea, ScrollbarOrientation orientation, ScrollbarWidth widthStyle)
 {
     bool hasCustomScrollbarStyle = style().hasPseudoStyle(PseudoId::Scrollbar);
     if (hasCustomScrollbarStyle)
         return RenderScrollbar::createCustomScrollbar(scrollableArea, orientation, &inputElement());
-    return Scrollbar::createNativeScrollbar(scrollableArea, orientation, controlSize);
+    return Scrollbar::createNativeScrollbar(scrollableArea, orientation, widthStyle);
 }
 
 }

--- a/Source/WebCore/rendering/RenderSearchField.h
+++ b/Source/WebCore/rendering/RenderSearchField.h
@@ -82,7 +82,7 @@ private:
     void setTextFromItem(unsigned listIndex) override;
     FontSelector* fontSelector() const override;
     HostWindow* hostWindow() const override;
-    Ref<Scrollbar> createScrollbar(ScrollableArea&, ScrollbarOrientation, ScrollbarControlSize) override;
+    Ref<Scrollbar> createScrollbar(ScrollableArea&, ScrollbarOrientation, ScrollbarWidth) override;
 
     HTMLElement* resultsButtonElement() const;
     HTMLElement* cancelButtonElement() const;

--- a/Source/WebCore/rendering/RenderTextControl.cpp
+++ b/Source/WebCore/rendering/RenderTextControl.cpp
@@ -104,11 +104,7 @@ int RenderTextControl::textBlockLogicalWidth() const
 int RenderTextControl::scrollbarThickness() const
 {
     // FIXME: We should get the size of the scrollbar from the RenderTheme instead.
-    auto scrollbarSize = this->style().scrollbarWidth() == ScrollbarWidth::Thin
-        ? ScrollbarControlSize::Small
-        : ScrollbarControlSize::Regular;
-
-    return ScrollbarTheme::theme().scrollbarThickness(scrollbarSize, this->style().scrollbarWidth());
+    return ScrollbarTheme::theme().scrollbarThickness(this->style().scrollbarWidth());
 }
 
 RenderBox::LogicalExtentComputedValues RenderTextControl::computeLogicalHeight(LayoutUnit logicalHeight, LayoutUnit logicalTop) const

--- a/Source/WebCore/rendering/RenderTheme.h
+++ b/Source/WebCore/rendering/RenderTheme.h
@@ -212,7 +212,7 @@ public:
     virtual bool popupOptionSupportsTextIndent() const { return false; }
     virtual PopupMenuStyle::PopupMenuSize popupMenuSize(const RenderStyle&, IntRect&) const { return PopupMenuStyle::PopupMenuSizeNormal; }
 
-    virtual ScrollbarControlSize scrollbarControlSizeForPart(StyleAppearance) { return ScrollbarControlSize::Regular; }
+    virtual ScrollbarWidth scrollbarWidthStyleForPart(StyleAppearance) { return ScrollbarWidth::Auto; }
 
     // Returns the repeat interval of the animation for the progress bar.
     virtual Seconds animationRepeatIntervalForProgressBar(const RenderProgress&) const;

--- a/Source/WebCore/rendering/RenderThemeMac.h
+++ b/Source/WebCore/rendering/RenderThemeMac.h
@@ -64,7 +64,7 @@ public:
     Color platformDefaultButtonTextColor(OptionSet<StyleColorOptions>) const final;
     Color platformAutocorrectionReplacementMarkerColor(OptionSet<StyleColorOptions>) const final;
 
-    ScrollbarControlSize scrollbarControlSizeForPart(StyleAppearance) final { return ScrollbarControlSize::Small; }
+    ScrollbarWidth scrollbarWidthStyleForPart(StyleAppearance) final { return ScrollbarWidth::Thin; }
 
     int minimumMenuListSize(const RenderStyle&) const final;
 

--- a/Source/WebCore/rendering/style/RenderStyleConstants.cpp
+++ b/Source/WebCore/rendering/style/RenderStyleConstants.cpp
@@ -943,17 +943,6 @@ TextStream& operator<<(TextStream& ts, ScrollSnapStop stop)
     }
     return ts;
 }
-
-TextStream& operator<<(TextStream& ts, ScrollbarWidth width)
-{
-    switch (width) {
-    case ScrollbarWidth::Auto: ts << "auto"; break;
-    case ScrollbarWidth::Thin: ts << "thin"; break;
-    case ScrollbarWidth::None: ts << "none"; break;
-    }
-    return ts;
-}
-
 TextStream& operator<<(TextStream& ts, SpeakAs speakAs)
 {
     switch (speakAs) {

--- a/Source/WebCore/rendering/style/RenderStyleConstants.h
+++ b/Source/WebCore/rendering/style/RenderStyleConstants.h
@@ -1101,12 +1101,6 @@ enum class ScrollSnapStop : bool {
     Always,
 };
 
-enum class ScrollbarWidth : uint8_t {
-    Auto,
-    Thin,
-    None
-};
-
 // These are all minimized combinations of paint-order.
 enum class PaintOrder : uint8_t {
     Normal,
@@ -1258,7 +1252,6 @@ WTF::TextStream& operator<<(WTF::TextStream&, ScrollSnapAxis);
 WTF::TextStream& operator<<(WTF::TextStream&, ScrollSnapAxisAlignType);
 WTF::TextStream& operator<<(WTF::TextStream&, ScrollSnapStop);
 WTF::TextStream& operator<<(WTF::TextStream&, ScrollSnapStrictness);
-WTF::TextStream& operator<<(WTF::TextStream&, ScrollbarWidth);
 WTF::TextStream& operator<<(WTF::TextStream&, SpeakAs);
 WTF::TextStream& operator<<(WTF::TextStream&, StyleDifference);
 WTF::TextStream& operator<<(WTF::TextStream&, TableLayoutType);

--- a/Source/WebCore/rendering/style/StyleRareNonInheritedData.h
+++ b/Source/WebCore/rendering/style/StyleRareNonInheritedData.h
@@ -35,6 +35,7 @@
 #include "PathOperation.h"
 #include "RotateTransformOperation.h"
 #include "ScaleTransformOperation.h"
+#include "ScrollTypes.h"
 #include "ScrollbarGutter.h"
 #include "ShapeValue.h"
 #include "StyleColor.h"

--- a/Source/WebKit/UIProcess/win/WebPopupMenuProxyWin.cpp
+++ b/Source/WebKit/UIProcess/win/WebPopupMenuProxyWin.cpp
@@ -191,7 +191,7 @@ void WebPopupMenuProxyWin::showPopupMenu(const IntRect& rect, TextDirection, dou
     HWND hostWindow = m_webView->window();
 
     if (!m_scrollbar && visibleItems() < m_items.size()) {
-        m_scrollbar = Scrollbar::createNativeScrollbar(*this, ScrollbarOrientation::Vertical, ScrollbarControlSize::Small);
+        m_scrollbar = Scrollbar::createNativeScrollbar(*this, ScrollbarOrientation::Vertical, ScrollbarWidth::Thin);
         m_scrollbar->styleChanged();
     }
 
@@ -372,7 +372,7 @@ void WebPopupMenuProxyWin::calculatePositionAndSize(const IntRect& rect)
 
     if (naturalHeight > maxPopupHeight) {
         // We need room for a scrollbar
-        popupWidth += ScrollbarTheme::theme().scrollbarThickness(ScrollbarControlSize::Small);
+        popupWidth += ScrollbarTheme::theme().scrollbarThickness(ScrollbarWidth::Thin);
     }
 
     popupHeight += 2 * popupWindowBorderWidth;

--- a/Source/WebKit/WebProcess/Plugins/PDF/PDFPlugin.mm
+++ b/Source/WebKit/WebProcess/Plugins/PDF/PDFPlugin.mm
@@ -1384,7 +1384,7 @@ void PDFPlugin::updateScrollbars()
 
 Ref<Scrollbar> PDFPlugin::createScrollbar(ScrollbarOrientation orientation)
 {
-    auto widget = Scrollbar::createNativeScrollbar(*this, orientation, ScrollbarControlSize::Regular);
+    auto widget = Scrollbar::createNativeScrollbar(*this, orientation, ScrollbarWidth::Auto);
     auto shouldFlip = m_view->isUsingUISideCompositing();
     if (orientation == ScrollbarOrientation::Horizontal) {
         m_horizontalScrollbarLayer = adoptNS([[WKPDFPluginScrollbarLayer alloc] initWithPDFPlugin:this shouldFlip:shouldFlip]);


### PR DESCRIPTION
#### 0b067f49ace27bae454e8d9fc0daf079a7970ca5
<pre>
Replace usages of ScrollbarControlSize with ScrollbarWidth
<a href="https://bugs.webkit.org/show_bug.cgi?id=257415">https://bugs.webkit.org/show_bug.cgi?id=257415</a>

Reviewed by Tim Nguyen.

ScrollbarControlSize enum has been removed and usages of it replaced with the equivalent ScrollbarWidth enum.
ScrollbarWidth enum has been moved into ScrollTypes.h

This patch has no behaviour changes.

* Source/WebCore/page/LocalFrameView.cpp:
(WebCore::LocalFrameView::createScrollbar):
* Source/WebCore/platform/PopupMenuClient.h:
* Source/WebCore/platform/ScrollTypes.cpp:
(WebCore::operator&lt;&lt;):
* Source/WebCore/platform/ScrollTypes.h:
* Source/WebCore/platform/ScrollView.cpp:
(WebCore::ScrollView::createScrollbar):
* Source/WebCore/platform/Scrollbar.cpp:
(WebCore::Scrollbar::createNativeScrollbar):
(WebCore::Scrollbar::Scrollbar):
(WebCore::Scrollbar::isHiddenByStyle const):
* Source/WebCore/platform/Scrollbar.h:
(WebCore::Scrollbar::widthStyle const):
(WebCore::Scrollbar::controlSize const): Deleted.
* Source/WebCore/platform/ScrollbarTheme.h:
(WebCore::ScrollbarTheme::scrollbarThickness):
* Source/WebCore/platform/ScrollbarThemeComposite.cpp:
(WebCore::ScrollbarThemeComposite::minimumThumbLength):
* Source/WebCore/platform/adwaita/ScrollbarThemeAdwaita.cpp:
(WebCore::ScrollbarThemeAdwaita::scrollbarThickness):
* Source/WebCore/platform/adwaita/ScrollbarThemeAdwaita.h:
* Source/WebCore/platform/gtk/ScrollbarThemeGtk.cpp:
(WebCore::ScrollbarThemeGtk::scrollbarThickness):
* Source/WebCore/platform/gtk/ScrollbarThemeGtk.h:
* Source/WebCore/platform/ios/ScrollbarThemeIOS.h:
* Source/WebCore/platform/ios/ScrollbarThemeIOS.mm:
(WebCore::ScrollbarThemeIOS::scrollbarThickness):
* Source/WebCore/platform/mac/ScrollbarThemeMac.h:
* Source/WebCore/platform/mac/ScrollbarThemeMac.mm:
(WebCore::scrollbarWidthToNSControlSize):
(WebCore::ScrollbarThemeMac::registerScrollbar):
(WebCore::ScrollbarThemeMac::scrollbarThickness):
(WebCore::scrollbarWidthToIndex):
(WebCore::ScrollbarThemeMac::hasButtons):
(WebCore::buttonRepaintRect):
(WebCore::ScrollbarThemeMac::backButtonRect):
(WebCore::ScrollbarThemeMac::forwardButtonRect):
(WebCore::ScrollbarThemeMac::trackRect):
(WebCore::scrollbarControlSizeToNSControlSize): Deleted.
(WebCore::scrollbarSizeToIndex): Deleted.
* Source/WebCore/platform/mac/ScrollbarsControllerMac.mm:
(WebCore::ScrollbarsControllerMac::updateScrollerStyle):
* Source/WebCore/platform/mock/ScrollbarThemeMock.cpp:
(WebCore::ScrollbarThemeMock::scrollbarThickness):
* Source/WebCore/platform/mock/ScrollbarThemeMock.h:
* Source/WebCore/platform/playstation/ScrollbarThemePlayStation.cpp:
(WebCore::ScrollbarThemePlayStation::scrollbarThickness):
* Source/WebCore/platform/playstation/ScrollbarThemePlayStation.h:
* Source/WebCore/platform/win/PopupMenuWin.cpp:
(WebCore::PopupMenuWin::show):
(WebCore::PopupMenuWin::calculatePositionAndSize):
* Source/WebCore/platform/win/ScrollbarThemeWin.cpp:
(WebCore::ScrollbarThemeWin::scrollbarThickness):
* Source/WebCore/platform/win/ScrollbarThemeWin.h:
* Source/WebCore/rendering/RenderLayerScrollableArea.cpp:
(WebCore::RenderLayerScrollableArea::createScrollbar):
* Source/WebCore/rendering/RenderListBox.cpp:
(WebCore::RenderListBox::createScrollbar):
* Source/WebCore/rendering/RenderMenuList.cpp:
(RenderMenuList::createScrollbar):
* Source/WebCore/rendering/RenderMenuList.h:
* Source/WebCore/rendering/RenderScrollbar.cpp:
(WebCore::RenderScrollbar::RenderScrollbar):
* Source/WebCore/rendering/RenderScrollbarTheme.h:
* Source/WebCore/rendering/RenderSearchField.cpp:
(WebCore::RenderSearchField::createScrollbar):
* Source/WebCore/rendering/RenderSearchField.h:
* Source/WebCore/rendering/RenderTextControl.cpp:
(WebCore::RenderTextControl::scrollbarThickness const):
* Source/WebCore/rendering/RenderTheme.h:
(WebCore::RenderTheme::scrollbarWidthStyleForPart):
(WebCore::RenderTheme::scrollbarControlSizeForPart): Deleted.
* Source/WebCore/rendering/RenderThemeMac.h:
* Source/WebCore/rendering/style/RenderStyleConstants.cpp:
(WebCore::operator&lt;&lt;):
* Source/WebCore/rendering/style/RenderStyleConstants.h:
* Source/WebCore/rendering/style/StyleRareNonInheritedData.h:
* Source/WebKit/UIProcess/win/WebPopupMenuProxyWin.cpp:
(WebKit::WebPopupMenuProxyWin::showPopupMenu):
(WebKit::WebPopupMenuProxyWin::calculatePositionAndSize):
* Source/WebKit/WebProcess/Plugins/PDF/PDFPlugin.mm:
(WebKit::PDFPlugin::createScrollbar):

Canonical link: <a href="https://commits.webkit.org/264639@main">https://commits.webkit.org/264639@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4dc212d6b94e47b4d0e9c8166f7be3f80f2d4a7c

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/8227 "1 style error") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/8519 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/8736 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/9894 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/8293 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/8236 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/10507 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/8430 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/11168 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/8372 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/9438 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/7461 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/10039 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/6737 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/7526 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/15086 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/7860 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/7657 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/11016 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/8132 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/6612 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/7422 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/1978 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/11630 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/7873 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->