### PR TITLE
[WGSL] Refactor ConstantRewriter

### DIFF
--- a/Source/WebGPU/WGSL/ConstantValue.h
+++ b/Source/WebGPU/WGSL/ConstantValue.h
@@ -46,12 +46,22 @@ struct ConstantArray {
     {
     }
 
+    ConstantArray(FixedVector<ConstantValue>&& elements)
+        : elements(WTFMove(elements))
+    {
+    }
+
     FixedVector<ConstantValue> elements;
 };
 
 struct ConstantVector {
     ConstantVector(size_t size)
         : elements(size)
+    {
+    }
+
+    ConstantVector(FixedVector<ConstantValue>&& elements)
+        : elements(WTFMove(elements))
     {
     }
 


### PR DESCRIPTION
#### 0eb4e8349d52a742ea400a944fe328f284cebb9b
<pre>
[WGSL] Refactor ConstantRewriter
<a href="https://bugs.webkit.org/show_bug.cgi?id=257492">https://bugs.webkit.org/show_bug.cgi?id=257492</a>
rdar://110008653

Reviewed by Myles C. Maxfield.

The original implementation had a stricter separation between &quot;visiting&quot; and
&quot;evaluating&quot; constants. As I continued to work on the rewriter, that seems like
the wrong approach. Unifying it (similarly to how the type checker works)
simplifies the code and makes it easier to optimize operations on constants
in any context. (e.g. some of the calls to `pow` in the overload.wgsl test were
optimized into the result value)

* Source/WebGPU/WGSL/ConstantRewriter.cpp:
(WGSL::ConstantRewriter::visit):
(WGSL::ConstantRewriter::evaluate):
(WGSL::ConstantRewriter::materialize):
(WGSL::ConstantRewriter::evaluated):
* Source/WebGPU/WGSL/ConstantValue.h:
(WGSL::ConstantArray::ConstantArray):
(WGSL::ConstantVector::ConstantVector):

Canonical link: <a href="https://commits.webkit.org/264728@main">https://commits.webkit.org/264728@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f8f0001381f0f6624e7350ac44d789d2a400a86b

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/8469 "1 style error") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/8762 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/8981 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/10136 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/8515 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/10752 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/8701 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/11383 "101 failures") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/8615 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/9657 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/7638 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/10291 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/6955 "Passed tests") | | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/15298 "3 flakes 111 failures") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/8076 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/7896 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/11250 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/8368 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/6831 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/7654 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/2050 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/11865 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/8113 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->