### PR TITLE
[WGSL] Global consts should be serialized as regular globals

### DIFF
--- a/Source/WebGPU/WGSL/tests/valid/global-constant-vector.wgsl
+++ b/Source/WebGPU/WGSL/tests/valid/global-constant-vector.wgsl
@@ -1,0 +1,8 @@
+// RUN: %metal main 2>&1 | %check
+const a = vec2(0);
+@compute @workgroup_size(1)
+fn main() {
+  // CHECK: vec.* local\d+ = vec.*
+  // CHECK: \(void\)\(local\d+\)
+  _ = a;
+}


### PR DESCRIPTION
#### 504a47e5dc40f3f7f7c30e51e248bf1ff9033b2f
<pre>
[WGSL] Global consts should be serialized as regular globals
<a href="https://bugs.webkit.org/show_bug.cgi?id=257496">https://bugs.webkit.org/show_bug.cgi?id=257496</a>
rdar://110010424

Reviewed by Myles C. Maxfield.

Global consts, which still have references to it, should be serialized similarly
to global private vars. We reuse the same logic in GlobalVariableRewriter, with
the only modification of transforming `const` into `let`, because after PR#14488
consts will be skipped by the code generator.

* Source/WebGPU/WGSL/GlobalVariableRewriter.cpp:
(WGSL::RewriteGlobalVariables::determineUsedGlobals):
(WGSL::RewriteGlobalVariables::insertLocalDefinitions):
* Source/WebGPU/WGSL/tests/valid/global-constant-vector.wgsl: Added.

Canonical link: <a href="https://commits.webkit.org/264734@main">https://commits.webkit.org/264734@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/970b1e455312996065ad39c1d174887c84dc2d1b

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/8479 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/8772 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/8991 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/10146 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/8525 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/10762 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/8719 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/11392 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/8626 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/9666 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/7645 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/10301 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/6964 "Passed tests") | | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/15307 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/8085 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/7904 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/11258 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/8378 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/6842 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/7664 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/2054 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/11875 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/8123 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->