### PR TITLE
[popover] Check for modal flag instead of open attribute

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/popovers/popover-top-layer-combinations.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/popovers/popover-top-layer-combinations.html
@@ -54,8 +54,9 @@ window.onload = () => requestAnimationFrame(() => requestAnimationFrame(() => {
       if (ex.hasAttribute('open')) {
         assert_true(isDialog(ex));
         assert_true(isElementVisible(ex),'Open dialog should be visible by default');
-        assert_throws_dom("InvalidStateError",() => ex.showPopover(),'Calling showPopover on an already-showing element should throw InvalidStateError');
+        ex.showPopover(); // Should not throw
         ex.removeAttribute('open');
+        ex.hidePopover();
         assert_false(isElementVisible(ex),'Removing the open attribute should hide the dialog');
       } else {
         ex.showPopover(); // Should not throw
@@ -72,7 +73,9 @@ window.onload = () => requestAnimationFrame(() => requestAnimationFrame(() => {
       if (isDialog(ex)) {
         tested_something=true;
         assert_throws_dom("InvalidStateError",() => ex.showModal(),'Calling showModal() on an already-showing Popover should throw InvalidStateError');
-        assert_throws_dom("InvalidStateError",() => ex.show(),'Calling show() on an already-showing Popover should throw InvalidStateError');
+        ex.show(); // Should not throw
+        ex.close();
+        ex.showPopover();
       }
       if (isFullscreen(ex)) {
         tested_something=true;
@@ -94,14 +97,16 @@ window.onload = () => requestAnimationFrame(() => requestAnimationFrame(() => {
       if (isDialog(ex)) {
         ex.show();
         assert_true(ex.hasAttribute('open'));
-        assert_throws_dom("InvalidStateError",() => ex.showPopover(),'Calling showPopover() on an already-showing non-modal dialog should throw InvalidStateError');
+        ex.showPopover(); // Should not throw
         ex.close();
         assert_false(ex.hasAttribute('open'));
+        ex.hidePopover();
         ex.showModal();
         assert_true(ex.hasAttribute('open'));
         assert_throws_dom("InvalidStateError",() => ex.showPopover(),'Calling showPopover() on an already-showing modal dialog should throw InvalidStateError');
         ex.close();
         assert_false(ex.hasAttribute('open'));
+        ex.hidePopover();
       } else if (isFullscreen(ex)) {
         let requestSucceeded = false;
         await blessTopLayer(visible);

--- a/Source/WebCore/html/HTMLDialogElement.cpp
+++ b/Source/WebCore/html/HTMLDialogElement.cpp
@@ -59,9 +59,6 @@ ExceptionOr<void> HTMLDialogElement::show()
         return Exception { InvalidStateError, "Cannot call show() on an open modal dialog."_s };
     }
 
-    if (isPopoverShowing())
-        return Exception { InvalidStateError, "Element is already an open popover."_s };
-
     setBooleanAttribute(openAttr, true);
 
     m_previouslyFocusedElement = document().focusedElement();
@@ -114,13 +111,13 @@ void HTMLDialogElement::close(const String& result)
 
     setBooleanAttribute(openAttr, false);
 
+    if (isModal())
+        removeFromTopLayer();
+
     setIsModal(false);
 
     if (!result.isNull())
         m_returnValue = result;
-
-    if (isInTopLayer())
-        removeFromTopLayer();
 
     if (RefPtr element = std::exchange(m_previouslyFocusedElement, nullptr).get()) {
         FocusOptions options;

--- a/Source/WebCore/html/HTMLElement.cpp
+++ b/Source/WebCore/html/HTMLElement.cpp
@@ -1251,8 +1251,8 @@ static ExceptionOr<bool> checkPopoverValidity(HTMLElement& element, PopoverVisib
     if (expectedDocument && element.document() != *expectedDocument)
         return Exception { InvalidStateError, "Invalid when the document changes while showing or hiding a popover element"_s };
 
-    if (is<HTMLDialogElement>(element) && element.hasAttributeWithoutSynchronization(HTMLNames::openAttr))
-        return Exception { InvalidStateError, "Element is an open <dialog> element"_s };
+    if (is<HTMLDialogElement>(element) && downcast<HTMLDialogElement>(element).isModal())
+        return Exception { InvalidStateError, "Element is a modal <dialog> element"_s };
 
 #if ENABLE(FULLSCREEN_API)
     if (element.hasFullscreenFlag())


### PR DESCRIPTION
#### 62bb3c714cc988dad1913f7c2b6193182b7f4318
<pre>
[popover] Check for modal flag instead of open attribute
<a href="https://bugs.webkit.org/show_bug.cgi?id=257412">https://bugs.webkit.org/show_bug.cgi?id=257412</a>

Reviewed by Tim Nguyen.

Check for modal flag instead of open attribute in checkPopoverValidity check:
<a href="https://github.com/whatwg/html/pull/9344">https://github.com/whatwg/html/pull/9344</a>

* LayoutTests/imported/w3c/web-platform-tests/html/semantics/popovers/popover-top-layer-combinations.html:
* Source/WebCore/html/HTMLDialogElement.cpp:
(WebCore::HTMLDialogElement::show):
(WebCore::HTMLDialogElement::close):
* Source/WebCore/html/HTMLElement.cpp:
(WebCore::checkPopoverValidity):

Canonical link: <a href="https://commits.webkit.org/264876@main">https://commits.webkit.org/264876@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/fef69f8ea541d78cb36a50d48cd0eb7a9103f0be

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/8927 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/9215 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/9433 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/10580 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/8907 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/8935 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/11202 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/9182 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/11755 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/9073 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/10062 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/7864 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/10739 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/7357 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/8162 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/15650 "Passed tests") | 
| | [❌ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/8466 "4 api tests failed or timed out") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/8310 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/11638 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/8804 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/7184 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/8059 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/8069 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/2169 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/12271 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/8551 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->