### PR TITLE
[iOS] Safari hangs under sync IPC when requesting autocorrection context

### DIFF
--- a/Source/WebKit/Platform/spi/ios/UIKitSPI.h
+++ b/Source/WebKit/Platform/spi/ios/UIKitSPI.h
@@ -445,6 +445,7 @@ typedef struct CGSVGDocument *CGSVGDocumentRef;
 + (CGSize)defaultSizeForInterfaceOrientation:(UIInterfaceOrientation)orientation;
 + (BOOL)isInHardwareKeyboardMode;
 + (BOOL)isOnScreen;
++ (BOOL)usesInputSystemUI;
 @end
 
 @interface UIKeyboardImpl : UIView <UIKeyboardCandidateListDelegate>

--- a/Source/WebKit/UIProcess/ios/WKContentViewInteraction.mm
+++ b/Source/WebKit/UIProcess/ios/WKContentViewInteraction.mm
@@ -5193,6 +5193,11 @@ static void logTextInteractionAssistantSelectionChange(const char* methodName, U
         return;
     }
 
+    if ([UIKeyboard usesInputSystemUI]) {
+        completionHandler(WKAutocorrectionContext.emptyAutocorrectionContext);
+        return;
+    }
+
     if ([self _disableAutomaticKeyboardUI]) {
         completionHandler(WKAutocorrectionContext.emptyAutocorrectionContext);
         return;

--- a/Tools/TestWebKitAPI/Tests/ios/AutocorrectionTestsIOS.mm
+++ b/Tools/TestWebKitAPI/Tests/ios/AutocorrectionTestsIOS.mm
@@ -125,6 +125,8 @@ TEST(AutocorrectionTests, RequestAutocorrectionContextAfterClosingPage)
 
 TEST(AutocorrectionTests, AutocorrectionContextDoesNotIncludeNewlineInTextField)
 {
+    if ([UIKeyboard usesInputSystemUI])
+        return;
     auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, 568)]);
     [webView synchronouslyLoadTestPageNamed:@"autofocused-text-input"];
 
@@ -144,6 +146,8 @@ TEST(AutocorrectionTests, AutocorrectionContextDoesNotIncludeNewlineInTextField)
 
 TEST(AutocorrectionTests, AutocorrectionContextBeforeAndAfterEditing)
 {
+    if ([UIKeyboard usesInputSystemUI])
+        return;
     auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, 568)]);
     auto inputDelegate = adoptNS([[TestInputDelegate alloc] init]);
     [inputDelegate setFocusStartsInputSessionPolicyHandler:[] (WKWebView *, id <_WKFocusedElementInfo>) -> _WKFocusStartsInputSessionPolicy {

--- a/Tools/TestWebKitAPI/ios/UIKitSPI.h
+++ b/Tools/TestWebKitAPI/ios/UIKitSPI.h
@@ -329,6 +329,7 @@ typedef NS_ENUM(NSInteger, _UITextSearchMatchMethod) {
 
 @interface UIKeyboard ()
 + (BOOL)isInHardwareKeyboardMode;
++ (BOOL)usesInputSystemUI;
 @end
 
 @interface UIKeyboardImpl (UIKitIPI)


### PR DESCRIPTION
#### caddd0f8263c37de2007be394191c8950df9aac4
<pre>
[iOS] Safari hangs under sync IPC when requesting autocorrection context
<a href="https://bugs.webkit.org/show_bug.cgi?id=257513">https://bugs.webkit.org/show_bug.cgi?id=257513</a>
rdar://104969174

Reviewed by Wenson Hsieh.

After focusing on a text field, clients often hang under sync IPC when
requesting autocorrection context through -[WKContentView requestAutocorrectionContextWithCompletionHandler:].
Some analysis has shown that out-of-process keyboard codepaths have
mostly moved on to -[WKContentView requestDocumentContext:] instead, and
even though there are still calls made into -[WKContentView requestAutocorrectionContextWithCompletionHandler:],
it seems that autocorrect suggestions are unaffected by the results
provided by said method.

As such, we provide a mitigation to further harden us against hangs of
this nature by early returning with an empty autocorrection context if
out-of-process keyboard is detected.

* Source/WebKit/Platform/spi/ios/UIKitSPI.h:

Add new SPI declarations to detect out-of-process keyboard.

* Source/WebKit/UIProcess/ios/WKContentViewInteraction.mm:
(-[WKContentView requestAutocorrectionContextWithCompletionHandler:]):

Early return with an empty autocorrection context when out-of-process
keyboard is detected.

* Tools/TestWebKitAPI/Tests/ios/AutocorrectionTestsIOS.mm:
(TEST):

Early return from tests in situations where -[WKContentView requestAutocorrectionContextWithCompletionHandler:]
is expected to be a no-op.

* Tools/TestWebKitAPI/ios/UIKitSPI.h:

Add new SPI declarations to detect out-of-process keyboard.

Canonical link: <a href="https://commits.webkit.org/264745@main">https://commits.webkit.org/264745@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9a65848e82697ca3d2628e3009a75798f2949432

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/8474 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/8767 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/8986 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/10141 "Built successfully") | [✅ 🛠 wincairo](https://ews-build.webkit.org/#/builders/32/builds/8520 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/8482 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/10757 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/8713 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/11388 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/8620 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/9662 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/7642 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/10296 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/6960 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/10/builds/7754 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/15304 "Passed tests") | 
| | [❌ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/8081 "1 api test failed or timed out") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/7901 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/11255 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/8373 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/6838 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/7659 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/2061 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/11870 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/8118 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->