### PR TITLE
Add `nowrap` white-space to UA Stylesheet for `option` element

### DIFF
--- a/LayoutTests/fast/forms/select/options-default-white-space-expected.txt
+++ b/LayoutTests/fast/forms/select/options-default-white-space-expected.txt
@@ -1,0 +1,4 @@
+
+
+PASS <option>'s user agent 'white-space' should be 'nowrap'.
+

--- a/LayoutTests/fast/forms/select/options-default-white-space.html
+++ b/LayoutTests/fast/forms/select/options-default-white-space.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<script src="../../../resources/testharness.js"></script>
+<script src="../../../resources/testharnessreport.js"></script>
+<select>
+  <option id=option value="hello">Hello</option>
+</select>
+<script>
+test(() => {
+  assert_equals(
+    window.getComputedStyle(option)['white-space'],
+    'nowrap');
+}, `<option>'s user agent 'white-space' should be 'nowrap'.`);
+</script>

--- a/Source/WebCore/css/html.css
+++ b/Source/WebCore/css/html.css
@@ -1111,6 +1111,7 @@ optgroup {
 
 option {
     font-weight: normal;
+    white-space: nowrap;
 }
 
 output {


### PR DESCRIPTION
#### 574b3a2d4a361e64e71f945c3d2dc22fdfac74db
<pre>
Add `nowrap` white-space to UA Stylesheet for `option` element

<a href="https://bugs.webkit.org/show_bug.cgi?id=257477">https://bugs.webkit.org/show_bug.cgi?id=257477</a>

Reviewed by Tim Nguyen.

This patch aligns WebKit with Blink / Chromium and Gecko / Firefox.

Merge: <a href="https://chromium.googlesource.com/chromium/src/+/bcb42ec47ad8a9a6726e1e12e112838c4dfe3142">https://chromium.googlesource.com/chromium/src/+/bcb42ec47ad8a9a6726e1e12e112838c4dfe3142</a>

When the option element is rendered, neither spaces nor line breaks are
preserved in the text, so `nowrap` makes more sense.

* Source/WebCore/css/html.css: As above
* LayoutTests/fast/forms/select/options-default-white-space.html: Add Test Case
* LayoutTests/fast/forms/select/options-default-white-space-expected.txt: Add Test Case Expectation

Canonical link: <a href="https://commits.webkit.org/264691@main">https://commits.webkit.org/264691@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/308751a55e681be97306fe10e2ad5603caae3340

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/8365 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/8658 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/8875 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/10033 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/8430 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/8374 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/10646 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/8569 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/11293 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/8511 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/9565 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/7582 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/10180 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/6863 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/7654 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/15215 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/7984 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/7797 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/11147 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/8270 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/6740 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/7559 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/7566 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/2016 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/11769 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/8013 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->