### PR TITLE
Use signpost instead of trace-point in critical rendering path

### DIFF
--- a/Source/WebCore/page/Page.cpp
+++ b/Source/WebCore/page/Page.cpp
@@ -1735,7 +1735,7 @@ void Page::updateRendering()
 
     bool isSVGImagePage = chrome().client().isSVGImageChromeClient();
     if (!isSVGImagePage)
-        tracePoint(RenderingUpdateStart);
+        WTFBeginSignpost(this, "RenderingUpdate");
 
     layoutIfNeeded();
 
@@ -1844,7 +1844,7 @@ void Page::updateRendering()
     doAfterUpdateRendering();
 
     if (!isSVGImagePage)
-        tracePoint(RenderingUpdateEnd);
+        WTFEndSignpost(this, "RenderingUpdate");
 }
 
 void Page::isolatedUpdateRendering()

--- a/Source/WebCore/page/RenderingUpdateScheduler.cpp
+++ b/Source/WebCore/page/RenderingUpdateScheduler.cpp
@@ -78,7 +78,7 @@ void RenderingUpdateScheduler::scheduleRenderingUpdate()
         return;
     }
 
-    tracePoint(ScheduleRenderingUpdate);
+    WTFEmitSignpost(this, "ScheduleRenderingUpdate");
 
     if (!scheduleAnimation()) {
         LOG_WITH_STREAM(DisplayLink, stream << "RenderingUpdateScheduler::scheduleRenderingUpdate for interval " << m_page.preferredRenderingUpdateInterval() << " falling back to timer");
@@ -125,7 +125,7 @@ void RenderingUpdateScheduler::displayRefreshFired()
 {
     LOG_WITH_STREAM(EventLoop, stream << "RenderingUpdateScheduler for page " << &m_page << " displayRefreshFired()");
 
-    tracePoint(TriggerRenderingUpdate);
+    WTFEmitSignpost(this, "TriggerRenderingUpdate");
 
     clearScheduled();
     


### PR DESCRIPTION
#### 8e098a4b2a09ad70a6c87f4cec865bf4cef17484
<pre>
Use signpost instead of trace-point in critical rendering path
<a href="https://bugs.webkit.org/show_bug.cgi?id=257465">https://bugs.webkit.org/show_bug.cgi?id=257465</a>
rdar://109977538

Reviewed by NOBODY (OOPS!).

trace-point is *incredibly* costly operation. When it is used in wasm entry point, it caused massive regression[1],
and in JSC, trace-point is used only when explicit option is specified `JSC_useTracePoints`.
And the same issue is happening in WebCore. We have several tracePoint in super critical hot path
like `RenderingUpdateScheduler::scheduleRenderingUpdate` in WebCore, and dominated massive amount of time due to this
system call.

This patch switches them to signpost instead. If we use WTFEmitSignpost etc., it is collected only when explicit option
is attached to the tracing command. This avoids doing super costly tracing in the critical hot path, while we can collect
this information when we would like to do by explicitly attaching an option.

[1]: <a href="https://trac.webkit.org/changeset/233378/webkit">https://trac.webkit.org/changeset/233378/webkit</a>

* Source/WebCore/page/Page.cpp:
(WebCore::Page::updateRendering):
* Source/WebCore/page/RenderingUpdateScheduler.cpp:
(WebCore::RenderingUpdateScheduler::scheduleRenderingUpdate):
(WebCore::RenderingUpdateScheduler::displayRefreshFired):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/8e098a4b2a09ad70a6c87f4cec865bf4cef17484

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/8289 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/8581 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/8798 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/9956 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/8353 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/8298 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/10569 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/8492 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/11224 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/8434 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/9491 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/7521 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/10100 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/6790 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/7581 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/15143 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/7913 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/7721 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/11071 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/8193 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/6669 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/7483 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/11692 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/7936 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->