### PR TITLE
Ignore ::-webkit-scrollbar styles when scrollbar-width is not auto

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-scrollbars/scrollbar-color-001-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-scrollbars/scrollbar-color-001-expected.txt
@@ -1,0 +1,3 @@
+
+PASS scrollbar-color auto on the root defers to ::-webkit-scrollbar
+

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-scrollbars/scrollbar-color-001.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-scrollbars/scrollbar-color-001.html
@@ -1,0 +1,62 @@
+<!doctype html>
+<meta charset="utf-8">
+<title>CSS Scrollbars: scrollbar-color auto on the root defers to ::-webkit-scrollbar</title>
+<link rel="author" title="Luke Warlow" href="mailto:luke@warlow.dev" />
+<link rel="help" href="https://drafts.csswg.org/css-scrollbars-1/" />
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/css/support/parsing-testcommon.js"></script>
+<style>
+  :root {
+    scrollbar-color: auto;
+  }
+
+  :root::-webkit-scrollbar {
+    display: none;
+  }
+
+  /* This is so that browsers that don't implement the WebKit prefix still pass the test */
+  @supports not selector(::-webkit-scrollbar) {
+    :root {
+      overflow: hidden;
+    }
+  }
+
+  :root,
+  body {
+    margin: 0;
+    padding: 0;
+  }
+
+  #content {
+    height: 10vh;
+    width: 100%;
+    background: lightsalmon;
+  }
+
+  #expander {
+    /* force vertical scroll */
+    height: 200vh;
+    width: 300px;
+    background: gray;
+  }
+</style>
+
+<body>
+
+  <div id="content"></div>
+
+  <div id="expander"></div>
+
+  <script>
+    test(function () {
+      let root = document.documentElement;
+      let body = document.body;
+      let content = document.getElementById('content');
+
+      assert_equals(root.offsetWidth, window.innerWidth, "viewport does not show a scrollbar");
+      assert_equals(body.offsetWidth, root.offsetWidth, "body matches root");
+      assert_equals(content.offsetWidth, body.offsetWidth, "content matches body");
+    }, "scrollbar-color auto on the root defers to ::-webkit-scrollbar");
+  </script>
+</body>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-scrollbars/scrollbar-color-002-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-scrollbars/scrollbar-color-002-expected.txt
@@ -1,0 +1,3 @@
+
+FAIL scrollbar-color non-auto on the root overrides ::-webkit-scrollbar assert_less_than: viewport has a scrollbar expected a number less than 800 but got 800
+

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-scrollbars/scrollbar-color-002.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-scrollbars/scrollbar-color-002.html
@@ -1,0 +1,55 @@
+<!doctype html>
+<meta charset="utf-8">
+<title>CSS Scrollbars: scrollbar-color non-auto on the root overrides ::-webkit-scrollbar</title>
+<link rel="author" title="Luke Warlow" href="mailto:luke@warlow.dev" />
+<link rel="help" href="https://drafts.csswg.org/css-scrollbars-1/" />
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/css/support/parsing-testcommon.js"></script>
+<style>
+  :root {
+    scrollbar-color: yellow blue;
+  }
+
+  :root::-webkit-scrollbar {
+    display: none;
+  }
+
+  :root,
+  body {
+    margin: 0;
+    padding: 0;
+  }
+
+  #content {
+    height: 10vh;
+    width: 100%;
+    background: lightsalmon;
+  }
+
+  #expander {
+    /* force vertical scroll */
+    height: 200vh;
+    width: 300px;
+    background: gray;
+  }
+</style>
+
+<body>
+
+  <div id="content"></div>
+
+  <div id="expander"></div>
+
+  <script>
+    test(function () {
+      let root = document.documentElement;
+      let body = document.body;
+      let content = document.getElementById('content');
+
+      assert_less_than(root.offsetWidth, window.innerWidth, "viewport has a scrollbar");
+      assert_equals(body.offsetWidth, root.offsetWidth, "body matches root");
+      assert_equals(content.offsetWidth, body.offsetWidth, "content matches body");
+    }, "scrollbar-color non-auto on the root overrides ::-webkit-scrollbar");
+  </script>
+</body>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-scrollbars/scrollbar-color-003-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-scrollbars/scrollbar-color-003-expected.txt
@@ -1,0 +1,7 @@
+Test scrollbar-color: vertical scrollbar
+auto
+themed
+
+PASS scrollbar-color auto defers to ::-webkit-scrollbar
+FAIL scrollbar-color yellow blue overrides ::-webkit-scrollbar assert_less_than: themed scrollWidth expected a number less than 200 but got 200
+

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-scrollbars/scrollbar-color-003.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-scrollbars/scrollbar-color-003.html
@@ -1,0 +1,89 @@
+<!doctype html>
+<meta charset="utf-8">
+<title>CSS Scrollbars: scrollbar-color on scrollable areas correctly interacts with ::-webkit-scrollbar on container</title>
+<link rel="author" title="Luke Warlow" href="mailto:luke@warlow.dev" />
+<link rel="help" href="https://drafts.csswg.org/css-scrollbars-1/" />
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/css/support/parsing-testcommon.js"></script>
+<style>
+  .container {
+    overflow: auto;
+    height: 200px;
+    width: 200px;
+    margin: 1px;
+    padding: 0px;
+    border: none;
+    background: deepskyblue;
+  }
+
+  .content {
+    height: 300px;
+    width: 100%;
+    background: lightsalmon;
+  }
+
+  .container.auto {
+    scrollbar-color: auto;
+  }
+
+  .container.auto::-webkit-scrollbar {
+    display: none;
+  }
+
+  /* This is so that browsers that don't implement the WebKit prefix still pass the test */
+  @supports not selector(::-webkit-scrollbar) {
+    .container.auto {
+      overflow: hidden;
+    }
+  }
+
+  .container.themed {
+    scrollbar-color: yellow blue;
+  }
+
+  .container.themed::-webkit-scrollbar {
+    display: none;
+  }
+</style>
+<script>
+  function performTest() {
+    setup({ explicit_done: true });
+
+    test(function () {
+      let container = document.getElementById('container_auto');
+      let content = document.getElementById('content_auto');
+      assert_equals(container.scrollWidth, 200, "auto scrollWidth");
+      assert_equals(container.clientWidth, 200, "auto clientWidth");
+      assert_equals(container.offsetLeft, content.offsetLeft, "auto offsetLeft");
+      assert_equals(container.clientWidth, content.clientWidth, "auto clientWidth");
+      assert_equals(container.offsetWidth, content.offsetWidth, "auto offsetWidth");
+    }, "scrollbar-color auto defers to ::-webkit-scrollbar");
+
+    test(function () {
+      let container = document.getElementById('container_themed');
+      let content = document.getElementById('content_themed');
+      assert_less_than(container.scrollWidth, container.offsetWidth, "themed scrollWidth");
+      assert_less_than(container.clientWidth, container.offsetWidth, "themed clientWidth");
+      assert_equals(container.offsetLeft, content.offsetLeft, "themed offsetLeft");
+      assert_equals(container.clientWidth, content.clientWidth, "themed clientWidth");
+      assert_not_equals(container.offsetWidth, content.offsetWidth, "themed offsetWidth");
+    }, "scrollbar-color yellow blue overrides ::-webkit-scrollbar");
+
+    done();
+  }
+</script>
+
+<body onload="performTest()">
+
+  Test scrollbar-color: vertical scrollbar
+
+  <div class="container auto" id="container_auto">
+    <div class="content" id="content_auto">auto</div>
+  </div>
+
+  <div class="container themed" id="container_themed">
+    <div class="content" id="content_themed">themed</div>
+  </div>
+
+</body>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-scrollbars/scrollbar-color-004-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-scrollbars/scrollbar-color-004-expected.txt
@@ -1,0 +1,5 @@
+Test scrollbar-color: vertical scrollbar
+themed
+
+FAIL scrollbar-color yellow blue on body overrides ::-webkit-scrollbar assert_less_than: themed scrollWidth expected a number less than 200 but got 200
+

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-scrollbars/scrollbar-color-004.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-scrollbars/scrollbar-color-004.html
@@ -1,0 +1,60 @@
+<!doctype html>
+<meta charset="utf-8">
+<title>CSS Scrollbars: scrollbar-color on body correctly interacts with ::-webkit-scrollbar</title>
+<link rel="author" title="Luke Warlow" href="mailto:luke@warlow.dev" />
+<link rel="help" href="https://drafts.csswg.org/css-scrollbars-1/" />
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/css/support/parsing-testcommon.js"></script>
+<style>
+  .container {
+    overflow: auto;
+    height: 200px;
+    width: 200px;
+    margin: 1px;
+    padding: 0px;
+    border: none;
+    background: deepskyblue;
+  }
+
+  .content {
+    height: 300px;
+    width: 100%;
+    background: lightsalmon;
+  }
+
+  body {
+    scrollbar-color: yellow blue;
+  }
+
+  ::-webkit-scrollbar {
+    display: none;
+  }
+</style>
+<script>
+  function performTest() {
+    setup({ explicit_done: true });
+
+    test(function () {
+      let container = document.getElementById('container_themed');
+      let content = document.getElementById('content_themed');
+      assert_less_than(container.scrollWidth, container.offsetWidth, "themed scrollWidth");
+      assert_less_than(container.clientWidth, container.offsetWidth, "themed clientWidth");
+      assert_equals(container.offsetLeft, content.offsetLeft, "themed offsetLeft");
+      assert_equals(container.clientWidth, content.clientWidth, "themed clientWidth");
+      assert_not_equals(container.offsetWidth, content.offsetWidth, "themed offsetWidth");
+    }, "scrollbar-color yellow blue on body overrides ::-webkit-scrollbar");
+
+    done();
+  }
+</script>
+
+<body onload="performTest()">
+
+  Test scrollbar-color: vertical scrollbar
+
+  <div class="container themed" id="container_themed">
+    <div class="content" id="content_themed">themed</div>
+  </div>
+
+</body>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-scrollbars/scrollbar-color-005-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-scrollbars/scrollbar-color-005-expected.txt
@@ -1,0 +1,5 @@
+Test scrollbar-color: vertical scrollbar
+themed
+
+FAIL scrollbar-color yellow blue on body overrides ::-webkit-scrollbar on scrollable area assert_less_than: themed scrollWidth expected a number less than 200 but got 200
+

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-scrollbars/scrollbar-color-005.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-scrollbars/scrollbar-color-005.html
@@ -1,0 +1,60 @@
+<!doctype html>
+<meta charset="utf-8">
+<title>CSS Scrollbars: scrollbar-color on body correctly interacts with ::-webkit-scrollbar on scrollable area</title>
+<link rel="author" title="Luke Warlow" href="mailto:luke@warlow.dev" />
+<link rel="help" href="https://drafts.csswg.org/css-scrollbars-1/" />
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/css/support/parsing-testcommon.js"></script>
+<style>
+  .container {
+    overflow: auto;
+    height: 200px;
+    width: 200px;
+    margin: 1px;
+    padding: 0px;
+    border: none;
+    background: deepskyblue;
+  }
+
+  .content {
+    height: 300px;
+    width: 100%;
+    background: lightsalmon;
+  }
+
+  body {
+    scrollbar-color: yellow blue;
+  }
+
+  .container::-webkit-scrollbar {
+    display: none;
+  }
+</style>
+<script>
+  function performTest() {
+    setup({ explicit_done: true });
+
+    test(function () {
+      let container = document.getElementById('container_themed');
+      let content = document.getElementById('content_themed');
+      assert_less_than(container.scrollWidth, container.offsetWidth, "themed scrollWidth");
+      assert_less_than(container.clientWidth, container.offsetWidth, "themed clientWidth");
+      assert_equals(container.offsetLeft, content.offsetLeft, "themed offsetLeft");
+      assert_equals(container.clientWidth, content.clientWidth, "themed clientWidth");
+      assert_not_equals(container.offsetWidth, content.offsetWidth, "themed offsetWidth");
+    }, "scrollbar-color yellow blue on body overrides ::-webkit-scrollbar on scrollable area");
+
+    done();
+  }
+</script>
+
+<body onload="performTest()">
+
+  Test scrollbar-color: vertical scrollbar
+
+  <div class="container themed" id="container_themed">
+    <div class="content" id="content_themed">themed</div>
+  </div>
+
+</body>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-scrollbars/scrollbar-width-010-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-scrollbars/scrollbar-width-010-expected.txt
@@ -1,0 +1,3 @@
+
+PASS scrollbar-width auto on the root defers to ::-webkit-scrollbar
+

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-scrollbars/scrollbar-width-010.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-scrollbars/scrollbar-width-010.html
@@ -1,0 +1,62 @@
+<!doctype html>
+<meta charset="utf-8">
+<title>CSS Scrollbars: scrollbar-width auto on the root defers to ::-webkit-scrollbar on the root</title>
+<link rel="author" title="Luke Warlow" href="mailto:luke@warlow.dev" />
+<link rel="help" href="https://drafts.csswg.org/css-scrollbars-1/" />
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/css/support/parsing-testcommon.js"></script>
+<style>
+  :root {
+    scrollbar-width: auto;
+  }
+
+  :root::-webkit-scrollbar {
+    display: none;
+  }
+
+  /* This is so that browsers that don't implement the WebKit prefix still pass the test */
+  @supports not selector(::-webkit-scrollbar) {
+    :root {
+      overflow: hidden;
+    }
+  }
+
+  :root,
+  body {
+    margin: 0;
+    padding: 0;
+  }
+
+  #content {
+    height: 10vh;
+    width: 100%;
+    background: lightsalmon;
+  }
+
+  #expander {
+    /* force vertical scroll */
+    height: 200vh;
+    width: 300px;
+    background: gray;
+  }
+</style>
+
+<body>
+
+  <div id="content"></div>
+
+  <div id="expander"></div>
+
+  <script>
+    test(function () {
+      let root = document.documentElement;
+      let body = document.body;
+      let content = document.getElementById('content');
+
+      assert_equals(root.offsetWidth, window.innerWidth, "viewport does not show a scrollbar");
+      assert_equals(body.offsetWidth, root.offsetWidth, "body matches root");
+      assert_equals(content.offsetWidth, body.offsetWidth, "content matches body");
+    }, "scrollbar-width auto on the root defers to ::-webkit-scrollbar");
+  </script>
+</body>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-scrollbars/scrollbar-width-011-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-scrollbars/scrollbar-width-011-expected.txt
@@ -1,0 +1,3 @@
+
+PASS scrollbar-width thin on the root overrides ::-webkit-scrollbar
+

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-scrollbars/scrollbar-width-011.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-scrollbars/scrollbar-width-011.html
@@ -1,0 +1,55 @@
+<!doctype html>
+<meta charset="utf-8">
+<title>CSS Scrollbars: scrollbar-width thin on the root overrides ::-webkit-scrollbar on the root</title>
+<link rel="author" title="Luke Warlow" href="mailto:luke@warlow.dev" />
+<link rel="help" href="https://drafts.csswg.org/css-scrollbars-1/" />
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/css/support/parsing-testcommon.js"></script>
+<style>
+  :root {
+    scrollbar-width: thin;
+  }
+
+  :root::-webkit-scrollbar {
+    display: none;
+  }
+
+  :root,
+  body {
+    margin: 0;
+    padding: 0;
+  }
+
+  #content {
+    height: 10vh;
+    width: 100%;
+    background: lightsalmon;
+  }
+
+  #expander {
+    /* force vertical scroll */
+    height: 200vh;
+    width: 300px;
+    background: gray;
+  }
+</style>
+
+<body>
+
+  <div id="content"></div>
+
+  <div id="expander"></div>
+
+  <script>
+    test(function () {
+      let root = document.documentElement;
+      let body = document.body;
+      let content = document.getElementById('content');
+
+      assert_less_than(root.offsetWidth, window.innerWidth, "viewport has a scrollbar");
+      assert_equals(body.offsetWidth, root.offsetWidth, "body matches root");
+      assert_equals(content.offsetWidth, body.offsetWidth, "content matches body");
+    }, "scrollbar-width thin on the root overrides ::-webkit-scrollbar");
+  </script>
+</body>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-scrollbars/scrollbar-width-012-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-scrollbars/scrollbar-width-012-expected.txt
@@ -1,0 +1,3 @@
+
+PASS scrollbar-width none on the root overrides ::-webkit-scrollbar
+

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-scrollbars/scrollbar-width-012.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-scrollbars/scrollbar-width-012.html
@@ -1,0 +1,56 @@
+<!doctype html>
+<meta charset="utf-8">
+<title>CSS Scrollbars: scrollbar-width none on the root overrides ::-webkit-scrollbar on the root</title>
+<link rel="author" title="Luke Warlow" href="mailto:luke@warlow.dev" />
+<link rel="help" href="https://drafts.csswg.org/css-scrollbars-1/" />
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/css/support/parsing-testcommon.js"></script>
+<style>
+  :root {
+    scrollbar-width: none;
+  }
+
+  :root::-webkit-scrollbar {
+    width: 20px;
+    background-color: lightgray;
+  }
+
+  :root,
+  body {
+    margin: 0;
+    padding: 0;
+  }
+
+  #content {
+    height: 10vh;
+    width: 100%;
+    background: lightsalmon;
+  }
+
+  #expander {
+    /* force vertical scroll */
+    height: 200vh;
+    width: 300px;
+    background: gray;
+  }
+</style>
+
+<body>
+
+  <div id="content"></div>
+
+  <div id="expander"></div>
+
+  <script>
+    test(function () {
+      let root = document.documentElement;
+      let body = document.body;
+      let content = document.getElementById('content');
+
+      assert_equals(root.offsetWidth, window.innerWidth, "viewport does not show a scrollbar");
+      assert_equals(body.offsetWidth, root.offsetWidth, "body matches root");
+      assert_equals(content.offsetWidth, body.offsetWidth, "content matches body");
+    }, "scrollbar-width none on the root overrides ::-webkit-scrollbar");
+  </script>
+</body>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-scrollbars/scrollbar-width-013-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-scrollbars/scrollbar-width-013-expected.txt
@@ -1,0 +1,3 @@
+
+PASS scrollbar-width thin on the root overridess ::-webkit-scrollbar
+

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-scrollbars/scrollbar-width-013.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-scrollbars/scrollbar-width-013.html
@@ -1,0 +1,55 @@
+<!doctype html>
+<meta charset="utf-8">
+<title>CSS Scrollbars: scrollbar-width thin on the root overridess ::-webkit-scrollbar</title>
+<link rel="author" title="Luke Warlow" href="mailto:luke@warlow.dev" />
+<link rel="help" href="https://drafts.csswg.org/css-scrollbars-1/" />
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/css/support/parsing-testcommon.js"></script>
+<style>
+  :root {
+    scrollbar-width: thin;
+  }
+
+  ::-webkit-scrollbar {
+    display: none;
+  }
+
+  :root,
+  body {
+    margin: 0;
+    padding: 0;
+  }
+
+  #content {
+    height: 10vh;
+    width: 100%;
+    background: lightsalmon;
+  }
+
+  #expander {
+    /* force vertical scroll */
+    height: 200vh;
+    width: 300px;
+    background: gray;
+  }
+</style>
+
+<body>
+
+  <div id="content"></div>
+
+  <div id="expander"></div>
+
+  <script>
+    test(function () {
+      let root = document.documentElement;
+      let body = document.body;
+      let content = document.getElementById('content');
+
+      assert_less_than(root.offsetWidth, window.innerWidth, "viewport has a scrollbar");
+      assert_equals(body.offsetWidth, root.offsetWidth, "body matches root");
+      assert_equals(content.offsetWidth, body.offsetWidth, "content matches body");
+    }, "scrollbar-width thin on the root overridess ::-webkit-scrollbar");
+  </script>
+</body>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-scrollbars/scrollbar-width-014-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-scrollbars/scrollbar-width-014-expected.txt
@@ -1,0 +1,3 @@
+
+PASS scrollbar-width thin on the body doesn't override ::-webkit-scrollbar on root
+

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-scrollbars/scrollbar-width-014.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-scrollbars/scrollbar-width-014.html
@@ -1,0 +1,55 @@
+<!doctype html>
+<meta charset="utf-8">
+<title>CSS Scrollbars: scrollbar-width thin on the body doesn't override ::-webkit-scrollbar on root</title>
+<link rel="author" title="Luke Warlow" href="mailto:luke@warlow.dev" />
+<link rel="help" href="https://drafts.csswg.org/css-scrollbars-1/" />
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/css/support/parsing-testcommon.js"></script>
+<style>
+  body {
+    scrollbar-width: thin;
+  }
+
+  :root::-webkit-scrollbar {
+    display: none;
+  }
+
+  :root,
+  body {
+    margin: 0;
+    padding: 0;
+  }
+
+  #content {
+    height: 10vh;
+    width: 100%;
+    background: lightsalmon;
+  }
+
+  #expander {
+    /* force vertical scroll */
+    height: 200vh;
+    width: 300px;
+    background: gray;
+  }
+</style>
+
+<body>
+
+  <div id="content"></div>
+
+  <div id="expander"></div>
+
+  <script>
+    test(function () {
+      let root = document.documentElement;
+      let body = document.body;
+      let content = document.getElementById('content');
+
+      assert_equals(root.offsetWidth, window.innerWidth, "viewport does not show a scrollbar");
+      assert_equals(body.offsetWidth, root.offsetWidth, "body matches root");
+      assert_equals(content.offsetWidth, body.offsetWidth, "content matches body");
+    }, "scrollbar-width thin on the body doesn't override ::-webkit-scrollbar on root");
+  </script>
+</body>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-scrollbars/scrollbar-width-015-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-scrollbars/scrollbar-width-015-expected.txt
@@ -1,0 +1,7 @@
+Test scrollbar-width: vertical scrollbar
+auto
+thin
+
+PASS scrollbar-width auto defers to ::-webkit-scrollbar
+PASS scrollbar-width thin overrides ::-webkit-scrollbar
+

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-scrollbars/scrollbar-width-015.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-scrollbars/scrollbar-width-015.html
@@ -1,0 +1,87 @@
+<!doctype html>
+<meta charset="utf-8">
+<title>CSS Scrollbars: scrollbar-width on scrollable areas correctly interacts with ::-webkit-scrollbar</title>
+<link rel="author" title="Luke Warlow" href="mailto:luke@warlow.dev" />
+<link rel="help" href="https://drafts.csswg.org/css-scrollbars-1/" />
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/css/support/parsing-testcommon.js"></script>
+<style>
+  .container {
+    overflow: auto;
+    height: 200px;
+    width: 200px;
+    margin: 1px;
+    padding: 0px;
+    border: none;
+    background: deepskyblue;
+  }
+
+  .content {
+    height: 300px;
+    width: 100%;
+    background: lightsalmon;
+  }
+
+  .container.auto {
+    scrollbar-width: auto;
+  }
+
+  /* This is so that browsers that don't implement the WebKit prefix still pass the test */
+  @supports not selector(::-webkit-scrollbar) {
+    .container.auto {
+      overflow: hidden;
+    }
+  }
+
+  ::-webkit-scrollbar {
+    display: none;
+  }
+
+  .container.thin {
+    scrollbar-width: thin;
+  }
+</style>
+<script>
+  function performTest() {
+    setup({ explicit_done: true });
+
+    // ltr
+
+    test(function () {
+      let container = document.getElementById('container_auto');
+      let content = document.getElementById('content_auto');
+      assert_equals(container.scrollWidth, 200, "auto scrollWidth");
+      assert_equals(container.clientWidth, 200, "auto clientWidth");
+      assert_equals(container.offsetLeft, content.offsetLeft, "auto offsetLeft");
+      assert_equals(container.clientWidth, content.clientWidth, "auto clientWidth");
+      assert_equals(container.offsetWidth, content.offsetWidth, "auto offsetWidth");
+    }, "scrollbar-width auto defers to ::-webkit-scrollbar");
+
+    test(function () {
+      let container = document.getElementById('container_thin');
+      let content = document.getElementById('content_thin');
+      assert_less_than(container.scrollWidth, container.offsetWidth, "thin scrollWidth");
+      assert_less_than(container.clientWidth, container.offsetWidth, "thin clientWidth");
+      assert_equals(container.offsetLeft, content.offsetLeft, "thin offsetLeft");
+      assert_equals(container.clientWidth, content.clientWidth, "thin clientWidth");
+      assert_not_equals(container.offsetWidth, content.offsetWidth, "thin offsetWidth");
+    }, "scrollbar-width thin overrides ::-webkit-scrollbar");
+
+    done();
+  }
+</script>
+
+<body onload="performTest()">
+
+  Test scrollbar-width: vertical scrollbar
+
+  <div class="container auto" id="container_auto">
+    <div class="content" id="content_auto">auto</div>
+  </div>
+
+  <div class="container thin" id="container_thin">
+    <div class="content" id="content_thin">thin</div>
+  </div>
+
+</body>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-scrollbars/scrollbar-width-016-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-scrollbars/scrollbar-width-016-expected.txt
@@ -1,0 +1,9 @@
+Test scrollbar-width: vertical scrollbar
+auto
+thin
+none
+
+PASS scrollbar-width auto defers to ::-webkit-scrollbar
+PASS scrollbar-width thin overrides ::-webkit-scrollbar
+PASS scrollbar-width none overrides ::-webkit-scrollbar
+

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-scrollbars/scrollbar-width-016.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-scrollbars/scrollbar-width-016.html
@@ -1,0 +1,114 @@
+<!doctype html>
+<meta charset="utf-8">
+<title>CSS Scrollbars: scrollbar-width on scrollable areas correctly interacts with ::-webkit-scrollbar on container</title>
+<link rel="author" title="Luke Warlow" href="mailto:luke@warlow.dev" />
+<link rel="help" href="https://drafts.csswg.org/css-scrollbars-1/" />
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/css/support/parsing-testcommon.js"></script>
+<style>
+  .container {
+    overflow: auto;
+    height: 200px;
+    width: 200px;
+    margin: 1px;
+    padding: 0px;
+    border: none;
+    background: deepskyblue;
+  }
+
+  .content {
+    height: 300px;
+    width: 100%;
+    background: lightsalmon;
+  }
+
+  .container.auto {
+    scrollbar-width: auto;
+  }
+
+  .container.auto::-webkit-scrollbar {
+    display: none;
+  }
+
+  /* This is so that browsers that don't implement the WebKit prefix still pass the test */
+  @supports not selector(::-webkit-scrollbar) {
+    .container.auto {
+      overflow: hidden;
+    }
+  }
+
+  .container.thin {
+    scrollbar-width: thin;
+  }
+
+  .container.thin::-webkit-scrollbar {
+    display: none;
+  }
+
+  .container.none {
+    scrollbar-width: none;
+  }
+
+  .container.none::-webkit-scrollbar {
+    width: 20px;
+    background-color: lightgray;
+  }
+</style>
+<script>
+  function performTest() {
+    setup({ explicit_done: true });
+
+    // ltr
+
+    test(function () {
+      let container = document.getElementById('container_auto');
+      let content = document.getElementById('content_auto');
+      assert_equals(container.scrollWidth, 200, "auto scrollWidth");
+      assert_equals(container.clientWidth, 200, "auto clientWidth");
+      assert_equals(container.offsetLeft, content.offsetLeft, "auto offsetLeft");
+      assert_equals(container.clientWidth, content.clientWidth, "auto clientWidth");
+      assert_equals(container.offsetWidth, content.offsetWidth, "auto offsetWidth");
+    }, "scrollbar-width auto defers to ::-webkit-scrollbar");
+
+    test(function () {
+      let container = document.getElementById('container_thin');
+      let content = document.getElementById('content_thin');
+      assert_less_than(container.scrollWidth, container.offsetWidth, "thin scrollWidth");
+      assert_less_than(container.clientWidth, container.offsetWidth, "thin clientWidth");
+      assert_equals(container.offsetLeft, content.offsetLeft, "thin offsetLeft");
+      assert_equals(container.clientWidth, content.clientWidth, "thin clientWidth");
+      assert_not_equals(container.offsetWidth, content.offsetWidth, "thin offsetWidth");
+    }, "scrollbar-width thin overrides ::-webkit-scrollbar");
+
+    test(function () {
+      let container = document.getElementById('container_none');
+      let content = document.getElementById('content_none');
+      assert_equals(container.scrollWidth, 200, "none scrollWidth");
+      assert_equals(container.clientWidth, 200, "none clientWidth");
+      assert_equals(container.offsetLeft, content.offsetLeft, "none offsetLeft");
+      assert_equals(container.clientWidth, content.clientWidth, "none clientWidth");
+      assert_equals(container.offsetWidth, content.offsetWidth, "none offsetWidth");
+    }, "scrollbar-width none overrides ::-webkit-scrollbar");
+
+    done();
+  }
+</script>
+
+<body onload="performTest()">
+
+  Test scrollbar-width: vertical scrollbar
+
+  <div class="container auto" id="container_auto">
+    <div class="content" id="content_auto">auto</div>
+  </div>
+
+  <div class="container thin" id="container_thin">
+    <div class="content" id="content_thin">thin</div>
+  </div>
+
+  <div class="container none" id="container_none">
+    <div class="content" id="content_none">none</div>
+  </div>
+
+</body>

