### PR TITLE
[WGSL] AST::Visitor should visit attribute's children

### DIFF
--- a/Source/WebGPU/WGSL/AST/ASTVisitor.cpp
+++ b/Source/WebGPU/WGSL/AST/ASTVisitor.cpp
@@ -105,12 +105,14 @@ void Visitor::visit(Attribute& attribute)
     }
 }
 
-void Visitor::visit(AST::AlignAttribute&)
+void Visitor::visit(AST::AlignAttribute& attribute)
 {
+    visit(attribute.alignment());
 }
 
-void Visitor::visit(AST::BindingAttribute&)
+void Visitor::visit(AST::BindingAttribute& attribute)
 {
+    visit(attribute.binding());
 }
 
 void Visitor::visit(AST::ConstAttribute&)
@@ -121,12 +123,14 @@ void Visitor::visit(AST::BuiltinAttribute&)
 {
 }
 
-void Visitor::visit(GroupAttribute&)
+void Visitor::visit(GroupAttribute& attribute)
 {
+    visit(attribute.group());
 }
 
-void Visitor::visit(AST::IdAttribute&)
+void Visitor::visit(AST::IdAttribute& attribute)
 {
+    visit(attribute.value());
 }
 
 void Visitor::visit(AST::InterpolateAttribute&)
@@ -137,12 +141,14 @@ void Visitor::visit(AST::InvariantAttribute&)
 {
 }
 
-void Visitor::visit(AST::LocationAttribute&)
+void Visitor::visit(AST::LocationAttribute& attribute)
 {
+    visit(attribute.location());
 }
 
-void Visitor::visit(AST::SizeAttribute&)
+void Visitor::visit(AST::SizeAttribute& attribute)
 {
+    visit(attribute.size());
 }
 
 void Visitor::visit(AST::StageAttribute&)

--- a/Source/WebGPU/WGSL/tests/valid/constants.wgsl
+++ b/Source/WebGPU/WGSL/tests/valid/constants.wgsl
@@ -52,3 +52,17 @@ fn testAbstractIntPromotion()
 {
     const f = pow(vec2(0), vec2(0));
 }
+
+// Attribute constants
+const group = 0;
+const binding = 1;
+@group(group) @binding(binding) var w: i32;
+
+const x = 8;
+const y = 4;
+const z = 2;
+@compute @workgroup_size(x, y, z)
+fn main()
+{
+    _ = y;
+}


### PR DESCRIPTION
#### 36a138f7b86d3bd10166a50030c3cf006fe62d45
<pre>
[WGSL] AST::Visitor should visit attribute&apos;s children
<a href="https://bugs.webkit.org/show_bug.cgi?id=257483">https://bugs.webkit.org/show_bug.cgi?id=257483</a>
rdar://110003839

Reviewed by Dan Glastonbury.

Some of attributes have expression children, which should be visited
by the default implementation in AST::Visitor

* Source/WebGPU/WGSL/AST/ASTVisitor.cpp:
(WGSL::AST::Visitor::visit):
* Source/WebGPU/WGSL/ConstantRewriter.cpp:
(WGSL::ConstantRewriter::visit):
* Source/WebGPU/WGSL/tests/valid/constants.wgsl:

Canonical link: <a href="https://commits.webkit.org/264781@main">https://commits.webkit.org/264781@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e733d54d7bee840485ddcedaf48d90a2127b01b7

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/8507 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/8800 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/9019 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/10174 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/8550 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/10790 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/8757 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/11420 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/8654 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/9697 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/7667 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/10331 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/6995 "Passed tests") | | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/15345 "5 flakes 137 failures") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/8116 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/7937 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/11301 "9 api tests failed or timed out") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/8406 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/6876 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/7691 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/2087 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/11902 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/8151 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->