### PR TITLE
Pass scrollbarWidth through when using UISideCompositing

### DIFF
--- a/Source/WebCore/page/scrolling/AsyncScrollingCoordinator.cpp
+++ b/Source/WebCore/page/scrolling/AsyncScrollingCoordinator.cpp
@@ -946,6 +946,7 @@ void AsyncScrollingCoordinator::setScrollingNodeScrollableAreaGeometry(Scrolling
     scrollParameters.horizontalNativeScrollbarVisibility = scrollableArea.horizontalNativeScrollbarVisibility();
     scrollParameters.verticalNativeScrollbarVisibility = scrollableArea.verticalNativeScrollbarVisibility();
     scrollParameters.useDarkAppearanceForScrollbars = scrollableArea.useDarkAppearanceForScrollbars();
+    scrollParameters.scrollbarWidthStyle = scrollableArea.scrollbarWidthStyle();
 
     scrollingNode->setScrollableAreaParameters(scrollParameters);
 

--- a/Source/WebCore/page/scrolling/ScrollingCoordinatorTypes.h
+++ b/Source/WebCore/page/scrolling/ScrollingCoordinatorTypes.h
@@ -89,6 +89,8 @@ struct ScrollableAreaParameters {
 
     bool useDarkAppearanceForScrollbars { false };
 
+    ScrollbarWidth scrollbarWidthStyle { ScrollbarWidth::Auto };
+
     bool operator==(const ScrollableAreaParameters& other) const
     {
         return horizontalScrollElasticity == other.horizontalScrollElasticity
@@ -101,7 +103,8 @@ struct ScrollableAreaParameters {
             && allowsVerticalScrolling == other.allowsVerticalScrolling
             && horizontalNativeScrollbarVisibility == other.horizontalNativeScrollbarVisibility
             && verticalNativeScrollbarVisibility == other.verticalNativeScrollbarVisibility
-            && useDarkAppearanceForScrollbars == other.useDarkAppearanceForScrollbars;
+            && useDarkAppearanceForScrollbars == other.useDarkAppearanceForScrollbars
+            && scrollbarWidthStyle == other.scrollbarWidthStyle;
     }
 };
 

--- a/Source/WebCore/page/scrolling/ScrollingTreeScrollingNode.h
+++ b/Source/WebCore/page/scrolling/ScrollingTreeScrollingNode.h
@@ -127,7 +127,9 @@ public:
 
     const LayerRepresentation& scrollContainerLayer() const { return m_scrollContainerLayer; }
     const LayerRepresentation& scrolledContentsLayer() const { return m_scrolledContentsLayer; }
-    
+
+    ScrollbarWidth scrollbarWidthStyle() const { return m_scrollableAreaParameters.scrollbarWidthStyle; }
+
     OverscrollBehavior horizontalOverscrollBehavior() const { return m_scrollableAreaParameters.horizontalOverscrollBehavior; }
     OverscrollBehavior verticalOverscrollBehavior() const { return m_scrollableAreaParameters.verticalOverscrollBehavior; }
     

--- a/Source/WebCore/page/scrolling/mac/ScrollerMac.mm
+++ b/Source/WebCore/page/scrolling/mac/ScrollerMac.mm
@@ -330,7 +330,7 @@ ScrollerMac::~ScrollerMac()
 void ScrollerMac::attach()
 {
     m_scrollerImpDelegate = adoptNS([[WebScrollerImpDelegateMac alloc] initWithScroller:this]);
-    m_scrollerImp = [NSScrollerImp scrollerImpWithStyle:nsScrollerStyle(m_pair.scrollbarStyle()) controlSize:NSControlSizeRegular horizontal:m_orientation == ScrollbarOrientation::Horizontal replacingScrollerImp:nil];
+    m_scrollerImp = [NSScrollerImp scrollerImpWithStyle:nsScrollerStyle(m_pair.scrollbarStyle()) controlSize:nsControlSizeFromScrollbarWidth(m_pair.scrollbarWidthStyle()) horizontal:m_orientation == ScrollbarOrientation::Horizontal replacingScrollerImp:nil];
     [m_scrollerImp setDelegate:m_scrollerImpDelegate.get()];
 }
 
@@ -369,7 +369,7 @@ void ScrollerMac::updateValues()
 
 void ScrollerMac::updateScrollbarStyle()
 {
-    m_scrollerImp = [NSScrollerImp scrollerImpWithStyle:nsScrollerStyle(m_pair.scrollbarStyle()) controlSize:NSControlSizeRegular horizontal:m_orientation == ScrollbarOrientation::Horizontal replacingScrollerImp:takeScrollerImp().get()];
+    m_scrollerImp = [NSScrollerImp scrollerImpWithStyle:nsScrollerStyle(m_pair.scrollbarStyle()) controlSize:nsControlSizeFromScrollbarWidth(m_pair.scrollbarWidthStyle()) horizontal:m_orientation == ScrollbarOrientation::Horizontal replacingScrollerImp:takeScrollerImp().get()];
     updatePairScrollerImps();
 }
 

--- a/Source/WebCore/page/scrolling/mac/ScrollerPairMac.h
+++ b/Source/WebCore/page/scrolling/mac/ScrollerPairMac.h
@@ -72,6 +72,7 @@ public:
 
     FloatSize visibleSize() const;
     bool useDarkAppearance() const;
+    ScrollbarWidth scrollbarWidthStyle() const;
 
     struct Values {
         float value;
@@ -96,6 +97,8 @@ public:
 
     ScrollbarStyle scrollbarStyle() const { return m_scrollbarStyle; }
     void setScrollbarStyle(ScrollbarStyle);
+
+    void updateScrollbarWidth();
 
     void setVerticalScrollerImp(NSScrollerImp *);
     void setHorizontalScrollerImp(NSScrollerImp *);

--- a/Source/WebCore/page/scrolling/mac/ScrollerPairMac.mm
+++ b/Source/WebCore/page/scrolling/mac/ScrollerPairMac.mm
@@ -260,6 +260,11 @@ bool ScrollerPairMac::useDarkAppearance() const
     return m_scrollingNode.useDarkAppearanceForScrollbars();
 }
 
+ScrollbarWidth ScrollerPairMac::scrollbarWidthStyle() const
+{
+    return m_scrollingNode.scrollbarWidthStyle();
+}
+
 ScrollerPairMac::Values ScrollerPairMac::valuesForOrientation(ScrollbarOrientation orientation)
 {
     float position;
@@ -326,6 +331,14 @@ void ScrollerPairMac::setScrollbarStyle(ScrollbarStyle style)
         m_horizontalScroller.updateScrollbarStyle();
         m_verticalScroller.updateScrollbarStyle();
         [m_scrollerImpPair setScrollerStyle:scrollerStyle];
+    });
+}
+
+void ScrollerPairMac::updateScrollbarWidth()
+{
+    ensureOnMainThreadWithProtectedThis([this] {
+        m_horizontalScroller.updateScrollbarStyle();
+        m_verticalScroller.updateScrollbarStyle();
     });
 }
 

