### PR TITLE
Add a bounds check in [RTCCVPixelBuffer toI420]

### DIFF
--- a/Source/ThirdParty/libwebrtc/Source/webrtc/sdk/objc/components/video_frame_buffer/RTCCVPixelBuffer.mm
+++ b/Source/ThirdParty/libwebrtc/Source/webrtc/sdk/objc/components/video_frame_buffer/RTCCVPixelBuffer.mm
@@ -174,6 +174,25 @@
       srcY += srcYStride * _cropY + _cropX;
       srcUV += srcUVStride * (_cropY / 2) + _cropX;
 
+#if defined(WEBRTC_WEBKIT_BUILD)
+      auto srcWidthY = CVPixelBufferGetWidthOfPlane(_pixelBuffer, 0);
+      auto srcHeightY = CVPixelBufferGetHeightOfPlane(_pixelBuffer, 0);
+      auto srcWidthUV = CVPixelBufferGetWidthOfPlane(_pixelBuffer, 1);
+      auto srcHeightUV = CVPixelBufferGetHeightOfPlane(_pixelBuffer, 1);
+
+      auto destWidthY = i420Buffer.width;
+      auto destHeightY = i420Buffer.height;
+      auto destWidthUV = i420Buffer.chromaWidth;
+      auto destHeightUV = i420Buffer.chromaHeight;
+
+      RTC_DCHECK(srcWidthUV && srcWidthUV == destWidthUV && srcHeightUV && srcHeightUV == destHeightUV && srcWidthY == destWidthY && srcHeightY == destHeightY);
+      if (![self requiresCropping] && (!srcWidthUV || srcWidthUV != destWidthUV || !srcHeightUV || srcHeightUV != destHeightUV || srcWidthY != destWidthY || srcHeightY != destHeightY)) {
+        RTC_LOG(LS_ERROR) << "RTCI420Buffer toI420 bad size: " << srcWidthY << " x " << srcHeightY;
+        CVPixelBufferUnlockBaseAddress(_pixelBuffer, kCVPixelBufferLock_ReadOnly);
+        return nullptr;
+      }
+#endif // defined(WEBRTC_WEBKIT_BUILD)
+
       // TODO(magjed): Use a frame buffer pool.
       webrtc::NV12ToI420Scaler nv12ToI420Scaler;
       nv12ToI420Scaler.NV12ToI420Scale(srcY,

--- a/Source/ThirdParty/libwebrtc/Source/webrtc/sdk/objc/native/src/objc_frame_buffer.mm
+++ b/Source/ThirdParty/libwebrtc/Source/webrtc/sdk/objc/native/src/objc_frame_buffer.mm
@@ -88,15 +88,11 @@ rtc::scoped_refptr<I420BufferInterface> ObjCFrameBuffer::ToI420() {
 }
 
 id<RTCVideoFrameBuffer> ObjCFrameBuffer::wrapped_frame_buffer() const {
-  if (frame_buffer_)
-    return frame_buffer_;
-
-  {
-    webrtc::MutexLock lock(&mutex_);
-    if (!frame_buffer_ && frame_buffer_provider_.getBuffer)
-      const_cast<ObjCFrameBuffer*>(this)->frame_buffer_ = [[RTCCVPixelBuffer alloc] initWithPixelBuffer:frame_buffer_provider_.getBuffer(frame_buffer_provider_.pointer)];
-  }
-
+#if defined(WEBRTC_WEBKIT_BUILD)
+  webrtc::MutexLock lock(&mutex_);
+  if (!frame_buffer_ && frame_buffer_provider_.getBuffer)
+    const_cast<ObjCFrameBuffer*>(this)->frame_buffer_ = [[RTCCVPixelBuffer alloc] initWithPixelBuffer:frame_buffer_provider_.getBuffer(frame_buffer_provider_.pointer)];
+#endif
   return frame_buffer_;
 }
 


### PR DESCRIPTION
#### ebb91ef51ed3a08bfe50add2a3ce4e7da96e25e3
<pre>
Add a bounds check in [RTCCVPixelBuffer toI420]
<a href="https://bugs.webkit.org/show_bug.cgi?id=257479">https://bugs.webkit.org/show_bug.cgi?id=257479</a>
rdar://108377764

Reviewed by Jean-Yves Avenard.

Add a width/height check to toI420 for extra safety.
Update ObjCFrameBuffer::wrapped_frame_buffer to always use a mutex.

* Source/ThirdParty/libwebrtc/Source/webrtc/sdk/objc/components/video_frame_buffer/RTCCVPixelBuffer.mm:
(-[RTCCVPixelBuffer toI420]):
* Source/ThirdParty/libwebrtc/Source/webrtc/sdk/objc/native/src/objc_frame_buffer.mm:
(webrtc::ObjCFrameBuffer::wrapped_frame_buffer const):

Canonical link: <a href="https://commits.webkit.org/264670@main">https://commits.webkit.org/264670@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d8ea808103752247e549b233ba0b9ade0e24eb25

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/8328 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/8621 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/8838 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/9996 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/8393 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/10609 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/8532 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/11261 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/8474 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/9530 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/7552 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/10140 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/6828 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/7620 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/15182 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/7949 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/7762 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/11109 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/8233 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/6707 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/7522 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/1999 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/11732 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/7976 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->