### PR TITLE
[Cocoa] Hook "prior context" infrastructure up to TextBreakIteratorCF

### DIFF
--- a/Source/WTF/WTF.xcodeproj/project.pbxproj
+++ b/Source/WTF/WTF.xcodeproj/project.pbxproj
@@ -52,6 +52,8 @@
 		1C2BA32628E6C19B00FA6E17 /* TextBreakIteratorCFCharacterCluster.h in Headers */ = {isa = PBXBuildFile; fileRef = 1C2BA32528E6C19500FA6E17 /* TextBreakIteratorCFCharacterCluster.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		1C2BA32828E6C24900FA6E17 /* TextBreakIteratorCFStringTokenizer.h in Headers */ = {isa = PBXBuildFile; fileRef = 1C2BA32728E6C24400FA6E17 /* TextBreakIteratorCFStringTokenizer.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		1C503BE623AAE0AE0072E66B /* LanguageCocoa.mm in Sources */ = {isa = PBXBuildFile; fileRef = 1C503BE523AAE0AE0072E66B /* LanguageCocoa.mm */; };
+		1C867D772A254F08000DE93D /* ContextualizedCFString.mm in Sources */ = {isa = PBXBuildFile; fileRef = 1C867D752A254F08000DE93D /* ContextualizedCFString.mm */; };
+		1C867D782A254F08000DE93D /* ContextualizedCFString.h in Headers */ = {isa = PBXBuildFile; fileRef = 1C867D762A254F08000DE93D /* ContextualizedCFString.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		1C96836426BE74DF00A2A2F9 /* LogInitialization.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 1C96836226BE74DF00A2A2F9 /* LogInitialization.cpp */; };
 		1C96836726BE754600A2A2F9 /* Logging.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 1C96836526BE754600A2A2F9 /* Logging.cpp */; };
 		1C96836926BE76B600A2A2F9 /* LoggingCocoa.mm in Sources */ = {isa = PBXBuildFile; fileRef = 1C96836826BE76B600A2A2F9 /* LoggingCocoa.mm */; };
@@ -1078,6 +1080,8 @@
 		1C2BA32528E6C19500FA6E17 /* TextBreakIteratorCFCharacterCluster.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = TextBreakIteratorCFCharacterCluster.h; sourceTree = "<group>"; };
 		1C2BA32728E6C24400FA6E17 /* TextBreakIteratorCFStringTokenizer.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = TextBreakIteratorCFStringTokenizer.h; sourceTree = "<group>"; };
 		1C503BE523AAE0AE0072E66B /* LanguageCocoa.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = LanguageCocoa.mm; sourceTree = "<group>"; };
+		1C867D752A254F08000DE93D /* ContextualizedCFString.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = ContextualizedCFString.mm; sourceTree = "<group>"; };
+		1C867D762A254F08000DE93D /* ContextualizedCFString.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = ContextualizedCFString.h; sourceTree = "<group>"; };
 		1C96836226BE74DF00A2A2F9 /* LogInitialization.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = LogInitialization.cpp; sourceTree = "<group>"; };
 		1C96836326BE74DF00A2A2F9 /* LogInitialization.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = LogInitialization.h; sourceTree = "<group>"; };
 		1C96836526BE754600A2A2F9 /* Logging.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = Logging.cpp; sourceTree = "<group>"; };
@@ -1916,6 +1920,8 @@
 			isa = PBXGroup;
 			children = (
 				4655743527F5FC4A002D5522 /* ASCIILiteralCocoa.mm */,
+				1C867D762A254F08000DE93D /* ContextualizedCFString.h */,
+				1C867D752A254F08000DE93D /* ContextualizedCFString.mm */,
 				1CA6FBAA2A1D75CD001D4402 /* ContextualizedNSString.h */,
 				1CA6FBA82A1D75B9001D4402 /* ContextualizedNSString.mm */,
 				A5BA15F2182433A900A82E69 /* StringCocoa.mm */,
@@ -2988,6 +2994,7 @@
 				DD3DC88F27A4BF8E007E5B61 /* ConcurrentVector.h in Headers */,
 				DD3DC8D027A4BF8E007E5B61 /* Condition.h in Headers */,
 				DDF307F527C0870E006A526F /* config.h in Headers */,
+				1C867D782A254F08000DE93D /* ContextualizedCFString.h in Headers */,
 				1CA6FBAB2A1D75D8001D4402 /* ContextualizedNSString.h in Headers */,
 				DDF307C627C086DF006A526F /* ConversionMode.h in Headers */,
 				DD3DC8D127A4BF8E007E5B61 /* CountingLock.h in Headers */,
@@ -3709,6 +3716,7 @@
 				0F8F2B92172E0103007DBDA5 /* CompilationThread.cpp in Sources */,
 				E3149A3B228BDCAC00BFA6C7 /* ConcurrentBuffer.cpp in Sources */,
 				0F30CB5A1FCDF134004B5323 /* ConcurrentPtrHashSet.cpp in Sources */,
+				1C867D772A254F08000DE93D /* ContextualizedCFString.mm in Sources */,
 				1CA6FBA92A1D75B9001D4402 /* ContextualizedNSString.mm in Sources */,
 				0F8E85DB1FD485B000691889 /* CountingLock.cpp in Sources */,
 				E38C41281EB4E0680042957D /* CPUTime.cpp in Sources */,

--- a/Source/WTF/wtf/text/NullTextBreakIterator.h
+++ b/Source/WTF/wtf/text/NullTextBreakIterator.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017 Apple Inc. All rights reserved.
+ * Copyright (C) 2017-2023 Apple Inc. All rights reserved.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Library General Public
@@ -51,7 +51,7 @@ public:
         return false;
     }
 
