### PR TITLE
[WGSL] Add type checking for attributes

### DIFF
--- a/Source/WebGPU/WGSL/tests/invalid/attributes.wgsl
+++ b/Source/WebGPU/WGSL/tests/invalid/attributes.wgsl
@@ -1,0 +1,46 @@
+// RUN: %not %wgslc | %check
+
+struct S {
+    // CHECK-L: @align must be an i32 or u32 value
+    @align(4.0) x: i32,
+
+    // CHECK-L: @location must be an i32 or u32 value
+    @location(0.0) y: i32,
+
+    // CHECK-L: @size must be an i32 or u32 value
+    @size(4.0) z: i32,
+}
+
+// CHECK-L: @group must be an i32 or u32 value
+@group(0.0) @binding(0) var x : i32;
+
+// CHECK-L: @binding must be an i32 or u32 value
+@group(0) @binding(0.0) var y : i32;
+
+// FIXME: Type checking is implemented, but we don't yet parse @id
+// FIXME: CHECK-L: @binding must be an i32 or u32 value
+// @id(0.0) override z : i32;
+
+// CHECK-L: @workgroup_size x dimension must be an i32 or u32 value
+@compute @workgroup_size(1.0)
+fn f1() { }
+
+// CHECK-L: @workgroup_size y dimension must be an i32 or u32 value
+@compute @workgroup_size(1, 1.0)
+fn f2() { }
+
+// CHECK-L: @workgroup_size z dimension must be an i32 or u32 value
+@compute @workgroup_size(1, 1, 1.0)
+fn f3() { }
+
+// CHECK-L: workgroup_size arguments must be of the same type, either i32 or u32
+@compute @workgroup_size(1i, 1u)
+fn f4() { }
+
+// CHECK-L: workgroup_size arguments must be of the same type, either i32 or u32
+@compute @workgroup_size(1, 1i, 1u)
+fn f5() { }
+
+// CHECK-L: workgroup_size arguments must be of the same type, either i32 or u32
+@compute @workgroup_size(1, 1u, 1i)
+fn f6() { }

--- a/Source/WebGPU/WGSL/tests/valid/attributes.wgsl
+++ b/Source/WebGPU/WGSL/tests/valid/attributes.wgsl
@@ -1,0 +1,38 @@
+// RUN: %wgslc
+
+struct S {
+    @align(4) x: i32,
+    @location(0) y: i32,
+    @size(4) z: i32,
+}
+
+@group(0) @binding(0) var x : i32;
+
+@group(0) @binding(0) var y : i32;
+
+// FIXME: we don't yet parse @id
+// @id(0) override z : i32;
+
+@compute @workgroup_size(1)
+fn f1() { }
+
+@compute @workgroup_size(1, 1)
+fn f2() { }
+
+@compute @workgroup_size(1, 1, 1)
+fn f3() { }
+
+@compute @workgroup_size(1i, 1i, 1i)
+fn f4() { }
+
+@compute @workgroup_size(1, 1, 1i)
+fn f5() { }
+
+@compute @workgroup_size(1, 1, 1u)
+fn f6() { }
+
+@compute @workgroup_size(1, 1i, 1)
+fn f7() { }
+
+@compute @workgroup_size(1, 1u, 1)
+fn f8() { }


### PR DESCRIPTION
#### 81ed9b8c42882f4626f9468e19a34ec60c5d7fc5
<pre>
[WGSL] Add type checking for attributes
<a href="https://bugs.webkit.org/show_bug.cgi?id=257472">https://bugs.webkit.org/show_bug.cgi?id=257472</a>
rdar://109995534

Reviewed by Myles C. Maxfield.

Validate the types of the expressions provided to all attributes. Most require
trivially checking that the values are integers, the only interesting one is
@workgroup_size which requires the three arguments to be of the same type.

* Source/WebGPU/WGSL/TypeCheck.cpp:
(WGSL::TypeChecker::visitStructMembers):
(WGSL::TypeChecker::visitVariable):
(WGSL::TypeChecker::visit):
(WGSL::TypeChecker::visitAttributes):
* Source/WebGPU/WGSL/tests/invalid/attributes.wgsl: Added.
* Source/WebGPU/WGSL/tests/valid/attributes.wgsl: Added.

Canonical link: <a href="https://commits.webkit.org/264720@main">https://commits.webkit.org/264720@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0828e45cbaac8b85fcb1f67abdfe647bfa7be0bf

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/8449 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/8742 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/8961 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/10116 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/8496 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/10732 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/8671 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/11363 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/8595 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/9636 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/7631 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/10270 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/6934 "Passed tests") | | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/15279 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/8055 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/7880 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/11226 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/8348 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/6809 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/7635 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/2041 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/11845 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/8093 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->