### PR TITLE
[popover] Refactor all popover showing checks

### DIFF
--- a/Source/WebCore/css/SelectorCheckerTestFunctions.h
+++ b/Source/WebCore/css/SelectorCheckerTestFunctions.h
@@ -575,10 +575,7 @@ ALWAYS_INLINE bool matchesModalPseudoClass(const Element& element)
 
 ALWAYS_INLINE bool matchesPopoverOpenPseudoClass(const Element& element)
 {
-    if (auto* popoverData = element.popoverData())
-        return popoverData->visibilityState() == PopoverVisibilityState::Showing;
-
-    return false;
+    return element.isPopoverShowing();
 }
 
 ALWAYS_INLINE bool matchesUserInvalidPseudoClass(const Element& element)

--- a/Source/WebCore/dom/Document.cpp
+++ b/Source/WebCore/dom/Document.cpp
@@ -9054,7 +9054,7 @@ void Document::hideAllPopoversUntil(Element* endpoint, FocusPreviousElement focu
         }
         if (!foundEndPoint)
             return closeAllOpenPopovers();
-        while (lastToHide && lastToHide->popoverData() && lastToHide->popoverData()->visibilityState() == PopoverVisibilityState::Showing) {
+        while (lastToHide && lastToHide->isPopoverShowing()) {
             auto* topmostAutoPopover = this->topmostAutoPopover();
             if (!topmostAutoPopover)
                 break;

--- a/Source/WebCore/dom/Element.cpp
+++ b/Source/WebCore/dom/Element.cpp
@@ -5358,4 +5358,9 @@ void Element::setHasDuplicateAttribute(bool hasDuplicateAttribute)
     setEventTargetFlag(EventTargetFlag::HasDuplicateAttribute, hasDuplicateAttribute);
 }
 
+bool Element::isPopoverShowing() const
+{
+    return popoverData() && popoverData()->visibilityState() == PopoverVisibilityState::Showing;
+}
+
 } // namespace WebCore

--- a/Source/WebCore/dom/Element.h
+++ b/Source/WebCore/dom/Element.h
@@ -589,6 +589,7 @@ public:
     PopoverData* popoverData() const;
     PopoverData& ensurePopoverData();
     void clearPopoverData();
+    bool isPopoverShowing() const;
 
     ExceptionOr<void> setPointerCapture(int32_t);
     ExceptionOr<void> releasePointerCapture(int32_t);

--- a/Source/WebCore/dom/FullscreenManager.cpp
+++ b/Source/WebCore/dom/FullscreenManager.cpp
@@ -41,7 +41,6 @@
 #include "LocalFrame.h"
 #include "Logging.h"
 #include "Page.h"
-#include "PopoverData.h"
 #include "PseudoClassChangeInvalidation.h"
 #include "QualifiedName.h"
 #include "Settings.h"
@@ -69,11 +68,6 @@ Element* FullscreenManager::fullscreenElement() const
     }
 
     return nullptr;
-}
-
-inline bool isInPopoverShowingState(Element& element)
-{
-    return element.popoverData() && element.popoverData()->visibilityState() == PopoverVisibilityState::Showing;
 }
 
 // https://fullscreen.spec.whatwg.org/#dom-element-requestfullscreen
@@ -109,7 +103,7 @@ void FullscreenManager::requestFullscreenForElement(Ref<Element>&& element, RefP
         return;
     }
 