-    void setText(StringView)
+    void setText(StringView, StringView)
     {
         ASSERT_NOT_REACHED();
     }

--- a/Source/WTF/wtf/text/TextBreakIterator.h
+++ b/Source/WTF/wtf/text/TextBreakIterator.h
@@ -99,10 +99,10 @@ private:
     // Use CachedTextBreakIterator instead of constructing one of these directly.
     WTF_EXPORT_PRIVATE TextBreakIterator(StringView, Mode, const AtomString& locale);
 
-    void setText(StringView string)
+    void setText(StringView string, StringView priorContext = { })
     {
         return switchOn(m_backing, [&](auto& iterator) {
-            return iterator.setText(string);
+            return iterator.setText(string, priorContext);
         });
     }
 

--- a/Source/WTF/wtf/text/cf/TextBreakIteratorCF.h
+++ b/Source/WTF/wtf/text/cf/TextBreakIteratorCF.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017 Apple Inc. All rights reserved.
+ * Copyright (C) 2017-2023 Apple Inc. All rights reserved.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Library General Public
@@ -38,8 +38,8 @@ public:
         WordBoundary,
     };
 
-    TextBreakIteratorCF(StringView string, Mode mode, const AtomString& locale)
-        : m_backing(mapModeToBackingIterator(string, mode, locale))
+    TextBreakIteratorCF(StringView string, StringView priorContext, Mode mode, const AtomString& locale)
+        : m_backing(mapModeToBackingIterator(string, priorContext, mode, locale))
     {
     }
 
@@ -49,10 +49,10 @@ public:
     TextBreakIteratorCF& operator=(const TextBreakIteratorCF&) = delete;
     TextBreakIteratorCF& operator=(TextBreakIteratorCF&&) = default;
 
-    void setText(StringView string)
+    void setText(StringView string, StringView priorContext)
     {
         return switchOn(m_backing, [&](auto& iterator) {
-            return iterator.setText(string);
+            return iterator.setText(string, priorContext);
         });
     }
 
@@ -80,23 +80,23 @@ public:
 private:
     using BackingVariant = std::variant<TextBreakIteratorCFCharacterCluster, TextBreakIteratorCFStringTokenizer>;
 
