### PR TITLE
[WGSL] Add support for constant vectors

### DIFF
--- a/Source/WebGPU/WGSL/AST/ASTExpression.h
+++ b/Source/WebGPU/WGSL/AST/ASTExpression.h
@@ -30,6 +30,7 @@
 #include <wtf/ReferenceWrapperVector.h>
 
 namespace WGSL {
+class ConstantRewriter;
 class TypeChecker;
 struct Type;
 
@@ -37,6 +38,7 @@ namespace AST {
 
 class Expression : public Node {
     WGSL_AST_BUILDER_NODE(Expression);
+    friend ConstantRewriter;
     friend TypeChecker;
 
 public:

--- a/Source/WebGPU/WGSL/AST/ASTTypeName.h
+++ b/Source/WebGPU/WGSL/AST/ASTTypeName.h
@@ -30,6 +30,7 @@
 #include "ASTIdentifier.h"
 
 namespace WGSL {
+class ConstantRewriter;
 class EntryPointRewriter;
 class RewriteGlobalVariables;
 class TypeChecker;
@@ -40,6 +41,7 @@ class Structure;
 
 class TypeName : public Node {
     friend TypeChecker;
+    friend ConstantRewriter;
     friend EntryPointRewriter;
     friend RewriteGlobalVariables;
 

--- a/Source/WebGPU/WGSL/tests/valid/constants.wgsl
+++ b/Source/WebGPU/WGSL/tests/valid/constants.wgsl
@@ -37,3 +37,13 @@ fn testArrayConstants() -> i32
     }
     return 0;
 }
+
+@compute @workgroup_size(1)
+fn testVectorConstants() -> i32
+{
+    if (false) {
+        const a = vec3(0, 0, 0);
+        return a.x;
+    }
+    return 0;
+}


### PR DESCRIPTION
#### 22282c4a26cfe887327093bc42513472a26b12fc
<pre>
[WGSL] Add support for constant vectors
<a href="https://bugs.webkit.org/show_bug.cgi?id=257460">https://bugs.webkit.org/show_bug.cgi?id=257460</a>
rdar://109975610

Reviewed by Myles C. Maxfield.

Continue extending the ConstantRewriter phase by adding support for vectors

* Source/WebGPU/WGSL/AST/ASTExpression.h:
* Source/WebGPU/WGSL/AST/ASTTypeName.h:
* Source/WebGPU/WGSL/ConstantRewriter.cpp:
(WGSL::ConstantVector::ConstantVector):
(WGSL::ConstantValue::dump const):
(WGSL::ConstantRewriter::evaluate):
(WGSL::ConstantRewriter::materialize):

Canonical link: <a href="https://commits.webkit.org/264668@main">https://commits.webkit.org/264668@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9b2dc4c8279bcb3723d1503792459c71d1068f03

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/8314 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/8607 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/8824 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/9982 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/8379 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/10595 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/8518 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/11249 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/8460 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/15/builds/9518 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/7542 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/10126 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/6817 "Passed tests") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/15170 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/7938 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/7749 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/11097 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/8219 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/6696 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/7508 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/1998 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/11718 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/7962 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->