### PR TITLE
Handle multiple fragments in the getCharNumberAtPosition SVGTextQuery

### DIFF
--- a/LayoutTests/svg/text/getcharnumatposition-multiple-fragments-expected.txt
+++ b/LayoutTests/svg/text/getcharnumatposition-multiple-fragments-expected.txt
@@ -1,0 +1,4 @@
+AAAA
+
+PASS SVGTextContentElement.getCharNumAtPosition w/ multiple fragments per text box.
+

--- a/LayoutTests/svg/text/getcharnumatposition-multiple-fragments.html
+++ b/LayoutTests/svg/text/getcharnumatposition-multiple-fragments.html
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<script src="../../resources/testharness.js"></script>
+<script src="../../resources/testharnessreport.js"></script>
+<svg height="0">
+  <defs><path id="p" d="M0,20h100"/></defs>
+  <text y="20" font-size="20" font-family="Ahem"><textPath xlink:href="#p">AAAA</textPath></text>
+</svg>
+<script>
+test(function() {
+  var text = document.querySelector('text');
+  var extents = text.getExtentOfChar(0);
+  var point = document.querySelector('svg').createSVGPoint();
+  point.x = extents.width / 2;
+  point.y = 10;
+  for (var i = 0; i < 4; ++i) {
+    assert_equals(text.getCharNumAtPosition(point), i);
+
+    point.x += extents.width;
+  }
+}, 'SVGTextContentElement.getCharNumAtPosition w/ multiple fragments per text box.');
+</script>

--- a/Source/WebCore/rendering/svg/SVGTextQuery.cpp
+++ b/Source/WebCore/rendering/svg/SVGTextQuery.cpp
@@ -1,5 +1,6 @@
 /*
  * Copyright (C) Research In Motion Limited 2010-2012. All rights reserved.
+ * Copyright (C) 2014 Google Inc. All rights reserved.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Library General Public
@@ -521,16 +522,19 @@ bool SVGTextQuery::characterNumberAtPositionCallback(Data* queryData, const SVGT
 {
     CharacterNumberAtPositionData* data = static_cast<CharacterNumberAtPositionData*>(queryData);
 
+    // Offset of the fragment within the text box.
+    unsigned boxOffset = fragment.characterOffset - queryData->textBox->start();
+
     FloatRect extent;
     for (unsigned i = 0; i < fragment.length; ++i) {
-        unsigned startPosition = data->processedCharacters + i;
+        unsigned startPosition = data->processedCharacters + boxOffset + i;
         unsigned endPosition = startPosition + 1;
         if (!mapStartEndPositionsIntoFragmentCoordinates(queryData, fragment, startPosition, endPosition))
             continue;
 
         calculateGlyphBoundaries(queryData, fragment, startPosition, extent);
         if (extent.contains(data->position)) {
-            data->processedCharacters += i;
+            data->processedCharacters += i + boxOffset;
             return true;
         }
     }


### PR DESCRIPTION
#### c01e3bafb0da4100588fd6c68b0752393d706a24
<pre>
Handle multiple fragments in the getCharNumberAtPosition SVGTextQuery

<a href="https://bugs.webkit.org/show_bug.cgi?id=257429">https://bugs.webkit.org/show_bug.cgi?id=257429</a>

Reviewed by Simon Fraser.

This patch aligns WebKit with Blink / Chromium and Gecko / Firefox.

Merge: <a href="https://src.chromium.org/viewvc/blink?view=revision&amp">https://src.chromium.org/viewvc/blink?view=revision&amp</a>;revision=176936

The start position (and thus indirectly end position) used to compute the
extents of a glyph to check against the point is computed based on the
&apos;processedCharacter&apos; query data state. Following state is only updated after
each text box has been processed, meaning that for a text box with
multiple fragments, the offset of the fragment within the box needs to be
included to get the correct start/end position.

* Source/WebCore/rendering/svg/SVGTextQuery.cpp:
(SVGTextQuery::characterNumberAtPositionCallback): As above
* LayoutTests/svg/text/getcharnumatposition-multiple-fragments.html: Add Test Case
* LayoutTests/svg/text/getcharnumatposition-multiple-fragments-expected.txt: Add Test Case Expectation

Canonical link: <a href="https://commits.webkit.org/264796@main">https://commits.webkit.org/264796@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/863d265df4d9730aa445b836486785da3608c7fb

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/8204 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/8496 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/8713 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/9871 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/8270 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/8213 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/10484 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/8407 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/11147 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/8349 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/9414 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/7442 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/10016 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/6714 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/7507 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/15063 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/7837 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/7637 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/10994 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/8109 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/6592 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/7400 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/7419 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/2101 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/11607 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/7850 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->