### PR TITLE
[WGSL] @group, @binding and @location should accept expressions

### DIFF
--- a/Source/WebGPU/WGSL/AST/ASTBindingAttribute.h
+++ b/Source/WebGPU/WGSL/AST/ASTBindingAttribute.h
@@ -27,6 +27,7 @@
 
 #include "ASTAttribute.h"
 #include "ASTBuilder.h"
+#include "ASTExpression.h"
 
 namespace WGSL::AST {
 
@@ -34,15 +35,15 @@ class BindingAttribute final : public Attribute {
     WGSL_AST_BUILDER_NODE(BindingAttribute);
 public:
     NodeKind kind() const override;
-    unsigned binding() const { return m_value; }
+    Expression& binding() const { return m_value; }
 
 private:
-    BindingAttribute(SourceSpan span, unsigned binding)
+    BindingAttribute(SourceSpan span, Expression::Ref&& binding)
         : Attribute(span)
         , m_value(binding)
     { }
 
-    unsigned m_value;
+    Expression::Ref m_value;
 };
 
 } // namespace WGSL::AST

--- a/Source/WebGPU/WGSL/AST/ASTGroupAttribute.h
+++ b/Source/WebGPU/WGSL/AST/ASTGroupAttribute.h
@@ -34,15 +34,15 @@ class GroupAttribute final : public Attribute {
     WGSL_AST_BUILDER_NODE(GroupAttribute);
 public:
     NodeKind kind() const override;
-    unsigned group() const { return m_value; }
+    Expression& group() const { return m_value; }
 
 private:
-    GroupAttribute(SourceSpan span, unsigned group)
+    GroupAttribute(SourceSpan span, Expression::Ref&& group)
         : Attribute(span)
         , m_value(group)
     { }
 
-    unsigned m_value;
+    Expression::Ref m_value;
 };
 
 } // namespace WGSL::AST

--- a/Source/WebGPU/WGSL/AST/ASTLocationAttribute.h
+++ b/Source/WebGPU/WGSL/AST/ASTLocationAttribute.h
@@ -35,15 +35,15 @@ class LocationAttribute final : public Attribute {
     WGSL_AST_BUILDER_NODE(LocationAttribute);
 public:
     NodeKind kind() const override;
-    unsigned location() const { return m_value; }
+    Expression& location() const { return m_value; }
 
 private:
-    LocationAttribute(SourceSpan span, unsigned value)
+    LocationAttribute(SourceSpan span, Expression::Ref value)
         : Attribute(span)
         , m_value(value)
     { }
 
-    unsigned m_value;
+    Expression::Ref m_value;
 };
 
 } // namespace WGSL::AST

--- a/Source/WebGPU/WGSL/AST/ASTStringDumper.cpp
+++ b/Source/WebGPU/WGSL/AST/ASTStringDumper.cpp
@@ -96,7 +96,9 @@ void StringDumper::visit(Directive& directive)
 // Attribute
 void StringDumper::visit(BindingAttribute& binding)
 {
-    m_out.print("@binding(", binding.binding(), ")");
+    m_out.print("@binding(");
+    visit(binding.binding());
+    m_out.print(")");
 }
 
 void StringDumper::visit(BuiltinAttribute& builtin)
@@ -106,12 +108,16 @@ void StringDumper::visit(BuiltinAttribute& builtin)
 
 void StringDumper::visit(GroupAttribute& group)
 {
-    m_out.print("@group(", group.group(), ")");
+    m_out.print("@group(");
+    visit(group.group());
+    m_out.print(")");
 }
 
 void StringDumper::visit(LocationAttribute& location)
 {
-    m_out.print("@location(", location.location(), ")");
+    m_out.print("@location(");
+    visit(location.location());
+    m_out.print(")");
 }
 
 void StringDumper::visit(StageAttribute& stage)

