### PR TITLE
[WGSL] AST::Builder needs to shrink nodes when restoring state

### DIFF
--- a/Source/WebGPU/WGSL/AST/ASTBuilder.cpp
+++ b/Source/WebGPU/WGSL/AST/ASTBuilder.cpp
@@ -79,6 +79,7 @@ void Builder::restore(State&& state)
 {
     for (size_t i = state.m_numberOfNodes; i < m_nodes.size(); ++i)
         m_nodes[i]->~Node();
+    m_nodes.shrink(state.m_numberOfNodes);
     m_arena = state.m_arena;
     m_arenas.shrink(state.m_numberOfArenas);
     m_arenaEnd = m_arenas.last().get() + arenaSize;


### PR DESCRIPTION
#### c94bdc51378de64788a375c8dd75feb58bdd172f
<pre>
[WGSL] AST::Builder needs to shrink nodes when restoring state
<a href="https://bugs.webkit.org/show_bug.cgi?id=257457">https://bugs.webkit.org/show_bug.cgi?id=257457</a>
rdar://109974514

Reviewed by Myles C. Maxfield.

When restoring the previous state of the AST builder we free the nodes that were
allocated during the current compilation, but we also need to remove them from
m_nodes, otherwise they&apos;ll be freed multiple times.

* Source/WebGPU/WGSL/AST/ASTBuilder.cpp:
(WGSL::AST::Builder::restore):

Canonical link: <a href="https://commits.webkit.org/264663@main">https://commits.webkit.org/264663@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/66752d7c71594b222337556bd7fe2886dc64ea6f

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/8279 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/8571 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/8788 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/9946 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/8343 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/10559 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/8482 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/11217 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/8424 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/9484 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/7513 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/10090 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/6783 "Passed tests") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/15136 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/7906 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/7714 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/11064 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/8183 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/6662 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/7473 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/1993 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/11682 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/7926 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->