### PR TITLE
Add runtime logging to AudioSession and related classes

### DIFF
--- a/Source/WebCore/platform/audio/AudioSession.cpp
+++ b/Source/WebCore/platform/audio/AudioSession.cpp
@@ -30,6 +30,7 @@
 
 #include "Logging.h"
 #include "NotImplemented.h"
+#include <wtf/LoggerHelper.h>
 #include <wtf/NeverDestroyed.h>
 
 #if PLATFORM(MAC)
@@ -101,6 +102,8 @@ bool AudioSession::tryToSetActive(bool active)
     if (!tryToSetActiveInternal(active))
         return false;
 
+    ALWAYS_LOG(LOGIDENTIFIER, "is active = ", m_active, ", previousIsActive = ", previousIsActive);
+
     bool hasActiveChanged = previousIsActive != isActive();
     m_active = active;
     if (m_isInterrupted && m_active) {
@@ -129,6 +132,7 @@ void AudioSession::removeInterruptionObserver(InterruptionObserver& observer)
 
 void AudioSession::beginInterruption()
 {
+    ALWAYS_LOG(LOGIDENTIFIER);
     if (m_isInterrupted) {
         RELEASE_LOG_ERROR(WebRTC, "AudioSession::beginInterruption but session is already interrupted!");
         return;
@@ -140,6 +144,7 @@ void AudioSession::beginInterruption()
 
 void AudioSession::endInterruption(MayResume mayResume)
 {
+    ALWAYS_LOG(LOGIDENTIFIER);
     if (!m_isInterrupted) {
         RELEASE_LOG_ERROR(WebRTC, "AudioSession::endInterruption but session is already uninterrupted!");
         return;
@@ -165,6 +170,8 @@ void AudioSession::setCategoryOverride(CategoryType category)
 {
     if (m_categoryOverride == category)
         return;
+
+    ALWAYS_LOG(LOGIDENTIFIER);
 
     m_categoryOverride = category;
     if (category != CategoryType::None)
@@ -257,6 +264,19 @@ void AudioSession::removeConfigurationChangeObserver(ConfigurationChangeObserver
 void AudioSession::setIsPlayingToBluetoothOverride(std::optional<bool>)
 {
     notImplemented();
+}
+
+Logger& AudioSession::logger()
+{
+    if (!m_logger)
+        m_logger = Logger::create(this);
+
+    return *m_logger;
+}
+
+WTFLogChannel& AudioSession::logChannel() const
+{
+    return LogMedia;
 }
 
 String convertEnumerationToString(RouteSharingPolicy enumerationValue)

--- a/Source/WebCore/platform/audio/AudioSession.h
+++ b/Source/WebCore/platform/audio/AudioSession.h
@@ -37,6 +37,10 @@
 #include <wtf/WeakHashSet.h>
 #include <wtf/text/WTFString.h>
 
+namespace WTF {
+class Logger;
+}
+
 namespace WebCore {
 
 enum class RouteSharingPolicy : uint8_t {
@@ -157,6 +161,13 @@ protected:
     virtual bool tryToSetActiveInternal(bool);
     void activeStateChanged();
 
+    Logger& logger();
+    const char* logClassName() const { return "AudioSession"; }
+    WTFLogChannel& logChannel() const;
+    const void* logIdentifier() const { return nullptr; }
+
+    mutable RefPtr<Logger> m_logger;
+
     WeakHashSet<InterruptionObserver> m_interruptionObservers;
 
     WeakPtr<AudioSessionRoutingArbitrationClient> m_routingArbitrationClient;
@@ -180,6 +191,9 @@ public:
 
     virtual void beginRoutingArbitrationWithCategory(AudioSession::CategoryType, ArbitrationCallback&&) = 0;
     virtual void leaveRoutingAbritration() = 0;
+
+    virtual const void* logIdentifier() const = 0;
+    virtual bool canLog() const = 0;
 
     using WeakValueType = AudioSessionRoutingArbitrationClient;
 };
@@ -228,6 +242,7 @@ struct LogArgument<WebCore::AudioSessionRoutingArbitrationClient::RoutingArbitra
         return convertEnumerationToString(error);
     }
 };
+
 template <>
 struct LogArgument<WebCore::AudioSessionRoutingArbitrationClient::DefaultRouteChanged> {
     static String toString(const WebCore::AudioSessionRoutingArbitrationClient::DefaultRouteChanged changed)

--- a/Source/WebCore/platform/audio/mac/AudioSessionMac.h
+++ b/Source/WebCore/platform/audio/mac/AudioSessionMac.h
@@ -81,6 +81,9 @@ private:
     void addConfigurationChangeObserver(ConfigurationChangeObserver&) final;
     void removeConfigurationChangeObserver(ConfigurationChangeObserver&) final;
 
+    WTFLogChannel& logChannel() const;
+    const void* logIdentifier() const;
+
     std::optional<bool> m_lastMutedState;
     mutable WeakHashSet<ConfigurationChangeObserver> m_configurationChangeObservers;
     AudioSession::CategoryType m_category { AudioSession::CategoryType::None };

--- a/Source/WebCore/platform/audio/mac/SharedRoutingArbitrator.h
+++ b/Source/WebCore/platform/audio/mac/SharedRoutingArbitrator.h
@@ -30,6 +30,10 @@
 #include "AudioSession.h"
 #include <wtf/UniqueRef.h>
 
+namespace WTF {
+class Logger;
+}
+
 namespace WebCore {
 
 class WEBCORE_EXPORT SharedRoutingArbitrator {
@@ -44,19 +48,28 @@ public:
         WTF_MAKE_FAST_ALLOCATED;
     public:
         static UniqueRef<Token> create();
+        const void* logIdentifier() const;
     private:
         friend UniqueRef<Token> WTF::makeUniqueRefWithoutFastMallocCheck<Token>();
         Token() = default;
+        mutable const void* m_logIdentifier;
     };
 
     bool isInRoutingArbitrationForToken(const Token&);
     void beginRoutingArbitrationForToken(const Token&, AudioSession::CategoryType, ArbitrationCallback&&);
     void endRoutingArbitrationForToken(const Token&);
 
+    void setLogger(const Logger&);
+
 private:
+    const Logger& logger();
+    const char* logClassName() const { return "SharedRoutingArbitrator"; }
+    WTFLogChannel& logChannel() const;
+
     std::optional<AudioSession::CategoryType> m_currentCategory { AudioSession::CategoryType::None };
     WeakHashSet<Token> m_tokens;
     Vector<ArbitrationCallback> m_enqueuedCallbacks;
+    RefPtr<const Logger> m_logger;
     bool m_setupArbitrationOngoing { false };
 };
 

--- a/Source/WebKit/GPUProcess/mac/LocalAudioSessionRoutingArbitrator.cpp
+++ b/Source/WebKit/GPUProcess/mac/LocalAudioSessionRoutingArbitrator.cpp
@@ -29,6 +29,8 @@
 #include "GPUConnectionToWebProcess.h"
 #include "GPUProcess.h"
 #include "GPUProcessConnectionMessages.h"
+#include "Logging.h"
+#include <wtf/LoggerHelper.h>
 
 #if ENABLE(ROUTING_ARBITRATION) && HAVE(AVAUDIO_ROUTING_ARBITER)
 
@@ -43,6 +45,7 @@ UniqueRef<LocalAudioSessionRoutingArbitrator> LocalAudioSessionRoutingArbitrator
 
 LocalAudioSessionRoutingArbitrator::LocalAudioSessionRoutingArbitrator(GPUConnectionToWebProcess& gpuConnectionToWebProcess)
     : m_connectionToWebProcess(gpuConnectionToWebProcess)
+    , m_logIdentifier(LoggerHelper::uniqueLogIdentifier())
 {
 }
 
@@ -55,12 +58,28 @@ void LocalAudioSessionRoutingArbitrator::processDidTerminate()
 
 void LocalAudioSessionRoutingArbitrator::beginRoutingArbitrationWithCategory(AudioSession::CategoryType category, CompletionHandler<void(RoutingArbitrationError, DefaultRouteChanged)>&& callback)
 {
+    ALWAYS_LOG(LOGIDENTIFIER, category);
     m_connectionToWebProcess.connection().sendWithAsyncReply(Messages::GPUProcessConnection::BeginRoutingArbitrationWithCategory(category), WTFMove(callback), 0);
 }
 
 void LocalAudioSessionRoutingArbitrator::leaveRoutingAbritration()
 {
     m_connectionToWebProcess.connection().send(Messages::GPUProcessConnection::EndRoutingArbitration(), 0);
+}
+
+Logger& LocalAudioSessionRoutingArbitrator::logger()
+{
+    return m_connectionToWebProcess.logger();
+};
+
+WTFLogChannel& LocalAudioSessionRoutingArbitrator::logChannel() const
+{
+    return WebKit2LogMedia;
+}
+
+bool LocalAudioSessionRoutingArbitrator::canLog() const
+{
+    return m_connectionToWebProcess.sessionID().isAlwaysOnLoggingAllowed();
 }
 
 }

--- a/Source/WebKit/GPUProcess/mac/LocalAudioSessionRoutingArbitrator.h
+++ b/Source/WebKit/GPUProcess/mac/LocalAudioSessionRoutingArbitrator.h
@@ -29,6 +29,10 @@
 
 #include "AudioSessionRoutingArbitratorProxy.h"
 
+namespace WTF {
+class Logger;
+}
+
 namespace WebKit {
 
 class GPUConnectionToWebProcess;
@@ -53,7 +57,14 @@ private:
     void beginRoutingArbitrationWithCategory(WebCore::AudioSession::CategoryType, ArbitrationCallback&&) final;
     void leaveRoutingAbritration() final;
 
+    Logger& logger();
+    const char* logClassName() const { return "LocalAudioSessionRoutingArbitrator"; }
+    WTFLogChannel& logChannel() const;
+    const void* logIdentifier() const final { return m_logIdentifier; }
+    bool canLog() const final;
+
     GPUConnectionToWebProcess& m_connectionToWebProcess;
+    const void* m_logIdentifier;
 };
 
 }

--- a/Source/WebKit/UIProcess/Media/AudioSessionRoutingArbitratorProxy.cpp
+++ b/Source/WebKit/UIProcess/Media/AudioSessionRoutingArbitratorProxy.cpp
@@ -25,15 +25,21 @@
 
 #include "config.h"
 #include "AudioSessionRoutingArbitratorProxy.h"
+#include "Logging.h"
+#include "WebProcessProxy.h"
+#include <wtf/LoggerHelper.h>
 
-#if ENABLE(ROUTING_ARBITRATION) && !HAVE(AVAUDIO_ROUTING_ARBITER)
+#if ENABLE(ROUTING_ARBITRATION)
 
 #include "AudioSessionRoutingArbitratorProxyMessages.h"
 
 namespace WebKit {
 
+#if !HAVE(AVAUDIO_ROUTING_ARBITER)
+
 AudioSessionRoutingArbitratorProxy::AudioSessionRoutingArbitratorProxy(WebProcessProxy& proxy)
     : m_process(proxy)
+    , m_logIdentifier(LoggerHelper::uniqueLogIdentifier())
 {
     notImplemented();
 }
@@ -59,6 +65,18 @@ void AudioSessionRoutingArbitratorProxy::endRoutingArbitration()
     notImplemented();
 }
 
+#endif // ENABLE(AVAUDIO_ROUTING_ARBITER)
+
+Logger& AudioSessionRoutingArbitratorProxy::logger()
+{
+    return m_process.logger();
 }
 
-#endif
+WTFLogChannel& AudioSessionRoutingArbitratorProxy::logChannel() const
+{
+    return WebKit2LogMedia;
+}
+
+}
+
+#endif // ENABLE(ROUTING_ARBITRATION)

--- a/Source/WebKit/UIProcess/Media/AudioSessionRoutingArbitratorProxy.h
+++ b/Source/WebKit/UIProcess/Media/AudioSessionRoutingArbitratorProxy.h
@@ -65,6 +65,12 @@ public:
     ArbitrationStatus arbitrationStatus() const { return m_arbitrationStatus; }
     WallTime arbitrationUpdateTime() const { return m_arbitrationUpdateTime; }
 
+protected:
+    Logger& logger();
+    const void* logIdentifier() const { return m_logIdentifier; }
+    const char* logClassName() const { return "AudioSessionRoutingArbitrator"; }
+    WTFLogChannel& logChannel() const;
+
 private:
     // IPC::MessageReceiver
     void didReceiveMessage(IPC::Connection&, IPC::Decoder&) final;
@@ -77,6 +83,7 @@ private:
     WebCore::AudioSession::CategoryType m_category { WebCore::AudioSession::CategoryType::None };
     ArbitrationStatus m_arbitrationStatus { ArbitrationStatus::None };
     WallTime m_arbitrationUpdateTime;
+    const void* m_logIdentifier;
 
 #if HAVE(AVAUDIO_ROUTING_ARBITER)
     UniqueRef<WebCore::SharedRoutingArbitrator::Token> m_token;

--- a/Source/WebKit/UIProcess/Media/cocoa/AudioSessionRoutingArbitratorProxyCocoa.mm
+++ b/Source/WebKit/UIProcess/Media/cocoa/AudioSessionRoutingArbitratorProxyCocoa.mm
@@ -42,6 +42,8 @@ AudioSessionRoutingArbitratorProxy::AudioSessionRoutingArbitratorProxy(WebProces
     : m_process(proxy)
     , m_token(SharedRoutingArbitrator::Token::create())
 {
+    m_logIdentifier = m_token->logIdentifier();
+    SharedRoutingArbitrator::sharedInstance().setLogger(logger());
     m_process.addMessageReceiver(Messages::AudioSessionRoutingArbitratorProxy::messageReceiverName(), destinationId(), *this);
 }
 
@@ -58,10 +60,14 @@ void AudioSessionRoutingArbitratorProxy::processDidTerminate()
 
 void AudioSessionRoutingArbitratorProxy::beginRoutingArbitrationWithCategory(WebCore::AudioSession::CategoryType category, ArbitrationCallback&& callback)
 {
+    auto identifier = LOGIDENTIFIER;
+    ALWAYS_LOG(identifier, category);
+
     m_category = category;
     m_arbitrationStatus = ArbitrationStatus::Pending;
     m_arbitrationUpdateTime = WallTime::now();
-    SharedRoutingArbitrator::sharedInstance().beginRoutingArbitrationForToken(m_token, category, [weakThis = WeakPtr { *this }, callback = WTFMove(callback)] (RoutingArbitrationError error, DefaultRouteChanged routeChanged) mutable {
+    SharedRoutingArbitrator::sharedInstance().beginRoutingArbitrationForToken(m_token, category, [this, weakThis = WeakPtr { *this }, callback = WTFMove(callback), identifier = WTFMove(identifier)] (RoutingArbitrationError error, DefaultRouteChanged routeChanged) mutable {
+        ALWAYS_LOG(identifier, "callback, error = ", error, ", routeChanged = ", routeChanged);
         if (weakThis)
             weakThis->m_arbitrationStatus = error == RoutingArbitrationError::None ? ArbitrationStatus::Active : ArbitrationStatus::None;
         callback(error, routeChanged);
@@ -70,6 +76,7 @@ void AudioSessionRoutingArbitratorProxy::beginRoutingArbitrationWithCategory(Web
 
 void AudioSessionRoutingArbitratorProxy::endRoutingArbitration()
 {
+    ALWAYS_LOG(LOGIDENTIFIER);
     SharedRoutingArbitrator::sharedInstance().endRoutingArbitrationForToken(m_token);
     m_arbitrationStatus = ArbitrationStatus::None;
 }

--- a/Source/WebKit/UIProcess/WebProcessProxy.h
+++ b/Source/WebKit/UIProcess/WebProcessProxy.h
@@ -490,6 +490,8 @@ public:
     static void permissionChanged(WebCore::PermissionName, const WebCore::SecurityOriginData&);
     void sendPermissionChanged(WebCore::PermissionName, const WebCore::SecurityOriginData&);
 
+    Logger& logger();
+
 protected:
     WebProcessProxy(WebProcessPool&, WebsiteDataStore*, IsPrewarmed, WebCore::CrossOriginMode, LockdownMode);
 
@@ -673,10 +675,6 @@ private:
     DisplayLinkProcessProxyClient m_displayLinkClient;
 #endif
 
-#if ENABLE(ROUTING_ARBITRATION)
-    UniqueRef<AudioSessionRoutingArbitratorProxy> m_routingArbitrator;
-#endif
-
 #if PLATFORM(COCOA)
     bool m_hasSentMessageToUnblockAccessibilityServer { false };
 #endif
@@ -759,6 +757,9 @@ private:
 #endif
     std::unique_ptr<WebLockRegistryProxy> m_webLockRegistry;
     std::unique_ptr<WebPermissionControllerProxy> m_webPermissionController;
+#if ENABLE(ROUTING_ARBITRATION)
+    UniqueRef<AudioSessionRoutingArbitratorProxy> m_routingArbitrator;
+#endif
     bool m_isConnectedToHardwareConsole { true };
 #if PLATFORM(MAC)
     bool m_platformSuspendDidReleaseNearSuspendedAssertion { false };

--- a/Source/WebKit/WebProcess/cocoa/AudioSessionRoutingArbitrator.cpp
+++ b/Source/WebKit/WebProcess/cocoa/AudioSessionRoutingArbitrator.cpp
@@ -32,6 +32,7 @@
 #include "AudioSessionRoutingArbitratorProxyMessages.h"
 #include "WebConnectionToUIProcess.h"
 #include "WebProcess.h"
+#include <wtf/LoggerHelper.h>
 
 namespace WebKit {
 
@@ -40,6 +41,7 @@ using namespace WebCore;
 AudioSessionRoutingArbitrator::AudioSessionRoutingArbitrator(WebProcess& process)
     : m_process(process)
     , m_observer([this] (AudioSession& session) { session.setRoutingArbitrationClient(*this); })
+    , m_logIdentifier(LoggerHelper::uniqueLogIdentifier())
 {
     AudioSession::addAudioSessionChangedObserver(m_observer);
 }
@@ -59,6 +61,11 @@ void AudioSessionRoutingArbitrator::beginRoutingArbitrationWithCategory(AudioSes
 void AudioSessionRoutingArbitrator::leaveRoutingAbritration()
 {
     m_process.parentProcessConnection()->send(Messages::AudioSessionRoutingArbitratorProxy::EndRoutingArbitration(), AudioSessionRoutingArbitratorProxy::destinationId());
+}
+
+bool AudioSessionRoutingArbitrator::canLog() const
+{
+    return m_process.sessionID().isAlwaysOnLoggingAllowed();
 }
 
 }

--- a/Source/WebKit/WebProcess/cocoa/AudioSessionRoutingArbitrator.h
+++ b/Source/WebKit/WebProcess/cocoa/AudioSessionRoutingArbitrator.h
@@ -52,8 +52,12 @@ public:
     void leaveRoutingAbritration() final;
 
 private:
+    const void* logIdentifier() const final { return m_logIdentifier; }
+    bool canLog() const final;
+
     WebProcess& m_process;
     WebCore::AudioSession::ChangedObserver m_observer;
+    const void* m_logIdentifier;
 };
 
 }


### PR DESCRIPTION
#### cd551880cee9f2657d8d315d51eea9ac9c40d73e
<pre>
Add runtime logging to AudioSession and related classes
<a href="https://bugs.webkit.org/show_bug.cgi?id=257431">https://bugs.webkit.org/show_bug.cgi?id=257431</a>
rdar://109934372

Reviewed by Youenn Fablet.

* Source/WebCore/platform/audio/AudioSession.cpp:
(WebCore::AudioSession::tryToSetActive):
(WebCore::AudioSession::beginInterruption):
(WebCore::AudioSession::endInterruption):
(WebCore::AudioSession::setCategoryOverride):
(WebCore::AudioSession::logger):
(WebCore::AudioSession::logChannel const):
* Source/WebCore/platform/audio/AudioSession.h:
* Source/WebCore/platform/audio/ios/AudioSessionIOS.mm:
(WebCore::AudioSessionIOS::setHostProcessAttribution):
(WebCore::AudioSessionIOS::setPresentingProcesses):
(WebCore::AudioSessionIOS::setCategory):
(WebCore::AudioSessionIOS::setPreferredBufferSize):
* Source/WebCore/platform/audio/mac/AudioSessionMac.h:
* Source/WebCore/platform/audio/mac/AudioSessionMac.mm:
(WebCore::AudioSessionMac::audioOutputDeviceChanged):
(WebCore::AudioSessionMac::setIsPlayingToBluetoothOverride):
(WebCore::AudioSessionMac::setCategory):
(WebCore::AudioSessionMac::setPreferredBufferSize):
(WebCore::AudioSessionMac::logChannel const):
(WebCore::AudioSessionMac::logIdentifier const):
* Source/WebCore/platform/audio/mac/SharedRoutingArbitrator.h:
* Source/WebCore/platform/audio/mac/SharedRoutingArbitrator.mm:
(WebCore::SharedRoutingArbitrator::Token::logIdentifier const):
(WebCore::SharedRoutingArbitrator::beginRoutingArbitrationForToken):
(WebCore::SharedRoutingArbitrator::endRoutingArbitrationForToken):
(WebCore::SharedRoutingArbitrator::setLogger):
(WebCore::SharedRoutingArbitrator::logger):
(WebCore::SharedRoutingArbitrator::logChannel const):
* Source/WebKit/GPUProcess/mac/LocalAudioSessionRoutingArbitrator.cpp:
(WebKit::LocalAudioSessionRoutingArbitrator::LocalAudioSessionRoutingArbitrator):
(WebKit::LocalAudioSessionRoutingArbitrator::beginRoutingArbitrationWithCategory):
(WebKit::LocalAudioSessionRoutingArbitrator::logger):
(WebKit::LocalAudioSessionRoutingArbitrator::logChannel const):
(WebKit::LocalAudioSessionRoutingArbitrator::canLog const):
* Source/WebKit/GPUProcess/mac/LocalAudioSessionRoutingArbitrator.h:
* Source/WebKit/UIProcess/Media/AudioSessionRoutingArbitratorProxy.cpp:
(WebKit::AudioSessionRoutingArbitratorProxy::AudioSessionRoutingArbitratorProxy):
(WebKit::AudioSessionRoutingArbitratorProxy::logger):
(WebKit::AudioSessionRoutingArbitratorProxy::logChannel const):
* Source/WebKit/UIProcess/Media/AudioSessionRoutingArbitratorProxy.h:
(WebKit::AudioSessionRoutingArbitratorProxy::logIdentifier const):
(WebKit::AudioSessionRoutingArbitratorProxy::logClassName const):
* Source/WebKit/UIProcess/Media/cocoa/AudioSessionRoutingArbitratorProxyCocoa.mm:
(WebKit::AudioSessionRoutingArbitratorProxy::AudioSessionRoutingArbitratorProxy):
(WebKit::AudioSessionRoutingArbitratorProxy::beginRoutingArbitrationWithCategory):
(WebKit::AudioSessionRoutingArbitratorProxy::endRoutingArbitration):
* Source/WebKit/UIProcess/WebProcessProxy.cpp:
(WebKit::WebProcessProxy::WebProcessProxy):
(WebKit::m_routingArbitrator):
(WebKit::WebProcessProxy::setWebsiteDataStore):
(WebKit::WebProcessProxy::logger):
(WebKit::m_webPermissionController): Deleted.
* Source/WebKit/UIProcess/WebProcessProxy.h:
* Source/WebKit/WebProcess/cocoa/AudioSessionRoutingArbitrator.cpp:
(WebKit::m_logIdentifier):
(WebKit::AudioSessionRoutingArbitrator::canLog const):
* Source/WebKit/WebProcess/cocoa/AudioSessionRoutingArbitrator.h:

Canonical link: <a href="https://commits.webkit.org/264658@main">https://commits.webkit.org/264658@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/19da6f56d2b59d6281d6f6a16d56af0843105d3e

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/8241 "4 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/8533 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/8750 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/9908 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/8307 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/8250 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/10521 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/8444 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/11182 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/8386 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/9452 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/7474 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/10053 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/6751 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/7539 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/15099 "2 flakes 114 failures") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/7874 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/7671 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/11029 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/8146 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/6626 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/7436 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/1989 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/11644 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/7887 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->