### PR TITLE
Use UCHAR_MAX_VALUE more

### DIFF
--- a/Source/JavaScriptCore/yarr/YarrPattern.cpp
+++ b/Source/JavaScriptCore/yarr/YarrPattern.cpp
@@ -151,7 +151,7 @@ public:
         }
 
         addSortedInverted(0, 0x7f, other->m_matches, other->m_ranges, m_matches, m_ranges);
-        addSortedInverted(0x80, 0x10ffff, other->m_matchesUnicode, other->m_rangesUnicode, m_matchesUnicode, m_rangesUnicode);
+        addSortedInverted(0x80, UCHAR_MAX_VALUE, other->m_matchesUnicode, other->m_rangesUnicode, m_matchesUnicode, m_rangesUnicode);
     }
 
     void putChar(UChar32 ch)
@@ -905,7 +905,7 @@ private:
         if (!m_matches.size() && !m_matchesUnicode.size()
             && m_ranges.size() == 1 && m_rangesUnicode.size() == 1
             && m_ranges[0].begin == 0 && m_ranges[0].end == 0x7f
-            && m_rangesUnicode[0].begin == 0x80 && m_rangesUnicode[0].end == 0x10ffff)
+            && m_rangesUnicode[0].begin == 0x80 && m_rangesUnicode[0].end == UCHAR_MAX_VALUE)
             m_anyCharacter = true;
     }
 
@@ -2441,7 +2441,7 @@ std::unique_ptr<CharacterClass> anycharCreate()
 {
     auto characterClass = makeUnique<CharacterClass>();
     characterClass->m_ranges.append(CharacterRange(0x00, 0x7f));
-    characterClass->m_rangesUnicode.append(CharacterRange(0x0080, 0x10ffff));
+    characterClass->m_rangesUnicode.append(CharacterRange(0x0080, UCHAR_MAX_VALUE));
     characterClass->m_characterWidths = CharacterClassWidths::HasBothBMPAndNonBMP;
     characterClass->m_anyCharacter = true;
     return characterClass;

--- a/Source/JavaScriptCore/yarr/YarrPattern.h
+++ b/Source/JavaScriptCore/yarr/YarrPattern.h
@@ -49,7 +49,7 @@ enum class CompileMode : uint8_t {
 
 struct CharacterRange {
     UChar32 begin { 0 };
-    UChar32 end { 0x10ffff };
+    UChar32 end { UCHAR_MAX_VALUE };
 
     CharacterRange(UChar32 begin, UChar32 end)
         : begin(begin)

--- a/Source/WebCore/PAL/pal/text/TextCodec.cpp
+++ b/Source/WebCore/PAL/pal/text/TextCodec.cpp
@@ -26,6 +26,7 @@
 
 #include "config.h"
 #include "TextCodec.h"
+#include <unicode/uchar.h>
 #include <wtf/unicode/CharacterNames.h>
 
 #include <array>
@@ -35,7 +36,7 @@ namespace PAL {
 
 int TextCodec::getUnencodableReplacement(UChar32 codePoint, UnencodableHandling handling, UnencodableReplacementArray& replacement)
 {
-    ASSERT(!(codePoint > 0x10FFFF));
+    ASSERT(!(codePoint > UCHAR_MAX_VALUE));
 
     // The Encoding Standard doesn't have surrogate code points in the input, but that would require
     // scanning and potentially manipulating inputs ahead of time. Instead handle them at the last

--- a/Source/WebCore/css/parser/CSSTokenizer.cpp
+++ b/Source/WebCore/css/parser/CSSTokenizer.cpp
@@ -804,7 +804,7 @@ UChar32 CSSTokenizer::consumeEscape()
         };
         consumeSingleWhitespaceIfNext();
         auto codePoint = parseInteger<uint32_t>(hexChars, 16).value();
-        if (!codePoint || U_IS_SURROGATE(codePoint) || codePoint > 0x10FFFF)
+        if (!codePoint || U_IS_SURROGATE(codePoint) || codePoint > UCHAR_MAX_VALUE)
             return replacementCharacter;
         return codePoint;
     }


### PR DESCRIPTION
#### 3cac44f05d6632ce4aaa4db59666a251bfffb0fb
<pre>
Use UCHAR_MAX_VALUE more
<a href="https://bugs.webkit.org/show_bug.cgi?id=257470">https://bugs.webkit.org/show_bug.cgi?id=257470</a>
rdar://109994606

Reviewed by Darin Adler.

This is slightly clearer, although it does come at the cost of an
additional import.

Follow-up to <a href="https://bugs.webkit.org/show_bug.cgi?id=254984">https://bugs.webkit.org/show_bug.cgi?id=254984</a> where I
should have searched for this constant case-insensitively.

* Source/JavaScriptCore/yarr/YarrPattern.cpp:
(JSC::Yarr::CharacterClassConstructor::appendInverted):
(JSC::Yarr::CharacterClassConstructor::coalesceTables):
(JSC::Yarr::anycharCreate):
* Source/JavaScriptCore/yarr/YarrPattern.h:
* Source/WebCore/PAL/pal/text/TextCodec.cpp:
(PAL::TextCodec::getUnencodableReplacement):
* Source/WebCore/css/parser/CSSTokenizer.cpp:
(WebCore::CSSTokenizer::consumeEscape):

Canonical link: <a href="https://commits.webkit.org/264687@main">https://commits.webkit.org/264687@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4edc5c554129171858aa9433c816deb469e8b78c

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/8313 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/8606 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/8823 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/9981 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/8378 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/8322 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/10594 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/8517 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/11247 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/8459 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/9517 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/7541 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/10125 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/6816 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/7607 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/15168 "Passed tests") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/7131 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/7937 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/7748 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/11095 "Passed tests") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/7932 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/8218 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/6695 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/8486 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/7507 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/2032 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/2013 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/11717 "Built successfully") | | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/24/builds/8711 "Built successfully") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/7961 "Built successfully") | | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/3/builds/2157 "Passed tests") | 
<!--EWS-Status-Bubble-End-->