### PR TITLE
Set echoCancellation to true if not explicitly set within a getUserMedia call

### DIFF
--- a/LayoutTests/fast/mediastream/getUserMedia-echoCancellation-expected.txt
+++ b/LayoutTests/fast/mediastream/getUserMedia-echoCancellation-expected.txt
@@ -1,0 +1,3 @@
+
+PASS echoCancellation should be on by default if not explictly disabled
+

--- a/LayoutTests/fast/mediastream/getUserMedia-echoCancellation.html
+++ b/LayoutTests/fast/mediastream/getUserMedia-echoCancellation.html
@@ -1,0 +1,11 @@
+<script src="../../resources/testharness.js"></script>
+<script src="../../resources/testharnessreport.js"></script>
+<script>
+promise_test(async () => {
+    const stream1 = await navigator.mediaDevices.getUserMedia({ audio: { echoCancellation: false } });
+    assert_false(stream1.getAudioTracks()[0].getSettings().echoCancellation);
+
+    const stream2 = await navigator.mediaDevices.getUserMedia({ audio: true });
+    assert_true(stream2.getAudioTracks()[0].getSettings().echoCancellation);
+}, "echoCancellation should be on by default if not explictly disabled");
+</script>

--- a/Source/WebCore/Modules/mediastream/MediaDevices.cpp
+++ b/Source/WebCore/Modules/mediastream/MediaDevices.cpp
@@ -149,9 +149,10 @@ void MediaDevices::getUserMedia(StreamConstraints&& constraints, Promise&& promi
 
     bool isUserGesturePriviledged = false;
 
-    if (audioConstraints.isValid)
+    if (audioConstraints.isValid) {
         isUserGesturePriviledged |= computeUserGesturePriviledge(GestureAllowedRequest::Microphone);
-
+        audioConstraints.setDefaultAudioConstraints();
+    }
     if (videoConstraints.isValid) {
         isUserGesturePriviledged |= computeUserGesturePriviledge(GestureAllowedRequest::Camera);
         videoConstraints.setDefaultVideoConstraints();

--- a/Source/WebCore/platform/mediastream/MediaConstraints.cpp
+++ b/Source/WebCore/platform/mediastream/MediaConstraints.cpp
@@ -395,6 +395,19 @@ bool MediaConstraints::isConstraintSet(const Function<bool(const MediaTrackConst
     return false;
 }
 
+void MediaConstraints::setDefaultAudioConstraints()
+{
+    bool needsEchoCancellationConstraint = !isConstraintSet([](const MediaTrackConstraintSetMap& constraint) {
+        return !!constraint.echoCancellation();
+    });
+
+    if (needsEchoCancellationConstraint) {
+        BooleanConstraint echoCancellationConstraint({ }, MediaConstraintType::EchoCancellation);
+        echoCancellationConstraint.setIdeal(true);
+        mandatoryConstraints.set(MediaConstraintType::EchoCancellation, WTFMove(echoCancellationConstraint));
+    }
+}
+
 void MediaConstraints::setDefaultVideoConstraints()
 {
     // 640x480, 30fps camera

--- a/Source/WebCore/platform/mediastream/MediaConstraints.h
+++ b/Source/WebCore/platform/mediastream/MediaConstraints.h
@@ -793,6 +793,7 @@ private:
 };
 
 struct MediaConstraints {
+    void setDefaultAudioConstraints();
     void setDefaultVideoConstraints();
     bool isConstraintSet(const Function<bool(const MediaTrackConstraintSetMap&)>&);
 


### PR DESCRIPTION
#### 3fb10034184d64c5a4bb2b753c1f2dbbf31b4e1f
<pre>
Set echoCancellation to true if not explicitly set within a getUserMedia call
<a href="https://bugs.webkit.org/show_bug.cgi?id=257495">https://bugs.webkit.org/show_bug.cgi?id=257495</a>
rdar://110010294

Reviewed by Eric Carlson.

Before the patch, if the web page does not provide a echoCancellation setting, we would use whatever setting was used by the previous web application using the microphone.
This might break some applications that want echoCancellation but do not set it explicitly.
This change aligns with Chrome&apos;s behavior.

* Source/WebCore/Modules/mediastream/MediaDevices.cpp:
(WebCore::MediaDevices::getUserMedia):
* Source/WebCore/platform/mediastream/MediaConstraints.cpp:
(WebCore::MediaConstraints::setDefaultAudioConstraints):
* Source/WebCore/platform/mediastream/MediaConstraints.h:
* LayoutTests/fast/mediastream/getUserMedia-echoCancellation-expected.txt: Added.
* LayoutTests/fast/mediastream/getUserMedia-echoCancellation.html: Added.

Canonical link: <a href="https://commits.webkit.org/264721@main">https://commits.webkit.org/264721@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5bdab04281d71663d0a4eef8d0b6de1e582ceb3a

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/8444 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/8737 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/8956 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/10111 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/8491 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/8452 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/10727 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/8665 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/11357 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/8590 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/9632 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/7627 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/10265 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/6930 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/7727 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/15280 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/8051 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/7873 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/11227 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/8343 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/6807 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/7630 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/7638 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/2037 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/11840 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/8088 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->