### PR TITLE
Unreviewed, fix the internal watchOS build after rdar://109783639

### DIFF
--- a/Source/WebKit/UIProcess/ios/forms/WKDatePickerViewController.mm
+++ b/Source/WebKit/UIProcess/ios/forms/WKDatePickerViewController.mm
@@ -325,7 +325,9 @@ struct EraAndYear {
 
 - (void)_handleStatusBarNavigation
 {
-    [self.delegate quickboardInputCancelled:self];
+    ALLOW_DEPRECATED_DECLARATIONS_BEGIN
+    [self.delegate quickboardInputCancelled:static_cast<id<PUICQuickboardController>>(self)];
+    ALLOW_DEPRECATED_DECLARATIONS_END
 }
 
 - (void)viewWillLayoutSubviews
@@ -425,7 +427,9 @@ struct EraAndYear {
     [self _canonicalizeAndUpdateSelectedDate];
 
     auto attributedStringValue = adoptNS([[NSAttributedString alloc] initWithString:[self _valueForInput]]);
-    [self.delegate quickboard:self textEntered:attributedStringValue.get()];
+    ALLOW_DEPRECATED_DECLARATIONS_BEGIN
+    [self.delegate quickboard:static_cast<id<PUICQuickboardController>>(self) textEntered:attributedStringValue.get()];
+    ALLOW_DEPRECATED_DECLARATIONS_END
 }
 
 - (void)_updateSelectedPickerViewIndices

--- a/Source/WebKit/UIProcess/ios/forms/WKNumberPadViewController.mm
+++ b/Source/WebKit/UIProcess/ios/forms/WKNumberPadViewController.mm
@@ -161,7 +161,9 @@ static CGFloat inputLabelFontSize()
         [_inputText appendString:@"+"];
         break;
     case WKNumberPadKeyAccept:
-        [self.delegate quickboard:self textEntered:adoptNS([[NSAttributedString alloc] initWithString:_inputText.get()]).get()];
+        ALLOW_DEPRECATED_DECLARATIONS_BEGIN
+        [self.delegate quickboard:static_cast<id<PUICQuickboardController>>(self) textEntered:adoptNS([[NSAttributedString alloc] initWithString:_inputText.get()]).get()];
+        ALLOW_DEPRECATED_DECLARATIONS_END
         return;
     case WKNumberPadKey0:
         [_inputText appendString:@"0"];
@@ -204,7 +206,9 @@ static CGFloat inputLabelFontSize()
 - (void)_cancelInput
 {
     _shouldDismissWithFadeAnimation = YES;
-    [self.delegate quickboardInputCancelled:self];
+    ALLOW_DEPRECATED_DECLARATIONS_BEGIN
+    [self.delegate quickboardInputCancelled:static_cast<id<PUICQuickboardController>>(self)];
+    ALLOW_DEPRECATED_DECLARATIONS_END
 }
 
 - (void)_deleteLastInputCharacter

--- a/Source/WebKit/UIProcess/ios/forms/WKTextInputListViewController.mm
+++ b/Source/WebKit/UIProcess/ios/forms/WKTextInputListViewController.mm
@@ -119,7 +119,9 @@ ALLOW_DEPRECATED_DECLARATIONS_END
 
 - (void)enterText:(NSString *)text
 {
-    [self.delegate quickboard:self textEntered:adoptNS([[NSAttributedString alloc] initWithString:text]).get()];
+    ALLOW_DEPRECATED_DECLARATIONS_BEGIN
+    [self.delegate quickboard:static_cast<id<PUICQuickboardController>>(self) textEntered:adoptNS([[NSAttributedString alloc] initWithString:text]).get()];
+    ALLOW_DEPRECATED_DECLARATIONS_END
 }
 
 #pragma mark - Quickboard subclassing

--- a/Source/WebKit/UIProcess/ios/forms/WKTimePickerViewController.mm
+++ b/Source/WebKit/UIProcess/ios/forms/WKTimePickerViewController.mm
@@ -135,14 +135,18 @@ static NSString *timePickerDateFormat = @"HH:mm";
 - (void)leftButtonWOTAction
 {
     // Handle an action on the 'Cancel' button.
-    [self.delegate quickboardInputCancelled:self];
+    ALLOW_DEPRECATED_DECLARATIONS_BEGIN
+    [self.delegate quickboardInputCancelled:static_cast<id<PUICQuickboardController>>(self)];
+    ALLOW_DEPRECATED_DECLARATIONS_END
 }
 
 - (void)rightButtonWOTAction
 {
     // Handle an action on the 'Set' button.
     auto valueAsAttributedString = adoptNS([[NSAttributedString alloc] initWithString:self.timeValueForFormControls]);
-    [self.delegate quickboard:self textEntered:valueAsAttributedString.get()];
+    ALLOW_DEPRECATED_DECLARATIONS_BEGIN
+    [self.delegate quickboard:static_cast<id<PUICQuickboardController>>(self) textEntered:valueAsAttributedString.get()];
+    ALLOW_DEPRECATED_DECLARATIONS_END
 }
 
 @end


### PR DESCRIPTION
#### c4fc0ec9e315e758c452c78cf697d0e329b4f1d2
<pre>
Unreviewed, fix the internal watchOS build after rdar://109783639
rdar://109993902

Add some deprecation warnings, and also explicitly cast to `id&lt;PUICQuickboardController&gt;` when
invoking several delegate methods. This is because, on some version of the internal watchOS SDK,
`PUICQuickboardViewController` now conforms to a protocol named `PUICQuickboardControllerProtocol`,
rather than `PUICQuickboardController`; instead, `PUICQuickboardController` is now a deprecated
protocol that conforms to `PUICQuickboardControllerProtocol` (and provides no added functionality,
such that it&apos;s entirely interchangeable with the new `PUICQuickboardControllerProtocol`).

* Source/WebKit/UIProcess/ios/forms/WKDatePickerViewController.mm:
(-[WKDatePickerViewController _handleStatusBarNavigation]):
(-[WKDatePickerViewController _setButtonPressed]):
* Source/WebKit/UIProcess/ios/forms/WKNumberPadViewController.mm:
(-[WKNumberPadViewController _handleKeyPress:]):
(-[WKNumberPadViewController _cancelInput]):
* Source/WebKit/UIProcess/ios/forms/WKTextInputListViewController.mm:
(-[WKTextInputListViewController enterText:]):
* Source/WebKit/UIProcess/ios/forms/WKTimePickerViewController.mm:
(-[WKTimePickerViewController leftButtonWOTAction]):
(-[WKTimePickerViewController rightButtonWOTAction]):

Canonical link: <a href="https://commits.webkit.org/264702@main">https://commits.webkit.org/264702@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/011c4a35cd9a023bb0d8f76dfb264a03fbd9c2c2

| Misc | iOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/8384 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/26/builds/8677 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/14/builds/8894 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/10052 "Built successfully") | [  ~~🛠 wincairo~~](https://ews-build.webkit.org/#/builders/32/builds/8448 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/23/builds/10665 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/16/builds/8588 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/11310 "Passed tests") | 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/8530 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/15/builds/9581 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/7596 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/10203 "Built successfully") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/39/builds/6879 "Passed tests") | | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/15234 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/8000 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/36/builds/7816 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/11166 "Passed tests") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/7/builds/8288 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/17/builds/6757 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/30/builds/7577 "Built successfully") | | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/2025 "Built successfully and passed tests") | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/4/builds/11787 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/31/builds/8031 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->