--- a/Source/WebGPU/WGSL/GlobalVariableRewriter.cpp
+++ b/Source/WebGPU/WGSL/GlobalVariableRewriter.cpp
@@ -172,11 +172,11 @@ void RewriteGlobalVariables::collectGlobals()
         std::optional<unsigned> binding;
         for (auto& attribute : globalVar.attributes()) {
             if (is<AST::GroupAttribute>(attribute)) {
-                group = { downcast<AST::GroupAttribute>(attribute).group() };
+                group = { *AST::extractInteger(downcast<AST::GroupAttribute>(attribute).group()) };
                 continue;
             }
             if (is<AST::BindingAttribute>(attribute)) {
-                binding = { downcast<AST::BindingAttribute>(attribute).binding() };
+                binding = { *AST::extractInteger(downcast<AST::BindingAttribute>(attribute).binding()) };
                 continue;
             }
         }
@@ -327,7 +327,10 @@ void RewriteGlobalVariables::insertStructs(const UsedResources& usedResources)
                 AST::Identifier::make(global->declaration->name()),
                 *global->declaration->maybeReferenceType(),
                 AST::Attribute::List {
-                    m_callGraph.ast().astBuilder().construct<AST::BindingAttribute>(span, binding)
+                    m_callGraph.ast().astBuilder().construct<AST::BindingAttribute>(
+                        span,
+                        m_callGraph.ast().astBuilder().construct<AST::AbstractIntegerLiteral>(span, binding)
+                    )
                 }
             ));
         }
@@ -355,7 +358,10 @@ void RewriteGlobalVariables::insertParameters(AST::Function& function, const Use
             argumentBufferParameterName(group),
             type,
             AST::Attribute::List {
-                m_callGraph.ast().astBuilder().construct<AST::GroupAttribute>(span, group)
+                m_callGraph.ast().astBuilder().construct<AST::GroupAttribute>(
+                    span,
+                    m_callGraph.ast().astBuilder().construct<AST::AbstractIntegerLiteral>(span, group)
+                )
             },
             AST::ParameterRole::BindGroup
         ));

