### PR TITLE
RemoteLayerTreeDisplayRefreshMonitor::displayNominalFramesPerSecond returns the preferred frames per secon

### DIFF
--- a/Source/WebCore/page/Page.cpp
+++ b/Source/WebCore/page/Page.cpp
@@ -1394,11 +1394,6 @@ void Page::windowScreenDidChange(PlatformDisplayID displayID, std::optional<Fram
 
     m_displayID = displayID;
     m_displayNominalFramesPerSecond = nominalFramesPerSecond;
-    if (!m_displayNominalFramesPerSecond) {
-        // If the caller didn't give us a refresh rate, maybe the relevant DisplayRefreshMonitor can? This happens in WebKitLegacy
-        // because WebView doesn't have a convenient way to access the display refresh rate.
-        m_displayNominalFramesPerSecond = DisplayRefreshMonitorManager::sharedManager().nominalFramesPerSecondForDisplay(m_displayID, chrome().client().displayRefreshMonitorFactory());
-    }
 
     forEachDocument([&] (Document& document) {
         document.windowScreenDidChange(displayID);

--- a/Source/WebCore/platform/graphics/DisplayRefreshMonitorManager.h
+++ b/Source/WebCore/platform/graphics/DisplayRefreshMonitorManager.h
@@ -47,7 +47,7 @@ public:
     bool scheduleAnimation(DisplayRefreshMonitorClient&);
     void windowScreenDidChange(PlatformDisplayID, DisplayRefreshMonitorClient&);
     
-    std::optional<FramesPerSecond> nominalFramesPerSecondForDisplay(PlatformDisplayID, DisplayRefreshMonitorFactory*);
+    WEBCORE_EXPORT std::optional<FramesPerSecond> nominalFramesPerSecondForDisplay(PlatformDisplayID, DisplayRefreshMonitorFactory*);
 
     void clientPreferredFramesPerSecondChanged(DisplayRefreshMonitorClient&);
 

--- a/Source/WebKit/UIProcess/DrawingAreaProxy.h
+++ b/Source/WebKit/UIProcess/DrawingAreaProxy.h
@@ -76,7 +76,8 @@ public:
 
     virtual void deviceScaleFactorDidChange() = 0;
     virtual void colorSpaceDidChange() { }
-    virtual void windowScreenDidChange(WebCore::PlatformDisplayID, std::optional<WebCore::FramesPerSecond> /* nominalFramesPerSecond */) { }
+    virtual void windowScreenDidChange(WebCore::PlatformDisplayID) { }
+    virtual std::optional<WebCore::FramesPerSecond> displayNominalFramesPerSecond() { return std::nullopt; }
 
     // FIXME: These should be pure virtual.
     virtual void setBackingStoreIsDiscardable(bool) { }

--- a/Source/WebKit/UIProcess/RemoteLayerTree/ios/RemoteLayerTreeDrawingAreaProxyIOS.h
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/ios/RemoteLayerTreeDrawingAreaProxyIOS.h
@@ -47,6 +47,8 @@ private:
     void scheduleDisplayRefreshCallbacks() override;
     void pauseDisplayRefreshCallbacks() override;
 
+    std::optional<WebCore::FramesPerSecond> displayNominalFramesPerSecond() override;
+
     WKDisplayLinkHandler *displayLinkHandler();
 
     RetainPtr<WKDisplayLinkHandler> m_displayLinkHandler;

--- a/Source/WebKit/UIProcess/RemoteLayerTree/ios/RemoteLayerTreeDrawingAreaProxyIOS.mm
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/ios/RemoteLayerTreeDrawingAreaProxyIOS.mm
@@ -36,6 +36,8 @@
 #import <WebCore/ScrollView.h>
 #import <pal/spi/cocoa/QuartzCoreSPI.h>
 
+constexpr WebCore::FramesPerSecond DisplayLinkFramesPerSecond = 60;
+
 @interface WKDisplayLinkHandler : NSObject {
     WebKit::RemoteLayerTreeDrawingAreaProxy* _drawingAreaProxy;
     CADisplayLink *_displayLink;
@@ -50,6 +52,7 @@
 - (void)displayLinkFired:(CADisplayLink *)sender;
 - (void)invalidate;
 - (void)schedule;
+- (WebCore::FramesPerSecond)nominalFramesPerSecond;
 
 @end
 
@@ -76,20 +79,7 @@
             if (drawingAreaProxy && !drawingAreaProxy->page().preferences().preferPageRenderingUpdatesNear60FPSEnabled())
                 _displayLink.preferredFramesPerSecond = (1.0 / _displayLink.maximumRefreshRate);
             else
-                _displayLink.preferredFramesPerSecond = 60;
-        }
-
-        if (drawingAreaProxy) {
-            auto& page = drawingAreaProxy->page();
-            if (page.preferences().webAnimationsCustomFrameRateEnabled() || !page.preferences().preferPageRenderingUpdatesNear60FPSEnabled()) {
-                auto minimumRefreshInterval = _displayLink.maximumRefreshRate;
-                if (minimumRefreshInterval > 0) {
-                    if (auto displayID = page.displayID()) {
-                        WebCore::FramesPerSecond frameRate = std::round(1.0 / minimumRefreshInterval);
-                        page.windowScreenDidChange(*displayID, frameRate);
-                    }
-                }
-            }
+                _displayLink.preferredFramesPerSecond = DisplayLinkFramesPerSecond;
         }
     }
     return self;
@@ -149,6 +139,18 @@
 #endif
 }
 
+- (WebCore::FramesPerSecond)nominalFramesPerSecond
+{
+    auto& page = _drawingAreaProxy->page();
+    if (page.preferences().webAnimationsCustomFrameRateEnabled() || !page.preferences().preferPageRenderingUpdatesNear60FPSEnabled()) {
+        auto minimumRefreshInterval = _displayLink.maximumRefreshRate;
+        if (minimumRefreshInterval > 0)
+            return std::round(1.0 / minimumRefreshInterval);
+    }
+
+    return DisplayLinkFramesPerSecond;
+}
+
 @end
 
 namespace WebKit {
@@ -195,6 +197,11 @@ void RemoteLayerTreeDrawingAreaProxyIOS::scheduleDisplayRefreshCallbacks()
 void RemoteLayerTreeDrawingAreaProxyIOS::pauseDisplayRefreshCallbacks()
 {
     [displayLinkHandler() pause];
+}
+
+std::optional<WebCore::FramesPerSecond> RemoteLayerTreeDrawingAreaProxyIOS::displayNominalFramesPerSecond()
+{
+    return [displayLinkHandler() nominalFramesPerSecond];
 }
 
 } // namespace WebKit

--- a/Source/WebKit/UIProcess/RemoteLayerTree/mac/RemoteLayerTreeDrawingAreaProxyMac.h
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/mac/RemoteLayerTreeDrawingAreaProxyMac.h
@@ -71,7 +71,8 @@ private:
     void scheduleDisplayRefreshCallbacks() override;
     void pauseDisplayRefreshCallbacks() override;
     void setPreferredFramesPerSecond(WebCore::FramesPerSecond) override;
-    void windowScreenDidChange(WebCore::PlatformDisplayID, std::optional<WebCore::FramesPerSecond>) override;
+    void windowScreenDidChange(WebCore::PlatformDisplayID) override;
+    std::optional<WebCore::FramesPerSecond> displayNominalFramesPerSecond() override;
     void colorSpaceDidChange() override;
 
     void didChangeViewExposedRect() override;

--- a/Source/WebKit/UIProcess/RemoteLayerTree/mac/RemoteLayerTreeDrawingAreaProxyMac.mm
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/mac/RemoteLayerTreeDrawingAreaProxyMac.mm
@@ -377,9 +377,9 @@ void RemoteLayerTreeDrawingAreaProxyMac::setDisplayLinkWantsFullSpeedUpdates(boo
         removeObserver(m_fullSpeedUpdateObserverID);
 }
 
-void RemoteLayerTreeDrawingAreaProxyMac::windowScreenDidChange(PlatformDisplayID displayID, std::optional<FramesPerSecond> nominalFramesPerSecond)
+void RemoteLayerTreeDrawingAreaProxyMac::windowScreenDidChange(PlatformDisplayID displayID)
 {
-    if (displayID == m_displayID && m_displayNominalFramesPerSecond == nominalFramesPerSecond)
+    if (displayID == m_displayID)
         return;
 
     bool hadFullSpeedOberver = m_fullSpeedUpdateObserverID.has_value();
@@ -389,9 +389,9 @@ void RemoteLayerTreeDrawingAreaProxyMac::windowScreenDidChange(PlatformDisplayID
     pauseDisplayRefreshCallbacks();
 
     m_displayID = displayID;
-    m_displayNominalFramesPerSecond = nominalFramesPerSecond;
+    m_displayNominalFramesPerSecond = displayNominalFramesPerSecond();
 
-    m_webPageProxy.scrollingCoordinatorProxy()->windowScreenDidChange(displayID, nominalFramesPerSecond);
+    m_webPageProxy.scrollingCoordinatorProxy()->windowScreenDidChange(displayID, m_displayNominalFramesPerSecond);
 
     scheduleDisplayRefreshCallbacks();
     if (hadFullSpeedOberver) {
@@ -399,6 +399,11 @@ void RemoteLayerTreeDrawingAreaProxyMac::windowScreenDidChange(PlatformDisplayID
         if (auto* displayLink = exisingDisplayLink())
             displayLink->addObserver(*m_displayLinkClient, *m_fullSpeedUpdateObserverID, displayLink->nominalFramesPerSecond());
     }
+}
+
+std::optional<WebCore::FramesPerSecond> RemoteLayerTreeDrawingAreaProxyMac::displayNominalFramesPerSecond()
+{
+    return displayLink().nominalFramesPerSecond();
 }
 
 void RemoteLayerTreeDrawingAreaProxyMac::didRefreshDisplay()

--- a/Source/WebKit/UIProcess/WebPageProxy.h
+++ b/Source/WebKit/UIProcess/WebPageProxy.h
@@ -1190,7 +1190,7 @@ public:
 
     void accessibilitySettingsDidChange();
 
-    void windowScreenDidChange(WebCore::PlatformDisplayID, std::optional<WebCore::FramesPerSecond> nominalFramesPerSecond);
+    void windowScreenDidChange(WebCore::PlatformDisplayID);
     std::optional<WebCore::PlatformDisplayID> displayID() const { return m_displayID; }
 
 #if PLATFORM(IOS_FAMILY)

--- a/Source/WebKit/UIProcess/ios/WKContentView.mm
+++ b/Source/WebKit/UIProcess/ios/WKContentView.mm
@@ -207,7 +207,7 @@ static NSArray *keyCommandsPlaceholderHackForEvernote(id self, SEL _cmd)
     _page->setUseFixedLayout(true);
     _page->setScreenIsBeingCaptured([[[self window] screen] isCaptured]);
 
-    _page->windowScreenDidChange(_page->generateDisplayIDFromPageID(), std::nullopt);
+    _page->windowScreenDidChange(_page->generateDisplayIDFromPageID());
 
 #if ENABLE(FULLSCREEN_API)
     _page->setFullscreenClient(makeUnique<WebKit::FullscreenClient>(self.webView));

--- a/Source/WebKit/UIProcess/mac/TiledCoreAnimationDrawingAreaProxy.h
+++ b/Source/WebKit/UIProcess/mac/TiledCoreAnimationDrawingAreaProxy.h
@@ -54,6 +54,8 @@ private:
     void waitForDidUpdateActivityState(ActivityStateChangeID, WebProcessProxy&) override;
     void dispatchPresentationCallbacksAfterFlushingLayers(IPC::Connection&, Vector<IPC::AsyncReplyID>&&) final;
 
+    std::optional<WebCore::FramesPerSecond> displayNominalFramesPerSecond() final;
+
     void willSendUpdateGeometry();
 
     WTF::MachSendRight createFence() override;

--- a/Source/WebKit/UIProcess/mac/TiledCoreAnimationDrawingAreaProxy.mm
+++ b/Source/WebKit/UIProcess/mac/TiledCoreAnimationDrawingAreaProxy.mm
@@ -214,6 +214,13 @@ void TiledCoreAnimationDrawingAreaProxy::dispatchPresentationCallbacksAfterFlush
     }
 }
 
+std::optional<WebCore::FramesPerSecond> TiledCoreAnimationDrawingAreaProxy::displayNominalFramesPerSecond()
+{
+    if (!m_webPageProxy.displayID())
+        return std::nullopt;
+    return m_webPageProxy.process().nominalFramesPerSecondForDisplay(*m_webPageProxy.displayID());
+}
+
 } // namespace WebKit
 
 #endif // !PLATFORM(IOS_FAMILY)