--- a/Source/WebCore/page/scrolling/mac/ScrollingTreeScrollingNodeDelegateMac.mm
+++ b/Source/WebCore/page/scrolling/mac/ScrollingTreeScrollingNodeDelegateMac.mm
@@ -81,6 +81,10 @@ void ScrollingTreeScrollingNodeDelegateMac::updateFromStateNode(const ScrollingS
             m_scrollerPair->horizontalScroller().setHostLayer(nullptr);
         if (scrollingStateNode.scrollableAreaParameters().verticalNativeScrollbarVisibility != NativeScrollbarVisibility::Visible)
             m_scrollerPair->verticalScroller().setHostLayer(nullptr);
+
+        // TODO: Find a way to make this not run when UISideCompositing is off because it breaks initial scrollbar rendering
+        // TODO: Potentially should only run this when ScrollbarWidth updates specifically but I don't think we have an old copy of the scrollingStateNode to diff
+        m_scrollerPair->updateScrollbarWidth();
     }
     
     if (scrollingStateNode.hasChangedProperty(ScrollingStateNode::Property::ContentAreaHoverState)) {

--- a/Source/WebCore/platform/ScrollTypes.h
+++ b/Source/WebCore/platform/ScrollTypes.h
@@ -427,4 +427,13 @@ template<> struct EnumTraits<WebCore::ScrollbarOrientation> {
         WebCore::ScrollbarOrientation::Vertical
     >;
 };
+
+template<> struct EnumTraits<WebCore::ScrollbarWidth> {
+    using values = EnumValues<
+        WebCore::ScrollbarWidth,
+        WebCore::ScrollbarWidth::Auto,
+        WebCore::ScrollbarWidth::Thin,
+        WebCore::ScrollbarWidth::None
+    >;
+};
 } // namespace WTF

