### PR TITLE
Apply cookie policy on WebSocket request

### DIFF
--- a/LayoutTests/http/tests/resources/redirect.py
+++ b/LayoutTests/http/tests/resources/redirect.py
@@ -14,6 +14,10 @@ def add_cache_control(allow_cache):
         sys.stdout.write('Cache-Control: no-store\r\n\r\n')
 
 
+def set_cookie(cookies):
+    for cookie in cookies:
+        sys.stdout.write('Set-Cookie: {}\r\n'.format(cookie.replace(':', '=')))
+
 query = {}
 for key_value in os.environ.get('QUERY_STRING', '').split('&'):
     arr = key_value.split('=')
@@ -30,6 +34,7 @@ allow_cache = query.get('allowCache', [None])[0]
 code = int(query.get('code', [302])[0])
 refresh = query.get('refresh', [None])[0]
 url = query.get('url', [''])[0]
+cookies = query.get('cookie', [''])
 
 sys.stdout.write('Content-Type: text/html\r\n')
 
@@ -39,6 +44,7 @@ if refresh is not None:
         'Refresh: {}; url={}\r\n'.format(refresh, url)
     )
 
+    set_cookie(cookies)
     add_cache_control(allow_cache)
     sys.exit(0)
 
@@ -47,4 +53,5 @@ sys.stdout.write(
     'Location: {}\r\n'.format(code, url)
 )
 
+set_cookie(cookies)
 add_cache_control(allow_cache)

--- a/LayoutTests/http/tests/websocket/tests/hybi/websocket-blocked-sending-cookie-as-third-party-after-redirect-expected.txt
+++ b/LayoutTests/http/tests/websocket/tests/hybi/websocket-blocked-sending-cookie-as-third-party-after-redirect-expected.txt
@@ -1,0 +1,15 @@
+Tests WebSocket cookie behavior for third-parties with existing cookies.
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+PASS  is undefined.
+PASS document.location.host is "127.0.0.1:8000"
+
+Sending third-party cookie through cross-origin WebSocket handshake is blocked.
+Created a socket to 'ws://localhost:8880/websocket/tests/hybi/websocket-blocked-sending-cookie-as-third-party'; readyState 0.
+PASS Connection was allowed (request did not contain cookies).
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/http/tests/websocket/tests/hybi/websocket-blocked-sending-cookie-as-third-party-after-redirect.html
+++ b/LayoutTests/http/tests/websocket/tests/hybi/websocket-blocked-sending-cookie-as-third-party-after-redirect.html
@@ -1,0 +1,70 @@
+<!DOCTYPE HTML><!-- webkit-test-runner [ dumpJSConsoleLogInStdErr=true ] -->
+<html>
+<head>
+    <script src="../../../../js-test-resources/js-test.js"></script>
+    <script src="../../../cookies/resources/cookie-utilities.js"></script>
+    <script>
+        window.jsTestIsAsync = true;
+
+        async function testGetCookie()
+        {
+            debug("<br>Opening socket to check its cookies.");
+            let ws = new WebSocket("ws://127.0.0.1:8880/websocket/tests/hybi/websocket-blocked-sending-cookie-as-third-party");
+            debug("Created a socket to '" + ws.url + "'; readyState " + ws.readyState + ".");
+
+            ws.onopen = (e) => {
+                debug(`Connection opened`);
+            };
+            ws.onerror = (e) => {
+                testFailed(`Connection was unexpectedly rejected. ${e}`);
+                finishJSTest();
+            };
+            ws.onmessage = (message) => {
+                debug(`Received headers: ${message.data}`);
+                finishJSTest();
+            };
+        }
+
+        async function testThirdPartyCookie()
+        {
+            shouldBeEqualToString("document.location.host", "127.0.0.1:8000");
+            debug("<br>Sending third-party cookie through cross-origin WebSocket handshake is blocked.");
+            let ws = new WebSocket("ws://localhost:8880/websocket/tests/hybi/websocket-blocked-sending-cookie-as-third-party");
+            debug("Created a socket to '" + ws.url + "'; readyState " + ws.readyState + ".");
+            ws.onopen = () => {
+                ws.close();
+                testPassed("Connection was allowed (request did not contain cookies).");
+                finishJSTest();
+            };
+            ws.onerror = (e) => {
+                testFailed(`Connection was rejected (request did contained cookies).`);
+                testGetCookie();
+            };
+        }
+
+        async function runTest()
+        {
+            switch (document.location.hash) {
+                case "":
+                    // Navigate to localhost to set first-party cookie 'setAsFirstParty'.
+                    document.location.href = "http://localhost:8000/resources/redirect.py?cookie=" + encodeURIComponent("setAsFirstPartyHTTP=value") + "&url=" + encodeURIComponent("http://127.0.0.1:8000/websocket/tests/hybi/websocket-blocked-sending-cookie-as-third-party-after-redirect.html#didSetCookieAsFirstParty");
+                    break;
+                case "#didSetCookieAsFirstParty":
+                    shouldBeUndefined(document.cookie);
+                    await testThirdPartyCookie();
+                    break;
+            }
+        }
+    </script>
+</head>
+<body>
+<div id="output"></div>
+<script>
+    description("Tests WebSocket cookie behavior for third-parties with existing cookies.");
+    if (window.testRunner && testRunner.setStatisticsShouldBlockThirdPartyCookies)
+        testRunner.setStatisticsShouldBlockThirdPartyCookies(true, runTest);
+    else
+        runTest();
+</script>
+</body>
+</html>

--- a/LayoutTests/http/tests/websocket/tests/hybi/websocket-blocked-sending-cookie-as-third-party-after-ws-redirect-expected.txt
+++ b/LayoutTests/http/tests/websocket/tests/hybi/websocket-blocked-sending-cookie-as-third-party-after-ws-redirect-expected.txt
@@ -1,0 +1,19 @@
+Tests WebSocket cookie behavior for third-parties with existing cookies.
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+PASS document.location.host is "127.0.0.1:8000"
+
+Setting first-party cookie and sending through cross-origin WebSocket handshake is blocked.
+Created a socket to 'ws://127.0.0.1:8000/resources/redirect.py?cookie=setAsFirstPartyHTTP%3Dvalue&url=ws%3A%2F%2Flocalhost%3A8880%2Fwebsocket%2Ftests%2Fhybi%2Fwebsocket-blocked-sending-cookie-as-third-party'; readyState 0.
+PASS Connection was allowed (request did not contain cookies).
+PASS document.location.host is "127.0.0.1:8000"
+
+Setting and sending third-party cookie through cross-origin WebSocket handshake is blocked.
+Created a socket to 'ws://localhost:8000/resources/redirect.py?cookie=setAsThirdPartyHTTP%3Dvalue&url=ws%3A%2F%2Flocalhost%3A8880%2Fwebsocket%2Ftests%2Fhybi%2Fwebsocket-blocked-sending-cookie-as-third-party'; readyState 0.
+PASS Connection was allowed (request did not contain cookies).
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/http/tests/websocket/tests/hybi/websocket-blocked-sending-cookie-as-third-party-after-ws-redirect.html
+++ b/LayoutTests/http/tests/websocket/tests/hybi/websocket-blocked-sending-cookie-as-third-party-after-ws-redirect.html
@@ -1,0 +1,72 @@
+<!DOCTYPE HTML><!-- webkit-test-runner [ dumpJSConsoleLogInStdErr=true ] -->
+<html>
+<head>
+    <script src="../../../../js-test-resources/js-test.js"></script>
+    <script>
+        window.jsTestIsAsync = true;
+
+        async function testGetCookie()
+        {
+            debug("<br>Opening socket to check its cookies.");
+            let ws = new WebSocket("ws://127.0.0.1:8880/websocket/tests/hybi/websocket-blocked-sending-cookie-as-third-party");
+            debug("Created a socket to '" + ws.url + "'; readyState " + ws.readyState + ".");
+
+            ws.onopen = (e) => {
+                debug(`Connection opened`);
+            };
+            ws.onerror = (e) => {
+                testFailed(`Connection was unexpectedly rejected. ${e}`);
+                finishJSTest();
+            };
+            ws.onmessage = (message) => {
+                debug(`Received headers: ${message.data}`);
+                finishJSTest();
+            };
+        }
+
+        async function testFirstPartyCookie()
+        {
+            shouldBeEqualToString("document.location.host", "127.0.0.1:8000");
+            debug("<br>Setting first-party cookie and sending through cross-origin WebSocket handshake is blocked.");
+            let ws = new WebSocket("ws://127.0.0.1:8000/resources/redirect.py?cookie=" + encodeURIComponent("setAsFirstPartyHTTP=value") + "&url=" + encodeURIComponent("ws://localhost:8880/websocket/tests/hybi/websocket-blocked-sending-cookie-as-third-party"));
+            debug("Created a socket to '" + ws.url + "'; readyState " + ws.readyState + ".");
+            ws.onopen = () => {
+                ws.close();
+                testPassed("Connection was allowed (request did not contain cookies).");
+                testThirdPartyCookie();
+            };
+            ws.onerror = (e) => {
+                testFailed(`Connection was rejected (request did contained cookies).`);
+                testGetCookie();
+            };
+        }
+
+        async function testThirdPartyCookie()
+        {
+            shouldBeEqualToString("document.location.host", "127.0.0.1:8000");
+            debug("<br>Setting and sending third-party cookie through cross-origin WebSocket handshake is blocked.");
+            let ws = new WebSocket("ws://localhost:8000/resources/redirect.py?cookie=" + encodeURIComponent("setAsThirdPartyHTTP=value") + "&url=" + encodeURIComponent("ws://localhost:8880/websocket/tests/hybi/websocket-blocked-sending-cookie-as-third-party"));
+            debug("Created a socket to '" + ws.url + "'; readyState " + ws.readyState + ".");
+            ws.onopen = () => {
+                ws.close();
+                testPassed("Connection was allowed (request did not contain cookies).");
+                finishJSTest();
+            };
+            ws.onerror = (e) => {
+                testFailed(`Connection was rejected (request did contained cookies).`);
+                testGetCookie();
+            };
+        }
+    </script>
+</head>
+<body>
+<div id="output"></div>
+<script>
+    description("Tests WebSocket cookie behavior for third-parties with existing cookies.");
+    if (window.testRunner && testRunner.setStatisticsShouldBlockThirdPartyCookies)
+        testRunner.setStatisticsShouldBlockThirdPartyCookies(true, testFirstPartyCookie);
+    else
+        testFirstPartyCookie();
+</script>
+</body>
+</html>

