### PR TITLE
[JSC] ASSERTION FAILED: term.quantityMinCount == 1 && term.quantityMaxCount == 1 && term.quantityType == QuantifierType::FixedCount

### DIFF
--- a/JSTests/stress/regexp-vflag-property-of-strings.js
+++ b/JSTests/stress/regexp-vflag-property-of-strings.js
@@ -370,122 +370,139 @@ testRegExpSyntaxError("[&&-", "v", "SyntaxError: Invalid regular expression: inv
 
 // Test 151
 testRegExpSyntaxError("[--&", "v", "SyntaxError: Invalid regular expression: invalid operation in class set");
+testRegExpSyntaxError("a?[^\\q{ab}]", "v", "SyntaxError: Invalid regular expression: negated class set may contain strings");
+testRegExpSyntaxError("a?[^\\q{ab}]?", "v", "SyntaxError: Invalid regular expression: negated class set may contain strings");
+testRegExpSyntaxError("a?[^\\q{ab}]*", "v", "SyntaxError: Invalid regular expression: negated class set may contain strings");
+testRegExpSyntaxError("a?[^\\q{ab}]+", "v", "SyntaxError: Invalid regular expression: negated class set may contain strings");
+
+// Test 156
+testRegExpSyntaxError("a?[^\\q{ab}]{1,3}", "v", "SyntaxError: Invalid regular expression: negated class set may contain strings");
 testRegExp(/[\p{ASCII}&&\&]/v, "a&b", ["&"]);
 testRegExp(/[\p{ASCII}&&\-]/v, "a-b", ["-"]);
 testRegExp(/[\p{ASCII}--\&]/v, "&b", ["b"]);
 testRegExp(/[\p{ASCII}--&]/v, "&b", ["b"]);
 
-// Test 156
+// Test 161
 testRegExp(/[\p{ASCII}--\-]/v, "-b", ["b"]);
 testRegExp(/[\p{RGI_Emoji_Tag_Sequence}a]/, "a", ["a"]);
 testRegExp(/[\p{RGI_Emoji_Tag_Sequence}a]/v, "a", ["a"]);
 testRegExp(/(?:\u{1f3f4}\u{e0067}\u{e0062}\u{e0065}\u{e006e}\u{e0067}\u{e007F}|\u{1f3f4}\u{e0067}\u{e0062}\u{e0073}\u{e0063}\u{e0074}\u{e007f}|\u{1f3f4}\u{e0067}\u{e0062}\u{e0077}\u{e006C}\u{e0073}\u{e007F}|[a])/v, "\u{1f3f4}\u{e0067}\u{e0062}\u{e0073}\u{e0063}\u{e0074}\u{e007f}", ["\u{1f3f4}\u{e0067}\u{e0062}\u{e0073}\u{e0063}\u{e0074}\u{e007f}"]);
 testRegExp(/[\p{RGI_Emoji_Tag_Sequence}a]/v, "\u{1f3f4}\u{e0067}\u{e0062}\u{e0073}\u{e0063}\u{e0074}\u{e007f}", ["\u{1f3f4}\u{e0067}\u{e0062}\u{e0073}\u{e0063}\u{e0074}\u{e007f}"]);
 
-// Test 161
+// Test 166
 testRegExp(/[a\p{RGI_Emoji_Tag_Sequence}]/v, "a", ["a"]);
 testRegExp(/[\p{RGI_Emoji_Tag_Sequence}\q{\u{1f1fa}\u{1f1f8}}]/v, "\u{1f3f4}\u{e0067}\u{e0062}\u{e0073}\u{e0063}\u{e0074}\u{e007f}", ["\u{1f3f4}\u{e0067}\u{e0062}\u{e0073}\u{e0063}\u{e0074}\u{e007f}"]);
 testRegExp(/[\p{RGI_Emoji_Tag_Sequence}\q{\u{1f1fa}\u{1f1f8}}]/v, "\u{1f1fa}\u{1f1f8}", ["\u{1f1fa}\u{1f1f8}"]);
 testRegExp(/[\p{RGI_Emoji_Tag_Sequence}\q{\u{1f1fa}\u{1f1f8}}]/v, "a", null);
 testRegExp(/[\q{\u{1f1fa}\u{1f1f8}}a]/v, "a", ["a"]);
 
-// Test 166
+// Test 171
 testRegExp(/[\q{\u{1f1fa}\u{1f1f8}}a]/v, "\u{1f1fa}\u{1f1f8}", ["\u{1f1fa}\u{1f1f8}"]);
 testRegExp(/[\q{\u{1f1fa}}\q{\u{1f1fa}\u{1f1f8}}]/v, "\u{1f1fa}\u{1f1f8}", ["\u{1f1fa}\u{1f1f8}"]);
 testRegExp(/[\q{\u{1f3f4}\u{e0067}\u{e0062}\u{e0073}\u{e0063}\u{e0074}}\p{RGI_Emoji_Tag_Sequence}]/v, "\u{1f3f4}\u{e0067}\u{e0062}\u{e0073}\u{e0063}\u{e0074}\u{e007f}", ["\u{1f3f4}\u{e0067}\u{e0062}\u{e0073}\u{e0063}\u{e0074}\u{e007f}"]);
 testRegExp(/[\p{RGI_Emoji_Tag_Sequence}[\q{\u{1f1fa}\u{1f1f8}}a]]/v, "\u{1f1fa}\u{1f1f8}", ["\u{1f1fa}\u{1f1f8}"]);
 testRegExp(/[\p{RGI_Emoji_Tag_Sequence}[\q{\u{1f1fa}\u{1f1f8}}a]]/v, "a", ["a"]);
 
-// Test 171
+// Test 176
 testRegExp(/[b-z[a]]/v, "a", ["a"]);
 testRegExp(/[[a-z]--k]/v, "a", ["a"]);
 testRegExp(/[\p{RGI_Emoji_Tag_Sequence}--\q{\u{1F3f4}\u{e0067}\u{e0062}\u{e0077}\u{e006c}\u{e0073}\u{e007f}}]/v, "\u{1f3f4}\u{e0067}\u{e0062}\u{e0073}\u{e0063}\u{e0074}\u{e007f}", ["\u{1f3f4}\u{e0067}\u{e0062}\u{e0073}\u{e0063}\u{e0074}\u{e007f}"]);
 testRegExp(/[a-z\q{X}]/v, "X", ["X"]);
 testRegExp(/[[a-z]--\q{k}]/v, "a", ["a"]);
 
-// Test 176
+// Test 181
 testRegExp(/[\p{RGI_Emoji_Tag_Sequence}\q{\u{1f1fa}\u{1f1f8}|abc|a|\u{1f1fa}}]/v, "a", ["a"]);
 testRegExp(/[\p{RGI_Emoji_Tag_Sequence}--\q{\u{1f3f4}\u{e0067}\u{e0062}\u{e0073}\u{e0063}\u{e0074}\u{e007f}}]/v, "\u{1f3f4}\u{e0067}\u{e0062}\u{e0073}\u{e0063}\u{e0074}\u{e007f}", null);
 testRegExp(/[\p{RGI_Emoji_Tag_Sequence}--\q{\u{1f3f4}\u{e0067}\u{e0062}\u{e0073}\u{e0063}\u{e0074}\u{e007f}}]/v, "\u{1f3f4}\u{e0067}\u{e0062}\u{e0077}\u{e006c}\u{e0073}\u{e007f}", ["\u{1f3f4}\u{e0067}\u{e0062}\u{e0077}\u{e006c}\u{e0073}\u{e007f}"]);
 testRegExp(/[\p{RGI_Emoji_Tag_Sequence}&&\q{\u{1f3f4}\u{e0067}\u{e0062}\u{e0073}\u{e0063}\u{e0074}\u{e007f}}]/v, "\u{1f3f4}\u{e0067}\u{e0062}\u{e0073}\u{e0063}\u{e0074}\u{e007f}", ["\u{1f3f4}\u{e0067}\u{e0062}\u{e0073}\u{e0063}\u{e0074}\u{e007f}"]);
 testRegExp(/[\p{RGI_Emoji_Tag_Sequence}&&\q{\u{1f3f4}\u{e0067}\u{e0062}\u{e0073}\u{e0063}\u{e0074}\u{e007f}}]/v, "\u{1f3f4}\u{e0067}\u{e0062}\u{e0077}\u{e006c}\u{e0073}\u{e007f}", null);
 
-// Test 181
+// Test 186
 testRegExp(/[[a-z]&&\q{a|e|i|o|u|X|Y|Z}]/v, "a", ["a"]);
 testRegExp(/[\p{White_Space}&&\p{ASCII}]/v, " ", [" "]);
 testRegExp(/[\p{White_Space}&&\p{ASCII}]/v, "\u2028", null);
 testRegExp(/[\p{White_Space}--\p{ASCII}]/v, " ", null);
 testRegExp(/[\p{White_Space}--\p{ASCII}]/v, "\u2028", ["\u2028"]);
 
-// Test 186
+// Test 191
 testRegExp(/^[[0-9]&&\d]+$/v, "0", ["0"]);
 testRegExp(/^[_--[0-9]]+$/v, "_", ["_"]);
 testRegExp(/[[a-z]--[a]]/v, "a", null);
 testRegExp(/^\p{RGI_Emoji_Flag_Sequence}+$/v, "\u{1F1E6}\u{1F1E8}", ["\u{1F1E6}\u{1F1E8}"]);
 testRegExp(/^\p{RGI_Emoji_Flag_Sequence}+$/v, "\u{1F1E6}\u{1F1E8}\u{1f1e7}\u{1f1f1}", ["\u{1f1e6}\u{1f1e8}\u{1f1e7}\u{1f1f1}"]);
 
-// Test 191
+// Test 196
 testRegExp(/^\p{RGI_Emoji_Flag_Sequence}+$/v, "\u{1f1f9}\u{1f1ef}\u{1F1E6}\u{1F1E8}\u{1f1f9}\u{1f1f7}", ["\u{1f1f9}\u{1f1ef}\u{1F1E6}\u{1F1E8}\u{1f1f9}\u{1f1f7}"]);
 testRegExp(/^\p{Emoji_Keycap_Sequence}+$/v, "#\u{fe0f}\u{20e3}", ["#\u{fe0f}\u{20e3}"]);
 testRegExp(/^\p{RGI_Emoji}+$/v, "#\u{fe0f}\u{20e3}", ["#\u{fe0f}\u{20e3}"]);
 testRegExp(/[a\(\)]+/v, "a()", ["a()"]);
 testRegExp(/[a\q{\(\)}]{2}/v, "()a()", ["()a"]);
 
-// Test 196
+// Test 201
 testRegExp(/[a\q{\(\)}]+/v, "()a()", ["()a()"]);
 testRegExp(/[a\q{\=\=}]+/v, "==a==", ["==a=="]);
 testRegExp(/[\q{\u{3373}}\q{\u{1813}}\q{\u{0250}}a]/v, "a", ["a"]);
 testRegExp(/[\q{\u{3373}}\q{\u{1813}}\q{\u{0250}}a]/v, "\u{0250}", ["\u{0250}"]);
 testRegExp(/[\q{\u{3373}}\q{\u{1813}}\q{\u{0250}}a]/v, "\u{1813}", ["\u{1813}"]);
 
-// Test 201
+// Test 206
 testRegExp(/[\q{\u{3373}}\q{\u{1813}}\q{\u{0250}}a]/v, "\u{3373}", ["\u{3373}"]);
 testRegExp(/[[\u{0250}-\u{3373}a]--[\q{\u{3373}}\q{\u{1813}}\q{\u{0250}}]]/v, "a", ["a"]);
 testRegExp(/[[\u{0250}-\u{3373}a]--[\q{\u{3373}}\q{\u{1813}}\q{\u{0250}}]]/v, "\u{0250}", null);
 testRegExp(/[[\u{0250}-\u{3373}a]--[\q{\u{3373}}\q{\u{1813}}\q{\u{0250}}]]/v, "\u{1813}", null);
 testRegExp(/[[\u{0250}-\u{3373}a]--[\q{\u{3373}}\q{\u{1813}}\q{\u{0250}}]]/v, "\u{3373}", null);
 
-// Test 206
+// Test 211
 testRegExp(/[[\u{0250}-\u{3373}a]--[\q{\u{3373}}\q{\u{1813}}a]]/v, "a", null);
 testRegExp(/[[\u{0250}-\u{3373}a]--[\q{\u{3373}}\q{\u{1813}}a]]/v, "\u{0250}", ["\u{0250}"]);
 testRegExp(/[[\u{0250}-\u{3373}a]--[\q{\u{3373}}\q{\u{1813}}a]]/v, "\u{1813}", null);
 testRegExp(/[[\u{0250}-\u{3373}a]--[\q{\u{3373}}\q{\u{1813}}a]]/v, "\u{3373}", null);
 testRegExp(/[[\u{0250}-\u{3373}a]--[\q{\u{3373}}\q{\u{0250}}a]]/v, "a", null);
 
-// Test 211
+// Test 216
 testRegExp(/[[\u{0250}-\u{3373}a]--[\q{\u{3373}}\q{\u{0250}}a]]/v, "\u{0250}", null);
 testRegExp(/[[\u{0250}-\u{3373}a]--[\q{\u{3373}}\q{\u{0250}}a]]/v, "\u{1813}", ["\u{1813}"]);
 testRegExp(/[[\u{0250}-\u{3373}a]--[\q{\u{3373}}\q{\u{0250}}a]]/v, "\u{3373}", null);
 testRegExp(/[[\u{0250}-\u{3373}a]--[\q{\u{1813}}\q{\u{0250}}a]]/v, "a", null);
 testRegExp(/[[\u{0250}-\u{3373}a]--[\q{\u{1813}}\q{\u{0250}}a]]/v, "\u{0250}", null);
 
-// Test 216
+// Test 221
 testRegExp(/[[\u{0250}-\u{3373}a]--[\q{\u{1813}}\q{\u{0250}}a]]/v, "\u{1813}", null);
 testRegExp(/[[\u{0250}-\u{3373}a]--[\q{\u{1813}}\q{\u{0250}}a]]/v, "\u{3373}", ["\u{3373}"]);
 testRegExp(/[[\u{0250}-\u{3373}a]&&[a]]/v, "a", ["a"]);
 testRegExp(/[[\u{0250}-\u{3373}a]&&[a]]/v, "\u{0250}", null);
 testRegExp(/[[\u{0250}-\u{3373}a]&&[a]]/v, "\u{1813}", null);
 
-// Test 221
+// Test 226
 testRegExp(/[[\u{0250}-\u{3373}a]&&[a]]/v, "\u{3373}", null);
 testRegExp(/[[\u{0250}-\u{3373}a]&&[\q{\u{0250}}]]/v, "a", null);
 testRegExp(/[[\u{0250}-\u{3373}a]&&[\q{\u{0250}}]]/v, "\u{0250}", ["\u{0250}"]);
 testRegExp(/[[\u{0250}-\u{3373}a]&&[\q{\u{0250}}]]/v, "\u{1813}", null);
 testRegExp(/[[\u{0250}-\u{3373}a]&&[\q{\u{0250}}]]/v, "\u{3373}", null);
 
-// Test 226
+// Test 231
 testRegExp(/[[\u{0250}-\u{3373}a]&&[\q{\u{1813}}]]/v, "a", null);
 testRegExp(/[[\u{0250}-\u{3373}a]&&[\q{\u{1813}}]]/v, "\u{0250}", null);
 testRegExp(/[[\u{0250}-\u{3373}a]&&[\q{\u{1813}}]]/v, "\u{1813}", ["\u{1813}"]);
 testRegExp(/[[\u{0250}-\u{3373}a]&&[\q{\u{1813}}]]/v, "\u{3373}", null);
 testRegExp(/[[\u{0250}-\u{3373}a]&&[\q{\u{3373}}]]/v, "a", null);
 
-// Test 231
+// Test 236
 testRegExp(/[[\u{0250}-\u{3373}a]&&[\q{\u{3373}}]]/v, "\u{0250}", null);
 testRegExp(/[[\u{0250}-\u{3373}a]&&[\q{\u{3373}}]]/v, "\u{1813}", null);
 testRegExp(/[[\u{0250}-\u{3373}a]&&[\q{\u{3373}}]]/v, "\u{3373}", ["\u{3373}"]);
 testRegExp(/[[]a]/v, "a", ["a"]);
 testRegExp(/[\p{ASCII}--[a-z]][\.!]/v, "TEST!", ["T!"]);
 
-// Test 236
+// Test 241
 testRegExp(/[ab][c--c]/v, "a", null);
+testRegExp(/a?[\q{bc}]?/v, "a", ["a"]);
+testRegExp(/a?[\q{bc}]?/v, "ab", ["a"]);
+testRegExp(/a?[\q{bc}]?/v, "abc", ["abc"]);
+testRegExp(/a?[\q{bc}]?/v, "bc", ["bc"]);
+
+// Test 246
+testRegExp(/[a&&[\q{a|ab}]]/v, "ab", ["a"]);
+testRegExp(/[a--[\q{ab}]]/v, "ab", ["a"]);
+testRegExp(/[[\q{a|ab}]&&a]/v, "ab", ["a"]);
+testRegExp(/[[\q{a|ab}]--a]/v, "ab", ["ab"]);

--- a/Source/JavaScriptCore/yarr/YarrErrorCode.cpp
+++ b/Source/JavaScriptCore/yarr/YarrErrorCode.cpp
@@ -51,7 +51,7 @@ ASCIILiteral errorMessage(ErrorCode error)
         REGEXP_ERROR_PREFIX "missing terminating ] for character class"_s,            // CharacterClassUnmatched
         REGEXP_ERROR_PREFIX "range out of order in character class"_s,                // CharacterClassRangeOutOfOrder
         REGEXP_ERROR_PREFIX "invalid range in character class for Unicode pattern"_s, // CharacterClassRangeInvalid
-        REGEXP_ERROR_PREFIX "missing terminating } for class string disjunction"_s,   // ClassStringDIsjunctionUnmatched
+        REGEXP_ERROR_PREFIX "missing terminating } for class string disjunction"_s,   // ClassStringDisjunctionUnmatched
         REGEXP_ERROR_PREFIX "\\ at end of pattern"_s,                                 // EscapeUnterminated
         REGEXP_ERROR_PREFIX "invalid Unicode \\u escape"_s,                           // InvalidUnicodeEscape
         REGEXP_ERROR_PREFIX "invalid Unicode code point \\u{} escape"_s,              // InvalidUnicodeCodePointEscape
@@ -93,7 +93,7 @@ JSObject* errorToThrow(JSGlobalObject* globalObject, ErrorCode error)
     case ErrorCode::CharacterClassUnmatched:
     case ErrorCode::CharacterClassRangeOutOfOrder:
     case ErrorCode::CharacterClassRangeInvalid:
-    case ErrorCode::ClassStringDIsjunctionUnmatched:
+    case ErrorCode::ClassStringDisjunctionUnmatched:
     case ErrorCode::EscapeUnterminated:
     case ErrorCode::InvalidUnicodeEscape:
     case ErrorCode::InvalidUnicodeCodePointEscape:

--- a/Source/JavaScriptCore/yarr/YarrErrorCode.h
+++ b/Source/JavaScriptCore/yarr/YarrErrorCode.h
@@ -52,7 +52,7 @@ enum class ErrorCode : uint8_t {
     CharacterClassUnmatched,
     CharacterClassRangeOutOfOrder,
     CharacterClassRangeInvalid,
-    ClassStringDIsjunctionUnmatched,
+    ClassStringDisjunctionUnmatched,
     EscapeUnterminated,
     InvalidUnicodeEscape,
     InvalidUnicodeCodePointEscape,

--- a/Source/JavaScriptCore/yarr/YarrPattern.cpp
+++ b/Source/JavaScriptCore/yarr/YarrPattern.cpp
@@ -188,6 +188,9 @@ public:
         Vector<UChar32> unicodeMatches;
         Vector<CharacterRange> emptyRanges;
 
+        if (m_setOp == CharacterClassSetOp::Intersection)
+            m_strings.clear();
+
         auto addChar = [&] (UChar32 ch) {
             if (isASCII(ch))
                 asciiMatches.append(ch);


### PR DESCRIPTION
#### 3713b5294002cff4f0149ec026265aea3a555556
<pre>
[JSC] ASSERTION FAILED: term.quantityMinCount == 1 &amp;&amp; term.quantityMaxCount == 1 &amp;&amp; term.quantityType == QuantifierType::FixedCount
<a href="https://bugs.webkit.org/show_bug.cgi?id=257432">https://bugs.webkit.org/show_bug.cgi?id=257432</a>
rdar://109355826

Reviewed by Yusuke Suzuki.

This crash was due to not properly recognizing that the class set prior to the quantifier
was invalid due to inverted contents that contained strings.

Strengthened the &quot;May Contain Strings&quot; processing in accordance with the specification changes
for Class Sets.  Instead of trying to compute the error cases during parsing involving may
contain strings, that computation is now centralized in the new
ClassSetParserDelegate::computeMayContainStrings() method.  Now the various productions
feed their string-ness into the new method.  The error determination using the results of that
computation is done when a class set is closed, including nested sets.  Added a new Token Type,
SetDisjunctionMayContainStrings, for Set Disjunctions that contain strings.

While writing new tests, found that there was a bug with expressions like:
  /[[\q{abc|a}&amp;&amp;a}]/v
We were not handling the intersection where the RHS of the intersection doesn&apos;t include any
strings.

Also found and fixed spelling error in ClassStringDIsjunctionUnmatched.

Added several syntax and matching tests.

* JSTests/stress/regexp-vflag-property-of-strings.js:
* Source/JavaScriptCore/yarr/YarrErrorCode.cpp:
(JSC::Yarr::errorMessage):
(JSC::Yarr::errorToThrow):
* Source/JavaScriptCore/yarr/YarrErrorCode.h:
* Source/JavaScriptCore/yarr/YarrParser.h:
(JSC::Yarr::Parser::ClassSetParserDelegate::NestingState::NestingState):
(JSC::Yarr::Parser::ClassSetParserDelegate::ClassSetParserDelegate):
(JSC::Yarr::Parser::ClassSetParserDelegate::nestedClassBegin):
(JSC::Yarr::Parser::ClassSetParserDelegate::nestedClassEnd):
(JSC::Yarr::Parser::ClassSetParserDelegate::computeMayContainStrings):
(JSC::Yarr::Parser::ClassSetParserDelegate::atomBuiltInCharacterClass):
(JSC::Yarr::Parser::ClassSetParserDelegate::end):
(JSC::Yarr::Parser::ClassSetParserDelegate::isInverted):
(JSC::Yarr::Parser::ClassStringDisjunctionParserDelegate::ClassStringDisjunctionParserDelegate):
(JSC::Yarr::Parser::ClassStringDisjunctionParserDelegate::atomPatternCharacter):
(JSC::Yarr::Parser::ClassStringDisjunctionParserDelegate::mayContainStrings):
(JSC::Yarr::Parser::parseEscape):
(JSC::Yarr::Parser::parseClassSet):
(JSC::Yarr::Parser::parseClassStringDisjunction):
* Source/JavaScriptCore/yarr/YarrPattern.cpp:
(JSC::Yarr::CharacterClassConstructor::putCharNonUnion):

Canonical link: <a href="https://commits.webkit.org/264704@main">https://commits.webkit.org/264704@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/96c205427377af0ce2f7024aeb597f5b61be1ff1

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/8211 "1 style error") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/8503 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/8720 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/9878 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/8277 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/10491 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/8414 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/11153 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/8356 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/9421 "2 flakes 2 failures") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/7449 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/10023 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/6721 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/7514 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/15070 "Passed tests") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/7004 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/7844 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/7644 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/11001 "Passed tests") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/7780 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/8116 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/6599 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/8383 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/7406 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/1937 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/2028 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/11614 "Built successfully") | | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/24/builds/8608 "Built successfully") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/7857 "Built successfully") | | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/3/builds/2079 "Passed tests") | 
<!--EWS-Status-Bubble-End-->