--- a/Source/WebKit/UIProcess/mac/WebViewImpl.mm
+++ b/Source/WebKit/UIProcess/mac/WebViewImpl.mm
@@ -2035,8 +2035,7 @@ void WebViewImpl::windowDidChangeScreen()
 {
     NSWindow *window = m_targetWindowForMovePreparation ? m_targetWindowForMovePreparation.get() : [m_view window];
     auto displayID = WebCore::displayID(window.screen);
-    auto framesPerSecond = m_page->process().nominalFramesPerSecondForDisplay(displayID);
-    m_page->windowScreenDidChange(displayID, framesPerSecond);
+    m_page->windowScreenDidChange(displayID);
 }
 
 void WebViewImpl::windowDidChangeLayerHosting()

--- a/Source/WebKit/WebProcess/WebPage/RemoteLayerTree/RemoteLayerTreeDisplayRefreshMonitor.h
+++ b/Source/WebKit/WebProcess/WebPage/RemoteLayerTree/RemoteLayerTreeDisplayRefreshMonitor.h
@@ -50,7 +50,6 @@ private:
 
     bool startNotificationMechanism() final { return true; }
     void stopNotificationMechanism() final { }
-    std::optional<WebCore::FramesPerSecond> displayNominalFramesPerSecond() final;
 
     void triggerDisplayDidRefresh();
 