--- a/Source/WebCore/platform/mac/ScrollTypesMac.h
+++ b/Source/WebCore/platform/mac/ScrollTypesMac.h
@@ -56,6 +56,20 @@ inline ScrollbarStyle scrollbarStyle(NSScrollerStyle style)
     return ScrollbarStyle::AlwaysVisible;
 }
 
+inline NSControlSize nsControlSizeFromScrollbarWidth(ScrollbarWidth width)
+{
+    switch (width) {
+    case ScrollbarWidth::Auto:
+    case ScrollbarWidth::None:
+        return NSControlSizeRegular;
+    case ScrollbarWidth::Thin:
+        return NSControlSizeSmall;
+    }
+
+    ASSERT_NOT_REACHED();
+    return NSControlSizeRegular;
+}
+
 } // namespace WebCore
 
 #endif // PLATFORM(MAC)

--- a/Source/WebCore/platform/mac/ScrollbarThemeMac.mm
+++ b/Source/WebCore/platform/mac/ScrollbarThemeMac.mm
@@ -34,6 +34,7 @@
 #import "LocalCurrentGraphicsContext.h"
 #import "NSScrollerImpDetails.h"
 #import "PlatformMouseEvent.h"
+#import "ScrollTypesMac.h"
 #import "ScrollView.h"
 #import "ScrollbarTrackCornerSystemImageMac.h"
 #import <Carbon/Carbon.h>
@@ -141,20 +142,6 @@ static bool gUsesOverlayScrollbars = false;
 
 static ScrollbarButtonsPlacement gButtonPlacement = ScrollbarButtonsDoubleEnd;
 