-    static BackingVariant mapModeToBackingIterator(StringView string, Mode mode, const AtomString& locale)
+    static BackingVariant mapModeToBackingIterator(StringView string, StringView priorContext, Mode mode, const AtomString& locale)
     {
         switch (mode) {
         case Mode::ComposedCharacter:
-            return TextBreakIteratorCFCharacterCluster(string, TextBreakIteratorCFCharacterCluster::Mode::ComposedCharacter);
+            return TextBreakIteratorCFCharacterCluster(string, priorContext, TextBreakIteratorCFCharacterCluster::Mode::ComposedCharacter);
         case Mode::BackwardDeletion:
-            return TextBreakIteratorCFCharacterCluster(string, TextBreakIteratorCFCharacterCluster::Mode::BackwardDeletion);
+            return TextBreakIteratorCFCharacterCluster(string, priorContext, TextBreakIteratorCFCharacterCluster::Mode::BackwardDeletion);
         case Mode::Word:
-            return TextBreakIteratorCFStringTokenizer(string, TextBreakIteratorCFStringTokenizer::Mode::Word, locale);
+            return TextBreakIteratorCFStringTokenizer(string, priorContext, TextBreakIteratorCFStringTokenizer::Mode::Word, locale);
         case Mode::Sentence:
-            return TextBreakIteratorCFStringTokenizer(string, TextBreakIteratorCFStringTokenizer::Mode::Sentence, locale);
+            return TextBreakIteratorCFStringTokenizer(string, priorContext, TextBreakIteratorCFStringTokenizer::Mode::Sentence, locale);
         case Mode::Paragraph:
-            return TextBreakIteratorCFStringTokenizer(string, TextBreakIteratorCFStringTokenizer::Mode::Paragraph, locale);
+            return TextBreakIteratorCFStringTokenizer(string, priorContext, TextBreakIteratorCFStringTokenizer::Mode::Paragraph, locale);
         case Mode::LineBreak:
-            return TextBreakIteratorCFStringTokenizer(string, TextBreakIteratorCFStringTokenizer::Mode::LineBreak, locale);
+            return TextBreakIteratorCFStringTokenizer(string, priorContext, TextBreakIteratorCFStringTokenizer::Mode::LineBreak, locale);
         case Mode::WordBoundary:
-            return TextBreakIteratorCFStringTokenizer(string, TextBreakIteratorCFStringTokenizer::Mode::WordBoundary, locale);
+            return TextBreakIteratorCFStringTokenizer(string, priorContext, TextBreakIteratorCFStringTokenizer::Mode::WordBoundary, locale);
         }
     }
 

--- a/Source/WTF/wtf/text/cf/TextBreakIteratorCFStringTokenizer.h
+++ b/Source/WTF/wtf/text/cf/TextBreakIteratorCFStringTokenizer.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2022 Apple Inc. All rights reserved.
+ * Copyright (C) 2017-2023 Apple Inc. All rights reserved.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Library General Public
@@ -25,6 +25,7 @@
 #include <wtf/spi/cf/CFStringSPI.h>
 #include <wtf/text/AtomString.h>
 #include <wtf/text/StringView.h>
+#include <wtf/text/cocoa/ContextualizedCFString.h>
 
 namespace WTF {
 
@@ -39,7 +40,7 @@ public:
         WordBoundary,
     };
 
-    TextBreakIteratorCFStringTokenizer(StringView string, Mode mode, const AtomString& locale)
+    TextBreakIteratorCFStringTokenizer(StringView string, StringView priorContext, Mode mode, const AtomString& locale)
     {
         auto options = [mode] {
             switch (mode) {
@@ -56,10 +57,11 @@ public:
             }
         }();
 
-        auto stringObject = string.createCFStringWithoutCopying();
-        m_stringLength = static_cast<unsigned long>(CFStringGetLength(stringObject.get()));
+        auto stringObject = createContextualizedCFString(string, priorContext);
+        m_stringLength = string.length();
+        m_priorContextLength = priorContext.length();
         auto localeObject = adoptCF(CFLocaleCreate(kCFAllocatorDefault, locale.string().createCFString().get()));
-        m_stringTokenizer = adoptCF(CFStringTokenizerCreate(kCFAllocatorDefault, stringObject.get(), CFRangeMake(0, m_stringLength), options, localeObject.get()));
+        m_stringTokenizer = adoptCF(CFStringTokenizerCreate(kCFAllocatorDefault, stringObject.get(), CFRangeMake(0, m_stringLength + m_priorContextLength), options, localeObject.get()));
     }
 
     TextBreakIteratorCFStringTokenizer() = delete;