--- a/LayoutTests/http/tests/websocket/tests/hybi/websocket-blocked-sending-cookie-as-third-party-expected.txt
+++ b/LayoutTests/http/tests/websocket/tests/hybi/websocket-blocked-sending-cookie-as-third-party-expected.txt
@@ -1,0 +1,15 @@
+Tests WebSocket cookie behavior for third-parties with existing cookies.
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+PASS  is undefined.
+PASS document.location.host is "127.0.0.1:8000"
+
+Sending third-party cookie through cross-origin WebSocket handshake is blocked.
+Created a socket to 'ws://localhost:8880/websocket/tests/hybi/websocket-blocked-sending-cookie-as-third-party'; readyState 0.
+PASS Connection was allowed (request did not contain cookies).
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/http/tests/websocket/tests/hybi/websocket-blocked-sending-cookie-as-third-party.html
+++ b/LayoutTests/http/tests/websocket/tests/hybi/websocket-blocked-sending-cookie-as-third-party.html
@@ -1,0 +1,85 @@
+<!DOCTYPE HTML><!-- webkit-test-runner [ dumpJSConsoleLogInStdErr=true ] -->
+<html>
+<head>
+    <script src="../../../../js-test-resources/js-test.js"></script>
+    <script src="../../../cookies/resources/cookie-utilities.js"></script>
+    <script>
+        window.jsTestIsAsync = true;
+
+        async function testGetCookie()
+        {
+            debug("<br>Opening socket to check its cookies.");
+            let ws = new WebSocket("ws://127.0.0.1:8880/websocket/tests/hybi/websocket-blocked-sending-cookie-as-third-party");
+            debug("Created a socket to '" + ws.url + "'; readyState " + ws.readyState + ".");
+
+            ws.onopen = (e) => {
+                debug(`Connection opened`);
+            };
+            ws.onerror = (e) => {
+                testFailed(`Connection was unexpectedly rejected. ${e}`);
+                finishJSTest();
+            };
+            ws.onmessage = (message) => {
+                debug(`Received headers: ${message.data}`);
+                finishJSTest();
+            };
+        }
+
+        async function testThirdPartyCookie()
+        {
+            shouldBeEqualToString("document.location.host", "127.0.0.1:8000");
+            debug("<br>Sending third-party cookie through cross-origin WebSocket handshake is blocked.");
+            let ws = new WebSocket("ws://localhost:8880/websocket/tests/hybi/websocket-blocked-sending-cookie-as-third-party");
+            debug("Created a socket to '" + ws.url + "'; readyState " + ws.readyState + ".");
+            ws.onopen = () => {
+                ws.close();
+                testPassed("Connection was allowed (request did not contain cookies).");
+                finishJSTest();
+            };
+            ws.onerror = (e) => {
+                testFailed(`Connection was rejected (request contained cookies).`);
+                testGetCookie();
+            };
+        }
+
+        async function runTest()
+        {
+            switch (document.location.hash) {
+                case "":
+                    // Navigate to localhost to set first-party cookie 'setAsFirstParty'.
+                    await setCookie("setAsFirstPartyHTTPLoopback", "value");
+                    document.location.href = "http://localhost:8000/websocket/tests/hybi/websocket-blocked-sending-cookie-as-third-party.html#setCookieAsFirstParty";
+                    break;
+                case "#setCookieAsFirstParty":
+                    await setCookie("setAsFirstPartyHTTP", "value");
+                    await setCookie("setAsFirstPartyHTTPHTTPOnly", "value", "HTTPOnly");
+                    await setCookie("setAsFirstPartyHTTPSameSiteNone", "value", {"SameSite": "None"});
+                    await setCookie("setAsFirstPartyHTTPSameSiteLax", "value", {"SameSite": "Lax" });
+                    await setCookie("setAsFirstPartyHTTPSameSiteStrict", "value", {"SameSite": "Strict" });
+                    document.cookie = "setAsFirstPartyJS=value";
+                    document.cookie = "setAsFirstPartyJSHTTPOnly=value;HTTPOnly";
+                    document.cookie = "setAsFirstPartyJSSameSiteNone=value;SameSite=None";
+                    document.cookie = "setAsFirstPartyJSSameSiteLax=value;SameSite=Lax";
+                    document.cookie = "setAsFirstPartyJSSameSiteStrict=value;SameSite=Strict";
+
+                    document.location.href = "http://127.0.0.1:8000/websocket/tests/hybi/websocket-blocked-sending-cookie-as-third-party.html#didSetCookieAsFirstParty";
+                    break;
+                case "#didSetCookieAsFirstParty":
+                    shouldBeUndefined(document.cookie);
+                    await testThirdPartyCookie();
+                    break;
+            }
+        }
+    </script>
+</head>
+<body>
+<div id="output"></div>
+<script>
+    description("Tests WebSocket cookie behavior for third-parties with existing cookies.");
+    if (window.testRunner && testRunner.setStatisticsShouldBlockThirdPartyCookies)
+        testRunner.setStatisticsShouldBlockThirdPartyCookies(true, runTest);
+    else
+        runTest();
+</script>
+</body>
+</html>

--- a/LayoutTests/http/tests/websocket/tests/hybi/websocket-blocked-sending-cookie-as-third-party_wsh.py
+++ b/LayoutTests/http/tests/websocket/tests/hybi/websocket-blocked-sending-cookie-as-third-party_wsh.py
@@ -1,0 +1,22 @@
+#!/usr/bin/env python3
+
+from mod_pywebsocket import handshake
+from mod_pywebsocket.handshake.hybi import compute_accept_from_unicode
+
+
+class HeaderCache:
+    previousHeaders = ""
+
+
+def web_socket_do_extra_handshake(request):
+    message = b''
+
+    if request.headers_in['Cookie']:
+        HeaderCache.previousHeaders = request.headers_in['Cookie']
+        message += b'HTTP/1.1 403\r\n\r\n'
+        request.connection.write(message)
+        raise handshake.AbortedByUserException('Abort the connection')  # Prevents pywebsocket from sending its own handshake message.
+
+
+def web_socket_transfer_data(request):
+    request.ws_stream.send_message('Cookies are: {}\r\n'.format(HeaderCache.previousHeaders), binary=False)

--- a/LayoutTests/platform/gtk/TestExpectations
+++ b/LayoutTests/platform/gtk/TestExpectations
@@ -188,6 +188,9 @@ webkit.org/b/254733 inspector/canvas/recording-offscreen-canvas-2d-frameCount.ht
 webkit.org/b/254733 inspector/canvas/recording-offscreen-canvas-2d-full.html [ Failure ]
 webkit.org/b/254733 inspector/canvas/recording-offscreen-canvas-2d-memoryLimit.html [ Failure ]
 
+# Websocket.
+webkit.org/b/254220 http/tests/websocket/tests/hybi/websocket-blocked-sending-cookie-as-third-party.html [ Skip ]
+
 # WebXR is not yet supported in GTK
 webkit.org/b/208988 http/wpt/webxr [ Skip ]
 webkit.org/b/208988 imported/w3c/web-platform-tests/webxr [ Skip ]

--- a/LayoutTests/platform/mac-wk1/TestExpectations
+++ b/LayoutTests/platform/mac-wk1/TestExpectations
@@ -839,6 +839,11 @@ imported/w3c/web-platform-tests/websockets/interfaces/WebSocket/bufferedAmount/b
 imported/w3c/web-platform-tests/websockets/interfaces/WebSocket/events/015.html [ Pass Failure ]
 imported/w3c/web-platform-tests/websockets/interfaces/WebSocket/readyState/006.html [ Pass Failure ]
 
+# Tests are only relevant in WK2
+http/tests/websocket/tests/hybi/websocket-blocked-sending-cookie-as-third-party-after-redirect.html [ Skip ]
+http/tests/websocket/tests/hybi/websocket-blocked-sending-cookie-as-third-party-after-ws-redirect.html [ Skip ]
+http/tests/websocket/tests/hybi/websocket-blocked-sending-cookie-as-third-party.html [ Skip ]
+
 # ShouldOpenExternalURLs not yet supported in WK1
 loader/navigation-policy [ Skip ]
 

--- a/Source/WebKit/NetworkProcess/NetworkConnectionToWebProcess.cpp
+++ b/Source/WebKit/NetworkProcess/NetworkConnectionToWebProcess.cpp
@@ -482,10 +482,10 @@ void NetworkConnectionToWebProcess::didReceiveInvalidMessage(IPC::Connection&, I
     m_networkProcess->parentProcessConnection()->send(Messages::NetworkProcessProxy::TerminateWebProcess(m_webProcessIdentifier), 0);
 }
 
-void NetworkConnectionToWebProcess::createSocketChannel(const ResourceRequest& request, const String& protocol, WebSocketIdentifier identifier,  WebPageProxyIdentifier webPageProxyID, const ClientOrigin& clientOrigin, bool hadMainFrameMainResourcePrivateRelayed, bool allowPrivacyProxy, OptionSet<NetworkConnectionIntegrity> networkConnectionIntegrityPolicy)
+void NetworkConnectionToWebProcess::createSocketChannel(const ResourceRequest& request, const String& protocol, WebSocketIdentifier identifier, WebPageProxyIdentifier webPageProxyID, std::optional<FrameIdentifier> frameID, std::optional<PageIdentifier> pageID, const ClientOrigin& clientOrigin, bool hadMainFrameMainResourcePrivateRelayed, bool allowPrivacyProxy, OptionSet<NetworkConnectionIntegrity> networkConnectionIntegrityPolicy, ShouldRelaxThirdPartyCookieBlocking shouldRelaxThirdPartyCookieBlocking, WebCore::StoredCredentialsPolicy storedCredentialsPolicy)
 {
     ASSERT(!m_networkSocketChannels.contains(identifier));
-    if (auto channel = NetworkSocketChannel::create(*this, m_sessionID, request, protocol, identifier, webPageProxyID, clientOrigin, hadMainFrameMainResourcePrivateRelayed, allowPrivacyProxy, networkConnectionIntegrityPolicy))
+    if (auto channel = NetworkSocketChannel::create(*this, m_sessionID, request, protocol, identifier, webPageProxyID, frameID, pageID, clientOrigin, hadMainFrameMainResourcePrivateRelayed, allowPrivacyProxy, networkConnectionIntegrityPolicy, shouldRelaxThirdPartyCookieBlocking, storedCredentialsPolicy))
         m_networkSocketChannels.add(identifier, WTFMove(channel));
 }
 

--- a/Source/WebKit/NetworkProcess/NetworkConnectionToWebProcess.h
+++ b/Source/WebKit/NetworkProcess/NetworkConnectionToWebProcess.h
@@ -262,7 +262,7 @@ private:
 
     void setCaptureExtraNetworkLoadMetricsEnabled(bool);
 
-    void createSocketChannel(const WebCore::ResourceRequest&, const String& protocol, WebCore::WebSocketIdentifier, WebPageProxyIdentifier, const WebCore::ClientOrigin&, bool hadMainFrameMainResourcePrivateRelayed, bool allowPrivacyProxy, OptionSet<WebCore::NetworkConnectionIntegrity> networkConnectionIntegrityPolicy);
+    void createSocketChannel(const WebCore::ResourceRequest&, const String& protocol, WebCore::WebSocketIdentifier, WebPageProxyIdentifier, std::optional<WebCore::FrameIdentifier>, std::optional<WebCore::PageIdentifier>, const WebCore::ClientOrigin&, bool hadMainFrameMainResourcePrivateRelayed, bool allowPrivacyProxy, OptionSet<WebCore::NetworkConnectionIntegrity> networkConnectionIntegrityPolicy, WebCore::ShouldRelaxThirdPartyCookieBlocking, WebCore::StoredCredentialsPolicy);
     void updateQuotaBasedOnSpaceUsageForTesting(WebCore::ClientOrigin&&);
 
     void establishSharedWorkerServerConnection();

