### PR TITLE
Hook "prior context" infrastructure up to TextBreakIteratorICU

### DIFF
--- a/Source/WTF/wtf/text/NullTextBreakIterator.h
+++ b/Source/WTF/wtf/text/NullTextBreakIterator.h
@@ -51,7 +51,7 @@ public:
         return false;
     }
 
-    void setText(StringView, StringView)
+    void setText(StringView, const UChar*, unsigned)
     {
         ASSERT_NOT_REACHED();
     }

--- a/Source/WTF/wtf/text/TextBreakIterator.cpp
+++ b/Source/WTF/wtf/text/TextBreakIterator.cpp
@@ -46,13 +46,13 @@ TextBreakIteratorCache& TextBreakIteratorCache::singleton()
 TextBreakIterator::Backing TextBreakIterator::mapModeToBackingIterator(StringView string, TextBreakIterator::Mode mode, const AtomString& locale)
 {
     return switchOn(mode, [string, &locale](TextBreakIterator::LineMode lineMode) -> TextBreakIterator::Backing {
-        return TextBreakIteratorICU(string, TextBreakIteratorICU::LineMode { lineMode.behavior }, locale);
+        return TextBreakIteratorICU(string, nullptr, 0, TextBreakIteratorICU::LineMode { lineMode.behavior }, locale);
     }, [string, &locale](TextBreakIterator::CaretMode) -> TextBreakIterator::Backing {
-        return TextBreakIteratorICU(string, TextBreakIteratorICU::CharacterMode { }, locale);
+        return TextBreakIteratorICU(string, nullptr, 0, TextBreakIteratorICU::CharacterMode { }, locale);
     }, [string, &locale](TextBreakIterator::DeleteMode) -> TextBreakIterator::Backing {
-        return TextBreakIteratorICU(string, TextBreakIteratorICU::CharacterMode { }, locale);
+        return TextBreakIteratorICU(string, nullptr, 0, TextBreakIteratorICU::CharacterMode { }, locale);
     }, [string, &locale](TextBreakIterator::CharacterMode) -> TextBreakIterator::Backing {
-        return TextBreakIteratorICU(string, TextBreakIteratorICU::CharacterMode { }, locale);
+        return TextBreakIteratorICU(string, nullptr, 0, TextBreakIteratorICU::CharacterMode { }, locale);
     });
 }
 