@@ -68,10 +70,11 @@ public:
     TextBreakIteratorCFStringTokenizer& operator=(const TextBreakIteratorCFStringTokenizer&) = delete;
     TextBreakIteratorCFStringTokenizer& operator=(TextBreakIteratorCFStringTokenizer&&) = default;
 
-    void setText(StringView string)
+    void setText(StringView string, StringView priorContext)
     {
-        auto stringObject = string.createCFStringWithoutCopying();
-        m_stringLength = static_cast<unsigned long>(CFStringGetLength(stringObject.get()));
+        auto stringObject = createContextualizedCFString(string, priorContext);
+        m_stringLength = string.length();
+        m_priorContextLength = priorContext.length();
         CFStringTokenizerSetString(m_stringTokenizer.get(), stringObject.get(), CFRangeMake(0, m_stringLength));
     }
 
@@ -81,32 +84,39 @@ public:
             return { };
         if (location > m_stringLength)
             return m_stringLength;
-        CFStringTokenizerGoToTokenAtIndex(m_stringTokenizer.get(), location - 1);
+        CFStringTokenizerGoToTokenAtIndex(m_stringTokenizer.get(), location - 1 + m_priorContextLength);
         auto range = CFStringTokenizerGetCurrentTokenRange(m_stringTokenizer.get());
-        return range.location;
+        if (range.location == kCFNotFound)
+            return { };
+        return std::max(static_cast<unsigned long>(range.location), m_priorContextLength) - m_priorContextLength;
     }
 
     std::optional<unsigned> following(unsigned location) const
     {
         if (location >= m_stringLength)
             return { };
-        CFStringTokenizerGoToTokenAtIndex(m_stringTokenizer.get(), location);
+        CFStringTokenizerGoToTokenAtIndex(m_stringTokenizer.get(), location + m_priorContextLength);
         auto range = CFStringTokenizerGetCurrentTokenRange(m_stringTokenizer.get());
-        return range.location + range.length;
+        if (range.location == kCFNotFound)
+            return { };
+        return range.location + range.length - m_priorContextLength;
     }
 
     bool isBoundary(unsigned location) const
     {
         if (location == m_stringLength)
             return true;
-        CFStringTokenizerGoToTokenAtIndex(m_stringTokenizer.get(), location);
+        CFStringTokenizerGoToTokenAtIndex(m_stringTokenizer.get(), location + m_priorContextLength);
         auto range = CFStringTokenizerGetCurrentTokenRange(m_stringTokenizer.get());
-        return static_cast<unsigned long>(range.location) == location;
+        if (range.location == kCFNotFound)
+            return true;
+        return static_cast<unsigned long>(range.location) == location + m_priorContextLength;
     }
 
 private:
     RetainPtr<CFStringTokenizerRef> m_stringTokenizer;
     unsigned long m_stringLength { 0 };
+    unsigned long m_priorContextLength { 0 };
 };
 
 }