--- a/Source/WebKit/WebProcess/WebPage/RemoteLayerTree/RemoteLayerTreeDisplayRefreshMonitor.mm
+++ b/Source/WebKit/WebProcess/WebPage/RemoteLayerTree/RemoteLayerTreeDisplayRefreshMonitor.mm
@@ -113,9 +113,4 @@ void RemoteLayerTreeDisplayRefreshMonitor::updateDrawingArea(RemoteLayerTreeDraw
     m_drawingArea = drawingArea;
 }
 
-std::optional<FramesPerSecond> RemoteLayerTreeDisplayRefreshMonitor::displayNominalFramesPerSecond()
-{
-    return m_preferredFramesPerSecond;
-}
-
 } // namespace WebKit

--- a/Source/WebKitLegacy/mac/WebView/WebView.mm
+++ b/Source/WebKitLegacy/mac/WebView/WebView.mm
@@ -146,6 +146,7 @@
 #import <WebCore/DeprecatedGlobalSettings.h>
 #import <WebCore/DictationAlternative.h>
 #import <WebCore/DictionaryLookup.h>
+#import <WebCore/DisplayRefreshMonitorManager.h>
 #import <WebCore/Document.h>
 #import <WebCore/DocumentLoader.h>
 #import <WebCore/DragController.h>