@@ -159,6 +159,7 @@ static UBreakIterator* setContextAwareTextForIterator(UBreakIterator& iterator, 
 
 // Static iterators
 
+// FIXME: Delete this in favor of CachedTextBreakIterator.
 UBreakIterator* wordBreakIterator(StringView string)
 {
     static UBreakIterator* staticWordBreakIterator = initializeIterator(UBRK_WORD);
@@ -168,6 +169,7 @@ UBreakIterator* wordBreakIterator(StringView string)
     return setTextForIterator(*staticWordBreakIterator, string);
 }
 
+// FIXME: Delete this in favor of CachedTextBreakIterator.
 UBreakIterator* sentenceBreakIterator(StringView string)
 {
     static UBreakIterator* staticSentenceBreakIterator = initializeIterator(UBRK_SENTENCE);

--- a/Source/WTF/wtf/text/TextBreakIterator.h
+++ b/Source/WTF/wtf/text/TextBreakIterator.h
@@ -99,10 +99,10 @@ private:
     // Use CachedTextBreakIterator instead of constructing one of these directly.
     WTF_EXPORT_PRIVATE TextBreakIterator(StringView, Mode, const AtomString& locale);
 
-    void setText(StringView string, StringView priorContext = { })
+    void setText(StringView string, const UChar* priorContext = nullptr, unsigned priorContextLength = 0)
     {
         return switchOn(m_backing, [&](auto& iterator) {
-            return iterator.setText(string, priorContext);
+            return iterator.setText(string, priorContext, priorContextLength);
         });
     }
 

--- a/Source/WTF/wtf/text/cf/TextBreakIteratorCF.h
+++ b/Source/WTF/wtf/text/cf/TextBreakIteratorCF.h
@@ -49,10 +49,10 @@ public:
     TextBreakIteratorCF& operator=(const TextBreakIteratorCF&) = delete;
     TextBreakIteratorCF& operator=(TextBreakIteratorCF&&) = default;
 
-    void setText(StringView string, StringView priorContext)
+    void setText(StringView string, const UChar* priorContext, unsigned priorContextLength)
     {
         return switchOn(m_backing, [&](auto& iterator) {
-            return iterator.setText(string, priorContext);
+            return iterator.setText(string, { priorContext, priorContextLength });
         });
     }
 

--- a/Source/WTF/wtf/text/cocoa/TextBreakIteratorInternalICUCocoa.cpp
+++ b/Source/WTF/wtf/text/cocoa/TextBreakIteratorInternalICUCocoa.cpp
@@ -34,7 +34,7 @@ using LocaleIDBuffer = std::array<char, 33>;
 TextBreakIterator::Backing TextBreakIterator::mapModeToBackingIterator(StringView string, TextBreakIterator::Mode mode, const AtomString& locale)
 {
     return switchOn(mode, [string, &locale](TextBreakIterator::LineMode lineMode) -> TextBreakIterator::Backing {
-        return TextBreakIteratorICU(string, TextBreakIteratorICU::LineMode { lineMode.behavior }, locale);
+        return TextBreakIteratorICU(string, nullptr, 0, TextBreakIteratorICU::LineMode { lineMode.behavior }, locale);
     }, [string, &locale](TextBreakIterator::CaretMode) -> TextBreakIterator::Backing {
         return TextBreakIteratorCF(string, { }, TextBreakIteratorCF::Mode::ComposedCharacter, locale);
     }, [string, &locale](TextBreakIterator::DeleteMode) -> TextBreakIterator::Backing {

--- a/Source/WTF/wtf/text/icu/UTextProviderLatin1.h
+++ b/Source/WTF/wtf/text/icu/UTextProviderLatin1.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2014 Apple Inc. All rights reserved.
+ * Copyright (C) 2014-2023 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -38,7 +38,7 @@ struct UTextWithBuffer {
     UChar buffer[UTextWithBufferInlineCapacity];
 };
 
-WTF_EXPORT_PRIVATE UText* openLatin1UTextProvider(UTextWithBuffer* utWithBuffer, const LChar* string, unsigned length, UErrorCode* status);
-UText* openLatin1ContextAwareUTextProvider(UTextWithBuffer* utWithBuffer, const LChar* string, unsigned length, const UChar* priorContext, int priorContextLength, UErrorCode* status);
+UText* openLatin1UTextProvider(UTextWithBuffer* utWithBuffer, const LChar* string, unsigned length, UErrorCode* status);
+WTF_EXPORT_PRIVATE UText* openLatin1ContextAwareUTextProvider(UTextWithBuffer* utWithBuffer, const LChar* string, unsigned length, const UChar* priorContext, int priorContextLength, UErrorCode* status);
 
 } // namespace WTF

--- a/Source/WTF/wtf/text/icu/UTextProviderUTF16.h
+++ b/Source/WTF/wtf/text/icu/UTextProviderUTF16.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2014 Apple Inc. All rights reserved.
+ * Copyright (C) 2014-2023 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -29,6 +29,6 @@
 
 namespace WTF {
 
-UText* openUTF16ContextAwareUTextProvider(UText*, const UChar*, unsigned length, const UChar* priorContext, int priorContextLength, UErrorCode*);
+WTF_EXPORT_PRIVATE UText* openUTF16ContextAwareUTextProvider(UText*, const UChar*, unsigned length, const UChar* priorContext, int priorContextLength, UErrorCode*);
 
 } // namespace WTF


### PR DESCRIPTION
#### b42c0d74cd2e6aa99232eeb0f0267c4a3e660d04
<pre>
Hook &quot;prior context&quot; infrastructure up to TextBreakIteratorICU
<a href="https://bugs.webkit.org/show_bug.cgi?id=257469">https://bugs.webkit.org/show_bug.cgi?id=257469</a>
rdar://109989795

Reviewed by Alan Baradlay.

This patch is the next step toward replacing LazyLineBreakIterator with TextBreakIterator.
This &quot;prior context&quot; infrastructure is the last feature that LazyLineBreakIterator supports
that TextBreakIterator doesn&apos;t. Because LazyLineBreakIterator already uses ICU, hooking up
support to TextBreakIteratorICU is quite straightforward.

Once this piece and <a href="https://bugs.webkit.org/show_bug.cgi?id=257467">https://bugs.webkit.org/show_bug.cgi?id=257467</a> are landed,
TextBreakIterator will support all the features as LazyLineBreakIterator. At that point, we
can compare performance to determine if we can make the switch over, and determine if we can
do line breaking using platform iterators instead of ICU.

* Source/WTF/wtf/text/NullTextBreakIterator.h:
(WTF::NullTextBreakIterator::setText):
* Source/WTF/wtf/text/TextBreakIterator.cpp:
(WTF::TextBreakIterator::mapModeToBackingIterator):
* Source/WTF/wtf/text/TextBreakIterator.h:
(WTF::TextBreakIterator::setText):
* Source/WTF/wtf/text/cf/TextBreakIteratorCF.h:
(WTF::TextBreakIteratorCF::setText):
* Source/WTF/wtf/text/cocoa/TextBreakIteratorInternalICUCocoa.cpp:
(WTF::TextBreakIterator::mapModeToBackingIterator):
* Source/WTF/wtf/text/icu/TextBreakIteratorICU.h:
(WTF::TextBreakIteratorICU::TextBreakIteratorICU):
(WTF::TextBreakIteratorICU::~TextBreakIteratorICU):
(WTF::TextBreakIteratorICU::setText):
(WTF::TextBreakIteratorICU::preceding const):
(WTF::TextBreakIteratorICU::following const):
(WTF::TextBreakIteratorICU::isBoundary const):
(WTF::TextBreakIteratorICU::set8BitText): Deleted.
* Source/WTF/wtf/text/icu/UTextProviderLatin1.h:
* Source/WTF/wtf/text/icu/UTextProviderUTF16.h:
* Tools/TestWebKitAPI/Tests/WTF/TextBreakIterator.cpp:
(TestWebKitAPI::TEST):

Canonical link: <a href="https://commits.webkit.org/264722@main">https://commits.webkit.org/264722@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/87d43526640798e1cc9868c4350d5796ff1ddcc9

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/8451 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/8744 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/8963 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/10118 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/8498 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/8459 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/10734 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/8673 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/11365 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/8597 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/9639 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/7630 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/2/builds/10284 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/6937 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/7732 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/15283 "layout-tests (failure)") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/7264 "Built successfully and passed tests") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/8058 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/7878 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/11230 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/8091 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/8350 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/6813 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/8626 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/7637 "Built successfully") | | [  ~~🧪 jsc-armv7-tests~~](https://ews-build.webkit.org/#/builders/25/builds/2074 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/2042 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/11847 "Built successfully") | | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/24/builds/8851 "Built successfully") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/8095 "Built successfully") | | [  ~~🧪 jsc-mips-tests~~](https://ews-build.webkit.org/#/builders/3/builds/2195 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
<!--EWS-Status-Bubble-End-->