### PR TITLE
[popover] Cache auto popover list to avoid unnecessarily iterating the top layer

### DIFF
--- a/Source/WebCore/dom/Document.h
+++ b/Source/WebCore/dom/Document.h
@@ -1630,10 +1630,12 @@ public:
     const ListHashSet<Ref<Element>>& topLayerElements() const { return m_topLayerElements; }
     bool hasTopLayerElement() const { return !m_topLayerElements.isEmpty(); }
 
+    const ListHashSet<Ref<HTMLElement>>& autoPopoverList() const { return m_autoPopoverList; }
+
     HTMLDialogElement* activeModalDialog() const;
     HTMLElement* topmostAutoPopover() const;
 
-    void hideAllPopoversUntil(Element*, FocusPreviousElement, FireEvents);
+    void hideAllPopoversUntil(HTMLElement*, FocusPreviousElement, FireEvents);
     void handlePopoverLightDismiss(const PointerEvent&, Node&);
 
 #if ENABLE(ATTACHMENT_ELEMENT)
@@ -2207,10 +2209,11 @@ private:
     Ref<UndoManager> m_undoManager;
     UniqueRef<Editor> m_editor;
     UniqueRef<FrameSelection> m_selection;
-        
+
     String m_fragmentDirective;
 
     ListHashSet<Ref<Element>> m_topLayerElements;
+    ListHashSet<Ref<HTMLElement>> m_autoPopoverList;
 
     WeakPtr<HTMLElement, WeakPtrImplWithEventTargetData> m_popoverPointerDownTarget;
 

--- a/Source/WebCore/html/HTMLElement.cpp
+++ b/Source/WebCore/html/HTMLElement.cpp
@@ -1265,16 +1265,13 @@ static ExceptionOr<bool> checkPopoverValidity(HTMLElement& element, PopoverVisib
 // https://html.spec.whatwg.org/#topmost-popover-ancestor
 // Consider both DOM ancestors and popovers where the given popover was invoked from as ancestors.
 // Use top layer positions to disambiguate the topmost one when both exist.
-static HTMLElement* topmostPopoverAncestor(Element& newPopover)
+static HTMLElement* topmostPopoverAncestor(HTMLElement& newPopover)
 {
     // Store positions to avoid having to do O(n) search for every popover invoker.
-    HashMap<Ref<Element>, size_t> topLayerPositions;
+    HashMap<Ref<const HTMLElement>, size_t> topLayerPositions;
     size_t i = 0;
-    for (auto& element : newPopover.document().topLayerElements()) {
-        if (!is<HTMLElement>(element) || downcast<HTMLElement>(element.get()).popoverState() != PopoverState::Auto)
-            continue;
+    for (auto& element : newPopover.document().autoPopoverList())
         topLayerPositions.add(element, i++);
-    }
 
     topLayerPositions.add(newPopover, i);
 


### PR DESCRIPTION
#### 8141e23838a14f06695a9e7c94c326ca0ceb3c70
<pre>
[popover] Cache auto popover list to avoid unnecessarily iterating the top layer
<a href="https://bugs.webkit.org/show_bug.cgi?id=257427">https://bugs.webkit.org/show_bug.cgi?id=257427</a>
rdar://109932621

Reviewed by Ryosuke Niwa.

hideAllPopoversUntil calls autoPopoverList() and topmostAutoPopover() multiple times, which iterates through the top layer
multiple times. Store another ListHashSet which is a subset of topLayerElements(). Additions/removals are done at the same time
as adding/removing to the top layer, which prevents leaks.

* Source/WebCore/dom/Document.cpp:
(WebCore::Document::addTopLayerElement):
(WebCore::Document::removeTopLayerElement):
(WebCore::Document::topmostAutoPopover const):
(WebCore::Document::hideAllPopoversUntil):
(WebCore::Document::handlePopoverLightDismiss):
* Source/WebCore/dom/Document.h:
(WebCore::Document::autoPopoverList const):
* Source/WebCore/html/HTMLElement.cpp:
(WebCore::topmostPopoverAncestor):

Canonical link: <a href="https://commits.webkit.org/264810@main">https://commits.webkit.org/264810@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9d3e277c86da135ec5865d2d60f2f03fd0c54ee6

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/8685 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/8975 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/9190 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/10342 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/32/builds/8686 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/8694 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/10963 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/8946 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/11559 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/8831 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/9846 "Passed tests") | [⏳ 🧪 api-mac](https://ews-build.webkit.org/#/builders/API-Tests-macOS-EWS "Waiting to run tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/10499 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/7146 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/7942 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/15459 "Passed tests") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/8263 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/8090 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/11433 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/8572 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/6992 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/7838 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/2111 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/12050 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/8317 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->