### PR TITLE
[WGSL] Don't rewrite complex constants

### DIFF
--- a/Source/WebGPU/WGSL/ConstantRewriter.cpp
+++ b/Source/WebGPU/WGSL/ConstantRewriter.cpp
@@ -302,16 +302,16 @@ void ConstantRewriter::materialize(AST::Expression& expression, const ConstantVa
             }
         },
         [&](const Vector&) {
-            replace.operator()<AST::CallExpression>();
+            // Do not materialize complex types
         },
         [&](const Matrix&) {
-            replace.operator()<AST::CallExpression>();
+            // Do not materialize complex types
         },
         [&](const Array&) {
-            replace.operator()<AST::CallExpression>();
+            // Do not materialize complex types
         },
         [&](const Struct&) {
-            replace.operator()<AST::CallExpression>();
+            // Do not materialize complex types
         },
         [&](const Reference&) {
             RELEASE_ASSERT_NOT_REACHED();
@@ -356,70 +356,16 @@ AST::Expression& ConstantRewriter::materialize(const ConstantValue& value)
                 RELEASE_ASSERT_NOT_REACHED();
             }
         },
-        [&](const Vector& vectorType) -> AST::Expression& {
-            AST::ParameterizedTypeName::Base base;
-            switch (vectorType.size) {
-            case 2:
-                base = AST::ParameterizedTypeName::Base::Vec2;
-                break;
-            case 3:
-                base = AST::ParameterizedTypeName::Base::Vec3;
-                break;
-            case 4:
-                base = AST::ParameterizedTypeName::Base::Vec4;
-                break;
-            default:
-                RELEASE_ASSERT_NOT_REACHED();
-            }
-
-            AST::Expression::List arguments;
-            auto& vector = std::get<ConstantVector>(value);
-            arguments.reserveCapacity(vector.elements.size());
-            for (const auto& element : vector.elements)
-                arguments.append(materialize(element));
-
-            auto& typeName = m_shaderModule.astBuilder().construct<AST::NamedTypeName>(
-                SourceSpan::empty(),
-                AST::Identifier::make(AST::ParameterizedTypeName::baseToString(base))
-            );
-            typeName.m_resolvedType = value.type;
-
-            auto& call = m_shaderModule.astBuilder().construct<AST::CallExpression>(
-                SourceSpan::empty(),
-                typeName,
-                WTFMove(arguments)
-            );
-            call.m_inferredType = value.type;
-
-            return call;
+        [&](const Vector&) -> AST::Expression& {
+            RELEASE_ASSERT_NOT_REACHED();
         },
-        [&](const Matrix& matrix) -> AST::Expression& {
-            // FIXME: implement
-            UNUSED_PARAM(matrix);
+        [&](const Matrix&) -> AST::Expression& {
             RELEASE_ASSERT_NOT_REACHED();
         },
         [&](const Array&) -> AST::Expression& {
-            AST::Expression::List arguments;
-            auto& array = std::get<ConstantArray>(value);
-            arguments.reserveCapacity(array.elements.size());
-            for (const auto& element : array.elements)
-                arguments.append(materialize(element));
-
-            auto& typeName = m_shaderModule.astBuilder().construct<AST::ArrayTypeName>(
-                SourceSpan::empty(),
-                nullptr,
-                nullptr
-            );
-
-            return m_shaderModule.astBuilder().construct<AST::CallExpression>(
-                SourceSpan::empty(),
-                typeName,
-                WTFMove(arguments)
-            );
+            RELEASE_ASSERT_NOT_REACHED();
         },
-        [&](const Struct& structure) -> AST::Expression& {
-            // FIXME: implement
-            UNUSED_PARAM(structure);
+        [&](const Struct&) -> AST::Expression& {
             RELEASE_ASSERT_NOT_REACHED();
         },
         [&](const Reference&) -> AST::Expression& {

--- a/Source/WebGPU/WGSL/tests/lit.cfg
+++ b/Source/WebGPU/WGSL/tests/lit.cfg
@@ -22,4 +22,5 @@ config.environment['DYLD_FRAMEWORK_PATH'] = port._build_path()
 
 config.substitutions.append(('%check', '{}/bin/OutputCheck --comment=".*//" %s'.format(site.getuserbase())))
 config.substitutions.append(('%wgslc', '{} %s _ 2>&1'.format(wgslc)))
+config.substitutions.append(('%metal', '{} --dump-generated-code %s'.format(wgslc)))
 config.substitutions.append(('%not', 'eval !'))

--- a/Source/WebGPU/WGSL/tests/valid/local-constant-vector.wgsl
+++ b/Source/WebGPU/WGSL/tests/valid/local-constant-vector.wgsl
@@ -1,0 +1,11 @@
+// RUN: %metal main 2>&1 | %check
+
+fn f(x: i32) { }
+@compute @workgroup_size(1)
+fn main() {
+  // CHECK: vec.* local\d+ = vec.*
+  const a = vec2(0);
+
+  // CHECK: \(void\)\(local\d+\)
+  _ = a;
+}


### PR DESCRIPTION
#### dd455ea08bb0f0467f73e9d8fa271b2bf5c65dba
<pre>
[WGSL] Don&apos;t rewrite complex constants
<a href="https://bugs.webkit.org/show_bug.cgi?id=257486">https://bugs.webkit.org/show_bug.cgi?id=257486</a>
rdar://110005210

Reviewed by Dan Glastonbury.

The original implementation assumed we would completely remove every constant
declaration, but upon further consideration, it doesn&apos;t seem like a great idea
to replace every reference to a constant with its value when the value is a
non-trivial value. i.e. it makes sense to replace literals, but probably not
with vectors, arrays, matrices and structs.

* Source/WebGPU/WGSL/ConstantRewriter.cpp:
(WGSL::ConstantRewriter::materialize):
* Source/WebGPU/WGSL/tests/lit.cfg:
* Source/WebGPU/WGSL/tests/valid/local-constant-vector.wgsl: Added.

Canonical link: <a href="https://commits.webkit.org/264723@main">https://commits.webkit.org/264723@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d5339828a0897da98e037deab2d8546242cde049

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/8337 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/8630 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/8847 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/10005 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/8402 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/10618 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/8541 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/11268 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/8483 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/9539 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/7559 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/10153 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/6837 "Passed tests") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/15192 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/7958 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/7771 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/11119 "7 api tests failed or timed out") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/8242 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/6716 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/7531 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/2044 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/11741 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/7985 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->