### PR TITLE
[GTK][WPE]  fast/mediastream/RTCRtpSender-outlives-RTCPeerConnection.html crashing

### DIFF
--- a/Source/WebCore/Modules/mediastream/gstreamer/GStreamerMediaEndpoint.cpp
+++ b/Source/WebCore/Modules/mediastream/gstreamer/GStreamerMediaEndpoint.cpp
@@ -1347,6 +1347,9 @@ void GStreamerMediaEndpoint::onNegotiationNeeded()
     GST_DEBUG_OBJECT(m_pipeline.get(), "Scheduling negotiation-needed");
     ++m_negotiationNeededEventId;
     callOnMainThread([protectedThis = Ref(*this), this] {
+        if (isStopped())
+            return;
+
         GST_DEBUG_OBJECT(m_pipeline.get(), "Negotiation needed!");
         m_peerConnectionBackend.markAsNeedingNegotiation(m_negotiationNeededEventId);
     });


### PR DESCRIPTION
#### b670af1bd93cee969f139d75f4161695287cfb7d
<pre>
[GTK][WPE]  fast/mediastream/RTCRtpSender-outlives-RTCPeerConnection.html crashing
<a href="https://bugs.webkit.org/show_bug.cgi?id=257456">https://bugs.webkit.org/show_bug.cgi?id=257456</a>

Reviewed by Xabier Rodriguez-Calvar.

Prospective fix for the crash happening flakily on the bots, don&apos;t chain up the negotation-needed
request to the PeerConnection if the pipeline has been teared down. The LibWebRTC end-point uses a
similar approach.

* Source/WebCore/Modules/mediastream/gstreamer/GStreamerMediaEndpoint.cpp:
(WebCore::GStreamerMediaEndpoint::onNegotiationNeeded):

Canonical link: <a href="https://commits.webkit.org/264662@main">https://commits.webkit.org/264662@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/cecfa1e621b838673df7154822bbe2384af215f5

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/8282 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/8574 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/8791 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/9949 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/8346 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/8291 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/10562 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/8485 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/11221 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/8427 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/9487 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/7517 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/10093 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/6786 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/7577 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/15140 "2 flakes 114 failures") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/7909 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/7717 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/11068 "10 api tests failed or timed out") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/8186 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/6665 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/7476 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/1995 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/11685 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/7929 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->