### PR TITLE
Regression(248952@main) setInterval and setTimeout order isn't respected when timeout is 0

### DIFF
--- a/LayoutTests/fast/dom/Window/setInterval-setTimeout-zero-ordering-expected.txt
+++ b/LayoutTests/fast/dom/Window/setInterval-setTimeout-zero-ordering-expected.txt
@@ -1,0 +1,17 @@
+Checks that setTimeout(0) & setInterval(0) ordering is maintained
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+* setInterval(0)
+* setTimeout(0)
+PASS setInterval0Called is true
+* setInterval(1)
+PASS setInterval0Called is true
+PASS setTimeout0Called is true
+* setTimeout(1)
+PASS setInterval1Called is true
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/fast/dom/Window/setInterval-setTimeout-zero-ordering.html
+++ b/LayoutTests/fast/dom/Window/setInterval-setTimeout-zero-ordering.html
@@ -1,0 +1,40 @@
+<!DOCTYPE html>
+<html>
+<body>
+<script src="../../../resources/js-test.js"></script>
+<script>
+description("Checks that setTimeout(0) & setInterval(0) ordering is maintained");
+jsTestIsAsync = true;
+
+let setInterval0Called = false;
+let setInterval1Called = false;
+let setTimeout0Called = false;
+
+setInterval1Handle = setInterval(() => {
+    debug("* setInterval(1)");
+    shouldBeTrue("setInterval0Called");
+    shouldBeTrue("setTimeout0Called");
+    setInterval1Called = true;
+}, 1);
+
+setTimeout(() => {
+    debug("* setTimeout(1)");
+    shouldBeTrue("setInterval1Called");
+    clearInterval(setInterval1Handle);
+    finishJSTest();
+}, 1);
+
+setInterval0Handle = setInterval(() => {
+    debug("* setInterval(0)");
+    setInterval0Called = true;
+}, 0);
+
+setTimeout(() => {
+    debug("* setTimeout(0)");
+    shouldBeTrue("setInterval0Called");
+    clearInterval(setInterval0Handle);
+    setTimeout0Called = true;
+}, 0);
+</script>
+</body>
+</html>

--- a/Source/WebCore/page/DOMTimer.cpp
+++ b/Source/WebCore/page/DOMTimer.cpp
@@ -171,7 +171,7 @@ DOMTimer::DOMTimer(ScriptExecutionContext& context, Function<void(ScriptExecutio
     if (oneShot)
         startOneShot(m_currentTimerInterval);
     else
-        startRepeating(m_currentTimerInterval);
+        startRepeating(m_originalInterval, m_currentTimerInterval);
 }
 
 DOMTimer::~DOMTimer() = default;

--- a/Source/WebCore/page/SuspendableTimer.cpp
+++ b/Source/WebCore/page/SuspendableTimer.cpp
@@ -90,13 +90,13 @@ void SuspendableTimerBase::cancel()
         m_suspended = false;
 }
 
-void SuspendableTimerBase::startRepeating(Seconds repeatInterval)
+void SuspendableTimerBase::startRepeating(Seconds nextFireInterval, Seconds repeatInterval)
 {
     if (!m_suspended)
-        TimerBase::startRepeating(repeatInterval);
+        TimerBase::start(nextFireInterval, repeatInterval);
     else {
         m_savedIsActive = true;
-        m_savedNextFireInterval = repeatInterval;
+        m_savedNextFireInterval = nextFireInterval;
         m_savedRepeatInterval = repeatInterval;
     }
 }

--- a/Source/WebCore/page/SuspendableTimer.h
+++ b/Source/WebCore/page/SuspendableTimer.h
@@ -49,7 +49,8 @@ public:
 
     Seconds repeatInterval() const;
 
-    void startRepeating(Seconds repeatInterval);
+    void startRepeating(Seconds nextFireTime, Seconds repeatInterval);
+    void startRepeating(Seconds repeatInterval) { startRepeating(repeatInterval, repeatInterval); }
     void startOneShot(Seconds interval);
 
     void augmentFireInterval(Seconds delta);


### PR DESCRIPTION
#### 09e6c5eb406c8f5d1b112d1fb0fda1cb5db53751
<pre>
Regression(248952@main) setInterval and setTimeout order isn&apos;t respected when timeout is 0
<a href="https://bugs.webkit.org/show_bug.cgi?id=253423">https://bugs.webkit.org/show_bug.cgi?id=253423</a>
rdar://106576260

Reviewed by Darin Adler.

In 248952@main, we made it so that the setTimeout() delay no longer gets clamped
to 1ms. However, we didn&apos;t change the behavior for setInterval(). As a result, the
ordering between `setInterval(0)` and `setTimeout(0)` would no longer be preserved.

To address the issue, we no longer clamp the initial `setInterval()`&apos;s fire
interval to 1ms, only its repeat interval. As a result, `setInterval(0)` will run
on next runloop iteration and then every 1ms.

* LayoutTests/fast/dom/Window/setInterval-setTimeout-zero-ordering-expected.txt: Added.
* LayoutTests/fast/dom/Window/setInterval-setTimeout-zero-ordering.html: Added.
* Source/WebCore/page/DOMTimer.cpp:
(WebCore::DOMTimer::DOMTimer):
* Source/WebCore/page/SuspendableTimer.cpp:
(WebCore::SuspendableTimerBase::startRepeating):
* Source/WebCore/page/SuspendableTimer.h:
(WebCore::SuspendableTimerBase::startRepeating):

Canonical link: <a href="https://commits.webkit.org/264701@main">https://commits.webkit.org/264701@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/120d876efdb165dc4a1dd743d4a4c99ffff6d8fd

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/8369 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/8662 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/8879 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/10037 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/8434 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/8378 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/10650 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/8573 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/11297 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/8515 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/9570 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/7586 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/10184 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/6868 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/7658 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/15218 "1 flakes 149 failures") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/7989 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/7801 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/11150 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/8274 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/17/builds/6745 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/7563 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/7570 "Passed tests") | | 
| [  ~~🛠 🧪 merge~~](https://ews-build.webkit.org/#/builders/19/builds/2026 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/11773 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/8017 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->