@@ -5622,8 +5623,13 @@ static NSString * const backingPropertyOldScaleFactorKey = @"NSBackingPropertyOl
 #if !PLATFORM(IOS_FAMILY)
 - (void)doWindowDidChangeScreen
 {
-    if (_private && _private->page)
-        _private->page->chrome().windowScreenDidChange(WebCore::displayID(self.window.screen), std::nullopt);
+    if (_private && _private->page) {
+        // Try to find the refresh rate from the display refresh monitor, since
+        // we don't have any other easy way to access it from here.
+        auto displayID = WebCore::displayID(self.window.screen);
+        auto nominalFramesPerSecond = WebCore::DisplayRefreshMonitorManager::sharedManager().nominalFramesPerSecondForDisplay(displayID, _private->page->chrome().client().displayRefreshMonitorFactory());
+        _private->page->chrome().windowScreenDidChange(displayID, nominalFramesPerSecond);
+    }
 }
 
 - (void)_windowChangedKeyState


### PR DESCRIPTION
#### e85bed10ffa8086b32e83b3ddbfce028d22dcb67
<pre>
RemoteLayerTreeDisplayRefreshMonitor::displayNominalFramesPerSecond returns the preferred frames per secon
<a href="https://bugs.webkit.org/show_bug.cgi?id=257443">https://bugs.webkit.org/show_bug.cgi?id=257443</a>
&lt;rdar://problem/109953270&gt;

Reviewed by Simon Fraser.

displayNominalFramesPerSecond is intended to return the refresh rate of the display, but RemoteLayerTreeDisplayRefreshMonitor returns the preferred value set by the Page.
This might be the nominal rate, but could also be a lower value if the Page applied throttling.
The only caller of this function is Page, so it&apos;s a circular dependency, that can&apos;t return any useful information.

