### PR TITLE
[GTK] Use three buffers for DMA-BUF renderer

### DIFF
--- a/Source/WebKit/UIProcess/gtk/AcceleratedBackingStoreDMABuf.messages.in
+++ b/Source/WebKit/UIProcess/gtk/AcceleratedBackingStoreDMABuf.messages.in
@@ -21,7 +21,7 @@
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 messages -> AcceleratedBackingStoreDMABuf NotRefCounted {
-    Configure(UnixFileDescriptor backFD, UnixFileDescriptor frontFD, WebCore::IntSize size, uint32_t format, uint32_t offset, uint32_t stride, uint64_t modifier)
-    ConfigureSHM(WebKit::ShareableBitmap::Handle backBufferHandle, WebKit::ShareableBitmap::Handle frontBufferHandle)
+    Configure(UnixFileDescriptor backFD, UnixFileDescriptor frontFD, UnixFileDescriptor displayFD, WebCore::IntSize size, uint32_t format, uint32_t offset, uint32_t stride, uint64_t modifier)
+    ConfigureSHM(WebKit::ShareableBitmap::Handle backBufferHandle, WebKit::ShareableBitmap::Handle frontBufferHandle, WebKit::ShareableBitmap::Handle displayBufferHandle)
     Frame()
 }

--- a/Source/WebKit/WebProcess/WebPage/gtk/AcceleratedSurfaceDMABuf.h
+++ b/Source/WebKit/WebProcess/WebPage/gtk/AcceleratedSurfaceDMABuf.h
@@ -80,8 +80,8 @@ private:
         virtual ~RenderTarget();
 
         void willRenderFrame() const;
-        virtual void didRenderFrame() const { }
-        virtual void swap();
+        virtual void didRenderFrame();
+        virtual void didDisplayFrame();
 
     protected:
         explicit RenderTarget(WebCore::PageIdentifier, const WebCore::IntSize&);
@@ -89,6 +89,7 @@ private:
         WebCore::PageIdentifier m_pageID;
         unsigned m_backColorBuffer { 0 };
         unsigned m_frontColorBuffer { 0 };
+        unsigned m_displayColorBuffer { 0 };
         unsigned m_depthStencilBuffer { 0 };
     };
 
@@ -96,29 +97,32 @@ private:
     class RenderTargetEGLImage final : public RenderTarget {
     public:
         static std::unique_ptr<RenderTarget> create(WebCore::PageIdentifier, const WebCore::IntSize&);
-        RenderTargetEGLImage(WebCore::PageIdentifier, const WebCore::IntSize&, EGLImage, EGLImage, WTF::UnixFileDescriptor&&, WTF::UnixFileDescriptor&&, uint32_t format, uint32_t offset, uint32_t stride, uint64_t modifier);
+        RenderTargetEGLImage(WebCore::PageIdentifier, const WebCore::IntSize&, EGLImage, WTF::UnixFileDescriptor&&, EGLImage, WTF::UnixFileDescriptor&&, EGLImage, WTF::UnixFileDescriptor&&, uint32_t format, uint32_t offset, uint32_t stride, uint64_t modifier);
         ~RenderTargetEGLImage();
 
     private:
-        void swap() override;
+        void didRenderFrame() override;
+        void didDisplayFrame() override;
 
         EGLImage m_backImage { nullptr };
         EGLImage m_frontImage { nullptr };
+        EGLImage m_displayImage { nullptr };
     };
 #endif
 
     class RenderTargetSHMImage final : public RenderTarget {
     public:
         static std::unique_ptr<RenderTarget> create(WebCore::PageIdentifier, const WebCore::IntSize&);
-        RenderTargetSHMImage(WebCore::PageIdentifier, const WebCore::IntSize&, Ref<ShareableBitmap>&&, ShareableBitmapHandle&&, Ref<ShareableBitmap>&&, ShareableBitmapHandle&&);
+        RenderTargetSHMImage(WebCore::PageIdentifier, const WebCore::IntSize&, Ref<ShareableBitmap>&&, ShareableBitmapHandle&&, Ref<ShareableBitmap>&&, ShareableBitmapHandle&&, Ref<ShareableBitmap>&&, ShareableBitmapHandle&&);
         ~RenderTargetSHMImage() = default;
 
     private:
-        void didRenderFrame() const override;
-        void swap() override;
+        void didRenderFrame() override;
+        void didDisplayFrame() override;
 
         Ref<ShareableBitmap> m_backBitmap;
         Ref<ShareableBitmap> m_frontBitmap;
+        Ref<ShareableBitmap> m_displayBitmap;
     };
 
     unsigned m_fbo { 0 };


### PR DESCRIPTION
#### 0e48ee99a1fc29e246900829c7e241587e59d22d
<pre>
[GTK] Use three buffers for DMA-BUF renderer
<a href="https://bugs.webkit.org/show_bug.cgi?id=257475">https://bugs.webkit.org/show_bug.cgi?id=257475</a>

Reviewed by Alejandro G. Castro.

