### PR TITLE
[GStreamer][WebRTC] Tests crashing due to empty mediastream ID

### DIFF
--- a/Source/WebCore/Modules/mediastream/gstreamer/GStreamerMediaEndpoint.cpp
+++ b/Source/WebCore/Modules/mediastream/gstreamer/GStreamerMediaEndpoint.cpp
@@ -886,7 +886,7 @@ void GStreamerMediaEndpoint::addRemoteStream(GstPad* pad)
             mediaStreamId = String::fromLatin1(msid.get());
     }
 
-    if (!mediaStreamId) {
+    if (mediaStreamId.isEmpty()) {
         if (const char* msidAttribute = gst_sdp_media_get_attribute_val(media, "msid")) {
             auto components = makeString(msidAttribute).split(' ');
             if (components.size() == 2)
@@ -894,7 +894,7 @@ void GStreamerMediaEndpoint::addRemoteStream(GstPad* pad)
         }
     }
 
-    if (!mediaStreamId) {
+    if (mediaStreamId.isEmpty()) {
         GUniquePtr<gchar> name(gst_pad_get_name(pad));
         mediaStreamId = String::fromLatin1(name.get());
     }


### PR DESCRIPTION
#### e07e832d0677655e411f1e017e34e5f318c27de8
<pre>
[GStreamer][WebRTC] Tests crashing due to empty mediastream ID
<a href="https://bugs.webkit.org/show_bug.cgi?id=257476">https://bugs.webkit.org/show_bug.cgi?id=257476</a>

Reviewed by Xabier Rodriguez-Calvar.

The !operator of String is not about checking the string is empty, we need to check with isEmpty().
Not sure if that recently changed or something...

* Source/WebCore/Modules/mediastream/gstreamer/GStreamerMediaEndpoint.cpp:
(WebCore::GStreamerMediaEndpoint::addRemoteStream):

Canonical link: <a href="https://commits.webkit.org/264727@main">https://commits.webkit.org/264727@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/cf71aaeb1e4b43731816ec5206a9508e1c3f1899

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/8325 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/8618 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/8835 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/9993 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/8390 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/8334 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/10606 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/8529 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/11256 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/8471 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/9525 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/7546 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/10137 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/6823 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/7612 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/15175 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/7944 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/7753 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/11102 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/8230 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/6701 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/7519 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/2049 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/11729 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/7973 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->