I&apos;m not aware of current bugs from this, but it seems plausible that we&apos;d issue a windowScreenDidChange on iOS, and retrieve a throttled rate from the existing refresh monitor.

This change removes the callsite from Page, and moves the responsibility for determining the nominal refresh rate to the (WebKit) callers of windowScreenDidChange.

For RemoteLayerTree rendering, the WebPageProxy (in the UI process) now queries the DrawingAreaProxy for the rate. Both mac and iOS implementations retrieve the actual
nominal refresh rate from the display link.
iOS previously synthesized a second windowScreenDidChange message to override the nominal rate when required by config settings, this is now removed as we query the
desired rate correctly the first time.

The call to DisplayRefreshMonitorManager::normalFramesPerSecond is moved from Page, into WebKitLegacy&apos;s WebView. This call was added specifically for WK1, and
the only useful implementation is LegacyDisplayRefreshMonitorMac, so moving it into WK1 code makes it clearer where it&apos;s adding value.

* Source/WebCore/page/Page.cpp:
(WebCore::Page::windowScreenDidChange):
* Source/WebCore/platform/graphics/DisplayRefreshMonitorManager.h:
* Source/WebKit/UIProcess/DrawingAreaProxy.h:
(WebKit::DrawingAreaProxy::windowScreenDidChange):
(WebKit::DrawingAreaProxy::displayNominalFramesPerSecond):
* Source/WebKit/UIProcess/RemoteLayerTree/ios/RemoteLayerTreeDrawingAreaProxyIOS.h:
* Source/WebKit/UIProcess/RemoteLayerTree/ios/RemoteLayerTreeDrawingAreaProxyIOS.mm:
(-[WKDisplayLinkHandler initWithDrawingAreaProxy:]):
(-[WKDisplayLinkHandler nominalFramesPerSecond]):
(WebKit::RemoteLayerTreeDrawingAreaProxyIOS::displayNominalFramesPerSecond):
* Source/WebKit/UIProcess/RemoteLayerTree/mac/RemoteLayerTreeDrawingAreaProxyMac.h:
* Source/WebKit/UIProcess/RemoteLayerTree/mac/RemoteLayerTreeDrawingAreaProxyMac.mm:
(WebKit::RemoteLayerTreeDrawingAreaProxyMac::windowScreenDidChange):
(WebKit::RemoteLayerTreeDrawingAreaProxyMac::displayNominalFramesPerSecond):
* Source/WebKit/UIProcess/WebPageProxy.cpp:
(WebKit::WebPageProxy::swapToProvisionalPage):
(WebKit::WebPageProxy::windowScreenDidChange):
* Source/WebKit/UIProcess/WebPageProxy.h:
* Source/WebKit/UIProcess/ios/WKContentView.mm:
(-[WKContentView _commonInitializationWithProcessPool:configuration:]):
* Source/WebKit/UIProcess/mac/TiledCoreAnimationDrawingAreaProxy.h:
* Source/WebKit/UIProcess/mac/TiledCoreAnimationDrawingAreaProxy.mm:
(WebKit::TiledCoreAnimationDrawingAreaProxy::displayNominalFramesPerSecond):
* Source/WebKit/UIProcess/mac/WebViewImpl.mm:
(WebKit::WebViewImpl::windowDidChangeScreen):
* Source/WebKit/WebProcess/WebPage/RemoteLayerTree/RemoteLayerTreeDisplayRefreshMonitor.h:
* Source/WebKit/WebProcess/WebPage/RemoteLayerTree/RemoteLayerTreeDisplayRefreshMonitor.mm:
(WebKit::RemoteLayerTreeDisplayRefreshMonitor::displayNominalFramesPerSecond): Deleted.
* Source/WebKitLegacy/mac/WebView/WebView.mm:
(-[WebView doWindowDidChangeScreen]):

Canonical link: <a href="https://commits.webkit.org/264775@main">https://commits.webkit.org/264775@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/af249145afae7ea5adddfdf8c31d28616b54b20c

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/8248 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/8540 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/8757 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/9915 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/8314 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/8257 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/10528 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/8451 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/11189 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/8393 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/9459 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/7481 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/10060 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/6758 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/7546 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/15108 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/7881 "Passed tests") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/7681 "2 failures") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/11037 "6 api tests failed or timed out") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/8153 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/6633 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/7443 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/2085 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/11651 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/7896 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->