Two buffers is not enough, because we might be rendering in the UI
process with the buffer that is being used by the web process. The first
time we render a frame in the UI process we notify the web process that
the buffer has been painted and web process does a swap and starts
rendering the next frame. If there&apos;s a web view redraw before the next
frame message is received in the UI process we would be using the
current web process back buffer to repaint.

This patch adds a third buffer, the display buffer, that is the one
always used by the UI process for rendering and ensured that is never
used by the web process as the back buffer until a new display buffer
is set in the UI process.

* Source/WebKit/UIProcess/gtk/AcceleratedBackingStoreDMABuf.cpp:
(WebKit::AcceleratedBackingStoreDMABuf::Texture::Texture):
(WebKit::AcceleratedBackingStoreDMABuf::Texture::~Texture):
(WebKit::AcceleratedBackingStoreDMABuf::Texture::frame):
(WebKit::AcceleratedBackingStoreDMABuf::Texture::willDisplayFrame):
(WebKit::AcceleratedBackingStoreDMABuf::Texture::prepareForRendering):
(WebKit::AcceleratedBackingStoreDMABuf::Surface::Surface):
(WebKit::AcceleratedBackingStoreDMABuf::Surface::~Surface):
(WebKit::AcceleratedBackingStoreDMABuf::Surface::frame):
(WebKit::AcceleratedBackingStoreDMABuf::Surface::willDisplayFrame):
(WebKit::AcceleratedBackingStoreDMABuf::Surface::prepareForRendering):
(WebKit::AcceleratedBackingStoreDMABuf::configure):
(WebKit::AcceleratedBackingStoreDMABuf::configureSHM):
(WebKit::AcceleratedBackingStoreDMABuf::createSource):
(WebKit::AcceleratedBackingStoreDMABuf::frame):
(WebKit::AcceleratedBackingStoreDMABuf::willDisplayFrame):
(WebKit::AcceleratedBackingStoreDMABuf::snapshot):
(WebKit::AcceleratedBackingStoreDMABuf::paint):
(WebKit::AcceleratedBackingStoreDMABuf::Texture::swap): Deleted.
(WebKit::AcceleratedBackingStoreDMABuf::Surface::swap): Deleted.
* Source/WebKit/UIProcess/gtk/AcceleratedBackingStoreDMABuf.h:
* Source/WebKit/UIProcess/gtk/AcceleratedBackingStoreDMABuf.messages.in:
* Source/WebKit/WebProcess/WebPage/gtk/AcceleratedSurfaceDMABuf.cpp:
(WebKit::AcceleratedSurfaceDMABuf::RenderTarget::RenderTarget):
(WebKit::AcceleratedSurfaceDMABuf::RenderTarget::~RenderTarget):
(WebKit::AcceleratedSurfaceDMABuf::RenderTarget::didRenderFrame):
(WebKit::AcceleratedSurfaceDMABuf::RenderTarget::didDisplayFrame):
(WebKit::AcceleratedSurfaceDMABuf::RenderTargetEGLImage::create):
(WebKit::AcceleratedSurfaceDMABuf::RenderTargetEGLImage::RenderTargetEGLImage):
(WebKit::AcceleratedSurfaceDMABuf::RenderTargetEGLImage::~RenderTargetEGLImage):
(WebKit::AcceleratedSurfaceDMABuf::RenderTargetEGLImage::didRenderFrame):
(WebKit::AcceleratedSurfaceDMABuf::RenderTargetEGLImage::didDisplayFrame):
(WebKit::AcceleratedSurfaceDMABuf::RenderTargetSHMImage::create):
(WebKit::AcceleratedSurfaceDMABuf::RenderTargetSHMImage::RenderTargetSHMImage):
(WebKit::AcceleratedSurfaceDMABuf::RenderTargetSHMImage::didRenderFrame):
(WebKit::AcceleratedSurfaceDMABuf::RenderTargetSHMImage::didDisplayFrame):
(WebKit::AcceleratedSurfaceDMABuf::frameDone):
(WebKit::AcceleratedSurfaceDMABuf::RenderTarget::swap): Deleted.
(WebKit::AcceleratedSurfaceDMABuf::RenderTargetEGLImage::swap): Deleted.
(WebKit::AcceleratedSurfaceDMABuf::RenderTargetSHMImage::didRenderFrame const): Deleted.
(WebKit::AcceleratedSurfaceDMABuf::RenderTargetSHMImage::swap): Deleted.
* Source/WebKit/WebProcess/WebPage/gtk/AcceleratedSurfaceDMABuf.h:

Canonical link: <a href="https://commits.webkit.org/265192@main">https://commits.webkit.org/265192@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e1c59bf27b1ac57895baecc656b37c43915c7451

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/10190 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/10427 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/10688 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/11835 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/32/builds/9834 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/12421 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/10379 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/12764 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/10346 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/11095 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/8589 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/12218 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/8400 "Passed tests") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/16517 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/9499 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/9380 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/12623 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/9839 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/7989 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/8998 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/13244 "Built successfully") | | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/1145 "Built successfully and passed tests") | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/9665 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->