### PR TITLE
Minor CharacterNames cleanup

### DIFF
--- a/Source/WTF/wtf/unicode/CharacterNames.h
+++ b/Source/WTF/wtf/unicode/CharacterNames.h
@@ -35,15 +35,12 @@ namespace Unicode {
 // Most of these are UChar constants, not UChar32, which makes them
 // more convenient for WebCore code that mostly uses UTF-16.
 
-constexpr UChar AppleLogo = 0xF8FF;
 constexpr UChar HiraganaLetterSmallA = 0x3041;
 constexpr UChar32 aegeanWordSeparatorDot = 0x10101;
 constexpr UChar32 aegeanWordSeparatorLine = 0x10100;
 constexpr UChar apostrophe = 0x0027;
 constexpr UChar blackCircle = 0x25CF;
-constexpr UChar blackDownPointingSmallTriangle = 0x25BE;
 constexpr UChar blackLeftPointingSmallTriangle = 0x25C2;
-constexpr UChar blackRightPointingSmallTriangle = 0x25B8;
 constexpr UChar blackSquare = 0x25A0;
 constexpr UChar blackUpPointingTriangle = 0x25B2;
 constexpr UChar bullet = 0x2022;
@@ -56,6 +53,7 @@ constexpr UChar deleteCharacter = 0x007F;
 constexpr UChar doubleHighReversed9QuotationMark = 0x201F;
 constexpr UChar doubleLowReversed9QuotationMark = 0x2E42;
 constexpr UChar doublePrimeQuotationMark = 0x301E;
+constexpr UChar emSpace = 0x2003;
 constexpr UChar ethiopicPrefaceColon = 0x1366;
 constexpr UChar ethiopicWordspace = 0x1361;
 constexpr UChar firstStrongIsolate = 0x2068;
@@ -88,6 +86,7 @@ constexpr UChar leftWhiteCornerBracket = 0x300E;
 constexpr UChar lowDoublePrimeQuotationMark = 0x301F;
 constexpr UChar lowLine = 0x005F;
 constexpr UChar minusSign = 0x2212;
+constexpr UChar multiplicationSign = 0x00D7;
 constexpr UChar narrowNoBreakSpace = 0x202F;
 constexpr UChar newlineCharacter = 0x000A;
 constexpr UChar noBreakSpace = 0x00A0;
@@ -142,14 +141,11 @@ constexpr UChar zeroWidthSpace = 0x200B;
 } // namespace Unicode
 } // namespace WTF
 
-using WTF::Unicode::AppleLogo;
 using WTF::Unicode::HiraganaLetterSmallA;
 using WTF::Unicode::aegeanWordSeparatorDot;
 using WTF::Unicode::aegeanWordSeparatorLine;
 using WTF::Unicode::blackCircle;
-using WTF::Unicode::blackDownPointingSmallTriangle;
 using WTF::Unicode::blackLeftPointingSmallTriangle;
-using WTF::Unicode::blackRightPointingSmallTriangle;
 using WTF::Unicode::blackSquare;
 using WTF::Unicode::blackUpPointingTriangle;
 using WTF::Unicode::bullet;
@@ -159,6 +155,7 @@ using WTF::Unicode::carriageReturn;
 using WTF::Unicode::cjkWater;
 using WTF::Unicode::combiningEnclosingKeycap;
 using WTF::Unicode::deleteCharacter;
+using WTF::Unicode::emSpace;
 using WTF::Unicode::ethiopicPrefaceColon;
 using WTF::Unicode::ethiopicWordspace;
 using WTF::Unicode::firstStrongIsolate;
@@ -205,6 +202,7 @@ using WTF::Unicode::leftToRightMark;
 using WTF::Unicode::leftToRightOverride;
 using WTF::Unicode::lowLine;
 using WTF::Unicode::minusSign;
+using WTF::Unicode::multiplicationSign;
 using WTF::Unicode::narrowNoBreakSpace;
 using WTF::Unicode::newlineCharacter;
 using WTF::Unicode::noBreakSpace;

--- a/Source/WebCore/inspector/InspectorOverlay.cpp
+++ b/Source/WebCore/inspector/InspectorOverlay.cpp
@@ -76,6 +76,7 @@
 #include "TextDirection.h"
 #include <wtf/MathExtras.h>
 #include <wtf/text/StringBuilder.h>