-static NSControlSize scrollbarWidthToNSControlSize(ScrollbarWidth scrollbarWidth)
-{
-    switch (scrollbarWidth) {
-    case ScrollbarWidth::Auto:
-    case ScrollbarWidth::None:
-        return NSControlSizeRegular;
-    case ScrollbarWidth::Thin:
-        return NSControlSizeSmall;
-    }
-
-    ASSERT_NOT_REACHED();
-    return NSControlSizeRegular;
-}
-
 void ScrollbarThemeMac::didCreateScrollerImp(Scrollbar& scrollbar)
 {
 #if PLATFORM(MAC)
@@ -172,7 +159,7 @@ void ScrollbarThemeMac::registerScrollbar(Scrollbar& scrollbar)
         return;
 
     bool isHorizontal = scrollbar.orientation() == ScrollbarOrientation::Horizontal;
-    auto scrollerImp = retainPtr([NSScrollerImp scrollerImpWithStyle:ScrollerStyle::recommendedScrollerStyle() controlSize:scrollbarWidthToNSControlSize(scrollbar.widthStyle()) horizontal:isHorizontal replacingScrollerImp:nil]);
+    auto scrollerImp = retainPtr([NSScrollerImp scrollerImpWithStyle:ScrollerStyle::recommendedScrollerStyle() controlSize:nsControlSizeFromScrollbarWidth(scrollbar.widthStyle()) horizontal:isHorizontal replacingScrollerImp:nil]);
     scrollbarMap().add(&scrollbar, WTFMove(scrollerImp));
     didCreateScrollerImp(scrollbar);
     updateEnabledState(scrollbar);
@@ -249,7 +236,7 @@ int ScrollbarThemeMac::scrollbarThickness(ScrollbarWidth scrollbarWidth, Scrollb
     BEGIN_BLOCK_OBJC_EXCEPTIONS
     if (scrollbarWidth == ScrollbarWidth::None)
         return 0;
-    NSScrollerImp *scrollerImp = [NSScrollerImp scrollerImpWithStyle:ScrollerStyle::recommendedScrollerStyle() controlSize:scrollbarWidthToNSControlSize(scrollbarWidth) horizontal:NO replacingScrollerImp:nil];
+    NSScrollerImp *scrollerImp = [NSScrollerImp scrollerImpWithStyle:ScrollerStyle::recommendedScrollerStyle() controlSize:nsControlSizeFromScrollbarWidth(scrollbarWidth) horizontal:NO replacingScrollerImp:nil];
     [scrollerImp setExpanded:(expansionState == ScrollbarExpansionState::Expanded)];
     return [scrollerImp trackBoxWidth];
     END_BLOCK_OBJC_EXCEPTIONS

--- a/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
+++ b/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
@@ -1978,6 +1978,13 @@ header: <WebCore/ScrollTypes.h>
     ReplacedByCustomScrollbar
 };
 
+header: <WebCore/ScrollTypes.h>
+[CustomHeader] enum class WebCore::ScrollbarWidth : uint8_t {
+    Auto,
+    Thin,
+    None
+};
+
 header: <WebCore/ScrollingCoordinatorTypes.h>
 [CustomHeader] struct WebCore::ScrollableAreaParameters {
     WebCore::ScrollElasticity horizontalScrollElasticity;
@@ -1991,6 +1998,7 @@ header: <WebCore/ScrollingCoordinatorTypes.h>
     WebCore::NativeScrollbarVisibility horizontalNativeScrollbarVisibility;
     WebCore::NativeScrollbarVisibility verticalNativeScrollbarVisibility;
     bool useDarkAppearanceForScrollbars;
+    WebCore::ScrollbarWidth scrollbarWidthStyle;
 };
 
 header: <WebCore/ScrollingCoordinatorTypes.h>


### PR DESCRIPTION
#### 1306f071c9cab8f2ba8a23d0830d554b1d64dcf4
<pre>
Pass scrollbarWidth through when using UISideCompositing
<a href="https://bugs.webkit.org/show_bug.cgi?id=257430">https://bugs.webkit.org/show_bug.cgi?id=257430</a>

Reviewed by NOBODY (OOPS!).

This change passes through the scrollbarWidthStyle into
ScrollableAreaParams which is used inside of ScrollerMac.

The Scroller implementation is reset when ScrollableAreaParameters updates
this fixes scrollbar-width: thin when UISideCompositing is enabled.

* Source/WebCore/page/scrolling/AsyncScrollingCoordinator.cpp:
(WebCore::AsyncScrollingCoordinator::setScrollingNodeScrollableAreaGeometry):
* Source/WebCore/page/scrolling/ScrollingCoordinatorTypes.h:
(WebCore::ScrollableAreaParameters::operator== const):
* Source/WebCore/page/scrolling/ScrollingTreeScrollingNode.h:
* Source/WebCore/page/scrolling/mac/ScrollerMac.mm:
(WebCore::ScrollerMac::attach):
(WebCore::ScrollerMac::updateScrollbarStyle):
* Source/WebCore/page/scrolling/mac/ScrollerPairMac.h:
* Source/WebCore/page/scrolling/mac/ScrollerPairMac.mm:
(WebCore::ScrollerPairMac::scrollbarWidthStyle const):
(WebCore::ScrollerPairMac::updateScrollbarWidth):
* Source/WebCore/page/scrolling/mac/ScrollingTreeScrollingNodeDelegateMac.mm:
(WebCore::ScrollingTreeScrollingNodeDelegateMac::updateFromStateNode):
* Source/WebCore/platform/ScrollTypes.h:
* Source/WebCore/platform/mac/ScrollTypesMac.h:
(WebCore::nsControlSizeFromScrollbarWidth):
* Source/WebCore/platform/mac/ScrollbarThemeMac.mm:
(WebCore::ScrollbarThemeMac::registerScrollbar):
(WebCore::ScrollbarThemeMac::scrollbarThickness):
(WebCore::scrollbarWidthToNSControlSize): Deleted.
* Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1306f071c9cab8f2ba8a23d0830d554b1d64dcf4

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/10350 "1 style error") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/10584 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/10855 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/11995 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/9944 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/12656 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/10536 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/12909 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/10508 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/11294 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/8724 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/12390 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/8597 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/9378 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/16646 "Passed tests") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/8744 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/9691 "Passed tests") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/9529 "4 failures") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/12776 "Passed tests") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/9818 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/9966 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/8090 "2 failures") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/10481 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/9125 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/9273 "Passed tests") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/2724 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/13376 "Built successfully") | | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/24/builds/10768 "Built successfully") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/9817 "Built successfully") | | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/3/builds/2659 "Passed tests") | 
<!--EWS-Status-Bubble-End-->