--- a/Source/WebGPU/WGSL/Metal/MetalFunctionWriter.cpp
+++ b/Source/WebGPU/WGSL/Metal/MetalFunctionWriter.cpp
@@ -371,7 +371,7 @@ void FunctionDefinitionWriter::visit(AST::StageAttribute& stage)
 
 void FunctionDefinitionWriter::visit(AST::GroupAttribute& group)
 {
-    unsigned bufferIndex = group.group();
+    unsigned bufferIndex = *AST::extractInteger(group.group());
     if (m_entryPointStage.has_value() && *m_entryPointStage == AST::StageAttribute::Stage::Vertex) {
         auto max = m_callGraph.ast().configuration().maxBuffersPlusVertexBuffersForVertexStage;
         bufferIndex = vertexBufferIndexForBindGroup(bufferIndex, max);
@@ -381,7 +381,7 @@ void FunctionDefinitionWriter::visit(AST::GroupAttribute& group)
 
 void FunctionDefinitionWriter::visit(AST::BindingAttribute& binding)
 {
-    m_stringBuilder.append("[[id(", binding.binding(), ")]]");
+    m_stringBuilder.append("[[id(", *AST::extractInteger(binding.binding()), ")]]");
 }
 
 void FunctionDefinitionWriter::visit(AST::LocationAttribute& location)
@@ -391,14 +391,14 @@ void FunctionDefinitionWriter::visit(AST::LocationAttribute& location)
         switch (role) {
         case AST::StructureRole::VertexOutput:
         case AST::StructureRole::FragmentInput:
-            m_stringBuilder.append("[[user(loc", location.location(), ")]]");
+            m_stringBuilder.append("[[user(loc", *AST::extractInteger(location.location()), ")]]");
             return;
         case AST::StructureRole::BindGroup:
         case AST::StructureRole::UserDefined:
         case AST::StructureRole::ComputeInput:
             return;
         case AST::StructureRole::VertexInput:
-            m_stringBuilder.append("[[attribute(", location.location(), ")]]");
+            m_stringBuilder.append("[[attribute(", *AST::extractInteger(location.location()), ")]]");
             break;
         }
     }

--- a/Source/WebGPU/WGSL/Parser.cpp
+++ b/Source/WebGPU/WGSL/Parser.cpp
@@ -430,26 +430,23 @@ Result<AST::Attribute::Ref> Parser<Lexer>::parseAttribute()
 
     if (ident.ident == "group"_s) {
         CONSUME_TYPE(ParenLeft);
-        // FIXME: should more kinds of literals be accepted here?
-        CONSUME_TYPE_NAMED(id, IntegerLiteral);
+        PARSE(group, Expression);
         CONSUME_TYPE(ParenRight);
-        RETURN_ARENA_NODE(GroupAttribute, id.literalValue);
+        RETURN_ARENA_NODE(GroupAttribute, WTFMove(group));
     }
 
     if (ident.ident == "binding"_s) {
         CONSUME_TYPE(ParenLeft);
-        // FIXME: should more kinds of literals be accepted here?
-        CONSUME_TYPE_NAMED(id, IntegerLiteral);
+        PARSE(binding, Expression);
         CONSUME_TYPE(ParenRight);
-        RETURN_ARENA_NODE(BindingAttribute, id.literalValue);
+        RETURN_ARENA_NODE(BindingAttribute, WTFMove(binding));
     }
 
     if (ident.ident == "location"_s) {
         CONSUME_TYPE(ParenLeft);
-        // FIXME: should more kinds of literals be accepted here?
-        CONSUME_TYPE_NAMED(id, IntegerLiteral);
+        PARSE(location, Expression);
         CONSUME_TYPE(ParenRight);
-        RETURN_ARENA_NODE(LocationAttribute, id.literalValue);
+        RETURN_ARENA_NODE(LocationAttribute, WTFMove(location));
     }
 
     if (ident.ident == "builtin"_s) {


### PR DESCRIPTION
#### b2ed50ad2834520be40430fd7bd6fac12965c151
<pre>
[WGSL] @group, @binding and @location should accept expressions
<a href="https://bugs.webkit.org/show_bug.cgi?id=257471">https://bugs.webkit.org/show_bug.cgi?id=257471</a>
rdar://109995472

Reviewed by NOBODY (OOPS!).

Currently we are only parsing integer literals as arguments to these attributes,
but according to the grammar they should accept any const expressions.

* Source/WebGPU/WGSL/AST/ASTBindingAttribute.h:
* Source/WebGPU/WGSL/AST/ASTGroupAttribute.h:
* Source/WebGPU/WGSL/AST/ASTLocationAttribute.h:
* Source/WebGPU/WGSL/AST/ASTStringDumper.cpp:
(WGSL::AST::StringDumper::visit):
* Source/WebGPU/WGSL/GlobalVariableRewriter.cpp:
(WGSL::RewriteGlobalVariables::collectGlobals):
(WGSL::RewriteGlobalVariables::insertStructs):
(WGSL::RewriteGlobalVariables::insertParameters):
* Source/WebGPU/WGSL/Metal/MetalFunctionWriter.cpp:
(WGSL::Metal::FunctionDefinitionWriter::visit):
* Source/WebGPU/WGSL/Parser.cpp:
(WGSL::Parser&lt;Lexer&gt;::parseAttribute):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b2ed50ad2834520be40430fd7bd6fac12965c151

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/8316 "Passed style check") | [❌ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/8609 "Failed to compile WebKit") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/14/builds/8826 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/9984 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/32/builds/8381 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| | [❌ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/10597 "Failed to compile WebKit") | [❌ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/8520 "Failed to compile WebKit") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/11248 "Passed tests") | 
| [  ~~🧪 webkitperl~~](https://ews-build.webkit.org/#/builders/11/builds/8462 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/23/builds/10597 "Failed to compile WebKit") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/14/builds/8826 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/2/builds/10128 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/23/builds/10597 "Failed to compile WebKit") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/14/builds/8826 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/15169 "Build is in progress. Recent messages:Printed configuration; Skipping applying patch since patch_id isn't provided; Checked out pull request; Skipped layout-tests; Running layout-tests") | 
| [⏳ 🛠 🧪 jsc ](https://ews-build.webkit.org/#/builders/JSC-Tests-EWS "Waiting in queue, processing has not started yet") | [❌ 🧪 api-ios](https://ews-build.webkit.org/#/builders/23/builds/10597 "Failed to compile WebKit") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/14/builds/8826 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/11096 "Passed tests") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/7/builds/8221 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/16/builds/8520 "Failed to compile WebKit") | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/30/builds/7510 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/14/builds/8826 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [❌ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/11720 "Failed to compile WebKit") | | | 
| | [❌ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/7964 "Failed to compile WebKit") | | | 
<!--EWS-Status-Bubble-End-->