### PR TITLE
[WGSL] Constant values might not match type

### DIFF
--- a/Source/WebGPU/WGSL/ConstantFunctions.h
+++ b/Source/WebGPU/WGSL/ConstantFunctions.h
@@ -34,15 +34,15 @@ static ConstantValue constantPow(const FixedVector<ConstantValue>& arguments)
     const auto& value = arguments[0];
     const auto& exponent = arguments[1];
 
-    if (auto* f32 = std::get_if<double>(&value))
-        return { value.type, std::pow(*f32, std::get<double>(exponent)) };
+    if (value.isNumber())
+        return { value.type, std::pow(value.toDouble(), exponent.toDouble()) };
 
     auto& baseVector = std::get<ConstantVector>(value);
     auto& expVector = std::get<ConstantVector>(exponent);
     auto size = baseVector.elements.size();
     ConstantVector result(size);
     for (unsigned i = 0; i < size; ++i)
-        result.elements[i] = { baseVector.elements[i].type, std::pow(std::get<double>(baseVector.elements[i]), std::get<double>(expVector.elements[i])) };
+        result.elements[i] = { baseVector.elements[i].type, std::pow(baseVector.elements[i].toDouble(), expVector.elements[i].toDouble()) };
     return { value.type, result };
 }
 

--- a/Source/WebGPU/WGSL/ConstantRewriter.cpp
+++ b/Source/WebGPU/WGSL/ConstantRewriter.cpp
@@ -147,10 +147,6 @@ ConstantValue ConstantRewriter::evaluate(AST::Expression& expression)
             return ConstantValue(expression.inferredType(), downcast<AST::AbstractFloatLiteral>(expression).value());
         case AST::NodeKind::AbstractIntegerLiteral: {
             auto value = downcast<AST::AbstractIntegerLiteral>(expression).value();
-            if (!satisfies(expression.inferredType(), Constraints::ConcreteInteger)) {
-                // The abstract integer was promoted to a float
-                return ConstantValue(expression.inferredType(), static_cast<double>(value));
-            }
             return ConstantValue(expression.inferredType(), value);
         }
         case AST::NodeKind::Float32Literal:

--- a/Source/WebGPU/WGSL/ConstantValue.h
+++ b/Source/WebGPU/WGSL/ConstantValue.h
@@ -80,6 +80,19 @@ struct ConstantValue : BaseValue {
 
     void dump(PrintStream&) const;
 
+    bool isNumber() const
+    {
+        return std::holds_alternative<int64_t>(*this) || std::holds_alternative<double>(*this);
+    }
+
+    double toDouble() const
+    {
+        ASSERT(isNumber());
+        if (std::holds_alternative<double>(*this))
+            return std::get<double>(*this);
+        return static_cast<double>(std::get<int64_t>(*this));
+    }
+
     const Type* type;
 };
 

--- a/Source/WebGPU/WGSL/tests/valid/constants.wgsl
+++ b/Source/WebGPU/WGSL/tests/valid/constants.wgsl
@@ -47,3 +47,8 @@ fn testVectorConstants() -> i32
     }
     return 0;
 }
+
+fn testAbstractIntPromotion()
+{
+    const f = pow(vec2(0), vec2(0));
+}


### PR DESCRIPTION
#### e8c12535c74ae70cd22109daed317e6fe4df2f73
<pre>
[WGSL] Constant values might not match type
<a href="https://bugs.webkit.org/show_bug.cgi?id=257491">https://bugs.webkit.org/show_bug.cgi?id=257491</a>
rdar://110007144

Reviewed by Myles C. Maxfield.

Because AbtractInt values can be promoted to floats, the inferred type might
might not match the constant value, since the constant value is derived from
the AST node. In the original implementation, I tried to account for that by
checking the inferred type for the literal node, but that does not cover all
cases. The new test case shows that for calls nested at multiple levels that
can still be an issue. Instead we add new helper functions to ConstantValue
that allow promoting an AbstractInt to double, to match the behavior of the
type system.

* Source/WebGPU/WGSL/ConstantFunctions.h:
(WGSL::constantPow):
* Source/WebGPU/WGSL/ConstantRewriter.cpp:
(WGSL::ConstantRewriter::evaluate):
* Source/WebGPU/WGSL/ConstantValue.h:
(WGSL::ConstantValue::isNumber const):
(WGSL::ConstantValue::toDouble const):
* Source/WebGPU/WGSL/tests/valid/constants.wgsl:

Canonical link: <a href="https://commits.webkit.org/264726@main">https://commits.webkit.org/264726@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/073a1d0f13b7494496e239264680b24c6462c3f3

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/8460 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/8753 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/8972 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/10127 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/8507 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/10743 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/8686 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/11372 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/8606 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/9648 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/7636 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/10281 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/6946 "Passed tests") | | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/15290 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/8067 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/7887 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/11237 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/8359 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/6823 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/7646 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/2045 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/11856 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/8104 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->