--- a/Source/WTF/wtf/text/cocoa/ContextualizedCFString.h
+++ b/Source/WTF/wtf/text/cocoa/ContextualizedCFString.h
@@ -1,0 +1,38 @@
+/*
+ * Copyright (C) 2023 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include <CoreFoundation/CoreFoundation.h>
+#include <wtf/RetainPtr.h>
+
+namespace WTF {
+
+class StringView;
+
+// This exists so C++ files (rather than Objective-C++ files) can use ContextualizedNSString.
+WTF_EXPORT_PRIVATE RetainPtr<CFStringRef> createContextualizedCFString(StringView, StringView priorContext);
+
+} // namespace WTF

--- a/Source/WTF/wtf/text/cocoa/ContextualizedCFString.mm
+++ b/Source/WTF/wtf/text/cocoa/ContextualizedCFString.mm
@@ -1,0 +1,40 @@
+/*
+ * Copyright (C) 2023 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#import "config.h"
+#import <wtf/text/cocoa/ContextualizedCFString.h>
+
+#import <wtf/cocoa/TypeCastsCocoa.h>
+#import <wtf/text/cocoa/ContextualizedNSString.h>
+
+namespace WTF {
+
+RetainPtr<CFStringRef> createContextualizedCFString(StringView string, StringView priorContext)
+{
+    RetainPtr<NSString> result = adoptNS([[WTFContextualizedNSString alloc] initWithContext:priorContext contents:string]);
+    return bridge_cast(WTFMove(result));
+}
+
+} // namespace WTF

--- a/Source/WTF/wtf/text/cocoa/TextBreakIteratorInternalICUCocoa.cpp
+++ b/Source/WTF/wtf/text/cocoa/TextBreakIteratorInternalICUCocoa.cpp
@@ -36,11 +36,11 @@ TextBreakIterator::Backing TextBreakIterator::mapModeToBackingIterator(StringVie
     return switchOn(mode, [string, &locale](TextBreakIterator::LineMode lineMode) -> TextBreakIterator::Backing {
         return TextBreakIteratorICU(string, TextBreakIteratorICU::LineMode { lineMode.behavior }, locale);
     }, [string, &locale](TextBreakIterator::CaretMode) -> TextBreakIterator::Backing {
-        return TextBreakIteratorCF(string, TextBreakIteratorCF::Mode::ComposedCharacter, locale);
+        return TextBreakIteratorCF(string, { }, TextBreakIteratorCF::Mode::ComposedCharacter, locale);
     }, [string, &locale](TextBreakIterator::DeleteMode) -> TextBreakIterator::Backing {
-        return TextBreakIteratorCF(string, TextBreakIteratorCF::Mode::BackwardDeletion, locale);
+        return TextBreakIteratorCF(string, { }, TextBreakIteratorCF::Mode::BackwardDeletion, locale);
     }, [string, &locale](TextBreakIterator::CharacterMode) -> TextBreakIterator::Backing {
-        return TextBreakIteratorCF(string, TextBreakIteratorCF::Mode::ComposedCharacter, locale);
+        return TextBreakIteratorCF(string, { }, TextBreakIteratorCF::Mode::ComposedCharacter, locale);
     });
 }
 

--- a/Source/WTF/wtf/text/icu/TextBreakIteratorICU.h
+++ b/Source/WTF/wtf/text/icu/TextBreakIteratorICU.h
@@ -114,8 +114,10 @@ public:
             ubrk_close(m_iterator);
     }
 
-    void setText(StringView string)
+    void setText(StringView string, StringView priorContext)
     {
+        UNUSED_PARAM(priorContext); // FIXME: Implement prior context.
+
         if (string.is8Bit()) {
             set8BitText(string.characters8(), string.length());
             return;

--- a/Tools/TestWebKitAPI/Tests/WTF/cocoa/ContextualizedNSString.mm
+++ b/Tools/TestWebKitAPI/Tests/WTF/cocoa/ContextualizedNSString.mm
@@ -44,6 +44,18 @@ TEST(WTF_ContextualizedNSString, Basic)
     EXPECT_EQ([contextualizedString characterAtIndex:5], 'f');
 }
 
+TEST(WTF_ContextualizedNSString, BasicNoContext)
+{
+    auto contents = "abc"_str;
+    auto contextualizedString = adoptNS([[WTFContextualizedNSString alloc] initWithContext: { } contents:contents]);
+    EXPECT_TRUE([contextualizedString isEqualToString:@"abc"]);
+    EXPECT_TRUE([@"abc" isEqualToString:contextualizedString.get()]);
+    EXPECT_EQ(contextualizedString.get().length, 3UL);
+    EXPECT_EQ([contextualizedString characterAtIndex:0], 'a');
+    EXPECT_EQ([contextualizedString characterAtIndex:1], 'b');
+    EXPECT_EQ([contextualizedString characterAtIndex:2], 'c');
+}
+
 TEST(WTF_ContextualizedNSString, getCharacters)
 {
     auto context = "abc"_str;


### PR DESCRIPTION
#### 7d9c042f3a2b131e83b2fed0647f75c5aff524e5
<pre>
[Cocoa] Hook &quot;prior context&quot; infrastructure up to TextBreakIteratorCF
<a href="https://bugs.webkit.org/show_bug.cgi?id=257467">https://bugs.webkit.org/show_bug.cgi?id=257467</a>
rdar://109983296

Reviewed by Alan Baradlay.

This patch is the next step to being able to use platform text iterators to break lines.
Previously, I implemented ContextualizedNSString, which is a subclass of NSString whose
backing store is 2 StringViews: one for the prior context of the string at hand, and one
for the string at hand itself. This patch hooks up ContextualizedNSString to our
TextBreakIteratorCF class, to allow TextBreakIteratorCF to work with prior context. This
is necessary because our line breaking code requires this prior context to work correctly,
and TextBreakIterator is the object which has a Core Foundation backend. If we want to be
able to do line breaking using Core Foundation, this patch is necessary.

The next patch will do something similar for TextBreakIteratorICU (which we luckily
already have UText support for). Once that&apos;s done, we should be able to migrate entirely
from LazyLineBreakIterator to TextBreakIterator.

* Source/WTF/WTF.xcodeproj/project.pbxproj:
* Source/WTF/wtf/text/TextBreakIterator.h:
(WTF::TextBreakIterator::setText):
* Source/WTF/wtf/text/cf/TextBreakIteratorCF.h:
(WTF::TextBreakIteratorCF::TextBreakIteratorCF):
(WTF::TextBreakIteratorCF::setText):
(WTF::TextBreakIteratorCF::mapModeToBackingIterator):
* Source/WTF/wtf/text/cf/TextBreakIteratorCFCharacterCluster.h:
(WTF::TextBreakIteratorCFCharacterCluster::TextBreakIteratorCFCharacterCluster):
(WTF::TextBreakIteratorCFCharacterCluster::setText):
(WTF::TextBreakIteratorCFCharacterCluster::preceding const):
(WTF::TextBreakIteratorCFCharacterCluster::following const):
(WTF::TextBreakIteratorCFCharacterCluster::isBoundary const):
* Source/WTF/wtf/text/cf/TextBreakIteratorCFStringTokenizer.h:
(WTF::TextBreakIteratorCFStringTokenizer::TextBreakIteratorCFStringTokenizer):
(WTF::TextBreakIteratorCFStringTokenizer::setText):
(WTF::TextBreakIteratorCFStringTokenizer::preceding const):
(WTF::TextBreakIteratorCFStringTokenizer::following const):
(WTF::TextBreakIteratorCFStringTokenizer::isBoundary const):
* Source/WTF/wtf/text/cocoa/ContextualizedCFString.h: Added.
* Source/WTF/wtf/text/cocoa/ContextualizedCFString.mm: Added.
(WTF::createContextualizedCFString):
* Source/WTF/wtf/text/cocoa/TextBreakIteratorInternalICUCocoa.cpp:
(WTF::TextBreakIterator::mapModeToBackingIterator):
* Source/WTF/wtf/text/icu/TextBreakIteratorICU.h:
(WTF::TextBreakIteratorICU::setText):
* Tools/TestWebKitAPI/Tests/WTF/TextBreakIterator.cpp:
(TestWebKitAPI::TEST):
* Tools/TestWebKitAPI/Tests/WTF/cocoa/ContextualizedNSString.mm:
(TEST):

Canonical link: <a href="https://commits.webkit.org/264714@main">https://commits.webkit.org/264714@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f5dc39a6cb4e776ef17fd4892bc419d341901d69

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/8306 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/8598 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/8815 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/9973 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/8370 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/8315 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/10586 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/8509 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/11238 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/8451 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/9510 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/7534 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/10117 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/6809 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/7599 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/15161 "2 flakes 112 failures") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/7122 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/7930 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/7740 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/11088 "Passed tests") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/7923 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/8210 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/6687 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/8478 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/7500 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/2028 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/2034 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/11709 "Built successfully") | | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/24/builds/8703 "Built successfully") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/7953 "Built successfully") | | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/3/builds/2153 "Passed tests") | 
<!--EWS-Status-Bubble-End-->