-    if (isInPopoverShowingState(element)) {
+    if (element->isPopoverShowing()) {
         ERROR_LOG(identifier, "Element to fullscreen is an open popover; failing.");
         failedPreflights(WTFMove(element), WTFMove(promise));
         return;
@@ -207,7 +201,7 @@ void FullscreenManager::requestFullscreenForElement(Ref<Element>&& element, RefP
         }
 
         // The element is an open popover.
-        if (isInPopoverShowingState(element)) {
+        if (element->isPopoverShowing()) {
             ERROR_LOG(identifier, "Element to fullscreen is an open popover; failing.");
             failedPreflights(WTFMove(element), WTFMove(promise));
             return;
@@ -476,7 +470,7 @@ bool FullscreenManager::willEnterFullscreen(Element& element)
     }
 
     // The element is an open popover.
-    if (isInPopoverShowingState(element)) {
+    if (element.isPopoverShowing()) {
         ERROR_LOG(LOGIDENTIFIER, "Element to fullscreen is an open popover; bailing.");
         return false;
     }

--- a/Source/WebCore/html/HTMLDialogElement.cpp
+++ b/Source/WebCore/html/HTMLDialogElement.cpp
@@ -59,7 +59,7 @@ ExceptionOr<void> HTMLDialogElement::show()
         return Exception { InvalidStateError, "Cannot call show() on an open modal dialog."_s };
     }
 
-    if (popoverData() && popoverData()->visibilityState() == PopoverVisibilityState::Showing)
+    if (isPopoverShowing())
         return Exception { InvalidStateError, "Element is already an open popover."_s };
 
     setBooleanAttribute(openAttr, true);
@@ -85,7 +85,7 @@ ExceptionOr<void> HTMLDialogElement::showModal()
     if (!isConnected())
         return Exception { InvalidStateError, "Element is not connected."_s };
 
-    if (popoverData() && popoverData()->visibilityState() == PopoverVisibilityState::Showing)
+    if (isPopoverShowing())
         return Exception { InvalidStateError, "Element is already an open popover."_s };
 
     // setBooleanAttribute will dispatch a DOMSubtreeModified event.

--- a/Source/WebCore/html/HTMLElement.cpp
+++ b/Source/WebCore/html/HTMLElement.cpp
@@ -1483,7 +1483,7 @@ ExceptionOr<void> HTMLElement::hidePopover()
 
 ExceptionOr<void> HTMLElement::togglePopover(std::optional<bool> force)
 {
-    if (popoverData() && popoverData()->visibilityState() == PopoverVisibilityState::Showing && !force.value_or(false))
+    if (isPopoverShowing() && !force.value_or(false))
         return hidePopover();
 
     if ((!popoverData() || popoverData()->visibilityState() == PopoverVisibilityState::Hidden) && force.value_or(true))
@@ -1512,7 +1512,7 @@ void HTMLElement::popoverAttributeChanged(const AtomString& value)
 
     Style::PseudoClassChangeInvalidation styleInvalidation(*this, CSSSelector::PseudoClassPopoverOpen, false);
 
-    if (popoverData() && popoverData()->visibilityState() == PopoverVisibilityState::Showing) {
+    if (isPopoverShowing()) {
         hidePopoverInternal(FocusPreviousElement::Yes, FireEvents::Yes);
         newPopoverState = computePopoverState(attributeWithoutSynchronization(popoverAttr));
     }

--- a/Source/WebCore/page/FocusController.cpp
+++ b/Source/WebCore/page/FocusController.cpp
@@ -73,7 +73,7 @@ using namespace HTMLNames;
 static bool isOpenPopoverWithInvoker(const Node* node)
 {
     RefPtr popover = dynamicDowncast<HTMLElement>(node);
-    return popover && popover->popoverData() && popover->popoverData()->visibilityState() == PopoverVisibilityState::Showing && popover->popoverData()->invoker();
+    return popover && popover->isPopoverShowing() && popover->popoverData()->invoker();
 }
 
 static const HTMLFormControlElement* invokerForPopoverShowingState(const Node* node)
@@ -82,7 +82,7 @@ static const HTMLFormControlElement* invokerForPopoverShowingState(const Node* n
     if (!invoker)
         return nullptr;
     HTMLElement* popover = invoker->popoverTargetElement();
-    if (popover && popover->popoverData() && popover->popoverData()->visibilityState() == PopoverVisibilityState::Showing && popover->popoverData()->invoker() == invoker)
+    if (popover && popover->isPopoverShowing() && popover->popoverData()->invoker() == invoker)
         return invoker.get();
     return nullptr;
 }


### PR DESCRIPTION
#### 415cdc82121c8d27beea7a1d5cfe3f543ee7c0fe
<pre>
[popover] Refactor all popover showing checks
<a href="https://bugs.webkit.org/show_bug.cgi?id=257428">https://bugs.webkit.org/show_bug.cgi?id=257428</a>

Reviewed by Tim Nguyen.

Add a helper to test whether the popover is showing, which is
asked in quite a lot of places.

* Source/WebCore/css/SelectorCheckerTestFunctions.h:
(WebCore::matchesPopoverOpenPseudoClass):
* Source/WebCore/dom/Document.cpp:
(WebCore::Document::hideAllPopoversUntil):
* Source/WebCore/dom/Element.cpp:
(WebCore::Element::isPopoverShowing const):
* Source/WebCore/dom/Element.h:
* Source/WebCore/dom/FullscreenManager.cpp:
(WebCore::FullscreenManager::requestFullscreenForElement):
(WebCore::FullscreenManager::willEnterFullscreen):
(WebCore::isInPopoverShowingState): Deleted.
* Source/WebCore/html/HTMLDialogElement.cpp:
(WebCore::HTMLDialogElement::show):
(WebCore::HTMLDialogElement::showModal):
* Source/WebCore/html/HTMLElement.cpp:
(WebCore::HTMLElement::togglePopover):
(WebCore::HTMLElement::popoverAttributeChanged):
* Source/WebCore/page/FocusController.cpp:
(WebCore::isOpenPopoverWithInvoker):
(WebCore::invokerForPopoverShowingState):

Canonical link: <a href="https://commits.webkit.org/264693@main">https://commits.webkit.org/264693@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1f53e9780bbf7178036f2e013bf60e92416855ae

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/8348 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/8641 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/8858 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/10016 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/8413 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/8357 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/10629 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/8552 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/11280 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/8494 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/9551 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/7570 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/10162 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/6849 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/7639 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/15202 "Passed tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/7970 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/7782 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/11131 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/8253 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/6728 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/7542 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/2017 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/11752 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/7996 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->