--- a/LayoutTests/platform/ios-wk2/TestExpectations
+++ b/LayoutTests/platform/ios-wk2/TestExpectations
@@ -2406,6 +2406,20 @@ imported/w3c/web-platform-tests/css/css-scrollbars/scrollbar-width-006.html [ Sk
 imported/w3c/web-platform-tests/css/css-scrollbars/scrollbar-width-007.html [ Skip ]
 imported/w3c/web-platform-tests/css/css-scrollbars/scrollbar-width-008.html [ Skip ]
 imported/w3c/web-platform-tests/css/css-scrollbars/scrollbar-width-009.html [ Skip ]
+imported/w3c/web-platform-tests/css/css-scrollbars/scrollbar-width-010.html [ Skip ]
+imported/w3c/web-platform-tests/css/css-scrollbars/scrollbar-width-011.html [ Skip ]
+imported/w3c/web-platform-tests/css/css-scrollbars/scrollbar-width-012.html [ Skip ]
+imported/w3c/web-platform-tests/css/css-scrollbars/scrollbar-width-013.html [ Skip ]
+imported/w3c/web-platform-tests/css/css-scrollbars/scrollbar-width-014.html [ Skip ]
+imported/w3c/web-platform-tests/css/css-scrollbars/scrollbar-width-015.html [ Skip ]
+imported/w3c/web-platform-tests/css/css-scrollbars/scrollbar-width-016.html [ Skip ]
+
+# Skipping scrollbar-color tests that don't work with overlay scrollbars
+imported/w3c/web-platform-tests/css/css-scrollbars/scrollbar-color-001.html [ Skip ]
+imported/w3c/web-platform-tests/css/css-scrollbars/scrollbar-color-002.html [ Skip ]
+imported/w3c/web-platform-tests/css/css-scrollbars/scrollbar-color-003.html [ Skip ]
+imported/w3c/web-platform-tests/css/css-scrollbars/scrollbar-color-004.html [ Skip ]
+imported/w3c/web-platform-tests/css/css-scrollbars/scrollbar-color-005.html [ Skip ]
 
 # Skipping scrollbar-gutter tests that don't work with overlay scrollbars
 imported/w3c/web-platform-tests/css/css-overflow/overflow-auto-scrollbar-gutter-intrinsic-001.html [ Skip ]

--- a/LayoutTests/platform/mac-wk1/TestExpectations
+++ b/LayoutTests/platform/mac-wk1/TestExpectations
@@ -2538,3 +2538,9 @@ http/tests/resourceLoadStatistics/website-data-removal-for-site-navigated-to-wit
 
 # Site-isolation isn't supported in WK1
 http/tests/site-isolation [ Skip ]
+
+# WebKit Legacy doesn't properly support ::-webkit-scrollbar on viewport
+imported/w3c/web-platform-tests/css/css-scrollbars/scrollbar-color-001.html  [ Skip ]
+imported/w3c/web-platform-tests/css/css-scrollbars/scrollbar-color-002.html  [ Skip ]
+imported/w3c/web-platform-tests/css/css-scrollbars/scrollbar-width-010.html  [ Skip ]
+imported/w3c/web-platform-tests/css/css-scrollbars/scrollbar-width-014.html  [ Skip ]

--- a/Source/WebCore/page/LocalFrameView.h
+++ b/Source/WebCore/page/LocalFrameView.h
@@ -848,7 +848,7 @@ private:
     IntSize sizeForResizeEvent() const;
     void scheduleResizeEventIfNeeded();
     
-    RefPtr<Element> rootElementForCustomScrollbarPartStyle(PseudoId) const;
+    RefPtr<Element> rootElementForCustomScrollbarPartStyle() const;
 
     void adjustScrollbarsForLayout(bool firstLayout);
 

--- a/Source/WebCore/rendering/RenderBox.cpp
+++ b/Source/WebCore/rendering/RenderBox.cpp
@@ -1085,7 +1085,7 @@ void RenderBox::panScroll(const IntPoint& source)
 
 bool RenderBox::canUseOverlayScrollbars() const
 {
-    return !style().hasPseudoStyle(PseudoId::Scrollbar) && ScrollbarTheme::theme().usesOverlayScrollbars();
+    return !style().hasCustomScrollbarStyle() && ScrollbarTheme::theme().usesOverlayScrollbars();
 }
 
 bool RenderBox::hasAutoScrollbar(ScrollbarOrientation orientation) const

--- a/Source/WebCore/rendering/RenderLayerScrollableArea.cpp
+++ b/Source/WebCore/rendering/RenderLayerScrollableArea.cpp
@@ -872,7 +872,7 @@ Ref<Scrollbar> RenderLayerScrollableArea::createScrollbar(ScrollbarOrientation o
     RefPtr<Scrollbar> widget;
     ASSERT(rendererForScrollbar(renderer));
     auto& actualRenderer = *rendererForScrollbar(renderer);
-    bool hasCustomScrollbarStyle = is<RenderBox>(actualRenderer) && downcast<RenderBox>(actualRenderer).style().hasPseudoStyle(PseudoId::Scrollbar);
+    bool hasCustomScrollbarStyle = is<RenderBox>(actualRenderer) && downcast<RenderBox>(actualRenderer).style().hasCustomScrollbarStyle();
     auto element = downcast<RenderBox>(actualRenderer).element();
     if (hasCustomScrollbarStyle && element)
         widget = RenderScrollbar::createCustomScrollbar(*this, orientation, element);

--- a/Source/WebCore/rendering/RenderListBox.cpp
+++ b/Source/WebCore/rendering/RenderListBox.cpp
@@ -975,7 +975,7 @@ void RenderListBox::didStartScrollAnimation()
 Ref<Scrollbar> RenderListBox::createScrollbar()
 {
     RefPtr<Scrollbar> widget;
-    bool hasCustomScrollbarStyle = style().hasPseudoStyle(PseudoId::Scrollbar);
+    bool hasCustomScrollbarStyle = style().hasCustomScrollbarStyle();
     if (hasCustomScrollbarStyle)
         widget = RenderScrollbar::createCustomScrollbar(*this, ScrollbarOrientation::Vertical, &selectElement());
     else {

--- a/Source/WebCore/rendering/RenderMenuList.cpp
+++ b/Source/WebCore/rendering/RenderMenuList.cpp
@@ -562,7 +562,7 @@ HostWindow* RenderMenuList::hostWindow() const
 
 Ref<Scrollbar> RenderMenuList::createScrollbar(ScrollableArea& scrollableArea, ScrollbarOrientation orientation, ScrollbarWidth widthStyle)
 {
-    bool hasCustomScrollbarStyle = style().hasPseudoStyle(PseudoId::Scrollbar);
+    bool hasCustomScrollbarStyle = style().hasCustomScrollbarStyle();
     if (hasCustomScrollbarStyle)
         return RenderScrollbar::createCustomScrollbar(scrollableArea, orientation, &selectElement());
     return Scrollbar::createNativeScrollbar(scrollableArea, orientation, widthStyle);

--- a/Source/WebCore/rendering/RenderSearchField.cpp
+++ b/Source/WebCore/rendering/RenderSearchField.cpp
@@ -374,7 +374,7 @@ HostWindow* RenderSearchField::hostWindow() const
 
 Ref<Scrollbar> RenderSearchField::createScrollbar(ScrollableArea& scrollableArea, ScrollbarOrientation orientation, ScrollbarWidth widthStyle)
 {
-    bool hasCustomScrollbarStyle = style().hasPseudoStyle(PseudoId::Scrollbar);
+    bool hasCustomScrollbarStyle = style().hasCustomScrollbarStyle();
     if (hasCustomScrollbarStyle)
         return RenderScrollbar::createCustomScrollbar(scrollableArea, orientation, &inputElement());
     return Scrollbar::createNativeScrollbar(scrollableArea, orientation, widthStyle);

--- a/Source/WebCore/rendering/style/RenderStyle.h
+++ b/Source/WebCore/rendering/style/RenderStyle.h
@@ -1039,6 +1039,8 @@ public:
 
     bool shouldPlaceVerticalScrollbarOnLeft() const;
 
+    inline bool hasCustomScrollbarStyle() const;
+
 #if ENABLE(APPLE_PAY)
     inline ApplePayButtonStyle applePayButtonStyle() const;
     inline ApplePayButtonType applePayButtonType() const;

--- a/Source/WebCore/rendering/style/RenderStyleInlines.h
+++ b/Source/WebCore/rendering/style/RenderStyleInlines.h
@@ -717,6 +717,9 @@ inline WordBreak RenderStyle::wordBreak() const { return static_cast<WordBreak>(
 constexpr LengthType RenderStyle::zeroLength() { return LengthType::Fixed; }
 inline float RenderStyle::zoom() const { return m_nonInheritedData->rareData->zoom; }
 
+// ignore non-standard ::-webkit-scrollbar when standard properties are in use
+inline bool RenderStyle::hasCustomScrollbarStyle() const { return hasPseudoStyle(PseudoId::Scrollbar) && scrollbarWidth() == ScrollbarWidth::Auto; }
+
 #if ENABLE(APPLE_PAY)
 inline ApplePayButtonStyle RenderStyle::applePayButtonStyle() const { return static_cast<ApplePayButtonStyle>(m_nonInheritedData->rareData->applePayButtonStyle); }
 inline ApplePayButtonType RenderStyle::applePayButtonType() const { return static_cast<ApplePayButtonType>(m_nonInheritedData->rareData->applePayButtonType); }


### PR DESCRIPTION
#### 964948660ae097f883e12408b84dea3efd98a7ae
<pre>
Ignore ::-webkit-scrollbar styles when scrollbar-width is not auto
<a href="https://bugs.webkit.org/show_bug.cgi?id=257052">https://bugs.webkit.org/show_bug.cgi?id=257052</a>

Reviewed by Tim Nguyen and Simon Fraser.

RenderStyle::hasCustomScrollbarStyle() returns true if a custom style
for the scrollbar has been set via ::-webkit-scrollbar and the value of
scrollbar-width is auto (default). This replaces usages of
hasPseudoStyle(PseudoId::Scrollbar)
so the standard properties for styling scrollbars take precedence over
the non-standard.

WPT tests are included.

* LayoutTests/imported/w3c/web-platform-tests/css/css-scrollbars/scrollbar-color-001-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-scrollbars/scrollbar-color-001.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-scrollbars/scrollbar-color-002-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-scrollbars/scrollbar-color-002.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-scrollbars/scrollbar-color-003-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-scrollbars/scrollbar-color-003.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-scrollbars/scrollbar-color-004-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-scrollbars/scrollbar-color-004.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-scrollbars/scrollbar-color-005-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-scrollbars/scrollbar-color-005.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-scrollbars/scrollbar-width-010-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-scrollbars/scrollbar-width-010.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-scrollbars/scrollbar-width-011-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-scrollbars/scrollbar-width-011.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-scrollbars/scrollbar-width-012-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-scrollbars/scrollbar-width-012.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-scrollbars/scrollbar-width-013-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-scrollbars/scrollbar-width-013.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-scrollbars/scrollbar-width-014-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-scrollbars/scrollbar-width-014.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-scrollbars/scrollbar-width-015-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-scrollbars/scrollbar-width-015.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-scrollbars/scrollbar-width-016-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-scrollbars/scrollbar-width-016.html: Added.
* LayoutTests/platform/ios-wk2/TestExpectations:
* LayoutTests/platform/mac-wk1/TestExpectations:
* Source/WebCore/page/LocalFrameView.cpp:
(WebCore::LocalFrameView::rootElementForCustomScrollbarPartStyle const):
(WebCore::LocalFrameView::createScrollbar):
(WebCore::LocalFrameView::canShowNonOverlayScrollbars const):
(WebCore::LocalFrameView::styleHidesScrollbarWithOrientation const):
* Source/WebCore/page/LocalFrameView.h:
* Source/WebCore/rendering/RenderBox.cpp:
(WebCore::RenderBox::canUseOverlayScrollbars const):
* Source/WebCore/rendering/RenderLayerScrollableArea.cpp:
(WebCore::RenderLayerScrollableArea::createScrollbar):
* Source/WebCore/rendering/RenderListBox.cpp:
(WebCore::RenderListBox::createScrollbar):
* Source/WebCore/rendering/RenderMenuList.cpp:
(RenderMenuList::createScrollbar):
* Source/WebCore/rendering/RenderSearchField.cpp:
(WebCore::RenderSearchField::createScrollbar):
* Source/WebCore/rendering/style/RenderStyle.h:
* Source/WebCore/rendering/style/RenderStyleInlines.h:
(WebCore::RenderStyle::hasCustomScrollbarStyle const):

Canonical link: <a href="https://commits.webkit.org/265129@main">https://commits.webkit.org/265129@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/3475ee299519a17e898f28bf9321873c16579507

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/9884 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/10132 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/10381 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/11537 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/9588 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/9893 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/12117 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/10084 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/12537 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/10038 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/10841 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/8378 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/11920 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/8147 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/8967 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/16311 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/9246 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/9116 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/12393 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/9616 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/7814 "1 flakes 3 failures") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/8777 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/8864 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/2380 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/13002 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/9390 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->