### PR TITLE
[WGSL] Don't serialize unused constants

### DIFF
--- a/Source/WebGPU/WGSL/AST/ASTVariable.h
+++ b/Source/WebGPU/WGSL/AST/ASTVariable.h
@@ -55,6 +55,7 @@ public:
 
     NodeKind kind() const override;
     VariableFlavor flavor() const { return m_flavor; };
+    VariableFlavor& flavor() { return m_flavor; };
     Identifier& name() { return m_name; }
     Attribute::List& attributes() { return m_attributes; }
     VariableQualifier* maybeQualifier() { return m_qualifier; }

--- a/Source/WebGPU/WGSL/Metal/MetalFunctionWriter.cpp
+++ b/Source/WebGPU/WGSL/Metal/MetalFunctionWriter.cpp
@@ -291,6 +291,9 @@ void FunctionDefinitionWriter::visitGlobal(AST::Variable& variable)
 
 void FunctionDefinitionWriter::serializeVariable(AST::Variable& variable)
 {
+    if (variable.flavor() == AST::VariableFlavor::Const)
+        return;
+
     const Type* type = variable.storeType();
     if (isPrimitiveReference(type, Types::Primitive::TextureExternal)) {
         ASSERT(variable.maybeInitializer());

--- a/Source/WebGPU/WGSL/tests/valid/local-constant-trivial.wgsl
+++ b/Source/WebGPU/WGSL/tests/valid/local-constant-trivial.wgsl
@@ -1,0 +1,11 @@
+// RUN: %metal main 2>&1 | %check
+
+@compute @workgroup_size(1)
+fn main() {
+  // CHECK-NOT: pow\(.*\)
+  // CHECK-NOT: float .* = \d
+  const a = pow(2, 2);
+  // CHECK-L: (void)(4)
+  _ = a;
+}
+


### PR DESCRIPTION
#### 353252b02ec1e00a79bc45466ae67bc8c619077c
<pre>
[WGSL] Don&apos;t serialize unused constants
<a href="https://bugs.webkit.org/show_bug.cgi?id=257494">https://bugs.webkit.org/show_bug.cgi?id=257494</a>
rdar://110009934

Reviewed by Dan Glastonbury.

If all references to a constant are replaced with its value, we should no longer serialize
the constant declaration in the generated code. In order to do that, while looking at
variable uses and definitions to rewrite globals, we changen all consts which still
have uses into lets, and later in the code generation we simply skip over consts.

* Source/WebGPU/WGSL/AST/ASTVariable.h:
* Source/WebGPU/WGSL/GlobalVariableRewriter.cpp:
(WGSL::RewriteGlobalVariables::visit):
(WGSL::RewriteGlobalVariables::def):
(WGSL::RewriteGlobalVariables::read):
* Source/WebGPU/WGSL/Metal/MetalFunctionWriter.cpp:
(WGSL::Metal::FunctionDefinitionWriter::serializeVariable):
* Source/WebGPU/WGSL/tests/valid/local-constant-trivial.wgsl: Added.

Canonical link: <a href="https://commits.webkit.org/264732@main">https://commits.webkit.org/264732@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ec8fe6c9ed3cbab8d444f02896eb6d65ad976cf0

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/8473 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/8766 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/8985 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/10140 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/8519 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/10756 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/8710 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/11387 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/8619 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/15/builds/9661 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/7640 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/10295 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/6959 "Passed tests") | | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/15302 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/8080 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/7899 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/11254 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/8372 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/6836 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/7658 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/2052 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/11869 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/8117 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->