--- a/Source/WebKit/NetworkProcess/NetworkConnectionToWebProcess.messages.in
+++ b/Source/WebKit/NetworkProcess/NetworkConnectionToWebProcess.messages.in
@@ -61,7 +61,7 @@ messages -> NetworkConnectionToWebProcess LegacyReceiver {
 
     SetCaptureExtraNetworkLoadMetricsEnabled(bool enabled)
 
-    CreateSocketChannel(WebCore::ResourceRequest request, String protocol, WebCore::WebSocketIdentifier identifier, WebKit::WebPageProxyIdentifier webPageProxyID, struct WebCore::ClientOrigin clientOrigin, bool hadMainFrameMainResourcePrivateRelayed, bool allowPrivacyProxy, OptionSet<WebCore::NetworkConnectionIntegrity> networkConnectionIntegrityPolicy)
+    CreateSocketChannel(WebCore::ResourceRequest request, String protocol, WebCore::WebSocketIdentifier identifier, WebKit::WebPageProxyIdentifier webPageProxyID, std::optional<WebCore::FrameIdentifier> frameID, std::optional<WebCore::PageIdentifier> pageID, struct WebCore::ClientOrigin clientOrigin, bool hadMainFrameMainResourcePrivateRelayed, bool allowPrivacyProxy, OptionSet<WebCore::NetworkConnectionIntegrity> networkConnectionIntegrityPolicy, enum:bool WebCore::ShouldRelaxThirdPartyCookieBlocking shouldRelaxThirdPartyCookieBlocking, enum:uint8_t WebCore::StoredCredentialsPolicy storedCredentialsPolicy)
 
     ClearPageSpecificData(WebCore::PageIdentifier pageID);
 

--- a/Source/WebKit/NetworkProcess/NetworkSession.cpp
+++ b/Source/WebKit/NetworkProcess/NetworkSession.cpp
@@ -593,7 +593,7 @@ void NetworkSession::removeLoaderWaitingWebProcessTransfer(NetworkResourceLoadId
         cachedResourceLoader->takeLoader()->abort();
 }
 
-std::unique_ptr<WebSocketTask> NetworkSession::createWebSocketTask(WebPageProxyIdentifier, NetworkSocketChannel&, const WebCore::ResourceRequest&, const String& protocol, const WebCore::ClientOrigin&, bool, bool, OptionSet<WebCore::NetworkConnectionIntegrity>)
+std::unique_ptr<WebSocketTask> NetworkSession::createWebSocketTask(WebPageProxyIdentifier, std::optional<WebCore::FrameIdentifier>, std::optional<WebCore::PageIdentifier>, NetworkSocketChannel&, const WebCore::ResourceRequest&, const String& protocol, const WebCore::ClientOrigin&, bool, bool, OptionSet<WebCore::NetworkConnectionIntegrity>, WebCore::ShouldRelaxThirdPartyCookieBlocking, WebCore::StoredCredentialsPolicy)
 {
     return nullptr;
 }

--- a/Source/WebKit/NetworkProcess/NetworkSession.h
+++ b/Source/WebKit/NetworkProcess/NetworkSession.h
@@ -189,7 +189,7 @@ public:
     PrefetchCache& prefetchCache() { return m_prefetchCache; }
     void clearPrefetchCache() { m_prefetchCache.clear(); }
 
-    virtual std::unique_ptr<WebSocketTask> createWebSocketTask(WebPageProxyIdentifier, NetworkSocketChannel&, const WebCore::ResourceRequest&, const String& protocol, const WebCore::ClientOrigin&, bool hadMainFrameMainResourcePrivateRelayed, bool allowPrivacyProxy, OptionSet<WebCore::NetworkConnectionIntegrity> networkConnectionIntegrityPolicy);
+    virtual std::unique_ptr<WebSocketTask> createWebSocketTask(WebPageProxyIdentifier, std::optional<WebCore::FrameIdentifier>, std::optional<WebCore::PageIdentifier>, NetworkSocketChannel&, const WebCore::ResourceRequest&, const String& protocol, const WebCore::ClientOrigin&, bool hadMainFrameMainResourcePrivateRelayed, bool allowPrivacyProxy, OptionSet<WebCore::NetworkConnectionIntegrity>, WebCore::ShouldRelaxThirdPartyCookieBlocking, WebCore::StoredCredentialsPolicy);
     virtual void removeWebSocketTask(SessionSet&, WebSocketTask&) { }
     virtual void addWebSocketTask(WebPageProxyIdentifier, WebSocketTask&) { }
 

--- a/Source/WebKit/NetworkProcess/NetworkSocketChannel.cpp
+++ b/Source/WebKit/NetworkProcess/NetworkSocketChannel.cpp
@@ -37,9 +37,9 @@
 namespace WebKit {
 using namespace WebCore;
 
-std::unique_ptr<NetworkSocketChannel> NetworkSocketChannel::create(NetworkConnectionToWebProcess& connection, PAL::SessionID sessionID, const ResourceRequest& request, const String& protocol, WebSocketIdentifier identifier, WebPageProxyIdentifier webPageProxyID, const WebCore::ClientOrigin& clientOrigin, bool hadMainFrameMainResourcePrivateRelayed, bool allowPrivacyProxy, OptionSet<NetworkConnectionIntegrity> networkConnectionIntegrityPolicy)
+std::unique_ptr<NetworkSocketChannel> NetworkSocketChannel::create(NetworkConnectionToWebProcess& connection, PAL::SessionID sessionID, const ResourceRequest& request, const String& protocol, WebSocketIdentifier identifier, WebPageProxyIdentifier webPageProxyID, std::optional<FrameIdentifier> frameID, std::optional<PageIdentifier> pageID, const WebCore::ClientOrigin& clientOrigin, bool hadMainFrameMainResourcePrivateRelayed, bool allowPrivacyProxy, OptionSet<NetworkConnectionIntegrity> networkConnectionIntegrityPolicy, ShouldRelaxThirdPartyCookieBlocking shouldRelaxThirdPartyCookieBlocking, WebCore::StoredCredentialsPolicy storedCredentialsPolicy)
 {
-    auto result = makeUnique<NetworkSocketChannel>(connection, connection.networkProcess().networkSession(sessionID), request, protocol, identifier, webPageProxyID, clientOrigin, hadMainFrameMainResourcePrivateRelayed, allowPrivacyProxy, networkConnectionIntegrityPolicy);
+    auto result = makeUnique<NetworkSocketChannel>(connection, connection.networkProcess().networkSession(sessionID), request, protocol, identifier, webPageProxyID, frameID, pageID, clientOrigin, hadMainFrameMainResourcePrivateRelayed, allowPrivacyProxy, networkConnectionIntegrityPolicy, shouldRelaxThirdPartyCookieBlocking, storedCredentialsPolicy);
     if (!result->m_socket) {
         result->didClose(0, "Cannot create a web socket task"_s);
         return nullptr;
@@ -47,7 +47,7 @@ std::unique_ptr<NetworkSocketChannel> NetworkSocketChannel::create(NetworkConnec
     return result;
 }
 
-NetworkSocketChannel::NetworkSocketChannel(NetworkConnectionToWebProcess& connection, NetworkSession* session, const ResourceRequest& request, const String& protocol, WebSocketIdentifier identifier, WebPageProxyIdentifier webPageProxyID, const WebCore::ClientOrigin& clientOrigin, bool hadMainFrameMainResourcePrivateRelayed, bool allowPrivacyProxy, OptionSet<NetworkConnectionIntegrity> networkConnectionIntegrityPolicy)
+NetworkSocketChannel::NetworkSocketChannel(NetworkConnectionToWebProcess& connection, NetworkSession* session, const ResourceRequest& request, const String& protocol, WebSocketIdentifier identifier, WebPageProxyIdentifier webPageProxyID, std::optional<FrameIdentifier> frameID, std::optional<PageIdentifier> pageID, const WebCore::ClientOrigin& clientOrigin, bool hadMainFrameMainResourcePrivateRelayed, bool allowPrivacyProxy, OptionSet<NetworkConnectionIntegrity> networkConnectionIntegrityPolicy, ShouldRelaxThirdPartyCookieBlocking shouldRelaxThirdPartyCookieBlocking, WebCore::StoredCredentialsPolicy storedCredentialsPolicy)
     : m_connectionToWebProcess(connection)
     , m_identifier(identifier)
     , m_session(session)
@@ -57,7 +57,7 @@ NetworkSocketChannel::NetworkSocketChannel(NetworkConnectionToWebProcess& connec
     if (!m_session)
         return;
 
-    m_socket = m_session->createWebSocketTask(webPageProxyID, *this, request, protocol, clientOrigin, hadMainFrameMainResourcePrivateRelayed, allowPrivacyProxy, networkConnectionIntegrityPolicy);
+    m_socket = m_session->createWebSocketTask(webPageProxyID, frameID, pageID, *this, request, protocol, clientOrigin, hadMainFrameMainResourcePrivateRelayed, allowPrivacyProxy, networkConnectionIntegrityPolicy, shouldRelaxThirdPartyCookieBlocking, storedCredentialsPolicy);
     if (m_socket) {
         m_session->addWebSocketTask(webPageProxyID, *m_socket);
         m_socket->resume();
@@ -156,7 +156,7 @@ IPC::Connection* NetworkSocketChannel::messageSenderConnection() const
     return &m_connectionToWebProcess.connection();
 }
 
-NetworkSession* NetworkSocketChannel::session()
+NetworkSession* NetworkSocketChannel::session() const
 {
     return m_session.get();
 }

--- a/Source/WebKit/NetworkProcess/NetworkSocketChannel.h
+++ b/Source/WebKit/NetworkProcess/NetworkSocketChannel.h
@@ -29,6 +29,9 @@
 #include "MessageReceiver.h"
 #include "MessageSender.h"
 #include "WebPageProxyIdentifier.h"
+#include <WebCore/FrameIdentifier.h>
+#include <WebCore/PageIdentifier.h>
+#include <WebCore/ShouldRelaxThirdPartyCookieBlocking.h>
 #include <WebCore/Timer.h>
 #include <WebCore/WebSocketIdentifier.h>
 #include <pal/SessionID.h>
@@ -38,6 +41,7 @@
 namespace WebCore {
 struct ClientOrigin;
 enum class NetworkConnectionIntegrity : uint16_t;
+enum class StoredCredentialsPolicy : uint8_t;
 class ResourceRequest;
 class ResourceResponse;
 }
@@ -57,9 +61,9 @@ class NetworkSession;
 class NetworkSocketChannel : public IPC::MessageSender, public IPC::MessageReceiver {
     WTF_MAKE_FAST_ALLOCATED;
 public:
-    static std::unique_ptr<NetworkSocketChannel> create(NetworkConnectionToWebProcess&, PAL::SessionID, const WebCore::ResourceRequest&, const String& protocol, WebCore::WebSocketIdentifier, WebPageProxyIdentifier, const WebCore::ClientOrigin&, bool hadMainFrameMainResourcePrivateRelayed, bool allowPrivacyProxy, OptionSet<WebCore::NetworkConnectionIntegrity> networkConnectionIntegrityPolicy);
+    static std::unique_ptr<NetworkSocketChannel> create(NetworkConnectionToWebProcess&, PAL::SessionID, const WebCore::ResourceRequest&, const String& protocol, WebCore::WebSocketIdentifier, WebPageProxyIdentifier, std::optional<WebCore::FrameIdentifier>, std::optional<WebCore::PageIdentifier>, const WebCore::ClientOrigin&, bool hadMainFrameMainResourcePrivateRelayed, bool allowPrivacyProxy, OptionSet<WebCore::NetworkConnectionIntegrity> networkConnectionIntegrityPolicy, WebCore::ShouldRelaxThirdPartyCookieBlocking, WebCore::StoredCredentialsPolicy);
 
-    NetworkSocketChannel(NetworkConnectionToWebProcess&, NetworkSession*, const WebCore::ResourceRequest&, const String& protocol, WebCore::WebSocketIdentifier, WebPageProxyIdentifier, const WebCore::ClientOrigin&, bool hadMainFrameMainResourcePrivateRelayed, bool allowPrivacyProxy, OptionSet<WebCore::NetworkConnectionIntegrity> networkConnectionIntegrityPolicy);
+    NetworkSocketChannel(NetworkConnectionToWebProcess&, NetworkSession*, const WebCore::ResourceRequest&, const String& protocol, WebCore::WebSocketIdentifier, WebPageProxyIdentifier, std::optional<WebCore::FrameIdentifier>, std::optional<WebCore::PageIdentifier>, const WebCore::ClientOrigin&, bool hadMainFrameMainResourcePrivateRelayed, bool allowPrivacyProxy, OptionSet<WebCore::NetworkConnectionIntegrity> networkConnectionIntegrityPolicy, WebCore::ShouldRelaxThirdPartyCookieBlocking, WebCore::StoredCredentialsPolicy);
     ~NetworkSocketChannel();
 
     void didReceiveMessage(IPC::Connection&, IPC::Decoder&);
@@ -80,7 +84,7 @@ private:
     void close(int32_t code, const String& reason);
     void sendDelayedError();
 
-    NetworkSession* session();
+    NetworkSession* session() const;
 
     IPC::Connection* messageSenderConnection() const final;
     uint64_t messageSenderDestinationID() const final { return m_identifier.toUInt64(); }

--- a/Source/WebKit/NetworkProcess/cocoa/NetworkDataTaskCocoa.h
+++ b/Source/WebKit/NetworkProcess/cocoa/NetworkDataTaskCocoa.h
@@ -28,6 +28,7 @@
 #include "NetworkActivityTracker.h"
 #include "NetworkDataTask.h"
 #include "NetworkLoadParameters.h"
+#include "NetworkTaskCocoa.h"
 #include <WebCore/NetworkLoadMetrics.h>
 #include <WebCore/PrivateClickMeasurement.h>
 #include <wtf/RetainPtr.h>
@@ -48,7 +49,7 @@ class Download;
 class NetworkSessionCocoa;
 struct SessionWrapper;
 
-class NetworkDataTaskCocoa final : public NetworkDataTask {
+class NetworkDataTaskCocoa final : public NetworkDataTask, public NetworkTaskCocoa {
 public:
     static Ref<NetworkDataTask> create(NetworkSession& session, NetworkDataTaskClient& client, const NetworkLoadParameters& parameters)
     {
@@ -79,9 +80,8 @@ public:
 
     WebCore::NetworkLoadMetrics& networkLoadMetrics() { return m_networkLoadMetrics; }
 
-    WebCore::FrameIdentifier frameID() const { return m_frameID; };
-    WebCore::PageIdentifier pageID() const { return m_pageID; };
-    WebCore::ShouldRelaxThirdPartyCookieBlocking shouldRelaxThirdPartyCookieBlocking() const { return m_shouldRelaxThirdPartyCookieBlocking; }
+    std::optional<WebCore::FrameIdentifier> frameID() const final { return m_frameID; };
+    std::optional<WebCore::PageIdentifier> pageID() const final { return m_pageID; };
 
     String description() const override;
 
@@ -100,15 +100,11 @@ private:
     void applySniffingPoliciesAndBindRequestToInferfaceIfNeeded(RetainPtr<NSURLRequest>&, bool shouldContentSniff, WebCore::ContentEncodingSniffingPolicy);
 
 #if ENABLE(TRACKING_PREVENTION)
-    static NSHTTPCookieStorage *statelessCookieStorage();
     void updateFirstPartyInfoForSession(const URL&);
-    bool shouldApplyCookiePolicyForThirdPartyCloaking() const;
-    void applyCookiePolicyForThirdPartyCloaking(const WebCore::ResourceRequest&);
-    void blockCookies();
-    void unblockCookies();
-    bool needsFirstPartyCookieBlockingLatchModeQuirk(const URL& firstPartyURL, const URL& requestURL, const URL& redirectingURL) const;
 #endif
-    bool isAlwaysOnLoggingAllowed() const;
+
+    NSURLSessionTask* task() const final;
+    WebCore::StoredCredentialsPolicy storedCredentialsPolicy() const final { return m_storedCredentialsPolicy; }
 
     WeakPtr<SessionWrapper> m_sessionWrapper;
     RefPtr<SandboxExtension> m_sandboxExtension;
@@ -118,14 +114,7 @@ private:
     WebCore::PageIdentifier m_pageID;
     WebPageProxyIdentifier m_webPageProxyID;
 
-#if ENABLE(TRACKING_PREVENTION)
-    bool m_hasBeenSetToUseStatelessCookieStorage { false };
-    Seconds m_ageCapForCNAMECloakedCookies { 24_h * 7 };
-#endif
-
     bool m_isForMainResourceNavigationForAnyFrame { false };
-    bool m_isAlwaysOnLoggingAllowed { false };
-    WebCore::ShouldRelaxThirdPartyCookieBlocking m_shouldRelaxThirdPartyCookieBlocking { WebCore::ShouldRelaxThirdPartyCookieBlocking::No };
     RefPtr<WebCore::SecurityOrigin> m_sourceOrigin;
 };
 

--- a/Source/WebKit/NetworkProcess/cocoa/NetworkDataTaskCocoa.mm
+++ b/Source/WebKit/NetworkProcess/cocoa/NetworkDataTaskCocoa.mm
@@ -70,13 +70,6 @@ void enableNetworkConnectionIntegrity(NSMutableURLRequest *, OptionSet<WebCore::
 
 namespace WebKit {
 
-static NSString *lastRemoteIPAddress(NSURLSessionDataTask *task)
-{
-    // FIXME (246428): In a future patch, this should adopt CFNetwork API that retrieves the original
-    // IP address of the proxied response, rather than the proxy itself.
-    return task._incompleteTaskMetrics.transactionMetrics.lastObject.remoteAddress;
-}
-
 void setPCMDataCarriedOnRequest(WebCore::PrivateClickMeasurement::PcmDataCarried pcmDataCarried, NSMutableURLRequest *request)
 {
 #if ENABLE(TRACKER_DISPOSITION)
@@ -120,7 +113,7 @@ void NetworkDataTaskCocoa::applySniffingPoliciesAndBindRequestToInferfaceIfNeede
     UNUSED_PARAM(contentEncodingSniffingPolicy);
 #endif
 
-    auto& cocoaSession = static_cast<NetworkSessionCocoa&>(*m_session);
+    auto& cocoaSession = static_cast<NetworkSessionCocoa&>(*networkSession());
     auto& boundInterfaceIdentifier = cocoaSession.boundInterfaceIdentifier();
     if (shouldContentSniff
 #if USE(CFNETWORK_CONTENT_ENCODING_SNIFFING_OVERRIDE)
@@ -145,43 +138,17 @@ void NetworkDataTaskCocoa::applySniffingPoliciesAndBindRequestToInferfaceIfNeede
     nsRequest = WTFMove(mutableRequest);
 }
 
-#if ENABLE(TRACKING_PREVENTION)
-NSHTTPCookieStorage *NetworkDataTaskCocoa::statelessCookieStorage()
-{
-    static NeverDestroyed<RetainPtr<NSHTTPCookieStorage>> statelessCookieStorage;
-    if (!statelessCookieStorage.get()) {
-        statelessCookieStorage.get() = adoptNS([[NSHTTPCookieStorage alloc] _initWithIdentifier:nil private:YES]);
-        statelessCookieStorage.get().get().cookieAcceptPolicy = NSHTTPCookieAcceptPolicyNever;
-    }
-    ASSERT(statelessCookieStorage.get().get().cookies.count == 0);
-    return statelessCookieStorage.get().get();
-}
-
-static WebCore::RegistrableDomain lastCNAMEDomain(NSArray<NSString *> *cnames)
-{
-    if (auto* lastResolvedCNAMEInChain = [cnames lastObject]) {
-        auto cname = String(lastResolvedCNAMEInChain);
-        if (cname.endsWith('.'))
-            cname = cname.left(cname.length() - 1);
-        return WebCore::RegistrableDomain::uncheckedCreateFromHost(cname);
-    }
-
-    return { };
-}
-
-bool NetworkDataTaskCocoa::shouldApplyCookiePolicyForThirdPartyCloaking() const
-{
-    auto* session = networkSession();
-    return session && session->networkStorageSession() && session->networkStorageSession()->trackingPreventionEnabled();
-}
-
 void NetworkDataTaskCocoa::updateFirstPartyInfoForSession(const URL& requestURL)
 {
     if (!shouldApplyCookiePolicyForThirdPartyCloaking() || requestURL.host().isEmpty())
         return;
 
     auto* session = networkSession();
-    auto cnameDomain = lastCNAMEDomain([m_task _resolvedCNAMEChain]);
+    auto cnameDomain = [this]() {
+        if (auto* lastResolvedCNAMEInChain = [[m_task _resolvedCNAMEChain] lastObject])
+            return lastCNAMEDomain(lastResolvedCNAMEInChain);
+        return WebCore::RegistrableDomain { };
+    }();
     if (!cnameDomain.isEmpty())
         session->setFirstPartyHostCNAMEDomain(requestURL.host().toString(), WTFMove(cnameDomain));
 
@@ -189,166 +156,14 @@ void NetworkDataTaskCocoa::updateFirstPartyInfoForSession(const URL& requestURL)
         session->setFirstPartyHostIPAddress(requestURL.host().toString(), ipAddress);
 }
 
-static NSArray<NSHTTPCookie *> *cookiesByCappingExpiry(NSArray<NSHTTPCookie *> *cookies, Seconds ageCap)
-{
-    auto *cappedCookies = [NSMutableArray arrayWithCapacity:cookies.count];
-    for (NSHTTPCookie *cookie in cookies)
-        [cappedCookies addObject:WebCore::NetworkStorageSession::capExpiryOfPersistentCookie(cookie, ageCap)];
-    return cappedCookies;
-}
-
-static bool shouldCapCookieExpiryForThirdPartyIPAddress(const WebCore::IPAddress& remote, const WebCore::IPAddress& firstParty)
-{
-    auto matchingLength = remote.matchingNetMaskLength(firstParty);
-    if (remote.isIPv4())
-        return matchingLength < 4 * sizeof(struct in_addr);
-    return matchingLength < 4 * sizeof(struct in6_addr);
-}
-
-void NetworkDataTaskCocoa::applyCookiePolicyForThirdPartyCloaking(const WebCore::ResourceRequest& request)
-{
-    if (isTopLevelNavigation() || !shouldApplyCookiePolicyForThirdPartyCloaking())
-        return;
-
-    if (request.isThirdParty()) {
-        m_task.get()._cookieTransformCallback = nil;
-        return;
-    }
-
-    // Cap expiry of incoming cookies in response if it is a same-site
-    // subresource but it resolves to a different CNAME than the top
-    // site request, a.k.a. third-party CNAME cloaking.
-    auto firstPartyURL = request.firstPartyForCookies();
-    auto firstPartyHostName = firstPartyURL.host().toString();
-    auto firstPartyHostCNAME = networkSession()->firstPartyHostCNAMEDomain(firstPartyHostName);
-    auto firstPartyAddress = networkSession()->firstPartyHostIPAddress(firstPartyHostName);
-
-    m_task.get()._cookieTransformCallback = makeBlockPtr([requestURL = crossThreadCopy(request.url()), firstPartyURL = crossThreadCopy(firstPartyURL), firstPartyHostCNAME = crossThreadCopy(firstPartyHostCNAME), firstPartyAddress = crossThreadCopy(firstPartyAddress), thirdPartyCNAMEDomainForTesting = crossThreadCopy(networkSession()->thirdPartyCNAMEDomainForTesting()), ageCapForCNAMECloakedCookies = crossThreadCopy(m_ageCapForCNAMECloakedCookies), weakTask = WeakObjCPtr<NSURLSessionDataTask>(m_task.get()), debugLoggingEnabled = networkSession()->networkStorageSession()->trackingPreventionDebugLoggingEnabled()] (NSArray<NSHTTPCookie*> *cookiesSetInResponse) -> NSArray<NSHTTPCookie*> * {
-        auto task = weakTask.get();
-        if (!task || ![cookiesSetInResponse count])
-            return cookiesSetInResponse;
-
-        auto cnameDomain = lastCNAMEDomain([task _resolvedCNAMEChain]);
-        if (cnameDomain.isEmpty() && thirdPartyCNAMEDomainForTesting)
-            cnameDomain = *thirdPartyCNAMEDomainForTesting;
-
-        if (cnameDomain.isEmpty()) {
-            if (!firstPartyAddress)
-                return cookiesSetInResponse;
-
-            auto remoteAddress = WebCore::IPAddress::fromString(lastRemoteIPAddress(task.get()));
-            if (!remoteAddress)
-                return cookiesSetInResponse;
-
-            if (shouldCapCookieExpiryForThirdPartyIPAddress(*remoteAddress, *firstPartyAddress)) {
-                cookiesSetInResponse = cookiesByCappingExpiry(cookiesSetInResponse, ageCapForCNAMECloakedCookies);
-                if (debugLoggingEnabled) {
-                    for (NSHTTPCookie *cookie in cookiesSetInResponse)
-                        RELEASE_LOG_INFO(ITPDebug, "Capped the expiry of third-party IP address cookie named %{public}@.", cookie.name);
-                }
-            }
-
-            return cookiesSetInResponse;
-        }
-
-        // CNAME cloaking is a first-party sub resource that resolves
-        // through a CNAME that differs from the first-party domain and
-        // also differs from the top frame host's CNAME, if one exists.
-        if (!cnameDomain.matches(firstPartyURL) && (!firstPartyHostCNAME || cnameDomain != *firstPartyHostCNAME)) {
-            // Don't use RetainPtr here. This array has to be retained and
-            // auto released to not be released before returned to the code
-            // executing the block.
-            cookiesSetInResponse = cookiesByCappingExpiry(cookiesSetInResponse, ageCapForCNAMECloakedCookies);
-            if (debugLoggingEnabled) {
-                for (NSHTTPCookie *cookie in cookiesSetInResponse)
-                    RELEASE_LOG_INFO(ITPDebug, "Capped the expiry of third-party CNAME cloaked cookie named %{public}@.", cookie.name);
-            }
-        }
-
-        return cookiesSetInResponse;
-    }).get();
-}
-
-void NetworkDataTaskCocoa::blockCookies()
-{
-    ASSERT(hasProcessPrivilege(ProcessPrivilege::CanAccessRawCookies));
-
-    if (m_hasBeenSetToUseStatelessCookieStorage)
-        return;
-
-    [m_task _setExplicitCookieStorage:statelessCookieStorage()._cookieStorage];
-    m_hasBeenSetToUseStatelessCookieStorage = true;
-}
-
-void NetworkDataTaskCocoa::unblockCookies()
-{
-    ASSERT(hasProcessPrivilege(ProcessPrivilege::CanAccessRawCookies));
-
-    if (!m_hasBeenSetToUseStatelessCookieStorage)
-        return;
-
-    if (auto* storageSession = m_session->networkStorageSession()) {
-        [m_task _setExplicitCookieStorage:storageSession->nsCookieStorage()._cookieStorage];
-        m_hasBeenSetToUseStatelessCookieStorage = false;
-    }
-}
-
-// FIXME: Temporary fix for <rdar://60089022> and <rdar://100500464> until content can be updated.
-bool NetworkDataTaskCocoa::needsFirstPartyCookieBlockingLatchModeQuirk(const URL& firstPartyURL, const URL& requestURL, const URL& redirectingURL) const
-{
-    using RegistrableDomain = WebCore::RegistrableDomain;
-    static NeverDestroyed<HashMap<RegistrableDomain, RegistrableDomain>> quirkPairs = [] {
-        HashMap<RegistrableDomain, RegistrableDomain> map;
-        map.add(RegistrableDomain::uncheckedCreateFromRegistrableDomainString("ymail.com"_s), RegistrableDomain::uncheckedCreateFromRegistrableDomainString("yahoo.com"_s));
-        map.add(RegistrableDomain::uncheckedCreateFromRegistrableDomainString("aolmail.com"_s), RegistrableDomain::uncheckedCreateFromRegistrableDomainString("aol.com"_s));
-        map.add(RegistrableDomain::uncheckedCreateFromRegistrableDomainString("googleusercontent.com"_s), RegistrableDomain::uncheckedCreateFromRegistrableDomainString("google.com"_s));
-        return map;
-    }();
-
-    RegistrableDomain firstPartyDomain { firstPartyURL };
-    RegistrableDomain requestDomain { requestURL };
-    if (firstPartyDomain != requestDomain)
-        return false;
-
-    RegistrableDomain redirectingDomain { redirectingURL };
-    auto quirk = quirkPairs.get().find(redirectingDomain);
-    if (quirk == quirkPairs.get().end())
-        return false;
-
-    return quirk->value == requestDomain;
-}
-#endif
-
-static void updateTaskWithFirstPartyForSameSiteCookies(NSURLSessionDataTask* task, const WebCore::ResourceRequest& request)
-{
-    if (request.isSameSiteUnspecified())
-        return;
-#if HAVE(FOUNDATION_WITH_SAME_SITE_COOKIE_SUPPORT)
-    static NSURL *emptyURL = [[NSURL alloc] initWithString:@""];
-    task._siteForCookies = request.isSameSite() ? task.currentRequest.URL : emptyURL;
-    task._isTopLevelNavigation = request.isTopSite();
-#else
-    UNUSED_PARAM(task);
-#endif
-}
-
-static inline bool computeIsAlwaysOnLoggingAllowed(NetworkSession& session)
-{
-    if (session.networkProcess().sessionIsControlledByAutomation(session.sessionID()))
-        return true;
-
-    return session.sessionID().isAlwaysOnLoggingAllowed();
-}
-
 NetworkDataTaskCocoa::NetworkDataTaskCocoa(NetworkSession& session, NetworkDataTaskClient& client, const NetworkLoadParameters& parameters)
     : NetworkDataTask(session, client, parameters.request, parameters.storedCredentialsPolicy, parameters.shouldClearReferrerOnHTTPSToHTTPRedirect, parameters.isMainFrameNavigation)
+    , NetworkTaskCocoa(session, parameters.shouldRelaxThirdPartyCookieBlocking)
     , m_sessionWrapper(static_cast<NetworkSessionCocoa&>(session).sessionWrapperForTask(parameters.webPageProxyID, parameters.request, parameters.storedCredentialsPolicy, parameters.isNavigatingToAppBoundDomain))
     , m_frameID(parameters.webFrameID)
     , m_pageID(parameters.webPageID)
     , m_webPageProxyID(parameters.webPageProxyID)
     , m_isForMainResourceNavigationForAnyFrame(parameters.isMainResourceNavigationForAnyFrame)
-    , m_isAlwaysOnLoggingAllowed(computeIsAlwaysOnLoggingAllowed(session))
-    , m_shouldRelaxThirdPartyCookieBlocking(parameters.shouldRelaxThirdPartyCookieBlocking)
     , m_sourceOrigin(parameters.sourceOrigin)
 {
     auto request = parameters.request;
@@ -377,7 +192,7 @@ NetworkDataTaskCocoa::NetworkDataTaskCocoa(NetworkSession& session, NetworkDataT
     shouldBlockCookies = m_storedCredentialsPolicy == WebCore::StoredCredentialsPolicy::EphemeralStateless;
     if (auto* networkStorageSession = session.networkStorageSession()) {
         if (!shouldBlockCookies)
-            shouldBlockCookies = networkStorageSession->shouldBlockCookies(request, frameID(), pageID(), m_shouldRelaxThirdPartyCookieBlocking);
+            shouldBlockCookies = networkStorageSession->shouldBlockCookies(request, frameID(), pageID(), shouldRelaxThirdPartyCookieBlocking());
     }
 #endif
     restrictRequestReferrerToOriginIfNeeded(request);
@@ -470,11 +285,12 @@ NetworkDataTaskCocoa::NetworkDataTaskCocoa(NetworkSession& session, NetworkDataT
     }
 
 #if ENABLE(TRACKING_PREVENTION)
-    applyCookiePolicyForThirdPartyCloaking(request);
+    if (!isTopLevelNavigation())
+        applyCookiePolicyForThirdPartyCloaking(request);
     if (shouldBlockCookies) {
 #if !RELEASE_LOG_DISABLED
         if (m_session->shouldLogCookieInformation())
-            RELEASE_LOG_IF(isAlwaysOnLoggingAllowed(), Network, "%p - NetworkDataTaskCocoa::logCookieInformation: pageID=%" PRIu64 ", frameID=%" PRIu64 ", taskID=%lu: Blocking cookies for URL %s", this, pageID().toUInt64(), frameID().object().toUInt64(), (unsigned long)[m_task taskIdentifier], [nsRequest URL].absoluteString.UTF8String);
+            RELEASE_LOG_IF(isAlwaysOnLoggingAllowed(), Network, "%p - NetworkDataTaskCocoa::logCookieInformation: pageID=%" PRIu64 ", frameID=%" PRIu64 ", taskID=%lu: Blocking cookies for URL %s", this, pageID() ? pageID()->toUInt64() : 0, frameID() ? frameID()->object().toUInt64() : 0, (unsigned long)[m_task taskIdentifier], [nsRequest URL].absoluteString.UTF8String);
 #else
         LOG(NetworkSession, "%lu Blocking cookies for URL %s", (unsigned long)[m_task taskIdentifier], [nsRequest URL].absoluteString.UTF8String);
 #endif
@@ -622,30 +438,13 @@ void NetworkDataTaskCocoa::willPerformHTTPRedirection(WebCore::ResourceResponse&
     if (isTopLevelNavigation())
         request.setFirstPartyForCookies(request.url());
 
-#if ENABLE(APP_PRIVACY_REPORT)
-    request.setIsAppInitiated(request.nsURLRequest(WebCore::HTTPBodyUpdatePolicy::DoNotUpdateHTTPBody).attribution == NSURLRequestAttributionDeveloper);
-#endif
-
-#if ENABLE(TRACKING_PREVENTION)
-    applyCookiePolicyForThirdPartyCloaking(request);
-    if (!m_hasBeenSetToUseStatelessCookieStorage) {
-        if (m_storedCredentialsPolicy == WebCore::StoredCredentialsPolicy::EphemeralStateless
-            || (m_session->networkStorageSession() && m_session->networkStorageSession()->shouldBlockCookies(request, m_frameID, m_pageID, m_shouldRelaxThirdPartyCookieBlocking)))
-            blockCookies();
-    } else if (m_storedCredentialsPolicy != WebCore::StoredCredentialsPolicy::EphemeralStateless && needsFirstPartyCookieBlockingLatchModeQuirk(request.firstPartyForCookies(), request.url(), redirectResponse.url()))
-        unblockCookies();
-#if !RELEASE_LOG_DISABLED
-    if (m_session->shouldLogCookieInformation())
-        RELEASE_LOG_IF(isAlwaysOnLoggingAllowed(), Network, "%p - NetworkDataTaskCocoa::willPerformHTTPRedirection::logCookieInformation: pageID=%" PRIu64 ", frameID=%" PRIu64 ", taskID=%lu: %s cookies for redirect URL %s", this, m_pageID.toUInt64(), m_frameID.object().toUInt64(), (unsigned long)[m_task taskIdentifier], (m_hasBeenSetToUseStatelessCookieStorage ? "Blocking" : "Not blocking"), request.url().string().utf8().data());
-#else
-    LOG(NetworkSession, "%lu %s cookies for redirect URL %s", (unsigned long)[m_task taskIdentifier], (m_hasBeenSetToUseStatelessCookieStorage ? "Blocking" : "Not blocking"), request.url().string().utf8().data());
-#endif
-#endif
-
-    updateTaskWithFirstPartyForSameSiteCookies(m_task.get(), request);
-
-    if (m_client)
-        m_client->willPerformHTTPRedirection(WTFMove(redirectResponse), WTFMove(request), [completionHandler = WTFMove(completionHandler), this, weakThis = ThreadSafeWeakPtr { *this }] (auto&& request) mutable {
+    NetworkTaskCocoa::willPerformHTTPRedirection(WTFMove(redirectResponse), WTFMove(request), [completionHandler = WTFMove(completionHandler), this, weakThis = ThreadSafeWeakPtr { *this }, redirectResponse] (auto&& request) mutable {
+        auto strongThis = weakThis.get();
+        if (!strongThis)
+            return completionHandler({ });
+        if (!m_client)
+            return completionHandler({ });
+        m_client->willPerformHTTPRedirection(WTFMove(redirectResponse), WTFMove(request), [completionHandler = WTFMove(completionHandler), this, weakThis] (auto&& request) mutable {
             auto strongThis = weakThis.get();
             if (!strongThis || !m_session)
                 return completionHandler({ });
@@ -653,10 +452,7 @@ void NetworkDataTaskCocoa::willPerformHTTPRedirection(WebCore::ResourceResponse&
                 restrictRequestReferrerToOriginIfNeeded(request);
             completionHandler(WTFMove(request));
         });
-    else {
-        ASSERT_NOT_REACHED();
-        completionHandler({ });
-    }
+    });
 }
 
 void NetworkDataTaskCocoa::setPendingDownloadLocation(const WTF::String& filename, SandboxExtension::Handle&& sandboxExtensionHandle, bool allowOverwrite)
@@ -798,11 +594,6 @@ WebCore::Credential serverTrustCredential(const WebCore::AuthenticationChallenge
     return WebCore::Credential([NSURLCredential credentialForTrust:challenge.nsURLAuthenticationChallenge().protectionSpace.serverTrust]);
 }
 
-bool NetworkDataTaskCocoa::isAlwaysOnLoggingAllowed() const
-{
-    return m_isAlwaysOnLoggingAllowed;
-}
-
 String NetworkDataTaskCocoa::description() const
 {
     return String([m_task description]);
@@ -857,6 +648,11 @@ void NetworkDataTaskCocoa::checkTAO(const WebCore::ResourceResponse& response)
 
     if (origin)
         networkLoadMetrics().failsTAOCheck = !passesTimingAllowOriginCheck(response, *origin);
+}
+
+NSURLSessionTask* NetworkDataTaskCocoa::task() const
+{
+    return m_task.get();
 }
 
 }

--- a/Source/WebKit/NetworkProcess/cocoa/NetworkSessionCocoa.h
+++ b/Source/WebKit/NetworkProcess/cocoa/NetworkSessionCocoa.h
@@ -174,7 +174,7 @@ private:
     void clearAlternativeServices(WallTime) override;
 
 #if HAVE(NSURLSESSION_WEBSOCKET)
-    std::unique_ptr<WebSocketTask> createWebSocketTask(WebPageProxyIdentifier, NetworkSocketChannel&, const WebCore::ResourceRequest&, const String& protocol, const WebCore::ClientOrigin&, bool hadMainFrameMainResourcePrivateRelayed, bool allowPrivacyProxy, OptionSet<WebCore::NetworkConnectionIntegrity>) final;
+    std::unique_ptr<WebSocketTask> createWebSocketTask(WebPageProxyIdentifier, std::optional<WebCore::FrameIdentifier>, std::optional<WebCore::PageIdentifier>, NetworkSocketChannel&, const WebCore::ResourceRequest&, const String& protocol, const WebCore::ClientOrigin&, bool hadMainFrameMainResourcePrivateRelayed, bool allowPrivacyProxy, OptionSet<WebCore::NetworkConnectionIntegrity>, WebCore::ShouldRelaxThirdPartyCookieBlocking, WebCore::StoredCredentialsPolicy) final;
     void addWebSocketTask(WebPageProxyIdentifier, WebSocketTask&) final;
     void removeWebSocketTask(SessionSet&, WebSocketTask&) final;
 #endif

--- a/Source/WebKit/NetworkProcess/cocoa/NetworkTaskCocoa.h
+++ b/Source/WebKit/NetworkProcess/cocoa/NetworkTaskCocoa.h
@@ -1,0 +1,84 @@
+/*
+ * Copyright (C) 2023 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include "NetworkDataTask.h"
+#include <WebCore/FrameIdentifier.h>
+#include <WebCore/PageIdentifier.h>
+#include <WebCore/ResourceRequest.h>
+#include <WebCore/ResourceResponse.h>
+#include <WebCore/ShouldRelaxThirdPartyCookieBlocking.h>
+
+OBJC_CLASS NSArray;
+OBJC_CLASS NSString;
+OBJC_CLASS NSURLSessionTask;
+
+namespace WebCore {
+class RegistrableDomain;
+}
+
+namespace WebKit {
+
+class NetworkTaskCocoa {
+public:
+    virtual ~NetworkTaskCocoa() = default;
+
+    void willPerformHTTPRedirection(WebCore::ResourceResponse&&, WebCore::ResourceRequest&&, RedirectCompletionHandler&&);
+    virtual std::optional<WebCore::FrameIdentifier> frameID() const = 0;
+    virtual std::optional<WebCore::PageIdentifier> pageID() const = 0;
+
+    WebCore::ShouldRelaxThirdPartyCookieBlocking shouldRelaxThirdPartyCookieBlocking() const { return m_shouldRelaxThirdPartyCookieBlocking; }
+
+protected:
+    NetworkTaskCocoa(NetworkSession&, WebCore::ShouldRelaxThirdPartyCookieBlocking);
+
+#if ENABLE(TRACKING_PREVENTION)
+    static NSHTTPCookieStorage *statelessCookieStorage();
+    bool shouldApplyCookiePolicyForThirdPartyCloaking() const;
+    void applyCookiePolicyForThirdPartyCloaking(const WebCore::ResourceRequest&);
+    void blockCookies();
+    void unblockCookies();
+    static void updateTaskWithFirstPartyForSameSiteCookies(NSURLSessionTask*, const WebCore::ResourceRequest&);
+    bool needsFirstPartyCookieBlockingLatchModeQuirk(const URL& firstPartyURL, const URL& requestURL, const URL& redirectingURL) const;
+    static NSString *lastRemoteIPAddress(NSURLSessionTask *);
+    static WebCore::RegistrableDomain lastCNAMEDomain(String);
+#endif
+
+    bool isAlwaysOnLoggingAllowed() const { return m_isAlwaysOnLoggingAllowed; }
+    virtual NSURLSessionTask* task() const = 0;
+    virtual WebCore::StoredCredentialsPolicy storedCredentialsPolicy() const = 0;
+
+private:
+    WeakPtr<NetworkSession> m_networkSession;
+#if ENABLE(TRACKING_PREVENTION)
+    bool m_hasBeenSetToUseStatelessCookieStorage { false };
+    Seconds m_ageCapForCNAMECloakedCookies { 24_h * 7 };
+#endif
+    bool m_isAlwaysOnLoggingAllowed { false };
+    WebCore::ShouldRelaxThirdPartyCookieBlocking m_shouldRelaxThirdPartyCookieBlocking { WebCore::ShouldRelaxThirdPartyCookieBlocking::No };
+};
+
+} // namespace WebKit

--- a/Source/WebKit/NetworkProcess/cocoa/NetworkTaskCocoa.mm
+++ b/Source/WebKit/NetworkProcess/cocoa/NetworkTaskCocoa.mm
@@ -1,0 +1,248 @@
+/*
+ * Copyright (C) 2023 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#import "config.h"
+#include "NetworkTaskCocoa.h"
+
+using namespace WebCore;
+
+static inline bool computeIsAlwaysOnLoggingAllowed(NetworkSession& session)
+{
+    if (session.networkProcess().sessionIsControlledByAutomation(session.sessionID()))
+        return true;
+
+    return session.sessionID().isAlwaysOnLoggingAllowed();
+}
+
+NetworkTaskCocoa::NetworkTaskCocoa(NetworkSession& session, ShouldRelaxThirdPartyCookieBlocking shouldRelaxThirdPartyCookieBlocking)
+    : m_networkSession(session)
+    , m_isAlwaysOnLoggingAllowed(computeIsAlwaysOnLoggingAllowed(session))
+    , m_shouldRelaxThirdPartyCookieBlocking(shouldRelaxThirdPartyCookieBlocking)
+{
+}
+
+static bool shouldCapCookieExpiryForThirdPartyIPAddress(const WebCore::IPAddress& remote, const WebCore::IPAddress& firstParty)
+{
+    auto matchingLength = remote.matchingNetMaskLength(firstParty);
+    if (remote.isIPv4())
+        return matchingLength < 4 * sizeof(struct in_addr);
+    return matchingLength < 4 * sizeof(struct in6_addr);
+}
+
+bool NetworkTaskCocoa::shouldApplyCookiePolicyForThirdPartyCloaking() const
+{
+    return m_networkSession->networkStorageSession() && m_networkSession->networkStorageSession()->trackingPreventionEnabled();
+}
+
+#if ENABLE(TRACKING_PREVENTION)
+NSHTTPCookieStorage *NetworkTaskCocoa::statelessCookieStorage()
+{
+    static NeverDestroyed<RetainPtr<NSHTTPCookieStorage>> statelessCookieStorage;
+    if (!statelessCookieStorage.get()) {
+        statelessCookieStorage.get() = adoptNS([[NSHTTPCookieStorage alloc] _initWithIdentifier:nil private:YES]);
+        statelessCookieStorage.get().get().cookieAcceptPolicy = NSHTTPCookieAcceptPolicyNever;
+    }
+    ASSERT(!statelessCookieStorage.get().get().cookies.count);
+    return statelessCookieStorage.get().get();
+}
+
+NSString *NetworkTaskCocoa::lastRemoteIPAddress(NSURLSessionTask *task)
+{
+    // FIXME (246428): In a future patch, this should adopt CFNetwork API that retrieves the original
+    // IP address of the proxied response, rather than the proxy itself.
+    return task._incompleteTaskMetrics.transactionMetrics.lastObject.remoteAddress;
+}
+
+WebCore::RegistrableDomain NetworkTaskCocoa::lastCNAMEDomain(String cname)
+{
+    if (cname.endsWith('.'))
+        cname = cname.left(cname.length() - 1);
+    return WebCore::RegistrableDomain::uncheckedCreateFromHost(cname);
+}
+
+static NSArray<NSHTTPCookie *> *cookiesByCappingExpiry(NSArray<NSHTTPCookie *> *cookies, Seconds ageCap)
+{
+    auto *cappedCookies = [NSMutableArray arrayWithCapacity:cookies.count];
+    for (NSHTTPCookie *cookie in cookies)
+        [cappedCookies addObject:WebCore::NetworkStorageSession::capExpiryOfPersistentCookie(cookie, ageCap)];
+    return cappedCookies;
+}
+
+// FIXME: Temporary fix for <rdar://60089022> and <rdar://100500464> until content can be updated.
+bool NetworkTaskCocoa::needsFirstPartyCookieBlockingLatchModeQuirk(const URL& firstPartyURL, const URL& requestURL, const URL& redirectingURL) const
+{
+    using RegistrableDomain = WebCore::RegistrableDomain;
+    static NeverDestroyed<HashMap<RegistrableDomain, RegistrableDomain>> quirkPairs = [] {
+        HashMap<RegistrableDomain, RegistrableDomain> map;
+        map.add(RegistrableDomain::uncheckedCreateFromRegistrableDomainString("ymail.com"_s), RegistrableDomain::uncheckedCreateFromRegistrableDomainString("yahoo.com"_s));
+        map.add(RegistrableDomain::uncheckedCreateFromRegistrableDomainString("aolmail.com"_s), RegistrableDomain::uncheckedCreateFromRegistrableDomainString("aol.com"_s));
+        map.add(RegistrableDomain::uncheckedCreateFromRegistrableDomainString("googleusercontent.com"_s), RegistrableDomain::uncheckedCreateFromRegistrableDomainString("google.com"_s));
+        return map;
+    }();
+
+    RegistrableDomain firstPartyDomain { firstPartyURL };
+    RegistrableDomain requestDomain { requestURL };
+    if (firstPartyDomain != requestDomain)
+        return false;
+
+    RegistrableDomain redirectingDomain { redirectingURL };
+    auto quirk = quirkPairs.get().find(redirectingDomain);
+    if (quirk == quirkPairs.get().end())
+        return false;
+
+    return quirk->value == requestDomain;
+}
+#endif
+
+void NetworkTaskCocoa::applyCookiePolicyForThirdPartyCloaking(const WebCore::ResourceRequest& request)
+{
+    if (!shouldApplyCookiePolicyForThirdPartyCloaking())
+        return;
+
+    if (request.isThirdParty()) {
+        task()._cookieTransformCallback = nil;
+        return;
+    }
+
+    // Cap expiry of incoming cookies in response if it is a same-site
+    // subresource but it resolves to a different CNAME than the top
+    // site request, a.k.a. third-party CNAME cloaking.
+    auto firstPartyURL = request.firstPartyForCookies();
+    auto firstPartyHostName = firstPartyURL.host().toString();
+    auto firstPartyHostCNAME = m_networkSession->firstPartyHostCNAMEDomain(firstPartyHostName);
+    auto firstPartyAddress = m_networkSession->firstPartyHostIPAddress(firstPartyHostName);
+
+    task()._cookieTransformCallback = makeBlockPtr([requestURL = crossThreadCopy(request.url()), firstPartyURL = crossThreadCopy(firstPartyURL), firstPartyHostCNAME = crossThreadCopy(firstPartyHostCNAME), firstPartyAddress = crossThreadCopy(firstPartyAddress), thirdPartyCNAMEDomainForTesting = crossThreadCopy(m_networkSession->thirdPartyCNAMEDomainForTesting()), ageCapForCNAMECloakedCookies = crossThreadCopy(m_ageCapForCNAMECloakedCookies), weakTask = WeakObjCPtr<NSURLSessionTask>(task()), debugLoggingEnabled = m_networkSession->networkStorageSession()->trackingPreventionDebugLoggingEnabled()] (NSArray<NSHTTPCookie*> *cookiesSetInResponse) -> NSArray<NSHTTPCookie*> * {
+        auto task = weakTask.get();
+        if (!task || ![cookiesSetInResponse count])
+            return cookiesSetInResponse;
+
+        auto cnameDomain = [&task]() {
+            if (auto* lastResolvedCNAMEInChain = [[task _resolvedCNAMEChain] lastObject])
+                return lastCNAMEDomain(lastResolvedCNAMEInChain);
+            return RegistrableDomain { };
+        }();
+        if (cnameDomain.isEmpty() && thirdPartyCNAMEDomainForTesting)
+            cnameDomain = *thirdPartyCNAMEDomainForTesting;
+
+        if (cnameDomain.isEmpty()) {
+            if (!firstPartyAddress)
+                return cookiesSetInResponse;
+
+            auto remoteAddress = WebCore::IPAddress::fromString(lastRemoteIPAddress(task.get()));
+            if (!remoteAddress)
+                return cookiesSetInResponse;
+
+            if (shouldCapCookieExpiryForThirdPartyIPAddress(*remoteAddress, *firstPartyAddress)) {
+                cookiesSetInResponse = cookiesByCappingExpiry(cookiesSetInResponse, ageCapForCNAMECloakedCookies);
+                if (debugLoggingEnabled) {
+                    for (NSHTTPCookie *cookie in cookiesSetInResponse)
+                        RELEASE_LOG_INFO(ITPDebug, "Capped the expiry of third-party IP address cookie named %{public}@.", cookie.name);
+                }
+            }
+
+            return cookiesSetInResponse;
+        }
+
+        // CNAME cloaking is a first-party sub resource that resolves
+        // through a CNAME that differs from the first-party domain and
+        // also differs from the top frame host's CNAME, if one exists.
+        if (!cnameDomain.matches(firstPartyURL) && (!firstPartyHostCNAME || cnameDomain != *firstPartyHostCNAME)) {
+            // Don't use RetainPtr here. This array has to be retained and
+            // auto released to not be released before returned to the code
+            // executing the block.
+            cookiesSetInResponse = cookiesByCappingExpiry(cookiesSetInResponse, ageCapForCNAMECloakedCookies);
+            if (debugLoggingEnabled) {
+                for (NSHTTPCookie *cookie in cookiesSetInResponse)
+                    RELEASE_LOG_INFO(ITPDebug, "Capped the expiry of third-party CNAME cloaked cookie named %{public}@.", cookie.name);
+            }
+        }
+
+        return cookiesSetInResponse;
+    }).get();
+}
+
+void NetworkTaskCocoa::blockCookies()
+{
+    ASSERT(hasProcessPrivilege(ProcessPrivilege::CanAccessRawCookies));
+
+    if (m_hasBeenSetToUseStatelessCookieStorage)
+        return;
+
+    [task() _setExplicitCookieStorage:statelessCookieStorage()._cookieStorage];
+    m_hasBeenSetToUseStatelessCookieStorage = true;
+}
+
+void NetworkTaskCocoa::unblockCookies()
+{
+    ASSERT(hasProcessPrivilege(ProcessPrivilege::CanAccessRawCookies));
+
+    if (!m_hasBeenSetToUseStatelessCookieStorage)
+        return;
+
+    if (auto* storageSession = m_networkSession->networkStorageSession()) {
+        [task() _setExplicitCookieStorage:storageSession->nsCookieStorage()._cookieStorage];
+        m_hasBeenSetToUseStatelessCookieStorage = false;
+    }
+}
+
+void NetworkTaskCocoa::updateTaskWithFirstPartyForSameSiteCookies(NSURLSessionTask* task, const WebCore::ResourceRequest& request)
+{
+    if (request.isSameSiteUnspecified())
+        return;
+#if HAVE(FOUNDATION_WITH_SAME_SITE_COOKIE_SUPPORT)
+    static NSURL *emptyURL = [[NSURL alloc] initWithString:@""];
+    task._siteForCookies = request.isSameSite() ? task.currentRequest.URL : emptyURL;
+    task._isTopLevelNavigation = request.isTopSite();
+#else
+    UNUSED_PARAM(task);
+#endif
+}
+
+void NetworkTaskCocoa::willPerformHTTPRedirection(WebCore::ResourceResponse&& redirectResponse, WebCore::ResourceRequest&& request, RedirectCompletionHandler&& completionHandler)
+{
+#if ENABLE(APP_PRIVACY_REPORT)
+    request.setIsAppInitiated(request.nsURLRequest(WebCore::HTTPBodyUpdatePolicy::DoNotUpdateHTTPBody).attribution == NSURLRequestAttributionDeveloper);
+#endif
+
+#if ENABLE(TRACKING_PREVENTION)
+    applyCookiePolicyForThirdPartyCloaking(request);
+    if (!m_hasBeenSetToUseStatelessCookieStorage) {
+        if (storedCredentialsPolicy() == WebCore::StoredCredentialsPolicy::EphemeralStateless
+            || (m_networkSession->networkStorageSession() && m_networkSession->networkStorageSession()->shouldBlockCookies(request, frameID(), pageID(), m_shouldRelaxThirdPartyCookieBlocking)))
+            blockCookies();
+    } else if (storedCredentialsPolicy() != WebCore::StoredCredentialsPolicy::EphemeralStateless && needsFirstPartyCookieBlockingLatchModeQuirk(request.firstPartyForCookies(), request.url(), redirectResponse.url()))
+        unblockCookies();
+#if !RELEASE_LOG_DISABLED
+    if (m_networkSession->shouldLogCookieInformation())
+        RELEASE_LOG_IF(isAlwaysOnLoggingAllowed(), Network, "%p - NetworkTaskCocoa::willPerformHTTPRedirection::logCookieInformation: pageID=%" PRIu64 ", frameID=%" PRIu64 ", taskID=%lu: %s cookies for redirect URL %s", this, pageID()->toUInt64(), frameID()->object().toUInt64(), (unsigned long)[task() taskIdentifier], (m_hasBeenSetToUseStatelessCookieStorage ? "Blocking" : "Not blocking"), request.url().string().utf8().data());
+#else
+    LOG(NetworkSession, "%lu %s cookies for redirect URL %s", (unsigned long)[task() taskIdentifier], (m_hasBeenSetToUseStatelessCookieStorage ? "Blocking" : "Not blocking"), request.url().string().utf8().data());
+#endif
+#endif
+
+    updateTaskWithFirstPartyForSameSiteCookies(task(), request);
+    completionHandler(WTFMove(request));
+}

--- a/Source/WebKit/NetworkProcess/cocoa/WebSocketTaskCocoa.mm
+++ b/Source/WebKit/NetworkProcess/cocoa/WebSocketTaskCocoa.mm
@@ -41,24 +41,34 @@ namespace WebKit {
 
 using namespace WebCore;
 
-WebSocketTask::WebSocketTask(NetworkSocketChannel& channel, WebPageProxyIdentifier pageID, WeakPtr<SessionSet>&& sessionSet, const WebCore::ResourceRequest& request, const WebCore::ClientOrigin& clientOrigin, RetainPtr<NSURLSessionWebSocketTask>&& task)
-    : m_channel(channel)
+WebSocketTask::WebSocketTask(NetworkSocketChannel& channel, WebPageProxyIdentifier webProxyPageID, std::optional<FrameIdentifier> frameID, std::optional<PageIdentifier> pageID, WeakPtr<SessionSet>&& sessionSet, const WebCore::ResourceRequest& request, const WebCore::ClientOrigin& clientOrigin, RetainPtr<NSURLSessionWebSocketTask>&& task, ShouldRelaxThirdPartyCookieBlocking shouldRelaxThirdPartyCookieBlocking, WebCore::StoredCredentialsPolicy storedCredentialsPolicy)
+    : NetworkTaskCocoa(*channel.session(), shouldRelaxThirdPartyCookieBlocking)
+    , m_channel(channel)
     , m_task(WTFMove(task))
+    , m_webProxyPageID(webProxyPageID)
+    , m_frameID(frameID)
     , m_pageID(pageID)
     , m_sessionSet(WTFMove(sessionSet))
     , m_partition(request.cachePartition())
+    , m_storedCredentialsPolicy(storedCredentialsPolicy)
 {
     // We use topOrigin in case of service worker websocket connections, for which pageID does not link to a real page.
     // In that case, let's only call the callback for same origin loads.
     if (clientOrigin.topOrigin == clientOrigin.clientOrigin)
         m_topOrigin = clientOrigin.topOrigin;
 
+#if ENABLE(TRACKING_PREVENTION)
+    bool shouldBlockCookies = storedCredentialsPolicy == WebCore::StoredCredentialsPolicy::EphemeralStateless;
+    if (auto* networkStorageSession = networkSession() ? networkSession()->networkStorageSession() : nullptr) {
+        if (!shouldBlockCookies)
+            shouldBlockCookies = networkStorageSession->shouldBlockCookies(request, frameID, pageID, shouldRelaxThirdPartyCookieBlocking);
+    }
+    if (shouldBlockCookies)
+        blockCookies();
+#endif
+
     readNextMessage();
     m_channel.didSendHandshakeRequest(ResourceRequest { [m_task currentRequest] });
-}
-
-WebSocketTask::~WebSocketTask()
-{
 }
 
 void WebSocketTask::readNextMessage()
@@ -167,6 +177,10 @@ NetworkSessionCocoa* WebSocketTask::networkSession()
     return static_cast<NetworkSessionCocoa*>(m_channel.session());
 }
 
+NSURLSessionTask* WebSocketTask::task() const
+{
+    return m_task.get();
 }
 
+}
 #endif

--- a/Source/WebKit/NetworkProcess/curl/NetworkSessionCurl.cpp
+++ b/Source/WebKit/NetworkProcess/curl/NetworkSessionCurl.cpp
@@ -64,7 +64,7 @@ void NetworkSessionCurl::clearAlternativeServices(WallTime)
     networkStorageSession()->clearAlternativeServices();
 }
 
-std::unique_ptr<WebSocketTask> NetworkSessionCurl::createWebSocketTask(WebPageProxyIdentifier, NetworkSocketChannel& channel, const WebCore::ResourceRequest& request, const String& protocol, const WebCore::ClientOrigin&, bool, bool, OptionSet<WebCore::NetworkConnectionIntegrity>)
+std::unique_ptr<WebSocketTask> NetworkSessionCurl::createWebSocketTask(WebPageProxyIdentifier, std::optional<FrameIdentifier>, std::optional<PageIdentifier>, NetworkSocketChannel& channel, const WebCore::ResourceRequest& request, const String& protocol, const WebCore::ClientOrigin&, bool, bool, OptionSet<WebCore::NetworkConnectionIntegrity>, ShouldRelaxThirdPartyCookieBlocking, StoredCredentialsPolicy)
 {
     return makeUnique<WebSocketTask>(channel, request, protocol);
 }

--- a/Source/WebKit/NetworkProcess/curl/NetworkSessionCurl.h
+++ b/Source/WebKit/NetworkProcess/curl/NetworkSessionCurl.h
@@ -43,7 +43,7 @@ public:
     void clearAlternativeServices(WallTime) override;
 
 private:
-    std::unique_ptr<WebSocketTask> createWebSocketTask(WebPageProxyIdentifier, NetworkSocketChannel&, const WebCore::ResourceRequest&, const String& protocol, const WebCore::ClientOrigin&, bool, bool, OptionSet<WebCore::NetworkConnectionIntegrity>) final;
+    std::unique_ptr<WebSocketTask> createWebSocketTask(WebPageProxyIdentifier, std::optional<WebCore::FrameIdentifier>, std::optional<WebCore::PageIdentifier>, NetworkSocketChannel&, const WebCore::ResourceRequest&, const String& protocol, const WebCore::ClientOrigin&, bool, bool, OptionSet<WebCore::NetworkConnectionIntegrity>, WebCore::ShouldRelaxThirdPartyCookieBlocking, WebCore::StoredCredentialsPolicy) final;
 };
 
 } // namespace WebKit

--- a/Source/WebKit/NetworkProcess/soup/NetworkSessionSoup.cpp
+++ b/Source/WebKit/NetworkProcess/soup/NetworkSessionSoup.cpp
@@ -119,7 +119,7 @@ static void webSocketMessageNetworkEventCallback(SoupMessage* soupMessage, GSock
 }
 #endif
 
-std::unique_ptr<WebSocketTask> NetworkSessionSoup::createWebSocketTask(WebPageProxyIdentifier, NetworkSocketChannel& channel, const ResourceRequest& request, const String& protocol, const ClientOrigin&, bool, bool, OptionSet<WebCore::NetworkConnectionIntegrity>)
+std::unique_ptr<WebSocketTask> NetworkSessionSoup::createWebSocketTask(WebPageProxyIdentifier, std::optional<FrameIdentifier>, std::optional<PageIdentifier>, NetworkSocketChannel& channel, const ResourceRequest& request, const String& protocol, const ClientOrigin&, bool, bool, OptionSet<WebCore::NetworkConnectionIntegrity>, ShouldRelaxThirdPartyCookieBlocking, StoredCredentialsPolicy)
 {
     GRefPtr<SoupMessage> soupMessage = request.createSoupMessage(blobRegistry());
     if (!soupMessage)

--- a/Source/WebKit/NetworkProcess/soup/NetworkSessionSoup.h
+++ b/Source/WebKit/NetworkProcess/soup/NetworkSessionSoup.h
@@ -65,7 +65,7 @@ public:
     void setProxySettings(const WebCore::SoupNetworkProxySettings&);
 
 private:
-    std::unique_ptr<WebSocketTask> createWebSocketTask(WebPageProxyIdentifier, NetworkSocketChannel&, const WebCore::ResourceRequest&, const String& protocol, const WebCore::ClientOrigin&, bool, bool, OptionSet<WebCore::NetworkConnectionIntegrity>) final;
+    std::unique_ptr<WebSocketTask> createWebSocketTask(WebPageProxyIdentifier, std::optional<WebCore::FrameIdentifier>, std::optional<WebCore::PageIdentifier>, NetworkSocketChannel&, const WebCore::ResourceRequest&, const String& protocol, const WebCore::ClientOrigin&, bool, bool, OptionSet<WebCore::NetworkConnectionIntegrity>, WebCore::ShouldRelaxThirdPartyCookieBlocking, WebCore::StoredCredentialsPolicy) final;
     void clearCredentials(WallTime) final;
 
     std::unique_ptr<WebCore::SoupNetworkSession> m_networkSession;

--- a/Source/WebKit/SourcesCocoa.txt
+++ b/Source/WebKit/SourcesCocoa.txt
@@ -28,6 +28,7 @@ NetworkProcess/cocoa/NetworkActivityTrackerCocoa.mm
 NetworkProcess/cocoa/NetworkDataTaskCocoa.mm
 NetworkProcess/cocoa/NetworkProcessCocoa.mm
 NetworkProcess/cocoa/NetworkSessionCocoa.mm
+NetworkProcess/cocoa/NetworkTaskCocoa.mm
 NetworkProcess/cocoa/WKURLSessionTaskDelegate.mm
 
 NetworkProcess/Classifier/WebResourceLoadStatisticsStore.cpp

--- a/Source/WebKit/WebKit.xcodeproj/project.pbxproj
+++ b/Source/WebKit/WebKit.xcodeproj/project.pbxproj
@@ -2057,6 +2057,7 @@
 		CEC8F9CB1FDF5870002635E7 /* WKWebProcessPlugInNodeHandlePrivate.h in Headers */ = {isa = PBXBuildFile; fileRef = CEC8F9CA1FDF5870002635E7 /* WKWebProcessPlugInNodeHandlePrivate.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		CEDA12E3152CD1B300D9E08D /* WebAlternativeTextClient.h in Headers */ = {isa = PBXBuildFile; fileRef = CEDA12DE152CCAE800D9E08D /* WebAlternativeTextClient.h */; };
 		CEE4AE2B1A5DCF430002F49B /* UIKitSPI.h in Headers */ = {isa = PBXBuildFile; fileRef = CEE4AE2A1A5DCF430002F49B /* UIKitSPI.h */; };
+		D2E2FE6E29C8C30D00023E6B /* NetworkTaskCocoa.h in Headers */ = {isa = PBXBuildFile; fileRef = D2E2FE6D29C8C30D00023E6B /* NetworkTaskCocoa.h */; };
 		D3B9484711FF4B6500032B39 /* WebPopupMenu.h in Headers */ = {isa = PBXBuildFile; fileRef = D3B9484311FF4B6500032B39 /* WebPopupMenu.h */; };
 		D3B9484911FF4B6500032B39 /* WebSearchPopupMenu.h in Headers */ = {isa = PBXBuildFile; fileRef = D3B9484511FF4B6500032B39 /* WebSearchPopupMenu.h */; };
 		D952EC7A289C6BFA006C240A /* WebPermissionControllerProxy.h in Headers */ = {isa = PBXBuildFile; fileRef = D952EC76289C4299006C240A /* WebPermissionControllerProxy.h */; };
@@ -7025,6 +7026,8 @@
 		CEDA12DE152CCAE800D9E08D /* WebAlternativeTextClient.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = WebAlternativeTextClient.h; sourceTree = "<group>"; };
 		CEDA12DF152CCAE800D9E08D /* WebAlternativeTextClient.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = WebAlternativeTextClient.cpp; sourceTree = "<group>"; };
 		CEE4AE2A1A5DCF430002F49B /* UIKitSPI.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = UIKitSPI.h; sourceTree = "<group>"; };
+		D2E2FE6D29C8C30D00023E6B /* NetworkTaskCocoa.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = NetworkTaskCocoa.h; sourceTree = "<group>"; };
+		D2E2FE6F29C8C4F900023E6B /* NetworkTaskCocoa.mm */ = {isa = PBXFileReference; explicitFileType = sourcecode.cpp.objcpp; path = NetworkTaskCocoa.mm; sourceTree = "<group>"; };
 		D3B9484211FF4B6500032B39 /* WebPopupMenu.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = WebPopupMenu.cpp; sourceTree = "<group>"; };
 		D3B9484311FF4B6500032B39 /* WebPopupMenu.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = WebPopupMenu.h; sourceTree = "<group>"; };
 		D3B9484411FF4B6500032B39 /* WebSearchPopupMenu.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = WebSearchPopupMenu.cpp; sourceTree = "<group>"; };
@@ -11521,6 +11524,8 @@
 				7EC4F0F918E4A945008056AF /* NetworkProcessCocoa.mm */,
 				532159501DBAE6D70054AA3C /* NetworkSessionCocoa.h */,
 				5C20CB9B1BB0DCD200895BB1 /* NetworkSessionCocoa.mm */,
+				D2E2FE6D29C8C30D00023E6B /* NetworkTaskCocoa.h */,
+				D2E2FE6F29C8C4F900023E6B /* NetworkTaskCocoa.mm */,
 				41287D4C225C05C5009A3E26 /* WebSocketTaskCocoa.h */,
 				41287D4B225C05C4009A3E26 /* WebSocketTaskCocoa.mm */,
 				5C2C6FA827C96FF900CCDA9E /* WKURLSessionTaskDelegate.h */,
@@ -14548,6 +14553,7 @@
 				417915B92257046F00D6F97E /* NetworkSocketChannel.h in Headers */,
 				93085DE026E5BCFD000EC6A7 /* NetworkStorageManager.h in Headers */,
 				93085DE126E5BD13000EC6A7 /* NetworkStorageManagerMessages.h in Headers */,
+				D2E2FE6E29C8C30D00023E6B /* NetworkTaskCocoa.h in Headers */,
 				570DAAC22303730300E8FC04 /* NfcConnection.h in Headers */,
 				570DAAAE23026F5C00E8FC04 /* NfcService.h in Headers */,
 				514526FF271FB7EC000467B6 /* NotificationManagerMessageHandler.h in Headers */,


### PR DESCRIPTION
#### 97aedd23dc64dbdfdc65f6edf5753ebcf5197c28
<pre>
Apply cookie policy on WebSocket request
<a href="https://bugs.webkit.org/show_bug.cgi?id=254220">https://bugs.webkit.org/show_bug.cgi?id=254220</a>
rdar://106831525

Reviewed by Alex Christensen.

WebKit&apos;s cookie policy was not correctly applied in the WebSocket handshake. In
this patch we now use the same logic in WebSocket requests as we already used
in HTTP requests. This policy is applied during HTTP redirects, as well. The
shared logic is moved into a new common base class that is shared by
WebSocketTasks and DataTasks.

Covered by new Layout and API tests.

* LayoutTests/http/tests/resources/redirect.py:
(set_cookie):
* LayoutTests/http/tests/websocket/tests/hybi/websocket-blocked-sending-cookie-as-third-party-after-redirect-expected.txt: Added.
* LayoutTests/http/tests/websocket/tests/hybi/websocket-blocked-sending-cookie-as-third-party-after-redirect.html: Added.
* LayoutTests/http/tests/websocket/tests/hybi/websocket-blocked-sending-cookie-as-third-party-after-ws-redirect-expected.txt: Added.
* LayoutTests/http/tests/websocket/tests/hybi/websocket-blocked-sending-cookie-as-third-party-after-ws-redirect.html: Added.
* LayoutTests/http/tests/websocket/tests/hybi/websocket-blocked-sending-cookie-as-third-party-expected.txt: Added.
* LayoutTests/http/tests/websocket/tests/hybi/websocket-blocked-sending-cookie-as-third-party.html: Added.
* LayoutTests/http/tests/websocket/tests/hybi/websocket-blocked-sending-cookie-as-third-party_wsh.py: Added.
(HeaderCache):
(web_socket_do_extra_handshake):
(web_socket_transfer_data):
* LayoutTests/platform/gtk/TestExpectations:
* LayoutTests/platform/mac-wk1/TestExpectations:
Add new tests.

* Source/WebKit/NetworkProcess/NetworkConnectionToWebProcess.cpp:
(WebKit::NetworkConnectionToWebProcess::createSocketChannel):
* Source/WebKit/NetworkProcess/NetworkConnectionToWebProcess.h:
* Source/WebKit/NetworkProcess/NetworkConnectionToWebProcess.messages.in:
* Source/WebKit/NetworkProcess/NetworkSession.cpp:
(WebKit::NetworkSession::createWebSocketTask):
* Source/WebKit/NetworkProcess/NetworkSession.h:
* Source/WebKit/NetworkProcess/NetworkSocketChannel.cpp:
(WebKit::NetworkSocketChannel::create):
(WebKit::NetworkSocketChannel::NetworkSocketChannel):
(WebKit::NetworkSocketChannel::session const):
(WebKit::NetworkSocketChannel::session): Deleted.
* Source/WebKit/NetworkProcess/NetworkSocketChannel.h:
Generally, plumb some required information down in to the Network Process for making policy decisions.

* Source/WebKit/NetworkProcess/cocoa/NetworkDataTaskCocoa.h:
* Source/WebKit/NetworkProcess/cocoa/NetworkDataTaskCocoa.mm:
(WebKit::NetworkDataTaskCocoa::applySniffingPoliciesAndBindRequestToInferfaceIfNeeded):
(WebKit::NetworkDataTaskCocoa::updateFirstPartyInfoForSession):
(WebKit::NetworkDataTaskCocoa::NetworkDataTaskCocoa):
(WebKit::NetworkDataTaskCocoa::willPerformHTTPRedirection):
(WebKit::NetworkDataTaskCocoa::task const):
(WebKit::lastRemoteIPAddress): Deleted.
(WebKit::NetworkDataTaskCocoa::statelessCookieStorage): Deleted.
(WebKit::lastCNAMEDomain): Deleted.
(WebKit::NetworkDataTaskCocoa::shouldApplyCookiePolicyForThirdPartyCloaking const): Deleted.
(): Deleted.
(WebKit::shouldCapCookieExpiryForThirdPartyIPAddress): Deleted.
(WebKit::NetworkDataTaskCocoa::applyCookiePolicyForThirdPartyCloaking): Deleted.
(WebKit::NetworkDataTaskCocoa::blockCookies): Deleted.
(WebKit::NetworkDataTaskCocoa::unblockCookies): Deleted.
(WebKit::NetworkDataTaskCocoa::needsFirstPartyCookieBlockingLatchModeQuirk const): Deleted.
(WebKit::updateTaskWithFirstPartyForSameSiteCookies): Deleted.
(WebKit::computeIsAlwaysOnLoggingAllowed): Deleted.
(WebKit::NetworkDataTaskCocoa::isAlwaysOnLoggingAllowed const): Deleted.
These deleted functions are moved into the NetworkTaskCocoa class.

* Source/WebKit/NetworkProcess/cocoa/NetworkSessionCocoa.h:
* Source/WebKit/NetworkProcess/cocoa/NetworkSessionCocoa.mm:
(-[WKNetworkSessionDelegate URLSession:task:willPerformHTTPRedirection:newRequest:completionHandler:]):
(-[WKNetworkSessionDelegate existingWebSocketTask:]):
(WebKit::NetworkSessionCocoa::continueDidReceiveChallenge):
(WebKit::NetworkSessionCocoa::createWebSocketTask):
* Source/WebKit/NetworkProcess/cocoa/NetworkTaskCocoa.h: Added.
(WebKit::NetworkTaskCocoa::shouldRelaxThirdPartyCookieBlocking const):
(WebKit::NetworkTaskCocoa::isAlwaysOnLoggingAllowed const):
* Source/WebKit/NetworkProcess/cocoa/NetworkTaskCocoa.mm: Added.
(computeIsAlwaysOnLoggingAllowed):
(NetworkTaskCocoa::NetworkTaskCocoa):
(shouldCapCookieExpiryForThirdPartyIPAddress):
(NetworkTaskCocoa::shouldApplyCookiePolicyForThirdPartyCloaking const):
(NetworkTaskCocoa::statelessCookieStorage):
(NetworkTaskCocoa::lastRemoteIPAddress):
(NetworkTaskCocoa::lastCNAMEDomain):
(NetworkTaskCocoa::needsFirstPartyCookieBlockingLatchModeQuirk const):
(NetworkTaskCocoa::applyCookiePolicyForThirdPartyCloaking):
(NetworkTaskCocoa::blockCookies):
(NetworkTaskCocoa::unblockCookies):
(NetworkTaskCocoa::updateTaskWithFirstPartyForSameSiteCookies):
(NetworkTaskCocoa::willPerformHTTPRedirection):
New common base class for NetworkDataTaskCocoa and WebSocketTaskCocoa.

* Source/WebKit/NetworkProcess/cocoa/WebSocketTaskCocoa.h:
(WebKit::WebSocketTask::webProxyPageID const):
(WebKit::WebSocketTask::pageID const): Deleted.
* Source/WebKit/NetworkProcess/cocoa/WebSocketTaskCocoa.mm:
(WebKit::WebSocketTask::WebSocketTask):
(WebKit::WebSocketTask::task const):
(WebKit::WebSocketTask::~WebSocketTask): Deleted.
* Source/WebKit/NetworkProcess/curl/NetworkSessionCurl.cpp:
(WebKit::NetworkSessionCurl::createWebSocketTask):
* Source/WebKit/NetworkProcess/curl/NetworkSessionCurl.h:
* Source/WebKit/NetworkProcess/soup/NetworkSessionSoup.cpp:
(WebKit::NetworkSessionSoup::createWebSocketTask):
* Source/WebKit/NetworkProcess/soup/NetworkSessionSoup.h:
* Source/WebKit/SourcesCocoa.txt:
* Source/WebKit/WebKit.xcodeproj/project.pbxproj:
* Source/WebKit/WebProcess/Network/WebSocketChannel.cpp:
(WebKit::WebSocketChannel::connect):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/WKHTTPCookieStore.mm:
(TEST):

Originally-landed-as: 259548.477@safari-7615-branch (a5d38dc00a5d). rdar://106831525
Canonical link: <a href="https://commits.webkit.org/264753@main">https://commits.webkit.org/264753@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/48bc32c9e70f0a673a9f0ceeee219b2f12d21c61

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/8494 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/8787 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/9006 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/10161 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/8540 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/8503 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/10777 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/8737 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/11406 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/8641 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/9682 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/7658 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/10329 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/6980 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/7773 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/15340 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/8101 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/7920 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/11292 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/8393 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/6859 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/7679 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/7684 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/2067 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/11890 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/8138 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->