### PR TITLE
Remove stripLeadingAndTrailingHTMLSpaces()

### DIFF
--- a/Source/WebCore/accessibility/AccessibilityObject.cpp
+++ b/Source/WebCore/accessibility/AccessibilityObject.cpp
@@ -61,7 +61,6 @@
 #include "HTMLMediaElement.h"
 #include "HTMLModelElement.h"
 #include "HTMLNames.h"
-#include "HTMLParserIdioms.h"
 #include "HTMLTextAreaElement.h"
 #include "HitTestResult.h"
 #include "LocalFrame.h"
@@ -2237,8 +2236,8 @@ String AccessibilityObject::invalidStatus() const
     String undefinedValue = "undefined"_s;
 
     // aria-invalid can return false (default), grammar, spelling, or true.
-    String ariaInvalid = stripLeadingAndTrailingHTMLSpaces(getAttribute(aria_invalidAttr));
-    
+    auto ariaInvalid = getAttribute(aria_invalidAttr).string().trim(isASCIIWhitespace);
+
     if (ariaInvalid.isEmpty()) {
         auto* htmlElement = dynamicDowncast<HTMLElement>(this->node());
         if (auto* validatedFormListedElement = htmlElement ? htmlElement->asValidatedFormListedElement() : nullptr) {
@@ -2270,8 +2269,8 @@ bool AccessibilityObject::supportsCurrent() const
 AccessibilityCurrentState AccessibilityObject::currentState() const
 {
     // aria-current can return false (default), true, page, step, location, date or time.
-    String currentStateValue = stripLeadingAndTrailingHTMLSpaces(getAttribute(aria_currentAttr));
-    
+    auto currentStateValue = getAttribute(aria_currentAttr).string().trim(isASCIIWhitespace);
+
     // If "false", empty, or missing, return false state.
     if (currentStateValue.isEmpty() || currentStateValue == "false"_s)
         return AccessibilityCurrentState::False;
@@ -2731,7 +2730,7 @@ String AccessibilityObject::roleDescription() const
 {
     // aria-roledescription takes precedence over any other rule.
     if (supportsARIARoleDescription()) {
-        auto roleDescription = stripLeadingAndTrailingHTMLSpaces(getAttribute(aria_roledescriptionAttr));
+        auto roleDescription = getAttribute(aria_roledescriptionAttr).string().trim(isASCIIWhitespace);
         if (!roleDescription.isEmpty())
             return roleDescription;
     }

--- a/Source/WebCore/dom/DataTransfer.cpp
+++ b/Source/WebCore/dom/DataTransfer.cpp
@@ -39,7 +39,6 @@
 #include "FrameDestructionObserverInlines.h"
 #include "FrameLoader.h"
 #include "HTMLImageElement.h"
-#include "HTMLParserIdioms.h"
 #include "Image.h"
 #include "LocalFrame.h"
 #include "Page.h"
@@ -128,7 +127,7 @@ static String normalizeType(const String& type)
     if (type.isNull())
         return type;
 
-    String lowercaseType = stripLeadingAndTrailingHTMLSpaces(type).convertToASCIILowercase();
+    auto lowercaseType = type.trim(isASCIIWhitespace).convertToASCIILowercase();
     if (lowercaseType == "text"_s || lowercaseType.startsWith("text/plain;"_s))
         return textPlainContentTypeAtom();
     if (lowercaseType == "url"_s || lowercaseType.startsWith("text/uri-list;"_s))
@@ -175,7 +174,7 @@ String DataTransfer::getDataForItem(Document& document, const String& type) cons
     if (!canReadData())
         return { };
 
-    auto lowercaseType = stripLeadingAndTrailingHTMLSpaces(type).convertToASCIILowercase();
+    auto lowercaseType = type.trim(isASCIIWhitespace).convertToASCIILowercase();
     if (shouldSuppressGetAndSetDataToAvoidExposingFilePaths()) {
         if (lowercaseType == "text/uri-list"_s) {
             return readURLsFromPasteboardAsString(document.page(), *m_pasteboard, [] (auto& urlString) {

--- a/Source/WebCore/dom/Document.cpp
+++ b/Source/WebCore/dom/Document.cpp
@@ -119,7 +119,6 @@
 #include "HTMLMediaElement.h"
 #include "HTMLMetaElement.h"
 #include "HTMLNameCollection.h"
-#include "HTMLParserIdioms.h"
 #include "HTMLPictureElement.h"
 #include "HTMLPlugInElement.h"
 #include "HTMLScriptElement.h"
@@ -3696,9 +3695,9 @@ void Document::processBaseElement()
     // FIXME: Since this doesn't share code with completeURL it may not handle encodings correctly.
     URL baseElementURL;
     if (href) {
-        String strippedHref = stripLeadingAndTrailingHTMLSpaces(*href);
-        if (!strippedHref.isEmpty())
-            baseElementURL = URL(fallbackBaseURL(), strippedHref);
+        auto trimmedHref = href->string().trim(isASCIIWhitespace);
+        if (!trimmedHref.isEmpty())
+            baseElementURL = URL(fallbackBaseURL(), trimmedHref);
     }
     if (m_baseElementURL != baseElementURL && contentSecurityPolicy()->allowBaseURI(baseElementURL)) {
         if (settings().shouldRestrictBaseURLSchemes() && !SecurityPolicy::isBaseURLSchemeAllowed(baseElementURL))

--- a/Source/WebCore/dom/Element.cpp
+++ b/Source/WebCore/dom/Element.cpp
@@ -2466,7 +2466,7 @@ bool Element::isEventHandlerAttribute(const Attribute& attribute) const
 
 bool Element::attributeContainsJavaScriptURL(const Attribute& attribute) const
 {
-    return isURLAttribute(attribute) && WTF::protocolIsJavaScript(stripLeadingAndTrailingHTMLSpaces(attribute.value()));
+    return isURLAttribute(attribute) && WTF::protocolIsJavaScript(attribute.value());
 }
 
 void Element::stripScriptingAttributes(Vector<Attribute>& attributeVector) const
@@ -4322,7 +4322,7 @@ URL Element::getNonEmptyURLAttribute(const QualifiedName& name) const
             ASSERT(isURLAttribute(*attribute));
     }
 #endif
-    String value = stripLeadingAndTrailingHTMLSpaces(getAttribute(name));
+    auto value = getAttribute(name).string().trim(isASCIIWhitespace);
     if (value.isEmpty())
         return URL();
     return document().completeURL(value);

--- a/Source/WebCore/dom/ScriptElement.cpp
+++ b/Source/WebCore/dom/ScriptElement.cpp
@@ -37,7 +37,6 @@
 #include "EventNames.h"
 #include "FrameLoader.h"
 #include "HTMLNames.h"
-#include "HTMLParserIdioms.h"
 #include "HTMLScriptElement.h"
 #include "IgnoreDestructiveWriteCountIncrementer.h"
 #include "InlineClassicScript.h"
@@ -315,7 +314,7 @@ bool ScriptElement::requestClassicScript(const String& sourceURL)
 {
     ASSERT(m_element.isConnected());
     ASSERT(!m_loadableScript);
-    if (!stripLeadingAndTrailingHTMLSpaces(sourceURL).isEmpty()) {
+    if (!StringView(sourceURL).isAllSpecialCharacters<isASCIIWhitespace<UChar>>()) {
         auto script = LoadableClassicScript::create(m_element.nonce(), m_element.attributeWithoutSynchronization(HTMLNames::integrityAttr), referrerPolicy(), fetchPriorityHint(),
             m_element.attributeWithoutSynchronization(HTMLNames::crossoriginAttr), scriptCharset(), m_element.localName(), m_element.isInUserAgentShadowTree(), hasAsyncAttribute());
 
@@ -354,7 +353,7 @@ bool ScriptElement::requestModuleScript(const TextPosition& scriptStartPosition)
         ASSERT(m_element.isConnected());
 
         String sourceURL = sourceAttributeValue();
-        if (stripLeadingAndTrailingHTMLSpaces(sourceURL).isEmpty()) {
+        if (StringView(sourceURL).isAllSpecialCharacters<isASCIIWhitespace<UChar>>()) {
             dispatchErrorEvent();
             return false;
         }
@@ -399,7 +398,7 @@ bool ScriptElement::requestImportMap(LocalFrame& frame, const String& sourceURL)
 {
     ASSERT(m_element.isConnected());
     ASSERT(!m_loadableScript);
-    if (!stripLeadingAndTrailingHTMLSpaces(sourceURL).isEmpty()) {
+    if (!StringView(sourceURL).isAllSpecialCharacters<isASCIIWhitespace<UChar>>()) {
         auto script = LoadableImportMap::create(m_element.nonce(), m_element.attributeWithoutSynchronization(HTMLNames::integrityAttr), referrerPolicy(),
             m_element.attributeWithoutSynchronization(HTMLNames::crossoriginAttr), m_element.localName(), m_element.isInUserAgentShadowTree(), hasAsyncAttribute());
 
@@ -613,11 +612,11 @@ bool ScriptElement::isScriptForEventSupported() const
     String eventAttribute = eventAttributeValue();
     String forAttribute = forAttributeValue();
     if (!eventAttribute.isNull() && !forAttribute.isNull()) {
-        forAttribute = stripLeadingAndTrailingHTMLSpaces(forAttribute);
+        forAttribute = forAttribute.trim(isASCIIWhitespace);
         if (!equalLettersIgnoringASCIICase(forAttribute, "window"_s))
             return false;
 
-        eventAttribute = stripLeadingAndTrailingHTMLSpaces(eventAttribute);
+        eventAttribute = eventAttribute.trim(isASCIIWhitespace);
         if (!equalLettersIgnoringASCIICase(eventAttribute, "onload"_s) && !equalLettersIgnoringASCIICase(eventAttribute, "onload()"_s))
             return false;
     }

--- a/Source/WebCore/dom/TextDecoder.cpp
+++ b/Source/WebCore/dom/TextDecoder.cpp
@@ -25,7 +25,6 @@
 #include "config.h"
 #include "TextDecoder.h"
 
-#include "HTMLParserIdioms.h"
 #include <pal/text/TextCodec.h>
 #include <pal/text/TextEncodingRegistry.h>
 
@@ -41,11 +40,11 @@ TextDecoder::~TextDecoder() = default;
 
 ExceptionOr<Ref<TextDecoder>> TextDecoder::create(const String& label, Options options)
 {
-    String strippedLabel = stripLeadingAndTrailingHTMLSpaces(label);
+    auto trimmedLabel = label.trim(isASCIIWhitespace);
     const UChar nullCharacter = '\0';
-    if (strippedLabel.contains(nullCharacter))
+    if (trimmedLabel.contains(nullCharacter))
         return Exception { RangeError };
-    auto decoder = adoptRef(*new TextDecoder(strippedLabel, options));
+    auto decoder = adoptRef(*new TextDecoder(trimmedLabel, options));
     if (!decoder->m_textEncoding.isValid() || !strcmp(decoder->m_textEncoding.name(), "replacement"))
         return Exception { RangeError };
     return decoder;

--- a/Source/WebCore/html/EmailInputType.cpp
+++ b/Source/WebCore/html/EmailInputType.cpp
@@ -68,7 +68,7 @@ bool EmailInputType::typeMismatchFor(const String& value) const
     if (!element()->multiple())
         return !isValidEmailAddress(value);
     for (auto& address : value.splitAllowingEmptyEntries(',')) {
-        if (!isValidEmailAddress(stripLeadingAndTrailingHTMLSpaces(address)))
+        if (!isValidEmailAddress(address.trim(isASCIIWhitespace)))
             return true;
     }
     return false;
@@ -107,13 +107,13 @@ String EmailInputType::sanitizeValue(const String& proposedValue) const
     });
     ASSERT(element());
     if (!element()->multiple())
-        return stripLeadingAndTrailingHTMLSpaces(noLineBreakValue);
+        return noLineBreakValue.trim(isASCIIWhitespace);
     Vector<String> addresses = noLineBreakValue.splitAllowingEmptyEntries(',');
     StringBuilder strippedValue;
     for (unsigned i = 0; i < addresses.size(); ++i) {
         if (i > 0)
             strippedValue.append(',');
-        strippedValue.append(stripLeadingAndTrailingHTMLSpaces(addresses[i]));
+        strippedValue.append(addresses[i].trim(isASCIIWhitespace));
     }
     return strippedValue.toString();
 }

--- a/Source/WebCore/html/HTMLAnchorElement.cpp
+++ b/Source/WebCore/html/HTMLAnchorElement.cpp
@@ -245,7 +245,7 @@ void HTMLAnchorElement::attributeChanged(const QualifiedName& name, const AtomSt
         if (wasLink != isLink())
             invalidateStyleForSubtree();
         if (isLink()) {
-            String parsedURL = stripLeadingAndTrailingHTMLSpaces(newValue);
+            auto parsedURL = newValue.string().trim(isASCIIWhitespace);
             if (document().isDNSPrefetchEnabled() && document().frame()) {
                 if (protocolIsInHTTPFamily(parsedURL) || parsedURL.startsWith("//"_s))
                     document().frame()->loader().client().prefetchDNS(document().completeURL(parsedURL).host().toString());
@@ -577,7 +577,7 @@ void HTMLAnchorElement::handleClick(Event& event)
         return;
 
     StringBuilder url;
-    url.append(stripLeadingAndTrailingHTMLSpaces(attributeWithoutSynchronization(hrefAttr)));
+    url.append(attributeWithoutSynchronization(hrefAttr).string().trim(isASCIIWhitespace));
     appendServerMapMousePosition(url, event);
     URL completedURL = document().completeURL(url.toString());
 

--- a/Source/WebCore/html/HTMLBodyElement.cpp
+++ b/Source/WebCore/html/HTMLBodyElement.cpp
@@ -33,7 +33,6 @@
 #include "HTMLFrameElement.h"
 #include "HTMLIFrameElement.h"
 #include "HTMLNames.h"
-#include "HTMLParserIdioms.h"
 #include "JSHTMLBodyElement.h"
 #include "LocalDOMWindow.h"
 #include "MutableStyleProperties.h"
@@ -87,7 +86,7 @@ void HTMLBodyElement::collectPresentationalHintsForAttribute(const QualifiedName
 {
     switch (name.nodeName()) {
     case AttributeNames::backgroundAttr: {
-        String url = stripLeadingAndTrailingHTMLSpaces(value);
+        auto url = value.string().trim(isASCIIWhitespace);
         if (!url.isEmpty()) {
             auto imageValue = CSSImageValue::create(document().completeURL(url), LoadedFromOpaqueSource::No, localName());
             style.setProperty(CSSProperty(CSSPropertyBackgroundImage, WTFMove(imageValue)));

--- a/Source/WebCore/html/HTMLEmbedElement.cpp
+++ b/Source/WebCore/html/HTMLEmbedElement.cpp
@@ -30,7 +30,6 @@
 #include "HTMLImageLoader.h"
 #include "HTMLNames.h"
 #include "HTMLObjectElement.h"
-#include "HTMLParserIdioms.h"
 #include "LocalFrame.h"
 #include "LocalFrameView.h"
 #include "NodeName.h"
@@ -109,12 +108,14 @@ void HTMLEmbedElement::attributeChanged(const QualifiedName& name, const AtomStr
             invalidateStyle();
         break;
     case AttributeNames::codeAttr:
-        m_url = stripLeadingAndTrailingHTMLSpaces(newValue);
+        // FIXME: trimming whitespace is probably redundant with the URL parser
+        m_url = newValue.string().trim(isASCIIWhitespace);
         // FIXME: Why no call to updateImageLoaderWithNewURLSoon?
         // FIXME: If both code and src attributes are specified, last one parsed/changed wins. That can't be right!
         break;
     case AttributeNames::srcAttr:
-        m_url = stripLeadingAndTrailingHTMLSpaces(newValue);
+        // FIXME: trimming whitespace is probably redundant with the URL parser
+        m_url = newValue.string().trim(isASCIIWhitespace);
         updateImageLoaderWithNewURLSoon();
         if (renderer() && !hasTypeOrSrc(*this))
             invalidateStyle();

--- a/Source/WebCore/html/HTMLImageElement.cpp
+++ b/Source/WebCore/html/HTMLImageElement.cpp
@@ -40,7 +40,6 @@
 #include "HTMLFormElement.h"
 #include "HTMLImageLoader.h"
 #include "HTMLMapElement.h"
-#include "HTMLParserIdioms.h"
 #include "HTMLPictureElement.h"
 #include "HTMLSourceElement.h"
 #include "HTMLSrcsetParser.h"
@@ -240,7 +239,7 @@ static String extractMIMETypeFromTypeAttributeForLookup(const String& typeAttrib
 {
     auto semicolonIndex = typeAttribute.find(';');
     if (semicolonIndex == notFound)
-        return stripLeadingAndTrailingHTMLSpaces(typeAttribute);
+        return typeAttribute.trim(isASCIIWhitespace);
     return StringView(typeAttribute).left(semicolonIndex).trim(isASCIIWhitespace<UChar>).toStringWithoutCopying();
 }
 

--- a/Source/WebCore/html/HTMLImageLoader.cpp
+++ b/Source/WebCore/html/HTMLImageLoader.cpp
@@ -29,7 +29,6 @@
 #include "EventNames.h"
 #include "HTMLNames.h"
 #include "HTMLObjectElement.h"
-#include "HTMLParserIdioms.h"
 #include "HTMLVideoElement.h"
 #include "LocalDOMWindow.h"
 #include "Settings.h"
@@ -75,7 +74,8 @@ void HTMLImageLoader::dispatchLoadEvent()
 
 String HTMLImageLoader::sourceURI(const AtomString& attr) const
 {
-    return stripLeadingAndTrailingHTMLSpaces(attr);
+    // FIXME: trimming whitespace is probably redundant with the URL parser
+    return attr.string().trim(isASCIIWhitespace);
 }
 
 void HTMLImageLoader::notifyFinished(CachedResource&, const NetworkLoadMetrics& metrics)

--- a/Source/WebCore/html/HTMLObjectElement.cpp
+++ b/Source/WebCore/html/HTMLObjectElement.cpp
@@ -36,7 +36,6 @@
 #include "HTMLMetaElement.h"
 #include "HTMLNames.h"
 #include "HTMLParamElement.h"
-#include "HTMLParserIdioms.h"
 #include "LocalFrame.h"
 #include "MIMETypeRegistry.h"
 #include "NodeList.h"
@@ -114,7 +113,8 @@ void HTMLObjectElement::attributeChanged(const QualifiedName& name, const AtomSt
         needsWidgetUpdate = true;
         break;
     case AttributeNames::dataAttr:
-        m_url = stripLeadingAndTrailingHTMLSpaces(newValue);
+        // FIXME: trimming whitespace is probably redundant with the URL parser
+        m_url = newValue.string().trim(isASCIIWhitespace);
         invalidateRenderer = !hasAttributeWithoutSynchronization(classidAttr);
         needsWidgetUpdate = true;
         updateImageLoaderWithNewURLSoon();
@@ -176,7 +176,7 @@ void HTMLObjectElement::parametersForPlugin(Vector<AtomString>& paramNames, Vect
 
         // FIXME: url adjustment does not belong in this function.
         if (url.isEmpty() && urlParameter.isEmpty() && (equalLettersIgnoringASCIICase(name, "src"_s) || equalLettersIgnoringASCIICase(name, "movie"_s) || equalLettersIgnoringASCIICase(name, "code"_s) || equalLettersIgnoringASCIICase(name, "url"_s)))
-            urlParameter = stripLeadingAndTrailingHTMLSpaces(param.value());
+            urlParameter = param.value().string().trim(isASCIIWhitespace);
         // FIXME: serviceType calculation does not belong in this function.
         if (serviceType.isEmpty() && equalLettersIgnoringASCIICase(name, "type"_s)) {
             serviceType = param.value();

--- a/Source/WebCore/html/HTMLOptionElement.cpp
+++ b/Source/WebCore/html/HTMLOptionElement.cpp
@@ -34,7 +34,6 @@
 #include "HTMLDataListElement.h"
 #include "HTMLNames.h"
 #include "HTMLOptGroupElement.h"
-#include "HTMLParserIdioms.h"
 #include "HTMLSelectElement.h"
 #include "NodeName.h"
 #include "NodeRenderStyle.h"
@@ -109,7 +108,7 @@ String HTMLOptionElement::text() const
 
     // FIXME: Is displayStringModifiedByEncoding helpful here?
     // If it's correct here, then isn't it needed in the value and label functions too?
-    return stripLeadingAndTrailingHTMLSpaces(document().displayStringModifiedByEncoding(text)).simplifyWhiteSpace(isASCIIWhitespace);
+    return document().displayStringModifiedByEncoding(text).trim(isASCIIWhitespace).simplifyWhiteSpace(isASCIIWhitespace);
 }
 
 void HTMLOptionElement::setText(String&& text)
@@ -209,7 +208,7 @@ String HTMLOptionElement::value() const
     const AtomString& value = attributeWithoutSynchronization(valueAttr);
     if (!value.isNull())
         return value;
-    return stripLeadingAndTrailingHTMLSpaces(collectOptionInnerText()).simplifyWhiteSpace(isASCIIWhitespace);
+    return collectOptionInnerText().trim(isASCIIWhitespace).simplifyWhiteSpace(isASCIIWhitespace);
 }
 
 void HTMLOptionElement::setValue(const AtomString& value)
@@ -279,15 +278,15 @@ String HTMLOptionElement::label() const
 {
     String label = attributeWithoutSynchronization(labelAttr);
     if (!label.isNull())
-        return stripLeadingAndTrailingHTMLSpaces(label);
-    return stripLeadingAndTrailingHTMLSpaces(collectOptionInnerText()).simplifyWhiteSpace(isASCIIWhitespace);
+        return label.trim(isASCIIWhitespace);
+    return collectOptionInnerText().trim(isASCIIWhitespace).simplifyWhiteSpace(isASCIIWhitespace);
 }
 
 // Same as label() but ignores the label content attribute in quirks mode for compatibility with other browsers.
 String HTMLOptionElement::displayLabel() const
 {
     if (document().inQuirksMode())
-        return stripLeadingAndTrailingHTMLSpaces(collectOptionInnerText()).simplifyWhiteSpace(isASCIIWhitespace);
+        return collectOptionInnerText().trim(isASCIIWhitespace).simplifyWhiteSpace(isASCIIWhitespace);
     return label();
 }
 

--- a/Source/WebCore/html/HTMLTableElement.cpp
+++ b/Source/WebCore/html/HTMLTableElement.cpp
@@ -32,7 +32,6 @@
 #include "ElementChildIteratorInlines.h"
 #include "GenericCachedHTMLCollection.h"
 #include "HTMLNames.h"
-#include "HTMLParserIdioms.h"
 #include "HTMLTableCaptionElement.h"
 #include "HTMLTableRowElement.h"
 #include "HTMLTableRowsCollection.h"
@@ -325,7 +324,7 @@ void HTMLTableElement::collectPresentationalHintsForAttribute(const QualifiedNam
         addHTMLColorToStyle(style, CSSPropertyBackgroundColor, value);
         break;
     case AttributeNames::backgroundAttr:
-        if (String url = stripLeadingAndTrailingHTMLSpaces(value); !url.isEmpty())
+        if (auto url = value.string().trim(isASCIIWhitespace); !url.isEmpty())
             style.setProperty(CSSProperty(CSSPropertyBackgroundImage, CSSImageValue::create(document().completeURL(url), LoadedFromOpaqueSource::No)));
         break;
     case AttributeNames::valignAttr:

--- a/Source/WebCore/html/HTMLTablePartElement.cpp
+++ b/Source/WebCore/html/HTMLTablePartElement.cpp
@@ -31,7 +31,6 @@
 #include "Document.h"
 #include "ElementAncestorIteratorInlines.h"
 #include "HTMLNames.h"
-#include "HTMLParserIdioms.h"
 #include "HTMLTableElement.h"
 #include "MutableStyleProperties.h"
 #include "NodeName.h"
@@ -65,8 +64,8 @@ void HTMLTablePartElement::collectPresentationalHintsForAttribute(const Qualifie
         addHTMLColorToStyle(style, CSSPropertyBackgroundColor, value);
         break;
     case AttributeNames::backgroundAttr:
-        if (String url = stripLeadingAndTrailingHTMLSpaces(value); !url.isEmpty())
-            style.setProperty(CSSProperty(CSSPropertyBackgroundImage, CSSImageValue::create(document().completeURL(url), LoadedFromOpaqueSource::No)));
+        if (!StringView(value).isAllSpecialCharacters<isASCIIWhitespace<UChar>>())
+            style.setProperty(CSSProperty(CSSPropertyBackgroundImage, CSSImageValue::create(document().completeURL(value), LoadedFromOpaqueSource::No)));
         break;
     case AttributeNames::valignAttr:
         if (equalLettersIgnoringASCIICase(value, "top"_s))

--- a/Source/WebCore/html/HTMLVideoElement.cpp
+++ b/Source/WebCore/html/HTMLVideoElement.cpp
@@ -36,7 +36,6 @@
 #include "EventNames.h"
 #include "HTMLImageLoader.h"
 #include "HTMLNames.h"
-#include "HTMLParserIdioms.h"
 #include "ImageBuffer.h"
 #include "JSDOMPromiseDeferred.h"
 #include "LocalFrame.h"
@@ -241,8 +240,8 @@ bool HTMLVideoElement::isURLAttribute(const Attribute& attribute) const
 
 const AtomString& HTMLVideoElement::imageSourceURL() const
 {
-    const AtomString& url = attributeWithoutSynchronization(posterAttr);
-    if (!stripLeadingAndTrailingHTMLSpaces(url).isEmpty())
+    const auto& url = attributeWithoutSynchronization(posterAttr);
+    if (!StringView(url).isAllSpecialCharacters<isASCIIWhitespace<UChar>>())
         return url;
     return m_defaultPosterURL;
 }
@@ -419,7 +418,7 @@ unsigned HTMLVideoElement::webkitDroppedFrameCount() const
 
 URL HTMLVideoElement::posterImageURL() const
 {
-    String url = stripLeadingAndTrailingHTMLSpaces(imageSourceURL());
+    auto url = imageSourceURL().string().trim(isASCIIWhitespace);
     if (url.isEmpty())
         return URL();
     return document().completeURL(url);

--- a/Source/WebCore/html/URLInputType.cpp
+++ b/Source/WebCore/html/URLInputType.cpp
@@ -33,7 +33,6 @@
 #include "URLInputType.h"
 
 #include "HTMLInputElement.h"
-#include "HTMLParserIdioms.h"
 #include "InputTypeNames.h"
 #include "LocalizedStrings.h"
 #include <wtf/URL.h>
@@ -63,7 +62,7 @@ String URLInputType::typeMismatchText() const
 
 String URLInputType::sanitizeValue(const String& proposedValue) const
 {
-    return stripLeadingAndTrailingHTMLSpaces(BaseTextInputType::sanitizeValue(proposedValue));
+    return BaseTextInputType::sanitizeValue(proposedValue).trim(isASCIIWhitespace);
 }
 
 } // namespace WebCore

--- a/Source/WebCore/html/parser/HTMLParserIdioms.cpp
+++ b/Source/WebCore/html/parser/HTMLParserIdioms.cpp
@@ -41,46 +41,6 @@
 
 namespace WebCore {
 
-template <typename CharType>
-static String stripLeadingAndTrailingHTMLSpaces(String string, CharType characters, unsigned length)
-{
-    unsigned numLeadingSpaces = 0;
-    unsigned numTrailingSpaces = 0;
-
-    for (; numLeadingSpaces < length; ++numLeadingSpaces) {
-        if (!isASCIIWhitespace(characters[numLeadingSpaces]))
-            break;
-    }
-
-    if (numLeadingSpaces == length)
-        return string.isNull() ? string : emptyAtom().string();
-
-    for (; numTrailingSpaces < length; ++numTrailingSpaces) {
-        if (!isASCIIWhitespace(characters[length - numTrailingSpaces - 1]))
-            break;
-    }
-
-    ASSERT(numLeadingSpaces + numTrailingSpaces < length);
-
-    if (!(numLeadingSpaces | numTrailingSpaces))
-        return string;
-
-    return string.substring(numLeadingSpaces, length - (numLeadingSpaces + numTrailingSpaces));
-}
-
-String stripLeadingAndTrailingHTMLSpaces(const String& string)
-{
-    unsigned length = string.length();
-
-    if (!length)
-        return string.isNull() ? string : emptyAtom().string();
-
-    if (string.is8Bit())
-        return stripLeadingAndTrailingHTMLSpaces(string, string.characters8(), length);
-
-    return stripLeadingAndTrailingHTMLSpaces(string, string.characters16(), length);
-}
-
 String serializeForNumberType(const Decimal& number)
 {
     if (number.isZero()) {

--- a/Source/WebCore/html/parser/HTMLParserIdioms.h
+++ b/Source/WebCore/html/parser/HTMLParserIdioms.h
@@ -41,9 +41,6 @@ bool isHTMLSpaceButNotLineBreak(UChar);
 // 2147483647 is 2^31 - 1.
 static const unsigned maxHTMLNonNegativeInteger = 2147483647;
 
-// Strip leading and trailing whitespace as defined by the HTML specification. 
-WEBCORE_EXPORT String stripLeadingAndTrailingHTMLSpaces(const String&);
-
 // An implementation of the HTML specification's algorithm to convert a number to a string for number and range types.
 String serializeForNumberType(const Decimal&);
 String serializeForNumberType(double);

--- a/Source/WebCore/loader/FormSubmission.cpp
+++ b/Source/WebCore/loader/FormSubmission.cpp
@@ -47,7 +47,6 @@
 #include "HTMLFormElement.h"
 #include "HTMLInputElement.h"
 #include "HTMLNames.h"
-#include "HTMLParserIdioms.h"
 #include "LocalFrame.h"
 #include "ScriptDisallowedScope.h"
 #include <pal/text/TextEncoding.h>
@@ -96,8 +95,8 @@ ASCIILiteral FormSubmission::Attributes::methodString(Method method, bool dialog
 
 void FormSubmission::Attributes::parseAction(const String& action)
 {
-    // FIXME: Can we parse into a URL?
-    m_action = stripLeadingAndTrailingHTMLSpaces(action);
+    // FIXME: Can we parse into a URL? Then we also don't need to trim anymore.
+    m_action = action.trim(isASCIIWhitespace);
 }
 
 String FormSubmission::Attributes::parseEncodingType(const String& type)

--- a/Source/WebCore/loader/FrameLoader.cpp
+++ b/Source/WebCore/loader/FrameLoader.cpp
@@ -750,7 +750,7 @@ static AtomString extractContentLanguageFromHeader(const String& header)
 {
     auto commaIndex = header.find(',');
     if (commaIndex == notFound)
-        return AtomString { stripLeadingAndTrailingHTMLSpaces(header) };
+        return AtomString { header.trim(isASCIIWhitespace) };
     return StringView(header).left(commaIndex).trim(isASCIIWhitespace<UChar>).toAtomString();
 }
 

--- a/Source/WebCore/loader/ImageLoader.cpp
+++ b/Source/WebCore/loader/ImageLoader.cpp
@@ -36,7 +36,6 @@
 #include "HTMLImageElement.h"
 #include "HTMLNames.h"
 #include "HTMLObjectElement.h"
-#include "HTMLParserIdioms.h"
 #include "HTMLPlugInElement.h"
 #include "InspectorInstrumentation.h"
 #include "JSDOMPromiseDeferred.h"
@@ -184,7 +183,7 @@ void ImageLoader::updateFromElement(RelevantMutation relevantMutation)
     // Do not load any image if the 'src' attribute is missing or if it is
     // an empty string.
     CachedResourceHandle<CachedImage> newImage = nullptr;
-    if (!attr.isNull() && !stripLeadingAndTrailingHTMLSpaces(attr).isEmpty()) {
+    if (!attr.isNull() && !StringView(attr).isAllSpecialCharacters<isASCIIWhitespace<UChar>>()) {
         ResourceLoaderOptions options = CachedResourceLoader::defaultCachedResourceOptions();
         options.contentSecurityPolicyImposition = element().isInUserAgentShadowTree() ? ContentSecurityPolicyImposition::SkipPolicyCheck : ContentSecurityPolicyImposition::DoPolicyCheck;
         options.loadedFromPluginElement = is<HTMLPlugInElement>(element()) ? LoadedFromPluginElement::Yes : LoadedFromPluginElement::No;
@@ -488,8 +487,8 @@ void ImageLoader::decode(Ref<DeferredPromise>&& promise)
         return;
     }
 
-    AtomString attr = element().imageSourceURL();
-    if (stripLeadingAndTrailingHTMLSpaces(attr).isEmpty()) {
+    auto attr = element().imageSourceURL();
+    if (StringView(attr).isAllSpecialCharacters<isASCIIWhitespace<UChar>>()) {
         rejectDecodePromises("Missing source URL."_s);
         return;
     }

--- a/Source/WebCore/platform/ContentType.cpp
+++ b/Source/WebCore/platform/ContentType.cpp
@@ -27,7 +27,6 @@
 
 #include "config.h"
 #include "ContentType.h"
-#include "HTMLParserIdioms.h"
 #include <wtf/JSONValues.h>
 #include <wtf/NeverDestroyed.h>
 
@@ -94,7 +93,7 @@ String ContentType::containerType() const
 {
     // Strip parameters that come after a semicolon.
     // FIXME: This will ignore a quotation mark if it comes before the semicolon. Is that the desired behavior?
-    return stripLeadingAndTrailingHTMLSpaces(m_type.left(m_type.find(';')));
+    return m_type.left(m_type.find(';')).trim(isASCIIWhitespace);
 }
 
 static inline Vector<String> splitParameters(StringView parametersView)

--- a/Source/WebCore/svg/SVGAElement.cpp
+++ b/Source/WebCore/svg/SVGAElement.cpp
@@ -30,7 +30,6 @@
 #include "FrameLoader.h"
 #include "FrameLoaderTypes.h"
 #include "HTMLAnchorElement.h"
-#include "HTMLParserIdioms.h"
 #include "KeyboardEvent.h"
 #include "LegacyRenderSVGTransformableContainer.h"
 #include "LocalFrame.h"
@@ -129,7 +128,7 @@ void SVGAElement::defaultEventHandler(Event& event)
         }
 
         if (MouseEvent::canTriggerActivationBehavior(event)) {
-            String url = stripLeadingAndTrailingHTMLSpaces(href());
+            auto url = href().trim(isASCIIWhitespace);
 
             if (url[0] == '#') {
                 RefPtr targetElement = treeScope().getElementById(url.substringSharingImpl(1));

--- a/Source/WebCore/svg/SVGAnimationElement.cpp
+++ b/Source/WebCore/svg/SVGAnimationElement.cpp
@@ -32,7 +32,6 @@
 #include "CSSPropertyParser.h"
 #include "Document.h"
 #include "FloatConversion.h"
-#include "HTMLParserIdioms.h"
 #include "NodeName.h"
 #include "RenderObject.h"
 #include "SVGAnimateColorElement.h"
@@ -152,11 +151,11 @@ bool SVGAnimationElement::isSupportedAttribute(const QualifiedName& attrName)
 bool SVGAnimationElement::attributeContainsJavaScriptURL(const Attribute& attribute) const
 {
     if (attribute.name() == SVGNames::fromAttr || attribute.name() == SVGNames::toAttr)
-        return WTF::protocolIsJavaScript(stripLeadingAndTrailingHTMLSpaces(attribute.value()));
+        return WTF::protocolIsJavaScript(attribute.value());
 
     if (attribute.name() == SVGNames::valuesAttr) {
         for (auto innerValue : StringView(attribute.value()).split(';')) {
-            if (WTF::protocolIsJavaScript(innerValue.trim(isASCIIWhitespace<UChar>)))
+            if (WTF::protocolIsJavaScript(innerValue))
                 return true;
         }
         return false;

--- a/Source/WebKit/WebProcess/WebPage/ios/WebPageIOS.mm
+++ b/Source/WebKit/WebProcess/WebPage/ios/WebPageIOS.mm
@@ -106,7 +106,6 @@
 #import <WebCore/HTMLLabelElement.h>
 #import <WebCore/HTMLOptGroupElement.h>
 #import <WebCore/HTMLOptionElement.h>
-#import <WebCore/HTMLParserIdioms.h>
 #import <WebCore/HTMLSelectElement.h>
 #import <WebCore/HTMLSummaryElement.h>
 #import <WebCore/HTMLTextAreaElement.h>
@@ -3469,7 +3468,7 @@ void WebPage::performActionOnElement(uint32_t action, const String& authorizatio
                     titleToCopy = linkElement->attributeWithoutSynchronization(HTMLNames::titleAttr);
                     if (!titleToCopy.length())
                         titleToCopy = linkElement->textContent();
-                    titleToCopy = stripLeadingAndTrailingHTMLSpaces(titleToCopy);
+                    titleToCopy = titleToCopy.trim(isASCIIWhitespace);
                 }
             }
             m_interactionNode->document().editor().writeImageToPasteboard(*Pasteboard::createForCopyAndPaste(PagePasteboardContext::create(element.document().pageID())), element, urlToCopy, titleToCopy);


### PR DESCRIPTION
#### ea527fa9c22d43cf4075f0364a6327a569a14a54
<pre>
Remove stripLeadingAndTrailingHTMLSpaces()
<a href="https://bugs.webkit.org/show_bug.cgi?id=257414">https://bugs.webkit.org/show_bug.cgi?id=257414</a>
rdar://109923008

Reviewed by Chris Dumez and Darin Adler.

Replace it with trim(isASCIIWhitespace),
isAllSpecialCharacters&lt;isASCIIWhitespace&lt;UChar&gt;&gt;, or remove it
altogether when the result is passed to WTF::protocolIsJavaScript() or
completeURL().

Also sprinkle a few FIXMEs around as we can probably do even better in
the future.

* Source/WebCore/accessibility/AccessibilityObject.cpp:
(WebCore::AccessibilityObject::invalidStatus const):
(WebCore::AccessibilityObject::currentState const):
(WebCore::AccessibilityObject::roleDescription const):
* Source/WebCore/dom/DataTransfer.cpp:
(WebCore::normalizeType):
(WebCore::DataTransfer::getDataForItem const):
* Source/WebCore/dom/Document.cpp:
(WebCore::Document::processBaseElement):
* Source/WebCore/dom/Element.cpp:
(WebCore::Element::attributeContainsJavaScriptURL const):
(WebCore::Element::getNonEmptyURLAttribute const):
* Source/WebCore/dom/ScriptElement.cpp:
(WebCore::ScriptElement::requestClassicScript):
(WebCore::ScriptElement::requestModuleScript):
(WebCore::ScriptElement::requestImportMap):
(WebCore::ScriptElement::isScriptForEventSupported const):
* Source/WebCore/dom/TextDecoder.cpp:
(WebCore::TextDecoder::create):
* Source/WebCore/html/EmailInputType.cpp:
(WebCore::EmailInputType::typeMismatchFor const):
(WebCore::EmailInputType::sanitizeValue const):
* Source/WebCore/html/HTMLAnchorElement.cpp:
(WebCore::HTMLAnchorElement::attributeChanged):
(WebCore::HTMLAnchorElement::handleClick):
* Source/WebCore/html/HTMLBodyElement.cpp:
(WebCore::HTMLBodyElement::collectPresentationalHintsForAttribute):
* Source/WebCore/html/HTMLEmbedElement.cpp:
(WebCore::HTMLEmbedElement::attributeChanged):
* Source/WebCore/html/HTMLFrameElementBase.cpp:
(WebCore::HTMLFrameElementBase::attributeChanged):
(WebCore::HTMLFrameElementBase::setLocation):
* Source/WebCore/html/HTMLImageElement.cpp:
(WebCore::extractMIMETypeFromTypeAttributeForLookup):
* Source/WebCore/html/HTMLImageLoader.cpp:
(WebCore::HTMLImageLoader::sourceURI const):
* Source/WebCore/html/HTMLObjectElement.cpp:
(WebCore::HTMLObjectElement::attributeChanged):
(WebCore::HTMLObjectElement::parametersForPlugin):
* Source/WebCore/html/HTMLOptionElement.cpp:
(WebCore::HTMLOptionElement::text const):
(WebCore::HTMLOptionElement::value const):
(WebCore::HTMLOptionElement::label const):
(WebCore::HTMLOptionElement::displayLabel const):
* Source/WebCore/html/HTMLTableElement.cpp:
(WebCore::HTMLTableElement::collectPresentationalHintsForAttribute):
* Source/WebCore/html/HTMLTablePartElement.cpp:
(WebCore::HTMLTablePartElement::collectPresentationalHintsForAttribute):
* Source/WebCore/html/HTMLVideoElement.cpp:
(WebCore::HTMLVideoElement::imageSourceURL const):
(WebCore::HTMLVideoElement::posterImageURL const):
* Source/WebCore/html/URLInputType.cpp:
(WebCore::URLInputType::sanitizeValue const):
* Source/WebCore/html/parser/HTMLParserIdioms.cpp:
(WebCore::stripLeadingAndTrailingHTMLSpaces): Deleted.
* Source/WebCore/html/parser/HTMLParserIdioms.h:
* Source/WebCore/loader/FormSubmission.cpp:
(WebCore::FormSubmission::Attributes::parseAction):
* Source/WebCore/loader/FrameLoader.cpp:
(WebCore::extractContentLanguageFromHeader):
* Source/WebCore/loader/ImageLoader.cpp:
(WebCore::ImageLoader::updateFromElement):
(WebCore::ImageLoader::decode):
* Source/WebCore/page/csp/ContentSecurityPolicy.cpp:
(WebCore::ContentSecurityPolicy::allowScriptWithNonce const):
(WebCore::ContentSecurityPolicy::allowStyleWithNonce const):
(WebCore::ContentSecurityPolicy::allowNonParserInsertedScripts const):
(WebCore::ContentSecurityPolicy::allowInlineScript const):
(WebCore::ContentSecurityPolicy::allowInlineStyle const):
(WebCore::ContentSecurityPolicy::allowScriptFromSource const):
(WebCore::ContentSecurityPolicy::allowStyleFromSource const):
* Source/WebCore/platform/ContentType.cpp:
(WebCore::ContentType::containerType const):
* Source/WebCore/svg/SVGAElement.cpp:
(WebCore::SVGAElement::defaultEventHandler):
* Source/WebCore/svg/SVGAnimationElement.cpp:
(WebCore::SVGAnimationElement::attributeContainsJavaScriptURL const):
* Source/WebKit/WebProcess/WebPage/ios/WebPageIOS.mm:
(WebKit::WebPage::performActionOnElement):

Canonical link: <a href="https://commits.webkit.org/264713@main">https://commits.webkit.org/264713@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/3d4509ceb701e9b2b6c5bbc9ae1570999d701c33

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/8356 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/8649 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/8866 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/10024 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/8421 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/8365 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/10637 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/8560 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/11285 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/8502 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/9561 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/7575 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/10205 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/6859 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/7646 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/15232 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/7980 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/7789 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/11174 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/8261 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/6735 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/7550 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/2033 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/11760 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/8004 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->