### PR TITLE
Improve comparison of intervals in SVGSMILElement::resolveFirstInterval

### DIFF
--- a/Source/WebCore/svg/animation/SMILTime.h
+++ b/Source/WebCore/svg/animation/SMILTime.h
@@ -1,5 +1,6 @@
 /*
  * Copyright (C) 2008 Apple Inc. All rights reserved.
+ * Copyright (C) 2014 Google Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -81,6 +82,18 @@ private:
     Origin m_origin;
 };
 
+struct SMILInterval {
+    SMILInterval() { }
+    SMILInterval(const SMILTime& begin, const SMILTime& end)
+        : begin(begin)
+        , end(end)
+        {
+        }
+
+    SMILTime begin;
+    SMILTime end;
+};
+
 inline bool operator==(const SMILTime& a, const SMILTime& b) { return a.isFinite() && a.value() == b.value(); }
 inline bool operator!(const SMILTime& a) { return !a.isFinite() || !a.value(); }
 inline bool operator>(const SMILTime& a, const SMILTime& b) { return a.value() > b.value(); }
@@ -93,5 +106,12 @@ SMILTime operator+(const SMILTime&, const SMILTime&);
 SMILTime operator-(const SMILTime&, const SMILTime&);
 // So multiplying times does not make too much sense but SMIL defines it for duration * repeatCount
 SMILTime operator*(const SMILTime&, const SMILTime&);
+
+inline bool operator!=(const SMILInterval& a, const SMILInterval& b)
+{
+    // Compare the "raw" values since the operator!= for SMILTime always return
+    // true for non-finite times.
+    return a.begin.value() != b.begin.value() || a.end.value() != b.end.value();
+}
 
 } // namespace WebCore

--- a/Source/WebCore/svg/animation/SVGSMILElement.cpp
+++ b/Source/WebCore/svg/animation/SVGSMILElement.cpp
@@ -882,15 +882,14 @@ void SVGSMILElement::resolveInterval(bool first, SMILTime& beginResult, SMILTime
     
 void SVGSMILElement::resolveFirstInterval()
 {
-    SMILTime begin;
-    SMILTime end;
-    resolveInterval(true, begin, end);
-    ASSERT(!begin.isIndefinite());
+    SMILInterval firstInterval;
+    resolveInterval(true, firstInterval.begin, firstInterval.end);
+    ASSERT(!firstInterval.begin.isIndefinite());
 
-    if (!begin.isUnresolved() && (begin != m_intervalBegin || end != m_intervalEnd)) {   
+    if (!firstInterval.begin.isUnresolved() && firstInterval != SMILInterval(m_intervalBegin, m_intervalEnd)) {
         bool wasUnresolved = m_intervalBegin.isUnresolved();
-        m_intervalBegin = begin;
-        m_intervalEnd = end;
+        m_intervalBegin = firstInterval.begin;
+        m_intervalEnd = firstInterval.end;
         notifyDependentsIntervalChanged(wasUnresolved ? NewInterval : ExistingInterval);
         m_nextProgressTime = std::min(m_nextProgressTime, m_intervalBegin);
 


### PR DESCRIPTION
<pre>
Improve comparison of intervals in SVGSMILElement::resolveFirstInterval
<a href="https://bugs.webkit.org/show_bug.cgi?id=250481">https://bugs.webkit.org/show_bug.cgi?id=250481</a>
rdar://104399900

Reviewed by NOBODY (OOPS!).

Merge: <a href="https://src.chromium.org/viewvc/blink?revision=175122&view=revision">https://src.chromium.org/viewvc/blink?revision=175122&view=revision</a>

For open-ended intervals such as [3) - i.e. begin=3s and end/duration/etc
unspecified - every call to resolveFirstInterval() would think that a new
interval had been created, and notify/require a reschedule of the
animations.
Add a new type SMILInterval and a suitable operator for that, and then
use it to compare the raw values (i.e. if both endpoints are exacly the same.)

This patch does not change behavior but reduces call to 'resolveFirstInterval' 
function. Hence, no new tests added.

* Source/WebCore/svg/animation/SVGSMILElement.cpp:
(SVGSMILElement::resolveFirstInterval):
* Source/WebCore/svg/animation/SMILTime.h:
(1) Add new 'Struct' of 'SMILInterval'
(2) New 'operator' function

</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/75e31f4ce4332434b0913513aedb94a7736b1097

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/8207 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/8499 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/8716 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/9874 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/8273 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/8216 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/10487 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/8410 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/11150 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/8352 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/9417 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/7445 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/10019 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/6717 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/7510 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/15065 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/7840 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/7640 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/10996 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/8112 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/6594 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/7403 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/11610 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/7853 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->