+#include <wtf/unicode/CharacterNames.h>
 
 namespace WebCore {
 
@@ -87,12 +88,6 @@ static constexpr float rulerStepIncrement = 50;
 static constexpr float rulerStepLength = 8;
 static constexpr float rulerSubStepIncrement = 5;
 static constexpr float rulerSubStepLength = 5;
-
-static constexpr UChar bullet = 0x2022;
-static constexpr UChar ellipsis = 0x2026;
-static constexpr UChar multiplicationSign = 0x00D7;
-static constexpr UChar thinSpace = 0x2009;
-static constexpr UChar emSpace = 0x2003;
 
 enum class Flip : bool { No, Yes };
 
@@ -108,7 +103,7 @@ static bool isInNodeList(const Node& node, const NodeList& list)
 static void truncateWithEllipsis(String& string, size_t length)
 {
     if (string.length() > length)
-        string = makeString(StringView(string).left(length), ellipsis);
+        string = makeString(StringView(string).left(length), horizontalEllipsis);
 }
 
 static FloatPoint localPointToRootPoint(const LocalFrameView* view, const FloatPoint& point)

--- a/Source/WebCore/inspector/agents/InspectorDOMAgent.cpp
+++ b/Source/WebCore/inspector/agents/InspectorDOMAgent.cpp
@@ -123,6 +123,7 @@
 #include <wtf/text/CString.h>
 #include <wtf/text/StringToIntegerConversion.h>
 #include <wtf/text/WTFString.h>
+#include <wtf/unicode/CharacterNames.h>
 
 namespace WebCore {
 
@@ -131,7 +132,7 @@ using namespace Inspector;
 using namespace HTMLNames;
 
 static const size_t maxTextSize = 10000;
-static const UChar ellipsisUChar[] = { 0x2026, 0 };
+static const UChar horizontalEllipsisUChar[] = { horizontalEllipsis, 0 };
 
 static std::optional<Color> parseColor(RefPtr<JSON::Object>&& colorObject)
 {
@@ -1923,7 +1924,7 @@ Ref<Protocol::DOM::Node> InspectorDOMAgent::buildObjectForNode(Node* node, int d
     case Node::CDATA_SECTION_NODE:
         nodeValue = node->nodeValue();
         if (nodeValue.length() > maxTextSize)
-            nodeValue = makeString(StringView(nodeValue).left(maxTextSize), ellipsisUChar);
+            nodeValue = makeString(StringView(nodeValue).left(maxTextSize), horizontalEllipsisUChar);
         break;
     case Node::ATTRIBUTE_NODE:
         localName = node->localName();


### PR DESCRIPTION
#### ff8e8bd010721963f939c38c6e30289b7e34ead9
<pre>
Minor CharacterNames cleanup
<a href="https://bugs.webkit.org/show_bug.cgi?id=257473">https://bugs.webkit.org/show_bug.cgi?id=257473</a>
rdar://109995750

Reviewed by Patrick Angle.

Remove some unused names and deduplicate with InspectorOverlay.

* Source/WTF/wtf/unicode/CharacterNames.h:
* Source/WebCore/inspector/InspectorOverlay.cpp:
(WebCore::truncateWithEllipsis):
* Source/WebCore/inspector/agents/InspectorDOMAgent.cpp:
(WebCore::InspectorDOMAgent::buildObjectForNode):

Canonical link: <a href="https://commits.webkit.org/264741@main">https://commits.webkit.org/264741@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/858eccfc6fefbbac270cbf5a7203f49d149e32a8

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/8318 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/8611 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/8828 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/9986 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/8383 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/8327 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/10599 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/8522 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/11251 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/8464 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/9524 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/7544 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/10130 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/6818 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/7610 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/15173 "148 failures") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/7135 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/7939 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/7751 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/11100 "Passed tests") | 
| [✅ 🛠 🧪 jsc-arm64](https://ews-build.webkit.org/#/builders/12/builds/7938 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/8223 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/6698 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/8491 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/7512 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/2034 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/2059 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/11722 "Built successfully") | | [✅ 🛠 jsc-mips](https://ews-build.webkit.org/#/builders/24/builds/8716 "Built successfully") | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/7966 "Built successfully") | | [✅ 🧪 jsc-mips-tests](https://ews-build.webkit.org/#/builders/3/builds/2159 "Passed tests") | 
<!--EWS-Status-Bubble-End-->